### PR TITLE
pkg/trace/api: evp proxy forwards a list of allowed headers

### DIFF
--- a/pkg/trace/api/endpoints.go
+++ b/pkg/trace/api/endpoints.go
@@ -117,6 +117,10 @@ var endpoints = []Endpoint{
 		Handler: func(r *HTTPReceiver) http.Handler { return r.evpProxyHandler(2) },
 	},
 	{
+		Pattern: "/evp_proxy/v3/",
+		Handler: func(r *HTTPReceiver) http.Handler { return r.evpProxyHandler(2) },
+	},
+	{
 		Pattern: "/debugger/v1/input",
 		Handler: func(r *HTTPReceiver) http.Handler { return r.debuggerProxyHandler() },
 	},

--- a/pkg/trace/api/info_test.go
+++ b/pkg/trace/api/info_test.go
@@ -191,6 +191,7 @@ func TestInfoHandler(t *testing.T) {
 		"/v0.1/pipeline_stats",
 		"/evp_proxy/v1/",
 		"/evp_proxy/v2/",
+		"/evp_proxy/v3/",
 		"/debugger/v1/input"
 		"/dogstatsd/v1/proxy"
 	],


### PR DESCRIPTION
### What does this PR do?

* Adds a list of headers that the evp proxy will forward and not discard.
* Allows the DD-CI-PROVIDER-NAME header, used in CI Visibility Webhooks.
* Bumps the proxy version to v3 so clients can query if it has this change.

### Motivation

* We want to use the EVP Proxy to target the webhook-intake, which requires the `DD-CI-PROVIDER-NAME` header.
* This might have uses for other products in the future.

### Describe how to test/QA your changes

- Run Jenkins with the [Datadog Jenkins Plugin](https://github.com/jenkinsci/datadog-plugin) configured to use the Agent to report metrics. 
- Check that CI Visibility works via the Agent using the Webhooks API instead of APM (Jenkins will print `isEvpProxySupported: true` in fine-level logs).

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
