### PR TITLE
[pkg/otlp] Make hostname logic consistent with exporter

### DIFF
--- a/cmd/trace-agent/config/config.go
+++ b/cmd/trace-agent/config/config.go
@@ -274,11 +274,12 @@ func applyDatadogConfig(c *config.AgentConfig) error {
 		grpcPort = coreconfig.Datadog.GetInt(coreconfig.OTLPTracePort)
 	}
 	c.OTLPReceiver = &config.OTLP{
-		BindHost:               c.ReceiverHost,
-		GRPCPort:               grpcPort,
-		MaxRequestBytes:        c.MaxRequestBytes,
-		SpanNameRemappings:     coreconfig.Datadog.GetStringMapString("otlp_config.traces.span_name_remappings"),
-		SpanNameAsResourceName: coreconfig.Datadog.GetBool("otlp_config.traces.span_name_as_resource_name"),
+		BindHost:                c.ReceiverHost,
+		GRPCPort:                grpcPort,
+		UsePreviewHostnameLogic: true,
+		MaxRequestBytes:         c.MaxRequestBytes,
+		SpanNameRemappings:      coreconfig.Datadog.GetStringMapString("otlp_config.traces.span_name_remappings"),
+		SpanNameAsResourceName:  coreconfig.Datadog.GetBool("otlp_config.traces.span_name_as_resource_name"),
 	}
 
 	if coreconfig.Datadog.GetBool("apm_config.telemetry.enabled") {

--- a/pkg/otlp/internal/serializerexporter/exporter.go
+++ b/pkg/otlp/internal/serializerexporter/exporter.go
@@ -90,6 +90,7 @@ func translatorFromConfig(logger *zap.Logger, cfg *exporterConfig) (*translator.
 
 	options := []translator.Option{
 		translator.WithFallbackSourceProvider(sourceProviderFunc(hostname.Get)),
+		translator.WithPreviewHostnameFromAttributes(),
 		translator.WithHistogramMode(histogramMode),
 		translator.WithDeltaTTL(cfg.Metrics.DeltaTTL),
 	}

--- a/releasenotes/notes/fix-hostname-d787b81e9103c48a.yaml
+++ b/releasenotes/notes/fix-hostname-d787b81e9103c48a.yaml
@@ -8,4 +8,4 @@
 ---
 fixes:
   - |
-    The OTLP ingest now is consistent with the Datadog exporter (v0.56+) when getting a hostname from OTLP resource attributes for metrics and traces.
+    The OTLP ingest is now consistent with the Datadog exporter (v0.56+) when getting a hostname from OTLP resource attributes for metrics and traces.

--- a/releasenotes/notes/fix-hostname-d787b81e9103c48a.yaml
+++ b/releasenotes/notes/fix-hostname-d787b81e9103c48a.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    The OTLP ingest now is consistent with the Datadog exporter (v0.56+) when getting a hostname from OTLP resource attributes for metrics and traces.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Use preview hostname resolution for the Datadog Agent, to make it consistent with the logic from the Datadog exporter. This relates to open-telemetry/opentelemetry-collector-contrib/issues/10424

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Consistency across products. Ignore container id when getting hostname.


### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

- [ ] Send OTLP metrics with  `container.id` set in the resource attribute. Check that the hostname on these metrics is **not** that value, but rather the one resolved by the Agent
- [ ] Send OTLP traces with  `container.id` set in the resource attribute. Check that the hostname on these metrics is **not** that value, but rather the one resolved by the Agent

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
