### PR TITLE
Add integration config digest in config check id hash

### DIFF
--- a/pkg/autodiscovery/integration/config.go
+++ b/pkg/autodiscovery/integration/config.go
@@ -7,7 +7,6 @@ package integration
 
 import (
 	"fmt"
-	"hash/fnv"
 	"sort"
 	"strconv"
 	"strings"
@@ -18,6 +17,11 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/tmplvar"
+)
+
+const (
+	// Used in unit tests
+	FakeConfigHash = 1
 )
 
 // Data contains YAML code
@@ -354,8 +358,12 @@ func (c *Data) SetField(key string, value interface{}) error {
 // The ClusterCheck field is intentionally left out to keep a stable digest
 // between the cluster-agent and the node-agents
 func (c *Config) Digest() string {
-	h := fnv.New64()
-	h.Write([]byte(c.Name)) //nolint:errcheck
+	return strconv.FormatUint(c.IntDigest(), 16)
+}
+
+func (c *Config) IntDigest() uint64 {
+	h := murmur3.New64()
+	_, _ = h.Write([]byte(c.Name))
 	for _, i := range c.Instances {
 		inst := RawMap{}
 		err := yaml.Unmarshal(i, &inst)
@@ -383,18 +391,18 @@ func (c *Config) Digest() string {
 			log.Debugf("Error while calculating config digest for %s, skipping: %v", c.Name, err)
 			continue
 		}
-		h.Write(out) //nolint:errcheck
+		_, _ = h.Write(out)
 	}
-	h.Write([]byte(c.InitConfig)) //nolint:errcheck
+	_, _ = h.Write([]byte(c.InitConfig))
 	for _, i := range c.ADIdentifiers {
-		h.Write([]byte(i)) //nolint:errcheck
+		_, _ = h.Write([]byte(i))
 	}
-	h.Write([]byte(c.NodeName))                                    //nolint:errcheck
-	h.Write([]byte(c.LogsConfig))                                  //nolint:errcheck
-	h.Write([]byte(c.ServiceID))                                   //nolint:errcheck
-	h.Write([]byte(strconv.FormatBool(c.IgnoreAutodiscoveryTags))) //nolint:errcheck
+	_, _ = h.Write([]byte(c.NodeName))
+	_, _ = h.Write([]byte(c.LogsConfig))
+	_, _ = h.Write([]byte(c.ServiceID))
+	_, _ = h.Write([]byte(strconv.FormatBool(c.IgnoreAutodiscoveryTags)))
 
-	return strconv.FormatUint(h.Sum64(), 16)
+	return h.Sum64()
 }
 
 // FastDigest returns an hash value representing the data stored in this configuration.

--- a/pkg/autodiscovery/integration/config_test.go
+++ b/pkg/autodiscovery/integration/config_test.go
@@ -158,43 +158,43 @@ func TestSetField(t *testing.T) {
 
 func TestDigest(t *testing.T) {
 	emptyConfig := &Config{}
-	assert.Equal(t, "8cbd29bb83d5daa", emptyConfig.Digest())
+	assert.Equal(t, "c4bf6d05e5b795e4", emptyConfig.Digest())
 	simpleConfig := &Config{
 		Name:       "foo",
 		InitConfig: Data(""),
 	}
-	assert.Equal(t, "86fa755714dd0344", simpleConfig.Digest())
+	assert.Equal(t, "6eba821f0cd8c6d0", simpleConfig.Digest())
 	simpleConfigWithLogs := &Config{
 		Name:       "foo",
 		InitConfig: Data(""),
 		LogsConfig: Data("[{\"service\":\"any_service\",\"source\":\"any_source\"}]"),
 	}
-	assert.Equal(t, "6221a1957297b66", simpleConfigWithLogs.Digest())
+	assert.Equal(t, "68db1fd44ee9e556", simpleConfigWithLogs.Digest())
 	simpleConfigWithInstances := &Config{
 		Name:       "foo",
 		InitConfig: Data(""),
 		Instances:  []Data{Data("{foo:bar}")},
 	}
-	assert.Equal(t, "88e8dfc8b715052", simpleConfigWithInstances.Digest())
+	assert.Equal(t, "bac28046698f8f94", simpleConfigWithInstances.Digest())
 	simpleConfigWithInstancesAndLogs := &Config{
 		Name:       "foo",
 		InitConfig: Data(""),
 		Instances:  []Data{Data("{foo:bar}")},
 		LogsConfig: Data("[{\"service\":\"any_service\",\"source\":\"any_source\"}]"),
 	}
-	assert.Equal(t, "6692ced6b2ad5480", simpleConfigWithInstancesAndLogs.Digest())
+	assert.Equal(t, "8ae67f131af76048", simpleConfigWithInstancesAndLogs.Digest())
 	simpleConfigWithTags := &Config{
 		Name:       "foo",
 		InitConfig: Data(""),
 		Instances:  []Data{Data("tags: [\"foo\", \"foo:bar\"]")},
 	}
-	assert.Equal(t, "4702b7464dedf680", simpleConfigWithTags.Digest())
+	assert.Equal(t, "acf96a2e562b1adf", simpleConfigWithTags.Digest())
 	simpleConfigWithOtherTags := &Config{
 		Name:       "foo",
 		InitConfig: Data(""),
 		Instances:  []Data{Data("tags: [\"foo\", \"foo:baf\"]")},
 	}
-	assert.Equal(t, "c3fabecd59ae4584", simpleConfigWithOtherTags.Digest())
+	assert.Equal(t, "3aa6edecf7fa8bcd", simpleConfigWithOtherTags.Digest())
 
 	// assert a character change in a tag produces different hash
 	assert.NotEqual(t, simpleConfigWithTags.Digest(), simpleConfigWithOtherTags.Digest())
@@ -204,7 +204,7 @@ func TestDigest(t *testing.T) {
 		InitConfig: Data(""),
 		Instances:  []Data{Data("tags: [\"foo:bar\", \"foo\"]")},
 	}
-	assert.Equal(t, "4702b7464dedf680", simpleConfigWithTagsDifferentOrder.Digest())
+	assert.Equal(t, "acf96a2e562b1adf", simpleConfigWithTagsDifferentOrder.Digest())
 
 	// assert an order change in the tags list doesn't change the hash
 	assert.Equal(t, simpleConfigWithTags.Digest(), simpleConfigWithTagsDifferentOrder.Digest())
@@ -214,7 +214,7 @@ func TestDigest(t *testing.T) {
 		InitConfig:   Data(""),
 		ClusterCheck: true,
 	}
-	assert.Equal(t, "86fa755714dd0344", simpleClusterCheckConfig.Digest())
+	assert.Equal(t, "6eba821f0cd8c6d0", simpleClusterCheckConfig.Digest())
 
 	// assert the ClusterCheck field is not taken into account
 	assert.Equal(t, simpleConfig.Digest(), simpleClusterCheckConfig.Digest())
@@ -224,14 +224,14 @@ func TestDigest(t *testing.T) {
 		InitConfig: Data(""),
 		ServiceID:  "docker://f556178a47cf65fb70cd5772a9e80e661f71e021da49d3dc99565b861707041c",
 	}
-	assert.Equal(t, "6f0d4b04bfbf4321", configWithEntity.Digest())
+	assert.Equal(t, "87124897c6c72173", configWithEntity.Digest())
 
 	configWithAnotherEntity := &Config{
 		Name:       "foo",
 		InitConfig: Data(""),
 		ServiceID:  "docker://ddcd8a64616772f7ad4524f09fd75c9e3a265144050fc077563e63ea2eb46db0",
 	}
-	assert.Equal(t, "22e040015f8c50b1", configWithAnotherEntity.Digest())
+	assert.Equal(t, "3cbee6f3b98b9b98", configWithAnotherEntity.Digest())
 
 	// assert an entity change produces different hash
 	assert.NotEqual(t, configWithEntity.Digest(), configWithAnotherEntity.Digest())
@@ -241,7 +241,7 @@ func TestDigest(t *testing.T) {
 		InitConfig:              Data(""),
 		IgnoreAutodiscoveryTags: true,
 	}
-	assert.Equal(t, "ef50ccb77f4cc8eb", simpleIngoreADTagsConfig.Digest())
+	assert.Equal(t, "28242ab6104a4de1", simpleIngoreADTagsConfig.Digest())
 
 	// assert the ClusterCheck field is not taken into account
 	assert.NotEqual(t, simpleConfig.Digest(), simpleIngoreADTagsConfig.Digest())

--- a/pkg/clusteragent/clusterchecks/dispatcher_configs.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_configs.go
@@ -48,9 +48,10 @@ func (d *dispatcher) addConfig(config integration.Config, targetNodeName string)
 
 	// Register config
 	digest := config.Digest()
+	fastDigest := config.FastDigest()
 	d.store.digestToConfig[digest] = config
 	for _, instance := range config.Instances {
-		checkID := check.BuildID(config.Name, instance, config.InitConfig)
+		checkID := check.BuildID(config.Name, fastDigest, instance, config.InitConfig)
 		d.store.idToDigest[checkID] = digest
 		if targetNodeName != "" {
 			configsInfo.Set(1.0, targetNodeName, string(checkID), le.JoinLeaderValue)

--- a/pkg/clusteragent/clusterchecks/dispatcher_rebalance_test.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_rebalance_test.go
@@ -371,7 +371,8 @@ func TestRebalance(t *testing.T) {
 					},
 				},
 			},
-		}, {
+		},
+		{
 			in: map[string]*nodeStore{
 				"A": {
 					clcRunnerStats: types.CLCRunnersStats{
@@ -717,7 +718,8 @@ func TestRebalance(t *testing.T) {
 					},
 				},
 			},
-		}, {
+		},
+		{
 			in: map[string]*nodeStore{
 				"A": {
 					clcRunnerStats: types.CLCRunnersStats{
@@ -746,7 +748,8 @@ func TestRebalance(t *testing.T) {
 					clcRunnerStats: types.CLCRunnersStats{},
 				},
 			},
-		}, {
+		},
+		{
 			in: map[string]*nodeStore{
 				"A": {
 					clcRunnerStats: types.CLCRunnersStats{
@@ -787,7 +790,8 @@ func TestRebalance(t *testing.T) {
 					},
 				},
 			},
-		}, {
+		},
+		{
 			in: map[string]*nodeStore{
 				"A": {
 					clcRunnerStats: types.CLCRunnersStats{},
@@ -832,7 +836,8 @@ func TestRebalance(t *testing.T) {
 					},
 				},
 			},
-		}, {
+		},
+		{
 			in: map[string]*nodeStore{
 				"A": {
 					clcRunnerStats: types.CLCRunnersStats{},
@@ -976,7 +981,8 @@ func TestRebalance(t *testing.T) {
 					},
 				},
 			},
-		}, {
+		},
+		{
 			in: map[string]*nodeStore{
 				"A": {
 					clcRunnerStats: types.CLCRunnersStats{},
@@ -1418,7 +1424,7 @@ func TestMoveCheck(t *testing.T) {
 			dispatcher := newDispatcher()
 
 			// setup check id
-			id := check.BuildID(tc.check.config.Name, tc.check.config.Instances[0], tc.check.config.InitConfig)
+			id := check.BuildID(tc.check.config.Name, tc.check.config.FastDigest(), tc.check.config.Instances[0], tc.check.config.InitConfig)
 
 			// prepare store
 			dispatcher.store.active = true

--- a/pkg/collector/check/check.go
+++ b/pkg/collector/check/check.go
@@ -24,7 +24,7 @@ type Check interface {
 	// String provides a printable version of the check name
 	String() string
 	// Configure configures the check
-	Configure(config, initConfig integration.Data, source string) error
+	Configure(integrationConfigDigest uint64, config, initConfig integration.Data, source string) error
 	// Interval returns the interval time for the check
 	Interval() time.Duration
 	// ID provides a unique identifier for every check instance

--- a/pkg/collector/check/id_test.go
+++ b/pkg/collector/check/id_test.go
@@ -14,18 +14,20 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 )
 
-func TestIdentify(t *testing.T) {
+func TestBuildID(t *testing.T) {
 	testCheck := &StubCheck{}
 
 	instance1 := integration.Data("key1:value1\nkey2:value2")
 	initConfig1 := integration.Data("key:value")
 	instance2 := instance1
 	initConfig2 := initConfig1
-	assert.Equal(t, Identify(testCheck, instance1, initConfig1), Identify(testCheck, instance2, initConfig2))
+	assert.Equal(t, BuildID(testCheck.String(), 1, instance1, initConfig1), BuildID(testCheck.String(), 1, instance2, initConfig2))
+	// Different integration config digest
+	assert.NotEqual(t, BuildID(testCheck.String(), 1, instance1, initConfig1), BuildID(testCheck.String(), 2, instance2, initConfig2))
 
 	instance3 := integration.Data("key1:value1\nkey2:value3")
 	initConfig3 := integration.Data("key:value")
-	assert.NotEqual(t, Identify(testCheck, instance1, initConfig1), Identify(testCheck, instance3, initConfig3))
+	assert.NotEqual(t, BuildID(testCheck.String(), 1, instance1, initConfig1), BuildID(testCheck.String(), 1, instance3, initConfig3))
 }
 
 func TestIDToCheckName(t *testing.T) {

--- a/pkg/collector/check/stub.go
+++ b/pkg/collector/check/stub.go
@@ -30,7 +30,7 @@ func (c *StubCheck) Stop() {}
 func (c *StubCheck) Cancel() {}
 
 // Configure is a noop
-func (c *StubCheck) Configure(integration.Data, integration.Data, string) error { return nil }
+func (c *StubCheck) Configure(uint64, integration.Data, integration.Data, string) error { return nil }
 
 // Interval returns a duration of one second
 func (c *StubCheck) Interval() time.Duration { return 1 * time.Second }

--- a/pkg/collector/corechecks/checkbase.go
+++ b/pkg/collector/corechecks/checkbase.go
@@ -65,14 +65,14 @@ func NewCheckBaseWithInterval(name string, defaultInterval time.Duration) CheckB
 
 // BuildID is to be called by the check's Config() method to generate
 // the unique check ID.
-func (c *CheckBase) BuildID(instance, initConfig integration.Data) {
-	c.checkID = check.BuildID(c.checkName, instance, initConfig)
+func (c *CheckBase) BuildID(integrationConfigDigest uint64, instance, initConfig integration.Data) {
+	c.checkID = check.BuildID(c.checkName, integrationConfigDigest, instance, initConfig)
 }
 
 // Configure is provided for checks that require no config. If overridden,
 // the call to CommonConfigure must be preserved.
-func (c *CheckBase) Configure(data integration.Data, initConfig integration.Data, source string) error {
-	err := c.CommonConfigure(initConfig, data, source)
+func (c *CheckBase) Configure(integrationConfigDigest uint64, data integration.Data, initConfig integration.Data, source string) error {
+	err := c.CommonConfigure(integrationConfigDigest, initConfig, data, source)
 	if err != nil {
 		return err
 	}
@@ -90,7 +90,7 @@ func (c *CheckBase) Configure(data integration.Data, initConfig integration.Data
 
 // CommonConfigure is called when checks implement their own Configure method,
 // in order to setup common options (run interval, empty hostname)
-func (c *CheckBase) CommonConfigure(initConfig, instanceConfig integration.Data, source string) error {
+func (c *CheckBase) CommonConfigure(integrationConfigDigest uint64, initConfig, instanceConfig integration.Data, source string) error {
 	handleConf := func(conf integration.Data, c *CheckBase) error {
 		commonOptions := integration.CommonInstanceConfig{}
 		err := yaml.Unmarshal(conf, &commonOptions)

--- a/pkg/collector/corechecks/checkbase_test.go
+++ b/pkg/collector/corechecks/checkbase_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/collector/check/defaults"
 )
 
@@ -37,17 +38,17 @@ func TestCommonConfigure(t *testing.T) {
 	}
 	mockSender := mocksender.NewMockSender(mycheck.ID())
 
-	err := mycheck.CommonConfigure(nil, []byte(defaultsInstance), "test")
+	err := mycheck.CommonConfigure(integration.FakeConfigHash, nil, []byte(defaultsInstance), "test")
 	assert.NoError(t, err)
 	assert.Equal(t, defaults.DefaultCheckInterval, mycheck.Interval())
 	mockSender.AssertNumberOfCalls(t, "DisableDefaultHostname", 0)
 
 	mockSender.On("DisableDefaultHostname", true).Return().Once()
-	err = mycheck.CommonConfigure(nil, []byte(customInstance), "test")
+	err = mycheck.CommonConfigure(integration.FakeConfigHash, nil, []byte(customInstance), "test")
 	assert.NoError(t, err)
 	assert.Equal(t, 60*time.Second, mycheck.Interval())
-	mycheck.BuildID([]byte(customInstance), []byte(initConfig))
-	assert.Equal(t, string(mycheck.ID()), "test:foobar:bd63a7031add5db9")
+	mycheck.BuildID(1, []byte(customInstance), []byte(initConfig))
+	assert.Equal(t, string(mycheck.ID()), "test:foobar:a934df33209f45f4")
 	mockSender.AssertExpectations(t)
 }
 
@@ -56,15 +57,15 @@ func TestCommonConfigureCustomID(t *testing.T) {
 	mycheck := &dummyCheck{
 		CheckBase: NewCheckBase(checkName),
 	}
-	mycheck.BuildID([]byte(customInstance), nil)
+	mycheck.BuildID(1, []byte(customInstance), nil)
 	assert.NotEqual(t, checkName, string(mycheck.ID()))
 	mockSender := mocksender.NewMockSender(mycheck.ID())
 
 	mockSender.On("DisableDefaultHostname", true).Return().Once()
-	err := mycheck.CommonConfigure(nil, []byte(customInstance), "test")
+	err := mycheck.CommonConfigure(integration.FakeConfigHash, nil, []byte(customInstance), "test")
 	assert.NoError(t, err)
 	assert.Equal(t, 60*time.Second, mycheck.Interval())
-	mycheck.BuildID([]byte(customInstance), []byte(initConfig))
-	assert.Equal(t, string(mycheck.ID()), "test:foobar:bd63a7031add5db9")
+	mycheck.BuildID(1, []byte(customInstance), []byte(initConfig))
+	assert.Equal(t, string(mycheck.ID()), "test:foobar:a934df33209f45f4")
 	mockSender.AssertExpectations(t)
 }

--- a/pkg/collector/corechecks/cluster/helm/helm.go
+++ b/pkg/collector/corechecks/cluster/helm/helm.go
@@ -97,10 +97,10 @@ func factory() check.Check {
 }
 
 // Configure configures the Helm check
-func (hc *HelmCheck) Configure(config, initConfig integration.Data, source string) error {
-	hc.BuildID(config, initConfig)
+func (hc *HelmCheck) Configure(integrationConfigDigest uint64, config, initConfig integration.Data, source string) error {
+	hc.BuildID(integrationConfigDigest, config, initConfig)
 
-	err := hc.CommonConfigure(initConfig, config, source)
+	err := hc.CommonConfigure(integrationConfigDigest, initConfig, config, source)
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
@@ -185,10 +185,10 @@ func init() {
 }
 
 // Configure prepares the configuration of the KSM check instance
-func (k *KSMCheck) Configure(config, initConfig integration.Data, source string) error {
-	k.BuildID(config, initConfig)
+func (k *KSMCheck) Configure(integrationConfigDigest uint64, config, initConfig integration.Data, source string) error {
+	k.BuildID(integrationConfigDigest, config, initConfig)
 
-	err := k.CommonConfigure(initConfig, config, source)
+	err := k.CommonConfigure(integrationConfigDigest, initConfig, config, source)
 	if err != nil {
 		return err
 	}
@@ -784,9 +784,9 @@ func resourceNameFromMetric(name string) string {
 
 // isKnownMetric returns whether the KSM metric name is known by the check
 // A known metric should satisfy one of the conditions:
-//  - has a datadog metric name
-//  - has a metric transformer
-//  - has a metric aggregator
+//   - has a datadog metric name
+//   - has a metric transformer
+//   - has a metric aggregator
 func (k *KSMCheck) isKnownMetric(name string) bool {
 	if _, found := k.metricNamesMapper[name]; found {
 		return true

--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_apiserver.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_apiserver.go
@@ -133,8 +133,8 @@ func KubernetesASFactory() check.Check {
 }
 
 // Configure parses the check configuration and init the check.
-func (k *KubeASCheck) Configure(config, initConfig integration.Data, source string) error {
-	err := k.CommonConfigure(initConfig, config, source)
+func (k *KubeASCheck) Configure(integrationConfigDigest uint64, config, initConfig integration.Data, source string) error {
+	err := k.CommonConfigure(integrationConfigDigest, initConfig, config, source)
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_openshift_test.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_openshift_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
@@ -32,10 +33,10 @@ func TestReportClusterQuotas(t *testing.T) {
 	config.Datadog.Set("cluster_name", "test-cluster-name")
 	defer config.Datadog.Set("cluster_name", prevClusterName)
 
-	var instanceCfg = []byte("")
-	var initCfg = []byte("")
+	instanceCfg := []byte("")
+	initCfg := []byte("")
 	kubeASCheck := KubernetesASFactory().(*KubeASCheck)
-	err = kubeASCheck.Configure(instanceCfg, initCfg, "test")
+	err = kubeASCheck.Configure(integration.FakeConfigHash, instanceCfg, initCfg, "test")
 	require.NoError(t, err)
 
 	mocked := mocksender.NewMockSender(kubeASCheck.ID())

--- a/pkg/collector/corechecks/cluster/orchestrator/orchestrator.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/orchestrator.go
@@ -93,10 +93,10 @@ func (o *OrchestratorCheck) Interval() time.Duration {
 }
 
 // Configure configures the orchestrator check
-func (o *OrchestratorCheck) Configure(config, initConfig integration.Data, source string) error {
-	o.BuildID(config, initConfig)
+func (o *OrchestratorCheck) Configure(integrationConfigDigest uint64, config, initConfig integration.Data, source string) error {
+	o.BuildID(integrationConfigDigest, config, initConfig)
 
-	err := o.CommonConfigure(initConfig, config, source)
+	err := o.CommonConfigure(integrationConfigDigest, initConfig, config, source)
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/containerlifecycle/check.go
+++ b/pkg/collector/corechecks/containerlifecycle/check.go
@@ -51,14 +51,14 @@ type Check struct {
 }
 
 // Configure parses the check configuration and initializes the container_lifecycle check
-func (c *Check) Configure(config, initConfig integration.Data, source string) error {
+func (c *Check) Configure(integrationConfigDigest uint64, config, initConfig integration.Data, source string) error {
 	if !ddConfig.Datadog.GetBool("container_lifecycle.enabled") {
 		return errors.New("collection of container lifecycle events is disabled")
 	}
 
 	var err error
 
-	err = c.CommonConfigure(initConfig, config, source)
+	err = c.CommonConfigure(integrationConfigDigest, initConfig, config, source)
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/containers/containerd/check.go
+++ b/pkg/collector/corechecks/containers/containerd/check.go
@@ -66,9 +66,9 @@ func (co *ContainerdConfig) Parse(data []byte) error {
 }
 
 // Configure parses the check configuration and init the check
-func (c *ContainerdCheck) Configure(config, initConfig integration.Data, source string) error {
+func (c *ContainerdCheck) Configure(integrationConfigDigest uint64, config, initConfig integration.Data, source string) error {
 	var err error
-	if err = c.CommonConfigure(initConfig, config, source); err != nil {
+	if err = c.CommonConfigure(integrationConfigDigest, initConfig, config, source); err != nil {
 		return err
 	}
 

--- a/pkg/collector/corechecks/containers/cri/check.go
+++ b/pkg/collector/corechecks/containers/cri/check.go
@@ -64,9 +64,9 @@ func (c *CRIConfig) Parse(data []byte) error {
 }
 
 // Configure parses the check configuration and init the check
-func (c *CRICheck) Configure(config, initConfig integration.Data, source string) error {
+func (c *CRICheck) Configure(integrationConfigDigest uint64, config, initConfig integration.Data, source string) error {
 	var err error
-	if err = c.CommonConfigure(initConfig, config, source); err != nil {
+	if err = c.CommonConfigure(integrationConfigDigest, initConfig, config, source); err != nil {
 		return err
 	}
 

--- a/pkg/collector/corechecks/containers/docker/check.go
+++ b/pkg/collector/corechecks/containers/docker/check.go
@@ -72,8 +72,8 @@ func DockerFactory() check.Check {
 }
 
 // Configure parses the check configuration and init the check
-func (d *DockerCheck) Configure(config, initConfig integration.Data, source string) error {
-	err := d.CommonConfigure(initConfig, config, source)
+func (d *DockerCheck) Configure(integrationConfigDigest uint64, config, initConfig integration.Data, source string) error {
+	err := d.CommonConfigure(integrationConfigDigest, initConfig, config, source)
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/containers/generic/check.go
+++ b/pkg/collector/corechecks/containers/generic/check.go
@@ -50,8 +50,8 @@ func ContainerCheckFactory() check.Check {
 }
 
 // Configure parses the check configuration and init the check
-func (c *ContainerCheck) Configure(config, initConfig integration.Data, source string) error {
-	err := c.CommonConfigure(initConfig, config, source)
+func (c *ContainerCheck) Configure(integrationConfigDigest uint64, config, initConfig integration.Data, source string) error {
+	err := c.CommonConfigure(integrationConfigDigest, initConfig, config, source)
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/ebpf/oom_kill.go
+++ b/pkg/collector/corechecks/ebpf/oom_kill.go
@@ -68,11 +68,11 @@ func (c *OOMKillConfig) Parse(data []byte) error {
 }
 
 // Configure parses the check configuration and init the check
-func (m *OOMKillCheck) Configure(config, initConfig integration.Data, source string) error {
+func (m *OOMKillCheck) Configure(integrationConfigDigest uint64, config, initConfig integration.Data, source string) error {
 	// TODO: Remove that hard-code and put it somewhere else
 	process_net.SetSystemProbePath(dd_config.Datadog.GetString("system_probe_config.sysprobe_socket"))
 
-	err := m.CommonConfigure(initConfig, config, source)
+	err := m.CommonConfigure(integrationConfigDigest, initConfig, config, source)
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/ebpf/tcp_queue_length.go
+++ b/pkg/collector/corechecks/ebpf/tcp_queue_length.go
@@ -65,11 +65,11 @@ func (t *TCPQueueLengthConfig) Parse(data []byte) error {
 }
 
 // Configure parses the check configuration and init the check
-func (t *TCPQueueLengthCheck) Configure(config, initConfig integration.Data, source string) error {
+func (t *TCPQueueLengthCheck) Configure(integrationConfigDigest uint64, config, initConfig integration.Data, source string) error {
 	// TODO: Remove that hard-code and put it somewhere else
 	process_net.SetSystemProbePath(dd_config.Datadog.GetString("system_probe_config.sysprobe_socket"))
 
-	err := t.CommonConfigure(initConfig, config, source)
+	err := t.CommonConfigure(integrationConfigDigest, initConfig, config, source)
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/embed/jmx/check.go
+++ b/pkg/collector/corechecks/embed/jmx/check.go
@@ -31,15 +31,16 @@ type JMXCheck struct {
 }
 
 func newJMXCheck(config integration.Config, source string) *JMXCheck {
+	digest := config.IntDigest()
 	check := &JMXCheck{
 		config:    config,
 		stop:      make(chan struct{}),
 		name:      config.Name,
-		id:        check.ID(fmt.Sprintf("%v_%v", config.Name, config.Digest())),
+		id:        check.ID(fmt.Sprintf("%v_%x", config.Name, digest)),
 		source:    source,
 		telemetry: telemetry_utils.IsCheckEnabled("jmx"),
 	}
-	check.Configure(config.InitConfig, config.MetricConfig, source) //nolint:errcheck
+	check.Configure(digest, config.InitConfig, config.MetricConfig, source) //nolint:errcheck
 
 	return check
 }
@@ -96,7 +97,7 @@ func (c *JMXCheck) InstanceConfig() string {
 }
 
 // Configure TODO <agent-core> : IML-199
-func (c *JMXCheck) Configure(config integration.Data, initConfig integration.Data, source string) error {
+func (c *JMXCheck) Configure(integrationConfigDigest uint64, config integration.Data, initConfig integration.Data, source string) error {
 	c.initConfig = string(config)
 	c.instanceConfig = string(initConfig)
 	return nil

--- a/pkg/collector/corechecks/loader.go
+++ b/pkg/collector/corechecks/loader.go
@@ -68,7 +68,7 @@ func (gl *GoCheckLoader) Load(config integration.Config, instance integration.Da
 	}
 
 	c = factory()
-	if err := c.Configure(instance, config.InitConfig, config.Source); err != nil {
+	if err := c.Configure(config.FastDigest(), instance, config.InitConfig, config.Source); err != nil {
 		log.Errorf("core.loader: could not configure check %s: %s", c, err)
 		msg := fmt.Sprintf("Could not configure check %s: %s", c, err)
 		return c, fmt.Errorf(msg)

--- a/pkg/collector/corechecks/loader_test.go
+++ b/pkg/collector/corechecks/loader_test.go
@@ -18,7 +18,7 @@ type TestCheck struct {
 	check.StubCheck
 }
 
-func (c *TestCheck) Configure(data integration.Data, initData integration.Data, source string) error {
+func (c *TestCheck) Configure(integrationConfigDigest uint64, data integration.Data, initData integration.Data, source string) error {
 	if string(data) == "err" {
 		return fmt.Errorf("testError")
 	}
@@ -54,7 +54,6 @@ func TestLoad(t *testing.T) {
 	l, _ := NewGoCheckLoader()
 
 	_, err := l.Load(cc, i[0])
-
 	if err != nil {
 		t.Fatalf("Expected nil error, found: %v", err)
 	}

--- a/pkg/collector/corechecks/net/network.go
+++ b/pkg/collector/corechecks/net/network.go
@@ -235,7 +235,6 @@ func submitConnectionsMetrics(sender aggregator.Sender, protocolName string, sta
 }
 
 func netstatTCPExtCounters() (map[string]int64, error) {
-
 	f, err := os.Open("/proc/net/netstat")
 	if err != nil {
 		return nil, err
@@ -280,8 +279,8 @@ func netstatTCPExtCounters() (map[string]int64, error) {
 }
 
 // Configure configures the network checks
-func (c *NetworkCheck) Configure(rawInstance integration.Data, rawInitConfig integration.Data, source string) error {
-	err := c.CommonConfigure(rawInitConfig, rawInstance, source)
+func (c *NetworkCheck) Configure(integrationConfigDigest uint64, rawInstance integration.Data, rawInitConfig integration.Data, source string) error {
+	err := c.CommonConfigure(integrationConfigDigest, rawInitConfig, rawInstance, source)
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/net/network_test.go
+++ b/pkg/collector/corechecks/net/network_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/mock"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 )
 
 type fakeNetworkStats struct {
@@ -66,7 +67,7 @@ func (n *fakeNetworkStats) NetstatTCPExtCounters() (map[string]int64, error) {
 
 func TestDefaultConfiguration(t *testing.T) {
 	check := NetworkCheck{}
-	check.Configure([]byte(``), []byte(``), "test")
+	check.Configure(integration.FakeConfigHash, []byte(``), []byte(``), "test")
 
 	assert.Equal(t, false, check.config.instance.CollectConnectionState)
 	assert.Equal(t, []string(nil), check.config.instance.ExcludedInterfaces)
@@ -82,7 +83,7 @@ excluded_interfaces:
     - lo0
 excluded_interface_re: "eth.*"
 `)
-	err := check.Configure(rawInstanceConfig, []byte(``), "test")
+	err := check.Configure(integration.FakeConfigHash, rawInstanceConfig, []byte(``), "test")
 
 	assert.Nil(t, err)
 	assert.Equal(t, true, check.config.instance.CollectConnectionState)
@@ -91,7 +92,6 @@ excluded_interface_re: "eth.*"
 }
 
 func TestNetworkCheck(t *testing.T) {
-
 	net := &fakeNetworkStats{
 		counterStats: []net.IOCountersStat{
 			{
@@ -272,7 +272,7 @@ func TestNetworkCheck(t *testing.T) {
 collect_connection_state: true
 `)
 
-	err := networkCheck.Configure(rawInstanceConfig, []byte(``), "test")
+	err := networkCheck.Configure(integration.FakeConfigHash, rawInstanceConfig, []byte(``), "test")
 	assert.Nil(t, err)
 
 	mockSender := mocksender.NewMockSender(networkCheck.ID())
@@ -392,7 +392,7 @@ excluded_interfaces:
     - lo0
 `)
 
-	networkCheck.Configure(rawInstanceConfig, []byte(``), "test")
+	networkCheck.Configure(integration.FakeConfigHash, rawInstanceConfig, []byte(``), "test")
 
 	mockSender := mocksender.NewMockSender(networkCheck.ID())
 
@@ -472,7 +472,7 @@ func TestExcludedInterfacesRe(t *testing.T) {
 excluded_interface_re: "eth[0-9]"
 `)
 
-	err := networkCheck.Configure(rawInstanceConfig, []byte(``), "test")
+	err := networkCheck.Configure(integration.FakeConfigHash, rawInstanceConfig, []byte(``), "test")
 	assert.Nil(t, err)
 
 	mockSender := mocksender.NewMockSender(networkCheck.ID())

--- a/pkg/collector/corechecks/net/ntp.go
+++ b/pkg/collector/corechecks/net/ntp.go
@@ -139,7 +139,7 @@ func (c *ntpConfig) parse(data []byte, initData []byte, getLocalServers func() (
 }
 
 // Configure configure the data from the yaml
-func (c *NTPCheck) Configure(data integration.Data, initConfig integration.Data, source string) error {
+func (c *NTPCheck) Configure(integrationConfigDigest uint64, data integration.Data, initConfig integration.Data, source string) error {
 	cfg := new(ntpConfig)
 	err := cfg.parse(data, initConfig, getLocalDefinedNTPServers)
 	if err != nil {
@@ -147,10 +147,10 @@ func (c *NTPCheck) Configure(data integration.Data, initConfig integration.Data,
 		return err
 	}
 
-	c.BuildID(data, initConfig)
+	c.BuildID(integrationConfigDigest, data, initConfig)
 	c.cfg = cfg
 
-	err = c.CommonConfigure(initConfig, data, source)
+	err = c.CommonConfigure(integrationConfigDigest, initConfig, data, source)
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/net/ntp_test.go
+++ b/pkg/collector/corechecks/net/ntp_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/mock"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
 	"github.com/DataDog/datadog-agent/pkg/util/cloudproviders"
@@ -51,15 +52,15 @@ func testNTPQuery(host string, opt ntp.QueryOptions) (*ntp.Response, error) {
 }
 
 func TestNTPOK(t *testing.T) {
-	var ntpCfg = []byte(ntpCfgString)
-	var ntpInitCfg = []byte("")
+	ntpCfg := []byte(ntpCfgString)
+	ntpInitCfg := []byte("")
 
 	offset = 21
 	ntpQuery = testNTPQuery
 	defer func() { ntpQuery = ntp.QueryWithOptions }()
 
 	ntpCheck := new(NTPCheck)
-	ntpCheck.Configure(ntpCfg, ntpInitCfg, "test")
+	ntpCheck.Configure(integration.FakeConfigHash, ntpCfg, ntpInitCfg, "test")
 
 	mockSender := mocksender.NewMockSender(ntpCheck.ID())
 
@@ -81,15 +82,15 @@ func TestNTPOK(t *testing.T) {
 }
 
 func TestNTPCritical(t *testing.T) {
-	var ntpCfg = []byte(ntpCfgString)
-	var ntpInitCfg = []byte("")
+	ntpCfg := []byte(ntpCfgString)
+	ntpInitCfg := []byte("")
 
 	offset = 100
 	ntpQuery = testNTPQuery
 	defer func() { ntpQuery = ntp.QueryWithOptions }()
 
 	ntpCheck := new(NTPCheck)
-	ntpCheck.Configure(ntpCfg, ntpInitCfg, "test")
+	ntpCheck.Configure(integration.FakeConfigHash, ntpCfg, ntpInitCfg, "test")
 
 	mockSender := mocksender.NewMockSender(ntpCheck.ID())
 
@@ -111,14 +112,14 @@ func TestNTPCritical(t *testing.T) {
 }
 
 func TestNTPError(t *testing.T) {
-	var ntpCfg = []byte(ntpCfgString)
-	var ntpInitCfg = []byte("")
+	ntpCfg := []byte(ntpCfgString)
+	ntpInitCfg := []byte("")
 
 	ntpQuery = testNTPQueryError
 	defer func() { ntpQuery = ntp.QueryWithOptions }()
 
 	ntpCheck := new(NTPCheck)
-	ntpCheck.Configure(ntpCfg, ntpInitCfg, "test")
+	ntpCheck.Configure(integration.FakeConfigHash, ntpCfg, ntpInitCfg, "test")
 
 	mockSender := mocksender.NewMockSender(ntpCheck.ID())
 
@@ -139,14 +140,14 @@ func TestNTPError(t *testing.T) {
 }
 
 func TestNTPInvalid(t *testing.T) {
-	var ntpCfg = []byte(ntpCfgString)
-	var ntpInitCfg = []byte("")
+	ntpCfg := []byte(ntpCfgString)
+	ntpInitCfg := []byte("")
 
 	ntpQuery = testNTPQueryInvalid
 	defer func() { ntpQuery = ntp.QueryWithOptions }()
 
 	ntpCheck := new(NTPCheck)
-	ntpCheck.Configure(ntpCfg, ntpInitCfg, "test")
+	ntpCheck.Configure(integration.FakeConfigHash, ntpCfg, ntpInitCfg, "test")
 
 	mockSender := mocksender.NewMockSender(ntpCheck.ID())
 
@@ -167,15 +168,15 @@ func TestNTPInvalid(t *testing.T) {
 }
 
 func TestNTPNegativeOffsetCritical(t *testing.T) {
-	var ntpCfg = []byte(ntpCfgString)
-	var ntpInitCfg = []byte("")
+	ntpCfg := []byte(ntpCfgString)
+	ntpInitCfg := []byte("")
 
 	offset = -100
 	ntpQuery = testNTPQuery
 	defer func() { ntpQuery = ntp.QueryWithOptions }()
 
 	ntpCheck := new(NTPCheck)
-	ntpCheck.Configure(ntpCfg, ntpInitCfg, "test")
+	ntpCheck.Configure(integration.FakeConfigHash, ntpCfg, ntpInitCfg, "test")
 
 	mockSender := mocksender.NewMockSender(ntpCheck.ID())
 
@@ -197,13 +198,13 @@ func TestNTPNegativeOffsetCritical(t *testing.T) {
 }
 
 func TestNTPResiliencyOK(t *testing.T) {
-	var ntpCfg = []byte(`
+	ntpCfg := []byte(`
 hosts:
   - 1
   - 400
   - 2
 `)
-	var ntpInitCfg = []byte("")
+	ntpInitCfg := []byte("")
 
 	offset = 1
 	ntpQuery = func(host string, opt ntp.QueryOptions) (*ntp.Response, error) {
@@ -216,7 +217,7 @@ hosts:
 	defer func() { ntpQuery = ntp.QueryWithOptions }()
 
 	ntpCheck := new(NTPCheck)
-	ntpCheck.Configure(ntpCfg, ntpInitCfg, "test")
+	ntpCheck.Configure(integration.FakeConfigHash, ntpCfg, ntpInitCfg, "test")
 
 	mockSender := mocksender.NewMockSender(ntpCheck.ID())
 
@@ -238,13 +239,13 @@ hosts:
 }
 
 func TestNTPResiliencyCritical(t *testing.T) {
-	var ntpCfg = []byte(`
+	ntpCfg := []byte(`
 hosts:
   - 1
   - 400
   - 400
 `)
-	var ntpInitCfg = []byte("")
+	ntpInitCfg := []byte("")
 
 	offset = 1
 	ntpQuery = func(host string, opt ntp.QueryOptions) (*ntp.Response, error) {
@@ -257,7 +258,7 @@ hosts:
 	defer func() { ntpQuery = ntp.QueryWithOptions }()
 
 	ntpCheck := new(NTPCheck)
-	ntpCheck.Configure(ntpCfg, ntpInitCfg, "test")
+	ntpCheck.Configure(integration.FakeConfigHash, ntpCfg, ntpInitCfg, "test")
 
 	mockSender := mocksender.NewMockSender(ntpCheck.ID())
 
@@ -279,7 +280,6 @@ hosts:
 }
 
 func TestHostConfigsMerge(t *testing.T) {
-
 	expectedHosts := []string{"0.time.dogo", "1.time.dogo", "2.time.dogo"}
 	testedConfig := []byte(`
 host: 0.time.dogo
@@ -289,13 +289,12 @@ hosts:
 `)
 
 	ntpCheck := new(NTPCheck)
-	ntpCheck.Configure(testedConfig, []byte(""), "test")
+	ntpCheck.Configure(integration.FakeConfigHash, testedConfig, []byte(""), "test")
 
 	assert.Equal(t, expectedHosts, ntpCheck.cfg.instance.Hosts)
 }
 
 func TestHostConfigsMergeNoDuplicate(t *testing.T) {
-
 	expectedHosts := []string{"0.time.dogo", "1.time.dogo", "2.time.dogo"}
 	testedConfig := []byte(`
 host: 0.time.dogo
@@ -306,7 +305,7 @@ hosts:
 `)
 
 	ntpCheck := new(NTPCheck)
-	ntpCheck.Configure(testedConfig, []byte(""), "test")
+	ntpCheck.Configure(integration.FakeConfigHash, testedConfig, []byte(""), "test")
 
 	assert.Equal(t, expectedHosts, ntpCheck.cfg.instance.Hosts)
 }
@@ -318,7 +317,7 @@ host: time.dogo
 `)
 
 	ntpCheck := new(NTPCheck)
-	ntpCheck.Configure(testedConfig, []byte(""), "test")
+	ntpCheck.Configure(integration.FakeConfigHash, testedConfig, []byte(""), "test")
 
 	assert.Equal(t, expectedHosts, ntpCheck.cfg.instance.Hosts)
 }
@@ -332,7 +331,7 @@ hosts:
 `)
 
 	ntpCheck := new(NTPCheck)
-	ntpCheck.Configure(testedConfig, []byte(""), "test")
+	ntpCheck.Configure(integration.FakeConfigHash, testedConfig, []byte(""), "test")
 
 	assert.Equal(t, expectedHosts, ntpCheck.cfg.instance.Hosts)
 }
@@ -347,7 +346,7 @@ func TestDefaultHostConfig(t *testing.T) {
 	config.Datadog.Set("cloud_provider_metadata", []string{})
 
 	ntpCheck := new(NTPCheck)
-	ntpCheck.Configure(testedConfig, []byte(""), "test")
+	ntpCheck.Configure(integration.FakeConfigHash, testedConfig, []byte(""), "test")
 
 	assert.Equal(t, expectedHosts, ntpCheck.cfg.instance.Hosts)
 }
@@ -367,7 +366,7 @@ func TestNTPPortConfig(t *testing.T) {
 offset_threshold: 60
 port: %d
 `, expectedPort))
-	err := ntpCheck.Configure(ntpCfg, []byte(""), "test")
+	err := ntpCheck.Configure(integration.FakeConfigHash, ntpCfg, []byte(""), "test")
 	assert.Nil(t, err)
 
 	mockSender := mocksender.NewMockSender(ntpCheck.ID())
@@ -386,7 +385,7 @@ func TestNTPPortNotInt(t *testing.T) {
 offset_threshold: 60
 port: ntp`)
 
-	err := ntpCheck.Configure(ntpCfg, []byte(""), "test")
+	err := ntpCheck.Configure(integration.FakeConfigHash, ntpCfg, []byte(""), "test")
 	assert.EqualError(t, err, "yaml: unmarshal errors:\n  line 3: cannot unmarshal !!str `ntp` into int")
 }
 

--- a/pkg/collector/corechecks/nvidia/jetson/jetson.go
+++ b/pkg/collector/corechecks/nvidia/jetson/jetson.go
@@ -153,8 +153,8 @@ func (c *JetsonCheck) Run() error {
 }
 
 // Configure the GPU check
-func (c *JetsonCheck) Configure(data integration.Data, initConfig integration.Data, source string) error {
-	err := c.CommonConfigure(initConfig, data, source)
+func (c *JetsonCheck) Configure(integrationConfigDigest uint64, data integration.Data, initConfig integration.Data, source string) error {
+	err := c.CommonConfigure(integrationConfigDigest, initConfig, data, source)
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/nvidia/jetson/jetson_test.go
+++ b/pkg/collector/corechecks/nvidia/jetson/jetson_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 )
 
 const (
@@ -25,9 +26,8 @@ const (
 )
 
 func TestNano(t *testing.T) {
-
 	tegraCheck := new(JetsonCheck)
-	tegraCheck.Configure(nil, nil, "test")
+	tegraCheck.Configure(integration.FakeConfigHash, nil, nil, "test")
 
 	assert.Equal(t, tegraCheck.tegraStatsPath, "/usr/bin/tegrastats")
 
@@ -80,9 +80,8 @@ func TestNano(t *testing.T) {
 }
 
 func TestTX1(t *testing.T) {
-
 	tegraCheck := new(JetsonCheck)
-	tegraCheck.Configure(nil, nil, "test")
+	tegraCheck.Configure(integration.FakeConfigHash, nil, nil, "test")
 
 	assert.Equal(t, tegraCheck.tegraStatsPath, "/usr/bin/tegrastats")
 
@@ -134,9 +133,8 @@ func TestTX1(t *testing.T) {
 }
 
 func TestTX2(t *testing.T) {
-
 	tegraCheck := new(JetsonCheck)
-	tegraCheck.Configure(nil, nil, "test")
+	tegraCheck.Configure(integration.FakeConfigHash, nil, nil, "test")
 
 	assert.Equal(t, tegraCheck.tegraStatsPath, "/usr/bin/tegrastats")
 
@@ -198,9 +196,8 @@ func TestTX2(t *testing.T) {
 }
 
 func TestAgxXavier(t *testing.T) {
-
 	tegraCheck := new(JetsonCheck)
-	tegraCheck.Configure(nil, nil, "test")
+	tegraCheck.Configure(integration.FakeConfigHash, nil, nil, "test")
 
 	assert.Equal(t, tegraCheck.tegraStatsPath, "/usr/bin/tegrastats")
 	mock := mocksender.NewMockSender(tegraCheck.ID())
@@ -266,9 +263,8 @@ func TestAgxXavier(t *testing.T) {
 }
 
 func TestXavierNx(t *testing.T) {
-
 	tegraCheck := new(JetsonCheck)
-	tegraCheck.Configure(nil, nil, "test")
+	tegraCheck.Configure(integration.FakeConfigHash, nil, nil, "test")
 
 	assert.Equal(t, tegraCheck.tegraStatsPath, "/usr/bin/tegrastats")
 	mock := mocksender.NewMockSender(tegraCheck.ID())

--- a/pkg/collector/corechecks/snmp/profile_test.go
+++ b/pkg/collector/corechecks/snmp/profile_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/version"
 
@@ -55,7 +56,7 @@ profiles:
     definition_file: f5-big-ip.yaml
 `)
 
-	err := chk.Configure(rawInstanceConfig, rawInitConfig, "test")
+	err := chk.Configure(integration.FakeConfigHash, rawInstanceConfig, rawInitConfig, "test")
 	assert.NoError(t, err)
 
 	sender := mocksender.NewMockSender(chk.ID()) // required to initiate aggregator

--- a/pkg/collector/corechecks/snmp/snmp.go
+++ b/pkg/collector/corechecks/snmp/snmp.go
@@ -111,7 +111,7 @@ func (c *Check) runCheckDevice(deviceCk *devicecheck.DeviceCheck) error {
 }
 
 // Configure configures the snmp checks
-func (c *Check) Configure(rawInstance integration.Data, rawInitConfig integration.Data, source string) error {
+func (c *Check) Configure(integrationConfigDigest uint64, rawInstance integration.Data, rawInitConfig integration.Data, source string) error {
 	var err error
 
 	c.config, err = checkconfig.NewCheckConfig(rawInstance, rawInitConfig)
@@ -137,9 +137,9 @@ func (c *Check) Configure(rawInstance integration.Data, rawInitConfig integratio
 	}
 
 	// Must be called before c.CommonConfigure
-	c.BuildID(rawInstance, rawInitConfig)
+	c.BuildID(integrationConfigDigest, rawInstance, rawInitConfig)
 
-	err = c.CommonConfigure(rawInitConfig, rawInstance, source)
+	err = c.CommonConfigure(integrationConfigDigest, rawInitConfig, rawInstance, source)
 	if err != nil {
 		return fmt.Errorf("common configure failed: %s", err)
 	}

--- a/pkg/collector/corechecks/snmp/snmp_test.go
+++ b/pkg/collector/corechecks/snmp/snmp_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	coreconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/metadata/externalhost"
@@ -88,7 +89,7 @@ tags:
   - "mytag:foo"
 `)
 
-	err := chk.Configure(rawInstanceConfig, []byte(``), "test")
+	err := chk.Configure(integration.FakeConfigHash, rawInstanceConfig, []byte(``), "test")
 	assert.Nil(t, err)
 
 	sender := mocksender.NewMockSender(chk.ID()) // required to initiate aggregator
@@ -144,7 +145,7 @@ tags:
 			{
 				Name:  "1.3.6.1.2.1.2.2.1.6.1",
 				Type:  gosnmp.OctetString,
-				Value: []byte{00, 00, 00, 00, 00, 01},
+				Value: []byte{0o0, 0o0, 0o0, 0o0, 0o0, 0o1},
 			},
 			{
 				Name:  "1.3.6.1.2.1.2.2.1.7.1",
@@ -169,7 +170,7 @@ tags:
 			{
 				Name:  "1.3.6.1.2.1.2.2.1.6.2",
 				Type:  gosnmp.OctetString,
-				Value: []byte{00, 00, 00, 00, 00, 02},
+				Value: []byte{0o0, 0o0, 0o0, 0o0, 0o0, 0o2},
 			},
 			{
 				Name:  "1.3.6.1.2.1.2.2.1.7.2",
@@ -312,7 +313,7 @@ metrics:
     name: SomeCounter64Metric
 `)
 
-	err := chk.Configure(rawInstanceConfig, []byte(``), "test")
+	err := chk.Configure(integration.FakeConfigHash, rawInstanceConfig, []byte(``), "test")
 	assert.Nil(t, err)
 
 	sender := mocksender.NewMockSender(chk.ID()) // required to initiate aggregator
@@ -392,7 +393,7 @@ profiles:
     definition_file: f5-big-ip.yaml
 `)
 
-	err := chk.Configure(rawInstanceConfig, rawInitConfig, "test")
+	err := chk.Configure(integration.FakeConfigHash, rawInstanceConfig, rawInitConfig, "test")
 	assert.NoError(t, err)
 
 	sender := mocksender.NewMockSender(chk.ID()) // required to initiate aggregator
@@ -461,7 +462,7 @@ profiles:
 			{
 				Name:  "1.3.6.1.2.1.2.2.1.6.1",
 				Type:  gosnmp.OctetString,
-				Value: []byte{00, 00, 00, 00, 00, 01},
+				Value: []byte{0o0, 0o0, 0o0, 0o0, 0o0, 0o1},
 			},
 			{
 				Name:  "1.3.6.1.2.1.2.2.1.7.1",
@@ -496,7 +497,7 @@ profiles:
 			{
 				Name:  "1.3.6.1.2.1.2.2.1.6.2",
 				Type:  gosnmp.OctetString,
-				Value: []byte{00, 00, 00, 00, 00, 02},
+				Value: []byte{0o0, 0o0, 0o0, 0o0, 0o0, 0o2},
 			},
 			{
 				Name:  "1.3.6.1.2.1.2.2.1.7.2",
@@ -695,7 +696,7 @@ ip_address: 1.2.3.4
 community_string: public
 `)
 
-	err := chk.Configure(rawInstanceConfig, []byte(``), "test")
+	err := chk.Configure(integration.FakeConfigHash, rawInstanceConfig, []byte(``), "test")
 	assert.Nil(t, err)
 
 	sender := mocksender.NewMockSender(chk.ID()) // required to initiate aggregator
@@ -744,19 +745,19 @@ community_string: abc
 namespace: nsSubnet
 `)
 
-	err := check1.Configure(rawInstanceConfig1, []byte(``), "test")
+	err := check1.Configure(integration.FakeConfigHash, rawInstanceConfig1, []byte(``), "test")
 	assert.Nil(t, err)
-	err = check2.Configure(rawInstanceConfig2, []byte(``), "test")
+	err = check2.Configure(integration.FakeConfigHash, rawInstanceConfig2, []byte(``), "test")
 	assert.Nil(t, err)
-	err = check3.Configure(rawInstanceConfig3, []byte(``), "test")
+	err = check3.Configure(integration.FakeConfigHash, rawInstanceConfig3, []byte(``), "test")
 	assert.Nil(t, err)
-	err = checkSubnet.Configure(rawInstanceConfigSubnet, []byte(``), "test")
+	err = checkSubnet.Configure(integration.FakeConfigHash, rawInstanceConfigSubnet, []byte(``), "test")
 	assert.Nil(t, err)
 
-	assert.Equal(t, check.ID("snmp:default:1.1.1.1:a3ec59dfb03e4457"), check1.ID())
-	assert.Equal(t, check.ID("snmp:default:2.2.2.2:3979cd473e4beb3f"), check2.ID())
-	assert.Equal(t, check.ID("snmp:ns3:3.3.3.3:819516f4c3986cc6"), check3.ID())
-	assert.Equal(t, check.ID("snmp:nsSubnet:10.10.10.0/24:be3c32b7c5c1c696"), checkSubnet.ID())
+	assert.Equal(t, check.ID("snmp:default:1.1.1.1:d03f28dacffc6886"), check1.ID())
+	assert.Equal(t, check.ID("snmp:default:2.2.2.2:b757d26210a16a9e"), check2.ID())
+	assert.Equal(t, check.ID("snmp:ns3:3.3.3.3:cc7fb36641d79afd"), check3.ID())
+	assert.Equal(t, check.ID("snmp:nsSubnet:10.10.10.0/24:6b68b30a87454899"), checkSubnet.ID())
 	assert.NotEqual(t, check1.ID(), check2.ID())
 }
 
@@ -944,14 +945,13 @@ community_string: public
 namespace: '%s'
 `, tt.name))
 
-			err := chk.Configure(rawInstanceConfig, []byte(``), "test")
+			err := chk.Configure(integration.FakeConfigHash, rawInstanceConfig, []byte(``), "test")
 			assert.Nil(t, err)
 
 			sender := new(mocksender.MockSender)
 
 			if !tt.disableAggregator {
 				aggregator.InitAndStartAgentDemultiplexer(demuxOpts(), "")
-
 			}
 
 			mocksender.SetSender(sender, chk.ID())
@@ -1002,7 +1002,7 @@ metrics:
     name: myMetric
 `)
 
-	err := chk.Configure(rawInstanceConfig, []byte(``), "test")
+	err := chk.Configure(integration.FakeConfigHash, rawInstanceConfig, []byte(``), "test")
 	assert.Nil(t, err)
 
 	sender := mocksender.NewMockSender(chk.ID()) // required to initiate aggregator
@@ -1051,7 +1051,7 @@ tags:
 	// language=yaml
 	rawInitConfig := []byte(``)
 
-	err := chk.Configure(rawInstanceConfig, rawInitConfig, "test")
+	err := chk.Configure(integration.FakeConfigHash, rawInstanceConfig, rawInitConfig, "test")
 	assert.Nil(t, err)
 
 	sender := mocksender.NewMockSender(chk.ID()) // required to initiate aggregator
@@ -1096,7 +1096,7 @@ tags:
 			{
 				Name:  "1.3.6.1.2.1.2.2.1.6.1",
 				Type:  gosnmp.OctetString,
-				Value: []byte{00, 00, 00, 00, 00, 01},
+				Value: []byte{0o0, 0o0, 0o0, 0o0, 0o0, 0o1},
 			},
 			{
 				Name:  "1.3.6.1.2.1.2.2.1.7.1",
@@ -1126,7 +1126,7 @@ tags:
 			{
 				Name:  "1.3.6.1.2.1.2.2.1.6.2",
 				Type:  gosnmp.OctetString,
-				Value: []byte{00, 00, 00, 00, 00, 02},
+				Value: []byte{0o0, 0o0, 0o0, 0o0, 0o0, 0o2},
 			},
 			{
 				Name:  "1.3.6.1.2.1.2.2.1.7.2",
@@ -1295,7 +1295,7 @@ tags:
 	// language=yaml
 	rawInitConfig := []byte(``)
 
-	err := chk.Configure(rawInstanceConfig, rawInitConfig, "test")
+	err := chk.Configure(integration.FakeConfigHash, rawInstanceConfig, rawInitConfig, "test")
 	assert.Nil(t, err)
 
 	sender := mocksender.NewMockSender(chk.ID()) // required to initiate aggregator
@@ -1403,7 +1403,7 @@ metric_tags:
 	sess.On("GetNext", []string{"1.0"}).Return(&gosnmplib.MockValidReachableGetNextPacket, nil)
 	sess.On("Get", []string{"1.3.6.1.2.1.1.2.0"}).Return(&discoveryPacket, nil)
 
-	err := chk.Configure(rawInstanceConfig, []byte(``), "test")
+	err := chk.Configure(integration.FakeConfigHash, rawInstanceConfig, []byte(``), "test")
 	assert.Nil(t, err)
 
 	time.Sleep(100 * time.Millisecond)
@@ -1449,7 +1449,7 @@ metric_tags:
 			{
 				Name:  "1.3.6.1.2.1.2.2.1.6.1",
 				Type:  gosnmp.OctetString,
-				Value: []byte{00, 00, 00, 00, 00, 01},
+				Value: []byte{0o0, 0o0, 0o0, 0o0, 0o0, 0o1},
 			},
 			{
 				Name:  "1.3.6.1.2.1.2.2.1.7.1",
@@ -1479,7 +1479,7 @@ metric_tags:
 			{
 				Name:  "1.3.6.1.2.1.2.2.1.6.2",
 				Type:  gosnmp.OctetString,
-				Value: []byte{00, 00, 00, 00, 00, 02},
+				Value: []byte{0o0, 0o0, 0o0, 0o0, 0o0, 0o2},
 			},
 			{
 				Name:  "1.3.6.1.2.1.2.2.1.7.2",
@@ -1687,7 +1687,7 @@ metric_tags:
 	sess.On("GetNext", []string{"1.0"}).Return(&gosnmplib.MockValidReachableGetNextPacket, nil)
 	sess.On("Get", []string{"1.3.6.1.2.1.1.2.0"}).Return(&discoveryPacket, nil)
 
-	err := chk.Configure(rawInstanceConfig, []byte(``), "test")
+	err := chk.Configure(integration.FakeConfigHash, rawInstanceConfig, []byte(``), "test")
 	assert.Nil(t, err)
 
 	time.Sleep(100 * time.Millisecond)
@@ -1746,7 +1746,7 @@ metrics:
 use_device_id_as_hostname: true
 `)
 
-	err := chk.Configure(rawInstanceConfig, []byte(``), "test")
+	err := chk.Configure(integration.FakeConfigHash, rawInstanceConfig, []byte(``), "test")
 	assert.Nil(t, err)
 
 	sender := mocksender.NewMockSender(chk.ID()) // required to initiate aggregator
@@ -1786,7 +1786,7 @@ use_device_id_as_hostname: true
 				{
 					Name:  "1.3.6.1.2.1.2.2.1.6.1",
 					Type:  gosnmp.OctetString,
-					Value: []byte{00, 00, 00, 00, 00, 01},
+					Value: []byte{0o0, 0o0, 0o0, 0o0, 0o0, 0o1},
 				},
 				{
 					Name:  "1.3.6.1.2.1.2.2.1.7.1",
@@ -1926,7 +1926,7 @@ metrics:
 	}
 	sess.On("Get", []string{"1.3.6.1.2.1.1.2.0"}).Return(&discoveryPacket, nil)
 
-	err := chk.Configure(rawInstanceConfig, []byte(``), "test")
+	err := chk.Configure(integration.FakeConfigHash, rawInstanceConfig, []byte(``), "test")
 	assert.Nil(t, err)
 
 	time.Sleep(100 * time.Millisecond)
@@ -1971,7 +1971,7 @@ metrics:
 			{
 				Name:  "1.3.6.1.2.1.2.2.1.6.1",
 				Type:  gosnmp.OctetString,
-				Value: []byte{00, 00, 00, 00, 00, 01},
+				Value: []byte{0o0, 0o0, 0o0, 0o0, 0o0, 0o1},
 			},
 			{
 				Name:  "1.3.6.1.2.1.2.2.1.7.1",
@@ -2077,7 +2077,7 @@ ip_address: 1.2.3.4
 community_string: public
 `)
 
-	err := chk.Configure(rawInstanceConfig, []byte(``), "test")
+	err := chk.Configure(integration.FakeConfigHash, rawInstanceConfig, []byte(``), "test")
 	assert.Nil(t, err)
 
 	// check Cancel does not panic when called with single check

--- a/pkg/collector/corechecks/system/cpu/cpu.go
+++ b/pkg/collector/corechecks/system/cpu/cpu.go
@@ -89,8 +89,8 @@ func (c *Check) Run() error {
 }
 
 // Configure the CPU check
-func (c *Check) Configure(data integration.Data, initConfig integration.Data, source string) error {
-	err := c.CommonConfigure(initConfig, data, source)
+func (c *Check) Configure(integrationConfigDigest uint64, data integration.Data, initConfig integration.Data, source string) error {
+	err := c.CommonConfigure(integrationConfigDigest, initConfig, data, source)
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/system/cpu/cpu_test.go
+++ b/pkg/collector/corechecks/system/cpu/cpu_test.go
@@ -11,12 +11,12 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
 
 	"github.com/shirou/gopsutil/v3/cpu"
 	"github.com/stretchr/testify/mock"
-
-	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
 )
 
 var (
@@ -81,7 +81,7 @@ func TestCPUCheckLinux(t *testing.T) {
 	times = CPUTimes
 	cpuInfo = CPUInfo
 	cpuCheck := new(Check)
-	cpuCheck.Configure(nil, nil, "test")
+	cpuCheck.Configure(integration.FakeConfigHash, nil, nil, "test")
 
 	m := mocksender.NewMockSender(cpuCheck.ID())
 	m.On(metrics.GaugeType.String(), "system.cpu.num_cores", 1.0, "", []string(nil)).Return().Times(1)

--- a/pkg/collector/corechecks/system/cpu/cpu_windows.go
+++ b/pkg/collector/corechecks/system/cpu/cpu_windows.go
@@ -124,8 +124,8 @@ func getProcessorPDHCounter(counterName, instance string) (*pdhutil.PdhSingleIns
 }
 
 // Configure the CPU check doesn't need configuration
-func (c *Check) Configure(data integration.Data, initConfig integration.Data, source string) error {
-	if err := c.CommonConfigure(initConfig, data, source); err != nil {
+func (c *Check) Configure(integrationConfigDigest uint64, data integration.Data, initConfig integration.Data, source string) error {
+	if err := c.CommonConfigure(integrationConfigDigest, initConfig, data, source); err != nil {
 		return err
 	}
 

--- a/pkg/collector/corechecks/system/cpu/cpu_windows_test.go
+++ b/pkg/collector/corechecks/system/cpu/cpu_windows_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/metrics"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	pdhtest "github.com/DataDog/datadog-agent/pkg/util/winutil/pdhutil"
 )
 
@@ -32,7 +33,7 @@ func TestCPUCheckWindows(t *testing.T) {
 	pdhtest.SetQueryReturnValue("\\\\.\\Processor Information(_Total)\\% Privileged Time", 8.5)
 
 	cpuCheck := new(Check)
-	cpuCheck.Configure(nil, nil, "test")
+	cpuCheck.Configure(integration.FakeConfigHash, nil, nil, "test")
 
 	m := mocksender.NewMockSender(cpuCheck.ID())
 	m.On(metrics.GaugeType.String(), "system.cpu.num_cores", 1.0, "", []string(nil)).Return().Times(1)

--- a/pkg/collector/corechecks/system/cpu/load.go
+++ b/pkg/collector/corechecks/system/cpu/load.go
@@ -55,8 +55,8 @@ func (c *LoadCheck) Run() error {
 }
 
 // Configure the CPU check
-func (c *LoadCheck) Configure(data integration.Data, initConfig integration.Data, source string) error {
-	err := c.CommonConfigure(initConfig, data, source)
+func (c *LoadCheck) Configure(integrationConfigDigest uint64, data integration.Data, initConfig integration.Data, source string) error {
+	err := c.CommonConfigure(integrationConfigDigest, initConfig, data, source)
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/system/cpu/load_test.go
+++ b/pkg/collector/corechecks/system/cpu/load_test.go
@@ -13,15 +13,14 @@ import (
 	"github.com/shirou/gopsutil/v3/load"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 )
 
-var (
-	avgSample = load.AvgStat{
-		Load1:  0.83,
-		Load5:  0.96,
-		Load15: 1.15,
-	}
-)
+var avgSample = load.AvgStat{
+	Load1:  0.83,
+	Load5:  0.96,
+	Load15: 1.15,
+}
 
 func Avg() (*load.AvgStat, error) {
 	return &avgSample, nil
@@ -31,7 +30,7 @@ func TestLoadCheckLinux(t *testing.T) {
 	loadAvg = Avg
 	cpuInfo = CPUInfo
 	loadCheck := new(LoadCheck)
-	loadCheck.Configure(nil, nil, "test")
+	loadCheck.Configure(integration.FakeConfigHash, nil, nil, "test")
 
 	mock := mocksender.NewMockSender(loadCheck.ID())
 

--- a/pkg/collector/corechecks/system/disk/disk_nix.go
+++ b/pkg/collector/corechecks/system/disk/disk_nix.go
@@ -131,7 +131,6 @@ func (c *Check) sendPartitionMetrics(sender aggregator.Sender, usage *disk.Usage
 	sender.Gauge(fmt.Sprintf(inodeMetric, "free"), float64(usage.InodesFree), "", tags)
 	// FIXME(8.x): use percent, a lot more logical than in_use
 	sender.Gauge(fmt.Sprintf(inodeMetric, "in_use"), usage.InodesUsedPercent/100, "", tags)
-
 }
 
 func (c *Check) sendDiskMetrics(sender aggregator.Sender, ioCounter disk.IOCountersStat, tags []string) {
@@ -143,8 +142,8 @@ func (c *Check) sendDiskMetrics(sender aggregator.Sender, ioCounter disk.IOCount
 }
 
 // Configure the disk check
-func (c *Check) Configure(data integration.Data, initConfig integration.Data, source string) error {
-	err := c.CommonConfigure(initConfig, data, source)
+func (c *Check) Configure(integrationConfigDigest uint64, data integration.Data, initConfig integration.Data, source string) error {
+	err := c.CommonConfigure(integrationConfigDigest, initConfig, data, source)
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/system/disk/disk_test.go
+++ b/pkg/collector/corechecks/system/disk/disk_test.go
@@ -19,7 +19,6 @@ import (
 
 var (
 	diskSamples = []disk.PartitionStat{
-
 		{
 			Device:     "/dev/sda2",
 			Mountpoint: "/",
@@ -46,7 +45,8 @@ var (
 			InodesFree:        0,
 			InodesUsedPercent: 0,
 		},
-		"/": {Path: "/",
+		"/": {
+			Path:              "/",
 			Fstype:            "ext2/ext3",
 			Total:             52045545472,
 			Free:              39085445120,
@@ -94,7 +94,7 @@ func TestDiskCheck(t *testing.T) {
 	diskUsage = diskUsageSampler
 	ioCounters = diskIoSampler
 	diskCheck := new(Check)
-	diskCheck.Configure(nil, nil, "test")
+	diskCheck.Configure(integration.FakeConfigHash, nil, nil, "test")
 
 	mock := mocksender.NewMockSender(diskCheck.ID())
 
@@ -141,7 +141,7 @@ func TestDiskCheckExcludedDiskFilsystem(t *testing.T) {
 	diskUsage = diskUsageSampler
 	ioCounters = diskIoSampler
 	diskCheck := new(Check)
-	diskCheck.Configure(nil, nil, "test")
+	diskCheck.Configure(integration.FakeConfigHash, nil, nil, "test")
 
 	diskCheck.cfg.excludedFilesystems = []string{"vfat"}
 	diskCheck.cfg.excludedDisks = []string{"/dev/sda2"}
@@ -173,7 +173,7 @@ func TestDiskCheckExcludedRe(t *testing.T) {
 	diskUsage = diskUsageSampler
 	ioCounters = diskIoSampler
 	diskCheck := new(Check)
-	diskCheck.Configure(nil, nil, "test")
+	diskCheck.Configure(integration.FakeConfigHash, nil, nil, "test")
 
 	diskCheck.cfg.excludedMountpointRe = regexp.MustCompile("/boot/efi")
 	diskCheck.cfg.excludedDiskRe = regexp.MustCompile("/dev/sda2")
@@ -208,7 +208,7 @@ func TestDiskCheckTags(t *testing.T) {
 
 	config := integration.Data([]byte("use_mount: true\ntag_by_filesystem: true\nall_partitions: true\ndevice_tag_re:\n  /boot/efi: role:esp\n  /dev/sda2: device_type:sata,disk_size:large"))
 
-	diskCheck.Configure(config, nil, "test")
+	diskCheck.Configure(integration.FakeConfigHash, config, nil, "test")
 
 	mock := mocksender.NewMockSender(diskCheck.ID())
 

--- a/pkg/collector/corechecks/system/disk/iostats.go
+++ b/pkg/collector/corechecks/system/disk/iostats.go
@@ -24,8 +24,8 @@ const (
 )
 
 // Configure the IOstats check
-func (c *IOCheck) commonConfigure(data integration.Data, initConfig integration.Data, source string) error {
-	if err := c.CommonConfigure(initConfig, data, source); err != nil {
+func (c *IOCheck) commonConfigure(integrationConfigDigest uint64, data integration.Data, initConfig integration.Data, source string) error {
+	if err := c.CommonConfigure(integrationConfigDigest, initConfig, data, source); err != nil {
 		return err
 	}
 

--- a/pkg/collector/corechecks/system/disk/iostats_nix.go
+++ b/pkg/collector/corechecks/system/disk/iostats_nix.go
@@ -41,8 +41,8 @@ type IOCheck struct {
 }
 
 // Configure the IOstats check
-func (c *IOCheck) Configure(data integration.Data, initConfig integration.Data, source string) error {
-	err := c.commonConfigure(data, initConfig, source)
+func (c *IOCheck) Configure(integrationConfigDigest uint64, data integration.Data, initConfig integration.Data, source string) error {
+	err := c.commonConfigure(integrationConfigDigest, data, initConfig, source)
 	return err
 }
 
@@ -130,11 +130,11 @@ func (c *IOCheck) nixIO() error {
 		diffNRIO := float64(incrementWithOverflow(ioStats.ReadCount, lastIOStats.ReadCount))
 		diffNWIO := float64(incrementWithOverflow(ioStats.WriteCount, lastIOStats.WriteCount))
 		if diffNRIO != 0 {
-			//Note we use math.MaxUint32 because this value is always 32-bit, even on 64 bit machines
+			// Note we use math.MaxUint32 because this value is always 32-bit, even on 64 bit machines
 			rAwait = float64(incrementWithOverflow(ioStats.ReadTime, lastIOStats.ReadTime)) / diffNRIO
 		}
 		if diffNWIO != 0 {
-			//Note we use math.MaxUint32 because this value is always 32-bit, even on 64 bit machines
+			// Note we use math.MaxUint32 because this value is always 32-bit, even on 64 bit machines
 			wAwait = float64(incrementWithOverflow(ioStats.WriteTime, lastIOStats.WriteTime)) / diffNWIO
 		}
 
@@ -144,7 +144,7 @@ func (c *IOCheck) nixIO() error {
 		if diffNIO != 0 {
 			avgrqsz = float64((incrementWithOverflow(ioStats.ReadBytes, lastIOStats.ReadBytes)+
 				incrementWithOverflow(ioStats.WriteBytes, lastIOStats.WriteBytes))/SectorSize) / diffNIO
-			//Note we use math.MaxUint32 because these values are always 32-bit, even on 64 bit machines
+			// Note we use math.MaxUint32 because these values are always 32-bit, even on 64 bit machines
 			aWait = float64(
 				incrementWithOverflow(ioStats.ReadTime, lastIOStats.ReadTime)+
 					incrementWithOverflow(ioStats.WriteTime, lastIOStats.WriteTime)) / diffNIO

--- a/pkg/collector/corechecks/system/disk/iostats_nix_test.go
+++ b/pkg/collector/corechecks/system/disk/iostats_nix_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 )
 
 var currentStats = map[string]disk.IOCountersStat{
@@ -83,9 +84,8 @@ func TestIncrementWithOverflow(t *testing.T) {
 }
 
 func TestIoStatsOverflow(t *testing.T) {
-
 	ioCheck := new(IOCheck)
-	ioCheck.Configure(nil, nil, "test")
+	ioCheck.Configure(integration.FakeConfigHash, nil, nil, "test")
 	ioCheck.stats = lastStats
 	ioCheck.ts = 1000
 	ioCounters = func(names ...string) (map[string]disk.IOCountersStat, error) {

--- a/pkg/collector/corechecks/system/disk/iostats_pdh_windows.go
+++ b/pkg/collector/corechecks/system/disk/iostats_pdh_windows.go
@@ -70,8 +70,8 @@ func isDrive(instance string) bool {
 }
 
 // Configure the IOstats check
-func (c *IOCheck) Configure(data integration.Data, initConfig integration.Data, source string) error {
-	err := c.commonConfigure(data, initConfig, source)
+func (c *IOCheck) Configure(integrationConfigDigest uint64, data integration.Data, initConfig integration.Data, source string) error {
+	err := c.commonConfigure(integrationConfigDigest, data, initConfig, source)
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/system/disk/iostats_pdh_windows_test.go
+++ b/pkg/collector/corechecks/system/disk/iostats_pdh_windows_test.go
@@ -13,12 +13,14 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	pdhtest "github.com/DataDog/datadog-agent/pkg/util/winutil/pdhutil"
 )
 
 func testGetDriveType(drive string) uintptr {
 	return DRIVE_FIXED
 }
+
 func addDefaultQueryReturnValues() {
 	pdhtest.SetQueryReturnValue("\\\\.\\LogicalDisk(_Total)\\Disk Write Bytes/sec", 1.111)
 	pdhtest.SetQueryReturnValue("\\\\.\\LogicalDisk(C:)\\Disk Write Bytes/sec", 1.222)
@@ -57,18 +59,16 @@ func addDriveDReturnValues() {
 
 	pdhtest.SetQueryReturnValue("\\\\.\\LogicalDisk(Y:)\\Current Disk Queue Length", 5.444)
 	pdhtest.SetQueryReturnValue("\\\\.\\LogicalDisk(HarddiskVolume2)\\Current Disk Queue Length", 5.555)
-
 }
 
 func TestIoCheckWindows(t *testing.T) {
-
 	pfnGetDriveType = testGetDriveType
 	pdhtest.SetupTesting("..\\testfiles\\counter_indexes_en-us.txt", "..\\testfiles\\allcounters_en-us.txt")
 
 	addDefaultQueryReturnValues()
 
 	ioCheck := new(IOCheck)
-	ioCheck.Configure(nil, nil, "test")
+	ioCheck.Configure(integration.FakeConfigHash, nil, nil, "test")
 
 	mock := mocksender.NewMockSender(ioCheck.ID())
 
@@ -93,11 +93,9 @@ func TestIoCheckWindows(t *testing.T) {
 	mock.AssertExpectations(t)
 	mock.AssertNumberOfCalls(t, "Gauge", 10)
 	mock.AssertNumberOfCalls(t, "Commit", 1)
-
 }
 
 func TestIoCheckLowercaseDeviceTag(t *testing.T) {
-
 	pfnGetDriveType = testGetDriveType
 	pdhtest.SetupTesting("..\\testfiles\\counter_indexes_en-us.txt", "..\\testfiles\\allcounters_en-us.txt")
 
@@ -107,7 +105,7 @@ func TestIoCheckLowercaseDeviceTag(t *testing.T) {
 	rawInitConfigYaml := []byte(`
 lowercase_device_tag: true
 `)
-	err := ioCheck.Configure(nil, rawInitConfigYaml, "test")
+	err := ioCheck.Configure(integration.FakeConfigHash, nil, rawInitConfigYaml, "test")
 	require.NoError(t, err)
 
 	mock := mocksender.NewMockSender(ioCheck.ID())
@@ -133,7 +131,6 @@ lowercase_device_tag: true
 	mock.AssertExpectations(t)
 	mock.AssertNumberOfCalls(t, "Gauge", 10)
 	mock.AssertNumberOfCalls(t, "Commit", 1)
-
 }
 
 func TestIoCheckInstanceAdded(t *testing.T) {
@@ -147,7 +144,7 @@ func TestIoCheckInstanceAdded(t *testing.T) {
 	addDriveDReturnValues()
 
 	ioCheck := new(IOCheck)
-	ioCheck.Configure(nil, nil, "test")
+	ioCheck.Configure(integration.FakeConfigHash, nil, nil, "test")
 
 	pdhtest.AddCounterInstance("LogicalDisk", "Y:")
 	pdhtest.AddCounterInstance("LogicalDisk", "HarddiskVolume2")
@@ -191,7 +188,6 @@ func TestIoCheckInstanceAdded(t *testing.T) {
 	mock.AssertExpectations(t)
 	mock.AssertNumberOfCalls(t, "Gauge", 30)
 	mock.AssertNumberOfCalls(t, "Commit", 2)
-
 }
 
 func TestIoCheckInstanceRemoved(t *testing.T) {
@@ -209,7 +205,7 @@ func TestIoCheckInstanceRemoved(t *testing.T) {
 	addDriveDReturnValues()
 
 	ioCheck := new(IOCheck)
-	ioCheck.Configure(nil, nil, "test")
+	ioCheck.Configure(integration.FakeConfigHash, nil, nil, "test")
 
 	mock := mocksender.NewMockSender(ioCheck.ID())
 
@@ -254,5 +250,4 @@ func TestIoCheckInstanceRemoved(t *testing.T) {
 	mock.AssertExpectations(t)
 	mock.AssertNumberOfCalls(t, "Gauge", 40)
 	mock.AssertNumberOfCalls(t, "Commit", 3)
-
 }

--- a/pkg/collector/corechecks/system/disk/iostats_test.go
+++ b/pkg/collector/corechecks/system/disk/iostats_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/shirou/gopsutil/v3/mem"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 )
 
 var (
@@ -79,8 +80,10 @@ var (
 
 var sampleIdx = 0
 
-var ioSampler = func(names ...string) (map[string]disk.IOCountersStat, error) { return sampler(ioSamples, names...) }
-var ioSamplerDM = func(names ...string) (map[string]disk.IOCountersStat, error) { return sampler(ioSamplesDM, names...) }
+var (
+	ioSampler   = func(names ...string) (map[string]disk.IOCountersStat, error) { return sampler(ioSamples, names...) }
+	ioSamplerDM = func(names ...string) (map[string]disk.IOCountersStat, error) { return sampler(ioSamplesDM, names...) }
+)
 
 func SwapMemory() (*mem.SwapMemoryStat, error) {
 	return &mem.SwapMemoryStat{
@@ -106,7 +109,7 @@ func TestIOCheckDM(t *testing.T) {
 	ioCounters = ioSamplerDM
 	swapMemory = SwapMemory
 	ioCheck := new(IOCheck)
-	ioCheck.Configure(nil, nil, "test")
+	ioCheck.Configure(integration.FakeConfigHash, nil, nil, "test")
 
 	mock := mocksender.NewMockSender(ioCheck.ID())
 
@@ -132,7 +135,7 @@ func TestIOCheck(t *testing.T) {
 	ioCounters = ioSampler
 	swapMemory = SwapMemory
 	ioCheck := new(IOCheck)
-	ioCheck.Configure(nil, nil, "test")
+	ioCheck.Configure(integration.FakeConfigHash, nil, nil, "test")
 
 	mock := mocksender.NewMockSender(ioCheck.ID())
 
@@ -200,14 +203,14 @@ func TestIOCheckBlacklist(t *testing.T) {
 	ioCounters = ioSampler
 	swapMemory = SwapMemory
 	ioCheck := new(IOCheck)
-	ioCheck.Configure(nil, nil, "test")
+	ioCheck.Configure(integration.FakeConfigHash, nil, nil, "test")
 
 	mock := mocksender.NewMockSender(ioCheck.ID())
 
 	expectedRates := 0
 	expectedGauges := 0
 
-	//set blacklist
+	// set blacklist
 	bl, err := regexp.Compile("sd.*")
 	if err != nil {
 		t.FailNow()

--- a/pkg/collector/corechecks/system/filehandles/file_handles_freebsd.go
+++ b/pkg/collector/corechecks/system/filehandles/file_handles_freebsd.go
@@ -52,8 +52,8 @@ func (c *fhCheck) Run() error {
 }
 
 // The check doesn't need configuration
-func (c *fhCheck) Configure(data integration.Data, initConfig integration.Data, source string) (err error) {
-	if err := c.CommonConfigure(initConfig, data, source); err != nil {
+func (c *fhCheck) Configure(integrationConfigDigest uint64, data integration.Data, initConfig integration.Data, source string) (err error) {
+	if err := c.CommonConfigure(integrationConfigDigest, initConfig, data, source); err != nil {
 		return err
 	}
 

--- a/pkg/collector/corechecks/system/filehandles/file_handles_freebsd_test.go
+++ b/pkg/collector/corechecks/system/filehandles/file_handles_freebsd_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 )
 
 func GetInt64(name string) (value int64, err error) {
@@ -23,7 +24,7 @@ func TestFhCheckFreeBSD(t *testing.T) {
 	getInt64 = GetInt64
 
 	fileHandleCheck := new(fhCheck)
-	fileHandleCheck.Configure(nil, nil, "test")
+	fileHandleCheck.Configure(integration.FakeConfigHash, nil, nil, "test")
 
 	mock := mocksender.NewMockSender(fileHandleCheck.ID())
 
@@ -35,5 +36,4 @@ func TestFhCheckFreeBSD(t *testing.T) {
 	mock.AssertExpectations(t)
 	mock.AssertNumberOfCalls(t, "Gauge", 2)
 	mock.AssertNumberOfCalls(t, "Commit", 1)
-
 }

--- a/pkg/collector/corechecks/system/filehandles/file_handles_test.go
+++ b/pkg/collector/corechecks/system/filehandles/file_handles_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -35,7 +36,6 @@ func getFileNr() (f *os.File, err error) {
 }
 
 func TestFhCheckLinux(t *testing.T) {
-
 	tmpFile, err := getFileNr()
 	if err != nil {
 		t.Fatalf("unable to create temporary file-nr file: %v", err)
@@ -45,7 +45,7 @@ func TestFhCheckLinux(t *testing.T) {
 	fileNrHandle = writeSampleFile(tmpFile, samplecontent1)
 	t.Logf("Testing from file %s", fileNrHandle) // To pass circle ci tests
 
-	// we have to init the mocked sender here before fileHandleCheck.Configure(...)
+	// we have to init the mocked sender here before fileHandleCheck.Configure(integration.FakeConfigHash, ...)
 	// (and append it to the aggregator, which is automatically done in NewMockSender)
 	// because the FinalizeCheckServiceTag is called in Configure.
 	// Hopefully, the check ID is an empty string while running unit tests;
@@ -53,7 +53,7 @@ func TestFhCheckLinux(t *testing.T) {
 	mock.On("FinalizeCheckServiceTag").Return()
 
 	fileHandleCheck := new(fhCheck)
-	fileHandleCheck.Configure(nil, nil, "test")
+	fileHandleCheck.Configure(integration.FakeConfigHash, nil, nil, "test")
 
 	// reset the check ID for the sake of correctness
 	mocksender.SetSender(mock, fileHandleCheck.ID())

--- a/pkg/collector/corechecks/system/filehandles/file_handles_windows.go
+++ b/pkg/collector/corechecks/system/filehandles/file_handles_windows.go
@@ -51,8 +51,8 @@ func (c *fhCheck) Run() error {
 }
 
 // The check doesn't need configuration
-func (c *fhCheck) Configure(data integration.Data, initConfig integration.Data, source string) (err error) {
-	if err := c.CommonConfigure(initConfig, data, source); err != nil {
+func (c *fhCheck) Configure(integrationConfigDigest uint64, data integration.Data, initConfig integration.Data, source string) (err error) {
+	if err := c.CommonConfigure(integrationConfigDigest, initConfig, data, source); err != nil {
 		return err
 	}
 

--- a/pkg/collector/corechecks/system/filehandles/file_handles_windows_test.go
+++ b/pkg/collector/corechecks/system/filehandles/file_handles_windows_test.go
@@ -11,16 +11,16 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	pdhtest "github.com/DataDog/datadog-agent/pkg/util/winutil/pdhutil"
 )
 
 func TestFhCheckWindows(t *testing.T) {
-
 	pdhtest.SetupTesting("..\\testfiles\\counter_indexes_en-us.txt", "..\\testfiles\\allcounters_en-us.txt")
 	pdhtest.SetQueryReturnValue("\\\\.\\Process(_Total)\\Handle Count", 0.006848775103963421)
 
 	fileHandleCheck := new(fhCheck)
-	fileHandleCheck.Configure(nil, nil, "test")
+	fileHandleCheck.Configure(integration.FakeConfigHash, nil, nil, "test")
 
 	mock := mocksender.NewMockSender(fileHandleCheck.ID())
 
@@ -31,5 +31,4 @@ func TestFhCheckWindows(t *testing.T) {
 	mock.AssertExpectations(t)
 	mock.AssertNumberOfCalls(t, "Gauge", 1)
 	mock.AssertNumberOfCalls(t, "Commit", 1)
-
 }

--- a/pkg/collector/corechecks/system/memory/memory_windows.go
+++ b/pkg/collector/corechecks/system/memory/memory_windows.go
@@ -17,8 +17,11 @@ import (
 
 // For testing purpose
 var virtualMemory = winutil.VirtualMemory
-var swapMemory = winutil.SwapMemory
-var pageMemory = winutil.PagefileMemory
+
+var (
+	swapMemory = winutil.SwapMemory
+	pageMemory = winutil.PagefileMemory
+)
 
 // Check doesn't need additional fields
 type Check struct {
@@ -32,12 +35,8 @@ type Check struct {
 const mbSize float64 = 1024 * 1024
 
 // Configure handles initial configuration/initialization of the check
-func (c *Check) Configure(data integration.Data, initConfig integration.Data, source string) (err error) {
-	if err := c.CommonConfigure(initConfig, data, source); err != nil {
-		return err
-	}
-
-	return err
+func (c *Check) Configure(integrationConfigDigest uint64, data integration.Data, initConfig integration.Data, source string) error {
+	return c.CommonConfigure(integrationConfigDigest, initConfig, data, source)
 }
 
 // Run executes the check

--- a/pkg/collector/corechecks/system/memory/memory_windows_test.go
+++ b/pkg/collector/corechecks/system/memory/memory_windows_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/util/winutil"
 	pdhtest "github.com/DataDog/datadog-agent/pkg/util/winutil/pdhutil"
 )
@@ -61,7 +62,7 @@ func TestMemoryCheckWindows(t *testing.T) {
 	addDefaultQueryReturnValues()
 
 	memCheck := new(Check)
-	memCheck.Configure(nil, nil, "test")
+	memCheck.Configure(integration.FakeConfigHash, nil, nil, "test")
 
 	mock := mocksender.NewMockSender(memCheck.ID())
 

--- a/pkg/collector/corechecks/system/uptime/uptime_test.go
+++ b/pkg/collector/corechecks/system/uptime/uptime_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 )
 
 func uptimeSampler() (uint64, error) {
@@ -25,7 +26,7 @@ func TestUptimeCheckLinux(t *testing.T) {
 
 	uptime = uptimeSampler
 	uptimeCheck := new(Check)
-	uptimeCheck.Configure(nil, nil, "test")
+	uptimeCheck.Configure(integration.FakeConfigHash, nil, nil, "test")
 
 	// reset the check ID for the sake of correctness
 	mocksender.SetSender(mock, uptimeCheck.ID())

--- a/pkg/collector/corechecks/system/winkmem/winkmem.go
+++ b/pkg/collector/corechecks/system/winkmem/winkmem.go
@@ -79,8 +79,7 @@ init_config:
 */
 
 // Configure is called to configure the object prior to the first run
-func (w *KMemCheck) Configure(data integration.Data, initConfig integration.Data, source string) error {
-
+func (w *KMemCheck) Configure(integrationConfigDigest uint64, data integration.Data, initConfig integration.Data, source string) error {
 	// check to make sure the function is actually there, so we can fail gracefully
 	// if it's not
 	if err := modntdll.Load(); err != nil {
@@ -90,7 +89,7 @@ func (w *KMemCheck) Configure(data integration.Data, initConfig integration.Data
 		return err
 	}
 
-	if err := w.CommonConfigure(initConfig, data, source); err != nil {
+	if err := w.CommonConfigure(integrationConfigDigest, initConfig, data, source); err != nil {
 		return err
 	}
 	cf := Config{
@@ -145,7 +144,7 @@ func (w *KMemCheck) Run() error {
 	for k, v := range tagmap {
 		// double sanity check, but should always be true
 		if v {
-			var tags = []string{}
+			tags := []string{}
 			pti := spi.spti.poolTags[k]
 
 			tags = append(tags, "kmemtag:"+string(pti.tag[:]))
@@ -160,7 +159,6 @@ func (w *KMemCheck) Run() error {
 	sender.Commit()
 	log.Debugf("Logged %v entries", len(tagmap))
 	return nil
-
 }
 
 type systemPooltag struct {

--- a/pkg/collector/corechecks/system/winkmem/winkmem_test.go
+++ b/pkg/collector/corechecks/system/winkmem/winkmem_test.go
@@ -13,12 +13,12 @@ import (
 	"github.com/stretchr/testify/mock"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 )
 
 func TestWinKMem(t *testing.T) {
-
 	kcheck := new(KMemCheck)
-	kcheck.Configure(nil, nil, "test")
+	kcheck.Configure(integration.FakeConfigHash, nil, nil, "test")
 
 	m := mocksender.NewMockSender(kcheck.ID())
 

--- a/pkg/collector/corechecks/system/winproc/winproc_windows.go
+++ b/pkg/collector/corechecks/system/winproc/winproc_windows.go
@@ -61,8 +61,8 @@ func (c *processChk) Run() error {
 	return nil
 }
 
-func (c *processChk) Configure(data integration.Data, initConfig integration.Data, source string) error {
-	err := c.CommonConfigure(initConfig, data, source)
+func (c *processChk) Configure(integrationConfigDigest uint64, data integration.Data, initConfig integration.Data, source string) error {
+	err := c.CommonConfigure(integrationConfigDigest, initConfig, data, source)
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/system/winproc/winproc_windows_test.go
+++ b/pkg/collector/corechecks/system/winproc/winproc_windows_test.go
@@ -11,17 +11,17 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	pdhtest "github.com/DataDog/datadog-agent/pkg/util/winutil/pdhutil"
 )
 
 func TestWinprocCheckWindows(t *testing.T) {
-
 	pdhtest.SetupTesting("..\\testfiles\\counter_indexes_en-us.txt", "..\\testfiles\\allcounters_en-us.txt")
 	pdhtest.SetQueryReturnValue("\\\\.\\System\\Processor Queue Length", 2.0)
 	pdhtest.SetQueryReturnValue("\\\\.\\System\\Processes", 32.0)
 
 	winprocCheck := new(processChk)
-	winprocCheck.Configure(nil, nil, "test")
+	winprocCheck.Configure(integration.FakeConfigHash, nil, nil, "test")
 
 	mock := mocksender.NewMockSender(winprocCheck.ID())
 
@@ -33,5 +33,4 @@ func TestWinprocCheckWindows(t *testing.T) {
 	mock.AssertExpectations(t)
 	mock.AssertNumberOfCalls(t, "Gauge", 2)
 	mock.AssertNumberOfCalls(t, "Commit", 1)
-
 }

--- a/pkg/collector/corechecks/systemd/systemd.go
+++ b/pkg/collector/corechecks/systemd/systemd.go
@@ -520,12 +520,12 @@ func isValidServiceCheckStatus(serviceCheckStatus string) bool {
 }
 
 // Configure configures the systemd checks
-func (c *SystemdCheck) Configure(rawInstance integration.Data, rawInitConfig integration.Data, source string) error {
+func (c *SystemdCheck) Configure(integrationConfigDigest uint64, rawInstance integration.Data, rawInitConfig integration.Data, source string) error {
 	// Make sure check id is different for each different config
 	// Must be called before CommonConfigure that uses checkID
-	c.BuildID(rawInstance, rawInitConfig)
+	c.BuildID(integrationConfigDigest, rawInstance, rawInitConfig)
 
-	err := c.CommonConfigure(rawInitConfig, rawInstance, source)
+	err := c.CommonConfigure(integrationConfigDigest, rawInitConfig, rawInstance, source)
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/systemd/systemd_test.go
+++ b/pkg/collector/corechecks/systemd/systemd_test.go
@@ -14,18 +14,17 @@ import (
 	"testing"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/aggregator"
-
-	"github.com/DataDog/datadog-agent/pkg/collector/check"
-	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
-	"github.com/DataDog/datadog-agent/pkg/metadata/inventories"
-
 	"github.com/coreos/go-systemd/dbus"
 	godbus "github.com/godbus/dbus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
+	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
+	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
+	"github.com/DataDog/datadog-agent/pkg/metadata/inventories"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
 )
 
@@ -100,7 +99,7 @@ unit_names:
  - ssh.service
  - syslog.socket
 `)
-	err := check.Configure(rawInstanceConfig, []byte(``), "test")
+	err := check.Configure(integration.FakeConfigHash, rawInstanceConfig, []byte(``), "test")
 
 	assert.Nil(t, err)
 	assert.ElementsMatch(t, []string{"ssh.service", "syslog.socket"}, check.config.instance.UnitNames)
@@ -108,7 +107,7 @@ unit_names:
 
 func TestMissingUnitNamesShouldRaiseError(t *testing.T) {
 	check := SystemdCheck{}
-	err := check.Configure([]byte(``), []byte(``), "test")
+	err := check.Configure(integration.FakeConfigHash, []byte(``), []byte(``), "test")
 
 	expectedErrorMsg := "instance config `unit_names` must not be empty"
 	assert.EqualError(t, err, expectedErrorMsg)
@@ -124,7 +123,7 @@ substate_status_mapping:
     exited: critical
     running: ok
 `)
-	err := check.Configure(rawInstanceConfig, []byte(``), "test")
+	err := check.Configure(integration.FakeConfigHash, rawInstanceConfig, []byte(``), "test")
 
 	expectedErrorMsg := "instance config specifies a custom substate mapping for unit 'bar' but this unit is not monitored. Please add 'bar' to 'unit_names'"
 	assert.EqualError(t, err, expectedErrorMsg)
@@ -140,7 +139,7 @@ substate_status_mapping:
     running: ok
     exited: Critical
 `)
-	err := check.Configure(rawInstanceConfig, []byte(``), "test")
+	err := check.Configure(integration.FakeConfigHash, rawInstanceConfig, []byte(``), "test")
 
 	expectedErrorMsg := "Status 'Critical' for unit 'foo' in 'substate_status_mapping' is invalid. It should be one of 'ok, warning, critical, unknown'"
 	assert.EqualError(t, err, expectedErrorMsg)
@@ -163,7 +162,7 @@ substate_status_mapping:
     plugged: ok
     running: ok
 `)
-	err := check.Configure(rawInstanceConfig, []byte(``), "test")
+	err := check.Configure(integration.FakeConfigHash, rawInstanceConfig, []byte(``), "test")
 	assert.Nil(t, err)
 }
 
@@ -177,7 +176,7 @@ unit_names:
 private_socket: /tmp/foo/private_socket
 `)
 	check := SystemdCheck{stats: stats}
-	check.Configure(rawInstanceConfig, []byte(``), "test")
+	check.Configure(integration.FakeConfigHash, rawInstanceConfig, []byte(``), "test")
 	conn, err := check.getDbusConnection()
 
 	assert.Nil(t, err)
@@ -196,7 +195,7 @@ unit_names:
 private_socket: /tmp/foo/private_socket
 `)
 	check := SystemdCheck{stats: stats}
-	check.Configure(rawInstanceConfig, []byte(``), "test")
+	check.Configure(integration.FakeConfigHash, rawInstanceConfig, []byte(``), "test")
 	conn, err := check.getDbusConnection()
 
 	assert.EqualError(t, err, "some error")
@@ -215,7 +214,7 @@ unit_names:
 - ssh.service
 `)
 	check := SystemdCheck{stats: stats}
-	check.Configure(rawInstanceConfig, []byte(``), "test")
+	check.Configure(integration.FakeConfigHash, rawInstanceConfig, []byte(``), "test")
 	conn, err := check.getDbusConnection()
 
 	assert.Nil(t, err)
@@ -233,7 +232,7 @@ unit_names:
 - ssh.service
 `)
 	check := SystemdCheck{stats: stats}
-	check.Configure(rawInstanceConfig, []byte(``), "test")
+	check.Configure(integration.FakeConfigHash, rawInstanceConfig, []byte(``), "test")
 	conn, err := check.getDbusConnection()
 
 	assert.Nil(t, err)
@@ -253,7 +252,7 @@ unit_names:
 - ssh.service
 `)
 	check := SystemdCheck{stats: stats}
-	check.Configure(rawInstanceConfig, []byte(``), "test")
+	check.Configure(integration.FakeConfigHash, rawInstanceConfig, []byte(``), "test")
 	conn, err := check.getDbusConnection()
 
 	assert.Nil(t, err)
@@ -273,7 +272,7 @@ unit_names:
 - ssh.service
 `)
 	check := SystemdCheck{stats: stats}
-	check.Configure(rawInstanceConfig, []byte(``), "test")
+	check.Configure(integration.FakeConfigHash, rawInstanceConfig, []byte(``), "test")
 	conn, err := check.getDbusConnection()
 
 	assert.NotNil(t, err)
@@ -288,7 +287,7 @@ func TestDbusConnectionErr(t *testing.T) {
 	stats.On("SystemBusSocketConnection").Return((*dbus.Conn)(nil), fmt.Errorf("some error"))
 
 	check := SystemdCheck{stats: stats}
-	check.Configure([]byte(``), []byte(``), "test")
+	check.Configure(integration.FakeConfigHash, []byte(``), []byte(``), "test")
 
 	mockSender := mocksender.NewMockSender(check.ID()) // required to initiate aggregator
 	mockSender.On("ServiceCheck", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
@@ -298,7 +297,6 @@ func TestDbusConnectionErr(t *testing.T) {
 	expectedErrorMsg := "cannot create a connection: some error"
 	assert.EqualError(t, err, expectedErrorMsg)
 	mockSender.AssertCalled(t, "ServiceCheck", canConnectServiceCheck, metrics.ServiceCheckCritical, "", []string(nil), expectedErrorMsg)
-
 }
 
 func TestSystemStateCallFailGracefully(t *testing.T) {
@@ -309,7 +307,7 @@ func TestSystemStateCallFailGracefully(t *testing.T) {
 	stats.On("GetVersion", mock.Anything).Return(systemdVersion)
 
 	check := SystemdCheck{stats: stats}
-	check.Configure([]byte(``), []byte(``), "test")
+	check.Configure(integration.FakeConfigHash, []byte(``), []byte(``), "test")
 
 	mockSender := mocksender.NewMockSender(check.ID()) // required to initiate aggregator
 	mockSender.On("Gauge", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
@@ -328,7 +326,7 @@ func TestListUnitErr(t *testing.T) {
 	stats.On("GetVersion", mock.Anything).Return(systemdVersion)
 
 	check := SystemdCheck{stats: stats}
-	check.Configure([]byte(``), []byte(``), "test")
+	check.Configure(integration.FakeConfigHash, []byte(``), []byte(``), "test")
 
 	mockSender := mocksender.NewMockSender(check.ID()) // required to initiate aggregator
 	mockSender.On("ServiceCheck", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
@@ -363,7 +361,7 @@ unit_names:
  - unit2.service
 `)
 	check := SystemdCheck{stats: stats}
-	check.Configure(rawInstanceConfig, nil, "test")
+	check.Configure(integration.FakeConfigHash, rawInstanceConfig, nil, "test")
 
 	// setup expectations
 	stats.On("GetUnitTypeProperties", mock.Anything, mock.Anything, mock.Anything).Return(map[string]interface{}{}, nil)
@@ -424,7 +422,7 @@ unit_names:
 	stats.On("GetVersion", mock.Anything).Return(systemdVersion)
 
 	check := SystemdCheck{stats: stats}
-	check.Configure(rawInstanceConfig, nil, "test")
+	check.Configure(integration.FakeConfigHash, rawInstanceConfig, nil, "test")
 
 	// setup expectation
 	mockSender := mocksender.NewMockSender(check.ID())
@@ -491,7 +489,7 @@ unit_names:
 	stats.On("GetVersion", mock.Anything).Return(systemdVersion)
 
 	check := SystemdCheck{stats: stats}
-	check.Configure(rawInstanceConfig, nil, "test")
+	check.Configure(integration.FakeConfigHash, rawInstanceConfig, nil, "test")
 
 	// setup expectation
 	mockSender := mocksender.NewMockSender(check.ID())
@@ -566,7 +564,7 @@ unit_names:
 	stats.On("GetVersion", mock.Anything).Return(systemdVersion)
 
 	check := SystemdCheck{stats: stats}
-	check.Configure(rawInstanceConfig, nil, "test")
+	check.Configure(integration.FakeConfigHash, rawInstanceConfig, nil, "test")
 
 	// setup expectation
 	mockSender := mocksender.NewMockSender(check.ID())
@@ -615,7 +613,7 @@ func TestServiceCheckSystemStateAndCanConnect(t *testing.T) {
 			stats.On("GetVersion", mock.Anything).Return(systemdVersion)
 
 			check := SystemdCheck{stats: stats}
-			check.Configure([]byte(``), []byte(``), "test")
+			check.Configure(integration.FakeConfigHash, []byte(``), []byte(``), "test")
 
 			mockSender := mocksender.NewMockSender(check.ID()) // required to initiate aggregator
 			mockSender.On("ServiceCheck", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
@@ -662,7 +660,7 @@ unit_names:
 	stats.On("GetVersion", mock.Anything).Return(systemdVersion)
 
 	check := SystemdCheck{stats: stats}
-	check.Configure(rawInstanceConfig, nil, "test")
+	check.Configure(integration.FakeConfigHash, rawInstanceConfig, nil, "test")
 
 	// setup expectation
 	mockSender := mocksender.NewMockSender(check.ID())
@@ -727,7 +725,7 @@ substate_status_mapping:
 	stats.On("GetVersion", mock.Anything).Return(systemdVersion)
 
 	check := SystemdCheck{stats: stats}
-	check.Configure(rawInstanceConfig, nil, "test")
+	check.Configure(integration.FakeConfigHash, rawInstanceConfig, nil, "test")
 
 	// setup expectation
 	mockSender := mocksender.NewMockSender(check.ID())
@@ -830,7 +828,7 @@ unit_names:
 `)
 
 	check := SystemdCheck{}
-	check.Configure(rawInstanceConfig, nil, "test")
+	check.Configure(integration.FakeConfigHash, rawInstanceConfig, nil, "test")
 
 	data := []struct {
 		unitName              string
@@ -850,7 +848,7 @@ unit_names:
 func TestIsMonitoredEmptyConfigShouldNone(t *testing.T) {
 	rawInstanceConfig := []byte(``)
 	check := SystemdCheck{}
-	check.Configure(rawInstanceConfig, nil, "test")
+	check.Configure(integration.FakeConfigHash, rawInstanceConfig, nil, "test")
 
 	data := []struct {
 		unitName              string
@@ -974,7 +972,6 @@ func (m mockCollector) MapOverChecks(fn func([]check.Info)) {
 }
 
 func TestGetVersion(t *testing.T) {
-
 	rawInstanceConfig := []byte(`
 unit_names:
  - ssh.service
@@ -993,7 +990,7 @@ unit_names:
 	mockSender.On("ServiceCheck", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 	mockSender.On("Commit").Return()
 
-	systemdCheck.Configure(rawInstanceConfig, nil, "test")
+	systemdCheck.Configure(integration.FakeConfigHash, rawInstanceConfig, nil, "test")
 	// run
 	systemdCheck.Run()
 
@@ -1006,7 +1003,8 @@ unit_names:
 				InitConf:     "",
 				InstanceConf: "{}",
 			},
-		}}
+		},
+	}
 
 	p := inventories.GetPayload(context.Background(), "testHostname", coll, false)
 	checkMetadata := *p.CheckMetadata
@@ -1032,13 +1030,13 @@ unit_names:
  - ssh.service2
 `)
 
-	err := check1.Configure(rawInstanceConfig1, []byte(``), "test")
+	err := check1.Configure(integration.FakeConfigHash, rawInstanceConfig1, []byte(``), "test")
 	assert.Nil(t, err)
 
-	err = check2.Configure(rawInstanceConfig2, []byte(``), "test")
+	err = check2.Configure(integration.FakeConfigHash, rawInstanceConfig2, []byte(``), "test")
 	assert.Nil(t, err)
 
-	assert.Equal(t, check.ID("systemd:29388db26b0a8c38"), check1.ID())
-	assert.Equal(t, check.ID("systemd:31a0335c91ba9ae6"), check2.ID())
+	assert.Equal(t, check.ID("systemd:71ee0a4fef872b6d"), check1.ID())
+	assert.Equal(t, check.ID("systemd:b1fb7cdd591e17a1"), check2.ID())
 	assert.NotEqual(t, check1.ID(), check2.ID())
 }

--- a/pkg/collector/internal/middleware/check_wrapper.go
+++ b/pkg/collector/internal/middleware/check_wrapper.go
@@ -58,8 +58,8 @@ func (c *CheckWrapper) String() string {
 }
 
 // Configure implements Check#Configure
-func (c *CheckWrapper) Configure(config, initConfig integration.Data, source string) error {
-	return c.inner.Configure(config, initConfig, source)
+func (c *CheckWrapper) Configure(integrationConfigDigest uint64, config, initConfig integration.Data, source string) error {
+	return c.inner.Configure(integrationConfigDigest, config, initConfig, source)
 }
 
 // Interval implements Check#Interval

--- a/pkg/collector/python/check.go
+++ b/pkg/collector/python/check.go
@@ -207,9 +207,9 @@ func (c *PythonCheck) getPythonWarnings(gstate *stickyLock) []error {
 }
 
 // Configure the Python check from YAML data
-func (c *PythonCheck) Configure(data integration.Data, initConfig integration.Data, source string) error {
+func (c *PythonCheck) Configure(integrationConfigDigest uint64, data integration.Data, initConfig integration.Data, source string) error {
 	// Generate check ID
-	c.id = check.Identify(c, data, initConfig)
+	c.id = check.BuildID(c.String(), integrationConfigDigest, data, initConfig)
 
 	commonGlobalOptions := integration.CommonGlobalConfig{}
 	if err := yaml.Unmarshal(initConfig, &commonGlobalOptions); err != nil {

--- a/pkg/collector/python/test_check.go
+++ b/pkg/collector/python/test_check.go
@@ -562,7 +562,7 @@ func testConfigure(t *testing.T) {
 
 	C.get_check_return = 1
 	C.get_check_check = newMockPyObjectPtr()
-	err = c.Configure(integration.Data("{\"val\": 21}"), integration.Data("{\"val\": 21}"), "test")
+	err = c.Configure(integration.FakeConfigHash, integration.Data("{\"val\": 21}"), integration.Data("{\"val\": 21}"), "test")
 	assert.Nil(t, err)
 
 	assert.Equal(t, c.class, C.get_check_py_class)
@@ -597,7 +597,7 @@ func testConfigureDeprecated(t *testing.T) {
 	C.get_check_return = 0
 	C.get_check_deprecated_check = newMockPyObjectPtr()
 	C.get_check_deprecated_return = 1
-	err = c.Configure(integration.Data("{\"val\": 21}"), integration.Data("{\"val\": 21}"), "test")
+	err = c.Configure(integration.FakeConfigHash, integration.Data("{\"val\": 21}"), integration.Data("{\"val\": 21}"), "test")
 	assert.Nil(t, err)
 
 	assert.Equal(t, c.class, C.get_check_py_class)

--- a/pkg/collector/scheduler/scheduler.go
+++ b/pkg/collector/scheduler/scheduler.go
@@ -86,10 +86,10 @@ func (s *Scheduler) Enter(check check.Check) error {
 	}
 
 	if check.Interval() < minAllowedInterval {
-		return fmt.Errorf("Schedule interval must be greater than %v or 0", minAllowedInterval)
+		return fmt.Errorf("schedule interval must be greater than %v or 0", minAllowedInterval)
 	}
 
-	log.Infof("Scheduling check %v with an interval of %v", check, check.Interval())
+	log.Infof("Scheduling check %s with an interval of %v", check.ID(), check.Interval())
 
 	// sync when accessing `jobQueues` and `check2queue`
 	s.mu.Lock()

--- a/pkg/compliance/checks/check.go
+++ b/pkg/compliance/checks/check.go
@@ -50,7 +50,7 @@ func (c *complianceCheck) String() string {
 	return compliance.CheckName(c.ruleID, c.description)
 }
 
-func (c *complianceCheck) Configure(config, initConfig integration.Data, source string) error {
+func (c *complianceCheck) Configure(integrationConfigDigest uint64, config, initConfig integration.Data, source string) error {
 	return nil
 }
 

--- a/pkg/flare/config_check.go
+++ b/pkg/flare/config_check.go
@@ -103,6 +103,7 @@ func PrintConfig(w io.Writer, c integration.Config, checkName string) {
 	if checkName != "" && c.Name != checkName {
 		return
 	}
+	configDigest := c.FastDigest()
 	if !c.ClusterCheck {
 		fmt.Fprintln(w, fmt.Sprintf("\n=== %s check ===", color.GreenString(c.Name)))
 	} else {
@@ -120,7 +121,7 @@ func PrintConfig(w io.Writer, c integration.Config, checkName string) {
 		fmt.Fprintln(w, fmt.Sprintf("%s: %s", color.BlueString("Configuration source"), color.RedString("Unknown configuration source")))
 	}
 	for _, inst := range c.Instances {
-		ID := string(check.BuildID(c.Name, inst, c.InitConfig))
+		ID := string(check.BuildID(c.Name, configDigest, inst, c.InitConfig))
 		fmt.Fprintln(w, fmt.Sprintf("%s: %s", color.BlueString("Instance ID"), color.CyanString(ID)))
 		fmt.Fprint(w, fmt.Sprintf("%s", inst))
 		fmt.Fprintln(w, "~")

--- a/test/integration/corechecks/docker/main_test.go
+++ b/test/integration/corechecks/docker/main_test.go
@@ -16,6 +16,7 @@ import (
 	log "github.com/cihub/seelog"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/containers/docker"
 	"github.com/DataDog/datadog-agent/pkg/config"
@@ -137,9 +138,9 @@ func doRun(m *testing.M) int {
 	sender.SetupAcceptAll()
 
 	// Setup docker check
-	dockerCfg := []byte(dockerCfgString)
-	dockerInitCfg := []byte("")
-	dockerCheck.Configure(dockerCfg, dockerInitCfg, "test")
+	dockerCfg := integration.Data(dockerCfgString)
+	dockerInitCfg := integration.Data("")
+	dockerCheck.Configure(integration.FakeConfigHash, dockerCfg, dockerInitCfg, "test")
 
 	dockerCheck.Run()
 	return m.Run()


### PR DESCRIPTION
### What does this PR do?

Inject `integration.Configuration` Digest into check ID.
It allows to avoid conflicts between un-finished checks (as we cannot kill a check) that may be running and newly scheduled checks that need to start (typical case: a container restart).

### Motivation

Bugfix.

### Additional Notes

### Possible Drawbacks / Trade-offs

There a subtle issue that was introduced by #6636.
If the Agent is CPU-starved, it may happen that the `500ms` delay happens while everything is working (otherwise) fine.
The failure in `Unschedule` will not clean up resources in `Collectors/Scheduler/etc...`, yet the configuration was removed from Autodiscovery.

When the same check comes back (e.g. container restart), the check cannot be scheduled because the old one is still there (in the Scheduler).
With this change, there will a "dead" check and a new check instead of no check running.

This should be addressed by a refactoring in the Scheduler/AD interactions. Instead of solely relying on events, there should be a reconciling mechanism that will clear the diffs between AD and actual running checks.

### Describe how to test/QA your changes

There are multiple angles to QA this change.

Non regression: Make sure AD still works correctly with standard operations: adding/deleting container/pods.
Change itself: On internal environment, you should not see logs like:
```
failed to retrieve a sender for check
or
Unable to run Check .... is already running
```

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
