### PR TITLE
Add CO-RE version of OOM-Kill probe

### DIFF
--- a/.gitlab/binary_build/system_probe.yml
+++ b/.gitlab/binary_build/system_probe.yml
@@ -27,6 +27,7 @@
     - $S3_CP_CMD $CI_PROJECT_DIR/pkg/ebpf/bytecode/build/runtime-security.o $S3_ARTIFACTS_URI/runtime-security.o.$ARCH
     - $S3_CP_CMD $CI_PROJECT_DIR/pkg/ebpf/bytecode/build/runtime-security-syscall-wrapper.o $S3_ARTIFACTS_URI/runtime-security-syscall-wrapper.o.$ARCH
     - $S3_CP_CMD $CI_PROJECT_DIR/pkg/ebpf/bytecode/build/runtime-security-offset-guesser.o $S3_ARTIFACTS_URI/runtime-security-offset-guesser.o.$ARCH
+    - $S3_CP_CMD $CI_PROJECT_DIR/pkg/ebpf/bytecode/build/co-re/oom-kill.o $S3_ARTIFACTS_URI/oom-kill-co-re.o.$ARCH
     - $S3_CP_CMD $CI_PROJECT_DIR/pkg/ebpf/bytecode/build/runtime/tracer.c $S3_ARTIFACTS_URI/tracer.c.$ARCH
     - $S3_CP_CMD $CI_PROJECT_DIR/pkg/ebpf/bytecode/build/runtime/http.c $S3_ARTIFACTS_URI/http.c.$ARCH
     - $S3_CP_CMD $CI_PROJECT_DIR/pkg/ebpf/bytecode/build/runtime/runtime-security.c $S3_ARTIFACTS_URI/runtime-security.c.$ARCH

--- a/.gitlab/package_build/deb.yml
+++ b/.gitlab/package_build/deb.yml
@@ -29,6 +29,7 @@
     - $S3_CP_CMD $S3_ARTIFACTS_URI/runtime-security.o.${PACKAGE_ARCH} /tmp/system-probe/runtime-security.o
     - $S3_CP_CMD $S3_ARTIFACTS_URI/runtime-security-syscall-wrapper.o.${PACKAGE_ARCH} /tmp/system-probe/runtime-security-syscall-wrapper.o
     - $S3_CP_CMD $S3_ARTIFACTS_URI/runtime-security-offset-guesser.o.${PACKAGE_ARCH} /tmp/system-probe/runtime-security-offset-guesser.o
+    - $S3_CP_CMD $S3_ARTIFACTS_URI/oom-kill-co-re.o.${PACKAGE_ARCH} /tmp/system-probe/oom-kill-co-re.o
     - $S3_CP_CMD $S3_ARTIFACTS_URI/tracer.c.${PACKAGE_ARCH} /tmp/system-probe/tracer.c
     - $S3_CP_CMD $S3_ARTIFACTS_URI/http.c.${PACKAGE_ARCH} /tmp/system-probe/http.c
     - $S3_CP_CMD $S3_ARTIFACTS_URI/runtime-security.c.${PACKAGE_ARCH} /tmp/system-probe/runtime-security.c

--- a/.gitlab/package_build/rpm.yml
+++ b/.gitlab/package_build/rpm.yml
@@ -27,6 +27,7 @@
     - $S3_CP_CMD $S3_ARTIFACTS_URI/runtime-security.o.${PACKAGE_ARCH} /tmp/system-probe/runtime-security.o
     - $S3_CP_CMD $S3_ARTIFACTS_URI/runtime-security-syscall-wrapper.o.${PACKAGE_ARCH} /tmp/system-probe/runtime-security-syscall-wrapper.o
     - $S3_CP_CMD $S3_ARTIFACTS_URI/runtime-security-offset-guesser.o.${PACKAGE_ARCH} /tmp/system-probe/runtime-security-offset-guesser.o
