### PR TITLE
Added encoding of kafka connections

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	code.cloudfoundry.org/bbs v0.0.0-20200403215808-d7bc971db0db
 	code.cloudfoundry.org/garden v0.0.0-20210208153517-580cadd489d2
 	code.cloudfoundry.org/lager v2.0.0+incompatible
-	github.com/DataDog/agent-payload/v5 v5.0.32
+	github.com/DataDog/agent-payload/v5 v5.0.39
 	github.com/DataDog/datadog-agent/pkg/obfuscate v0.40.0-rc.2
 	github.com/DataDog/datadog-agent/pkg/otlp/model v0.40.0-rc.2
 	github.com/DataDog/datadog-agent/pkg/quantile v0.40.0-rc.2

--- a/go.sum
+++ b/go.sum
@@ -129,6 +129,8 @@ github.com/BurntSushi/toml v1.1.0/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbi
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DataDog/agent-payload/v5 v5.0.32 h1:zfa5gXGfjzBza9klKWFoxM8qUBmvQfzoseI9odQHc0g=
 github.com/DataDog/agent-payload/v5 v5.0.32/go.mod h1:2gapp8p4Vd548JI+axD8kCExklNvVI6AMF5/+IfN/4g=
+github.com/DataDog/agent-payload/v5 v5.0.39 h1:BItsikvj6UQzz+hoF+qVhzPJLsPDpwtR1Ry5/5n7RHY=
+github.com/DataDog/agent-payload/v5 v5.0.39/go.mod h1:vhXPNG7eNDOLeW94Z7dLNUBv61kRBHK7vXnQ+RQfckk=
 github.com/DataDog/aptly v1.5.0 h1:Oy6JVRC9iDgnmpeVYa4diXwP/exU7wJ/U1kuI4Zacxg=
 github.com/DataDog/aptly v1.5.0/go.mod h1:KVyvkYXGcFugxadGFZ+u5Fc3M6q/EfzFZyeTD9HVbkY=
 github.com/DataDog/cast v1.3.1-0.20190301154711-1ee8c8bd14a3 h1:SobA9WYm4K/MUtWlbKaomWTmnuYp1KhIm8Wlx3vmpsg=

