### PR TITLE
Adding DMI and hypervisor info to the inventory payload

### DIFF
--- a/pkg/metadata/inventories/README.md
+++ b/pkg/metadata/inventories/README.md
@@ -127,6 +127,14 @@ The payload is a JSON dict with the following fields
   - `mac_address` - **string**: the MAC address for the host.
   - `agent_version` - **string**: the version of the Agent that sent this payload.
   - `cloud_provider` - **string**: the name of the cloud provider detected by the Agent.
+  - `hypervisor_guest_uuid` - **string**: the hypervisor guest UUID (Unix only, empty string on Windows or if we can't
+    read the data). On `ec2` instance this might start by "ec2". This was introduce in `7.41.0`/`6.41.0`.
+  - `dmi_product_uuid` - **string**: the DMI product UUID (Unix only, empty string on Windows or if we can't read the
+    data). On `ec2` instances this might start by "ec2". This was introduce in `7.41.0`/`6.41.0`.
+  - `dmi_board_asset_tag` - **string**: the DMI board tag (Unix only, empty string on Windows or if we can't read the
+    data). On `ec2` Nitro instance this contains the EC2 instance ID. This was introduce in `7.41.0`/`6.41.0`.
+  - `dmi_board_vendor` - **string**: the DMI board vendor (Unix only, empty string on Windows or if we can't read the
+    data). On `ec2` Nitro instance this might equal to "Amazon EC2". This was introduce in `7.41.0`/`6.41.0`.
 
 ("scrubbed" indicates that secrets are removed from the field value just as they are in logs)
 
@@ -253,7 +261,11 @@ Here an example of an inventory payload:
         "ipv6_address": "fe80::1ff:fe23:4567:890a",
         "mac_address": "01:23:45:67:89:AB",
         "agent_version": "7.37.0-devel+git.198.68a5b69",
-        "cloud_provider": "AWS"
+        "cloud_provider": "AWS",
+        "hypervisor_guest_uuid": "ec24ce06-9ac4-42df-9c10-14772aeb06d7",
+        "dmi_product_uuid": "ec24ce06-9ac4-42df-9c10-14772aeb06d7",
+        "dmi_board_asset_tag": "i-abcedf",
+        "dmi_board_vendor": "Amazon EC2"
     },
     "hostname": "my-host",
     "timestamp": 1631281754507358895

--- a/pkg/metadata/inventories/host_metadata.go
+++ b/pkg/metadata/inventories/host_metadata.go
@@ -16,10 +16,11 @@ import (
 
 // for testing purpose
 var (
-	cpuGet      = cpu.Get
-	memoryGet   = memory.Get
-	networkGet  = network.Get
-	platformGet = platform.Get
+	cpuGet                         = cpu.Get
+	memoryGet                      = memory.Get
+	networkGet                     = network.Get
+	platformGet                    = platform.Get
+	systemSpecificHosttMetadataGet = getSystemSpecificHosttMetadata
 )
 
 // HostMetadata contains metadata about the host
@@ -55,6 +56,12 @@ type HostMetadata struct {
 	AgentVersion  string `json:"agent_version"`
 	CloudProvider string `json:"cloud_provider"`
 	OsVersion     string `json:"os_version"`
+
+	// From file system
+	HypervisorGuestUUID string `json:"hypervisor_guest_uuid"`
+	DmiProductUUID      string `json:"dmi_product_uuid"`
+	DmiBoardAssetTag    string `json:"dmi_board_asset_tag"`
+	DmiBoardVendor      string `json:"dmi_board_vendor"`
 }
 
 // For now we simply logs warnings from gohai.
@@ -140,5 +147,8 @@ func getHostMetadata() *HostMetadata {
 	} else {
 		logErrorf("OS version not found in agent metadata cache") //nolint:errcheck
 	}
+
+	systemSpecificHosttMetadataGet(metadata)
+
 	return metadata
 }

--- a/pkg/metadata/inventories/host_metadata_nix.go
+++ b/pkg/metadata/inventories/host_metadata_nix.go
@@ -1,0 +1,36 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !windows
+// +build !windows
+
+package inventories
+
+import (
+	"os"
+	"strings"
+)
+
+var (
+	hypervisorUUIDPath   = "/sys/hypervisor/uuid"
+	dmiProductUUIDPath   = "/sys/devices/virtual/dmi/id/product_uuid"
+	dmiBoardAssetTagPath = "/sys/devices/virtual/dmi/id/board_asset_tag"
+	dmiBoardVendorPath   = "/sys/devices/virtual/dmi/id/board_vendor"
+)
+
+func readFile(path string) string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSuffix(string(data), "\n")
+}
+
+func getSystemSpecificHosttMetadata(metadata *HostMetadata) {
+	metadata.HypervisorGuestUUID = readFile(hypervisorUUIDPath)
+	metadata.DmiProductUUID = readFile(dmiProductUUIDPath)
+	metadata.DmiBoardAssetTag = readFile(dmiBoardAssetTagPath)
+	metadata.DmiBoardVendor = readFile(dmiBoardVendorPath)
+}

