### PR TITLE
Constructor for bundle params

### DIFF
--- a/cmd/agent/subcommands/config/command.go
+++ b/cmd/agent/subcommands/config/command.go
@@ -42,10 +42,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 			cliParams.args = args
 			return fxutil.OneShot(callback,
 				fx.Supply(cliParams),
-				fx.Supply(core.BundleParams{
-					ConfFilePath:      globalParams.ConfFilePath,
-					ConfigLoadSecrets: false,
-				}.LogForOneShot("CORE", "off", true)),
+				fx.Supply(core.CreateAgentBundleParams(globalParams.ConfFilePath, false).LogForOneShot("CORE", "off", true)),
 				core.Bundle,
 			)
 		}

--- a/cmd/agent/subcommands/configcheck/command.go
+++ b/cmd/agent/subcommands/configcheck/command.go
@@ -43,10 +43,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(run,
 				fx.Supply(cliParams),
-				fx.Supply(core.BundleParams{
-					ConfFilePath:      globalParams.ConfFilePath,
-					ConfigLoadSecrets: true,
-				}.LogForOneShot("CORE", "off", true)),
+				fx.Supply(core.CreateAgentBundleParams(globalParams.ConfFilePath, true).LogForOneShot("CORE", "off", true)),
 				core.Bundle,
 			)
 		},

--- a/cmd/agent/subcommands/diagnose/command.go
+++ b/cmd/agent/subcommands/diagnose/command.go
@@ -54,10 +54,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(runAll,
 				fx.Supply(cliParams),
-				fx.Supply(core.BundleParams{
-					ConfFilePath:      globalParams.ConfFilePath,
-					ConfigLoadSecrets: false,
-				}.LogForOneShot("CORE", "info", true)),
+				fx.Supply(core.CreateAgentBundleParams(globalParams.ConfFilePath, false).LogForOneShot("CORE", "info", true)),
 				core.Bundle,
 			)
 		},
@@ -70,10 +67,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(runDatadogConnectivityDiagnose,
 				fx.Supply(cliParams),
-				fx.Supply(core.BundleParams{
-					ConfFilePath:      globalParams.ConfFilePath,
-					ConfigLoadSecrets: false,
-				}.LogForOneShot("CORE", "info", true)),
+				fx.Supply(core.CreateAgentBundleParams(globalParams.ConfFilePath, false).LogForOneShot("CORE", "info", true)),
 				core.Bundle,
 			)
 		},
@@ -100,10 +94,7 @@ This command print the V5 metadata payload for the Agent. This payload is used t
 			cliParams.payloadName = "v5"
 			return fxutil.OneShot(printPayload,
 				fx.Supply(cliParams),
-				fx.Supply(core.BundleParams{
-					ConfFilePath:      globalParams.ConfFilePath,
-					ConfigLoadSecrets: false,
-				}.LogForOneShot("CORE", "off", true)),
+				fx.Supply(core.CreateAgentBundleParams(globalParams.ConfFilePath, false).LogForOneShot("CORE", "off", true)),
 				core.Bundle,
 			)
 		},
@@ -118,10 +109,7 @@ This command print the last Inventory metadata payload sent by the Agent. This p
 			cliParams.payloadName = "inventory"
 			return fxutil.OneShot(printPayload,
 				fx.Supply(cliParams),
-				fx.Supply(core.BundleParams{
-					ConfFilePath:      globalParams.ConfFilePath,
-					ConfigLoadSecrets: false,
-				}.LogForOneShot("CORE", "off", true)),
+				fx.Supply(core.CreateAgentBundleParams(globalParams.ConfFilePath, false).LogForOneShot("CORE", "off", true)),
 				core.Bundle,
 			)
 		},

--- a/cmd/agent/subcommands/dogstatsdcapture/command.go
+++ b/cmd/agent/subcommands/dogstatsdcapture/command.go
@@ -58,10 +58,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(dogstatsdCapture,
 				fx.Supply(cliParams),
-				fx.Supply(core.BundleParams{
-					ConfFilePath:      globalParams.ConfFilePath,
-					ConfigLoadSecrets: false,
-				}.LogForOneShot("CORE", "off", true)),
+				fx.Supply(core.CreateAgentBundleParams(globalParams.ConfFilePath, false).LogForOneShot("CORE", "off", true)),
 				core.Bundle,
 			)
 		},

