### PR TITLE
[CWS] remove useless CGo call

### DIFF
--- a/pkg/security/probe/dentry_resolver.go
+++ b/pkg/security/probe/dentry_resolver.go
@@ -559,10 +559,6 @@ func (dr *DentryResolver) preventSegmentMajorPageFault() {
 	dr.erpcSegment[6*os.Getpagesize()] = 0
 }
 
-func (dr *DentryResolver) markSegmentAsZero() {
-	model.ByteOrder.PutUint64(dr.erpcSegment[0:8], 0)
-}
-
 func (dr *DentryResolver) requestResolve(op uint8, mountID uint32, inode uint64, pathID uint32) (uint32, error) {
 	// create eRPC request
 	challenge := rand.Uint32()

--- a/pkg/security/probe/dentry_resolver.go
+++ b/pkg/security/probe/dentry_resolver.go
@@ -9,7 +9,6 @@
 package probe
 
 import (
-	"C"
 	"errors"
 	"fmt"
 	"math/rand"
@@ -24,13 +23,14 @@ import (
 	"go.uber.org/atomic"
 	"golang.org/x/sys/unix"
 
+	"strings"
+
 	"github.com/DataDog/datadog-agent/pkg/security/config"
 	"github.com/DataDog/datadog-agent/pkg/security/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/security/metrics"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
 )
-import "strings"
 
 var (
 	fakeInodeMSW = uint64(0xdeadc001)
@@ -132,7 +132,7 @@ type PathEntry struct {
 
 // GetName returns the path value as a string
 func (pv *PathLeaf) GetName() string {
-	return C.GoString((*C.char)(unsafe.Pointer(&pv.Name)))
+	return model.NullTerminatedString(pv.Name)
 }
 
 // eRPCStats is used to collect kernel space metrics about the eRPC resolution
@@ -498,7 +498,7 @@ func (dr *DentryResolver) ResolveFromMap(mountID uint32, inode uint64, pathID ui
 		if path.Name[0] == '/' {
 			name = "/"
 		} else {
-			name = C.GoString((*C.char)(unsafe.Pointer(&path.Name)))
+			name = model.NullTerminatedString(path.Name)
 			filenameParts = append(filenameParts, name)
 		}
 
@@ -598,7 +598,7 @@ func (dr *DentryResolver) GetNameFromERPC(mountID uint32, inode uint64, pathID u
 		return "", errERPCRequestNotProcessed
 	}
 
-	seg := C.GoString((*C.char)(unsafe.Pointer(&dr.erpcSegment[16])))
+	seg := model.NullTerminatedString(dr.erpcSegment[16:])
 	if len(seg) == 0 || len(seg) > 0 && seg[0] == 0 {
 		dr.missCounters[entry].Inc()
 		return "", fmt.Errorf("couldn't resolve segment (len: %d)", len(seg))
@@ -684,7 +684,7 @@ func (dr *DentryResolver) ResolveFromERPC(mountID uint32, inode uint64, pathID u
 		}
 
 		if dr.erpcSegment[i] != '/' {
-			segment = C.GoString((*C.char)(unsafe.Pointer(&dr.erpcSegment[i])))
+			segment = model.NullTerminatedString(dr.erpcSegment[i:])
 			filenameParts = append(filenameParts, segment)
 			i += len(segment) + 1
 		} else {

--- a/pkg/security/probe/dentry_resolver.go
+++ b/pkg/security/probe/dentry_resolver.go
@@ -132,7 +132,7 @@ type PathEntry struct {
 
 // GetName returns the path value as a string
 func (pv *PathLeaf) GetName() string {
-	return model.NullTerminatedString(pv.Name)
+	return model.NullTerminatedString(pv.Name[:])
 }
 
 // eRPCStats is used to collect kernel space metrics about the eRPC resolution
@@ -498,7 +498,7 @@ func (dr *DentryResolver) ResolveFromMap(mountID uint32, inode uint64, pathID ui
 		if path.Name[0] == '/' {
 			name = "/"
 		} else {
-			name = model.NullTerminatedString(path.Name)
+			name = model.NullTerminatedString(path.Name[:])
 			filenameParts = append(filenameParts, name)
 		}
 

--- a/pkg/security/secl/model/utils.go
+++ b/pkg/security/secl/model/utils.go
@@ -47,11 +47,11 @@ func UnmarshalStringArray(data []byte) ([]string, error) {
 
 		if i+n > len {
 			// truncated
-			arg := nullTerminatedString(data[i:len])
+			arg := NullTerminatedString(data[i:len])
 			return append(result, arg), ErrStringArrayOverflow
 		}
 
-		arg := nullTerminatedString(data[i : i+n])
+		arg := NullTerminatedString(data[i : i+n])
 		i += n
 
 		result = append(result, arg)

--- a/pkg/security/secl/model/utils.go
+++ b/pkg/security/secl/model/utils.go
@@ -66,10 +66,10 @@ func UnmarshalString(data []byte, size int) (string, error) {
 		return "", ErrNotEnoughData
 	}
 
-	return nullTerminatedString(data[:size]), nil
+	return NullTerminatedString(data[:size]), nil
 }
 
-func nullTerminatedString(d []byte) string {
+func NullTerminatedString(d []byte) string {
 	idx := bytes.IndexByte(d, 0)
 	if idx == -1 {
 		return string(d)

--- a/pkg/security/secl/model/utils_test.go
+++ b/pkg/security/secl/model/utils_test.go
@@ -26,7 +26,7 @@ func BenchmarkNullTerminatedString(b *testing.B) {
 	array := []byte{65, 66, 67, 0, 0, 0, 65, 66}
 	var s string
 	for i := 0; i < b.N; i++ {
-		s = nullTerminatedString(array)
+		s = NullTerminatedString(array)
 	}
 	runtime.KeepAlive(s)
 }


### PR DESCRIPTION
### What does this PR do?

`C.GoString` is already doing a copy, there is no advantage to do this unsafe CGo trickery

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
