### PR TITLE
[CWS] support new BTFHub `RELEASE_ID` mapping

### DIFF
--- a/pkg/security/probe/constantfetch/btfhub.go
+++ b/pkg/security/probe/constantfetch/btfhub.go
@@ -28,15 +28,6 @@ type BTFHubConstantFetcher struct {
 	res           map[string]uint64
 }
 
-var idToDistribMapping = map[string]string{
-	"ubuntu": "ubuntu",
-	"debian": "debian",
-	"amzn":   "amzn",
-	"centos": "centos",
-	"fedora": "fedora",
-	"ol":     "oracle-linux",
-}
-
 var archMapping = map[string]string{
 	"amd64": "x86_64",
 	"arm64": "arm64",
@@ -110,14 +101,9 @@ type kernelInfos struct {
 }
 
 func newKernelInfos(kv *kernel.Version) (*kernelInfos, error) {
-	releaseID, ok := kv.OsRelease["ID"]
+	distribution, ok := kv.OsRelease["ID"]
 	if !ok {
 		return nil, fmt.Errorf("failed to collect os-release ID")
-	}
-
-	distribution, ok := idToDistribMapping[releaseID]
-	if !ok {
-		return nil, fmt.Errorf("failed to map release ID to distribution")
 	}
 
 	version, ok := kv.OsRelease["VERSION_ID"]
@@ -125,13 +111,12 @@ func newKernelInfos(kv *kernel.Version) (*kernelInfos, error) {
 		return nil, fmt.Errorf("failed to collect os-release VERSION_ID")
 	}
 
-	// HACK: fix mapping of version for oracle-linux
-	if distribution == "oracle-linux" {
-		if strings.HasPrefix(version, "7.") {
-			version = "ol7"
-		} else {
-			return nil, fmt.Errorf("failed to collect version for non ol7 oracle linux")
-		}
+	// HACK: fix mapping of version for oracle-linux and amazon linux 2018
+	switch {
+	case distribution == "ol" && strings.HasPrefix(version, "7."):
+		version = "7"
+	case distribution == "amzn" && strings.HasPrefix(version, "2018."):
+		version = "2018"
 	}
 
 	arch, ok := archMapping[runtime.GOARCH]

--- a/pkg/security/probe/constantfetch/btfhub/constants.json
+++ b/pkg/security/probe/constantfetch/btfhub/constants.json
@@ -20,92 +20,35 @@
 			"pid_numbers_offset": 48,
 			"pipe_inode_info_bufs_offset": 120,
 			"sb_magic_offset": 96,
-			"sizeof_inode": 600,
-			"sizeof_upid": 32,
-			"sock_common_skc_family_offset": 16,
-			"sock_common_skc_net_offset": 48,
-			"socket_sock_offset": 32,
-			"tty_name_offset": 368,
-			"tty_offset": 368
-		},
-		{
-			"binprm_file_offset": 168,
-			"bpf_map_id_offset": 48,
-			"bpf_map_type_offset": 24,
-			"bpf_prog_aux_id_offset": 16,
-			"bpf_prog_aux_offset": 24,
-			"bpf_prog_tag_offset": 16,
-			"bpf_prog_type_offset": 4,
-			"creds_uid_offset": 4,
-			"dentry_sb_offset": 104,
-			"flowi4_saddr_offset": 40,
-			"flowi4_uli_offset": 48,
-			"flowi6_saddr_offset": 56,
-			"flowi6_uli_offset": 76,
-			"net_device_ifindex_offset": 264,
-			"net_ns_offset": 120,
-			"pid_level_offset": 4,
-			"pid_numbers_offset": 48,
-			"pipe_inode_info_bufs_offset": 120,
-			"sb_magic_offset": 96,
-			"sizeof_inode": 608,
-			"sizeof_upid": 32,
-			"sock_common_skc_family_offset": 16,
-			"sock_common_skc_net_offset": 48,
-			"socket_sock_offset": 32,
-			"tty_name_offset": 368,
-			"tty_offset": 368
-		},
-		{
-			"binprm_file_offset": 168,
-			"bpf_map_id_offset": 48,
-			"bpf_map_type_offset": 24,
-			"bpf_prog_aux_id_offset": 16,
-			"bpf_prog_aux_offset": 24,
-			"bpf_prog_tag_offset": 16,
-			"bpf_prog_type_offset": 4,
-			"creds_uid_offset": 4,
-			"dentry_sb_offset": 104,
-			"flowi4_saddr_offset": 40,
-			"flowi4_uli_offset": 48,
-			"flowi6_saddr_offset": 56,
-			"flowi6_uli_offset": 76,
-			"net_device_ifindex_offset": 264,
-			"net_ns_offset": 120,
-			"nf_conn_ct_net_offset": 144,
-			"pid_level_offset": 4,
-			"pid_numbers_offset": 48,
-			"pipe_inode_info_bufs_offset": 120,
-			"sb_magic_offset": 96,
-			"sizeof_inode": 608,
-			"sizeof_upid": 32,
-			"sock_common_skc_family_offset": 16,
-			"sock_common_skc_net_offset": 48,
-			"socket_sock_offset": 32,
-			"tty_name_offset": 368,
-			"tty_offset": 368
-		},
-		{
-			"binprm_file_offset": 168,
-			"bpf_map_id_offset": 48,
-			"bpf_map_type_offset": 24,
-			"bpf_prog_aux_id_offset": 16,
-			"bpf_prog_aux_offset": 24,
-			"bpf_prog_tag_offset": 16,
-			"bpf_prog_type_offset": 4,
-			"creds_uid_offset": 4,
-			"dentry_sb_offset": 104,
-			"flowi4_saddr_offset": 40,
-			"flowi4_uli_offset": 48,
-			"flowi6_saddr_offset": 56,
-			"flowi6_uli_offset": 76,
-			"net_device_ifindex_offset": 264,
-			"net_ns_offset": 120,
-			"pid_level_offset": 4,
-			"pid_numbers_offset": 48,
-			"pipe_inode_info_bufs_offset": 120,
-			"sb_magic_offset": 96,
 			"sizeof_inode": 592,
+			"sizeof_upid": 32,
+			"sock_common_skc_family_offset": 16,
+			"sock_common_skc_net_offset": 48,
+			"socket_sock_offset": 32,
+			"tty_name_offset": 368,
+			"tty_offset": 368
+		},
+		{
+			"binprm_file_offset": 168,
+			"bpf_map_id_offset": 48,
+			"bpf_map_type_offset": 24,
+			"bpf_prog_aux_id_offset": 16,
+			"bpf_prog_aux_offset": 24,
+			"bpf_prog_tag_offset": 16,
+			"bpf_prog_type_offset": 4,
+			"creds_uid_offset": 4,
+			"dentry_sb_offset": 104,
+			"flowi4_saddr_offset": 40,
+			"flowi4_uli_offset": 48,
+			"flowi6_saddr_offset": 56,
+			"flowi6_uli_offset": 76,
+			"net_device_ifindex_offset": 264,
+			"net_ns_offset": 120,
+			"pid_level_offset": 4,
+			"pid_numbers_offset": 48,
+			"pipe_inode_info_bufs_offset": 120,
+			"sb_magic_offset": 96,
+			"sizeof_inode": 600,
 			"sizeof_upid": 32,
 			"sock_common_skc_family_offset": 16,
 			"sock_common_skc_net_offset": 48,
@@ -169,6 +112,63 @@
 			"socket_sock_offset": 32,
 			"tty_name_offset": 368,
 			"tty_offset": 376
+		},
+		{
+			"binprm_file_offset": 168,
+			"bpf_map_id_offset": 48,
+			"bpf_map_type_offset": 24,
+			"bpf_prog_aux_id_offset": 16,
+			"bpf_prog_aux_offset": 24,
+			"bpf_prog_tag_offset": 16,
+			"bpf_prog_type_offset": 4,
+			"creds_uid_offset": 4,
+			"dentry_sb_offset": 104,
+			"flowi4_saddr_offset": 40,
+			"flowi4_uli_offset": 48,
+			"flowi6_saddr_offset": 56,
+			"flowi6_uli_offset": 76,
+			"net_device_ifindex_offset": 264,
+			"net_ns_offset": 120,
+			"pid_level_offset": 4,
+			"pid_numbers_offset": 48,
+			"pipe_inode_info_bufs_offset": 120,
+			"sb_magic_offset": 96,
+			"sizeof_inode": 608,
+			"sizeof_upid": 32,
+			"sock_common_skc_family_offset": 16,
+			"sock_common_skc_net_offset": 48,
+			"socket_sock_offset": 32,
+			"tty_name_offset": 368,
+			"tty_offset": 368
+		},
+		{
+			"binprm_file_offset": 168,
+			"bpf_map_id_offset": 48,
+			"bpf_map_type_offset": 24,
+			"bpf_prog_aux_id_offset": 16,
+			"bpf_prog_aux_offset": 24,
+			"bpf_prog_tag_offset": 16,
+			"bpf_prog_type_offset": 4,
+			"creds_uid_offset": 4,
+			"dentry_sb_offset": 104,
+			"flowi4_saddr_offset": 40,
+			"flowi4_uli_offset": 48,
+			"flowi6_saddr_offset": 56,
+			"flowi6_uli_offset": 76,
+			"net_device_ifindex_offset": 264,
+			"net_ns_offset": 120,
+			"nf_conn_ct_net_offset": 144,
+			"pid_level_offset": 4,
+			"pid_numbers_offset": 48,
+			"pipe_inode_info_bufs_offset": 120,
+			"sb_magic_offset": 96,
+			"sizeof_inode": 608,
+			"sizeof_upid": 32,
+			"sock_common_skc_family_offset": 16,
+			"sock_common_skc_net_offset": 48,
+			"socket_sock_offset": 32,
+			"tty_name_offset": 368,
+			"tty_offset": 368
 		},
 		{
 			"binprm_file_offset": 168,
@@ -2110,1543 +2110,1102 @@
 	"kernels": [
 		{
 			"distrib": "amzn",
-			"version": "1",
-			"arch": "x86_64",
-			"uname_release": "4.14.101-75.76.amzn1.x86_64",
-			"cindex": 0
-		},
-		{
-			"distrib": "amzn",
-			"version": "1",
-			"arch": "x86_64",
-			"uname_release": "4.14.104-78.84.amzn1.x86_64",
-			"cindex": 0
-		},
-		{
-			"distrib": "amzn",
-			"version": "1",
-			"arch": "x86_64",
-			"uname_release": "4.14.106-79.86.amzn1.x86_64",
-			"cindex": 0
-		},
-		{
-			"distrib": "amzn",
-			"version": "1",
-			"arch": "x86_64",
-			"uname_release": "4.14.109-80.92.amzn1.x86_64",
-			"cindex": 0
-		},
-		{
-			"distrib": "amzn",
-			"version": "1",
-			"arch": "x86_64",
-			"uname_release": "4.14.114-82.97.amzn1.x86_64",
-			"cindex": 0
-		},
-		{
-			"distrib": "amzn",
-			"version": "1",
-			"arch": "x86_64",
-			"uname_release": "4.14.114-83.126.amzn1.x86_64",
-			"cindex": 0
-		},
-		{
-			"distrib": "amzn",
-			"version": "1",
-			"arch": "x86_64",
-			"uname_release": "4.14.121-85.96.amzn1.x86_64",
-			"cindex": 0
-		},
-		{
-			"distrib": "amzn",
-			"version": "1",
-			"arch": "x86_64",
-			"uname_release": "4.14.123-86.109.amzn1.x86_64",
-			"cindex": 0
-		},
-		{
-			"distrib": "amzn",
-			"version": "1",
-			"arch": "x86_64",
-			"uname_release": "4.14.128-87.105.amzn1.x86_64",
-			"cindex": 0
-		},
-		{
-			"distrib": "amzn",
-			"version": "1",
-			"arch": "x86_64",
-			"uname_release": "4.14.133-88.105.amzn1.x86_64",
-			"cindex": 0
-		},
-		{
-			"distrib": "amzn",
-			"version": "1",
-			"arch": "x86_64",
-			"uname_release": "4.14.133-88.112.amzn1.x86_64",
-			"cindex": 0
-		},
-		{
-			"distrib": "amzn",
-			"version": "1",
-			"arch": "x86_64",
-			"uname_release": "4.14.138-89.102.amzn1.x86_64",
-			"cindex": 0
-		},
-		{
-			"distrib": "amzn",
-			"version": "1",
-			"arch": "x86_64",
-			"uname_release": "4.14.143-91.122.amzn1.x86_64",
-			"cindex": 0
-		},
-		{
-			"distrib": "amzn",
-			"version": "1",
-			"arch": "x86_64",
-			"uname_release": "4.14.146-93.123.amzn1.x86_64",
-			"cindex": 0
-		},
-		{
-			"distrib": "amzn",
-			"version": "1",
-			"arch": "x86_64",
-			"uname_release": "4.14.152-98.182.amzn1.x86_64",
-			"cindex": 0
-		},
-		{
-			"distrib": "amzn",
-			"version": "1",
-			"arch": "x86_64",
-			"uname_release": "4.14.154-99.181.amzn1.x86_64",
-			"cindex": 0
-		},
-		{
-			"distrib": "amzn",
-			"version": "1",
-			"arch": "x86_64",
-			"uname_release": "4.14.158-101.185.amzn1.x86_64",
-			"cindex": 0
-		},
-		{
-			"distrib": "amzn",
-			"version": "1",
-			"arch": "x86_64",
-			"uname_release": "4.14.165-102.185.amzn1.x86_64",
-			"cindex": 0
-		},
-		{
-			"distrib": "amzn",
-			"version": "1",
-			"arch": "x86_64",
-			"uname_release": "4.14.165-103.209.amzn1.x86_64",
-			"cindex": 0
-		},
-		{
-			"distrib": "amzn",
-			"version": "1",
-			"arch": "x86_64",
-			"uname_release": "4.14.171-105.231.amzn1.x86_64",
-			"cindex": 0
-		},
-		{
-			"distrib": "amzn",
-			"version": "1",
-			"arch": "x86_64",
-			"uname_release": "4.14.173-106.229.amzn1.x86_64",
-			"cindex": 0
-		},
-		{
-			"distrib": "amzn",
-			"version": "1",
-			"arch": "x86_64",
-			"uname_release": "4.14.177-107.254.amzn1.x86_64",
-			"cindex": 1
-		},
-		{
-			"distrib": "amzn",
-			"version": "1",
-			"arch": "x86_64",
-			"uname_release": "4.14.181-108.257.amzn1.x86_64",
-			"cindex": 1
-		},
-		{
-			"distrib": "amzn",
-			"version": "1",
-			"arch": "x86_64",
-			"uname_release": "4.14.186-110.268.amzn1.x86_64",
-			"cindex": 1
-		},
-		{
-			"distrib": "amzn",
-			"version": "1",
-			"arch": "x86_64",
-			"uname_release": "4.14.193-113.317.amzn1.x86_64",
-			"cindex": 1
-		},
-		{
-			"distrib": "amzn",
-			"version": "1",
-			"arch": "x86_64",
-			"uname_release": "4.14.200-116.320.amzn1.x86_64",
-			"cindex": 1
-		},
-		{
-			"distrib": "amzn",
-			"version": "1",
-			"arch": "x86_64",
-			"uname_release": "4.14.203-116.332.amzn1.x86_64",
-			"cindex": 1
-		},
-		{
-			"distrib": "amzn",
-			"version": "1",
-			"arch": "x86_64",
-			"uname_release": "4.14.209-117.337.amzn1.x86_64",
-			"cindex": 1
-		},
-		{
-			"distrib": "amzn",
-			"version": "1",
-			"arch": "x86_64",
-			"uname_release": "4.14.214-118.339.amzn1.x86_64",
-			"cindex": 1
-		},
-		{
-			"distrib": "amzn",
-			"version": "1",
-			"arch": "x86_64",
-			"uname_release": "4.14.219-119.340.amzn1.x86_64",
-			"cindex": 1
-		},
-		{
-			"distrib": "amzn",
-			"version": "1",
-			"arch": "x86_64",
-			"uname_release": "4.14.225-121.357.amzn1.x86_64",
-			"cindex": 2
-		},
-		{
-			"distrib": "amzn",
-			"version": "1",
-			"arch": "x86_64",
-			"uname_release": "4.14.225-121.362.amzn1.x86_64",
-			"cindex": 2
-		},
-		{
-			"distrib": "amzn",
-			"version": "1",
-			"arch": "x86_64",
-			"uname_release": "4.14.232-123.381.amzn1.x86_64",
-			"cindex": 2
-		},
-		{
-			"distrib": "amzn",
-			"version": "1",
-			"arch": "x86_64",
-			"uname_release": "4.14.238-125.421.amzn1.x86_64",
-			"cindex": 2
-		},
-		{
-			"distrib": "amzn",
-			"version": "1",
-			"arch": "x86_64",
-			"uname_release": "4.14.238-125.422.amzn1.x86_64",
-			"cindex": 2
-		},
-		{
-			"distrib": "amzn",
-			"version": "1",
-			"arch": "x86_64",
-			"uname_release": "4.14.248-129.473.amzn1.x86_64",
-			"cindex": 2
-		},
-		{
-			"distrib": "amzn",
-			"version": "1",
-			"arch": "x86_64",
-			"uname_release": "4.14.252-131.483.amzn1.x86_64",
-			"cindex": 2
-		},
-		{
-			"distrib": "amzn",
-			"version": "1",
-			"arch": "x86_64",
-			"uname_release": "4.14.262-135.486.amzn1.x86_64",
-			"cindex": 2
-		},
-		{
-			"distrib": "amzn",
-			"version": "1",
-			"arch": "x86_64",
-			"uname_release": "4.14.262-135.489.amzn1.x86_64",
-			"cindex": 2
-		},
-		{
-			"distrib": "amzn",
-			"version": "1",
-			"arch": "x86_64",
-			"uname_release": "4.14.268-139.500.amzn1.x86_64",
-			"cindex": 2
-		},
-		{
-			"distrib": "amzn",
-			"version": "1",
-			"arch": "x86_64",
-			"uname_release": "4.14.273-140.502.amzn1.x86_64",
-			"cindex": 2
-		},
-		{
-			"distrib": "amzn",
-			"version": "1",
-			"arch": "x86_64",
-			"uname_release": "4.14.275-142.503.amzn1.x86_64",
-			"cindex": 2
-		},
-		{
-			"distrib": "amzn",
-			"version": "1",
-			"arch": "x86_64",
-			"uname_release": "4.14.281-144.502.amzn1.x86_64",
-			"cindex": 2
-		},
-		{
-			"distrib": "amzn",
-			"version": "1",
-			"arch": "x86_64",
-			"uname_release": "4.14.285-147.501.amzn1.x86_64",
-			"cindex": 2
-		},
-		{
-			"distrib": "amzn",
-			"version": "1",
-			"arch": "x86_64",
-			"uname_release": "4.14.287-148.504.amzn1.x86_64",
-			"cindex": 2
-		},
-		{
-			"distrib": "amzn",
-			"version": "1",
-			"arch": "x86_64",
-			"uname_release": "4.14.33-51.34.amzn1.x86_64",
-			"cindex": 0
-		},
-		{
-			"distrib": "amzn",
-			"version": "1",
-			"arch": "x86_64",
-			"uname_release": "4.14.33-51.37.amzn1.x86_64",
-			"cindex": 0
-		},
-		{
-			"distrib": "amzn",
-			"version": "1",
-			"arch": "x86_64",
-			"uname_release": "4.14.42-52.37.amzn1.x86_64",
-			"cindex": 0
-		},
-		{
-			"distrib": "amzn",
-			"version": "1",
-			"arch": "x86_64",
-			"uname_release": "4.14.47-56.37.amzn1.x86_64",
-			"cindex": 0
-		},
-		{
-			"distrib": "amzn",
-			"version": "1",
-			"arch": "x86_64",
-			"uname_release": "4.14.51-60.38.amzn1.x86_64",
-			"cindex": 0
-		},
-		{
-			"distrib": "amzn",
-			"version": "1",
-			"arch": "x86_64",
-			"uname_release": "4.14.55-62.37.amzn1.x86_64",
-			"cindex": 0
-		},
-		{
-			"distrib": "amzn",
-			"version": "1",
-			"arch": "x86_64",
-			"uname_release": "4.14.59-64.43.amzn1.x86_64",
-			"cindex": 0
-		},
-		{
-			"distrib": "amzn",
-			"version": "1",
-			"arch": "x86_64",
-			"uname_release": "4.14.62-65.117.amzn1.x86_64",
-			"cindex": 0
-		},
-		{
-			"distrib": "amzn",
-			"version": "1",
-			"arch": "x86_64",
-			"uname_release": "4.14.67-66.56.amzn1.x86_64",
-			"cindex": 0
-		},
-		{
-			"distrib": "amzn",
-			"version": "1",
-			"arch": "x86_64",
-			"uname_release": "4.14.70-67.55.amzn1.x86_64",
-			"cindex": 0
-		},
-		{
-			"distrib": "amzn",
-			"version": "1",
-			"arch": "x86_64",
-			"uname_release": "4.14.72-68.55.amzn1.x86_64",
-			"cindex": 0
-		},
-		{
-			"distrib": "amzn",
-			"version": "1",
-			"arch": "x86_64",
-			"uname_release": "4.14.77-69.57.amzn1.x86_64",
-			"cindex": 0
-		},
-		{
-			"distrib": "amzn",
-			"version": "1",
-			"arch": "x86_64",
-			"uname_release": "4.14.77-70.59.amzn1.x86_64",
-			"cindex": 0
-		},
-		{
-			"distrib": "amzn",
-			"version": "1",
-			"arch": "x86_64",
-			"uname_release": "4.14.77-70.82.amzn1.x86_64",
-			"cindex": 0
-		},
-		{
-			"distrib": "amzn",
-			"version": "1",
-			"arch": "x86_64",
-			"uname_release": "4.14.88-72.73.amzn1.x86_64",
-			"cindex": 0
-		},
-		{
-			"distrib": "amzn",
-			"version": "1",
-			"arch": "x86_64",
-			"uname_release": "4.14.88-72.76.amzn1.x86_64",
-			"cindex": 0
-		},
-		{
-			"distrib": "amzn",
-			"version": "1",
-			"arch": "x86_64",
-			"uname_release": "4.14.94-73.73.amzn1.x86_64",
-			"cindex": 0
-		},
-		{
-			"distrib": "amzn",
-			"version": "1",
-			"arch": "x86_64",
-			"uname_release": "4.14.97-74.72.amzn1.x86_64",
-			"cindex": 0
-		},
-		{
-			"distrib": "amzn",
 			"version": "2",
 			"arch": "arm64",
 			"uname_release": "4.14.101-91.76.amzn2.aarch64",
-			"cindex": 3
+			"cindex": 0
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "arm64",
 			"uname_release": "4.14.104-95.84.amzn2.aarch64",
-			"cindex": 3
+			"cindex": 0
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "arm64",
 			"uname_release": "4.14.106-97.85.amzn2.aarch64",
-			"cindex": 3
+			"cindex": 0
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "arm64",
 			"uname_release": "4.14.109-99.92.amzn2.aarch64",
-			"cindex": 3
+			"cindex": 0
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "arm64",
 			"uname_release": "4.14.114-103.97.amzn2.aarch64",
-			"cindex": 3
+			"cindex": 0
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "arm64",
 			"uname_release": "4.14.114-105.126.amzn2.aarch64",
-			"cindex": 3
+			"cindex": 0
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "arm64",
 			"uname_release": "4.14.121-109.96.amzn2.aarch64",
-			"cindex": 3
+			"cindex": 0
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "arm64",
 			"uname_release": "4.14.123-111.109.amzn2.aarch64",
-			"cindex": 3
+			"cindex": 0
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "arm64",
 			"uname_release": "4.14.128-112.105.amzn2.aarch64",
-			"cindex": 3
+			"cindex": 0
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "arm64",
 			"uname_release": "4.14.133-113.105.amzn2.aarch64",
-			"cindex": 3
+			"cindex": 0
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "arm64",
 			"uname_release": "4.14.133-113.112.amzn2.aarch64",
-			"cindex": 3
+			"cindex": 0
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "arm64",
 			"uname_release": "4.14.138-114.102.amzn2.aarch64",
-			"cindex": 3
+			"cindex": 0
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "arm64",
 			"uname_release": "4.14.143-118.123.amzn2.aarch64",
-			"cindex": 3
+			"cindex": 0
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "arm64",
 			"uname_release": "4.14.146-119.123.amzn2.aarch64",
-			"cindex": 3
+			"cindex": 0
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "arm64",
 			"uname_release": "4.14.146-120.181.amzn2.aarch64",
-			"cindex": 3
+			"cindex": 0
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "arm64",
 			"uname_release": "4.14.152-124.171.amzn2.aarch64",
-			"cindex": 3
+			"cindex": 0
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "arm64",
 			"uname_release": "4.14.152-127.182.amzn2.aarch64",
-			"cindex": 3
+			"cindex": 0
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "arm64",
 			"uname_release": "4.14.154-128.181.amzn2.aarch64",
-			"cindex": 3
+			"cindex": 0
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "arm64",
 			"uname_release": "4.14.158-129.185.amzn2.aarch64",
-			"cindex": 3
+			"cindex": 0
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "arm64",
 			"uname_release": "4.14.165-131.185.amzn2.aarch64",
-			"cindex": 3
+			"cindex": 0
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "arm64",
 			"uname_release": "4.14.165-133.209.amzn2.aarch64",
-			"cindex": 3
+			"cindex": 0
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "arm64",
 			"uname_release": "4.14.171-136.231.amzn2.aarch64",
-			"cindex": 3
+			"cindex": 0
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "arm64",
 			"uname_release": "4.14.173-137.228.amzn2.aarch64",
-			"cindex": 3
+			"cindex": 0
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "arm64",
 			"uname_release": "4.14.173-137.229.amzn2.aarch64",
-			"cindex": 3
+			"cindex": 0
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "arm64",
 			"uname_release": "4.14.177-139.253.amzn2.aarch64",
-			"cindex": 0
+			"cindex": 1
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "arm64",
 			"uname_release": "4.14.177-139.254.amzn2.aarch64",
-			"cindex": 0
+			"cindex": 1
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "arm64",
 			"uname_release": "4.14.181-140.257.amzn2.aarch64",
-			"cindex": 0
+			"cindex": 1
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "arm64",
 			"uname_release": "4.14.181-142.260.amzn2.aarch64",
-			"cindex": 0
+			"cindex": 1
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "arm64",
 			"uname_release": "4.14.186-146.268.amzn2.aarch64",
-			"cindex": 0
+			"cindex": 1
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "arm64",
 			"uname_release": "4.14.192-147.314.amzn2.aarch64",
-			"cindex": 0
+			"cindex": 1
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "arm64",
 			"uname_release": "4.14.193-149.317.amzn2.aarch64",
-			"cindex": 0
+			"cindex": 1
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "arm64",
 			"uname_release": "4.14.198-152.320.amzn2.aarch64",
-			"cindex": 0
+			"cindex": 1
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "arm64",
 			"uname_release": "4.14.200-155.322.amzn2.aarch64",
-			"cindex": 0
+			"cindex": 1
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "arm64",
 			"uname_release": "4.14.203-156.332.amzn2.aarch64",
-			"cindex": 0
+			"cindex": 1
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "arm64",
 			"uname_release": "4.14.209-160.335.amzn2.aarch64",
-			"cindex": 0
+			"cindex": 1
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "arm64",
 			"uname_release": "4.14.209-160.339.amzn2.aarch64",
-			"cindex": 0
+			"cindex": 1
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "arm64",
 			"uname_release": "4.14.214-160.339.amzn2.aarch64",
-			"cindex": 0
+			"cindex": 1
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "arm64",
 			"uname_release": "4.14.219-161.340.amzn2.aarch64",
-			"cindex": 0
+			"cindex": 1
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "arm64",
 			"uname_release": "4.14.219-164.354.amzn2.aarch64",
-			"cindex": 0
+			"cindex": 1
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "arm64",
 			"uname_release": "4.14.225-168.357.amzn2.aarch64",
-			"cindex": 4
+			"cindex": 2
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "arm64",
 			"uname_release": "4.14.225-169.362.amzn2.aarch64",
-			"cindex": 4
+			"cindex": 2
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "arm64",
 			"uname_release": "4.14.231-173.360.amzn2.aarch64",
-			"cindex": 4
+			"cindex": 2
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "arm64",
 			"uname_release": "4.14.231-173.361.amzn2.aarch64",
-			"cindex": 4
+			"cindex": 2
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "arm64",
 			"uname_release": "4.14.232-176.381.amzn2.aarch64",
-			"cindex": 4
+			"cindex": 2
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "arm64",
 			"uname_release": "4.14.232-177.418.amzn2.aarch64",
-			"cindex": 4
+			"cindex": 2
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "arm64",
 			"uname_release": "4.14.238-182.421.amzn2.aarch64",
-			"cindex": 4
+			"cindex": 2
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "arm64",
 			"uname_release": "4.14.238-182.422.amzn2.aarch64",
-			"cindex": 4
+			"cindex": 2
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "arm64",
 			"uname_release": "4.14.241-184.433.amzn2.aarch64",
-			"cindex": 4
+			"cindex": 2
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "arm64",
 			"uname_release": "4.14.243-185.433.amzn2.aarch64",
-			"cindex": 4
+			"cindex": 2
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "arm64",
 			"uname_release": "4.14.246-187.474.amzn2.aarch64",
-			"cindex": 4
+			"cindex": 2
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "arm64",
 			"uname_release": "4.14.248-189.473.amzn2.aarch64",
-			"cindex": 4
+			"cindex": 2
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "arm64",
 			"uname_release": "4.14.252-195.481.amzn2.aarch64",
-			"cindex": 4
+			"cindex": 2
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "arm64",
 			"uname_release": "4.14.252-195.483.amzn2.aarch64",
-			"cindex": 4
+			"cindex": 2
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "arm64",
 			"uname_release": "4.14.256-197.484.amzn2.aarch64",
-			"cindex": 4
+			"cindex": 2
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "arm64",
 			"uname_release": "4.14.262-200.489.amzn2.aarch64",
-			"cindex": 4
+			"cindex": 2
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "arm64",
 			"uname_release": "4.14.268-205.500.amzn2.aarch64",
-			"cindex": 4
+			"cindex": 2
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "arm64",
 			"uname_release": "4.14.273-207.502.amzn2.aarch64",
-			"cindex": 4
+			"cindex": 2
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "arm64",
 			"uname_release": "4.14.275-207.503.amzn2.aarch64",
-			"cindex": 4
+			"cindex": 2
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "arm64",
 			"uname_release": "4.14.276-211.499.amzn2.aarch64",
-			"cindex": 4
+			"cindex": 2
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "arm64",
 			"uname_release": "4.14.281-212.502.amzn2.aarch64",
-			"cindex": 4
+			"cindex": 2
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "arm64",
 			"uname_release": "4.14.285-215.501.amzn2.aarch64",
-			"cindex": 4
+			"cindex": 2
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "arm64",
 			"uname_release": "4.14.287-215.504.amzn2.aarch64",
-			"cindex": 4
+			"cindex": 2
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "arm64",
 			"uname_release": "4.14.290-217.505.amzn2.aarch64",
-			"cindex": 4
+			"cindex": 2
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "arm64",
 			"uname_release": "4.14.291-218.527.amzn2.aarch64",
-			"cindex": 4
+			"cindex": 2
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "arm64",
 			"uname_release": "4.14.294-220.533.amzn2.aarch64",
-			"cindex": 4
+			"cindex": 2
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "arm64",
 			"uname_release": "4.14.77-80.57.amzn2.aarch64",
-			"cindex": 5
+			"cindex": 3
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "arm64",
 			"uname_release": "4.14.77-81.59.amzn2.aarch64",
-			"cindex": 5
+			"cindex": 3
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "arm64",
 			"uname_release": "4.14.77-86.82.amzn2.aarch64",
-			"cindex": 3
+			"cindex": 0
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "arm64",
 			"uname_release": "4.14.88-88.73.amzn2.aarch64",
-			"cindex": 3
+			"cindex": 0
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "arm64",
 			"uname_release": "4.14.88-88.76.amzn2.aarch64",
-			"cindex": 3
+			"cindex": 0
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "arm64",
 			"uname_release": "4.14.94-89.73.amzn2.aarch64",
-			"cindex": 3
+			"cindex": 0
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "arm64",
 			"uname_release": "4.14.97-90.72.amzn2.aarch64",
-			"cindex": 3
+			"cindex": 0
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "x86_64",
 			"uname_release": "4.14.101-91.76.amzn2.x86_64",
-			"cindex": 0
+			"cindex": 1
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "x86_64",
 			"uname_release": "4.14.104-95.84.amzn2.x86_64",
-			"cindex": 0
+			"cindex": 1
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "x86_64",
 			"uname_release": "4.14.106-97.85.amzn2.x86_64",
-			"cindex": 0
+			"cindex": 1
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "x86_64",
 			"uname_release": "4.14.109-99.92.amzn2.x86_64",
-			"cindex": 0
+			"cindex": 1
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "x86_64",
 			"uname_release": "4.14.114-103.97.amzn2.x86_64",
-			"cindex": 0
+			"cindex": 1
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "x86_64",
 			"uname_release": "4.14.114-105.126.amzn2.x86_64",
-			"cindex": 0
+			"cindex": 1
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "x86_64",
 			"uname_release": "4.14.121-109.96.amzn2.x86_64",
-			"cindex": 0
+			"cindex": 1
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "x86_64",
 			"uname_release": "4.14.123-111.109.amzn2.x86_64",
-			"cindex": 0
+			"cindex": 1
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "x86_64",
 			"uname_release": "4.14.128-112.105.amzn2.x86_64",
-			"cindex": 0
+			"cindex": 1
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "x86_64",
 			"uname_release": "4.14.133-113.105.amzn2.x86_64",
-			"cindex": 0
+			"cindex": 1
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "x86_64",
 			"uname_release": "4.14.133-113.112.amzn2.x86_64",
-			"cindex": 0
+			"cindex": 1
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "x86_64",
 			"uname_release": "4.14.138-114.102.amzn2.x86_64",
-			"cindex": 0
+			"cindex": 1
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "x86_64",
 			"uname_release": "4.14.143-118.123.amzn2.x86_64",
-			"cindex": 0
+			"cindex": 1
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "x86_64",
 			"uname_release": "4.14.146-119.123.amzn2.x86_64",
-			"cindex": 0
+			"cindex": 1
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "x86_64",
 			"uname_release": "4.14.146-120.181.amzn2.x86_64",
-			"cindex": 0
+			"cindex": 1
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "x86_64",
 			"uname_release": "4.14.152-124.171.amzn2.x86_64",
-			"cindex": 0
+			"cindex": 1
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "x86_64",
 			"uname_release": "4.14.152-127.182.amzn2.x86_64",
-			"cindex": 0
+			"cindex": 1
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "x86_64",
 			"uname_release": "4.14.154-128.181.amzn2.x86_64",
-			"cindex": 0
+			"cindex": 1
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "x86_64",
 			"uname_release": "4.14.158-129.185.amzn2.x86_64",
-			"cindex": 0
+			"cindex": 1
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "x86_64",
 			"uname_release": "4.14.165-131.185.amzn2.x86_64",
-			"cindex": 0
+			"cindex": 1
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "x86_64",
 			"uname_release": "4.14.165-133.209.amzn2.x86_64",
-			"cindex": 0
+			"cindex": 1
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "x86_64",
 			"uname_release": "4.14.171-136.231.amzn2.x86_64",
-			"cindex": 0
+			"cindex": 1
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "x86_64",
 			"uname_release": "4.14.173-137.228.amzn2.x86_64",
-			"cindex": 0
+			"cindex": 1
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "x86_64",
 			"uname_release": "4.14.173-137.229.amzn2.x86_64",
-			"cindex": 0
+			"cindex": 1
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "x86_64",
 			"uname_release": "4.14.177-139.253.amzn2.x86_64",
-			"cindex": 1
+			"cindex": 4
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "x86_64",
 			"uname_release": "4.14.177-139.254.amzn2.x86_64",
-			"cindex": 1
+			"cindex": 4
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "x86_64",
 			"uname_release": "4.14.181-140.257.amzn2.x86_64",
-			"cindex": 1
+			"cindex": 4
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "x86_64",
 			"uname_release": "4.14.181-142.260.amzn2.x86_64",
-			"cindex": 1
+			"cindex": 4
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "x86_64",
 			"uname_release": "4.14.186-146.268.amzn2.x86_64",
-			"cindex": 1
+			"cindex": 4
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "x86_64",
 			"uname_release": "4.14.192-147.314.amzn2.x86_64",
-			"cindex": 1
+			"cindex": 4
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "x86_64",
 			"uname_release": "4.14.193-149.317.amzn2.x86_64",
-			"cindex": 1
+			"cindex": 4
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "x86_64",
 			"uname_release": "4.14.198-152.320.amzn2.x86_64",
-			"cindex": 1
+			"cindex": 4
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "x86_64",
 			"uname_release": "4.14.200-155.322.amzn2.x86_64",
-			"cindex": 1
+			"cindex": 4
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "x86_64",
 			"uname_release": "4.14.203-156.332.amzn2.x86_64",
-			"cindex": 1
+			"cindex": 4
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "x86_64",
 			"uname_release": "4.14.209-160.335.amzn2.x86_64",
-			"cindex": 1
+			"cindex": 4
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "x86_64",
 			"uname_release": "4.14.209-160.339.amzn2.x86_64",
-			"cindex": 1
+			"cindex": 4
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "x86_64",
 			"uname_release": "4.14.214-160.339.amzn2.x86_64",
-			"cindex": 1
+			"cindex": 4
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "x86_64",
 			"uname_release": "4.14.219-161.340.amzn2.x86_64",
-			"cindex": 1
+			"cindex": 4
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "x86_64",
 			"uname_release": "4.14.219-164.354.amzn2.x86_64",
-			"cindex": 1
+			"cindex": 4
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "x86_64",
 			"uname_release": "4.14.225-168.357.amzn2.x86_64",
-			"cindex": 2
+			"cindex": 5
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "x86_64",
 			"uname_release": "4.14.225-169.362.amzn2.x86_64",
-			"cindex": 2
+			"cindex": 5
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "x86_64",
 			"uname_release": "4.14.231-173.360.amzn2.x86_64",
-			"cindex": 2
+			"cindex": 5
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "x86_64",
 			"uname_release": "4.14.231-173.361.amzn2.x86_64",
-			"cindex": 2
+			"cindex": 5
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "x86_64",
 			"uname_release": "4.14.232-176.381.amzn2.x86_64",
-			"cindex": 2
+			"cindex": 5
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "x86_64",
 			"uname_release": "4.14.232-177.418.amzn2.x86_64",
-			"cindex": 2
+			"cindex": 5
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "x86_64",
 			"uname_release": "4.14.238-182.421.amzn2.x86_64",
-			"cindex": 2
+			"cindex": 5
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "x86_64",
 			"uname_release": "4.14.238-182.422.amzn2.x86_64",
-			"cindex": 2
+			"cindex": 5
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "x86_64",
 			"uname_release": "4.14.241-184.433.amzn2.x86_64",
-			"cindex": 2
+			"cindex": 5
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "x86_64",
 			"uname_release": "4.14.243-185.433.amzn2.x86_64",
-			"cindex": 2
+			"cindex": 5
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "x86_64",
 			"uname_release": "4.14.246-187.474.amzn2.x86_64",
-			"cindex": 2
+			"cindex": 5
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "x86_64",
 			"uname_release": "4.14.248-189.473.amzn2.x86_64",
-			"cindex": 2
+			"cindex": 5
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "x86_64",
 			"uname_release": "4.14.252-195.481.amzn2.x86_64",
-			"cindex": 2
+			"cindex": 5
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "x86_64",
 			"uname_release": "4.14.252-195.483.amzn2.x86_64",
-			"cindex": 2
+			"cindex": 5
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "x86_64",
 			"uname_release": "4.14.256-197.484.amzn2.x86_64",
-			"cindex": 2
+			"cindex": 5
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "x86_64",
 			"uname_release": "4.14.26-54.32.amzn2.x86_64",
-			"cindex": 0
+			"cindex": 1
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "x86_64",
 			"uname_release": "4.14.262-200.489.amzn2.x86_64",
-			"cindex": 2
+			"cindex": 5
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "x86_64",
 			"uname_release": "4.14.268-205.500.amzn2.x86_64",
-			"cindex": 2
+			"cindex": 5
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "x86_64",
 			"uname_release": "4.14.273-207.502.amzn2.x86_64",
-			"cindex": 2
+			"cindex": 5
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "x86_64",
 			"uname_release": "4.14.275-207.503.amzn2.x86_64",
-			"cindex": 2
+			"cindex": 5
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "x86_64",
 			"uname_release": "4.14.276-211.499.amzn2.x86_64",
-			"cindex": 2
+			"cindex": 5
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "x86_64",
 			"uname_release": "4.14.281-212.502.amzn2.x86_64",
-			"cindex": 2
+			"cindex": 5
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "x86_64",
 			"uname_release": "4.14.285-215.501.amzn2.x86_64",
-			"cindex": 2
+			"cindex": 5
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "x86_64",
 			"uname_release": "4.14.287-215.504.amzn2.x86_64",
-			"cindex": 2
+			"cindex": 5
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "x86_64",
 			"uname_release": "4.14.290-217.505.amzn2.x86_64",
-			"cindex": 2
+			"cindex": 5
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "x86_64",
 			"uname_release": "4.14.291-218.527.amzn2.x86_64",
-			"cindex": 2
+			"cindex": 5
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "x86_64",
 			"uname_release": "4.14.294-220.533.amzn2.x86_64",
-			"cindex": 2
+			"cindex": 5
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "x86_64",
 			"uname_release": "4.14.33-59.34.amzn2.x86_64",
-			"cindex": 0
+			"cindex": 1
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "x86_64",
 			"uname_release": "4.14.33-59.37.amzn2.x86_64",
-			"cindex": 0
+			"cindex": 1
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "x86_64",
 			"uname_release": "4.14.42-61.37.amzn2.x86_64",
-			"cindex": 0
+			"cindex": 1
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "x86_64",
 			"uname_release": "4.14.47-63.37.amzn2.x86_64",
-			"cindex": 0
+			"cindex": 1
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "x86_64",
 			"uname_release": "4.14.47-64.38.amzn2.x86_64",
-			"cindex": 0
+			"cindex": 1
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "x86_64",
 			"uname_release": "4.14.51-66.38.amzn2.x86_64",
-			"cindex": 0
+			"cindex": 1
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "x86_64",
 			"uname_release": "4.14.55-68.37.amzn2.x86_64",
-			"cindex": 0
+			"cindex": 1
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "x86_64",
 			"uname_release": "4.14.59-68.43.amzn2.x86_64",
-			"cindex": 0
+			"cindex": 1
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "x86_64",
 			"uname_release": "4.14.62-70.117.amzn2.x86_64",
-			"cindex": 0
+			"cindex": 1
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "x86_64",
 			"uname_release": "4.14.67-71.56.amzn2.x86_64",
-			"cindex": 0
+			"cindex": 1
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "x86_64",
 			"uname_release": "4.14.70-72.55.amzn2.x86_64",
-			"cindex": 0
+			"cindex": 1
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "x86_64",
 			"uname_release": "4.14.72-73.55.amzn2.x86_64",
-			"cindex": 0
+			"cindex": 1
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "x86_64",
 			"uname_release": "4.14.77-80.57.amzn2.x86_64",
-			"cindex": 0
+			"cindex": 1
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "x86_64",
 			"uname_release": "4.14.77-81.59.amzn2.x86_64",
-			"cindex": 0
+			"cindex": 1
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "x86_64",
 			"uname_release": "4.14.77-86.82.amzn2.x86_64",
-			"cindex": 0
+			"cindex": 1
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "x86_64",
 			"uname_release": "4.14.88-88.73.amzn2.x86_64",
-			"cindex": 0
+			"cindex": 1
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "x86_64",
 			"uname_release": "4.14.88-88.76.amzn2.x86_64",
-			"cindex": 0
+			"cindex": 1
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "x86_64",
 			"uname_release": "4.14.94-89.73.amzn2.x86_64",
-			"cindex": 0
+			"cindex": 1
 		},
 		{
 			"distrib": "amzn",
 			"version": "2",
 			"arch": "x86_64",
 			"uname_release": "4.14.97-90.72.amzn2.x86_64",
-			"cindex": 0
+			"cindex": 1
 		},
 		{
 			"distrib": "amzn",
@@ -3703,6 +3262,447 @@
 			"arch": "x86_64",
 			"uname_release": "4.9.85-47.59.amzn2.x86_64",
 			"cindex": 7
+		},
+		{
+			"distrib": "amzn",
+			"version": "2018",
+			"arch": "x86_64",
+			"uname_release": "4.14.101-75.76.amzn1.x86_64",
+			"cindex": 1
+		},
+		{
+			"distrib": "amzn",
+			"version": "2018",
+			"arch": "x86_64",
+			"uname_release": "4.14.104-78.84.amzn1.x86_64",
+			"cindex": 1
+		},
+		{
+			"distrib": "amzn",
+			"version": "2018",
+			"arch": "x86_64",
+			"uname_release": "4.14.106-79.86.amzn1.x86_64",
+			"cindex": 1
+		},
+		{
+			"distrib": "amzn",
+			"version": "2018",
+			"arch": "x86_64",
+			"uname_release": "4.14.109-80.92.amzn1.x86_64",
+			"cindex": 1
+		},
+		{
+			"distrib": "amzn",
+			"version": "2018",
+			"arch": "x86_64",
+			"uname_release": "4.14.114-82.97.amzn1.x86_64",
+			"cindex": 1
+		},
+		{
+			"distrib": "amzn",
+			"version": "2018",
+			"arch": "x86_64",
+			"uname_release": "4.14.114-83.126.amzn1.x86_64",
+			"cindex": 1
+		},
+		{
+			"distrib": "amzn",
+			"version": "2018",
+			"arch": "x86_64",
+			"uname_release": "4.14.121-85.96.amzn1.x86_64",
+			"cindex": 1
+		},
+		{
+			"distrib": "amzn",
+			"version": "2018",
+			"arch": "x86_64",
+			"uname_release": "4.14.123-86.109.amzn1.x86_64",
+			"cindex": 1
+		},
+		{
+			"distrib": "amzn",
+			"version": "2018",
+			"arch": "x86_64",
+			"uname_release": "4.14.128-87.105.amzn1.x86_64",
+			"cindex": 1
+		},
+		{
+			"distrib": "amzn",
+			"version": "2018",
+			"arch": "x86_64",
+			"uname_release": "4.14.133-88.105.amzn1.x86_64",
+			"cindex": 1
+		},
+		{
+			"distrib": "amzn",
+			"version": "2018",
+			"arch": "x86_64",
+			"uname_release": "4.14.133-88.112.amzn1.x86_64",
+			"cindex": 1
+		},
+		{
+			"distrib": "amzn",
+			"version": "2018",
+			"arch": "x86_64",
+			"uname_release": "4.14.138-89.102.amzn1.x86_64",
+			"cindex": 1
+		},
+		{
+			"distrib": "amzn",
+			"version": "2018",
+			"arch": "x86_64",
+			"uname_release": "4.14.143-91.122.amzn1.x86_64",
+			"cindex": 1
+		},
+		{
+			"distrib": "amzn",
+			"version": "2018",
+			"arch": "x86_64",
+			"uname_release": "4.14.146-93.123.amzn1.x86_64",
+			"cindex": 1
+		},
+		{
+			"distrib": "amzn",
+			"version": "2018",
+			"arch": "x86_64",
+			"uname_release": "4.14.152-98.182.amzn1.x86_64",
+			"cindex": 1
+		},
+		{
+			"distrib": "amzn",
+			"version": "2018",
+			"arch": "x86_64",
+			"uname_release": "4.14.154-99.181.amzn1.x86_64",
+			"cindex": 1
+		},
+		{
+			"distrib": "amzn",
+			"version": "2018",
+			"arch": "x86_64",
+			"uname_release": "4.14.158-101.185.amzn1.x86_64",
+			"cindex": 1
+		},
+		{
+			"distrib": "amzn",
+			"version": "2018",
+			"arch": "x86_64",
+			"uname_release": "4.14.165-102.185.amzn1.x86_64",
+			"cindex": 1
+		},
+		{
+			"distrib": "amzn",
+			"version": "2018",
+			"arch": "x86_64",
+			"uname_release": "4.14.165-103.209.amzn1.x86_64",
+			"cindex": 1
+		},
+		{
+			"distrib": "amzn",
+			"version": "2018",
+			"arch": "x86_64",
+			"uname_release": "4.14.171-105.231.amzn1.x86_64",
+			"cindex": 1
+		},
+		{
+			"distrib": "amzn",
+			"version": "2018",
+			"arch": "x86_64",
+			"uname_release": "4.14.173-106.229.amzn1.x86_64",
+			"cindex": 1
+		},
+		{
+			"distrib": "amzn",
+			"version": "2018",
+			"arch": "x86_64",
+			"uname_release": "4.14.177-107.254.amzn1.x86_64",
+			"cindex": 4
+		},
+		{
+			"distrib": "amzn",
+			"version": "2018",
+			"arch": "x86_64",
+			"uname_release": "4.14.181-108.257.amzn1.x86_64",
+			"cindex": 4
+		},
+		{
+			"distrib": "amzn",
+			"version": "2018",
+			"arch": "x86_64",
+			"uname_release": "4.14.186-110.268.amzn1.x86_64",
+			"cindex": 4
+		},
+		{
+			"distrib": "amzn",
+			"version": "2018",
+			"arch": "x86_64",
+			"uname_release": "4.14.193-113.317.amzn1.x86_64",
+			"cindex": 4
+		},
+		{
+			"distrib": "amzn",
+			"version": "2018",
+			"arch": "x86_64",
+			"uname_release": "4.14.200-116.320.amzn1.x86_64",
+			"cindex": 4
+		},
+		{
+			"distrib": "amzn",
+			"version": "2018",
+			"arch": "x86_64",
+			"uname_release": "4.14.203-116.332.amzn1.x86_64",
+			"cindex": 4
+		},
+		{
+			"distrib": "amzn",
+			"version": "2018",
+			"arch": "x86_64",
+			"uname_release": "4.14.209-117.337.amzn1.x86_64",
+			"cindex": 4
+		},
+		{
+			"distrib": "amzn",
+			"version": "2018",
+			"arch": "x86_64",
+			"uname_release": "4.14.214-118.339.amzn1.x86_64",
+			"cindex": 4
+		},
+		{
+			"distrib": "amzn",
+			"version": "2018",
+			"arch": "x86_64",
+			"uname_release": "4.14.219-119.340.amzn1.x86_64",
+			"cindex": 4
+		},
+		{
+			"distrib": "amzn",
+			"version": "2018",
+			"arch": "x86_64",
+			"uname_release": "4.14.225-121.357.amzn1.x86_64",
+			"cindex": 5
+		},
+		{
+			"distrib": "amzn",
+			"version": "2018",
+			"arch": "x86_64",
+			"uname_release": "4.14.225-121.362.amzn1.x86_64",
+			"cindex": 5
+		},
+		{
+			"distrib": "amzn",
+			"version": "2018",
+			"arch": "x86_64",
+			"uname_release": "4.14.232-123.381.amzn1.x86_64",
+			"cindex": 5
+		},
+		{
+			"distrib": "amzn",
+			"version": "2018",
+			"arch": "x86_64",
+			"uname_release": "4.14.238-125.421.amzn1.x86_64",
+			"cindex": 5
+		},
+		{
+			"distrib": "amzn",
+			"version": "2018",
+			"arch": "x86_64",
+			"uname_release": "4.14.238-125.422.amzn1.x86_64",
+			"cindex": 5
+		},
+		{
+			"distrib": "amzn",
+			"version": "2018",
+			"arch": "x86_64",
+			"uname_release": "4.14.248-129.473.amzn1.x86_64",
+			"cindex": 5
+		},
+		{
+			"distrib": "amzn",
+			"version": "2018",
+			"arch": "x86_64",
+			"uname_release": "4.14.252-131.483.amzn1.x86_64",
+			"cindex": 5
+		},
+		{
+			"distrib": "amzn",
+			"version": "2018",
+			"arch": "x86_64",
+			"uname_release": "4.14.262-135.486.amzn1.x86_64",
+			"cindex": 5
+		},
+		{
+			"distrib": "amzn",
+			"version": "2018",
+			"arch": "x86_64",
+			"uname_release": "4.14.262-135.489.amzn1.x86_64",
+			"cindex": 5
+		},
+		{
+			"distrib": "amzn",
+			"version": "2018",
+			"arch": "x86_64",
+			"uname_release": "4.14.268-139.500.amzn1.x86_64",
+			"cindex": 5
+		},
+		{
+			"distrib": "amzn",
+			"version": "2018",
+			"arch": "x86_64",
+			"uname_release": "4.14.273-140.502.amzn1.x86_64",
+			"cindex": 5
+		},
+		{
+			"distrib": "amzn",
+			"version": "2018",
+			"arch": "x86_64",
+			"uname_release": "4.14.275-142.503.amzn1.x86_64",
+			"cindex": 5
+		},
+		{
+			"distrib": "amzn",
+			"version": "2018",
+			"arch": "x86_64",
+			"uname_release": "4.14.281-144.502.amzn1.x86_64",
+			"cindex": 5
+		},
+		{
+			"distrib": "amzn",
+			"version": "2018",
+			"arch": "x86_64",
+			"uname_release": "4.14.285-147.501.amzn1.x86_64",
+			"cindex": 5
+		},
+		{
+			"distrib": "amzn",
+			"version": "2018",
+			"arch": "x86_64",
+			"uname_release": "4.14.287-148.504.amzn1.x86_64",
+			"cindex": 5
+		},
+		{
+			"distrib": "amzn",
+			"version": "2018",
+			"arch": "x86_64",
+			"uname_release": "4.14.33-51.34.amzn1.x86_64",
+			"cindex": 1
+		},
+		{
+			"distrib": "amzn",
+			"version": "2018",
+			"arch": "x86_64",
+			"uname_release": "4.14.33-51.37.amzn1.x86_64",
+			"cindex": 1
+		},
+		{
+			"distrib": "amzn",
+			"version": "2018",
+			"arch": "x86_64",
+			"uname_release": "4.14.42-52.37.amzn1.x86_64",
+			"cindex": 1
+		},
+		{
+			"distrib": "amzn",
+			"version": "2018",
+			"arch": "x86_64",
+			"uname_release": "4.14.47-56.37.amzn1.x86_64",
+			"cindex": 1
+		},
+		{
+			"distrib": "amzn",
+			"version": "2018",
+			"arch": "x86_64",
+			"uname_release": "4.14.51-60.38.amzn1.x86_64",
+			"cindex": 1
+		},
+		{
+			"distrib": "amzn",
+			"version": "2018",
+			"arch": "x86_64",
+			"uname_release": "4.14.55-62.37.amzn1.x86_64",
+			"cindex": 1
+		},
+		{
+			"distrib": "amzn",
+			"version": "2018",
+			"arch": "x86_64",
+			"uname_release": "4.14.59-64.43.amzn1.x86_64",
+			"cindex": 1
+		},
+		{
+			"distrib": "amzn",
+			"version": "2018",
+			"arch": "x86_64",
+			"uname_release": "4.14.62-65.117.amzn1.x86_64",
+			"cindex": 1
+		},
+		{
+			"distrib": "amzn",
+			"version": "2018",
+			"arch": "x86_64",
+			"uname_release": "4.14.67-66.56.amzn1.x86_64",
+			"cindex": 1
+		},
+		{
+			"distrib": "amzn",
+			"version": "2018",
+			"arch": "x86_64",
+			"uname_release": "4.14.70-67.55.amzn1.x86_64",
+			"cindex": 1
+		},
+		{
+			"distrib": "amzn",
+			"version": "2018",
+			"arch": "x86_64",
+			"uname_release": "4.14.72-68.55.amzn1.x86_64",
+			"cindex": 1
+		},
+		{
+			"distrib": "amzn",
+			"version": "2018",
+			"arch": "x86_64",
+			"uname_release": "4.14.77-69.57.amzn1.x86_64",
+			"cindex": 1
+		},
+		{
+			"distrib": "amzn",
+			"version": "2018",
+			"arch": "x86_64",
+			"uname_release": "4.14.77-70.59.amzn1.x86_64",
+			"cindex": 1
+		},
+		{
+			"distrib": "amzn",
+			"version": "2018",
+			"arch": "x86_64",
+			"uname_release": "4.14.77-70.82.amzn1.x86_64",
+			"cindex": 1
+		},
+		{
+			"distrib": "amzn",
+			"version": "2018",
+			"arch": "x86_64",
+			"uname_release": "4.14.88-72.73.amzn1.x86_64",
+			"cindex": 1
+		},
+		{
+			"distrib": "amzn",
+			"version": "2018",
+			"arch": "x86_64",
+			"uname_release": "4.14.88-72.76.amzn1.x86_64",
+			"cindex": 1
+		},
+		{
+			"distrib": "amzn",
+			"version": "2018",
+			"arch": "x86_64",
+			"uname_release": "4.14.94-73.73.amzn1.x86_64",
+			"cindex": 1
+		},
+		{
+			"distrib": "amzn",
+			"version": "2018",
+			"arch": "x86_64",
+			"uname_release": "4.14.97-74.72.amzn1.x86_64",
+			"cindex": 1
 		},
 		{
 			"distrib": "centos",
@@ -5266,3760 +5266,3760 @@
 			"cindex": 46
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-1902.300.11.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-1902.301.1.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-1902.302.0.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-1902.302.1.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-1902.302.2.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-1902.303.0.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-1902.303.1.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-1902.303.2.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-1902.303.4.1.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-1902.303.5.3.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-1902.304.5.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-1902.304.6.3.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-1902.304.6.4.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-1902.304.6.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-1902.305.0.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-1902.305.1.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-1902.305.4.1.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-1902.305.4.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-1902.306.2.1.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-1902.306.2.10.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-1902.306.2.12.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-1902.306.2.13.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-1902.306.2.14.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-1902.306.2.2.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-1902.306.2.4.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-1902.306.2.5.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-1902.306.2.7.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-1902.306.2.8.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-1902.306.2.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-1903.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-1904.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-1905.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-1906.1.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-1907.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-1908.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-1909.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-1910a.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-1911.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-1912.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-1915.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-1916.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-1917.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-1923.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-1929.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-1933.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-1941.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2013.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2015.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2016.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2017.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2018.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2019.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2020.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2025.400.3.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2025.400.8.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2025.400.9.1.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2025.400.9.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2025.401.4.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2025.402.0.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2025.402.2.1.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2025.403.1.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2025.403.2.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2025.403.3.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2025.403.4.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2025.403.5.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2025.404.0.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2025.404.1.1.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2025.404.1.2.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2025.405.1.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2025.405.2.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2025.405.3.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2039.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2040.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2041.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.500.10.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.500.5.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.500.9.1.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.500.9.3.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.501.0.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.501.1.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.501.2.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.502.3.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.502.4.1.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.502.4.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.502.5.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.503.0.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.503.1.1.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.503.1.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.504.0.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.504.1.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.504.2.3.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.504.2.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.505.0.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.505.1.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.505.2.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.505.3.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.505.4.2.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.505.4.3.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.505.4.4.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.505.4.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.506.0.el7uek.aarch64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.506.1.el7uek.aarch64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.506.10.el7uek.aarch64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.506.2.el7uek.aarch64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.506.4.el7uek.aarch64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.506.8.1.el7uek.aarch64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.506.8.el7uek.aarch64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.507.0.el7uek.aarch64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.507.1.el7uek.aarch64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.507.7.4.el7uek.aarch64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.507.7.5.el7uek.aarch64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.507.7.6.el7uek.aarch64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.508.3.1.el7uek.aarch64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.508.3.2.el7uek.aarch64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.508.3.3.el7uek.aarch64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.508.3.el7uek.aarch64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.509.1.el7uek.aarch64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.509.2.2.el7uek.aarch64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.509.2.3.el7uek.aarch64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.510.0.el7uek.aarch64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.510.1.el7uek.aarch64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.510.2.el7uek.aarch64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.510.3.el7uek.aarch64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.510.4.1.el7uek.aarch64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.510.5.2.el7uek.aarch64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.510.5.3.el7uek.aarch64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.510.5.4.el7uek.aarch64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.510.5.5.el7uek.aarch64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.510.5.6.el7uek.aarch64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.511.0.el7uek.aarch64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.511.2.el7uek.aarch64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.511.3.el7uek.aarch64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.511.5.2.el7uek.aarch64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.511.5.3.el7uek.aarch64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.511.5.4.el7uek.aarch64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.511.5.5.1.el7uek.aarch64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.511.5.5.3.el7uek.aarch64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.511.5.5.el7uek.aarch64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.511.5.6.el7uek.aarch64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.511.5.7.el7uek.aarch64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.511.5.8.el7uek.aarch64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.511.5.el7uek.aarch64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.512.0.el7uek.aarch64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.512.1.el7uek.aarch64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.512.2.el7uek.aarch64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.512.4.el7uek.aarch64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.512.5.el7uek.aarch64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.512.6.el7uek.aarch64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.513.0.el7uek.aarch64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.513.1.el7uek.aarch64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.513.2.1.el7uek.aarch64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.513.2.2.el7uek.aarch64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.513.2.3.el7uek.aarch64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.513.2.el7uek.aarch64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.514.0.el7uek.aarch64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.514.2.el7uek.aarch64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.514.3.el7uek.aarch64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.514.5.1.1.el7uek.aarch64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.514.5.1.2.el7uek.aarch64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.514.5.el7uek.aarch64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.515.3.el7uek.aarch64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.516.1.1.el7uek.aarch64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.516.1.el7uek.aarch64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.516.2.1.el7uek.aarch64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.516.2.2.el7uek.aarch64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.516.2.el7uek.aarch64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.517.1.el7uek.aarch64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.517.2.el7uek.aarch64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2047.518.0.el7uek.aarch64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2048.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2049.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2050.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2051.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2052.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2102.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2103.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2104.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2105.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2106.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2108.el7uek.aarch64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2109.el7uek.aarch64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2110.el7uek.aarch64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2111.el7uek.aarch64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2112.el7uek.aarch64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2113.el7uek.aarch64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2114.el7uek.aarch64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2115.el7uek.aarch64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2116.el7uek.aarch64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2118.el7uek.aarch64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2120.el7uek.aarch64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2121.el7uek.aarch64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2122.el7uek.aarch64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "4.14.35-2124.el7uek.aarch64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "5.4.0-1948.3.el7uek.aarch64",
 			"cindex": 50
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "5.4.17-2006.5.el7uek.aarch64",
 			"cindex": 50
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "5.4.17-2011.4.6.el7uek.aarch64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "5.4.17-2011.6.2.el7uek.aarch64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "5.4.17-2028.2.el7uek.aarch64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "5.4.17-2036.100.1.el7uek.aarch64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "5.4.17-2036.100.3.el7uek.aarch64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "5.4.17-2036.100.6.el7uek.aarch64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "5.4.17-2036.101.0.el7uek.aarch64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "5.4.17-2036.101.1.el7uek.aarch64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "5.4.17-2036.101.2.el7uek.aarch64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "5.4.17-2036.102.0.el7uek.aarch64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "5.4.17-2036.103.2.el7uek.aarch64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "5.4.17-2036.104.0.el7uek.aarch64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "5.4.17-2036.104.2.el7uek.aarch64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "5.4.17-2036.105.1.el7uek.aarch64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "5.4.17-2036.105.3.el7uek.aarch64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "5.4.17-2040.el7uek.aarch64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "5.4.17-2041.el7uek.aarch64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "5.4.17-2051.el7uek.aarch64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "5.4.17-2102.200.7.el7uek.aarch64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "5.4.17-2102.200.9.el7uek.aarch64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "5.4.17-2102.202.4.el7uek.aarch64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "5.4.17-2102.202.5.el7uek.aarch64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "5.4.17-2102.203.3.el7uek.aarch64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "5.4.17-2102.203.4.el7uek.aarch64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "5.4.17-2102.204.0.el7uek.aarch64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "5.4.17-2102.204.1.el7uek.aarch64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "5.4.17-2102.204.2.el7uek.aarch64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "5.4.17-2102.204.3.el7uek.aarch64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "5.4.17-2102.204.4.3.el7uek.aarch64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "5.4.17-2102.205.2.el7uek.aarch64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "5.4.17-2102.205.7.2.el7uek.aarch64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "5.4.17-2102.205.7.3.el7uek.aarch64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "5.4.17-2102.206.1.el7uek.aarch64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "5.4.17-2106.el7uek.aarch64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "5.4.17-2108.el7uek.aarch64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "5.4.17-2109.el7uek.aarch64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "5.4.17-2111.el7uek.aarch64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "5.4.17-2114.el7uek.aarch64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "5.4.17-2118.el7uek.aarch64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "5.4.17-2120.el7uek.aarch64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "5.4.17-2122.303.5.el7uek.aarch64",
 			"cindex": 52
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "5.4.17-2122.el7uek.aarch64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "5.4.17-2136.300.7.el7uek.aarch64",
 			"cindex": 52
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "5.4.17-2136.301.0.el7uek.aarch64",
 			"cindex": 52
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "arm64",
 			"uname_release": "5.4.2-1950.2.el7uek.aarch64",
 			"cindex": 50
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "3.10.0-1127.0.0.0.1.el7.x86_64",
 			"cindex": 53
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "3.10.0-1127.10.1.0.1.el7.x86_64",
 			"cindex": 53
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "3.10.0-1127.10.1.el7.x86_64",
 			"cindex": 53
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "3.10.0-1127.13.1.0.1.el7.x86_64",
 			"cindex": 53
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "3.10.0-1127.13.1.el7.x86_64",
 			"cindex": 53
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "3.10.0-1127.18.2.0.1.el7.x86_64",
 			"cindex": 53
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "3.10.0-1127.18.2.el7.x86_64",
 			"cindex": 53
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "3.10.0-1127.19.1.0.1.el7.x86_64",
 			"cindex": 53
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "3.10.0-1127.19.1.0.2.el7.x86_64",
 			"cindex": 53
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "3.10.0-1127.19.1.el7.x86_64",
 			"cindex": 53
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "3.10.0-1127.8.2.0.1.el7.x86_64",
 			"cindex": 53
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "3.10.0-1127.8.2.el7.x86_64",
 			"cindex": 53
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "3.10.0-1160.11.1.0.1.el7.x86_64",
 			"cindex": 53
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "3.10.0-1160.11.1.el7.x86_64",
 			"cindex": 53
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "3.10.0-1160.15.2.0.1.el7.x86_64",
 			"cindex": 53
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "3.10.0-1160.15.2.el7.x86_64",
 			"cindex": 53
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "3.10.0-1160.2.1.0.1.el7.x86_64",
 			"cindex": 53
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "3.10.0-1160.2.1.el7.x86_64",
 			"cindex": 53
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "3.10.0-1160.2.2.0.1.el7.x86_64",
 			"cindex": 53
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "3.10.0-1160.2.2.el7.x86_64",
 			"cindex": 53
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "3.10.0-1160.21.1.0.1.el7.x86_64",
 			"cindex": 53
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "3.10.0-1160.21.1.el7.x86_64",
 			"cindex": 53
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "3.10.0-1160.24.1.0.1.el7.x86_64",
 			"cindex": 53
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "3.10.0-1160.24.1.el7.x86_64",
 			"cindex": 53
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "3.10.0-1160.25.1.0.1.el7.x86_64",
 			"cindex": 53
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "3.10.0-1160.25.1.el7.x86_64",
 			"cindex": 53
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "3.10.0-1160.31.1.0.1.el7.x86_64",
 			"cindex": 53
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "3.10.0-1160.31.1.el7.x86_64",
 			"cindex": 53
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "3.10.0-1160.36.2.0.1.el7.x86_64",
 			"cindex": 53
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "3.10.0-1160.36.2.el7.x86_64",
 			"cindex": 53
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "3.10.0-1160.41.1.0.1.el7.x86_64",
 			"cindex": 53
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "3.10.0-1160.41.1.el7.x86_64",
 			"cindex": 53
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "3.10.0-1160.42.2.0.1.el7.x86_64",
 			"cindex": 53
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "3.10.0-1160.42.2.el7.x86_64",
 			"cindex": 53
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "3.10.0-1160.45.1.0.1.el7.x86_64",
 			"cindex": 53
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "3.10.0-1160.45.1.0.2.el7.x86_64",
 			"cindex": 53
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "3.10.0-1160.45.1.el7.x86_64",
 			"cindex": 53
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "3.10.0-1160.6.1.0.1.el7.x86_64",
 			"cindex": 53
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "3.10.0-1160.6.1.el7.x86_64",
 			"cindex": 53
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "3.10.0-1160.el7.x86_64",
 			"cindex": 53
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-1902.300.11.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-1902.301.1.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-1902.302.0.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-1902.302.1.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-1902.302.2.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-1902.303.0.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-1902.303.1.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-1902.303.2.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-1902.303.4.1.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-1902.303.5.3.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-1902.304.4.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-1902.304.5.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-1902.304.6.3.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-1902.304.6.4.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-1902.304.6.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-1902.305.0.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-1902.305.1.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-1902.305.4.1.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-1902.305.4.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-1902.306.2.1.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-1902.306.2.12.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-1902.306.2.13.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-1902.306.2.14.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-1902.306.2.2.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-1902.306.2.4.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-1902.306.2.7.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-1902.306.2.8.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-1902.306.2.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-1903.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-1904.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-1905.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-1906.1.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-1907.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-1908.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-1909.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-1910a.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-1911.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-1912.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-1915.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-1916.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-1917.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-1923.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-1929.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-1933.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-1941.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2013.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2015.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2016.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2017.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2018.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2019.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2020.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2025.400.3.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2025.400.8.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2025.400.9.1.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2025.400.9.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2025.401.4.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2025.402.0.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2025.402.2.1.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2025.403.1.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2025.403.2.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2025.403.3.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2025.403.4.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2025.403.5.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2025.404.0.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2025.404.1.1.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2025.404.1.2.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2025.405.1.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2025.405.2.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2025.405.3.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2039.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2040.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2041.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.500.10.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.500.5.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.500.9.1.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.500.9.3.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.501.0.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.501.1.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.501.2.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.502.3.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.502.4.1.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.502.4.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.502.5.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.503.0.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.503.1.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.504.0.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.504.1.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.504.2.3.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.504.2.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.505.0.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.505.1.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.505.2.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.505.3.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.505.4.2.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.505.4.3.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.505.4.4.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.505.4.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.506.0.el7uek.x86_64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.506.1.el7uek.x86_64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.506.10.el7uek.x86_64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.506.2.el7uek.x86_64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.506.4.el7uek.x86_64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.506.8.1.el7uek.x86_64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.506.8.el7uek.x86_64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.507.0.el7uek.x86_64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.507.1.el7uek.x86_64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.507.7.4.el7uek.x86_64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.507.7.5.el7uek.x86_64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.507.7.6.el7uek.x86_64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.508.3.1.el7uek.x86_64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.508.3.2.el7uek.x86_64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.508.3.3.el7uek.x86_64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.508.3.el7uek.x86_64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.509.1.el7uek.x86_64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.509.2.2.el7uek.x86_64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.509.2.3.el7uek.x86_64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.510.0.el7uek.x86_64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.510.1.el7uek.x86_64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.510.2.el7uek.x86_64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.510.3.el7uek.x86_64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.510.4.1.el7uek.x86_64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.510.5.2.el7uek.x86_64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.510.5.3.el7uek.x86_64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.510.5.4.el7uek.x86_64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.510.5.5.el7uek.x86_64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.510.5.6.el7uek.x86_64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.511.0.el7uek.x86_64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.511.2.el7uek.x86_64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.511.3.el7uek.x86_64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.511.5.2.el7uek.x86_64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.511.5.3.el7uek.x86_64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.511.5.4.el7uek.x86_64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.511.5.5.1.el7uek.x86_64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.511.5.5.3.el7uek.x86_64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.511.5.5.el7uek.x86_64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.511.5.6.el7uek.x86_64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.511.5.7.el7uek.x86_64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.511.5.8.el7uek.x86_64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.511.5.el7uek.x86_64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.512.0.el7uek.x86_64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.512.1.el7uek.x86_64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.512.2.el7uek.x86_64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.512.4.el7uek.x86_64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.512.5.el7uek.x86_64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.512.6.el7uek.x86_64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.513.0.el7uek.x86_64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.513.1.el7uek.x86_64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.513.2.1.el7uek.x86_64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.513.2.2.el7uek.x86_64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.513.2.3.el7uek.x86_64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.513.2.el7uek.x86_64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.514.0.el7uek.x86_64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.514.2.el7uek.x86_64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.514.3.el7uek.x86_64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.514.5.1.1.el7uek.x86_64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.514.5.1.2.el7uek.x86_64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.514.5.el7uek.x86_64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.515.3.el7uek.x86_64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.516.1.1.el7uek.x86_64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.516.1.el7uek.x86_64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.516.2.1.el7uek.x86_64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.516.2.2.el7uek.x86_64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.516.2.el7uek.x86_64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.517.1.el7uek.x86_64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.517.2.el7uek.x86_64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2047.518.0.el7uek.x86_64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2048.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2049.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2050.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2051.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2052.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2102.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2103.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2104.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2105.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2106.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2108.el7uek.x86_64",
 			"cindex": 48
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2109.el7uek.x86_64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2110.el7uek.x86_64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2111.el7uek.x86_64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2112.el7uek.x86_64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2113.el7uek.x86_64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2114.el7uek.x86_64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2115.el7uek.x86_64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2116.el7uek.x86_64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2118.el7uek.x86_64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2120.el7uek.x86_64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2121.el7uek.x86_64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2122.el7uek.x86_64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "4.14.35-2124.el7uek.x86_64",
 			"cindex": 49
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "5.4.0-1948.3.el7uek.x86_64",
 			"cindex": 54
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "5.4.17-2006.5.el7uek.x86_64",
 			"cindex": 50
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "5.4.17-2011.0.7.el7uek.x86_64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "5.4.17-2011.1.2.el7uek.x86_64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "5.4.17-2011.2.2.el7uek.x86_64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "5.4.17-2011.3.2.1.el7uek.x86_64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "5.4.17-2011.4.4.el7uek.x86_64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "5.4.17-2011.4.6.el7uek.x86_64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "5.4.17-2011.5.3.el7uek.x86_64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "5.4.17-2011.6.2.el7uek.x86_64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "5.4.17-2011.7.4.el7uek.x86_64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "5.4.17-2028.2.el7uek.x86_64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "5.4.17-2036.100.1.el7uek.x86_64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "5.4.17-2036.100.3.el7uek.x86_64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "5.4.17-2036.100.6.1.el7uek.x86_64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "5.4.17-2036.100.6.el7uek.x86_64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "5.4.17-2036.101.0.el7uek.x86_64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "5.4.17-2036.101.1.el7uek.x86_64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "5.4.17-2036.101.2.el7uek.x86_64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "5.4.17-2036.102.0.2.el7uek.x86_64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "5.4.17-2036.102.0.el7uek.x86_64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "5.4.17-2036.103.2.el7uek.x86_64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "5.4.17-2036.103.3.1.el7uek.x86_64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "5.4.17-2036.103.3.el7uek.x86_64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "5.4.17-2036.104.0.el7uek.x86_64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "5.4.17-2036.104.2.el7uek.x86_64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "5.4.17-2036.104.4.el7uek.x86_64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "5.4.17-2036.104.5.el7uek.x86_64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "5.4.17-2036.105.1.el7uek.x86_64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "5.4.17-2036.105.3.el7uek.x86_64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "5.4.17-2040.el7uek.x86_64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "5.4.17-2041.el7uek.x86_64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "5.4.17-2051.el7uek.x86_64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "5.4.17-2102.200.13.el7uek.x86_64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "5.4.17-2102.200.7.el7uek.x86_64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "5.4.17-2102.200.9.el7uek.x86_64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "5.4.17-2102.201.3.el7uek.x86_64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "5.4.17-2102.202.4.el7uek.x86_64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "5.4.17-2102.202.5.el7uek.x86_64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "5.4.17-2102.203.3.el7uek.x86_64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "5.4.17-2102.203.4.el7uek.x86_64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "5.4.17-2102.203.5.el7uek.x86_64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "5.4.17-2102.203.6.el7uek.x86_64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "5.4.17-2102.204.0.el7uek.x86_64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "5.4.17-2102.204.1.el7uek.x86_64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "5.4.17-2102.204.2.el7uek.x86_64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "5.4.17-2102.204.3.el7uek.x86_64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "5.4.17-2102.204.4.2.el7uek.x86_64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "5.4.17-2102.204.4.3.el7uek.x86_64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "5.4.17-2102.204.4.4.el7uek.x86_64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "5.4.17-2102.205.2.el7uek.x86_64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "5.4.17-2102.205.7.2.el7uek.x86_64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "5.4.17-2102.205.7.3.el7uek.x86_64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "5.4.17-2102.206.1.el7uek.x86_64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "5.4.17-2106.el7uek.x86_64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "5.4.17-2108.el7uek.x86_64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "5.4.17-2109.el7uek.x86_64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "5.4.17-2111.el7uek.x86_64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "5.4.17-2114.el7uek.x86_64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "5.4.17-2118.el7uek.x86_64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "5.4.17-2120.el7uek.x86_64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "5.4.17-2122.303.5.el7uek.x86_64",
 			"cindex": 52
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "5.4.17-2122.el7uek.x86_64",
 			"cindex": 51
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "5.4.17-2136.300.7.el7uek.x86_64",
 			"cindex": 52
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "5.4.17-2136.301.0.el7uek.x86_64",
 			"cindex": 52
 		},
 		{
-			"distrib": "oracle-linux",
-			"version": "ol7",
+			"distrib": "ol",
+			"version": "7",
 			"arch": "x86_64",
 			"uname_release": "5.4.2-1950.2.el7uek.x86_64",
 			"cindex": 50


### PR DESCRIPTION
### What does this PR do?

BTFHub archive is in the process of mapping more closely to what is available in `/etc/os-release`, this means that some of our mappings are becoming useless. This PR cleans up the new non-required mappings and update the BTFHub constants.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
