### PR TITLE
[pkg/otlp] Make debug section aligned with logging exporter

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -3425,13 +3425,24 @@ api_key:
 
   ## @param debug - custom object - optional
   ## Debug-specific configuration for OTLP ingest in the Datadog Agent.
+  ## This template lists the most commonly used settings; see the OpenTelemetry Collector documentation
+  ## for a full list of available settings:
+  ## https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/loggingexporter#getting-started
   #
   # debug:
 
-    ## @param loglevel - string - optional - default: info
-    ## @env DD_OTLP_CONFIG_DEBUG_LOGLEVEL - string - optional - default: info
-    ## Loglevel for logs when Datadog Agent receives otlp traces/metrics.
-    ## Options are disabled, debug, info, error, warn.
+    ## Deprecated (v[6/7].41.0) - use `verbosity` instead
+    ## @param loglevel - string - optional - default: none
+    ## @env DD_OTLP_CONFIG_DEBUG_LOGLEVEL - string - optional - default: none
+    ## Verbosity of debug logs when Datadog Agent receives otlp traces/metrics.
+    ## Valid values are disabled, debug, info, error, warn.
     #
     # loglevel: info
+
+    ## @param verbosity - string - optional - default: normal
+    ## @env DD_OTLP_CONFIG_DEBUG_VERBOSITY - string - optional - default: normal
+    ## Verbosity of debug logs when Datadog Agent receives otlp traces/metrics.
+    ## Valid values are basic, normal, detailed.
+    #
+    # verbosity: normal
 {{end -}}

--- a/pkg/config/otlp.go
+++ b/pkg/config/otlp.go
@@ -19,45 +19,27 @@ const (
 	OTLPTagCardinalityKey     = OTLPMetrics + ".tag_cardinality"
 	OTLPDebugKey              = "debug"
 	OTLPDebug                 = OTLPSection + "." + OTLPDebugKey
-	OTLPDebugLogLevel         = OTLPDebug + ".loglevel"
 )
