### PR TITLE
Revert to TLS1.2 for Agent API due to JMXFetch

### DIFF
--- a/cmd/agent/api/server.go
+++ b/cmd/agent/api/server.go
@@ -140,7 +140,7 @@ func StartServer(configService *remoteconfig.Service) error {
 		TLSConfig: &tls.Config{
 			Certificates: []tls.Certificate{*tlsKeyPair},
 			NextProtos:   []string{"h2"},
-			MinVersion:   tls.VersionTLS13,
+			MinVersion:   tls.VersionTLS12,
 		},
 		ErrorLog: stdLog.New(logWriter, "Error from the agent http API server: ", 0), // log errors to seelog,
 		ConnContext: func(ctx context.Context, c net.Conn) context.Context {


### PR DESCRIPTION
### What does this PR do?

Partial fallback of #14077 for Agent API (localhost) because (system) JRE version may not support TLS 1.3.

### Motivation

Issue spotted in QA env.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

No manual QA required, it will be validated in QA env.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
