### PR TITLE
Make BunbleParams.DefaultConfPath mandatory

### DIFF
--- a/cmd/dogstatsd/main.go
+++ b/cmd/dogstatsd/main.go
@@ -114,12 +114,11 @@ func runDogstatsdFct(cliParams *cliParams, defaultConfPath string, fct interface
 	return fxutil.OneShot(fct,
 		fx.Supply(cliParams),
 		fx.Supply(core.CreateBundleParams(
+			defaultConfPath,
 			core.WithConfFilePath(cliParams.confPath),
 			core.WithConfigLoadSecrets(true),
 			core.WithConfigMissingOK(true),
 			core.WithConfigName("dogstatsd"),
-			core.WithExcludeDefaultConfPath(true),
-			core.WithDefaultConfPath(defaultConfPath),
 		)),
 		core.Bundle,
 	)

--- a/cmd/security-agent/app/subcommands/status/command.go
+++ b/cmd/security-agent/app/subcommands/status/command.go
@@ -44,6 +44,7 @@ func Commands(globalParams *common.GlobalParams) []*cobra.Command {
 			return fxutil.OneShot(runStatus,
 				fx.Supply(cliParams),
 				fx.Supply(core.CreateBundleParams(
+					"",
 					core.WithSecurityAgentConfigFilePaths(globalParams.ConfPathArray),
 					core.WithConfigLoadSecurityAgent(true),
 				).LogForOneShot(common.LoggerName, "off", true)),

--- a/comp/core/bundle_params.go
+++ b/comp/core/bundle_params.go
@@ -6,6 +6,7 @@
 package core
 
 import (
+	"github.com/DataDog/datadog-agent/cmd/agent/common"
 	"github.com/DataDog/datadog-agent/comp/core/internal"
 )
 
@@ -14,15 +15,17 @@ type BundleParams = internal.BundleParams
 
 // CreateAgentBundleParams creates a new BundleParams for the Core Agent
 func CreateAgentBundleParams(confFilePath string, configLoadSecrets bool, options ...func(*BundleParams)) BundleParams {
-	params := CreateBundleParams(options...)
+	params := CreateBundleParams(common.DefaultConfPath, options...)
 	params.ConfFilePath = confFilePath
 	params.ConfigLoadSecrets = configLoadSecrets
 	return params
 }
 
 // CreateBundleParams creates a new BundleParams
-func CreateBundleParams(options ...func(*BundleParams)) BundleParams {
-	bundleParams := BundleParams{}
+func CreateBundleParams(defaultConfPath string, options ...func(*BundleParams)) BundleParams {
+	bundleParams := BundleParams{
+		DefaultConfPath: defaultConfPath,
+	}
 	for _, o := range options {
 		o(&bundleParams)
 	}
@@ -68,18 +71,6 @@ func WithConfFilePath(confFilePath string) func(*BundleParams) {
 func WithConfigLoadSecrets(configLoadSecrets bool) func(*BundleParams) {
 	return func(b *BundleParams) {
 		b.ConfigLoadSecrets = configLoadSecrets
-	}
-}
-
-func WithExcludeDefaultConfPath(excludeDefaultConfPath bool) func(*BundleParams) {
-	return func(b *BundleParams) {
-		b.ExcludeDefaultConfPath = excludeDefaultConfPath
-	}
-}
-
-func WithDefaultConfPath(defaultConfPath string) func(*BundleParams) {
-	return func(b *BundleParams) {
-		b.DefaultConfPath = defaultConfPath
 	}
 }
 

--- a/comp/core/config/config.go
+++ b/comp/core/config/config.go
@@ -44,7 +44,6 @@ func newConfig(deps dependencies) (Component, error) {
 		deps.Params.ConfigName,
 		!deps.Params.ConfigLoadSecrets,
 		!deps.Params.ConfigMissingOK,
-		!deps.Params.ExcludeDefaultConfPath,
 		deps.Params.DefaultConfPath)
 	if err != nil {
 		return nil, err

--- a/comp/core/config/setup.go
+++ b/comp/core/config/setup.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/DataDog/viper"
 
-	"github.com/DataDog/datadog-agent/cmd/agent/common"
 	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
@@ -25,7 +24,6 @@ func setupConfig(
 	configName string,
 	withoutSecrets bool,
 	failOnMissingFile bool,
-	useDefaultConfigPath bool,
 	defaultConfPath string) (*config.Warnings, error) {
 	if configName != "" {
 		config.Datadog.SetConfigName(configName)
@@ -40,10 +38,7 @@ func setupConfig(
 			config.Datadog.SetConfigFile(confFilePath)
 		}
 	}
-	if useDefaultConfigPath {
-		if len(defaultConfPath) == 0 {
-			defaultConfPath = common.DefaultConfPath
-		}
+	if len(defaultConfPath) > 0 {
 		config.Datadog.AddConfigPath(defaultConfPath)
 	}
 
@@ -94,7 +89,7 @@ func MergeConfigurationFiles(configName string, configurationFilesArray []string
 			continue
 		}
 		if !loadedConfiguration {
-			w, err := setupConfig(configurationFilename, "", false, true, true, "")
+			w, err := setupConfig(configurationFilename, "", false, true, "")
 			if err != nil {
 				if userDefined {
 					fmt.Printf("Warning: unable to open %s\n", configurationFilename)

--- a/comp/core/internal/params.go
+++ b/comp/core/internal/params.go
@@ -56,12 +56,8 @@ type BundleParams struct {
 	// LoggerName is the name that appears in the logfile
 	LoggerName string
 
-	// ExcludeDefaultConfPath determines whether the default config path must be excluded.
-	ExcludeDefaultConfPath bool
-
 	// DefaultConfPath determines the default configuration path.
-	// if DefaultConfPath is empty, then the default configuration path of the Agent is used.
-	// if ExcludeDefaultConfPath is true this field is ignored.
+	// if DefaultConfPath is empty, then no default configuration path is used.
 	DefaultConfPath string
 
 	// LogLevelFn returns the log level. This field is set by methods on this


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This PR makes `BunbleParams.DefaultConfPath` field mandatory. This change allows to remove `ExcludeDefaultConfPath` and make the default configuration path API simpler.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
- Shared components team 
  - Make sure DogstatsD binary don't try to load `dogstatsd.yaml` from `/opt/datadog-agent/etc`
  - Make sure the Agent try to load the configuration from the default path  `/opt/datadog-agent/etc`
- Security team: Check the default paths for `status` command work as expected. 
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
