### PR TITLE
Backport #14191 to `7.40.x`: Fix log collection on OpenShift (#14191)

### DIFF
--- a/pkg/logs/internal/launchers/container/launcher.go
+++ b/pkg/logs/internal/launchers/container/launcher.go
@@ -28,6 +28,7 @@ var containerSourceTypes = map[string]struct{}{
 	"docker":     {},
 	"containerd": {},
 	"podman":     {},
+	"cri-o":      {},
 }
 
 // A Launcher starts and stops new tailers for every new containers discovered

--- a/releasenotes/notes/fix_log_collection-c6273a2bbdd553e7.yaml
+++ b/releasenotes/notes/fix_log_collection-c6273a2bbdd553e7.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix log collection on Kubernetes distributions using ``cri-o`` like OpenShift, which
+    began failing in 7.40.0.


### PR DESCRIPTION
### What does this PR do?

Fix log collection on OpenShift.

### Motivation


### Additional Notes


### Possible Drawbacks / Trade-offs


### Describe how to test/QA your changes

Deploy the agent on OpenShift and configure it to collect logs, for ex. with `logs_config.container_collect_all: true`
Do not touch `logs_config.cca_in_ad` and let it with the default value, which is `true` since `7.40.0`.

Without this fix, no logs are collected and `agent status` shows a lot of stuck collectors:
```
===============
Agent (v7.40.0)
===============
[…]
Logs Agent
==========
    Reliable: Sending compressed logs in HTTPS to agent-http-intake.logs.datadoghq.com on port 443
    BytesSent: 0
    EncodedBytesSent: 0
    LogsProcessed: 0
    LogsSent: 0
[…]

  container_collect_all
  ---------------------
    - Type: cri-o
      Status: Pending
      BytesRead: 0
      Average Latency (ms): 0
      24h Average Latency (ms): 0
      Peak Latency (ms): 0
      24h Peak Latency (ms): 0
[…]
```

With this fix, logs are properly collected:
```
==========
Logs Agent
==========
    Reliable: Sending compressed logs in HTTPS to agent-http-intake.logs.datadoghq.com on port 443
    BytesSent: 1.15643492e+08
    EncodedBytesSent: 1.29309e+06
    LogsProcessed: 120244
    LogsSent: 120208

  openshift-rbac-permissions/rbac-permissions-operator-registry-q2qnc/registry-server
  -----------------------------------------------------------------------------------
    - Type: file
      Identifier: 4cc22daa3d884747c96407b4df3a7094ca0a49304528bfaf7093c5312e76f4ee
      Path: /var/log/pods/openshift-rbac-permissions_rbac-permissions-operator-registry-q2qnc_fcdf01d4-bd5c-43c0-9379-94d733243bea/registry-server/*.log
      Service: rbac-permissions-operator-registry
      Source: rbac-permissions-operator-registry
      Status: OK
        1 files tailed out of 1 files matching
      Inputs:
        /var/log/pods/openshift-rbac-permissions_rbac-permissions-operator-registry-q2qnc_fcdf01d4-bd5c-43c0-9379-94d733243bea/registry-server/0.log
      BytesRead: 0
      Average Latency (ms): 0
      24h Average Latency (ms): 0
      Peak Latency (ms): 0
      24h Peak Latency (ms): 0
[…]
```

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
