### PR TITLE
Fix connection classification flakiness

### DIFF
--- a/pkg/ebpf/bytecode/runtime/conntrack.go
+++ b/pkg/ebpf/bytecode/runtime/conntrack.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var Conntrack = newAsset("conntrack.c", "7d456a75b2ae67e7ca365042a13a9c16ec68305dd667195c4e9ac7929519b853")
+var Conntrack = newAsset("conntrack.c", "1b52b0b4573e72f895e86c1dc15cb8a8b30a19d3e93897cc84fb404474d24a12")

--- a/pkg/ebpf/bytecode/runtime/conntrack.go
+++ b/pkg/ebpf/bytecode/runtime/conntrack.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var Conntrack = newAsset("conntrack.c", "9133f017cdb0302b433da78f307e8a5ab9b79f0e4c662d31a0a07b148ce8183c")
+var Conntrack = newAsset("conntrack.c", "7d456a75b2ae67e7ca365042a13a9c16ec68305dd667195c4e9ac7929519b853")

--- a/pkg/ebpf/bytecode/runtime/http.go
+++ b/pkg/ebpf/bytecode/runtime/http.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var Http = newAsset("http.c", "2bd619d9d3200cffd5ee356e1c4d74c0ea6a550d40fca15642938b7b5f8663b3")
+var Http = newAsset("http.c", "fc69125cacc68764cac3b1a50f0cb59f03dd0025a9e1b8343856c6c9412caac3")

--- a/pkg/ebpf/bytecode/runtime/http.go
+++ b/pkg/ebpf/bytecode/runtime/http.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var Http = newAsset("http.c", "33bf9efe973cb331d6b86ab9e6066735543010f13143c70dcecd9c4398ed75d8")
+var Http = newAsset("http.c", "2bd619d9d3200cffd5ee356e1c4d74c0ea6a550d40fca15642938b7b5f8663b3")

--- a/pkg/ebpf/bytecode/runtime/tracer.go
+++ b/pkg/ebpf/bytecode/runtime/tracer.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var Tracer = newAsset("tracer.c", "f6fee46081a50392240f04448ccdf8a0f3b791d6ccf09bafbcde85c33127b0ab")
+var Tracer = newAsset("tracer.c", "4a1833b16e71e4845dcff098d3fc4b655560c341873f02466ce1192b5b5e51a5")

--- a/pkg/ebpf/bytecode/runtime/tracer.go
+++ b/pkg/ebpf/bytecode/runtime/tracer.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var Tracer = newAsset("tracer.c", "4a1833b16e71e4845dcff098d3fc4b655560c341873f02466ce1192b5b5e51a5")
+var Tracer = newAsset("tracer.c", "344ebdd88f88d7f7fa87cb7fa5731545c59898cf7839e651dc257d5e2a6afe4f")

--- a/pkg/network/ebpf/c/ip.h
+++ b/pkg/network/ebpf/c/ip.h
@@ -113,15 +113,8 @@ __maybe_unused static __always_inline __u64 read_conn_tuple_skb(struct __sk_buff
 }
 
 __maybe_unused static __always_inline bool is_equal(conn_tuple_t *t, conn_tuple_t *t2) {
-    return t->saddr_l == t2->saddr_l &&
-        t->saddr_h == t2->saddr_h &&
-        t->daddr_l == t2->daddr_l &&
-        t->daddr_h == t2->daddr_h &&
-        t->sport == t2->sport &&
-        t->dport == t2->dport &&
-        t->netns == t2->netns &&
-        t->pid == t2->pid &&
-        t->metadata == t2->metadata;
+    bool match = !bpf_memcmp(t, t2, sizeof(conn_tuple_t));
+    return match;
 }
 
 // On older kernels, clang can generate Wunused-function warnings on static inline functions defined in

--- a/pkg/network/ebpf/c/ip.h
+++ b/pkg/network/ebpf/c/ip.h
@@ -51,7 +51,7 @@ static __always_inline void read_ipv4_skb(struct __sk_buff *skb, __u64 off, __u6
     *addr = bpf_ntohll(*addr) >> 32;
 }
 
