### PR TITLE
improve clang version check

### DIFF
--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from subprocess import check_output
 
 from invoke import task
-from invoke.exceptions import Exit, UnexpectedExit
+from invoke.exceptions import Exit
 
 from .build_tags import get_default_build_tags
 from .libs.ninja_syntax import NinjaWriter
@@ -663,13 +663,13 @@ def kitchen_genconfig(
     elif arch == "arm64":
         arch = "arm64"
     else:
-        raise UnexpectedExit("unsupported arch specified")
+        raise Exit("unsupported arch specified")
 
     if not image_size and provider == "azure":
         image_size = "Standard_D2_v2"
 
     if not image_size:
-        raise UnexpectedExit("Image size must be specified")
+        raise Exit("Image size must be specified")
 
     if azure_sub_id is None and provider == "azure":
         raise Exit("azure subscription id must be specified with --azure-sub-id")
@@ -977,9 +977,13 @@ def setup_runtime_clang(ctx):
 
 def verify_system_clang_version(ctx):
     clang_res = ctx.run("clang --version", warn=True)
-    clang_version_str = clang_res.stdout.split("\n")[0].split(" ")[2].strip() if clang_res.ok else ""
+    clang_version_str = ""
+    if clang_res.ok:
+        clang_version_str = clang_res.stdout.splitlines()[0].split(" ")[-1].strip()
+        clang_version_str = clang_version_str.split("-")[0]
+
     if clang_version_str != CLANG_VERSION:
-        raise UnexpectedExit(f"unsupported clang version {clang_version_str} in use. Please install {CLANG_VERSION}.")
+        raise Exit(f"unsupported clang version {clang_version_str} in use. Please install {CLANG_VERSION}.")
 
 
 def build_object_files(

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -979,8 +979,9 @@ def verify_system_clang_version(ctx):
     clang_res = ctx.run("clang --version", warn=True)
     clang_version_str = ""
     if clang_res.ok:
-        clang_version_str = clang_res.stdout.splitlines()[0].split(" ")[-1].strip()
-        clang_version_str = clang_version_str.split("-")[0]
+        clang_version_parts = clang_res.stdout.splitlines()[0].split(" ")
+        version_index = clang_version_parts.index("version")
+        clang_version_str = clang_version_parts[version_index + 1].split("-")[0]
 
     if clang_version_str != CLANG_VERSION:
         raise Exit(f"unsupported clang version {clang_version_str} in use. Please install {CLANG_VERSION}.")


### PR DESCRIPTION
### What does this PR do?

This PR fixes the clang version check by so that it works if:
```
>> clang --version
Ubuntu clang version 12.0.1-19ubuntu3
Target: aarch64-unknown-linux-gnu
Thread model: posix
InstalledDir: /usr/bin
```
- by selecting the part after the "version" instead of the second one
- by taking the part before the first `-`

It also replaces the `UnexpectedExit` with standard `Exit` since unexpected exits do not take strings as argument resulting in:
```
>> inv -e system-probe.build
clang --version
Ubuntu clang version 12.0.1-19ubuntu3
Target: aarch64-unknown-linux-gnu
Thread model: posix
InstalledDir: /usr/bin
Traceback (most recent call last):
  File "/home/vagrant/.local/lib/python3.10/site-packages/invoke/program.py", line 384, in run
    self.execute()
  File "/home/vagrant/.local/lib/python3.10/site-packages/invoke/program.py", line 569, in execute
    executor.execute(*self.tasks)
  File "/home/vagrant/.local/lib/python3.10/site-packages/invoke/executor.py", line 129, in execute
    result = call.task(*args, **call.kwargs)
  File "/home/vagrant/.local/lib/python3.10/site-packages/invoke/tasks.py", line 127, in __call__
    result = self.body(*args, **kwargs)
  File "/home/vagrant/go/src/github.com/DataDog/datadog-agent/tasks/system_probe.py", line 385, in build
    build_object_files(
  File "/home/vagrant/go/src/github.com/DataDog/datadog-agent/tasks/system_probe.py", line 997, in build_object_files
    verify_system_clang_version(ctx)
  File "/home/vagrant/go/src/github.com/DataDog/datadog-agent/tasks/system_probe.py", line 982, in verify_system_clang_version
    raise UnexpectedExit(f"unsupported clang version {clang_version_str} in use. Please install {CLANG_VERSION}.")
invoke.exceptions.UnexpectedExit: <exception str() failed>

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/vagrant/.local/bin/inv", line 8, in <module>
    sys.exit(program.run())
  File "/home/vagrant/.local/lib/python3.10/site-packages/invoke/program.py", line 386, in run
    debug("Received a possibly-skippable exception: {!r}".format(e))
  File "/home/vagrant/.local/lib/python3.10/site-packages/invoke/exceptions.py", line 81, in __repr__
    return self._repr()
  File "/home/vagrant/.local/lib/python3.10/site-packages/invoke/exceptions.py", line 133, in _repr
    kwargs.setdefault("exited", self.result.exited)
AttributeError: 'str' object has no attribute 'exited'
```

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