-
-// Following consts define log level of the logging exporter.
-// see: https://github.com/open-telemetry/opentelemetry-collector/blob/6fb884b2dbdc37ef2e1aea924040822ce38584bd/exporter/loggingexporter/config.go#L27-L28
-const (
-	OTLPDebugLogLevelDisabled = "disabled"
-	OTLPDebugLogLevelDebug    = "debug"
-	OTLPDebugLogLevelInfo     = "info"
-	OTLPDebugLogLevelWarn     = "warn"
-	OTLPDebugLogLevelError    = "error"
-)
-
-// OTLPDebugLogLevelMap TODO <agent-core>
-var OTLPDebugLogLevelMap = map[string]struct{}{
-	OTLPDebugLogLevelDisabled: {},
-	OTLPDebugLogLevelDebug:    {},
-	OTLPDebugLogLevelInfo:     {},
-	OTLPDebugLogLevelWarn:     {},
-	OTLPDebugLogLevelError:    {},
-}
 
 // SetupOTLP related configuration.
 func SetupOTLP(config Config) {
 	config.BindEnvAndSetDefault(OTLPTracePort, 5003)
 	config.BindEnvAndSetDefault(OTLPMetricsEnabled, true)
 	config.BindEnvAndSetDefault(OTLPTracesEnabled, true)
-	config.BindEnvAndSetDefault(OTLPDebugLogLevel, "info")
 
 	// NOTE: This only partially works.
 	// The environment variable is also manually checked in pkg/otlp/config.go
 	config.BindEnvAndSetDefault(OTLPTagCardinalityKey, "low", "DD_OTLP_TAG_CARDINALITY")
 
 	config.SetKnown(OTLPMetrics)
-	// Set all subkeys of otlp.metrics as known
+	// Set all subkeys of otlp_config.metrics as known
 	config.SetKnown(OTLPMetrics + ".*")
 	config.SetKnown(OTLPReceiverSection)
-	// Set all subkeys of otlp.receiver as known
+	// Set all subkeys of otlp_config.receiver as known
 	config.SetKnown(OTLPReceiverSection + ".*")
+	config.SetKnown(OTLPDebug)
+	// Set all subkeys of otlp_config.debug as known
+	config.SetKnown(OTLPDebug + ".*")
 
 	// set environment variables for selected fields
 	setupOTLPEnvironmentVariables(config)
@@ -100,6 +82,7 @@ func setupOTLPEnvironmentVariables(config Config) {
 	config.BindEnv(OTLPSection + ".metrics.sums.cumulative_monotonic_mode")
 	config.BindEnv(OTLPSection + ".metrics.summaries.mode")
 
-	// Debug setting
-	config.BindEnv(OTLPSection + ".debug.loglevel")
+	// Debug settings
+	config.BindEnv(OTLPSection + ".debug.loglevel") // Deprecated
+	config.BindEnv(OTLPSection + ".debug.verbosity")
 }

--- a/pkg/otlp/collector.go
+++ b/pkg/otlp/collector.go
@@ -100,23 +100,34 @@ type PipelineConfig struct {
 	TracesEnabled bool
 	// Debug contains debug configurations.
 	Debug map[string]interface{}
-
 	// Metrics contains configuration options for the serializer metrics exporter
 	Metrics map[string]interface{}
 }
 
-// DebugLogEnabled returns whether debug logging is enabled. If invalid loglevel value is set,
-// it assume debug logging is disabled.
-func (p *PipelineConfig) DebugLogEnabled() bool {
+// valid values for debug log level.
+var debugLogLevelMap = map[string]struct{}{
+	"disabled": {},
+	"debug":    {},
+	"info":     {},
+	"warn":     {},
+	"error":    {},
+}
+
+// shouldSetLoggingSection returns whether debug logging is enabled.
+// If an invalid loglevel value is set, it assumes debug logging is disabled.
+// If the special 'disabled' value is set, it returns false.
+// Otherwise it returns true and lets the Collector handle the rest.
+func (p *PipelineConfig) shouldSetLoggingSection() bool {
+	// Legacy behavior: keep it so that we support `loglevel: disabled`.
 	if v, ok := p.Debug["loglevel"]; ok {
 		if s, ok := v.(string); ok {
-			_, ok := config.OTLPDebugLogLevelMap[s]
-			if ok {
-				return s != config.OTLPDebugLogLevelDisabled
-			}
+			_, ok := debugLogLevelMap[s]
+			return ok && s != "disabled"
 		}
 	}
-	return false
+
+	// If the legacy behavior does not apply, we always want to set the logging section.
+	return true
 }
 
 // Pipeline is an OTLP pipeline.

--- a/pkg/otlp/config.go
+++ b/pkg/otlp/config.go
@@ -83,6 +83,7 @@ func FromAgentConfig(cfg config.Config) (PipelineConfig, error) {
 		errs = append(errs, fmt.Errorf("at least one OTLP signal needs to be enabled"))
 	}
 	metricsConfig := readConfigSection(cfg, config.OTLPMetrics)
+	debugConfig := readConfigSection(cfg, config.OTLPDebug)
 
 	return PipelineConfig{
 		OTLPReceiverConfig: otlpConfig.ToStringMap(),
@@ -90,7 +91,7 @@ func FromAgentConfig(cfg config.Config) (PipelineConfig, error) {
 		MetricsEnabled:     metricsEnabled,
 		TracesEnabled:      tracesEnabled,
 		Metrics:            metricsConfig.ToStringMap(),
-		Debug:              map[string]interface{}{"loglevel": cfg.GetString(config.OTLPDebugLogLevel)},
+		Debug:              debugConfig.ToStringMap(),
 	}, multierr.Combine(errs...)
 }
 

--- a/pkg/otlp/map_provider.go
+++ b/pkg/otlp/map_provider.go
@@ -122,12 +122,10 @@ func buildMap(cfg PipelineConfig) (*confmap.Conf, error) {
 		err = retMap.Merge(metricsMap)
 		errs = append(errs, err)
 	}
-	if cfg.DebugLogEnabled() {
+	if cfg.shouldSetLoggingSection() {
 		m := map[string]interface{}{
 			"exporters": map[string]interface{}{
-				"logging": map[string]interface{}{
-					"loglevel": cfg.Debug["loglevel"],
-				},
+				"logging": cfg.Debug,
 			},
 		}
 		if cfg.MetricsEnabled {

--- a/pkg/otlp/testdata/debug/empty_but_set_debug.yaml
+++ b/pkg/otlp/testdata/debug/empty_but_set_debug.yaml
@@ -1,0 +1,2 @@
+otlp_config:
+  debug:

--- a/pkg/otlp/testdata/debug/loglevel_debug.yaml
+++ b/pkg/otlp/testdata/debug/loglevel_debug.yaml
@@ -1,0 +1,3 @@
+otlp_config:
+  debug:
+    loglevel: debug

--- a/pkg/otlp/testdata/debug/loglevel_disabled.yaml
+++ b/pkg/otlp/testdata/debug/loglevel_disabled.yaml
@@ -1,0 +1,3 @@
+otlp_config:
+  debug:
+    loglevel: disabled

--- a/pkg/otlp/testdata/debug/verbosity_normal.yaml
+++ b/pkg/otlp/testdata/debug/verbosity_normal.yaml
@@ -1,0 +1,3 @@
+otlp_config:
+  debug:
+    verbosity: normal

--- a/releasenotes/notes/loglevel-deprecated-e489aa5d4a79fc3e.yaml
+++ b/releasenotes/notes/loglevel-deprecated-e489aa5d4a79fc3e.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+deprecations:
+  - |
+    The ``otlp_config.debug.loglevel`` setting was deprecated in favor of ``otlp_config.debug.verbosity``.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Make the `otlp_config.debug` section aligned with the `logging` exporter by supporting (slightly) the same settings.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

The logging exporter added the `verbosity` option on v0.63.0 to deprecate `loglevel`. In order to be aligned with upstream, we are adding support for it. 


### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Test the Agent with the following setups:

- [ ] Set `loglevel` to `disabled`; check that there is no log mentioning the logging exporter and/or that no logs come up when sending metrics/traces. Example config for this:

```
otlp_config:
  receiver:
    protocols:
      grpc:
  debug:
    loglevel: disabled
```

- [ ] Do not set any `debug` section. Check that the logging exporter does show up on logs and that the logs come up in metrics/traces. Example config:

```
otlp_config:
  receiver:
    protocols:
      grpc:
```

- [ ] Set `verbosity` to `detailed` and send some metrics/traces. Check that verbose logs (including all details from payload) show up in the Agent logs.

```
otlp_config:
  receiver:
    protocols:
      grpc:
  debug:
    verbosity: detailed
```

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
