### PR TITLE
Move `AssertProcessEvents` to a test only file

### DIFF
--- a/pkg/process/events/listener_linux_test.go
+++ b/pkg/process/events/listener_linux_test.go
@@ -92,7 +92,7 @@ func TestProcessEventHandling(t *testing.T) {
 			t.Error("should not have received more process events")
 		}
 
-		model.AssertProcessEvents(t, events[i], e)
+		AssertProcessEvents(t, events[i], e)
 		// all message have been consumed
 		if i == len(events)-1 {
 			close(rcvMessage)

--- a/pkg/process/events/model/model_common.go
+++ b/pkg/process/events/model/model_common.go
@@ -6,10 +6,7 @@
 package model
 
 import (
-	"testing"
 	"time"
-
-	"github.com/stretchr/testify/assert"
 )
 
 // EventType represents the type of the process lifecycle event
@@ -125,26 +122,4 @@ func NewMockedExitEvent(ts time.Time, pid uint32, exe string, args []string, cod
 		ExitTime:       ts,
 		ExitCode:       code,
 	}
-}
-
-// AssertProcessEvents compares two ProcessEvents. Two events can't be compared using directly assert.Equal
-// due to the embedded time fields
-func AssertProcessEvents(t *testing.T, expected, actual *ProcessEvent) {
-	t.Helper()
-
-	assert.Equal(t, expected.EventType, actual.EventType)
-	assert.WithinDuration(t, expected.CollectionTime, actual.CollectionTime, 0)
-	assert.Equal(t, expected.Pid, actual.Pid)
-	assert.Equal(t, expected.ContainerID, actual.ContainerID)
-	assert.Equal(t, expected.Ppid, actual.Ppid)
-	assert.Equal(t, expected.UID, actual.UID)
-	assert.Equal(t, expected.GID, actual.GID)
-	assert.Equal(t, expected.Username, actual.Username)
-	assert.Equal(t, expected.Group, actual.Group)
-	assert.Equal(t, expected.Exe, actual.Exe)
-	assert.Equal(t, expected.Cmdline, actual.Cmdline)
-	assert.WithinDuration(t, expected.ForkTime, actual.ForkTime, 0)
-	assert.WithinDuration(t, expected.ExecTime, actual.ExecTime, 0)
-	assert.WithinDuration(t, expected.ExitTime, actual.ExitTime, 0)
-	assert.Equal(t, expected.ExitCode, actual.ExitCode)
 }

--- a/pkg/process/events/model/model_common_test.go
+++ b/pkg/process/events/model/model_common_test.go
@@ -1,0 +1,34 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// AssertProcessEvents compares two ProcessEvents. Two events can't be compared using directly assert.Equal
+// due to the embedded time fields
+func AssertProcessEvents(t *testing.T, expected, actual *ProcessEvent) {
+	t.Helper()
+
+	assert.Equal(t, expected.EventType, actual.EventType)
+	assert.WithinDuration(t, expected.CollectionTime, actual.CollectionTime, 0)
+	assert.Equal(t, expected.Pid, actual.Pid)
+	assert.Equal(t, expected.ContainerID, actual.ContainerID)
+	assert.Equal(t, expected.Ppid, actual.Ppid)
+	assert.Equal(t, expected.UID, actual.UID)
+	assert.Equal(t, expected.GID, actual.GID)
+	assert.Equal(t, expected.Username, actual.Username)
+	assert.Equal(t, expected.Group, actual.Group)
+	assert.Equal(t, expected.Exe, actual.Exe)
+	assert.Equal(t, expected.Cmdline, actual.Cmdline)
+	assert.WithinDuration(t, expected.ForkTime, actual.ForkTime, 0)
+	assert.WithinDuration(t, expected.ExecTime, actual.ExecTime, 0)
+	assert.WithinDuration(t, expected.ExitTime, actual.ExitTime, 0)
+	assert.Equal(t, expected.ExitCode, actual.ExitCode)
+}

--- a/pkg/process/events/model_test.go
+++ b/pkg/process/events/model_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	
+
 	"github.com/DataDog/datadog-agent/pkg/process/events/model"
 )
 

--- a/pkg/process/events/model_test.go
+++ b/pkg/process/events/model_test.go
@@ -3,17 +3,18 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-package model
+package events
 
 import (
 	"testing"
 
+	"github.com/DataDog/datadog-agent/pkg/process/events/model"
 	"github.com/stretchr/testify/assert"
 )
 
 // AssertProcessEvents compares two ProcessEvents. Two events can't be compared using directly assert.Equal
 // due to the embedded time fields
-func AssertProcessEvents(t *testing.T, expected, actual *ProcessEvent) {
+func AssertProcessEvents(t *testing.T, expected, actual *model.ProcessEvent) {
 	t.Helper()
 
 	assert.Equal(t, expected.EventType, actual.EventType)

--- a/pkg/process/events/model_test.go
+++ b/pkg/process/events/model_test.go
@@ -8,8 +8,9 @@ package events
 import (
 	"testing"
 
-	"github.com/DataDog/datadog-agent/pkg/process/events/model"
 	"github.com/stretchr/testify/assert"
+	
+	"github.com/DataDog/datadog-agent/pkg/process/events/model"
 )
 
 // AssertProcessEvents compares two ProcessEvents. Two events can't be compared using directly assert.Equal

--- a/pkg/process/events/store_test.go
+++ b/pkg/process/events/store_test.go
@@ -181,7 +181,7 @@ func TestRingStoreWithDroppedData(t *testing.T) {
 	// Assert that the expected events have been dropped
 	require.Equal(t, len(expectedDrops), len(droppedEvents))
 	for i := range droppedEvents {
-		model.AssertProcessEvents(t, expectedDrops[i], droppedEvents[i])
+		AssertProcessEvents(t, expectedDrops[i], droppedEvents[i])
 	}
 
 	data, err := s.Pull(ctx, timeout)


### PR DESCRIPTION
### What does this PR do?

Before this PR, running
```
strings ./bin/system-probe/system-probe | grep testify
```
would show that the testify lib is actually built into the system probe process. This should not be happening and this PR fixes the issue by ensuring that testify is only used in test files.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
