### PR TITLE
[CWS] groundwork of removing `SYSCALL_KPROBE[^0]` where possible

### DIFF
--- a/pkg/security/ebpf/c/chmod.h
+++ b/pkg/security/ebpf/c/chmod.h
@@ -37,15 +37,9 @@ int __attribute__((always_inline)) trace__sys_chmod(umode_t mode) {
     return 0;
 }
 
-SYSCALL_KPROBE2(chmod, const char*, filename, umode_t, mode) {
-    return trace__sys_chmod(mode);
-}
-
-SYSCALL_KPROBE2(fchmod, int, fd, umode_t, mode) {
-    return trace__sys_chmod(mode);
-}
-
-SYSCALL_KPROBE3(fchmodat, int, dirfd, const char*, filename, umode_t, mode) {
+SEC("kprobe/chmod_common")
+int kprobe_chmod_common(struct pt_regs *ctx) {
+    umode_t mode = PT_REGS_PARM2(ctx);
     return trace__sys_chmod(mode);
 }
 
@@ -85,15 +79,8 @@ int __attribute__((always_inline)) kprobe_sys_chmod_ret(struct pt_regs *ctx) {
     return sys_chmod_ret(ctx, retval);
 }
 
-SYSCALL_KRETPROBE(chmod) {
-    return kprobe_sys_chmod_ret(ctx);
-}
-
-SYSCALL_KRETPROBE(fchmod) {
-    return kprobe_sys_chmod_ret(ctx);
-}
-
-SYSCALL_KRETPROBE(fchmodat) {
+SEC("kretprobe/chmod_common")
+int kretprobe_chmod_common(struct pt_regs *ctx) {
     return kprobe_sys_chmod_ret(ctx);
 }
 

--- a/pkg/security/ebpf/c/chown.h
+++ b/pkg/security/ebpf/c/chown.h
@@ -45,19 +45,10 @@ int kprobe_do_fchownat(struct pt_regs *ctx) {
     return trace__sys_chown(user, group);
 }
 
-SYSCALL_KPROBE3(fchown, int, fd, uid_t, user, gid_t, group) {
-    return trace__sys_chown(user, group);
-}
-
-SYSCALL_KPROBE3(lchown16, const char*, filename, uid_t, user, gid_t, group) {
-    return trace__sys_chown(user, group);
-}
-
-SYSCALL_KPROBE3(fchown16, int, fd, uid_t, user, gid_t, group) {
-    return trace__sys_chown(user, group);
-}
-
-SYSCALL_KPROBE3(chown16, const char*, filename, uid_t, user, gid_t, group) {
+SEC("kprobe/vfs_fchown")
+int kprobe_vfs_fchown(struct pt_regs *ctx) {
+    uid_t user = PT_REGS_PARM2(ctx);
+    uid_t group = PT_REGS_PARM3(ctx);
     return trace__sys_chown(user, group);
 }
 
@@ -103,19 +94,8 @@ int kretprobe_do_fchownat(struct pt_regs *ctx) {
     return kprobe_sys_chown_ret(ctx);
 }
 
-SYSCALL_KRETPROBE(fchown) {
-    return kprobe_sys_chown_ret(ctx);
-}
-
-SYSCALL_KRETPROBE(lchown16) {
-    return kprobe_sys_chown_ret(ctx);
-}
-
-SYSCALL_KRETPROBE(fchown16) {
-    return kprobe_sys_chown_ret(ctx);
-}
-
-SYSCALL_KRETPROBE(chown16) {
+SEC("kretprobe/vfs_fchown")
+int kretprobe_vfs_fchown(struct pt_regs *ctx) {
     return kprobe_sys_chown_ret(ctx);
 }
 

--- a/pkg/security/ebpf/c/chown.h
+++ b/pkg/security/ebpf/c/chown.h
@@ -52,6 +52,13 @@ int kprobe_vfs_fchown(struct pt_regs *ctx) {
     return trace__sys_chown(user, group);
 }
 
+SEC("kprobe/ksys_fchown")
+int kprobe_ksys_fchown(struct pt_regs *ctx) {
+    uid_t user = PT_REGS_PARM2(ctx);
+    uid_t group = PT_REGS_PARM3(ctx);
+    return trace__sys_chown(user, group);
+}
+
 int __attribute__((always_inline)) sys_chown_ret(void *ctx, int retval) {
     struct syscall_cache_t *syscall = pop_syscall(EVENT_CHOWN);
     if (!syscall) {
@@ -96,6 +103,11 @@ int kretprobe_do_fchownat(struct pt_regs *ctx) {
 
 SEC("kretprobe/vfs_fchown")
 int kretprobe_vfs_fchown(struct pt_regs *ctx) {
+    return kprobe_sys_chown_ret(ctx);
+}
+
+SEC("kretprobe/ksys_fchown")
+int kretprobe_ksys_fchown(struct pt_regs *ctx) {
     return kprobe_sys_chown_ret(ctx);
 }
 

--- a/pkg/security/ebpf/c/chown.h
+++ b/pkg/security/ebpf/c/chown.h
@@ -20,8 +20,8 @@ int __attribute__((always_inline)) chown_approvers(struct syscall_cache_t *sysca
 
 int __attribute__((always_inline)) trace__sys_chown(uid_t user, gid_t group) {
     // if we are already working on this syscall, we simply skip it
-    struct syscall_cache_t *syscall = peek_syscall_with(EVENT_CHOWN);
-    if (syscall) {
+    struct syscall_cache_t *syscall_check = peek_syscall(EVENT_CHOWN);
+    if (syscall_check) {
         return 0;
     }
 

--- a/pkg/security/ebpf/c/chown.h
+++ b/pkg/security/ebpf/c/chown.h
@@ -38,15 +38,14 @@ int __attribute__((always_inline)) trace__sys_chown(uid_t user, gid_t group) {
     return 0;
 }
 
-SYSCALL_KPROBE3(lchown, const char*, filename, uid_t, user, gid_t, group) {
+SEC("kprobe/do_fchownat")
+int kprobe_do_fchownat(struct pt_regs *ctx) {
+    uid_t user = PT_REGS_PARM3(ctx);
+    uid_t group = PT_REGS_PARM4(ctx);
     return trace__sys_chown(user, group);
 }
 
 SYSCALL_KPROBE3(fchown, int, fd, uid_t, user, gid_t, group) {
-    return trace__sys_chown(user, group);
-}
-
-SYSCALL_KPROBE3(chown, const char*, filename, uid_t, user, gid_t, group) {
     return trace__sys_chown(user, group);
 }
 
@@ -59,10 +58,6 @@ SYSCALL_KPROBE3(fchown16, int, fd, uid_t, user, gid_t, group) {
 }
 
 SYSCALL_KPROBE3(chown16, const char*, filename, uid_t, user, gid_t, group) {
-    return trace__sys_chown(user, group);
-}
-
-SYSCALL_KPROBE4(fchownat, int, dirfd, const char*, filename, uid_t, user, gid_t, group) {
     return trace__sys_chown(user, group);
 }
 
@@ -103,15 +98,12 @@ int __attribute__((always_inline)) kprobe_sys_chown_ret(struct pt_regs *ctx) {
     return sys_chown_ret(ctx, retval);
 }
 
-SYSCALL_KRETPROBE(lchown) {
+SEC("kretprobe/do_fchownat")
+int kretprobe_do_fchownat(struct pt_regs *ctx) {
     return kprobe_sys_chown_ret(ctx);
 }
 
 SYSCALL_KRETPROBE(fchown) {
-    return kprobe_sys_chown_ret(ctx);
-}
-
-SYSCALL_KRETPROBE(chown) {
     return kprobe_sys_chown_ret(ctx);
 }
 
@@ -124,10 +116,6 @@ SYSCALL_KRETPROBE(fchown16) {
 }
 
 SYSCALL_KRETPROBE(chown16) {
-    return kprobe_sys_chown_ret(ctx);
-}
-
-SYSCALL_KRETPROBE(fchownat) {
     return kprobe_sys_chown_ret(ctx);
 }
 

--- a/pkg/security/ebpf/probes/attr.go
+++ b/pkg/security/ebpf/probes/attr.go
@@ -26,13 +26,11 @@ func getAttrProbes() []*manager.Probe {
 		&manager.Probe{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
 				UID:          SecurityAgentUID,
-				EBPFSection:  "kprobe/chmod_common",
 				EBPFFuncName: "kprobe_chmod_common",
 			},
 		}, &manager.Probe{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
 				UID:          SecurityAgentUID,
-				EBPFSection:  "kretprobe/chmod_common",
 				EBPFFuncName: "kretprobe_chmod_common",
 			},
 		},

--- a/pkg/security/ebpf/probes/attr.go
+++ b/pkg/security/ebpf/probes/attr.go
@@ -50,31 +50,19 @@ func getAttrProbes() []*manager.Probe {
 				EBPFFuncName: "kretprobe_do_fchownat",
 			},
 		},
+		&manager.Probe{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "kprobe_vfs_fchown",
+			},
+		},
+		&manager.Probe{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "kretprobe_vfs_fchown",
+			},
+		},
 	)
-	attrProbes = append(attrProbes, ExpandSyscallProbes(&manager.Probe{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID: SecurityAgentUID,
-		},
-		SyscallFuncName: "chown16",
-	}, EntryAndExit)...)
-	attrProbes = append(attrProbes, ExpandSyscallProbes(&manager.Probe{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID: SecurityAgentUID,
-		},
-		SyscallFuncName: "fchown",
-	}, EntryAndExit)...)
-	attrProbes = append(attrProbes, ExpandSyscallProbes(&manager.Probe{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID: SecurityAgentUID,
-		},
-		SyscallFuncName: "fchown16",
-	}, EntryAndExit)...)
-	attrProbes = append(attrProbes, ExpandSyscallProbes(&manager.Probe{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID: SecurityAgentUID,
-		},
-		SyscallFuncName: "lchown16",
-	}, EntryAndExit)...)
 
 	// utime
 	attrProbes = append(attrProbes, ExpandSyscallProbes(&manager.Probe{

--- a/pkg/security/ebpf/probes/attr.go
+++ b/pkg/security/ebpf/probes/attr.go
@@ -37,12 +37,20 @@ func getAttrProbes() []*manager.Probe {
 	)
 
 	// chown
-	attrProbes = append(attrProbes, ExpandSyscallProbes(&manager.Probe{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID: SecurityAgentUID,
+	attrProbes = append(attrProbes,
+		&manager.Probe{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "kprobe_do_fchownat",
+			},
 		},
-		SyscallFuncName: "chown",
-	}, EntryAndExit)...)
+		&manager.Probe{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "kretprobe_do_fchownat",
+			},
+		},
+	)
 	attrProbes = append(attrProbes, ExpandSyscallProbes(&manager.Probe{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID: SecurityAgentUID,
@@ -60,18 +68,6 @@ func getAttrProbes() []*manager.Probe {
 			UID: SecurityAgentUID,
 		},
 		SyscallFuncName: "fchown16",
-	}, EntryAndExit)...)
-	attrProbes = append(attrProbes, ExpandSyscallProbes(&manager.Probe{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID: SecurityAgentUID,
-		},
-		SyscallFuncName: "fchownat",
-	}, EntryAndExit)...)
-	attrProbes = append(attrProbes, ExpandSyscallProbes(&manager.Probe{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID: SecurityAgentUID,
-		},
-		SyscallFuncName: "lchown",
 	}, EntryAndExit)...)
 	attrProbes = append(attrProbes, ExpandSyscallProbes(&manager.Probe{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{

--- a/pkg/security/ebpf/probes/attr.go
+++ b/pkg/security/ebpf/probes/attr.go
@@ -62,6 +62,18 @@ func getAttrProbes() []*manager.Probe {
 				EBPFFuncName: "kretprobe_vfs_fchown",
 			},
 		},
+		&manager.Probe{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "kprobe_ksys_fchown",
+			},
+		},
+		&manager.Probe{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "kretprobe_ksys_fchown",
+			},
+		},
 	)
 
 	// utime

--- a/pkg/security/ebpf/probes/attr.go
+++ b/pkg/security/ebpf/probes/attr.go
@@ -74,6 +74,18 @@ func getAttrProbes() []*manager.Probe {
 				EBPFFuncName: "kretprobe_ksys_fchown",
 			},
 		},
+		&manager.Probe{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "kprobe_chown_common",
+			},
+		},
+		&manager.Probe{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "kretprobe_chown_common",
+			},
+		},
 	)
 
 	// utime

