### PR TITLE
Check go version in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,6 +65,10 @@ jobs:
             python3 -m pip install -r requirements.txt
             python3 -m pip install -r .circleci/requirements.txt
       - run:
+          name: check go version
+          command: |
+            inv -e check-go-version
+      - run:
           name: grab go deps
           command: |
             inv -e deps

--- a/.gitlab/binary_build/cluster_agent.yml
+++ b/.gitlab/binary_build/cluster_agent.yml
@@ -3,6 +3,7 @@
   stage: binary_build
   needs: ["go_mod_tidy_check"]
   script:
+    - inv check-go-version
     - inv -e cluster-agent.build --release-version "$RELEASE_VERSION_7"
     - $S3_CP_CMD $CI_PROJECT_DIR/$CLUSTER_AGENT_BINARIES_DIR/datadog-cluster-agent $S3_ARTIFACTS_URI/datadog-cluster-agent.$ARCH
     - $S3_CP_CMD $CI_PROJECT_DIR/Dockerfiles/cluster-agent/datadog-cluster.yaml $S3_ARTIFACTS_URI/datadog-cluster.yaml

--- a/.gitlab/binary_build/cluster_agent_cloudfoundry.yml
+++ b/.gitlab/binary_build/cluster_agent_cloudfoundry.yml
@@ -16,6 +16,7 @@ cluster_agent_cloudfoundry-build_amd64:
     - !reference [.retrieve_linux_go_deps]
     - source /root/.bashrc && conda activate ddpy3
   script:
+    - inv check-go-version
     - inv -e cluster-agent-cloudfoundry.build
     - cd $CI_PROJECT_DIR/$CLUSTER_AGENT_CLOUDFOUNDRY_BINARIES_DIR
     - mkdir -p $OMNIBUS_PACKAGE_DIR

--- a/.gitlab/binary_build/linux.yml
+++ b/.gitlab/binary_build/linux.yml
@@ -11,6 +11,7 @@ build_dogstatsd_static-binary_x64:
     - !reference [.retrieve_linux_go_deps]
     - source /root/.bashrc && conda activate ddpy3
   script:
+    - inv check-go-version
     - inv -e dogstatsd.build --static --major-version 7
     - $S3_CP_CMD $CI_PROJECT_DIR/$STATIC_BINARIES_DIR/dogstatsd $S3_ARTIFACTS_URI/static/dogstatsd
 
@@ -27,6 +28,7 @@ build_dogstatsd_static-binary_arm64:
     - !reference [.retrieve_linux_go_deps]
     - source /root/.bashrc && conda activate ddpy3
   script:
+    - inv check-go-version
     - inv -e dogstatsd.build --static --major-version 7
     - $S3_CP_CMD $CI_PROJECT_DIR/$STATIC_BINARIES_DIR/dogstatsd $S3_ARTIFACTS_URI/static/dogstatsd.$ARCH
 
@@ -41,6 +43,7 @@ build_dogstatsd-binary_x64:
     - !reference [.retrieve_linux_go_deps]
     - source /root/.bashrc && conda activate ddpy3
   script:
+    - inv check-go-version
     - inv -e dogstatsd.build --major-version 7
     - $S3_CP_CMD $CI_PROJECT_DIR/$DOGSTATSD_BINARIES_DIR/dogstatsd $S3_ARTIFACTS_URI/dogstatsd/dogstatsd
 
@@ -57,6 +60,7 @@ build_dogstatsd-binary_arm64:
     - !reference [.retrieve_linux_go_deps]
     - source /root/.bashrc && conda activate ddpy3
   script:
+    - inv check-go-version
     - inv -e dogstatsd.build --major-version 7
     - $S3_CP_CMD $CI_PROJECT_DIR/$DOGSTATSD_BINARIES_DIR/dogstatsd $S3_ARTIFACTS_URI/dogstatsd/dogstatsd.$ARCH
 
@@ -71,6 +75,7 @@ build_iot_agent-binary_x64:
   before_script:
     - !reference [.retrieve_linux_go_deps]
   script:
+    - inv check-go-version
     - inv -e agent.build --flavor iot --major-version 7
     - $S3_CP_CMD $CI_PROJECT_DIR/$AGENT_BINARIES_DIR/agent $S3_ARTIFACTS_URI/iot/agent
 
