### PR TITLE
Adding release not about Agent configuration being sent

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -467,6 +467,15 @@ api_key:
 #
 # use_proxy_for_cloud_metadata: false
 
+## @param inventories_configuration_enabled - boolean - optional - default: false
+## @env DD_INVENTORIES_CONFIGURATION_ENABLED - boolean - optional - default: false
+## The Agent can send its own configuration to Datadog to be displayed in the `Agent Configuration` section of the host
+## detail panel. See https://docs.datadoghq.com/infrastructure/list/#agent-configuration for more information.
+##
+## The Agent configuration is scrubbed of any sensitive information.
+#
+# inventories_configuration_enabled: false
+
 ## @param auto_exit - custom object - optional
 ## Configuration for the automatic exit mechanism: the Agent stops when some conditions are met.
 #

--- a/releasenotes/notes/send-agent-config-inventory-8e941acddf483f20.yaml
+++ b/releasenotes/notes/send-agent-config-inventory-8e941acddf483f20.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    The Agent can send its own configuration to Datadog to be displayed in the `Agent Configuration` section of the host
+    detail panel. See https://docs.datadoghq.com/infrastructure/list/#agent-configuration for more information. The
+    Agent configuration is scrubbed of any sensitive information and only contains configuration you’ve set using the
+    configuration file or environment variables.


### PR DESCRIPTION
### What does this PR do?
Adding release not about Agent configuration being sent

The feature is now public.