+    - $S3_CP_CMD $S3_ARTIFACTS_URI/oom-kill-co-re.o.${PACKAGE_ARCH} /tmp/system-probe/oom-kill-co-re.o
     - $S3_CP_CMD $S3_ARTIFACTS_URI/tracer.c.${PACKAGE_ARCH} /tmp/system-probe/tracer.c
     - $S3_CP_CMD $S3_ARTIFACTS_URI/http.c.${PACKAGE_ARCH} /tmp/system-probe/http.c
     - $S3_CP_CMD $S3_ARTIFACTS_URI/runtime-security.c.${PACKAGE_ARCH} /tmp/system-probe/runtime-security.c

--- a/.gitlab/package_build/suse_rpm.yml
+++ b/.gitlab/package_build/suse_rpm.yml
@@ -26,6 +26,7 @@
     - $S3_CP_CMD $S3_ARTIFACTS_URI/runtime-security.o.${PACKAGE_ARCH} /tmp/system-probe/runtime-security.o
     - $S3_CP_CMD $S3_ARTIFACTS_URI/runtime-security-syscall-wrapper.o.${PACKAGE_ARCH} /tmp/system-probe/runtime-security-syscall-wrapper.o
     - $S3_CP_CMD $S3_ARTIFACTS_URI/runtime-security-offset-guesser.o.${PACKAGE_ARCH} /tmp/system-probe/runtime-security-offset-guesser.o
+    - $S3_CP_CMD $S3_ARTIFACTS_URI/oom-kill-co-re.o.${PACKAGE_ARCH} /tmp/system-probe/oom-kill-co-re.o
     - $S3_CP_CMD $S3_ARTIFACTS_URI/tracer.c.${PACKAGE_ARCH} /tmp/system-probe/tracer.c
     - $S3_CP_CMD $S3_ARTIFACTS_URI/http.c.${PACKAGE_ARCH} /tmp/system-probe/http.c
     - $S3_CP_CMD $S3_ARTIFACTS_URI/runtime-security.c.${PACKAGE_ARCH} /tmp/system-probe/runtime-security.c

--- a/.gitlab/package_deps_build.yml
+++ b/.gitlab/package_deps_build.yml
@@ -10,7 +10,8 @@
     - cd $CI_PROJECT_DIR
     - $S3_CP_CMD $S3_PERMANENT_ARTIFACTS_URI/btfs-$ARCH.tar.gz .
     - tar -xf btfs-$ARCH.tar.gz
-    - inv -e system-probe.generate-minimized-btfs --source-dir "$CI_PROJECT_DIR/btfs-$ARCH" --output-dir "$CI_PROJECT_DIR/minimized-btfs" --input-bpf-programs ""
+    - $S3_CP_CMD $S3_ARTIFACTS_URI/oom-kill-co-re.o.$ARCH oom-kill.o
+    - inv -e system-probe.generate-minimized-btfs --source-dir "$CI_PROJECT_DIR/btfs-$ARCH" --output-dir "$CI_PROJECT_DIR/minimized-btfs" --input-bpf-programs "$CI_PROJECT_DIR/oom-kill.o"
     - cd minimized-btfs
     - tar -cJf minimized-btfs.tar.xz *
     - $S3_CP_CMD minimized-btfs.tar.xz $S3_ARTIFACTS_URI/minimized-btfs-$ARCH.tar.xz

--- a/.gitlab/source_test/ebpf.yml
+++ b/.gitlab/source_test/ebpf.yml
@@ -20,6 +20,7 @@
   - cp $CI_PROJECT_DIR/pkg/ebpf/bytecode/build/http-debug.o $CI_PROJECT_DIR/.tmp/binary-ebpf/http-debug.o
   - cp $CI_PROJECT_DIR/pkg/ebpf/bytecode/build/dns.o $CI_PROJECT_DIR/.tmp/binary-ebpf/dns.o
   - cp $CI_PROJECT_DIR/pkg/ebpf/bytecode/build/dns-debug.o $CI_PROJECT_DIR/.tmp/binary-ebpf/dns-debug.o
