### PR TITLE
[pkg/otlp/model] Use min and max fields for delta Histograms and ExponentialHistograms

### DIFF
--- a/pkg/otlp/model/translator/exponential_histograms_translator.go
+++ b/pkg/otlp/model/translator/exponential_histograms_translator.go
@@ -149,11 +149,9 @@ func (t *Translator) mapExponentialHistogramMetrics(
 			agentSketch.Basic.Avg = agentSketch.Basic.Sum / float64(agentSketch.Basic.Cnt)
 		}
 		if delta && p.HasMin() {
-			// override min if available and delta.
 			agentSketch.Basic.Min = p.Min()
 		}
 		if delta && p.HasMax() {
-			// override max if available and delta.
 			agentSketch.Basic.Max = p.Max()
 		}
 

--- a/pkg/otlp/model/translator/exponential_histograms_translator.go
+++ b/pkg/otlp/model/translator/exponential_histograms_translator.go
@@ -78,8 +78,9 @@ func (t *Translator) exponentialHistogramToDDSketch(
 // - The sum of values in the population
 // - A scale, from which the base of the exponential histogram is computed
 // - Two bucket stores, each with:
-//     - an offset
-//     - a list of bucket counts
+//   - an offset
+//   - a list of bucket counts
+//
 // - A count of zero values in the population
 func (t *Translator) mapExponentialHistogramMetrics(
 	ctx context.Context,
@@ -146,6 +147,14 @@ func (t *Translator) mapExponentialHistogramMetrics(
 			agentSketch.Basic.Cnt = int64(histInfo.count)
 			agentSketch.Basic.Sum = histInfo.sum
 			agentSketch.Basic.Avg = agentSketch.Basic.Sum / float64(agentSketch.Basic.Cnt)
+		}
+		if delta && p.HasMin() {
+			// override min if available and delta.
+			agentSketch.Basic.Min = p.Min()
+		}
+		if delta && p.HasMax() {
+			// override max if available and delta.
+			agentSketch.Basic.Max = p.Max()
 		}
 
 		consumer.ConsumeSketch(ctx, pointDims, ts, agentSketch)

--- a/pkg/otlp/model/translator/metrics_translator.go
+++ b/pkg/otlp/model/translator/metrics_translator.go
@@ -229,6 +229,15 @@ func (t *Translator) getSketchBuckets(
 			sketch.Basic.Sum = histInfo.sum
 			sketch.Basic.Avg = sketch.Basic.Sum / float64(sketch.Basic.Cnt)
 		}
+		if delta && p.HasMin() {
+			// override min if available and delta.
+			sketch.Basic.Min = p.Min()
+		}
+		if delta && p.HasMax() {
+			// override max if available and delta.
+			sketch.Basic.Max = p.Max()
+		}
+
 		consumer.ConsumeSketch(ctx, pointDims, ts, sketch)
 	}
 }

--- a/pkg/otlp/model/translator/metrics_translator.go
+++ b/pkg/otlp/model/translator/metrics_translator.go
@@ -230,11 +230,9 @@ func (t *Translator) getSketchBuckets(
 			sketch.Basic.Avg = sketch.Basic.Sum / float64(sketch.Basic.Cnt)
 		}
 		if delta && p.HasMin() {
-			// override min if available and delta.
 			sketch.Basic.Min = p.Min()
 		}
 		if delta && p.HasMax() {
-			// override max if available and delta.
 			sketch.Basic.Max = p.Max()
 		}
 

