### PR TITLE
(RCM-539) Add RC service and client to cluster-agent

### DIFF
--- a/cmd/agent/api/grpc.go
+++ b/cmd/agent/api/grpc.go
@@ -128,7 +128,7 @@ func (s *serverSecure) ClientGetConfigs(ctx context.Context, in *pb.ClientGetCon
 		log.Debug("Remote configuration service not initialized")
 		return nil, errors.New("remote configuration service not initialized")
 	}
-	return s.configService.ClientGetConfigs(in)
+	return s.configService.ClientGetConfigs(ctx, in)
 }
 
 func (s *serverSecure) GetConfigState(ctx context.Context, e *emptypb.Empty) (*pb.GetStateConfigResponse, error) {

--- a/cmd/cluster-agent/app/app.go
+++ b/cmd/cluster-agent/app/app.go
@@ -446,7 +446,7 @@ func initializeRemoteConfig(ctx context.Context) (*remote.Client, error) {
 
 	rcClient, err := remote.NewClient("cluster-agent", configService, version.AgentVersion, []data.Product{}, time.Second*5)
 	if err != nil {
-		return nil, fmt.Errorf("unable to create local remote-config client: %v", err)
+		return nil, fmt.Errorf("unable to create local remote-config client: %w", err)
 	}
 
 	rcClient.Start()

--- a/cmd/cluster-agent/app/app.go
+++ b/cmd/cluster-agent/app/app.go
@@ -204,7 +204,7 @@ func start(cmd *cobra.Command, args []string) error {
 	if config.Datadog.GetBool("remote_configuration.enabled") {
 		configService, err = remoteconfig.NewService()
 		if err == nil {
-			if err := configService.Start(context.Background()); err == nil {
+			if err := configService.Start(mainCtx); err == nil {
 				rcClient, err = remote.NewClient("cluster-agent", configService, version.AgentVersion, []data.Product{data.ProductTesting1}, time.Second*5)
 				if err != nil {
 					log.Errorf("Failed to start local config management service client: %s", err)

--- a/cmd/cluster-agent/app/app.go
+++ b/cmd/cluster-agent/app/app.go
@@ -199,11 +199,13 @@ func start(cmd *cobra.Command, args []string) error {
 	}
 
 	// Initialize remote configuration
-	var rcClient *remote.Client
 	if config.Datadog.GetBool("remote_configuration.enabled") {
-		rcClient, err = initializeRemoteConfig(mainCtx)
+		rcClient, err := initializeRemoteConfig(mainCtx)
 		if err != nil {
 			log.Errorf("Failed to start remote-configuration: %v", err)
+		} else {
+		    rcClient.Start()
+		    defer rcClient.Close()
 		}
 	}
 

--- a/cmd/cluster-agent/app/app.go
+++ b/cmd/cluster-agent/app/app.go
@@ -441,7 +441,7 @@ func initializeRemoteConfig(ctx context.Context) (*remote.Client, error) {
 	}
 
 	if err := configService.Start(ctx); err != nil {
-		return nil, fmt.Errorf("unable to start remote-config service: %v", err)
+		return nil, fmt.Errorf("unable to start remote-config service: %w", err)
 	}
 
 	rcClient, err := remote.NewClient("cluster-agent", configService, version.AgentVersion, []data.Product{}, time.Second*5)

--- a/cmd/cluster-agent/app/app.go
+++ b/cmd/cluster-agent/app/app.go
@@ -414,10 +414,6 @@ func start(cmd *cobra.Command, args []string) error {
 		log.Errorf("Error shutdowning metrics server on port %d: %v", metricsPort, err)
 	}
 
-	if rcClient != nil {
-		rcClient.Close()
-	}
-
 	log.Info("See ya!")
 	log.Flush()
 	return nil

--- a/cmd/cluster-agent/app/app.go
+++ b/cmd/cluster-agent/app/app.go
@@ -437,7 +437,7 @@ func setupClusterCheck(ctx context.Context) (*clusterchecks.Handler, error) {
 func initializeRemoteConfig(ctx context.Context) (*remote.Client, error) {
 	configService, err := remoteconfig.NewService()
 	if err != nil {
-		return nil, fmt.Errorf("unable to create remote-config service: %v", err)
+		return nil, fmt.Errorf("unable to create remote-config service: %w", err)
 	}
 
 	if err := configService.Start(ctx); err != nil {

--- a/cmd/cluster-agent/app/app.go
+++ b/cmd/cluster-agent/app/app.go
@@ -204,8 +204,8 @@ func start(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			log.Errorf("Failed to start remote-configuration: %v", err)
 		} else {
-		    rcClient.Start()
-		    defer rcClient.Close()
+			rcClient.Start()
+			defer rcClient.Close()
 		}
 	}
 
@@ -446,8 +446,6 @@ func initializeRemoteConfig(ctx context.Context) (*remote.Client, error) {
 	if err != nil {
 		return nil, fmt.Errorf("unable to create local remote-config client: %w", err)
 	}
-
-	rcClient.Start()
 
 	return rcClient, nil
 }

--- a/cmd/trace-agent/config/config.go
+++ b/cmd/trace-agent/config/config.go
@@ -91,7 +91,7 @@ func prepareConfig(path string) (*config.AgentConfig, error) {
 	}
 	cfg.ConfigPath = path
 	if coreconfig.Datadog.GetBool("remote_configuration.enabled") && coreconfig.Datadog.GetBool("remote_configuration.apm_sampling.enabled") {
-		client, err := remote.NewClient(rcClientName, version.AgentVersion, []data.Product{data.ProductAPMSampling}, rcClientPollInterval)
+		client, err := remote.NewGRPCClient(rcClientName, version.AgentVersion, []data.Product{data.ProductAPMSampling}, rcClientPollInterval)
 		if err != nil {
 			log.Errorf("Error when subscribing to remote config management %v", err)
 		} else {

--- a/pkg/config/remote/client.go
+++ b/pkg/config/remote/client.go
@@ -33,6 +33,12 @@ const (
 	recoveryInterval      = 2
 )
 
+// ConfigUpdater defines the interface that an agent client uses to get config updates
+// from the core remote-config service
+type ConfigUpdater interface {
+	ClientGetConfigs(context.Context, *pbgo.ClientGetConfigsRequest) (*pbgo.ClientGetConfigsResponse, error)
+}
+
 // Client is a remote-configuration client to obtain configurations from the local API
 type Client struct {
 	m sync.Mutex
@@ -52,34 +58,78 @@ type Client struct {
 	backoffPolicy     backoff.Policy
 	backoffErrorCount int
 
-	state *state.Repository
+	updater ConfigUpdater
 
-	grpc pbgo.AgentSecureClient
+	state *state.Repository
 
 	// Listeners
 	apmListeners []func(update map[string]state.APMSamplingConfig)
 	cwsListeners []func(update map[string]state.ConfigCWSDD)
 }
 
+// agentGRPCConfigFetcher defines how to retrieve config updates over a
+// datadog-agent's secure GRPC client
+type agentGRPCConfigFetcher struct {
+	client pbgo.AgentSecureClient
+}
+
+func newAgentGRPCConfigFetcher() (*agentGRPCConfigFetcher, error) {
+	c, err := grpc.GetDDAgentSecureClient(context.Background())
+	if err != nil {
+		return nil, err
+	}
+
+	return &agentGRPCConfigFetcher{
+		client: c,
+	}, nil
+}
+
+// ClientGetConfigs implements the ConfigUpdater interface for agentGRPCConfigFetcher
+func (g *agentGRPCConfigFetcher) ClientGetConfigs(ctx context.Context, request *pbgo.ClientGetConfigsRequest) (*pbgo.ClientGetConfigsResponse, error) {
+	// This client is running, at the moment, in the trace-agent or the security-agent. The auth token is handled
+	// by the core-agent, running independently. It's not guaranteed it starts before us, or that if it restarts that
+	// the auth token remains the same. Thus we need to do this every request.
+	token, err := security.FetchAuthToken()
+	if err != nil {
+		return nil, errors.Wrap(err, "could not acquire agent auth token")
+	}
+	md := metadata.MD{
+		"authorization": []string{fmt.Sprintf("Bearer %s", token)},
+	}
+
+	ctx = metadata.NewOutgoingContext(ctx, md)
+
+	return g.client.ClientGetConfigs(ctx, request)
+}
+
 // NewClient creates a new client
-func NewClient(agentName string, agentVersion string, products []data.Product, pollInterval time.Duration) (*Client, error) {
-	return newClient(agentName, true, agentVersion, products, pollInterval)
+func NewClient(agentName string, updater ConfigUpdater, agentVersion string, products []data.Product, pollInterval time.Duration) (*Client, error) {
+	return newClient(agentName, updater, true, agentVersion, products, pollInterval)
+}
+
+// NewGRPCClient creats a new client that retrieves updates over the datadog-agnet's secure GRPC client
+func NewGRPCClient(agentName string, agentVersion string, products []data.Product, pollInterval time.Duration) (*Client, error) {
+	grpcClient, err := newAgentGRPCConfigFetcher()
+	if err != nil {
+		return nil, err
+	}
+
+	return newClient(agentName, grpcClient, true, agentVersion, products, pollInterval)
 }
 
 // NewUnverifiedClient creates a new client that does not perform any TUF verification
 func NewUnverifiedClient(agentName string, agentVersion string, products []data.Product, pollInterval time.Duration) (*Client, error) {
-	return newClient(agentName, false, agentVersion, products, pollInterval)
-}
-
-func newClient(agentName string, doTufVerification bool, agentVersion string, products []data.Product, pollInterval time.Duration) (*Client, error) {
-	ctx, close := context.WithCancel(context.Background())
-	grpcClient, err := grpc.GetDDAgentSecureClient(ctx)
+	grpcClient, err := newAgentGRPCConfigFetcher()
 	if err != nil {
-		close()
 		return nil, err
 	}
 
+	return newClient(agentName, grpcClient, false, agentVersion, products, pollInterval)
+}
+
+func newClient(agentName string, updater ConfigUpdater, doTufVerification bool, agentVersion string, products []data.Product, pollInterval time.Duration) (*Client, error) {
 	var repository *state.Repository
+	var err error
 
 	if doTufVerification {
 		repository, err = state.NewRepository(meta.RootsDirector().Last())
@@ -87,7 +137,6 @@ func newClient(agentName string, doTufVerification bool, agentVersion string, pr
 		repository, err = state.NewUnverifiedRepository()
 	}
 	if err != nil {
-		close()
 		return nil, err
 	}
 
@@ -101,6 +150,8 @@ func newClient(agentName string, doTufVerification bool, agentVersion string, pr
 	backoffPolicy := backoff.NewPolicy(minBackoffFactor, pollInterval.Seconds(),
 		maximalMaxBackoffTime.Seconds(), recoveryInterval, false)
 
+	ctx, close := context.WithCancel(context.Background())
+
 	return &Client{
 		ID:            generateID(),
 		startupSync:   sync.Once{},
@@ -109,12 +160,12 @@ func newClient(agentName string, doTufVerification bool, agentVersion string, pr
 		agentName:     agentName,
 		agentVersion:  agentVersion,
 		products:      data.ProductListToString(products),
-		grpc:          grpcClient,
 		state:         repository,
 		pollInterval:  pollInterval,
 		backoffPolicy: backoffPolicy,
 		apmListeners:  make([]func(update map[string]state.APMSamplingConfig), 0),
 		cwsListeners:  make([]func(update map[string]state.ConfigCWSDD), 0),
+		updater:       updater,
 	}, nil
 }
 
@@ -163,23 +214,12 @@ func (c *Client) pollLoop() {
 // applies that update, informing any registered listeners of any config state changes
 // that occurred.
 func (c *Client) update() error {
-	// This client is running, at the moment, in the trace-agent or the security-agent. The auth token is handled
-	// by the core-agent, running independently. It's not guaranteed it starts before us, or that if it restarts that
-	// the auth token remains the same. Thus we need to do this every request.
-	token, err := security.FetchAuthToken()
-	if err != nil {
-		return errors.Wrap(err, "could not acquire agent auth token")
-	}
-	md := metadata.MD{
-		"authorization": []string{fmt.Sprintf("Bearer %s", token)},
-	}
-	ctx := metadata.NewOutgoingContext(c.ctx, md)
-
 	req, err := c.newUpdateRequest()
 	if err != nil {
 		return err
 	}
-	response, err := c.grpc.ClientGetConfigs(ctx, req)
+
+	response, err := c.updater.ClientGetConfigs(c.ctx, req)
 	if err != nil {
 		return err
 	}

--- a/pkg/config/remote/client.go
+++ b/pkg/config/remote/client.go
@@ -86,9 +86,9 @@ func newAgentGRPCConfigFetcher() (*agentGRPCConfigFetcher, error) {
 
 // ClientGetConfigs implements the ConfigUpdater interface for agentGRPCConfigFetcher
 func (g *agentGRPCConfigFetcher) ClientGetConfigs(ctx context.Context, request *pbgo.ClientGetConfigsRequest) (*pbgo.ClientGetConfigsResponse, error) {
-	// This client is running, at the moment, in the trace-agent or the security-agent. The auth token is handled
-	// by the core-agent, running independently. It's not guaranteed it starts before us, or that if it restarts that
-	// the auth token remains the same. Thus we need to do this every request.
+	// When communicating with the core service via grpc, the auth token is handled
+	// by the core-agent, which runs independently. It's not guaranteed it starts before us,
+	// or that if it restarts that the auth token remains the same. Thus we need to do this every request.
 	token, err := security.FetchAuthToken()
 	if err != nil {
 		return nil, errors.Wrap(err, "could not acquire agent auth token")

--- a/pkg/config/remote/client.go
+++ b/pkg/config/remote/client.go
@@ -107,7 +107,7 @@ func NewClient(agentName string, updater ConfigUpdater, agentVersion string, pro
 	return newClient(agentName, updater, true, agentVersion, products, pollInterval)
 }
 
-// NewGRPCClient creats a new client that retrieves updates over the datadog-agnet's secure GRPC client
+// NewGRPCClient creates a new client that retrieves updates over the datadog-agent's secure GRPC client
 func NewGRPCClient(agentName string, agentVersion string, products []data.Product, pollInterval time.Duration) (*Client, error) {
 	grpcClient, err := newAgentGRPCConfigFetcher()
 	if err != nil {

--- a/pkg/config/remote/service/service.go
+++ b/pkg/config/remote/service/service.go
@@ -353,7 +353,7 @@ func (s *Service) getRefreshInterval() (time.Duration, error) {
 }
 
 // ClientGetConfigs is the polling API called by tracers and agents to get the latest configurations
-func (s *Service) ClientGetConfigs(request *pbgo.ClientGetConfigsRequest) (*pbgo.ClientGetConfigsResponse, error) {
+func (s *Service) ClientGetConfigs(ctx context.Context, request *pbgo.ClientGetConfigsRequest) (*pbgo.ClientGetConfigsResponse, error) {
 	s.Lock()
 	defer s.Unlock()
 	err := validateRequest(request)

--- a/pkg/config/remote/service/service_test.go
+++ b/pkg/config/remote/service/service_test.go
@@ -262,13 +262,13 @@ func TestClientGetConfigsRequestMissingFields(t *testing.T) {
 
 	// The Client object is missing
 	req := &pbgo.ClientGetConfigsRequest{}
-	_, err := service.ClientGetConfigs(req)
+	_, err := service.ClientGetConfigs(context.Background(), req)
 	assert.Error(t, err)
 	assert.Equal(t, status.Convert(err).Code(), codes.InvalidArgument)
 
 	// The Client object is present, but State is missing
 	req.Client = &pbgo.Client{}
-	_, err = service.ClientGetConfigs(req)
+	_, err = service.ClientGetConfigs(context.Background(), req)
 	assert.Error(t, err)
 	assert.Equal(t, status.Convert(err).Code(), codes.InvalidArgument)
 
@@ -276,7 +276,7 @@ func TestClientGetConfigsRequestMissingFields(t *testing.T) {
 	req.Client = &pbgo.Client{
 		State: &pbgo.ClientState{},
 	}
-	_, err = service.ClientGetConfigs(req)
+	_, err = service.ClientGetConfigs(context.Background(), req)
 	assert.Error(t, err)
 	assert.Equal(t, status.Convert(err).Code(), codes.InvalidArgument)
 
@@ -287,7 +287,7 @@ func TestClientGetConfigsRequestMissingFields(t *testing.T) {
 		},
 		IsAgent: true,
 	}
-	_, err = service.ClientGetConfigs(req)
+	_, err = service.ClientGetConfigs(context.Background(), req)
 	assert.Error(t, err)
 	assert.Equal(t, status.Convert(err).Code(), codes.InvalidArgument)
 
@@ -298,7 +298,7 @@ func TestClientGetConfigsRequestMissingFields(t *testing.T) {
 		},
 		IsTracer: true,
 	}
-	_, err = service.ClientGetConfigs(req)
+	_, err = service.ClientGetConfigs(context.Background(), req)
 	assert.Error(t, err)
 	assert.Equal(t, status.Convert(err).Code(), codes.InvalidArgument)
 
@@ -312,7 +312,7 @@ func TestClientGetConfigsRequestMissingFields(t *testing.T) {
 		IsAgent:      true,
 		ClientTracer: &pbgo.ClientTracer{},
 	}
-	_, err = service.ClientGetConfigs(req)
+	_, err = service.ClientGetConfigs(context.Background(), req)
 	assert.Error(t, err)
 	assert.Equal(t, status.Convert(err).Code(), codes.InvalidArgument)
 }
@@ -420,7 +420,7 @@ func TestService(t *testing.T) {
 	}).Return(lastConfigResponse, nil)
 
 	service.clients.seen(client) // Avoid blocking on channel sending when nothing is at the other end
-	configResponse, err := service.ClientGetConfigs(&pbgo.ClientGetConfigsRequest{Client: client})
+	configResponse, err := service.ClientGetConfigs(context.Background(), &pbgo.ClientGetConfigsRequest{Client: client})
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, [][]byte{canonicalRoot3, canonicalRoot4}, configResponse.Roots)
 	assert.ElementsMatch(t, []*pbgo.File{{Path: "datadog/2/APM_SAMPLING/id/1", Raw: fileAPM1}, {Path: "datadog/2/APM_SAMPLING/id/2", Raw: fileAPM2}}, configResponse.TargetFiles)
@@ -526,7 +526,7 @@ func TestServiceClientPredicates(t *testing.T) {
 	}).Return(lastConfigResponse, nil)
 
 	service.clients.seen(client) // Avoid blocking on channel sending when nothing is at the other end
-	configResponse, err := service.ClientGetConfigs(&pbgo.ClientGetConfigsRequest{Client: client})
+	configResponse, err := service.ClientGetConfigs(context.Background(), &pbgo.ClientGetConfigsRequest{Client: client})
 	assert.NoError(err)
 	assert.ElementsMatch(
 		configResponse.ClientConfigs,
@@ -786,7 +786,7 @@ func TestConfigExpiration(t *testing.T) {
 	}).Return(lastConfigResponse, nil)
 
 	service.clients.seen(client) // Avoid blocking on channel sending when nothing is at the other end
-	configResponse, err := service.ClientGetConfigs(&pbgo.ClientGetConfigsRequest{Client: client})
+	configResponse, err := service.ClientGetConfigs(context.Background(), &pbgo.ClientGetConfigsRequest{Client: client})
 	assert.NoError(err)
 	assert.ElementsMatch(
 		configResponse.ClientConfigs,

--- a/pkg/security/rconfig/rconfig.go
+++ b/pkg/security/rconfig/rconfig.go
@@ -39,7 +39,7 @@ var _ rules.PolicyProvider = (*RCPolicyProvider)(nil)
 
 // NewRCPolicyProvider returns a new Remote Config based policy provider
 func NewRCPolicyProvider(name string, agentVersion *semver.Version) (*RCPolicyProvider, error) {
-	c, err := remote.NewClient(name, agentVersion.String(), []data.Product{data.ProductCWSDD}, securityAgentRCPollInterval)
+	c, err := remote.NewGRPCClient(name, agentVersion.String(), []data.Product{data.ProductCWSDD}, securityAgentRCPollInterval)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
A work in progress branch for porting the core remote config service into the cluster agent, along with an in-process agent client.