### PR TITLE
refactor: move from `io/ioutil` to `io` and `os` packages

### DIFF
--- a/cmd/agent/api/internal/agent/agent.go
+++ b/cmd/agent/api/internal/agent/agent.go
@@ -12,7 +12,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"sort"
@@ -107,7 +107,7 @@ func makeFlare(w http.ResponseWriter, r *http.Request) {
 	var profile flare.ProfileData
 
 	if r.Body != http.NoBody {
-		body, err := ioutil.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			http.Error(w, log.Errorf("Error while reading HTTP request body: %s", err).Error(), 500)
 			return
@@ -225,7 +225,7 @@ func streamLogs(w http.ResponseWriter, r *http.Request) {
 	var filters diagnostic.Filters
 
 	if r.Body != http.NoBody {
-		body, err := ioutil.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			http.Error(w, log.Errorf("Error while reading HTTP request body: %s", err).Error(), 500)
 			return

--- a/cmd/agent/common/import.go
+++ b/cmd/agent/common/import.go
@@ -9,7 +9,6 @@ package common
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -72,7 +71,7 @@ func ImportConfig(oldConfigDir string, newConfigDir string, force bool) error {
 	}
 
 	// move existing config files to the new configuration directory
-	files, err := ioutil.ReadDir(filepath.Join(oldConfigDir, "conf.d"))
+	files, err := os.ReadDir(filepath.Join(oldConfigDir, "conf.d"))
 	if err != nil {
 		if os.IsNotExist(err) {
 			fmt.Fprintln(color.Output,
@@ -146,7 +145,7 @@ func ImportConfig(oldConfigDir string, newConfigDir string, force bool) error {
 	// dump the current configuration to datadog.yaml
 	// file permissions will be used only to create the file if doesn't exist,
 	// please note on Windows such permissions have no effect.
-	if err = ioutil.WriteFile(datadogYamlPath, b, 0640); err != nil {
+	if err = os.WriteFile(datadogYamlPath, b, 0640); err != nil {
 		return fmt.Errorf("unable to write config to %s: %v", datadogYamlPath, err)
 	}
 
@@ -160,7 +159,7 @@ func ImportConfig(oldConfigDir string, newConfigDir string, force bool) error {
 	)
 
 	// move existing config templates to the new auto_conf directory
-	autoConfFiles, err := ioutil.ReadDir(filepath.Join(oldConfigDir, "conf.d", "auto_conf"))
+	autoConfFiles, err := os.ReadDir(filepath.Join(oldConfigDir, "conf.d", "auto_conf"))
 	if err != nil {
 		if os.IsNotExist(err) {
 			fmt.Fprintln(color.Output,
@@ -187,13 +186,13 @@ func ImportConfig(oldConfigDir string, newConfigDir string, force bool) error {
 		}
 
 		// Transform if needed AD configuration
-		input, err := ioutil.ReadFile(dst)
+		input, err := os.ReadFile(dst)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "unable to open %s", dst)
 			continue
 		}
 		output := strings.Replace(string(input), "docker_images:", "ad_identifiers:", 1)
-		err = ioutil.WriteFile(dst, []byte(output), 0640)
+		err = os.WriteFile(dst, []byte(output), 0640)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "unable to write %s", dst)
 			continue
@@ -241,7 +240,7 @@ func copyFile(src, dst string, overwrite bool, transformations []TransformationF
 		return err
 	}
 
-	data, err := ioutil.ReadFile(src)
+	data, err := os.ReadFile(src)
 	if err != nil {
 		return fmt.Errorf("unable to read file %s : %s", src, err)
 	}
@@ -253,7 +252,7 @@ func copyFile(src, dst string, overwrite bool, transformations []TransformationF
 		}
 	}
 
-	ioutil.WriteFile(dst, data, 0640) //nolint:errcheck
+	os.WriteFile(dst, data, 0640) //nolint:errcheck
 
 	ddGroup, errGroup := user.LookupGroup("dd-agent")
 	ddUser, errUser := user.LookupId("dd-agent")

--- a/cmd/agent/common/import_test.go
+++ b/cmd/agent/common/import_test.go
@@ -6,7 +6,7 @@
 package common
 
 import (
-	"io/ioutil"
+	"os"
 	"path"
 	"strconv"
 	"strings"
@@ -109,7 +109,7 @@ type paramMatcher struct {
 }
 
 func validateSelectedParameters(t *testing.T, migratedConfigFile, oldConfigFile string) {
-	migratedBytes, err := ioutil.ReadFile(migratedConfigFile)
+	migratedBytes, err := os.ReadFile(migratedConfigFile)
 	require.NoError(t, err, "Failed to read"+migratedConfigFile)
 	migratedConf := make(map[string]interface{})
 	yaml.Unmarshal(migratedBytes, migratedConf)
@@ -172,12 +172,12 @@ func toInt(val interface{}) interface{} {
 }
 
 func assertYAMLEquality(t *testing.T, f1, f2 string) {
-	f1Bytes, err := ioutil.ReadFile(f1)
+	f1Bytes, err := os.ReadFile(f1)
 	require.NoError(t, err, "Failed to read "+f1)
 	migratedContent := make(map[string]interface{})
 	yaml.Unmarshal(f1Bytes, migratedContent)
 
-	f2Bytes, err := ioutil.ReadFile(f2)
+	f2Bytes, err := os.ReadFile(f2)
 	require.NoError(t, err, "Failed to read "+f2)
 	expectedContent := make(map[string]interface{})
 	yaml.Unmarshal(f2Bytes, expectedContent)

--- a/cmd/agent/gui/agent.go
+++ b/cmd/agent/gui/agent.go
@@ -9,8 +9,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"html"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -105,7 +105,7 @@ func getLog(w http.ResponseWriter, r *http.Request) {
 		logFile = common.DefaultLogFile
 	}
 
-	logFileContents, e := ioutil.ReadFile(logFile)
+	logFileContents, e := os.ReadFile(logFile)
 	if e != nil {
 		w.Write([]byte("Error: " + e.Error()))
 		return
@@ -203,7 +203,7 @@ func getConfigSetting(w http.ResponseWriter, r *http.Request) {
 // Sends the configuration (aka datadog.yaml) file
 func getConfigFile(w http.ResponseWriter, r *http.Request) {
 	path := config.Datadog.ConfigFileUsed()
-	settings, e := ioutil.ReadFile(path)
+	settings, e := os.ReadFile(path)
 	if e != nil {
 		w.Write([]byte("Error: " + e.Error()))
 		return
@@ -230,7 +230,7 @@ func setConfigFile(w http.ResponseWriter, r *http.Request) {
 	}
 
 	path := config.Datadog.ConfigFileUsed()
-	e = ioutil.WriteFile(path, data, 0644)
+	e = os.WriteFile(path, data, 0644)
 	if e != nil {
 		w.Write([]byte("Error: " + e.Error()))
 		return

--- a/cmd/agent/gui/checks.go
+++ b/cmd/agent/gui/checks.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"html"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -200,7 +199,7 @@ func getCheckConfigFile(w http.ResponseWriter, r *http.Request) {
 			log.Errorf("Error: Unable to join config path with the file name: %s", fileName)
 			continue
 		}
-		file, e = ioutil.ReadFile(filePath)
+		file, e = os.ReadFile(filePath)
 		if e == nil {
 			break
 		}
@@ -267,7 +266,7 @@ func setCheckConfigFile(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		os.MkdirAll(checkConfFolderPath, os.FileMode(0755)) //nolint:errcheck
-		e = ioutil.WriteFile(path, data, 0600)
+		e = os.WriteFile(path, data, 0600)
 
 		// If the write didn't work, try writing to the default checks directory
 		if e != nil && strings.Contains(e.Error(), "no such file or directory") {
@@ -277,7 +276,7 @@ func setCheckConfigFile(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 			os.MkdirAll(defaultCheckConfFolderPath, os.FileMode(0755)) //nolint:errcheck
-			e = ioutil.WriteFile(path, data, 0600)
+			e = os.WriteFile(path, data, 0600)
 		}
 
 		if e != nil {
@@ -341,13 +340,13 @@ func getWheelsChecks() ([]string, error) {
 func listChecks(w http.ResponseWriter, r *http.Request) {
 	integrations := []string{}
 	for _, path := range checkPaths {
-		files, err := ioutil.ReadDir(path)
+		files, err := os.ReadDir(path)
 		if err != nil {
 			continue
 		}
 
 		for _, file := range files {
-			if ext := filepath.Ext(file.Name()); ext == ".py" && file.Mode().IsRegular() {
+			if ext := filepath.Ext(file.Name()); ext == ".py" && file.Type().IsRegular() {
 				integrations = append(integrations, file.Name())
 			}
 		}
@@ -442,7 +441,7 @@ func listConfigs(w http.ResponseWriter, r *http.Request) {
 // Helper function which returns all the filenames in a check config directory
 func readConfDir(path string) ([]string, error) {
 	var filenames []string
-	entries, err := ioutil.ReadDir(path)
+	entries, err := os.ReadDir(path)
 	if err != nil {
 		return filenames, err
 	}
@@ -454,10 +453,10 @@ func readConfDir(path string) ([]string, error) {
 				continue
 			}
 
-			subEntries, err := ioutil.ReadDir(filepath.Join(path, entry.Name()))
+			subEntries, err := os.ReadDir(filepath.Join(path, entry.Name()))
 			if err == nil {
 				for _, subEntry := range subEntries {
-					if hasRightEnding(subEntry.Name()) && subEntry.Mode().IsRegular() {
+					if hasRightEnding(subEntry.Name()) && subEntry.Type().IsRegular() {
 						// Save the full path of the config file {check_name.d}/{filename}
 						filenames = append(filenames, entry.Name()+"/"+subEntry.Name())
 					}
@@ -466,7 +465,7 @@ func readConfDir(path string) ([]string, error) {
 			continue
 		}
 
-		if hasRightEnding(entry.Name()) && entry.Mode().IsRegular() {
+		if hasRightEnding(entry.Name()) && entry.Type().IsRegular() {
 			filenames = append(filenames, entry.Name())
 		}
 	}

--- a/cmd/agent/gui/gui.go
+++ b/cmd/agent/gui/gui.go
@@ -12,7 +12,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"html/template"
-	"io/ioutil"
+	"io"
 	"mime"
 	"net"
 	"net/http"
@@ -222,7 +222,7 @@ func authorizePOST(w http.ResponseWriter, r *http.Request, next http.HandlerFunc
 // Helper function which unmarshals a POST requests data into a Payload object
 func parseBody(r *http.Request) (Payload, error) {
 	var p Payload
-	body, e := ioutil.ReadAll(r.Body)
+	body, e := io.ReadAll(r.Body)
 	if e != nil {
 		return p, e
 	}

--- a/cmd/agent/subcommands/dogstatsdcapture/command.go
+++ b/cmd/agent/subcommands/dogstatsdcapture/command.go
@@ -10,7 +10,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"time"
 
 	"go.uber.org/fx"
@@ -72,7 +72,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 	dogstatsdCaptureCmd.Flags().BoolVarP(&cliParams.dsdCaptureCompressed, "compressed", "z", true, "Should capture be zstd compressed.")
 
 	// shut up grpc client!
-	grpclog.SetLoggerV2(grpclog.NewLoggerV2(ioutil.Discard, ioutil.Discard, ioutil.Discard))
+	grpclog.SetLoggerV2(grpclog.NewLoggerV2(io.Discard, io.Discard, io.Discard))
 
 	return []*cobra.Command{dogstatsdCaptureCmd}
 }

--- a/cmd/agent/subcommands/dogstatsdstats/command.go
+++ b/cmd/agent/subcommands/dogstatsdstats/command.go
@@ -10,7 +10,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"go.uber.org/fx"
@@ -132,7 +131,7 @@ func requestDogstatsdStats(log log.Component, config config.Component, cliParams
 		}
 	}
 
-	if err := ioutil.WriteFile(cliParams.dsdStatsFilePath, []byte(s), 0644); err != nil {
+	if err := os.WriteFile(cliParams.dsdStatsFilePath, []byte(s), 0644); err != nil {
 		fmt.Println("Error while writing the file (is the location writable by the dd-agent user?):", err)
 	} else {
 		fmt.Println("Dogstatsd stats written in:", cliParams.dsdStatsFilePath)

--- a/cmd/agent/subcommands/integrations/command.go
+++ b/cmd/agent/subcommands/integrations/command.go
@@ -16,7 +16,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -699,7 +698,7 @@ func validateRequirement(version *semver.Version, comp string, versionReq *semve
 }
 
 func minAllowedVersion(integration string) (*semver.Version, bool, error) {
-	lines, err := ioutil.ReadFile(reqAgentReleasePath)
+	lines, err := os.ReadFile(reqAgentReleasePath)
 	if err != nil {
 		return nil, false, err
 	}
@@ -795,7 +794,7 @@ func moveConfigurationFilesOf(cliParams *cliParams, integration string) error {
 }
 
 func moveConfigurationFiles(srcFolder string, dstFolder string) error {
-	files, err := ioutil.ReadDir(srcFolder)
+	files, err := os.ReadDir(srcFolder)
 	if err != nil {
 		return err
 	}
@@ -825,12 +824,12 @@ func moveConfigurationFiles(srcFolder string, dstFolder string) error {
 		}
 		src := filepath.Join(srcFolder, filename)
 		dst := filepath.Join(dstFolder, filename)
-		srcContent, err := ioutil.ReadFile(src)
+		srcContent, err := os.ReadFile(src)
 		if err != nil {
 			errorMsg = fmt.Sprintf("%s\nError reading configuration file %s: %v", errorMsg, src, err)
 			continue
 		}
-		err = ioutil.WriteFile(dst, srcContent, 0644)
+		err = os.WriteFile(dst, srcContent, 0644)
 		if err != nil {
 			errorMsg = fmt.Sprintf("%s\nError writing configuration file %s: %v", errorMsg, dst, err)
 			continue

--- a/cmd/agent/subcommands/integrations/integrations_test.go
+++ b/cmd/agent/subcommands/integrations/integrations_test.go
@@ -9,7 +9,6 @@
 package integrations
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -29,7 +28,7 @@ func TestMoveConfigurationsFiles(t *testing.T) {
 		assert.NoError(t, f.Close())
 	}
 
-	filesCreated, _ := ioutil.ReadDir(srcFolder)
+	filesCreated, _ := os.ReadDir(srcFolder)
 	assert.Equal(t, 5, len(filesCreated))
 	for _, file := range filesCreated {
 		assert.Contains(t, append(yamlFiles, otherFile), file.Name())
@@ -37,7 +36,7 @@ func TestMoveConfigurationsFiles(t *testing.T) {
 
 	moveConfigurationFiles(srcFolder, dstFolder)
 
-	filesMoved, _ := ioutil.ReadDir(dstFolder)
+	filesMoved, _ := os.ReadDir(dstFolder)
 	assert.Equal(t, 4, len(filesMoved))
 	for _, file := range filesMoved {
 		assert.Contains(t, yamlFiles, file.Name())

--- a/cmd/agent/subcommands/status/command.go
+++ b/cmd/agent/subcommands/status/command.go
@@ -11,7 +11,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"time"
@@ -175,7 +174,7 @@ func requestStatus(config config.Component, cliParams *cliParams) error {
 	}
 
 	if cliParams.statusFilePath != "" {
-		ioutil.WriteFile(cliParams.statusFilePath, []byte(s), 0644) //nolint:errcheck
+		os.WriteFile(cliParams.statusFilePath, []byte(s), 0644) //nolint:errcheck
 	} else {
 		fmt.Println(s)
 	}
@@ -238,7 +237,7 @@ func componentStatus(config config.Component, cliParams *cliParams, component st
 	}
 
 	if cliParams.statusFilePath != "" {
-		ioutil.WriteFile(cliParams.statusFilePath, []byte(s), 0644) //nolint:errcheck
+		os.WriteFile(cliParams.statusFilePath, []byte(s), 0644) //nolint:errcheck
 	} else {
 		fmt.Println(s)
 	}

--- a/cmd/cluster-agent/admission/server.go
+++ b/cmd/cluster-agent/admission/server.go
@@ -13,7 +13,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -127,7 +127,7 @@ func (s *Server) mutateHandler(w http.ResponseWriter, r *http.Request, mutateFun
 		return
 	}
 
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		log.Warnf("Could not read request body: %v", err)

--- a/cmd/cluster-agent/app/metadata_mapper_digest.go
+++ b/cmd/cluster-agent/app/metadata_mapper_digest.go
@@ -12,7 +12,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
@@ -103,7 +103,7 @@ func getMetadataMap(nodeName string) error {
 	}
 
 	if statusFilePath != "" {
-		ioutil.WriteFile(statusFilePath, []byte(s), 0644) //nolint:errcheck
+		os.WriteFile(statusFilePath, []byte(s), 0644) //nolint:errcheck
 	} else {
 		fmt.Println(s)
 	}

--- a/cmd/cluster-agent/app/status.go
+++ b/cmd/cluster-agent/app/status.go
@@ -12,7 +12,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
@@ -113,7 +113,7 @@ func requestStatus() error {
 	}
 
 	if statusFilePath != "" {
-		ioutil.WriteFile(statusFilePath, []byte(s), 0644) //nolint:errcheck
+		os.WriteFile(statusFilePath, []byte(s), 0644) //nolint:errcheck
 	} else {
 		fmt.Println(s)
 	}

--- a/cmd/cluster-agent/commands/check/check.go
+++ b/cmd/cluster-agent/commands/check/check.go
@@ -11,7 +11,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -207,7 +206,7 @@ func Check(loggerName config.LoggerName, confFilePath *string, flagNoColor *bool
 			if profileMemory {
 				// If no directory is specified, make a temporary one
 				if profileMemoryDir == "" {
-					profileMemoryDir, err = ioutil.TempDir("", "datadog-agent-memory-profiler")
+					profileMemoryDir, err = os.MkdirTemp("", "datadog-agent-memory-profiler")
 					if err != nil {
 						return err
 					}
@@ -356,7 +355,7 @@ func Check(loggerName config.LoggerName, confFilePath *string, flagNoColor *bool
 
 					snapshotDir := filepath.Join(profileDataDir, "snapshots")
 					if _, err := os.Stat(snapshotDir); !os.IsNotExist(err) {
-						snapshots, err := ioutil.ReadDir(snapshotDir)
+						snapshots, err := os.ReadDir(snapshotDir)
 						if err != nil {
 							return err
 						}
@@ -364,7 +363,7 @@ func Check(loggerName config.LoggerName, confFilePath *string, flagNoColor *bool
 						numSnapshots := len(snapshots)
 						if numSnapshots > 0 {
 							lastSnapshot := snapshots[numSnapshots-1]
-							snapshotContents, err := ioutil.ReadFile(filepath.Join(snapshotDir, lastSnapshot.Name()))
+							snapshotContents, err := os.ReadFile(filepath.Join(snapshotDir, lastSnapshot.Name()))
 							if err != nil {
 								return err
 							}
@@ -379,7 +378,7 @@ func Check(loggerName config.LoggerName, confFilePath *string, flagNoColor *bool
 
 					diffDir := filepath.Join(profileDataDir, "diffs")
 					if _, err := os.Stat(diffDir); !os.IsNotExist(err) {
-						diffs, err := ioutil.ReadDir(diffDir)
+						diffs, err := os.ReadDir(diffDir)
 						if err != nil {
 							return err
 						}
@@ -387,7 +386,7 @@ func Check(loggerName config.LoggerName, confFilePath *string, flagNoColor *bool
 						numDiffs := len(diffs)
 						if numDiffs > 0 {
 							lastDiff := diffs[numDiffs-1]
-							diffContents, err := ioutil.ReadFile(filepath.Join(diffDir, lastDiff.Name()))
+							diffContents, err := os.ReadFile(filepath.Join(diffDir, lastDiff.Name()))
 							if err != nil {
 								return err
 							}
@@ -497,7 +496,7 @@ func writeCheckToFile(checkName string, checkFileOutput *bytes.Buffer) {
 	if err != nil {
 		fmt.Println("Error while scrubbing the check file:", err)
 	}
-	err = ioutil.WriteFile(flarePath, scrubbed, os.ModePerm)
+	err = os.WriteFile(flarePath, scrubbed, os.ModePerm)
 
 	if err != nil {
 		fmt.Println("Error while writing the check file (is the location writable by the dd-agent user?):", err)

--- a/cmd/process-agent/collector_api_test.go
+++ b/cmd/process-agent/collector_api_test.go
@@ -7,7 +7,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -729,7 +729,7 @@ func (m *mockEndpoint) handleValidate(w http.ResponseWriter, _ *http.Request) {
 }
 
 func (m *mockEndpoint) handle(w http.ResponseWriter, req *http.Request) {
-	body, err := ioutil.ReadAll(req.Body)
+	body, err := io.ReadAll(req.Body)
 	require.NoError(m.t, err)
 
 	err = req.Body.Close()
@@ -770,7 +770,7 @@ func (m *mockEndpoint) handle(w http.ResponseWriter, req *http.Request) {
 }
 
 func (m *mockEndpoint) handleEvents(w http.ResponseWriter, req *http.Request) {
-	body, err := ioutil.ReadAll(req.Body)
+	body, err := io.ReadAll(req.Body)
 	require.NoError(m.t, err)
 
 	err = req.Body.Close()

--- a/cmd/py-launcher/py-launcher.go
+++ b/cmd/py-launcher/py-launcher.go
@@ -11,7 +11,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -59,7 +58,7 @@ func main() {
 
 	pyRtLoader := python.GetRtLoader()
 	rtloader := (*C.rtloader_t)(pyRtLoader)
-	pythonCode, err := ioutil.ReadFile(*pythonScript)
+	pythonCode, err := os.ReadFile(*pythonScript)
 	if err != nil {
 		fmt.Printf("Could not read %s: %s\n", *pythonScript, err)
 		os.Exit(1)

--- a/cmd/secrethelper/providers/file.go
+++ b/cmd/secrethelper/providers/file.go
@@ -10,7 +10,7 @@ package providers
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -75,7 +75,7 @@ func ReadSecretFile(path string) s.Secret {
 		return s.Secret{Value: "", ErrorMsg: err.Error()}
 	}
 
-	bytes, err := ioutil.ReadAll(file)
+	bytes, err := io.ReadAll(file)
 	if err != nil {
 		return s.Secret{Value: "", ErrorMsg: err.Error()}
 	}

--- a/cmd/secrethelper/secret_helper.go
+++ b/cmd/secrethelper/secret_helper.go
@@ -32,7 +32,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -121,7 +120,7 @@ func readSecrets(r io.Reader, w io.Writer, dir string, usePrefixes bool, newKube
 }
 
 func parseInputSecrets(r io.Reader) ([]string, error) {
-	in, err := ioutil.ReadAll(r)
+	in, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/serverless-init/cloudservice/helper/gcp.go
+++ b/cmd/serverless-init/cloudservice/helper/gcp.go
@@ -7,7 +7,7 @@ package helper
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"sync"
@@ -128,7 +128,7 @@ func getSingleMetadata(httpClient *http.Client, url string) string {
 		return "unknown"
 	}
 	defer res.Body.Close()
-	data, err := ioutil.ReadAll(res.Body)
+	data, err := io.ReadAll(res.Body)
 	if err != nil {
 		log.Error("unable to read metadata body, defaulting to unknown")
 		return "unknown"

--- a/cmd/trace-agent/config/config_test.go
+++ b/cmd/trace-agent/config/config_test.go
@@ -8,7 +8,6 @@ package config
 import (
 	"errors"
 	"html/template"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/exec"
@@ -274,14 +273,14 @@ func TestConfigHostname(t *testing.T) {
 	})
 
 	t.Run("external", func(t *testing.T) {
-		body, err := ioutil.ReadFile("testdata/stringcode.go.tmpl")
+		body, err := os.ReadFile("testdata/stringcode.go.tmpl")
 		if err != nil {
 			t.Fatal(err)
 		}
 		// makeProgram creates a new binary file which returns the given response and exits to the OS
 		// given the specified code, returning the path of the program.
 		makeProgram := func(response string, code int) string {
-			f, err := ioutil.TempFile("", "trace-test-hostname.*.go")
+			f, err := os.CreateTemp("", "trace-test-hostname.*.go")
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/cmd/trace-agent/remote_config_test.go
+++ b/cmd/trace-agent/remote_config_test.go
@@ -8,7 +8,7 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -71,7 +71,7 @@ func TestConfigEndpoint(t *testing.T) {
 			req.Header.Set("Content-Type", "application/msgpack")
 			resp, err := http.DefaultClient.Do(req)
 			assert.Nil(err)
-			body, err := ioutil.ReadAll(resp.Body)
+			body, err := io.ReadAll(resp.Body)
 			resp.Body.Close()
 			assert.Nil(err)
 			assert.Equal(tc.expectedStatusCode, resp.StatusCode)
@@ -141,7 +141,7 @@ func TestTags(t *testing.T) {
 			req.Header.Set("Datadog-Container-ID", "cid")
 			resp, err := http.DefaultClient.Do(req)
 			assert.Nil(err)
-			body, err := ioutil.ReadAll(resp.Body)
+			body, err := io.ReadAll(resp.Body)
 			resp.Body.Close()
 			assert.Nil(err)
 			assert.Equal(200, resp.StatusCode)

--- a/cmd/trace-agent/test/agent.go
+++ b/cmd/trace-agent/test/agent.go
@@ -9,7 +9,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 	"os/exec"
@@ -39,7 +39,7 @@ type agentRunner struct {
 }
 
 func newAgentRunner(ddAddr string, verbose bool) (*agentRunner, error) {
-	bindir, err := ioutil.TempDir("", "trace-agent-integration-tests")
+	bindir, err := os.MkdirTemp("", "trace-agent-integration-tests")
 	if err != nil {
 		return nil, err
 	}
@@ -138,7 +138,7 @@ func (s *agentRunner) runAgentConfig(path string) <-chan error {
 	cmd := exec.Command(filepath.Join(s.bindir, "trace-agent"), "-config", path)
 	s.log.Reset()
 	cmd.Stdout = s.log
-	cmd.Stderr = ioutil.Discard
+	cmd.Stderr = io.Discard
 	if err := cmd.Start(); err != nil {
 		log.Print("error starting process: ", err)
 	}

--- a/cmd/trace-agent/test/backend.go
+++ b/cmd/trace-agent/test/backend.go
@@ -11,7 +11,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"time"
@@ -135,7 +134,7 @@ func readProtoRequest(req *http.Request, msg proto.Message) error {
 	if err != nil {
 		return err
 	}
-	slurp, err := ioutil.ReadAll(rc)
+	slurp, err := io.ReadAll(rc)
 	defer rc.Close()
 	if err != nil {
 		return err

--- a/cmd/trace-agent/test/example_test.go
+++ b/cmd/trace-agent/test/example_test.go
@@ -7,8 +7,8 @@ package test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
+	"os"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/trace/pb"
@@ -25,7 +25,7 @@ func Example() {
 	defer log.Fatal(runner.Shutdown(time.Second))
 
 	// Run an agent with a given config.
-	conf, err := ioutil.ReadFile("/opt/datadog-agent/etc/datadog.yaml")
+	conf, err := os.ReadFile("/opt/datadog-agent/etc/datadog.yaml")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/trace-agent/test/runner.go
+++ b/cmd/trace-agent/test/runner.go
@@ -9,7 +9,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 	"testing"
@@ -184,7 +184,7 @@ func (s *Runner) doRequest(req *http.Request) error {
 		defer resp.Body.Close()
 	}
 	if resp.StatusCode != 200 {
-		slurp, err := ioutil.ReadAll(resp.Body)
+		slurp, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return fmt.Errorf("%s (error reading response body: %v)", resp.Status, err)
 		}

--- a/cmd/trace-agent/test/testsuite/events_test.go
+++ b/cmd/trace-agent/test/testsuite/events_test.go
@@ -7,7 +7,7 @@ package testsuite
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"testing"
 	"time"
 
@@ -17,7 +17,7 @@ import (
 )
 
 func jsonTraceFromPath(path string) (pb.Trace, error) {
-	slurp, err := ioutil.ReadFile(path)
+	slurp, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/trace-agent/test/testsuite/secrets_test.go
+++ b/cmd/trace-agent/test/testsuite/secrets_test.go
@@ -7,7 +7,7 @@ package testsuite
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -24,7 +24,7 @@ func TestSecrets(t *testing.T) {
 	// install trace-agent with -tags=secrets
 	binTraceAgent := filepath.Join(tmpDir, "trace-agent")
 	cmd := exec.Command("go", "build", "-o", binTraceAgent, "-tags=secrets", "github.com/DataDog/datadog-agent/cmd/trace-agent")
-	cmd.Stdout = ioutil.Discard
+	cmd.Stdout = io.Discard
 	if err := cmd.Run(); err != nil {
 		t.Skip(err.Error())
 	}
@@ -33,7 +33,7 @@ func TestSecrets(t *testing.T) {
 	// install a secrets provider script
 	binSecrets := filepath.Join(tmpDir, "secret-script.test")
 	cmd = exec.Command("go", "build", "-o", binSecrets, "./testdata/secretscript.go")
-	cmd.Stdout = ioutil.Discard
+	cmd.Stdout = io.Discard
 	if err := cmd.Run(); err != nil {
 		t.Skip(err.Error())
 	}
@@ -44,7 +44,7 @@ func TestSecrets(t *testing.T) {
 
 	// CI environment might have no datadog.yaml; we don't care in this
 	// case so we can just use an empty file to avoid failure.
-	if err := ioutil.WriteFile(filepath.Join(tmpDir, "datadog.yaml"), []byte(""), os.ModePerm); err != nil {
+	if err := os.WriteFile(filepath.Join(tmpDir, "datadog.yaml"), []byte(""), os.ModePerm); err != nil {
 		t.Skip(err.Error())
 	}
 

--- a/cmd/trace-agent/test/testsuite/testdata/secretscript.go
+++ b/cmd/trace-agent/test/testsuite/testdata/secretscript.go
@@ -17,7 +17,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 )
@@ -28,7 +27,7 @@ type secretsPayload struct {
 }
 
 func main() {
-	data, err := ioutil.ReadAll(os.Stdin)
+	data, err := io.ReadAll(os.Stdin)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Could not read from stdin: %s", err)
 		os.Exit(1)

--- a/internal/third_party/kubernetes/pkg/kubelet/cri/remote/util/util_unix.go
+++ b/internal/third_party/kubernetes/pkg/kubelet/cri/remote/util/util_unix.go
@@ -22,7 +22,6 @@ package util
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/url"
 	"os"
@@ -58,7 +57,7 @@ func CreateListener(endpoint string) (net.Listener, error) {
 	}
 
 	// Create the socket on a tempfile and move it to the destination socket to handle improper cleanup
-	file, err := ioutil.TempFile(filepath.Dir(addr), "")
+	file, err := os.CreateTemp(filepath.Dir(addr), "")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create temporary file: %v", err)
 	}

--- a/internal/third_party/kubernetes/pkg/kubelet/cri/remote/util/util_unix_test.go
+++ b/internal/third_party/kubernetes/pkg/kubelet/cri/remote/util/util_unix_test.go
@@ -20,7 +20,6 @@ limitations under the License.
 package util
 
 import (
-	"io/ioutil"
 	"net"
 	"os"
 	"testing"
@@ -102,7 +101,7 @@ func TestIsUnixDomainSocket(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		f, err := ioutil.TempFile("", "test-domain-socket")
+		f, err := os.CreateTemp("", "test-domain-socket")
 		require.NoErrorf(t, err, "Failed to create file for test purposes: %v while setting up: %s", err, test.label)
 		addr := f.Name()
 		f.Close()

--- a/internal/third_party/kubernetes/pkg/kubelet/cri/remote/util/util_windows_test.go
+++ b/internal/third_party/kubernetes/pkg/kubelet/cri/remote/util/util_windows_test.go
@@ -20,7 +20,6 @@ limitations under the License.
 package util
 
 import (
-	"io/ioutil"
 	"math/rand"
 	"net"
 	"os"
@@ -119,7 +118,7 @@ func testPipe(t *testing.T, label string) {
 }
 
 func testRegularFile(t *testing.T, label string, exists bool) {
-	f, err := ioutil.TempFile("", "test-file")
+	f, err := os.CreateTemp("", "test-file")
 	require.NoErrorf(t, err, "Failed to create file for test purposes: %v while setting up: %s", err, label)
 	testFile := f.Name()
 	if !exists {
@@ -133,7 +132,7 @@ func testRegularFile(t *testing.T, label string, exists bool) {
 }
 
 func testUnixDomainSocket(t *testing.T, label string) {
-	f, err := ioutil.TempFile("", "test-domain-socket")
+	f, err := os.CreateTemp("", "test-domain-socket")
 	require.NoErrorf(t, err, "Failed to create file for test purposes: %v while setting up: %s", err, label)
 	testFile := f.Name()
 	f.Close()

--- a/pkg/aggregator/ckey/tests/collisions_test.go
+++ b/pkg/aggregator/ckey/tests/collisions_test.go
@@ -7,7 +7,7 @@ package ckey_test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -20,7 +20,7 @@ import (
 func TestCollisions(t *testing.T) {
 	assert := assert.New(t)
 
-	data, err := ioutil.ReadFile("./random_sorted_uniq_contexts.csv")
+	data, err := os.ReadFile("./random_sorted_uniq_contexts.csv")
 	assert.NoError(err)
 
 	generator := ckey.NewKeyGenerator()

--- a/pkg/api/security/security.go
+++ b/pkg/api/security/security.go
@@ -13,7 +13,6 @@ import (
 	"encoding/hex"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"net"
 	"os"
@@ -144,7 +143,7 @@ func fetchAuthToken(tokenCreationAllowed bool) (string, error) {
 		log.Infof("Saved a new authentication token to %s", authTokenFile)
 	}
 	// Read the token
-	authTokenRaw, e := ioutil.ReadFile(authTokenFile)
+	authTokenRaw, e := os.ReadFile(authTokenFile)
 	if e != nil {
 		return "", fmt.Errorf("unable to read authentication token file: " + e.Error())
 	}
@@ -214,7 +213,7 @@ func getClusterAgentAuthToken(tokenCreationAllowed bool) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("empty cluster_agent.auth_token and cannot find %q: %s", tokenAbsPath, err)
 	}
-	b, err := ioutil.ReadFile(tokenAbsPath)
+	b, err := os.ReadFile(tokenAbsPath)
 	if err != nil {
 		return "", fmt.Errorf("empty cluster_agent.auth_token and cannot read %s: %s", tokenAbsPath, err)
 	}
@@ -233,7 +232,7 @@ func validateAuthToken(authToken string) error {
 
 // writes auth token(s) to a file with the same permissions as datadog.yaml
 func saveAuthToken(token, tokenPath string) error {
-	if err := ioutil.WriteFile(tokenPath, []byte(token), 0o600); err != nil {
+	if err := os.WriteFile(tokenPath, []byte(token), 0o600); err != nil {
 		return err
 	}
 

--- a/pkg/api/security/security_test.go
+++ b/pkg/api/security/security_test.go
@@ -10,7 +10,6 @@ package security
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -24,7 +23,7 @@ import (
 func initMockConf(t *testing.T) string {
 	testDir := t.TempDir()
 
-	f, err := ioutil.TempFile(testDir, "fake-datadog-yaml-")
+	f, err := os.CreateTemp(testDir, "fake-datadog-yaml-")
 	require.Nil(t, err, fmt.Errorf("%v", err))
 	t.Cleanup(func() {
 		f.Close()

--- a/pkg/api/util/doget.go
+++ b/pkg/api/util/doget.go
@@ -9,7 +9,6 @@ import (
 	"crypto/tls"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 )
 
@@ -55,7 +54,7 @@ func DoGet(c *http.Client, url string, conn ShouldCloseConnection) (body []byte,
 	if e != nil {
 		return body, e
 	}
-	body, e = ioutil.ReadAll(r.Body)
+	body, e = io.ReadAll(r.Body)
 	r.Body.Close()
 	if e != nil {
 		return body, e
@@ -80,7 +79,7 @@ func DoPost(c *http.Client, url string, contentType string, body io.Reader) (res
 	if e != nil {
 		return resp, e
 	}
-	resp, e = ioutil.ReadAll(r.Body)
+	resp, e = io.ReadAll(r.Body)
 	r.Body.Close()
 	if e != nil {
 		return resp, e

--- a/pkg/autodiscovery/providers/config_reader.go
+++ b/pkg/autodiscovery/providers/config_reader.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -171,7 +170,7 @@ func (r *configFilesReader) read(keep FilterFunc) ([]integration.Config, map[str
 	for _, path := range r.paths {
 		log.Infof("Searching for configuration files at: %s", path)
 
-		entries, err := ioutil.ReadDir(path)
+		entries, err := os.ReadDir(path)
 		if err != nil {
 			log.Warnf("Skipping, %s", err)
 			continue
@@ -236,7 +235,7 @@ func (r *configFilesReader) read(keep FilterFunc) ([]integration.Config, map[str
 
 // collectEntry collects a file entry and return it's configuration if valid
 // the integrationName can be manually provided else it'll use the filename
-func collectEntry(file os.FileInfo, path string, integrationName string, integrationErrors map[string]string) (configEntry, map[string]string) {
+func collectEntry(file os.DirEntry, path string, integrationName string, integrationErrors map[string]string) (configEntry, map[string]string) {
 	const defaultExt string = ".default"
 	fileName := file.Name()
 	ext := filepath.Ext(fileName)
@@ -297,7 +296,7 @@ func collectEntry(file os.FileInfo, path string, integrationName string, integra
 	return entry, integrationErrors
 }
 
-func collectDir(parentPath string, folder os.FileInfo, integrationErrors map[string]string) (configPkg, map[string]string) {
+func collectDir(parentPath string, folder os.DirEntry, integrationErrors map[string]string) (configPkg, map[string]string) {
 	configs := []integration.Config{}
 	defaultConfigs := []integration.Config{}
 	otherConfigs := []integration.Config{}
@@ -311,7 +310,7 @@ func collectDir(parentPath string, folder os.FileInfo, integrationErrors map[str
 	}
 
 	// search for yaml files within this directory
-	subEntries, err := ioutil.ReadDir(dirPath)
+	subEntries, err := os.ReadDir(dirPath)
 	if err != nil {
 		log.Warnf("Skipping config directory %s: %s", dirPath, err)
 		return configPkg{configs, defaultConfigs, otherConfigs}, integrationErrors
@@ -351,7 +350,7 @@ func GetIntegrationConfigFromFile(name, fpath string) (integration.Config, error
 
 	// Read file contents
 	// FIXME: ReadFile reads the entire file, possible security implications
-	yamlFile, err := ioutil.ReadFile(fpath)
+	yamlFile, err := os.ReadFile(fpath)
 	if err != nil {
 		return conf, err
 	}

--- a/pkg/cli/subcommands/check/command.go
+++ b/pkg/cli/subcommands/check/command.go
@@ -12,7 +12,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -237,7 +236,7 @@ func run(log log.Component, config config.Component, cliParams *cliParams) error
 	if cliParams.profileMemory {
 		// If no directory is specified, make a temporary one
 		if cliParams.profileMemoryDir == "" {
-			cliParams.profileMemoryDir, err = ioutil.TempDir("", "datadog-agent-memory-profiler")
+			cliParams.profileMemoryDir, err = os.MkdirTemp("", "datadog-agent-memory-profiler")
 			if err != nil {
 				return err
 			}
@@ -386,7 +385,7 @@ func run(log log.Component, config config.Component, cliParams *cliParams) error
 
 			snapshotDir := filepath.Join(profileDataDir, "snapshots")
 			if _, err := os.Stat(snapshotDir); !os.IsNotExist(err) {
-				snapshots, err := ioutil.ReadDir(snapshotDir)
+				snapshots, err := os.ReadDir(snapshotDir)
 				if err != nil {
 					return err
 				}
@@ -394,7 +393,7 @@ func run(log log.Component, config config.Component, cliParams *cliParams) error
 				numSnapshots := len(snapshots)
 				if numSnapshots > 0 {
 					lastSnapshot := snapshots[numSnapshots-1]
-					snapshotContents, err := ioutil.ReadFile(filepath.Join(snapshotDir, lastSnapshot.Name()))
+					snapshotContents, err := os.ReadFile(filepath.Join(snapshotDir, lastSnapshot.Name()))
 					if err != nil {
 						return err
 					}
@@ -409,7 +408,7 @@ func run(log log.Component, config config.Component, cliParams *cliParams) error
 
 			diffDir := filepath.Join(profileDataDir, "diffs")
 			if _, err := os.Stat(diffDir); !os.IsNotExist(err) {
-				diffs, err := ioutil.ReadDir(diffDir)
+				diffs, err := os.ReadDir(diffDir)
 				if err != nil {
 					return err
 				}
@@ -417,7 +416,7 @@ func run(log log.Component, config config.Component, cliParams *cliParams) error
 				numDiffs := len(diffs)
 				if numDiffs > 0 {
 					lastDiff := diffs[numDiffs-1]
-					diffContents, err := ioutil.ReadFile(filepath.Join(diffDir, lastDiff.Name()))
+					diffContents, err := os.ReadFile(filepath.Join(diffDir, lastDiff.Name()))
 					if err != nil {
 						return err
 					}
@@ -524,7 +523,7 @@ func writeCheckToFile(checkName string, checkFileOutput *bytes.Buffer) {
 	if err != nil {
 		fmt.Println("Error while scrubbing the check file:", err)
 	}
-	err = ioutil.WriteFile(flarePath, scrubbed, os.ModePerm)
+	err = os.WriteFile(flarePath, scrubbed, os.ModePerm)
 
 	if err != nil {
 		fmt.Println("Error while writing the check file (is the location writable by the dd-agent user?):", err)

--- a/pkg/collector/check/check_test.go
+++ b/pkg/collector/check/check_test.go
@@ -6,7 +6,7 @@
 package check
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -71,7 +71,7 @@ func LoadCheck(name, path string) (integration.Config, error) {
 	cf := config{}
 	config := integration.Config{Name: name}
 
-	yamlFile, err := ioutil.ReadFile(path)
+	yamlFile, err := os.ReadFile(path)
 	if err != nil {
 		return config, err
 	}

--- a/pkg/collector/corechecks/cluster/helm/release.go
+++ b/pkg/collector/corechecks/cluster/helm/release.go
@@ -14,7 +14,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 )
 
 // The "release" struct and the related ones, are a simplified version of the
@@ -90,7 +90,7 @@ func decodeRelease(data string) (*release, error) {
 			return nil, err
 		}
 		defer r.Close()
-		b2, err := ioutil.ReadAll(r)
+		b2, err := io.ReadAll(r)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_openshift_test.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_openshift_test.go
@@ -11,7 +11,7 @@ package kubernetesapiserver
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	osq "github.com/openshift/api/quota/v1"
@@ -22,7 +22,7 @@ import (
 )
 
 func TestReportClusterQuotas(t *testing.T) {
-	raw, err := ioutil.ReadFile("./testdata/oshift_crq_list.json")
+	raw, err := os.ReadFile("./testdata/oshift_crq_list.json")
 	require.NoError(t, err)
 	list := osq.ClusterResourceQuotaList{}
 	json.Unmarshal(raw, &list)

--- a/pkg/collector/corechecks/ebpf/probe/oom_kill_test.go
+++ b/pkg/collector/corechecks/ebpf/probe/oom_kill_test.go
@@ -10,7 +10,6 @@ package probe
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"syscall"
@@ -38,7 +37,7 @@ exec systemd-run --scope -p MemoryLimit=1M python3 %v # replace shell, so that t
 `
 
 func writeTempFile(pattern string, content string) (*os.File, error) {
-	f, err := ioutil.TempFile("", pattern)
+	f, err := os.CreateTemp("", pattern)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/collector/corechecks/net/ntp_local_defined_server_nowindows.go
+++ b/pkg/collector/corechecks/net/ntp_local_defined_server_nowindows.go
@@ -10,7 +10,7 @@ package net
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 )
 
@@ -22,7 +22,7 @@ func getNTPServersFromFiles(files []string) ([]string, error) {
 	serversMap := make(map[string]bool)
 
 	for _, conf := range files {
-		content, err := ioutil.ReadFile(conf)
+		content, err := os.ReadFile(conf)
 		if err == nil {
 			lines := strings.Split(string(content), "\n")
 

--- a/pkg/collector/corechecks/net/ntp_local_defined_server_nowindows_test.go
+++ b/pkg/collector/corechecks/net/ntp_local_defined_server_nowindows_test.go
@@ -9,7 +9,6 @@
 package net
 
 import (
-	"io/ioutil"
 	"os"
 	"sort"
 	"testing"
@@ -23,13 +22,13 @@ func TestGetNTPServersFromFileNotExist(t *testing.T) {
 }
 
 func createTempFile(t *testing.T, content string, callback func(filename string)) {
-	file, err := ioutil.TempFile("", "")
+	file, err := os.CreateTemp("", "")
 
 	filename := file.Name()
 	defer os.Remove(filename)
 	assert.NoError(t, err)
 
-	ioutil.WriteFile(filename, []byte(content), 0)
+	os.WriteFile(filename, []byte(content), 0)
 	callback(filename)
 }
 

--- a/pkg/collector/corechecks/snmp/internal/checkconfig/profile.go
+++ b/pkg/collector/corechecks/snmp/internal/checkconfig/profile.go
@@ -7,7 +7,7 @@ package checkconfig
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -78,7 +78,7 @@ func loadDefaultProfiles() (profileDefinitionMap, error) {
 
 func getDefaultProfilesDefinitionFiles() (profileConfigMap, error) {
 	profilesRoot := getProfileConfdRoot()
-	files, err := ioutil.ReadDir(profilesRoot)
+	files, err := os.ReadDir(profilesRoot)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read dir `%s`: %v", profilesRoot, err)
 	}
@@ -126,7 +126,7 @@ func loadProfiles(pConfig profileConfigMap) (profileDefinitionMap, error) {
 
 func readProfileDefinition(definitionFile string) (*profileDefinition, error) {
 	filePath := resolveProfileDefinitionPath(definitionFile)
-	buf, err := ioutil.ReadFile(filePath)
+	buf, err := os.ReadFile(filePath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read file `%s`: %s", filePath, err)
 	}

--- a/pkg/collector/corechecks/snmp/internal/session/session_test.go
+++ b/pkg/collector/corechecks/snmp/internal/session/session_test.go
@@ -9,7 +9,7 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	stdlog "log"
 	"testing"
 	"time"
@@ -282,7 +282,7 @@ func Test_snmpSession_Connect_Logger(t *testing.T) {
 	gosnmpSess := s.(*GosnmpSession)
 	require.NoError(t, err)
 
-	logger := gosnmp.NewLogger(stdlog.New(ioutil.Discard, "abc", 0))
+	logger := gosnmp.NewLogger(stdlog.New(io.Discard, "abc", 0))
 	gosnmpSess.gosnmpInst.Logger = logger
 	s.Connect()
 	assert.Equal(t, logger, gosnmpSess.gosnmpInst.Logger)
@@ -290,7 +290,7 @@ func Test_snmpSession_Connect_Logger(t *testing.T) {
 	s.Connect()
 	assert.Equal(t, logger, gosnmpSess.gosnmpInst.Logger)
 
-	logger2 := gosnmp.NewLogger(stdlog.New(ioutil.Discard, "123", 0))
+	logger2 := gosnmp.NewLogger(stdlog.New(io.Discard, "123", 0))
 	gosnmpSess.gosnmpInst.Logger = logger2
 	s.Connect()
 	assert.NotEqual(t, logger, gosnmpSess.gosnmpInst.Logger)

--- a/pkg/collector/corechecks/system/filehandles/file_handles.go
+++ b/pkg/collector/corechecks/system/filehandles/file_handles.go
@@ -9,7 +9,7 @@ package filehandles
 
 import (
 	"errors"
-	"io/ioutil"
+	"os"
 	"strconv"
 	"strings"
 
@@ -28,7 +28,7 @@ type fhCheck struct {
 }
 
 func (c *fhCheck) getFileNrValues(fn string) ([]string, error) {
-	dat, err := ioutil.ReadFile(fn)
+	dat, err := os.ReadFile(fn)
 	if err != nil {
 		log.Error(err.Error())
 		return nil, err

--- a/pkg/collector/corechecks/system/filehandles/file_handles_test.go
+++ b/pkg/collector/corechecks/system/filehandles/file_handles_test.go
@@ -8,7 +8,6 @@
 package filehandles
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -32,7 +31,7 @@ func writeSampleFile(f *os.File, content []byte) string {
 }
 
 func getFileNr() (f *os.File, err error) {
-	return ioutil.TempFile("", "file-nr")
+	return os.CreateTemp("", "file-nr")
 }
 
 func TestFhCheckLinux(t *testing.T) {

--- a/pkg/collector/python/util.go
+++ b/pkg/collector/python/util.go
@@ -17,7 +17,7 @@ import "C"
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os/exec"
 	"sync"
 	"syscall"
@@ -52,7 +52,7 @@ func GetSubprocessOutput(argv **C.char, env **C.char, cStdout **C.char, cStderr 
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		output, _ = ioutil.ReadAll(stdout)
+		output, _ = io.ReadAll(stdout)
 	}()
 
 	stderr, err := cmd.StderrPipe()
@@ -65,7 +65,7 @@ func GetSubprocessOutput(argv **C.char, env **C.char, cStdout **C.char, cStderr 
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		outputErr, _ = ioutil.ReadAll(stderr)
+		outputErr, _ = io.ReadAll(stderr)
 	}()
 
 	cmd.Start() //nolint:errcheck

--- a/pkg/config/legacy/docker.go
+++ b/pkg/config/legacy/docker.go
@@ -10,7 +10,6 @@ package legacy
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -126,7 +125,7 @@ func ImportDockerConf(src, dst string, overwrite bool, converter *config.LegacyC
 		return err
 	}
 
-	if err := ioutil.WriteFile(dst, data, 0640); err != nil {
+	if err := os.WriteFile(dst, data, 0640); err != nil {
 		return fmt.Errorf("Could not write new docker configuration to %s: %s", dst, err)
 	}
 

--- a/pkg/config/legacy/docker_test.go
+++ b/pkg/config/legacy/docker_test.go
@@ -11,7 +11,6 @@
 package legacy
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -87,14 +86,14 @@ func TestConvertDocker(t *testing.T) {
 	src := filepath.Join(dir, "docker_daemon.yaml")
 	dst := filepath.Join(dir, "docker.yaml")
 
-	err := ioutil.WriteFile(src, []byte(dockerDaemonLegacyConf), 0640)
+	err := os.WriteFile(src, []byte(dockerDaemonLegacyConf), 0640)
 	require.Nil(t, err)
 
 	configConverter := config.NewConfigConverter()
 	err = ImportDockerConf(src, dst, true, configConverter)
 	require.Nil(t, err)
 
-	newConf, err := ioutil.ReadFile(filepath.Join(dir, "docker.yaml"))
+	newConf, err := os.ReadFile(filepath.Join(dir, "docker.yaml"))
 	require.Nil(t, err)
 
 	assert.Equal(t, dockerNewConf, string(newConf))

--- a/pkg/config/legacy/importer_test.go
+++ b/pkg/config/legacy/importer_test.go
@@ -7,7 +7,7 @@ package legacy
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -20,7 +20,7 @@ func TestGetAgentConfig(t *testing.T) {
 	require.Nil(t, err)
 
 	pyConfig := map[string]string{}
-	data, err := ioutil.ReadFile("./tests/config.json")
+	data, err := os.ReadFile("./tests/config.json")
 	require.Nil(t, err)
 	err = json.Unmarshal(data, &pyConfig)
 	require.Nil(t, err)

--- a/pkg/config/legacy/kubernetes.go
+++ b/pkg/config/legacy/kubernetes.go
@@ -7,7 +7,6 @@ package legacy
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -135,7 +134,7 @@ func importKubernetesConfWithDeprec(src, dst string, overwrite bool, converter *
 	if err != nil {
 		return deprecations, err
 	}
-	if err := ioutil.WriteFile(dst, data, 0640); err != nil {
+	if err := os.WriteFile(dst, data, 0640); err != nil {
 		return deprecations, fmt.Errorf("Could not write new kubelet configuration to %s: %s", dst, err)
 	}
 	fmt.Printf("Successfully imported the contents of %s into %s\n", src, dst)

--- a/pkg/config/legacy/kubernetes_test.go
+++ b/pkg/config/legacy/kubernetes_test.go
@@ -6,7 +6,6 @@
 package legacy
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -114,9 +113,9 @@ func TestConvertKubernetes(t *testing.T) {
 	dst := filepath.Join(dir, "kubelet.yaml")
 	dstEmpty := filepath.Join(dir, "kubelet-empty.yaml")
 
-	err := ioutil.WriteFile(src, []byte(kubernetesLegacyConf), 0640)
+	err := os.WriteFile(src, []byte(kubernetesLegacyConf), 0640)
 	require.NoError(t, err)
-	err = ioutil.WriteFile(srcEmpty, []byte(kubernetesLegacyEmptyConf), 0640)
+	err = os.WriteFile(srcEmpty, []byte(kubernetesLegacyEmptyConf), 0640)
 	require.NoError(t, err)
 
 	configConverter := config.NewConfigConverter()
@@ -124,7 +123,7 @@ func TestConvertKubernetes(t *testing.T) {
 	require.NoError(t, err)
 	require.EqualValues(t, expectedKubeDeprecations, deprecations)
 
-	newConf, err := ioutil.ReadFile(dst)
+	newConf, err := os.ReadFile(dst)
 	require.NoError(t, err)
 	assert.Equal(t, kubeletNewConf, string(newConf))
 
@@ -149,7 +148,7 @@ func TestConvertKubernetes(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, true, config.Datadog.GetBool("kubelet_tls_verify"))
 	assert.Equal(t, 0, len(deprecations))
-	newEmptyConf, err := ioutil.ReadFile(dstEmpty)
+	newEmptyConf, err := os.ReadFile(dstEmpty)
 	require.NoError(t, err)
 	assert.Equal(t, kubeletNewEmptyConf, string(newEmptyConf))
 

--- a/pkg/config/remote/api/http.go
+++ b/pkg/config/remote/api/http.go
@@ -9,7 +9,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 
@@ -98,7 +98,7 @@ func (c *HTTPClient) Fetch(ctx context.Context, request *pbgo.LatestConfigsReque
 	defer resp.Body.Close()
 
 	if resp.StatusCode != 200 {
-		body, err = ioutil.ReadAll(resp.Body)
+		body, err = io.ReadAll(resp.Body)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read response: %w", err)
 		}
@@ -106,7 +106,7 @@ func (c *HTTPClient) Fetch(ctx context.Context, request *pbgo.LatestConfigsReque
 		return nil, fmt.Errorf("non-200 response code: %d", resp.StatusCode)
 	}
 
-	body, err = ioutil.ReadAll(resp.Body)
+	body, err = io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response: %w", err)
 	}
@@ -142,7 +142,7 @@ func (c *HTTPClient) FetchOrgData(ctx context.Context) (*pbgo.OrgDataResponse, e
 		return nil, fmt.Errorf("non-200 response code: %d", resp.StatusCode)
 	}
 
-	body, err = ioutil.ReadAll(resp.Body)
+	body, err = io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response body: %w", err)
 	}

--- a/pkg/config/remote/uptane/remote_store.go
+++ b/pkg/config/remote/uptane/remote_store.go
@@ -8,7 +8,6 @@ package uptane
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 
 	"github.com/theupdateframework/go-tuf/client"
 
@@ -80,7 +79,7 @@ func (s *remoteStore) GetMeta(path string) (io.ReadCloser, int64, error) {
 	if !versionFound {
 		return nil, 0, client.ErrNotFound{File: path}
 	}
-	return ioutil.NopCloser(bytes.NewReader(requestedVersion)), int64(len(requestedVersion)), nil
+	return io.NopCloser(bytes.NewReader(requestedVersion)), int64(len(requestedVersion)), nil
 }
 
 // GetMeta implements go-tuf's RemoteStore.GetTarget
@@ -93,7 +92,7 @@ func (s *remoteStore) GetTarget(targetPath string) (stream io.ReadCloser, size i
 	if !found {
 		return nil, 0, client.ErrNotFound{File: targetPath}
 	}
-	return ioutil.NopCloser(bytes.NewReader(target)), int64(len(target)), nil
+	return io.NopCloser(bytes.NewReader(target)), int64(len(target)), nil
 }
 
 type remoteStoreDirector struct {

--- a/pkg/config/remote/uptane/remote_store_test.go
+++ b/pkg/config/remote/uptane/remote_store_test.go
@@ -7,7 +7,7 @@ package uptane
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -222,7 +222,7 @@ func assertGetMeta(t *testing.T, store *remoteStore, path string, expectedConten
 	}
 	assert.NoError(t, err)
 	assert.Equal(t, int64(len(expectedContent)), size)
-	content, err := ioutil.ReadAll(stream)
+	content, err := io.ReadAll(stream)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedContent, content)
 }
@@ -235,7 +235,7 @@ func assertGetTarget(t *testing.T, store *remoteStore, path string, expectedCont
 	}
 	assert.NoError(t, err)
 	assert.Equal(t, int64(len(expectedContent)), size)
-	content, err := ioutil.ReadAll(stream)
+	content, err := io.ReadAll(stream)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedContent, content)
 }

--- a/pkg/dogstatsd/replay/reader_nix.go
+++ b/pkg/dogstatsd/replay/reader_nix.go
@@ -9,7 +9,6 @@
 package replay
 
 import (
-	"io/ioutil"
 	"os"
 
 	"golang.org/x/sys/unix"
@@ -21,7 +20,7 @@ import (
 func getFileContent(path string, mmap bool) ([]byte, error) {
 
 	if !mmap {
-		return ioutil.ReadFile(path)
+		return os.ReadFile(path)
 	}
 
 	f, err := os.Open(path)

--- a/pkg/dogstatsd/replay/reader_windows.go
+++ b/pkg/dogstatsd/replay/reader_windows.go
@@ -10,7 +10,6 @@ package replay
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"sync"
@@ -39,7 +38,7 @@ func (m *memoryMap) header() *reflect.SliceHeader {
 func getFileContent(path string, mmap bool) ([]byte, error) {
 
 	if !mmap {
-		return ioutil.ReadFile(path)
+		return os.ReadFile(path)
 	}
 
 	f, err := os.Open(path)

--- a/pkg/ebpf/cgo/genpost.go
+++ b/pkg/ebpf/cgo/genpost.go
@@ -7,7 +7,7 @@ package main
 
 import (
 	"go/format"
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 	"regexp"
@@ -15,7 +15,7 @@ import (
 )
 
 func main() {
-	b, err := ioutil.ReadAll(os.Stdin)
+	b, err := io.ReadAll(os.Stdin)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/ebpf/compiler/compiler.go
+++ b/pkg/ebpf/compiler/compiler.go
@@ -14,7 +14,6 @@ import (
 	_ "embed"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -47,7 +46,7 @@ func CompileToObjectFile(in io.Reader, outputFile string, cflags []string, heade
 		return fmt.Errorf("unable to get kernel arch for %s", runtime.GOARCH)
 	}
 
-	tmpIncludeDir, err := ioutil.TempDir(os.TempDir(), "include-")
+	tmpIncludeDir, err := os.MkdirTemp(os.TempDir(), "include-")
 	if err != nil {
 		return fmt.Errorf("error creating temporary include directory: %s", err.Error())
 	}

--- a/pkg/ebpf/compiler/compiler_test.go
+++ b/pkg/ebpf/compiler/compiler_test.go
@@ -10,7 +10,6 @@ package compiler
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -42,7 +41,7 @@ func TestCompilerMatch(t *testing.T) {
 		"-I../network/ebpf/c",
 		"-includeasm_goto_workaround.h",
 	}
-	tmpObjFile, err := ioutil.TempFile("", "offset-guess-static-*.o")
+	tmpObjFile, err := os.CreateTemp("", "offset-guess-static-*.o")
 	require.NoError(t, err)
 	defer os.Remove(tmpObjFile.Name())
 
@@ -50,7 +49,7 @@ func TestCompilerMatch(t *testing.T) {
 	err = CompileToObjectFile(input, onDiskObjFilename, cflags, nil)
 	require.NoError(t, err)
 
-	bs, err := ioutil.ReadFile(onDiskObjFilename)
+	bs, err := os.ReadFile(onDiskObjFilename)
 	require.NoError(t, err)
 
 	bundleFilename := "offset-guess.o"
@@ -58,7 +57,7 @@ func TestCompilerMatch(t *testing.T) {
 	require.NoError(t, err)
 	defer actualReader.Close()
 
-	actual, err := ioutil.ReadAll(actualReader)
+	actual, err := io.ReadAll(actualReader)
 	require.NoError(t, err)
 
 	assert.Equal(t, bs, actual, fmt.Sprintf("prebuilt file %s and statically-linked clang compiled content %s are different", bundleFilename, onDiskObjFilename))

--- a/pkg/ebpf/preprocess_test.go
+++ b/pkg/ebpf/preprocess_test.go
@@ -9,7 +9,7 @@
 package ebpf
 
 import (
-	"io/ioutil"
+	"os"
 	"path"
 	"testing"
 
@@ -42,11 +42,11 @@ struct test_struct {
 #endif /* defined(TEST_H) */
 `
 
-	if err := ioutil.WriteFile(path.Join(testBPFDir, "test-asset.c"), []byte(assetSource), 0644); err != nil {
+	if err := os.WriteFile(path.Join(testBPFDir, "test-asset.c"), []byte(assetSource), 0644); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := ioutil.WriteFile(path.Join(testBPFDir, "test-header.h"), []byte(assetHeader), 0644); err != nil {
+	if err := os.WriteFile(path.Join(testBPFDir, "test-header.h"), []byte(assetHeader), 0644); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/flare/archive_dca.go
+++ b/pkg/flare/archive_dca.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -140,7 +139,7 @@ func writeLocal(tempDir, hostname string) error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(f, []byte{}, os.ModePerm)
+	return os.WriteFile(f, []byte{}, os.ModePerm)
 }
 
 func zipDCAStatusFile(tempDir, hostname string) error {
@@ -166,7 +165,7 @@ func zipDCAStatusFile(tempDir, hostname string) error {
 		return err
 	}
 
-	err = ioutil.WriteFile(f, cleaned, os.ModePerm)
+	err = os.WriteFile(f, cleaned, os.ModePerm)
 	return err
 }
 
@@ -203,7 +202,7 @@ func zipMetadataMap(tempDir, hostname string) error {
 		return err
 	}
 
-	return ioutil.WriteFile(f, sByte, os.ModePerm)
+	return os.WriteFile(f, sByte, os.ModePerm)
 }
 
 func zipClusterAgentClusterChecks(tempDir, hostname string) error {
@@ -250,7 +249,7 @@ func zipHPAStatus(tempDir, hostname string) error {
 		return err
 	}
 
-	err = ioutil.WriteFile(f, sByte, os.ModePerm)
+	err = os.WriteFile(f, sByte, os.ModePerm)
 	if err != nil {
 		return err
 	}

--- a/pkg/flare/archive_linux_test.go
+++ b/pkg/flare/archive_linux_test.go
@@ -9,7 +9,6 @@
 package flare
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -35,7 +34,7 @@ func TestZipLinuxFileWrapper(t *testing.T) {
 	require.NoError(t, err)
 
 	targetPath := filepath.Join(dstDir, "hostname", "testfile.txt")
-	actualContent, err := ioutil.ReadFile(targetPath)
+	actualContent, err := os.ReadFile(targetPath)
 	require.NoError(t, err)
 	require.Equal(t, expectedContent, string(actualContent))
 }

--- a/pkg/flare/archive_nix_test.go
+++ b/pkg/flare/archive_nix_test.go
@@ -10,7 +10,6 @@ package flare
 
 import (
 	"archive/zip"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -56,10 +55,10 @@ func TestAddPermsInfo(t *testing.T) {
 	permsInfos := make(permissionsInfos)
 
 	// create two files for which we'll add infos into the permissions.log
-	f1, err := ioutil.TempFile("", "ddtests*")
+	f1, err := os.CreateTemp("", "ddtests*")
 	assert.NoError(err, "creating a temporary file should not fail")
 	assert.NotNil(f1, "temporary file should not be nil")
-	f2, err := ioutil.TempFile("", "ddtests*")
+	f2, err := os.CreateTemp("", "ddtests*")
 	assert.NoError(err, "creating a temporary file should not fail")
 	assert.NotNil(f2, "temporary file should not be nil")
 
@@ -73,7 +72,7 @@ func TestAddPermsInfo(t *testing.T) {
 
 	// should have created a permissions.log in the tmp dir
 	// + added headers and info of the previously created files
-	data, err := ioutil.ReadFile(permsFilePath)
+	data, err := os.ReadFile(permsFilePath)
 	assert.NoError(err, "should be able to read the temporary permissions file")
 	assert.Equal(4, strings.Count(string(data), "\n"), "the permissions file should contain 2 lines of headers, 2 lines of entries")
 

--- a/pkg/flare/archive_security.go
+++ b/pkg/flare/archive_security.go
@@ -7,7 +7,6 @@ package flare
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -152,7 +151,7 @@ func zipSecurityAgentStatusFile(tempDir, hostname string, runtimeStatus, complia
 		return err
 	}
 
-	err = ioutil.WriteFile(f, cleaned, os.ModePerm)
+	err = os.WriteFile(f, cleaned, os.ModePerm)
 	return err
 }
 

--- a/pkg/flare/archive_test.go
+++ b/pkg/flare/archive_test.go
@@ -9,7 +9,7 @@ import (
 	"archive/zip"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -141,7 +141,7 @@ func TestCreateArchiveAndGoRoutines(t *testing.T) {
 			}
 			defer dump.Close()
 
-			routines, err := ioutil.ReadAll(dump)
+			routines, err := io.ReadAll(dump)
 			if err != nil {
 				assert.Fail(t, "Unable to read go-routine dump")
 			}
@@ -190,7 +190,7 @@ func TestZipConfigCheck(t *testing.T) {
 	dir := t.TempDir()
 
 	zipConfigCheck(dir, "")
-	content, err := ioutil.ReadFile(filepath.Join(dir, "config-check.log"))
+	content, err := os.ReadFile(filepath.Join(dir, "config-check.log"))
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -346,7 +346,7 @@ func TestZipRegistryJSON(t *testing.T) {
 	require.NoError(t, err)
 
 	targetPath := filepath.Join(dstDir, "test", "registry.json")
-	actualContent, err := ioutil.ReadFile(targetPath)
+	actualContent, err := os.ReadFile(targetPath)
 	require.NoError(t, err)
 	require.Equal(t, "mockfilecontent", string(actualContent))
 }
@@ -372,7 +372,7 @@ func TestZipTaggerList(t *testing.T) {
 
 	taggerListURL = s.URL
 	zipAgentTaggerList(dir, "")
-	content, err := ioutil.ReadFile(filepath.Join(dir, "tagger-list.json"))
+	content, err := os.ReadFile(filepath.Join(dir, "tagger-list.json"))
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -405,7 +405,7 @@ func TestZipWorkloadList(t *testing.T) {
 
 	workloadListURL = s.URL
 	zipWorkloadList(dir, "")
-	content, err := ioutil.ReadFile(filepath.Join(dir, "workload-list.log"))
+	content, err := os.ReadFile(filepath.Join(dir, "workload-list.log"))
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -477,7 +477,7 @@ instances:
 	err := writeScrubbedFile(filename, []byte(clear))
 	require.NoError(t, err)
 
-	got, err := ioutil.ReadFile(filename)
+	got, err := os.ReadFile(filename)
 	require.NoError(t, err)
 	assert.Equal(t, redacted, string(got))
 }
@@ -490,7 +490,7 @@ func TestZipFile(t *testing.T) {
 	require.NoError(t, err)
 
 	targetPath := filepath.Join(dstDir, "test.json")
-	actualContent, err := ioutil.ReadFile(targetPath)
+	actualContent, err := os.ReadFile(targetPath)
 	require.NoError(t, err)
 	require.Equal(t, "mockfilecontent", string(actualContent))
 }
@@ -507,7 +507,7 @@ func TestZipVersionHistory(t *testing.T) {
 	require.NoError(t, err)
 
 	targetPath := filepath.Join(dstDir, "test", "version-history.json")
-	actualContent, err := ioutil.ReadFile(targetPath)
+	actualContent, err := os.ReadFile(targetPath)
 	require.NoError(t, err)
 	require.Equal(t, "mockfilecontent", string(actualContent))
 }
@@ -538,7 +538,7 @@ process_config:
 		dir := t.TempDir()
 
 		zipProcessAgentFullConfig(dir, "")
-		content, err := ioutil.ReadFile(filepath.Join(dir, "process_agent_runtime_config_dump.yaml"))
+		content, err := os.ReadFile(filepath.Join(dir, "process_agent_runtime_config_dump.yaml"))
 		require.NoError(t, err)
 		assert.Equal(t, "error: process-agent is not running or is unreachable", string(content))
 	})
@@ -560,7 +560,7 @@ process_config:
 
 		procStatusURL = srv.URL
 		zipProcessAgentFullConfig(dir, "")
-		content, err := ioutil.ReadFile(filepath.Join(dir, "process_agent_runtime_config_dump.yaml"))
+		content, err := os.ReadFile(filepath.Join(dir, "process_agent_runtime_config_dump.yaml"))
 		require.NoError(t, err)
 		assert.Equal(t, exp, string(content))
 	})
@@ -610,7 +610,7 @@ func TestZipProcessAgentChecks(t *testing.T) {
 		err = zipProcessChecks(dir, "", func() (string, error) { return "fake:1337", nil })
 		require.NoError(t, err)
 
-		content, err := ioutil.ReadFile(filepath.Join(dir, "process_check_output.json"))
+		content, err := os.ReadFile(filepath.Join(dir, "process_check_output.json"))
 		require.NoError(t, err)
 		assert.True(t, strings.HasPrefix(string(content), "error: process-agent is not running or is unreachable"))
 	})
@@ -643,15 +643,15 @@ func TestZipProcessAgentChecks(t *testing.T) {
 		err = zipProcessChecks(dir, "", func() (string, error) { return strings.TrimPrefix(srv.URL, "http://"), nil })
 		require.NoError(t, err)
 
-		content, err := ioutil.ReadFile(filepath.Join(dir, "process_check_output.json"))
+		content, err := os.ReadFile(filepath.Join(dir, "process_check_output.json"))
 		require.NoError(t, err)
 		assert.Equal(t, expectedProcessesJSON, content)
 
-		content, err = ioutil.ReadFile(filepath.Join(dir, "container_check_output.json"))
+		content, err = os.ReadFile(filepath.Join(dir, "container_check_output.json"))
 		require.NoError(t, err)
 		assert.Equal(t, expectedContainersJSON, content)
 
-		content, err = ioutil.ReadFile(filepath.Join(dir, "process_discovery_check_output.json"))
+		content, err = os.ReadFile(filepath.Join(dir, "process_discovery_check_output.json"))
 		require.NoError(t, err)
 		assert.Equal(t, expectedProcessDiscoveryJSON, content)
 	})

--- a/pkg/flare/archive_win.go
+++ b/pkg/flare/archive_win.go
@@ -12,7 +12,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -114,7 +113,7 @@ func zipTypeperfData(tempDir, hostname string) error {
 		return err
 	}
 
-	err = ioutil.WriteFile(f, out.Bytes(), os.ModePerm)
+	err = os.WriteFile(f, out.Bytes(), os.ModePerm)
 	if err != nil {
 		return err
 	}
@@ -142,7 +141,7 @@ func zipLodctrOutput(tempDir, hostname string) error {
 		return err
 	}
 
-	err = ioutil.WriteFile(f, out.Bytes(), os.ModePerm)
+	err = os.WriteFile(f, out.Bytes(), os.ModePerm)
 	if err != nil {
 		log.Warnf("Error writing file %v", err)
 		return err
@@ -296,7 +295,7 @@ func zipDatadogRegistry(tempDir, hostname string) error {
 	defer os.Remove(rawf)
 
 	// Read raw registry file in memory ...
-	data, err := ioutil.ReadFile(rawf)
+	data, err := os.ReadFile(rawf)
 	if err != nil {
 		return err
 	}

--- a/pkg/flare/dca_telemetry.go
+++ b/pkg/flare/dca_telemetry.go
@@ -7,7 +7,7 @@ package flare
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
@@ -20,5 +20,5 @@ func QueryDCAMetrics() ([]byte, error) {
 		return nil, err
 	}
 	defer r.Body.Close()
-	return ioutil.ReadAll(r.Body)
+	return io.ReadAll(r.Body)
 }

--- a/pkg/flare/flare.go
+++ b/pkg/flare/flare.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"mime/multipart"
 	"net/http"
 	"os"
@@ -182,7 +181,7 @@ func analyzeResponse(r *http.Response, err error) (string, error) {
 	}
 
 	var res flareResponse
-	b, _ := ioutil.ReadAll(r.Body)
+	b, _ := io.ReadAll(r.Body)
 	if r.StatusCode != http.StatusOK {
 		err = fmt.Errorf("HTTP %d %s", r.StatusCode, r.Status)
 	} else if contentType := r.Header.Get("Content-Type"); !strings.HasPrefix(contentType, "application/json") {

--- a/pkg/flare/flare_test.go
+++ b/pkg/flare/flare_test.go
@@ -9,7 +9,6 @@ import (
 	"bytes"
 	"errors"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -95,7 +94,7 @@ func TestAnalyzeResponse(t *testing.T) {
 		r := &http.Response{
 			StatusCode: 200,
 			Header:     http.Header{"Content-Type": []string{"application/json; charset=UTF-8"}},
-			Body:       ioutil.NopCloser(bytes.NewBuffer([]byte("{\"case_id\": 1234}"))),
+			Body:       io.NopCloser(bytes.NewBuffer([]byte("{\"case_id\": 1234}"))),
 		}
 		resstr, reserr := analyzeResponse(r, nil)
 		require.NoError(t, reserr)
@@ -108,7 +107,7 @@ func TestAnalyzeResponse(t *testing.T) {
 		r := &http.Response{
 			StatusCode: 200,
 			Header:     http.Header{"Content-Type": []string{"application/json; charset=UTF-8"}},
-			Body:       ioutil.NopCloser(bytes.NewBuffer([]byte("{\"case_id\": 1234, \"error\": \"uhoh\"}"))),
+			Body:       io.NopCloser(bytes.NewBuffer([]byte("{\"case_id\": 1234, \"error\": \"uhoh\"}"))),
 		}
 		resstr, reserr := analyzeResponse(r, nil)
 		require.Equal(t, errors.New("uhoh"), reserr)
@@ -121,7 +120,7 @@ func TestAnalyzeResponse(t *testing.T) {
 		r := &http.Response{
 			StatusCode: 200,
 			Header:     http.Header{"Content-Type": []string{"application/json; charset=UTF-8"}},
-			Body:       ioutil.NopCloser(bytes.NewBuffer([]byte("thats-not-json"))),
+			Body:       io.NopCloser(bytes.NewBuffer([]byte("thats-not-json"))),
 		}
 		resstr, reserr := analyzeResponse(r, nil)
 		require.Equal(t,
@@ -142,7 +141,7 @@ func TestAnalyzeResponse(t *testing.T) {
 		r := &http.Response{
 			StatusCode: 200,
 			Header:     http.Header{"Content-Type": []string{"application/json"}},
-			Body:       ioutil.NopCloser(bytes.NewBuffer([]byte(resp))),
+			Body:       io.NopCloser(bytes.NewBuffer([]byte(resp))),
 		}
 		resstr, reserr := analyzeResponse(r, nil)
 		require.Equal(t,
@@ -158,7 +157,7 @@ func TestAnalyzeResponse(t *testing.T) {
 	t.Run("no-content-type", func(t *testing.T) {
 		r := &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewBuffer([]byte("{\"json\": true}"))),
+			Body:       io.NopCloser(bytes.NewBuffer([]byte("{\"json\": true}"))),
 		}
 		resstr, reserr := analyzeResponse(r, nil)
 		require.Equal(t,
@@ -175,7 +174,7 @@ func TestAnalyzeResponse(t *testing.T) {
 		r := &http.Response{
 			StatusCode: 200,
 			Header:     http.Header{"Content-Type": []string{"text/plain"}},
-			Body:       ioutil.NopCloser(bytes.NewBuffer([]byte("{\"json\": true}"))),
+			Body:       io.NopCloser(bytes.NewBuffer([]byte("{\"json\": true}"))),
 		}
 		resstr, reserr := analyzeResponse(r, nil)
 		require.Equal(t,
@@ -192,7 +191,7 @@ func TestAnalyzeResponse(t *testing.T) {
 		r := &http.Response{
 			StatusCode: 502,
 			Status:     "Bad Gateway",
-			Body:       ioutil.NopCloser(bytes.NewBuffer([]byte("<html>.."))),
+			Body:       io.NopCloser(bytes.NewBuffer([]byte("<html>.."))),
 		}
 		resstr, reserr := analyzeResponse(r, nil)
 		require.Equal(t,

--- a/pkg/forwarder/forwarder_test.go
+++ b/pkg/forwarder/forwarder_test.go
@@ -7,7 +7,7 @@ package forwarder
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -614,7 +614,7 @@ func TestHighPriorityTransaction(t *testing.T) {
 		mutex.Lock()
 		defer mutex.Unlock()
 		defer r.Body.Close()
-		body, err := ioutil.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
 		assert.NoError(t, err)
 		bodyStr := string(body)
 

--- a/pkg/forwarder/internal/retry/file_removal_policy.go
+++ b/pkg/forwarder/internal/retry/file_removal_policy.go
@@ -9,7 +9,6 @@ import (
 	"crypto/md5"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -89,14 +88,14 @@ func (p *FileRemovalPolicy) RemoveUnknownDomains() ([]string, error) {
 }
 
 func (p *FileRemovalPolicy) forEachDomainPath(callback func(folderPath string) ([]string, error)) ([]string, error) {
-	entries, err := ioutil.ReadDir(p.rootPath)
+	entries, err := os.ReadDir(p.rootPath)
 	if err != nil {
 		return nil, err
 	}
 
 	var paths []string
 	for _, domain := range entries {
-		if domain.Mode().IsDir() {
+		if domain.IsDir() {
 			folderPath := path.Join(p.rootPath, domain.Name())
 			files, err := callback(folderPath)
 
@@ -159,13 +158,13 @@ func (p *FileRemovalPolicy) removeRetryFiles(folderPath string, shouldRemove fun
 }
 
 func (p *FileRemovalPolicy) getRetryFiles(folder string) ([]string, error) {
-	entries, err := ioutil.ReadDir(folder)
+	entries, err := os.ReadDir(folder)
 	if err != nil {
 		return nil, err
 	}
 	var files []string
 	for _, entry := range entries {
-		if entry.Mode().IsRegular() && filepath.Ext(entry.Name()) == retryTransactionsExtension {
+		if entry.Type().IsRegular() && filepath.Ext(entry.Name()) == retryTransactionsExtension {
 			files = append(files, path.Join(folder, entry.Name()))
 		}
 	}

--- a/pkg/forwarder/internal/retry/file_removal_policy_test.go
+++ b/pkg/forwarder/internal/retry/file_removal_policy_test.go
@@ -6,7 +6,6 @@
 package retry
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -83,7 +82,7 @@ func createRetryFile(a *assert.Assertions, root string, filename string) string 
 func createFile(a *assert.Assertions, root string, filename string) string {
 	a.NoError(os.MkdirAll(root, 0755))
 	fullPath := path.Join(root, filename)
-	a.NoError(ioutil.WriteFile(fullPath, []byte{1, 2, 3}, 0644))
+	a.NoError(os.WriteFile(fullPath, []byte{1, 2, 3}, 0644))
 	return fullPath
 }
 

--- a/pkg/forwarder/internal/retry/on_disk_retry_queue.go
+++ b/pkg/forwarder/internal/retry/on_disk_retry_queue.go
@@ -237,6 +237,7 @@ func (s *onDiskRetryQueue) getExistingRetryFiles() ([]os.FileInfo, int64, error)
 	for _, entry := range entries {
 		info, err := entry.Info()
 		if err != nil {
+			log.Warn("Can't get file info", err)
 			continue
 		}
 

--- a/pkg/logs/auditor/auditor.go
+++ b/pkg/logs/auditor/auditor.go
@@ -8,7 +8,6 @@ package auditor
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sync"
@@ -194,7 +193,7 @@ func (a *RegistryAuditor) run() {
 
 // recoverRegistry rebuilds the registry from the state file found at path
 func (a *RegistryAuditor) recoverRegistry() map[string]*RegistryEntry {
-	mr, err := ioutil.ReadFile(a.registryPath)
+	mr, err := os.ReadFile(a.registryPath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			log.Debugf("Could not find state file at %q, will start with default offsets", a.registryPath)
@@ -268,7 +267,7 @@ func (a *RegistryAuditor) flushRegistry() error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(a.registryPath, mr, 0644)
+	return os.WriteFile(a.registryPath, mr, 0644)
 }
 
 // marshalRegistry marshals a registry

--- a/pkg/logs/auditor/auditor_test.go
+++ b/pkg/logs/auditor/auditor_test.go
@@ -7,7 +7,6 @@ package auditor
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -77,7 +76,7 @@ func (suite *AuditorTestSuite) TestAuditorFlushesAndRecoversRegistry() {
 		TailingMode: "end",
 	}
 	suite.a.flushRegistry()
-	r, err := ioutil.ReadFile(suite.testPath)
+	r, err := os.ReadFile(suite.testPath)
 	suite.Nil(err)
 	suite.Equal("{\"Version\":2,\"Registry\":{\"testpath\":{\"LastUpdated\":\"2006-01-12T01:01:01.000000001Z\",\"Offset\":\"42\",\"TailingMode\":\"end\",\"IngestionTimestamp\":0}}}", string(r))
 

--- a/pkg/logs/client/http/destination.go
+++ b/pkg/logs/client/http/destination.go
@@ -11,7 +11,7 @@ import (
 	"errors"
 	"expvar"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"sync"
@@ -291,7 +291,7 @@ func (d *Destination) unconditionalSend(payload *message.Payload) (err error) {
 	}
 
 	defer resp.Body.Close()
-	response, err := ioutil.ReadAll(resp.Body)
+	response, err := io.ReadAll(resp.Body)
 	if err != nil {
 		// the read failed because the server closed or terminated the connection
 		// *after* serving the request.

--- a/pkg/logs/client/mock/mock.go
+++ b/pkg/logs/client/mock/mock.go
@@ -6,7 +6,7 @@
 package mock
 
 import (
-	"io/ioutil"
+	"io"
 	"net"
 	"testing"
 )
@@ -28,7 +28,7 @@ func NewMockLogsIntake(t *testing.T) net.Listener {
 		defer conn.Close()
 
 		for {
-			_, err := ioutil.ReadAll(conn)
+			_, err := io.ReadAll(conn)
 			if err != nil {
 				break
 			}

--- a/pkg/logs/internal/launchers/container/tailerfactory/file_test.go
+++ b/pkg/logs/internal/launchers/container/tailerfactory/file_test.go
@@ -9,7 +9,6 @@
 package tailerfactory
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -80,7 +79,7 @@ func TestMakeFileSource_docker_success(t *testing.T) {
 
 	p := filepath.Join(platformDockerLogsBasePath, filepath.FromSlash("containers/abc/abc-json.log"))
 	require.NoError(t, os.MkdirAll(filepath.Dir(p), 0o777))
-	require.NoError(t, ioutil.WriteFile(p, []byte("{}"), 0o666))
+	require.NoError(t, os.WriteFile(p, []byte("{}"), 0o666))
 
 	tf := &factory{
 		pipelineProvider: pipeline.NewMockProvider(),
@@ -139,7 +138,7 @@ func TestDockerOverride(t *testing.T) {
 
 	p := filepath.Join(mockConfig.GetString("logs_config.docker_path_override"), filepath.FromSlash("containers/abc/abc-json.log"))
 	require.NoError(t, os.MkdirAll(filepath.Dir(p), 0o777))
-	require.NoError(t, ioutil.WriteFile(p, []byte("{}"), 0o666))
+	require.NoError(t, os.WriteFile(p, []byte("{}"), 0o666))
 
 	tf := &factory{
 		pipelineProvider: pipeline.NewMockProvider(),
@@ -167,7 +166,7 @@ func TestMakeK8sSource(t *testing.T) {
 	dir := filepath.Join(podLogsBasePath, filepath.FromSlash("podns_podname_poduuid/cname"))
 	require.NoError(t, os.MkdirAll(dir, 0o777))
 	filename := filepath.Join(dir, "somefile.log")
-	require.NoError(t, ioutil.WriteFile(filename, []byte("{}"), 0o666))
+	require.NoError(t, os.WriteFile(filename, []byte("{}"), 0o666))
 	wildcard := filepath.Join(dir, "*.log")
 
 	store := workloadmeta.NewMockStore()
@@ -211,7 +210,7 @@ func TestMakeK8sSource_pod_not_found(t *testing.T) {
 
 	p := filepath.Join(platformDockerLogsBasePath, "containers/abc/abc-json.log")
 	require.NoError(t, os.MkdirAll(filepath.Dir(p), 0o777))
-	require.NoError(t, ioutil.WriteFile(p, []byte("{}"), 0o666))
+	require.NoError(t, os.WriteFile(p, []byte("{}"), 0o666))
 
 	tf := &factory{
 		pipelineProvider:  pipeline.NewMockProvider(),
@@ -243,7 +242,7 @@ func TestFindK8sLogPath(t *testing.T) {
 			expectedPattern := filepath.FromSlash(test.expectedPattern)
 			p := filepath.Join(podLogsBasePath, pathExists)
 			require.NoError(t, os.MkdirAll(filepath.Dir(p), 0o777))
-			require.NoError(t, ioutil.WriteFile(p, []byte("xx"), 0o666))
+			require.NoError(t, os.WriteFile(p, []byte("xx"), 0o666))
 			defer func() {
 				require.NoError(t, os.RemoveAll(podLogsBasePath))
 			}()

--- a/pkg/logs/internal/launchers/docker/launcher_windows.go
+++ b/pkg/logs/internal/launchers/docker/launcher_windows.go
@@ -10,7 +10,7 @@ package docker
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 )
 
@@ -20,7 +20,7 @@ const (
 
 func checkReadAccess() error {
 	// We need read access to the docker folder
-	_, err := ioutil.ReadDir(basePath)
+	_, err := os.ReadDir(basePath)
 	return err
 }
 

--- a/pkg/metadata/host/host.go
+++ b/pkg/metadata/host/host.go
@@ -32,8 +32,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/ec2"
 	httputils "github.com/DataDog/datadog-agent/pkg/util/http"
 
-	"io/ioutil"
-
 	yaml "gopkg.in/yaml.v2"
 )
 
@@ -257,7 +255,7 @@ func getInstallInfoPath() string {
 }
 
 func getInstallInfo(infoPath string) (*installInfo, error) {
-	yamlContent, err := ioutil.ReadFile(infoPath)
+	yamlContent, err := os.ReadFile(infoPath)
 
 	if err != nil {
 		return nil, err

--- a/pkg/metadata/host/host_test.go
+++ b/pkg/metadata/host/host_test.go
@@ -10,7 +10,7 @@ package host
 
 import (
 	"context"
-	"io/ioutil"
+	"os"
 	"path"
 	"testing"
 	"time"
@@ -151,7 +151,7 @@ install_method:
   tool: chef
   installer_version: datadog-cookbook-4.2.1
 `
-	assert.Nil(t, ioutil.WriteFile(installInfoPath, []byte(installInfoContent), 0666))
+	assert.Nil(t, os.WriteFile(installInfoPath, []byte(installInfoContent), 0666))
 
 	// the install is considered coming from chef (example)
 	installMethod = getInstallMethod(installInfoPath)
@@ -168,7 +168,7 @@ install_methodlol:
   name: chef-15
   version: datadog-cookbook-4.2.1
 `
-	assert.Nil(t, ioutil.WriteFile(installInfoPath, []byte(installInfoContent), 0666))
+	assert.Nil(t, os.WriteFile(installInfoPath, []byte(installInfoContent), 0666))
 
 	// the parsing does not occur and the install is kept undefined
 	installMethod = getInstallMethod(installInfoPath)

--- a/pkg/network/config/sysctl/sysctl.go
+++ b/pkg/network/config/sysctl/sysctl.go
@@ -9,7 +9,7 @@
 package sysctl
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -94,7 +94,7 @@ func (s *sctl) get(now time.Time) (string, bool, error) {
 		return "", false, nil
 	}
 
-	content, err := ioutil.ReadFile(s.path)
+	content, err := os.ReadFile(s.path)
 	if err != nil {
 		return "", false, err
 	}

--- a/pkg/network/config/sysctl/sysctl_test.go
+++ b/pkg/network/config/sysctl/sysctl_test.go
@@ -9,7 +9,6 @@
 package sysctl
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -101,5 +100,5 @@ func createTmpProcSys(t *testing.T) (procRoot string) {
 }
 
 func createTmpSysctl(t *testing.T, procRoot, sysctl string, v string) {
-	require.NoError(t, ioutil.WriteFile(filepath.Join(procRoot, "sys", sysctl), []byte(v), 0777))
+	require.NoError(t, os.WriteFile(filepath.Join(procRoot, "sys", sysctl), []byte(v), 0777))
 }

--- a/pkg/network/netlink/conntracker_integration_test.go
+++ b/pkg/network/netlink/conntracker_integration_test.go
@@ -11,7 +11,6 @@ package netlink
 import (
 	"encoding/binary"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"testing"
@@ -80,7 +79,7 @@ func TestMessageDump(t *testing.T) {
 
 	testutil.SetupDNAT(t)
 
-	f, err := ioutil.TempFile("", "message_dump")
+	f, err := os.CreateTemp("", "message_dump")
 	require.NoError(t, err)
 	defer os.Remove(f.Name())
 	defer f.Close()
@@ -93,7 +92,7 @@ func TestMessageDump6(t *testing.T) {
 
 	testutil.SetupDNAT6(t)
 
-	f, err := ioutil.TempFile("", "message_dump6")
+	f, err := os.CreateTemp("", "message_dump6")
 	require.NoError(t, err)
 	defer os.Remove(f.Name())
 	defer f.Close()

--- a/pkg/network/netlink/decoding_test.go
+++ b/pkg/network/netlink/decoding_test.go
@@ -12,7 +12,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/netip"
 	"os"
 	"testing"
@@ -84,7 +83,7 @@ func BenchmarkDecodeMultipleMessages(b *testing.B) {
 }
 
 func loadDumpData() ([]netlink.Message, error) {
-	f, err := ioutil.TempFile("", "message_dump")
+	f, err := os.CreateTemp("", "message_dump")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/network/proc_net_test.go
+++ b/pkg/network/proc_net_test.go
@@ -9,7 +9,6 @@
 package network
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -54,7 +53,7 @@ func TestReadProcNet(t *testing.T) {
 }
 
 func writeTestFile(content string) (f *os.File, err error) {
-	tmpfile, err := ioutil.TempFile("", "test-proc-net")
+	tmpfile, err := os.CreateTemp("", "test-proc-net")
 
 	if err != nil {
 		return nil, err

--- a/pkg/network/protocols/http/testutil/pythonserver.go
+++ b/pkg/network/protocols/http/testutil/pythonserver.go
@@ -8,8 +8,6 @@ package testutil
 import (
 	"context"
 	"fmt"
-	"github.com/stretchr/testify/require"
-	"io/ioutil"
 	"net"
 	"os"
 	"os/exec"
@@ -17,6 +15,8 @@ import (
 	"strconv"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -82,7 +82,7 @@ func HTTPPythonServer(t *testing.T, addr string, options Options) (func(), error
 }
 
 func writeTempFile(pattern string, content string) (*os.File, error) {
-	f, err := ioutil.TempFile("", pattern)
+	f, err := os.CreateTemp("", pattern)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/network/tracer/offsetguess.go
+++ b/pkg/network/tracer/offsetguess.go
@@ -12,7 +12,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"net"
 	"os"
@@ -934,7 +933,7 @@ func acceptHandler(l net.Listener) {
 			return
 		}
 
-		_, _ = io.Copy(ioutil.Discard, conn)
+		_, _ = io.Copy(io.Discard, conn)
 		if tcpc, ok := conn.(*net.TCPConn); ok {
 			_ = tcpc.SetLinger(0)
 		}

--- a/pkg/network/tracer/tracer_classification_test.go
+++ b/pkg/network/tracer/tracer_classification_test.go
@@ -13,7 +13,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	nethttp "net/http"
 	"testing"
@@ -119,7 +118,7 @@ func testProtocolClassification(t *testing.T, cfg *config.Config, clientHost, ta
 				}
 				resp, err := client.Get("http://" + serverAddr + "/test")
 				require.NoError(t, err)
-				io.Copy(ioutil.Discard, resp.Body)
+				io.Copy(io.Discard, resp.Body)
 				resp.Body.Close()
 			},
 			serverRun: func(t *testing.T, serverAddr string, done chan struct{}) string {
@@ -129,7 +128,7 @@ func testProtocolClassification(t *testing.T, cfg *config.Config, clientHost, ta
 				srv := &nethttp.Server{
 					Addr: ln.Addr().String(),
 					Handler: nethttp.HandlerFunc(func(w nethttp.ResponseWriter, req *nethttp.Request) {
-						io.Copy(ioutil.Discard, req.Body)
+						io.Copy(io.Discard, req.Body)
 						w.WriteHeader(200)
 					}),
 					ReadTimeout:  time.Second,

--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -13,7 +13,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"math/rand"
 	"net"
@@ -188,7 +187,7 @@ func TestTCPRetransmitSharedSocket(t *testing.T) {
 
 	// Create TCP Server that simply "drains" connection until receiving an EOF
 	server := NewTCPServer(func(c net.Conn) {
-		io.Copy(ioutil.Discard, c)
+		io.Copy(io.Discard, c)
 		c.Close()
 	})
 	doneChan := make(chan struct{})
@@ -253,7 +252,7 @@ func TestTCPRTT(t *testing.T) {
 
 	// Create TCP Server that simply "drains" connection until receiving an EOF
 	server := NewTCPServer(func(c net.Conn) {
-		io.Copy(ioutil.Discard, c)
+		io.Copy(io.Discard, c)
 		c.Close()
 	})
 	doneChan := make(chan struct{})
@@ -355,7 +354,7 @@ func TestConnectionExpirationRegression(t *testing.T) {
 	// Create TCP Server that simply "drains" connection until receiving an EOF
 	connClosed := make(chan struct{})
 	server := NewTCPServer(func(c net.Conn) {
-		io.Copy(ioutil.Discard, c)
+		io.Copy(io.Discard, c)
 		c.Close()
 		connClosed <- struct{}{}
 	})
@@ -416,7 +415,7 @@ func TestConntrackExpiration(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
 	port := 5430 + rand.Intn(100)
 	server := NewTCPServerOnAddress(fmt.Sprintf("1.1.1.1:%d", port), func(c net.Conn) {
-		io.Copy(ioutil.Discard, c)
+		io.Copy(io.Discard, c)
 		c.Close()
 	})
 	doneChan := make(chan struct{})
@@ -475,7 +474,7 @@ func TestConntrackDelays(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
 	port := 5430 + rand.Intn(100)
 	server := NewTCPServerOnAddress(fmt.Sprintf("1.1.1.1:%d", port), func(c net.Conn) {
-		io.Copy(ioutil.Discard, c)
+		io.Copy(io.Discard, c)
 		c.Close()
 	})
 	doneChan := make(chan struct{})
@@ -512,7 +511,7 @@ func TestTranslationBindingRegression(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
 	port := 5430 + rand.Intn(100)
 	server := NewTCPServerOnAddress(fmt.Sprintf("1.1.1.1:%d", port), func(c net.Conn) {
-		io.Copy(ioutil.Discard, c)
+		io.Copy(io.Discard, c)
 		c.Close()
 	})
 	doneChan := make(chan struct{})
@@ -1450,7 +1449,7 @@ func TestSendfileRegression(t *testing.T) {
 	defer tr.Stop()
 
 	// Create temporary file
-	tmpfile, err := ioutil.TempFile("", "sendfile_source")
+	tmpfile, err := os.CreateTemp("", "sendfile_source")
 	require.NoError(t, err)
 	defer os.Remove(tmpfile.Name())
 	n, err := tmpfile.Write(genPayload(clientMessageSize))
@@ -1462,7 +1461,7 @@ func TestSendfileRegression(t *testing.T) {
 	// Start TCP server
 	var rcvd int64
 	server := NewTCPServer(func(c net.Conn) {
-		rcvd, _ = io.Copy(ioutil.Discard, c)
+		rcvd, _ = io.Copy(io.Discard, c)
 		c.Close()
 	})
 	doneChan := make(chan struct{})
@@ -1511,7 +1510,7 @@ func TestSendfileError(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(tr.Stop)
 
-	tmpfile, err := ioutil.TempFile("", "sendfile_source")
+	tmpfile, err := os.CreateTemp("", "sendfile_source")
 	require.NoError(t, err)
 	t.Cleanup(func() { os.Remove(tmpfile.Name()) })
 
@@ -1522,7 +1521,7 @@ func TestSendfileError(t *testing.T) {
 	require.NoError(t, err)
 
 	server := NewTCPServer(func(c net.Conn) {
-		_, _ = io.Copy(ioutil.Discard, c)
+		_, _ = io.Copy(io.Discard, c)
 		c.Close()
 	})
 	doneChan := make(chan struct{})

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -15,7 +15,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"net"
 	nethttp "net/http"
@@ -1208,7 +1207,7 @@ func TestTCPEstablished(t *testing.T) {
 	initTracerState(t, tr)
 
 	server := NewTCPServer(func(c net.Conn) {
-		io.Copy(ioutil.Discard, c)
+		io.Copy(io.Discard, c)
 		c.Close()
 	})
 	doneChan := make(chan struct{})
@@ -1242,7 +1241,7 @@ func TestTCPEstablished(t *testing.T) {
 
 func TestTCPEstablishedPreExistingConn(t *testing.T) {
 	server := NewTCPServer(func(c net.Conn) {
-		io.Copy(ioutil.Discard, c)
+		io.Copy(io.Discard, c)
 		c.Close()
 	})
 	doneChan := make(chan struct{})
@@ -1472,7 +1471,7 @@ func TestTCPDirection(t *testing.T) {
 		Addr: serverAddr,
 		Handler: nethttp.HandlerFunc(func(w nethttp.ResponseWriter, req *nethttp.Request) {
 			t.Logf("received http request from %s", req.RemoteAddr)
-			io.Copy(ioutil.Discard, req.Body)
+			io.Copy(io.Discard, req.Body)
 			w.WriteHeader(200)
 		}),
 		ReadTimeout:  time.Second,

--- a/pkg/network/tracer/tracer_usm_linux_test.go
+++ b/pkg/network/tracer/tracer_usm_linux_test.go
@@ -13,9 +13,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"golang.org/x/sys/unix"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"net"
 	nethttp "net/http"
@@ -25,6 +23,8 @@ import (
 	"syscall"
 	"testing"
 	"time"
+
+	"golang.org/x/sys/unix"
 
 	"github.com/DataDog/datadog-agent/pkg/network"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
@@ -97,7 +97,7 @@ func TestHTTPStats(t *testing.T) {
 	srv := &nethttp.Server{
 		Addr: serverAddr,
 		Handler: nethttp.HandlerFunc(func(w nethttp.ResponseWriter, req *nethttp.Request) {
-			io.Copy(ioutil.Discard, req.Body)
+			io.Copy(io.Discard, req.Body)
 			w.WriteHeader(200)
 		}),
 		ReadTimeout:  time.Second,

--- a/pkg/otlp/internal/configutils/utils.go
+++ b/pkg/otlp/internal/configutils/utils.go
@@ -8,7 +8,7 @@ package configutils
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"strings"
 
 	"go.opentelemetry.io/collector/confmap"
@@ -20,7 +20,7 @@ import (
 // Adapted from: https://github.com/open-telemetry/opentelemetry-collector/blob/v0.41.0/config/configmapprovider/inmemory.go
 func NewMapFromYAMLString(cfg string) (*confmap.Conf, error) {
 	inp := strings.NewReader(cfg)
-	content, err := ioutil.ReadAll(inp)
+	content, err := io.ReadAll(inp)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/otlp/internal/configutils/utils_test.go
+++ b/pkg/otlp/internal/configutils/utils_test.go
@@ -8,7 +8,7 @@ package configutils
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -46,7 +46,7 @@ func buildTestFactories(t *testing.T) component.Factories {
 
 func TestNewConfigProviderFromMap(t *testing.T) {
 	// build constant provider
-	content, err := ioutil.ReadFile(testPath)
+	content, err := os.ReadFile(testPath)
 	require.NoError(t, err)
 	cfgMap, err := NewMapFromYAMLString(string(content))
 	require.NoError(t, err)

--- a/pkg/persistentcache/persistentcache.go
+++ b/pkg/persistentcache/persistentcache.go
@@ -6,7 +6,6 @@
 package persistentcache
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -44,7 +43,7 @@ func Write(key, value string) error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(path, []byte(value), 0600)
+	return os.WriteFile(path, []byte(value), 0600)
 }
 
 // Read returns a value previously stored, or the empty string.
@@ -57,7 +56,7 @@ func Read(key string) (string, error) {
 	if os.IsNotExist(err) {
 		return "", nil
 	}
-	content, err := ioutil.ReadFile(path)
+	content, err := os.ReadFile(path)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/pidfile/pidfile.go
+++ b/pkg/pidfile/pidfile.go
@@ -7,7 +7,6 @@ package pidfile
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -18,7 +17,7 @@ import (
 // doesn't exist or doesn't contain a PID for a running process.
 func WritePID(pidFilePath string) error {
 	// check whether the pidfile exists and contains the PID for a running proc...
-	if byteContent, err := ioutil.ReadFile(pidFilePath); err == nil {
+	if byteContent, err := os.ReadFile(pidFilePath); err == nil {
 		pidStr := strings.TrimSpace(string(byteContent))
 		pid, err := strconv.Atoi(pidStr)
 		if err == nil && isProcess(pid) {
@@ -35,7 +34,7 @@ func WritePID(pidFilePath string) error {
 
 	// write current pid in it
 	pidStr := fmt.Sprintf("%d", os.Getpid())
-	if err := ioutil.WriteFile(pidFilePath, []byte(pidStr), 0644); err != nil {
+	if err := os.WriteFile(pidFilePath, []byte(pidStr), 0644); err != nil {
 		return err
 	}
 

--- a/pkg/pidfile/pidfile_test.go
+++ b/pkg/pidfile/pidfile_test.go
@@ -6,7 +6,6 @@
 package pidfile
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -21,7 +20,7 @@ func TestWritePID(t *testing.T) {
 	pidFilePath := filepath.Join(dir, "this_should_be_created", "agent.pid")
 	err := WritePID(pidFilePath)
 	assert.Nil(t, err)
-	data, err := ioutil.ReadFile(pidFilePath)
+	data, err := os.ReadFile(pidFilePath)
 	assert.Nil(t, err)
 	pid, err := strconv.Atoi(string(data))
 	assert.Nil(t, err)

--- a/pkg/process/config/config_test.go
+++ b/pkg/process/config/config_test.go
@@ -12,7 +12,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/exec"
@@ -135,7 +134,7 @@ func TestYamlConfig(t *testing.T) {
 	// Reset the config
 	config.Datadog = config.NewConfig("datadog", "DD", strings.NewReplacer(".", "_"))
 
-	f, err := ioutil.TempFile("", "yamlConfigTest*.yaml")
+	f, err := os.CreateTemp("", "yamlConfigTest*.yaml")
 	defer os.Remove(f.Name())
 	assert.NoError(t, err)
 

--- a/pkg/process/net/check.go
+++ b/pkg/process/net/check.go
@@ -11,7 +11,7 @@ package net
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	sysconfig "github.com/DataDog/datadog-agent/cmd/system-probe/config"
@@ -38,7 +38,7 @@ func (r *RemoteSysProbeUtil) GetCheck(module sysconfig.ModuleName) (interface{},
 		return nil, fmt.Errorf("conn request failed: socket %s, url %s, status code: %d", r.path, fmt.Sprintf(checksURL, module), resp.StatusCode)
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/process/net/common.go
+++ b/pkg/process/net/common.go
@@ -13,7 +13,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"sync"
@@ -120,7 +120,7 @@ func (r *RemoteSysProbeUtil) GetProcStats(pids []int32) (*model.ProcStatsWithPer
 		return nil, fmt.Errorf("proc_stats request failed: Probe Path %s, url: %s, status code: %d", r.path, procStatsURL, resp.StatusCode)
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -153,7 +153,7 @@ func (r *RemoteSysProbeUtil) GetConnections(clientID string) (*model.Connections
 		return nil, fmt.Errorf("conn request failed: Probe Path %s, url: %s, status code: %d", r.path, connectionsURL, resp.StatusCode)
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -181,7 +181,7 @@ func (r *RemoteSysProbeUtil) GetStats() (map[string]interface{}, error) {
 		return nil, fmt.Errorf("conn request failed: Path %s, url: %s, status code: %d", r.path, statsURL, resp.StatusCode)
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	defer resp.Body.Close()
 	if err != nil {
 		return nil, err

--- a/pkg/process/procutil/process_linux.go
+++ b/pkg/process/procutil/process_linux.go
@@ -12,7 +12,6 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -346,7 +345,7 @@ func (p *probe) getActivePIDs() ([]int32, error) {
 
 // getCmdline retrieves the command line text from "cmdline" file for a process in procfs
 func (p *probe) getCmdline(pidPath string) []string {
-	cmdline, err := ioutil.ReadFile(filepath.Join(pidPath, "cmdline"))
+	cmdline, err := os.ReadFile(filepath.Join(pidPath, "cmdline"))
 	if err != nil {
 		log.Debugf("Unable to read process command line from %s: %s", pidPath, err)
 		return nil
@@ -440,7 +439,7 @@ func (p *probe) parseStatus(pidPath string) *statusInfo {
 		ctxSwitches: &NumCtxSwitchesStat{},
 	}
 
-	content, err := ioutil.ReadFile(path)
+	content, err := os.ReadFile(path)
 
 	if err != nil {
 		return sInfo
@@ -549,7 +548,7 @@ func (p *probe) parseStat(pidPath string, pid int32, now time.Time) *statInfo {
 		cpuStat: &CPUTimesStat{},
 	}
 
-	contents, err := ioutil.ReadFile(path)
+	contents, err := os.ReadFile(path)
 	if err != nil {
 		return sInfo
 	}
@@ -639,7 +638,7 @@ func (p *probe) parseStatm(pidPath string) *MemoryInfoExStat {
 
 	memInfoEx := &MemoryInfoExStat{}
 
-	contents, err := ioutil.ReadFile(path)
+	contents, err := os.ReadFile(path)
 	if err != nil {
 		return memInfoEx
 	}
@@ -802,7 +801,7 @@ func trimAndSplitBytes(bs []byte) []string {
 // the value is extracted from "/proc/stat"
 func bootTime(hostProc string) (uint64, error) {
 	filePath := filepath.Join(hostProc, "stat")
-	content, err := ioutil.ReadFile(filePath)
+	content, err := os.ReadFile(filePath)
 	if err != nil {
 		return 0, fmt.Errorf("unable to read stat file from %s: %s", filePath, err)
 	}

--- a/pkg/process/procutil/process_linux_test.go
+++ b/pkg/process/procutil/process_linux_test.go
@@ -9,7 +9,6 @@
 package procutil
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -1248,7 +1247,7 @@ func makeBenchmarkDir(b *testing.B, dirPath string, fileCount int) {
 
 	createEmptyFile := func(name string) {
 		d := []byte("")
-		err = ioutil.WriteFile(name, d, 0755)
+		err = os.WriteFile(name, d, 0755)
 		require.NoError(b, err)
 	}
 

--- a/pkg/process/util/util.go
+++ b/pkg/process/util/util.go
@@ -9,7 +9,6 @@ import (
 	"bufio"
 	"bytes"
 	"errors"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -132,7 +131,7 @@ func GetSysRoot() string {
 // passed the `pid`. If `fn` returns an error the iteration aborts,
 // returning the last error returned from `fn`.
 func WithAllProcs(procRoot string, fn func(int) error) error {
-	files, err := ioutil.ReadDir(procRoot)
+	files, err := os.ReadDir(procRoot)
 	if err != nil {
 		return err
 	}

--- a/pkg/remoteconfig/state/tuf.go
+++ b/pkg/remoteconfig/state/tuf.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"strconv"
 	"strings"
 
@@ -130,7 +129,7 @@ func (s *rootClientRemoteStore) GetMeta(name string) (stream io.ReadCloser, size
 			return nil, 0, err
 		}
 		if parsedRoot.Version == metaPath.version {
-			return ioutil.NopCloser(bytes.NewReader(root)), int64(len(root)), nil
+			return io.NopCloser(bytes.NewReader(root)), int64(len(root)), nil
 		}
 	}
 	return nil, 0, client.ErrNotFound{File: name}

--- a/pkg/secrets/check_rights_nix_test.go
+++ b/pkg/secrets/check_rights_nix_test.go
@@ -9,7 +9,6 @@
 package secrets
 
 import (
-	"io/ioutil"
 	"os"
 	"os/user"
 	"syscall"
@@ -27,7 +26,7 @@ func TestWrongPath(t *testing.T) {
 }
 
 func TestGroupOtherRights(t *testing.T) {
-	tmpfile, err := ioutil.TempFile("", "agent-collector-test")
+	tmpfile, err := os.CreateTemp("", "agent-collector-test")
 	require.Nil(t, err)
 	defer os.Remove(tmpfile.Name())
 

--- a/pkg/secrets/check_rights_windows_test.go
+++ b/pkg/secrets/check_rights_windows_test.go
@@ -9,7 +9,6 @@
 package secrets
 
 import (
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"testing"
@@ -32,7 +31,7 @@ func TestWrongPath(t *testing.T) {
 }
 
 func TestCheckRights(t *testing.T) {
-	_, err := ioutil.TempFile("", "agent-collector-test")
+	_, err := os.CreateTemp("", "agent-collector-test")
 	require.Nil(t, err)
 
 	// default options
@@ -42,7 +41,7 @@ func TestCheckRights(t *testing.T) {
 	require.NotNil(t, checkRights("/does not exists", allowGroupExec))
 
 	// missing current user
-	tmpfile, err := ioutil.TempFile("", "agent-collector-test")
+	tmpfile, err := os.CreateTemp("", "agent-collector-test")
 	require.Nil(t, err)
 	defer os.Remove(tmpfile.Name())
 
@@ -55,7 +54,7 @@ func TestCheckRights(t *testing.T) {
 	assert.NotNil(t, checkRights(tmpfile.Name(), allowGroupExec))
 
 	// missing localSystem
-	tmpfile, err = ioutil.TempFile("", "agent-collector-test")
+	tmpfile, err = os.CreateTemp("", "agent-collector-test")
 	require.Nil(t, err)
 	defer os.Remove(tmpfile.Name())
 	exec.Command("powershell", "test/setAcl.ps1",
@@ -67,7 +66,7 @@ func TestCheckRights(t *testing.T) {
 	assert.NotNil(t, checkRights(tmpfile.Name(), allowGroupExec))
 
 	// missing Administrator
-	tmpfile, err = ioutil.TempFile("", "agent-collector-test")
+	tmpfile, err = os.CreateTemp("", "agent-collector-test")
 	require.Nil(t, err)
 	defer os.Remove(tmpfile.Name())
 	exec.Command("powershell", "test/setAcl.ps1",
@@ -79,7 +78,7 @@ func TestCheckRights(t *testing.T) {
 	assert.NotNil(t, checkRights(tmpfile.Name(), allowGroupExec))
 
 	// extra rights for someone else
-	tmpfile, err = ioutil.TempFile("", "agent-collector-test")
+	tmpfile, err = os.CreateTemp("", "agent-collector-test")
 	require.Nil(t, err)
 	defer os.Remove(tmpfile.Name())
 	exec.Command("powershell", "test/setAcl.ps1",
@@ -91,7 +90,7 @@ func TestCheckRights(t *testing.T) {
 	assert.Nil(t, checkRights(tmpfile.Name(), allowGroupExec))
 
 	// missing localSystem or Administrator
-	tmpfile, err = ioutil.TempFile("", "agent-collector-test")
+	tmpfile, err = os.CreateTemp("", "agent-collector-test")
 	require.Nil(t, err)
 	defer os.Remove(tmpfile.Name())
 	exec.Command("powershell", "test/setAcl.ps1",

--- a/pkg/serializer/internal/metrics/service_checks_test.go
+++ b/pkg/serializer/internal/metrics/service_checks_test.go
@@ -12,7 +12,7 @@ import (
 	"bytes"
 	"compress/zlib"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"strings"
 	"testing"
 
@@ -161,7 +161,7 @@ func decompressPayload(payload []byte) ([]byte, error) {
 	}
 	defer r.Close()
 
-	dst, err := ioutil.ReadAll(r)
+	dst, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/serializer/internal/metrics/sketch_series_test.go
+++ b/pkg/serializer/internal/metrics/sketch_series_test.go
@@ -11,7 +11,7 @@ package metrics
 import (
 	"bytes"
 	"compress/zlib"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/DataDog/agent-payload/v5/gogen"
@@ -96,7 +96,7 @@ func TestSketchSeriesMarshalSplitCompressEmpty(t *testing.T) {
 	assert.Equal(t, 0, firstPayload.GetPointCount())
 	reader := bytes.NewReader(firstPayload.GetContent())
 	r, _ := zlib.NewReader(reader)
-	decompressed, _ := ioutil.ReadAll(r)
+	decompressed, _ := io.ReadAll(r)
 	r.Close()
 
 	// Check that we encoded the protobuf correctly
@@ -130,7 +130,7 @@ func TestSketchSeriesMarshalSplitCompressItemTooBigIsDropped(t *testing.T) {
 	require.Equal(t, 0, firstPayload.GetPointCount())
 	reader := bytes.NewReader(firstPayload.GetContent())
 	r, _ := zlib.NewReader(reader)
-	decompressed, _ := ioutil.ReadAll(r)
+	decompressed, _ := io.ReadAll(r)
 	r.Close()
 
 	pl := new(gogen.SketchPayload)
@@ -160,7 +160,7 @@ func TestSketchSeriesMarshalSplitCompress(t *testing.T) {
 	assert.Equal(t, 11, firstPayload.GetPointCount())
 	reader := bytes.NewReader(firstPayload.GetContent())
 	r, _ := zlib.NewReader(reader)
-	decompressed, _ := ioutil.ReadAll(r)
+	decompressed, _ := io.ReadAll(r)
 	r.Close()
 
 	// Check that we encoded the protobuf correctly
@@ -212,7 +212,7 @@ func TestSketchSeriesMarshalSplitCompressSplit(t *testing.T) {
 	for _, pld := range payloads {
 		reader := bytes.NewReader(pld.GetContent())
 		r, _ := zlib.NewReader(reader)
-		decompressed, _ := ioutil.ReadAll(r)
+		decompressed, _ := io.ReadAll(r)
 		r.Close()
 
 		pl := new(gogen.SketchPayload)

--- a/pkg/serializer/internal/stream/compressor_test.go
+++ b/pkg/serializer/internal/stream/compressor_test.go
@@ -12,7 +12,7 @@ import (
 	"bytes"
 	"compress/zlib"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	jsoniter "github.com/json-iterator/go"
@@ -37,7 +37,7 @@ func decompressPayload(payload []byte) ([]byte, error) {
 	}
 	defer r.Close()
 
-	dst, err := ioutil.ReadAll(r)
+	dst, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/serverless/daemon/routes.go
+++ b/pkg/serverless/daemon/routes.go
@@ -7,7 +7,7 @@ package daemon
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"time"
@@ -53,7 +53,7 @@ type StartInvocation struct {
 func (s *StartInvocation) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	log.Debug("Hit on the serverless.StartInvocation route.")
 	startTime := time.Now()
-	reqBody, err := ioutil.ReadAll(r.Body)
+	reqBody, err := io.ReadAll(r.Body)
 	if err != nil {
 		log.Error("Could not read StartInvocation request body")
 		http.Error(w, "Could not read StartInvocation request body", 400)
@@ -92,7 +92,7 @@ func (e *EndInvocation) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	log.Debug("Hit on the serverless.EndInvocation route.")
 	endTime := time.Now()
 	ecs := e.daemon.ExecutionContext.GetCurrentState()
-	responseBody, err := ioutil.ReadAll(r.Body)
+	responseBody, err := io.ReadAll(r.Body)
 	if err != nil {
 		err := log.Error("Could not read EndInvocation request body")
 		http.Error(w, err.Error(), 400)

--- a/pkg/serverless/executioncontext/executioncontext.go
+++ b/pkg/serverless/executioncontext/executioncontext.go
@@ -7,7 +7,7 @@ package executioncontext
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -99,7 +99,7 @@ func (ec *ExecutionContext) SaveCurrentExecutionContext() error {
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(persistedStateFilePath, file, 0600)
+	err = os.WriteFile(persistedStateFilePath, file, 0600)
 	if err != nil {
 		return err
 	}
@@ -110,7 +110,7 @@ func (ec *ExecutionContext) SaveCurrentExecutionContext() error {
 func (ec *ExecutionContext) RestoreCurrentStateFromFile() error {
 	ec.m.Lock()
 	defer ec.m.Unlock()
-	file, err := ioutil.ReadFile(persistedStateFilePath)
+	file, err := os.ReadFile(persistedStateFilePath)
 	if err != nil {
 		return err
 	}

--- a/pkg/serverless/logs/logs.go
+++ b/pkg/serverless/logs/logs.go
@@ -9,7 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"sort"
 	"strings"
@@ -288,7 +288,7 @@ func removeInvalidTracingItem(data []byte) []byte {
 
 // ServeHTTP - see type LambdaLogsCollector comment.
 func (c *LambdaLogsCollector) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	data, _ := ioutil.ReadAll(r.Body)
+	data, _ := io.ReadAll(r.Body)
 	defer r.Body.Close()
 	messages, err := parseLogsAPIPayload(data)
 	if err != nil {

--- a/pkg/serverless/logs/logs_test.go
+++ b/pkg/serverless/logs/logs_test.go
@@ -9,9 +9,9 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 	"time"
 
@@ -26,7 +26,7 @@ import (
 )
 
 func TestUnmarshalExtensionLog(t *testing.T) {
-	raw, err := ioutil.ReadFile("./testdata/extension_log.json")
+	raw, err := os.ReadFile("./testdata/extension_log.json")
 	require.NoError(t, err)
 	var messages []logMessage
 	err = json.Unmarshal(raw, &messages)
@@ -169,23 +169,23 @@ func TestCreateStringRecordForReportLogWithoutInitDuration(t *testing.T) {
 }
 
 func TestRemoveInvalidTracingItemWellFormatted(t *testing.T) {
-	raw, err := ioutil.ReadFile("./testdata/valid_logs_payload.json")
+	raw, err := os.ReadFile("./testdata/valid_logs_payload.json")
 	require.NoError(t, err)
 	sanitizedData := removeInvalidTracingItem(raw)
 	assert.Equal(t, raw, sanitizedData)
 }
 
 func TestRemoveInvalidTracingItemNotWellFormatted(t *testing.T) {
-	raw, err := ioutil.ReadFile("./testdata/invalid_logs_payload.json")
+	raw, err := os.ReadFile("./testdata/invalid_logs_payload.json")
 	require.NoError(t, err)
 	sanitizedData := removeInvalidTracingItem(raw)
-	sanitizedRaw, sanitizedErr := ioutil.ReadFile("./testdata/invalid_logs_payload_sanitized.json")
+	sanitizedRaw, sanitizedErr := os.ReadFile("./testdata/invalid_logs_payload_sanitized.json")
 	require.NoError(t, sanitizedErr)
 	assert.Equal(t, string(sanitizedRaw), string(sanitizedData))
 }
 
 func TestParseLogsAPIPayloadWellFormated(t *testing.T) {
-	raw, err := ioutil.ReadFile("./testdata/valid_logs_payload.json")
+	raw, err := os.ReadFile("./testdata/valid_logs_payload.json")
 	require.NoError(t, err)
 	messages, err := parseLogsAPIPayload(raw)
 	assert.Nil(t, err)
@@ -194,7 +194,7 @@ func TestParseLogsAPIPayloadWellFormated(t *testing.T) {
 }
 
 func TestParseLogsAPIPayloadNotWellFormated(t *testing.T) {
-	raw, err := ioutil.ReadFile("./testdata/invalid_logs_payload.json")
+	raw, err := os.ReadFile("./testdata/invalid_logs_payload.json")
 	require.NoError(t, err)
 	messages, err := parseLogsAPIPayload(raw)
 	assert.Nil(t, err)
@@ -202,7 +202,7 @@ func TestParseLogsAPIPayloadNotWellFormated(t *testing.T) {
 }
 
 func TestParseLogsAPIPayloadNotWellFormatedButNotRecoverable(t *testing.T) {
-	raw, err := ioutil.ReadFile("./testdata/invalid_logs_payload_unrecoverable.json")
+	raw, err := os.ReadFile("./testdata/invalid_logs_payload_unrecoverable.json")
 	require.NoError(t, err)
 	_, err = parseLogsAPIPayload(raw)
 	assert.NotNil(t, err)
@@ -643,7 +643,7 @@ func TestServeHTTPSuccess(t *testing.T) {
 		ExecutionContext: mockExecutionContext,
 	}
 
-	raw, err := ioutil.ReadFile("./testdata/extension_log.json")
+	raw, err := os.ReadFile("./testdata/extension_log.json")
 	if err != nil {
 		assert.Fail(t, "should be able to read the log file")
 	}
@@ -665,7 +665,7 @@ func TestUnmarshalJSONInvalid(t *testing.T) {
 
 func TestUnmarshalJSONMalformed(t *testing.T) {
 	logMessage := &logMessage{}
-	raw, errReadFile := ioutil.ReadFile("./testdata/invalid_log_no_type.json")
+	raw, errReadFile := os.ReadFile("./testdata/invalid_log_no_type.json")
 	if errReadFile != nil {
 		assert.Fail(t, "should be able to read the file")
 	}
@@ -676,7 +676,7 @@ func TestUnmarshalJSONMalformed(t *testing.T) {
 func TestUnmarshalJSONLogTypePlatformLogsSubscription(t *testing.T) {
 	// with the telemetry api, these events should not exist
 	logMessage := &logMessage{}
-	raw, errReadFile := ioutil.ReadFile("./testdata/platform_log.json")
+	raw, errReadFile := os.ReadFile("./testdata/platform_log.json")
 	if errReadFile != nil {
 		assert.Fail(t, "should be able to read the file")
 	}
@@ -688,7 +688,7 @@ func TestUnmarshalJSONLogTypePlatformLogsSubscription(t *testing.T) {
 func TestUnmarshalJSONLogTypePlatformFault(t *testing.T) {
 	// platform.fault events are not processed by the extension
 	logMessage := &logMessage{}
-	raw, errReadFile := ioutil.ReadFile("./testdata/platform_fault.json")
+	raw, errReadFile := os.ReadFile("./testdata/platform_fault.json")
 	if errReadFile != nil {
 		assert.Fail(t, "should be able to read the file")
 	}
@@ -700,7 +700,7 @@ func TestUnmarshalJSONLogTypePlatformFault(t *testing.T) {
 func TestUnmarshalJSONLogTypePlatformTelemetrySubscription(t *testing.T) {
 	// with the telemetry api, these events should not exist
 	logMessage := &logMessage{}
-	raw, errReadFile := ioutil.ReadFile("./testdata/platform_telemetry.json")
+	raw, errReadFile := os.ReadFile("./testdata/platform_telemetry.json")
 	if errReadFile != nil {
 		assert.Fail(t, "should be able to read the file")
 	}
@@ -712,7 +712,7 @@ func TestUnmarshalJSONLogTypePlatformTelemetrySubscription(t *testing.T) {
 func TestUnmarshalJSONLogTypePlatformExtension(t *testing.T) {
 	// platform.extension events are not processed by the extension
 	logMessage := &logMessage{}
-	raw, errReadFile := ioutil.ReadFile("./testdata/platform_extension.json")
+	raw, errReadFile := os.ReadFile("./testdata/platform_extension.json")
 	if errReadFile != nil {
 		assert.Fail(t, "should be able to read the file")
 	}
@@ -723,7 +723,7 @@ func TestUnmarshalJSONLogTypePlatformExtension(t *testing.T) {
 
 func TestUnmarshalJSONLogTypePlatformStart(t *testing.T) {
 	logMessage := &logMessage{}
-	raw, errReadFile := ioutil.ReadFile("./testdata/platform_start.json")
+	raw, errReadFile := os.ReadFile("./testdata/platform_start.json")
 	if errReadFile != nil {
 		assert.Fail(t, "should be able to read the file")
 	}
@@ -736,7 +736,7 @@ func TestUnmarshalJSONLogTypePlatformStart(t *testing.T) {
 func TestUnmarshalJSONLogTypePlatformEnd(t *testing.T) {
 	// with the telemetry api, these events should not exist
 	logMessage := &logMessage{}
-	raw, errReadFile := ioutil.ReadFile("./testdata/platform_end.json")
+	raw, errReadFile := os.ReadFile("./testdata/platform_end.json")
 	if errReadFile != nil {
 		assert.Fail(t, "should be able to read the file")
 	}
@@ -748,7 +748,7 @@ func TestUnmarshalJSONLogTypePlatformEnd(t *testing.T) {
 
 func TestUnmarshalJSONLogTypeIncorrectReportNotFatalMetrics(t *testing.T) {
 	logMessage := &logMessage{}
-	raw, errReadFile := ioutil.ReadFile("./testdata/platform_incorrect_report.json")
+	raw, errReadFile := os.ReadFile("./testdata/platform_incorrect_report.json")
 	if errReadFile != nil {
 		assert.Fail(t, "should be able to read the file")
 	}
@@ -758,7 +758,7 @@ func TestUnmarshalJSONLogTypeIncorrectReportNotFatalMetrics(t *testing.T) {
 
 func TestUnmarshalJSONLogTypeIncorrectReportNotFatalReport(t *testing.T) {
 	logMessage := &logMessage{}
-	raw, errReadFile := ioutil.ReadFile("./testdata/platform_incorrect_report_record.json")
+	raw, errReadFile := os.ReadFile("./testdata/platform_incorrect_report_record.json")
 	if errReadFile != nil {
 		assert.Fail(t, "should be able to read the file")
 	}
@@ -767,7 +767,7 @@ func TestUnmarshalJSONLogTypeIncorrectReportNotFatalReport(t *testing.T) {
 }
 
 func TestUnmarshalPlatformRuntimeDoneLog(t *testing.T) {
-	raw, err := ioutil.ReadFile("./testdata/platform_runtime_done_log_valid.json")
+	raw, err := os.ReadFile("./testdata/platform_runtime_done_log_valid.json")
 	require.NoError(t, err)
 	var message logMessage
 	err = json.Unmarshal(raw, &message)
@@ -787,7 +787,7 @@ func TestUnmarshalPlatformRuntimeDoneLog(t *testing.T) {
 }
 
 func TestUnmarshalPlatformRuntimeDoneLogWithTelemetry(t *testing.T) {
-	raw, err := ioutil.ReadFile("./testdata/platform_runtime_done_log_valid_with_telemetry.json")
+	raw, err := os.ReadFile("./testdata/platform_runtime_done_log_valid_with_telemetry.json")
 	require.NoError(t, err)
 	var message logMessage
 	err = json.Unmarshal(raw, &message)
@@ -813,7 +813,7 @@ func TestUnmarshalPlatformRuntimeDoneLogWithTelemetry(t *testing.T) {
 
 func TestUnmarshalPlatformRuntimeDoneLogNotFatal(t *testing.T) {
 	logMessage := &logMessage{}
-	raw, errReadFile := ioutil.ReadFile("./testdata/platform_incorrect_runtime_done_log.json")
+	raw, errReadFile := os.ReadFile("./testdata/platform_incorrect_runtime_done_log.json")
 	if errReadFile != nil {
 		assert.Fail(t, "should be able to read the file")
 	}

--- a/pkg/serverless/proc/proc.go
+++ b/pkg/serverless/proc/proc.go
@@ -8,7 +8,7 @@ package proc
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strconv"
 	"strings"
 
@@ -16,7 +16,7 @@ import (
 )
 
 func getPidList(procPath string) []int {
-	files, err := ioutil.ReadDir(procPath)
+	files, err := os.ReadDir(procPath)
 	pids := []int{}
 	if err != nil {
 		log.Debug("could not list /proc files")
@@ -35,7 +35,7 @@ func getPidList(procPath string) []int {
 func getEnvVariablesFromPid(procPath string, pid int) map[string]string {
 	envVars := map[string]string{}
 
-	bytesRead, err := ioutil.ReadFile(fmt.Sprintf("%s/%d/environ", procPath, pid))
+	bytesRead, err := os.ReadFile(fmt.Sprintf("%s/%d/environ", procPath, pid))
 	if err != nil {
 		log.Debug("could not list environment variable for proc id %d", pid)
 		return envVars

--- a/pkg/serverless/serverless.go
+++ b/pkg/serverless/serverless.go
@@ -10,7 +10,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"strings"
@@ -156,7 +156,7 @@ func WaitForNextInvocation(stopCh chan struct{}, daemon *daemon.Daemon, id regis
 	daemon.StoreInvocationTime(time.Now())
 
 	var body []byte
-	if body, err = ioutil.ReadAll(response.Body); err != nil {
+	if body, err = io.ReadAll(response.Body); err != nil {
 		return fmt.Errorf("WaitForNextInvocation: can't read the body: %v", err)
 	}
 	defer response.Body.Close()

--- a/pkg/serverless/tags/tags.go
+++ b/pkg/serverless/tags/tags.go
@@ -7,7 +7,6 @@ package tags
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"regexp"
 	"strings"
@@ -180,7 +179,7 @@ func addTag(tagMap map[string]string, tag string) map[string]string {
 
 func getRuntimeFromOsReleaseFile(osReleasePath string) string {
 	runtime := ""
-	bytesRead, err := ioutil.ReadFile(fmt.Sprintf("%s/os-release", osReleasePath))
+	bytesRead, err := os.ReadFile(fmt.Sprintf("%s/os-release", osReleasePath))
 	if err != nil {
 		log.Debug("could not read os-release file")
 		return ""

--- a/pkg/serverless/trigger/events_test.go
+++ b/pkg/serverless/trigger/events_test.go
@@ -7,7 +7,7 @@ package trigger
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"reflect"
 	"runtime"
@@ -38,7 +38,7 @@ func TestEventPayloadParsing(t *testing.T) {
 		file, err := os.Open(fmt.Sprintf("%v/%v", testDir, testFile))
 		assert.NoError(t, err)
 
-		jsonData, err := ioutil.ReadAll(file)
+		jsonData, err := io.ReadAll(file)
 		assert.NoError(t, err)
 
 		event, err := Unmarshal(strings.ToLower(string(jsonData)))
@@ -78,7 +78,7 @@ func TestEventPayloadParsingWrong(t *testing.T) {
 			file, err := os.Open(fmt.Sprintf("%v/%v", testDir, wrongTestFile.Name()))
 			assert.NoError(t, err)
 
-			jsonData, err := ioutil.ReadAll(file)
+			jsonData, err := io.ReadAll(file)
 			assert.NoError(t, err)
 
 			event, err := Unmarshal(strings.ToLower(string(jsonData)))
@@ -112,7 +112,7 @@ func TestGetEventType(t *testing.T) {
 		file, err := os.Open(fmt.Sprintf("%v/%v", testDir, testFile))
 		assert.NoError(t, err)
 
-		jsonData, err := ioutil.ReadAll(file)
+		jsonData, err := io.ReadAll(file)
 		assert.NoError(t, err)
 
 		jsonPayload, err := Unmarshal(strings.ToLower(string(jsonData)))

--- a/pkg/snmp/traps/oid_resolver.go
+++ b/pkg/snmp/traps/oid_resolver.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -172,7 +171,7 @@ func (or *MultiFilesOIDResolver) updateFromFile(filePath string) error {
 }
 
 func (or *MultiFilesOIDResolver) updateFromReader(reader io.Reader, unmarshalMethod unmarshaller) error {
-	fileContent, err := ioutil.ReadAll(reader)
+	fileContent, err := io.ReadAll(reader)
 	if err != nil {
 		return err
 	}

--- a/pkg/trace/agent/agent_test.go
+++ b/pkg/trace/agent/agent_test.go
@@ -8,7 +8,7 @@ package agent
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"io"
 	"math"
 	"net/http"
 	"net/http/httptest"
@@ -1419,7 +1419,7 @@ func tracesFromFile(file string) (raw []byte, count int, err error) {
 	// prepare the traces in this file by adding sampling.priority=2
 	// everywhere to ensure consistent sampling assumptions and results.
 	var traces pb.Traces
-	bts, err := ioutil.ReadAll(in)
+	bts, err := io.ReadAll(in)
 	if _, err = traces.UnmarshalMsg(bts); err != nil {
 		return nil, 0, err
 	}

--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -12,7 +12,6 @@ import (
 	"expvar"
 	"fmt"
 	"io"
-	"io/ioutil"
 	stdlog "log"
 	"math"
 	"mime"
@@ -519,7 +518,7 @@ func (r *HTTPReceiver) handleTraces(v Version, w http.ResponseWriter, req *http.
 	tracen, err := traceCount(req)
 	if err == nil && r.rateLimited(tracen) {
 		// this payload can not be accepted
-		io.Copy(ioutil.Discard, req.Body) //nolint:errcheck
+		io.Copy(io.Discard, req.Body) //nolint:errcheck
 		w.WriteHeader(r.rateLimiterResponse)
 		r.replyOK(req, v, w)
 		ts.PayloadRefused.Inc()

--- a/pkg/trace/api/api_test.go
+++ b/pkg/trace/api/api_test.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -362,7 +361,7 @@ func TestReceiverMsgpackDecoder(t *testing.T) {
 					t.Fatalf("no data received")
 				}
 
-				body, err := ioutil.ReadAll(resp.Body)
+				body, err := io.ReadAll(resp.Body)
 				assert.Nil(err)
 				assert.Equal("OK\n", string(body))
 			case v04:
@@ -386,7 +385,7 @@ func TestReceiverMsgpackDecoder(t *testing.T) {
 					t.Fatalf("no data received")
 				}
 
-				body, err := ioutil.ReadAll(resp.Body)
+				body, err := io.ReadAll(resp.Body)
 				assert.Nil(err)
 				var tr traceResponse
 				err = json.Unmarshal(body, &tr)
@@ -636,7 +635,7 @@ func TestHandleStats(t *testing.T) {
 			t.Fatal(err)
 		}
 		if resp.StatusCode != 200 {
-			slurp, _ := ioutil.ReadAll(resp.Body)
+			slurp, _ := io.ReadAll(resp.Body)
 			t.Fatal(string(slurp), resp.StatusCode)
 		}
 
@@ -1036,7 +1035,7 @@ func TestReplyOKV5(t *testing.T) {
 	path := fmt.Sprintf("http://%s:%d/v0.5/traces", r.conf.ReceiverHost, r.conf.ReceiverPort)
 	resp, err := http.Post(path, "application/msgpack", bytes.NewReader(data))
 	assert.NoError(t, err)
-	slurp, err := ioutil.ReadAll(resp.Body)
+	slurp, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/trace/api/apiutil/limited_reader_test.go
+++ b/pkg/trace/api/apiutil/limited_reader_test.go
@@ -8,7 +8,6 @@ package apiutil
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -49,7 +48,7 @@ func (f *fileMock) Close() error {
 
 func TestLimitedReader(t *testing.T) {
 	buf := bytes.NewBufferString("foobar")
-	r := ioutil.NopCloser(buf)
+	r := io.NopCloser(buf)
 	lr := NewLimitedReader(r, 3)
 
 	tmp := make([]byte, 1)
@@ -74,7 +73,7 @@ func TestLimitedReader(t *testing.T) {
 
 func TestLimitedReaderEOFBuffer(t *testing.T) {
 	buf := bytes.NewBufferString("foobar")
-	r := ioutil.NopCloser(buf)
+	r := io.NopCloser(buf)
 	lr := NewLimitedReader(r, 12)
 
 	tmp := make([]byte, 6)

--- a/pkg/trace/api/debugger_test.go
+++ b/pkg/trace/api/debugger_test.go
@@ -6,7 +6,7 @@
 package api
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -18,7 +18,7 @@ import (
 
 func TestDebuggerProxy(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		slurp, err := ioutil.ReadAll(req.Body)
+		slurp, err := io.ReadAll(req.Body)
 		_ = req.Body.Close()
 		if err != nil {
 			t.Fatal(err)
@@ -49,7 +49,7 @@ func TestDebuggerProxy(t *testing.T) {
 	c := &traceconfig.AgentConfig{}
 	newDebuggerProxy(c, u, "123", "key:val").ServeHTTP(rec, req)
 	result := rec.Result()
-	slurp, err := ioutil.ReadAll(result.Body)
+	slurp, err := io.ReadAll(result.Body)
 	result.Body.Close()
 	if err != nil {
 		t.Fatal(err)
@@ -129,7 +129,7 @@ func TestDebuggerProxyHandler(t *testing.T) {
 		if res.StatusCode != http.StatusInternalServerError {
 			t.Fatalf("invalid response: %s", res.Status)
 		}
-		slurp, err := ioutil.ReadAll(res.Body)
+		slurp, err := io.ReadAll(res.Body)
 		res.Body.Close()
 		if err != nil {
 			t.Fatal(err)

--- a/pkg/trace/api/dogstatsd_test.go
+++ b/pkg/trace/api/dogstatsd_test.go
@@ -8,7 +8,7 @@ package api
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -69,7 +69,7 @@ func TestDogStatsDReverseProxy(t *testing.T) {
 		require.NotNil(t, proxy)
 
 		rec := httptest.NewRecorder()
-		body := ioutil.NopCloser(bytes.NewBufferString("users.online:1|c|@0.5|#country:china"))
+		body := io.NopCloser(bytes.NewBufferString("users.online:1|c|@0.5|#country:china"))
 		proxy.ServeHTTP(rec, httptest.NewRequest("POST", "/", body))
 		require.Equal(t, http.StatusOK, rec.Code)
 	})
@@ -103,7 +103,7 @@ func TestDogStatsDReverseProxyEndToEndUDP(t *testing.T) {
 	payloads := [][]byte{[]byte("daemon:666|g|#sometag1:somevalue1,sometag2:somevalue2"), []byte("_e{21,36}:An exception occurred|Cannot parse CSV file from\\n10.0.0.17|t:warning|#err_type:bad_file")}
 	sep := []byte("\n")
 	msg := bytes.Join(payloads, sep)
-	body := ioutil.NopCloser(bytes.NewBuffer(msg))
+	body := io.NopCloser(bytes.NewBuffer(msg))
 	proxy.ServeHTTP(rec, httptest.NewRequest("POST", "/", body))
 	require.Equal(t, http.StatusOK, rec.Code)
 

--- a/pkg/trace/api/dogstatsd_uds_test.go
+++ b/pkg/trace/api/dogstatsd_uds_test.go
@@ -10,7 +10,7 @@ package api
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -48,7 +48,7 @@ func TestDogStatsDReverseProxyEndToEndUDS(t *testing.T) {
 	defer server.Close()
 
 	// Test metrics
-	body := ioutil.NopCloser(bytes.NewBufferString("daemon:666|g|#sometag1:somevalue1,sometag2:somevalue2"))
+	body := io.NopCloser(bytes.NewBufferString("daemon:666|g|#sometag1:somevalue1,sometag2:somevalue2"))
 	proxy.ServeHTTP(rec, httptest.NewRequest("POST", "/", body))
 	require.Equal(t, http.StatusServiceUnavailable, rec.Code)
 }

--- a/pkg/trace/api/evp_proxy.go
+++ b/pkg/trace/api/evp_proxy.go
@@ -9,7 +9,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	stdlog "log"
 	"net/http"
 	"net/http/httputil"
@@ -188,7 +187,7 @@ func (t *evpProxyTransport) RoundTrip(req *http.Request) (rresp *http.Response, 
 	// There's more than one destination endpoint
 	var slurp []byte
 	if req.Body != nil {
-		body, err := ioutil.ReadAll(req.Body)
+		body, err := io.ReadAll(req.Body)
 		if err != nil {
 			return nil, err
 		}
@@ -197,7 +196,7 @@ func (t *evpProxyTransport) RoundTrip(req *http.Request) (rresp *http.Response, 
 	for i, endpointDomain := range t.endpoints {
 		newreq := req.Clone(req.Context())
 		if slurp != nil {
-			newreq.Body = ioutil.NopCloser(bytes.NewReader(slurp))
+			newreq.Body = io.NopCloser(bytes.NewReader(slurp))
 		}
 		setTarget(newreq, endpointDomain.Host, endpointDomain.APIKey)
 		if i == 0 {
@@ -209,7 +208,7 @@ func (t *evpProxyTransport) RoundTrip(req *http.Request) (rresp *http.Response, 
 
 		if resp, err := t.transport.RoundTrip(newreq); err == nil {
 			// we discard responses for all subsequent requests
-			io.Copy(ioutil.Discard, resp.Body) //nolint:errcheck
+			io.Copy(io.Discard, resp.Body) //nolint:errcheck
 			resp.Body.Close()
 		} else {
 			log.Error(err)

--- a/pkg/trace/api/evp_proxy_test.go
+++ b/pkg/trace/api/evp_proxy_test.go
@@ -9,7 +9,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"math/rand"
 	"net/http"
@@ -37,7 +36,7 @@ func (r roundTripperMock) RoundTrip(req *http.Request) (*http.Response, error) {
 func sendRequestThroughForwarder(conf *config.AgentConfig, inReq *http.Request) (outReqs []*http.Request, resp *http.Response, logs string) {
 	mockRoundTripper := roundTripperMock(func(req *http.Request) (*http.Response, error) {
 		if req.Body != nil {
-			if _, err := ioutil.ReadAll(req.Body); err != nil && err != io.EOF {
+			if _, err := io.ReadAll(req.Body); err != nil && err != io.EOF {
 				return nil, err
 			}
 		}
@@ -45,7 +44,7 @@ func sendRequestThroughForwarder(conf *config.AgentConfig, inReq *http.Request) 
 		// If we got here it means the proxy didn't raise an error earlier, return an ok resp
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewBuffer([]byte("ok_resprino"))),
+			Body:       io.NopCloser(bytes.NewBuffer([]byte("ok_resprino"))),
 		}, nil
 	})
 	handler := evpProxyForwarder(conf)

--- a/pkg/trace/api/otlp.go
+++ b/pkg/trace/api/otlp.go
@@ -11,7 +11,7 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"strconv"
@@ -144,7 +144,7 @@ func (o *OTLPReceiver) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		r = gzipr
 	}
 	rd := apiutil.NewLimitedReader(r, o.conf.OTLPReceiver.MaxRequestBytes)
-	slurp, err := ioutil.ReadAll(rd)
+	slurp, err := io.ReadAll(rd)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		metrics.Count("datadog.trace_agent.otlp.error", 1, append(mtags, "reason:read_body"), 1)

--- a/pkg/trace/api/pipeline_stats_test.go
+++ b/pkg/trace/api/pipeline_stats_test.go
@@ -7,7 +7,7 @@ package api
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -21,7 +21,7 @@ import (
 
 func TestPipelineStatsProxy(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		slurp, err := ioutil.ReadAll(req.Body)
+		slurp, err := io.ReadAll(req.Body)
 		req.Body.Close()
 		if err != nil {
 			t.Fatal(err)
@@ -52,7 +52,7 @@ func TestPipelineStatsProxy(t *testing.T) {
 	c := &config.AgentConfig{}
 	newPipelineStatsProxy(c, u, "123", "key:val").ServeHTTP(rec, req)
 	result := rec.Result()
-	slurp, err := ioutil.ReadAll(result.Body)
+	slurp, err := io.ReadAll(result.Body)
 	result.Body.Close()
 	if err != nil {
 		t.Fatal(err)
@@ -160,7 +160,7 @@ func TestPipelineStatsProxyHandler(t *testing.T) {
 			t.Fatalf("invalid response: %s", res.Status)
 		}
 		res.Body.Close()
-		slurp, err := ioutil.ReadAll(res.Body)
+		slurp, err := io.ReadAll(res.Body)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/trace/api/profiles.go
+++ b/pkg/trace/api/profiles.go
@@ -9,7 +9,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	stdlog "log"
 	"net/http"
 	"net/http/httputil"
@@ -166,13 +165,13 @@ func (m *multiTransport) RoundTrip(req *http.Request) (rresp *http.Response, rer
 		setTarget(req, m.targets[0], m.keys[0])
 		return m.rt.RoundTrip(req)
 	}
-	slurp, err := ioutil.ReadAll(req.Body)
+	slurp, err := io.ReadAll(req.Body)
 	if err != nil {
 		return nil, err
 	}
 	for i, u := range m.targets {
 		newreq := req.Clone(req.Context())
-		newreq.Body = ioutil.NopCloser(bytes.NewReader(slurp))
+		newreq.Body = io.NopCloser(bytes.NewReader(slurp))
 		setTarget(newreq, u, m.keys[i])
 		if i == 0 {
 			// given the way we construct the list of targets the main endpoint
@@ -183,7 +182,7 @@ func (m *multiTransport) RoundTrip(req *http.Request) (rresp *http.Response, rer
 
 		if resp, err := m.rt.RoundTrip(newreq); err == nil {
 			// we discard responses for all subsequent requests
-			io.Copy(ioutil.Discard, resp.Body) //nolint:errcheck
+			io.Copy(io.Discard, resp.Body) //nolint:errcheck
 			resp.Body.Close()
 		} else {
 			log.Error(err)

--- a/pkg/trace/api/profiles_test.go
+++ b/pkg/trace/api/profiles_test.go
@@ -8,7 +8,7 @@ package api
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -34,7 +34,7 @@ func makeURLs(t *testing.T, ss ...string) []*url.URL {
 
 func TestProfileProxy(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		slurp, err := ioutil.ReadAll(req.Body)
+		slurp, err := io.ReadAll(req.Body)
 		req.Body.Close()
 		if err != nil {
 			t.Fatal(err)
@@ -65,7 +65,7 @@ func TestProfileProxy(t *testing.T) {
 	c := &config.AgentConfig{}
 	newProfileProxy(c, []*url.URL{u}, []string{"123"}, "key:val").ServeHTTP(rec, req)
 	result := rec.Result()
-	slurp, err := ioutil.ReadAll(result.Body)
+	slurp, err := io.ReadAll(result.Body)
 	result.Body.Close()
 	if err != nil {
 		t.Fatal(err)
@@ -235,7 +235,7 @@ func TestProfileProxyHandler(t *testing.T) {
 		if res.StatusCode != http.StatusInternalServerError {
 			t.Fatalf("invalid response: %s", res.Status)
 		}
-		slurp, err := ioutil.ReadAll(res.Body)
+		slurp, err := io.ReadAll(res.Body)
 		res.Body.Close()
 		if err != nil {
 			t.Fatal(err)

--- a/pkg/trace/api/telemetry.go
+++ b/pkg/trace/api/telemetry.go
@@ -9,7 +9,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	stdlog "log"
 	"net/http"
 	"net/http/httputil"
@@ -103,20 +102,20 @@ func (m *telemetryMultiTransport) RoundTrip(req *http.Request) (*http.Response, 
 	if len(m.Endpoints) == 1 {
 		return m.roundTrip(req, m.Endpoints[0])
 	}
-	slurp, err := ioutil.ReadAll(req.Body)
+	slurp, err := io.ReadAll(req.Body)
 	if err != nil {
 		return nil, err
 	}
 	newreq := req.Clone(req.Context())
-	newreq.Body = ioutil.NopCloser(bytes.NewReader(slurp))
+	newreq.Body = io.NopCloser(bytes.NewReader(slurp))
 	// despite the number of endpoints, we always return the response of the first
 	rresp, rerr := m.roundTrip(newreq, m.Endpoints[0])
 	for _, endpoint := range m.Endpoints[1:] {
 		newreq := req.Clone(req.Context())
-		newreq.Body = ioutil.NopCloser(bytes.NewReader(slurp))
+		newreq.Body = io.NopCloser(bytes.NewReader(slurp))
 		if resp, err := m.roundTrip(newreq, endpoint); err == nil {
 			// we discard responses for all subsequent requests
-			io.Copy(ioutil.Discard, resp.Body) //nolint:errcheck
+			io.Copy(io.Discard, resp.Body) //nolint:errcheck
 			resp.Body.Close()
 		} else {
 			log.Error(err)

--- a/pkg/trace/api/telemetry_test.go
+++ b/pkg/trace/api/telemetry_test.go
@@ -6,7 +6,7 @@
 package api
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"regexp"
@@ -24,7 +24,7 @@ import (
 // response OK.
 func assertingServer(t *testing.T, onReq func(req *http.Request, reqBody []byte) error) *httptest.Server {
 	return httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		body, err := ioutil.ReadAll(req.Body)
+		body, err := io.ReadAll(req.Body)
 		assert.NoError(t, err)
 		assert.NoError(t, onReq(req, body))
 		_, err = w.Write([]byte("OK"))
@@ -42,7 +42,7 @@ func newRequestRecorder(t *testing.T) (req *http.Request, rec *httptest.Response
 
 func recordedResponse(t *testing.T, rec *httptest.ResponseRecorder) string {
 	resp := rec.Result()
-	responseBody, err := ioutil.ReadAll(resp.Body)
+	responseBody, err := io.ReadAll(resp.Body)
 	resp.Body.Close()
 	assert.NoError(t, err)
 

--- a/pkg/trace/info/info_test.go
+++ b/pkg/trace/info/info_test.go
@@ -10,10 +10,10 @@ import (
 	"encoding/json"
 	"expvar"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -34,7 +34,7 @@ type testServerHandler struct {
 func (h *testServerHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
-	json, err := ioutil.ReadFile("./testdata/okay.json")
+	json, err := os.ReadFile("./testdata/okay.json")
 	if err != nil {
 		h.t.Errorf("error loading json file: %v", err)
 	}
@@ -66,7 +66,7 @@ type testServerWarningHandler struct {
 func (h *testServerWarningHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
-	json, err := ioutil.ReadFile("./testdata/warning.json")
+	json, err := os.ReadFile("./testdata/warning.json")
 	if err != nil {
 		h.t.Errorf("error loading json file: %v", err)
 	}
@@ -157,7 +157,7 @@ func TestInfo(t *testing.T) {
 	info := buf.String()
 	assert.NotEmpty(info)
 	t.Logf("Info:\n%s\n", info)
-	expectedInfo, err := ioutil.ReadFile("./testdata/okay.info")
+	expectedInfo, err := os.ReadFile("./testdata/okay.info")
 	re := regexp.MustCompile(`\r\n`)
 	expectedInfoString := re.ReplaceAllString(string(expectedInfo), "\n")
 	assert.NoError(err)
@@ -201,7 +201,7 @@ func TestWarning(t *testing.T) {
 	assert.NoError(err)
 	info := buf.String()
 
-	expectedWarning, err := ioutil.ReadFile("./testdata/warning.info")
+	expectedWarning, err := os.ReadFile("./testdata/warning.info")
 	re := regexp.MustCompile(`\r\n`)
 	expectedWarningString := re.ReplaceAllString(string(expectedWarning), "\n")
 	assert.NoError(err)

--- a/pkg/trace/writer/sender.go
+++ b/pkg/trace/writer/sender.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"math/rand"
 	"net/http"
@@ -345,7 +344,7 @@ func (s *sender) do(req *http.Request) error {
 	// From https://golang.org/pkg/net/http/#Response:
 	// The default HTTP client's Transport may not reuse HTTP/1.x "keep-alive"
 	// TCP connections if the Body is not read to completion and closed.
-	if _, err := io.Copy(ioutil.Discard, resp.Body); err != nil {
+	if _, err := io.Copy(io.Discard, resp.Body); err != nil {
 		log.Debugf("Error discarding request body: %v", err)
 	}
 	resp.Body.Close()

--- a/pkg/trace/writer/sender_test.go
+++ b/pkg/trace/writer/sender_test.go
@@ -8,7 +8,7 @@ package writer
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -299,7 +299,7 @@ func TestPayload(t *testing.T) {
 		assert.Equal("/my/path", req.URL.Path)
 		assert.Equal("4", req.Header.Get("Content-Length"))
 		assert.Equal(testAPIKey, req.Header.Get("DD-Api-Key"))
-		slurp, err := ioutil.ReadAll(req.Body)
+		slurp, err := io.ReadAll(req.Body)
 		assert.NoError(err)
 		req.Body.Close()
 		assert.Equal(expectBody.Bytes(), slurp)

--- a/pkg/trace/writer/testserver.go
+++ b/pkg/trace/writer/testserver.go
@@ -8,7 +8,7 @@ package writer
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -139,7 +139,7 @@ func (ts *testServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		time.Sleep(ts.latency)
 	}
 
-	slurp, err := ioutil.ReadAll(req.Body)
+	slurp, err := io.ReadAll(req.Body)
 	if err != nil {
 		panic(fmt.Sprintf("error reading request body: %v", err))
 	}

--- a/pkg/trace/writer/trace_test.go
+++ b/pkg/trace/writer/trace_test.go
@@ -7,7 +7,7 @@ package writer
 
 import (
 	"compress/gzip"
-	"io/ioutil"
+	"io"
 	"reflect"
 	"runtime"
 	"sync"
@@ -132,7 +132,7 @@ func payloadsContain(t *testing.T, payloads []*payload, sampledSpans []*SampledC
 		assert := assert.New(t)
 		gzipr, err := gzip.NewReader(p.body)
 		assert.NoError(err)
-		slurp, err := ioutil.ReadAll(gzipr)
+		slurp, err := io.ReadAll(gzipr)
 		assert.NoError(err)
 		var payload pb.AgentPayload
 		err = proto.Unmarshal(slurp, &payload)

--- a/pkg/util/cgroups/pid_mapper_test.go
+++ b/pkg/util/cgroups/pid_mapper_test.go
@@ -9,7 +9,6 @@
 package cgroups
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -108,8 +107,8 @@ func TestProcPidMapperCgroupV1(t *testing.T) {
 		path:       "kubepods/burstable/pod15513b48-e7a5-48fc-b9e3-92f713f36504/a51a9f7d073f848e7fc59e56e8f11524f330a2175a4ed26327da2dfe0d28015f",
 		pidMapper:  pidMapperV1,
 	}
-	assert.NoError(t, ioutil.WriteFile(filepath.Join(fakeFsPath, "/proc/420/cgroup"), []byte(cgroupV1ProcCgroup), 0o640))
-	assert.NoError(t, ioutil.WriteFile(filepath.Join(fakeFsPath, "/proc/421/cgroup"), []byte(cgroupV1ProcCgroup), 0o640))
+	assert.NoError(t, os.WriteFile(filepath.Join(fakeFsPath, "/proc/420/cgroup"), []byte(cgroupV1ProcCgroup), 0o640))
+	assert.NoError(t, os.WriteFile(filepath.Join(fakeFsPath, "/proc/421/cgroup"), []byte(cgroupV1ProcCgroup), 0o640))
 
 	pids, err := cgCgroupV1.GetPIDs(0)
 	assert.NoError(t, err)
@@ -120,7 +119,7 @@ func TestProcPidMapperCgroupV1(t *testing.T) {
 		path:       "docker/88ea268ece65a02d68b169fd74bcbcb427eb7f28900db0e3b906fb2eeb7341df/kubelet/kubepods/burstable/poda5ea884f-9e60-4912-bd62-fef9a31db47a/a51a9f7d073f848e7fc59e56e8f11524f330a2175a4ed26327da2dfe0d28015e",
 		pidMapper:  pidMapperV1,
 	}
-	assert.NoError(t, ioutil.WriteFile(filepath.Join(fakeFsPath, "/proc/430/cgroup"), []byte(dindProcCgroup), 0o640))
+	assert.NoError(t, os.WriteFile(filepath.Join(fakeFsPath, "/proc/430/cgroup"), []byte(dindProcCgroup), 0o640))
 
 	pids, err = cgDindv1.GetPIDs(0)
 	assert.NoError(t, err)
@@ -154,8 +153,8 @@ func TestProcPidMapperCgroupV2(t *testing.T) {
 			readerFilter:     ContainerFilter,
 		},
 	}
-	assert.NoError(t, ioutil.WriteFile(filepath.Join(fakeFsPath, "/proc/420/cgroup"), []byte(cgroupV2ProcCgroup), 0o640))
-	assert.NoError(t, ioutil.WriteFile(filepath.Join(fakeFsPath, "/proc/430/cgroup"), []byte(cgroupV2ProcCgroupNoHost), 0o640))
+	assert.NoError(t, os.WriteFile(filepath.Join(fakeFsPath, "/proc/420/cgroup"), []byte(cgroupV2ProcCgroup), 0o640))
+	assert.NoError(t, os.WriteFile(filepath.Join(fakeFsPath, "/proc/430/cgroup"), []byte(cgroupV2ProcCgroupNoHost), 0o640))
 
 	pids, err := cgFooV2.GetPIDs(0)
 	assert.NoError(t, err)

--- a/pkg/util/cgroups/readerv2_test.go
+++ b/pkg/util/cgroups/readerv2_test.go
@@ -9,7 +9,6 @@
 package cgroups
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -34,7 +33,7 @@ func TestReaderV2(t *testing.T) {
 		assert.NoErrorf(t, os.MkdirAll(finalPath, 0o750), "impossible to create temp directory '%s'", finalPath)
 	}
 
-	assert.NoError(t, ioutil.WriteFile(filepath.Join(fakeFsPath, "cgroup.controllers"), []byte("cpu io memory"), 0o640))
+	assert.NoError(t, os.WriteFile(filepath.Join(fakeFsPath, "cgroup.controllers"), []byte("cpu io memory"), 0o640))
 
 	controllers := map[string]struct{}{
 		"cpu":    {},

--- a/pkg/util/cloudproviders/cloudfoundry/types.go
+++ b/pkg/util/cloudproviders/cloudfoundry/types.go
@@ -11,7 +11,7 @@ package cloudfoundry
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -592,7 +592,7 @@ func (c *CFClient) ListSidecarsByApp(query url.Values, appGUID string) ([]CFSide
 		}
 
 		defer resp.Body.Close()
-		resBody, err := ioutil.ReadAll(resp.Body)
+		resBody, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return nil, fmt.Errorf("Error reading sidecars response for app %s for page %d: %s", appGUID, page, err)
 		}
@@ -626,7 +626,7 @@ func (c *CFClient) getIsolationSegmentRelationship(resource, guid string) (strin
 	}
 
 	defer resp.Body.Close()
-	resBody, err := ioutil.ReadAll(resp.Body)
+	resBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", fmt.Errorf("Error reading isolation segment %s response: %s", resource, err)
 	}
@@ -672,7 +672,7 @@ func (c *CFClient) ListProcessByAppGUID(query url.Values, appGUID string) ([]cfc
 		}
 
 		defer resp.Body.Close()
-		resBody, err := ioutil.ReadAll(resp.Body)
+		resBody, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return nil, fmt.Errorf("Error reading processes response for app %s for page %d: %s", appGUID, page, err)
 		}

--- a/pkg/util/cloudproviders/gce/gce_tags_test.go
+++ b/pkg/util/cloudproviders/gce/gce_tags_test.go
@@ -12,9 +12,9 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -60,7 +60,7 @@ var (
 )
 
 func mockMetadataRequest(t *testing.T) *httptest.Server {
-	content, err := ioutil.ReadFile("test/gce_metadata.json")
+	content, err := os.ReadFile("test/gce_metadata.json")
 	if err != nil {
 		assert.Fail(t, fmt.Sprintf("Error getting test data: %v", err))
 	}

--- a/pkg/util/clusteragent/clcrunner.go
+++ b/pkg/util/clusteragent/clcrunner.go
@@ -8,7 +8,7 @@ package clusteragent
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"sync"
 	"time"
@@ -98,7 +98,7 @@ func (c *CLCRunnerClient) GetVersion(IP string) (version.Version, error) {
 		return version, fmt.Errorf("unexpected status code from CLC runner: %d", resp.StatusCode)
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return version, err
 	}
@@ -131,7 +131,7 @@ func (c *CLCRunnerClient) GetRunnerStats(IP string) (types.CLCRunnersStats, erro
 		return stats, fmt.Errorf("unexpected status code from CLC runner: %d", resp.StatusCode)
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return stats, err
 	}

--- a/pkg/util/clusteragent/clcrunner_test.go
+++ b/pkg/util/clusteragent/clcrunner_test.go
@@ -7,7 +7,6 @@ package clusteragent
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -191,7 +190,7 @@ func TestCLCRunnerSuite(t *testing.T) {
 
 	fakeDir := t.TempDir()
 
-	f, err := ioutil.TempFile(fakeDir, "fake-datadog-yaml-")
+	f, err := os.CreateTemp(fakeDir, "fake-datadog-yaml-")
 	require.Nil(t, err, fmt.Errorf("%v", err))
 	t.Cleanup(func() {
 		require.NoError(t, f.Close())

--- a/pkg/util/clusteragent/clusteragent.go
+++ b/pkg/util/clusteragent/clusteragent.go
@@ -11,7 +11,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -318,7 +317,7 @@ func (c *DCAClient) doQuery(ctx context.Context, path, method string, body io.Re
 	defer resp.Body.Close()
 
 	if readResponseBody && resp.StatusCode == http.StatusOK {
-		respBody, err := ioutil.ReadAll(resp.Body)
+		respBody, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return nil, errors.NewRemoteServiceError(url, err.Error())
 		}

--- a/pkg/util/clusteragent/clusteragent_test.go
+++ b/pkg/util/clusteragent/clusteragent_test.go
@@ -8,7 +8,6 @@ package clusteragent
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -314,7 +313,7 @@ func (suite *clusterAgentSuite) TestGetClusterAgentAuthTokenEmpty() {
 
 func (suite *clusterAgentSuite) TestGetClusterAgentAuthTokenEmptyFile() {
 	mockConfig.Set("cluster_agent.auth_token", "")
-	err := ioutil.WriteFile(suite.authTokenPath, []byte(""), os.ModePerm)
+	err := os.WriteFile(suite.authTokenPath, []byte(""), os.ModePerm)
 	require.Nil(suite.T(), err, fmt.Sprintf("%v", err))
 	_, err = security.GetClusterAgentAuthToken()
 	require.NotNil(suite.T(), err, fmt.Sprintf("%v", err))
@@ -322,7 +321,7 @@ func (suite *clusterAgentSuite) TestGetClusterAgentAuthTokenEmptyFile() {
 
 func (suite *clusterAgentSuite) TestGetClusterAgentAuthTokenFileInvalid() {
 	mockConfig.Set("cluster_agent.auth_token", "")
-	err := ioutil.WriteFile(suite.authTokenPath, []byte("tooshort"), os.ModePerm)
+	err := os.WriteFile(suite.authTokenPath, []byte("tooshort"), os.ModePerm)
 	require.Nil(suite.T(), err, fmt.Sprintf("%v", err))
 
 	_, err = security.GetClusterAgentAuthToken()
@@ -332,7 +331,7 @@ func (suite *clusterAgentSuite) TestGetClusterAgentAuthTokenFileInvalid() {
 func (suite *clusterAgentSuite) TestGetClusterAgentAuthToken() {
 	const tokenFileValue = "abcdefabcdefabcdefabcdefabcdefabcdefabcdef"
 	mockConfig.Set("cluster_agent.auth_token", "")
-	err := ioutil.WriteFile(suite.authTokenPath, []byte(tokenFileValue), os.ModePerm)
+	err := os.WriteFile(suite.authTokenPath, []byte(tokenFileValue), os.ModePerm)
 	require.Nil(suite.T(), err, fmt.Sprintf("%v", err))
 
 	t, err := security.GetClusterAgentAuthToken()
@@ -343,7 +342,7 @@ func (suite *clusterAgentSuite) TestGetClusterAgentAuthToken() {
 func (suite *clusterAgentSuite) TestGetClusterAgentAuthTokenConfigPriority() {
 	const tokenFileValue = "abcdefabcdefabcdefabcdefabcdefabcdefabcdef"
 	mockConfig.Set("cluster_agent.auth_token", clusterAgentTokenValue)
-	err := ioutil.WriteFile(suite.authTokenPath, []byte(tokenFileValue), os.ModePerm)
+	err := os.WriteFile(suite.authTokenPath, []byte(tokenFileValue), os.ModePerm)
 	require.Nil(suite.T(), err, fmt.Sprintf("%v", err))
 
 	// load config token value instead of filesystem
@@ -355,7 +354,7 @@ func (suite *clusterAgentSuite) TestGetClusterAgentAuthTokenConfigPriority() {
 func (suite *clusterAgentSuite) TestGetClusterAgentAuthTokenTooShort() {
 	const tokenValue = "tooshort"
 	mockConfig.Set("cluster_agent.auth_token", "")
-	err := ioutil.WriteFile(suite.authTokenPath, []byte(tokenValue), os.ModePerm)
+	err := os.WriteFile(suite.authTokenPath, []byte(tokenValue), os.ModePerm)
 	require.Nil(suite.T(), err, fmt.Sprintf("%v", err))
 
 	_, err = security.GetClusterAgentAuthToken()
@@ -725,7 +724,7 @@ func TestClusterAgentSuite(t *testing.T) {
 
 	fakeDir := t.TempDir()
 
-	f, err := ioutil.TempFile(fakeDir, "fake-datadog-yaml-")
+	f, err := os.CreateTemp(fakeDir, "fake-datadog-yaml-")
 	require.Nil(t, err, fmt.Errorf("%v", err))
 	defer os.Remove(f.Name())
 

--- a/pkg/util/common.go
+++ b/pkg/util/common.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"net/http"
 	"os"
@@ -40,7 +39,7 @@ func CopyFile(src, dst string) error {
 	}
 	defer in.Close()
 
-	tmp, err := ioutil.TempFile(filepath.Dir(dst), "")
+	tmp, err := os.CreateTemp(filepath.Dir(dst), "")
 	if err != nil {
 		return err
 	}
@@ -88,7 +87,7 @@ func CopyFileAll(src, dst string) error {
 func CopyDir(src, dst string) error {
 	var (
 		err     error
-		fds     []os.FileInfo
+		fds     []os.DirEntry
 		srcinfo os.FileInfo
 	)
 
@@ -100,7 +99,7 @@ func CopyDir(src, dst string) error {
 		return err
 	}
 
-	if fds, err = ioutil.ReadDir(src); err != nil {
+	if fds, err = os.ReadDir(src); err != nil {
 		return err
 	}
 	for _, fd := range fds {
@@ -218,6 +217,6 @@ func GetGoRoutinesDump() (string, error) {
 	}
 	defer resp.Body.Close()
 
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	return string(data), err
 }

--- a/pkg/util/common_test.go
+++ b/pkg/util/common_test.go
@@ -8,7 +8,6 @@ package util
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -34,7 +33,7 @@ func TestJSONConverter(t *testing.T) {
 		var cf integration.RawMap
 
 		// Read file contents
-		yamlFile, err := ioutil.ReadFile(fmt.Sprintf("../collector/corechecks/embed/jmx/fixtures/%s.yaml", c))
+		yamlFile, err := os.ReadFile(fmt.Sprintf("../collector/corechecks/embed/jmx/fixtures/%s.yaml", c))
 		assert.Nil(t, err)
 
 		// Parse configuration
@@ -72,7 +71,7 @@ func TestCopyDir(t *testing.T) {
 		p := filepath.Join(src, file)
 		err := os.MkdirAll(filepath.Dir(p), os.ModePerm)
 		assert.NoError(err)
-		err = ioutil.WriteFile(p, []byte(content), os.ModePerm)
+		err = os.WriteFile(p, []byte(content), os.ModePerm)
 		assert.NoError(err)
 	}
 	err := CopyDir(src, dst)
@@ -80,7 +79,7 @@ func TestCopyDir(t *testing.T) {
 
 	for file, content := range files {
 		p := filepath.Join(dst, file)
-		actual, err := ioutil.ReadFile(p)
+		actual, err := os.ReadFile(p)
 		assert.NoError(err)
 		assert.Equal(string(actual), content)
 	}

--- a/pkg/util/compression/zlib.go
+++ b/pkg/util/compression/zlib.go
@@ -11,7 +11,7 @@ package compression
 import (
 	"bytes"
 	"compress/zlib"
-	"io/ioutil"
+	"io"
 )
 
 // ContentEncoding describes the HTTP header value associated with the compression method
@@ -42,7 +42,7 @@ func Decompress(src []byte) ([]byte, error) {
 	}
 	defer r.Close()
 
-	dst, err := ioutil.ReadAll(r)
+	dst, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/util/containers/metrics/docker/collector_linux_test.go
+++ b/pkg/util/containers/metrics/docker/collector_linux_test.go
@@ -9,7 +9,6 @@
 package docker
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -188,7 +187,7 @@ func Test_convertIOStats(t *testing.T) {
 			"   1       3 bar2 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0",
 	)
 
-	err := ioutil.WriteFile(dir+"/diskstats", diskstats, 0o644)
+	err := os.WriteFile(dir+"/diskstats", diskstats, 0o644)
 	assert.Nil(t, err)
 	defer os.Remove(dir + "/diskstats")
 

--- a/pkg/util/containers/metrics/kubelet/collector_test.go
+++ b/pkg/util/containers/metrics/kubelet/collector_test.go
@@ -9,7 +9,7 @@
 package kubelet
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 	"time"
 
@@ -189,7 +189,7 @@ func TestKubeletCollectorWindows(t *testing.T) {
 func setStatsSummaryFromFile(t *testing.T, filePath string, kubeletMock *mock.KubeletMock) {
 	t.Helper()
 
-	content, err := ioutil.ReadFile(filePath)
+	content, err := os.ReadFile(filePath)
 	if err != nil {
 		t.Errorf("unable to read test file at: %s, err: %v", filePath, err)
 	}

--- a/pkg/util/ec2/ec2_tags_test.go
+++ b/pkg/util/ec2/ec2_tags_test.go
@@ -12,9 +12,9 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -54,7 +54,7 @@ func TestGetSecurityCreds(t *testing.T) {
 			io.WriteString(w, "test-role")
 		} else if r.URL.Path == "/iam/security-credentials/test-role" {
 			w.Header().Set("Content-Type", "text/plain")
-			content, err := ioutil.ReadFile("payloads/security_cred.json")
+			content, err := os.ReadFile("payloads/security_cred.json")
 			require.Nil(t, err, fmt.Sprintf("failed to load json in payloads/security_cred.json: %v", err))
 			io.WriteString(w, string(content))
 		} else {
@@ -77,7 +77,7 @@ func TestGetInstanceIdentity(t *testing.T) {
 	ctx := context.Background()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/plain")
-		content, err := ioutil.ReadFile("payloads/instance_indentity.json")
+		content, err := os.ReadFile("payloads/instance_indentity.json")
 		require.Nil(t, err, fmt.Sprintf("failed to load json in payloads/instance_indentity.json: %v", err))
 		io.WriteString(w, string(content))
 	}))

--- a/pkg/util/ecs/metadata/testutil/dummy_ecs.go
+++ b/pkg/util/ecs/metadata/testutil/dummy_ecs.go
@@ -7,10 +7,10 @@ package testutil
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"strconv"
 )
 
@@ -54,7 +54,7 @@ func NewDummyECS(ops ...Option) (*DummyECS, error) {
 		o(d)
 	}
 	for pattern, testDataPath := range d.fileHandlers {
-		raw, err := ioutil.ReadFile(testDataPath)
+		raw, err := os.ReadFile(testDataPath)
 		if err != nil {
 			return nil, fmt.Errorf("failed to register handler for pattern %s: could not read test data file with path %s", pattern, testDataPath)
 		}

--- a/pkg/util/ecs/metadata/v2/client.go
+++ b/pkg/util/ecs/metadata/v2/client.go
@@ -12,7 +12,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"path"
@@ -100,7 +100,7 @@ func (c *Client) get(ctx context.Context, path string, v interface{}) error {
 
 	if resp.StatusCode != http.StatusOK {
 		var msg string
-		if buf, err := ioutil.ReadAll(resp.Body); err == nil {
+		if buf, err := io.ReadAll(resp.Body); err == nil {
 			msg = string(buf)
 		}
 		return fmt.Errorf("Unexpected HTTP status code in metadata v2 reply: [%s]: %d - %s", url, resp.StatusCode, msg)

--- a/pkg/util/grpc/logger.go
+++ b/pkg/util/grpc/logger.go
@@ -6,7 +6,7 @@
 package grpc
 
 import (
-	"io/ioutil"
+	"io"
 	"os"
 	"strconv"
 	"strings"
@@ -60,9 +60,9 @@ func (l redirectLogger) Write(b []byte) (int, error) {
 // NewLogger returns a gRPC logger that logs to the Datadog logger instead of
 // directly to stderr.
 func NewLogger() grpclog.LoggerV2 {
-	errorW := ioutil.Discard
-	warningW := ioutil.Discard
-	infoW := ioutil.Discard
+	errorW := io.Discard
+	warningW := io.Discard
+	infoW := io.Discard
 
 	// grpc-go logs to an io.Writer on a certain severity, and every single
 	// lower severity (so FATAL would log to FATAL, ERROR, WARN and INFO),

--- a/pkg/util/hostname/common.go
+++ b/pkg/util/hostname/common.go
@@ -8,7 +8,6 @@ package hostname
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -57,7 +56,7 @@ func fromHostnameFile(ctx context.Context, _ string) (string, error) {
 		return "", fmt.Errorf("'hostname_file' configuration is not enabled")
 	}
 
-	fileContent, err := ioutil.ReadFile(hostnameFilepath)
+	fileContent, err := os.ReadFile(hostnameFilepath)
 	if err != nil {
 		return "", fmt.Errorf("Could not read hostname from %s: %v", hostnameFilepath, err)
 	}

--- a/pkg/util/hostname/common_test.go
+++ b/pkg/util/hostname/common_test.go
@@ -8,7 +8,6 @@ package hostname
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -43,10 +42,10 @@ func TestFromConfigInvalid(t *testing.T) {
 
 func setupHostnameFile(t *testing.T, content string) {
 	dir := t.TempDir()
-	destFile, err := ioutil.TempFile(dir, "test-hostname-file-config-")
+	destFile, err := os.CreateTemp(dir, "test-hostname-file-config-")
 	require.NoError(t, err, "Could not create tmp file: %s", err)
 
-	err = ioutil.WriteFile(destFile.Name(), []byte(content), os.ModePerm)
+	err = os.WriteFile(destFile.Name(), []byte(content), os.ModePerm)
 	require.NoError(t, err, "Could not write to tmp file %s: %s", destFile.Name(), err)
 
 	config.Mock(t)

--- a/pkg/util/http/helpers.go
+++ b/pkg/util/http/helpers.go
@@ -9,7 +9,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 )
@@ -20,7 +20,7 @@ func parseResponse(res *http.Response, method string, URL string) (string, error
 	}
 
 	defer res.Body.Close()
-	all, err := ioutil.ReadAll(res.Body)
+	all, err := io.ReadAll(res.Body)
 	if err != nil {
 		return "", fmt.Errorf("error while reading response from %s: %s", URL, err)
 	}

--- a/pkg/util/kernel/find_headers.go
+++ b/pkg/util/kernel/find_headers.go
@@ -15,7 +15,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -302,7 +301,7 @@ func containsCriticalHeaders(dirs []string) bool {
 }
 
 func deleteKernelHeaderDirectory(dir string) {
-	files, err := ioutil.ReadDir(dir)
+	files, err := os.ReadDir(dir)
 	if err != nil {
 		log.Warnf("error deleting kernel headers: %v", err)
 	}

--- a/pkg/util/kernel/ip.go
+++ b/pkg/util/kernel/ip.go
@@ -9,7 +9,7 @@
 package kernel
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/DataDog/datadog-agent/pkg/process/util"
@@ -17,6 +17,6 @@ import (
 
 // IsIPv6Enabled returns whether or not IPv6 has been enabled on the host
 func IsIPv6Enabled() bool {
-	_, err := ioutil.ReadFile(filepath.Join(util.GetProcRoot(), "net/if_inet6"))
+	_, err := os.ReadFile(filepath.Join(util.GetProcRoot(), "net/if_inet6"))
 	return err == nil
 }

--- a/pkg/util/kernel/lockdown.go
+++ b/pkg/util/kernel/lockdown.go
@@ -9,7 +9,7 @@
 package kernel
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"regexp"
 
@@ -48,7 +48,7 @@ func getLockdownMode(data string) LockdownMode {
 
 // GetLockdownMode returns the lockdown
 func GetLockdownMode() LockdownMode {
-	data, err := ioutil.ReadFile(filepath.Join(util.GetSysRoot(), "kernel/security/lockdown"))
+	data, err := os.ReadFile(filepath.Join(util.GetSysRoot(), "kernel/security/lockdown"))
 	if err != nil {
 		return Unknown
 	}

--- a/pkg/util/kernel/version.go
+++ b/pkg/util/kernel/version.go
@@ -10,7 +10,7 @@ package kernel
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"regexp"
 	"strconv"
 
@@ -50,7 +50,7 @@ func HostVersion() (Version, error) {
 		return hostVersion, nil
 	}
 
-	if procVersion, err := ioutil.ReadFile("/proc/version_signature"); err == nil {
+	if procVersion, err := os.ReadFile("/proc/version_signature"); err == nil {
 		v, err := parseUbuntuVersion(string(procVersion))
 		if err != nil {
 			return 0, fmt.Errorf("error parsing ubuntu kernel version: %s", err)

--- a/pkg/util/kubernetes/apiserver/common/common.go
+++ b/pkg/util/kubernetes/apiserver/common/common.go
@@ -10,7 +10,7 @@ package common
 
 import (
 	"context"
-	"io/ioutil"
+	"os"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -39,7 +39,7 @@ func GetResourcesNamespace() string {
 // GetMyNamespace returns the namespace our pod is running in
 func GetMyNamespace() string {
 	namespacePath := "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
-	val, e := ioutil.ReadFile(namespacePath)
+	val, e := os.ReadFile(namespacePath)
 	if e == nil && val != nil {
 		return string(val)
 	}

--- a/pkg/util/kubernetes/auth.go
+++ b/pkg/util/kubernetes/auth.go
@@ -9,7 +9,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
 	"os"
 )
 
@@ -28,7 +27,7 @@ func IsServiceAccountTokenAvailable() bool {
 
 // GetBearerToken reads the serviceaccount token
 func GetBearerToken(authTokenPath string) (string, error) {
-	token, err := ioutil.ReadFile(authTokenPath)
+	token, err := os.ReadFile(authTokenPath)
 	if err != nil {
 		return "", fmt.Errorf("could not read token from %s: %s", authTokenPath, err)
 	}
@@ -47,7 +46,7 @@ func GetCertificates(certFilePath, keyFilePath string) ([]tls.Certificate, error
 
 // GetCertificateAuthority loads the issuing certificate authority
 func GetCertificateAuthority(certPath string) (*x509.CertPool, error) {
-	caCert, err := ioutil.ReadFile(certPath)
+	caCert, err := os.ReadFile(certPath)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/util/kubernetes/kubelet/kubelet_client.go
+++ b/pkg/util/kubernetes/kubelet/kubelet_client.go
@@ -14,7 +14,7 @@ import (
 	"errors"
 	"expvar"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"regexp"
@@ -146,7 +146,7 @@ func (kc *kubeletClient) query(ctx context.Context, path string) ([]byte, int, e
 	}
 	defer response.Body.Close()
 
-	b, err := ioutil.ReadAll(response.Body)
+	b, err := io.ReadAll(response.Body)
 	if err != nil {
 		log.Debugf("Fail to read request %s body: %s", req.URL.String(), err)
 		return nil, 0, err

--- a/pkg/util/kubernetes/kubelet/kubelet_common_test.go
+++ b/pkg/util/kubernetes/kubelet/kubelet_common_test.go
@@ -11,7 +11,7 @@ package kubelet
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -41,7 +41,7 @@ process_cpu_seconds_total 127923.04
 }
 
 func loadPodsFixture(path string) ([]*Pod, error) {
-	raw, err := ioutil.ReadFile(path)
+	raw, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/util/kubernetes/kubelet/kubelet_test.go
+++ b/pkg/util/kubernetes/kubelet/kubelet_test.go
@@ -14,7 +14,6 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -61,7 +60,7 @@ func newDummyKubelet(podListJSONPath string) (*dummyKubelet, error) {
 func (d *dummyKubelet) loadPodList(podListJSONPath string) error {
 	d.Lock()
 	defer d.Unlock()
-	podList, err := ioutil.ReadFile(podListJSONPath)
+	podList, err := os.ReadFile(podListJSONPath)
 	if err != nil {
 		return err
 	}
@@ -131,12 +130,12 @@ func (d *dummyKubelet) StartTLS() (*httptest.Server, int, error) {
 	if len(ts.TLS.Certificates) != 1 {
 		return ts, 0, fmt.Errorf("unexpected number of testing certificates: 1 != %d", len(ts.TLS.Certificates))
 	}
-	certOut, err := ioutil.TempFile("", "kubelet-test-cert-")
+	certOut, err := os.CreateTemp("", "kubelet-test-cert-")
 	d.testingCertificate = certOut.Name()
 	if err != nil {
 		return ts, 0, err
 	}
-	keyOut, err := ioutil.TempFile("", "kubelet-test-key-")
+	keyOut, err := os.CreateTemp("", "kubelet-test-key-")
 	d.testingPrivateKey = keyOut.Name()
 	if err != nil {
 		return ts, 0, err

--- a/pkg/util/scrubber/default_test.go
+++ b/pkg/util/scrubber/default_test.go
@@ -6,7 +6,6 @@
 package scrubber
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -29,11 +28,11 @@ func TestConfigScrubbedValidYaml(t *testing.T) {
 	wd, _ := os.Getwd()
 
 	inputConf := filepath.Join(wd, "test", "conf.yaml")
-	inputConfData, err := ioutil.ReadFile(inputConf)
+	inputConfData, err := os.ReadFile(inputConf)
 	require.NoError(t, err)
 
 	outputConf := filepath.Join(wd, "test", "conf_scrubbed.yaml")
-	outputConfData, err := ioutil.ReadFile(outputConf)
+	outputConfData, err := os.ReadFile(outputConf)
 	require.NoError(t, err)
 
 	cleaned, err := ScrubBytes([]byte(inputConfData))

--- a/pkg/util/scrubber/scrubber_test.go
+++ b/pkg/util/scrubber/scrubber_test.go
@@ -6,7 +6,7 @@
 package scrubber
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -69,7 +69,7 @@ func TestSkipComments(t *testing.T) {
 func TestCleanFile(t *testing.T) {
 	dir := t.TempDir()
 	filename := filepath.Join(dir, "test.yml")
-	ioutil.WriteFile(filename, []byte("a line with foo\n\na line with bar"), 0666)
+	os.WriteFile(filename, []byte("a line with foo\n\na line with bar"), 0666)
 
 	scrubber := New()
 	scrubber.AddReplacer(SingleLine, Replacer{

--- a/pkg/util/system/namespace_linux_test.go
+++ b/pkg/util/system/namespace_linux_test.go
@@ -9,7 +9,6 @@
 package system
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -24,9 +23,9 @@ func TestNamespacesInodes(t *testing.T) {
 	assert.NoError(t, os.MkdirAll(filepath.Join(fakeProc, "2", "ns"), 0o755))
 	assert.NoError(t, os.MkdirAll(filepath.Join(fakeProc, "3", "ns"), 0o755))
 
-	assert.NoError(t, ioutil.WriteFile(filepath.Join(fakeProc, "1", "ns", "net"), []byte{}, 0o644))
+	assert.NoError(t, os.WriteFile(filepath.Join(fakeProc, "1", "ns", "net"), []byte{}, 0o644))
 	assert.NoError(t, os.Link(filepath.Join(fakeProc, "1", "ns", "net"), filepath.Join(fakeProc, "2", "ns", "net")))
-	assert.NoError(t, ioutil.WriteFile(filepath.Join(fakeProc, "3", "ns", "net"), []byte{}, 0o644))
+	assert.NoError(t, os.WriteFile(filepath.Join(fakeProc, "3", "ns", "net"), []byte{}, 0o644))
 
 	pid2inode, err := GetProcessNamespaceInode(fakeProc, "2", "net")
 	assert.NoError(t, err)

--- a/pkg/util/testutil/tempfolder.go
+++ b/pkg/util/testutil/tempfolder.go
@@ -6,7 +6,6 @@
 package testutil
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -19,7 +18,7 @@ type TempFolder struct {
 
 // NewTempFolder creates a new temporary folder
 func NewTempFolder(namePrefix string) (*TempFolder, error) {
-	path, err := ioutil.TempDir("", namePrefix)
+	path, err := os.MkdirTemp("", namePrefix)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/util/winutil/iisconfig.go
+++ b/pkg/util/winutil/iisconfig.go
@@ -10,7 +10,6 @@ package winutil
 import (
 	"encoding/xml"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -130,7 +129,7 @@ type iisConfiguration struct {
 
 func (iiscfg *DynamicIISConfig) readXmlConfig() error {
 	var newcfg iisConfiguration
-	f, err := ioutil.ReadFile(iiscfg.path)
+	f, err := os.ReadFile(iiscfg.path)
 	if err != nil {
 		return err
 	}

--- a/rtloader/test/aggregator/aggregator.go
+++ b/rtloader/test/aggregator/aggregator.go
@@ -7,7 +7,6 @@ package testaggregator
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"runtime"
@@ -112,7 +111,7 @@ func setUp() error {
 
 func run(call string) (string, error) {
 	resetOuputValues()
-	tmpfile, err := ioutil.TempFile("", "testout")
+	tmpfile, err := os.CreateTemp("", "testout")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -141,7 +140,7 @@ except Exception as e:
 	}
 
 	var output []byte
-	output, err = ioutil.ReadFile(tmpfile.Name())
+	output, err = os.ReadFile(tmpfile.Name())
 
 	return strings.TrimSpace(string(output)), err
 }

--- a/rtloader/test/containers/containers.go
+++ b/rtloader/test/containers/containers.go
@@ -7,7 +7,6 @@ package testcontainers
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"runtime"
 	"strings"
@@ -50,7 +49,7 @@ func setUp() error {
 	}
 
 	var err error
-	tmpfile, err = ioutil.TempFile("", "testout")
+	tmpfile, err = os.CreateTemp("", "testout")
 	if err != nil {
 		return err
 	}
@@ -95,7 +94,7 @@ except Exception as e:
 		return "", fmt.Errorf("`run_simple_string` errored")
 	}
 
-	output, err := ioutil.ReadFile(tmpfile.Name())
+	output, err := os.ReadFile(tmpfile.Name())
 
 	return strings.TrimSpace(string(output)), err
 }

--- a/rtloader/test/datadog_agent/datadog_agent.go
+++ b/rtloader/test/datadog_agent/datadog_agent.go
@@ -8,7 +8,6 @@ package testdatadogagent
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"runtime"
 	"strings"
@@ -83,7 +82,7 @@ func setUp() error {
 	}
 
 	var err error
-	tmpfile, err = ioutil.TempFile("", "testout")
+	tmpfile, err = os.CreateTemp("", "testout")
 	if err != nil {
 		return err
 	}
@@ -130,7 +129,7 @@ except Exception as e:
 		return "", fmt.Errorf("`run_simple_string` errored")
 	}
 
-	output, err := ioutil.ReadFile(tmpfile.Name())
+	output, err := os.ReadFile(tmpfile.Name())
 
 	return strings.TrimSpace(string(output)), err
 }
@@ -186,7 +185,7 @@ func getTracemallocEnabled() C.bool {
 //export doLog
 func doLog(msg *C.char, level C.int) {
 	data := []byte(fmt.Sprintf("[%d]%s", int(level), C.GoString(msg)))
-	ioutil.WriteFile(tmpfile.Name(), data, 0644)
+	os.WriteFile(tmpfile.Name(), data, 0644)
 }
 
 //export setCheckMetadata

--- a/rtloader/test/kubeutil/kubeutil.go
+++ b/rtloader/test/kubeutil/kubeutil.go
@@ -7,7 +7,6 @@ package testkubeutil
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"runtime"
 	"unsafe"
@@ -46,7 +45,7 @@ func setUp() error {
 	}
 
 	var err error
-	tmpfile, err = ioutil.TempFile("", "testout")
+	tmpfile, err = os.CreateTemp("", "testout")
 	if err != nil {
 		return err
 	}
@@ -91,7 +90,7 @@ except Exception as e:
 		return "", fmt.Errorf("`run_simple_string` errored")
 	}
 
-	output, err := ioutil.ReadFile(tmpfile.Name())
+	output, err := os.ReadFile(tmpfile.Name())
 
 	return string(output), err
 }

--- a/rtloader/test/rtloader/rtloader.go
+++ b/rtloader/test/rtloader/rtloader.go
@@ -13,7 +13,6 @@ import "C"
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -39,7 +38,7 @@ func setUp() error {
 	}
 
 	var err error
-	tmpfile, err = ioutil.TempFile("", "testout")
+	tmpfile, err = os.CreateTemp("", "testout")
 	if err != nil {
 		return err
 	}
@@ -90,7 +89,7 @@ func runString(code string) (string, error) {
 		return "", fmt.Errorf("`run_simple_string` errored")
 	}
 
-	output, err := ioutil.ReadFile(tmpfile.Name())
+	output, err := os.ReadFile(tmpfile.Name())
 	return string(output), err
 }
 

--- a/rtloader/test/tagger/tagger.go
+++ b/rtloader/test/tagger/tagger.go
@@ -7,7 +7,6 @@ package testtagger
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"runtime"
 	"strings"
@@ -46,7 +45,7 @@ func setUp() error {
 	}
 
 	var err error
-	tmpfile, err = ioutil.TempFile("", "testout")
+	tmpfile, err = os.CreateTemp("", "testout")
 	if err != nil {
 		return err
 	}
@@ -91,7 +90,7 @@ except Exception as e:
 		return "", fmt.Errorf("`run_simple_string` errored")
 	}
 
-	output, err := ioutil.ReadFile(tmpfile.Name())
+	output, err := os.ReadFile(tmpfile.Name())
 	return strings.TrimSpace(string(output)), err
 }
 

--- a/rtloader/test/util/util.go
+++ b/rtloader/test/util/util.go
@@ -7,7 +7,6 @@ package testutil
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"runtime"
 	"unsafe"
@@ -51,7 +50,7 @@ func setUp() error {
 	}
 
 	var err error
-	tmpfile, err = ioutil.TempFile("", "testout")
+	tmpfile, err = os.CreateTemp("", "testout")
 	if err != nil {
 		return err
 	}
@@ -97,7 +96,7 @@ except Exception as e:
 		return "", fmt.Errorf("`run_simple_string` errored")
 	}
 
-	output, err := ioutil.ReadFile(tmpfile.Name())
+	output, err := os.ReadFile(tmpfile.Name())
 
 	return string(output), err
 }

--- a/rtloader/test/uutil/uutil.go
+++ b/rtloader/test/uutil/uutil.go
@@ -7,7 +7,6 @@ package testuutil
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"runtime"
 	"strings"
@@ -45,7 +44,7 @@ func setUp() error {
 	}
 
 	var err error
-	tmpfile, err = ioutil.TempFile("", "testout")
+	tmpfile, err = os.CreateTemp("", "testout")
 	if err != nil {
 		return err
 	}
@@ -92,7 +91,7 @@ except Exception as e:
 		return "", fmt.Errorf("`run_simple_string` errored")
 	}
 
-	output, err := ioutil.ReadFile(tmpfile.Name())
+	output, err := os.ReadFile(tmpfile.Name())
 
 	return strings.TrimSpace(string(output)), err
 }

--- a/test/benchmarks/aggregator/main.go
+++ b/test/benchmarks/aggregator/main.go
@@ -10,7 +10,7 @@ import (
 	_ "expvar"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math/rand"
 	"net/http"
 	"strconv"
@@ -114,7 +114,7 @@ func getExpvarJSON() (*aggregatorStats, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 
 	res := stats{}
 	err = json.Unmarshal(body, &res)

--- a/test/integration/serverless/recorder-extension/go.mod
+++ b/test/integration/serverless/recorder-extension/go.mod
@@ -1,6 +1,6 @@
 module datadog-lambda-extension/recorder-extension
 
-go 1.16
+go 1.18
 
 replace (
 	github.com/DataDog/datadog-agent/pkg/obfuscate => github.com/DataDog/datadog-agent/pkg/obfuscate v0.0.0-20211201172000-1fd9a353e8e4
@@ -36,4 +36,10 @@ replace (
 require (
 	github.com/DataDog/agent-payload/v5 v5.0.19
 	github.com/DataDog/datadog-agent v0.0.0-20211213161047-f82981e22ca1
+)
+
+require (
+	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/philhofer/fwd v1.1.1 // indirect
+	github.com/tinylib/msgp v1.1.6 // indirect
 )

--- a/test/integration/serverless/recorder-extension/main.go
+++ b/test/integration/serverless/recorder-extension/main.go
@@ -13,7 +13,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"os/signal"
@@ -176,7 +176,7 @@ func (e *Client) NextEvent(ctx context.Context) (*NextEventResponse, error) {
 		return nil, fmt.Errorf("request failed with status %s", httpRes.Status)
 	}
 	defer httpRes.Body.Close()
-	body, err := ioutil.ReadAll(httpRes.Body)
+	body, err := io.ReadAll(httpRes.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -196,7 +196,7 @@ func Start(port string) {
 func startHTTPServer(port string) {
 	http.HandleFunc("/api/beta/sketches", func(w http.ResponseWriter, r *http.Request) {
 		nbHitMetrics++
-		body, err := ioutil.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			fmt.Printf("Error while reading HTTP request body: %s \n", err)
 			return
@@ -227,7 +227,7 @@ func startHTTPServer(port string) {
 	})
 
 	http.HandleFunc("/api/v2/logs", func(w http.ResponseWriter, r *http.Request) {
-		body, err := ioutil.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			return
 		}
@@ -269,7 +269,7 @@ func startHTTPServer(port string) {
 
 	http.HandleFunc("/api/v0.2/traces", func(w http.ResponseWriter, r *http.Request) {
 		nbHitTraces++
-		body, err := ioutil.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			return
 		}

--- a/test/integration/serverless/src/go.mod
+++ b/test/integration/serverless/src/go.mod
@@ -1,10 +1,45 @@
 module lambda-time
 
-go 1.15
+go 1.18
 
 require (
 	github.com/DataDog/datadog-lambda-go v1.4.0
 	github.com/aws/aws-lambda-go v1.29.0
-	github.com/valyala/fasthttp v1.35.0 // indirect
 	gopkg.in/DataDog/dd-trace-go.v1 v1.37.1
+)
+
+require (
+	github.com/DataDog/datadog-agent/pkg/obfuscate v0.0.0-20211129110424-6491aa3bf583 // indirect
+	github.com/DataDog/datadog-go v4.8.2+incompatible // indirect
+	github.com/DataDog/datadog-go/v5 v5.0.2 // indirect
+	github.com/DataDog/sketches-go v1.0.0 // indirect
+	github.com/Microsoft/go-winio v0.5.1 // indirect
+	github.com/andybalholm/brotli v1.0.4 // indirect
+	github.com/aws/aws-sdk-go v1.40.2 // indirect
+	github.com/aws/aws-xray-sdk-go v1.6.0 // indirect
+	github.com/cenkalti/backoff v2.1.1+incompatible // indirect
+	github.com/cespare/xxhash/v2 v2.1.2 // indirect
+	github.com/dgraph-io/ristretto v0.1.0 // indirect
+	github.com/dustin/go-humanize v1.0.0 // indirect
+	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/google/uuid v1.3.0 // indirect
+	github.com/jmespath/go-jmespath v0.4.0 // indirect
+	github.com/josharian/intern v1.0.0 // indirect
+	github.com/klauspost/compress v1.15.0 // indirect
+	github.com/mailru/easyjson v0.7.7 // indirect
+	github.com/philhofer/fwd v1.1.1 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/sony/gobreaker v0.4.1 // indirect
+	github.com/tinylib/msgp v1.1.2 // indirect
+	github.com/valyala/bytebufferpool v1.0.0 // indirect
+	github.com/valyala/fasthttp v1.35.0 // indirect
+	golang.org/x/net v0.0.0-20220225172249-27dd8689420f // indirect
+	golang.org/x/sys v0.0.0-20220227234510-4e6760a101f9 // indirect
+	golang.org/x/text v0.3.7 // indirect
+	golang.org/x/time v0.0.0-20211116232009-f0f3c7e86c11 // indirect
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
+	google.golang.org/genproto v0.0.0-20210114201628-6edceaf6022f // indirect
+	google.golang.org/grpc v1.35.0 // indirect
+	google.golang.org/protobuf v1.27.1 // indirect
 )

--- a/test/integration/serverless/src/go.sum
+++ b/test/integration/serverless/src/go.sum
@@ -146,7 +146,6 @@ github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7
 github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
-github.com/cpuguy83/go-md2man/v2 v2.0.1/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v0.0.0-20151105211317-5215b55f46b2/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -507,14 +506,10 @@ github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfn
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.8/go.mod h1:O1sed60cT9XZ5uDucP5qwvh+TE3NnUj51EiZO/lmSfw=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
-github.com/labstack/echo v3.3.10+incompatible h1:pGRcYk231ExFAyoAjAfD85kQzRJCRI8bbnE7CX5OEgg=
 github.com/labstack/echo v3.3.10+incompatible/go.mod h1:0INS7j/VjnFxD4E2wkz67b8cVwCLbBmJyDaka6Cmk1s=
-github.com/labstack/echo/v4 v4.2.0 h1:jkCSsjXmBmapVXF6U4BrSz/cgofWM0CU3Q74wQvXkIc=
 github.com/labstack/echo/v4 v4.2.0/go.mod h1:AA49e0DZ8kk5jTOOCKNuPR6oTnBS0dYiM4FW1e6jwpg=
 github.com/labstack/gommon v0.3.0/go.mod h1:MULnywXg0yavhxWKc+lOruYdAhDwPK9wf0OL7NoOu+k=
-github.com/labstack/gommon v0.3.1 h1:OomWaJXm7xR6L1HmEtGyQf26TEn7V6X88mktX9kee9o=
 github.com/labstack/gommon v0.3.1/go.mod h1:uW6kP17uPlLJsD3ijUYn3/M5bAxtlZhMI6m3MFxTMTM=
 github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
@@ -534,7 +529,6 @@ github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVc
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.6/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-colorable v0.1.7/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
-github.com/mattn/go-colorable v0.1.11 h1:nQ+aFkoE2TMGc0b68U2OKSexC+eq46+XwZzWXHRmPYs=
 github.com/mattn/go-colorable v0.1.11/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.5/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
@@ -544,7 +538,6 @@ github.com/mattn/go-isatty v0.0.9/go.mod h1:YNRxwqDuOph6SZLI9vUUz6OYw3QyUt7WiY2y
 github.com/mattn/go-isatty v0.0.10/go.mod h1:qgIWMr58cqv1PHHyhnkY9lrL7etaEgOFcMEpPG5Rm84=
 github.com/mattn/go-isatty v0.0.11/go.mod h1:PhnuNfih5lzO57/f3n+odYbM4JtupLOxQOAqxQCu2WE=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
-github.com/mattn/go-isatty v0.0.14 h1:yVuAays6BHfxijgZPzw+3Zlu5yQgKGP2/hcQbHb7S9Y=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/mattn/go-sqlite3 v1.9.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/mattn/go-sqlite3 v1.14.12/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
@@ -577,7 +570,6 @@ github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7P
 github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
-github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
@@ -646,7 +638,6 @@ github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
 github.com/rs/zerolog v1.13.0/go.mod h1:YbFCdg8HfsridGWAh22vktObvhZbQsZXe4/zB0OKkWU=
 github.com/rs/zerolog v1.15.0/go.mod h1:xYTKnLHcpfU2225ny5qZjxnj9NvkumZYjJHlAThCjNc=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/ryanuber/columnize v2.1.0+incompatible/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/ryanuber/go-glob v1.0.0/go.mod h1:807d1WSdnB0XRJzKNil9Om6lcp/3a0v4qIHxIXzX/Yc=
@@ -716,7 +707,6 @@ github.com/ugorji/go v1.1.7/go.mod h1:kZn38zHttfInRq0xu/PH0az30d+z6vm202qpg1oXVM
 github.com/ugorji/go/codec v1.1.7/go.mod h1:Ax+UKWsSmolVDwsd+7N3ZtXu+yMGCf907BLYF3GoBXY=
 github.com/urfave/cli v0.0.0-20171014202726-7bc6a0acffa5/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli/v2 v2.2.0/go.mod h1:SE9GqnLQmjVa0iPEY0f1w3ygNIYcIJ0OKPMoW2caLfQ=
-github.com/urfave/cli/v2 v2.4.0/go.mod h1:NX9W0zmTvedE5oDoOMs2RTC8RvdK98NTYZE5LbaEYPg=
 github.com/urfave/negroni v1.0.0/go.mod h1:Meg73S6kFm/4PpbYdq35yYWoCZ9mS/YSx+lKnmiohz4=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
@@ -726,7 +716,6 @@ github.com/valyala/fasthttp v1.32.0/go.mod h1:2rsYD01CKFrjjsvFxx75KlEUNpWNBY9JWD
 github.com/valyala/fasthttp v1.35.0 h1:wwkR8mZn2NbigFsaw2Zj5r+xkmzjbrA/lyTmiSlal/Y=
 github.com/valyala/fasthttp v1.35.0/go.mod h1:t/G+3rLek+CyY9bnIE+YlMRddxVAAGjhxndDB4i4C0I=
 github.com/valyala/fasttemplate v1.0.1/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPUpymEIMZ47gx8=
-github.com/valyala/fasttemplate v1.2.1 h1:TVEnxayobAdVkhQfrfes2IzOB6o+z4roRkPF52WA1u4=
 github.com/valyala/fasttemplate v1.2.1/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
 github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a/go.mod h1:v3UYOV9WzVtRmSR+PDvWpU/qWl4Wa5LApYYX4ZtKbio=
 github.com/valyala/tcplisten v1.0.0/go.mod h1:T0xQ8SeCZGxckz9qRXTfG43PvQ/mcWh7FwZEA7Ioqkc=
@@ -795,7 +784,6 @@ golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a/go.mod h1:P+XmwS30IXTQdn5
 golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
-golang.org/x/crypto v0.0.0-20220214200702-86341886e292 h1:f+lwQ+GtmgoY+A2YaQxlSOnDjXcQ7ZRLWOHbC6HtRqE=
 golang.org/x/crypto v0.0.0-20220214200702-86341886e292/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -1137,7 +1125,6 @@ gopkg.in/asn1-ber.v1 v1.0.0-20181015200546-f715ec2f112d/go.mod h1:cuepJuh7vyXfUy
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8XK9/i0At2xKjWk4p6zsU=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=

--- a/test/system/dogstatsd/dogstatsd_test.go
+++ b/test/system/dogstatsd/dogstatsd_test.go
@@ -9,7 +9,7 @@ import (
 	"bufio"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -52,7 +52,7 @@ func (d *dogstatsdTest) setup(t *testing.T) {
 
 	// start fake backend
 	d.ts = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		body, err := ioutil.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
 		require.NoError(t, err, "Could not read request Body")
 
 		d.m.Lock()
@@ -67,8 +67,8 @@ func (d *dogstatsdTest) setup(t *testing.T) {
 
 	// write temp conf
 	content := []byte("dd_url: " + d.ts.URL + "\napi_key: dummy\n")
-	tmpConf := filepath.Join(dir, "datadog.yaml")
-	err := ioutil.WriteFile(tmpConf, content, 0666)
+	tmpConf := filepath.Join(d.tmpDir, "datadog.yaml")
+	err := os.WriteFile(tmpConf, content, 0666)
 	require.NoError(t, err, "Could not write temp conf")
 
 	// start dogstatsd

--- a/tools/retry_file_dump/main.go
+++ b/tools/retry_file_dump/main.go
@@ -13,7 +13,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 	"path"
 	"path/filepath"
 
@@ -41,13 +41,13 @@ func parseArg() (string, error) {
 }
 
 func dumpRetryFiles(folder string) error {
-	entries, err := ioutil.ReadDir(folder)
+	entries, err := os.ReadDir(folder)
 	if err != nil {
 		return err
 	}
 
 	for _, entry := range entries {
-		if entry.Mode().IsRegular() && filepath.Ext(entry.Name()) == ".retry" {
+		if entry.Type().IsRegular() && filepath.Ext(entry.Name()) == ".retry" {
 			fmt.Println(entry.Name())
 			filePath := path.Join(folder, entry.Name())
 			fileContent, err := dumpRetryFile(filePath)
@@ -55,7 +55,7 @@ func dumpRetryFiles(folder string) error {
 				return err
 			}
 			output := filePath + ".json"
-			err = ioutil.WriteFile(output, fileContent, 0600)
+			err = os.WriteFile(output, fileContent, 0600)
 			if err != nil {
 				return err
 			}
@@ -65,7 +65,7 @@ func dumpRetryFiles(folder string) error {
 }
 
 func dumpRetryFile(file string) ([]byte, error) {
-	content, err := ioutil.ReadFile(file)
+	content, err := os.ReadFile(file)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

The `io/ioutil` package has been deprecated in Go 1.16 (See https://pkg.go.dev/io/ioutil). This PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.

- `ioutil.Discard` => `io.Discard`
- `ioutil.NopCloser` => `io.NopCloser`
- `ioutil.ReadAll` => `io.ReadAll`
- `ioutil.ReadDir` => `os.ReadDir` (returns a slice of `os.DirEntry` rather than a slice of `fs.FileInfo`, this may improve performance in some cases as `os.ReadDir` is more efficient [\[1\]])
- `ioutil.ReadFile` => `os.ReadFile`
- `ioutil.TempDir` => `os.MkdirTemp`
- `ioutil.TempFile` => `os.CreateTemp`
- `ioutil.WriteFile` => `os.WriteFile`

[\[1\]]: https://pkg.go.dev/io/ioutil#ReadDir

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Code cleanup to replace deprecated functions.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

No user-facing changes introduced.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

All tests should continue to pass. `go build` should not fail.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
