### PR TITLE
[ebpf] add support for runtime compilation on oracle linux

### DIFF
--- a/pkg/security/tests/constants_test.go
+++ b/pkg/security/tests/constants_test.go
@@ -54,8 +54,8 @@ func TestOctogonConstants(t *testing.T) {
 	}
 
 	t.Run("rc-vs-fallback", func(t *testing.T) {
-		checkKernelCompatibility(t, "SLES and Oracle kernels", func(kv *kernel.Version) bool {
-			return kv.IsSLESKernel() || kv.IsOracleUEKKernel()
+		checkKernelCompatibility(t, "SLES kernels", func(kv *kernel.Version) bool {
+			return kv.IsSLESKernel()
 		})
 
 		fallbackFetcher := constantfetch.NewFallbackConstantFetcher(kv)
@@ -65,8 +65,8 @@ func TestOctogonConstants(t *testing.T) {
 	})
 
 	t.Run("btfhub-vs-rc", func(t *testing.T) {
-		checkKernelCompatibility(t, "SLES and Oracle kernels", func(kv *kernel.Version) bool {
-			return kv.IsSLESKernel() || kv.IsOracleUEKKernel()
+		checkKernelCompatibility(t, "SLES kernels", func(kv *kernel.Version) bool {
+			return kv.IsSLESKernel()
 		})
 
 		btfhubFetcher, err := constantfetch.NewBTFHubConstantFetcher(kv)
@@ -108,8 +108,8 @@ func TestOctogonConstants(t *testing.T) {
 	})
 
 	t.Run("guesser-vs-rc", func(t *testing.T) {
-		checkKernelCompatibility(t, "SLES and Oracle kernels", func(kv *kernel.Version) bool {
-			return kv.IsSLESKernel() || kv.IsOracleUEKKernel()
+		checkKernelCompatibility(t, "SLES kernels", func(kv *kernel.Version) bool {
+			return kv.IsSLESKernel()
 		})
 
 		rcFetcher := constantfetch.NewRuntimeCompilationConstantFetcher(&config.Config, nil)

--- a/pkg/util/kernel/download_headers.go
+++ b/pkg/util/kernel/download_headers.go
@@ -87,7 +87,7 @@ func (h *headerDownloader) downloadHeaders(headerDownloadDir string) error {
 func (h *headerDownloader) verifyReposDir(target types.Target) (string, error) {
 	var reposDir string
 	switch strings.ToLower(target.Distro.Display) {
-	case "fedora", "rhel", "redhat", "centos", "amazon":
+	case "fedora", "rhel", "redhat", "centos", "amazon", "oracle":
 		reposDir = h.yumReposDir
 	case "opensuse", "opensuse-leap", "opensuse-tumbleweed", "opensuse-tumbleweed-kubic", "suse", "sles", "sled", "caasp":
 		reposDir = h.zypperReposDir
@@ -111,7 +111,7 @@ func (h *headerDownloader) getHeaderDownloadBackend(target *types.Target, reposD
 	switch strings.ToLower(target.Distro.Display) {
 	case "fedora":
 		backend, err = rpm.NewFedoraBackend(target, reposDir, logger)
-	case "rhel", "redhat":
+	case "rhel", "redhat", "oracle":
 		backend, err = rpm.NewRedHatBackend(target, reposDir, logger)
 	case "amazon":
 		if target.Distro.Release == "2022" {


### PR DESCRIPTION
### What does this PR do?

Oracle Linux works in a very similar way to RHEL, runtime compilation works out of the box. This PR adds support to it (by mapping it to a rhel backend) and enables the RC Octogon tests on Oracle Linux 

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
