### PR TITLE
Modifies a pattern to use slashes or dashes for automatic multine detection for logs

### DIFF
--- a/pkg/logs/internal/decoder/auto_multiline_handler.go
+++ b/pkg/logs/internal/decoder/auto_multiline_handler.go
@@ -217,8 +217,8 @@ var formatsToTry = []*regexp.Regexp{
 	regexp.MustCompile(`^[A-Za-z_]+, \d+ [A-Za-z_]+ \d+ \d+:\d+:\d+ -\d+`),
 	// time.RFC3339Nano,
 	regexp.MustCompile(`^\d+-\d+-\d+[A-Za-z_]+\d+:\d+:\d+\.\d+[A-Za-z_]+\d+:\d+`),
-	// 2021-07-08 05:08:19,214
-	regexp.MustCompile(`^\d+-\d+-\d+ \d+:\d+:\d+(,\d+)?`),
+	// 2021-07-08 05:08:19,214 and 2021/07/08 05:08:19,214
+	regexp.MustCompile(`^\d+(?:/|-)\d+(?:/|-)\d+ \d+:\d+:\d+(,\d+)?`),
 	// Default java logging SimpleFormatter date format
 	regexp.MustCompile(`^[A-Za-z_]+ \d+, \d+ \d+:\d+:\d+ (AM|PM)`),
 	// 2021-01-31 - with stricter matching around the months/days

--- a/pkg/logs/internal/decoder/releasenotes/notes/adding_date_pattern_with_slashes-a687e37b0aa87c21.yaml
+++ b/pkg/logs/internal/decoder/releasenotes/notes/adding_date_pattern_with_slashes-a687e37b0aa87c21.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Adding the date pattern `2021/07/08 05:08:19,214` to the Agent automatic multiline detection feature.


### PR DESCRIPTION

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
Allows the pattern `2021/07/08 05:08:19,214` to be used by the Agent natively to aggregate logs by modifying the already existing pattern `2021-07-08 05:08:19,214`
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
* Some Kubernetes components in my customer's cluster are using this pattern, which is not present natively in the Agent detection. The workaround by annotating the pods with a `log_processing_rules` is not possible/suitable since these are system Kubernetes components
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
* Ensure new behaviour is working by sending multiline logs starting with `2021/07/08 05:08:19,214`
    * Raw log file and Datadog wanted output : 
```
2022/10/18 13:15:39 [INFO] Starting node-cache image: 1.22.9
2022/10/18 13:15:39 [INFO] Using Corefile /etc/Corefile
2022/10/18 13:15:39 [INFO] Using Pidfile 
2022/10/18 13:15:39 [INFO] Updated Corefile with 0 custom stubdomains and upstream servers /etc/resolv.conf
2022/10/18 13:15:39 [INFO] Using config file:
cluster.local:53 {
    errors
    cache {
            success 2560 30
            denial 2560 5
    }
``` 
<img width="2157" alt="Image 2022-11-08 at 4 23 43 PM" src="https://user-images.githubusercontent.com/97530782/200605488-19c33770-7650-4d28-ab9f-125e7cfca06d.png">

* Ensure old behaviour is still working by sending multiline logs starting with `2021-07-08 05:08:19,214`
    * Raw log file and Datadog wanted output : 
```
2022-10-18 13:15:39 [INFO] Starting node-cache image: 1.22.9
2022-10-18 13:15:39 [INFO] Using Corefile -etc-Corefile
2022-10-18 13:15:39 [INFO] Using Pidfile 
2022-10-18 13:15:39 [INFO] Updated Corefile with 0 custom stubdomains and upstream servers -etc-resolv.conf
2022-10-18 13:15:39 [INFO] Using config file:
cluster.local:53 {
    errors
    cache {
            success 2560 30
            denial 2560 5
    }
```
<img width="2152" alt="Image 2022-11-08 at 4 27 47 PM" src="https://user-images.githubusercontent.com/97530782/200606976-b840aa28-6589-4d03-8996-7293880d2a87.png">

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
