### PR TITLE
pkg/remoteconfig: add ASMDataRuleDataEntry type

### DIFF
--- a/pkg/remoteconfig/state/configs.go
+++ b/pkg/remoteconfig/state/configs.go
@@ -253,8 +253,8 @@ type ASMDataRuleData struct {
 
 // ASMDataRuleDataEntry represents a data entry in a rule data file
 type ASMDataRuleDataEntry struct {
-	Expiration int         `json:"expiration,omitempty"`
-	Value      interface{} `json:"value"`
+	Expiration int    `json:"expiration,omitempty"`
+	Value      string `json:"value"`
 }
 
 func parseConfigASMData(data []byte, metadata Metadata) (ASMDataConfig, error) {

--- a/pkg/remoteconfig/state/configs.go
+++ b/pkg/remoteconfig/state/configs.go
@@ -10,9 +10,8 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/theupdateframework/go-tuf/data"
-
 	"github.com/DataDog/datadog-agent/pkg/remoteconfig/state/products/apmsampling"
+	"github.com/theupdateframework/go-tuf/data"
 )
 
 /*
@@ -247,9 +246,15 @@ type ASMDataRulesData struct {
 
 // ASMDataRuleData is an entry in the rules data list held by an ASMData configuration
 type ASMDataRuleData struct {
-	ID   string        `json:"id"`
-	Type string        `json:"type"`
-	Data []interface{} `json:"data"`
+	ID   string                 `json:"id"`
+	Type string                 `json:"type"`
+	Data []ASMDataRuleDataEntry `json:"data"`
+}
+
+// ASMDataRuleDataEntry represents a data entry in a rule data file
+type ASMDataRuleDataEntry struct {
+	Expiration int         `json:"expiration,omitempty"`
+	Value      interface{} `json:"value"`
 }
 
 func parseConfigASMData(data []byte, metadata Metadata) (ASMDataConfig, error) {

--- a/pkg/remoteconfig/state/configs_test.go
+++ b/pkg/remoteconfig/state/configs_test.go
@@ -36,12 +36,17 @@ func TestASMData(t *testing.T) {
 						{
 							ID:   "1",
 							Type: "test1",
-							Data: []interface{}{float64(1)},
+							Data: []ASMDataRuleDataEntry{
+								{
+									Value:      float64(1),
+									Expiration: 1234,
+								},
+							},
 						},
 					},
 				},
 			},
-			raw: []byte(`{"rules_data":[{"id":"1","type":"test1","data":[1]}]}`),
+			raw: []byte(`{"rules_data":[{"id":"1","type":"test1","data":[{"expiration":1234,"value":1}]}]}`),
 		},
 		{
 			name: "single-entry-string",
@@ -51,12 +56,17 @@ func TestASMData(t *testing.T) {
 						{
 							ID:   "1",
 							Type: "test1",
-							Data: []interface{}{"1"},
+							Data: []ASMDataRuleDataEntry{
+								{
+									Value:      "1",
+									Expiration: 1234,
+								},
+							},
 						},
 					},
 				},
 			},
-			raw: []byte(`{"rules_data":[{"id":"1","type":"test1","data":["1"]}]}`),
+			raw: []byte(`{"rules_data":[{"id":"1","type":"test1","data":[{"expiration":1234,"value":"1"}]}]}`),
 		},
 		{
 			name: "multiple-entries-float",
@@ -66,22 +76,40 @@ func TestASMData(t *testing.T) {
 						{
 							ID:   "empty",
 							Type: "",
-							Data: []interface{}{},
+							Data: []ASMDataRuleDataEntry{},
 						},
 						{
 							ID:   "1",
 							Type: "test1",
-							Data: []interface{}{float64(1)},
+							Data: []ASMDataRuleDataEntry{
+								{
+									Value:      float64(1),
+									Expiration: 1234,
+								},
+							},
 						},
 						{
 							ID:   "2",
 							Type: "test2",
-							Data: []interface{}{float64(1), float64(2), float64(3)},
+							Data: []ASMDataRuleDataEntry{
+								{
+									Value:      float64(1),
+									Expiration: 1234,
+								},
+								{
+									Value:      float64(2),
+									Expiration: 1234,
+								},
+								{
+									Value:      float64(3),
+									Expiration: 1234,
+								},
+							},
 						},
 					},
 				},
 			},
-			raw: []byte(`{"rules_data":[{"id":"empty","type":"","data":[]},{"id":"1","type":"test1","data":[1]},{"id":"2","type":"test2","data":[1,2,3]}]}`),
+			raw: []byte(`{"rules_data":[{"id":"empty","type":"","data":[]},{"id":"1","type":"test1","data":[{"expiration":1234,"value":1}]},{"id":"2","type":"test2","data":[{"expiration":1234,"value":1},{"expiration":1234,"value":2},{"expiration":1234,"value":3}]}]}`),
 		},
 		{
 			name: "multiple-entries-string",
@@ -91,22 +119,40 @@ func TestASMData(t *testing.T) {
 						{
 							ID:   "empty",
 							Type: "",
-							Data: []interface{}{},
+							Data: []ASMDataRuleDataEntry{},
 						},
 						{
 							ID:   "1",
 							Type: "test1",
-							Data: []interface{}{"1"},
+							Data: []ASMDataRuleDataEntry{
+								{
+									Value:      "1",
+									Expiration: 1234,
+								},
+							},
 						},
 						{
 							ID:   "2",
 							Type: "test2",
-							Data: []interface{}{"1", "2", "3"},
+							Data: []ASMDataRuleDataEntry{
+								{
+									Value:      "1",
+									Expiration: 1234,
+								},
+								{
+									Value:      "2",
+									Expiration: 1234,
+								},
+								{
+									Value:      "3",
+									Expiration: 1234,
+								},
+							},
 						},
 					},
 				},
 			},
-			raw: []byte(`{"rules_data":[{"id":"empty","type":"","data":[]},{"id":"1","type":"test1","data":["1"]},{"id":"2","type":"test2","data":["1","2","3"]}]}`),
+			raw: []byte(`{"rules_data":[{"id":"empty","type":"","data":[]},{"id":"1","type":"test1","data":[{"expiration":1234,"value":"1"}]},{"id":"2","type":"test2","data":[{"expiration":1234,"value":"1"},{"expiration":1234,"value":"2"},{"expiration":1234,"value":"3"}]}]}`),
 		},
 	} {
 		t.Run("marshall-"+tc.name, func(t *testing.T) {

--- a/pkg/remoteconfig/state/configs_test.go
+++ b/pkg/remoteconfig/state/configs_test.go
@@ -29,27 +29,7 @@ func TestASMData(t *testing.T) {
 			raw:  []byte(`{"rules_data":[]}`),
 		},
 		{
-			name: "single-entry-float",
-			cfg: ASMDataConfig{
-				Config: ASMDataRulesData{
-					RulesData: []ASMDataRuleData{
-						{
-							ID:   "1",
-							Type: "test1",
-							Data: []ASMDataRuleDataEntry{
-								{
-									Value:      float64(1),
-									Expiration: 1234,
-								},
-							},
-						},
-					},
-				},
-			},
-			raw: []byte(`{"rules_data":[{"id":"1","type":"test1","data":[{"expiration":1234,"value":1}]}]}`),
-		},
-		{
-			name: "single-entry-string",
+			name: "single-entry",
 			cfg: ASMDataConfig{
 				Config: ASMDataRulesData{
 					RulesData: []ASMDataRuleData{
@@ -69,7 +49,7 @@ func TestASMData(t *testing.T) {
 			raw: []byte(`{"rules_data":[{"id":"1","type":"test1","data":[{"expiration":1234,"value":"1"}]}]}`),
 		},
 		{
-			name: "multiple-entries-float",
+			name: "multiple-entries",
 			cfg: ASMDataConfig{
 				Config: ASMDataRulesData{
 					RulesData: []ASMDataRuleData{
@@ -83,7 +63,7 @@ func TestASMData(t *testing.T) {
 							Type: "test1",
 							Data: []ASMDataRuleDataEntry{
 								{
-									Value:      float64(1),
+									Value:      "127.0.0.1",
 									Expiration: 1234,
 								},
 							},
@@ -93,15 +73,15 @@ func TestASMData(t *testing.T) {
 							Type: "test2",
 							Data: []ASMDataRuleDataEntry{
 								{
-									Value:      float64(1),
+									Value:      "value1",
 									Expiration: 1234,
 								},
 								{
-									Value:      float64(2),
+									Value:      "value2",
 									Expiration: 1234,
 								},
 								{
-									Value:      float64(3),
+									Value:      "value3",
 									Expiration: 1234,
 								},
 							},
@@ -109,50 +89,7 @@ func TestASMData(t *testing.T) {
 					},
 				},
 			},
-			raw: []byte(`{"rules_data":[{"id":"empty","type":"","data":[]},{"id":"1","type":"test1","data":[{"expiration":1234,"value":1}]},{"id":"2","type":"test2","data":[{"expiration":1234,"value":1},{"expiration":1234,"value":2},{"expiration":1234,"value":3}]}]}`),
-		},
-		{
-			name: "multiple-entries-string",
-			cfg: ASMDataConfig{
-				Config: ASMDataRulesData{
-					RulesData: []ASMDataRuleData{
-						{
-							ID:   "empty",
-							Type: "",
-							Data: []ASMDataRuleDataEntry{},
-						},
-						{
-							ID:   "1",
-							Type: "test1",
-							Data: []ASMDataRuleDataEntry{
-								{
-									Value:      "1",
-									Expiration: 1234,
-								},
-							},
-						},
-						{
-							ID:   "2",
-							Type: "test2",
-							Data: []ASMDataRuleDataEntry{
-								{
-									Value:      "1",
-									Expiration: 1234,
-								},
-								{
-									Value:      "2",
-									Expiration: 1234,
-								},
-								{
-									Value:      "3",
-									Expiration: 1234,
-								},
-							},
-						},
-					},
-				},
-			},
-			raw: []byte(`{"rules_data":[{"id":"empty","type":"","data":[]},{"id":"1","type":"test1","data":[{"expiration":1234,"value":"1"}]},{"id":"2","type":"test2","data":[{"expiration":1234,"value":"1"},{"expiration":1234,"value":"2"},{"expiration":1234,"value":"3"}]}]}`),
+			raw: []byte(`{"rules_data":[{"id":"empty","type":"","data":[]},{"id":"1","type":"test1","data":[{"expiration":1234,"value":"127.0.0.1"}]},{"id":"2","type":"test2","data":[{"expiration":1234,"value":"value1"},{"expiration":1234,"value":"value2"},{"expiration":1234,"value":"value3"}]}]}`),
 		},
 	} {
 		t.Run("marshall-"+tc.name, func(t *testing.T) {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
Specify the `Data` field type for the `ASMDataRuleData` RC configuration.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
We expect to manipulate data entries that specify an expiration timestamp. Enforcing this here allows making sure that
the data format will respect this prerequisite.
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
