### PR TITLE
Send series with NoIndex at true only when using the serie API V2

### DIFF
--- a/pkg/serializer/internal/metrics/iterable_series.go
+++ b/pkg/serializer/internal/metrics/iterable_series.go
@@ -23,11 +23,33 @@ import (
 
 // IterableSeries is a serializer for metrics.IterableSeries
 type IterableSeries struct {
-	metrics.SerieSource
+	source metrics.SerieSource
+}
+
+// CreateIterableSeries creates a new instance of *IterableSeries
+func CreateIterableSeries(source metrics.SerieSource) *IterableSeries {
+	return &IterableSeries{
+		source: source,
+	}
+}
+
+// MoveNext moves to the next item.
+// This function skips the series when `NoIndex` is set at true as `NoIndex` is only supported by `MarshalSplitCompress`.
+func (series *IterableSeries) MoveNext() bool {
+	res := series.source.MoveNext()
+	for res {
+		serie := series.source.Current()
+		if serie == nil || !serie.NoIndex {
+			break
+		}
+		// Skip noIndex metric
+		res = series.source.MoveNext()
+	}
+	return res
 }
 
 // WriteHeader writes the payload header for this type
-func (series IterableSeries) WriteHeader(stream *jsoniter.Stream) error {
+func (series *IterableSeries) WriteHeader(stream *jsoniter.Stream) error {
 	return writeHeader(stream)
 }
 
@@ -39,7 +61,7 @@ func writeHeader(stream *jsoniter.Stream) error {
 }
 
 // WriteFooter writes the payload footer for this type
-func (series IterableSeries) WriteFooter(stream *jsoniter.Stream) error {
+func (series *IterableSeries) WriteFooter(stream *jsoniter.Stream) error {
 	return writeFooter(stream)
 }
 
@@ -50,8 +72,8 @@ func writeFooter(stream *jsoniter.Stream) error {
 }
 
 // WriteCurrentItem writes the json representation of an item
-func (series IterableSeries) WriteCurrentItem(stream *jsoniter.Stream) error {
-	current := series.Current()
+func (series *IterableSeries) WriteCurrentItem(stream *jsoniter.Stream) error {
+	current := series.source.Current()
 	if current == nil {
 		return errors.New("nil serie")
 	}
@@ -65,8 +87,8 @@ func writeItem(stream *jsoniter.Stream, serie *metrics.Serie) error {
 }
 
 // DescribeCurrentItem returns a text description for logs
-func (series IterableSeries) DescribeCurrentItem() string {
-	current := series.Current()
+func (series *IterableSeries) DescribeCurrentItem() string {
+	current := series.source.Current()
 	if current == nil {
 		return "nil serie"
 	}
@@ -74,8 +96,8 @@ func (series IterableSeries) DescribeCurrentItem() string {
 }
 
 // GetCurrentItemPointCount gets the number of points in the current serie
-func (series IterableSeries) GetCurrentItemPointCount() int {
-	return len(series.Current().Points)
+func (series *IterableSeries) GetCurrentItemPointCount() int {
+	return len(series.source.Current().Points)
 }
 
 func describeItem(serie *metrics.Serie) string {
@@ -85,7 +107,7 @@ func describeItem(serie *metrics.Serie) string {
 // MarshalSplitCompress uses the stream compressor to marshal and compress series payloads.
 // If a compressed payload is larger than the max, a new payload will be generated. This method returns a slice of
 // compressed protobuf marshaled MetricPayload objects.
-func (series IterableSeries) MarshalSplitCompress(bufferContext *marshaler.BufferContext) (transaction.BytesPayloads, error) {
+func (series *IterableSeries) MarshalSplitCompress(bufferContext *marshaler.BufferContext) (transaction.BytesPayloads, error) {
 	var err error
 	var compressor *stream.Compressor
 	buf := bufferContext.PrecompressionBuf
@@ -173,8 +195,10 @@ func (series IterableSeries) MarshalSplitCompress(bufferContext *marshaler.Buffe
 		return nil, err
 	}
 
-	for series.MoveNext() {
-		serie = series.Current()
+	// Use series.source.MoveNext() instead of series.MoveNext() because this function supports
+	// the serie.NoIndex field.
+	for series.source.MoveNext() {
+		serie = series.source.Current()
 
 		buf.Reset()
 		err = ps.Embedded(payloadSeries, func(ps *molecule.ProtoStream) error {
@@ -342,13 +366,13 @@ func (series IterableSeries) MarshalSplitCompress(bufferContext *marshaler.Buffe
 
 // MarshalJSON serializes timeseries to JSON so it can be sent to V1 endpoints
 //FIXME(maxime): to be removed when v2 endpoints are available
-func (series IterableSeries) MarshalJSON() ([]byte, error) {
+func (series *IterableSeries) MarshalJSON() ([]byte, error) {
 	// use an alias to avoid infinite recursion while serializing a Series
 	type SeriesAlias Series
 
 	seriesAlias := make(SeriesAlias, 0)
 	for series.MoveNext() {
-		serie := series.Current()
+		serie := series.source.Current()
 		serie.PopulateDeviceField()
 		seriesAlias = append(seriesAlias, serie)
 	}
@@ -362,7 +386,7 @@ func (series IterableSeries) MarshalJSON() ([]byte, error) {
 }
 
 // SplitPayload breaks the payload into, at least, "times" number of pieces
-func (series IterableSeries) SplitPayload(times int) ([]marshaler.AbstractMarshaler, error) {
+func (series *IterableSeries) SplitPayload(times int) ([]marshaler.AbstractMarshaler, error) {
 	seriesExpvar.Add("TimesSplit", 1)
 	tlmSeries.Inc("times_split")
 
@@ -371,7 +395,7 @@ func (series IterableSeries) SplitPayload(times int) ([]marshaler.AbstractMarsha
 	metricsPerName := map[string]Series{}
 	serieCount := 0
 	for series.MoveNext() {
-		s := series.Current()
+		s := series.source.Current()
 		serieCount++
 		if _, ok := metricsPerName[s.Name]; ok {
 			metricsPerName[s.Name] = append(metricsPerName[s.Name], s)

--- a/pkg/serializer/internal/metrics/iterable_series_test.go
+++ b/pkg/serializer/internal/metrics/iterable_series_test.go
@@ -16,8 +16,24 @@ import (
 
 func TestIterableSeriesEmptyMarshalJSON(t *testing.T) {
 	r := require.New(t)
-	iterableSerie := IterableSeries{SerieSource: CreateSerieSource(metrics.Series{})}
+	iterableSerie := CreateIterableSeries(CreateSerieSource(metrics.Series{}))
 	bytes, err := iterableSerie.MarshalJSON()
 	r.NoError(err)
 	r.Equal(`{"series":[]}`, strings.TrimSpace(string(bytes)))
+}
+
+func TestIterableSeriesMoveNext(t *testing.T) {
+	r := require.New(t)
+	series := metrics.Series{
+		&metrics.Serie{Name: "serie1", NoIndex: true},
+		&metrics.Serie{Name: "serie2", NoIndex: false},
+		&metrics.Serie{Name: "serie3", NoIndex: false},
+		&metrics.Serie{Name: "serie4", NoIndex: true},
+	}
+	iterableSerie := CreateIterableSeries(CreateSerieSource(series))
+	r.True(iterableSerie.MoveNext()) // Skip serie1
+	r.True(strings.Contains(iterableSerie.DescribeCurrentItem(), "serie2"))
+	r.True(iterableSerie.MoveNext())
+	r.True(strings.Contains(iterableSerie.DescribeCurrentItem(), "serie3"))
+	r.False(iterableSerie.MoveNext()) // Skip serie4
 }

--- a/pkg/serializer/internal/metrics/series_test.go
+++ b/pkg/serializer/internal/metrics/series_test.go
@@ -249,7 +249,7 @@ func TestStreamJSONMarshalerWithDevice(t *testing.T) {
 	}
 
 	stream := jsoniter.NewStream(jsoniter.ConfigDefault, nil, 0)
-	serializer := IterableSeries{SerieSource: CreateSerieSource(series)}
+	serializer := CreateIterableSeries(CreateSerieSource(series))
 	serializer.MoveNext()
 	err := serializer.WriteCurrentItem(stream)
 	assert.NoError(t, err)
@@ -277,7 +277,7 @@ func TestDescribeItem(t *testing.T) {
 		},
 	}
 
-	serializer := IterableSeries{SerieSource: CreateSerieSource(series)}
+	serializer := CreateIterableSeries(CreateSerieSource(series))
 	serializer.MoveNext()
 	desc1 := serializer.DescribeCurrentItem()
 	assert.Equal(t, "name \"test.metrics\", 2 points", desc1)
@@ -302,7 +302,7 @@ func makeSeries(numItems, numPoints int) *IterableSeries {
 			Tags:     tagset.CompositeTagsFromSlice([]string{"tag1", "tag2:yes"}),
 		})
 	}
-	return &IterableSeries{SerieSource: CreateSerieSource(series)}
+	return CreateIterableSeries(CreateSerieSource(series))
 }
 
 func TestMarshalSplitCompress(t *testing.T) {
@@ -377,7 +377,7 @@ func TestPayloadsSeries(t *testing.T) {
 
 	originalLength := len(testSeries)
 	builder := stream.NewJSONPayloadBuilder(true)
-	iterableSeries := &IterableSeries{SerieSource: CreateSerieSource(testSeries)}
+	iterableSeries := CreateIterableSeries(CreateSerieSource(testSeries))
 	payloads, err := builder.BuildWithOnErrItemTooBigPolicy(iterableSeries, stream.DropItemOnErrItemTooBig)
 	require.Nil(t, err)
 	var splitSeries = []Series{}
@@ -425,7 +425,7 @@ func BenchmarkPayloadsSeries(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		// always record the result of Payloads to prevent
 		// the compiler eliminating the function call.
-		iterableSeries := &IterableSeries{SerieSource: CreateSerieSource(testSeries)}
+		iterableSeries := CreateIterableSeries(CreateSerieSource(testSeries))
 		r, _ = builder.BuildWithOnErrItemTooBigPolicy(iterableSeries, stream.DropItemOnErrItemTooBig)
 	}
 	// ensure we actually had to split

--- a/pkg/serializer/serializer.go
+++ b/pkg/serializer/serializer.go
@@ -314,7 +314,7 @@ func (s *Serializer) SendIterableSeries(serieSource metrics.SerieSource) error {
 		return nil
 	}
 
-	seriesSerializer := metricsserializer.IterableSeries{SerieSource: serieSource}
+	seriesSerializer := metricsserializer.CreateIterableSeries(serieSource)
 	useV1API := !config.Datadog.GetBool("use_v2_api.series")
 
 	var seriesBytesPayloads transaction.BytesPayloads

--- a/pkg/serializer/series_benchmark_test.go
+++ b/pkg/serializer/series_benchmark_test.go
@@ -76,13 +76,13 @@ func BenchmarkSeries(b *testing.B) {
 	}
 	bufferContext := marshaler.DefaultBufferContext()
 	pb := func(series metrics.Series) (transaction.BytesPayloads, error) {
-		iterableSeries := &metricsserializer.IterableSeries{SerieSource: metricsserializer.CreateSerieSource(series)}
+		iterableSeries := metricsserializer.CreateIterableSeries(metricsserializer.CreateSerieSource(series))
 		return iterableSeries.MarshalSplitCompress(bufferContext)
 	}
 
 	payloadBuilder := stream.NewJSONPayloadBuilder(true)
 	json := func(series metrics.Series) (transaction.BytesPayloads, error) {
-		iterableSeries := &metricsserializer.IterableSeries{SerieSource: metricsserializer.CreateSerieSource(series)}
+		iterableSeries := metricsserializer.CreateIterableSeries(metricsserializer.CreateSerieSource(series))
 		return payloadBuilder.BuildWithOnErrItemTooBigPolicy(iterableSeries, stream.DropItemOnErrItemTooBig)
 	}
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This PR skips series when `NoIndex` is set at `true` when using the serie API V1. API V1 doesn't support this field.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
- Start the Agent with `use_v2_api.series: true` and check `datadog.agent.point.dropped` is reported (be careful the metric is not indexed.)
- Start the Agent with `use_v2_api.series: false` and check `datadog.agent.point.dropped` is NOT reported 


<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