--- a/pkg/security/ebpf/probes/attr.go
+++ b/pkg/security/ebpf/probes/attr.go
@@ -22,24 +22,21 @@ var attrProbes = []*manager.Probe{
 
 func getAttrProbes() []*manager.Probe {
 	// chmod
-	attrProbes = append(attrProbes, ExpandSyscallProbes(&manager.Probe{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID: SecurityAgentUID,
+	attrProbes = append(attrProbes,
+		&manager.Probe{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFSection:  "kprobe/chmod_common",
+				EBPFFuncName: "kprobe_chmod_common",
+			},
+		}, &manager.Probe{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFSection:  "kretprobe/chmod_common",
+				EBPFFuncName: "kretprobe_chmod_common",
+			},
 		},
-		SyscallFuncName: "chmod",
-	}, EntryAndExit)...)
-	attrProbes = append(attrProbes, ExpandSyscallProbes(&manager.Probe{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID: SecurityAgentUID,
-		},
-		SyscallFuncName: "fchmod",
-	}, EntryAndExit)...)
-	attrProbes = append(attrProbes, ExpandSyscallProbes(&manager.Probe{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID: SecurityAgentUID,
-		},
-		SyscallFuncName: "fchmodat",
-	}, EntryAndExit)...)
+	)
 
 	// chown
 	attrProbes = append(attrProbes, ExpandSyscallProbes(&manager.Probe{

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -295,6 +295,10 @@ func GetSelectorsPerEventType() map[eval.EventType][]manager.ProbesSelector {
 						&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_ksys_fchown"}},
 						&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kretprobe_ksys_fchown"}},
 					}},
+					&manager.AllOf{Selectors: []manager.ProbesSelector{
+						&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_chown_common"}},
+						&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kretprobe_chown_common"}},
+					}},
 				}},
 			}},
 			&manager.OneOf{Selectors: []manager.ProbesSelector{

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -286,6 +286,8 @@ func GetSelectorsPerEventType() map[eval.EventType][]manager.ProbesSelector {
 				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kretprobe_do_fchownat"}},
 				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_vfs_fchown"}},
 				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kretprobe_vfs_fchown"}},
+				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_ksys_fchown"}},
+				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kretprobe_ksys_fchown"}},
 			}},
 			&manager.OneOf{Selectors: []manager.ProbesSelector{
 				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_mnt_want_write_file"}},

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -282,17 +282,16 @@ func GetSelectorsPerEventType() map[eval.EventType][]manager.ProbesSelector {
 		"chown": {
 			&manager.AllOf{Selectors: []manager.ProbesSelector{
 				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_mnt_want_write"}},
+				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_do_fchownat"}},
+				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kretprobe_do_fchownat"}},
 			}},
 			&manager.OneOf{Selectors: []manager.ProbesSelector{
 				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_mnt_want_write_file"}},
 				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_mnt_want_write_file_path"}},
 			}},
-			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "chown", EntryAndExit)},
 			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "chown16", EntryAndExit)},
 			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "fchown", EntryAndExit)},
 			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "fchown16", EntryAndExit)},
