### PR TITLE
[pkg/otlp] Set interval to 0 for OTLP timeseries and sketches

### DIFF
--- a/pkg/otlp/internal/serializerexporter/consumer.go
+++ b/pkg/otlp/internal/serializerexporter/consumer.go
@@ -61,7 +61,7 @@ func (c *serializerConsumer) ConsumeSketch(_ context.Context, dimensions *transl
 		Name:     dimensions.Name(),
 		Tags:     tagset.CompositeTagsFromSlice(c.enrichedTags(dimensions)),
 		Host:     dimensions.Host(),
-		Interval: 1,
+		Interval: 0, // OTLP metrics do not have an interval.
 		Points: []metrics.SketchPoint{{
 			Ts:     int64(ts / 1e9),
 			Sketch: qsketch,
@@ -87,7 +87,7 @@ func (c *serializerConsumer) ConsumeTimeSeries(ctx context.Context, dimensions *
 			Tags:     tagset.CompositeTagsFromSlice(c.enrichedTags(dimensions)),
 			Host:     dimensions.Host(),
 			MType:    apiTypeFromTranslatorType(typ),
-			Interval: 1,
+			Interval: 0, // OTLP metrics do not have an interval.
 		},
 	)
 }

--- a/releasenotes/notes/otlp-interval-1a7ee78a997e39de.yaml
+++ b/releasenotes/notes/otlp-interval-1a7ee78a997e39de.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Metrics reported through OTLP ingest now have the interval property unset.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Set interval to `0` for metrics coming from OTLP ingest.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

This was mistakenly set to `1` on #9260. It is inconsistent for timeseries with the Datadog exporter and `1` is wrong: while metrics from the OpenTelemetry language libraries come at regular intervals, this data is not available, and metrics coming from other sources do not have this guarantee.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

- [ ] Send an OTLP Gauge through OTLP ingest in the Agent (e.g. with the `Gauge` OTel API instrument). Check that the interval is unset in the metric metadata in-app.
- [ ] Send an OTLP Histogram through OTLP ingest in the Agent (e.g. with the `Histogram` OTel API instruments). Check that the interval is unset in the metric metadata in-app.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
