### PR TITLE
Extract common `agent` subcommands into packages

### DIFF
--- a/cmd/agent/subcommands/config/command.go
+++ b/cmd/agent/subcommands/config/command.go
@@ -7,180 +7,23 @@
 package config
 
 import (
-	"fmt"
-
-	"go.uber.org/fx"
-
 	"github.com/DataDog/datadog-agent/cmd/agent/command"
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
-	"github.com/DataDog/datadog-agent/comp/core"
-	"github.com/DataDog/datadog-agent/comp/core/config"
-	"github.com/DataDog/datadog-agent/comp/core/log"
-	"github.com/DataDog/datadog-agent/pkg/api/util"
-	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+	configcmd "github.com/DataDog/datadog-agent/pkg/cli/subcommands/config"
 
 	"github.com/spf13/cobra"
 )
 
-// cliParams are the command-line arguments for this subcommand
-type cliParams struct {
-	*command.GlobalParams
-
-	// args are the positional command line args
-	args []string
-}
-
 // Commands returns a slice of subcommands for the 'agent' command.
 func Commands(globalParams *command.GlobalParams) []*cobra.Command {
-	cliParams := &cliParams{
-		GlobalParams: globalParams,
-	}
-	// All subcommands use the same provided components, with a different
-	// oneShot callback.
-	oneShotRunE := func(callback interface{}) func(cmd *cobra.Command, args []string) error {
-		return func(cmd *cobra.Command, args []string) error {
-			cliParams.args = args
-			return fxutil.OneShot(callback,
-				fx.Supply(cliParams),
-				fx.Supply(core.BundleParams{
-					ConfFilePath:      globalParams.ConfFilePath,
-					ConfigLoadSecrets: false,
-				}.LogForOneShot("CORE", "off", true)),
-				core.Bundle,
-			)
+	cmd := configcmd.MakeCommand(func() configcmd.GlobalParams {
+		return configcmd.GlobalParams{
+			ConfFilePath:   globalParams.ConfFilePath,
+			ConfigName:     "datadog",
+			LoggerName:     "CORE",
+			SettingsClient: common.NewSettingsClient,
 		}
-	}
-	cmd := &cobra.Command{
-		Use:   "config",
-		Short: "Print the runtime configuration of a running agent",
-		Long:  ``,
-		RunE:  oneShotRunE(showRuntimeConfiguration),
-	}
-
-	listRuntimeCmd := &cobra.Command{
-		Use:   "list-runtime",
-		Short: "List settings that can be changed at runtime",
-		Long:  ``,
-		RunE:  oneShotRunE(listRuntimeConfigurableValue),
-	}
-	cmd.AddCommand(listRuntimeCmd)
-
-	setCmd := &cobra.Command{
-		Use:   "set [setting] [value]",
-		Short: "Set, for the current runtime, the value of a given configuration setting",
-		Long:  ``,
-		RunE:  oneShotRunE(setConfigValue),
-	}
-	cmd.AddCommand(setCmd)
-
-	getCmd := &cobra.Command{
-		Use:   "get [setting]",
-		Short: "Get, for the current runtime, the value of a given configuration setting",
-		Long:  ``,
-		RunE:  oneShotRunE(getConfigValue),
-	}
-	cmd.AddCommand(getCmd)
+	})
 
 	return []*cobra.Command{cmd}
-}
-
-func showRuntimeConfiguration(log log.Component, config config.Component, cliParams *cliParams) error {
-	err := util.SetAuthToken()
-	if err != nil {
-		return err
-	}
-
-	c, err := common.NewSettingsClient()
-	if err != nil {
-		return err
-	}
-
-	runtimeConfig, err := c.FullConfig()
-	if err != nil {
-		return err
-	}
-
-	fmt.Println(runtimeConfig)
-
-	return nil
-}
-
-func listRuntimeConfigurableValue(log log.Component, config config.Component, cliParams *cliParams) error {
-	err := util.SetAuthToken()
-	if err != nil {
-		return err
-	}
-
-	c, err := common.NewSettingsClient()
-	if err != nil {
-		return err
-	}
-
-	settingsList, err := c.List()
-	if err != nil {
-		return err
-	}
-
-	fmt.Println("=== Settings that can be changed at runtime ===")
-	for setting, details := range settingsList {
-		if !details.Hidden {
-			fmt.Printf("%-30s %s\n", setting, details.Description)
-		}
-	}
-
-	return nil
-}
-
-func setConfigValue(log log.Component, config config.Component, cliParams *cliParams) error {
-	if len(cliParams.args) != 2 {
-		return fmt.Errorf("exactly two parameters are required: the setting name and its value")
-	}
-
-	err := util.SetAuthToken()
-	if err != nil {
-		return err
-	}
-
-	c, err := common.NewSettingsClient()
-	if err != nil {
-		return err
-	}
-
-	hidden, err := c.Set(cliParams.args[0], cliParams.args[1])
-	if err != nil {
-		return err
-	}
-
-	if hidden {
-		fmt.Printf("IMPORTANT: you have modified a hidden option, this may incur billing charges or have other unexpected side-effects.\n")
-	}
-
-	fmt.Printf("Configuration setting %s is now set to: %s\n", cliParams.args[0], cliParams.args[1])
-
-	return nil
-}
-
-func getConfigValue(log log.Component, config config.Component, cliParams *cliParams) error {
-	if len(cliParams.args) != 1 {
-		return fmt.Errorf("a single setting name must be specified")
-	}
-
-	err := util.SetAuthToken()
-	if err != nil {
-		return err
-	}
-
-	c, err := common.NewSettingsClient()
-	if err != nil {
-		return err
-	}
-
-	value, err := c.Get(cliParams.args[0])
-	if err != nil {
-		return err
-	}
-
-	fmt.Printf("%s is set to: %v\n", cliParams.args[0], value)
-
-	return nil
 }

--- a/cmd/agent/subcommands/health/command.go
+++ b/cmd/agent/subcommands/health/command.go
@@ -7,116 +7,21 @@
 package health
 
 import (
-	"encoding/json"
-	"fmt"
-	"sort"
-	"strconv"
-	"strings"
-
-	"github.com/fatih/color"
 	"github.com/spf13/cobra"
-	"go.uber.org/fx"
 
 	"github.com/DataDog/datadog-agent/cmd/agent/command"
-	"github.com/DataDog/datadog-agent/comp/core"
-	"github.com/DataDog/datadog-agent/comp/core/config"
-	"github.com/DataDog/datadog-agent/comp/core/log"
-	"github.com/DataDog/datadog-agent/pkg/api/util"
-	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
-	"github.com/DataDog/datadog-agent/pkg/status/health"
-	"github.com/DataDog/datadog-agent/pkg/util/flavor"
-	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+	"github.com/DataDog/datadog-agent/pkg/cli/subcommands/health"
 )
-
-// cliParams are the command-line arguments for this subcommand
-type cliParams struct {
-	*command.GlobalParams
-}
 
 // Commands returns a slice of subcommands for the 'agent' command.
 func Commands(globalParams *command.GlobalParams) []*cobra.Command {
-	cliParams := &cliParams{
-		GlobalParams: globalParams,
-	}
-	cmd := &cobra.Command{
-		Use:          "health",
-		Short:        "Print the current agent health",
-		Long:         ``,
-		SilenceUsage: true,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return fxutil.OneShot(requestHealth,
-				fx.Supply(cliParams),
-				fx.Supply(core.BundleParams{
-					ConfFilePath:      globalParams.ConfFilePath,
-					ConfigLoadSecrets: false,
-					// TODO: when implementing `datadog-cluster-agent health`,
-					// ConfigName must be set to "datadog-cluster", and LogName
-					// should be changed as well.
-
-				}.LogForOneShot("CORE", "off", true)),
-				core.Bundle,
-			)
-		},
-	}
-	return []*cobra.Command{cmd}
-}
-func requestHealth(log log.Component, config config.Component, cliParams *cliParams) error {
-	c := util.GetClient(false) // FIX: get certificates right then make this true
-
-	ipcAddress, err := pkgconfig.GetIPCAddress()
-	if err != nil {
-		return err
-	}
-
-	var urlstr string
-	if flavor.GetFlavor() == flavor.ClusterAgent {
-		urlstr = fmt.Sprintf("https://%v:%v/status/health", ipcAddress, pkgconfig.Datadog.GetInt("cluster_agent.cmd_port"))
-	} else {
-		urlstr = fmt.Sprintf("https://%v:%v/agent/status/health", ipcAddress, pkgconfig.Datadog.GetInt("cmd_port"))
-	}
-
-	// Set session token
-	err = util.SetAuthToken()
-	if err != nil {
-		return err
-	}
-
-	r, err := util.DoGet(c, urlstr, util.LeaveConnectionOpen)
-	if err != nil {
-		var errMap = make(map[string]string)
-		json.Unmarshal(r, &errMap) //nolint:errcheck
-		// If the error has been marshalled into a json object, check it and return it properly
-		if e, found := errMap["error"]; found {
-			err = fmt.Errorf(e)
+	cmd := health.MakeCommand(func() health.GlobalParams {
+		return health.GlobalParams{
+			ConfFilePath: globalParams.ConfFilePath,
+			ConfigName:   "datadog",
+			LoggerName:   "CORE",
 		}
+	})
 
-		fmt.Printf("Could not reach agent: %v \nMake sure the agent is running before requesting the status and contact support if you continue having issues. \n", err)
-		return err
-	}
-
-	s := new(health.Status)
-	if err = json.Unmarshal(r, s); err != nil {
-		return fmt.Errorf("Error unmarshalling json: %s", err)
-	}
-
-	sort.Strings(s.Unhealthy)
-	sort.Strings(s.Healthy)
-
-	statusString := color.GreenString("PASS")
-	if len(s.Unhealthy) > 0 {
-		statusString = color.RedString("FAIL")
-	}
-	fmt.Fprintln(color.Output, fmt.Sprintf("Agent health: %s", statusString))
-
-	if len(s.Healthy) > 0 {
-		fmt.Fprintln(color.Output, fmt.Sprintf("=== %s healthy components ===", color.GreenString(strconv.Itoa(len(s.Healthy)))))
-		fmt.Fprintln(color.Output, strings.Join(s.Healthy, ", "))
-	}
-	if len(s.Unhealthy) > 0 {
-		fmt.Fprintln(color.Output, fmt.Sprintf("=== %s unhealthy components ===", color.RedString(strconv.Itoa(len(s.Unhealthy)))))
-		fmt.Fprintln(color.Output, strings.Join(s.Unhealthy, ", "))
-		return fmt.Errorf("found %d unhealthy components", len(s.Unhealthy))
-	}
-
-	return nil
+	return []*cobra.Command{cmd}
 }

--- a/cmd/agent/subcommands/version/command.go
+++ b/cmd/agent/subcommands/version/command.go
@@ -7,48 +7,15 @@
 package version
 
 import (
-	"fmt"
-	"runtime"
-
 	"github.com/DataDog/datadog-agent/cmd/agent/command"
-	"github.com/DataDog/datadog-agent/pkg/serializer"
-	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
-	"github.com/DataDog/datadog-agent/pkg/version"
+	"github.com/DataDog/datadog-agent/pkg/cli/subcommands/version"
 
-	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 )
 
 // Commands returns a slice of subcommands for the 'agent' command.
 func Commands(globalParams *command.GlobalParams) []*cobra.Command {
-	versionCmd := &cobra.Command{
-		Use:   "version",
-		Short: "Print the version info",
-		Long:  ``,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return fxutil.OneShot(run)
-		},
-	}
+	versionCmd := version.MakeCommand("Agent")
 
 	return []*cobra.Command{versionCmd}
-}
-
-func run() error {
-	av, _ := version.Agent()
-	meta := ""
-	if av.Meta != "" {
-		meta = fmt.Sprintf("- Meta: %s ", color.YellowString(av.Meta))
-	}
-	fmt.Fprintln(
-		color.Output,
-		fmt.Sprintf("Agent %s %s- Commit: %s - Serialization version: %s - Go version: %s",
-			color.CyanString(av.GetNumberAndPre()),
-			meta,
-			color.GreenString(av.Commit),
-			color.YellowString(serializer.AgentPayloadVersion),
-			color.RedString(runtime.Version()),
-		),
-	)
-
-	return nil
 }

