### PR TITLE
Modify position in CHANGELOG for hostname resolution change

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,10 @@ Release on: 2022-11-02
 Upgrade Notes
 -------------
 
+- Starting Agent 7.40, the Agent will fail to start when unable to determine hostname instead of silently using unrelevant hostname (usually, a container id).
+  Hostname resolution is key to many features and failure to determine hostname means that the Agent is not configured properly.
+  This change mostly affects Agents running in containerized environments as we cannot rely on OS hostname.
+
 - Universal Service Monitoring now requires a Linux kernel version of 4.14 or greater.
 
 
@@ -195,10 +199,6 @@ Other Notes
   selects updated codepaths in Autodiscovery and the Logs Agent.  No behavior
   change is expected.  Please report any behavior that is "fixed" by setting
   this flag to false.
-
-- Starting Agent 7.40, the Agent will fail to start when unable to determine hostname instead of silently using unrelevant hostname (usually, a container id).
-  Hostname resolution is key to many features and failure to determine hostname means that the Agent is not configured properly.
-  This change mostly affects Agents running in containerized environments as we cannot rely on OS hostname.
 
 
 .. _Release Notes_7.39.1:

--- a/releasenotes/notes/hostname-detection-container-e12cf0608270c9d4.yaml
+++ b/releasenotes/notes/hostname-detection-container-e12cf0608270c9d4.yaml
@@ -1,5 +1,5 @@
 ---
-other:
+upgrade:
   - |
     Starting Agent 7.40, the Agent will fail to start when unable to determine hostname instead of silently using unrelevant hostname (usually, a container id).
     Hostname resolution is key to many features and failure to determine hostname means that the Agent is not configured properly.


### PR DESCRIPTION
### What does this PR do?

Change position in CHANGELOG.

### Motivation

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
