### PR TITLE
Send a metric that count the number of points sent to the intake.

### DIFF
--- a/pkg/forwarder/domain_forwarder.go
+++ b/pkg/forwarder/domain_forwarder.go
@@ -41,6 +41,7 @@ type domainForwarder struct {
 	m                         sync.Mutex // To control Start/Stop races
 	transactionPrioritySorter retry.TransactionPrioritySorter
 	blockedList               *blockedEndpoints
+	pointDroppedSender        *retry.PointDroppedSender
 }
 
 func newDomainForwarder(
@@ -48,7 +49,8 @@ func newDomainForwarder(
 	retryQueue *retry.TransactionRetryQueue,
 	numberOfWorkers int,
 	connectionResetInterval time.Duration,
-	transactionPrioritySorter retry.TransactionPrioritySorter) *domainForwarder {
+	transactionPrioritySorter retry.TransactionPrioritySorter,
+	pointDroppedSender *retry.PointDroppedSender) *domainForwarder {
 	return &domainForwarder{
 		isRetrying:                atomic.NewBool(false),
 		domain:                    domain,
@@ -58,6 +60,7 @@ func newDomainForwarder(
 		internalState:             Stopped,
 		blockedList:               newBlockedEndpoints(),
 		transactionPrioritySorter: transactionPrioritySorter,
+		pointDroppedSender:        pointDroppedSender,
 	}
 }
 
@@ -198,7 +201,7 @@ func (f *domainForwarder) Start() error {
 	f.init()
 
 	for i := 0; i < f.numberOfWorkers; i++ {
-		w := NewWorker(f.highPrio, f.lowPrio, f.requeuedTransaction, f.blockedList)
+		w := NewWorker(f.highPrio, f.lowPrio, f.requeuedTransaction, f.blockedList, f.pointDroppedSender)
 		w.Start()
 		f.workers = append(f.workers, w)
 	}
@@ -207,7 +210,7 @@ func (f *domainForwarder) Start() error {
 		go f.scheduleConnectionResets()
 	}
 
-	f.retryQueue.Start()
+	f.pointDroppedSender.Start()
 	f.internalState = Started
 	return nil
 }
@@ -223,7 +226,7 @@ func (f *domainForwarder) Stop(purgeHighPrio bool) {
 		return
 	}
 
-	f.retryQueue.Stop()
+	f.pointDroppedSender.Stop()
 
 	if f.connectionResetInterval != 0 {
 		f.stopConnectionReset <- true

--- a/pkg/forwarder/domain_forwarder_test.go
+++ b/pkg/forwarder/domain_forwarder_test.go
@@ -255,7 +255,7 @@ func TestDomainForwarderRetryQueueAllPayloadsMaxSize(t *testing.T) {
 		0,
 		telemetry,
 		retry.NewPointDroppedSenderMock())
-	forwarder := newDomainForwarder("test", transactionRetryQueue, 0, 10, transaction.SortByCreatedTimeAndPriority{HighPriorityFirst: true})
+	forwarder := newDomainForwarder("test", transactionRetryQueue, 0, 10, transaction.SortByCreatedTimeAndPriority{HighPriorityFirst: true}, retry.NewPointDroppedSender("domain", nil))
 	forwarder.blockedList.close("blocked")
 	forwarder.blockedList.errorPerEndpoint["blocked"].until = time.Now().Add(1 * time.Minute)
 
@@ -315,7 +315,7 @@ func newDomainForwarderForTest(connectionResetInterval time.Duration) *domainFor
 		telemetry,
 		retry.NewPointDroppedSenderMock())
 
-	return newDomainForwarder("test", transactionRetryQueue, 1, connectionResetInterval, sorter)
+	return newDomainForwarder("test", transactionRetryQueue, 1, connectionResetInterval, sorter, retry.NewPointDroppedSender("domain", nil))
 }
 
 func requireLenForwarderRetryQueue(t *testing.T, forwarder *domainForwarder, expectedValue int) {

--- a/pkg/forwarder/domain_forwarder_test.go
+++ b/pkg/forwarder/domain_forwarder_test.go
@@ -254,8 +254,8 @@ func TestDomainForwarderRetryQueueAllPayloadsMaxSize(t *testing.T) {
 		1+2,
 		0,
 		telemetry,
-		retry.NewPointDroppedSenderMock())
-	forwarder := newDomainForwarder("test", transactionRetryQueue, 0, 10, transaction.SortByCreatedTimeAndPriority{HighPriorityFirst: true}, retry.NewPointDroppedSender("domain", nil))
+		retry.NewPointCountTelemetryMock())
+	forwarder := newDomainForwarder("test", transactionRetryQueue, 0, 10, transaction.SortByCreatedTimeAndPriority{HighPriorityFirst: true}, retry.NewPointCountTelemetry("domain", nil))
 	forwarder.blockedList.close("blocked")
 	forwarder.blockedList.errorPerEndpoint["blocked"].until = time.Now().Add(1 * time.Minute)
 
@@ -313,9 +313,9 @@ func newDomainForwarderForTest(connectionResetInterval time.Duration) *domainFor
 		2,
 		0,
 		telemetry,
-		retry.NewPointDroppedSenderMock())
+		retry.NewPointCountTelemetryMock())
 
