### PR TITLE
[CWS] do not send on closed channel if all components are disabled

### DIFF
--- a/cmd/security-agent/app/start.go
+++ b/cmd/security-agent/app/start.go
@@ -43,10 +43,6 @@ func start(cliParams *startCliParams) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer StopAgent(cancel)
 
-	stopCh := make(chan struct{})
-	defer close(stopCh)
-	go handleSignals(stopCh)
-
 	err := RunAgent(ctx, cliParams.pidfilePath)
 	if errors.Is(err, errAllComponentsDisabled) {
 		return nil
@@ -54,6 +50,10 @@ func start(cliParams *startCliParams) error {
 	if err != nil {
 		return err
 	}
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	go handleSignals(stopCh)
 
 	// Block here until we receive a stop signal
 	<-stopCh

--- a/releasenotes/notes/security-agent-fix-14214-8615ad801c6b8c83.yaml
+++ b/releasenotes/notes/security-agent-fix-14214-8615ad801c6b8c83.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fix an issue where the security agent would panic, sending on a close
+    channel, if it received a signal when shutting down because all
+    components were disabled.

--- a/releasenotes/notes/security-agent-fix-14214-8615ad801c6b8c83.yaml
+++ b/releasenotes/notes/security-agent-fix-14214-8615ad801c6b8c83.yaml
@@ -2,5 +2,5 @@
 fixes:
   - |
     Fix an issue where the security agent would panic, sending on a close
-    channel, if it received a signal when shutting down because all
+    channel, if it received a signal when shutting down while all
     components were disabled.


### PR DESCRIPTION
### What does this PR do?

As reported in https://github.com/DataDog/datadog-agent/issues/14214, there is a race between:
- the security agent shutting down because all components are disabled
- the core agent asking the security agent to shutdown, through a signal

If the security agent is shutting down, and has already closed the channel, at the time where the signal is received, the signal will be sent to a closed channel.

This PR fixes this issue by setting up the close channel after the components check. 

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
