### PR TITLE
[gitlab] Build Agent 7 ARM images on dev branches

### DIFF
--- a/.gitlab/container_build/docker_linux.yml
+++ b/.gitlab/container_build/docker_linux.yml
@@ -130,7 +130,7 @@ docker_build_agent7:
 docker_build_agent7_arm64:
   extends: .docker_build_job_definition_arm64
   rules:
-    !reference [.on_all_builds_a7]
+    !reference [.on_a7]
   needs:
     - job: agent_deb-arm64-a7
       artifacts: false
@@ -159,7 +159,7 @@ docker_build_agent7_jmx:
 docker_build_agent7_jmx_arm64:
   extends: .docker_build_job_definition_arm64
   rules:
-    !reference [.on_all_builds_a7]
+    !reference [.on_a7]
   needs:
     - job: agent_deb-arm64-a7
       artifacts: false

--- a/.gitlab/dev_container_deploy/docker_linux.yml
+++ b/.gitlab/dev_container_deploy/docker_linux.yml
@@ -38,23 +38,6 @@ dev_branch-dogstatsd:
     IMG_SOURCES: ${SRC_DSD}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-amd64,${SRC_DSD}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-arm64
     IMG_DESTINATIONS: dogstatsd-dev:${CI_COMMIT_REF_SLUG}
 
-dev_branch-a7:
-  extends: .docker_publish_job_definition
-  stage: dev_container_deploy
-  rules:
-    !reference [.on_a7_manual]
-  needs:
-    - docker_build_agent7
-    - docker_build_agent7_jmx
-  variables:
-    IMG_REGISTRIES: dev
-  parallel:
-    matrix:
-      - IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-amd64
-        IMG_DESTINATIONS: agent-dev:${CI_COMMIT_REF_SLUG}-py3
-      - IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx-amd64
-        IMG_DESTINATIONS: agent-dev:${CI_COMMIT_REF_SLUG}-py3-jmx
-
 dev_branch_multiarch-a6:
   extends: .docker_publish_job_definition
   stage: dev_container_deploy
@@ -81,7 +64,7 @@ dev_branch_multiarch-a7:
   extends: .docker_publish_job_definition
   stage: dev_container_deploy
   rules:
-    !reference [.on_all_builds_a7_manual]
+    !reference [.on_a7_manual]
   needs:
     - docker_build_agent7
     - docker_build_agent7_arm64

--- a/.gitlab/package_build/deb.yml
+++ b/.gitlab/package_build/deb.yml
@@ -113,7 +113,7 @@ agent_deb-arm64-a6:
 agent_deb-arm64-a7:
   extends: .agent_build_common_deb
   rules:
-    !reference [.on_all_builds_a7]
+    !reference [.on_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["runner:docker-arm", "platform:arm64"]


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Updates the Gitlab pipeline to automatically run jobs that are necessary to build & deploy Agent 7 arm64 images.

Removes the `dev_branch-a7`, a manual job that could be used to release the amd64 image alone to the `datadog/agent-dev` registry, and replaces it with `dev_branch_multiarch-a7` which releases a multiarch (amd64 + arm64) image to that same registry, available on all Agent 7 pipelines.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

More and more developers are using arm64 dev machines, so we should provide images for these by default.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

n/a

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

We'll need to monitor our arm64 infrastructure, in case these added jobs overload the current infra capacity.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Check that, in a dev branch pipeline, arm64 images can be produced.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
