### PR TITLE
Update the vagrant driver, add some windows vagrant boxes

### DIFF
--- a/test/kitchen/drivers/vagrant-driver.yml
+++ b/test/kitchen/drivers/vagrant-driver.yml
@@ -4,7 +4,11 @@ driver:
   provider: <%= ENV['KITCHEN_VAGRANT_PROVIDER'] %>
 
 provisioner:
-  name: chef_zero
+  name: chef_solo
+  product_name: chef
+  install_strategy: always
+  # Use the same product_version as the CI kitchen test in Azure.
+  product_version: 14.12.9
   # the following settings make it possible to do a reboot during setup
   # (necessary for FIPS tests which reboot to enable FIPS mode)
   max_retries: 3

--- a/test/kitchen/platforms.json
+++ b/test/kitchen/platforms.json
@@ -135,6 +135,16 @@
                 "win20H2": "ami-03661d5caaa2f79c1",
                 "comment-win20h2": "Windows_Server-20H2-English-Core-Base-2021.02.10"
             }
+        },
+        "vagrant": {
+            "x86_64": {
+                "win2022": "cdaf/WindowsServer2022",
+                "comment-win2022": "Windows Server 2022 Standard Desktop Experience Evaluation",
+                "win2022-dc": "cdaf/WindowsServerDC",
+                "comment-win2022-dc": "Windows Server 2022 Standard Evaluation + Domain Controller",
+                "win2019-core": "cdaf/WindowsServerCore",
+                "comment-win2019-core": "Windows Server 2019 Standard Core Evaluation"
+            }
         }
     }
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
This PR updates the vagrant driver to:
- use `chef_solo`. It's what the other driver use and it's more suited than `chef_zero`.
- pin the version of `chef` that we are using with the vagrant driver. We use here the same version as for the Azure kitchen tests.
- always install the `chef` client in the target machine. This setting potentially waste some time as it requires running the `chef` MSI for every `converge` operation, but it sort of guarantees that the `chef` version is correct.
Note that on some vagrant boxes that had much more recent `chef`(17), that parameter does not work since it's most likely not possible to downgrade `chef`.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
By running the kitchen tests locally we can:
- Save some Azure resources.
- Have faster development time.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
This PR requires https://github.com/DataDog/datadog-agent-buildimages/pull/316 as it installs the `kitchen-vagrant` gem necessary for this to work.

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs
N/A

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