-			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "fchownat", EntryAndExit)},
-			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "lchown", EntryAndExit)},
 			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "lchown16", EntryAndExit)},
 		},
 

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -273,10 +273,9 @@ func GetSelectorsPerEventType() map[eval.EventType][]manager.ProbesSelector {
 		"chmod": {
 			&manager.AllOf{Selectors: []manager.ProbesSelector{
 				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_mnt_want_write"}},
+				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_chmod_common"}},
+				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kretprobe_chmod_common"}},
 			}},
-			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "chmod", EntryAndExit)},
-			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "fchmod", EntryAndExit)},
-			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "fchmodat", EntryAndExit)},
 		},
 
 		// List of probes required to capture chown events

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -282,12 +282,20 @@ func GetSelectorsPerEventType() map[eval.EventType][]manager.ProbesSelector {
 		"chown": {
 			&manager.AllOf{Selectors: []manager.ProbesSelector{
 				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_mnt_want_write"}},
-				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_do_fchownat"}},
-				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kretprobe_do_fchownat"}},
-				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_vfs_fchown"}},
-				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kretprobe_vfs_fchown"}},
-				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_ksys_fchown"}},
-				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kretprobe_ksys_fchown"}},
+				&manager.BestEffort{Selectors: []manager.ProbesSelector{
+					&manager.AllOf{Selectors: []manager.ProbesSelector{
+						&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_do_fchownat"}},
+						&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kretprobe_do_fchownat"}},
+					}},
+					&manager.AllOf{Selectors: []manager.ProbesSelector{
+						&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_vfs_fchown"}},
+						&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kretprobe_vfs_fchown"}},
+					}},
+					&manager.AllOf{Selectors: []manager.ProbesSelector{
+						&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_ksys_fchown"}},
+						&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kretprobe_ksys_fchown"}},
+					}},
+				}},
 			}},
 			&manager.OneOf{Selectors: []manager.ProbesSelector{
 				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_mnt_want_write_file"}},

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -284,15 +284,13 @@ func GetSelectorsPerEventType() map[eval.EventType][]manager.ProbesSelector {
 				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_mnt_want_write"}},
 				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_do_fchownat"}},
 				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kretprobe_do_fchownat"}},
+				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_vfs_fchown"}},
+				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kretprobe_vfs_fchown"}},
 			}},
 			&manager.OneOf{Selectors: []manager.ProbesSelector{
 				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_mnt_want_write_file"}},
 				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_mnt_want_write_file_path"}},
 			}},
-			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "chown16", EntryAndExit)},
-			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "fchown", EntryAndExit)},
-			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "fchown16", EntryAndExit)},
-			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "lchown16", EntryAndExit)},
 		},
 
 		// List of probes required to capture mkdir events

