### PR TITLE
Fix Cloud Foundry CAPI metadata tags injection

### DIFF
--- a/pkg/cloudfoundry/containertagger/container_tagger.go
+++ b/pkg/cloudfoundry/containertagger/container_tagger.go
@@ -122,7 +122,7 @@ func (c *ContainerTagger) processEvent(ctx context.Context, evt workloadmeta.Eve
 			var exitCode int
 			var err error
 			for retry := 0; retry < c.retryCount; retry++ {
-				log.Infof("Updating tags in container `%s` retry #%d", retry, containerID)
+				log.Infof("Updating tags in container `%s` retry #%d", containerID, retry)
 				exitCode, err = updateTagsInContainer(container, tags)
 				if err != nil {
 					log.Warnf("Error running a process inside container `%s`: %v", containerID, err)

--- a/pkg/cloudfoundry/containertagger/container_tagger.go
+++ b/pkg/cloudfoundry/containertagger/container_tagger.go
@@ -146,8 +146,9 @@ func (c *ContainerTagger) processEvent(ctx context.Context, evt workloadmeta.Eve
 
 // updateTagsInContainer runs a script inside the container that handles updating the agent with the given tags
 func updateTagsInContainer(container garden.Container, tags []string) (int, error) {
+	shell_path := config.Datadog.GetString("cloud_foundry_container_tagger.shell_path")
 	process, err := container.Run(garden.ProcessSpec{
-		Path: "/bin/sh",
+		Path: shell_path,
 		Args: []string{"/home/vcap/app/.datadog/scripts/update_agent_config.sh"},
 		User: "vcap",
 		Env:  []string{fmt.Sprintf("DD_NODE_AGENT_TAGS=%s", strings.Join(tags, ","))},

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -770,6 +770,10 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("cloud_foundry_garden.listen_network", "unix")
 	config.BindEnvAndSetDefault("cloud_foundry_garden.listen_address", "/var/vcap/data/garden/garden.sock")
 
+	// Cloud Foundry Container Tagger
+	config.BindEnvAndSetDefault("cloud_foundry_container_tagger.retry_count", 10)
+	config.BindEnvAndSetDefault("cloud_foundry_container_tagger.retry_interval", 10*time.Second)
+
 	// Azure
 	config.BindEnvAndSetDefault("azure_hostname_style", "os")
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -771,6 +771,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("cloud_foundry_garden.listen_address", "/var/vcap/data/garden/garden.sock")
 
 	// Cloud Foundry Container Tagger
+	config.BindEnvAndSetDefault("cloud_foundry_container_tagger.shell_path", "/bin/sh")
 	config.BindEnvAndSetDefault("cloud_foundry_container_tagger.retry_count", 10)
 	config.BindEnvAndSetDefault("cloud_foundry_container_tagger.retry_interval", 10*time.Second)
 

--- a/releasenotes/notes/fix-capi-metadata-tags-injection-e0b1a102d229adae.yaml
+++ b/releasenotes/notes/fix-capi-metadata-tags-injection-e0b1a102d229adae.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix Cloud Foundry CAPI Metadata tags injection into application containers.

--- a/run-pcf-test.sh
+++ b/run-pcf-test.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-while true; do
-    invoke test --targets="./pkg/util/cloudproviders/cloudfoundry" --skip-linters --race --no-cache
-done

--- a/run-pcf-test.sh
+++ b/run-pcf-test.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+while true; do
+    invoke test --targets="./pkg/util/cloudproviders/cloudfoundry" --skip-linters --race --no-cache
+done


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Fixes a feature introduced in 7.40.0 where the container tagger would inject tags into cloudfoundry containers by running a script inside the target container.
Adds `container_tagger.retry_count` and `container_tagger.retry_interval` properties to control the container tagger behavior.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
The current implementation is inconsistent, sometimes the container tagger tries to run a process inside the container before it is ready (buildpack scripts still running), and that leads to a failure because the target script doesn't exist yet.
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
