### PR TITLE
[netflow] Add prometheus listener

### DIFF
--- a/pkg/netflow/common/constants.go
+++ b/pkg/netflow/common/constants.go
@@ -23,4 +23,7 @@ const (
 
 	// DefaultBindHost is the default bind host used for flow listeners
 	DefaultBindHost = "0.0.0.0"
+
+	// DefaultPrometheusListenerAddress is the default goflow prometheus listener address
+	DefaultPrometheusListenerAddress = "localhost:9090"
 )

--- a/pkg/netflow/config/config.go
+++ b/pkg/netflow/config/config.go
@@ -27,6 +27,9 @@ type NetflowConfig struct {
 
 	// AggregatorRollupTrackerRefreshInterval is useful to speed up testing to avoid wait for 1h default
 	AggregatorRollupTrackerRefreshInterval uint `mapstructure:"aggregator_rollup_tracker_refresh_interval"`
+
+	PrometheusListenerAddress string `mapstructure:"prometheus_listener_address"`
+	PrometheusListenerEnabled bool   `mapstructure:"prometheus_listener_enabled"`
 }
 
 // ListenerConfig contains configuration for a single flow listener
@@ -95,6 +98,10 @@ func ReadConfig() (*NetflowConfig, error) {
 	}
 	if mainConfig.AggregatorRollupTrackerRefreshInterval == 0 {
 		mainConfig.AggregatorRollupTrackerRefreshInterval = common.DefaultAggregatorRollupTrackerRefreshInterval
+	}
+
+	if mainConfig.PrometheusListenerAddress == "" {
+		mainConfig.PrometheusListenerAddress = common.DefaultPrometheusListenerAddress
 	}
 
 	return &mainConfig, nil

--- a/pkg/netflow/config/config.go
+++ b/pkg/netflow/config/config.go
@@ -28,7 +28,7 @@ type NetflowConfig struct {
 	// AggregatorRollupTrackerRefreshInterval is useful to speed up testing to avoid wait for 1h default
 	AggregatorRollupTrackerRefreshInterval uint `mapstructure:"aggregator_rollup_tracker_refresh_interval"`
 
-	PrometheusListenerAddress string `mapstructure:"prometheus_listener_address"`
+	PrometheusListenerAddress string `mapstructure:"prometheus_listener_address"` // Example `localhost:9090`
 	PrometheusListenerEnabled bool   `mapstructure:"prometheus_listener_enabled"`
 }
 

--- a/pkg/netflow/config/config_test.go
+++ b/pkg/netflow/config/config_test.go
@@ -37,6 +37,8 @@ network_devices:
     aggregator_rollup_tracker_refresh_interval: 60
     log_payloads: true
     aggregator_port_rollup_disabled: true
+    prometheus_listener_enabled: true
+    prometheus_listener_address: 127.0.0.1:9099
     listeners:
       - flow_type: netflow9
         bind_host: 127.0.0.1
@@ -59,6 +61,8 @@ network_devices:
 				AggregatorPortRollupThreshold:          20,
 				AggregatorRollupTrackerRefreshInterval: 60,
 				AggregatorPortRollupDisabled:           true,