--- a/cmd/agent/subcommands/dogstatsdreplay/command.go
+++ b/cmd/agent/subcommands/dogstatsdreplay/command.go
@@ -62,10 +62,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(dogstatsdReplay,
 				fx.Supply(cliParams),
-				fx.Supply(core.BundleParams{
-					ConfFilePath:      globalParams.ConfFilePath,
-					ConfigLoadSecrets: false,
-				}.LogForOneShot("CORE", "off", true)),
+				fx.Supply(core.CreateAgentBundleParams(globalParams.ConfFilePath, false).LogForOneShot("CORE", "off", true)),
 				core.Bundle,
 			)
 		},

--- a/cmd/agent/subcommands/dogstatsdstats/command.go
+++ b/cmd/agent/subcommands/dogstatsdstats/command.go
@@ -52,10 +52,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(requestDogstatsdStats,
 				fx.Supply(cliParams),
-				fx.Supply(core.BundleParams{
-					ConfFilePath:      globalParams.ConfFilePath,
-					ConfigLoadSecrets: false,
-				}.LogForOneShot("CORE", "off", true)),
+				fx.Supply(core.CreateAgentBundleParams(globalParams.ConfFilePath, false).LogForOneShot("CORE", "off", true)),
 				core.Bundle,
 			)
 		},

--- a/cmd/agent/subcommands/flare/command.go
+++ b/cmd/agent/subcommands/flare/command.go
@@ -62,10 +62,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 			cliParams.args = args
 			return fxutil.OneShot(makeFlare,
 				fx.Supply(cliParams),
-				fx.Supply(core.BundleParams{
-					ConfFilePath:      globalParams.ConfFilePath,
-					ConfigLoadSecrets: true,
-				}.LogForOneShot("CORE", "off", false)),
+				fx.Supply(core.CreateAgentBundleParams(globalParams.ConfFilePath, true).LogForOneShot("CORE", "off", false)),
 				core.Bundle,
 			)
 		},

--- a/cmd/agent/subcommands/health/command.go
+++ b/cmd/agent/subcommands/health/command.go
@@ -46,14 +46,10 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(requestHealth,
 				fx.Supply(cliParams),
-				fx.Supply(core.BundleParams{
-					ConfFilePath:      globalParams.ConfFilePath,
-					ConfigLoadSecrets: false,
-					// TODO: when implementing `datadog-cluster-agent health`,
-					// ConfigName must be set to "datadog-cluster", and LogName
-					// should be changed as well.
-
-				}.LogForOneShot("CORE", "off", true)),
+				fx.Supply(core.CreateAgentBundleParams(globalParams.ConfFilePath, false).LogForOneShot("CORE", "off", true)),
+				// TODO: when implementing `datadog-cluster-agent health`,
+				// ConfigName must be set to "datadog-cluster", and LogName
+				// should be changed as well.
 				core.Bundle,
 			)
 		},

--- a/cmd/agent/subcommands/hostname/command.go
+++ b/cmd/agent/subcommands/hostname/command.go
@@ -38,10 +38,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(getHostname,
 				fx.Supply(cliParams),
-				fx.Supply(core.BundleParams{
-					ConfFilePath:      globalParams.ConfFilePath,
-					ConfigLoadSecrets: false,
-				}.LogForOneShot("CORE", "off", false)), // never output anything but hostname
+				fx.Supply(core.CreateAgentBundleParams(globalParams.ConfFilePath, false).LogForOneShot("CORE", "off", false)), // never output anything but hostname
 				core.Bundle,
 			)
 		},

