### PR TITLE
[orchestration] add apigroupversion tag

### DIFF
--- a/pkg/collector/corechecks/cluster/orchestrator/collector_bundle.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collector_bundle.go
@@ -9,6 +9,7 @@
 package orchestrator
 
 import (
+	"fmt"
 	"strings"
 	"time"
 
@@ -222,7 +223,10 @@ func (cb *CollectorBundle) Run(sender aggregator.Sender) {
 	for _, collector := range cb.collectors {
 		runStartTime := time.Now()
 
+		cb.appendAdditionalCommonTags(collector)
+
 		result, err := collector.Run(cb.runCfg)
+
 		if err != nil {
 			_ = cb.check.Warnf("Collector %s failed to run: %s", collector.Metadata().FullName(), err.Error())
 			continue
@@ -237,4 +241,8 @@ func (cb *CollectorBundle) Run(sender aggregator.Sender) {
 			sender.OrchestratorManifest(result.Result.ManifestMessages, cb.check.clusterID)
 		}
 	}
+}
+
+func (cb *CollectorBundle) appendAdditionalCommonTags(collector collectors.Collector) {
+	cb.runCfg.Config.ExtraTags = append(cb.runCfg.Config.ExtraTags, fmt.Sprintf("%s:%s", "kube_api_version", collector.Metadata().Version))
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/collector_bundle.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collector_bundle.go
@@ -223,7 +223,6 @@ func (cb *CollectorBundle) Run(sender aggregator.Sender) {
 		runStartTime := time.Now()
 
 		result, err := collector.Run(cb.runCfg)
-
 		if err != nil {
 			_ = cb.check.Warnf("Collector %s failed to run: %s", collector.Metadata().FullName(), err.Error())
 			continue

--- a/pkg/collector/corechecks/cluster/orchestrator/collector_bundle.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collector_bundle.go
@@ -9,7 +9,6 @@
 package orchestrator
 
 import (
-	"fmt"
 	"strings"
 	"time"
 
@@ -223,8 +222,6 @@ func (cb *CollectorBundle) Run(sender aggregator.Sender) {
 	for _, collector := range cb.collectors {
 		runStartTime := time.Now()
 
-		cb.appendAdditionalCommonTags(collector)
-
 		result, err := collector.Run(cb.runCfg)
 
 		if err != nil {
@@ -241,8 +238,4 @@ func (cb *CollectorBundle) Run(sender aggregator.Sender) {
 			sender.OrchestratorManifest(result.Result.ManifestMessages, cb.check.clusterID)
 		}
 	}
-}
-
-func (cb *CollectorBundle) appendAdditionalCommonTags(collector collectors.Collector) {
-	cb.runCfg.Config.ExtraTags = append(cb.runCfg.Config.ExtraTags, fmt.Sprintf("%s:%s", "kube_api_version", collector.Metadata().Version))
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/collector.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/collector.go
@@ -105,3 +105,15 @@ type CollectorRunResult struct {
 	ResourcesListed    int
 	ResourcesProcessed int
 }
+
+func GetProcessorContext(rcfg *CollectorRunConfig, metadata *CollectorMetadata) *processors.ProcessorContext {
+	ctx := &processors.ProcessorContext{
+		APIClient:       rcfg.APIClient,
+		Cfg:             rcfg.Config,
+		ClusterID:       rcfg.ClusterID,
+		MsgGroupID:      rcfg.MsgGroupRef.Inc(),
+		NodeType:        metadata.NodeType,
+		ApiGroupVersion: metadata.Version,
+	}
+	return ctx
+}

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/collector.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/collector.go
@@ -106,14 +106,13 @@ type CollectorRunResult struct {
 	ResourcesProcessed int
 }
 
-func GetProcessorContext(rcfg *CollectorRunConfig, metadata *CollectorMetadata) *processors.ProcessorContext {
-	ctx := &processors.ProcessorContext{
-		APIClient:       rcfg.APIClient,
-		Cfg:             rcfg.Config,
-		ClusterID:       rcfg.ClusterID,
-		MsgGroupID:      rcfg.MsgGroupRef.Inc(),
-		NodeType:        metadata.NodeType,
-		ApiGroupVersion: metadata.Version,
+func NewProcessorContext(rcfg *CollectorRunConfig, metadata *CollectorMetadata) *processors.ProcessorContext {
+	return &processors.ProcessorContext{
+		APIClient:          rcfg.APIClient,
+		ApiGroupVersionTag: fmt.Sprintf("kube_api_version:%s", metadata.Version),
+		Cfg:                rcfg.Config,
+		ClusterID:          rcfg.ClusterID,
+		MsgGroupID:         rcfg.MsgGroupRef.Inc(),
+		NodeType:           metadata.NodeType,
 	}
-	return ctx
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/cluster.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/cluster.go
@@ -75,13 +75,7 @@ func (c *ClusterCollector) Run(rcfg *collectors.CollectorRunConfig) (*collectors
 		return nil, collectors.NewListingError(err)
 	}
 
-	ctx := &processors.ProcessorContext{
-		APIClient:  rcfg.APIClient,
-		Cfg:        rcfg.Config,
-		ClusterID:  rcfg.ClusterID,
-		MsgGroupID: rcfg.MsgGroupRef.Inc(),
-		NodeType:   c.metadata.NodeType,
-	}
+	ctx := processors.GetProcessorContext(rcfg, c.metadata)
 
 	processResult, processed, err := c.processor.Process(ctx, list)
 

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/cluster.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/cluster.go
@@ -10,7 +10,6 @@ package k8s
 
 import (
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/collectors"
-	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors"
 	k8sProcessors "github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors/k8s"
 	"github.com/DataDog/datadog-agent/pkg/orchestrator"
 
@@ -75,7 +74,7 @@ func (c *ClusterCollector) Run(rcfg *collectors.CollectorRunConfig) (*collectors
 		return nil, collectors.NewListingError(err)
 	}
 
-	ctx := processors.GetProcessorContext(rcfg, c.metadata)
+	ctx := collectors.GetProcessorContext(rcfg, c.metadata)
 
 	processResult, processed, err := c.processor.Process(ctx, list)
 

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/cluster.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/cluster.go
@@ -74,7 +74,7 @@ func (c *ClusterCollector) Run(rcfg *collectors.CollectorRunConfig) (*collectors
 		return nil, collectors.NewListingError(err)
 	}
 
-	ctx := collectors.GetProcessorContext(rcfg, c.metadata)
+	ctx := collectors.NewProcessorContext(rcfg, c.metadata)
 
 	processResult, processed, err := c.processor.Process(ctx, list)
 

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/clusterrole.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/clusterrole.go
@@ -76,7 +76,7 @@ func (c *ClusterRoleCollector) Run(rcfg *collectors.CollectorRunConfig) (*collec
 		return nil, collectors.NewListingError(err)
 	}
 
-	ctx := processors.GetProcessorContext(rcfg, c.metadata)
+	ctx := collectors.GetProcessorContext(rcfg, c.metadata)
 
 	processResult, processed := c.processor.Process(ctx, list)
 

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/clusterrole.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/clusterrole.go
@@ -76,13 +76,7 @@ func (c *ClusterRoleCollector) Run(rcfg *collectors.CollectorRunConfig) (*collec
 		return nil, collectors.NewListingError(err)
 	}
 
-	ctx := &processors.ProcessorContext{
-		APIClient:  rcfg.APIClient,
-		Cfg:        rcfg.Config,
-		ClusterID:  rcfg.ClusterID,
-		MsgGroupID: rcfg.MsgGroupRef.Inc(),
-		NodeType:   c.metadata.NodeType,
-	}
+	ctx := processors.GetProcessorContext(rcfg, c.metadata)
 
 	processResult, processed := c.processor.Process(ctx, list)
 

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/clusterrole.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/clusterrole.go
@@ -76,7 +76,7 @@ func (c *ClusterRoleCollector) Run(rcfg *collectors.CollectorRunConfig) (*collec
 		return nil, collectors.NewListingError(err)
 	}
 
-	ctx := collectors.GetProcessorContext(rcfg, c.metadata)
+	ctx := collectors.NewProcessorContext(rcfg, c.metadata)
 
 	processResult, processed := c.processor.Process(ctx, list)
 

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/clusterrolebinding.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/clusterrolebinding.go
@@ -76,13 +76,7 @@ func (c *ClusterRoleBindingCollector) Run(rcfg *collectors.CollectorRunConfig) (
 		return nil, collectors.NewListingError(err)
 	}
 
-	ctx := &processors.ProcessorContext{
-		APIClient:  rcfg.APIClient,
-		Cfg:        rcfg.Config,
-		ClusterID:  rcfg.ClusterID,
-		MsgGroupID: rcfg.MsgGroupRef.Inc(),
-		NodeType:   c.metadata.NodeType,
-	}
+	ctx := processors.GetProcessorContext(rcfg, c.metadata)
 
 	processResult, processed := c.processor.Process(ctx, list)
 

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/clusterrolebinding.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/clusterrolebinding.go
@@ -76,7 +76,7 @@ func (c *ClusterRoleBindingCollector) Run(rcfg *collectors.CollectorRunConfig) (
 		return nil, collectors.NewListingError(err)
 	}
 
-	ctx := collectors.GetProcessorContext(rcfg, c.metadata)
+	ctx := collectors.NewProcessorContext(rcfg, c.metadata)
 
 	processResult, processed := c.processor.Process(ctx, list)
 

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/clusterrolebinding.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/clusterrolebinding.go
@@ -76,7 +76,7 @@ func (c *ClusterRoleBindingCollector) Run(rcfg *collectors.CollectorRunConfig) (
 		return nil, collectors.NewListingError(err)
 	}
 
-	ctx := processors.GetProcessorContext(rcfg, c.metadata)
+	ctx := collectors.GetProcessorContext(rcfg, c.metadata)
 
 	processResult, processed := c.processor.Process(ctx, list)
 

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/cronjob_v1.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/cronjob_v1.go
@@ -68,13 +68,7 @@ func (c *CronJobV1Collector) Run(rcfg *collectors.CollectorRunConfig) (*collecto
 		return nil, collectors.NewListingError(err)
 	}
 
-	ctx := &processors.ProcessorContext{
-		APIClient:  rcfg.APIClient,
-		Cfg:        rcfg.Config,
-		ClusterID:  rcfg.ClusterID,
-		MsgGroupID: rcfg.MsgGroupRef.Inc(),
-		NodeType:   c.metadata.NodeType,
-	}
+	ctx := processors.GetProcessorContext(rcfg, c.metadata)
 
 	processResult, processed := c.processor.Process(ctx, list)
 

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/cronjob_v1.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/cronjob_v1.go
@@ -68,7 +68,7 @@ func (c *CronJobV1Collector) Run(rcfg *collectors.CollectorRunConfig) (*collecto
 		return nil, collectors.NewListingError(err)
 	}
 
-	ctx := processors.GetProcessorContext(rcfg, c.metadata)
+	ctx := collectors.GetProcessorContext(rcfg, c.metadata)
 
 	processResult, processed := c.processor.Process(ctx, list)
 

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/cronjob_v1.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/cronjob_v1.go
@@ -68,7 +68,7 @@ func (c *CronJobV1Collector) Run(rcfg *collectors.CollectorRunConfig) (*collecto
 		return nil, collectors.NewListingError(err)
 	}
 
-	ctx := collectors.GetProcessorContext(rcfg, c.metadata)
+	ctx := collectors.NewProcessorContext(rcfg, c.metadata)
 
 	processResult, processed := c.processor.Process(ctx, list)
 

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/cronjob_v1beta1.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/cronjob_v1beta1.go
@@ -68,7 +68,7 @@ func (c *CronJobV1Beta1Collector) Run(rcfg *collectors.CollectorRunConfig) (*col
 		return nil, collectors.NewListingError(err)
 	}
 
-	ctx := processors.GetProcessorContext(rcfg, c.metadata)
+	ctx := collectors.GetProcessorContext(rcfg, c.metadata)
 
 	processResult, processed := c.processor.Process(ctx, list)
 

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/cronjob_v1beta1.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/cronjob_v1beta1.go
@@ -68,13 +68,7 @@ func (c *CronJobV1Beta1Collector) Run(rcfg *collectors.CollectorRunConfig) (*col
 		return nil, collectors.NewListingError(err)
 	}
 
-	ctx := &processors.ProcessorContext{
-		APIClient:  rcfg.APIClient,
-		Cfg:        rcfg.Config,
-		ClusterID:  rcfg.ClusterID,
-		MsgGroupID: rcfg.MsgGroupRef.Inc(),
-		NodeType:   c.metadata.NodeType,
-	}
+	ctx := processors.GetProcessorContext(rcfg, c.metadata)
 
 	processResult, processed := c.processor.Process(ctx, list)
 

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/cronjob_v1beta1.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/cronjob_v1beta1.go
@@ -68,7 +68,7 @@ func (c *CronJobV1Beta1Collector) Run(rcfg *collectors.CollectorRunConfig) (*col
 		return nil, collectors.NewListingError(err)
 	}
 
-	ctx := collectors.GetProcessorContext(rcfg, c.metadata)
+	ctx := collectors.NewProcessorContext(rcfg, c.metadata)
 
 	processResult, processed := c.processor.Process(ctx, list)
 

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/daemonset.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/daemonset.go
@@ -76,7 +76,7 @@ func (c *DaemonSetCollector) Run(rcfg *collectors.CollectorRunConfig) (*collecto
 		return nil, collectors.NewListingError(err)
 	}
 
-	ctx := collectors.GetProcessorContext(rcfg, c.metadata)
+	ctx := collectors.NewProcessorContext(rcfg, c.metadata)
 
 	processResult, processed := c.processor.Process(ctx, list)
 

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/daemonset.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/daemonset.go
@@ -76,13 +76,7 @@ func (c *DaemonSetCollector) Run(rcfg *collectors.CollectorRunConfig) (*collecto
 		return nil, collectors.NewListingError(err)
 	}
 
-	ctx := &processors.ProcessorContext{
-		APIClient:  rcfg.APIClient,
-		Cfg:        rcfg.Config,
-		ClusterID:  rcfg.ClusterID,
-		MsgGroupID: rcfg.MsgGroupRef.Inc(),
-		NodeType:   c.metadata.NodeType,
-	}
+	ctx := processors.GetProcessorContext(rcfg, c.metadata)
 
 	processResult, processed := c.processor.Process(ctx, list)
 

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/daemonset.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/daemonset.go
@@ -76,7 +76,7 @@ func (c *DaemonSetCollector) Run(rcfg *collectors.CollectorRunConfig) (*collecto
 		return nil, collectors.NewListingError(err)
 	}
 
-	ctx := processors.GetProcessorContext(rcfg, c.metadata)
+	ctx := collectors.GetProcessorContext(rcfg, c.metadata)
 
 	processResult, processed := c.processor.Process(ctx, list)
 

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/deployment.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/deployment.go
@@ -76,13 +76,7 @@ func (c *DeploymentCollector) Run(rcfg *collectors.CollectorRunConfig) (*collect
 		return nil, collectors.NewListingError(err)
 	}
 
-	ctx := &processors.ProcessorContext{
-		APIClient:  rcfg.APIClient,
-		Cfg:        rcfg.Config,
-		ClusterID:  rcfg.ClusterID,
-		MsgGroupID: rcfg.MsgGroupRef.Inc(),
-		NodeType:   c.metadata.NodeType,
-	}
+	ctx := processors.GetProcessorContext(rcfg, c.metadata)
 
 	processResult, processed := c.processor.Process(ctx, list)
 

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/deployment.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/deployment.go
@@ -76,7 +76,7 @@ func (c *DeploymentCollector) Run(rcfg *collectors.CollectorRunConfig) (*collect
 		return nil, collectors.NewListingError(err)
 	}
 
-	ctx := collectors.GetProcessorContext(rcfg, c.metadata)
+	ctx := collectors.NewProcessorContext(rcfg, c.metadata)
 
 	processResult, processed := c.processor.Process(ctx, list)
 

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/deployment.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/deployment.go
@@ -76,7 +76,7 @@ func (c *DeploymentCollector) Run(rcfg *collectors.CollectorRunConfig) (*collect
 		return nil, collectors.NewListingError(err)
 	}
 
-	ctx := processors.GetProcessorContext(rcfg, c.metadata)
+	ctx := collectors.GetProcessorContext(rcfg, c.metadata)
 
 	processResult, processed := c.processor.Process(ctx, list)
 

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/ingress.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/ingress.go
@@ -100,13 +100,7 @@ func (c *IngressCollector) Run(rcfg *collectors.CollectorRunConfig) (*collectors
 		return nil, collectors.NewListingError(err)
 	}
 
-	ctx := &processors.ProcessorContext{
-		APIClient:  rcfg.APIClient,
-		Cfg:        rcfg.Config,
-		ClusterID:  rcfg.ClusterID,
-		MsgGroupID: rcfg.MsgGroupRef.Inc(),
-		NodeType:   c.metadata.NodeType,
-	}
+	ctx := processors.GetProcessorContext(rcfg, c.metadata)
 
 	processResult, processed := c.processor.Process(ctx, list)
 

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/ingress.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/ingress.go
@@ -100,7 +100,7 @@ func (c *IngressCollector) Run(rcfg *collectors.CollectorRunConfig) (*collectors
 		return nil, collectors.NewListingError(err)
 	}
 
-	ctx := processors.GetProcessorContext(rcfg, c.metadata)
+	ctx := collectors.GetProcessorContext(rcfg, c.metadata)
 
 	processResult, processed := c.processor.Process(ctx, list)
 

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/ingress.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/ingress.go
@@ -100,7 +100,7 @@ func (c *IngressCollector) Run(rcfg *collectors.CollectorRunConfig) (*collectors
 		return nil, collectors.NewListingError(err)
 	}
 
-	ctx := collectors.GetProcessorContext(rcfg, c.metadata)
+	ctx := collectors.NewProcessorContext(rcfg, c.metadata)
 
 	processResult, processed := c.processor.Process(ctx, list)
 

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/job.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/job.go
@@ -75,7 +75,7 @@ func (c *JobCollector) Run(rcfg *collectors.CollectorRunConfig) (*collectors.Col
 		return nil, collectors.NewListingError(err)
 	}
 
-	ctx := processors.GetProcessorContext(rcfg, c.metadata)
+	ctx := collectors.GetProcessorContext(rcfg, c.metadata)
 
 	processResult, processed := c.processor.Process(ctx, list)
 

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/job.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/job.go
@@ -75,7 +75,7 @@ func (c *JobCollector) Run(rcfg *collectors.CollectorRunConfig) (*collectors.Col
 		return nil, collectors.NewListingError(err)
 	}
 
-	ctx := collectors.GetProcessorContext(rcfg, c.metadata)
+	ctx := collectors.NewProcessorContext(rcfg, c.metadata)
 
 	processResult, processed := c.processor.Process(ctx, list)
 

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/job.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/job.go
@@ -75,13 +75,7 @@ func (c *JobCollector) Run(rcfg *collectors.CollectorRunConfig) (*collectors.Col
 		return nil, collectors.NewListingError(err)
 	}
 
-	ctx := &processors.ProcessorContext{
-		APIClient:  rcfg.APIClient,
-		Cfg:        rcfg.Config,
-		ClusterID:  rcfg.ClusterID,
-		MsgGroupID: rcfg.MsgGroupRef.Inc(),
-		NodeType:   c.metadata.NodeType,
-	}
+	ctx := processors.GetProcessorContext(rcfg, c.metadata)
 
 	processResult, processed := c.processor.Process(ctx, list)
 

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/namespace.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/namespace.go
@@ -76,7 +76,7 @@ func (c *NamespaceCollector) Run(rcfg *collectors.CollectorRunConfig) (*collecto
 		return nil, collectors.NewListingError(err)
 	}
 
-	ctx := collectors.GetProcessorContext(rcfg, c.metadata)
+	ctx := collectors.NewProcessorContext(rcfg, c.metadata)
 
 	processResult, processed := c.processor.Process(ctx, list)
 

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/namespace.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/namespace.go
@@ -76,7 +76,7 @@ func (c *NamespaceCollector) Run(rcfg *collectors.CollectorRunConfig) (*collecto
 		return nil, collectors.NewListingError(err)
 	}
 
-	ctx := processors.GetProcessorContext(rcfg, c.metadata)
+	ctx := collectors.GetProcessorContext(rcfg, c.metadata)
 
 	processResult, processed := c.processor.Process(ctx, list)
 

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/namespace.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/namespace.go
@@ -76,13 +76,7 @@ func (c *NamespaceCollector) Run(rcfg *collectors.CollectorRunConfig) (*collecto
 		return nil, collectors.NewListingError(err)
 	}
 
-	ctx := &processors.ProcessorContext{
-		APIClient:  rcfg.APIClient,
-		Cfg:        rcfg.Config,
-		ClusterID:  rcfg.ClusterID,
-		MsgGroupID: rcfg.MsgGroupRef.Inc(),
-		NodeType:   c.metadata.NodeType,
-	}
+	ctx := processors.GetProcessorContext(rcfg, c.metadata)
 
 	processResult, processed := c.processor.Process(ctx, list)
 

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/node.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/node.go
@@ -75,13 +75,7 @@ func (c *NodeCollector) Run(rcfg *collectors.CollectorRunConfig) (*collectors.Co
 		return nil, collectors.NewListingError(err)
 	}
 
-	ctx := &processors.ProcessorContext{
-		APIClient:  rcfg.APIClient,
-		Cfg:        rcfg.Config,
-		ClusterID:  rcfg.ClusterID,
-		MsgGroupID: rcfg.MsgGroupRef.Inc(),
-		NodeType:   c.metadata.NodeType,
-	}
+	ctx := processors.GetProcessorContext(rcfg, c.metadata)
 
 	processResult, processed := c.processor.Process(ctx, list)
 

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/node.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/node.go
@@ -75,7 +75,7 @@ func (c *NodeCollector) Run(rcfg *collectors.CollectorRunConfig) (*collectors.Co
 		return nil, collectors.NewListingError(err)
 	}
 
-	ctx := processors.GetProcessorContext(rcfg, c.metadata)
+	ctx := collectors.GetProcessorContext(rcfg, c.metadata)
 
 	processResult, processed := c.processor.Process(ctx, list)
 

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/node.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/node.go
@@ -75,7 +75,7 @@ func (c *NodeCollector) Run(rcfg *collectors.CollectorRunConfig) (*collectors.Co
 		return nil, collectors.NewListingError(err)
 	}
 
-	ctx := collectors.GetProcessorContext(rcfg, c.metadata)
+	ctx := collectors.NewProcessorContext(rcfg, c.metadata)
 
 	processResult, processed := c.processor.Process(ctx, list)
 

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/persistentvolume.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/persistentvolume.go
@@ -76,7 +76,7 @@ func (c *PersistentVolumeCollector) Run(rcfg *collectors.CollectorRunConfig) (*c
 		return nil, collectors.NewListingError(err)
 	}
 
-	ctx := processors.GetProcessorContext(rcfg, c.metadata)
+	ctx := collectors.GetProcessorContext(rcfg, c.metadata)
 
 	processResult, processed := c.processor.Process(ctx, list)
 

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/persistentvolume.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/persistentvolume.go
@@ -76,7 +76,7 @@ func (c *PersistentVolumeCollector) Run(rcfg *collectors.CollectorRunConfig) (*c
 		return nil, collectors.NewListingError(err)
 	}
 
-	ctx := collectors.GetProcessorContext(rcfg, c.metadata)
+	ctx := collectors.NewProcessorContext(rcfg, c.metadata)
 
 	processResult, processed := c.processor.Process(ctx, list)
 

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/persistentvolume.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/persistentvolume.go
@@ -76,13 +76,7 @@ func (c *PersistentVolumeCollector) Run(rcfg *collectors.CollectorRunConfig) (*c
 		return nil, collectors.NewListingError(err)
 	}
 
-	ctx := &processors.ProcessorContext{
-		APIClient:  rcfg.APIClient,
-		Cfg:        rcfg.Config,
-		ClusterID:  rcfg.ClusterID,
-		MsgGroupID: rcfg.MsgGroupRef.Inc(),
-		NodeType:   c.metadata.NodeType,
-	}
+	ctx := processors.GetProcessorContext(rcfg, c.metadata)
 
 	processResult, processed := c.processor.Process(ctx, list)
 

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/persistentvolumeclaim.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/persistentvolumeclaim.go
@@ -76,7 +76,7 @@ func (c *PersistentVolumeClaimCollector) Run(rcfg *collectors.CollectorRunConfig
 		return nil, collectors.NewListingError(err)
 	}
 
-	ctx := collectors.GetProcessorContext(rcfg, c.metadata)
+	ctx := collectors.NewProcessorContext(rcfg, c.metadata)
 
 	processResult, processed := c.processor.Process(ctx, list)
 

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/persistentvolumeclaim.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/persistentvolumeclaim.go
@@ -76,7 +76,7 @@ func (c *PersistentVolumeClaimCollector) Run(rcfg *collectors.CollectorRunConfig
 		return nil, collectors.NewListingError(err)
 	}
 
-	ctx := processors.GetProcessorContext(rcfg, c.metadata)
+	ctx := collectors.GetProcessorContext(rcfg, c.metadata)
 
 	processResult, processed := c.processor.Process(ctx, list)
 

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/persistentvolumeclaim.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/persistentvolumeclaim.go
@@ -76,13 +76,7 @@ func (c *PersistentVolumeClaimCollector) Run(rcfg *collectors.CollectorRunConfig
 		return nil, collectors.NewListingError(err)
 	}
 
-	ctx := &processors.ProcessorContext{
-		APIClient:  rcfg.APIClient,
-		Cfg:        rcfg.Config,
-		ClusterID:  rcfg.ClusterID,
-		MsgGroupID: rcfg.MsgGroupRef.Inc(),
-		NodeType:   c.metadata.NodeType,
-	}
+	ctx := processors.GetProcessorContext(rcfg, c.metadata)
 
 	processResult, processed := c.processor.Process(ctx, list)
 

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/pod_unassigned.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/pod_unassigned.go
@@ -77,13 +77,7 @@ func (c *UnassignedPodCollector) Run(rcfg *collectors.CollectorRunConfig) (*coll
 		return nil, collectors.NewListingError(err)
 	}
 
-	ctx := &processors.ProcessorContext{
-		APIClient:  rcfg.APIClient,
-		Cfg:        rcfg.Config,
-		ClusterID:  rcfg.ClusterID,
-		MsgGroupID: rcfg.MsgGroupRef.Inc(),
-		NodeType:   c.metadata.NodeType,
-	}
+	ctx := processors.GetProcessorContext(rcfg, c.metadata)
 
 	processResult, processed := c.processor.Process(ctx, list)
 

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/pod_unassigned.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/pod_unassigned.go
@@ -77,7 +77,7 @@ func (c *UnassignedPodCollector) Run(rcfg *collectors.CollectorRunConfig) (*coll
 		return nil, collectors.NewListingError(err)
 	}
 
-	ctx := collectors.GetProcessorContext(rcfg, c.metadata)
+	ctx := collectors.NewProcessorContext(rcfg, c.metadata)
 
 	processResult, processed := c.processor.Process(ctx, list)
 

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/pod_unassigned.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/pod_unassigned.go
@@ -77,7 +77,7 @@ func (c *UnassignedPodCollector) Run(rcfg *collectors.CollectorRunConfig) (*coll
 		return nil, collectors.NewListingError(err)
 	}
 
-	ctx := processors.GetProcessorContext(rcfg, c.metadata)
+	ctx := collectors.GetProcessorContext(rcfg, c.metadata)
 
 	processResult, processed := c.processor.Process(ctx, list)
 

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/replicaset.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/replicaset.go
@@ -76,13 +76,7 @@ func (c *ReplicaSetCollector) Run(rcfg *collectors.CollectorRunConfig) (*collect
 		return nil, collectors.NewListingError(err)
 	}
 
-	ctx := &processors.ProcessorContext{
-		APIClient:  rcfg.APIClient,
-		Cfg:        rcfg.Config,
-		ClusterID:  rcfg.ClusterID,
-		MsgGroupID: rcfg.MsgGroupRef.Inc(),
-		NodeType:   c.metadata.NodeType,
-	}
+	ctx := processors.GetProcessorContext(rcfg, c.metadata)
 
 	processResult, processed := c.processor.Process(ctx, list)
 

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/replicaset.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/replicaset.go
@@ -76,7 +76,7 @@ func (c *ReplicaSetCollector) Run(rcfg *collectors.CollectorRunConfig) (*collect
 		return nil, collectors.NewListingError(err)
 	}
 
-	ctx := collectors.GetProcessorContext(rcfg, c.metadata)
+	ctx := collectors.NewProcessorContext(rcfg, c.metadata)
 
 	processResult, processed := c.processor.Process(ctx, list)
 

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/replicaset.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/replicaset.go
@@ -76,7 +76,7 @@ func (c *ReplicaSetCollector) Run(rcfg *collectors.CollectorRunConfig) (*collect
 		return nil, collectors.NewListingError(err)
 	}
 
-	ctx := processors.GetProcessorContext(rcfg, c.metadata)
+	ctx := collectors.GetProcessorContext(rcfg, c.metadata)
 
 	processResult, processed := c.processor.Process(ctx, list)
 

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/role.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/role.go
@@ -75,13 +75,7 @@ func (c *RoleCollector) Run(rcfg *collectors.CollectorRunConfig) (*collectors.Co
 		return nil, collectors.NewListingError(err)
 	}
 
-	ctx := &processors.ProcessorContext{
-		APIClient:  rcfg.APIClient,
-		Cfg:        rcfg.Config,
-		ClusterID:  rcfg.ClusterID,
-		MsgGroupID: rcfg.MsgGroupRef.Inc(),
-		NodeType:   c.metadata.NodeType,
-	}
+	ctx := processors.GetProcessorContext(rcfg, c.metadata)
 
 	processResult, processed := c.processor.Process(ctx, list)
 

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/role.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/role.go
@@ -75,7 +75,7 @@ func (c *RoleCollector) Run(rcfg *collectors.CollectorRunConfig) (*collectors.Co
 		return nil, collectors.NewListingError(err)
 	}
 
-	ctx := collectors.GetProcessorContext(rcfg, c.metadata)
+	ctx := collectors.NewProcessorContext(rcfg, c.metadata)
 
 	processResult, processed := c.processor.Process(ctx, list)
 

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/role.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/role.go
@@ -75,7 +75,7 @@ func (c *RoleCollector) Run(rcfg *collectors.CollectorRunConfig) (*collectors.Co
 		return nil, collectors.NewListingError(err)
 	}
 
-	ctx := processors.GetProcessorContext(rcfg, c.metadata)
+	ctx := collectors.GetProcessorContext(rcfg, c.metadata)
 
 	processResult, processed := c.processor.Process(ctx, list)
 

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/rolebinding.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/rolebinding.go
@@ -76,7 +76,7 @@ func (c *RoleBindingCollector) Run(rcfg *collectors.CollectorRunConfig) (*collec
 		return nil, collectors.NewListingError(err)
 	}
 
-	ctx := collectors.GetProcessorContext(rcfg, c.metadata)
+	ctx := collectors.NewProcessorContext(rcfg, c.metadata)
 
 	processResult, processed := c.processor.Process(ctx, list)
 

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/rolebinding.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/rolebinding.go
@@ -76,13 +76,7 @@ func (c *RoleBindingCollector) Run(rcfg *collectors.CollectorRunConfig) (*collec
 		return nil, collectors.NewListingError(err)
 	}
 
-	ctx := &processors.ProcessorContext{
-		APIClient:  rcfg.APIClient,
-		Cfg:        rcfg.Config,
-		ClusterID:  rcfg.ClusterID,
-		MsgGroupID: rcfg.MsgGroupRef.Inc(),
-		NodeType:   c.metadata.NodeType,
-	}
+	ctx := processors.GetProcessorContext(rcfg, c.metadata)
 
 	processResult, processed := c.processor.Process(ctx, list)
 

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/rolebinding.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/rolebinding.go
@@ -76,7 +76,7 @@ func (c *RoleBindingCollector) Run(rcfg *collectors.CollectorRunConfig) (*collec
 		return nil, collectors.NewListingError(err)
 	}
 
-	ctx := processors.GetProcessorContext(rcfg, c.metadata)
+	ctx := collectors.GetProcessorContext(rcfg, c.metadata)
 
 	processResult, processed := c.processor.Process(ctx, list)
 

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/service.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/service.go
@@ -76,7 +76,7 @@ func (c *ServiceCollector) Run(rcfg *collectors.CollectorRunConfig) (*collectors
 		return nil, collectors.NewListingError(err)
 	}
 
-	ctx := processors.GetProcessorContext(rcfg, c.metadata)
+	ctx := collectors.GetProcessorContext(rcfg, c.metadata)
 
 	processResult, processed := c.processor.Process(ctx, list)
 

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/service.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/service.go
@@ -76,13 +76,7 @@ func (c *ServiceCollector) Run(rcfg *collectors.CollectorRunConfig) (*collectors
 		return nil, collectors.NewListingError(err)
 	}
 
-	ctx := &processors.ProcessorContext{
-		APIClient:  rcfg.APIClient,
-		Cfg:        rcfg.Config,
-		ClusterID:  rcfg.ClusterID,
-		MsgGroupID: rcfg.MsgGroupRef.Inc(),
-		NodeType:   c.metadata.NodeType,
-	}
+	ctx := processors.GetProcessorContext(rcfg, c.metadata)
 
 	processResult, processed := c.processor.Process(ctx, list)
 

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/service.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/service.go
@@ -76,7 +76,7 @@ func (c *ServiceCollector) Run(rcfg *collectors.CollectorRunConfig) (*collectors
 		return nil, collectors.NewListingError(err)
 	}
 
-	ctx := collectors.GetProcessorContext(rcfg, c.metadata)
+	ctx := collectors.NewProcessorContext(rcfg, c.metadata)
 
 	processResult, processed := c.processor.Process(ctx, list)
 

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/serviceaccount.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/serviceaccount.go
@@ -76,13 +76,7 @@ func (c *ServiceAccountCollector) Run(rcfg *collectors.CollectorRunConfig) (*col
 		return nil, collectors.NewListingError(err)
 	}
 
-	ctx := &processors.ProcessorContext{
-		APIClient:  rcfg.APIClient,
-		Cfg:        rcfg.Config,
-		ClusterID:  rcfg.ClusterID,
-		MsgGroupID: rcfg.MsgGroupRef.Inc(),
-		NodeType:   c.metadata.NodeType,
-	}
+	ctx := processors.GetProcessorContext(rcfg, c.metadata)
 
 	processResult, processed := c.processor.Process(ctx, list)
 

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/serviceaccount.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/serviceaccount.go
@@ -76,7 +76,7 @@ func (c *ServiceAccountCollector) Run(rcfg *collectors.CollectorRunConfig) (*col
 		return nil, collectors.NewListingError(err)
 	}
 
-	ctx := collectors.GetProcessorContext(rcfg, c.metadata)
+	ctx := collectors.NewProcessorContext(rcfg, c.metadata)
 
 	processResult, processed := c.processor.Process(ctx, list)
 

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/serviceaccount.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/serviceaccount.go
@@ -76,7 +76,7 @@ func (c *ServiceAccountCollector) Run(rcfg *collectors.CollectorRunConfig) (*col
 		return nil, collectors.NewListingError(err)
 	}
 
-	ctx := processors.GetProcessorContext(rcfg, c.metadata)
+	ctx := collectors.GetProcessorContext(rcfg, c.metadata)
 
 	processResult, processed := c.processor.Process(ctx, list)
 

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/statefulset.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/statefulset.go
@@ -76,7 +76,7 @@ func (c *StatefulSetCollector) Run(rcfg *collectors.CollectorRunConfig) (*collec
 		return nil, collectors.NewListingError(err)
 	}
 
-	ctx := processors.GetProcessorContext(rcfg, c.metadata)
+	ctx := collectors.GetProcessorContext(rcfg, c.metadata)
 
 	processResult, processed := c.processor.Process(ctx, list)
 

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/statefulset.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/statefulset.go
@@ -76,13 +76,7 @@ func (c *StatefulSetCollector) Run(rcfg *collectors.CollectorRunConfig) (*collec
 		return nil, collectors.NewListingError(err)
 	}
 
-	ctx := &processors.ProcessorContext{
-		APIClient:  rcfg.APIClient,
-		Cfg:        rcfg.Config,
-		ClusterID:  rcfg.ClusterID,
-		MsgGroupID: rcfg.MsgGroupRef.Inc(),
-		NodeType:   c.metadata.NodeType,
-	}
+	ctx := processors.GetProcessorContext(rcfg, c.metadata)
 
 	processResult, processed := c.processor.Process(ctx, list)
 

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/statefulset.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/statefulset.go
@@ -76,7 +76,7 @@ func (c *StatefulSetCollector) Run(rcfg *collectors.CollectorRunConfig) (*collec
 		return nil, collectors.NewListingError(err)
 	}
 
-	ctx := collectors.GetProcessorContext(rcfg, c.metadata)
+	ctx := collectors.NewProcessorContext(rcfg, c.metadata)
 
 	processResult, processed := c.processor.Process(ctx, list)
 

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/clusterrole.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/clusterrole.go
@@ -9,8 +9,6 @@
 package k8s
 
 import (
-	"fmt"
-
 	model "github.com/DataDog/agent-payload/v5/process"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors"
@@ -48,7 +46,7 @@ func (h *ClusterRoleHandlers) BuildMessageBody(ctx *processors.ProcessorContext,
 		GroupId:      ctx.MsgGroupID,
 		GroupSize:    int32(groupSize),
 		ClusterRoles: models,
-		Tags:         append(ctx.Cfg.ExtraTags, fmt.Sprintf("%s:%s", "kube_api_version", ctx.ApiGroupVersion))}
+		Tags:         append(ctx.Cfg.ExtraTags, ctx.ApiGroupVersionTag)}
 }
 
 // ExtractResource is a handler called to extract the resource model out of a raw resource.

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/clusterrole.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/clusterrole.go
@@ -9,6 +9,8 @@
 package k8s
 
 import (
+	"fmt"
+
 	model "github.com/DataDog/agent-payload/v5/process"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors"
@@ -46,8 +48,7 @@ func (h *ClusterRoleHandlers) BuildMessageBody(ctx *processors.ProcessorContext,
 		GroupId:      ctx.MsgGroupID,
 		GroupSize:    int32(groupSize),
 		ClusterRoles: models,
-		Tags:         ctx.Cfg.ExtraTags,
-	}
+		Tags:         append(ctx.Cfg.ExtraTags, fmt.Sprintf("%s:%s", "kube_api_version", ctx.ApiGroupVersion))}
 }
 
 // ExtractResource is a handler called to extract the resource model out of a raw resource.

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/clusterrolebinding.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/clusterrolebinding.go
@@ -9,8 +9,6 @@
 package k8s
 
 import (
-	"fmt"
-
 	model "github.com/DataDog/agent-payload/v5/process"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors"
@@ -48,7 +46,7 @@ func (h *ClusterRoleBindingHandlers) BuildMessageBody(ctx *processors.ProcessorC
 		GroupId:             ctx.MsgGroupID,
 		GroupSize:           int32(groupSize),
 		ClusterRoleBindings: models,
-		Tags:                append(ctx.Cfg.ExtraTags, fmt.Sprintf("%s:%s", "kube_api_version", ctx.ApiGroupVersion)),
+		Tags:                append(ctx.Cfg.ExtraTags, ctx.ApiGroupVersionTag),
 	}
 }
 

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/clusterrolebinding.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/clusterrolebinding.go
@@ -9,6 +9,8 @@
 package k8s
 
 import (
+	"fmt"
+
 	model "github.com/DataDog/agent-payload/v5/process"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors"
@@ -46,7 +48,7 @@ func (h *ClusterRoleBindingHandlers) BuildMessageBody(ctx *processors.ProcessorC
 		GroupId:             ctx.MsgGroupID,
 		GroupSize:           int32(groupSize),
 		ClusterRoleBindings: models,
-		Tags:                ctx.Cfg.ExtraTags,
+		Tags:                append(ctx.Cfg.ExtraTags, fmt.Sprintf("%s:%s", "kube_api_version", ctx.ApiGroupVersion)),
 	}
 }
 

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/cronjob_v1.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/cronjob_v1.go
@@ -9,8 +9,6 @@
 package k8s
 
 import (
-	"fmt"
-
 	model "github.com/DataDog/agent-payload/v5/process"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors"
 	k8sTransformers "github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s"
@@ -47,7 +45,7 @@ func (h *CronJobV1Handlers) BuildMessageBody(ctx *processors.ProcessorContext, r
 		GroupId:     ctx.MsgGroupID,
 		GroupSize:   int32(groupSize),
 		CronJobs:    models,
-		Tags:        append(ctx.Cfg.ExtraTags, fmt.Sprintf("%s:%s", "kube_api_version", ctx.ApiGroupVersion)),
+		Tags:        append(ctx.Cfg.ExtraTags, ctx.ApiGroupVersionTag),
 	}
 }
 

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/cronjob_v1.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/cronjob_v1.go
@@ -45,7 +45,7 @@ func (h *CronJobV1Handlers) BuildMessageBody(ctx *processors.ProcessorContext, r
 		GroupId:     ctx.MsgGroupID,
 		GroupSize:   int32(groupSize),
 		CronJobs:    models,
-		Tags:        ctx.Cfg.ExtraTags,
+		Tags:        append(ctx.Cfg.ExtraTags, ctx.CollectorTags...),
 	}
 }
 

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/cronjob_v1.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/cronjob_v1.go
@@ -9,6 +9,8 @@
 package k8s
 
 import (
+	"fmt"
+
 	model "github.com/DataDog/agent-payload/v5/process"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors"
 	k8sTransformers "github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s"
@@ -45,7 +47,7 @@ func (h *CronJobV1Handlers) BuildMessageBody(ctx *processors.ProcessorContext, r
 		GroupId:     ctx.MsgGroupID,
 		GroupSize:   int32(groupSize),
 		CronJobs:    models,
-		Tags:        append(ctx.Cfg.ExtraTags, ctx.CollectorTags...),
+		Tags:        append(ctx.Cfg.ExtraTags, fmt.Sprintf("%s:%s", "kube_api_version", ctx.ApiGroupVersion)),
 	}
 }
 

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/cronjob_v1beta1.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/cronjob_v1beta1.go
@@ -9,8 +9,6 @@
 package k8s
 
 import (
-	"fmt"
-
 	model "github.com/DataDog/agent-payload/v5/process"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors"
@@ -48,7 +46,7 @@ func (h *CronJobV1Beta1Handlers) BuildMessageBody(ctx *processors.ProcessorConte
 		GroupId:     ctx.MsgGroupID,
 		GroupSize:   int32(groupSize),
 		CronJobs:    models,
-		Tags:        append(ctx.Cfg.ExtraTags, fmt.Sprintf("%s:%s", "kube_api_version", ctx.ApiGroupVersion)),
+		Tags:        append(ctx.Cfg.ExtraTags, ctx.ApiGroupVersionTag),
 	}
 }
 

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/cronjob_v1beta1.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/cronjob_v1beta1.go
@@ -9,6 +9,8 @@
 package k8s
 
 import (
+	"fmt"
+
 	model "github.com/DataDog/agent-payload/v5/process"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors"
@@ -46,7 +48,7 @@ func (h *CronJobV1Beta1Handlers) BuildMessageBody(ctx *processors.ProcessorConte
 		GroupId:     ctx.MsgGroupID,
 		GroupSize:   int32(groupSize),
 		CronJobs:    models,
-		Tags:        append(ctx.Cfg.ExtraTags, ctx.CollectorTags...),
+		Tags:        append(ctx.Cfg.ExtraTags, fmt.Sprintf("%s:%s", "kube_api_version", ctx.ApiGroupVersion)),
 	}
 }
 

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/cronjob_v1beta1.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/cronjob_v1beta1.go
@@ -46,7 +46,7 @@ func (h *CronJobV1Beta1Handlers) BuildMessageBody(ctx *processors.ProcessorConte
 		GroupId:     ctx.MsgGroupID,
 		GroupSize:   int32(groupSize),
 		CronJobs:    models,
-		Tags:        ctx.Cfg.ExtraTags,
+		Tags:        append(ctx.Cfg.ExtraTags, ctx.CollectorTags...),
 	}
 }
 

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/daemonset.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/daemonset.go
@@ -9,6 +9,8 @@
 package k8s
 
 import (
+	"fmt"
+
 	model "github.com/DataDog/agent-payload/v5/process"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors"
@@ -46,7 +48,7 @@ func (h *DaemonSetHandlers) BuildMessageBody(ctx *processors.ProcessorContext, r
 		GroupId:     ctx.MsgGroupID,
 		GroupSize:   int32(groupSize),
 		DaemonSets:  models,
-		Tags:        append(ctx.Cfg.ExtraTags, ctx.CollectorTags...),
+		Tags:        append(ctx.Cfg.ExtraTags, fmt.Sprintf("%s:%s", "kube_api_version", ctx.ApiGroupVersion)),
 	}
 }
 

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/daemonset.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/daemonset.go
@@ -9,8 +9,6 @@
 package k8s
 
 import (
-	"fmt"
-
 	model "github.com/DataDog/agent-payload/v5/process"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors"
@@ -48,7 +46,7 @@ func (h *DaemonSetHandlers) BuildMessageBody(ctx *processors.ProcessorContext, r
 		GroupId:     ctx.MsgGroupID,
 		GroupSize:   int32(groupSize),
 		DaemonSets:  models,
-		Tags:        append(ctx.Cfg.ExtraTags, fmt.Sprintf("%s:%s", "kube_api_version", ctx.ApiGroupVersion)),
+		Tags:        append(ctx.Cfg.ExtraTags, ctx.ApiGroupVersionTag),
 	}
 }
 

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/daemonset.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/daemonset.go
@@ -46,7 +46,7 @@ func (h *DaemonSetHandlers) BuildMessageBody(ctx *processors.ProcessorContext, r
 		GroupId:     ctx.MsgGroupID,
 		GroupSize:   int32(groupSize),
 		DaemonSets:  models,
-		Tags:        ctx.Cfg.ExtraTags,
+		Tags:        append(ctx.Cfg.ExtraTags, ctx.CollectorTags...),
 	}
 }
 

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/deployment.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/deployment.go
@@ -9,6 +9,8 @@
 package k8s
 
 import (
+	"fmt"
+
 	model "github.com/DataDog/agent-payload/v5/process"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors"
@@ -46,7 +48,7 @@ func (h *DeploymentHandlers) BuildMessageBody(ctx *processors.ProcessorContext, 
 		GroupId:     ctx.MsgGroupID,
 		GroupSize:   int32(groupSize),
 		Deployments: models,
-		Tags:        append(ctx.Cfg.ExtraTags, ctx.CollectorTags...),
+		Tags:        append(ctx.Cfg.ExtraTags, fmt.Sprintf("%s:%s", "kube_api_version", ctx.ApiGroupVersion)),
 	}
 }
 

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/deployment.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/deployment.go
@@ -46,7 +46,7 @@ func (h *DeploymentHandlers) BuildMessageBody(ctx *processors.ProcessorContext, 
 		GroupId:     ctx.MsgGroupID,
 		GroupSize:   int32(groupSize),
 		Deployments: models,
-		Tags:        ctx.Cfg.ExtraTags,
+		Tags:        append(ctx.Cfg.ExtraTags, ctx.CollectorTags...),
 	}
 }
 

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/deployment.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/deployment.go
@@ -9,8 +9,6 @@
 package k8s
 
 import (
-	"fmt"
-
 	model "github.com/DataDog/agent-payload/v5/process"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors"
@@ -48,7 +46,7 @@ func (h *DeploymentHandlers) BuildMessageBody(ctx *processors.ProcessorContext, 
 		GroupId:     ctx.MsgGroupID,
 		GroupSize:   int32(groupSize),
 		Deployments: models,
-		Tags:        append(ctx.Cfg.ExtraTags, fmt.Sprintf("%s:%s", "kube_api_version", ctx.ApiGroupVersion)),
+		Tags:        append(ctx.Cfg.ExtraTags, ctx.ApiGroupVersionTag),
 	}
 }
 

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/ingress.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/ingress.go
@@ -9,6 +9,8 @@
 package k8s
 
 import (
+	"fmt"
+
 	model "github.com/DataDog/agent-payload/v5/process"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors"
@@ -46,7 +48,7 @@ func (h *IngressHandlers) BuildMessageBody(ctx *processors.ProcessorContext, res
 		GroupId:     ctx.MsgGroupID,
 		GroupSize:   int32(groupSize),
 		Ingresses:   models,
-		Tags:        append(ctx.Cfg.ExtraTags, ctx.CollectorTags...),
+		Tags:        append(ctx.Cfg.ExtraTags, fmt.Sprintf("%s:%s", "kube_api_version", ctx.ApiGroupVersion)),
 	}
 }
 

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/ingress.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/ingress.go
@@ -46,7 +46,7 @@ func (h *IngressHandlers) BuildMessageBody(ctx *processors.ProcessorContext, res
 		GroupId:     ctx.MsgGroupID,
 		GroupSize:   int32(groupSize),
 		Ingresses:   models,
-		Tags:        ctx.Cfg.ExtraTags,
+		Tags:        append(ctx.Cfg.ExtraTags, ctx.CollectorTags...),
 	}
 }
 

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/ingress.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/ingress.go
@@ -9,8 +9,6 @@
 package k8s
 
 import (
-	"fmt"
-
 	model "github.com/DataDog/agent-payload/v5/process"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors"
@@ -48,7 +46,7 @@ func (h *IngressHandlers) BuildMessageBody(ctx *processors.ProcessorContext, res
 		GroupId:     ctx.MsgGroupID,
 		GroupSize:   int32(groupSize),
 		Ingresses:   models,
-		Tags:        append(ctx.Cfg.ExtraTags, fmt.Sprintf("%s:%s", "kube_api_version", ctx.ApiGroupVersion)),
+		Tags:        append(ctx.Cfg.ExtraTags, ctx.ApiGroupVersionTag),
 	}
 }
 

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/job.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/job.go
@@ -9,8 +9,6 @@
 package k8s
 
 import (
-	"fmt"
-
 	model "github.com/DataDog/agent-payload/v5/process"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors"
@@ -48,7 +46,7 @@ func (h *JobHandlers) BuildMessageBody(ctx *processors.ProcessorContext, resourc
 		GroupId:     ctx.MsgGroupID,
 		GroupSize:   int32(groupSize),
 		Jobs:        models,
-		Tags:        append(ctx.Cfg.ExtraTags, fmt.Sprintf("%s:%s", "kube_api_version", ctx.ApiGroupVersion)),
+		Tags:        append(ctx.Cfg.ExtraTags, ctx.ApiGroupVersionTag),
 	}
 }
 

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/job.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/job.go
@@ -46,7 +46,7 @@ func (h *JobHandlers) BuildMessageBody(ctx *processors.ProcessorContext, resourc
 		GroupId:     ctx.MsgGroupID,
 		GroupSize:   int32(groupSize),
 		Jobs:        models,
-		Tags:        ctx.Cfg.ExtraTags,
+		Tags:        append(ctx.Cfg.ExtraTags, ctx.CollectorTags...),
 	}
 }
 

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/job.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/job.go
@@ -9,6 +9,8 @@
 package k8s
 
 import (
+	"fmt"
+
 	model "github.com/DataDog/agent-payload/v5/process"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors"
@@ -46,7 +48,7 @@ func (h *JobHandlers) BuildMessageBody(ctx *processors.ProcessorContext, resourc
 		GroupId:     ctx.MsgGroupID,
 		GroupSize:   int32(groupSize),
 		Jobs:        models,
-		Tags:        append(ctx.Cfg.ExtraTags, ctx.CollectorTags...),
+		Tags:        append(ctx.Cfg.ExtraTags, fmt.Sprintf("%s:%s", "kube_api_version", ctx.ApiGroupVersion)),
 	}
 }
 

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/namespace.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/namespace.go
@@ -9,8 +9,6 @@
 package k8s
 
 import (
-	"fmt"
-
 	model "github.com/DataDog/agent-payload/v5/process"
 	corev1 "k8s.io/api/core/v1"
 
@@ -56,7 +54,7 @@ func (h *NamespaceHandlers) BuildMessageBody(ctx *processors.ProcessorContext, r
 		GroupId:     ctx.MsgGroupID,
 		GroupSize:   int32(groupSize),
 		Namespaces:  models,
-		Tags:        append(ctx.Cfg.ExtraTags, fmt.Sprintf("%s:%s", "kube_api_version", ctx.ApiGroupVersion)),
+		Tags:        append(ctx.Cfg.ExtraTags, ctx.ApiGroupVersionTag),
 	}
 }
 

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/namespace.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/namespace.go
@@ -9,6 +9,8 @@
 package k8s
 
 import (
+	"fmt"
+
 	model "github.com/DataDog/agent-payload/v5/process"
 	corev1 "k8s.io/api/core/v1"
 
@@ -54,7 +56,7 @@ func (h *NamespaceHandlers) BuildMessageBody(ctx *processors.ProcessorContext, r
 		GroupId:     ctx.MsgGroupID,
 		GroupSize:   int32(groupSize),
 		Namespaces:  models,
-		Tags:        append(ctx.Cfg.ExtraTags, ctx.CollectorTags...),
+		Tags:        append(ctx.Cfg.ExtraTags, fmt.Sprintf("%s:%s", "kube_api_version", ctx.ApiGroupVersion)),
 	}
 }
 

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/namespace.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/namespace.go
@@ -54,7 +54,7 @@ func (h *NamespaceHandlers) BuildMessageBody(ctx *processors.ProcessorContext, r
 		GroupId:     ctx.MsgGroupID,
 		GroupSize:   int32(groupSize),
 		Namespaces:  models,
-		Tags:        ctx.Cfg.ExtraTags,
+		Tags:        append(ctx.Cfg.ExtraTags, ctx.CollectorTags...),
 	}
 }
 

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/node.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/node.go
@@ -46,7 +46,7 @@ func (h *NodeHandlers) BuildMessageBody(ctx *processors.ProcessorContext, resour
 		GroupId:     ctx.MsgGroupID,
 		GroupSize:   int32(groupSize),
 		Nodes:       models,
-		Tags:        ctx.Cfg.ExtraTags,
+		Tags:        append(ctx.Cfg.ExtraTags, ctx.CollectorTags...),
 	}
 }
 

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/node.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/node.go
@@ -9,8 +9,6 @@
 package k8s
 
 import (
-	"fmt"
-
 	model "github.com/DataDog/agent-payload/v5/process"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors"
@@ -48,7 +46,7 @@ func (h *NodeHandlers) BuildMessageBody(ctx *processors.ProcessorContext, resour
 		GroupId:     ctx.MsgGroupID,
 		GroupSize:   int32(groupSize),
 		Nodes:       models,
-		Tags:        append(ctx.Cfg.ExtraTags, fmt.Sprintf("%s:%s", "kube_api_version", ctx.ApiGroupVersion)),
+		Tags:        append(ctx.Cfg.ExtraTags, ctx.ApiGroupVersionTag),
 	}
 }
 

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/node.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/node.go
@@ -9,6 +9,8 @@
 package k8s
 
 import (
+	"fmt"
+
 	model "github.com/DataDog/agent-payload/v5/process"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors"
@@ -46,7 +48,7 @@ func (h *NodeHandlers) BuildMessageBody(ctx *processors.ProcessorContext, resour
 		GroupId:     ctx.MsgGroupID,
 		GroupSize:   int32(groupSize),
 		Nodes:       models,
-		Tags:        append(ctx.Cfg.ExtraTags, ctx.CollectorTags...),
+		Tags:        append(ctx.Cfg.ExtraTags, fmt.Sprintf("%s:%s", "kube_api_version", ctx.ApiGroupVersion)),
 	}
 }
 

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/persistentvolume.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/persistentvolume.go
@@ -9,8 +9,6 @@
 package k8s
 
 import (
-	"fmt"
-
 	model "github.com/DataDog/agent-payload/v5/process"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors"
@@ -48,7 +46,7 @@ func (h *PersistentVolumeHandlers) BuildMessageBody(ctx *processors.ProcessorCon
 		GroupId:           ctx.MsgGroupID,
 		GroupSize:         int32(groupSize),
 		PersistentVolumes: models,
-		Tags:              append(ctx.Cfg.ExtraTags, fmt.Sprintf("%s:%s", "kube_api_version", ctx.ApiGroupVersion)),
+		Tags:              append(ctx.Cfg.ExtraTags, ctx.ApiGroupVersionTag),
 	}
 }
 

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/persistentvolume.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/persistentvolume.go
@@ -9,6 +9,8 @@
 package k8s
 
 import (
+	"fmt"
+
 	model "github.com/DataDog/agent-payload/v5/process"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors"
@@ -46,7 +48,7 @@ func (h *PersistentVolumeHandlers) BuildMessageBody(ctx *processors.ProcessorCon
 		GroupId:           ctx.MsgGroupID,
 		GroupSize:         int32(groupSize),
 		PersistentVolumes: models,
-		Tags:              ctx.Cfg.ExtraTags,
+		Tags:              append(ctx.Cfg.ExtraTags, fmt.Sprintf("%s:%s", "kube_api_version", ctx.ApiGroupVersion)),
 	}
 }
 

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/persistentvolumeclaim.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/persistentvolumeclaim.go
@@ -9,6 +9,8 @@
 package k8s
 
 import (
+	"fmt"
+
 	model "github.com/DataDog/agent-payload/v5/process"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors"
@@ -46,7 +48,7 @@ func (h *PersistentVolumeClaimHandlers) BuildMessageBody(ctx *processors.Process
 		GroupId:                ctx.MsgGroupID,
 		GroupSize:              int32(groupSize),
 		PersistentVolumeClaims: models,
-		Tags:                   ctx.Cfg.ExtraTags,
+		Tags:                   append(ctx.Cfg.ExtraTags, fmt.Sprintf("%s:%s", "kube_api_version", ctx.ApiGroupVersion)),
 	}
 }
 

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/persistentvolumeclaim.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/persistentvolumeclaim.go
@@ -9,8 +9,6 @@
 package k8s
 
 import (
-	"fmt"
-
 	model "github.com/DataDog/agent-payload/v5/process"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors"
@@ -48,7 +46,7 @@ func (h *PersistentVolumeClaimHandlers) BuildMessageBody(ctx *processors.Process
 		GroupId:                ctx.MsgGroupID,
 		GroupSize:              int32(groupSize),
 		PersistentVolumeClaims: models,
-		Tags:                   append(ctx.Cfg.ExtraTags, fmt.Sprintf("%s:%s", "kube_api_version", ctx.ApiGroupVersion)),
+		Tags:                   append(ctx.Cfg.ExtraTags, ctx.ApiGroupVersionTag),
 	}
 }
 

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/pod.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/pod.go
@@ -102,7 +102,7 @@ func (h *PodHandlers) BuildMessageBody(ctx *processors.ProcessorContext, resourc
 		GroupSize:   int32(groupSize),
 		HostName:    ctx.HostName,
 		Pods:        models,
-		Tags:        append(ctx.Cfg.ExtraTags, fmt.Sprintf("%s:%s", "kube_api_version", ctx.ApiGroupVersion)),
+		Tags:        append(ctx.Cfg.ExtraTags, ctx.ApiGroupVersionTag),
 	}
 }
 

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/pod.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/pod.go
@@ -102,7 +102,7 @@ func (h *PodHandlers) BuildMessageBody(ctx *processors.ProcessorContext, resourc
 		GroupSize:   int32(groupSize),
 		HostName:    ctx.HostName,
 		Pods:        models,
-		Tags:        append(ctx.Cfg.ExtraTags, ctx.CollectorTags...),
+		Tags:        append(ctx.Cfg.ExtraTags, fmt.Sprintf("%s:%s", "kube_api_version", ctx.ApiGroupVersion)),
 	}
 }
 

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/pod.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/pod.go
@@ -102,7 +102,7 @@ func (h *PodHandlers) BuildMessageBody(ctx *processors.ProcessorContext, resourc
 		GroupSize:   int32(groupSize),
 		HostName:    ctx.HostName,
 		Pods:        models,
-		Tags:        ctx.Cfg.ExtraTags,
+		Tags:        append(ctx.Cfg.ExtraTags, ctx.CollectorTags...),
 	}
 }
 

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/replicaset.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/replicaset.go
@@ -46,7 +46,7 @@ func (h *ReplicaSetHandlers) BuildMessageBody(ctx *processors.ProcessorContext, 
 		GroupId:     ctx.MsgGroupID,
 		GroupSize:   int32(groupSize),
 		ReplicaSets: models,
-		Tags:        ctx.Cfg.ExtraTags,
+		Tags:        append(ctx.Cfg.ExtraTags, ctx.CollectorTags...),
 	}
 }
 

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/replicaset.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/replicaset.go
@@ -9,6 +9,8 @@
 package k8s
 
 import (
+	"fmt"
+
 	model "github.com/DataDog/agent-payload/v5/process"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors"
@@ -46,7 +48,7 @@ func (h *ReplicaSetHandlers) BuildMessageBody(ctx *processors.ProcessorContext, 
 		GroupId:     ctx.MsgGroupID,
 		GroupSize:   int32(groupSize),
 		ReplicaSets: models,
-		Tags:        append(ctx.Cfg.ExtraTags, ctx.CollectorTags...),
+		Tags:        append(ctx.Cfg.ExtraTags, fmt.Sprintf("%s:%s", "kube_api_version", ctx.ApiGroupVersion)),
 	}
 }
 

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/replicaset.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/replicaset.go
@@ -9,8 +9,6 @@
 package k8s
 
 import (
-	"fmt"
-
 	model "github.com/DataDog/agent-payload/v5/process"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors"
@@ -48,7 +46,7 @@ func (h *ReplicaSetHandlers) BuildMessageBody(ctx *processors.ProcessorContext, 
 		GroupId:     ctx.MsgGroupID,
 		GroupSize:   int32(groupSize),
 		ReplicaSets: models,
-		Tags:        append(ctx.Cfg.ExtraTags, fmt.Sprintf("%s:%s", "kube_api_version", ctx.ApiGroupVersion)),
+		Tags:        append(ctx.Cfg.ExtraTags, ctx.ApiGroupVersionTag),
 	}
 }
 

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/role.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/role.go
@@ -9,6 +9,8 @@
 package k8s
 
 import (
+	"fmt"
+
 	model "github.com/DataDog/agent-payload/v5/process"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors"
@@ -46,7 +48,7 @@ func (h *RoleHandlers) BuildMessageBody(ctx *processors.ProcessorContext, resour
 		GroupId:     ctx.MsgGroupID,
 		GroupSize:   int32(groupSize),
 		Roles:       models,
-		Tags:        append(ctx.Cfg.ExtraTags, ctx.CollectorTags...),
+		Tags:        append(ctx.Cfg.ExtraTags, fmt.Sprintf("%s:%s", "kube_api_version", ctx.ApiGroupVersion)),
 	}
 }
 

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/role.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/role.go
@@ -9,8 +9,6 @@
 package k8s
 
 import (
-	"fmt"
-
 	model "github.com/DataDog/agent-payload/v5/process"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors"
@@ -48,7 +46,7 @@ func (h *RoleHandlers) BuildMessageBody(ctx *processors.ProcessorContext, resour
 		GroupId:     ctx.MsgGroupID,
 		GroupSize:   int32(groupSize),
 		Roles:       models,
-		Tags:        append(ctx.Cfg.ExtraTags, fmt.Sprintf("%s:%s", "kube_api_version", ctx.ApiGroupVersion)),
+		Tags:        append(ctx.Cfg.ExtraTags, ctx.ApiGroupVersionTag),
 	}
 }
 

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/role.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/role.go
@@ -46,7 +46,7 @@ func (h *RoleHandlers) BuildMessageBody(ctx *processors.ProcessorContext, resour
 		GroupId:     ctx.MsgGroupID,
 		GroupSize:   int32(groupSize),
 		Roles:       models,
-		Tags:        ctx.Cfg.ExtraTags,
+		Tags:        append(ctx.Cfg.ExtraTags, ctx.CollectorTags...),
 	}
 }
 

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/rolebinding.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/rolebinding.go
@@ -9,8 +9,6 @@
 package k8s
 
 import (
-	"fmt"
-
 	model "github.com/DataDog/agent-payload/v5/process"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors"
@@ -48,7 +46,7 @@ func (h *RoleBindingHandlers) BuildMessageBody(ctx *processors.ProcessorContext,
 		GroupId:      ctx.MsgGroupID,
 		GroupSize:    int32(groupSize),
 		RoleBindings: models,
-		Tags:         append(ctx.Cfg.ExtraTags, fmt.Sprintf("%s:%s", "kube_api_version", ctx.ApiGroupVersion))}
+		Tags:         append(ctx.Cfg.ExtraTags, ctx.ApiGroupVersionTag)}
 }
 
 // ExtractResource is a handler called to extract the resource model out of a raw resource.

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/rolebinding.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/rolebinding.go
@@ -9,6 +9,8 @@
 package k8s
 
 import (
+	"fmt"
+
 	model "github.com/DataDog/agent-payload/v5/process"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors"
@@ -46,8 +48,7 @@ func (h *RoleBindingHandlers) BuildMessageBody(ctx *processors.ProcessorContext,
 		GroupId:      ctx.MsgGroupID,
 		GroupSize:    int32(groupSize),
 		RoleBindings: models,
-		Tags:         ctx.Cfg.ExtraTags,
-	}
+		Tags:         append(ctx.Cfg.ExtraTags, fmt.Sprintf("%s:%s", "kube_api_version", ctx.ApiGroupVersion))}
 }
 
 // ExtractResource is a handler called to extract the resource model out of a raw resource.

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/service.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/service.go
@@ -46,7 +46,7 @@ func (h *ServiceHandlers) BuildMessageBody(ctx *processors.ProcessorContext, res
 		GroupId:     ctx.MsgGroupID,
 		GroupSize:   int32(groupSize),
 		Services:    models,
-		Tags:        ctx.Cfg.ExtraTags,
+		Tags:        append(ctx.Cfg.ExtraTags, ctx.CollectorTags...),
 	}
 }
 

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/service.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/service.go
@@ -9,6 +9,8 @@
 package k8s
 
 import (
+	"fmt"
+
 	model "github.com/DataDog/agent-payload/v5/process"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors"
@@ -46,7 +48,7 @@ func (h *ServiceHandlers) BuildMessageBody(ctx *processors.ProcessorContext, res
 		GroupId:     ctx.MsgGroupID,
 		GroupSize:   int32(groupSize),
 		Services:    models,
-		Tags:        append(ctx.Cfg.ExtraTags, ctx.CollectorTags...),
+		Tags:        append(ctx.Cfg.ExtraTags, fmt.Sprintf("%s:%s", "kube_api_version", ctx.ApiGroupVersion)),
 	}
 }
 

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/service.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/service.go
@@ -9,8 +9,6 @@
 package k8s
 
 import (
-	"fmt"
-
 	model "github.com/DataDog/agent-payload/v5/process"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors"
@@ -48,7 +46,7 @@ func (h *ServiceHandlers) BuildMessageBody(ctx *processors.ProcessorContext, res
 		GroupId:     ctx.MsgGroupID,
 		GroupSize:   int32(groupSize),
 		Services:    models,
-		Tags:        append(ctx.Cfg.ExtraTags, fmt.Sprintf("%s:%s", "kube_api_version", ctx.ApiGroupVersion)),
+		Tags:        append(ctx.Cfg.ExtraTags, ctx.ApiGroupVersionTag),
 	}
 }
 

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/serviceaccount.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/serviceaccount.go
@@ -46,7 +46,7 @@ func (h *ServiceAccountHandlers) BuildMessageBody(ctx *processors.ProcessorConte
 		GroupId:         ctx.MsgGroupID,
 		GroupSize:       int32(groupSize),
 		ServiceAccounts: models,
-		Tags:            ctx.Cfg.ExtraTags,
+		Tags:            append(ctx.Cfg.ExtraTags, ctx.CollectorTags...),
 	}
 }
 

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/serviceaccount.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/serviceaccount.go
@@ -9,6 +9,8 @@
 package k8s
 
 import (
+	"fmt"
+
 	model "github.com/DataDog/agent-payload/v5/process"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors"
@@ -46,7 +48,7 @@ func (h *ServiceAccountHandlers) BuildMessageBody(ctx *processors.ProcessorConte
 		GroupId:         ctx.MsgGroupID,
 		GroupSize:       int32(groupSize),
 		ServiceAccounts: models,
-		Tags:            append(ctx.Cfg.ExtraTags, ctx.CollectorTags...),
+		Tags:            append(ctx.Cfg.ExtraTags, fmt.Sprintf("%s:%s", "kube_api_version", ctx.ApiGroupVersion)),
 	}
 }
 

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/serviceaccount.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/serviceaccount.go
@@ -9,8 +9,6 @@
 package k8s
 
 import (
-	"fmt"
-
 	model "github.com/DataDog/agent-payload/v5/process"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors"
@@ -48,7 +46,7 @@ func (h *ServiceAccountHandlers) BuildMessageBody(ctx *processors.ProcessorConte
 		GroupId:         ctx.MsgGroupID,
 		GroupSize:       int32(groupSize),
 		ServiceAccounts: models,
-		Tags:            append(ctx.Cfg.ExtraTags, fmt.Sprintf("%s:%s", "kube_api_version", ctx.ApiGroupVersion)),
+		Tags:            append(ctx.Cfg.ExtraTags, ctx.ApiGroupVersionTag),
 	}
 }
 

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/statefulset.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/statefulset.go
@@ -9,6 +9,8 @@
 package k8s
 
 import (
+	"fmt"
+
 	model "github.com/DataDog/agent-payload/v5/process"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors"
@@ -46,8 +48,7 @@ func (h *StatefulSetHandlers) BuildMessageBody(ctx *processors.ProcessorContext,
 		GroupId:      ctx.MsgGroupID,
 		GroupSize:    int32(groupSize),
 		StatefulSets: models,
-		Tags:         ctx.Cfg.ExtraTags,
-	}
+		Tags:         append(ctx.Cfg.ExtraTags, fmt.Sprintf("%s:%s", "kube_api_version", ctx.ApiGroupVersion))}
 }
 
 // ExtractResource is a handler called to extract the resource model out of a raw resource.

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/statefulset.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/statefulset.go
@@ -9,8 +9,6 @@
 package k8s
 
 import (
-	"fmt"
-
 	model "github.com/DataDog/agent-payload/v5/process"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors"
@@ -48,7 +46,7 @@ func (h *StatefulSetHandlers) BuildMessageBody(ctx *processors.ProcessorContext,
 		GroupId:      ctx.MsgGroupID,
 		GroupSize:    int32(groupSize),
 		StatefulSets: models,
-		Tags:         append(ctx.Cfg.ExtraTags, fmt.Sprintf("%s:%s", "kube_api_version", ctx.ApiGroupVersion))}
+		Tags:         append(ctx.Cfg.ExtraTags, ctx.ApiGroupVersionTag)}
 }
 
 // ExtractResource is a handler called to extract the resource model out of a raw resource.

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/processor.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/processor.go
@@ -10,6 +10,7 @@ package processors
 
 import (
 	model "github.com/DataDog/agent-payload/v5/process"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/collectors"
 
 	"github.com/DataDog/datadog-agent/pkg/orchestrator"
 	"github.com/DataDog/datadog-agent/pkg/orchestrator/config"
@@ -33,6 +34,9 @@ type ProcessorContext struct {
 	HostName   string
 	MsgGroupID int32
 	NodeType   orchestrator.NodeType
+	// CollectorTags are tags that are unique per collector Resource.
+	// They differ from Extra Tags as they are unique per resource.
+	CollectorTags []string
 }
 
 // Handlers is the interface that is to be implemented for every resource type
@@ -210,4 +214,15 @@ func buildManifestMessageBody(ctx *ProcessorContext, resourceManifests []interfa
 		GroupId:     ctx.MsgGroupID,
 		GroupSize:   int32(groupSize),
 	}
+}
+
+func GetProcessorContext(rcfg *collectors.CollectorRunConfig, metadata *collectors.CollectorMetadata) *ProcessorContext {
+	ctx := &ProcessorContext{
+		APIClient:  rcfg.APIClient,
+		Cfg:        rcfg.Config,
+		ClusterID:  rcfg.ClusterID,
+		MsgGroupID: rcfg.MsgGroupRef.Inc(),
+		NodeType:   metadata.NodeType,
+	}
+	return ctx
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/processor.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/processor.go
@@ -10,8 +10,6 @@ package processors
 
 import (
 	model "github.com/DataDog/agent-payload/v5/process"
-	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/collectors"
-
 	"github.com/DataDog/datadog-agent/pkg/orchestrator"
 	"github.com/DataDog/datadog-agent/pkg/orchestrator/config"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
@@ -28,15 +26,13 @@ var json = jsoniter.ConfigCompatibleWithStandardLibrary
 
 // ProcessorContext holds resource processing attributes
 type ProcessorContext struct {
-	APIClient  *apiserver.APIClient
-	Cfg        *config.OrchestratorConfig
-	ClusterID  string
-	HostName   string
-	MsgGroupID int32
-	NodeType   orchestrator.NodeType
-	// CollectorTags are tags that are unique per collector Resource.
-	// They differ from Extra Tags as they are unique per resource.
-	CollectorTags []string
+	APIClient       *apiserver.APIClient
+	Cfg             *config.OrchestratorConfig
+	ClusterID       string
+	HostName        string
+	MsgGroupID      int32
+	NodeType        orchestrator.NodeType
+	ApiGroupVersion string
 }
 
 // Handlers is the interface that is to be implemented for every resource type
@@ -214,15 +210,4 @@ func buildManifestMessageBody(ctx *ProcessorContext, resourceManifests []interfa
 		GroupId:     ctx.MsgGroupID,
 		GroupSize:   int32(groupSize),
 	}
-}
-
-func GetProcessorContext(rcfg *collectors.CollectorRunConfig, metadata *collectors.CollectorMetadata) *ProcessorContext {
-	ctx := &ProcessorContext{
-		APIClient:  rcfg.APIClient,
-		Cfg:        rcfg.Config,
-		ClusterID:  rcfg.ClusterID,
-		MsgGroupID: rcfg.MsgGroupRef.Inc(),
-		NodeType:   metadata.NodeType,
-	}
-	return ctx
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/processor.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/processor.go
@@ -26,13 +26,13 @@ var json = jsoniter.ConfigCompatibleWithStandardLibrary
 
 // ProcessorContext holds resource processing attributes
 type ProcessorContext struct {
-	APIClient       *apiserver.APIClient
-	Cfg             *config.OrchestratorConfig
-	ClusterID       string
-	HostName        string
-	MsgGroupID      int32
-	NodeType        orchestrator.NodeType
-	ApiGroupVersion string
+	APIClient          *apiserver.APIClient
+	Cfg                *config.OrchestratorConfig
+	ClusterID          string
+	HostName           string
+	MsgGroupID         int32
+	NodeType           orchestrator.NodeType
+	ApiGroupVersionTag string
 }
 
 // Handlers is the interface that is to be implemented for every resource type

--- a/pkg/process/checks/pod.go
+++ b/pkg/process/checks/pod.go
@@ -68,12 +68,12 @@ func (c *PodCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.MessageB
 	}
 
 	ctx := &processors.ProcessorContext{
-		ClusterID:       clusterID,
-		Cfg:             cfg.Orchestrator,
-		HostName:        cfg.HostName,
-		MsgGroupID:      groupID,
-		NodeType:        orchestrator.K8sPod,
-		ApiGroupVersion: "v1",
+		ClusterID:          clusterID,
+		Cfg:                cfg.Orchestrator,
+		HostName:           cfg.HostName,
+		MsgGroupID:         groupID,
+		NodeType:           orchestrator.K8sPod,
+		ApiGroupVersionTag: fmt.Sprintf("kube_api_version:%s", "v1"),
 	}
 
 	processResult, processed := c.processor.Process(ctx, podList)

--- a/pkg/process/checks/pod.go
+++ b/pkg/process/checks/pod.go
@@ -68,11 +68,12 @@ func (c *PodCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.MessageB
 	}
 
 	ctx := &processors.ProcessorContext{
-		ClusterID:  clusterID,
-		Cfg:        cfg.Orchestrator,
-		HostName:   cfg.HostName,
-		MsgGroupID: groupID,
-		NodeType:   orchestrator.K8sPod,
+		ClusterID:       clusterID,
+		Cfg:             cfg.Orchestrator,
+		HostName:        cfg.HostName,
+		MsgGroupID:      groupID,
+		NodeType:        orchestrator.K8sPod,
+		ApiGroupVersion: "v1",
 	}
 
 	processResult, processed := c.processor.Process(ctx, podList)

--- a/releasenotes/notes/add-api-version-tag-d0b8c8f427233fb1.yaml
+++ b/releasenotes/notes/add-api-version-tag-d0b8c8f427233fb1.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Adding the `kube_api_version` tag to all orchestrator resources.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

- adding the `kube_api_version` tag for the orchestrator explorer 
- By re-using the `extraTags` we can make the change in one-place and affect all the resources
![Screenshot 2022-11-09 at 15 23 55](https://user-images.githubusercontent.com/23652004/200855375-7d218186-d8d4-4c94-9b0c-d4ccf4554ba0.png)
![Screenshot 2022-11-09 at 15 24 14](https://user-images.githubusercontent.com/23652004/200855455-cf33d33b-ee18-47d9-b5e7-5917178df4d1.png)



### Motivation

- adding the `kube_api_version` tag for the orchestrator explorer because grouping and filtering for them can be useful (think about version migrations)