+  - cp $CI_PROJECT_DIR/pkg/ebpf/bytecode/build/co-re/oom-kill.o $CI_PROJECT_DIR/.tmp/binary-ebpf/co-re/oom-kill.o
   - cp $CI_PROJECT_DIR/pkg/ebpf/bytecode/build/runtime/tracer.c $CI_PROJECT_DIR/.tmp/binary-ebpf/tracer.c
   - cp $CI_PROJECT_DIR/pkg/ebpf/bytecode/build/runtime/http.c $CI_PROJECT_DIR/.tmp/binary-ebpf/http.c
   - cp $CI_PROJECT_DIR/pkg/ebpf/bytecode/build/runtime/runtime-security.c $CI_PROJECT_DIR/.tmp/binary-ebpf/runtime-security.c

--- a/omnibus/config/software/datadog-agent-finalize.rb
+++ b/omnibus/config/software/datadog-agent-finalize.rb
@@ -196,6 +196,7 @@ build do
             strip_exclude("*http*")
             strip_exclude("*runtime-security*")
             strip_exclude("*dns*")
+            strip_exclude("*oom-kill*")
         end
 
         if osx?

--- a/omnibus/config/software/system-probe.rb
+++ b/omnibus/config/software/system-probe.rb
@@ -31,6 +31,7 @@ build do
     copy "#{ENV['SYSTEM_PROBE_BIN']}/runtime-security.o", "#{install_dir}/embedded/share/system-probe/ebpf/"
     copy "#{ENV['SYSTEM_PROBE_BIN']}/runtime-security-syscall-wrapper.o", "#{install_dir}/embedded/share/system-probe/ebpf/"
     copy "#{ENV['SYSTEM_PROBE_BIN']}/runtime-security-offset-guesser.o", "#{install_dir}/embedded/share/system-probe/ebpf/"
+    copy "#{ENV['SYSTEM_PROBE_BIN']}/oom-kill-co-re.o", "#{install_dir}/embedded/share/system-probe/ebpf/co-re/oom-kill.o"
     copy "#{ENV['SYSTEM_PROBE_BIN']}/tracer.c", "#{install_dir}/embedded/share/system-probe/ebpf/runtime/"
     copy "#{ENV['SYSTEM_PROBE_BIN']}/http.c", "#{install_dir}/embedded/share/system-probe/ebpf/runtime/"
     copy "#{ENV['SYSTEM_PROBE_BIN']}/runtime-security.c", "#{install_dir}/embedded/share/system-probe/ebpf/runtime/"

--- a/pkg/collector/corechecks/ebpf/c/co-re/bpf-common.h
+++ b/pkg/collector/corechecks/ebpf/c/co-re/bpf-common.h
@@ -1,0 +1,24 @@
+#ifndef BPF_COMMON_H
+#define BPF_COMMON_H
+
+#include "vmlinux.h"
+#include "bpf_core_read.h"
+#include "bpf_helpers.h"
+
+static __always_inline int get_cgroup_name(char *buf, size_t sz) {
+    __builtin_memset(buf, 0, sz);
+
+    if (!bpf_core_enum_value_exists(enum bpf_func_id, BPF_FUNC_get_current_task)) {
+        return -1;
+    }
+
+    struct task_struct *cur_tsk = (struct task_struct *)bpf_get_current_task();
+
+    if (BPF_CORE_READ_STR_INTO(buf, cur_tsk, cgroups, subsys[0], cgroup, kn, name)) {
+        return -1;
+    }
+
+    return 0;
+}
+
+#endif /* defined(BPF_COMMON_H) */

--- a/pkg/collector/corechecks/ebpf/c/co-re/oom-kill-kern-user.h
+++ b/pkg/collector/corechecks/ebpf/c/co-re/oom-kill-kern-user.h
@@ -1,0 +1,26 @@
+#ifndef OOM_KILL_KERN_USER_H
+#define OOM_KILL_KERN_USER_H
+
+#include "vmlinux.h"
+
+#ifndef TASK_COMM_LEN
+#define TASK_COMM_LEN 16
+#endif
+
+struct oom_stats {
+    char cgroup_name[129];
+    // Pid of triggering process
+    __u32 pid;
+    // Pid of killed process
+    __u32 tpid;
+    // Name of triggering process
+    char fcomm[TASK_COMM_LEN];
+    // Name of killed process
+    char tcomm[TASK_COMM_LEN];
+    // Total number of pages
+    __u64 pages;
+    // Tracks if the OOM kill was triggered by a cgroup
+    __u32 memcg_oom;
+};
+
+#endif /* defined(OOM_KILL_KERN_USER_H) */