--- a/cmd/agent/subcommands/integrations/command.go
+++ b/cmd/agent/subcommands/integrations/command.go
@@ -106,11 +106,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 	runOneShot := func(callback interface{}) error {
 		return fxutil.OneShot(callback,
 			fx.Supply(cliParams),
-			fx.Supply(core.BundleParams{
-				ConfFilePath:      globalParams.ConfFilePath,
-				ConfigLoadSecrets: false,
-				ConfigMissingOK:   true,
-			}),
+			fx.Supply(core.CreateAgentBundleParams(globalParams.ConfFilePath, false, core.WithConfigMissingOK(true))),
 			core.Bundle,
 		)
 	}

--- a/cmd/agent/subcommands/jmx/command.go
+++ b/cmd/agent/subcommands/jmx/command.go
@@ -84,10 +84,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 			cliParams.jmxLogLevel = "debug"
 		}
 
-		params := core.BundleParams{
-			ConfFilePath:      globalParams.ConfFilePath,
-			ConfigLoadSecrets: true,
-		}.LogForOneShot("CORE", cliParams.jmxLogLevel, false)
+		params := core.CreateAgentBundleParams(globalParams.ConfFilePath, true).LogForOneShot("CORE", cliParams.jmxLogLevel, false)
 
 		if cliParams.logFile != "" {
 			params = params.LogToFile(cliParams.logFile)

--- a/cmd/agent/subcommands/launchgui/command.go
+++ b/cmd/agent/subcommands/launchgui/command.go
@@ -39,10 +39,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(launchGui,
 				fx.Supply(cliParams),
-				fx.Supply(core.BundleParams{
-					ConfFilePath:      globalParams.ConfFilePath,
-					ConfigLoadSecrets: false,
-				}),
+				fx.Supply(core.CreateAgentBundleParams(globalParams.ConfFilePath, false)),
 				core.Bundle,
 			)
 		},

--- a/cmd/agent/subcommands/remoteconfig/command.go
+++ b/cmd/agent/subcommands/remoteconfig/command.go
@@ -44,10 +44,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(state,
 				fx.Supply(cliParams),
-				fx.Supply(core.BundleParams{
-					ConfFilePath:      globalParams.ConfFilePath,
-					ConfigLoadSecrets: false,
-				}),
+				fx.Supply(core.CreateAgentBundleParams(globalParams.ConfFilePath, false)),
 				core.Bundle,
 			)
 		},

--- a/cmd/agent/subcommands/run/command.go
+++ b/cmd/agent/subcommands/run/command.go
@@ -114,10 +114,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		// this will use `fxutil.Run` instead of `fxutil.OneShot`.
 		return fxutil.OneShot(run,
 			fx.Supply(cliParams),
-			fx.Supply(core.BundleParams{
-				ConfFilePath:      globalParams.ConfFilePath,
-				ConfigLoadSecrets: true,
-			}.LogForDaemon("CORE", "log_file", common.DefaultLogFile)),
+			fx.Supply(core.CreateAgentBundleParams(globalParams.ConfFilePath, true).LogForDaemon("CORE", "log_file", common.DefaultLogFile)),
 			core.Bundle,
 		)
 	}
@@ -200,10 +197,8 @@ func StartAgentWithDefaults() error {
 	return fxutil.OneShot(func(log log.Component, config config.Component) error {
 		return startAgent(&cliParams{GlobalParams: &command.GlobalParams{}})
 	},
-		fx.Supply(core.BundleParams{
-			ConfFilePath:      "", // no config file path specification in this situation
-			ConfigLoadSecrets: true,
-		}.LogForDaemon("CORE", "log_file", common.DefaultLogFile)),
+		// no config file path specification in this situation
+		fx.Supply(core.CreateAgentBundleParams("", true).LogForDaemon("CORE", "log_file", common.DefaultLogFile)),
 		core.Bundle,
 	)
 }

--- a/cmd/agent/subcommands/secret/command.go
+++ b/cmd/agent/subcommands/secret/command.go
@@ -41,10 +41,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(secret,
 				fx.Supply(cliParams),
-				fx.Supply(core.BundleParams{
-					ConfFilePath:      globalParams.ConfFilePath,
-					ConfigLoadSecrets: false,
-				}.LogForOneShot("CORE", "off", true)),
+				fx.Supply(core.CreateAgentBundleParams(globalParams.ConfFilePath, false).LogForOneShot("CORE", "off", true)),
 				core.Bundle,
 			)
 		},

