### PR TITLE
[CWS] do not insert mount with error

### DIFF
--- a/pkg/security/probe/model.go
+++ b/pkg/security/probe/model.go
@@ -169,29 +169,37 @@ func (ev *Event) ResolveXAttrNamespace(e *model.SetXAttrEvent) string {
 }
 
 // SetMountPoint set the mount point information
-func (ev *Event) SetMountPoint(e *model.MountEvent) {
-	e.MountPointStr, e.MountPointPathResolutionError = ev.resolvers.DentryResolver.Resolve(e.ParentMountID, e.ParentInode, 0, true)
+func (ev *Event) SetMountPoint(e *model.MountEvent) error {
+	var err error
+	e.MountPointStr, err = ev.resolvers.DentryResolver.Resolve(e.ParentMountID, e.ParentInode, 0, true)
+	return err
 }
 
 // ResolveMountPoint resolves the mountpoint to a full path
-func (ev *Event) ResolveMountPoint(e *model.MountEvent) string {
+func (ev *Event) ResolveMountPoint(e *model.MountEvent) (string, error) {
 	if len(e.MountPointStr) == 0 {
-		ev.SetMountPoint(e)
+		if err := ev.SetMountPoint(e); err != nil {
+			return "", err
+		}
 	}
-	return e.MountPointStr
+	return e.MountPointStr, nil
 }
 
 // SetMountRoot set the mount point information
-func (ev *Event) SetMountRoot(e *model.MountEvent) {
-	e.RootStr, e.RootPathResolutionError = ev.resolvers.DentryResolver.Resolve(e.RootMountID, e.RootInode, 0, true)
+func (ev *Event) SetMountRoot(e *model.MountEvent) error {
+	var err error
+	e.RootStr, err = ev.resolvers.DentryResolver.Resolve(e.RootMountID, e.RootInode, 0, true)
+	return err
 }
 
 // ResolveMountRoot resolves the mountpoint to a full path
-func (ev *Event) ResolveMountRoot(e *model.MountEvent) string {
+func (ev *Event) ResolveMountRoot(e *model.MountEvent) (string, error) {
 	if len(e.RootStr) == 0 {
-		ev.SetMountRoot(e)
+		if err := ev.SetMountRoot(e); err != nil {
+			return "", err
+		}
 	}
-	return e.RootStr
+	return e.RootStr, nil
 }
 
 // ResolveContainerID resolves the container ID of the event

--- a/pkg/security/probe/mount_resolver.go
+++ b/pkg/security/probe/mount_resolver.go
@@ -11,7 +11,6 @@ package probe
 import (
 	"context"
 	"errors"
-	"fmt"
 	"os"
 	"strconv"
 	"strings"
@@ -213,11 +212,6 @@ func (mr *MountResolver) Get(mountID, pid uint32) (*model.MountEvent, error) {
 func (mr *MountResolver) Insert(e model.MountEvent) error {
 	mr.lock.Lock()
 	defer mr.lock.Unlock()
-
-	if e.MountPointPathResolutionError != nil || e.RootPathResolutionError != nil {
-		// do not insert an invalid value
-		return fmt.Errorf("couldn't insert mount_id %d: mount_point_error:%v root_error:%v", e.MountID, e.MountPointPathResolutionError, e.RootPathResolutionError)
-	}
 
 	mr.insert(e)
 

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -524,18 +524,16 @@ type ArgsEnvsEvent struct {
 //msgp:ignore MountEvent
 type MountEvent struct {
 	SyscallEvent
-	MountID                       uint32
-	GroupID                       uint32
-	Device                        uint32
-	ParentMountID                 uint32
-	ParentInode                   uint64
-	FSType                        string
-	MountPointStr                 string
-	MountPointPathResolutionError error
-	RootMountID                   uint32
-	RootInode                     uint64
-	RootStr                       string
-	RootPathResolutionError       error
+	MountID       uint32
+	GroupID       uint32
+	Device        uint32
+	ParentMountID uint32
+	ParentInode   uint64
+	FSType        string
+	MountPointStr string
+	RootMountID   uint32
+	RootInode     uint64
+	RootStr       string
 
 	FSTypeRaw [16]byte
 }
@@ -548,22 +546,6 @@ func (m *MountEvent) GetFSType() string {
 // IsOverlayFS returns whether it is an overlay fs
 func (m *MountEvent) IsOverlayFS() bool {
 	return m.GetFSType() == "overlay"
-}
-
-// GetRootPathResolutionError returns the root path resolution error as a string if there is one
-func (m *MountEvent) GetRootPathResolutionError() string {
-	if m.RootPathResolutionError != nil {
-		return m.RootPathResolutionError.Error()
-	}
-	return ""
-}
-
-// GetMountPointPathResolutionError returns the mount point path resolution error as a string if there is one
-func (m *MountEvent) GetMountPointPathResolutionError() string {
-	if m.MountPointPathResolutionError != nil {
-		return m.MountPointPathResolutionError.Error()
-	}
-	return ""
 }
 
 // OpenEvent represents an open event


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Do not insert mount point with resolution error and convert error into debug log level for mount resolution error. Path resolution error will still be reported has the mount won't be found in the cache.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