--- a/pkg/security/tests/chown_test.go
+++ b/pkg/security/tests/chown_test.go
@@ -9,9 +9,11 @@
 package tests
 
 import (
+	"bufio"
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 	"syscall"
 	"testing"
 
@@ -59,6 +61,19 @@ func TestChown(t *testing.T) {
 	testFile, testFilePtr, err := test.CreateWithOptions("test-chown", prevUID, prevGID, fileMode)
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	kallsyms, err := os.Open("/proc/kallsyms")
+	if err != nil {
+		t.Fatal(err)
+	}
+	scanner := bufio.NewScanner(kallsyms)
+	// optionally, resize scanner's capacity for lines over 64K, see next example
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.Contains(line, "chown") {
+			t.Log(line)
+		}
 	}
 
 	t.Run("fchown", func(t *testing.T) {

--- a/test/kitchen/test/integration/security-agent-test/rspec_datadog/security-agent-test_spec.rb
+++ b/test/kitchen/test/integration/security-agent-test/rspec_datadog/security-agent-test_spec.rb
@@ -75,6 +75,8 @@ shared_examples "passes" do |bundle, env|
         cmd = gotestsum_test2json_cmd.concat([testsuite_file_path, "-status-metrics", "-test.v", "-test.count=1"])
         output_line_tag = "h"
 
+        cmd.concat(["-test.run", "TestChown"])
+
         if bundle == "ad"
           cmd.concat(["-test.run", "TestActivityDump"])
           output_line_tag = "ad"


### PR DESCRIPTION
### What does this PR do?

The goal of this PR is to ease the possible transition to fentry/fexit hook types instead of kprobes (on supported kernels). We hit some issues trying to query the args syscalls when in fentry hooks and when the syscall wrapper is enabled.

One easy solution to help with this is to move some hook points to non-syscall functions, this is what this PR is doing.  

TODO (priority):
- [x] chmod (0)
- [x] chown (0)
- [ ] execve (0)
- [ ] creat/openat2 (0)
- [ ] unlinkat (0)
- [ ] setxattr (0)
- [ ] bind (1)
- [ ] bpf (1)
- [ ] mkdir (1)
- [ ] delete_module (1)
- [ ] unshare (1)
- [ ] ptrace (1)
- [ ] kill (1)

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
