### PR TITLE
[CWS] Minor activity dumps fixes

### DIFF
--- a/pkg/security/probe/activity_dump.go
+++ b/pkg/security/probe/activity_dump.go
@@ -500,13 +500,12 @@ func (ad *ActivityDump) debug(w io.Writer) {
 }
 
 func (ad *ActivityDump) isEventTypeTraced(event *Event) bool {
-	var traced bool
 	for _, evtType := range ad.LoadConfig.TracedEventTypes {
 		if evtType == event.GetEventType() {
-			traced = true
+			return true
 		}
 	}
-	return traced
+	return false
 }
 
 // Insert inserts the provided event in the active ActivityDump. This function returns true if a new entry was added,
@@ -1140,7 +1139,7 @@ func (ad *ActivityDump) snapshotProcess(pan *ProcessActivityNode) error {
 		return nil
 	}
 
-	for _, eventType := range ad.adm.probe.config.ActivityDumpTracedEventTypes {
+	for _, eventType := range ad.LoadConfig.TracedEventTypes {
 		switch eventType {
 		case model.FileOpenEventType:
 			if err = pan.snapshotFiles(p, ad); err != nil {

--- a/pkg/security/probe/activity_dump_load_controller.go
+++ b/pkg/security/probe/activity_dump_load_controller.go
@@ -22,7 +22,7 @@ import (
 
 var (
 	// TracedEventTypesReductionOrder is the order by which event types are reduced
-	TracedEventTypesReductionOrder = []model.EventType{model.FileOpenEventType, model.SyscallsEventType, model.DNSEventType, model.BindEventType}
+	TracedEventTypesReductionOrder = []model.EventType{model.BindEventType, model.DNSEventType, model.SyscallsEventType, model.FileOpenEventType}
 	// MinDumpTimeout is the shortest timeout for a dump
 	MinDumpTimeout = 10 * time.Minute
 )
@@ -106,13 +106,13 @@ func (lc *ActivityDumpLoadController) NextPartialDump(ad *ActivityDump) *Activit
 		}
 	}
 
-	if timeToThreshold < MinDumpTimeout/4 && ad.LoadConfig.Timeout > MinDumpTimeout {
+	if timeToThreshold < MinDumpTimeout/2 && ad.LoadConfig.Timeout > MinDumpTimeout {
 		if err := lc.reduceDumpTimeout(newDump); err != nil {
 			seclog.Errorf("%v", err)
 		}
 	}
 
-	if timeToThreshold < MinDumpTimeout/10 {
+	if timeToThreshold < MinDumpTimeout/4 {
 		if err := lc.reduceTracedEventTypes(ad, newDump); err != nil {
 			seclog.Errorf("%v", err)
 		}


### PR DESCRIPTION
### What does this PR do?

This will fix three little bugs:
* Event types are now also filtered for snapshot events with the related dump TracedEventTypes config
* Reverse the order of event types by witch they are reduced (now we first drop bind, then dns, then syscalls and finally open events)
* Change the thresholds for timeout and event types reducer, because the event types reducer should never trigger on less than 1 min (now it will trigger if we reach the memory limit before 2m30)


### Motivation


### Additional Notes

The threshold for event types reducer was change because I didn't manage to trigger the reducer while adding some functional tests. The minimum time it took to triggers it it's 1m50. But the "minimum trigger time" is dependent of:
* The memory threshold
* Load controller period
* Kernel rate limiter rate
* ActivityDump min timeout
* HW & local workload

Each time we'll change any of the first fourth values, we should consider also updating the different reducer thresholds.

### Possible Drawbacks / Trade-offs



### Describe how to test/QA your changes



### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
