### PR TITLE
[Orchestrator manifest] add K8sUnsetType

### DIFF
--- a/pkg/orchestrator/util.go
+++ b/pkg/orchestrator/util.go
@@ -18,8 +18,8 @@ type NodeType int
 var CheckName = "orchestrator"
 
 const (
-	// K8sDeployment represents a Kubernetes Deployment
-	K8sDeployment NodeType = iota
+	// K8sUnsetType represents a Kubernetes unset type
+	K8sUnsetType NodeType = iota
 	// K8sPod represents a Kubernetes Pod
 	K8sPod
 	// K8sReplicaSet represents a Kubernetes ReplicaSet
@@ -54,6 +54,8 @@ const (
 	K8sServiceAccount
 	// K8sIngress represents a Kubernetes Ingress
 	K8sIngress
+	// K8sDeployment represents a Kubernetes Deployment
+	K8sDeployment
 	// K8sNamespace represents a Kubernetes Namespace
 	K8sNamespace
 )
@@ -123,6 +125,8 @@ func (n NodeType) String() string {
 		return "Ingress"
 	case K8sNamespace:
 		return "Namespace"
+	case K8sUnsetType:
+		return "UnsetType"
 	default:
 		log.Errorf("Trying to convert unknown NodeType iota: %d", n)
 		return "Unknown"
@@ -150,7 +154,8 @@ func (n NodeType) Orchestrator() string {
 		K8sClusterRoleBinding,
 		K8sServiceAccount,
 		K8sIngress,
-		K8sNamespace:
+		K8sNamespace,
+		K8sUnsetType:
 		return "k8s"
 	default:
 		log.Errorf("Unknown NodeType %v", n)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

- Add K8sUnsetType at position 0
- Add k8s deployment at position 18

It's a short term solution to make it in  correct order, we eventually need to update it to make agent and backend services depend on a single node type list

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
