### PR TITLE
[CWS] btfhub archive sync improvements

### DIFF
--- a/.github/workflows/cws-btfhub-sync.yml
+++ b/.github/workflows/cws-btfhub-sync.yml
@@ -3,7 +3,7 @@ name: "CWS BTFHub constants sync"
 on:
   workflow_dispatch:
   schedule:
-    - cron: '30 4 * * *' # at 4:30 UTC every Tuesday https://crontab.guru/#30_4_*_*_2
+    - cron: '30 4 * * *' # at 4:30 UTC every day
 
 jobs:
   sync:

--- a/.github/workflows/cws-btfhub-sync.yml
+++ b/.github/workflows/cws-btfhub-sync.yml
@@ -3,7 +3,7 @@ name: "CWS BTFHub constants sync"
 on:
   workflow_dispatch:
   schedule:
-    - cron: '30 4 * * 2' # at 4:30 UTC every Tuesday https://crontab.guru/#30_4_*_*_2
+    - cron: '30 4 * * *' # at 4:30 UTC every Tuesday https://crontab.guru/#30_4_*_*_2
 
 jobs:
   sync:

--- a/pkg/security/probe/constantfetch/btfhub.go
+++ b/pkg/security/probe/constantfetch/btfhub.go
@@ -135,6 +135,7 @@ func newKernelInfos(kv *kernel.Version) (*kernelInfos, error) {
 // BTFHubConstants represents all the information required for identifying
 // a unique btf file from BTFHub
 type BTFHubConstants struct {
+	Commit    string              `json:"commit"`
 	Constants []map[string]uint64 `json:"constants"`
 	Kernels   []BTFHubKernel      `json:"kernels"`
 }

--- a/pkg/security/probe/constantfetch/btfhub/constants.json
+++ b/pkg/security/probe/constantfetch/btfhub/constants.json
@@ -1,4 +1,5 @@
 {
+	"commit": "6536b224fa95cc7fe6eacf630f345076802abac7",
 	"constants": [
 		{
 			"binprm_file_offset": 168,

--- a/pkg/security/probe/constantfetch/btfhub/main.go
+++ b/pkg/security/probe/constantfetch/btfhub/main.go
@@ -113,8 +113,10 @@ func getCommitSha(cwd string) (string, error) {
 }
 
 type treeWalkCollector struct {
-	counter   int
-	wg        sync.WaitGroup
+	counter int
+	// wg is used so that the finish waits on all kernels
+	wg sync.WaitGroup
+	// sem is used to limit the amount of parallel extractions
 	sem       *semaphore.Weighted
 	resultsMu sync.Mutex
 	results   []extractionResult

--- a/pkg/security/probe/constantfetch/btfhub/main.go
+++ b/pkg/security/probe/constantfetch/btfhub/main.go
@@ -228,11 +228,13 @@ func createBTFReaderFromTarball(archivePath string) (io.ReaderAt, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer archiveFile.Close()
 
 	xzReader, err := xz.NewReader(archiveFile)
 	if err != nil {
 		return nil, err
 	}
+	defer xzReader.Close()
 
 	tarReader := tar.NewReader(xzReader)
 

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -584,10 +584,11 @@ def cws_go_generate(ctx):
 
 
 @task
-def generate_btfhub_constants(ctx, archive_path):
+def generate_btfhub_constants(ctx, archive_path, force_refresh=False):
     output_path = "./pkg/security/probe/constantfetch/btfhub/constants.json"
+    force_refresh_opt = "-force-refresh" if force_refresh else ""
     ctx.run(
-        f"go run ./pkg/security/probe/constantfetch/btfhub/ -archive-root {archive_path} -output {output_path}",
+        f"go run ./pkg/security/probe/constantfetch/btfhub/ -archive-root {archive_path} -output {output_path} {force_refresh_opt}",
     )
 
 


### PR DESCRIPTION
### What does this PR do?

The goal of this PR is to run the sync workflow more frequently (every day instead of every week currently).

To achieve this without being too wasteful, this PR also includes a new mechanism that checks the commit of the current constants against the one in the argument path and return early if they match.

The goal being that in most cases were there is nothing to do it will simply exit early

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
