### PR TITLE
pkg/collector/corechecks/cluster/helm: added a new tag: helm_revision_is_most_recent

### DIFF
--- a/pkg/collector/corechecks/cluster/helm/releases_store_test.go
+++ b/pkg/collector/corechecks/cluster/helm/releases_store_test.go
@@ -42,9 +42,9 @@ func TestAdd(t *testing.T) {
 		release:                 &rel,
 		commonTags:              genericTags,
 		tagsForMetricsAndEvents: tagsForMetricsAndEvents,
-	}, store.get("default/my_datadog", 1, k8sSecrets))
+	}, store.get(k8sSecrets, "default/my_datadog", 1))
 
-	assert.Nil(t, store.get("default/my_datadog", 1, k8sConfigmaps)) // Different storage
+	assert.Nil(t, store.get(k8sConfigmaps, "default/my_datadog", 1)) // Different storage
 }
 
 func TestGetAll(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

This change aims to ease the identification of the most recent releases' revisions amongst the reported dataset. Introducing a new `helm_revision_is_most_recent` tag to metrics and events, this should give us some further filtering capabilities.

### Motivation

AFAIK it is not possible to sort metrics per tags/labels. At the moment it is therefore difficult to be able to query which one is representative of the most recent release.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist

<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
