### PR TITLE
[CWS][SEC-5905][SEC-6242] Add several new activity dump functional tests

### DIFF
--- a/.gitlab/functional_test/security_agent.yml
+++ b/.gitlab/functional_test/security_agent.yml
@@ -45,6 +45,9 @@ kitchen_test_security_agent_x64:
       - KITCHEN_PLATFORM: "ubuntu"
         KITCHEN_OSVERS: "ubuntu-20-04,ubuntu-20-04-2,ubuntu-22-04"
         KITCHEN_CWS_PLATFORM: [host, docker]
+      - KITCHEN_PLATFORM: "ubuntu"
+        KITCHEN_OSVERS: "ubuntu-22-04"
+        KITCHEN_CWS_PLATFORM: [ad]
       - KITCHEN_PLATFORM: "suse"
         KITCHEN_OSVERS: "sles-12,sles-15"
         KITCHEN_CWS_PLATFORM: [host]

--- a/pkg/security/probe/activity_dump.go
+++ b/pkg/security/probe/activity_dump.go
@@ -776,6 +776,8 @@ func (ad *ActivityDump) resolveTags() error {
 
 // ToSecurityActivityDumpMessage returns a pointer to a SecurityActivityDumpMessage
 func (ad *ActivityDump) ToSecurityActivityDumpMessage() *api.ActivityDumpMessage {
+	ad.Lock()
+	defer ad.Unlock()
 	var storage []*api.StorageRequestMessage
 	for _, requests := range ad.StorageRequests {
 		for _, request := range requests {

--- a/pkg/security/probe/activity_dump_manager.go
+++ b/pkg/security/probe/activity_dump_manager.go
@@ -636,3 +636,14 @@ func (adm *ActivityDumpManager) getOverweightDumps() []*ActivityDump {
 	}
 	return dumps
 }
+
+// FakeDumpOverweight fakes a dump stats to force triggering the load controller. For unitary tests purpose only.
+func (adm *ActivityDumpManager) FakeDumpOverweight(name string) {
+	adm.Lock()
+	defer adm.Unlock()
+	for _, ad := range adm.activeDumps {
+		if ad.Name == name {
+			ad.nodeStats.processNodes = int64(99999)
+		}
+	}
+}

--- a/pkg/security/tests/activity_dumps_test.go
+++ b/pkg/security/tests/activity_dumps_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 // v see test/kitchen/test/integration/security-agent-test/rspec/security-agent-test_spec.rb
-const dedicatedADNodeForTestsEnv = "DD_ACTIVITY_DUMP_NODE"
+const dedicatedADNodeForTestsEnv = "DEDICATED_ACTIVITY_DUMP_NODE"
 
 var expectedFormats = []string{"json", "protobuf"}
 

--- a/pkg/security/tests/activity_dumps_test.go
+++ b/pkg/security/tests/activity_dumps_test.go
@@ -23,6 +23,9 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// v see test/kitchen/test/integration/security-agent-test/rspec/security-agent-test_spec.rb
+const dedicatedADNodeForTestsEnv = "DD_ACTIVITY_DUMP_NODE"
+
 var expectedFormats = []string{"json", "protobuf"}
 
 const testActivityDumpRateLimiter = 20
@@ -37,6 +40,9 @@ func TestActivityDumps(t *testing.T) {
 	}
 	if _, err := whichNonFatal("docker"); err != nil {
 		t.Skip("Skip test where docker is unavailable")
+	}
+	if !IsDedicatedNode(dedicatedADNodeForTestsEnv) {
+		t.Skip("Skip test when not run in dedicated env")
 	}
 
 	outputDir := t.TempDir()
@@ -403,6 +409,9 @@ func TestActivityDumpsLoadControllerTimeout(t *testing.T) {
 	if _, err := whichNonFatal("docker"); err != nil {
 		t.Skip("Skip test where docker is unavailable")
 	}
+	if !IsDedicatedNode(dedicatedADNodeForTestsEnv) {
+		t.Skip("Skip test when not run in dedicated env")
+	}
 
 	outputDir := t.TempDir()
 	defer os.RemoveAll(outputDir)
@@ -458,6 +467,9 @@ func TestActivityDumpsLoadControllerEventTypes(t *testing.T) {
 	}
 	if _, err := whichNonFatal("docker"); err != nil {
 		t.Skip("Skip test where docker is unavailable")
+	}
+	if !IsDedicatedNode(dedicatedADNodeForTestsEnv) {
+		t.Skip("Skip test when not run in dedicated env")
 	}
 
 	outputDir := t.TempDir()
@@ -535,6 +547,9 @@ func TestActivityDumpsLoadControllerRateLimiter(t *testing.T) {
 	}
 	if _, err := whichNonFatal("docker"); err != nil {
 		t.Skip("Skip test where docker is unavailable")
+	}
+	if !IsDedicatedNode(dedicatedADNodeForTestsEnv) {
+		t.Skip("Skip test when not run in dedicated env")
 	}
 
 	outputDir := t.TempDir()

--- a/pkg/security/tests/filters_test.go
+++ b/pkg/security/tests/filters_test.go
@@ -183,7 +183,7 @@ func TestFilterOpenLeafDiscarderActivityDump(t *testing.T) {
 	defer os.Remove(testFile)
 
 	outputDir := t.TempDir()
-	_, err = test.StartActivityDumpComm(t, "testsuite", outputDir, []string{"protobuf"})
+	_, err = test.StartActivityDumpComm("testsuite", outputDir, []string{"protobuf"})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -52,6 +52,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	srand "k8s.io/apimachinery/pkg/util/rand"
 )
 
 var (
@@ -90,6 +91,8 @@ runtime_security_config:
   activity_dump:
     enabled: true
     rate_limiter: {{ .ActivityDumpRateLimiter }}
+    cgroup_dump_timeout: {{ .ActivityDumpCgroupDumpTimeout }}
+    traced_cgroups_count: {{ .ActivityDumpTracedCgroupsCount }}
     traced_event_types:   {{range .ActivityDumpTracedEventTypes}}
     - {{.}}
     {{end}}
@@ -181,6 +184,8 @@ type testOpts struct {
 	disableApprovers                    bool
 	enableActivityDump                  bool
 	activityDumpRateLimiter             int
+	activityDumpCgroupDumpTimeout       int
+	activityDumpTracedCgroupsCount      int
 	activityDumpTracedEventTypes        []string
 	activityDumpLocalStorageDirectory   string
 	activityDumpLocalStorageCompression bool
@@ -207,6 +212,8 @@ func (to testOpts) Equal(opts testOpts) bool {
 		to.disableApprovers == opts.disableApprovers &&
 		to.enableActivityDump == opts.enableActivityDump &&
 		to.activityDumpRateLimiter == opts.activityDumpRateLimiter &&
+		to.activityDumpCgroupDumpTimeout == opts.activityDumpCgroupDumpTimeout &&
+		to.activityDumpTracedCgroupsCount == opts.activityDumpTracedCgroupsCount &&
 		reflect.DeepEqual(to.activityDumpTracedEventTypes, opts.activityDumpTracedEventTypes) &&
 		to.activityDumpLocalStorageDirectory == opts.activityDumpLocalStorageDirectory &&
 		to.activityDumpLocalStorageCompression == opts.activityDumpLocalStorageCompression &&
@@ -581,6 +588,14 @@ func genTestConfig(dir string, opts testOpts) (*config.Config, error) {
 		opts.activityDumpRateLimiter = 500
 	}
 
+	if opts.activityDumpTracedCgroupsCount == 0 {
+		opts.activityDumpTracedCgroupsCount = 5
+	}
+
+	if opts.activityDumpCgroupDumpTimeout == 0 {
+		opts.activityDumpTracedCgroupsCount = 30
+	}
+
 	if len(opts.activityDumpTracedEventTypes) == 0 {
 		opts.activityDumpTracedEventTypes = []string{"exec", "open", "bind", "dns", "syscalls"}
 	}
@@ -605,6 +620,8 @@ func genTestConfig(dir string, opts testOpts) (*config.Config, error) {
 		"DisableApprovers":                    opts.disableApprovers,
 		"EnableActivityDump":                  opts.enableActivityDump,
 		"ActivityDumpRateLimiter":             opts.activityDumpRateLimiter,
+		"ActivityDumpCgroupDumpTimeout":       opts.activityDumpCgroupDumpTimeout,
+		"ActivityDumpTracedCgroupsCount":      opts.activityDumpTracedCgroupsCount,
 		"ActivityDumpTracedEventTypes":        opts.activityDumpTracedEventTypes,
 		"ActivityDumpLocalStorageDirectory":   opts.activityDumpLocalStorageDirectory,
 		"ActivityDumpLocalStorageCompression": opts.activityDumpLocalStorageCompression,
@@ -1481,7 +1498,7 @@ func checkKernelCompatibility(tb testing.TB, why string, skipCheck func(kv *kern
 	}
 }
 
-func (tm *testModule) StartActivityDumpComm(t *testing.T, comm string, outputDir string, formats []string) ([]string, error) {
+func (tm *testModule) StartActivityDumpComm(comm string, outputDir string, formats []string) ([]string, error) {
 	monitor := tm.probe.GetMonitor()
 	if monitor == nil {
 		return nil, errors.New("No monitor")
@@ -1500,8 +1517,7 @@ func (tm *testModule) StartActivityDumpComm(t *testing.T, comm string, outputDir
 	}
 	mess, err := monitor.DumpActivity(p)
 	if err != nil || mess == nil || len(mess.Storage) < 1 {
-		t.Errorf("failed to start activity dump: %s", err)
-		return nil, err
+		return nil, errors.New("failed to start activity dump")
 	}
 
 	var files []string
@@ -1531,10 +1547,11 @@ func (tm *testModule) StopActivityDump(name, containerID, comm string) error {
 type activityDumpIdentifier struct {
 	Name        string
 	ContainerID string
+	Timeout     string
 	OutputFiles []string
 }
 
-func (tm *testModule) ListActivityDumps() ([]activityDumpIdentifier, error) {
+func (tm *testModule) ListActivityDumps() ([]*activityDumpIdentifier, error) {
 	monitor := tm.probe.GetMonitor()
 	if monitor == nil {
 		return nil, errors.New("No monitor")
@@ -1545,7 +1562,7 @@ func (tm *testModule) ListActivityDumps() ([]activityDumpIdentifier, error) {
 		return nil, err
 	}
 
-	var dumps []activityDumpIdentifier
+	var dumps []*activityDumpIdentifier
 	for _, dump := range mess.Dumps {
 		var files []string
 		for _, storage := range dump.Storage {
@@ -1557,16 +1574,17 @@ func (tm *testModule) ListActivityDumps() ([]activityDumpIdentifier, error) {
 			continue // do not add activity dumps without any local storage files
 		}
 
-		dumps = append(dumps, activityDumpIdentifier{
+		dumps = append(dumps, &activityDumpIdentifier{
 			Name:        dump.Metadata.Name,
 			ContainerID: dump.Metadata.ContainerID,
+			Timeout:     dump.Metadata.Timeout,
 			OutputFiles: files,
 		})
 	}
 	return dumps, nil
 }
 
-func (tm *testModule) DecodeActivityDump(t *testing.T, path string) (*sprobe.ActivityDump, error) {
+func (tm *testModule) DecodeActivityDump(path string) (*sprobe.ActivityDump, error) {
 	monitor := tm.probe.GetMonitor()
 	if monitor == nil {
 		return nil, errors.New("No monitor")
@@ -1614,7 +1632,7 @@ func (tm *testModule) StartADockerGetDump() (*dockerCmdWrapper, *activityDumpIde
 		_, _ = dockerInstance.stop()
 		return nil, nil, err
 	}
-	dump := findLearningContainer(dumps, dockerInstance.containerID)
+	dump := findLearningContainerID(dumps, dockerInstance.containerID)
 	if dump == nil {
 		_, _ = dockerInstance.stop()
 		return nil, nil, errors.New("ContainerID not found on activity dump list")
@@ -1622,11 +1640,248 @@ func (tm *testModule) StartADockerGetDump() (*dockerCmdWrapper, *activityDumpIde
 	return dockerInstance, dump, nil
 }
 
-func findLearningContainer(dumps []activityDumpIdentifier, containerID string) *activityDumpIdentifier {
+//nolint:deadcode,unused
+func findLearningContainerID(dumps []*activityDumpIdentifier, containerID string) *activityDumpIdentifier {
 	for _, dump := range dumps {
 		if dump.ContainerID == containerID {
-			return &dump
+			return dump
 		}
+	}
+	return nil
+}
+
+//nolint:deadcode,unused
+func findLearningContainerName(dumps []*activityDumpIdentifier, name string) *activityDumpIdentifier {
+	for _, dump := range dumps {
+		if dump.Name == name {
+			return dump
+		}
+	}
+	return nil
+}
+
+//nolint:deadcode,unused
+func (tm *testModule) isDumpRunning(id *activityDumpIdentifier) bool {
+	dumps, err := tm.ListActivityDumps()
+	if err != nil {
+		return false
+	}
+	dump := findLearningContainerName(dumps, id.Name)
+	if dump == nil {
+		return false
+	}
+	return true
+}
+
+//nolint:deadcode,unused
+func (tm *testModule) findCgroupDump(id *activityDumpIdentifier) *activityDumpIdentifier {
+	dumps, err := tm.ListActivityDumps()
+	if err != nil {
+		return nil
+	}
+	dump := findLearningContainerID(dumps, id.ContainerID)
+	if dump == nil {
+		return nil
+	}
+	return dump
+}
+
+//nolint:deadcode,unused
+func (tm *testModule) addAllEventTypesOnDump(dockerInstance *dockerCmdWrapper, id *activityDumpIdentifier, syscallTester string) {
+	// open
+	cmd := dockerInstance.Command("touch", []string{filepath.Join(tm.Root(), "open")}, []string{})
+	_, _ = cmd.CombinedOutput()
+
+	// dns
+	cmd = dockerInstance.Command("nslookup", []string{"foo.bar"}, []string{})
+	_, _ = cmd.CombinedOutput()
+
+	// bind
+	cmd = dockerInstance.Command(syscallTester, []string{"bind", "AF_INET", "any", "tcp"}, []string{})
+	_, _ = cmd.CombinedOutput()
+
+	// syscalls should be added with previous events
+}
+
+//nolint:deadcode,unused
+func (tm *testModule) triggerLoadControlerReducer(dockerInstance *dockerCmdWrapper, id *activityDumpIdentifier) {
+	// fill a dump with processes/files until we reach the memory limit and trigger a partial dump
+	for tm.isDumpRunning(id) {
+		for i := 0; i < 500; i++ {
+			filename := filepath.Join(tm.Root(), srand.String(10))
+			cmd := dockerInstance.Command("touch", []string{filename}, []string{})
+			_, _ = cmd.CombinedOutput()
+		}
+		time.Sleep(time.Second * 1)
+	}
+}
+
+//nolint:deadcode,unused
+func (tm *testModule) dockerCreateFiles(dockerInstance *dockerCmdWrapper, syscallTester string, directory string, numberOfFiles int) error {
+	var files []string
+	for i := 0; i < numberOfFiles; i++ {
+		files = append(files, filepath.Join(directory, "ad-test-create-"+fmt.Sprintf("%d", i)))
+	}
+	args := []string{"sleep", "2", ";", "open"}
+	args = append(args, files...)
+	cmd := dockerInstance.Command(syscallTester, args, []string{})
+	_, err := cmd.CombinedOutput()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+//nolint:deadcode,unused
+func (tm *testModule) findNextPartialDump(dockerInstance *dockerCmdWrapper, id *activityDumpIdentifier) (*activityDumpIdentifier, error) {
+	for i := 0; i < 10; i++ { // retry during 5sec
+		dump := tm.findCgroupDump(id)
+		if dump != nil {
+			return dump, nil
+		}
+		cmd := dockerInstance.Command("echo", []string{"trying to trigger the dump"}, []string{})
+		_, err := cmd.CombinedOutput()
+		if err != nil {
+			return nil, err
+		}
+		time.Sleep(time.Second * 1)
+	}
+	return nil, errors.New("Unable to find the next partial dump")
+}
+
+//nolint:deadcode,unused
+func searchForOpen(ad *sprobe.ActivityDump) bool {
+	for _, node := range ad.ProcessActivityTree {
+		if len(node.Files) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+//nolint:deadcode,unused
+func searchForDns(ad *sprobe.ActivityDump) bool {
+	for _, node := range ad.ProcessActivityTree {
+		if len(node.DNSNames) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+//nolint:deadcode,unused
+func searchForBind(ad *sprobe.ActivityDump) bool {
+	for _, node := range ad.ProcessActivityTree {
+		if len(node.Sockets) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+//nolint:deadcode,unused
+func searchForSyscalls(ad *sprobe.ActivityDump) bool {
+	for _, node := range ad.ProcessActivityTree {
+		if len(node.Syscalls) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+//nolint:deadcode,unused
+func (tm *testModule) getADFromDumpId(id *activityDumpIdentifier) (*sprobe.ActivityDump, error) {
+	var fileProtobuf string
+	// decode the dump
+	for _, file := range id.OutputFiles {
+		if filepath.Ext(file) == ".protobuf" {
+			fileProtobuf = file
+			break
+		}
+	}
+	if len(fileProtobuf) < 1 {
+		return nil, errors.New("protobuf output file not found")
+	}
+	ad, err := tm.DecodeActivityDump(fileProtobuf)
+	if err != nil {
+		return nil, err
+	}
+	return ad, nil
+}
+
+//nolint:deadcode,unused
+func (tm *testModule) findNumberOfExistingDirectoryFiles(id *activityDumpIdentifier, testDir string) (int, error) {
+	ad, err := tm.getADFromDumpId(id)
+	if err != nil {
+		return 0, err
+	}
+
+	var total int
+	tempPathParts := strings.Split(testDir, "/")
+	lastDir := filepath.Base(testDir)
+
+firstLoop:
+	for _, node := range ad.ProcessActivityTree {
+		current := node.Files
+		for _, part := range tempPathParts {
+			if part == "" {
+				continue
+			}
+			next, found := current[part]
+			if !found {
+				continue firstLoop
+			}
+			current = next.Children
+			if part == lastDir {
+				total += len(current)
+				continue firstLoop
+			}
+		}
+	}
+	return total, nil
+}
+
+//nolint:deadcode,unused
+func (tm *testModule) extractAllDumpEventTypes(id *activityDumpIdentifier) ([]string, error) {
+	var res []string
+
+	ad, err := tm.getADFromDumpId(id)
+	if err != nil {
+		return res, err
+	}
+
+	if searchForBind(ad) {
+		res = append(res, "bind")
+	}
+	if searchForDns(ad) {
+		res = append(res, "dns")
+	}
+	if searchForSyscalls(ad) {
+		res = append(res, "syscalls")
+	}
+	if searchForOpen(ad) {
+		res = append(res, "open")
+	}
+	return res, nil
+}
+
+func (tm *testModule) StopAllActivityDumps() error {
+	dumps, err := tm.ListActivityDumps()
+	if err != nil {
+		return err
+	}
+	if len(dumps) == 0 {
+		return nil
+	}
+	for _, dump := range dumps {
+		_ = tm.StopActivityDump(dump.Name, "", "")
+	}
+	dumps, err = tm.ListActivityDumps()
+	if err != nil {
+		return err
+	}
+	if len(dumps) != 0 {
+		return errors.New("Didn't manage to stop all activity dumps")
 	}
 	return nil
 }

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -1885,3 +1885,8 @@ func (tm *testModule) StopAllActivityDumps() error {
 	}
 	return nil
 }
+
+func IsDedicatedNode(env string) bool {
+	_, present := os.LookupEnv(env)
+	return present
+}

--- a/test/kitchen/test/integration/security-agent-test/rspec/security-agent-test_spec.rb
+++ b/test/kitchen/test/integration/security-agent-test/rspec/security-agent-test_spec.rb
@@ -47,7 +47,7 @@ when "docker"
 when "ad"
   describe 'activity dump functional test running on dedicated node' do
     it 'successfully runs' do
-      Open3.popen2e({"DD_ACTIVITY_DUMP_NODE"=>"1", "DD_TESTS_RUNTIME_COMPILED"=>"1", "DD_RUNTIME_SECURITY_CONFIG_RUNTIME_COMPILATION_ENABLED"=>"true", "DD_SYSTEM_PROBE_BPF_DIR"=>"/tmp/security-agent/ebpf_bytecode"}, "sudo", "-E", "/tmp/security-agent/testsuite", "-test.v", "-status-metrics", "-test.run", "TestActivityDump") do |_, output, wait_thr|
+      Open3.popen2e({"DEDICATED_ACTIVITY_DUMP_NODE"=>"1", "DD_TESTS_RUNTIME_COMPILED"=>"1", "DD_RUNTIME_SECURITY_CONFIG_RUNTIME_COMPILATION_ENABLED"=>"true", "DD_SYSTEM_PROBE_BPF_DIR"=>"/tmp/security-agent/ebpf_bytecode"}, "sudo", "-E", "/tmp/security-agent/testsuite", "-test.v", "-status-metrics", "-test.run", "TestActivityDump") do |_, output, wait_thr|
         test_failures = check_output(output, wait_thr, "a")
         expect(test_failures).to be_empty, test_failures.join("\n")
       end

--- a/test/kitchen/test/integration/security-agent-test/rspec/security-agent-test_spec.rb
+++ b/test/kitchen/test/integration/security-agent-test/rspec/security-agent-test_spec.rb
@@ -44,6 +44,15 @@ when "docker"
       end
     end
   end
+when "ad"
+  describe 'activity dump functional test running on dedicated node' do
+    it 'successfully runs' do
+      Open3.popen2e({"DD_ACTIVITY_DUMP_NODE"=>"1", "DD_TESTS_RUNTIME_COMPILED"=>"1", "DD_RUNTIME_SECURITY_CONFIG_RUNTIME_COMPILATION_ENABLED"=>"true", "DD_SYSTEM_PROBE_BPF_DIR"=>"/tmp/security-agent/ebpf_bytecode"}, "sudo", "-E", "/tmp/security-agent/testsuite", "-test.v", "-status-metrics", "-test.run", "TestActivityDump") do |_, output, wait_thr|
+        test_failures = check_output(output, wait_thr, "a")
+        expect(test_failures).to be_empty, test_failures.join("\n")
+      end
+    end
+  end
 else
   raise "no CWS platform provided"
 end


### PR DESCRIPTION
### What does this PR do?

It adds some new activity dump functional tests:
* TestActivityDumps/activity-dump-timeout
* TestActivityDumps/activity-dump-cgroups-counts
* TestActivityDumpsLoadController/activity-dump-load-controller-timeout
* TestActivityDumpsLoadController/activity-dump-load-controller-event-types
* TestActivityDumpsLoadController/activity-dump-load-controller-ratelimiter

Also, makes the CI run activity dumps tests on a dedicated job (on ubuntu 22.04).

### Motivation

Cover more activity dumps feature with tests

### Additional Notes


### Possible Drawbacks / Trade-offs

Launching docker instances, triggering dumps timeout etc is .. long, this will add several minutes to the CI :/



### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