-// On older kernels, clang can generate Wunused-function warnings on static inline functions defined in 
+// On older kernels, clang can generate Wunused-function warnings on static inline functions defined in
 // header files, even if they are later used in source files. __maybe_unused prevents that issue
 __maybe_unused static __always_inline __u64 read_conn_tuple_skb(struct __sk_buff *skb, skb_info_t *info, conn_tuple_t *tup) {
     bpf_memset(info, 0, sizeof(skb_info_t));
@@ -112,7 +112,19 @@ __maybe_unused static __always_inline __u64 read_conn_tuple_skb(struct __sk_buff
     return 1;
 }
 
-// On older kernels, clang can generate Wunused-function warnings on static inline functions defined in 
+__maybe_unused static __always_inline bool is_equal(conn_tuple_t *t, conn_tuple_t *t2) {
+    return t->saddr_l == t2->saddr_l &&
+        t->saddr_h == t2->saddr_h &&
+        t->daddr_l == t2->daddr_l &&
+        t->daddr_h == t2->daddr_h &&
+        t->sport == t2->sport &&
+        t->dport == t2->dport &&
+        t->netns == t2->netns &&
+        t->pid == t2->pid &&
+        t->metadata == t2->metadata;
+}
+
+// On older kernels, clang can generate Wunused-function warnings on static inline functions defined in
 // header files, even if they are later used in source files. __maybe_unused prevents that issue
 __maybe_unused static __always_inline void flip_tuple(conn_tuple_t *t) {
     // TODO: we can probably replace this by swap operations
@@ -129,7 +141,7 @@ __maybe_unused static __always_inline void flip_tuple(conn_tuple_t *t) {
     t->daddr_h = tmp_ip_part;
 }
 
-// On older kernels, clang can generate Wunused-function warnings on static inline functions defined in 
+// On older kernels, clang can generate Wunused-function warnings on static inline functions defined in
 // header files, even if they are later used in source files. __maybe_unused prevents that issue
 __maybe_unused static __always_inline void print_ip(u64 ip_h, u64 ip_l, u16 port, u32 metadata) {
     if (metadata & CONN_V6) {

--- a/pkg/network/ebpf/c/protocols/protocol-classification-helpers.h
+++ b/pkg/network/ebpf/c/protocols/protocol-classification-helpers.h
@@ -31,7 +31,7 @@ static __always_inline bool is_http2(const char* buf, __u32 buf_size) {
 #define HTTP2_SIGNATURE "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n"
 
     bool match = !bpf_memcmp(buf, HTTP2_SIGNATURE, sizeof(HTTP2_SIGNATURE)-1);
-    
+
     return match;
 }
 
@@ -40,11 +40,11 @@ static __always_inline bool is_http2(const char* buf, __u32 buf_size) {
 static __always_inline bool is_http(const char *buf, __u32 size) {
     CHECK_PRELIMINARY_BUFFER_CONDITIONS(buf, size, HTTP_MIN_SIZE)
 
-#define HTTP "HTTP"
+#define HTTP "HTTP/"
 #define GET "GET /"
 #define POST "POST /"
 #define PUT "PUT /"
-#define DELETE "DELETE /" 
+#define DELETE "DELETE /"
 #define HEAD "HEAD /"
 #define OPTIONS1 "OPTIONS /"
 #define OPTIONS2 "OPTIONS *"
@@ -69,7 +69,7 @@ static __always_inline bool is_http(const char *buf, __u32 size) {
 // Determines the protocols of the given buffer. If we already classified the payload (a.k.a protocol out param
 // has a known protocol), then we do nothing.
 static __always_inline void classify_protocol(protocol_t *protocol, const char *buf, __u32 size) {
-    if (protocol == NULL || (*protocol != PROTOCOL_UNKNOWN && *protocol != PROTOCOL_UNCLASSIFIED)) {
+    if (protocol == NULL || *protocol != PROTOCOL_UNKNOWN) {
         return;
     }
 
@@ -154,67 +154,6 @@ static __always_inline void read_into_buffer_for_classification(char *buffer, st
     }
 }
 
-// checks if we have seen that tcp packet before. It can happen if a packet travels multiple interfaces or retransmissions.
-static __always_inline bool has_sequence_seen_before(conn_tuple_t *tup, skb_info_t *skb_info) {
-    if (!skb_info || !skb_info->tcp_seq) {
-        return false;
-    }
-
-    u32 *tcp_seq = bpf_map_lookup_elem(&connection_states, tup);
-
-    // check if we've seen this TCP segment before. this can happen in the
-    // context of localhost traffic where the same TCP segment can be seen
-    // multiple times coming in and out from different interfaces
-    if (tcp_seq != NULL && *tcp_seq == skb_info->tcp_seq) {
-        return true;
-    }
-
-    bpf_map_update_elem(&connection_states, tup, &skb_info->tcp_seq, BPF_ANY);
-    return false;
-}
-
-// Returns the cached protocol for the given connection tuple, or PROTOCOL_UNCLASSIFIED if missing.
-static __always_inline protocol_t get_cached_protocol_or_default(conn_tuple_t *tup) {
-    protocol_t *cached_protocol_ptr = bpf_map_lookup_elem(&connection_protocol, tup);
-    if (cached_protocol_ptr != NULL) {
-        return *cached_protocol_ptr;
-    }
-
-    return PROTOCOL_UNCLASSIFIED;
-}
-
-// Given protocols for the socket connection tuple, and the inverse skb connection tuple, the function returns
-// the final protocol among the two.
-// If the sock_tup_protocol is unclassified, then it does not matter what's the value of the inverse_skb_tup_protocol,
-// we will take it. If the inverse_skb_tup_protocol is unclassified as well, then it does not matter which "unclassified"
-// we choose. If it is unknown or classified, then we should choose it.
-// If the sock_tup_protocol is unknown, then we take the inverse_skb_tup_protocol if it is classified or unknown.
-// If both are unknown, then it does not matter which "unknown" we choose. If the inverse_skb_tup_protocol is classified,
-// then for sure we should choose it.
-// On any other case take sock_tup_protocol.
-static __always_inline protocol_t choose_protocol(protocol_t sock_tup_protocol, protocol_t inverse_skb_tup_protocol) {
-    if ((sock_tup_protocol == PROTOCOL_UNCLASSIFIED) ||
-        (sock_tup_protocol == PROTOCOL_UNKNOWN && inverse_skb_tup_protocol != PROTOCOL_UNCLASSIFIED)) {
-        return inverse_skb_tup_protocol;
-    }
-
-    // On any other case, we give the priority to the classified protocol for the socket connection tuple
-    return sock_tup_protocol;
-}
-
-// Replaces the source and dest fields (addresses and ports).
-static __always_inline void invert_conn_tuple(conn_tuple_t *original_conn, conn_tuple_t *output_conn) {
-    output_conn->saddr_h = original_conn->daddr_h;
-    output_conn->saddr_l = original_conn->daddr_l;
-    output_conn->daddr_h = original_conn->saddr_h;
-    output_conn->daddr_l = original_conn->saddr_l;
-    output_conn->sport = original_conn->dport;
-    output_conn->dport = original_conn->sport;
-    output_conn->metadata = original_conn->metadata;
-    output_conn->pid = original_conn->pid;
-    output_conn->netns = original_conn->netns;
-}
-
 // A shared implementation for the runtime & prebuilt socket filter that classifies the protocols of the connections.
 static __always_inline void protocol_classifier_entrypoint(struct __sk_buff *skb) {
     skb_info_t skb_info = {0};
@@ -230,42 +169,30 @@ static __always_inline void protocol_classifier_entrypoint(struct __sk_buff *skb
         return;
     }
 
-    // Making sure we've not processed the same tcp segment, which can happen when a single packet travels different
-    // interfaces.
-    if (has_sequence_seen_before(&skb_tup, &skb_info)) {
-        return;
-    }
+    protocol_t *cur_fragment_protocol_ptr = bpf_map_lookup_elem(&connection_protocol, &skb_tup);
+    if (cur_fragment_protocol_ptr == NULL) {
+        conn_tuple_t inverse_skb_conn_tup = skb_tup;
+        flip_tuple(&inverse_skb_conn_tup);
 
-    conn_tuple_t *cached_sock_conn_tup_ptr = bpf_map_lookup_elem(&skb_conn_tuple_to_socket_conn_tuple, &skb_tup);
-    if (cached_sock_conn_tup_ptr == NULL) {
-        return;
-    }
+        cur_fragment_protocol_ptr = bpf_map_lookup_elem(&connection_protocol, &inverse_skb_conn_tup);
 
-    conn_tuple_t cached_sock_conn_tup = *cached_sock_conn_tup_ptr;
-    conn_tuple_t inverse_skb_conn_tup = {0};
-    invert_conn_tuple(&skb_tup, &inverse_skb_conn_tup);
-    inverse_skb_conn_tup.pid = 0;
-    inverse_skb_conn_tup.netns = 0;
-
-    protocol_t sock_tup_protocol = get_cached_protocol_or_default(&cached_sock_conn_tup);
-    protocol_t inverse_skb_tup_protocol = get_cached_protocol_or_default(&inverse_skb_conn_tup);
-    protocol_t cur_fragment_protocol = choose_protocol(sock_tup_protocol, inverse_skb_tup_protocol);
-
-    // If we've already identified the protocol of the socket, no need to read the buffer and try to classify it.
-    if (cur_fragment_protocol == PROTOCOL_UNCLASSIFIED || cur_fragment_protocol == PROTOCOL_UNKNOWN) {
-        char request_fragment[CLASSIFICATION_MAX_BUFFER];
-        bpf_memset(request_fragment, 0, sizeof(request_fragment));
-        read_into_buffer_for_classification((char *)request_fragment, skb, &skb_info);
-        classify_protocol(&cur_fragment_protocol, request_fragment, sizeof(request_fragment));
-    }
-
-    log_debug("[protocol_classifier_entrypoint]: Classifying protocol as: %d\n", cur_fragment_protocol);
-    // If there has been a change in the classification, save the new protocol.
-    if (sock_tup_protocol != cur_fragment_protocol) {
-        bpf_map_update_with_telemetry(connection_protocol, &cached_sock_conn_tup, &cur_fragment_protocol, BPF_ANY);
-    }
-    if (inverse_skb_tup_protocol != cur_fragment_protocol) {
-        bpf_map_update_with_telemetry(connection_protocol, &inverse_skb_conn_tup, &cur_fragment_protocol, BPF_ANY);
+        // If we've already identified the protocol of the socket, no need to read the buffer and try to classify it.
+        if (cur_fragment_protocol_ptr == NULL) {
+            protocol_t cur_fragment_protocol = PROTOCOL_UNKNOWN;
+            log_debug("[protocol_classifier_entrypoint]: %p was not classified\n", skb);
+            char request_fragment[CLASSIFICATION_MAX_BUFFER];
+            bpf_memset(request_fragment, 0, sizeof(request_fragment));
+            read_into_buffer_for_classification((char *)request_fragment, skb, &skb_info);
+            const size_t payload_length = skb->len - skb_info.data_off;
+            const size_t final_fragment_size = payload_length < CLASSIFICATION_MAX_BUFFER ? payload_length : CLASSIFICATION_MAX_BUFFER;
+            classify_protocol(&cur_fragment_protocol, request_fragment, final_fragment_size);
+            log_debug("[protocol_classifier_entrypoint]: %p Classifying protocol as: %d\n", skb, cur_fragment_protocol);
+            // If there has been a change in the classification, save the new protocol.
+            if (cur_fragment_protocol != PROTOCOL_UNKNOWN) {
+                bpf_map_update_with_telemetry(connection_protocol, &skb_tup, &cur_fragment_protocol, BPF_NOEXIST);
+                bpf_map_update_with_telemetry(connection_protocol, &inverse_skb_conn_tup, &cur_fragment_protocol, BPF_NOEXIST);
+            }
+        }
     }
 }
 

--- a/pkg/network/ebpf/c/protocols/protocol-classification-maps.h
+++ b/pkg/network/ebpf/c/protocols/protocol-classification-maps.h
@@ -16,7 +16,6 @@ BPF_HASH_MAP(connection_protocol, conn_tuple_t, protocol_t, 1024)
 // one we extract from the sock object, and then we are not able to correctly classify those protocols.
 // To overcome those problems, we save two maps that translates from conn tuple of sk_buff to conn tuple of sock* and vice
 // versa (the vice versa is used for cleanup purposes).
-BPF_HASH_MAP(skb_conn_tuple_to_socket_conn_tuple, conn_tuple_t, conn_tuple_t, 1024)
 BPF_HASH_MAP(conn_tuple_to_socket_skb_conn_tuple, conn_tuple_t, conn_tuple_t, 1024)
 
 // Maps a connection tuple to latest tcp segment we've processed. Helps to detect same packets that travels multiple

--- a/pkg/network/ebpf/c/runtime/tracer.c
+++ b/pkg/network/ebpf/c/runtime/tracer.c
@@ -92,8 +92,7 @@ int kretprobe__tcp_sendmsg(struct pt_regs *ctx) {
     __u32 packets_out = 0;
     get_tcp_segment_counts(skp, &packets_in, &packets_out);
 
-    protocol_t protocol = get_protocol(&t);
-    return handle_message(&t, sent, 0, CONN_DIRECTION_UNKNOWN, packets_out, packets_in, PACKET_COUNT_ABSOLUTE, protocol, skp);
+    return handle_message(&t, sent, 0, CONN_DIRECTION_UNKNOWN, packets_out, packets_in, PACKET_COUNT_ABSOLUTE, skp);
 }
 
 SEC("kprobe/tcp_close")
@@ -209,7 +208,7 @@ int kretprobe__ip6_make_skb(struct pt_regs *ctx) {
     }
 
     log_debug("kprobe/ip6_make_skb: pid_tgid: %d, size: %d\n", pid_tgid, size);
-    handle_message(&t, size, 0, CONN_DIRECTION_UNKNOWN, 1, 0, PACKET_COUNT_INCREMENT, PROTOCOL_UNCLASSIFIED, sk);
+    handle_message(&t, size, 0, CONN_DIRECTION_UNKNOWN, 1, 0, PACKET_COUNT_INCREMENT, sk);
     increment_telemetry_count(udp_send_processed);
 
     return 0;
@@ -275,7 +274,7 @@ int kretprobe__ip_make_skb(struct pt_regs *ctx) {
     }
 
     log_debug("kprobe/ip_send_skb: pid_tgid: %d, size: %d\n", pid_tgid, size);
-    handle_message(&t, size, 0, CONN_DIRECTION_UNKNOWN, 1, 0, PACKET_COUNT_INCREMENT, PROTOCOL_UNCLASSIFIED, sk);
+    handle_message(&t, size, 0, CONN_DIRECTION_UNKNOWN, 1, 0, PACKET_COUNT_INCREMENT, sk);
     increment_telemetry_count(udp_send_processed);
 
     return 0;
@@ -300,7 +299,7 @@ static __always_inline void handle_skb_consume_udp(struct sock *sk, struct sk_bu
     u64 pid_tgid = bpf_get_current_pid_tgid();
     t.pid = pid_tgid >> 32;
     t.netns = get_netns(&sk->sk_net);
-    handle_message(&t, 0, data_len, CONN_DIRECTION_UNKNOWN, 0, 1, PACKET_COUNT_INCREMENT, PROTOCOL_UNCLASSIFIED, sk);
+    handle_message(&t, 0, data_len, CONN_DIRECTION_UNKNOWN, 0, 1, PACKET_COUNT_INCREMENT, sk);
 }
 
 static __always_inline int handle_udp_recvmsg(struct pt_regs *ctx) {
@@ -460,7 +459,7 @@ int kprobe__tcp_finish_connect(struct pt_regs *ctx) {
     }
 
     handle_tcp_stats(&t, skp, TCP_ESTABLISHED);
-    handle_message(&t, 0, 0, CONN_DIRECTION_OUTGOING, 0, 0, PACKET_COUNT_NONE, PROTOCOL_UNCLASSIFIED, skp);
+    handle_message(&t, 0, 0, CONN_DIRECTION_OUTGOING, 0, 0, PACKET_COUNT_NONE, skp);
 
     log_debug("kprobe/tcp_connect: netns: %u, sport: %u, dport: %u\n", t.netns, t.sport, t.dport);
 
@@ -482,7 +481,7 @@ int kretprobe__inet_csk_accept(struct pt_regs *ctx) {
         return 0;
     }
     handle_tcp_stats(&t, sk, TCP_ESTABLISHED);
-    handle_message(&t, 0, 0, CONN_DIRECTION_INCOMING, 0, 0, PACKET_COUNT_NONE, PROTOCOL_UNCLASSIFIED, sk);
+    handle_message(&t, 0, 0, CONN_DIRECTION_INCOMING, 0, 0, PACKET_COUNT_NONE, sk);
 
     port_binding_t pb = {};
     pb.netns = t.netns;
@@ -755,7 +754,7 @@ int kretprobe__do_sendfile(struct pt_regs *ctx) {
         __u32 packets_in = 0;
         __u32 packets_out = 0;
         get_tcp_segment_counts(*sock, &packets_in, &packets_out);
-        handle_message(&t, sent, 0, CONN_DIRECTION_UNKNOWN, packets_out, packets_in, PACKET_COUNT_ABSOLUTE, PROTOCOL_UNCLASSIFIED, *sock);
+        handle_message(&t, sent, 0, CONN_DIRECTION_UNKNOWN, packets_out, packets_in, PACKET_COUNT_ABSOLUTE, *sock);
     }
 cleanup:
     bpf_map_delete_elem(&do_sendfile_args, &pid_tgid);
@@ -796,9 +795,11 @@ int tracepoint__net__net_dev_queue(struct net_dev_queue_ctx* ctx) {
         return 0;
     }
     sock_tup.netns = 0;
+    sock_tup.pid = 0;
 
-    bpf_map_update_with_telemetry(skb_conn_tuple_to_socket_conn_tuple, &skb_tup, &sock_tup, BPF_ANY);
-    bpf_map_update_with_telemetry(conn_tuple_to_socket_skb_conn_tuple, &sock_tup, &skb_tup, BPF_ANY);
+    if (!is_equal(&skb_tup, &sock_tup)) {
+        bpf_map_update_with_telemetry(conn_tuple_to_socket_skb_conn_tuple, &sock_tup, &skb_tup, BPF_NOEXIST);
+    }
 
     return 0;
 }

--- a/pkg/network/ebpf/c/tcp-recv.h
+++ b/pkg/network/ebpf/c/tcp-recv.h
@@ -18,8 +18,7 @@ int __always_inline handle_tcp_recv(u64 pid_tgid, struct sock *skp, int recv) {
     __u32 packets_out = 0;
     get_tcp_segment_counts(skp, &packets_in, &packets_out);
 
-    protocol_t protocol = get_protocol(&t);
-    return handle_message(&t, 0, recv, CONN_DIRECTION_UNKNOWN, packets_out, packets_in, PACKET_COUNT_ABSOLUTE, protocol, skp);
+    return handle_message(&t, 0, recv, CONN_DIRECTION_UNKNOWN, packets_out, packets_in, PACKET_COUNT_ABSOLUTE, skp);
 }
 
 SEC("kprobe/tcp_recvmsg")

--- a/pkg/network/ebpf/c/tracer-events.h
+++ b/pkg/network/ebpf/c/tracer-events.h
@@ -25,12 +25,12 @@ static __always_inline void clean_protocol_classification(conn_tuple_t *tup) {
     conn_tuple_t *skb_tup_ptr = bpf_map_lookup_elem(&conn_tuple_to_socket_skb_conn_tuple, &conn_tuple);
     if (skb_tup_ptr != NULL) {
         conn_tuple_t skb_tup = *skb_tup_ptr;
-        conn_tuple_t inverse_skb_conn_tup = {0};
-        invert_conn_tuple(skb_tup_ptr, &inverse_skb_conn_tup);
+        conn_tuple_t inverse_skb_conn_tup = *skb_tup_ptr;
+        flip_tuple(&inverse_skb_conn_tup);
         inverse_skb_conn_tup.pid = 0;
         inverse_skb_conn_tup.netns = 0;
         bpf_map_delete_elem(&connection_protocol, &inverse_skb_conn_tup);
-        bpf_map_delete_elem(&conn_tuple_to_socket_skb_conn_tuple, &skb_tup);
+        bpf_map_delete_elem(&connection_protocol, &skb_tup);
     }
 
     bpf_map_delete_elem(&conn_tuple_to_socket_skb_conn_tuple, &conn_tuple);

--- a/pkg/network/ebpf/c/tracer-stats.h
+++ b/pkg/network/ebpf/c/tracer-stats.h
@@ -13,6 +13,7 @@ static __always_inline conn_stats_ts_t *get_conn_stats(conn_tuple_t *t, struct s
     conn_stats_ts_t empty = {};
     bpf_memset(&empty, 0, sizeof(conn_stats_ts_t));
     empty.cookie = get_sk_cookie(sk);
+    empty.protocol = PROTOCOL_UNKNOWN;
     bpf_map_update_with_telemetry(conn_stats, t, &empty, BPF_NOEXIST);
     return bpf_map_lookup_elem(&conn_stats, t);
 }
@@ -45,15 +46,39 @@ static __always_inline protocol_t get_protocol(conn_tuple_t *t) {
     conn_tuple_copy.netns = 0;
     conn_tuple_copy.pid = 0;
     protocol_t *cached_protocol_ptr = bpf_map_lookup_elem(&connection_protocol, &conn_tuple_copy);
-
     if (cached_protocol_ptr != NULL) {
        return *cached_protocol_ptr;
     }
-    return PROTOCOL_UNCLASSIFIED;
+
+    conn_tuple_t *cached_skb_conn_tup_ptr = bpf_map_lookup_elem(&conn_tuple_to_socket_skb_conn_tuple, &conn_tuple_copy);
+    if (cached_skb_conn_tup_ptr != NULL) {
+        conn_tuple_t skb_tup = *cached_skb_conn_tup_ptr;
+        cached_protocol_ptr = bpf_map_lookup_elem(&connection_protocol, &skb_tup);
+        if (cached_protocol_ptr != NULL) {
+           return *cached_protocol_ptr;
+        }
+    }
+
+    flip_tuple(&conn_tuple_copy);
+    cached_protocol_ptr = bpf_map_lookup_elem(&connection_protocol, &conn_tuple_copy);
+    if (cached_protocol_ptr != NULL) {
+       return *cached_protocol_ptr;
+    }
+
+    cached_skb_conn_tup_ptr = bpf_map_lookup_elem(&conn_tuple_to_socket_skb_conn_tuple, &conn_tuple_copy);
+    if (cached_skb_conn_tup_ptr != NULL) {
+        conn_tuple_t skb_tup = *cached_skb_conn_tup_ptr;
+        cached_protocol_ptr = bpf_map_lookup_elem(&connection_protocol, &skb_tup);
+        if (cached_protocol_ptr != NULL) {
+           return *cached_protocol_ptr;
+        }
+    }
+
+    return PROTOCOL_UNKNOWN;
 }
 
 static __always_inline void update_conn_stats(conn_tuple_t *t, size_t sent_bytes, size_t recv_bytes, u64 ts, conn_direction_t dir,
-    __u32 packets_out, __u32 packets_in, packet_count_increment_t segs_type, protocol_t protocol, struct sock *sk) {
+    __u32 packets_out, __u32 packets_in, packet_count_increment_t segs_type, struct sock *sk) {
     conn_stats_ts_t *val;
 
     val = get_conn_stats(t, sk);
@@ -61,9 +86,12 @@ static __always_inline void update_conn_stats(conn_tuple_t *t, size_t sent_bytes
         return;
     }
 
-    if ((val->protocol == PROTOCOL_UNCLASSIFIED) || (val->protocol == PROTOCOL_UNKNOWN && protocol != PROTOCOL_UNCLASSIFIED)) {
-        log_debug("[update_conn_stats]: A connection was classified with protocol %d\n", protocol);
-        val->protocol = protocol;
+    if (val->protocol == PROTOCOL_UNKNOWN) {
+        protocol_t protocol = get_protocol(t);
+        if (protocol != PROTOCOL_UNKNOWN) {
+            log_debug("[update_conn_stats]: A connection was classified with protocol %d\n", protocol);
+            val->protocol = protocol;
+        }
     }
 
     // If already in our map, increment size in-place
@@ -138,10 +166,10 @@ static __always_inline void update_tcp_stats(conn_tuple_t *t, tcp_stats_t stats)
 }
 
 static __always_inline int handle_message(conn_tuple_t *t, size_t sent_bytes, size_t recv_bytes, conn_direction_t dir,
-    __u32 packets_out, __u32 packets_in, packet_count_increment_t segs_type, protocol_t protocol, struct sock *sk) {
+    __u32 packets_out, __u32 packets_in, packet_count_increment_t segs_type, struct sock *sk) {
     u64 ts = bpf_ktime_get_ns();
 
-    update_conn_stats(t, sent_bytes, recv_bytes, ts, dir, packets_out, packets_in, segs_type, protocol, sk);
+    update_conn_stats(t, sent_bytes, recv_bytes, ts, dir, packets_out, packets_in, segs_type, sk);
 
     return 0;
 }

--- a/pkg/network/encoding/encoding_test.go
+++ b/pkg/network/encoding/encoding_test.go
@@ -513,12 +513,14 @@ func TestHTTPSerializationWithLocalhostTraffic(t *testing.T) {
 				Raddr:            &model.Addr{Ip: "127.0.0.1", Port: int32(serverPort)},
 				HttpAggregations: httpOutBlob,
 				RouteIdx:         -1,
+				Protocol:         formatProtocol(network.ProtocolUnknown),
 			},
 			{
 				Laddr:            &model.Addr{Ip: "127.0.0.1", Port: int32(serverPort)},
 				Raddr:            &model.Addr{Ip: "127.0.0.1", Port: int32(clientPort)},
 				HttpAggregations: httpOutBlob,
 				RouteIdx:         -1,
+				Protocol:         formatProtocol(network.ProtocolUnknown),
 			},
 		},
 		AgentConfiguration: &model.AgentConfiguration{

--- a/pkg/network/encoding/format.go
+++ b/pkg/network/encoding/format.go
@@ -285,7 +285,7 @@ func unsafeStringSlice(key string) []byte {
 //	}
 func formatProtocol(protocol network.ProtocolType) *model.ProtocolStack {
 	if protocol == network.ProtocolUnclassified {
-		return nil
+		protocol = network.ProtocolUnknown
 	}
 
 	return &model.ProtocolStack{

--- a/pkg/network/encoding/format_test.go
+++ b/pkg/network/encoding/format_test.go
@@ -110,7 +110,11 @@ func TestFormatProtocols(t *testing.T) {
 		{
 			name:     "unclassified protocol",
 			protocol: network.ProtocolUnclassified,
-			want:     nil,
+			want: &model.ProtocolStack{
+				Stack: []model.ProtocolType{
+					model.ProtocolType_protocolUnknown,
+				},
+			},
 		},
 		{
 			name:     "http protocol",

--- a/pkg/network/event_windows.go
+++ b/pkg/network/event_windows.go
@@ -158,12 +158,9 @@ func FlowToConnStat(cs *ConnectionStats, flow *driver.PerFlowData, enableMonoton
 					cs.Protocol = ProtocolHTTP
 				}
 			}
-
-		} else if flow.ClassificationStatus == driver.ClassificationUnclassified {
-			cs.Protocol = ProtocolUnclassified
 		} else {
 			// one of
-			// ClassificationUnableInsufficientData, ClassificationUnknown
+			// ClassificationUnableInsufficientData, ClassificationUnknown, ClassificationUnclassified
 			cs.Protocol = ProtocolUnknown
 		}
 	}

--- a/pkg/network/state.go
+++ b/pkg/network/state.go
@@ -738,4 +738,10 @@ func mergeConnectionStats(a, b *ConnectionStats) {
 	if a.IPTranslation == nil {
 		a.IPTranslation = b.IPTranslation
 	}
+
+	if a.Protocol == ProtocolUnknown && b.Protocol != ProtocolUnknown {
+		a.Protocol = b.Protocol
+	} else if b.Protocol == ProtocolUnknown && a.Protocol != ProtocolUnknown {
+		b.Protocol = a.Protocol
+	}
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Simplifies the classification code and fixes the flakiness we had in the CI.
The simplification is with removing the usage of PROTOCOL_UNCLASSIFIED, and instead using PROTOCOL_UNKNOWN for those scenarios.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Fixing flakiness in the CI

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
