### PR TITLE
[snmp walk] Fix default port for SNMP Walk command

### DIFF
--- a/cmd/agent/subcommands/snmp/command.go
+++ b/cmd/agent/subcommands/snmp/command.go
@@ -165,9 +165,6 @@ func snmpwalk(config config.Component, cliParams *cliParams) error {
 		deviceIP = address[:strings.Index(address, ":")]
 		value, _ = strconv.ParseUint(address[strings.Index(address, ":")+1:], 0, 16)
 		port = uint16(value)
-		if port == 0 {
-			port = defaultPort
-		}
 	} else {
 		//If the customer provides only 1 argument : the ip_address
 		//We check the ip address configuration in the agent runtime and we use it for the snmpwalk
@@ -198,10 +195,10 @@ func snmpwalk(config config.Component, cliParams *cliParams) error {
 			if instance.Timeout != 0 {
 				cliParams.timeout = instance.Timeout
 			}
-
-		} else {
-			port = defaultPort
 		}
+	}
+	if port == 0 {
+		port = defaultPort
 	}
 
 	// Communication options check


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

[snmp walk] Fix default port for SNMP Walk command

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

When the snmp credentials are from runtime configs (see `if instance.IPAddress != "" {` condition), 
we were not setting a default port to `161`. 
Hence, if the port is not set in runtime SNMP config, it won't default to `161` when running snmp walk command.

By moving default port logic downward, it will set the default port for this case above, it shouldn't change default port behaviour for other 2 cases, see delete code in red:
![image](https://user-images.githubusercontent.com/49917914/200329605-2403ed18-8b99-4143-b042-209396723523.png)


<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
