### PR TITLE
[windows] [system-probe] Split connection gathering between open and closed.

### DIFF
--- a/pkg/config/system_probe.go
+++ b/pkg/config/system_probe.go
@@ -118,6 +118,7 @@ func InitSystemProbeConfig(cfg Config) {
 
 	cfg.BindEnvAndSetDefault(join(spNS, "max_tracked_connections"), 65536)
 	cfg.BindEnv(join(spNS, "max_closed_connections_buffered"))
+	cfg.BindEnvAndSetDefault(join(spNS, "closed_connection_flush_threshold"), 0)
 	cfg.BindEnvAndSetDefault(join(spNS, "closed_channel_size"), 500)
 	cfg.BindEnvAndSetDefault(join(spNS, "max_connection_state_buffered"), 75000)
 

--- a/pkg/network/config/config.go
+++ b/pkg/network/config/config.go
@@ -6,6 +6,7 @@
 package config
 
 import (
+	"runtime"
 	"strings"
 	"time"
 
@@ -118,6 +119,10 @@ type Config struct {
 	// get flushed on every client request (default 30s check interval)
 	MaxClosedConnectionsBuffered int
 
+	// ClosedConnectionFlushThreshold represents the number of closed connections stored before signalling
+	// the agent to flush the connections.  This value only valid on Windows
+	ClosedConnectionFlushThreshold int
+
 	// MaxDNSStatsBuffered represents the maximum number of DNS stats we'll buffer in memory. These stats
 	// get flushed on every client request (default 30s check interval)
 	MaxDNSStatsBuffered int
@@ -224,11 +229,12 @@ func New() *Config {
 		ExcludedSourceConnections:      cfg.GetStringMapStringSlice(join(spNS, "source_excludes")),
 		ExcludedDestinationConnections: cfg.GetStringMapStringSlice(join(spNS, "dest_excludes")),
 
-		MaxTrackedConnections:        uint(cfg.GetInt(join(spNS, "max_tracked_connections"))),
-		MaxClosedConnectionsBuffered: cfg.GetInt(join(spNS, "max_closed_connections_buffered")),
-		ClosedChannelSize:            cfg.GetInt(join(spNS, "closed_channel_size")),
-		MaxConnectionsStateBuffered:  cfg.GetInt(join(spNS, "max_connection_state_buffered")),
-		ClientStateExpiry:            2 * time.Minute,
+		MaxTrackedConnections:          uint(cfg.GetInt(join(spNS, "max_tracked_connections"))),
+		MaxClosedConnectionsBuffered:   cfg.GetInt(join(spNS, "max_closed_connections_buffered")),
+		ClosedConnectionFlushThreshold: cfg.GetInt(join(spNS, "closed_connection_flush_threshold")),
+		ClosedChannelSize:              cfg.GetInt(join(spNS, "closed_channel_size")),
+		MaxConnectionsStateBuffered:    cfg.GetInt(join(spNS, "max_connection_state_buffered")),
+		ClientStateExpiry:              2 * time.Minute,
 
 		DNSInspection:       !cfg.GetBool(join(spNS, "disable_dns_inspection")),
 		CollectDNSStats:     cfg.GetBool(join(spNS, "collect_dns_stats")),
@@ -269,6 +275,14 @@ func New() *Config {
 		HTTPIdleConnectionTTL:  time.Duration(cfg.GetInt(join(spNS, "http_idle_connection_ttl_in_s"))) * time.Second,
 	}
 
+	if runtime.GOOS == "windows" {
+		if cfg.IsSet(join(spNS, "closed_connection_flush_threshold")) && c.ClosedConnectionFlushThreshold < 1024 {
+			log.Warnf("Closed connection notification threshold set to invalid value %d.  Resetting to default.", c.ClosedConnectionFlushThreshold)
+
+			// 0 will allow the underlying driver interface mechanism to choose appropriately
+			c.ClosedConnectionFlushThreshold = 0
+		}
+	}
 	if !cfg.IsSet(join(spNS, "max_closed_connections_buffered")) {
 		// make sure max_closed_connections_buffered is equal to
 		// max_tracked_connections, since the former is not set.

--- a/pkg/network/driver/types.go
+++ b/pkg/network/driver/types.go
@@ -31,6 +31,9 @@ const (
 	FlushPendingHttpTxnsIOCTL = C.DDNPMDRIVER_IOCTL_FLUSH_PENDING_HTTP_TRANSACTIONS
 	EnableHttpIOCTL           = C.DDNPMDRIVER_IOCTL_ENABLE_HTTP
 	EnableClassifyIOCTL       = C.DDNPMDRIVER_IOCTL_SET_CLASSIFY
+	SetClosedFlowsLimitIOCTL  = C.DDNPMDRIVER_IOCTL_SET_CLOSED_FLOWS_NOTIFY
+	GetOpenFlowsIOCTL         = C.DDNPMDRIVER_IOCTL_GET_OPEN_FLOWS
+	GetClosedFlowsIOCTL       = C.DDNPMDRIVER_IOCTL_GET_CLOSED_FLOWS
 )
 
 type FilterAddress C.struct__filterAddress
@@ -50,11 +53,11 @@ type Stats C.struct__stats
 
 const StatsSize = C.sizeof_struct__stats
 
-type PerFlowData C.struct__perFlowData
+type PerFlowData C.struct__userFlowData
 type TCPFlowData C.struct__tcpFlowData
 type UDPFlowData C.struct__udpFlowData
 
-const PerFlowDataSize = C.sizeof_struct__perFlowData
+const PerFlowDataSize = C.sizeof_struct__userFlowData
 
 const (
 	FlowDirectionMask     = C.FLOW_DIRECTION_MASK

--- a/pkg/network/driver/types_windows.go
+++ b/pkg/network/driver/types_windows.go
@@ -3,7 +3,7 @@
 
 package driver
 
-const Signature = 0xddfd00000014
+const Signature = 0xddfd00000015
 
 const (
 	GetStatsIOCTL             = 0x122004
@@ -15,6 +15,9 @@ const (
 	FlushPendingHttpTxnsIOCTL = 0x122020
 	EnableHttpIOCTL           = 0x122030
 	EnableClassifyIOCTL       = 0x122040
+	SetClosedFlowsLimitIOCTL  = 0x12203c
+	GetOpenFlowsIOCTL         = 0x122036
+	GetClosedFlowsIOCTL       = 0x12203a
 )
 
 type FilterAddress struct {
@@ -122,19 +125,20 @@ type PerFlowData struct {
 	Tls_version_chosen       uint16
 	Tls_alpn_requested       uint64
 	Tls_alpn_chosen          uint64
-	Protocol_u               [32]byte
+	Protocol_u               [36]byte
 }
 type TCPFlowData struct {
-	IRTT            uint64
-	SRTT            uint64
-	RttVariance     uint64
-	RetransmitCount uint64
+	IRTT             uint64
+	SRTT             uint64
+	RttVariance      uint64
+	RetransmitCount  uint64
+	ConnectionStatus uint32
 }
 type UDPFlowData struct {
 	Reserved uint64
 }
 
-const PerFlowDataSize = 0xb0
+const PerFlowDataSize = 0xb4
 
 const (
 	FlowDirectionMask     = 0x300

--- a/pkg/network/driver_interface_test.go
+++ b/pkg/network/driver_interface_test.go
@@ -72,7 +72,11 @@ func TestConnectionStatsInfiniteLoop(t *testing.T) {
 	})
 	require.NoError(t, err, "Failed to create new driver interface")
 
-	_, _, err = di.GetConnectionStats(activeBuf, closedBuf, func(c *ConnectionStats) bool {
+	_, err = di.GetClosedConnectionStats(closedBuf, func(c *ConnectionStats) bool {
+		return true
+	})
+	require.NoError(t, err, "Failed to get connection stats")
+	_, err = di.GetOpenConnectionStats(activeBuf, func(c *ConnectionStats) bool {
 		return true
 	})
 	require.NoError(t, err, "Failed to get connection stats")

--- a/pkg/network/tracer/tracer_windows.go
+++ b/pkg/network/tracer/tracer_windows.go
@@ -12,9 +12,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"runtime"
 	"sync"
 	"syscall"
 	"time"
+
+	"golang.org/x/sys/windows"
 
 	"github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/network"
@@ -50,6 +53,9 @@ type Tracer struct {
 	// Connections for the tracer to exclude
 	sourceExcludes []*network.ConnectionFilter
 	destExcludes   []*network.ConnectionFilter
+
+	// polling loop for connection event
+	closedEventLoop sync.WaitGroup
 }
 
 // NewTracer returns an initialized tracer struct
@@ -92,7 +98,33 @@ func NewTracer(config *config.Config) (*Tracer, error) {
 		sourceExcludes:  network.ParseConnectionFilters(config.ExcludedSourceConnections),
 		destExcludes:    network.ParseConnectionFilters(config.ExcludedDestinationConnections),
 	}
+	tr.closedEventLoop.Add(1)
+	go func() {
+		defer tr.closedEventLoop.Done()
 
+		runtime.LockOSThread()
+		defer runtime.UnlockOSThread()
+	waitloop:
+		for {
+			evt, _ := windows.WaitForSingleObject(di.GetClosedFlowsEvent(), windows.INFINITE)
+			switch evt {
+			case windows.WAIT_OBJECT_0:
+				_, err = tr.driverInterface.GetClosedConnectionStats(tr.closedBuffer, func(c *network.ConnectionStats) bool {
+					return !tr.shouldSkipConnection(c)
+				})
+				closedConnStats := tr.closedBuffer.Connections()
+
+				tr.state.StoreClosedConnections(closedConnStats)
+
+			case windows.WAIT_FAILED:
+				break waitloop
+
+			default:
+				log.Infof("got other wait value %v", evt)
+			}
+		}
+
+	}()
 	return tr, nil
 }
 
@@ -107,6 +139,7 @@ func (t *Tracer) Stop() {
 	if err != nil {
 		log.Errorf("error closing driver interface: %s", err)
 	}
+	t.closedEventLoop.Wait()
 }
 
 // GetActiveConnections returns all active connections
@@ -114,11 +147,17 @@ func (t *Tracer) GetActiveConnections(clientID string) (*network.Connections, er
 	t.connLock.Lock()
 	defer t.connLock.Unlock()
 
-	_, _, err := t.driverInterface.GetConnectionStats(t.activeBuffer, t.closedBuffer, func(c *network.ConnectionStats) bool {
+	_, err := t.driverInterface.GetOpenConnectionStats(t.activeBuffer, func(c *network.ConnectionStats) bool {
 		return !t.shouldSkipConnection(c)
 	})
 	if err != nil {
-		return nil, fmt.Errorf("error retrieving connections from driver: %w", err)
+		return nil, fmt.Errorf("error retrieving open connections from driver: %w", err)
+	}
+	_, err = t.driverInterface.GetClosedConnectionStats(t.closedBuffer, func(c *network.ConnectionStats) bool {
+		return !t.shouldSkipConnection(c)
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving closed connections from driver: %w", err)
 	}
 	activeConnStats := t.activeBuffer.Connections()
 	closedConnStats := t.closedBuffer.Connections()

--- a/release.json
+++ b/release.json
@@ -12,8 +12,8 @@
         "JMXFETCH_HASH": "92f9c744fe00c13c6401829b9eb50f44c5843ae9d1a14f7618531bdf0187e44f",
         "MACOS_BUILD_VERSION": "master",
         "WINDOWS_DDNPM_DRIVER": "testsigned",
-        "WINDOWS_DDNPM_VERSION": "2.2.0.git.2.b34cd3f",
-        "WINDOWS_DDNPM_SHASUM": "2a5f07f7c053c73fb9f812cc62842dcc54c3ac4cc1a6a04c21cff269f0c41d5a",
+        "WINDOWS_DDNPM_VERSION": "2.3.0",
+        "WINDOWS_DDNPM_SHASUM": "1a45a9cd6935e478441db73ae392285c746cdc62ea5a7ee94d23da9c827e76a4",
         "SECURITY_AGENT_POLICIES_VERSION": "master"
     },
     "nightly-a7": {
@@ -24,8 +24,8 @@
         "JMXFETCH_HASH": "92f9c744fe00c13c6401829b9eb50f44c5843ae9d1a14f7618531bdf0187e44f",
         "MACOS_BUILD_VERSION": "master",
         "WINDOWS_DDNPM_DRIVER": "testsigned",
-        "WINDOWS_DDNPM_VERSION": "2.2.0.git.2.b34cd3f",
-        "WINDOWS_DDNPM_SHASUM": "2a5f07f7c053c73fb9f812cc62842dcc54c3ac4cc1a6a04c21cff269f0c41d5a",
+        "WINDOWS_DDNPM_VERSION": "2.3.0",
+        "WINDOWS_DDNPM_SHASUM": "1a45a9cd6935e478441db73ae392285c746cdc62ea5a7ee94d23da9c827e76a4",
         "SECURITY_AGENT_POLICIES_VERSION": "master"
     },
     "release-a6": {

--- a/release.json
+++ b/release.json
@@ -11,9 +11,9 @@
         "JMXFETCH_VERSION": "0.47.2",
         "JMXFETCH_HASH": "92f9c744fe00c13c6401829b9eb50f44c5843ae9d1a14f7618531bdf0187e44f",
         "MACOS_BUILD_VERSION": "master",
-        "WINDOWS_DDNPM_DRIVER": "testsigned",
+        "WINDOWS_DDNPM_DRIVER": "release-signed",
         "WINDOWS_DDNPM_VERSION": "2.3.0",
-        "WINDOWS_DDNPM_SHASUM": "1a45a9cd6935e478441db73ae392285c746cdc62ea5a7ee94d23da9c827e76a4",
+        "WINDOWS_DDNPM_SHASUM": "36f28fabf3c3466d48265920c9c05ac25d04b9a812c1c3cbdf3933e2bec50233",
         "SECURITY_AGENT_POLICIES_VERSION": "master"
     },
     "nightly-a7": {
@@ -23,9 +23,9 @@
         "JMXFETCH_VERSION": "0.47.2",
         "JMXFETCH_HASH": "92f9c744fe00c13c6401829b9eb50f44c5843ae9d1a14f7618531bdf0187e44f",
         "MACOS_BUILD_VERSION": "master",
-        "WINDOWS_DDNPM_DRIVER": "testsigned",
+        "WINDOWS_DDNPM_DRIVER": "release-signed",
         "WINDOWS_DDNPM_VERSION": "2.3.0",
-        "WINDOWS_DDNPM_SHASUM": "1a45a9cd6935e478441db73ae392285c746cdc62ea5a7ee94d23da9c827e76a4",
+        "WINDOWS_DDNPM_SHASUM": "36f28fabf3c3466d48265920c9c05ac25d04b9a812c1c3cbdf3933e2bec50233",
         "SECURITY_AGENT_POLICIES_VERSION": "master"
     },
     "release-a6": {

--- a/release.json
+++ b/release.json
@@ -11,9 +11,9 @@
         "JMXFETCH_VERSION": "0.47.2",
         "JMXFETCH_HASH": "92f9c744fe00c13c6401829b9eb50f44c5843ae9d1a14f7618531bdf0187e44f",
         "MACOS_BUILD_VERSION": "master",
-        "WINDOWS_DDNPM_DRIVER": "release-signed",
-        "WINDOWS_DDNPM_VERSION": "2.1.1",
-        "WINDOWS_DDNPM_SHASUM": "f52d4db27715e32008c5903393d0bc990ceb134f269fa10e76d08b3659587731",
+        "WINDOWS_DDNPM_DRIVER": "testsigned",
+        "WINDOWS_DDNPM_VERSION": "2.2.0.git.2.b34cd3f",
+        "WINDOWS_DDNPM_SHASUM": "2a5f07f7c053c73fb9f812cc62842dcc54c3ac4cc1a6a04c21cff269f0c41d5a",
         "SECURITY_AGENT_POLICIES_VERSION": "master"
     },
     "nightly-a7": {
@@ -23,9 +23,9 @@
         "JMXFETCH_VERSION": "0.47.2",
         "JMXFETCH_HASH": "92f9c744fe00c13c6401829b9eb50f44c5843ae9d1a14f7618531bdf0187e44f",
         "MACOS_BUILD_VERSION": "master",
-        "WINDOWS_DDNPM_DRIVER": "release-signed",
-        "WINDOWS_DDNPM_VERSION": "2.1.1",
-        "WINDOWS_DDNPM_SHASUM": "f52d4db27715e32008c5903393d0bc990ceb134f269fa10e76d08b3659587731",
+        "WINDOWS_DDNPM_DRIVER": "testsigned",
+        "WINDOWS_DDNPM_VERSION": "2.2.0.git.2.b34cd3f",
+        "WINDOWS_DDNPM_SHASUM": "2a5f07f7c053c73fb9f812cc62842dcc54c3ac4cc1a6a04c21cff269f0c41d5a",
         "SECURITY_AGENT_POLICIES_VERSION": "master"
     },
     "release-a6": {


### PR DESCRIPTION
Continue to only poll open connections on 30s intervals. Poll closed connections on 30s interval, or when async notification threshold is reached.

### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Collect closed connections more frequently on high churn environments.
Reduce the driver memory consumption in those environments

### Additional Notes


### Possible Drawbacks / Trade-offs

Could result in higher CPU usage (although should be lower spikes more frequently)

### Describe how to test/QA your changes


### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
