### PR TITLE
Add `annotations_as_tags` parameter to kubernetes_state_core check

### DIFF
--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
@@ -89,6 +89,16 @@ type KSMConfig struct {
 	//     - "team_*"
 	LabelsAsTags map[string]map[string]string `yaml:"labels_as_tags"`
 
+	// AnnotationsAsTags
+	// Example:
+	// annotations_as_tags:
+	//   pod:
+	//     - "app_*"
+	//   node:
+	//     - "zone"
+	//     - "team_*"
+	AnnotationsAsTags map[string]map[string]string `yaml:"annotations_as_tags"`
+
 	// LabelsMapper can be used to translate kube-state-metrics labels to other tags.
 	// Example: Adding kube_namespace tag instead of namespace.
 	// labels_mapper:
@@ -209,6 +219,7 @@ func (k *KSMCheck) Configure(config, initConfig integration.Data, source string)
 	k.instance.labelsMapperByResourceKind = defaultLabelsMapperByResourceKind()
 
 	k.processLabelsAsTags()
+	k.processAnnotationsAsTags()
 
 	// Prepare labels mapper
 	labelsMapper := defaultLabelsMapper()
@@ -238,6 +249,16 @@ func (k *KSMCheck) Configure(config, initConfig integration.Data, source string)
 	}
 
 	builder.WithAllowLabels(allowedLabels)
+
+	// Enable exposing resource annotations explicitly for kube_<resource>_annotations metadata metrics.
+	// Equivalent to configuring --metric-annotations-allowlist.
+	allowedAnnotations := map[string][]string{}
+	for _, collector := range collectors {
+		// Any annotation can be used for label joins.
+		allowedAnnotations[collector] = []string{"*"}
+	}
+
+	builder.WithAllowAnnotations(allowedAnnotations)
 
 	// Prepare watched namespaces
 	namespaces := k.instance.Namespaces
