### PR TITLE
pkg/trace/watchdog: retrieve PID from same procfs that psutils uses

### DIFF
--- a/pkg/trace/watchdog/cpu.go
+++ b/pkg/trace/watchdog/cpu.go
@@ -8,7 +8,35 @@
 
 package watchdog
 
-import "github.com/shirou/gopsutil/v3/process"
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+
+	"github.com/DataDog/datadog-agent/pkg/trace/log"
+	"github.com/shirou/gopsutil/v3/process"
+)
+
+func getpid() int {
+	// Based on gopsutil's HostProc https://github.com/shirou/gopsutil/blob/672e2518f2ce365ab8504c9f1a8038dc3ad09cf6/internal/common/common.go#L343-L345
+	// This PID needs to match the one in the procfs that gopsutil is going to look in.
+	p := os.Getenv("HOST_PROC")
+	if p == "" {
+		p = "/proc"
+	}
+	self := filepath.Join(p, "self")
+	pidf, err := os.Readlink(self)
+	if err != nil {
+		log.Warnf("Failed to read pid from %s: %s. Falling back to os.Getpid", self, err)
+		return os.Getpid()
+	}
+	pid, err := strconv.Atoi(filepath.Base(pidf))
+	if err != nil {
+		log.Warnf("Failed to parse pid from %s: %s. Falling back to os.Getpid", pidf, err)
+		return os.Getpid()
+	}
+	return pid
+}
 
 func cpuTimeUser(pid int32) (float64, error) {
 	p, err := process.NewProcess(pid)

--- a/pkg/trace/watchdog/cpu_aix.go
+++ b/pkg/trace/watchdog/cpu_aix.go
@@ -105,3 +105,7 @@ func cpuTimeUser(pid int32) (float64, error) {
 	time := float64(userSecs) + (float64(userNsecs) / float64(time.Second))
 	return time, nil
 }
+
+func getpid() int {
+	return os.Getpid()
+}

--- a/pkg/trace/watchdog/cpu_windows.go
+++ b/pkg/trace/watchdog/cpu_windows.go
@@ -6,8 +6,14 @@
 package watchdog
 
 import (
+	"os"
+
 	"golang.org/x/sys/windows"
 )
+
+func getpid() int {
+	return os.Getpid()
+}
 
 // this code was copied over from shirou/gopsutil/process because we can't import this package on Windows,
 // due to its "wmi" dependency.

--- a/pkg/trace/watchdog/info.go
+++ b/pkg/trace/watchdog/info.go
@@ -6,12 +6,9 @@
 package watchdog
 
 import (
-	"os"
 	"runtime"
 	"sync"
 	"time"
-
-	"github.com/DataDog/datadog-agent/pkg/trace/log"
 )
 
 const (
@@ -62,20 +59,19 @@ type CurrentInfo struct {
 // if only one goroutine is polling for CPU() and Mem()
 var globalCurrentInfo *CurrentInfo
 
-func init() {
-	var err error
-	globalCurrentInfo, err = NewCurrentInfo()
-	if err != nil {
-		log.Errorf("Unable to create global Process: %v", err)
+func ensureGlobalInfo() {
+	if globalCurrentInfo != nil {
+		return
 	}
+	globalCurrentInfo = NewCurrentInfo()
 }
 
 // NewCurrentInfo creates a new CurrentInfo referring to the current running program.
-func NewCurrentInfo() (*CurrentInfo, error) {
+func NewCurrentInfo() *CurrentInfo {
 	return &CurrentInfo{
-		pid:        int32(os.Getpid()),
+		pid:        int32(getpid()),
 		cacheDelay: cacheDelay,
-	}, nil
+	}
 }
 
 // CPU returns basic CPU info, or the previous valid CPU info and an error.
@@ -115,16 +111,12 @@ func (pi *CurrentInfo) Mem() MemInfo {
 
 // CPU returns basic CPU info, or the previous valid CPU info and an error.
 func CPU(now time.Time) (CPUInfo, error) {
-	if globalCurrentInfo == nil {
-		return CPUInfo{}, nil
-	}
+	ensureGlobalInfo()
 	return globalCurrentInfo.CPU(now)
 }
 
 // Mem returns basic memory info.
 func Mem() MemInfo {
-	if globalCurrentInfo == nil {
-		return MemInfo{}
-	}
+	ensureGlobalInfo()
 	return globalCurrentInfo.Mem()
 }

--- a/releasenotes/notes/fix-container-pid-7d5ed61ab0718f10.yaml
+++ b/releasenotes/notes/fix-container-pid-7d5ed61ab0718f10.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix Trace Agent's CPU stats by reading correct PID in procfs


### PR DESCRIPTION

### What does this PR do?
This PR is a cherry-pick of #14273 (All details below are copied from there)
The agent has historically used os.Getpid to get its PID. It then uses this PID to retrieve its cpu/memory/etc. stats from gopsutil. Gopsutil in turn looks in a procfs either configured by the HOST_PROC env variable or /proc by default to find the process's stats.

This is a problem when we run the trace agent in a container and mount the host's procfs in the container at /host/proc. When /host/proc is mounted, the trace agent automatically sets HOST_PROC in pkg/config, presumably for the process agent.

The trace agent looks up its PID with os.Getpid, which returns the pid for the container's namespace, and then uses gopsutils, which is using the host's PID namespace to get the stats.

This results in either missing stats when gopsutils can't find the PID, or wrong stats when the PID corresponds to a different process in the host's PID namespace.

Instead, we will now look up our PID when retrieving stats by reading the 'self' file from the same procfs that gopsutils will use.

Fixes https://github.com/DataDog/datadog-agent/issues/8068
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
#8068 
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
Run this with DD_APM_MAX_CPU_PERCENT set and ensure that the CPU measurements reflect reality, and that no error messages about failing to "retrieve the current CPU usage".
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