-	return newDomainForwarder("test", transactionRetryQueue, 1, connectionResetInterval, sorter, retry.NewPointDroppedSender("domain", nil))
+	return newDomainForwarder("test", transactionRetryQueue, 1, connectionResetInterval, sorter, retry.NewPointCountTelemetry("domain", nil))
 }
 
 func requireLenForwarderRetryQueue(t *testing.T, forwarder *domainForwarder, expectedValue int) {

--- a/pkg/forwarder/forwarder.go
+++ b/pkg/forwarder/forwarder.go
@@ -277,7 +277,7 @@ func NewDefaultForwarder(options *Options) *DefaultForwarder {
 				}
 			}
 
-			pointDroppedSender := retry.NewPointDroppedSender(domain, telemetry.GetStatsTelemetryProvider())
+			pointCountTelemetry := retry.NewPointCountTelemetry(domain, telemetry.GetStatsTelemetryProvider())
 			transactionContainer := retry.BuildTransactionRetryQueue(
 				options.RetryQueuePayloadsTotalMaxSize,
 				flushToDiskMemRatio,
@@ -285,7 +285,7 @@ func NewDefaultForwarder(options *Options) *DefaultForwarder {
 				diskUsageLimit,
 				transactionContainerSort,
 				resolver,
-				pointDroppedSender)
+				pointCountTelemetry)
 			f.domainResolvers[domain] = resolver
 			fwd := newDomainForwarder(
 				domain,
@@ -293,7 +293,7 @@ func NewDefaultForwarder(options *Options) *DefaultForwarder {
 				options.NumberOfWorkers,
 				options.ConnectionResetInterval,
 				domainForwarderSort,
-				pointDroppedSender)
+				pointCountTelemetry)
 			f.domainForwarders[domain] = fwd
 			// Register all alternate domains for each forwarder
 			for _, v := range resolver.GetAlternateDomains() {

--- a/pkg/forwarder/forwarder.go
+++ b/pkg/forwarder/forwarder.go
@@ -277,20 +277,23 @@ func NewDefaultForwarder(options *Options) *DefaultForwarder {
 				}
 			}
 