--- a/cmd/agent/subcommands/snmp/command.go
+++ b/cmd/agent/subcommands/snmp/command.go
@@ -92,10 +92,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 			cliParams.cmd = cmd
 			return fxutil.OneShot(snmpwalk,
 				fx.Supply(cliParams),
-				fx.Supply(core.BundleParams{
-					ConfFilePath:      globalParams.ConfFilePath,
-					ConfigLoadSecrets: true,
-				}.LogForOneShot("CORE", "off", true)),
+				fx.Supply(core.CreateAgentBundleParams(globalParams.ConfFilePath, true).LogForOneShot("CORE", "off", true)),
 				core.Bundle,
 			)
 		},

--- a/cmd/agent/subcommands/status/command.go
+++ b/cmd/agent/subcommands/status/command.go
@@ -91,10 +91,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 
 			return fxutil.OneShot(componentStatusCmd,
 				fx.Supply(cliParams),
-				fx.Supply(core.BundleParams{
-					ConfFilePath:      globalParams.ConfFilePath,
-					ConfigLoadSecrets: false,
-				}.LogForOneShot("CORE", "off", true)),
+				fx.Supply(core.CreateAgentBundleParams(globalParams.ConfFilePath, false).LogForOneShot("CORE", "off", true)),
 				core.Bundle,
 			)
 		},

--- a/cmd/agent/subcommands/status/command.go
+++ b/cmd/agent/subcommands/status/command.go
@@ -63,11 +63,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 
 			return fxutil.OneShot(statusCmd,
 				fx.Supply(cliParams),
-				fx.Supply(core.BundleParams{
-					ConfFilePath:       globalParams.ConfFilePath,
-					ConfigLoadSecrets:  false,
-					ConfigLoadSysProbe: true,
-				}.LogForOneShot("CORE", "off", true)),
+				fx.Supply(core.CreateAgentBundleParams(globalParams.ConfFilePath, false, core.WithConfigLoadSysProbe(true)).LogForOneShot("CORE", "off", true)),
 				core.Bundle,
 			)
 		},

--- a/cmd/agent/subcommands/stop/command.go
+++ b/cmd/agent/subcommands/stop/command.go
@@ -41,10 +41,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(stop,
 				fx.Supply(cliParams),
-				fx.Supply(core.BundleParams{
-					ConfFilePath:      globalParams.ConfFilePath,
-					ConfigLoadSecrets: false,
-				}.LogForOneShot("CORE", "off", true)),
+				fx.Supply(core.CreateAgentBundleParams(globalParams.ConfFilePath, false).LogForOneShot("CORE", "off", true)),
 				core.Bundle,
 			)
 		},

--- a/cmd/agent/subcommands/streamlogs/command.go
+++ b/cmd/agent/subcommands/streamlogs/command.go
@@ -45,10 +45,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(streamLogs,
 				fx.Supply(cliParams),
-				fx.Supply(core.BundleParams{
-					ConfFilePath:      globalParams.ConfFilePath,
-					ConfigLoadSecrets: false,
-				}.LogForOneShot("CORE", "off", true)),
+				fx.Supply(core.CreateAgentBundleParams(globalParams.ConfFilePath, false).LogForOneShot("CORE", "off", true)),
 				core.Bundle,
 			)
 		},

--- a/cmd/agent/subcommands/taggerlist/command.go
+++ b/cmd/agent/subcommands/taggerlist/command.go
@@ -41,10 +41,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(taggerList,
 				fx.Supply(cliParams),
-				fx.Supply(core.BundleParams{
-					ConfFilePath:      globalParams.ConfFilePath,
-					ConfigLoadSecrets: false,
-				}.LogForOneShot("CORE", "off", true)),
+				fx.Supply(core.CreateAgentBundleParams(globalParams.ConfFilePath, false).LogForOneShot("CORE", "off", true)),
 				core.Bundle,
 			)
 		},

