### PR TITLE
[CWS][SEC-5238] Update activity dumps functional tests to use cgroups instead of comms

### DIFF
--- a/pkg/security/tests/activity_dumps_test.go
+++ b/pkg/security/tests/activity_dumps_test.go
@@ -27,6 +27,11 @@ var expectedFormats = []string{"json", "protobuf"}
 const testActivityDumpRateLimiter = 20
 
 func TestActivityDumps(t *testing.T) {
+	// skip test that are about to be run on docker (to avoid trying spawning docker in docker)
+	if testEnvironment == DockerEnvironment {
+		t.Skip("Skip test spawning docker containers on docker")
+	}
+
 	outputDir := t.TempDir()
 	defer os.RemoveAll(outputDir)
 	test, err := newTestModule(t, nil, []*rules.RuleDefinition{}, testOpts{

--- a/pkg/security/tests/activity_dumps_test.go
+++ b/pkg/security/tests/activity_dumps_test.go
@@ -10,9 +10,7 @@ package tests
 
 import (
 	"fmt"
-	"net"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -29,9 +27,14 @@ var expectedFormats = []string{"json", "protobuf"}
 const testActivityDumpRateLimiter = 20
 
 func TestActivityDumps(t *testing.T) {
+	outputDir := t.TempDir()
+	defer os.RemoveAll(outputDir)
 	test, err := newTestModule(t, nil, []*rules.RuleDefinition{}, testOpts{
-		enableActivityDump:      true,
-		activityDumpRateLimiter: testActivityDumpRateLimiter,
+		enableActivityDump:                  true,
+		activityDumpRateLimiter:             testActivityDumpRateLimiter,
+		activityDumpLocalStorageDirectory:   outputDir,
+		activityDumpLocalStorageCompression: false,
+		activityDumpLocalStorageFormats:     expectedFormats,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -41,35 +44,27 @@ func TestActivityDumps(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	outputDir, _, err := test.Path("test-activity-dump")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(outputDir)
 
-	test.Run(t, "activity-dump-comm-bind", func(t *testing.T, kind wrapperType,
-		cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
-
-		outputFiles, err := test.StartActivityDumpComm(t, "syscall_tester", outputDir, expectedFormats)
+	t.Run("activity-dump-cgroup-bind", func(t *testing.T) {
+		dockerInstance, dump, err := test.StartADockerGetDump()
 		if err != nil {
 			t.Fatal(err)
 		}
+		defer dockerInstance.stop()
 
-		args := []string{"bind", "AF_INET", "any", "tcp"}
-		envs := []string{}
-		cmd := cmdFunc(syscallTester, args, envs)
-		if out, err := cmd.CombinedOutput(); err != nil {
-			t.Fatal(fmt.Errorf("%s: %w", out, err))
+		cmd := dockerInstance.Command(syscallTester, []string{"bind", "AF_INET", "any", "tcp"}, []string{})
+		_, err = cmd.CombinedOutput()
+		if err != nil {
+			t.Fatal(err)
 		}
-
 		time.Sleep(1 * time.Second) // a quick sleep to let events to be added to the dump
 
-		err = test.StopActivityDumpComm(t, "syscall_tester")
+		err = test.StopActivityDumpComm(t, "")
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		validateActivityDumpOutputs(t, test, expectedFormats, outputFiles, func(ad *probe.ActivityDump) bool {
+		validateActivityDumpOutputs(t, test, expectedFormats, dump.OutputFiles, func(ad *probe.ActivityDump) bool {
 			nodes := ad.FindMatchingNodes("syscall_tester")
 			if nodes == nil {
 				t.Fatalf("Node not found in activity dump: %+v", nodes)
@@ -89,29 +84,32 @@ func TestActivityDumps(t *testing.T) {
 		})
 	})
 
-	test.Run(t, "activity-dump-comm-dns", func(t *testing.T, kind wrapperType,
-		cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
+	t.Run("activity-dump-cgroup-dns", func(t *testing.T) {
 		checkKernelCompatibility(t, "RHEL, SLES and Oracle kernels", func(kv *kernel.Version) bool {
 			// TODO: Oracle because we are missing offsets. See dns_test.go
 			return kv.IsRH7Kernel() || kv.IsOracleUEKKernel() || kv.IsSLESKernel()
 		})
 
-		outputFiles, err := test.StartActivityDumpComm(t, "testsuite", outputDir, expectedFormats)
+		dockerInstance, dump, err := test.StartADockerGetDump()
 		if err != nil {
 			t.Fatal(err)
 		}
+		defer dockerInstance.stop()
 
-		net.LookupIP("foo.bar")
-
+		cmd := dockerInstance.Command("nslookup", []string{"foo.bar"}, []string{})
+		_, err = cmd.CombinedOutput()
+		if err != nil {
+			t.Fatal(err)
+		}
 		time.Sleep(1 * time.Second) // a quick sleep to let events to be added to the dump
 
-		err = test.StopActivityDumpComm(t, "testsuite")
+		err = test.StopActivityDumpComm(t, "")
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		validateActivityDumpOutputs(t, test, expectedFormats, outputFiles, func(ad *probe.ActivityDump) bool {
-			nodes := ad.FindMatchingNodes("testsuite")
+		validateActivityDumpOutputs(t, test, expectedFormats, dump.OutputFiles, func(ad *probe.ActivityDump) bool {
+			nodes := ad.FindMatchingNodes("nslookup")
 			if nodes == nil {
 				t.Fatal("Node not found in activity dump")
 			}
@@ -126,35 +124,34 @@ func TestActivityDumps(t *testing.T) {
 		})
 	})
 
-	test.Run(t, "activity-dump-comm-file", func(t *testing.T, kind wrapperType,
-		cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
-
-		outputFiles, err := test.StartActivityDumpComm(t, "testsuite", outputDir, expectedFormats)
+	t.Run("activity-dump-cgroup-file", func(t *testing.T) {
+		dockerInstance, dump, err := test.StartADockerGetDump()
 		if err != nil {
 			t.Fatal(err)
 		}
+		defer dockerInstance.stop()
 
-		temp, err := os.CreateTemp("", "ad-test-create")
+		temp, _ := os.CreateTemp(test.st.Root(), "ad-test-create")
+		os.Remove(temp.Name()) // next touch command have to create the file
+
+		cmd := dockerInstance.Command("touch", []string{temp.Name()}, []string{})
+		_, err = cmd.CombinedOutput()
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer os.Remove(temp.Name())
-
 		time.Sleep(1 * time.Second) // a quick sleep to let events to be added to the dump
 
-		err = test.StopActivityDumpComm(t, "testsuite")
+		err = test.StopActivityDumpComm(t, "")
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		tempPathParts := strings.Split(temp.Name(), "/")
-
-		validateActivityDumpOutputs(t, test, expectedFormats, outputFiles, func(ad *probe.ActivityDump) bool {
-			nodes := ad.FindMatchingNodes("testsuite")
+		validateActivityDumpOutputs(t, test, expectedFormats, dump.OutputFiles, func(ad *probe.ActivityDump) bool {
+			nodes := ad.FindMatchingNodes("touch")
 			if nodes == nil {
 				t.Fatal("Node not found in activity dump")
 			}
-
 			for _, node := range nodes {
 				current := node.Files
 				for _, part := range tempPathParts {
@@ -168,34 +165,30 @@ func TestActivityDumps(t *testing.T) {
 					current = next.Children
 				}
 			}
-
 			return true
 		})
 	})
 
-	test.Run(t, "activity-dump-comm-syscalls", func(t *testing.T, kind wrapperType,
-		cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
-
-		outputFiles, err := test.StartActivityDumpComm(t, "syscall_tester", outputDir, expectedFormats)
+	t.Run("activity-dump-cgroup-syscalls", func(t *testing.T) {
+		dockerInstance, dump, err := test.StartADockerGetDump()
 		if err != nil {
 			t.Fatal(err)
 		}
+		defer dockerInstance.stop()
 
-		args := []string{"bind", "AF_INET", "any", "tcp"}
-		envs := []string{}
-		cmd := cmdFunc(syscallTester, args, envs)
-		if out, err := cmd.CombinedOutput(); err != nil {
-			t.Fatal(fmt.Errorf("%s: %w", out, err))
+		cmd := dockerInstance.Command(syscallTester, []string{"bind", "AF_INET", "any", "tcp"}, []string{})
+		_, err = cmd.CombinedOutput()
+		if err != nil {
+			t.Fatal(err)
 		}
-
 		time.Sleep(1 * time.Second) // a quick sleep to let events to be added to the dump
 
-		err = test.StopActivityDumpComm(t, "syscall_tester")
+		err = test.StopActivityDumpComm(t, "")
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		validateActivityDumpOutputs(t, test, expectedFormats, outputFiles, func(ad *probe.ActivityDump) bool {
+		validateActivityDumpOutputs(t, test, expectedFormats, dump.OutputFiles, func(ad *probe.ActivityDump) bool {
 			nodes := ad.FindMatchingNodes("syscall_tester")
 			if nodes == nil {
 				t.Fatal("Node not found in activity dump")
@@ -221,34 +214,37 @@ func TestActivityDumps(t *testing.T) {
 		})
 	})
 
-	test.Run(t, "activity-dump-comm-rate-limiter", func(t *testing.T, kind wrapperType,
-		cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
-
-		outputFiles, err := test.StartActivityDumpComm(t, "testsuite", outputDir, expectedFormats)
+	t.Run("activity-dump-cgroup-rate-limiter", func(t *testing.T) {
+		dockerInstance, dump, err := test.StartADockerGetDump()
 		if err != nil {
 			t.Fatal(err)
 		}
+		defer dockerInstance.stop()
 
-		time.Sleep(2 * time.Second) // a quick sleep to let starts and snapshot events to be added to the dump
-
-		tempDir := t.TempDir()
-		defer os.RemoveAll(tempDir)
-		for i := 0; i < testActivityDumpRateLimiter*10; i++ {
-			_, err := os.CreateTemp(tempDir, "ad-test-create")
-			if err != nil {
-				t.Fatal(err)
-			}
+		testDir := filepath.Join(test.st.Root(), "ratelimiter")
+		if err := os.MkdirAll(testDir, os.ModePerm); err != nil {
+			t.Fatal(err)
 		}
-
+		var files []string
+		for i := 0; i < testActivityDumpRateLimiter*10; i++ {
+			files = append(files, filepath.Join(testDir, "ad-test-create-"+fmt.Sprintf("%d", i)))
+		}
+		args := []string{"sleep", "2", ";", "open"}
+		args = append(args, files...)
+		cmd := dockerInstance.Command(syscallTester, args, []string{})
+		_, err = cmd.CombinedOutput()
+		if err != nil {
+			t.Fatal(err)
+		}
 		time.Sleep(1 * time.Second) // a quick sleep to let events to be added to the dump
 
-		err = test.StopActivityDumpComm(t, "testsuite")
+		err = test.StopActivityDumpComm(t, "")
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		validateActivityDumpOutputs(t, test, expectedFormats, outputFiles, func(ad *probe.ActivityDump) bool {
-			nodes := ad.FindMatchingNodes("testsuite")
+		validateActivityDumpOutputs(t, test, expectedFormats, dump.OutputFiles, func(ad *probe.ActivityDump) bool {
+			nodes := ad.FindMatchingNodes("syscall_tester")
 			if nodes == nil {
 				t.Fatal("Node not found in activity dump")
 			}
@@ -256,24 +252,24 @@ func TestActivityDumps(t *testing.T) {
 				t.Fatal("Captured more than one testsuite node")
 			}
 
-			dirs := strings.Split(tempDir, "/")
-			node := nodes[0].Files[dirs[1]]
-			if node == nil {
-				t.Fatalf("Didn't find %s node", dirs[1])
-			}
-			for _, dir := range dirs[2:] {
-				node = node.Children[dir]
-				if node == nil {
-					t.Fatalf("Didn't find %s node", dir)
+			tempPathParts := strings.Split(testDir, "/")
+			for _, node := range nodes {
+				current := node.Files
+				for _, part := range tempPathParts {
+					if part == "" {
+						continue
+					}
+					next, found := current[part]
+					if !found {
+						return false
+					}
+					current = next.Children
+					numberOfFiles := len(current)
+					if part == "ratelimiter" && (numberOfFiles < testActivityDumpRateLimiter/4 || numberOfFiles > testActivityDumpRateLimiter) {
+						t.Fatalf("Didn't find the good number of files in tmp node (%d/%d)", numberOfFiles, testActivityDumpRateLimiter)
+					}
 				}
 			}
-
-			numberOfFiles := len(node.Children)
-			if numberOfFiles < testActivityDumpRateLimiter/4 || numberOfFiles > testActivityDumpRateLimiter {
-				t.Fatalf("Didn't find the good number of files in tmp node (%d/%d)",
-					numberOfFiles, testActivityDumpRateLimiter)
-			}
-
 			return true
 		})
 	})

--- a/pkg/security/tests/cmdwrapper.go
+++ b/pkg/security/tests/cmdwrapper.go
@@ -11,6 +11,7 @@ package tests
 import (
 	"fmt"
 	"os/exec"
+	"strings"
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
@@ -72,6 +73,7 @@ type dockerCmdWrapper struct {
 	executable    string
 	root          string
 	containerName string
+	containerID   string
 	image         string
 }
 
@@ -92,7 +94,11 @@ func (d *dockerCmdWrapper) Command(bin string, args []string, envs []string) *ex
 func (d *dockerCmdWrapper) start() ([]byte, error) {
 	d.containerName = fmt.Sprintf("docker-wrapper-%s", eval.RandString(6))
 	cmd := exec.Command(d.executable, "run", "--rm", "-d", "--name", d.containerName, "-v", d.root+":"+d.root, d.image, "sleep", "600")
-	return cmd.CombinedOutput()
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		d.containerID = strings.TrimSpace(string(out))
+	}
+	return out, err
 }
 
 func (d *dockerCmdWrapper) stop() ([]byte, error) {

--- a/pkg/security/tests/syscall_tester/c/syscall_tester.c
+++ b/pkg/security/tests/syscall_tester/c/syscall_tester.c
@@ -591,6 +591,19 @@ int test_exec_in_pthread(int argc, char **argv) {
     return EXIT_SUCCESS;
 }
 
+int test_sleep(int argc, char **argv) {
+    if (argc != 2) {
+        fprintf(stderr, "Please specify at a sleep duration\n");
+        return EXIT_FAILURE;
+    }
+    int duration = atoi(argv[1]);
+    if (duration <= 0) {
+        fprintf(stderr, "Please specify at a valid sleep duration\n");
+    }
+    sleep(duration);
+    return EXIT_SUCCESS;
+}
+
 int main(int argc, char **argv) {
     if (argc <= 1) {
         fprintf(stderr, "Please pass a command\n");
@@ -654,6 +667,8 @@ int main(int argc, char **argv) {
             exit_code = test_unlink(sub_argc, sub_argv);
         } else if (strcmp(cmd, "exec-in-pthread") == 0) {
             exit_code = test_exec_in_pthread(sub_argc, sub_argv);
+        } else if (strcmp(cmd, "sleep") == 0) {
+            exit_code = test_sleep(sub_argc, sub_argv);
         } else {
             fprintf(stderr, "Unknown command `%s`\n", cmd);
             exit_code = EXIT_FAILURE;


### PR DESCRIPTION
### What does this PR do?

This change the way we generate activity dumps during the functional tests, we now use the automatic cgroup learning way (not the manual method, filtering on a comm).

### Motivation

Having tests testing the way the feature will work on production

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
