### PR TITLE
[Windows][system probe] Reduce log verbosity

### DIFF
--- a/pkg/network/etw/etw-http-service.go
+++ b/pkg/network/etw/etw-http-service.go
@@ -1124,19 +1124,19 @@ func etwHttpServiceSummary() {
 	lastSummaryTime = time.Now()
 	summaryCount++
 
-	log.Infof("=====================\n")
-	log.Infof("  SUMMARY #%v\n", summaryCount)
-	log.Infof("=====================\n")
-	log.Infof("  Pid:                      %v\n", os.Getpid())
-	log.Infof("  Conn map:                 %v\n", len(connOpened))
-	log.Infof("  Req/Resp map:             %v\n", len(http2openConn))
-	log.Infof("  Cache map:                %v\n", len(httpCache))
-	log.Infof("  All Events(not handled):  %v(%v)\n", formatUInt(eventCount), formatUInt(notHandledEventsCount))
-	log.Infof("  Requests(cached):         %v(%v)\n", formatUInt(completedRequestCount), formatUInt(servedFromCache))
-	log.Infof("  Missed Conn:              %v\n", formatUInt(missedConnectionCount))
-	log.Infof("  Parsing Error:            %v\n", formatUInt(parsingErrorCount))
-	log.Infof("  ETW Bytes Total(Payload): %v(%v)\n", bytesFormat(transferedETWBytesTotal), bytesFormat(transferedETWBytesPayload))
-	log.Infof("  Dropped Tx (Limit):       %v(%v)\n", completedHttpTxDropped, completedHttpTxMaxCount)
+	log.Debugf("=====================\n")
+	log.Debugf("  SUMMARY #%v\n", summaryCount)
+	log.Debugf("=====================\n")
+	log.Debugf("  Pid:                      %v\n", os.Getpid())
+	log.Debugf("  Conn map:                 %v\n", len(connOpened))
+	log.Debugf("  Req/Resp map:             %v\n", len(http2openConn))
+	log.Debugf("  Cache map:                %v\n", len(httpCache))
+	log.Debugf("  All Events(not handled):  %v(%v)\n", formatUInt(eventCount), formatUInt(notHandledEventsCount))
+	log.Debugf("  Requests(cached):         %v(%v)\n", formatUInt(completedRequestCount), formatUInt(servedFromCache))
+	log.Debugf("  Missed Conn:              %v\n", formatUInt(missedConnectionCount))
+	log.Debugf("  Parsing Error:            %v\n", formatUInt(parsingErrorCount))
+	log.Debugf("  ETW Bytes Total(Payload): %v(%v)\n", bytesFormat(transferedETWBytesTotal), bytesFormat(transferedETWBytesPayload))
+	log.Debugf("  Dropped Tx (Limit):       %v(%v)\n", completedHttpTxDropped, completedHttpTxMaxCount)
 
 	/*
 		* dbtodo


### PR DESCRIPTION
During testing, noticed that system probe is emitting at info level information that's more suited to debug.

### What does this PR do?

Changes log level of ETW output to debug
### Motivation

Reducing noise in info level logs

### Additional Notes


### Possible Drawbacks / Trade-offs


### Describe how to test/QA your changes


### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
