### PR TITLE
Add support for system-probe profile in flare

### DIFF
--- a/cmd/agent/subcommands/flare/command.go
+++ b/cmd/agent/subcommands/flare/command.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path"
 
 	"github.com/fatih/color"
 	"github.com/hashicorp/go-multierror"
@@ -60,9 +61,17 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		Long:  ``,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cliParams.args = args
+			bundleParams := core.CreateAgentBundleParams(globalParams.ConfFilePath, true, core.WithLogForOneShot("CORE", "off", false))
+			bundleParams.SecurityAgentConfigFilePaths = []string{
+				path.Join(common.DefaultConfPath, "security-agent.yaml"),
+			}
+			bundleParams.ConfigLoadSecurityAgent = true
+			bundleParams.SysProbeConfFilePath = globalParams.SysProbeConfFilePath
+			bundleParams.ConfigLoadSysProbe = true
+
 			return fxutil.OneShot(makeFlare,
 				fx.Supply(cliParams),
-				fx.Supply(core.CreateAgentBundleParams(globalParams.ConfFilePath, true, core.WithLogForOneShot("CORE", "off", false))),
+				fx.Supply(bundleParams),
 				core.Bundle,
 			)
 		},
@@ -128,10 +137,15 @@ func readProfileData(cliParams *cliParams, pdata *flare.ProfileData, seconds int
 		})
 	}
 
-	if pkgconfig.Datadog.GetBool("runtime_security_config.enabled") || pkgconfig.Datadog.GetBool("compliance_config.enabled") {
+	agentCollectors = append(agentCollectors, agentCollector{
+		name: "security-agent",
+		fn:   serviceProfileCollector("security-agent", "security_agent.expvar_port", seconds),
+	})
+
+	if debugPort := pkgconfig.Datadog.GetInt("system_probe_config.debug_port"); debugPort > 0 {
 		agentCollectors = append(agentCollectors, agentCollector{
-			name: "security-agent",
-			fn:   serviceProfileCollector("security-agent", "security_agent.expvar_port", seconds),
+			name: "system-probe",
+			fn:   serviceProfileCollector("system-probe", "system_probe_config.debug_port", seconds),
 		})
 	}
 
@@ -166,7 +180,6 @@ func makeFlare(log log.Component, config config.Component, cliParams *cliParams)
 
 	customerEmail := cliParams.customerEmail
 	if customerEmail == "" {
-		var err error
 		customerEmail, err = input.AskForEmail()
 		if err != nil {
 			fmt.Println("Error reading email, please retry or contact support")

--- a/cmd/agent/subcommands/flare/command_test.go
+++ b/cmd/agent/subcommands/flare/command_test.go
@@ -46,6 +46,7 @@ func TestReadProfileData(t *testing.T) {
 	m.On("CreatePerformanceProfile", "core", "http://127.0.0.1:1001/debug/pprof", 30, pdata).Return(nil)
 	m.On("CreatePerformanceProfile", "trace", "http://127.0.0.1:1002/debug/pprof", 9, pdata).Return(nil)
 	m.On("CreatePerformanceProfile", "process", "http://127.0.0.1:1003/debug/pprof", 30, pdata).Return(nil)
+	m.On("CreatePerformanceProfile", "security-agent", "http://127.0.0.1:5011/debug/pprof", 30, pdata).Return(nil)
 
 	err := readProfileData(&cliParams{}, pdata, 30, m.CreatePerformanceProfile)
 	assert.NoError(t, err)
@@ -64,6 +65,7 @@ func TestReadProfileDataNoTraceAgent(t *testing.T) {
 
 	m.On("CreatePerformanceProfile", "core", "http://127.0.0.1:1001/debug/pprof", 30, pdata).Return(nil)
 	m.On("CreatePerformanceProfile", "process", "http://127.0.0.1:1003/debug/pprof", 30, pdata).Return(nil)
+	m.On("CreatePerformanceProfile", "security-agent", "http://127.0.0.1:5011/debug/pprof", 30, pdata).Return(nil)
 
 	err := readProfileData(&cliParams{}, pdata, 30, m.CreatePerformanceProfile)
 	assert.NoError(t, err)
@@ -85,6 +87,7 @@ func TestReadProfileDataErrors(t *testing.T) {
 	m.On("CreatePerformanceProfile", "core", "http://127.0.0.1:1001/debug/pprof", 30, pdata).Return(errors.New("can't connect to core agent"))
 	m.On("CreatePerformanceProfile", "trace", "http://127.0.0.1:1002/debug/pprof", 9, pdata).Return(errors.New("can't connect to trace agent"))
 	m.On("CreatePerformanceProfile", "process", "http://127.0.0.1:1003/debug/pprof", 30, pdata).Return(nil)
+	m.On("CreatePerformanceProfile", "security-agent", "http://127.0.0.1:5011/debug/pprof", 30, pdata).Return(nil)
 
 	err := readProfileData(&cliParams{}, pdata, 30, m.CreatePerformanceProfile)
 

--- a/cmd/security-agent/config/config.go
+++ b/cmd/security-agent/config/config.go
@@ -1,0 +1,31 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package config
+
+import (
+	"fmt"
+	"os"
+
+	aconfig "github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// Merge will merge the security-agent configuration into the existing datadog configuration
+func Merge(configPaths []string) error {
+	for _, configPath := range configPaths {
+		if f, err := os.Open(configPath); err == nil {
+			err = aconfig.Datadog.MergeConfig(f)
+			_ = f.Close()
+			if err != nil {
+				return fmt.Errorf("error merging %s config file: %w", configPath, err)
+			}
+		} else {
+			log.Infof("no config exists at %s, ignoring...", configPath)
+		}
+	}
+
+	return nil
+}

--- a/comp/core/config/config.go
+++ b/comp/core/config/config.go
@@ -13,6 +13,7 @@ import (
 
 	"go.uber.org/fx"
 
+	secconfig "github.com/DataDog/datadog-agent/cmd/security-agent/config"
 	sysconfig "github.com/DataDog/datadog-agent/cmd/system-probe/config"
 	"github.com/DataDog/datadog-agent/comp/core/internal"
 	"github.com/DataDog/datadog-agent/pkg/config"
@@ -34,11 +35,6 @@ type dependencies struct {
 }
 
 func newConfig(deps dependencies) (Component, error) {
-	if deps.Params.ConfigLoadSecurityAgent {
-		warnings, err := MergeConfigurationFiles("datadog", deps.Params.SecurityAgentConfigFilePaths, true)
-		return &cfg{warnings}, err
-	}
-
 	warnings, err := setupConfig(
 		deps.Params.ConfFilePath,
 		deps.Params.ConfigName,
@@ -52,7 +48,13 @@ func newConfig(deps dependencies) (Component, error) {
 	if deps.Params.ConfigLoadSysProbe {
 		_, err := sysconfig.Merge(deps.Params.SysProbeConfFilePath)
 		if err != nil {
-			return nil, err
+			return &cfg{warnings}, err
+		}
+	}
+
+	if deps.Params.ConfigLoadSecurityAgent {
+		if err := secconfig.Merge(deps.Params.SecurityAgentConfigFilePaths); err != nil {
+			return &cfg{warnings}, err
 		}
 	}
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This PR add the system-probe profile to the profiles collected in the flare
with the `--profile` option

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
