### PR TITLE
Set mininum TLS version 1.3 everywhere

### DIFF
--- a/cmd/agent/api/server.go
+++ b/cmd/agent/api/server.go
@@ -140,6 +140,7 @@ func StartServer(configService *remoteconfig.Service) error {
 		TLSConfig: &tls.Config{
 			Certificates: []tls.Certificate{*tlsKeyPair},
 			NextProtos:   []string{"h2"},
+			MinVersion:   tls.VersionTLS13,
 		},
 		ErrorLog: stdLog.New(logWriter, "Error from the agent http API server: ", 0), // log errors to seelog,
 		ConnContext: func(ctx context.Context, c net.Conn) context.Context {

--- a/cmd/agent/subcommands/run/internal/clcrunnerapi/clc_runner_server.go
+++ b/cmd/agent/subcommands/run/internal/clcrunnerapi/clc_runner_server.go
@@ -79,6 +79,7 @@ func StartCLCRunnerServer(extraHandlers map[string]http.Handler) error {
 
 	tlsConfig := tls.Config{
 		Certificates: []tls.Certificate{rootTLSCert},
+		MinVersion:   tls.VersionTLS13,
 	}
 
 	// Use a stack depth of 4 on top of the default one to get a relevant filename in the stdlib

--- a/cmd/cluster-agent/custommetrics/server.go
+++ b/cmd/cluster-agent/custommetrics/server.go
@@ -42,6 +42,7 @@ const (
 	metricsServerConf = "external_metrics_provider.config"
 	adapterName       = "datadog-custom-metrics-adapter"
 	adapterVersion    = "1.0.0"
+	tlsVersion13Str   = "VersionTLS13"
 )
 
 // RunServer creates and start a k8s custom metrics API server
@@ -128,6 +129,10 @@ func (a *DatadogMetricsAdapter) Config() (*apiserver.Config, error) {
 		// Ensure backward compatibility. 443 by default, but will error out if incorrectly set.
 		// refer to apiserver code in k8s.io/apiserver/pkg/server/option/serving.go
 		a.SecureServing.BindPort = config.Datadog.GetInt("external_metrics_provider.port")
+		// Default in External Metrics is TLS 1.2
+		if !config.Datadog.GetBool("cluster_agent.allow_legacy_tls") {
+			a.SecureServing.MinTLSVersion = tlsVersion13Str
+		}
 	}
 	if err := a.SecureServing.MaybeDefaultWithSelfSignedCerts("localhost", nil, []net.IP{net.ParseIP("127.0.0.1")}); err != nil {
 		log.Errorf("Failed to create self signed AuthN/Z configuration %#v", err)

--- a/cmd/security-agent/api/server.go
+++ b/cmd/security-agent/api/server.go
@@ -84,6 +84,7 @@ func (s *Server) Start() error {
 
 	tlsConfig := tls.Config{
 		Certificates: []tls.Certificate{rootTLSCert},
+		MinVersion:   tls.VersionTLS13,
 	}
 
 	// Use a stack depth of 4 on top of the default one to get a relevant filename in the stdlib


### PR DESCRIPTION
### What does this PR do?

Make sure all endpoints are >= TLS 1.3.
Extension of #11443

### Motivation

Security.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Run the Cluster Agent and the CLC with external metrics. It can be verified with `curl --tls-max 1.2` targeting:
- External metrics server (was 1.2 before)
- Admission controller (was 1.0 before)
- Cluster Checks Server (was 1.0 before)

Everything should fail.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
