### PR TITLE
Do not make the binaries and configuration owned by dd-agent

### DIFF
--- a/cmd/agent/install_script.sh
+++ b/cmd/agent/install_script.sh
@@ -9,7 +9,7 @@ set -e
 
 echo -e "\033[33m
  install_script.sh is deprecated. Please use one of
- 
+
  * https://s3.amazonaws.com/dd-agent/scripts/install_script_agent6.sh to install Agent 6
  * https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh to install Agent 7
 \033[0m"

--- a/omnibus/package-scripts/agent-deb/postinst
+++ b/omnibus/package-scripts/agent-deb/postinst
@@ -65,30 +65,14 @@ install_method:
     echo "$install_info_content" > $CONFIG_DIR/install_info
 fi
 
-# Set proper rights to the dd-agent user
-chown -R dd-agent:dd-agent ${CONFIG_DIR}
+# Set proper rights to the dd-agent user and group
+chown -R root:dd-agent ${CONFIG_DIR}
+find ${CONFIG_DIR} -type d -not -path ${CONFIG_DIR}/conf.d -exec chmod 2750 {} \;
+find ${CONFIG_DIR} -type f -not -path ${CONFIG_DIR}/conf.d -exec chmod 640 {} \;
+find ${CONFIG_DIR}/conf.d -type d -exec chmod 3770 {} \;
+find ${CONFIG_DIR}/conf.d -type f -exec chmod 660 {} \;
 chown -R dd-agent:dd-agent ${LOG_DIR}
 chown -R dd-agent:dd-agent ${INSTALL_DIR}
-
-# Make system-probe configs read-only
-chmod 0440 ${CONFIG_DIR}/system-probe.yaml.example || true
-if [ -f "$CONFIG_DIR/system-probe.yaml" ]; then
-    chmod 0440 ${CONFIG_DIR}/system-probe.yaml || true
-fi
-
-# Make security-agent config read-only
-chmod 0440 ${CONFIG_DIR}/security-agent.yaml.example || true
-if [ -f "$CONFIG_DIR/security-agent.yaml" ]; then
-    chmod 0440 ${CONFIG_DIR}/security-agent.yaml || true
-fi
-
-if [ -d "$CONFIG_DIR/compliance.d" ]; then
-    chown -R root:root ${CONFIG_DIR}/compliance.d || true
-fi
-
-if [ -d "$CONFIG_DIR/runtime-security.d" ]; then
-    chown -R root:root ${CONFIG_DIR}/runtime-security.d || true
-fi
 
 # Make the system-probe and security-agent binaries and eBPF programs owned by root
 chown root:root ${INSTALL_DIR}/embedded/bin/system-probe

--- a/omnibus/package-scripts/agent-deb/postinst
+++ b/omnibus/package-scripts/agent-deb/postinst
@@ -8,6 +8,8 @@ INSTALL_DIR=/opt/datadog-agent
 LOG_DIR=/var/log/datadog
 CONFIG_DIR=/etc/datadog-agent
 SERVICE_NAME=datadog-agent
+RUN_DIR=/opt/datadog-agent/run
+SITE_PACKAGES_DIR="${INSTALL_DIR}/embedded/lib/python*/site-packages"
 
 # If we are inside the Docker container, do nothing
 if [ -n "$DOCKER_DD_AGENT" ]; then
@@ -67,18 +69,22 @@ fi
 
 # Set proper rights to the dd-agent user and group
 chown -R root:dd-agent ${CONFIG_DIR}
+
+# Only provide read access to dd-agent by default
 find ${CONFIG_DIR} -type d -not -path ${CONFIG_DIR}/conf.d -exec chmod 2750 {} \;
 find ${CONFIG_DIR} -type f -not -path ${CONFIG_DIR}/conf.d -exec chmod 640 {} \;
+
+# Allow write access to dd-agent for integration installation
 find ${CONFIG_DIR}/conf.d -type d -exec chmod 3770 {} \;
 find ${CONFIG_DIR}/conf.d -type f -exec chmod 660 {} \;
-chown -R dd-agent:dd-agent ${LOG_DIR}
-chown -R dd-agent:dd-agent ${INSTALL_DIR}
+chown -R dd-agent:dd-agent ${SITE_PACKAGES_DIR} || true
 
-# Make the system-probe and security-agent binaries and eBPF programs owned by root
-chown root:root ${INSTALL_DIR}/embedded/bin/system-probe
-chown root:root ${INSTALL_DIR}/embedded/bin/security-agent
-chown -R root:root ${INSTALL_DIR}/embedded/share/system-probe/ebpf
-chown -R root:root ${INSTALL_DIR}/embedded/share/system-probe/java
+chown -R dd-agent:dd-agent ${LOG_DIR}
+chown -R dd-agent:dd-agent ${RUN_DIR}
+
+# Allow dd-agent to create files such as the auth token
+chmod g+w ${CONFIG_DIR}
+chmod +t ${CONFIG_DIR}
 
 # Enable and restart the agent service here on Debian platforms
 # On RHEL, this is done in the posttrans script

--- a/omnibus/package-scripts/agent-deb/postinst
+++ b/omnibus/package-scripts/agent-deb/postinst
@@ -79,6 +79,11 @@ find ${CONFIG_DIR}/conf.d -type d -exec chmod 3770 {} \;
 find ${CONFIG_DIR}/conf.d -type f -exec chmod 660 {} \;
 chown -R dd-agent:dd-agent ${SITE_PACKAGES_DIR} || true
 
+# This is done to allow integrations to install their binaries
+chown -R root:dd-agent ${INSTALL_DIR}/embedded/bin
+chmod g+w ${INSTALL_DIR}/embedded/bin
+chmod +t ${INSTALL_DIR}/embedded/bin
+
 chown -R dd-agent:dd-agent ${LOG_DIR}
 chown -R dd-agent:dd-agent ${RUN_DIR}
 

--- a/omnibus/package-scripts/agent-deb/postinst
+++ b/omnibus/package-scripts/agent-deb/postinst
@@ -77,7 +77,7 @@ find ${CONFIG_DIR} -type f -not -path ${CONFIG_DIR}/conf.d -exec chmod 640 {} \;
 # Allow write access to dd-agent for integration installation
 find ${CONFIG_DIR}/conf.d -type d -exec chmod 3770 {} \;
 find ${CONFIG_DIR}/conf.d -type f -exec chmod 660 {} \;
-chown -R dd-agent:dd-agent ${SITE_PACKAGES_DIR} || true
+chown -R dd-agent:dd-agent "${SITE_PACKAGES_DIR}" || true
 
 # This is done to allow integrations to install their binaries
 chown -R root:dd-agent ${INSTALL_DIR}/embedded/bin

--- a/omnibus/package-scripts/agent-rpm/postinst
+++ b/omnibus/package-scripts/agent-rpm/postinst
@@ -21,7 +21,7 @@ find ${CONFIG_DIR} -type f -not -path ${CONFIG_DIR}/conf.d -exec chmod 640 {} \;
 # Allow write access to dd-agent for integration installation
 find ${CONFIG_DIR}/conf.d -type d -exec chmod 3770 {} \;
 find ${CONFIG_DIR}/conf.d -type f -exec chmod 660 {} \;
-chown -R dd-agent:dd-agent ${SITE_PACKAGES_DIR} || true
+chown -R dd-agent:dd-agent "${SITE_PACKAGES_DIR}" || true
 
 # This is done to allow integrations to install their binaries
 chown -R root:dd-agent ${INSTALL_DIR}/embedded/bin

--- a/omnibus/package-scripts/agent-rpm/postinst
+++ b/omnibus/package-scripts/agent-rpm/postinst
@@ -23,6 +23,11 @@ find ${CONFIG_DIR}/conf.d -type d -exec chmod 3770 {} \;
 find ${CONFIG_DIR}/conf.d -type f -exec chmod 660 {} \;
 chown -R dd-agent:dd-agent ${SITE_PACKAGES_DIR} || true
 
+# This is done to allow integrations to install their binaries
+chown -R root:dd-agent ${INSTALL_DIR}/embedded/bin
+chmod g+w ${INSTALL_DIR}/embedded/bin
+chmod +t ${INSTALL_DIR}/embedded/bin
+
 chown -R dd-agent:dd-agent ${LOG_DIR}
 chown -R dd-agent:dd-agent ${RUN_DIR}
 

--- a/omnibus/package-scripts/agent-rpm/postinst
+++ b/omnibus/package-scripts/agent-rpm/postinst
@@ -8,20 +8,26 @@
 INSTALL_DIR=/opt/datadog-agent
 LOG_DIR=/var/log/datadog
 CONFIG_DIR=/etc/datadog-agent
+RUN_DIR=/opt/datadog-agent/run
+SITE_PACKAGES_DIR="${INSTALL_DIR}/embedded/lib/python*/site-packages"
 
-# Set proper rights to the dd-agent user
+# Set proper rights to the dd-agent user and group
 chown -R root:dd-agent ${CONFIG_DIR}
+
+# Only provide read access to dd-agent by default
 find ${CONFIG_DIR} -type d -not -path ${CONFIG_DIR}/conf.d -exec chmod 2750 {} \;
 find ${CONFIG_DIR} -type f -not -path ${CONFIG_DIR}/conf.d -exec chmod 640 {} \;
+
+# Allow write access to dd-agent for integration installation
 find ${CONFIG_DIR}/conf.d -type d -exec chmod 3770 {} \;
 find ${CONFIG_DIR}/conf.d -type f -exec chmod 660 {} \;
-chown -R dd-agent:dd-agent ${LOG_DIR}
-chown -R dd-agent:dd-agent ${INSTALL_DIR}
+chown -R dd-agent:dd-agent ${SITE_PACKAGES_DIR} || true
 
-# Make the system-probe and security-agent binaries and eBPF programs owned by root
-chown root:root ${INSTALL_DIR}/embedded/bin/system-probe
-chown root:root ${INSTALL_DIR}/embedded/bin/security-agent
-chown -R root:root ${INSTALL_DIR}/embedded/share/system-probe/ebpf
-chown -R root:root ${INSTALL_DIR}/embedded/share/system-probe/java
+chown -R dd-agent:dd-agent ${LOG_DIR}
+chown -R dd-agent:dd-agent ${RUN_DIR}
+
+# Allow dd-agent to create files such as the auth token
+chmod g+w ${CONFIG_DIR}
+chmod +t ${CONFIG_DIR}
 
 exit 0

--- a/omnibus/package-scripts/agent-rpm/postinst
+++ b/omnibus/package-scripts/agent-rpm/postinst
@@ -10,29 +10,13 @@ LOG_DIR=/var/log/datadog
 CONFIG_DIR=/etc/datadog-agent
 
 # Set proper rights to the dd-agent user
-chown -R dd-agent:dd-agent ${CONFIG_DIR}
+chown -R root:dd-agent ${CONFIG_DIR}
+find ${CONFIG_DIR} -type d -not -path ${CONFIG_DIR}/conf.d -exec chmod 2750 {} \;
+find ${CONFIG_DIR} -type f -not -path ${CONFIG_DIR}/conf.d -exec chmod 640 {} \;
+find ${CONFIG_DIR}/conf.d -type d -exec chmod 3770 {} \;
+find ${CONFIG_DIR}/conf.d -type f -exec chmod 660 {} \;
 chown -R dd-agent:dd-agent ${LOG_DIR}
 chown -R dd-agent:dd-agent ${INSTALL_DIR}
-
-# Make system-probe configs read-only
-chmod 0440 ${CONFIG_DIR}/system-probe.yaml.example || true
-if [ -f "$CONFIG_DIR/system-probe.yaml" ]; then
-    chmod 0440 ${CONFIG_DIR}/system-probe.yaml || true
-fi
-
-# Make security-agent config read-only
-chmod 0440 ${CONFIG_DIR}/security-agent.yaml.example || true
-if [ -f "$CONFIG_DIR/security-agent.yaml" ]; then
-    chmod 0440 ${CONFIG_DIR}/security-agent.yaml || true
-fi
-
-if [ -d "$CONFIG_DIR/compliance.d" ]; then
-    chown -R root:root ${CONFIG_DIR}/compliance.d || true
-fi
-
-if [ -d "$CONFIG_DIR/runtime-security.d" ]; then
-    chown -R root:root ${CONFIG_DIR}/runtime-security.d || true
-fi
 
 # Make the system-probe and security-agent binaries and eBPF programs owned by root
 chown root:root ${INSTALL_DIR}/embedded/bin/system-probe

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -624,6 +624,8 @@ api_key:
 ## Default is:
 ##  * Windows & macOS : `5002`
 ##  * Linux: `-1`
+## On Linux, to be able to edit the configuration from the GUI
+## you need to give write access on this file to the dd-agent user.
 ##
 #
 # GUI_port: <GUI_PORT>

--- a/releasenotes/notes/agent-file-ownership-13f077681711995c.yaml
+++ b/releasenotes/notes/agent-file-ownership-13f077681711995c.yaml
@@ -1,0 +1,8 @@
+---
+upgrade:
+  - |
+    The files provided by the agent and its configuration are no longer
+    owned by the ``dd-agent`` user but by ``root`` instead.
+    Users of the embedded agent GUI on Linux who need to edit the agent
+    configuration file should change the file permission to keep using
+    this feature.

--- a/test/kitchen/test/integration/common/rspec_datadog/spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec_datadog/spec_helper.rb
@@ -386,23 +386,31 @@ def read_conf_file(conf_path = "")
   if conf_path == ""
     conf_path = get_conf_file("datadog.yaml")
   end
-  f = `sudo cat #{conf_path}`
+  if os == :windows
+    f = File.read(conf_path)
+  else
+    f = `sudo cat #{conf_path}`
+  end
   confYaml = YAML.load(f)
   confYaml || {}
 end
 
 def write_conf_file(conf_path, data)
-  file = Tempfile.new(File.basename(conf_path))
-  begin
-    file.write(data)
-    file.close
-    system "sudo cp #{file.path} #{conf_path}"
-    system "sudo chown :dd-agent #{conf_path}"
-    system "sudo chmod 640 #{conf_path}"
-    system "sudo chmod +x #{File.dirname(conf_path)}"
-  ensure
-    file.close
-    file.unlink
+  if os == :windows
+    File.write(conf_path, data)
+  else
+    file = Tempfile.new(File.basename(conf_path))
+    begin
+      file.write(data)
+      file.close
+      system "sudo cp #{file.path} #{conf_path}"
+      system "sudo chown :dd-agent #{conf_path}"
+      system "sudo chmod 640 #{conf_path}"
+      system "sudo chmod +x #{File.dirname(conf_path)}"
+    ensure
+      file.close
+      file.unlink
+    end
   end
 end
 

--- a/test/kitchen/test/integration/common/rspec_datadog/spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec_datadog/spec_helper.rb
@@ -383,13 +383,27 @@ def get_conf_file(conf_path)
 end
 
 def read_conf_file(conf_path = "")
-    if conf_path == ""
-      conf_path = get_conf_file("datadog.yaml")
-    end
-    puts "cp is #{conf_path}"
-    f = File.read(conf_path)
-    confYaml = YAML.load(f)
-    confYaml
+  if conf_path == ""
+    conf_path = get_conf_file("datadog.yaml")
+  end
+  f = `sudo cat #{conf_path}`
+  confYaml = YAML.load(f)
+  confYaml || {}
+end
+
+def write_conf_file(conf_path, data)
+  file = Tempfile.new(File.basename(conf_path))
+  begin
+    file.write(data)
+    file.close
+    system "sudo cp #{file.path} #{conf_path}"
+    system "sudo chown :dd-agent #{conf_path}"
+    system "sudo chmod 640 #{conf_path}"
+    system "sudo chmod +x #{File.dirname(conf_path)}"
+  ensure
+    file.close
+    file.unlink
+  end
 end
 
 def fetch_python_version(timeout = 15)
@@ -604,13 +618,12 @@ shared_examples_for "a running Agent with APM manually disabled" do
   it 'is not bound to the port that receives traces when apm_enabled is set to false' do
     conf_path = get_conf_file("datadog.yaml")
 
-    f = File.read(conf_path)
-    confYaml = YAML.load(f)
+    confYaml = read_conf_file()
     if !confYaml.key("apm_config")
       confYaml["apm_config"] = {}
     end
     confYaml["apm_config"]["enabled"] = false
-    File.write(conf_path, confYaml.to_yaml)
+    write_conf_file(conf_path, confYaml.to_yaml)
 
     output = restart "datadog-agent"
     if os != :windows
@@ -687,10 +700,9 @@ end
 shared_examples_for 'an Agent with python3 enabled' do
   it 'restarts after python_version is set to 3' do
     conf_path = get_conf_file("datadog.yaml")
-    f = File.read(conf_path)
-    confYaml = YAML.load(f)
+    confYaml = read_conf_file(conf_path)
     confYaml["python_version"] = 3
-    File.write(conf_path, confYaml.to_yaml)
+    write_conf_file(conf_path, confYaml.to_yaml)
 
     output = restart "datadog-agent"
     expect(output).to be_truthy
@@ -708,10 +720,9 @@ shared_examples_for 'an Agent with python3 enabled' do
   it 'restarts after python_version is set back to 2' do
     skip if info.include? "v7."
     conf_path = get_conf_file("datadog.yaml")
-    f = File.read(conf_path)
-    confYaml = YAML.load(f)
+    confYaml = read_conf_file(conf_path)
     confYaml["python_version"] = 2
-    File.write(conf_path, confYaml.to_yaml)
+    write_conf_file(conf_path, confYaml.to_yaml)
 
     output = restart "datadog-agent"
     expect(output).to be_truthy
@@ -740,7 +751,7 @@ shared_examples_for 'an Agent with integrations' do
   before do
     freeze_content = File.read(integrations_freeze_file)
     freeze_content.gsub!(/datadog-cilium==.*/, 'datadog-cilium==2.2.1')
-    File.write(integrations_freeze_file, freeze_content)
+    write_conf_file(integrations_freeze_file, freeze_content)
 
     integration_remove('datadog-cilium')
   end
@@ -967,8 +978,7 @@ end
 
 def enable_cws(conf_path, state)
   begin
-    f = File.read(conf_path)
-    confYaml = YAML.load(f)
+    confYaml = read_conf_file(conf_path)
     if !confYaml.key("runtime_security_config")
       confYaml["runtime_security_config"] = {}
     end
@@ -976,7 +986,7 @@ def enable_cws(conf_path, state)
   rescue
     confYaml = {'runtime_security_config' => {'enabled' => state}}
   ensure
-    File.write(conf_path, confYaml.to_yaml)
+    write_conf_file(conf_path, confYaml.to_yaml)
   end
 end
 


### PR DESCRIPTION
Making the binaries owned by the user used to run a service is not necessary and
may not be a good security practice.

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

- By default, make all binaries owned by root:root
- Make Python's site-packages and conf.d owned by dd-agent so that integrations can be installed as dd-agent 
- Make all configuration files only readable by dd-agent This would allow privileged services such as the security-agent to read from datadog.yaml (avoiding having to configure common settings in multiple files)

### Motivation

Until now, system-probe and security-agent had their own configuration files as `datadog.yaml` is owned and writable by
the `dd-agent` user. Write access to `datadog.yaml` seems to be only required for the internal GUI to be able to edit configuration
which is disabled by default so it is reasonable to request setting specific write access when using this feature. Having all the services be able to read `datadog.yaml` makes unnecessary the need to configure some features - such as remote tagger port or endpoints - twice.

Having the binaries owned by dd-agent is unnecessary and may introduces a potential security risk.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

- Test the different installation methods for the agent, in particular installing directly using the packages and using the install script.
- Make sure all the agent starts properly
- That the agent hasn't the permissions to modify its own binaries and configuration files
- Integrations can still be installed
- Agent CLI such as flare or status still work as expected
- Package can still be uninstalled

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
