### PR TITLE
Fix metric loss with re-scheduled checks

### DIFF
--- a/pkg/aggregator/aggregator_test.go
+++ b/pkg/aggregator/aggregator_test.go
@@ -84,17 +84,20 @@ func TestRegisterCheckSampler(t *testing.T) {
 	agg := getAggregator()
 	agg.checkSamplers = make(map[check.ID]*CheckSampler)
 
+	lenSenders := func(n int) bool {
+		agg.mu.Lock()
+		defer agg.mu.Unlock()
+		return len(agg.checkSamplers) == n
+	}
+
 	err := agg.registerSender(checkID1)
 	assert.Nil(t, err)
-	assert.Len(t, agg.checkSamplers, 1)
+
+	require.Eventually(t, func() bool { return lenSenders(1) }, time.Second, 10*time.Millisecond)
 
 	err = agg.registerSender(checkID2)
 	assert.Nil(t, err)
-	assert.Len(t, agg.checkSamplers, 2)
-
-	// Already registered sender => error
-	err = agg.registerSender(checkID2)
-	assert.NotNil(t, err)
+	require.Eventually(t, func() bool { return lenSenders(2) }, time.Second, 10*time.Millisecond)
 }
 
 func TestDeregisterCheckSampler(t *testing.T) {
@@ -110,20 +113,20 @@ func TestDeregisterCheckSampler(t *testing.T) {
 
 	agg.registerSender(checkID1)
 	agg.registerSender(checkID2)
-	assert.Len(t, agg.checkSamplers, 2)
+
+	require.Eventually(t, func() bool {
+		agg.mu.Lock()
+		defer agg.mu.Unlock()
+		return len(agg.checkSamplers) == 2
+	}, time.Second, 10*time.Millisecond)
 
 	agg.deregisterSender(checkID1)
 
-	for tries := 100; tries > 0; tries-- {
+	require.Eventually(t, func() bool {
 		agg.mu.Lock()
-		ok := agg.checkSamplers[checkID1].deregistered && !agg.checkSamplers[checkID2].deregistered
-		agg.mu.Unlock()
-		if !ok && tries > 1 {
-			time.Sleep(100 * time.Millisecond)
-			continue
-		}
-		require.True(t, ok)
-	}
+		defer agg.mu.Unlock()
+		return agg.checkSamplers[checkID1].deregistered && !agg.checkSamplers[checkID2].deregistered
+	}, time.Second, 10*time.Millisecond)
 
 	agg.Flush(testNewFlushTrigger(time.Now(), false))
 

--- a/pkg/aggregator/sender_test.go
+++ b/pkg/aggregator/sender_test.go
@@ -50,22 +50,36 @@ func testDemux() *AgentDemultiplexer {
 	return demux
 }
 
+func assertAggSamplersLen(t *testing.T, agg *BufferedAggregator, n int) {
+	assert.Eventually(t, func() bool {
+		agg.mu.Lock()
+		defer agg.mu.Unlock()
+		return len(agg.checkSamplers) == n
+	}, time.Second, 10*time.Millisecond)
+
+	agg.mu.Lock()
+	defer agg.mu.Unlock()
+	// This provides a nicer error message than Eventually if the test fails
+	assert.Len(t, agg.checkSamplers, n)
+}
+
 func TestGetDefaultSenderReturnsSameSender(t *testing.T) {
 	// this test not using anything global
 	// -
 
 	demux := testDemux()
 	aggregatorInstance := demux.Aggregator()
+	go aggregatorInstance.run()
+	defer aggregatorInstance.Stop()
 
 	s, err := demux.GetDefaultSender()
 	assert.Nil(t, err)
 	defaultSender1 := s.(*checkSender)
-	assert.Len(t, aggregatorInstance.checkSamplers, 1)
+	assertAggSamplersLen(t, aggregatorInstance, 1)
 
 	s, err = demux.GetDefaultSender()
 	assert.Nil(t, err)
 	defaultSender2 := s.(*checkSender)
-	assert.Len(t, aggregatorInstance.checkSamplers, 1)
 	assert.Equal(t, defaultSender1.id, defaultSender2.id)
 }
 
@@ -75,22 +89,24 @@ func TestGetSenderWithDifferentIDsReturnsDifferentCheckSamplers(t *testing.T) {
 
 	demux := testDemux()
 	aggregatorInstance := demux.Aggregator()
+	go aggregatorInstance.run()
+	defer aggregatorInstance.Stop()
 
 	s, err := demux.GetSender(checkID1)
 	assert.Nil(t, err)
 	sender1 := s.(*checkSender)
-	assert.Len(t, aggregatorInstance.checkSamplers, 1)
+	assertAggSamplersLen(t, aggregatorInstance, 1)
 
 	s, err = demux.GetSender(checkID2)
 	assert.Nil(t, err)
 	sender2 := s.(*checkSender)
-	assert.Len(t, aggregatorInstance.checkSamplers, 2)
+	assertAggSamplersLen(t, aggregatorInstance, 2)
 	assert.NotEqual(t, sender1.id, sender2.id)
 
 	s, err = demux.GetDefaultSender()
 	assert.Nil(t, err)
 	defaultSender := s.(*checkSender)
-	assert.Len(t, aggregatorInstance.checkSamplers, 3)
+	assertAggSamplersLen(t, aggregatorInstance, 3)
 	assert.NotEqual(t, sender1.id, defaultSender.id)
 	assert.NotEqual(t, sender2.id, defaultSender.id)
 }
@@ -101,17 +117,19 @@ func TestGetSenderWithSameIDsReturnsSameSender(t *testing.T) {
 
 	demux := testDemux()
 	aggregatorInstance := demux.Aggregator()
+	go aggregatorInstance.run()
+	defer aggregatorInstance.Stop()
 
 	sender1, err := demux.GetSender(checkID1)
 	assert.Nil(t, err)
-	assert.Len(t, aggregatorInstance.checkSamplers, 1)
+	assertAggSamplersLen(t, aggregatorInstance, 1)
+
 	assert.Len(t, demux.senderPool.senders, 1)
 
 	sender2, err := demux.GetSender(checkID1)
 	assert.Nil(t, err)
 	assert.Equal(t, sender1, sender2)
 
-	assert.Len(t, aggregatorInstance.checkSamplers, 1)
 	assert.Len(t, demux.senderPool.senders, 1)
 }
 
@@ -126,38 +144,22 @@ func TestDestroySender(t *testing.T) {
 
 	_, err := demux.GetSender(checkID1)
 	assert.Nil(t, err)
-	assert.Len(t, aggregatorInstance.checkSamplers, 1)
+	assertAggSamplersLen(t, aggregatorInstance, 1)
 
 	_, err = demux.GetSender(checkID2)
 	assert.Nil(t, err)
-
-	aggregatorInstance.mu.Lock()
-	assert.Len(t, aggregatorInstance.checkSamplers, 2)
-	aggregatorInstance.mu.Unlock()
+	assertAggSamplersLen(t, aggregatorInstance, 2)
 
 	demux.DestroySender(checkID1)
 
-	aggregatorInstance.mu.Lock()
-	assert.Len(t, aggregatorInstance.checkSamplers, 2)
-	aggregatorInstance.mu.Unlock()
-
-	for tries := 100; tries > 0 && !aggregatorInstance.IsInputQueueEmpty(); tries-- {
-		time.Sleep(100 * time.Millisecond)
-	}
+	assert.Eventually(t, func() bool {
+		aggregatorInstance.mu.Lock()
+		defer aggregatorInstance.mu.Unlock()
+		return aggregatorInstance.checkSamplers[checkID1].deregistered
+	}, time.Second, 10*time.Millisecond)
 
 	aggregatorInstance.Flush(testNewFlushTrigger(time.Now(), false))
-
-	for tries := 100; tries > 0; tries-- {
-		aggregatorInstance.mu.Lock()
-		ok := len(aggregatorInstance.checkSamplers) == 1
-		aggregatorInstance.mu.Unlock()
-		if !ok && tries > 1 {
-			time.Sleep(100 * time.Millisecond)
-			continue
-		}
-		assert.True(t, ok)
-
-	}
+	assertAggSamplersLen(t, aggregatorInstance, 1)
 }
 
 func TestGetAndSetSender(t *testing.T) {

--- a/pkg/aggregator/test_common.go
+++ b/pkg/aggregator/test_common.go
@@ -1,0 +1,18 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build test
+// +build test
+
+package aggregator
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/collector/check"
+)
+
+// PeekSender returns a Sender with passed ID or an error if the sender is not registered
+func (s *senders) PeekSender(cid check.ID) (Sender, error) {
+	return s.senderPool.getSender(cid)
+}

--- a/pkg/collector/collector_demux_test.go
+++ b/pkg/collector/collector_demux_test.go
@@ -1,0 +1,193 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package collector
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator"
+	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	"github.com/DataDog/datadog-agent/pkg/metrics"
+)
+
+type CollectorDemuxTestSuite struct {
+	suite.Suite
+	c *Collector
+}
+
+func (suite *CollectorDemuxTestSuite) SetupTest() {
+	suite.c = NewCollector()
+	suite.c.Start()
+}
+
+func (suite *CollectorDemuxTestSuite) TearDownTest() {
+	suite.c.Stop()
+	suite.c = nil
+}
+
+func (suite *CollectorDemuxTestSuite) TestCancelledCheckCanSendMetrics() {
+	// Test that a long running check can send metrics using
+	// correct sender after it was cancelled, and destroys a
+	// sender at the end.
+
+	demux := aggregator.InitTestAgentDemultiplexerWithFlushInterval(100 * time.Hour)
+	defer demux.Stop(false)
+
+	flip := make(chan struct{})
+	flop := make(chan struct{})
+
+	ch := &cancelledCheck{
+		flip: flip,
+		flop: flop,
+	}
+
+	sender, _ := aggregator.GetSender(ch.ID())
+	sender.DisableDefaultHostname(true)
+
+	suite.c.RunCheck(ch)
+
+	// Wait for Check#Run to start before cancelling the check: otherwise it may not run at all.
+	_ = <-flip
+
+	err := suite.c.StopCheck(ch.ID())
+	assert.NoError(suite.T(), err)
+
+	flop <- struct{}{}
+
+	suite.waitForCancelledCheckMetrics(demux.Aggregator())
+
+	newSender, err := aggregator.GetSender(ch.ID())
+	assert.Nil(suite.T(), err)
+	assert.NotEqual(suite.T(), sender, newSender) // GetSedner returns a new instance, which means the old sender was destroyed correctly.
+}
+
+func (suite *CollectorDemuxTestSuite) waitForCancelledCheckMetrics(agg *aggregator.BufferedAggregator) {
+	require.Eventually(suite.T(), func() bool {
+		series, _ := agg.GetSeriesAndSketches(time.Time{})
+		for _, serie := range series {
+			if serie.Name == "test.metric" {
+				assert.Empty(suite.T(), serie.Host)
+				assert.Equal(suite.T(), serie.MType, metrics.APIGaugeType)
+				return true
+			}
+		}
+		return false
+	}, time.Second, 10*time.Millisecond)
+}
+
+func (suite *CollectorDemuxTestSuite) TestCancelledCheckDestroysSender() {
+	// Test that a check destroys a sender if it is not running when it is cancelled.
+
+	demux := aggregator.InitTestAgentDemultiplexerWithFlushInterval(100 * time.Hour)
+	defer demux.Stop(false)
+
+	flip := make(chan struct{})
+	flop := make(chan struct{})
+
+	ch := &cancelledCheck{
+		flip: flip,
+		flop: flop,
+	}
+
+	sender, _ := aggregator.GetSender(ch.ID())
+	sender.DisableDefaultHostname(true)
+
+	suite.c.RunCheck(ch)
+	<-flip
+	flop <- struct{}{}
+	suite.c.checks[ch.ID()].Wait()
+	err := suite.c.StopCheck(ch.ID())
+	assert.NoError(suite.T(), err)
+
+	suite.waitForCancelledCheckMetrics(demux.Aggregator())
+
+	newSender, err := aggregator.GetSender(ch.ID())
+	assert.Nil(suite.T(), err)
+	assert.NotEqual(suite.T(), sender, newSender) // GetSedner returns a new instance, which means the old sender was destroyed correctly.
+}
+
+func (suite *CollectorDemuxTestSuite) TestRescheduledCheckReusesSampler() {
+	// When a check is cancelled and then scheduled again while the aggregator still holds on to sampler (because it contains unsent metrics)
+
+	demux := aggregator.InitTestAgentDemultiplexerWithFlushInterval(100 * time.Hour)
+	defer demux.Stop(false)
+
+	flip := make(chan struct{})
+	flop := make(chan struct{})
+
+	ch := &cancelledCheck{
+		flip: flip,
+		flop: flop,
+	}
+
+	sender, err := aggregator.GetSender(ch.ID())
+	assert.NoError(suite.T(), err)
+	sender.DisableDefaultHostname(true)
+
+	suite.c.RunCheck(ch)
+
+	<-flip
+	flop <- struct{}{}
+
+	err = suite.c.StopCheck(ch.ID())
+	assert.NoError(suite.T(), err)
+
+	// Wait for the check to drop the sender
+	require.Eventually(suite.T(), func() bool {
+		// returns error if sender was not found, which is what we are waiting for
+		sender, _ := demux.PeekSender(ch.ID())
+		return sender == nil
+	}, time.Second, 10*time.Millisecond)
+
+	//create new sender and try registering sampler before flush
+	sender, err = aggregator.GetSender(ch.ID())
+	assert.NoError(suite.T(), err)
+
+	// flush
+	suite.waitForCancelledCheckMetrics(demux.Aggregator())
+
+	sender, _ = aggregator.GetSender(ch.ID())
+	sender.DisableDefaultHostname(true)
+
+	// Run the check again
+	suite.c.RunCheck(ch)
+
+	<-flip
+	flop <- struct{}{}
+
+	// flush again, check should contain metrics
+	suite.waitForCancelledCheckMetrics(demux.Aggregator())
+}
+
+func TestCollectorSuite(t *testing.T) {
+	suite.Run(t, new(CollectorDemuxTestSuite))
+}
+
+type cancelledCheck struct {
+	check.StubCheck
+	flip chan struct{}
+	flop chan struct{}
+}
+
+func (c *cancelledCheck) Run() error {
+	c.flip <- struct{}{}
+
+	<-c.flop
+	s, err := aggregator.GetSender(c.ID())
+	if err != nil {
+		return err
+	}
+
+	s.Gauge("test.metric", 1, "", []string{})
+	s.Commit()
+
+	return nil
+}

--- a/pkg/collector/collector_test.go
+++ b/pkg/collector/collector_test.go
@@ -7,18 +7,14 @@ package collector
 
 import (
 	"sort"
-	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/collector/internal/middleware"
-	"github.com/DataDog/datadog-agent/pkg/metrics"
 )
 
 // FIXTURE
@@ -239,163 +235,4 @@ func (suite *CollectorTestSuite) TestReloadAllCheckInstances() {
 	assert.Equal(suite.T(), killed, []check.ID{"baz", "qux"})
 
 	assert.Zero(suite.T(), len(suite.c.checks))
-}
-
-func (suite *CollectorTestSuite) TestCancelledCheckCanSendMetrics() {
-	// Test that a long running check can send metrics using
-	// correct sender after it was cancelled, and destroys a
-	// sender at the end.
-
-	demux := aggregator.InitTestAgentDemultiplexerWithFlushInterval(100 * time.Hour)
-	defer demux.Stop(false)
-
-	flip := make(chan struct{})
-	flop := make(chan struct{})
-
-	ch := &cancelledCheck{
-		flip: flip,
-		flop: flop,
-	}
-
-	sender, _ := aggregator.GetSender(ch.ID())
-	sender.DisableDefaultHostname(true)
-
-	suite.c.RunCheck(ch)
-
-	// Wait for Check#Run to start before cancelling the check: otherwise it may not run at all.
-	_ = <-flip
-
-	err := suite.c.StopCheck(ch.ID())
-	assert.NoError(suite.T(), err)
-
-	flop <- struct{}{}
-
-	suite.waitForCancelledCheckMetrics(demux.Aggregator())
-
-	newSender, err := aggregator.GetSender(ch.ID())
-	assert.Nil(suite.T(), err)
-	assert.NotEqual(suite.T(), sender, newSender) // GetSedner returns a new instance, which means the old sender was destroyed correctly.
-}
-
-func (suite *CollectorTestSuite) waitForCancelledCheckMetrics(agg *aggregator.BufferedAggregator) {
-	require.Eventually(suite.T(), func() bool {
-		series, _ := agg.GetSeriesAndSketches(time.Time{})
-		for _, serie := range series {
-			if serie.Name == "test.metric" {
-				assert.Empty(suite.T(), serie.Host)
-				assert.Equal(suite.T(), serie.MType, metrics.APIGaugeType)
-				return true
-			}
-		}
-		return false
-	}, time.Second, 10*time.Millisecond)
-}
-
-func (suite *CollectorTestSuite) TestCancelledCheckDestroysSender() {
-	// Test that a check destroys a sender if it is not running when it is cancelled.
-
-	demux := aggregator.InitTestAgentDemultiplexerWithFlushInterval(100 * time.Hour)
-	defer demux.Stop(false)
-
-	flip := make(chan struct{})
-	flop := make(chan struct{})
-
-	ch := &cancelledCheck{
-		flip: flip,
-		flop: flop,
-	}
-
-	sender, _ := aggregator.GetSender(ch.ID())
-	sender.DisableDefaultHostname(true)
-
-	suite.c.RunCheck(ch)
-	<-flip
-	flop <- struct{}{}
-	suite.c.checks[ch.ID()].Wait()
-	err := suite.c.StopCheck(ch.ID())
-	assert.NoError(suite.T(), err)
-
-	suite.waitForCancelledCheckMetrics(demux.Aggregator())
-
-	newSender, err := aggregator.GetSender(ch.ID())
-	assert.Nil(suite.T(), err)
-	assert.NotEqual(suite.T(), sender, newSender) // GetSedner returns a new instance, which means the old sender was destroyed correctly.
-}
-
-func (suite *CollectorTestSuite) TestRescheduledCheckReusesSampler() {
-	// When a check is cancelled and then scheduled again while the aggregator still holds on to sampler (because it contains unsent metrics)
-
-	demux := aggregator.InitTestAgentDemultiplexerWithFlushInterval(100 * time.Hour)
-	defer demux.Stop(false)
-
-	flip := make(chan struct{})
-	flop := make(chan struct{})
-
-	ch := &cancelledCheck{
-		flip: flip,
-		flop: flop,
-	}
-
-	sender, err := aggregator.GetSender(ch.ID())
-	assert.NoError(suite.T(), err)
-	sender.DisableDefaultHostname(true)
-
-	suite.c.RunCheck(ch)
-
-	<-flip
-	flop <- struct{}{}
-
-	err = suite.c.StopCheck(ch.ID())
-	assert.NoError(suite.T(), err)
-
-	// Wait for the check to drop the sender
-	require.Eventually(suite.T(), func() bool {
-		// returns error if sender was not found, which is what we are waiting for
-		sender, _ := demux.PeekSender(ch.ID())
-		return sender == nil
-	}, time.Second, 10*time.Millisecond)
-
-	//create new sender and try registering sampler before flush
-	sender, err = aggregator.GetSender(ch.ID())
-	assert.NoError(suite.T(), err)
-
-	// flush
-	suite.waitForCancelledCheckMetrics(demux.Aggregator())
-
-	sender, _ = aggregator.GetSender(ch.ID())
-	sender.DisableDefaultHostname(true)
-
-	// Run the check again
-	suite.c.RunCheck(ch)
-
-	<-flip
-	flop <- struct{}{}
-
-	// flush again, check should contain metrics
-	suite.waitForCancelledCheckMetrics(demux.Aggregator())
-}
-
-func TestCollectorSuite(t *testing.T) {
-	suite.Run(t, new(CollectorTestSuite))
-}
-
-type cancelledCheck struct {
-	check.StubCheck
-	flip chan struct{}
-	flop chan struct{}
-}
-
-func (c *cancelledCheck) Run() error {
-	c.flip <- struct{}{}
-
-	<-c.flop
-	s, err := aggregator.GetSender(c.ID())
-	if err != nil {
-		return err
-	}
-
-	s.Gauge("test.metric", 1, "", []string{})
-	s.Commit()
-
-	return nil
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Since delaying sampler destruction for cancelled checks, checks that were quickly re-scheduled were getting errors from GetSender because the sampler for the check was still in the aggregator. A bit later, once deregisterSampler message is handled and the sampler is removed during flush, metrics from such checks would be completely lost.

This patch fixes the issue by making sampler re-use a normal condition instead of an error: now that the sampler can outlive the check (this is because we want to send the metrics from the previous run still waiting for the flush) it isn't an error to have a sampler exist when the check is scheduled.

To prevent race condition when registerSender may be called before deregisterSampler message is even processed by the aggregator, sender creation (or reuse) is now handled by a dedicated message as well. As long as registerSender is called before the check run, sampler will be created before metrics arrive: both sampler creation message and metrics are sent via the same channel.
### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Make an empty directory and place a openmetrics check configuration file inside:
```
mkdir -p tmp && cat > tmp/openmetrics.yaml <<EOF
init_config:
instances:
  - metrics: [ '*' ]
    prometheus_url: http://localhost:5000/telemetry
    namespace: check.metric
    service: qa
EOF
```

Run the agent with the following settings:

```
docker run --rm --name qa \
  -e DD_API_KEY=none \
  -e DD_TELEMETRY_ENABLED=true \
  -e DD_LOG_LEVEL=debug \
  -e DD_LOG_PAYLOADS=true \
  -e DD_HOSTNAME=qa \
  -e DD_AUTOCONF_CONFIG_FILES_POLL=true \
  -e DD_AUTOCONF_CONFIG_FILES_POLL_INTERVAL=2 \
  -v $(pwd)/tmp:/etc/datadog-agent/conf.d/openmetrics.d/ \
  IMAGE \
 | grep check.metric
```

Verify that the payloads from the openmetrics are present during flush, `service:qa` tag is present.

Trigger check re-scheduling, this needs to happen between flushes:

```
mv tmp/openmetrics.yaml{,.disabled}; sleep 5; mv tmp/openmetrics.yaml{.disabled,}
```

Check for at least 2-3 flushes that check continues to send metrics, and the `service:qa` tag is present. There should be no errors about missing sampler.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
