### PR TITLE
[config] FIPS: adding a couple more config fields to the FIPS feature

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1544,7 +1544,6 @@ func setupFipsEndpoints(config Config) error {
 	protocol := "http://"
 	if config.GetBool("fips.https") {
 		protocol = "https://"
-		// top-level setting override precedence
 		config.Set("skip_ssl_validation", !config.GetBool("fips.tls_verify"))
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1544,10 +1544,8 @@ func setupFipsEndpoints(config Config) error {
 	protocol := "http://"
 	if config.GetBool("fips.https") {
 		protocol = "https://"
-		// top-level setting takes precedence
-		if config.GetBool("skip_ssl_validation") {
-			config.Set("skip_ssl_validation", !config.GetBool("fips.tls_verify"))
-		}
+		// top-level setting override precedence
+		config.Set("skip_ssl_validation", !config.GetBool("fips.tls_verify"))
 	}
 
 	// The following overwrites should be sync with the documentation for the fips.enabled config setting in the

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1567,6 +1567,9 @@ func setupFipsEndpoints(config Config) error {
 	// Logs
 	config.Set("logs_config.use_http", true)
 	config.Set("logs_config.logs_no_ssl", true)
+	if config.GetBool("fips.https") {
+		config.Set("logs_config.logs_no_ssl", false)
+	}
 	config.Set("logs_config.logs_dd_url", urlFor(logs))
 
 	// Database monitoring

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1541,15 +1541,13 @@ func setupFipsEndpoints(config Config) error {
 	os.Unsetenv("HTTPS_PROXY")
 
 	// HTTP for now, will soon be updated to HTTPS
-	var protocol string
+	protocol := "http://"
 	if config.GetBool("fips.https") {
 		protocol = "https://"
 		// top-level setting takes precedence
 		if config.GetBool("skip_ssl_validation") {
 			config.Set("skip_ssl_validation", !config.GetBool("fips.tls_verify"))
 		}
-	} else {
-		protocol = "http://"
 	}
 
 	// The following overwrites should be sync with the documentation for the fips.enabled config setting in the

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -281,6 +281,8 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("fips.enabled", false)
 	config.BindEnvAndSetDefault("fips.port_range_start", 3833)
 	config.BindEnvAndSetDefault("fips.local_address", "localhost")
+	config.BindEnvAndSetDefault("fips.https", true)
+	config.BindEnvAndSetDefault("fips.tls_verify", true)
 
 	// Remote config
 	config.BindEnvAndSetDefault("remote_configuration.enabled", false)
@@ -1539,7 +1541,16 @@ func setupFipsEndpoints(config Config) error {
 	os.Unsetenv("HTTPS_PROXY")
 
 	// HTTP for now, will soon be updated to HTTPS
-	protocol := "http://"
+	var protocol string
+	if config.GetBool("fips.https") {
+		protocol = "https://"
+		// top-level setting takes precedence
+		if config.GetBool("skip_ssl_validation") {
+			config.Set("skip_ssl_validation", !config.GetBool("fips.tls_verify"))
+		}
+	} else {
+		protocol = "http://"
+	}
 
 	// The following overwrites should be sync with the documentation for the fips.enabled config setting in the
 	// config_template.yaml

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1216,7 +1216,7 @@ fips:
 
 	assertFipsProxyExpectedConfig(t, expectedHTTPURL, expectedURL, true, testConfig)
 	assert.Equal(t, true, testConfig.GetBool("logs_config.use_http"))
-	assert.Equal(t, true, testConfig.GetBool("logs_config.logs_no_ssl"))
+	assert.Equal(t, false, testConfig.GetBool("logs_config.logs_no_ssl"))
 	assert.Equal(t, true, testConfig.GetBool("skip_ssl_validation"))
 	assert.Nil(t, GetProxies())
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1210,6 +1210,7 @@ fips:
 
 	expectedHTTPURL = "https://" + expectedURL
 	testConfig = setupConfFromYAML(datadogYamlFips)
+	testConfig.Set("skip_ssl_validation", false) // should be overridden by fips.tls_verify
 	LoadProxyFromEnv(testConfig)
 	err = setupFipsEndpoints(testConfig)
 	require.NoError(t, err)
@@ -1220,8 +1221,7 @@ fips:
 	assert.Equal(t, true, testConfig.GetBool("skip_ssl_validation"))
 	assert.Nil(t, GetProxies())
 
-	// override to check consistent TLS validation
-	testConfig.Set("skip_ssl_validation", true)
+	testConfig.Set("skip_ssl_validation", true) // should be overridden by fips.tls_verify
 	testConfig.Set("fips.tls_verify", true)
 	LoadProxyFromEnv(testConfig)
 	err = setupFipsEndpoints(testConfig)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1133,6 +1133,8 @@ func TestSetupFipsEndpoints(t *testing.T) {
 	datadogYaml := `
 dd_url: https://somehost:1234
 
+skip_ssl_validation: true
+
 apm_config:
   apm_dd_url: https://somehost:1234
   profiling_dd_url: https://somehost:1234
@@ -1170,49 +1172,89 @@ proxy:
 	err := setupFipsEndpoints(testConfig)
 	require.NoError(t, err)
 
-	assert.Equal(t, expectedHTTPURL, testConfig.GetString("dd_url"))
-	assert.Equal(t, expectedHTTPURL, testConfig.GetString("apm_config.apm_dd_url"))
-	assert.Equal(t, expectedHTTPURL, testConfig.GetString("apm_config.profiling_dd_url"))
-	assert.Equal(t, expectedHTTPURL, testConfig.GetString("apm_config.telemetry.dd_url"))
-	assert.Equal(t, expectedHTTPURL, testConfig.GetString("process_config.process_dd_url"))
+	assertFipsProxyExpectedConfig(t, expectedHTTPURL, expectedURL, false, testConfig)
 	assert.Equal(t, false, testConfig.GetBool("logs_config.use_http"))
 	assert.Equal(t, false, testConfig.GetBool("logs_config.logs_no_ssl"))
-	assert.Equal(t, expectedURL, testConfig.GetString("logs_config.logs_dd_url"))
-	assert.Equal(t, expectedURL, testConfig.GetString("database_monitoring.metrics.dd_url"))
-	assert.Equal(t, expectedURL, testConfig.GetString("database_monitoring.activity.dd_url"))
-	assert.Equal(t, expectedURL, testConfig.GetString("database_monitoring.samples.dd_url"))
-	assert.Equal(t, expectedURL, testConfig.GetString("network_devices.metadata.dd_url"))
 	assert.NotNil(t, GetProxies())
 	// reseting proxies
 	proxies = nil
 
-	datadogYaml += `
+	datadogYamlFips := datadogYaml + `
 fips:
   enabled: true
   local_address: localhost
   port_range_start: 5000
+  https: false
 `
 
 	expectedURL = "localhost:50"
 	expectedHTTPURL = "http://" + expectedURL
-	testConfig = setupConfFromYAML(datadogYaml)
+	testConfig = setupConfFromYAML(datadogYamlFips)
 	LoadProxyFromEnv(testConfig)
 	err = setupFipsEndpoints(testConfig)
 	require.NoError(t, err)
 
-	assert.Equal(t, expectedHTTPURL+"01", testConfig.GetString("dd_url"))
-	assert.Equal(t, expectedHTTPURL+"02", testConfig.GetString("apm_config.apm_dd_url"))
-	assert.Equal(t, expectedHTTPURL+"03", testConfig.GetString("apm_config.profiling_dd_url"))
-	assert.Equal(t, expectedHTTPURL+"10", testConfig.GetString("apm_config.telemetry.dd_url"))
-	assert.Equal(t, expectedHTTPURL+"04", testConfig.GetString("process_config.process_dd_url"))
+	assertFipsProxyExpectedConfig(t, expectedHTTPURL, expectedURL, true, testConfig)
 	assert.Equal(t, true, testConfig.GetBool("logs_config.use_http"))
 	assert.Equal(t, true, testConfig.GetBool("logs_config.logs_no_ssl"))
-	assert.Equal(t, expectedURL+"05", testConfig.GetString("logs_config.logs_dd_url"))
-	assert.Equal(t, expectedURL+"06", testConfig.GetString("database_monitoring.metrics.dd_url"))
-	assert.Equal(t, expectedURL+"06", testConfig.GetString("database_monitoring.activity.dd_url"))
-	assert.Equal(t, expectedURL+"07", testConfig.GetString("database_monitoring.samples.dd_url"))
-	assert.Equal(t, expectedURL+"08", testConfig.GetString("network_devices.metadata.dd_url"))
 	assert.Nil(t, GetProxies())
+
+	datadogYamlFips = datadogYaml + `
+fips:
+  enabled: true
+  local_address: localhost
+  port_range_start: 5000
+  https: true
+  tls_verify: false
+`
+
+	expectedHTTPURL = "https://" + expectedURL
+	testConfig = setupConfFromYAML(datadogYamlFips)
+	LoadProxyFromEnv(testConfig)
+	err = setupFipsEndpoints(testConfig)
+	require.NoError(t, err)
+
+	assertFipsProxyExpectedConfig(t, expectedHTTPURL, expectedURL, true, testConfig)
+	assert.Equal(t, true, testConfig.GetBool("logs_config.use_http"))
+	assert.Equal(t, true, testConfig.GetBool("logs_config.logs_no_ssl"))
+	assert.Equal(t, true, testConfig.GetBool("skip_ssl_validation"))
+	assert.Nil(t, GetProxies())
+
+	// override to check consistent TLS validation
+	testConfig.Set("skip_ssl_validation", true)
+	testConfig.Set("fips.tls_verify", true)
+	LoadProxyFromEnv(testConfig)
+	err = setupFipsEndpoints(testConfig)
+	require.NoError(t, err)
+
+	assert.Equal(t, false, testConfig.GetBool("skip_ssl_validation"))
+	assert.Nil(t, GetProxies())
+}
+
+func assertFipsProxyExpectedConfig(t *testing.T, expectedBaseHTTPURL, expectedBaseURL string, rng bool, c Config) {
+	if rng {
+		assert.Equal(t, expectedBaseHTTPURL+"01", c.GetString("dd_url"))
+		assert.Equal(t, expectedBaseHTTPURL+"02", c.GetString("apm_config.apm_dd_url"))
+		assert.Equal(t, expectedBaseHTTPURL+"03", c.GetString("apm_config.profiling_dd_url"))
+		assert.Equal(t, expectedBaseHTTPURL+"10", c.GetString("apm_config.telemetry.dd_url"))
+		assert.Equal(t, expectedBaseHTTPURL+"04", c.GetString("process_config.process_dd_url"))
+		assert.Equal(t, expectedBaseURL+"05", c.GetString("logs_config.logs_dd_url"))
+		assert.Equal(t, expectedBaseURL+"06", c.GetString("database_monitoring.metrics.dd_url"))
+		assert.Equal(t, expectedBaseURL+"06", c.GetString("database_monitoring.activity.dd_url"))
+		assert.Equal(t, expectedBaseURL+"07", c.GetString("database_monitoring.samples.dd_url"))
+		assert.Equal(t, expectedBaseURL+"08", c.GetString("network_devices.metadata.dd_url"))
+	} else {
+		assert.Equal(t, expectedBaseHTTPURL, c.GetString("dd_url"))
+		assert.Equal(t, expectedBaseHTTPURL, c.GetString("apm_config.apm_dd_url"))
+		assert.Equal(t, expectedBaseHTTPURL, c.GetString("apm_config.profiling_dd_url"))
+		assert.Equal(t, expectedBaseHTTPURL, c.GetString("apm_config.telemetry.dd_url"))
+		assert.Equal(t, expectedBaseHTTPURL, c.GetString("process_config.process_dd_url"))
+		assert.Equal(t, expectedBaseURL, c.GetString("logs_config.logs_dd_url"))
+		assert.Equal(t, expectedBaseURL, c.GetString("database_monitoring.metrics.dd_url"))
+		assert.Equal(t, expectedBaseURL, c.GetString("database_monitoring.activity.dd_url"))
+		assert.Equal(t, expectedBaseURL, c.GetString("database_monitoring.samples.dd_url"))
+		assert.Equal(t, expectedBaseURL, c.GetString("network_devices.metadata.dd_url"))
+	}
 }
 
 func TestSetupFipsEndpointsNonLocalAddress(t *testing.T) {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR simply adds a couple more options to the FIPS config section:
```
fips:
   ...
   https: true/false
   tls_verify: true/false
```

Please note that the top level `skip_ssl_validation` option takes precedence. We can maybe debate if that should be the
case or if an explicit setting here is *more* significant and should override any prior setting. In any case, this enforces validation if either option is set to true, which seems like the desirable outcome.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Future support; desirable feature for the future of FIPS.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

None AFAICT

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

You will need an intermediate HAproxy setup with TLS enabled on the frontend. Setting `https` to true should allow comms to succeed and allow the payloads to go through the proxy. If using self-signed certificates, you will also need to set `tls_verify` to false as otherwise certificate verification will prevent the transactions from suceeding.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
