### PR TITLE
[CWS] do not auto update the security agent policies tag when creating releases

### DIFF
--- a/tasks/release.py
+++ b/tasks/release.py
@@ -718,8 +718,9 @@ def _update_release_json(release_json, release_entry, new_version: Version, max_
         "jmxfetch", release_json, new_version.major, github_token, "JMXFETCH_VERSION"
     )
 
-    security_agent_policies_version = _fetch_independent_dependency_repo_version(
-        "security-agent-policies", release_json, new_version.major, github_token, "SECURITY_AGENT_POLICIES_VERSION"
+    # security agent policies are updated directly by the CWS team
+    security_agent_policies_version = _get_release_version_from_release_json(
+        release_json, new_version.major, VERSION_RE, "SECURITY_AGENT_POLICIES_VERSION"
     )
 
     windows_ddnpm_driver, windows_ddnpm_version, windows_ddnpm_shasum = _get_windows_ddnpm_release_json_info(

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -722,6 +722,7 @@ def _update_release_json(release_json, release_entry, new_version: Version, max_
     security_agent_policies_version = _get_release_version_from_release_json(
         release_json, new_version.major, VERSION_RE, "SECURITY_AGENT_POLICIES_VERSION"
     )
+    print(TAG_FOUND_TEMPLATE.format("security-agent-policies", security_agent_policies_version))
 
     windows_ddnpm_driver, windows_ddnpm_version, windows_ddnpm_shasum = _get_windows_ddnpm_release_json_info(
         release_json, new_version.major, is_first_rc=(new_version.rc == 1)


### PR DESCRIPTION
### What does this PR do?

The CWS team does it's own PR to bump the tag in `release.json`.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
