### PR TITLE
[system-probe] Use flow handle as connection stat cookie on windows

### DIFF
--- a/pkg/network/event_windows.go
+++ b/pkg/network/event_windows.go
@@ -168,6 +168,6 @@ func FlowToConnStat(cs *ConnectionStats, flow *driver.PerFlowData, enableMonoton
 		}
 	}
 
-	cs.Monotonic.Put(0, m)
+	cs.Monotonic.Put(uint32(flow.FlowHandle), m)
 
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Backport of https://github.com/DataDog/datadog-agent/pull/14290

Use the flow handle as a connection stat "cookie" on windows. This it the equivalent of the stat cookie used on linux: https://github.com/DataDog/datadog-agent/blob/main/pkg/network/ebpf/c/cookie.h

### Motivation

Underflows reported on windows (on three different hosts):

```
...
2022-11-11 19:06:05 GMT | SYS-PROBE | WARN | (pkg/network/state.go:298 in logTelemetry) | state telemetry: [2 stats stats_underflows] [0 connections dropped due to stats] [0 closed connections dropped] [0 dns stats dropped] [0 HTTP stats dropped] [0 DNS pid collisions] [0 time sync collisions]
...
2022-11-11 19:06:05 GMT | SYS-PROBE | WARN | (pkg/network/state.go:298 in logTelemetry) | state telemetry: [2 stats stats_underflows] [0 connections dropped due to stats] [0 closed connections dropped] [0 dns stats dropped] [0 HTTP stats dropped] [0 DNS pid collisions] [0 time sync collisions]
...
2022-11-11 19:05:59 GMT | SYS-PROBE | WARN | (pkg/network/state.go:298 in logTelemetry) | state telemetry: [1 stats stats_underflows] [0 connections dropped due to stats] [0 closed connections dropped] [0 dns stats dropped] [0 HTTP stats dropped] [0 DNS pid collisions] [0 time sync collisions]
```

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