@@ -86,4 +91,5 @@ build_iot_agent-binary_arm64:
   before_script:
     - !reference [.retrieve_linux_go_deps]
   script:
+    - inv check-go-version
     - inv -e agent.build --flavor iot --major-version 7

--- a/.gitlab/binary_build/serverless.yml
+++ b/.gitlab/binary_build/serverless.yml
@@ -4,6 +4,7 @@
   before_script:
     - !reference [.retrieve_linux_go_deps]
   script:
+    - inv check-go-version
     - cd cmd/serverless && go build -ldflags="-w -s" -a -v -tags serverless -o $BINARY_NAME
 
 .check_size_common:

--- a/.gitlab/binary_build/system_probe.yml
+++ b/.gitlab/binary_build/system_probe.yml
@@ -12,6 +12,7 @@
     - mkdir -p $NIKOS_EMBEDDED_PATH
     - tar -xf /tmp/nikos.tar.gz -C $NIKOS_EMBEDDED_PATH
   script:
+    - inv check-go-version
     - inv -e system-probe.build --nikos-embedded-path=$NIKOS_EMBEDDED_PATH --strip-object-files
     # fail if references to glibc >= 2.18
     - objdump -p $CI_PROJECT_DIR/$SYSTEM_PROBE_BINARIES_DIR/system-probe | egrep 'GLIBC_2\.(1[8-9]|[2-9][0-9])' && exit 1

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -31,6 +31,7 @@ from .build_tags import audit_tag_impact, print_default_build_tags
 from .components import lint_components
 from .fuzz import fuzz
 from .go import (
+    check_go_version,
     check_mod_tidy,
     deps,
     deps_vendored,
@@ -88,6 +89,7 @@ ns.add_task(download_tools)
 ns.add_task(install_tools)
 ns.add_task(check_mod_tidy)
 ns.add_task(tidy_all)
+ns.add_task(check_go_version)
 ns.add_task(generate_config)
 ns.add_task(junit_upload)
 ns.add_task(fuzz)

--- a/tasks/go.py
+++ b/tasks/go.py
@@ -263,3 +263,19 @@ def tidy_all(ctx):
     for mod in DEFAULT_MODULES.values():
         with ctx.cd(mod.full_path()):
             ctx.run("go mod tidy -compat=1.17")
+
+
+@task
+def check_go_version(ctx):
+    go_version_output = ctx.run('go version')
+    # result is like "go version go1.18.7 linux/amd64"
+    running_go_version = go_version_output.stdout.split(' ')[2]
+
+    with open(".go-version") as f:
+        dot_go_version = f.read()
+        dot_go_version = dot_go_version.strip()
+        if not dot_go_version.startswith("go"):
+            dot_go_version = f"go{dot_go_version}"
+
+    if dot_go_version != running_go_version:
+        raise Exit(message=f"Expected {dot_go_version} (from `.go-version`), but running {running_go_version}")

--- a/tasks/winbuildscripts/dobuild.bat
+++ b/tasks/winbuildscripts/dobuild.bat
@@ -45,6 +45,7 @@ cd \dev\go\src\github.com\DataDog\datadog-agent || exit /b 101
 pip3 install -r requirements.txt || exit /b 102
 
 inv -e deps || exit /b 103
+inv check-go-version || exit /b 104
 
 @echo "inv -e %OMNIBUS_BUILD% %OMNIBUS_ARGS% --skip-deps --major-version %MAJOR_VERSION% --release-version %RELEASE_VERSION%"
-inv -e %OMNIBUS_BUILD% %OMNIBUS_ARGS% --skip-deps --major-version %MAJOR_VERSION% --release-version %RELEASE_VERSION% || exit /b 104
+inv -e %OMNIBUS_BUILD% %OMNIBUS_ARGS% --skip-deps --major-version %MAJOR_VERSION% --release-version %RELEASE_VERSION% || exit /b 105


### PR DESCRIPTION
### Motivation

It's easy to use the wrong rev of a docker image and end up building with the wrong version of Go, and not catch that soon enough.

### Additional Notes

I'll add a similar check to the macos repo.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

No need - test only.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