+				PrometheusListenerEnabled:              true,
+				PrometheusListenerAddress:              "127.0.0.1:9099",
 				Listeners: []ListenerConfig{
 					{
 						FlowType:  common.TypeNetFlow9,
@@ -93,6 +97,7 @@ network_devices:
 				AggregatorFlowContextTTL:               300,
 				AggregatorPortRollupThreshold:          10,
 				AggregatorRollupTrackerRefreshInterval: 300,
+				PrometheusListenerAddress:              "localhost:9090",
 				Listeners: []ListenerConfig{
 					{
 						FlowType:  common.TypeNetFlow9,
@@ -121,6 +126,7 @@ network_devices:
 				AggregatorFlowContextTTL:               50,
 				AggregatorPortRollupThreshold:          10,
 				AggregatorRollupTrackerRefreshInterval: 300,
+				PrometheusListenerAddress:              "localhost:9090",
 				Listeners: []ListenerConfig{
 					{
 						FlowType:  common.TypeNetFlow9,

--- a/pkg/netflow/goflowlib/flowstate.go
+++ b/pkg/netflow/goflowlib/flowstate.go
@@ -7,6 +7,7 @@ package goflowlib
 
 import (
 	"fmt"
+
 	"github.com/netsampler/goflow2/utils"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"

--- a/pkg/netflow/goflowlib/flowstate.go
+++ b/pkg/netflow/goflowlib/flowstate.go
@@ -7,7 +7,6 @@ package goflowlib
 
 import (
 	"fmt"
-
 	"github.com/netsampler/goflow2/utils"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"

--- a/pkg/netflow/server.go
+++ b/pkg/netflow/server.go
@@ -7,14 +7,14 @@ package netflow
 
 import (
 	"context"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"net/http"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/util/hostname"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	coreconfig "github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/hostname"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
 	"github.com/DataDog/datadog-agent/pkg/netflow/config"

--- a/pkg/netflow/server.go
+++ b/pkg/netflow/server.go
@@ -49,12 +49,11 @@ func NewNetflowServer(sender aggregator.Sender) (*Server, error) {
 	flowAgg := flowaggregator.NewFlowAggregator(sender, mainConfig, hostnameDetected)
 	go flowAgg.Start()
 
-	defer func() {
-		if mainConfig.PrometheusListenerEnabled {
-			http.Handle("/metrics", promhttp.Handler())
-			go http.ListenAndServe(mainConfig.PrometheusListenerAddress, nil)
-		}
-	}()
+	if mainConfig.PrometheusListenerEnabled {
+		serverMux := http.NewServeMux()
+		serverMux.Handle("/metrics", promhttp.Handler())
+		go http.ListenAndServe(mainConfig.PrometheusListenerAddress, serverMux)
+	}
 
 	log.Debugf("NetFlow Server configs (aggregator_buffer_size=%d, aggregator_flush_interval=%d, aggregator_flow_context_ttl=%d)", mainConfig.AggregatorBufferSize, mainConfig.AggregatorFlushInterval, mainConfig.AggregatorFlowContextTTL)
 	for _, listenerConfig := range mainConfig.Listeners {

--- a/pkg/netflow/server.go
+++ b/pkg/netflow/server.go
@@ -50,9 +50,14 @@ func NewNetflowServer(sender aggregator.Sender) (*Server, error) {
 	go flowAgg.Start()
 
 	if mainConfig.PrometheusListenerEnabled {
-		serverMux := http.NewServeMux()
-		serverMux.Handle("/metrics", promhttp.Handler())
-		go http.ListenAndServe(mainConfig.PrometheusListenerAddress, serverMux)
+		go func() {
+			serverMux := http.NewServeMux()
+			serverMux.Handle("/metrics", promhttp.Handler())
+			err := http.ListenAndServe(mainConfig.PrometheusListenerAddress, serverMux)
+			if err != nil {
+				log.Errorf("error starting prometheus server `%s`", mainConfig.PrometheusListenerAddress)
+			}
+		}()
 	}
 
 	log.Debugf("NetFlow Server configs (aggregator_buffer_size=%d, aggregator_flush_interval=%d, aggregator_flow_context_ttl=%d)", mainConfig.AggregatorBufferSize, mainConfig.AggregatorFlushInterval, mainConfig.AggregatorFlowContextTTL)

--- a/pkg/netflow/server.go
+++ b/pkg/netflow/server.go
@@ -7,6 +7,8 @@ package netflow
 
 import (
 	"context"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"net/http"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/util/hostname"
@@ -46,6 +48,13 @@ func NewNetflowServer(sender aggregator.Sender) (*Server, error) {
 
 	flowAgg := flowaggregator.NewFlowAggregator(sender, mainConfig, hostnameDetected)
 	go flowAgg.Start()
+
+	defer func() {
+		if mainConfig.PrometheusListenerEnabled {
+			http.Handle("/metrics", promhttp.Handler())
+			go http.ListenAndServe(mainConfig.PrometheusListenerAddress, nil)
+		}
+	}()
 
 	log.Debugf("NetFlow Server configs (aggregator_buffer_size=%d, aggregator_flush_interval=%d, aggregator_flow_context_ttl=%d)", mainConfig.AggregatorBufferSize, mainConfig.AggregatorFlushInterval, mainConfig.AggregatorFlowContextTTL)
 	for _, listenerConfig := range mainConfig.Listeners {

--- a/releasenotes/notes/netflow_add_prometheus_listener-b48896bda5c03c03.yaml
+++ b/releasenotes/notes/netflow_add_prometheus_listener-b48896bda5c03c03.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    [netflow] Add prometheus listener to expose goflow telemetry


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

[netflow] Add prometheus listener

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Have way to optionally expose prometheus http endpoint. This way, we can ask user to enable it and send use the output for metrics that we don’t collect via https://github.com/DataDog/datadog-agent/pull/14231 .


<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Can be tested by making a curl:
```
curl localhost:9090/metrics
```
and check if metrics starting by `flow_` are present

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