+			pointDroppedSender := retry.NewPointDroppedSender(domain, telemetry.GetStatsTelemetryProvider())
 			transactionContainer := retry.BuildTransactionRetryQueue(
 				options.RetryQueuePayloadsTotalMaxSize,
 				flushToDiskMemRatio,
 				domainFolderPath,
 				diskUsageLimit,
 				transactionContainerSort,
-				resolver)
+				resolver,
+				pointDroppedSender)
 			f.domainResolvers[domain] = resolver
 			fwd := newDomainForwarder(
 				domain,
 				transactionContainer,
 				options.NumberOfWorkers,
 				options.ConnectionResetInterval,
-				domainForwarderSort)
+				domainForwarderSort,
+				pointDroppedSender)
 			f.domainForwarders[domain] = fwd
 			// Register all alternate domains for each forwarder
 			for _, v := range resolver.GetAlternateDomains() {

--- a/pkg/forwarder/internal/retry/on_disk_retry_queue.go
+++ b/pkg/forwarder/internal/retry/on_disk_retry_queue.go
@@ -185,7 +185,7 @@ func (s *onDiskRetryQueue) makeRoomFor(bufferSize int64) error {
 
 func (s *onDiskRetryQueue) onPointDropped(count int) {
 	s.telemetry.addPointDroppedCount(count)
-	s.pointCountTelemetry.AddDroppedPointCount(count)
+	s.pointCountTelemetry.OnPointDropped(count)
 }
 
 func (s *onDiskRetryQueue) removeFileAt(index int) error {

--- a/pkg/forwarder/internal/retry/on_disk_retry_queue.go
+++ b/pkg/forwarder/internal/retry/on_disk_retry_queue.go
@@ -23,13 +23,13 @@ const retryTransactionsExtension = ".retry"
 const retryFileFormat = "2006_01_02__15_04_05_"
 
 type onDiskRetryQueue struct {
-	serializer         *HTTPTransactionsSerializer
-	storagePath        string
-	diskUsageLimit     *DiskUsageLimit
-	filenames          []string
-	currentSizeInBytes int64
-	telemetry          onDiskRetryQueueTelemetry
-	pointDroppedSender *PointDroppedSender
+	serializer          *HTTPTransactionsSerializer
+	storagePath         string
+	diskUsageLimit      *DiskUsageLimit
+	filenames           []string
+	currentSizeInBytes  int64
+	telemetry           onDiskRetryQueueTelemetry
+	pointCountTelemetry *PointCountTelemetry
 }
 
 func newOnDiskRetryQueue(
@@ -37,18 +37,18 @@ func newOnDiskRetryQueue(
 	storagePath string,
 	diskUsageLimit *DiskUsageLimit,
 	telemetry onDiskRetryQueueTelemetry,
-	pointDroppedSender *PointDroppedSender) (*onDiskRetryQueue, error) {
+	pointCountTelemetry *PointCountTelemetry) (*onDiskRetryQueue, error) {
 
 	if err := os.MkdirAll(storagePath, 0700); err != nil {
 		return nil, err
 	}
 
 	storage := &onDiskRetryQueue{
-		serializer:         serializer,
-		storagePath:        storagePath,
-		diskUsageLimit:     diskUsageLimit,
-		telemetry:          telemetry,
-		pointDroppedSender: pointDroppedSender,
+		serializer:          serializer,
+		storagePath:         storagePath,
+		diskUsageLimit:      diskUsageLimit,
+		telemetry:           telemetry,
+		pointCountTelemetry: pointCountTelemetry,
 	}
 
 	if err := storage.reloadExistingRetryFiles(); err != nil {
@@ -185,7 +185,7 @@ func (s *onDiskRetryQueue) makeRoomFor(bufferSize int64) error {
 
 func (s *onDiskRetryQueue) onPointDropped(count int) {
 	s.telemetry.addPointDroppedCount(count)
-	s.pointDroppedSender.AddDroppedPointCount(count)
+	s.pointCountTelemetry.AddDroppedPointCount(count)
 }
 
 func (s *onDiskRetryQueue) removeFileAt(index int) error {

--- a/pkg/forwarder/internal/retry/on_disk_retry_queue_test.go
+++ b/pkg/forwarder/internal/retry/on_disk_retry_queue_test.go
@@ -130,7 +130,7 @@ func newTestOnDiskRetryQueue(a *assert.Assertions, path string, maxSizeInBytes i
 			Total:     10000,
 		}}
 	diskUsageLimit := NewDiskUsageLimit("", disk, maxSizeInBytes, 1)
-	storage, err := newOnDiskRetryQueue(NewHTTPTransactionsSerializer(resolver.NewSingleDomainResolver(domainName, nil)), path, diskUsageLimit, telemetry, NewPointDroppedSenderMock())
+	storage, err := newOnDiskRetryQueue(NewHTTPTransactionsSerializer(resolver.NewSingleDomainResolver(domainName, nil)), path, diskUsageLimit, telemetry, NewPointCountTelemetryMock())
 	a.NoError(err)
 	return storage
 }

--- a/pkg/forwarder/internal/retry/point_count_telemetry.go
+++ b/pkg/forwarder/internal/retry/point_count_telemetry.go
@@ -57,8 +57,8 @@ func (t *PointCountTelemetry) Stop() {
 	t.startStopAction.Stop()
 }
 
-// AddDroppedPointCount increases the telemetry that counts the number of points droppped
-func (t *PointCountTelemetry) AddDroppedPointCount(count int) {
+// OnPointDropped increases the telemetry that counts the number of points droppped
+func (t *PointCountTelemetry) OnPointDropped(count int) {
 	t.droppedPointCount.Add(int64(count))
 }
 

--- a/pkg/forwarder/internal/retry/point_count_telemetry.go
+++ b/pkg/forwarder/internal/retry/point_count_telemetry.go
@@ -14,8 +14,8 @@ import (
 	"go.uber.org/atomic"
 )
 
-// PointDroppedSender sends the number of points dropped
-type PointDroppedSender struct {
+// PointCountTelemetry sends the number of points successfully sent and the number of points dropped.
+type PointCountTelemetry struct {
 	tags              []string
 	provider          *telemetry.StatsTelemetryProvider
 	droppedPointCount atomic.Int64
@@ -23,16 +23,16 @@ type PointDroppedSender struct {
 	startStopAction   *util.StartStopAction
 }
 
-// NewPointDroppedSender creates a new instance of PointDroppedSender.
-func NewPointDroppedSender(domain string, provider *telemetry.StatsTelemetryProvider) *PointDroppedSender {
-	return &PointDroppedSender{
+// NewPointCountTelemetry creates a new instance of PointCountTelemetry.
+func NewPointCountTelemetry(domain string, provider *telemetry.StatsTelemetryProvider) *PointCountTelemetry {
+	return &PointCountTelemetry{
 		tags:            []string{"domain:" + domain},
 		provider:        provider,
 		startStopAction: util.NewStartStopAction()}
 }
 
 // Start starts sending metrics.
-func (t *PointDroppedSender) Start() {
+func (t *PointCountTelemetry) Start() {
 	t.startStopAction.Start(func(context context.Context) {
 		ticker := time.NewTicker(30 * time.Second)
 		for {
@@ -53,16 +53,16 @@ func (t *PointDroppedSender) Start() {
 }
 
 // Stop stops sending metrics.
-func (t *PointDroppedSender) Stop() {
+func (t *PointCountTelemetry) Stop() {
 	t.startStopAction.Stop()
 }
 
 // AddDroppedPointCount increases the telemetry that counts the number of points droppped
-func (t *PointDroppedSender) AddDroppedPointCount(count int) {
+func (t *PointCountTelemetry) AddDroppedPointCount(count int) {
 	t.droppedPointCount.Add(int64(count))
 }
 
 // OnPointSuccessfullySent increases the telemetry that counts the number of points successfully sent.
-func (t *PointDroppedSender) OnPointSuccessfullySent(count int) {
+func (t *PointCountTelemetry) OnPointSuccessfullySent(count int) {
 	t.pointSentCount.Add(int64(count))
 }

--- a/pkg/forwarder/internal/retry/point_dropped_sender.go
+++ b/pkg/forwarder/internal/retry/point_dropped_sender.go
@@ -19,6 +19,7 @@ type PointDroppedSender struct {
 	tags              []string
 	provider          *telemetry.StatsTelemetryProvider
 	droppedPointCount atomic.Int64
+	pointSentCount    atomic.Int64
 	startStopAction   *util.StartStopAction
 }
 
@@ -43,6 +44,9 @@ func (t *PointDroppedSender) Start() {
 				// recovers, the gauge gives the total amount of points dropped.
 				count := t.droppedPointCount.Load()
 				t.provider.GaugeNoIndex("datadog.agent.point.dropped", float64(count), t.tags)
+
+				count = t.pointSentCount.Load()
+				t.provider.GaugeNoIndex("datadog.agent.point.sent", float64(count), t.tags)
 			}
 		}
 	})
@@ -56,4 +60,9 @@ func (t *PointDroppedSender) Stop() {
 // AddDroppedPointCount increases the telemetry that counts the number of points droppped
 func (t *PointDroppedSender) AddDroppedPointCount(count int) {
 	t.droppedPointCount.Add(int64(count))
+}
+
+// OnPointSuccessfullySent increases the telemetry that counts the number of points successfully sent.
+func (t *PointDroppedSender) OnPointSuccessfullySent(count int) {
+	t.pointSentCount.Add(int64(count))
 }

--- a/pkg/forwarder/internal/retry/test_common.go
+++ b/pkg/forwarder/internal/retry/test_common.go
@@ -10,9 +10,9 @@ package retry
 
 import "github.com/DataDog/datadog-agent/pkg/telemetry"
 
-func NewPointDroppedSenderMock() *PointDroppedSender {
+func NewPointCountTelemetryMock() *PointCountTelemetry {
 	provider := telemetry.NewStatsTelemetryProvider(StatsTelemetrySenderMock{})
-	return NewPointDroppedSender("domain", provider)
+	return NewPointCountTelemetry("domain", provider)
 }
 
 type StatsTelemetrySenderMock struct{}

--- a/pkg/forwarder/internal/retry/transaction_retry_queue.go
+++ b/pkg/forwarder/internal/retry/transaction_retry_queue.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/config/resolver"
 	"github.com/DataDog/datadog-agent/pkg/forwarder/transaction"
-	"github.com/DataDog/datadog-agent/pkg/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -50,11 +49,11 @@ func BuildTransactionRetryQueue(
 	optionalDomainFolderPath string,
 	optionalDiskUsageLimit *DiskUsageLimit,
 	dropPrioritySorter TransactionPrioritySorter,
-	resolver resolver.DomainResolver) *TransactionRetryQueue {
+	resolver resolver.DomainResolver,
+	pointDroppedSender *PointDroppedSender) *TransactionRetryQueue {
 	var storage TransactionDiskStorage
 	var err error
 	domain := resolver.GetBaseDomain()
-	pointDroppedSender := NewPointDroppedSender(domain, telemetry.GetStatsTelemetryProvider())
 
 	if optionalDomainFolderPath != "" && optionalDiskUsageLimit != nil {
 		serializer := NewHTTPTransactionsSerializer(resolver)
@@ -249,14 +248,4 @@ func (tc *TransactionRetryQueue) extractTransactionsFromMemory(payloadSizeInByte
 	tc.transactions = tc.transactions[i:]
 	tc.currentMemSizeInBytes -= sizeInBytesExtracted
 	return transactionsExtracted
-}
-
-// Start starts pointDroppedSender
-func (tc *TransactionRetryQueue) Start() {
-	tc.pointDroppedSender.Start()
-}
-
-// Stop stops pointDroppedSender
-func (tc *TransactionRetryQueue) Stop() {
-	tc.pointDroppedSender.Stop()
 }

--- a/pkg/forwarder/internal/retry/transaction_retry_queue.go
+++ b/pkg/forwarder/internal/retry/transaction_retry_queue.go
@@ -38,7 +38,7 @@ type TransactionRetryQueue struct {
 	dropPrioritySorter    TransactionPrioritySorter
 	optionalStorage       TransactionDiskStorage
 	telemetry             TransactionRetryQueueTelemetry
-	pointDroppedSender    *PointDroppedSender
+	pointCountTelemetry   *PointCountTelemetry
 	mutex                 sync.RWMutex
 }
 
@@ -50,14 +50,14 @@ func BuildTransactionRetryQueue(
 	optionalDiskUsageLimit *DiskUsageLimit,
 	dropPrioritySorter TransactionPrioritySorter,
 	resolver resolver.DomainResolver,
-	pointDroppedSender *PointDroppedSender) *TransactionRetryQueue {
+	pointCountTelemetry *PointCountTelemetry) *TransactionRetryQueue {
 	var storage TransactionDiskStorage
 	var err error
 	domain := resolver.GetBaseDomain()
 
 	if optionalDomainFolderPath != "" && optionalDiskUsageLimit != nil {
 		serializer := NewHTTPTransactionsSerializer(resolver)
-		storage, err = newOnDiskRetryQueue(serializer, optionalDomainFolderPath, optionalDiskUsageLimit, newOnDiskRetryQueueTelemetry(resolver.GetBaseDomain()), pointDroppedSender)
+		storage, err = newOnDiskRetryQueue(serializer, optionalDomainFolderPath, optionalDiskUsageLimit, newOnDiskRetryQueueTelemetry(resolver.GetBaseDomain()), pointCountTelemetry)
 
 		// If the storage on disk cannot be used, log the error and continue.
 		// Returning `nil, err` would mean not using `TransactionRetryQueue` and so not using `forwarder_retry_queue_payloads_max_size` config.
@@ -72,7 +72,7 @@ func BuildTransactionRetryQueue(
 		maxMemSizeInBytes,
 		flushToStorageRatio,
 		NewTransactionRetryQueueTelemetry(domain),
-		pointDroppedSender)
+		pointCountTelemetry)
 }
 
 // NewTransactionRetryQueue creates a new instance of NewTransactionRetryQueue
@@ -82,14 +82,14 @@ func NewTransactionRetryQueue(
 	maxMemSizeInBytes int,
 	flushToStorageRatio float64,
 	telemetry TransactionRetryQueueTelemetry,
-	pointDroppedSender *PointDroppedSender) *TransactionRetryQueue {
+	pointCountTelemetry *PointCountTelemetry) *TransactionRetryQueue {
 	return &TransactionRetryQueue{
 		maxMemSizeInBytes:   maxMemSizeInBytes,
 		flushToStorageRatio: flushToStorageRatio,
 		dropPrioritySorter:  dropPrioritySorter,
 		optionalStorage:     optionalTransactionStorage,
 		telemetry:           telemetry,
-		pointDroppedSender:  pointDroppedSender,
+		pointCountTelemetry: pointCountTelemetry,
 	}
 }
 
@@ -152,7 +152,7 @@ func (tc *TransactionRetryQueue) Add(t transaction.Transaction) (int, error) {
 
 func (tc *TransactionRetryQueue) onDropPoints(count int) {
 	tc.telemetry.addPointDroppedCount(count)
-	tc.pointDroppedSender.AddDroppedPointCount(count)
+	tc.pointCountTelemetry.AddDroppedPointCount(count)
 }
 
 // ExtractTransactions extracts transactions from the container.

--- a/pkg/forwarder/internal/retry/transaction_retry_queue.go
+++ b/pkg/forwarder/internal/retry/transaction_retry_queue.go
@@ -152,7 +152,7 @@ func (tc *TransactionRetryQueue) Add(t transaction.Transaction) (int, error) {
 
 func (tc *TransactionRetryQueue) onDropPoints(count int) {
 	tc.telemetry.addPointDroppedCount(count)
-	tc.pointCountTelemetry.AddDroppedPointCount(count)
+	tc.pointCountTelemetry.OnPointDropped(count)
 }
 
 // ExtractTransactions extracts transactions from the container.

--- a/pkg/forwarder/internal/retry/transaction_retry_queue_test.go
+++ b/pkg/forwarder/internal/retry/transaction_retry_queue_test.go
@@ -20,7 +20,7 @@ func TestTransactionRetryQueueAdd(t *testing.T) {
 	pointDropped := transactionContainerPointDroppedCountTelemetry.expvar.Value()
 	q := newOnDiskRetryQueueTest(t, a)
 
-	container := NewTransactionRetryQueue(createDropPrioritySorter(), q, 100, 0.6, NewTransactionRetryQueueTelemetry("domain"), NewPointDroppedSenderMock())
+	container := NewTransactionRetryQueue(createDropPrioritySorter(), q, 100, 0.6, NewTransactionRetryQueueTelemetry("domain"), NewPointCountTelemetryMock())
 
 	// When adding the last element `15`, the buffer becomes full and the first 3
 	// transactions are flushed to the disk as 10 + 20 + 30 >= 100 * 0.6
@@ -48,7 +48,7 @@ func TestTransactionRetryQueueSeveralFlushToDisk(t *testing.T) {
 	a := assert.New(t)
 	q := newOnDiskRetryQueueTest(t, a)
 
-	container := NewTransactionRetryQueue(createDropPrioritySorter(), q, 50, 0.1, NewTransactionRetryQueueTelemetry("domain"), NewPointDroppedSenderMock())
+	container := NewTransactionRetryQueue(createDropPrioritySorter(), q, 50, 0.1, NewTransactionRetryQueueTelemetry("domain"), NewPointCountTelemetryMock())
 
 	// Flush to disk when adding `40`
 	for _, payloadSize := range []int{9, 10, 11, 40} {
@@ -68,7 +68,7 @@ func TestTransactionRetryQueueSeveralFlushToDisk(t *testing.T) {
 func TestTransactionRetryQueueNoTransactionStorage(t *testing.T) {
 	a := assert.New(t)
 	pointDropped := transactionContainerPointDroppedCountTelemetry.expvar.Value()
-	container := NewTransactionRetryQueue(createDropPrioritySorter(), nil, 50, 0.1, NewTransactionRetryQueueTelemetry("domain"), NewPointDroppedSenderMock())
+	container := NewTransactionRetryQueue(createDropPrioritySorter(), nil, 50, 0.1, NewTransactionRetryQueueTelemetry("domain"), NewPointCountTelemetryMock())
 
 	for _, payloadSize := range []int{9, 10, 11} {
 		dropCount, err := container.Add(createTransactionWithPayloadSize(payloadSize))
@@ -93,7 +93,7 @@ func TestTransactionRetryQueueZeroMaxMemSizeInBytes(t *testing.T) {
 
 	maxMemSizeInBytes := 0
 	pointDropped := transactionContainerPointDroppedCountTelemetry.expvar.Value()
-	container := NewTransactionRetryQueue(createDropPrioritySorter(), q, maxMemSizeInBytes, 0.1, NewTransactionRetryQueueTelemetry("domain"), NewPointDroppedSenderMock())
+	container := NewTransactionRetryQueue(createDropPrioritySorter(), q, maxMemSizeInBytes, 0.1, NewTransactionRetryQueueTelemetry("domain"), NewPointCountTelemetryMock())
 
 	inMemTrDropped, err := container.Add(createTransactionWithPayloadSize(10))
 	a.NoError(err)
@@ -147,7 +147,7 @@ func newOnDiskRetryQueueTest(t *testing.T, a *assert.Assertions) *onDiskRetryQue
 		path,
 		diskUsageLimit,
 		newOnDiskRetryQueueTelemetry("domain"),
-		NewPointDroppedSenderMock())
+		NewPointCountTelemetryMock())
 	a.NoError(err)
 	return q
 }

--- a/pkg/forwarder/test_common.go
+++ b/pkg/forwarder/test_common.go
@@ -22,6 +22,7 @@ type testTransaction struct {
 	mock.Mock
 	assertClient bool
 	processed    chan bool
+	pointCount   int
 }
 
 func newTestTransaction() *testTransaction {
@@ -72,7 +73,7 @@ func (t *testTransaction) SerializeTo(serializer transaction.TransactionsSeriali
 }
 
 func (t *testTransaction) GetPointCount() int {
-	return 0
+	return t.pointCount
 }
 
 // Compile-time checking to ensure that MockedForwarder implements Forwarder

--- a/pkg/forwarder/worker.go
+++ b/pkg/forwarder/worker.go
@@ -32,10 +32,16 @@ type Worker struct {
 	// RequeueChan is the channel used to send failed transaction back to the Forwarder.
 	RequeueChan chan<- transaction.Transaction
 
-	resetConnectionChan chan struct{}
-	stopChan            chan struct{}
-	stopped             chan struct{}
-	blockedList         *blockedEndpoints
+	resetConnectionChan   chan struct{}
+	stopChan              chan struct{}
+	stopped               chan struct{}
+	blockedList           *blockedEndpoints
+	pointSuccessfullySent PointSuccessfullySent
+}
+
+// PointSuccessfullySent is called when sending successfully a point to the intake.
+type PointSuccessfullySent interface {
+	OnPointSuccessfullySent(int)
 }
 
 // NewWorker returns a new worker to consume Transaction from inputChan
@@ -44,16 +50,18 @@ func NewWorker(
 	highPrioChan <-chan transaction.Transaction,
 	lowPrioChan <-chan transaction.Transaction,
 	requeueChan chan<- transaction.Transaction,
-	blocked *blockedEndpoints) *Worker {
+	blocked *blockedEndpoints,
+	pointSuccessfullySent PointSuccessfullySent) *Worker {
 	return &Worker{
-		HighPrio:            highPrioChan,
-		LowPrio:             lowPrioChan,
-		RequeueChan:         requeueChan,
-		resetConnectionChan: make(chan struct{}, 1),
-		stopChan:            make(chan struct{}),
-		stopped:             make(chan struct{}),
-		Client:              NewHTTPClient(),
-		blockedList:         blocked,
+		HighPrio:              highPrioChan,
+		LowPrio:               lowPrioChan,
+		RequeueChan:           requeueChan,
+		resetConnectionChan:   make(chan struct{}, 1),
+		stopChan:              make(chan struct{}),
+		stopped:               make(chan struct{}),
+		Client:                NewHTTPClient(),
+		blockedList:           blocked,
+		pointSuccessfullySent: pointSuccessfullySent,
 	}
 }
 
@@ -183,6 +191,7 @@ func (w *Worker) process(ctx context.Context, t transaction.Transaction) {
 		requeue()
 		log.Errorf("Error while processing transaction: %v", err)
 	} else {
+		w.pointSuccessfullySent.OnPointSuccessfullySent(t.GetPointCount())
 		w.blockedList.recover(target)
 	}
 }

--- a/pkg/forwarder/worker_test.go
+++ b/pkg/forwarder/worker_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/atomic"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/forwarder/transaction"
@@ -73,7 +74,7 @@ func TestWorkerStart(t *testing.T) {
 	mock2.AssertExpectations(t)
 	mock2.AssertNumberOfCalls(t, "Process", 1)
 
-	assert.Equal(t, mock.pointCount+mock2.pointCount, sender.count)
+	assert.Equal(t, int64(mock.pointCount+mock2.pointCount), sender.count.Load())
 	w.Stop(false)
 }
 
@@ -196,9 +197,9 @@ func TestWorkerPurgeOnStop(t *testing.T) {
 }
 
 type PointSuccessfullySentMock struct {
-	count int
+	count atomic.Int64
 }
 
 func (m *PointSuccessfullySentMock) OnPointSuccessfullySent(count int) {
-	m.count += count
+	m.count.Add(int64(count))
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This PR sends the metric `datadog.agent.point.sent`  that counts the number of points successfully sent to the intake.
This is a followup of https://github.com/DataDog/datadog-agent/pull/14183 in order to compute the percentage of points dropped.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

Reviewing commit by commit is strongly recommended.

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
- Write a local proxy that rejects the first 20 payloads but accept all payloads sent to `/api/beta/sketches`.
- Setup the Agent to use this local proxy by setting `dd_url`. Make sure `forwarder_retry_queue_payloads_max_size` is set to the default value.
- Write an application that sents a distribution metric with 1000 unique contextes using DogStatsD.
- Check that the value of `datadog.agent.point.sent` is 1000 for a few points in time before increasing.

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
