### PR TITLE
trace-agent: Add regex support for filtering tags

### DIFF
--- a/cmd/trace-agent/test/testsuite/traces_test.go
+++ b/cmd/trace-agent/test/testsuite/traces_test.go
@@ -104,8 +104,11 @@ func TestTraces(t *testing.T) {
 	t.Run("filter_tags", func(t *testing.T) {
 		if err := r.RunAgent([]byte(`apm_config:
   filter_tags:
-    require: ["env:^prod$", "db:mysql"]
-    reject: ["outcome:^success$"]`)); err != nil {
+    require: ["env:prod", "db:mysql"]
+    reject: ["outcome:success"]
+  filter_tags_regex:
+    require: ["env:^prod[0-9]{1}$", "priority:^high$"]
+    reject: ["outcome:^success[0-9]{1}$", "bad-key:^bad-value$"]`)); err != nil {
 			t.Fatal(err)
 		}
 		defer r.KillAgent()
@@ -116,22 +119,33 @@ func TestTraces(t *testing.T) {
 		}, nil)
 		for _, span := range p[0] {
 			span.Meta = map[string]string{
-				"env": "prod",
-				"db":  "mysql",
+				"env":      "prod",
+				"db":       "mysql",
+				"priority": "high",
 			}
 		}
 		for _, span := range p[1] {
 			span.Meta = map[string]string{
-				"env":     "prod",
-				"db":      "mysql",
-				"outcome": "success123",
+				"env":      "prod",
+				"db":       "mysql",
+				"priority": "high",
+				"outcome":  "success1",
+			}
+		}
+		for _, span := range p[2] {
+			span.Meta = map[string]string{
+				"env":      "prod",
+				"db":       "mysql",
+				"priority": "high",
+				"outcome":  "success",
 			}
 		}
 		for _, span := range p[3] {
 			span.Meta = map[string]string{
-				"outcome": "success",
-				"db":      "mysql",
-				"env":     "prod",
+				"env":      "prod",
+				"db":       "mysql",
+				"priority": "high",
+				"bad-key":  "bad-value",
 			}
 		}
 		if err := r.Post(p); err != nil {

--- a/cmd/trace-agent/test/testsuite/traces_test.go
+++ b/cmd/trace-agent/test/testsuite/traces_test.go
@@ -104,8 +104,8 @@ func TestTraces(t *testing.T) {
 	t.Run("filter_tags", func(t *testing.T) {
 		if err := r.RunAgent([]byte(`apm_config:
   filter_tags:
-    require: ["env:prod", "db:mysql"]
-    reject: ["outcome:success"]`)); err != nil {
+    require: ["env:^prod$", "db:mysql"]
+    reject: ["outcome:^success$"]`)); err != nil {
 			t.Fatal(err)
 		}
 		defer r.KillAgent()
@@ -122,14 +122,16 @@ func TestTraces(t *testing.T) {
 		}
 		for _, span := range p[1] {
 			span.Meta = map[string]string{
-				"env": "prod",
-				"db":  "mysql",
+				"env":     "prod",
+				"db":      "mysql",
+				"outcome": "success123",
 			}
 		}
 		for _, span := range p[3] {
 			span.Meta = map[string]string{
 				"outcome": "success",
 				"db":      "mysql",
+				"env":     "prod",
 			}
 		}
 		if err := r.Post(p); err != nil {

--- a/comp/trace/config/setup.go
+++ b/comp/trace/config/setup.go
@@ -444,12 +444,12 @@ func applyDatadogConfig(c *config.AgentConfig, core corecompcfg.Component) error
 		}
 	}
 
-
 	if coreconfig.Datadog.IsSet("apm_config.filter_tags_regex.require") {
 		tags := coreconfig.Datadog.GetStringSlice("apm_config.filter_tags_regex.require")
 		for _, tag := range tags {
 			splitTag := splitTagRegex(tag)
 			if containsKey(c.RequireTags, splitTag.K) {
+				// RequireTags already has this tag, so skip the regexp.
 				continue
 			}
 			c.RequireTagsRegex = append(c.RequireTagsRegex, splitTag)
@@ -460,6 +460,7 @@ func applyDatadogConfig(c *config.AgentConfig, core corecompcfg.Component) error
 		for _, tag := range tags {
 			splitTag := splitTagRegex(tag)
 			if containsKey(c.RejectTags, splitTag.K) {
+				// RejectTags already has this tag, so skip the regexp.
 				continue
 			}
 			c.RejectTagsRegex = append(c.RejectTagsRegex, splitTag)
@@ -738,7 +739,6 @@ func splitTagRegex(tag string) *config.TagRegex {
 	}
 	return kv
 }
-
 
 // validate validates if the current configuration is good for the agent to start with.
 func validate(c *config.AgentConfig, core corecompcfg.Component) error {

--- a/comp/trace/config/setup.go
+++ b/comp/trace/config/setup.go
@@ -682,9 +682,13 @@ func splitTag(tag string) *config.Tag {
 		K: strings.TrimSpace(parts[0]),
 	}
 	if len(parts) > 1 {
-		if v := strings.TrimSpace(parts[1]); v != "" {
-			kv.V = v
+		v := strings.TrimSpace(parts[1])
+		re, err := regexp.Compile(v)
+		if err != nil {
+			log.Errorf("Invalid tag filter: %q:%q", kv.K, v)
+			return nil
 		}
+		kv.V = re
 	}
 	return kv
 }

--- a/comp/trace/config/testdata/full.yaml
+++ b/comp/trace/config/testdata/full.yaml
@@ -50,8 +50,8 @@ apm_config:
     - /500
 
   filter_tags:
-    require: ["env:prod", "db:mongodb"]
-    reject: ["outcome:success"]
+    require: ["env:^prod$", "db:mongodb"]
+    reject: ["outcome:^success$"]
 
   replace_tags:
     - name: "http.method"

--- a/comp/trace/config/testdata/full.yaml
+++ b/comp/trace/config/testdata/full.yaml
@@ -50,8 +50,12 @@ apm_config:
     - /500
 
   filter_tags:
-    require: ["env:^prod$", "db:mongodb"]
-    reject: ["outcome:^success$"]
+    require: ["env:prod", "db:mongodb"]
+    reject: ["outcome:success", "bad-key:bad-value"]
+
+  filter_tags_regex:
+    require: ["env:^prod123$", "type: ^internal$"]
+    reject: ["filter:^true$", "bad-key:$another-bad-value$"]
 
   replace_tags:
     - name: "http.method"

--- a/pkg/config/apm.go
+++ b/pkg/config/apm.go
@@ -41,6 +41,8 @@ func setupAPM(config Config) {
 	config.BindEnv("apm_config.obfuscation.memcached.keep_command", "DD_APM_OBFUSCATION_MEMCACHED_KEEP_COMMAND")
 	config.SetKnown("apm_config.filter_tags.require")
 	config.SetKnown("apm_config.filter_tags.reject")
+	config.SetKnown("apm_config.filter_tags_regex.require")
+	config.SetKnown("apm_config.filter_tags_regex.reject")
 	config.SetKnown("apm_config.extra_sample_rate")
 	config.SetKnown("apm_config.dd_agent_bin")
 	config.SetKnown("apm_config.trace_writer.connection_limit")
@@ -107,6 +109,8 @@ func setupAPM(config Config) {
 	config.BindEnv("apm_config.sync_flushing", "DD_APM_SYNC_FLUSHING")
 	config.BindEnv("apm_config.filter_tags.require", "DD_APM_FILTER_TAGS_REQUIRE")
 	config.BindEnv("apm_config.filter_tags.reject", "DD_APM_FILTER_TAGS_REJECT")
+	config.BindEnv("apm_config.filter_tags_regex.reject", "DD_APM_FILTER_TAGS_REGEX_REJECT")
+	config.BindEnv("apm_config.filter_tags_regex.require", "DD_APM_FILTER_TAGS_REGEX_REQUIRE")
 	config.BindEnv("apm_config.internal_profiling.enabled", "DD_APM_INTERNAL_PROFILING_ENABLED")
 	config.BindEnv("apm_config.debugger_dd_url", "DD_APM_DEBUGGER_DD_URL")
 	config.BindEnv("apm_config.debugger_api_key", "DD_APM_DEBUGGER_API_KEY")
@@ -149,6 +153,10 @@ func setupAPM(config Config) {
 	config.SetEnvKeyTransformer("apm_config.filter_tags.require", parseKVList("apm_config.filter_tags.require"))
 
 	config.SetEnvKeyTransformer("apm_config.filter_tags.reject", parseKVList("apm_config.filter_tags.reject"))
+
+	config.SetEnvKeyTransformer("apm_config.filter_tags_regex.require", parseKVList("apm_config.filter_tags_regex.require"))
+
+	config.SetEnvKeyTransformer("apm_config.filter_tags_regex.reject", parseKVList("apm_config.filter_tags_regex.reject"))
 
 	config.SetEnvKeyTransformer("apm_config.replace_tags", func(in string) interface{} {
 		var out []map[string]string

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1421,15 +1421,15 @@ api_key:
   ## Please note that:
   ##   1. Rules take into account the intersection of tags defined.
   ##   2. When `filter_tags` and `filter_tags_regex` are used at the same time, all rules are united for filtering.
-  ##      In the case when rule in `filter_tags` and `filter_tags_regex` have the same key, rule from `filter_tags`
-  ##      have precendence over the `filter_tags_regex`.
+  ##      In cases where rules in `filter_tags` and `filter_tags_regex` have the same key, the rule from `filter_tags`
+  ##      takes precendence over the rule from `filter_tags_regex`.
   ##
   ##      In the case of the following configuration:
   ##        filter_tags:
   ##          require: ["foo:bar"]
   ##        filter_tags_regex:
   ##          require: ["foo:^bar[0-9]{1}$"]
-  ##      resulting combined rule will match `foo:bar` and not `foo:bar1`
+  ##      The resulting combined rule will match `foo:bar` and not `foo:bar1`
   #
   # filter_tags:
   #     require: [<LIST_OF_KEY_VALUE_TAGS>]

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1418,10 +1418,18 @@ api_key:
   ## Defines rules by which to filter traces based on tags.
   ##  * require - list of key or key/value strings - traces must have those tags in order to be sent to Datadog
   ##  * reject - list of key or key/value strings - traces with these tags are dropped by the Agent
-  ## Note: Rules take into account the intersection of tags defined.
-  ##       When `filter_tags` and `filter_tags_regex` are used at the same time, all rules are united for filtering.
-  ##       In the case when rule in `filter_tags` and `filter_tags_regex` have the same key, rule from `filter_tags`
-  ##       have precendence over the `filter_tags_regex`.
+  ## Please note that:
+  ##   1. Rules take into account the intersection of tags defined.
+  ##   2. When `filter_tags` and `filter_tags_regex` are used at the same time, all rules are united for filtering.
+  ##      In the case when rule in `filter_tags` and `filter_tags_regex` have the same key, rule from `filter_tags`
+  ##      have precendence over the `filter_tags_regex`.
+  ##
+  ##      In the case of the following configuration:
+  ##        filter_tags:
+  ##          require: ["foo:bar"]
+  ##        filter_tags_regex:
+  ##          require: ["foo:^bar[0-9]{1}$"]
+  ##      resulting combined rule will match `foo:bar` and not `foo:bar1`
   #
   # filter_tags:
   #     require: [<LIST_OF_KEY_VALUE_TAGS>]
@@ -1434,8 +1442,8 @@ api_key:
   ## Note: Rules take into account the intersection of tags defined.
   #
   # filter_tags_regex:
-  #     require: [<LIST_OF_KEY_VALUE_REGEX_TAGS>]
-  #     reject: [<LIST_OF_KEY_VALUE_REGEX_TAGS>]
+  #     require: [<LIST_OF_KEY_VALUE_REGEX_TAGS>]    # e.g. ["<key>:<regex>"]
+  #     reject: [<LIST_OF_KEY_VALUE_REGEX_TAGS>]     # e.g. ["<key>:<regex>"]
 
   ## @param replace_tags - list of objects - optional
   ## @env DD_APM_REPLACE_TAGS  - list of objects - optional

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1416,13 +1416,13 @@ api_key:
   ## @env DD_APM_FILTER_TAG_REQUIRE - object - optional
   ## @env DD_APM_FILTER_TAG_REJECT - object - optional
   ## Defines rules by which to filter traces based on tags.
-  ##  * require - list of key or key/value strings - traces must have those tags in order to be sent to Datadog
-  ##  * reject - list of key or key/value strings - traces with these tags are dropped by the Agent
+  ##  * require - list of key or key/value regex pattern strings - traces must have those tags in order to be sent to Datadog
+  ##  * reject - list of key or key/value regex pattern strings - traces with these tags are dropped by the Agent
   ## Note: Rules take into account the intersection of tags defined.
   #
   # filter_tags:
-  #     require: [<LIST_OF_KEY_VALUE_TAGS>]
-  #     reject: [<LIST_OF_KEY_VALUE_TAGS>]
+  #     require: [<LIST_OF_KEY_VALUE_REGEX_PATTERN_TAGS>]
+  #     reject: [<LIST_OF_KEY_VALUE_REGEX_PATTERN_TAGS>]
 
   ## @param replace_tags - list of objects - optional
   ## @env DD_APM_REPLACE_TAGS  - list of objects - optional

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1212,7 +1212,7 @@ api_key:
 
   ## @param max_message_size_bytes - integer - optional - default: 256000
   ## @env DD_LOGS_CONFIG_MAX_MESSAGE_SIZE_BYTES - integer - optional - default : 256000
-  ## The maximum size of single log message in bytes. If maxMessageSizeBytes exceeds 
+  ## The maximum size of single log message in bytes. If maxMessageSizeBytes exceeds
   ## the documented API limit of 1MB - any payloads larger than 1MB will be dropped by the intake.
   # https://docs.datadoghq.com/api/latest/logs/
   #
@@ -1421,15 +1421,15 @@ api_key:
   ## Please note that:
   ##   1. Rules take into account the intersection of tags defined.
   ##   2. When `filter_tags` and `filter_tags_regex` are used at the same time, all rules are united for filtering.
-  ##      In cases where rules in `filter_tags` and `filter_tags_regex` have the same key, the rule from `filter_tags`
+  ##      In cases where rules in `filter_tags` and `filter_tags_regex` match the same key, the rule from `filter_tags`
   ##      takes precendence over the rule from `filter_tags_regex`.
   ##
-  ##      In the case of the following configuration:
+  ##      For example, in the case of the following configuration:
   ##        filter_tags:
   ##          require: ["foo:bar"]
   ##        filter_tags_regex:
   ##          require: ["foo:^bar[0-9]{1}$"]
-  ##      The resulting combined rule will match `foo:bar` and not `foo:bar1`
+  ##      With these rules, traces with a tag `foo:bar1` will be dropped, and those with a `foo:bar` tag will be kept
   #
   # filter_tags:
   #     require: [<LIST_OF_KEY_VALUE_TAGS>]
@@ -1440,6 +1440,7 @@ api_key:
   ##  * require - list of key or key/value regex pattern strings - traces must have those tags in order to be sent to Datadog
   ##  * reject - list of key or key/value regex pattern strings - traces with these tags are dropped by the Agent
   ## Note: Rules take into account the intersection of tags defined.
+  ## More detailed information can be found in the description of the `filter_tags` parameter above
   #
   # filter_tags_regex:
   #     require: [<LIST_OF_KEY_VALUE_REGEX_TAGS>]    # e.g. ["<key>:<regex>"]

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1416,13 +1416,26 @@ api_key:
   ## @env DD_APM_FILTER_TAG_REQUIRE - object - optional
   ## @env DD_APM_FILTER_TAG_REJECT - object - optional
   ## Defines rules by which to filter traces based on tags.
+  ##  * require - list of key or key/value strings - traces must have those tags in order to be sent to Datadog
+  ##  * reject - list of key or key/value strings - traces with these tags are dropped by the Agent
+  ## Note: Rules take into account the intersection of tags defined.
+  ##       When `filter_tags` and `filter_tags_regex` are used at the same time, all rules are united for filtering.
+  ##       In the case when rule in `filter_tags` and `filter_tags_regex` have the same key, rule from `filter_tags`
+  ##       have precendence over the `filter_tags_regex`.
+  #
+  # filter_tags:
+  #     require: [<LIST_OF_KEY_VALUE_TAGS>]
+  #     reject: [<LIST_OF_KEY_VALUE_TAGS>]
+
+  ## @param filter_tags_regex - object - optional
+  ## Defines rules by which to filter traces based on tags with regex pattern for tag values.
   ##  * require - list of key or key/value regex pattern strings - traces must have those tags in order to be sent to Datadog
   ##  * reject - list of key or key/value regex pattern strings - traces with these tags are dropped by the Agent
   ## Note: Rules take into account the intersection of tags defined.
   #
   # filter_tags:
-  #     require: [<LIST_OF_KEY_VALUE_REGEX_PATTERN_TAGS>]
-  #     reject: [<LIST_OF_KEY_VALUE_REGEX_PATTERN_TAGS>]
+  #     require: [<LIST_OF_KEY_VALUE_REGEX_TAGS>]
+  #     reject: [<LIST_OF_KEY_VALUE_REGEX_TAGS>]
 
   ## @param replace_tags - list of objects - optional
   ## @env DD_APM_REPLACE_TAGS  - list of objects - optional

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1440,9 +1440,9 @@ api_key:
   ##  * require - list of key or key/value regex pattern strings - traces must have those tags in order to be sent to Datadog
   ##  * reject - list of key or key/value regex pattern strings - traces with these tags are dropped by the Agent
   ## Note: Rules take into account the intersection of tags defined.
-  ## Using regex patterns in the tag filtering reduces performance by about 3 times.
-  ## But it should be noted that tag filtering only apply to the root span of a trace.
-  ## Therefore this should not have a critical impact on overall performance.
+  ## Using regexp patterns for tag filtering can have performance implications, and is slower than typical tag filtering
+  ## without regexp. However, this regexp is only run on the root span of a trace, so should not have a critical impact
+  ## on overall performance.
   ## More detailed information can be found in the description of the `filter_tags` parameter above
   #
   # filter_tags_regex:

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1440,6 +1440,9 @@ api_key:
   ##  * require - list of key or key/value regex pattern strings - traces must have those tags in order to be sent to Datadog
   ##  * reject - list of key or key/value regex pattern strings - traces with these tags are dropped by the Agent
   ## Note: Rules take into account the intersection of tags defined.
+  ## Using regex patterns in the tag filtering reduces performance by about 3 times.
+  ## But it should be noted that tag filtering only apply to the root span of a trace.
+  ## Therefore this should not have a critical impact on overall performance.
   ## More detailed information can be found in the description of the `filter_tags` parameter above
   #
   # filter_tags_regex:

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1433,7 +1433,7 @@ api_key:
   ##  * reject - list of key or key/value regex pattern strings - traces with these tags are dropped by the Agent
   ## Note: Rules take into account the intersection of tags defined.
   #
-  # filter_tags:
+  # filter_tags_regex:
   #     require: [<LIST_OF_KEY_VALUE_REGEX_TAGS>]
   #     reject: [<LIST_OF_KEY_VALUE_REGEX_TAGS>]
 

--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -582,13 +582,13 @@ func traceContainsError(trace pb.Trace) bool {
 
 func filteredByTags(root *pb.Span, require, reject []*config.Tag) bool {
 	for _, tag := range reject {
-		if v, ok := root.Meta[tag.K]; ok && (tag.V == "" || v == tag.V) {
+		if v, ok := root.Meta[tag.K]; ok && (tag.V == nil || tag.V.MatchString(v)) {
 			return true
 		}
 	}
 	for _, tag := range require {
 		v, ok := root.Meta[tag.K]
-		if !ok || (tag.V != "" && v != tag.V) {
+		if !ok || (tag.V != nil && !tag.V.MatchString(v)) {
 			return true
 		}
 	}

--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -268,7 +268,7 @@ func (a *Agent) Process(p *api.Payload) {
 			continue
 		}
 
-		if filteredByTags(root, a.conf.RequireTags, a.conf.RejectTags) {
+		if filteredByTags(root, a.conf.RequireTags, a.conf.RejectTags, a.conf.RequireTagsRegex, a.conf.RejectTagsRegex) {
 			log.Debugf("Trace rejected as it fails to meet tag requirements. root: %v", root)
 			ts.TracesFiltered.Inc()
 			ts.SpansFiltered.Add(tracen)
@@ -580,13 +580,24 @@ func traceContainsError(trace pb.Trace) bool {
 	return false
 }
 
-func filteredByTags(root *pb.Span, require, reject []*config.Tag) bool {
+func filteredByTags(root *pb.Span, require, reject []*config.Tag, requireRegex, rejectRegex []*config.TagRegex) bool {
 	for _, tag := range reject {
+		if v, ok := root.Meta[tag.K]; ok && (tag.V == "" || v == tag.V) {
+			return true
+		}
+	}
+	for _, tag := range rejectRegex {
 		if v, ok := root.Meta[tag.K]; ok && (tag.V == nil || tag.V.MatchString(v)) {
 			return true
 		}
 	}
 	for _, tag := range require {
+		v, ok := root.Meta[tag.K]
+		if !ok || (tag.V != "" && v != tag.V) {
+			return true
+		}
+	}
+	for _, tag := range requireRegex {
 		v, ok := root.Meta[tag.K]
 		if !ok || (tag.V != nil && !tag.V.MatchString(v)) {
 			return true

--- a/pkg/trace/agent/agent_test.go
+++ b/pkg/trace/agent/agent_test.go
@@ -782,7 +782,7 @@ func TestClientComputedTopLevel(t *testing.T) {
 }
 
 func TestFilteredByTags(t *testing.T) {
-	for name, tt := range map[string]struct {
+	for name, tt := range map[string]*struct {
 		require      []*config.Tag
 		reject       []*config.Tag
 		requireRegex []*config.TagRegex

--- a/pkg/trace/agent/agent_test.go
+++ b/pkg/trace/agent/agent_test.go
@@ -789,39 +789,39 @@ func TestFilteredByTags(t *testing.T) {
 		drop    bool
 	}{
 		{
-			require: []*config.Tag{{K: "key", V: "val"}},
+			require: []*config.Tag{{K: "key", V: regexp.MustCompile("val")}},
 			span:    pb.Span{Meta: map[string]string{"key": "val"}},
 			drop:    false,
 		},
 		{
-			reject: []*config.Tag{{K: "key", V: "val"}},
+			reject: []*config.Tag{{K: "key", V: regexp.MustCompile("^val$")}},
 			span:   pb.Span{Meta: map[string]string{"key": "val4"}},
 			drop:   false,
 		},
 		{
-			reject: []*config.Tag{{K: "something", V: "else"}},
+			reject: []*config.Tag{{K: "something", V: regexp.MustCompile("else")}},
 			span:   pb.Span{Meta: map[string]string{"key": "val"}},
 			drop:   false,
 		},
 		{
-			require: []*config.Tag{{K: "something", V: "else"}},
-			reject:  []*config.Tag{{K: "bad-key", V: "bad-value"}},
+			require: []*config.Tag{{K: "something", V: regexp.MustCompile("else")}},
+			reject:  []*config.Tag{{K: "bad-key", V: regexp.MustCompile("bad-value")}},
 			span:    pb.Span{Meta: map[string]string{"something": "else", "bad-key": "other-value"}},
 			drop:    false,
 		},
 		{
-			require: []*config.Tag{{K: "key", V: "value"}, {K: "key-only"}},
-			reject:  []*config.Tag{{K: "bad-key", V: "bad-value"}},
+			require: []*config.Tag{{K: "key", V: regexp.MustCompile("value")}, {K: "key-only"}},
+			reject:  []*config.Tag{{K: "bad-key", V: regexp.MustCompile("^bad-value$")}},
 			span:    pb.Span{Meta: map[string]string{"key": "value", "key-only": "but-also-value", "bad-key": "not-bad-value"}},
 			drop:    false,
 		},
 		{
-			require: []*config.Tag{{K: "key", V: "val"}},
+			require: []*config.Tag{{K: "key", V: regexp.MustCompile("^val$")}},
 			span:    pb.Span{Meta: map[string]string{"key": "val2"}},
 			drop:    true,
 		},
 		{
-			require: []*config.Tag{{K: "something", V: "else"}},
+			require: []*config.Tag{{K: "something", V: regexp.MustCompile("else")}},
 			span:    pb.Span{Meta: map[string]string{"key": "val"}},
 			drop:    true,
 		},
@@ -832,19 +832,19 @@ func TestFilteredByTags(t *testing.T) {
 			drop:    true,
 		},
 		{
-			require: []*config.Tag{{K: "valid-key", V: "valid-value"}, {K: "test"}},
-			reject:  []*config.Tag{{K: "test"}},
+			require: []*config.Tag{{K: "valid-key", V: regexp.MustCompile("valid-value")}, {K: "test"}},
+			reject:  []*config.Tag{{K: "test", V: regexp.MustCompile("")}},
 			span:    pb.Span{Meta: map[string]string{"test": "random", "valid-key": "wrong-value"}},
 			drop:    true,
 		},
 		{
-			reject: []*config.Tag{{K: "key", V: "val"}},
+			reject: []*config.Tag{{K: "key", V: regexp.MustCompile("val")}},
 			span:   pb.Span{Meta: map[string]string{"key": "val"}},
 			drop:   true,
 		},
 		{
-			require: []*config.Tag{{K: "something", V: "else"}, {K: "key-only"}},
-			reject:  []*config.Tag{{K: "bad-key", V: "bad-value"}, {K: "bad-key-only"}},
+			require: []*config.Tag{{K: "something", V: regexp.MustCompile("else")}, {K: "key-only"}},
+			reject:  []*config.Tag{{K: "bad-key", V: regexp.MustCompile("bad-value")}, {K: "bad-key-only"}},
 			span:    pb.Span{Meta: map[string]string{"something": "else", "key-only": "but-also-value", "bad-key-only": "random"}},
 			drop:    true,
 		},

--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -376,6 +376,12 @@ type AgentConfig struct {
 	// RejectTags specifies a list of tags which must be absent on the root span in order for a trace to be accepted.
 	RejectTags []*Tag
 
+	// RequireTagsRegex specifies a list of tags which must be present on the root span in order for a trace to be accepted.
+	RequireTagsRegex []*TagRegex
+
+	// RejectTagsRegex specifies a list of tags which must be absent on the root span in order for a trace to be accepted.
+	RejectTagsRegex []*TagRegex
+
 	// OTLPReceiver holds the configuration for OpenTelemetry receiver.
 	OTLPReceiver *OTLP
 
@@ -432,6 +438,11 @@ type RemoteClient interface {
 
 // Tag represents a key/value pair.
 type Tag struct {
+	K, V string
+}
+
+// TagRegex represents a key/value regex pattern pair.
+type TagRegex struct {
 	K string
 	V *regexp.Regexp
 }

--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -432,7 +432,8 @@ type RemoteClient interface {
 
 // Tag represents a key/value pair.
 type Tag struct {
-	K, V string
+	K string
+	V *regexp.Regexp
 }
 
 // New returns a configuration with the default values.

--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -376,10 +376,10 @@ type AgentConfig struct {
 	// RejectTags specifies a list of tags which must be absent on the root span in order for a trace to be accepted.
 	RejectTags []*Tag
 
-	// RequireTagsRegex specifies a list of tags which must be present on the root span in order for a trace to be accepted.
+	// RequireTagsRegex specifies a list of regexp for tags which must be present on the root span in order for a trace to be accepted.
 	RequireTagsRegex []*TagRegex
 
-	// RejectTagsRegex specifies a list of tags which must be absent on the root span in order for a trace to be accepted.
+	// RejectTagsRegex specifies a list of regexp for tags which must be absent on the root span in order for a trace to be accepted.
 	RejectTagsRegex []*TagRegex
 
 	// OTLPReceiver holds the configuration for OpenTelemetry receiver.

--- a/releasenotes/notes/apm-regex-filter-tags-afa1c48590101bed.yaml
+++ b/releasenotes/notes/apm-regex-filter-tags-afa1c48590101bed.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    APM: Add regex support for filtering tags by apm_config.filter_tags or environment
+    variables DD_APM_FILTER_TAGS_REQUIRE and DD_APM_FILTER_TAGS_REJECT.

--- a/releasenotes/notes/apm-regex-filter-tags-afa1c48590101bed.yaml
+++ b/releasenotes/notes/apm-regex-filter-tags-afa1c48590101bed.yaml
@@ -8,5 +8,5 @@
 ---
 enhancements:
   - |
-    APM: Add regex support for filtering tags by apm_config.filter_tags or environment
-    variables DD_APM_FILTER_TAGS_REQUIRE and DD_APM_FILTER_TAGS_REJECT.
+    APM: Add regex support for filtering tags by apm_config.filter_tags_regex or environment
+    variables DD_APM_FILTER_TAGS_REGEX_REQUIRE and DD_APM_FILTER_TAGS_REGEX_REJECT.


### PR DESCRIPTION
### What does this PR do?
In my opinion it's more flexible to use regex pattern matching instead of a direct comparison in filtering tags process.

For example datadog creates and adds additional span tags(`http.path_group` or `http.url_details.port`) to spans only after ingestion. So accodring to docs `...These tags cannot be used to drop traces at the Datadog Agent level...`

If we add regex pattern support to the tag filtering process, it will be possible for example to filter the incoming tracing stream based on the incomplete occurrence of a string in the `http.url` tag.

### Motivation
Resolves #13218

### Possible Drawbacks / Trade-offs
Regex-based filtering may be more resource-intensive compared to string comparison. But it should be noted that tag filtering only apply to the root span of a trace. Therefore this should not have a critical impact on overall performance.