--- a/pkg/network/ebpf/c/kafka/socket-filter-approach/kafka-types.h
+++ b/pkg/network/ebpf/c/kafka/socket-filter-approach/kafka-types.h
@@ -78,20 +78,15 @@ typedef struct {
 // HTTP transaction information associated to a certain socket (tuple_t)
 // Kafka transaction information associated to a certain socket (tuple_t)
 typedef struct {
-    // this field is used exclusively in the kernel side to prevent a TCP segment
-    // to be processed twice in the context of localhost traffic. The field will
-    // be populated with the "original" (pre-normalization) source port number of
-    // the TCP segment containing the beginning of a given HTTP request
-    __u16 owned_by_src_port;
     conn_tuple_t tup;
+
     __u16 request_api_key;
     __u16 request_api_version;
     __u32 correlation_id;
 
-//    __u64 request_started;
-//    __u8  request_method;
-//    __u16 response_status_code;
-//    __u64 response_last_seen;
+    // this field is used to disambiguate segments in the context of keep-alives
+    // we populate it with the TCP seq number of the request and then the response segments
+    __u32 tcp_seq;
 
     __u32 current_offset_in_request_fragment;
     char request_fragment[KAFKA_BUFFER_SIZE] __attribute__ ((aligned (8)));
@@ -99,9 +94,12 @@ typedef struct {
     // TODO: Support UTF8
     char topic_name[TOPIC_NAME_MAX_STRING_SIZE] __attribute__ ((aligned (8)));
 
-    // this field is used to disambiguate segments in the context of keep-alives
-    // we populate it with the TCP seq number of the request and then the response segments
-    __u32 tcp_seq;
+    // this field is used exclusively in the kernel side to prevent a TCP segment
+    // to be processed twice in the context of localhost traffic. The field will
+    // be populated with the "original" (pre-normalization) source port number of
+    // the TCP segment containing the beginning of a given HTTP request
+    __u16 owned_by_src_port;
+
 //
 //    __u64 tags;
 //} http_transaction_t;

--- a/pkg/network/encoding/encoding.go
+++ b/pkg/network/encoding/encoding.go
@@ -71,12 +71,13 @@ func modelConnections(conns *network.Connections) *model.Connections {
 	agentConns := make([]*model.Connection, len(conns.Conns))
 	routeIndex := make(map[string]RouteIdx)
 	httpEncoder := newHTTPEncoder(conns)
+	kafkaEncoder := newKafkaEncoder(conns)
 	ipc := make(ipCache, len(conns.Conns)/2)
 	dnsFormatter := newDNSFormatter(conns, ipc)
 	tagsSet := network.NewTagsSet()
 
 	for i, conn := range conns.Conns {
-		agentConns[i] = FormatConnection(conn, routeIndex, httpEncoder, dnsFormatter, ipc, tagsSet)
+		agentConns[i] = FormatConnection(conn, routeIndex, httpEncoder, kafkaEncoder, dnsFormatter, ipc, tagsSet)
 	}
 
 	if httpEncoder != nil && httpEncoder.orphanEntries > 0 {

--- a/pkg/network/encoding/format.go
+++ b/pkg/network/encoding/format.go
@@ -50,6 +50,7 @@ func FormatConnection(
 	conn network.ConnectionStats,
 	routes map[string]RouteIdx,
 	httpEncoder *httpEncoder,
+	kafkaEncoder *kafkaEncoder,
 	dnsFormatter *dnsFormatter,
 	ipc ipCache,
 	tagsSet *network.TagsSet,
@@ -84,6 +85,10 @@ func FormatConnection(
 		c.HttpAggregations, _ = proto.Marshal(httpStats)
 	}
 
+	kafkaStats := kafkaEncoder.GetKafkaAggregations(conn)
+	if kafkaStats != nil {
+		c.DataStreamsAggregations, _ = proto.Marshal(kafkaStats)
+	}
 	conn.Tags |= staticTags
 	c.Tags, c.TagsChecksum = formatTags(tagsSet, conn, dynamicTags)
 

--- a/pkg/network/encoding/kafka.go
+++ b/pkg/network/encoding/kafka.go
@@ -1,0 +1,149 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package encoding
+
+import (
+	model "github.com/DataDog/agent-payload/v5/process"
+
+	"github.com/DataDog/datadog-agent/pkg/network"
+	"github.com/DataDog/datadog-agent/pkg/network/kafka"
+)
+
+type kafkaEncoder struct {
+	aggregations  map[kafka.KeyTuple]*kafkaAggregationWrapper
+	orphanEntries int
+}
+
+// aggregationWrapper is meant to handle collision scenarios where multiple
+// `ConnectionStats` objects may claim the same `DataStreamsAggregations` object because
+// they generate the same kafka.KeyTuple
+// TODO: we should probably revist/get rid of this if we ever replace socket
+// filters by kprobes, since in that case we would have access to PIDs, and
+// could incorporate that information in the `kafka.KeyTuple` struct.
+type kafkaAggregationWrapper struct {
+	*model.DataStreamsAggregations
+
+	// we keep track of the source and destination ports of the first
+	// `ConnectionStats` to claim this `HTTPAggregations` object
+	sport, dport uint16
+}
+
+func (a *kafkaAggregationWrapper) ValueFor(c network.ConnectionStats) *model.DataStreamsAggregations {
+	if a == nil {
+		return nil
+	}
+
+	if a.sport == 0 && a.dport == 0 {
+		// This is the first time a ConnectionStats claim this aggregation. In
+		// this case we return the value and save the source and destination
+		// ports
+		a.sport = c.SPort
+		a.dport = c.DPort
+		return a.DataStreamsAggregations
+	}
+
+	if c.SPort == a.dport && c.DPort == a.sport {
+		// We have a collision with another `ConnectionStats`, but this is a
+		// legit scenario where we're dealing with the opposite ends of the
+		// same connection, which means both server and client are in the same host.
+		// In this particular case it is correct to have both connections
+		// (client:server and server:client) referencing the same HTTP data.
+		return a.DataStreamsAggregations
+	}
+
+	// Return nil otherwise. This is to prevent multiple `ConnectionStats` with
+	// exactly the same source and destination addresses but different PIDs to
+	// "bind" to the same HTTPAggregations object, which would result in a
+	// overcount problem. (Note that this is due to the fact that
+	// `kafka.KeyTuple` doesn't have a PID field.) This happens mostly in the
+	// context of pre-fork web servers, where multiple worker proceses share the
+	// same socket
+	return nil
+}
+
+func newKafkaEncoder(payload *network.Connections) *kafkaEncoder {
+	if len(payload.Kafka) == 0 {
+		return nil
+	}
+
+	encoder := &kafkaEncoder{
+		aggregations: make(map[kafka.KeyTuple]*kafkaAggregationWrapper, len(payload.Conns)),
+	}
+
+	// pre-populate aggregation map with keys for all existent connections
+	// this allows us to skip encoding orphan HTTP objects that can't be matched to a connection
+	for _, conn := range payload.Conns {
+		for _, key := range network.KafkaKeyTuplesFromConn(conn) {
+			encoder.aggregations[key] = nil
+		}
+	}
+	encoder.buildAggregations(payload)
+	return encoder
+}
+
+func (e *kafkaEncoder) GetKafkaAggregations(c network.ConnectionStats) *model.DataStreamsAggregations {
+	if e == nil {
+		return nil
+	}
+
+	keyTuples := network.KafkaKeyTuplesFromConn(c)
+	for _, key := range keyTuples {
+		if aggregation := e.aggregations[key]; aggregation != nil {
+			return e.aggregations[key].ValueFor(c)
+		}
+	}
+	return nil
+}
+
+func (e *kafkaEncoder) buildAggregations(payload *network.Connections) {
+	fetchAggrSize := make(map[kafka.KeyTuple]int)
+	produceAggrSize := make(map[kafka.KeyTuple]int)
+	for key, value := range payload.Kafka {
+		if value.Data[0] != nil {
+			produceAggrSize[key.KeyTuple] += value.Data[0].Count
+		}
+		if value.Data[1] != nil {
+			fetchAggrSize[key.KeyTuple] += value.Data[1].Count
+		}
+	}
+
+	for key, stats := range payload.Kafka {
+		aggregation, ok := e.aggregations[key.KeyTuple]
+		if !ok {
+			// if there is no matching connection don't even bother to serialize HTTP data
+			e.orphanEntries++
+			continue
+		}
+
+		if aggregation == nil {
+			aggregation = &kafkaAggregationWrapper{
+				DataStreamsAggregations: &model.DataStreamsAggregations{
+					KafkaProduceAggregations: &model.DataStreamsAggregations_KafkaProduceAggregations{
+						Stats: make([]*model.DataStreamsAggregations_TopicStats, 0, produceAggrSize[key.KeyTuple]),
+					},
+					KafkaFetchAggregations: &model.DataStreamsAggregations_KafkaFetchAggregations{
+						Stats: make([]*model.DataStreamsAggregations_TopicStats, 0, fetchAggrSize[key.KeyTuple]),
+					},
+				},
+			}
+			e.aggregations[key.KeyTuple] = aggregation
+		}
+
+		if stats.Data[0] != nil && stats.Data[0].Count > 0 {
+			aggregation.KafkaProduceAggregations.Stats = append(aggregation.KafkaProduceAggregations.Stats, &model.DataStreamsAggregations_TopicStats{
+				Topic: key.TopicName,
+				Count: uint32(stats.Data[0].Count),
+			})
+		}
+
+		if stats.Data[1] != nil && stats.Data[1].Count > 0 {
+			aggregation.KafkaFetchAggregations.Stats = append(aggregation.KafkaFetchAggregations.Stats, &model.DataStreamsAggregations_TopicStats{
+				Topic: key.TopicName,
+				Count: uint32(stats.Data[1].Count),
+			})
+		}
+	}
+}

--- a/pkg/network/encoding/kafka_test.go
+++ b/pkg/network/encoding/kafka_test.go
@@ -1,0 +1,229 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package encoding
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/network/kafka"
+	"testing"
+
+	model "github.com/DataDog/agent-payload/v5/process"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/network"
+	"github.com/DataDog/datadog-agent/pkg/process/util"
+)
+
+func TestFormatKafkaStats(t *testing.T) {
+	var (
+		clientPort = uint16(52800)
+		serverPort = uint16(8080)
+		localhost  = util.AddressFromString("127.0.0.1")
+	)
+
+	kafkaKey1 := kafka.NewKey(
+		localhost,
+		localhost,
+		clientPort,
+		serverPort,
+		"topic-1",
+	)
+	kafkaStats1 := kafka.RequestStats{
+		Data: [2]*kafka.RequestStat{
+			new(kafka.RequestStat),
+			new(kafka.RequestStat),
+		},
+	}
+	kafkaStats1.Data[0].Count = 3 // 3 produces
+	kafkaStats1.Data[1].Count = 5 // 5 fetches
+
+	kafkaKey2 := kafkaKey1
+	kafkaKey2.TopicName = "topic-2"
+	kafkaStats2 := kafka.RequestStats{
+		Data: [2]*kafka.RequestStat{
+			new(kafka.RequestStat),
+			new(kafka.RequestStat),
+		},
+	}
+	kafkaStats2.Data[0].Count = 0 // 3 produces
+	kafkaStats2.Data[1].Count = 9 // 5 fetches
+
+	in := &network.Connections{
+		BufferedData: network.BufferedData{
+			Conns: []network.ConnectionStats{
+				{
+					Source: localhost,
+					Dest:   localhost,
+					SPort:  clientPort,
+					DPort:  serverPort,
+				},
+			},
+		},
+		Kafka: map[kafka.Key]*kafka.RequestStats{
+			kafkaKey1: &kafkaStats1,
+			kafkaKey2: &kafkaStats2,
+		},
+	}
+
+	out := &model.DataStreamsAggregations{
+		KafkaProduceAggregations: &model.DataStreamsAggregations_KafkaProduceAggregations{
+			Stats: []*model.DataStreamsAggregations_TopicStats{
+				{
+					Topic: "topic-1",
+					Count: 3,
+				},
+			},
+		},
+		KafkaFetchAggregations: &model.DataStreamsAggregations_KafkaFetchAggregations{
+			Stats: []*model.DataStreamsAggregations_TopicStats{
+				{
+					Topic: "topic-1",
+					Count: 5,
+				},
+				{
+					Topic: "topic-2",
+					Count: 9,
+				},
+			},
+		},
+	}
+
+	kafkaEncoder := newKafkaEncoder(in)
+	aggregations := kafkaEncoder.GetKafkaAggregations(in.Conns[0])
+	require.NotNil(t, aggregations)
+	assert.ElementsMatch(t, out.KafkaProduceAggregations.Stats, aggregations.KafkaProduceAggregations.Stats)
+	assert.ElementsMatch(t, out.KafkaFetchAggregations.Stats, aggregations.KafkaFetchAggregations.Stats)
+}
+
+func TestKafkaIDCollisionRegression(t *testing.T) {
+	assert := assert.New(t)
+	connections := []network.ConnectionStats{
+		{
+			Source: util.AddressFromString("1.1.1.1"),
+			SPort:  60000,
+			Dest:   util.AddressFromString("2.2.2.2"),
+			DPort:  80,
+			Pid:    1,
+		},
+		{
+			Source: util.AddressFromString("1.1.1.1"),
+			SPort:  60000,
+			Dest:   util.AddressFromString("2.2.2.2"),
+			DPort:  80,
+			Pid:    2,
+		},
+	}
+
+	kafkaStats := kafka.RequestStats{
+		Data: [2]*kafka.RequestStat{
+			{
+				Count: 9,
+			},
+			{
+				Count: 2,
+			},
+		},
+	}
+	kafkaKey := kafka.NewKey(
+		util.AddressFromString("1.1.1.1"),
+		util.AddressFromString("2.2.2.2"),
+		60000,
+		80,
+		"topic1",
+	)
+
+	in := &network.Connections{
+		BufferedData: network.BufferedData{
+			Conns: connections,
+		},
+		Kafka: map[kafka.Key]*kafka.RequestStats{
+			kafkaKey: &kafkaStats,
+		},
+	}
+
+	kafkaEncoder := newKafkaEncoder(in)
+
+	// assert that the first connection matching the HTTP data will get
+	// back a non-nil result
+	aggregations := kafkaEncoder.GetKafkaAggregations(connections[0])
+	assert.NotNil(aggregations)
+	assert.Equal("topic1", aggregations.KafkaProduceAggregations.Stats[0].Topic)
+	assert.Equal(uint32(9), aggregations.KafkaProduceAggregations.Stats[0].Count)
+	assert.Equal("topic1", aggregations.KafkaFetchAggregations.Stats[0].Topic)
+	assert.Equal(uint32(2), aggregations.KafkaFetchAggregations.Stats[0].Count)
+
+	// assert that the other connections sharing the same (source,destination)
+	// addresses but different PIDs *won't* be associated with the HTTP stats
+	// object
+	aggregations = kafkaEncoder.GetKafkaAggregations(connections[1])
+	assert.Nil(aggregations)
+}
+
+func TestKafkaLocalhostScenario(t *testing.T) {
+	assert := assert.New(t)
+	connections := []network.ConnectionStats{
+		{
+			Source: util.AddressFromString("127.0.0.1"),
+			SPort:  60000,
+			Dest:   util.AddressFromString("127.0.0.1"),
+			DPort:  80,
+			Pid:    1,
+		},
+		{
+			Source: util.AddressFromString("127.0.0.1"),
+			SPort:  80,
+			Dest:   util.AddressFromString("127.0.0.1"),
+			DPort:  60000,
+			Pid:    2,
+		},
+	}
+
+	kafkaStats := kafka.RequestStats{
+		Data: [2]*kafka.RequestStat{
+			{
+				Count: 9,
+			},
+			{
+				Count: 2,
+			},
+		},
+	}
+
+	kafkaKey := kafka.NewKey(
+		util.AddressFromString("127.0.0.1"),
+		util.AddressFromString("127.0.0.1"),
+		60000,
+		80,
+		"topic1",
+	)
+
+	in := &network.Connections{
+		BufferedData: network.BufferedData{
+			Conns: connections,
+		},
+		Kafka: map[kafka.Key]*kafka.RequestStats{
+			kafkaKey: &kafkaStats,
+		},
+	}
+
+	kafkaEncoder := newKafkaEncoder(in)
+
+	// assert that both ends (client:server, server:client) of the connection
+	// will have Kafka stats
+	aggregations := kafkaEncoder.GetKafkaAggregations(connections[0])
+	assert.NotNil(aggregations)
+	assert.Equal("topic1", aggregations.KafkaProduceAggregations.Stats[0].Topic)
+	assert.Equal("topic1", aggregations.KafkaFetchAggregations.Stats[0].Topic)
+	assert.Equal(uint32(9), aggregations.KafkaProduceAggregations.Stats[0].Count)
+	assert.Equal(uint32(2), aggregations.KafkaFetchAggregations.Stats[0].Count)
+
+	aggregations = kafkaEncoder.GetKafkaAggregations(connections[1])
+	assert.NotNil(aggregations)
+	assert.Equal("topic1", aggregations.KafkaProduceAggregations.Stats[0].Topic)
+	assert.Equal("topic1", aggregations.KafkaFetchAggregations.Stats[0].Topic)
+	assert.Equal(uint32(9), aggregations.KafkaProduceAggregations.Stats[0].Count)
+	assert.Equal(uint32(2), aggregations.KafkaFetchAggregations.Stats[0].Count)
+}

--- a/pkg/network/event_common.go
+++ b/pkg/network/event_common.go
@@ -478,6 +478,21 @@ func HTTPKeyTuplesFromConn(c ConnectionStats) [2]http.KeyTuple {
 	}
 }
 
+// KafkaKeyTuplesFromConn build the key for the kafka map based on whether the local or remote side is kafka.
+func KafkaKeyTuplesFromConn(c ConnectionStats) [2]kafka.KeyTuple {
+	// Retrieve translated addresses
+	laddr, lport := GetNATLocalAddress(c)
+	raddr, rport := GetNATRemoteAddress(c)
+
+	// Kafka data is always indexed as (client, server), but we don't know which is the remote
+	// and which is the local address. To account for this, we'll construct 2 possible
+	// kafka keys and check for both of them in our kafka aggregations map.
+	return [2]kafka.KeyTuple{
+		kafka.NewKeyTuple(laddr, raddr, lport, rport),
+		kafka.NewKeyTuple(raddr, laddr, rport, lport),
+	}
+}
+
 func generateConnectionKey(c ConnectionStats, buf []byte, useNAT bool) []byte {
 	laddr, sport := c.Source, c.SPort
 	raddr, dport := c.Dest, c.DPort

--- a/pkg/network/kafka/kafka_stats.go
+++ b/pkg/network/kafka/kafka_stats.go
@@ -5,6 +5,8 @@
 
 package kafka
 
+import "github.com/DataDog/datadog-agent/pkg/process/util"
+
 //// Method is the type used to represent HTTP request methods
 //type Method uint8
 //
@@ -83,31 +85,27 @@ type Key struct {
 	//ApiKey uint16
 }
 
-//// NewKey generates a new Key
-//func NewKey(saddr, daddr util.Address, sport, dport uint16, path string, fullPath bool, method Method) Key {
-//	return Key{
-//		KeyTuple: NewKeyTuple(saddr, daddr, sport, dport),
-//		Path: Path{
-//			Content:  path,
-//			FullPath: fullPath,
-//		},
-//		Method: method,
-//	}
-//}
-//
-//// NewKeyTuple generates a new KeyTuple
-//func NewKeyTuple(saddr, daddr util.Address, sport, dport uint16) KeyTuple {
-//	saddrl, saddrh := util.ToLowHigh(saddr)
-//	daddrl, daddrh := util.ToLowHigh(daddr)
-//	return KeyTuple{
-//		SrcIPHigh: saddrh,
-//		SrcIPLow:  saddrl,
-//		SrcPort:   sport,
-//		DstIPHigh: daddrh,
-//		DstIPLow:  daddrl,
-//		DstPort:   dport,
-//	}
-//}
+// NewKey generates a new Key
+func NewKey(saddr, daddr util.Address, sport, dport uint16, topicName string) Key {
+	return Key{
+		KeyTuple:  NewKeyTuple(saddr, daddr, sport, dport),
+		TopicName: topicName,
+	}
+}
+
+// NewKeyTuple generates a new KeyTuple
+func NewKeyTuple(saddr, daddr util.Address, sport, dport uint16) KeyTuple {
+	saddrl, saddrh := util.ToLowHigh(saddr)
+	daddrl, daddrh := util.ToLowHigh(daddr)
+	return KeyTuple{
+		SrcIPHigh: saddrh,
+		SrcIPLow:  saddrl,
+		SrcPort:   sport,
+		DstIPHigh: daddrh,
+		DstIPLow:  daddrl,
+		DstPort:   dport,
+	}
+}
 
 //// NumStatusClasses represents the number of HTTP status classes (1XX, 2XX, 3XX, 4XX, 5XX)
 //const NumStatusClasses = 5

--- a/pkg/network/kafka/kafka_types_linux.go
+++ b/pkg/network/kafka/kafka_types_linux.go
@@ -20,18 +20,17 @@ type kafkaBatchState struct {
 }
 
 type ebpfKafkaTx struct {
-	Owned_by_src_port                  uint16
 	Tup                                kafkaConnTuple
 	Request_api_key                    uint16
 	Request_api_version                uint16
 	Correlation_id                     uint32
+	Tcp_seq                            uint32
 	Current_offset_in_request_fragment uint32
-	Pad_cgo_0                          [4]byte
 	Request_fragment                   [160]byte
 	Client_id                          [56]int8
 	Topic_name                         [64]int8
-	Tcp_seq                            uint32
-	Pad_cgo_1                          [4]byte
+	Owned_by_src_port                  uint16
+	Pad_cgo_0                          [6]byte
 }
 type kafkaBatch struct {
 	Idx uint64


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Adding encoding of kafka records in system-probe

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Sending the kafka traffic to the backend

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
