### PR TITLE
Fix the use of node labels to determine the cluster name on the DCA

### DIFF
--- a/pkg/util/kubernetes/apiserver/apiserver.go
+++ b/pkg/util/kubernetes/apiserver/apiserver.go
@@ -605,3 +605,18 @@ func convertmetadataMapperBundleToAPI(input *metadataMapperBundle) *apiv1.Metada
 	}
 	return output
 }
+
+func (c *APIClient) GetARandomNodeName(ctx context.Context) (string, error) {
+	nodeList, err := c.Cl.CoreV1().Nodes().List(ctx, metav1.ListOptions{
+		Limit: 1,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	if len(nodeList.Items) == 0 {
+		return "", fmt.Errorf("No node found")
+	}
+
+	return nodeList.Items[0].Name, nil
+}

--- a/pkg/util/kubernetes/clustername/clustername.go
+++ b/pkg/util/kubernetes/clustername/clustername.go
@@ -120,6 +120,7 @@ func getClusterName(ctx context.Context, data *clusterNameData, hostname string)
 				}
 			}
 			if len(clusterName) > 0 {
+				log.Infof("Using cluster name %s from the node label", clusterName)
 				data.clusterName = clusterName
 			}
 		}

--- a/pkg/util/kubernetes/hostinfo/cluster_name_from_node_label.go
+++ b/pkg/util/kubernetes/hostinfo/cluster_name_from_node_label.go
@@ -1,0 +1,64 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package hostinfo
+
+import (
+	"context"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+)
+
+const (
+	eksClusterNameLabelKey       = "alpha.eksctl.io/cluster-name"
+	datadogADClusterNameLabelKey = "ad.datadoghq.com/cluster-name"
+)
+
+// clusterNameLabelType this struct is used to attach to the label key the information if this label should
+// override cluster-name previously detected.
+type clusterNameLabelType struct {
+	key string
+	// shouldOverride if set to true override previous cluster-name
+	shouldOverride bool
+}
+
+var (
+	// We use a slice to define the default Node label key to keep the ordering
+	defaultClusterNameLabelKeyConfigs = []clusterNameLabelType{
+		{key: eksClusterNameLabelKey, shouldOverride: false},
+		{key: datadogADClusterNameLabelKey, shouldOverride: true},
+	}
+)
+
+// GetNodeClusterNameLabel returns clustername by fetching a node label
+func (n *NodeInfo) GetNodeClusterNameLabel(ctx context.Context, clusterName string) (string, error) {
+	nodeLabels, err := n.getANodeLabels(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	var clusterNameLabelKeys []clusterNameLabelType
+	// check if a node label has been added on the config
+	if customLabels := config.Datadog.GetString("kubernetes_node_label_as_cluster_name"); customLabels != "" {
+		clusterNameLabelKeys = append(clusterNameLabelKeys, clusterNameLabelType{key: customLabels, shouldOverride: true})
+	} else {
+		// Use default configuration
+		clusterNameLabelKeys = defaultClusterNameLabelKeyConfigs
+	}
+
+	for _, labelConfig := range clusterNameLabelKeys {
+		if v, ok := nodeLabels[labelConfig.key]; ok {
+			if clusterName == "" {
+				clusterName = v
+				continue
+			}
+
+			if labelConfig.shouldOverride {
+				clusterName = v
+			}
+		}
+	}
+	return clusterName, nil
+}

--- a/pkg/util/kubernetes/hostinfo/cluster_name_from_node_label_apiserver.go
+++ b/pkg/util/kubernetes/hostinfo/cluster_name_from_node_label_apiserver.go
@@ -1,0 +1,30 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !kubelet && kubeapiserver
+// +build !kubelet,kubeapiserver
+
+package hostinfo
+
+import (
+	"context"
+
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
+)
+
+// getANodeLabels returns node labels for a random node of this cluster
+func (_ *NodeInfo) getANodeLabels(ctx context.Context) (map[string]string, error) {
+	client, err := apiserver.WaitForAPIClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	aRandomNodeName, err := client.GetARandomNodeName(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return client.NodeLabels(aRandomNodeName)
+}

--- a/pkg/util/kubernetes/hostinfo/cluster_name_from_node_label_kubelet.go
+++ b/pkg/util/kubernetes/hostinfo/cluster_name_from_node_label_kubelet.go
@@ -1,0 +1,16 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubelet
+// +build kubelet
+
+package hostinfo
+
+import "context"
+
+// getANodeLabels returns node labels for this host
+func (n *NodeInfo) getANodeLabels(ctx context.Context) (map[string]string, error) {
+	return n.GetNodeLabels(ctx)
+}

--- a/pkg/util/kubernetes/hostinfo/cluster_name_from_node_label_nothing.go
+++ b/pkg/util/kubernetes/hostinfo/cluster_name_from_node_label_nothing.go
@@ -1,0 +1,18 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !kubelet && !kubeapiserver
+// +build !kubelet,!kubeapiserver
+
+package hostinfo
+
+import (
+	"context"
+)
+
+// getANodeLabels returns nothing
+func (_ *NodeInfo) getANodeLabels(_ context.Context) (map[string]string, error) {
+	return nil, nil
+}

--- a/pkg/util/kubernetes/hostinfo/no_node_labels.go
+++ b/pkg/util/kubernetes/hostinfo/no_node_labels.go
@@ -24,8 +24,3 @@ func NewNodeInfo() (*NodeInfo, error) {
 func (n *NodeInfo) GetNodeLabels(ctx context.Context) (map[string]string, error) {
 	return nil, nil
 }
-
-// GetNodeClusterNameLabel returns clustername by fetching a node label
-func (n *NodeInfo) GetNodeClusterNameLabel(ctx context.Context, currentClusterName string) (string, error) {
-	return "", nil
-}


### PR DESCRIPTION
### What does this PR do?

Fix the use of node labels (either `alpha.eksctl.io/cluster-name`, or `ad.datadoghq.com/cluster-name` or the one specified in the kubernetes_node_label_as_cluster_name` parameter) to determine the cluster name on the cluster agent.

### Motivation

Whereas the logic was working fine on the node agent, it was not working on the cluster agent. And the Orchestrator explorer UI was confused by the fact that node agents and cluster agents were reporting different cluster names.

### Additional Notes

The node agents are checking the labels of the node they are running on.
Without the `kubelet` build tag, I’m not sure the cluster agent can find the node it is running on.
But as we’re interested in the cluster name, which should be the same for all the nodes of the cluster, I choose to look at the labels of a random node.

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

See QA instructions in #14010.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
