### PR TITLE
[WA-105] Add agent user dialog to next-gen installer

### DIFF
--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentInstaller.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentInstaller.cs
@@ -191,7 +191,8 @@ namespace WixSetup.Datadog
             project.UI = WUI.WixUI_Common;
             project.CustomUI = _agentInstallerUi.CustomUI;
             project.AddXmlInclude("dialogs/apikeydlg.wxi")
-                   .AddXmlInclude("dialogs/sitedlg.wxi");
+                   .AddXmlInclude("dialogs/sitedlg.wxi")
+                   .AddXmlInclude("dialogs/ddagentuserdlg.wxi");
 
             return project;
         }

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentInstallerUI.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentInstallerUI.cs
@@ -32,10 +32,13 @@ namespace WixSetup.Datadog
             CustomUI.On(Dialogs.ApiKeyDialog, Buttons.Back, new ShowDialog(NativeDialogs.CustomizeDlg, Condition.NOT_Installed));
             CustomUI.On(Dialogs.ApiKeyDialog, Buttons.Back, new ShowDialog(NativeDialogs.MaintenanceTypeDlg, Conditions.Installed_AND_NOT_PATCH));
 
-            CustomUI.On(Dialogs.SiteSelectionDialog, Buttons.Next, new ShowDialog(NativeDialogs.VerifyReadyDlg));
+            CustomUI.On(Dialogs.SiteSelectionDialog, Buttons.Next, new ShowDialog(Dialogs.AgentUserDialog));
             CustomUI.On(Dialogs.SiteSelectionDialog, Buttons.Back, new ShowDialog(Dialogs.ApiKeyDialog));
 
-            CustomUI.On(NativeDialogs.VerifyReadyDlg, Buttons.Back, new ShowDialog(NativeDialogs.CustomizeDlg, Condition.NOT_Installed | Condition.Create("WixUI_InstallMode = \"Change\"")) { Order = 1 });
+            CustomUI.On(Dialogs.AgentUserDialog, Buttons.Next, new ShowDialog(NativeDialogs.VerifyReadyDlg));
+            CustomUI.On(Dialogs.AgentUserDialog, Buttons.Back, new ShowDialog(Dialogs.SiteSelectionDialog));
+
+            CustomUI.On(NativeDialogs.VerifyReadyDlg, Buttons.Back, new ShowDialog(Dialogs.AgentUserDialog, Condition.NOT_Installed | Condition.Create("WixUI_InstallMode = \"Change\"")) { Order = 1 });
             CustomUI.On(NativeDialogs.VerifyReadyDlg, Buttons.Back, new ShowDialog(NativeDialogs.MaintenanceTypeDlg, Conditions.Installed_AND_NOT_PATCH) { Order = 2 });
             CustomUI.On(NativeDialogs.VerifyReadyDlg, Buttons.Next, new ShowDialog(NativeDialogs.WelcomeDlg, Conditions.Installed_AND_PATCH) { Order = 3 });
 

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Dialogs.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Dialogs.cs
@@ -4,5 +4,6 @@
     {
         public const string ApiKeyDialog = "ApiKeyDlg";
         public const string SiteSelectionDialog = "SiteDlg";
+        public const string AgentUserDialog = "DDAgentUserDlg";
     }
 }

--- a/tools/windows/DatadogAgentInstaller/WixSetup/dialogs/ddagentuserdlg.wxi
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/dialogs/ddagentuserdlg.wxi
@@ -1,0 +1,48 @@
+<Include>
+  <UI>
+    <Dialog Id="DDAgentUserDlg" Width="370" Height="270" Title="!(loc.DDAgentUserDialog_Title)">
+
+      <!-- Username and Password fields
+           Sets the same property as the command line options
+             - DDAGENTUSER_NAME
+             - DDAGENTUSER_PASSWORD
+           If the properties are set on the command line, the controls will be pre-filled
+      -->
+      <Control Id="EnterUserName" Type="Text" Height="15" Width="320" X="25" Y="70"
+               Text="!(loc.DDAgentUserDialogUserNameLabel)" />
+      <Control Id="UserNameFromDefault" Type="Edit" Height="15" Width="320" X="25" Y="86"
+               Property="DDAGENTUSER_NAME" />
+      <Control Id="EnterPassword" Type="Text" Height="15" Width="320" X="25" Y="118"
+               Text="!(loc.DDAgentUserDialogPasswordLabel)" />
+      <Control Id="PasswordFromDefault" Type="Edit" Height="15" Width="320" X="25" Y="134"
+               Password="yes"
+               Property="DDAGENTUSER_PASSWORD" />
+
+      <!-- back button -->
+      <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17"
+               Text="Back">
+      </Control>
+
+      <!-- next button -->
+      <Control Id="Next" Type="PushButton" X="236" Y="243" Width="56" Height="17" Default="yes"
+                 Text="Next">
+      </Control>
+
+      <!-- cancel button -->
+      <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Cancel="yes"
+                 Text="Cancel">
+        <Publish Event="EndDialog" Value="Exit">1</Publish>
+      </Control>
+
+      <!-- Title + Banner -->
+      <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" TabSkip="no" Text="!(loc.LicenseAgreementDlgBannerBitmap)" />
+      <Control Id="BannerLine" Type="Line" X="0" Y="44" Width="370" Height="0" />
+      <Control Id="BottomLine" Type="Line" X="0" Y="234" Width="370" Height="0" />
+      <Control Id="Title" Type="Text" X="15" Y="6" Width="340" Height="15"
+               Transparent="yes" NoPrefix="yes" Text="!(loc.DDAgentUserDialogTitle)" />
+      <Control Id="Description" Type="Text" X="25" Y="23" Width="340" Height="15"
+               Transparent="yes" NoPrefix="yes" Text="!(loc.DDAgentUserDialogDescription)" />
+
+    </Dialog>
+  </UI>
+</Include>

--- a/tools/windows/DatadogAgentInstaller/WixSetup/localization-en-us.wxl
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/localization-en-us.wxl
@@ -41,6 +41,13 @@
   <String Id ="SiteDialogKeyLabel" Overridable="yes" Localizable="yes">Which [ShortCompanyName] region do you want the Agent to send data to?</String>
   <String Id ="SiteSampleKey" Overridable="yes" Localizable="yes"></String>
 
+  <!-- these strings for the agent user dialog -->
+  <String Id ="DDAgentUserDialog_Title" Overridable="yes" Localizable="yes">[ProductName] Setup</String>
+  <String Id ="DDAgentUserDialogDescription" Overridable="yes" Localizable="yes">{\WixUI_Font_Normal_White}Enter the agent user account</String>
+  <String Id ="DDAgentUserDialogTitle"  Overridable="yes" Localizable="yes">{\WixUI_Font_Title_White}[ShortCompanyName] Agent User Account</String>
+  <String Id ="DDAgentUserDialogUserNameLabel" Overridable="yes" Localizable="yes">Please enter the username (leave blank to use ddagentuser):</String>
+  <String Id ="DDAgentUserDialogPasswordLabel" Overridable="yes" Localizable="yes">Please enter the password (leave blank to use random password):</String>
+
   <String Id="MsiRMFilesInUse_Title" Overridable="yes">[ProductName] Setup</String>
   <String Id="MsiRMFilesInUseExit" Overridable="yes">E&amp;xit</String>
   <String Id="MsiRMFilesInUseBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
Add the agent user account name/password dialog to the next gen installer

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
This PR does not include the "validation" dialog present in the current installer.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
