### PR TITLE
pkg/trace/agent: Put error/rare sampler priority changes behind new feat flag

### DIFF
--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -463,8 +463,14 @@ func (a *Agent) sample(now time.Time, ts *info.TagStats, pt traceutil.ProcessedT
 		ts.TracesPriorityNone.Inc()
 	}
 
-	if isManualUserDrop(priority, pt) {
-		return 0, false, nil
+	if features.Has("error_rare_sample_tracer_drop") {
+		if isManualUserDrop(priority, pt) {
+			return 0, false, nil
+		}
+	} else { // This path to be deleted once manualUserDrop detection is available on all tracers for P < 1.
+		if priority < 0 {
+			return 0, false, nil
+		}
 	}
 
 	sampled := a.runSamplers(now, pt, hasPriority)

--- a/pkg/trace/agent/agent_test.go
+++ b/pkg/trace/agent/agent_test.go
@@ -972,49 +972,45 @@ func TestSample(t *testing.T) {
 		return pt
 	}
 	tests := map[string]struct {
-		trace               traceutil.ProcessedTrace
-		wantSampled         bool
-		sampleTracerDropped bool
+		trace              traceutil.ProcessedTrace
+		sampledNoFeature   bool
+		sampledWithFeature bool
 	}{
 		"userdrop-error-no-dm-sampled": {
-			trace:               genSpan("", sampler.PriorityUserDrop),
-			wantSampled:         true,
-			sampleTracerDropped: true,
+			trace:              genSpan("", sampler.PriorityUserDrop),
+			sampledNoFeature:   false,
+			sampledWithFeature: true,
 		},
 		"userdrop-error-manual-dm-unsampled": {
-			trace:               genSpan("-4", sampler.PriorityUserDrop),
-			wantSampled:         false,
-			sampleTracerDropped: true,
+			trace:              genSpan("-4", sampler.PriorityUserDrop),
+			sampledNoFeature:   false,
+			sampledWithFeature: false,
 		},
 		"userdrop-error-agent-dm-sampled": {
-			trace:               genSpan("-1", sampler.PriorityUserDrop),
-			wantSampled:         true,
-			sampleTracerDropped: true,
+			trace:              genSpan("-1", sampler.PriorityUserDrop),
+			sampledNoFeature:   false,
+			sampledWithFeature: true,
 		},
 		"userkeep-error-no-dm-sampled": {
-			trace:               genSpan("", sampler.PriorityUserKeep),
-			wantSampled:         true,
-			sampleTracerDropped: true,
+			trace:              genSpan("", sampler.PriorityUserKeep),
+			sampledNoFeature:   true,
+			sampledWithFeature: true,
 		},
 		"userkeep-error-agent-dm-sampled": {
-			trace:               genSpan("-1", sampler.PriorityUserKeep),
-			wantSampled:         true,
-			sampleTracerDropped: true,
-		},
-		"error-agent-no-feat-not-sampled": {
-			trace:               genSpan("", sampler.PriorityUserDrop),
-			wantSampled:         false,
-			sampleTracerDropped: false,
+			trace:              genSpan("-1", sampler.PriorityUserKeep),
+			sampledNoFeature:   true,
+			sampledWithFeature: true,
 		},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			if tt.sampleTracerDropped {
-				features.Set("error_rare_sample_tracer_drop")
-				defer features.Set("")
-			}
 			_, keep, _ := a.sample(time.Now(), info.NewReceiverStats().GetTagStats(info.Tags{}), tt.trace)
-			assert.Equal(t, tt.wantSampled, keep)
+			assert.Equal(t, tt.sampledNoFeature, keep)
+
+			features.Set("error_rare_sample_tracer_drop")
+			defer features.Set("")
+			_, keep, _ = a.sample(time.Now(), info.NewReceiverStats().GetTagStats(info.Tags{}), tt.trace)
+			assert.Equal(t, tt.sampledWithFeature, keep)
 		})
 	}
 }

--- a/releasenotes/notes/ErrorSampleMoreSpansDisableRareSamplerDefault-9f07d3643ee26930.yaml
+++ b/releasenotes/notes/ErrorSampleMoreSpansDisableRareSamplerDefault-9f07d3643ee26930.yaml
@@ -8,7 +8,7 @@
 ---
 enhancements:
   - |
-    APM: All non-manually dropped spans will go through the error sampler. 
+    APM: All spans can be sent through the error and rare samplers via custom feature flag `error_rare_sample_tracer_drop`. This can be useful if you want to run those samplers against traces that were not sampled by custom tracer sample rules.
 deprecations:
   - |
     APM: The Rare Sampler is now disabled by default. If you wish to enable it explicitly you can set apm_config.enable_rare_sampler or DD_APM_ENABLE_RARE_SAMPLER to true.

--- a/releasenotes/notes/ErrorSampleMoreSpansDisableRareSamplerDefault-9f07d3643ee26930.yaml
+++ b/releasenotes/notes/ErrorSampleMoreSpansDisableRareSamplerDefault-9f07d3643ee26930.yaml
@@ -8,7 +8,7 @@
 ---
 enhancements:
   - |
-    APM: All spans can be sent through the error and rare samplers via custom feature flag `error_rare_sample_tracer_drop`. This can be useful if you want to run those samplers against traces that were not sampled by custom tracer sample rules.
+    APM: All spans can be sent through the error and rare samplers via custom feature flag `error_rare_sample_tracer_drop`. This can be useful if you want to run those samplers against traces that were not sampled by custom tracer sample rules. Note that even user manual drop spans may be kept if this feature flag is set.
 deprecations:
   - |
     APM: The Rare Sampler is now disabled by default. If you wish to enable it explicitly you can set apm_config.enable_rare_sampler or DD_APM_ENABLE_RARE_SAMPLER to true.


### PR DESCRIPTION

### What does this PR do?
This puts the "run all non user manual drop spans" change from #13768 behind a feature flag.

### Motivation
It turns out that tracers don't set the _dd.p.dm tag on P < 1 traces. This meant the feature was broken and would cause even user manual drop traces to go through the error and rare samplers. This would have lead to confusing and non-clear behavior for customers who expected their traces to be dropped.

We keep the feature available behind a feature flag as there are a few customers who want to be able to do this now and do not care about the user manual drop spans being sampled by the error (and rare) sampler.

Once all tracers are sending _dd.p.dm for all traces we will remove the feature flag and the default behavior will become what was originally intended in the PR #13768. 


### Describe how to test/QA your changes
* Setup a tracer with local sampling rules that will send traces with priority -1. Enable the `error_rare_sample_tracer_drop` feature in the agent. Send error traces with priority -1, verify they are ingested and have ingestion_reason error
* Run the same test without the feature flag enabled and ensure they are not ingested with reason `error` 

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