--- a/cmd/agent/subcommands/workloadlist/command.go
+++ b/cmd/agent/subcommands/workloadlist/command.go
@@ -44,10 +44,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(workloadList,
 				fx.Supply(cliParams),
-				fx.Supply(core.BundleParams{
-					ConfFilePath:      globalParams.ConfFilePath,
-					ConfigLoadSecrets: false,
-				}.LogForOneShot("CORE", "off", true)),
+				fx.Supply(core.CreateAgentBundleParams(globalParams.ConfFilePath, false).LogForOneShot("CORE", "off", true)),
 				core.Bundle,
 			)
 		},

--- a/cmd/dogstatsd/main.go
+++ b/cmd/dogstatsd/main.go
@@ -113,14 +113,14 @@ func makeCommands() []*cobra.Command {
 func runDogstatsdFct(cliParams *cliParams, defaultConfPath string, fct interface{}) error {
 	return fxutil.OneShot(fct,
 		fx.Supply(cliParams),
-		fx.Supply(core.BundleParams{
-			ConfFilePath:           cliParams.confPath,
-			ConfigLoadSecrets:      true,
-			ConfigMissingOK:        true,
-			ConfigName:             "dogstatsd",
-			ExcludeDefaultConfPath: true,
-			DefaultConfPath:        defaultConfPath,
-		}),
+		fx.Supply(core.CreateBundleParams(
+			core.WithConfFilePath(cliParams.confPath),
+			core.WithConfigLoadSecrets(true),
+			core.WithConfigMissingOK(true),
+			core.WithConfigName("dogstatsd"),
+			core.WithExcludeDefaultConfPath(true),
+			core.WithDefaultConfPath(defaultConfPath),
+		)),
 		core.Bundle,
 	)
 }

--- a/cmd/security-agent/app/subcommands/status/command.go
+++ b/cmd/security-agent/app/subcommands/status/command.go
@@ -43,10 +43,10 @@ func Commands(globalParams *common.GlobalParams) []*cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(runStatus,
 				fx.Supply(cliParams),
-				fx.Supply(core.BundleParams{
-					SecurityAgentConfigFilePaths: globalParams.ConfPathArray,
-					ConfigLoadSecurityAgent:      true,
-				}.LogForOneShot(common.LoggerName, "off", true)),
+				fx.Supply(core.CreateBundleParams(
+					core.WithSecurityAgentConfigFilePaths(globalParams.ConfPathArray),
+					core.WithConfigLoadSecurityAgent(true),
+				).LogForOneShot(common.LoggerName, "off", true)),
 				core.Bundle,
 			)
 		},