--- a/pkg/cli/subcommands/check/command.go
+++ b/pkg/cli/subcommands/check/command.go
@@ -45,8 +45,6 @@ import (
 
 // cliParams are the command-line arguments for this subcommand
 type cliParams struct {
-	// *command.GlobalParams
-
 	// cmd is the running cobra.Command
 	cmd *cobra.Command
 
@@ -89,7 +87,7 @@ type GlobalParams struct {
 	LoggerName   string
 }
 
-// MakeCommand returns a `check` to be used by agent binaries.
+// MakeCommand returns a `check` command to be used by agent binaries.
 func MakeCommand(globalParamsGetter func() GlobalParams) *cobra.Command {
 	cliParams := &cliParams{}
 	cmd := &cobra.Command{

--- a/pkg/cli/subcommands/config/command.go
+++ b/pkg/cli/subcommands/config/command.go
@@ -1,0 +1,195 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package config builds a 'config' command to be used in binaries.
+package config
+
+import (
+	"fmt"
+
+	"go.uber.org/fx"
+
+	"github.com/DataDog/datadog-agent/comp/core"
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/log"
+	"github.com/DataDog/datadog-agent/pkg/api/util"
+	"github.com/DataDog/datadog-agent/pkg/config/settings"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+
+	"github.com/spf13/cobra"
+)
+
+// cliParams are the command-line arguments for this subcommand
+type cliParams struct {
+	GlobalParams
+
+	// args are the positional command line args
+	args []string
+}
+
+type GlobalParams struct {
+	ConfFilePath   string
+	ConfigName     string
+	LoggerName     string
+	SettingsClient func() (settings.Client, error)
+}
+
+// MakeCommand returns a `config` command to be used by agent binaries.
+func MakeCommand(globalParamsGetter func() GlobalParams) *cobra.Command {
+	cliParams := &cliParams{}
+	// All subcommands use the same provided components, with a different
+	// oneShot callback.
+	oneShotRunE := func(callback interface{}) func(cmd *cobra.Command, args []string) error {
+		return func(cmd *cobra.Command, args []string) error {
+			globalParams := globalParamsGetter()
+
+			cliParams.args = args
+			cliParams.GlobalParams = globalParams
+
+			return fxutil.OneShot(callback,
+				fx.Supply(cliParams),
+				fx.Supply(core.BundleParams{
+					ConfFilePath:      globalParams.ConfFilePath,
+					ConfigName:        globalParams.ConfigName,
+					ConfigLoadSecrets: false,
+				}.LogForOneShot(globalParams.LoggerName, "off", true)),
+				core.Bundle,
+			)
+		}
+	}
+	cmd := &cobra.Command{
+		Use:   "config",
+		Short: "Print the runtime configuration of a running agent",
+		Long:  ``,
+		RunE:  oneShotRunE(showRuntimeConfiguration),
+	}
+
+	listRuntimeCmd := &cobra.Command{
+		Use:   "list-runtime",
+		Short: "List settings that can be changed at runtime",
+		Long:  ``,
+		RunE:  oneShotRunE(listRuntimeConfigurableValue),
+	}
+	cmd.AddCommand(listRuntimeCmd)
+
+	setCmd := &cobra.Command{
+		Use:   "set [setting] [value]",
+		Short: "Set, for the current runtime, the value of a given configuration setting",
+		Long:  ``,
+		RunE:  oneShotRunE(setConfigValue),
+	}
+	cmd.AddCommand(setCmd)
+
+	getCmd := &cobra.Command{
+		Use:   "get [setting]",
+		Short: "Get, for the current runtime, the value of a given configuration setting",
+		Long:  ``,
+		RunE:  oneShotRunE(getConfigValue),
+	}
+	cmd.AddCommand(getCmd)
+
+	return cmd
+}
+
+func showRuntimeConfiguration(log log.Component, config config.Component, cliParams *cliParams) error {
+	err := util.SetAuthToken()
+	if err != nil {
+		return err
+	}
+
+	c, err := cliParams.GlobalParams.SettingsClient()
+	if err != nil {
+		return err
+	}
+
+	runtimeConfig, err := c.FullConfig()
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(runtimeConfig)
+
+	return nil
+}
+
+func listRuntimeConfigurableValue(log log.Component, config config.Component, cliParams *cliParams) error {
+	err := util.SetAuthToken()
+	if err != nil {
+		return err
+	}
+
+	c, err := cliParams.GlobalParams.SettingsClient()
+	if err != nil {
+		return err
+	}
+
+	settingsList, err := c.List()
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("=== Settings that can be changed at runtime ===")
+	for setting, details := range settingsList {
+		if !details.Hidden {
+			fmt.Printf("%-30s %s\n", setting, details.Description)
+		}
+	}
+
+	return nil
+}
+
+func setConfigValue(log log.Component, config config.Component, cliParams *cliParams) error {
+	if len(cliParams.args) != 2 {
+		return fmt.Errorf("exactly two parameters are required: the setting name and its value")
+	}
+
+	err := util.SetAuthToken()
+	if err != nil {
+		return err
+	}
+
+	c, err := cliParams.GlobalParams.SettingsClient()
+	if err != nil {
+		return err
+	}
+
+	hidden, err := c.Set(cliParams.args[0], cliParams.args[1])
+	if err != nil {
+		return err
+	}
+
+	if hidden {
+		fmt.Printf("IMPORTANT: you have modified a hidden option, this may incur billing charges or have other unexpected side-effects.\n")
+	}
+
+	fmt.Printf("Configuration setting %s is now set to: %s\n", cliParams.args[0], cliParams.args[1])
+
+	return nil
+}
+
+func getConfigValue(log log.Component, config config.Component, cliParams *cliParams) error {
+	if len(cliParams.args) != 1 {
+		return fmt.Errorf("a single setting name must be specified")
+	}
+
+	err := util.SetAuthToken()
+	if err != nil {
+		return err
+	}
+
+	c, err := cliParams.GlobalParams.SettingsClient()
+	if err != nil {
+		return err
+	}
+
+	value, err := c.Get(cliParams.args[0])
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("%s is set to: %v\n", cliParams.args[0], value)
+
+	return nil
+}

--- a/pkg/cli/subcommands/config/command_test.go
+++ b/pkg/cli/subcommands/config/command_test.go
@@ -8,16 +8,22 @@ package config
 import (
 	"testing"
 
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 
-	"github.com/DataDog/datadog-agent/cmd/agent/command"
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
 func TestConfigCommand(t *testing.T) {
+	commands := []*cobra.Command{
+		MakeCommand(func() GlobalParams {
+			return GlobalParams{}
+		}),
+	}
+
 	fxutil.TestOneShotSubcommand(t,
-		Commands(&command.GlobalParams{}),
+		commands,
 		[]string{"config"},
 		showRuntimeConfiguration,
 		func(cliParams *cliParams, coreParams core.BundleParams) {
@@ -27,8 +33,14 @@ func TestConfigCommand(t *testing.T) {
 }
 
 func TestConfigListRuntimeCommand(t *testing.T) {
+	commands := []*cobra.Command{
+		MakeCommand(func() GlobalParams {
+			return GlobalParams{}
+		}),
+	}
+
 	fxutil.TestOneShotSubcommand(t,
-		Commands(&command.GlobalParams{}),
+		commands,
 		[]string{"config", "list-runtime"},
 		listRuntimeConfigurableValue,
 		func(cliParams *cliParams, coreParams core.BundleParams) {
@@ -38,8 +50,14 @@ func TestConfigListRuntimeCommand(t *testing.T) {
 }
 
 func TestConfigSetCommand(t *testing.T) {
+	commands := []*cobra.Command{
+		MakeCommand(func() GlobalParams {
+			return GlobalParams{}
+		}),
+	}
+
 	fxutil.TestOneShotSubcommand(t,
-		Commands(&command.GlobalParams{}),
+		commands,
 		[]string{"config", "set", "foo", "bar"},
 		setConfigValue,
 		func(cliParams *cliParams, coreParams core.BundleParams) {
@@ -49,8 +67,14 @@ func TestConfigSetCommand(t *testing.T) {
 }
 
 func TestConfigGetCommand(t *testing.T) {
+	commands := []*cobra.Command{
+		MakeCommand(func() GlobalParams {
+			return GlobalParams{}
+		}),
+	}
+
 	fxutil.TestOneShotSubcommand(t,
-		Commands(&command.GlobalParams{}),
+		commands,
 		[]string{"config", "get", "foo"},
 		getConfigValue,
 		func(cliParams *cliParams, coreParams core.BundleParams) {

--- a/pkg/cli/subcommands/health/command.go
+++ b/pkg/cli/subcommands/health/command.go
@@ -1,0 +1,119 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package health builds a 'health' command to be used in binaries.
+package health
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+	"go.uber.org/fx"
+
+	"github.com/DataDog/datadog-agent/comp/core"
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/log"
+	"github.com/DataDog/datadog-agent/pkg/api/util"
+	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/status/health"
+	"github.com/DataDog/datadog-agent/pkg/util/flavor"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+type GlobalParams struct {
+	ConfFilePath string
+	ConfigName   string
+	LoggerName   string
+}
+
+// MakeCommand returns a `health` command to be used by agent binaries.
+func MakeCommand(globalParamsGetter func() GlobalParams) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "health",
+		Short:        "Print the current agent health",
+		Long:         ``,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			globalParams := globalParamsGetter()
+
+			return fxutil.OneShot(requestHealth,
+				fx.Supply(core.BundleParams{
+					ConfFilePath:      globalParams.ConfFilePath,
+					ConfigName:        globalParams.ConfigName,
+					ConfigLoadSecrets: false,
+				}.LogForOneShot(globalParams.LoggerName, "off", true)),
+				core.Bundle,
+			)
+		},
+	}
+
+	return cmd
+}
+
+func requestHealth(log log.Component, config config.Component) error {
+	c := util.GetClient(false) // FIX: get certificates right then make this true
+
+	ipcAddress, err := pkgconfig.GetIPCAddress()
+	if err != nil {
+		return err
+	}
+
+	var urlstr string
+	if flavor.GetFlavor() == flavor.ClusterAgent {
+		urlstr = fmt.Sprintf("https://%v:%v/status/health", ipcAddress, pkgconfig.Datadog.GetInt("cluster_agent.cmd_port"))
+	} else {
+		urlstr = fmt.Sprintf("https://%v:%v/agent/status/health", ipcAddress, pkgconfig.Datadog.GetInt("cmd_port"))
+	}
+
+	// Set session token
+	err = util.SetAuthToken()
+	if err != nil {
+		return err
+	}
+
+	r, err := util.DoGet(c, urlstr, util.LeaveConnectionOpen)
+	if err != nil {
+		var errMap = make(map[string]string)
+		json.Unmarshal(r, &errMap) //nolint:errcheck
+		// If the error has been marshalled into a json object, check it and return it properly
+		if e, found := errMap["error"]; found {
+			err = fmt.Errorf(e)
+		}
+
+		fmt.Printf("Could not reach agent: %v \nMake sure the agent is running before requesting the status and contact support if you continue having issues. \n", err)
+		return err
+	}
+
+	s := new(health.Status)
+	if err = json.Unmarshal(r, s); err != nil {
+		return fmt.Errorf("Error unmarshalling json: %s", err)
+	}
+
+	sort.Strings(s.Unhealthy)
+	sort.Strings(s.Healthy)
+
+	statusString := color.GreenString("PASS")
+	if len(s.Unhealthy) > 0 {
+		statusString = color.RedString("FAIL")
+	}
+	fmt.Fprintln(color.Output, fmt.Sprintf("Agent health: %s", statusString))
+
+	if len(s.Healthy) > 0 {
+		fmt.Fprintln(color.Output, fmt.Sprintf("=== %s healthy components ===", color.GreenString(strconv.Itoa(len(s.Healthy)))))
+		fmt.Fprintln(color.Output, strings.Join(s.Healthy, ", "))
+	}
+	if len(s.Unhealthy) > 0 {
+		fmt.Fprintln(color.Output, fmt.Sprintf("=== %s unhealthy components ===", color.RedString(strconv.Itoa(len(s.Unhealthy)))))
+		fmt.Fprintln(color.Output, strings.Join(s.Unhealthy, ", "))
+		return fmt.Errorf("found %d unhealthy components", len(s.Unhealthy))
+	}
+
+	return nil
+}

--- a/pkg/cli/subcommands/health/command_test.go
+++ b/pkg/cli/subcommands/health/command_test.go
@@ -3,19 +3,30 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-package version
+package health
 
 import (
 	"testing"
 
-	"github.com/DataDog/datadog-agent/cmd/agent/command"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
 func TestCommand(t *testing.T) {
+	commands := []*cobra.Command{
+		MakeCommand(func() GlobalParams {
+			return GlobalParams{}
+		}),
+	}
+
 	fxutil.TestOneShotSubcommand(t,
-		Commands(&command.GlobalParams{}),
-		[]string{"version"},
-		run,
-		func() {})
+		commands,
+		[]string{"health"},
+		requestHealth,
+		func(coreParams core.BundleParams) {
+			require.Equal(t, false, coreParams.ConfigLoadSecrets)
+		})
 }

--- a/pkg/cli/subcommands/version/command.go
+++ b/pkg/cli/subcommands/version/command.go
@@ -1,0 +1,60 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package version builds a 'version' command to be used in binaries.
+package version
+
+import (
+	"fmt"
+	"runtime"
+
+	"github.com/DataDog/datadog-agent/pkg/serializer"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+	"github.com/DataDog/datadog-agent/pkg/version"
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+	"go.uber.org/fx"
+)
+
+type params struct {
+	binary string
+}
+
+// MakeCommand returns a `version` command to be used by agent binaries.
+func MakeCommand(binary string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "version",
+		Short: "Print the version info",
+		Long:  ``,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return fxutil.OneShot(run, fx.Supply(&params{binary}))
+		},
+	}
+
+	return cmd
+}
+
+func run(params *params) error {
+	av, _ := version.Agent()
+	meta := ""
+
+	if av.Meta != "" {
+		meta = fmt.Sprintf("- Meta: %s ", color.YellowString(av.Meta))
+	}
+
+	fmt.Fprintln(
+		color.Output,
+		fmt.Sprintf("%s %s %s- Commit: %s - Serialization version: %s - Go version: %s",
+			params.binary,
+			color.CyanString(av.GetNumberAndPre()),
+			meta,
+			color.GreenString(version.Commit),
+			color.YellowString(serializer.AgentPayloadVersion),
+			color.RedString(runtime.Version()),
+		),
+	)
+
+	return nil
+}

--- a/pkg/cli/subcommands/version/command_test.go
+++ b/pkg/cli/subcommands/version/command_test.go
@@ -3,24 +3,23 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-package health
+package version
 
 import (
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
-	"github.com/DataDog/datadog-agent/cmd/agent/command"
-	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+	"github.com/spf13/cobra"
 )
 
 func TestCommand(t *testing.T) {
+	commands := []*cobra.Command{
+		MakeCommand("Agent"),
+	}
+
 	fxutil.TestOneShotSubcommand(t,
-		Commands(&command.GlobalParams{}),
-		[]string{"health"},
-		requestHealth,
-		func(cliParams *cliParams, coreParams core.BundleParams) {
-			require.Equal(t, false, coreParams.ConfigLoadSecrets)
-		})
+		commands,
+		[]string{"version"},
+		run,
+		func() {})
 }


### PR DESCRIPTION
### What does this PR do?

This follows the same steps of #13967, but for `config`, `health`, and `version`, which are all used by the DCA as well.

### Describe how to test/QA your changes

Same as #13967, but for the commands listed above. Applying the skip-qa label for the same reasons as well.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