@@ -637,10 +658,18 @@ func (k *KSMCheck) mergeLabelJoins(extra map[string]*JoinsConfig) {
 }
 
 func (k *KSMCheck) processLabelsAsTags() {
-	for resourceKind, labelsMapper := range k.instance.LabelsAsTags {
+	k.processLabelsOrAnnotationsAsTags("label", k.instance.LabelsAsTags)
+}
+
+func (k *KSMCheck) processAnnotationsAsTags() {
+	k.processLabelsOrAnnotationsAsTags("annotation", k.instance.AnnotationsAsTags)
+}
+
+func (k *KSMCheck) processLabelsOrAnnotationsAsTags(what string, configStuffAsTags map[string]map[string]string) {
+	for resourceKind, labelsMapper := range configStuffAsTags {
 		labels := make([]string, 0, len(labelsMapper))
 		for label, tag := range labelsMapper {
-			label = "label_" + labelRegexp.ReplaceAllString(label, "_")
+			label = what + "_" + labelRegexp.ReplaceAllString(label, "_")
 			if _, ok := k.instance.labelsMapperByResourceKind[resourceKind]; !ok {
 				k.instance.labelsMapperByResourceKind[resourceKind] = map[string]string{
 					label: tag,
@@ -651,14 +680,14 @@ func (k *KSMCheck) processLabelsAsTags() {
 			labels = append(labels, label)
 		}
 
-		if joinsConfig, ok := k.instance.LabelJoins["kube_"+resourceKind+"_labels"]; ok {
+		if joinsConfig, ok := k.instance.LabelJoins["kube_"+resourceKind+"_"+what+"s"]; ok {
 			joinsConfig.LabelsToGet = append(joinsConfig.LabelsToGet, labels...)
 		} else {
 			joinsConfig := &JoinsConfig{
 				LabelsToMatch: getLabelToMatchForKind(resourceKind),
 				LabelsToGet:   labels,
 			}
-			k.instance.LabelJoins["kube_"+resourceKind+"_labels"] = joinsConfig
+			k.instance.LabelJoins["kube_"+resourceKind+"_"+what+"s"] = joinsConfig
 		}
 	}
 }

--- a/pkg/kubestatemetrics/builder/builder.go
+++ b/pkg/kubestatemetrics/builder/builder.go
@@ -134,6 +134,11 @@ func (b *Builder) WithAllowLabels(l map[string][]string) {
 	b.ksmBuilder.WithAllowLabels(l)
 }
 
+// WithAllowAnnotations configures which annotations can be returned for metrics
+func (b *Builder) WithAllowAnnotations(l map[string][]string) {
+	b.ksmBuilder.WithAllowAnnotations(l)
+}
+
 // Build initializes and registers all enabled stores.
 // Returns metric writers.
 func (b *Builder) Build() []metricsstore.MetricsWriter {

--- a/releasenotes/notes/ksm_annotations_as_tags-3d8bdbb8daf0f736.yaml
+++ b/releasenotes/notes/ksm_annotations_as_tags-3d8bdbb8daf0f736.yaml
@@ -8,4 +8,4 @@
 ---
 enhancements:
   - |
-    Add an ``annotations_as_tags`` parameter to the kubernetes_state_core check that allows to attach kubernetes annotations as datadog tags in a similar way than ``labels_as_tags``
+    Add an ``annotations_as_tags`` parameter to the kubernetes_state_core check to allow attaching Kubernetes annotations as Datadog tags in a similar way that the ``labels_as_tags`` parameter does.

--- a/releasenotes/notes/ksm_annotations_as_tags-3d8bdbb8daf0f736.yaml
+++ b/releasenotes/notes/ksm_annotations_as_tags-3d8bdbb8daf0f736.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Add an ``annotations_as_tags`` parameter to the kubernetes_state_core check that allows to attach kubernetes annotations as datadog tags in a similar way than ``labels_as_tags``


### PR DESCRIPTION
### What does this PR do?

`kubernetes_state_core` check already had the `labels_as_tags` parameter in order to specify which labels must be attached KSM metrics.
This PR adds the `annotations_as_tags` parameter to implement the same functionality, but with annotations.
Both parameters share exactly the same syntax.

### Motivation

One may want to group KSM metrics based on annotations and not only labels.

### Additional Notes

Doc update: DataDog/integrations-core#13320.

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Label and annotate some kubernetes resources.
Configure KSM to get them.

Here is an example of a piece of configuration to use in the [official Helm chart](https://github.com/DataDog/helm-charts/tree/main/charts/datadog):
```yaml
clusterAgent:
  confd:
    kubernetes_state_core.yaml: |
      init_config:
      instances:
        - labels_as_tags:
            pod:
              my_pod_label: my_pod_tag
          annotations_as_tags:
            pod:
              my_pod_annotation: my_pod_annotation_tag
```

Then, ensure that some pods are labeled with `my_pod_label` and are annotated with `my_pod_annotation`
```bash
kubectl -n workload-nginx get deploy/nginx -o yaml
```
```yaml
apiVersion: apps/v1
kind: Deployment
[…]
spec:
[…]
  template:
    metadata:
      annotations:
        my_pod_annotation: my_pod_annotation_lenaic
      labels:
        my_pod_label: my_pod_label_lenaic
    spec:
[…]
```

And then validate that the label and annotation are both attached to the KSM metrics corresponding to the labelled and annotated resource:
```
kubectl --namespace datadog-agent-helm exec pod/datadog-agent-linux-cluster-agent-98786975f-knhdm -- agent check -r kubernetes_state_core --table | grep -E 'kubernetes_state\.pod\..* pod_name:nginx-'
```
```
[…]
  kubernetes_state.pod.uptime                                gauge  1668517429  431889        kube_cluster_name:gke-lenaic, kube_deployment:nginx, kube_namespace:workload-nginx, kube_replica_set:nginx-6856ccc9cf, my_pod_annotation_tag:my_pod_annotation_lenaic, my_pod_tag:my_pod_label_lenaic, node:gke-gke-lenaic-cos-containerd-213c6b14-lbnz, pod_name:nginx-6856ccc9cf-pwr45, pod_phase:Running, uid:6261b99a-f169-4777-b642-3f6a1f89145e
  kubernetes_state.pod.uptime                                gauge  1668517429  431877        kube_cluster_name:gke-lenaic, kube_deployment:nginx, kube_namespace:workload-nginx, kube_replica_set:nginx-6856ccc9cf, my_pod_annotation_tag:my_pod_annotation_lenaic, my_pod_tag:my_pod_label_lenaic, node:gke-gke-lenaic-ubuntu-containerd-7d222122-2ztz, pod_name:nginx-6856ccc9cf-2v2s8, pod_phase:Running, uid:b73e145b-8f7f-4044-96e6-cce81dc5ff49
[…]
```


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