--- a/pkg/collector/corechecks/ebpf/c/co-re/oom-kill.c
+++ b/pkg/collector/corechecks/ebpf/c/co-re/oom-kill.c
@@ -1,0 +1,60 @@
+#include "oom-kill-kern-user.h"
+#include "bpf-common.h"
+#include "bpf_helpers.h"
+#include "bpf_tracing.h"
+#include "bpf_core_read.h"
+#include "map-defs.h"
+
+/*
+ * The `oom_stats` hash map is used to share with the userland program system-probe
+ * the statistics per pid
+ */
+
+BPF_HASH_MAP(oom_stats, u32, struct oom_stats, 10240)
+
+SEC("kprobe/oom_kill_process")
+int BPF_KPROBE(kprobe__oom_kill_process, struct oom_control *oc) {
+    struct oom_stats zero = {};
+    u32 pid = bpf_get_current_pid_tgid() >> 32;
+
+    bpf_map_update_elem(&oom_stats, &pid, &zero, BPF_NOEXIST);
+    struct oom_stats *s = bpf_map_lookup_elem(&oom_stats, &pid);
+    if (!s) {
+        return 0;
+    }
+
+    s->pid = pid;
+
+    struct task_struct *p;
+    bpf_probe_read(&p, sizeof(p), &oc->chosen);
+    bpf_probe_read(&s->tpid, sizeof(s->tpid), &p->pid);
+
+    get_cgroup_name(s->cgroup_name, sizeof(s->cgroup_name));
+
+    BPF_CORE_READ_INTO(&s->tpid, oc, chosen, pid);
+
+    if (bpf_core_enum_value_exists(enum bpf_func_id, BPF_FUNC_get_current_comm)) {
+        bpf_get_current_comm(&s->fcomm, sizeof(s->fcomm));
+    }
+
+    if (bpf_core_enum_value_exists(enum bpf_func_id, BPF_FUNC_probe_read_str)) {
+        BPF_CORE_READ_STR_INTO(&s->tcomm, oc, chosen, comm);
+    } else {
+        BPF_CORE_READ_INTO(&s->tcomm, oc, chosen, comm);
+        s->tcomm[TASK_COMM_LEN - 1] = 0;
+    }
+
+    if (bpf_core_field_exists(oc->totalpages)) {
+        BPF_CORE_READ_INTO(&s->pages, oc, totalpages);
+    }
+
+    if (bpf_core_field_exists(oc->memcg)) {
+        struct mem_cgroup *memcg = NULL;
+        memcg = BPF_CORE_READ(oc, memcg);
+        s->memcg_oom = memcg != NULL ? 1 : 0;
+    }
+
+    return 0;
+}
+
+char _license[] SEC("license") = "GPL"; // NOLINT(bugprone-reserved-identifier)

