### PR TITLE
Remove SetHostname and co

### DIFF
--- a/pkg/aggregator/aggregator_test.go
+++ b/pkg/aggregator/aggregator_test.go
@@ -220,25 +220,6 @@ func TestAddEventDefaultValues(t *testing.T) {
 	assert.Equal(t, "custom_source_type", event2.SourceTypeName)
 }
 
-func TestSetHostname(t *testing.T) {
-	// this test IS USING globals
-	// -
-
-	agg := getAggregator()
-	agg.checkSamplers = make(map[check.ID]*CheckSampler)
-
-	assert.Equal(t, "hostname", agg.hostname)
-	sender, err := GetSender(checkID1)
-	require.NoError(t, err)
-	checkSender, ok := sender.(*checkSender)
-	require.True(t, ok)
-	assert.Equal(t, "hostname", checkSender.defaultHostname)
-
-	agg.SetHostname("different-hostname")
-	assert.Equal(t, "different-hostname", agg.hostname)
-	assert.Equal(t, "different-hostname", checkSender.defaultHostname)
-}
-
 func TestDefaultData(t *testing.T) {
 	// this test IS USING globals (tagsetTlm) but a local aggregator
 	// -

--- a/pkg/aggregator/demultiplexer.go
+++ b/pkg/aggregator/demultiplexer.go
@@ -76,7 +76,6 @@ type Demultiplexer interface {
 	SetSender(sender Sender, id check.ID) error
 	DestroySender(id check.ID)
 	GetDefaultSender() (Sender, error)
-	ChangeAllSendersDefaultHostname(hostname string)
 	cleanSenders()
 }
 

--- a/pkg/aggregator/demultiplexer_senders.go
+++ b/pkg/aggregator/demultiplexer_senders.go
@@ -60,15 +60,6 @@ func (s *senders) DestroySender(id check.ID) {
 	s.senderPool.removeSender(id)
 }
 
-// ChangeAllSendersDefaultHostname is to be called by the aggregator
-// when its hostname changes. All existing senders will have their
-// default hostname updated.
-func (s *senders) ChangeAllSendersDefaultHostname(hostname string) {
-	if s.senderPool != nil {
-		s.senderPool.changeAllSendersDefaultHostname(hostname)
-	}
-}
-
 // getDefaultSender returns a default sender.
 func (s *senders) GetDefaultSender() (Sender, error) {
 	s.senderInit.Do(func() {

--- a/pkg/aggregator/sender.go
+++ b/pkg/aggregator/sender.go
@@ -183,16 +183,6 @@ func GetDefaultSender() (Sender, error) {
 	return demultiplexerInstance.GetDefaultSender()
 }
 
-// changeAllSendersDefaultHostname is to be called by the aggregator
-// when its hostname changes. All existing senders will have their
-// default hostname updated.
-func changeAllSendersDefaultHostname(hostname string) {
-	if demultiplexerInstance == nil {
-		return
-	}
-	demultiplexerInstance.ChangeAllSendersDefaultHostname(hostname)
-}
-
 // DisableDefaultHostname allows check to override the default hostname that will be injected
 // when no hostname is specified at submission (for metrics, events and service checks).
 func (s *checkSender) DisableDefaultHostname(disable bool) {
@@ -446,19 +436,6 @@ func (s *checkSender) OrchestratorManifest(msgs []serializer.ProcessMessageBody,
 }
 func (s *checkSender) ContainerLifecycleEvent(msgs []serializer.ContainerLifecycleMessage) {
 	s.contlcycleOut <- senderContainerLifecycleEvent{msgs: msgs}
-}
-
-// changeAllSendersDefaultHostname u
-func (sp *checkSenderPool) changeAllSendersDefaultHostname(hostname string) {
-	sp.m.Lock()
-	defer sp.m.Unlock()
-	for _, sender := range sp.senders {
-		cs, ok := sender.(*checkSender)
-		if !ok {
-			continue
-		}
-		cs.defaultHostname = hostname
-	}
 }
 
 func (sp *checkSenderPool) getSender(id check.ID) (Sender, error) {

--- a/pkg/aggregator/sender_test.go
+++ b/pkg/aggregator/sender_test.go
@@ -193,15 +193,13 @@ func TestGetSenderDefaultHostname(t *testing.T) {
 	aggregatorInstance := demux.Aggregator()
 	go aggregatorInstance.run()
 
-	aggregatorInstance.SetHostname(altDefaultHostname)
-
 	sender, err := demux.GetSender(checkID1)
 	require.NoError(t, err)
 
 	checksender, ok := sender.(*checkSender)
 	require.True(t, ok)
 
-	assert.Equal(t, altDefaultHostname, checksender.defaultHostname)
+	assert.Equal(t, demux.Aggregator().hostname, checksender.defaultHostname)
 	assert.Equal(t, false, checksender.defaultHostnameDisabled)
 
 	aggregatorInstance.Stop()
@@ -596,28 +594,4 @@ func TestCheckSenderHostname(t *testing.T) {
 			assert.Equal(t, []string{"foo", "bar"}, event.Tags)
 		})
 	}
-}
-
-func TestChangeAllSendersDefaultHostname(t *testing.T) {
-	// this test not using anything global
-	// -
-
-	demux := testDemux()
-
-	s := initSender(checkID1, "hostname1")
-	demux.SetSender(s.sender, checkID1)
-
-	s.sender.Gauge("my.metric", 1.0, "", nil)
-	gaugeSenderSample := (<-s.itemChan).(*senderMetricSample)
-	assert.Equal(t, "hostname1", gaugeSenderSample.metricSample.Host)
-
-	demux.ChangeAllSendersDefaultHostname("hostname2")
-	s.sender.Gauge("my.metric", 1.0, "", nil)
-	gaugeSenderSample = (<-s.itemChan).(*senderMetricSample)
-	assert.Equal(t, "hostname2", gaugeSenderSample.metricSample.Host)
-
-	demux.ChangeAllSendersDefaultHostname("hostname1")
-	s.sender.Gauge("my.metric", 1.0, "", nil)
-	gaugeSenderSample = (<-s.itemChan).(*senderMetricSample)
-	assert.Equal(t, "hostname1", gaugeSenderSample.metricSample.Host)
 }


### PR DESCRIPTION

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Remove unused feature aggregator.SetHostname.

SetHostname is not called anywere outside of tests, and removing it allows us to remove a bunch of code that handled hostname changes.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
