### PR TITLE
Fix panic in the agent when the DCA isn’t reachable

### DIFF
--- a/pkg/util/kubernetes/hostinfo/tags.go
+++ b/pkg/util/kubernetes/hostinfo/tags.go
@@ -24,7 +24,7 @@ func GetTags(ctx context.Context) (tags []string, err error) {
 	if len(labelsToTags) > 0 {
 		var nodeLabels map[string]string
 		nodeInfo, e := NewNodeInfo()
-		if err != nil {
+		if e != nil {
 			err = e
 		} else {
 			nodeLabels, e = nodeInfo.GetNodeLabels(ctx)


### PR DESCRIPTION
### What does this PR do?

Fix a panic in the agent when the cluster agent isn’t reachable.

### Motivation

If the cluster agent isn’t reachable, executing `agent status` makes the agent panic:

```
2022-11-07 16:38:37 UTC | CORE | ERROR | (pkg/autodiscovery/config_poller.go:149 in poll) | Cache processing of cluster-checks configuration provider failed: "https://10.0.117.166:5005/api
/v1/clusterchecks/status/datadog-agent-linux-clusterchecks-7fb95f8584-f5zj8" is unavailable: timeout calling "https://10.0.117.166:5005/api/v1/clusterchecks/status/datadog-agent-linux-clus
terchecks-7fb95f8584-f5zj8": Post "https://10.0.117.166:5005/api/v1/clusterchecks/status/datadog-agent-linux-clusterchecks-7fb95f8584-f5zj8": dial tcp 10.0.117.166:5005: i/o timeout
2022-11-07 16:38:45 UTC | CORE | INFO | (cmd/agent/api/internal/agent/agent.go:181 in getStatus) | Got a request for the status. Making status.
2022-11-07 16:38:46 UTC | CORE | INFO | (pkg/metadata/host/host_tags.go:101 in GetHostTags) | Adding both tags cluster_name and kube_cluster_name. You can use 'disable_cluster_name_tag_key
' in the Agent config to keep the kube_cluster_name tag only
2022-11-07 16:38:46 UTC | CORE | ERROR | (/goroot/src/net/http/server.go:1826 in func1) | Error from the agent http API server: http: panic serving 127.0.0.1:39556: runtime error: invalid 
memory address or nil pointer dereference
goroutine 13338 [running]:
net/http.(*conn).serve.func1()
        /goroot/src/net/http/server.go:1825 +0xbf
panic({0x48f8c00, 0x77bbb10})
        /goroot/src/runtime/panic.go:844 +0x258
github.com/DataDog/datadog-agent/pkg/util/kubernetes/hostinfo.(*NodeInfo).GetNodeLabels(0x0, {0x57fc090, 0xc00013a008})
        /omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/util/kubernetes/hostinfo/node_labels.go:53 +0x27
github.com/DataDog/datadog-agent/pkg/util/kubernetes/hostinfo.GetTags({0x57fc090, 0xc00013a008})
        /omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/util/kubernetes/hostinfo/tags.go:30 +0x6c
github.com/DataDog/datadog-agent/pkg/metadata/host.GetHostTags({0x57fc090, 0xc00013a008}, 0x0)
        /omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/metadata/host/host_tags.go:112 +0x787
github.com/DataDog/datadog-agent/pkg/metadata/host.GetPayload({0x57fc090, 0xc00013a008}, {{0xc00005828c?, 0xc000043320?}, {0x4f1b89b?, 0xc0009c26f0?}})
        /omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/metadata/host/host.go:62 +0xdc
github.com/DataDog/datadog-agent/pkg/metadata/host.GetPayloadFromCache({0x57fc090, 0xc00013a008}, {{0xc00005828c?, 0x6?}, {0x4f1b89b?, 0x203000?}})
        /omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/metadata/host/host.go:85 +0x125
github.com/DataDog/datadog-agent/pkg/status.getCommonStatus()
        /omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/status/status.go:318 +0x27f
github.com/DataDog/datadog-agent/pkg/status.GetStatus()
        /omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/status/status.go:43 +0x2e
github.com/DataDog/datadog-agent/cmd/agent/api/internal/agent.getStatus({0x57f9740, 0xc000870a80}, 0x90?)
        /omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/cmd/agent/api/internal/agent/agent.go:182 +0x55
net/http.HandlerFunc.ServeHTTP(0x57f9740?, {0x57f9740?, 0xc000870a80?}, 0xc0009c25a0?)
        /goroot/src/net/http/server.go:2084 +0x2f
github.com/DataDog/datadog-agent/cmd/agent/api.validateToken.func1({0x57f9740, 0xc000870a80}, 0xc0009c25d0?)
        /omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/cmd/agent/api/security.go:43 +0xa2
net/http.HandlerFunc.ServeHTTP(0xc000be4800?, {0x57f9740?, 0xc000870a80?}, 0x1?)
        /goroot/src/net/http/server.go:2084 +0x2f
github.com/gorilla/mux.(*Router).ServeHTTP(0xc000dfa3c0, {0x57f9740, 0xc000870a80}, 0xc000be4700)
        /go/pkg/mod/github.com/gorilla/mux@v1.8.0/mux.go:210 +0x1cf
net/http.StripPrefix.func1({0x57f9740, 0xc000870a80}, 0xc000be4600)
        /goroot/src/net/http/server.go:2127 +0x330
net/http.HandlerFunc.ServeHTTP(0x77ba1a0?, {0x57f9740?, 0xc000870a80?}, 0x1c77406?)
        /goroot/src/net/http/server.go:2084 +0x2f
net/http.(*ServeMux).ServeHTTP(0xc0d26b0cefc8e772?, {0x57f9740, 0xc000870a80}, 0xc000be4600)
        /goroot/src/net/http/server.go:2462 +0x149
github.com/DataDog/datadog-agent/cmd/agent/api.timeoutHandlerFunc.func1({0x57f9740, 0xc000870a80}, 0xc000be4600)
        /omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/cmd/agent/api/server.go:62 +0x12c
net/http.HandlerFunc.ServeHTTP(0xffffffffffffffff?, {0x57f9740?, 0xc000870a80?}, 0x0?)
        /goroot/src/net/http/server.go:2084 +0x2f
github.com/DataDog/datadog-agent/cmd/agent/api.grpcHandlerFunc.func1({0x57f9740?, 0xc000870a80?}, 0xc000dcdac8?)
        /omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/cmd/agent/api/server.go:48 +0xa9
net/http.HandlerFunc.ServeHTTP(0x0?, {0x57f9740?, 0xc000870a80?}, 0xc000100800?)
        /goroot/src/net/http/server.go:2084 +0x2f
net/http.serverHandler.ServeHTTP({0xc0009c2450?}, {0x57f9740, 0xc000870a80}, 0xc000be4600)
        /goroot/src/net/http/server.go:2916 +0x43b
net/http.(*conn).serve(0xc001000fa0, {0x57fc100, 0xc0009c2150})
        /goroot/src/net/http/server.go:1966 +0x5d7
created by net/http.(*Server).Serve
        /goroot/src/net/http/server.go:3071 +0x4db
```

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

* Deploy the agent with a cluster-agent.
* Scale the cluster-agent deployment to 0.
* Execute `agent status`.
* 
With this fix, `agent status` should work.
Withouth this fix, `agent.status` would return:

```
Could not reach agent: Get "https://localhost:5001/agent/status": EOF 
Make sure the agent is running before requesting the status and contact support if you continue having issues. 
Error: Get "https://localhost:5001/agent/status": EOF
command terminated with exit code 255
```

and the logs of the agent would show the above panic.

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
