### PR TITLE
Use updated DataDog/gopsutil for platform identification

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -57,7 +57,7 @@ require (
 	github.com/DataDog/datadog-operator v0.7.1-0.20220602134901-4f6af09bf54f
 	github.com/DataDog/ebpf-manager v0.1.0
 	github.com/DataDog/gohai v0.0.0-20221011094921-fcc1e3d5ddda
-	github.com/DataDog/gopsutil v1.2.2-0.20221102174240-9f518111f45c
+	github.com/DataDog/gopsutil v1.2.2
 	github.com/DataDog/nikos v1.9.0
 	github.com/DataDog/sketches-go v1.4.1
 	github.com/DataDog/viper v1.12.0

--- a/go.mod
+++ b/go.mod
@@ -57,7 +57,7 @@ require (
 	github.com/DataDog/datadog-operator v0.7.1-0.20220602134901-4f6af09bf54f
 	github.com/DataDog/ebpf-manager v0.1.0
 	github.com/DataDog/gohai v0.0.0-20221011094921-fcc1e3d5ddda
-	github.com/DataDog/gopsutil v1.2.1
+	github.com/DataDog/gopsutil v1.2.2-0.20221102174240-9f518111f45c
 	github.com/DataDog/nikos v1.9.0
 	github.com/DataDog/sketches-go v1.4.1
 	github.com/DataDog/viper v1.12.0

--- a/go.sum
+++ b/go.sum
@@ -149,8 +149,8 @@ github.com/DataDog/go-tuf v0.3.0--fix-localmeta h1:lM/fRQNIaJpsnLU7edjV3jYHylCym
 github.com/DataDog/go-tuf v0.3.0--fix-localmeta/go.mod h1:E5XP0wXitrFUHe4b8cUcAAdxBW4LbfnqF4WXXGLgWNo=
 github.com/DataDog/gohai v0.0.0-20221011094921-fcc1e3d5ddda h1:0xPsvJrSNeob7C1fvh0i47XBX76HedF3LOFKsY/cqUM=
 github.com/DataDog/gohai v0.0.0-20221011094921-fcc1e3d5ddda/go.mod h1:MsW+WM5jOyvzu7KUfg5DB4nmTBYFdm4g0Bq3JhGy1oQ=
-github.com/DataDog/gopsutil v1.2.1 h1:FO3AZvwBUWlJZ0TL4T5/fsEoWxsGz0DFtaIB2bHn/OQ=
-github.com/DataDog/gopsutil v1.2.1/go.mod h1:glkxNt/qRu9lnpmUEQwOIAXW+COWDTBOTEAHqbgBPts=
+github.com/DataDog/gopsutil v1.2.2-0.20221102174240-9f518111f45c h1:6izdgVny3ymM5aaXUnUUPH9s30tOa8I1e/J1y5NUhOI=
+github.com/DataDog/gopsutil v1.2.2-0.20221102174240-9f518111f45c/go.mod h1:glkxNt/qRu9lnpmUEQwOIAXW+COWDTBOTEAHqbgBPts=
 github.com/DataDog/gostackparse v0.5.0 h1:jb72P6GFHPHz2W0onsN51cS3FkaMDcjb0QzgxxA4gDk=
 github.com/DataDog/gostackparse v0.5.0/go.mod h1:lTfqcJKqS9KnXQGnyQMCugq3u1FP6UZMfWR0aitKFMM=
 github.com/DataDog/mmh3 v0.0.0-20210722141835-012dc69a9e49 h1:EbzDX8HPk5uE2FsJYxD74QmMw0/3CqSKhEr6teh0ncQ=

--- a/go.sum
+++ b/go.sum
@@ -149,8 +149,8 @@ github.com/DataDog/go-tuf v0.3.0--fix-localmeta h1:lM/fRQNIaJpsnLU7edjV3jYHylCym
 github.com/DataDog/go-tuf v0.3.0--fix-localmeta/go.mod h1:E5XP0wXitrFUHe4b8cUcAAdxBW4LbfnqF4WXXGLgWNo=
 github.com/DataDog/gohai v0.0.0-20221011094921-fcc1e3d5ddda h1:0xPsvJrSNeob7C1fvh0i47XBX76HedF3LOFKsY/cqUM=
 github.com/DataDog/gohai v0.0.0-20221011094921-fcc1e3d5ddda/go.mod h1:MsW+WM5jOyvzu7KUfg5DB4nmTBYFdm4g0Bq3JhGy1oQ=
-github.com/DataDog/gopsutil v1.2.2-0.20221102174240-9f518111f45c h1:6izdgVny3ymM5aaXUnUUPH9s30tOa8I1e/J1y5NUhOI=
-github.com/DataDog/gopsutil v1.2.2-0.20221102174240-9f518111f45c/go.mod h1:glkxNt/qRu9lnpmUEQwOIAXW+COWDTBOTEAHqbgBPts=
+github.com/DataDog/gopsutil v1.2.2 h1:8lmthwyyCXa1NKiYcHlrtl9AAFdfbNI2gPcioCJcBPU=
+github.com/DataDog/gopsutil v1.2.2/go.mod h1:glkxNt/qRu9lnpmUEQwOIAXW+COWDTBOTEAHqbgBPts=
 github.com/DataDog/gostackparse v0.5.0 h1:jb72P6GFHPHz2W0onsN51cS3FkaMDcjb0QzgxxA4gDk=
 github.com/DataDog/gostackparse v0.5.0/go.mod h1:lTfqcJKqS9KnXQGnyQMCugq3u1FP6UZMfWR0aitKFMM=
 github.com/DataDog/mmh3 v0.0.0-20210722141835-012dc69a9e49 h1:EbzDX8HPk5uE2FsJYxD74QmMw0/3CqSKhEr6teh0ncQ=

--- a/pkg/ebpf/btf.go
+++ b/pkg/ebpf/btf.go
@@ -10,14 +10,15 @@ package ebpf
 
 import (
 	"errors"
+	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
 
+	"github.com/DataDog/gopsutil/host"
 	"github.com/cilium/ebpf/btf"
 	"github.com/mholt/archiver/v3"
 
-	"github.com/DataDog/datadog-agent/pkg/metadata/host"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -51,10 +52,14 @@ func GetBTF(userProvidedBtfPath, bpfDir string) (*btf.Spec, COREResult) {
 }
 
 func checkEmbeddedCollection(collectionPath string) (*btf.Spec, error) {
-	si := host.GetStatusInformation()
-	platform := si.Platform
-	platformVersion := si.PlatformVersion
-	kernelVersion := si.KernelVersion
+	info, err := host.Info()
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve host info: %s", err)
+	}
+
+	platform := info.Platform
+	platformVersion := info.PlatformVersion
+	kernelVersion := info.KernelVersion
 
 	btfSubdirectory := filepath.Join(platform)
 	if platform == "ubuntu" {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Switches to using DataDog fork of `gopsutil` for host platform identification. The fork contains a fix so that we read `VERSION_ID` instead of `VERSION` from `/etc/os-release`.

### Motivation

When we get host platform information from `/etc/os-release`, getting the platform version from the `VERSION` field can give us a string with the platform codename in it (ie "22.04.1 LTS (Jammy Jellyfish)"). We use the platform version to generate a file path for looking up BTFs, so we need to use the `VERSION_ID` field, which gives us the simplified version (ie "22.04").

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
