### PR TITLE
[Serverless] Reduce serverless unit testing time.

### DIFF
--- a/pkg/serverless/daemon/daemon.go
+++ b/pkg/serverless/daemon/daemon.go
@@ -23,10 +23,10 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-// shutdownDelay is the amount of time we wait before shutting down the HTTP server
+// ShutdownDelay is the amount of time we wait before shutting down the HTTP server
 // after we receive a Shutdown event. This allows time for the final log messages
 // to arrive from the Logs API.
-const shutdownDelay time.Duration = 1 * time.Second
+var ShutdownDelay time.Duration = 1 * time.Second
 
 // FlushTimeout is the amount of time to wait for a flush to complete.
 const FlushTimeout time.Duration = 5 * time.Second
@@ -281,7 +281,7 @@ func (d *Daemon) Stop() {
 
 	// Wait for any remaining logs to arrive via the logs API before shutting down the HTTP server
 	log.Debug("Waiting to shut down HTTP server")
-	time.Sleep(shutdownDelay)
+	time.Sleep(ShutdownDelay)
 
 	log.Debug("Shutting down HTTP server")
 	err := d.httpServer.Shutdown(context.Background())

--- a/pkg/serverless/daemon/daemon_test.go
+++ b/pkg/serverless/daemon/daemon_test.go
@@ -31,14 +31,13 @@ func TestWaitForDaemonBlocking(t *testing.T) {
 	assert := assert.New(t)
 	port := testutil.FreeTCPPort(t)
 	d := StartDaemon(fmt.Sprint("127.0.0.1:", port))
-	time.Sleep(100 * time.Millisecond)
 	defer d.Stop()
 
 	d.TellDaemonRuntimeStarted()
 
 	complete := false
 	go func() {
-		<-time.After(100 * time.Millisecond)
+		<-time.After(10 * time.Millisecond)
 		complete = true
 		d.TellDaemonRuntimeDone()
 	}()
@@ -54,7 +53,6 @@ func TestTellDaemonRuntimeDoneOnceStartOnly(t *testing.T) {
 	assert := assert.New(t)
 	port := testutil.FreeTCPPort(t)
 	d := StartDaemon(fmt.Sprint("127.0.0.1:", port))
-	time.Sleep(100 * time.Millisecond)
 	defer d.Stop()
 
 	d.TellDaemonRuntimeStarted()
@@ -65,7 +63,6 @@ func TestTellDaemonRuntimeDoneOnceStartAndEnd(t *testing.T) {
 	assert := assert.New(t)
 	port := testutil.FreeTCPPort(t)
 	d := StartDaemon(fmt.Sprint("127.0.0.1:", port))
-	time.Sleep(100 * time.Millisecond)
 	defer d.Stop()
 
 	d.TellDaemonRuntimeStarted()
@@ -79,7 +76,6 @@ func TestTellDaemonRuntimeDoneIfLocalTest(t *testing.T) {
 	assert := assert.New(t)
 	port := testutil.FreeTCPPort(t)
 	d := StartDaemon(fmt.Sprint("127.0.0.1:", port))
-	time.Sleep(100 * time.Millisecond)
 	defer d.Stop()
 	d.TellDaemonRuntimeStarted()
 	client := &http.Client{Timeout: 1 * time.Second}
@@ -109,7 +105,6 @@ func TestTellDaemonRuntimeNotDoneIf(t *testing.T) {
 	assert := assert.New(t)
 	port := testutil.FreeTCPPort(t)
 	d := StartDaemon(fmt.Sprint("127.0.0.1:", port))
-	time.Sleep(100 * time.Millisecond)
 	defer d.Stop()
 	d.TellDaemonRuntimeStarted()
 	assert.Equal(uint64(0), GetValueSyncOnce(d.TellDaemonRuntimeDoneOnce))
@@ -119,7 +114,6 @@ func TestTellDaemonRuntimeDoneOnceStartAndEndAndTimeout(t *testing.T) {
 	assert := assert.New(t)
 	port := testutil.FreeTCPPort(t)
 	d := StartDaemon(fmt.Sprint("127.0.0.1:", port))
-	time.Sleep(100 * time.Millisecond)
 	defer d.Stop()
 
 	d.TellDaemonRuntimeStarted()
@@ -132,7 +126,6 @@ func TestTellDaemonRuntimeDoneOnceStartAndEndAndTimeout(t *testing.T) {
 func TestRaceTellDaemonRuntimeStartedVersusTellDaemonRuntimeDone(t *testing.T) {
 	port := testutil.FreeTCPPort(t)
 	d := StartDaemon(fmt.Sprint("127.0.0.1:", port))
-	time.Sleep(100 * time.Millisecond)
 	defer d.Stop()
 
 	go d.TellDaemonRuntimeStarted()
@@ -176,7 +169,6 @@ func TestSetTraceTagOk(t *testing.T) {
 func TestOutOfOrderInvocations(t *testing.T) {
 	port := testutil.FreeTCPPort(t)
 	d := StartDaemon(fmt.Sprint("127.0.0.1:", port))
-	time.Sleep(100 * time.Millisecond)
 	defer d.Stop()
 
 	assert.NotPanics(t, d.TellDaemonRuntimeDone)

--- a/pkg/serverless/daemon/interval.go
+++ b/pkg/serverless/daemon/interval.go
@@ -49,13 +49,9 @@ func (d *Daemon) InvocationInterval() time.Duration {
 	if len(d.lastInvocations) < 20 {
 		return 0
 	}
-
-	var total int64
-	for i := 1; i < len(d.lastInvocations); i++ {
-		total += int64(d.lastInvocations[i].Sub(d.lastInvocations[i-1]))
-	}
-
-	return time.Duration(total / int64(len(d.lastInvocations)-1))
+	invs := len(d.lastInvocations)
+	total := int64(d.lastInvocations[invs-1].Sub(d.lastInvocations[0]))
+	return time.Duration(total / int64(invs-1))
 }
 
 // AutoSelectStrategy uses the invocation interval of the function to select the

--- a/pkg/serverless/daemon/interval_test.go
+++ b/pkg/serverless/daemon/interval_test.go
@@ -86,11 +86,9 @@ func TestInvocationInterval(t *testing.T) {
 	}
 
 	for i := 0; i < 19; i++ {
-		time.Sleep(100 * time.Millisecond)
 		d.lastInvocations = append(d.lastInvocations, time.Now())
 		assert.Equal(time.Duration(0), d.InvocationInterval(), "we should not compute any interval just yet since we don't have enough data")
 	}
-	time.Sleep(100 * time.Millisecond)
 	d.lastInvocations = append(d.lastInvocations, time.Now())
 
 	assert.NotEqual(time.Duration(0), d.InvocationInterval(), "we should compute some interval now")

--- a/pkg/serverless/daemon/interval_test.go
+++ b/pkg/serverless/daemon/interval_test.go
@@ -89,7 +89,7 @@ func TestInvocationInterval(t *testing.T) {
 		d.lastInvocations = append(d.lastInvocations, time.Now())
 		assert.Equal(time.Duration(0), d.InvocationInterval(), "we should not compute any interval just yet since we don't have enough data")
 	}
-	d.lastInvocations = append(d.lastInvocations, time.Now())
+	d.lastInvocations = append(d.lastInvocations, time.Now().Add(13*time.Second))
 
 	assert.NotEqual(time.Duration(0), d.InvocationInterval(), "we should compute some interval now")
 

--- a/pkg/serverless/metrics/metric_test.go
+++ b/pkg/serverless/metrics/metric_test.go
@@ -206,7 +206,7 @@ func TestRaceFlushVersusParsePacket(t *testing.T) {
 	go func(wg *sync.WaitGroup) {
 		for i := 0; i < 1000; i++ {
 			conn.Write([]byte("daemon:666|g|#sometag1:somevalue1,sometag2:somevalue2"))
-			time.Sleep(10 * time.Millisecond)
+			time.Sleep(10 * time.Nanosecond)
 		}
 		finish.Done()
 	}(finish)

--- a/pkg/serverless/metrics/metric_test.go
+++ b/pkg/serverless/metrics/metric_test.go
@@ -10,6 +10,7 @@ import (
 	"math/rand"
 	"net"
 	"net/http"
+	"os"
 	"strconv"
 	"sync"
 	"testing"
@@ -21,7 +22,16 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/dogstatsd"
+	"github.com/DataDog/datadog-agent/pkg/util/cache"
+	"github.com/DataDog/datadog-agent/pkg/util/hostname"
 )
+
+func TestMain(m *testing.M) {
+	// setting the hostname cache saves about 1s when starting the metric agent
+	cacheKey := cache.BuildAgentKey("hostname")
+	cache.Cache.Set(cacheKey, hostname.Data{}, cache.NoExpiration)
+	os.Exit(m.Run())
+}
 
 func TestStartDoesNotBlock(t *testing.T) {
 	config.DetectFeatures()

--- a/pkg/serverless/metrics/metric_test.go
+++ b/pkg/serverless/metrics/metric_test.go
@@ -30,8 +30,6 @@ func TestStartDoesNotBlock(t *testing.T) {
 	metricAgent.Start(10*time.Second, &MetricConfig{}, &MetricDogStatsD{})
 	assert.NotNil(t, metricAgent.Demux)
 	assert.True(t, metricAgent.IsReady())
-	// allow some time to stop to avoid 'can't listen: listen udp 127.0.0.1:8125: bind: address already in use'
-	time.Sleep(100 * time.Millisecond)
 }
 
 type ValidMetricConfigMocked struct {
@@ -53,8 +51,6 @@ func TestStartInvalidConfig(t *testing.T) {
 	defer metricAgent.Stop()
 	metricAgent.Start(1*time.Second, &InvalidMetricConfigMocked{}, &MetricDogStatsD{})
 	assert.False(t, metricAgent.IsReady())
-	// allow some time to stop to avoid 'can't listen: listen udp 127.0.0.1:8125: bind: address already in use'
-	time.Sleep(100 * time.Millisecond)
 }
 
 type MetricDogStatsDMocked struct {
@@ -69,8 +65,6 @@ func TestStartInvalidDogStatsD(t *testing.T) {
 	defer metricAgent.Stop()
 	metricAgent.Start(1*time.Second, &MetricConfig{}, &MetricDogStatsDMocked{})
 	assert.False(t, metricAgent.IsReady())
-	// allow some time to stop to avoid 'can't listen: listen udp 127.0.0.1:8125: bind: address already in use'
-	time.Sleep(1 * time.Second)
 }
 
 func TestStartWithProxy(t *testing.T) {

--- a/pkg/serverless/serverless_test.go
+++ b/pkg/serverless/serverless_test.go
@@ -7,6 +7,7 @@ package serverless
 
 import (
 	"fmt"
+	"os"
 	"runtime/debug"
 	"sort"
 	"testing"
@@ -17,6 +18,13 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/serverless/daemon"
 	"github.com/DataDog/datadog-agent/pkg/serverless/tags"
 )
+
+func TestMain(m *testing.M) {
+	origShutdownDelay := daemon.ShutdownDelay
+	daemon.ShutdownDelay = 0
+	defer func() { daemon.ShutdownDelay = origShutdownDelay }()
+	os.Exit(m.Run())
+}
 
 func TestHandleInvocationShouldSetExtraTags(t *testing.T) {
 	d := daemon.StartDaemon("http://localhost:8124")
@@ -68,9 +76,6 @@ func TestHandleInvocationShouldNotSIGSEGVWhenTimedOut(t *testing.T) {
 			assert.Fail(t, "Expected no panic, instead got ", r)
 		}
 	}()
-	origShutdownDelay := daemon.ShutdownDelay
-	daemon.ShutdownDelay = 0
-	defer func() { daemon.ShutdownDelay = origShutdownDelay }()
 
 	for i := 0; i < 10; i++ { // each one of these takes about a second on my laptop
 		fmt.Printf("Running this test the %d time\n", i)

--- a/pkg/serverless/serverless_test.go
+++ b/pkg/serverless/serverless_test.go
@@ -68,6 +68,10 @@ func TestHandleInvocationShouldNotSIGSEGVWhenTimedOut(t *testing.T) {
 			assert.Fail(t, "Expected no panic, instead got ", r)
 		}
 	}()
+	origShutdownDelay := daemon.ShutdownDelay
+	daemon.ShutdownDelay = 0
+	defer func() { daemon.ShutdownDelay = origShutdownDelay }()
+
 	for i := 0; i < 10; i++ { // each one of these takes about a second on my laptop
 		fmt.Printf("Running this test the %d time\n", i)
 		d := daemon.StartDaemon("http://localhost:8124")


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This pull request reduces the time to run `go test ./pkg/serverless/...` by over 75%; from around 20s to just under 5s.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

I hate slow tests.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

I've left comments to explain some of the changes.

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Run the serverless unit tests a bunch and make sure they _never_ fail.
```
go test -count=10 ./pkg/serverless/...
```

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
