### PR TITLE
Fix error in Mac agent install script

### DIFF
--- a/cmd/agent/install_mac_os.sh
+++ b/cmd/agent/install_mac_os.sh
@@ -24,7 +24,7 @@ if [ -n "$DD_UPGRADE" ]; then
 fi
 
 # Root user detection
-if [ "$(echo "$UID")" = "0" ]; then
+if [ "$(echo "$UID")" == "0" ]; then
     sudo_cmd=''
 else
     sudo_cmd='sudo'
@@ -253,7 +253,7 @@ fi`
 # If this is a systemwide install done over SSH or a similar method, the real_user is now root
 # which will eventually make the installation fail in the postinstall script. In this case, we
 # set real_user to the target user of the systemwide installation.
-if [ "$systemdaemon_install" = true ] && [ "$real_user" = root ]; then
+if [ "$systemdaemon_install" == true ] && [ "$real_user" == root ]; then
     real_user="$(echo "$systemdaemon_user_group" | awk -F: '{ print $1 }')"
     # The install will copy plist file to real_user home dir => we add `-H`
     # as a sudo argument to properly get its home for access to the plist file.
@@ -384,7 +384,7 @@ if grep -E 'api_key:( APIKEY)?$' "$etc_dir/datadog.yaml" > /dev/null 2>&1; then
     fi
     printf "\n\033[34m* Restarting the Agent...\n\033[0m\n"
     # systemwide installation is stopped at this point and will be started later on
-    if [ "$systemdaemon_install" != true ]; then
+    if [ "$systemdaemon_install" == true ]; then
       $cmd_launchctl stop $service_name
 
       # Wait for the agent to fully stop
@@ -407,7 +407,7 @@ else
 fi
 
 # Starting the app
-if [ "$systemdaemon_install" = false ]; then
+if [ "$systemdaemon_install" == false ]; then
     $cmd_real_user open -a 'Datadog Agent.app'
 else
     printf "\033[34m\n* Installing $service_name as a systemwide LaunchDaemon ...\n\n\033[0m"
@@ -442,7 +442,7 @@ or by opening the webui using the \"datadog-agent launch-gui\" command.
 
 \033[0m"
 
-if [ "$systemdaemon_install" = false ]; then
+if [ "$systemdaemon_install" == false ]; then
     printf "\033[32m
 If you ever want to stop the Agent, please use the Datadog Agent App or
 the launchctl command. It will start automatically at login.


### PR DESCRIPTION
Fixes #14316

I also went ahead and changed all the single-character equality checks with double, since this script is meant to be run as a Bash script and the usage was inconsistent throughout the file.

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
