### PR TITLE
Fix flaky TestDNSOverTCPSuccessfulResponseCountWithoutDomain

### DIFF
--- a/pkg/network/dns/snooper_test.go
+++ b/pkg/network/dns/snooper_test.go
@@ -200,15 +200,13 @@ func hasDomains(stats map[Hostname]map[QueryType]Stats, domains ...string) bool 
 	return true
 }
 
-func countDNSResponses(stats StatsByKeyByNameByType) int {
+func countDNSResponses(statsByDomain map[Hostname]map[QueryType]Stats) int {
 	total := 0
-	for _, statsByDomain := range stats {
-		for _, statsByType := range statsByDomain {
-			for _, s := range statsByType {
-				total += int(s.Timeouts)
-				for _, count := range s.CountByRcode {
-					total += int(count)
-				}
+	for _, statsByType := range statsByDomain {
+		for _, s := range statsByType {
+			total += int(s.Timeouts)
+			for _, count := range s.CountByRcode {
+				total += int(count)
 			}
 		}
 	}
@@ -236,7 +234,7 @@ func TestDNSOverTCPSuccessfulResponseCountWithoutDomain(t *testing.T) {
 	var allStats StatsByKeyByNameByType
 	require.Eventuallyf(t, func() bool {
 		allStats = statKeeper.Snapshot()
-		return allStats[key] != nil && countDNSResponses(allStats) >= len(domains)
+		return allStats[key] != nil && countDNSResponses(allStats[key]) >= len(domains)
 	}, 3*time.Second, 10*time.Millisecond, "not enough DNS responses")
 
 	// Exactly one rcode (0, success) is expected


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Fixes a flaky test by waiting for the right number of responses for the specific key, rather than in total.

### Motivation

Flaky test.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