--- a/pkg/collector/corechecks/ebpf/probe/oom_kill.go
+++ b/pkg/collector/corechecks/ebpf/probe/oom_kill.go
@@ -13,15 +13,19 @@ package probe
 
 import (
 	"fmt"
+	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 	"math"
+	"path/filepath"
 	"unsafe"
 
 	"golang.org/x/sys/unix"
 
 	manager "github.com/DataDog/ebpf-manager"
 	bpflib "github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/btf"
 
 	"github.com/DataDog/datadog-agent/pkg/ebpf"
+	"github.com/DataDog/datadog-agent/pkg/ebpf/bytecode"
 	"github.com/DataDog/datadog-agent/pkg/ebpf/bytecode/runtime"
 	"github.com/DataDog/datadog-agent/pkg/process/statsd"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -41,12 +45,70 @@ type OOMKillProbe struct {
 }
 
 func NewOOMKillProbe(cfg *ebpf.Config) (*OOMKillProbe, error) {
-	compiledOutput, err := runtime.OomKill.Compile(cfg, []string{"-g"}, statsd.Client)
+	if cfg.EnableCORE {
+		probe, err := loadCOREProbe(cfg)
+		if err == nil {
+			return probe, err
+		}
+
+		if !cfg.AllowRuntimeCompiledFallback {
+			return nil, fmt.Errorf("error loading CO-RE oom-kill probe: %s. set system_probe_config.allow_runtime_compiled_fallback to true to allow fallback to runtime compilation.", err)
+		}
+		log.Warnf("error loading CO-RE oom-kill probe: %s", err)
+	}
+
+	return loadRuntimeCompiledProbe(cfg)
+}
+
+func loadCOREProbe(cfg *ebpf.Config) (*OOMKillProbe, error) {
+	kv, err := kernel.HostVersion()
+	if err != nil {
+		return nil, fmt.Errorf("error detecting kernel version: %s", err)
+	}
+	if kv < kernel.VersionCode(4, 9, 0) {
+		return nil, fmt.Errorf("detected kernel version %s, but oom-kill probe requires a kernel version of at least 4.9.0.", kv)
+	}
+
+	var telemetry ebpf.COREResult
+	defer func() {
+		ebpf.StoreCORETelemetryForAsset("oomKill", telemetry)
+	}()
+
+	var btfData *btf.Spec
+	btfData, telemetry = ebpf.GetBTF(cfg.BTFPath, cfg.BPFDir)
+
+	if btfData == nil {
+		return nil, fmt.Errorf("could not find BTF data on host")
+	}
+
+	buf, err := bytecode.GetReader(filepath.Join(cfg.BPFDir, "co-re"), "oom-kill.o")
+	if err != nil {
+		telemetry = ebpf.AssetReadError
+		return nil, fmt.Errorf("error reading oom-kill.o file: %s", err)
+	}
+	defer buf.Close()
+
+	probe, err := startOOMKillProbe(buf, btfData)
+	if err != nil {
+		telemetry = ebpf.VerifierError
+		return nil, err
+	}
+
+	log.Debugf("successfully loaded CO-RE version of oom-kill probe")
+	return probe, nil
+}
+
+func loadRuntimeCompiledProbe(cfg *ebpf.Config) (*OOMKillProbe, error) {
+	buf, err := runtime.OomKill.Compile(cfg, []string{"-g"}, statsd.Client)
 	if err != nil {
 		return nil, err
 	}
-	defer compiledOutput.Close()
+	defer buf.Close()
 
+	return startOOMKillProbe(buf, nil)
+}
+
+func startOOMKillProbe(buf bytecode.AssetReader, btfData *btf.Spec) (*OOMKillProbe, error) {
 	probes := []*manager.Probe{
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFSection: "kprobe/oom_kill_process", EBPFFuncName: "kprobe__oom_kill_process", UID: "oom"},
@@ -67,9 +129,14 @@ func NewOOMKillProbe(cfg *ebpf.Config) (*OOMKillProbe, error) {
 			Cur: math.MaxUint64,
 			Max: math.MaxUint64,
 		},
+		VerifierOptions: bpflib.CollectionOptions{
+			Programs: bpflib.ProgramOptions{
+				KernelTypes: btfData,
+			},
+		},
 	}
 
-	if err := m.InitWithOptions(compiledOutput, managerOptions); err != nil {
+	if err := m.InitWithOptions(buf, managerOptions); err != nil {
 		return nil, fmt.Errorf("failed to init manager: %w", err)
 	}
 

--- a/pkg/collector/corechecks/ebpf/probe/oom_kill.go
+++ b/pkg/collector/corechecks/ebpf/probe/oom_kill.go
@@ -13,7 +13,6 @@ package probe
 
 import (
 	"fmt"
-	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 	"math"
 	"path/filepath"
 	"unsafe"
@@ -28,6 +27,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/ebpf/bytecode"
 	"github.com/DataDog/datadog-agent/pkg/ebpf/bytecode/runtime"
 	"github.com/DataDog/datadog-agent/pkg/process/statsd"
+	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -54,7 +54,7 @@ func NewOOMKillProbe(cfg *ebpf.Config) (*OOMKillProbe, error) {
 		if !cfg.AllowRuntimeCompiledFallback {
 			return nil, fmt.Errorf("error loading CO-RE oom-kill probe: %s. set system_probe_config.allow_runtime_compiled_fallback to true to allow fallback to runtime compilation.", err)
 		}
-		log.Warnf("error loading CO-RE oom-kill probe: %s", err)
+		log.Warnf("error loading CO-RE oom-kill probe: %s. falling back to runtime compiled probe", err)
 	}
 
 	return loadRuntimeCompiledProbe(cfg)

--- a/pkg/collector/corechecks/ebpf/probe/oom_kill_test.go
+++ b/pkg/collector/corechecks/ebpf/probe/oom_kill_test.go
@@ -10,7 +10,6 @@ package probe
 
 import (
 	"fmt"
-	"github.com/DataDog/datadog-agent/pkg/metadata/host"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -23,6 +22,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/ebpf/bytecode/runtime"
+	"github.com/DataDog/datadog-agent/pkg/metadata/host"
 	"github.com/DataDog/datadog-agent/pkg/process/statsd"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 )

--- a/pkg/collector/corechecks/ebpf/probe/oom_kill_test.go
+++ b/pkg/collector/corechecks/ebpf/probe/oom_kill_test.go
@@ -10,6 +10,7 @@ package probe
 
 import (
 	"fmt"
+	"github.com/DataDog/datadog-agent/pkg/metadata/host"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -36,6 +37,9 @@ const oomKilledBashScript = `
 exec systemd-run --scope -p MemoryLimit=1M python3 %v # replace shell, so that the process launched by Go is the one getting oom-killed
 `
 
+// COREEnvVar forces use of CO-RE for ebpf functionality
+const COREEnvVar = "DD_TESTS_CO_RE"
+
 func writeTempFile(pattern string, content string) (*os.File, error) {
 	f, err := ioutil.TempFile("", pattern)
 	if err != nil {
@@ -59,7 +63,7 @@ func TestOOMKillCompile(t *testing.T) {
 		t.Skipf("Kernel version %v is not supported by the OOM probe", kv)
 	}
 
-	cfg := ebpf.NewConfig()
+	cfg := testConfig()
 	cfg.BPFDebug = true
 	_, err = runtime.OomKill.Compile(cfg, []string{"-g"}, statsd.Client)
 	require.NoError(t, err)
@@ -74,7 +78,13 @@ func TestOOMKillProbe(t *testing.T) {
 		t.Skipf("Kernel version %v is not supported by the OOM probe", kv)
 	}
 
-	cfg := ebpf.NewConfig()
+	cfg := testConfig()
+
+	fullKV := host.GetStatusInformation().KernelVersion
+	if cfg.EnableCORE && (fullKV == "4.18.0-1018-azure" || fullKV == "4.18.0-147.43.1.el8_1.x86_64") {
+		t.Skipf("Skipping CO-RE tests for kernel version %v due to missing BTFs", fullKV)
+	}
+
 	oomKillProbe, err := NewOOMKillProbe(cfg)
 	if err != nil {
 		t.Fatal(err)
@@ -125,4 +135,17 @@ func TestOOMKillProbe(t *testing.T) {
 	if !found {
 		t.Errorf("failed to find an OOM killed process with pid %d in %+v", cmd.Process.Pid, results)
 	}
+}
+
+func testConfig() *ebpf.Config {
+	cfg := ebpf.NewConfig()
+
+	if os.Getenv(COREEnvVar) != "" {
+		cfg.EnableCORE = true
+		cfg.AllowRuntimeCompiledFallback = false
+	} else {
+		cfg.EnableCORE = false
+	}
+
+	return cfg
 }

--- a/pkg/config/system_probe.go
+++ b/pkg/config/system_probe.go
@@ -93,7 +93,7 @@ func InitSystemProbeConfig(cfg Config) {
 	cfg.BindEnvAndSetDefault(join(spNS, "bpf_dir"), defaultSystemProbeBPFDir, "DD_SYSTEM_PROBE_BPF_DIR")
 	cfg.BindEnvAndSetDefault(join(spNS, "excluded_linux_versions"), []string{})
 	cfg.BindEnvAndSetDefault(join(spNS, "enable_tracepoints"), false)
-	cfg.BindEnvAndSetDefault(join(spNS, "enable_co_re"), false, "DD_ENABLE_CO_RE")
+	cfg.BindEnvAndSetDefault(join(spNS, "enable_co_re"), true, "DD_ENABLE_CO_RE")
 	cfg.BindEnvAndSetDefault(join(spNS, "btf_path"), "", "DD_SYSTEM_PROBE_BTF_PATH")
 	cfg.BindEnv(join(spNS, "enable_runtime_compiler"), "DD_ENABLE_RUNTIME_COMPILER")
 	cfg.BindEnvAndSetDefault(join(spNS, "allow_precompiled_fallback"), true, "DD_ALLOW_PRECOMPILED_FALLBACK")

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -226,7 +226,7 @@ def ninja_network_ebpf_programs(nw, build_dir, co_re_build_dir):
 def ninja_container_integrations_ebpf_programs(nw, co_re_build_dir):
     container_integrations_co_re_dir = os.path.join("pkg", "collector", "corechecks", "ebpf", "c", "co-re")
     container_integrations_co_re_flags = f"-I{container_integrations_co_re_dir}"
-    container_integrations_co_re_programs = []
+    container_integrations_co_re_programs = ["oom-kill"]
 
     for prog in container_integrations_co_re_programs:
         infile = os.path.join(container_integrations_co_re_dir, f"{prog}.c")

--- a/test/kitchen/test/integration/system-probe-test/rspec/system-probe-test_spec.rb
+++ b/test/kitchen/test/integration/system-probe-test/rspec/system-probe-test_spec.rb
@@ -9,6 +9,7 @@ runtime_compiled_tests = Array.[](
 )
 
 co_re_tests = Array.[](
+  "/pkg/collector/corechecks/ebpf/probe"
 )
 
 def check_output(output, wait_thr)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Using the changes added by #13962, #13963 and #13964, this adds a version of the OOM-Kill probe which gets loaded using Compile Once Run Everywhere (CO-RE). If the probe fails to load with CO-RE, we fall back to the runtime compiled version.

### Motivation

See [the CO-RE RFC](https://docs.google.com/document/d/192SSbYu9JRfHtx9jMmYQ3SQdzBJWp9yB55uyqOXoLrs/edit?pli=1#heading=h.2eyrtulxbpb3) for more details.

### Additional Notes

This change has been tested on an internal experimental cluster.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

1. Enable debug logging
2. Run the system-probe on either
  a) a host running a newer kernel (ie >5.5), or
  b) on a machine running one of the kernels found [in this repository](https://docs.google.com/document/d/192SSbYu9JRfHtx9jMmYQ3SQdzBJWp9yB55uyqOXoLrs/edit?pli=1#heading=h.2eyrtulxbpb3) (these are the kernels for which BTF information has been bundled into the datadog-agent package).
3. Verify in the logs that the CO-RE oom-kill probe loads correctly:
```
| successfully loaded CO-RE version of oom-kill probe
| module: oom_kill_probe started
```
4. Force CO-RE to fail by removing the source program:
```
sudo mv /opt/datadog-agent/embedded/share/system-probe/ebpf/co-re/oom-kill.o /opt/datadog-agent/embedded/share/system-probe/ebpf/co-re/oom-kill-testfail.o
```
5. Run the system-probe and verify in the logs that the oom-kill probe loads via the runtime compilation fallback:
```
| error loading CO-RE oom-kill probe: error reading oom-kill.o file: error stat-ing asset file /opt/datadog-agent/embedded/share/system-probe/ebpf/co-re/oom-kill.o: stat /opt/datadog-agent/embedded/share/system-probe/ebpf/co-re/oom-kill.o: no such file or directory. falling back to runtime compiled probe
| starting runtime compilation of oom-kill.c
...
| module: oom_kill_probe started
```
6. Put the source program back:
```
sudo mv /opt/datadog-agent/embedded/share/system-probe/ebpf/co-re/oom-kill-testfail.o /opt/datadog-agent/embedded/share/system-probe/ebpf/co-re/oom-kill.o
```

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