--- a/pkg/metadata/inventories/host_metadata_nix_test.go
+++ b/pkg/metadata/inventories/host_metadata_nix_test.go
@@ -1,0 +1,59 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !windows
+// +build !windows
+
+package inventories
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func resetSysPath() {
+	hypervisorUUIDPath = "/sys/hypervisor/uuid"
+	dmiProductUUIDPath = "/sys/devices/virtual/dmi/id/product_uuid"
+	dmiBoardAssetTagPath = "/sys/devices/virtual/dmi/id/board_asset_tag"
+	dmiBoardVendorPath = "/sys/devices/virtual/dmi/id/board_vendor"
+}
+
+func TestGetSystemSpecificHosttMetadata(t *testing.T) {
+	tempDir := t.TempDir()
+	defer resetSysPath()
+
+	setTestFile := func(data string, name string) string {
+		tempPath := filepath.Join(tempDir, name)
+		os.WriteFile(tempPath, []byte(data), os.ModePerm)
+		return tempPath
+	}
+
+	hypervisorUUIDPath = setTestFile("a404eff4-bacf-4839-a33c-619c3a06abd1\n", "hypervisor_uuid")
+	dmiProductUUIDPath = setTestFile("a404eff4-bacf-4839-a33c-619c3a06abd1\n", "product_uuid")
+	dmiBoardAssetTagPath = setTestFile("i-test\n", "board_asset_tag")
+	dmiBoardVendorPath = setTestFile("test vendor\n", "board_vendor")
+
+	metadata := &HostMetadata{}
+	getSystemSpecificHosttMetadata(metadata)
+	assert.Equal(t, "a404eff4-bacf-4839-a33c-619c3a06abd1", metadata.HypervisorGuestUUID)
+	assert.Equal(t, "a404eff4-bacf-4839-a33c-619c3a06abd1", metadata.DmiProductUUID)
+	assert.Equal(t, "i-test", metadata.DmiBoardAssetTag)
+	assert.Equal(t, "test vendor", metadata.DmiBoardVendor)
+
+	hypervisorUUIDPath = "does not exist"
+	dmiProductUUIDPath = "does not exist"
+	dmiBoardAssetTagPath = "does not exist"
+	dmiBoardVendorPath = "does not exist"
+
+	metadata = &HostMetadata{}
+	getSystemSpecificHosttMetadata(metadata)
+	assert.Equal(t, "", metadata.HypervisorGuestUUID)
+	assert.Equal(t, "", metadata.DmiProductUUID)
+	assert.Equal(t, "", metadata.DmiBoardAssetTag)
+	assert.Equal(t, "", metadata.DmiBoardVendor)
+}

--- a/pkg/metadata/inventories/host_metadata_test.go
+++ b/pkg/metadata/inventories/host_metadata_test.go
@@ -42,6 +42,10 @@ var (
 		AgentVersion:         version.AgentVersion,
 		CloudProvider:        "some_cloud_provider",
 		OsVersion:            "testOS",
+		HypervisorGuestUUID:  "",
+		DmiProductUUID:       "",
+		DmiBoardAssetTag:     "",
+		DmiBoardVendor:       "",
 	}
 )
 
@@ -102,6 +106,7 @@ func setupHostMetadataMock() func() {
 		memoryGet = memory.Get
 		networkGet = network.Get
 		platformGet = platform.Get
+		systemSpecificHosttMetadataGet = getSystemSpecificHosttMetadata
 
 		inventoryMutex.Lock()
 		delete(agentMetadata, string(AgentCloudProvider))
@@ -113,6 +118,7 @@ func setupHostMetadataMock() func() {
 	memoryGet = memoryMock
 	networkGet = networkMock
 	platformGet = platformMock
+	systemSpecificHosttMetadataGet = func(*HostMetadata) {}
 
 	SetAgentMetadata(AgentCloudProvider, "some_cloud_provider")
 	SetHostMetadata(HostOSVersion, "testOS")
@@ -139,12 +145,14 @@ func setupHostMetadataErrorMock() func() {
 		memoryGet = memory.Get
 		networkGet = network.Get
 		platformGet = platform.Get
+		systemSpecificHosttMetadataGet = getSystemSpecificHosttMetadata
 	}
 
 	cpuGet = cpuErrorMock
 	memoryGet = memoryErrorMock
 	networkGet = networkErrorMock
 	platformGet = platformErrorMock
+	systemSpecificHosttMetadataGet = func(*HostMetadata) {}
 	return reset
 }
 

--- a/pkg/metadata/inventories/host_metadata_win.go
+++ b/pkg/metadata/inventories/host_metadata_win.go
@@ -1,0 +1,11 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build windows
+// +build windows
+
+package inventories
+
+func getSystemSpecificHosttMetadata(metadata *HostMetadata) {}

--- a/pkg/metadata/inventories/inventories_test.go
+++ b/pkg/metadata/inventories/inventories_test.go
@@ -296,7 +296,11 @@ func TestGetPayload(t *testing.T) {
 			"mac_address": "00:0c:29:b6:d2:32",
 			"agent_version": "%v",
 			"cloud_provider": "some_cloud_provider",
-			"os_version": "testOS"
+			"os_version": "testOS",
+			"hypervisor_guest_uuid": "",
+			"dmi_product_uuid": "",
+			"dmi_board_asset_tag": "",
+			"dmi_board_vendor": ""
 		}
 	}`
 	jsonString = fmt.Sprintf(jsonString, startNow.UnixNano(), version.AgentVersion)


### PR DESCRIPTION
### What does this PR do?

Adding DMI and hypervisor info to the inventory payload

### Describe how to test/QA your changes

Check that the content of the following files are shipped in the inventory payload.
- "/sys/hypervisor/uuid"
- "/sys/devices/virtual/dmi/id/product_uuid"
- "/sys/devices/virtual/dmi/id/board_asset_tag"
- "/sys/devices/virtual/dmi/id/board_vendor"

Not all file will exists on every linux. `board_vendor` and `board_asset_tag` are present on EC2 nitro instance (C5 for example).

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
