### PR TITLE
Add comp/core/stopper

### DIFF
--- a/cmd/agent/api/internal/agent/agent.go
+++ b/cmd/agent/api/internal/agent/agent.go
@@ -86,7 +86,7 @@ func setJSONError(w http.ResponseWriter, err error, errorCode int) {
 }
 
 func stopAgent(w http.ResponseWriter, r *http.Request) {
-	signals.Stopper <- true
+	signals.Stop(nil)
 	w.Header().Set("Content-Type", "application/json")
 	j, _ := json.Marshal("")
 	w.Write(j)

--- a/cmd/agent/common/common_darwin.go
+++ b/cmd/agent/common/common_darwin.go
@@ -10,8 +10,6 @@ import (
 )
 
 const (
-	// DefaultConfPath points to the folder containing datadog.yaml
-	DefaultConfPath = "/opt/datadog-agent/etc"
 	// DefaultLogFile points to the log file that will be used if not configured
 	DefaultLogFile = "/opt/datadog-agent/logs/agent.log"
 	// DefaultDCALogFile points to the log file that will be used if not configured

--- a/cmd/agent/common/common_freebsd.go
+++ b/cmd/agent/common/common_freebsd.go
@@ -10,8 +10,6 @@ import (
 )
 
 const (
-	// DefaultConfPath points to the folder containing datadog.yaml
-	DefaultConfPath = "/usr/local/etc/datadog-agent"
 	// DefaultLogFile points to the log file that will be used if not configured
 	DefaultLogFile = "/var/log/datadog/agent.log"
 	// DefaultDCALogFile points to the log file that will be used if not configured

--- a/cmd/agent/common/common_nix.go
+++ b/cmd/agent/common/common_nix.go
@@ -13,8 +13,6 @@ import (
 )
 
 const (
-	// DefaultConfPath points to the folder containing datadog.yaml
-	DefaultConfPath = "/etc/datadog-agent"
 	// DefaultLogFile points to the log file that will be used if not configured
 	DefaultLogFile = "/var/log/datadog/agent.log"
 	// DefaultDCALogFile points to the log file that will be used if not configured

--- a/cmd/agent/common/common_windows.go
+++ b/cmd/agent/common/common_windows.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 
+	coreConfig "github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/winutil"
@@ -31,8 +32,6 @@ var (
 )
 
 var (
-	// DefaultConfPath points to the folder containing datadog.yaml
-	DefaultConfPath = "c:\\programdata\\datadog"
 	// DefaultLogFile points to the log file that will be used if not configured
 	DefaultLogFile = "c:\\programdata\\datadog\\logs\\agent.log"
 	// DefaultDCALogFile points to the log file that will be used if not configured
@@ -48,11 +47,8 @@ var (
 func init() {
 	pd, err := winutil.GetProgramDataDir()
 	if err == nil {
-		DefaultConfPath = pd
 		DefaultLogFile = filepath.Join(pd, "logs", "agent.log")
 		DefaultDCALogFile = filepath.Join(pd, "logs", "cluster-agent.log")
-	} else {
-		winutil.LogEventViewer(config.ServiceName, 0x8000000F, DefaultConfPath)
 	}
 }
 
@@ -118,12 +114,12 @@ func GetViewsPath() string {
 // CheckAndUpgradeConfig checks to see if there's an old datadog.conf, and if
 // datadog.yaml is either missing or incomplete (no API key).  If so, upgrade it
 func CheckAndUpgradeConfig() error {
-	datadogConfPath := filepath.Join(DefaultConfPath, "datadog.conf")
+	datadogConfPath := filepath.Join(coreConfig.DefaultConfPath, "datadog.conf")
 	if _, err := os.Stat(datadogConfPath); os.IsNotExist(err) {
 		log.Debug("Previous config file not found, not upgrading")
 		return nil
 	}
-	config.Datadog.AddConfigPath(DefaultConfPath)
+	config.Datadog.AddConfigPath(coreConfig.DefaultConfPath)
 	_, err := config.Load()
 	if err == nil {
 		// was able to read config, check for api key
@@ -132,5 +128,5 @@ func CheckAndUpgradeConfig() error {
 			return nil
 		}
 	}
-	return ImportConfig(DefaultConfPath, DefaultConfPath, false)
+	return ImportConfig(coreConfig.DefaultConfPath, coreConfig.DefaultConfPath, false)
 }

--- a/cmd/agent/common/helpers.go
+++ b/cmd/agent/common/helpers.go
@@ -12,6 +12,7 @@ import (
 	"runtime"
 	"strings"
 
+	coreConfig "github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/config/settings"
@@ -59,7 +60,7 @@ func setupConfig(confFilePath string, configName string, withoutSecrets bool, fa
 			config.Datadog.SetConfigFile(confFilePath)
 		}
 	}
-	config.Datadog.AddConfigPath(DefaultConfPath)
+	config.Datadog.AddConfigPath(coreConfig.DefaultConfPath)
 	// load the configuration
 	var err error
 	var warnings *config.Warnings

--- a/cmd/cluster-agent/api/agent/agent.go
+++ b/cmd/cluster-agent/api/agent/agent.go
@@ -82,7 +82,7 @@ func getHealth(w http.ResponseWriter, r *http.Request) {
 }
 
 func stopAgent(w http.ResponseWriter, r *http.Request) {
-	signals.Stopper <- true
+	signals.Stop(nil)
 	w.Header().Set("Content-Type", "application/json")
 	j, _ := json.Marshal("")
 	w.Write(j)

--- a/cmd/security-agent/api/agent/agent.go
+++ b/cmd/security-agent/api/agent/agent.go
@@ -56,7 +56,7 @@ func (a *Agent) SetupHandlers(r *mux.Router) {
 }
 
 func (a *Agent) stopAgent(w http.ResponseWriter, r *http.Request) {
-	signals.Stopper <- true
+	signals.Stop(nil)
 	w.Header().Set("Content-Type", "application/json")
 	j, err := json.Marshal("")
 	if err != nil {

--- a/cmd/security-agent/app/app.go
+++ b/cmd/security-agent/app/app.go
@@ -25,7 +25,6 @@ import (
 
 	ddgostatsd "github.com/DataDog/datadog-go/v5/statsd"
 
-	commonagent "github.com/DataDog/datadog-agent/cmd/agent/common"
 	"github.com/DataDog/datadog-agent/cmd/manager"
 	"github.com/DataDog/datadog-agent/cmd/security-agent/api"
 	"github.com/DataDog/datadog-agent/cmd/security-agent/app/common"
@@ -84,8 +83,8 @@ Datadog Security Agent takes care of running compliance and security checks.`,
 	}
 
 	defaultConfPathArray := []string{
-		path.Join(commonagent.DefaultConfPath, "datadog.yaml"),
-		path.Join(commonagent.DefaultConfPath, "security-agent.yaml"),
+		path.Join(compconfig.DefaultConfPath, "datadog.yaml"),
+		path.Join(compconfig.DefaultConfPath, "security-agent.yaml"),
 	}
 	SecurityAgentCmd.PersistentFlags().StringArrayVarP(&globalParams.ConfPathArray, "cfgpath", "c", defaultConfPathArray, "path to a yaml configuration file")
 	SecurityAgentCmd.PersistentFlags().BoolVarP(&flagNoColor, "no-color", "n", false, "disable color output")

--- a/comp/README.md
+++ b/comp/README.md
@@ -23,4 +23,6 @@ Package log implements a component to handle logging internal to the agent.
 ### [comp/core/stopper](https://pkg.go.dev/github.com/DataDog/dd-agent-comp-experiments/comp/core/stopper)
 
 Package stopper implements a component that will shutdown a running Fx App
-on receipt of SIGINT or SIGTERM or of an explicit stop signal.
+on receipt of SIGINT or SIGTERM or of an explicit stop signal.  Note that
+this will only work with apps (fxutil.Run) and not with one-shot commands
+(fxutil.OneShot).

--- a/comp/README.md
+++ b/comp/README.md
@@ -19,3 +19,8 @@ component temporarily wraps pkg/config.
 ### [comp/core/log](https://pkg.go.dev/github.com/DataDog/dd-agent-comp-experiments/comp/core/log)
 
 Package log implements a component to handle logging internal to the agent.
+
+### [comp/core/stopper](https://pkg.go.dev/github.com/DataDog/dd-agent-comp-experiments/comp/core/stopper)
+
+Package stopper implements a component that will shutdown a running Fx App
+on receipt of SIGINT or SIGTERM or of an explicit stop signal.

--- a/comp/core/bundle.go
+++ b/comp/core/bundle.go
@@ -16,6 +16,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/internal"
 	"github.com/DataDog/datadog-agent/comp/core/log"
+	"github.com/DataDog/datadog-agent/comp/core/stopper"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
@@ -28,10 +29,12 @@ type BundleParams = internal.BundleParams
 var Bundle = fxutil.Bundle(
 	config.Module,
 	log.Module,
+	stopper.Module,
 )
 
 // MockBundle defines the mock fx options for this bundle.
 var MockBundle = fxutil.Bundle(
 	config.MockModule,
 	log.Module,
+	stopper.Module,
 )

--- a/comp/core/config/setup.go
+++ b/comp/core/config/setup.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/DataDog/viper"
 
-	"github.com/DataDog/datadog-agent/cmd/agent/common"
 	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
@@ -42,7 +41,7 @@ func setupConfig(
 	}
 	if useDefaultConfigPath {
 		if len(defaultConfPath) == 0 {
-			defaultConfPath = common.DefaultConfPath
+			defaultConfPath = DefaultConfPath
 		}
 		config.Datadog.AddConfigPath(defaultConfPath)
 	}

--- a/comp/core/config/setup_darwin.go
+++ b/comp/core/config/setup_darwin.go
@@ -1,0 +1,9 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package config
+
+// DefaultConfPath points to the folder containing datadog.yaml
+const DefaultConfPath = "/opt/datadog-agent/etc"

--- a/comp/core/config/setup_freebsd.go
+++ b/comp/core/config/setup_freebsd.go
@@ -1,0 +1,9 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package config
+
+// DefaultConfPath points to the folder containing datadog.yaml
+const DefaultConfPath = "/usr/local/etc/datadog-agent"

--- a/comp/core/config/setup_nix.go
+++ b/comp/core/config/setup_nix.go
@@ -1,0 +1,12 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build netbsd || openbsd || solaris || dragonfly || linux
+// +build netbsd openbsd solaris dragonfly linux
+
+package config
+
+// DefaultConfPath points to the folder containing datadog.yaml
+const DefaultConfPath = "/etc/datadog-agent"

--- a/comp/core/config/setup_windows.go
+++ b/comp/core/config/setup_windows.go
@@ -1,0 +1,22 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package config
+
+import "github.com/DataDog/datadog-agent/pkg/util/winutil"
+
+// DefaultConfPath points to the folder containing datadog.yaml
+var DefaultConfPath = "c:\\programdata\\datadog"
+
+func init() {
+	pd, err := winutil.GetProgramDataDir()
+	if err == nil {
+		DefaultConfPath = pd
+	} else {
+		// log a message to the Windows event viewer indicating this error
+		// occurred.
+		winutil.LogEventViewer(config.ServiceName, 0x8000000F, DefaultConfPath)
+	}
+}

--- a/comp/core/config/setup_windows.go
+++ b/comp/core/config/setup_windows.go
@@ -5,7 +5,10 @@
 
 package config
 
-import "github.com/DataDog/datadog-agent/pkg/util/winutil"
+import (
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/winutil"
+)
 
 // DefaultConfPath points to the folder containing datadog.yaml
 var DefaultConfPath = "c:\\programdata\\datadog"

--- a/comp/core/internal/params.go
+++ b/comp/core/internal/params.go
@@ -85,6 +85,15 @@ type BundleParams struct {
 	// LogFormatJSONFn returns a boolean determining whether logs should be
 	// written in JSON format.
 	LogFormatJSONFn func(configGetter) bool
+
+	// StopOnSignals determines whether the Fx app should be stopped (via
+	// fx.Shutdowner) on SIGINT or SIGTERM, via the comp/core/stopper component.
+	StopOnSignals bool
+
+	// StopErrorP points to an error value.  When comp/core/stopper stops the
+	// app, if this pointer is not nil then its referent will be set with the
+	// reason for the stop.
+	StopErrorP *error
 }
 
 // configGetter is a subset of the comp/core/config component, able to get

--- a/comp/core/stopper/component.go
+++ b/comp/core/stopper/component.go
@@ -1,0 +1,46 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package stopper implements a component that will shutdown a running Fx App
+// on receipt of SIGINT or SIGTERM or of an explicit stop signal.  Note that
+// this will only work with apps (fxutil.Run) and not with one-shot commands
+// (fxutil.OneShot).
+//
+// During the componentization process, this component also interfaces with
+// cmd/agent/common/signals.
+//
+// This component is not automatically instantiated.  Any apps using `fxutil.Run`
+// should instantiate the component to get the expected stopping behavior.  This
+// decision may be revisited once cmd/agent/common/signals is removed, at which
+// time there is no harm in always instantiating this component.
+//
+// The component registers for signals if BundlParams#StopOnSignals is true. In
+// this case, it also ignores SIGPIPE.
+package stopper
+
+import (
+	"go.uber.org/fx"
+)
+
+// team: agent-shared-components
+
+const componentName = "comp/core/stopper"
+
+// Component is the component type.
+type Component interface {
+	// Stop causes the running app to stop, asynchronously.  If the error is
+	// nil, then it is a "normal" stop; otherwise, it finishes with the error.
+	//
+	// This call is asynchronous, and will return immediately with app shutdown
+	// beginning in another goroutine.
+	Stop(error)
+}
+
+// Module defines the fx options for this component.
+var Module fx.Option = fx.Module(
+	componentName,
+
+	fx.Provide(newStopper),
+)

--- a/comp/core/stopper/stopper.go
+++ b/comp/core/stopper/stopper.go
@@ -1,0 +1,114 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package stopper
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+
+	"go.uber.org/fx"
+
+	"github.com/DataDog/datadog-agent/comp/core/internal"
+	"github.com/DataDog/datadog-agent/comp/core/log"
+)
+
+// RunningInstance is the running instance of this component, if any.
+//
+// This is a temporary workaround to allow this module to cooperate with
+// cmd/agent/common/signals.
+var RunningInstance Component
+
+type stopper struct {
+	log        log.Component
+	shutdowner fx.Shutdowner
+
+	// stopOnSignals determines whether to stop on SIGINT and SIGTERM.
+	stopOnSignals bool
+
+	// stopErrorP is the location to which the stop error should be written.
+	stopErrorP *error
+
+	// stopCh carries a single message which leads to the App stopping.
+	stopCh chan error
+}
+
+func newStopper(log log.Component, shutdowner fx.Shutdowner, bundleParams internal.BundleParams) Component {
+	st := &stopper{
+		log:           log,
+		shutdowner:    shutdowner,
+		stopOnSignals: bundleParams.StopOnSignals,
+		stopErrorP:    bundleParams.StopErrorP,
+		stopCh:        make(chan error, 1),
+	}
+
+	// This component starts immediately, so that shutdown signals can be
+	// handled without waiting for Fx startup to complete.
+
+	go st.wait()
+
+	RunningInstance = st
+
+	return st
+}
+
+// Stop implements Component#Stop.
+func (st *stopper) Stop(err error) {
+	if err != nil {
+		_ = st.log.Critical("The Agent has encountered an error, shutting down...")
+	} else {
+		st.log.Info("Received stop command, shutting down...")
+	}
+	// a non-blocking send allows this to be resilient to multiple Stop calls
+	select {
+	case st.stopCh <- err:
+	default:
+	}
+}
+
+// wait runs in a dedicated goroutine and waits for a reason to stop.
+func (st *stopper) wait() {
+	signalCh := make(chan os.Signal, 1)
+	sigpipeCh := make(chan os.Signal, 1)
+
+	if st.stopOnSignals {
+		// catch OS interrupt and term signals and report them via signalCh
+		signal.Notify(signalCh, os.Interrupt, syscall.SIGTERM)
+
+		// By default systemd redirects the stdout to journald. When journald
+		// is stopped or crashes we receive a SIGPIPE signal.  Go ignores
+		// SIGPIPE signals unless it is when stdout or stdout is closed, in
+		// this case the agent is stopped.  We never want the agent to stop
+		// upon receiving SIGPIPE, so we intercept the SIGPIPE signals and just
+		// discard them below.
+		signal.Notify(sigpipeCh, syscall.SIGPIPE)
+	}
+
+	defer func() { RunningInstance = nil }()
+
+	shutdown := func() {
+		err := st.shutdowner.Shutdown()
+		if err != nil {
+			st.log.Errorf("Error trying to shut down application: %s", err)
+		}
+	}
+
+	for {
+		select {
+		case sig := <-signalCh:
+			st.log.Infof("Received signal '%s', shutting down...", sig)
+			shutdown()
+			return
+		case err := <-st.stopCh:
+			if st.stopErrorP != nil {
+				*st.stopErrorP = err
+			}
+			shutdown()
+			return
+		case <-sigpipeCh: // ignore SIGPIPE
+		}
+	}
+}

--- a/comp/core/stopper/stopper_test.go
+++ b/comp/core/stopper/stopper_test.go
@@ -1,0 +1,51 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package stopper
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"go.uber.org/fx"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/comp/core/internal"
+	"github.com/DataDog/datadog-agent/comp/core/log"
+)
+
+// Note that we do not test catching signals, since that affects global state
+// (process signals)
+
+func TestStopper(t *testing.T) {
+	var stopper Component
+	var gotErr error
+	app := fx.New(
+		fx.Supply(fx.Annotate(t, fx.As(new(testing.TB)))),
+		fx.Supply(internal.BundleParams{StopErrorP: &gotErr}),
+		log.MockModule,
+		Module,
+		fx.Populate(&stopper),
+	)
+
+	startCtx, cancel := context.WithTimeout(context.Background(), app.StartTimeout())
+	defer cancel()
+
+	require.NoError(t, app.Start(startCtx))
+
+	select {
+	case <-app.Done():
+		t.Fatal("app should not have stopped yet")
+	default:
+	}
+
+	stopper.Stop(errors.New("uhoh"))
+
+	<-app.Done()
+
+	require.ErrorContains(t, gotErr, "uhoh")
+}

--- a/pkg/metadata/scheduler.go
+++ b/pkg/metadata/scheduler.go
@@ -149,8 +149,7 @@ func (c *Scheduler) TriggerAndResetCollectorTimer(name string, delay time.Durati
 func (c *Scheduler) firstRun() error {
 	p, found := catalog["host"]
 	if !found {
-		log.Error("Unable to find 'host' metadata collector in the catalog!")
-		signals.ErrorStopper <- true
+		signals.Stop(log.Error("Unable to find 'host' metadata collector in the catalog!"))
 	}
 	return p.Send(context.TODO(), c.demux.Serializer())
 }


### PR DESCRIPTION
### What does this PR do?

This adds a component that can be used to stop a running app when that's required.  There are three ways an agent can be stopped:
 * signals
 * API request (`agent stop` or via GUI)
 * windows service shutdown

The latter is not handled by this component, but that can be added later.

### Motivation

This is preliminary to making the core agent an actual app (with `fxutil.Run`).  At the moment, nothing uses `fxutil.Run` and thus nothing instantiates this component.  

### Additional Notes

The first commit here moves DefaultConfPath from cmd/agent to comp/core/config.  This is required to avoid package import cycles -- and generally we should avoid importing anything in cmd/ from outside of that tree.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Unused, so nothing to test.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