--- a/comp/core/bundle.go
+++ b/comp/core/bundle.go
@@ -24,6 +24,13 @@ import (
 // BundleParams defines the parameters for this bundle.
 type BundleParams = internal.BundleParams
 
+func CreateAgentBundleParams(confFilePath string, configLoadSecrets bool) BundleParams {
+	return BundleParams{
+		ConfFilePath:      confFilePath,
+		ConfigLoadSecrets: configLoadSecrets,
+	}
+}
+
 // Bundle defines the fx options for this bundle.
 var Bundle = fxutil.Bundle(
 	config.Module,

--- a/comp/core/bundle.go
+++ b/comp/core/bundle.go
@@ -14,84 +14,11 @@ package core
 
 import (
 	"github.com/DataDog/datadog-agent/comp/core/config"
-	"github.com/DataDog/datadog-agent/comp/core/internal"
 	"github.com/DataDog/datadog-agent/comp/core/log"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
 // team: agent-shared-components
-
-// BundleParams defines the parameters for this bundle.
-type BundleParams = internal.BundleParams
-
-func CreateAgentBundleParams(confFilePath string, configLoadSecrets bool, options ...func(*BundleParams)) BundleParams {
-	params := CreateBundleParams(options...)
-	params.ConfFilePath = confFilePath
-	params.ConfigLoadSecrets = configLoadSecrets
-	return params
-}
-
-func CreateBundleParams(options ...func(*BundleParams)) BundleParams {
-	bundleParams := BundleParams{}
-	for _, o := range options {
-		o(&bundleParams)
-	}
-	return bundleParams
-}
-
-func WithConfigName(name string) func(*BundleParams) {
-	return func(b *BundleParams) {
-		b.ConfigName = name
-	}
-}
-
-func WithConfigMissingOK(v bool) func(*BundleParams) {
-	return func(b *BundleParams) {
-		b.ConfigMissingOK = v
-	}
-}
-
-func WithConfigLoadSysProbe(v bool) func(*BundleParams) {
-	return func(b *BundleParams) {
-		b.ConfigLoadSysProbe = v
-	}
-}
-
-func WithSecurityAgentConfigFilePaths(securityAgentConfigFilePaths []string) func(*BundleParams) {
-	return func(b *BundleParams) {
-		b.SecurityAgentConfigFilePaths = securityAgentConfigFilePaths
-	}
-}
-
-func WithConfigLoadSecurityAgent(configLoadSecurityAgent bool) func(*BundleParams) {
-	return func(b *BundleParams) {
-		b.ConfigLoadSecurityAgent = configLoadSecurityAgent
-	}
-}
-
-func WithConfFilePath(confFilePath string) func(*BundleParams) {
-	return func(b *BundleParams) {
-		b.ConfFilePath = confFilePath
-	}
-}
-
-func WithConfigLoadSecrets(configLoadSecrets bool) func(*BundleParams) {
-	return func(b *BundleParams) {
-		b.ConfigLoadSecrets = configLoadSecrets
-	}
-}
-
-func WithExcludeDefaultConfPath(excludeDefaultConfPath bool) func(*BundleParams) {
-	return func(b *BundleParams) {
-		b.ExcludeDefaultConfPath = excludeDefaultConfPath
-	}
-}
-
-func WithDefaultConfPath(defaultConfPath string) func(*BundleParams) {
-	return func(b *BundleParams) {
-		b.DefaultConfPath = defaultConfPath
-	}
-}
 
 // Bundle defines the fx options for this bundle.
 var Bundle = fxutil.Bundle(

--- a/comp/core/bundle.go
+++ b/comp/core/bundle.go
@@ -24,10 +24,72 @@ import (
 // BundleParams defines the parameters for this bundle.
 type BundleParams = internal.BundleParams
 
-func CreateAgentBundleParams(confFilePath string, configLoadSecrets bool) BundleParams {
-	return BundleParams{
-		ConfFilePath:      confFilePath,
-		ConfigLoadSecrets: configLoadSecrets,
+func CreateAgentBundleParams(confFilePath string, configLoadSecrets bool, options ...func(*BundleParams)) BundleParams {
+	params := CreateBundleParams(options...)
+	params.ConfFilePath = confFilePath
+	params.ConfigLoadSecrets = configLoadSecrets
+	return params
+}
+
+func CreateBundleParams(options ...func(*BundleParams)) BundleParams {
+	bundleParams := BundleParams{}
+	for _, o := range options {
+		o(&bundleParams)
+	}
+	return bundleParams
+}
+
+func WithConfigName(name string) func(*BundleParams) {
+	return func(b *BundleParams) {
+		b.ConfigName = name
+	}
+}
+
+func WithConfigMissingOK(v bool) func(*BundleParams) {
+	return func(b *BundleParams) {
+		b.ConfigMissingOK = v
+	}
+}
+
+func WithConfigLoadSysProbe(v bool) func(*BundleParams) {
+	return func(b *BundleParams) {
+		b.ConfigLoadSysProbe = v
+	}
+}
+
+func WithSecurityAgentConfigFilePaths(securityAgentConfigFilePaths []string) func(*BundleParams) {
+	return func(b *BundleParams) {
+		b.SecurityAgentConfigFilePaths = securityAgentConfigFilePaths
+	}
+}
+
+func WithConfigLoadSecurityAgent(configLoadSecurityAgent bool) func(*BundleParams) {
+	return func(b *BundleParams) {
+		b.ConfigLoadSecurityAgent = configLoadSecurityAgent
+	}
+}
+
+func WithConfFilePath(confFilePath string) func(*BundleParams) {
+	return func(b *BundleParams) {
+		b.ConfFilePath = confFilePath
+	}
+}
+
+func WithConfigLoadSecrets(configLoadSecrets bool) func(*BundleParams) {
+	return func(b *BundleParams) {
+		b.ConfigLoadSecrets = configLoadSecrets
+	}
+}
+
+func WithExcludeDefaultConfPath(excludeDefaultConfPath bool) func(*BundleParams) {
+	return func(b *BundleParams) {
+		b.ExcludeDefaultConfPath = excludeDefaultConfPath
+	}
+}
+
+func WithDefaultConfPath(defaultConfPath string) func(*BundleParams) {
+	return func(b *BundleParams) {
+		b.DefaultConfPath = defaultConfPath
 	}
 }
 

--- a/comp/core/bundle_params.go
+++ b/comp/core/bundle_params.go
@@ -12,6 +12,7 @@ import (
 // BundleParams defines the parameters for this bundle.
 type BundleParams = internal.BundleParams
 
+// CreateAgentBundleParams creates a new BundleParams for the Core Agent
 func CreateAgentBundleParams(confFilePath string, configLoadSecrets bool, options ...func(*BundleParams)) BundleParams {
 	params := CreateBundleParams(options...)
 	params.ConfFilePath = confFilePath
@@ -19,6 +20,7 @@ func CreateAgentBundleParams(confFilePath string, configLoadSecrets bool, option
 	return params
 }
 
+// CreateBundleParams creates a new BundleParams
 func CreateBundleParams(options ...func(*BundleParams)) BundleParams {
 	bundleParams := BundleParams{}
 	for _, o := range options {

--- a/comp/core/bundle_params.go
+++ b/comp/core/bundle_params.go
@@ -1,0 +1,82 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package core
+
+import (
+	"github.com/DataDog/datadog-agent/comp/core/internal"
+)
+
+// BundleParams defines the parameters for this bundle.
+type BundleParams = internal.BundleParams
+
+func CreateAgentBundleParams(confFilePath string, configLoadSecrets bool, options ...func(*BundleParams)) BundleParams {
+	params := CreateBundleParams(options...)
+	params.ConfFilePath = confFilePath
+	params.ConfigLoadSecrets = configLoadSecrets
+	return params
+}
+
+func CreateBundleParams(options ...func(*BundleParams)) BundleParams {
+	bundleParams := BundleParams{}
+	for _, o := range options {
+		o(&bundleParams)
+	}
+	return bundleParams
+}
+
+func WithConfigName(name string) func(*BundleParams) {
+	return func(b *BundleParams) {
+		b.ConfigName = name
+	}
+}
+
+func WithConfigMissingOK(v bool) func(*BundleParams) {
+	return func(b *BundleParams) {
+		b.ConfigMissingOK = v
+	}
+}
+
+func WithConfigLoadSysProbe(v bool) func(*BundleParams) {
+	return func(b *BundleParams) {
+		b.ConfigLoadSysProbe = v
+	}
+}
+
+func WithSecurityAgentConfigFilePaths(securityAgentConfigFilePaths []string) func(*BundleParams) {
+	return func(b *BundleParams) {
+		b.SecurityAgentConfigFilePaths = securityAgentConfigFilePaths
+	}
+}
+
+func WithConfigLoadSecurityAgent(configLoadSecurityAgent bool) func(*BundleParams) {
+	return func(b *BundleParams) {
+		b.ConfigLoadSecurityAgent = configLoadSecurityAgent
+	}
+}
+
+func WithConfFilePath(confFilePath string) func(*BundleParams) {
+	return func(b *BundleParams) {
+		b.ConfFilePath = confFilePath
+	}
+}
+
+func WithConfigLoadSecrets(configLoadSecrets bool) func(*BundleParams) {
+	return func(b *BundleParams) {
+		b.ConfigLoadSecrets = configLoadSecrets
+	}
+}
+
+func WithExcludeDefaultConfPath(excludeDefaultConfPath bool) func(*BundleParams) {
+	return func(b *BundleParams) {
+		b.ExcludeDefaultConfPath = excludeDefaultConfPath
+	}
+}
+
+func WithDefaultConfPath(defaultConfPath string) func(*BundleParams) {
+	return func(b *BundleParams) {
+		b.DefaultConfPath = defaultConfPath
+	}
+}

--- a/docs/components/defining-apps.md
+++ b/docs/components/defining-apps.md
@@ -165,7 +165,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
             cliParams.args = args
             return fxutil.OneShot(run,
                 fx.Supply(cliParams),
-                fx.Supply(core.BundleParams{}),
+                fx.Supply(core.CreateaBundleParams()),
                 core.Bundle,
                 ..., // any other bundles needed for this app
             )

--- a/docs/components/defining-bundles.md
+++ b/docs/components/defining-bundles.md
@@ -80,7 +80,7 @@ This simply uses ValidateApp to check that all dependencies are satisfied when g
 ```go
 func TestBundleDependencies(t *testing.T) {
 	require.NoError(t, fx.ValidateApp(
-		fx.Supply(core.BundleParams{}),
+		fx.Supply(core.CreateBundleParams()),
 		core.Bundle,
 		fx.Supply(autodiscovery.BundleParams{}),
 		autodiscovery.Bundle,

--- a/pkg/cli/subcommands/check/command.go
+++ b/pkg/cli/subcommands/check/command.go
@@ -108,11 +108,8 @@ func MakeCommand(globalParamsGetter func() GlobalParams) *cobra.Command {
 			disableCmdPort()
 			return fxutil.OneShot(run,
 				fx.Supply(cliParams),
-				fx.Supply(core.BundleParams{
-					ConfFilePath:      globalParams.ConfFilePath,
-					ConfigName:        globalParams.ConfigName,
-					ConfigLoadSecrets: true,
-				}.LogForOneShot(globalParams.LoggerName, "off", true)),
+				fx.Supply(core.CreateAgentBundleParams(globalParams.ConfFilePath, true, core.WithConfigName(globalParams.ConfigName)).
+					LogForOneShot(globalParams.LoggerName, "off", true)),
 				core.Bundle,
 			)
 		},

--- a/pkg/cli/subcommands/config/command.go
+++ b/pkg/cli/subcommands/config/command.go
@@ -50,11 +50,8 @@ func MakeCommand(globalParamsGetter func() GlobalParams) *cobra.Command {
 
 			return fxutil.OneShot(callback,
 				fx.Supply(cliParams),
-				fx.Supply(core.BundleParams{
-					ConfFilePath:      globalParams.ConfFilePath,
-					ConfigName:        globalParams.ConfigName,
-					ConfigLoadSecrets: false,
-				}.LogForOneShot(globalParams.LoggerName, "off", true)),
+				fx.Supply(core.CreateAgentBundleParams(globalParams.ConfFilePath, false, core.WithConfigName(globalParams.ConfigName)).
+					LogForOneShot(globalParams.LoggerName, "off", true)),
 				core.Bundle,
 			)
 		}

--- a/pkg/cli/subcommands/health/command.go
+++ b/pkg/cli/subcommands/health/command.go
@@ -44,11 +44,8 @@ func MakeCommand(globalParamsGetter func() GlobalParams) *cobra.Command {
 			globalParams := globalParamsGetter()
 
 			return fxutil.OneShot(requestHealth,
-				fx.Supply(core.BundleParams{
-					ConfFilePath:      globalParams.ConfFilePath,
-					ConfigName:        globalParams.ConfigName,
-					ConfigLoadSecrets: false,
-				}.LogForOneShot(globalParams.LoggerName, "off", true)),
+				fx.Supply(core.CreateAgentBundleParams(globalParams.ConfFilePath, false, core.WithConfigName(globalParams.ConfigName)).
+					LogForOneShot(globalParams.LoggerName, "off", true)),
 				core.Bundle,
 			)
 		},


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This PR introduces constructors for `core.BundleParams`.  It makes it easier to set fields to a default value which is not the Go default value.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Be able to have a default value for `DefaultConfPath`.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Nothing to QA as the code is already unit tested.

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
