### PR TITLE
Mock `util.Fqdn` to make CF host alias tests less flakey

### DIFF
--- a/pkg/util/cloudproviders/cloudfoundry/cloudfoundry_test.go
+++ b/pkg/util/cloudproviders/cloudfoundry/cloudfoundry_test.go
@@ -50,7 +50,6 @@ func TestHostAlias(t *testing.T) {
 	assert.Nil(t, err)
 
 	hostname, _ := os.Hostname()
-	mockHostname := "hostname"
 
 	assert.Len(t, aliases, 2)
 	assert.Contains(t, aliases, "ID_CF")
@@ -58,14 +57,14 @@ func TestHostAlias(t *testing.T) {
 
 	// mock Fqdn returning something different
 	getFqdn = func(hostname string) string {
-		return mockHostname
+		return hostname + "suffix"
 	}
 	aliases, err = GetHostAliases(ctx)
 	assert.Nil(t, err)
 	assert.Len(t, aliases, 3)
 	assert.Contains(t, aliases, "ID_CF")
 	assert.Contains(t, aliases, hostname)
-	assert.Contains(t, aliases, mockHostname)
+	assert.Contains(t, aliases, hostname+"suffix")
 
 }
 

--- a/pkg/util/cloudproviders/cloudfoundry/cloudfoundry_test.go
+++ b/pkg/util/cloudproviders/cloudfoundry/cloudfoundry_test.go
@@ -50,6 +50,7 @@ func TestHostAlias(t *testing.T) {
 	assert.Nil(t, err)
 
 	hostname, _ := os.Hostname()
+	mockHostname := "hostname"
 
 	assert.Len(t, aliases, 2)
 	assert.Contains(t, aliases, "ID_CF")
@@ -57,20 +58,26 @@ func TestHostAlias(t *testing.T) {
 
 	// mock Fqdn returning something different
 	getFqdn = func(hostname string) string {
-		return hostname + "suffix"
+		return mockHostname
 	}
 	aliases, err = GetHostAliases(ctx)
 	assert.Nil(t, err)
 	assert.Len(t, aliases, 3)
 	assert.Contains(t, aliases, "ID_CF")
 	assert.Contains(t, aliases, hostname)
-	assert.Contains(t, aliases, hostname+"suffix")
+	assert.Contains(t, aliases, mockHostname)
 
 }
 
 func TestHostAliasDefault(t *testing.T) {
 	ctx := context.Background()
 	mockConfig := config.Mock(t)
+	mockHostname := "hostname"
+
+	// mock getFqdn to avoid flakes in CI runners
+	getFqdn = func(hostname string) string {
+		return mockHostname
+	}
 
 	mockConfig.Set("cloud_foundry", true)
 	mockConfig.Set("bosh_id", nil)
@@ -79,6 +86,5 @@ func TestHostAliasDefault(t *testing.T) {
 	aliases, err := GetHostAliases(ctx)
 	assert.Nil(t, err)
 
-	hostname, _ := os.Hostname()
-	assert.Equal(t, []string{util.Fqdn(hostname)}, aliases)
+	assert.Equal(t, []string{mockHostname}, aliases)
 }


### PR DESCRIPTION
### What does this PR do?

Mocks `util.Fqdn` in CF host tests so that the tests are less likely to flake

### Motivation

We had a rare flake where the expected and actual hostname were different, and since this test is only testing `GetHostAliases` and not `util.Fqdn` we can safely mock the function in our tests

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
