### PR TITLE
Reorder kafka_transaction_t struct to spare 2 bytes

### DIFF
--- a/pkg/network/ebpf/c/kafka/socket-filter-approach/kafka-types.h
+++ b/pkg/network/ebpf/c/kafka/socket-filter-approach/kafka-types.h
@@ -78,20 +78,15 @@ typedef struct {
 // HTTP transaction information associated to a certain socket (tuple_t)
 // Kafka transaction information associated to a certain socket (tuple_t)
 typedef struct {
-    // this field is used exclusively in the kernel side to prevent a TCP segment
-    // to be processed twice in the context of localhost traffic. The field will
-    // be populated with the "original" (pre-normalization) source port number of
-    // the TCP segment containing the beginning of a given HTTP request
-    __u16 owned_by_src_port;
     conn_tuple_t tup;
+
     __u16 request_api_key;
     __u16 request_api_version;
     __u32 correlation_id;
 
-//    __u64 request_started;
-//    __u8  request_method;
-//    __u16 response_status_code;
-//    __u64 response_last_seen;
+    // this field is used to disambiguate segments in the context of keep-alives
+    // we populate it with the TCP seq number of the request and then the response segments
+    __u32 tcp_seq;
 
     __u32 current_offset_in_request_fragment;
     char request_fragment[KAFKA_BUFFER_SIZE] __attribute__ ((aligned (8)));
@@ -99,9 +94,12 @@ typedef struct {
     // TODO: Support UTF8
     char topic_name[TOPIC_NAME_MAX_STRING_SIZE] __attribute__ ((aligned (8)));
 
-    // this field is used to disambiguate segments in the context of keep-alives
-    // we populate it with the TCP seq number of the request and then the response segments
-    __u32 tcp_seq;
+    // this field is used exclusively in the kernel side to prevent a TCP segment
+    // to be processed twice in the context of localhost traffic. The field will
+    // be populated with the "original" (pre-normalization) source port number of
+    // the TCP segment containing the beginning of a given HTTP request
+    __u16 owned_by_src_port;
+
 //
 //    __u64 tags;
 //} http_transaction_t;

--- a/pkg/network/kafka/kafka_types_linux.go
+++ b/pkg/network/kafka/kafka_types_linux.go
@@ -20,18 +20,17 @@ type kafkaBatchState struct {
 }
 
 type ebpfKafkaTx struct {
-	Owned_by_src_port                  uint16
 	Tup                                kafkaConnTuple
 	Request_api_key                    uint16
 	Request_api_version                uint16
 	Correlation_id                     uint32
+	Tcp_seq                            uint32
 	Current_offset_in_request_fragment uint32
-	Pad_cgo_0                          [4]byte
 	Request_fragment                   [160]byte
 	Client_id                          [56]int8
 	Topic_name                         [64]int8
-	Tcp_seq                            uint32
-	Pad_cgo_1                          [4]byte
+	Owned_by_src_port                  uint16
+	Pad_cgo_0                          [6]byte
 }
 type kafkaBatch struct {
 	Idx uint64


### PR DESCRIPTION
 which leads to compilation error of - stack exceeds limit

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
