### PR TITLE
[snmplistener] Add collect_topology config

### DIFF
--- a/cmd/agent/dist/conf.d/snmp.d/auto_conf.yaml
+++ b/cmd/agent/dist/conf.d/snmp.d/auto_conf.yaml
@@ -114,6 +114,11 @@ instances:
     #
     collect_device_metadata: "%%extra_collect_device_metadata%%"
 
+    ## @param collect_topology - boolean - optional - default: false
+    ## Enabled collection of topology data.
+    #
+    collect_topology: "%%extra_collect_topology%%"
+
     ## @param namespace - string - optional - default: default
     ## Namespace can be used to disambiguate devices with same IPs.
     ## Changing namespace will cause devices being recreated in NDM app.

--- a/pkg/autodiscovery/listeners/snmp.go
+++ b/pkg/autodiscovery/listeners/snmp.go
@@ -412,6 +412,8 @@ func (s *SNMPService) GetExtraConfig(key string) (string, error) {
 		return s.config.Namespace, nil
 	case "collect_device_metadata":
 		return strconv.FormatBool(s.config.CollectDeviceMetadata), nil
+	case "collect_topology":
+		return strconv.FormatBool(s.config.CollectTopology), nil
 	case "use_device_id_as_hostname":
 		return strconv.FormatBool(s.config.UseDeviceIDAsHostname), nil
 	case "tags":

--- a/pkg/autodiscovery/listeners/snmp_test.go
+++ b/pkg/autodiscovery/listeners/snmp_test.go
@@ -210,6 +210,20 @@ func TestExtraConfig(t *testing.T) {
 	assert.Equal(t, nil, err)
 	assert.Equal(t, "false", info)
 
+	info, err = svc.GetExtraConfig("collect_topology")
+	assert.Equal(t, nil, err)
+	assert.Equal(t, "false", info)
+
+	svc.config.CollectTopology = true
+	info, err = svc.GetExtraConfig("collect_topology")
+	assert.Equal(t, nil, err)
+	assert.Equal(t, "true", info)
+
+	svc.config.CollectTopology = false
+	info, err = svc.GetExtraConfig("collect_topology")
+	assert.Equal(t, nil, err)
+	assert.Equal(t, "false", info)
+
 	info, err = svc.GetExtraConfig("min_collection_interval")
 	assert.Equal(t, nil, err)
 	assert.Equal(t, "0", info)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -652,6 +652,7 @@ func InitConfig(config Config) {
 	config.SetKnown("snmp_listener.allowed_failures")
 	config.SetKnown("snmp_listener.discovery_allowed_failures")
 	config.SetKnown("snmp_listener.collect_device_metadata")
+	config.SetKnown("snmp_listener.collect_topology")
 	config.SetKnown("snmp_listener.workers")
 	config.SetKnown("snmp_listener.configs")
 	config.SetKnown("snmp_listener.loader")

--- a/pkg/snmp/snmp.go
+++ b/pkg/snmp/snmp.go
@@ -35,6 +35,7 @@ type ListenerConfig struct {
 	AllowedFailures       int      `mapstructure:"discovery_allowed_failures"`
 	Loader                string   `mapstructure:"loader"`
 	CollectDeviceMetadata bool     `mapstructure:"collect_device_metadata"`
+	CollectTopology       bool     `mapstructure:"collect_topology"`
 	MinCollectionInterval uint     `mapstructure:"min_collection_interval"`
 	Namespace             string   `mapstructure:"namespace"`
 	UseDeviceISAsHostname bool     `mapstructure:"use_device_id_as_hostname"`
@@ -65,6 +66,8 @@ type Config struct {
 	Loader                      string          `mapstructure:"loader"`
 	CollectDeviceMetadataConfig *bool           `mapstructure:"collect_device_metadata"`
 	CollectDeviceMetadata       bool
+	CollectTopologyConfig       *bool `mapstructure:"collect_topology"`
+	CollectTopology             bool
 	UseDeviceIDAsHostnameConfig *bool `mapstructure:"use_device_id_as_hostname"`
 	UseDeviceIDAsHostname       bool
 	Namespace                   string   `mapstructure:"namespace"`
@@ -102,6 +105,7 @@ func NewListenerConfig() (ListenerConfig, error) {
 	)
 	// Set defaults before unmarshalling
 	snmpConfig.CollectDeviceMetadata = true
+	snmpConfig.CollectTopology = false
 	if err := coreconfig.Datadog.UnmarshalKey("snmp_listener", &snmpConfig, opt); err != nil {
 		return snmpConfig, err
 	}
@@ -127,6 +131,11 @@ func NewListenerConfig() (ListenerConfig, error) {
 			config.CollectDeviceMetadata = *config.CollectDeviceMetadataConfig
 		} else {
 			config.CollectDeviceMetadata = snmpConfig.CollectDeviceMetadata
+		}
+		if config.CollectTopologyConfig != nil {
+			config.CollectTopology = *config.CollectTopologyConfig
+		} else {
+			config.CollectTopology = snmpConfig.CollectTopology
 		}
 
 		if config.UseDeviceIDAsHostnameConfig != nil {

--- a/pkg/snmp/snmp.go
+++ b/pkg/snmp/snmp.go
@@ -105,7 +105,7 @@ func NewListenerConfig() (ListenerConfig, error) {
 	)
 	// Set defaults before unmarshalling
 	snmpConfig.CollectDeviceMetadata = true
-	snmpConfig.CollectTopology = false
+	snmpConfig.CollectTopology = false // TODO: Set this to `true` when GA
 	if err := coreconfig.Datadog.UnmarshalKey("snmp_listener", &snmpConfig, opt); err != nil {
 		return snmpConfig, err
 	}

--- a/pkg/snmp/snmp_test.go
+++ b/pkg/snmp/snmp_test.go
@@ -342,6 +342,50 @@ snmp_listener:
 	assert.Equal(t, true, conf.Configs[1].UseDeviceIDAsHostname)
 }
 
+func Test_CollectTopology_withRootCollectTopologyFalse(t *testing.T) {
+	config.Datadog.SetConfigType("yaml")
+	err := config.Datadog.ReadConfig(strings.NewReader(`
+snmp_listener:
+  collect_topology: false
+  configs:
+   - network: 127.1.0.0/30
+     collect_topology: true
+   - network: 127.2.0.0/30
+     collect_topology: false
+   - network: 127.3.0.0/30
+`))
+	assert.NoError(t, err)
+
+	conf, err := NewListenerConfig()
+	assert.NoError(t, err)
+
+	assert.Equal(t, true, conf.Configs[0].CollectTopology)
+	assert.Equal(t, false, conf.Configs[1].CollectTopology)
+	assert.Equal(t, false, conf.Configs[2].CollectTopology)
+}
+
+func Test_CollectTopology_withRootCollectTopologyTrue(t *testing.T) {
+	config.Datadog.SetConfigType("yaml")
+	err := config.Datadog.ReadConfig(strings.NewReader(`
+snmp_listener:
+  collect_topology: true
+  configs:
+   - network: 127.1.0.0/30
+     collect_topology: true
+   - network: 127.2.0.0/30
+     collect_topology: false
+   - network: 127.3.0.0/30
+`))
+	assert.NoError(t, err)
+
+	conf, err := NewListenerConfig()
+	assert.NoError(t, err)
+
+	assert.Equal(t, true, conf.Configs[0].CollectTopology)
+	assert.Equal(t, false, conf.Configs[1].CollectTopology)
+	assert.Equal(t, true, conf.Configs[2].CollectTopology)
+}
+
 func TestConfig_Digest(t *testing.T) {
 	tests := []struct {
 		name         string


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Make it possible to enable topology data collection from snmp listener.

[snmplistener] Add collect_topology config

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Follow up of https://github.com/DataDog/datadog-agent/pull/13887

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