--- a/pkg/otlp/model/translator/metrics_translator_test.go
+++ b/pkg/otlp/model/translator/metrics_translator_test.go
@@ -540,6 +540,8 @@ func TestMapDeltaHistogramMetrics(t *testing.T) {
 	point := slice.AppendEmpty()
 	point.SetCount(20)
 	point.SetSum(math.Pi)
+	point.SetMin(-15)
+	point.SetMax(100)
 	point.BucketCounts().FromRaw([]uint64{2, 18})
 	point.ExplicitBounds().FromRaw([]float64{0})
 	point.SetTimestamp(ts)
@@ -568,8 +570,8 @@ func TestMapDeltaHistogramMetrics(t *testing.T) {
 
 	sketches := []sketch{
 		newSketch(dims, uint64(ts), summary.Summary{
-			Min: 0,
-			Max: 0,
+			Min: -15,
+			Max: 100,
 			Sum: point.Sum(),
 			Avg: point.Sum() / float64(point.Count()),
 			Cnt: int64(point.Count()),
@@ -578,8 +580,8 @@ func TestMapDeltaHistogramMetrics(t *testing.T) {
 
 	sketchesAttributeTags := []sketch{
 		newSketch(dimsTags, uint64(ts), summary.Summary{
-			Min: 0,
-			Max: 0,
+			Min: -15,
+			Max: 100,
 			Sum: point.Sum(),
 			Avg: point.Sum() / float64(point.Count()),
 			Cnt: 20,
@@ -1663,8 +1665,8 @@ func TestMapExponentialHistogram(t *testing.T) {
 			expectedMetrics:                      nil,
 			expectedSketches: []sketch{
 				newSketchWithHostname("double.exponential.delta.histogram", summary.Summary{
-					Min: -1.0475797592879845,
-					Max: 1.0974563270357618,
+					Min: -100_000,
+					Max: 100_000,
 					Sum: math.Pi,
 					Avg: math.Pi / float64(30),
 					Cnt: 30,
@@ -1681,8 +1683,8 @@ func TestMapExponentialHistogram(t *testing.T) {
 			expectedMetrics:                      nil,
 			expectedSketches: []sketch{
 				newSketchWithHostname("double.exponential.delta.histogram", summary.Summary{
-					Min: -1.0475797592879845,
-					Max: 1.0974563270357618,
+					Min: -100_000,
+					Max: 100_000,
 					Sum: math.Pi,
 					Avg: 0.10471975511965977,
 					Cnt: 30,
@@ -1702,8 +1704,8 @@ func TestMapExponentialHistogram(t *testing.T) {
 			},
 			expectedSketches: []sketch{
 				newSketchWithHostname("double.exponential.delta.histogram", summary.Summary{
-					Min: -1.0475797592879845,
-					Max: 1.0974563270357618,
+					Min: -100_000,
+					Max: 100_000,
 					Sum: math.Pi,
 					Avg: 0.10471975511965977,
 					Cnt: 30,
@@ -1720,8 +1722,8 @@ func TestMapExponentialHistogram(t *testing.T) {
 			expectedMetrics:                      nil,
 			expectedSketches: []sketch{
 				newSketchWithHostname("double.exponential.delta.histogram", summary.Summary{
-					Min: -1.0475797592879845,
-					Max: 1.0974563270357618,
+					Min: -100_000,
+					Max: 100_000,
 					Sum: math.Pi,
 					Avg: 0.10471975511965977,
 					Cnt: 30,
@@ -1738,8 +1740,8 @@ func TestMapExponentialHistogram(t *testing.T) {
 			expectedMetrics:                      nil,
 			expectedSketches: []sketch{
 				newSketchWithHostname("double.exponential.delta.histogram", summary.Summary{
-					Min: -1.0475797592879845,
-					Max: 1.0974563270357618,
+					Min: -100_000,
+					Max: 100_000,
 					Sum: math.Pi,
 					Avg: 0.10471975511965977,
 					Cnt: 30,
@@ -1759,8 +1761,8 @@ func TestMapExponentialHistogram(t *testing.T) {
 			},
 			expectedSketches: []sketch{
 				newSketchWithHostname("double.exponential.delta.histogram", summary.Summary{
-					Min: -1.0475797592879845,
-					Max: 1.0974563270357618,
+					Min: -100_000,
+					Max: 100_000,
 					Sum: math.Pi,
 					Avg: 0.10471975511965977,
 					Cnt: 30,
@@ -1776,8 +1778,8 @@ func TestMapExponentialHistogram(t *testing.T) {
 			withCountSum:                         false,
 			expectedSketches: []sketch{
 				newSketchWithHostname("double.exponential.delta.histogram", summary.Summary{
-					Min: -1.0475797592879845,
-					Max: 1.0974563270357618,
+					Min: -100_000,
+					Max: 100_000,
 					Sum: math.Pi,
 					Avg: 0.10471975511965977,
 					Cnt: 30,
@@ -1797,8 +1799,8 @@ func TestMapExponentialHistogram(t *testing.T) {
 			},
 			expectedSketches: []sketch{
 				newSketchWithHostname("double.exponential.delta.histogram", summary.Summary{
-					Min: -1.0475797592879845,
-					Max: 1.0974563270357618,
+					Min: -100_000,
+					Max: 100_000,
 					Sum: math.Pi,
 					Avg: 0.10471975511965977,
 					Cnt: 30,
@@ -1818,8 +1820,8 @@ func TestMapExponentialHistogram(t *testing.T) {
 			},
 			expectedSketches: []sketch{
 				newSketchWithHostname("double.exponential.delta.histogram", summary.Summary{
-					Min: -1.0475797592879845,
-					Max: 1.0974563270357618,
+					Min: -100_000,
+					Max: 100_000,
 					Sum: math.Pi,
 					Avg: 0.10471975511965977,
 					Cnt: 30,
@@ -1908,6 +1910,8 @@ func createTestExponentialHistogram(additionalAttributes map[string]string, name
 	expDeltaHist.SetCount(30)
 	expDeltaHist.SetZeroCount(10)
 	expDeltaHist.SetSum(math.Pi)
+	expDeltaHist.SetMin(-100_000)
+	expDeltaHist.SetMax(100_000)
 	expDeltaHist.Negative().SetOffset(2)
 
 	expDeltaHist.Negative().BucketCounts().FromRaw([]uint64{3, 2, 5})

--- a/releasenotes/notes/otlp-histogram-078c3b47edcb9556.yaml
+++ b/releasenotes/notes/otlp-histogram-078c3b47edcb9556.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    OTLP ingest now uses the minimum and maximum fields from delta OTLP Histograms and OTLP ExponentialHistograms when available.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Use minimum and maximum fields on delta OTLP Histograms and OTLP ExponentialHistograms when they are available.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

These fields were [added in OTLP v0.17.0](https://github.com/open-telemetry/opentelemetry-proto/blob/main/CHANGELOG.md#0170---2022-05-06) and are now supported by several OpenTelemetry language libraries. The minimum and maximum fields are necessary for sketches so up until now we were using estimates based on bucket boundaries that can produce incorrect results on the Datadog webapp.


### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

We are not using them for cumulative Histograms or ExponentialHistograms. Datadog is delta-based and we can't generally recover the minimum/maximum on a delta period from the cumulative minimum maximum (except for rare cases). 
In addition, some language libraries recommend not sending minimum and maximum for cumulative histograms (see open-telemetry/opentelemetry-go/pull/3403 for an example), so they wouldn't be practically useful.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

- [ ] Send a delta OTLP Histogram with the default mode from a library that supports min/max (e.g. see OpenTelemetry Go). Check that the minimum and maximum in-app correspond to the exact minimum and maximum from your sample distribution
- [ ] Send a delta OTLP ExponentialHistogram with the default mode from a library that supports min/max (e.g. see OpenTelemetry Go). Check that the minimum and maximum in-app correspond to the exact minimum and maximum from your sample distribution

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
