### PR TITLE
Always use python3 to invoke the integrations downloader

### DIFF
--- a/cmd/agent/subcommands/integrations/command.go
+++ b/cmd/agent/subcommands/integrations/command.go
@@ -499,6 +499,7 @@ func install(config config.Component, cliParams *cliParams) error {
 }
 
 func downloadWheel(cliParams *cliParams, integration, version, rootLayoutType string) (string, error) {
+	// We use python 3 to invoke the downloader regardless of config
 	pyPath, err := getCommandPython("3", cliParams.useSysPython)
 	if err != nil {
 		return "", err

--- a/cmd/agent/subcommands/integrations/command.go
+++ b/cmd/agent/subcommands/integrations/command.go
@@ -499,7 +499,7 @@ func install(config config.Component, cliParams *cliParams) error {
 }
 
 func downloadWheel(cliParams *cliParams, integration, version, rootLayoutType string) (string, error) {
-	pyPath, err := getCommandPython(cliParams.pythonMajorVersion, cliParams.useSysPython)
+	pyPath, err := getCommandPython("3", cliParams.useSysPython)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/agent/subcommands/integrations/command.go
+++ b/cmd/agent/subcommands/integrations/command.go
@@ -265,12 +265,12 @@ func PEP440ToSemver(pep440 string) (*semver.Version, error) {
 	return semver.NewVersion(versionString)
 }
 
-func getCommandPython(cliParams *cliParams) (string, error) {
-	if cliParams.useSysPython {
+func getCommandPython(pythonMajorVersion string, useSysPython bool) (string, error) {
+	if useSysPython {
 		return pythonBin, nil
 	}
 
-	pyPath := filepath.Join(rootDir, getRelPyPath(cliParams))
+	pyPath := filepath.Join(rootDir, getRelPyPath(pythonMajorVersion))
 
 	if _, err := os.Stat(pyPath); err != nil {
 		if os.IsNotExist(err) {
@@ -307,7 +307,7 @@ func validateArgs(args []string, local bool) error {
 }
 
 func pip(cliParams *cliParams, args []string, stdout io.Writer, stderr io.Writer) error {
-	pythonPath, err := getCommandPython(cliParams)
+	pythonPath, err := getCommandPython(cliParams.pythonMajorVersion, cliParams.useSysPython)
 	if err != nil {
 		return err
 	}
@@ -499,7 +499,7 @@ func install(config config.Component, cliParams *cliParams) error {
 }
 
 func downloadWheel(cliParams *cliParams, integration, version, rootLayoutType string) (string, error) {
-	pyPath, err := getCommandPython(cliParams)
+	pyPath, err := getCommandPython(cliParams.pythonMajorVersion, cliParams.useSysPython)
 	if err != nil {
 		return "", err
 	}
@@ -713,7 +713,7 @@ func minAllowedVersion(integration string) (*semver.Version, bool, error) {
 
 // Return the version of an installed integration and whether or not it was found
 func installedVersion(cliParams *cliParams, integration string) (*semver.Version, bool, error) {
-	pythonPath, err := getCommandPython(cliParams)
+	pythonPath, err := getCommandPython(cliParams.pythonMajorVersion, cliParams.useSysPython)
 	if err != nil {
 		return nil, false, err
 	}

--- a/cmd/agent/subcommands/integrations/integrations_nix_helpers.go
+++ b/cmd/agent/subcommands/integrations/integrations_nix_helpers.go
@@ -24,8 +24,8 @@ var (
 	pythonMinorVersion string
 )
 
-func getRelPyPath(cliParams *cliParams) string {
-	return filepath.Join("embedded", "bin", fmt.Sprintf("%s%s", pythonBin, cliParams.pythonMajorVersion))
+func getRelPyPath(pythonMajorVersion string) string {
+	return filepath.Join("embedded", "bin", fmt.Sprintf("%s%s", pythonBin, pythonMajorVersion))
 }
 
 func getRelChecksPath(cliParams *cliParams) (string, error) {
@@ -40,7 +40,7 @@ func getRelChecksPath(cliParams *cliParams) (string, error) {
 
 func detectPythonMinorVersion(cliParams *cliParams) error {
 	if pythonMinorVersion == "" {
-		pythonPath, err := getCommandPython(cliParams)
+		pythonPath, err := getCommandPython(cliParams.pythonMajorVersion, cliParams.useSysPython)
 		if err != nil {
 			return err
 		}

--- a/cmd/agent/subcommands/integrations/integrations_windows.go
+++ b/cmd/agent/subcommands/integrations/integrations_windows.go
@@ -19,8 +19,8 @@ const (
 	pythonBin = "python.exe"
 )
 
-func getRelPyPath(cliParams *cliParams) string {
-	return filepath.Join(fmt.Sprintf("embedded%s", cliParams.pythonMajorVersion), pythonBin)
+func getRelPyPath(pythonMajorVersion string) string {
+	return filepath.Join(fmt.Sprintf("embedded%s", pythonMajorVersion), pythonBin)
 }
 
 func getRelChecksPath(cliParams *cliParams) (string, error) {

--- a/releasenotes/notes/downloader-force-py3-3fb56a62ce62285d.yaml
+++ b/releasenotes/notes/downloader-force-py3-3fb56a62ce62285d.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+upgrade:
+  - |
+    Downloading and installing official checks with `agent integration install`
+    is no longer supported for agent installations that do not include an embedded
+    python3.

--- a/releasenotes/notes/downloader-force-py3-3fb56a62ce62285d.yaml
+++ b/releasenotes/notes/downloader-force-py3-3fb56a62ce62285d.yaml
@@ -9,5 +9,5 @@
 upgrade:
   - |
     Downloading and installing official checks with `agent integration install`
-    is no longer supported for agent installations that do not include an embedded
+    is no longer supported for Agent installations that do not include an embedded
     python3.


### PR DESCRIPTION
### What does this PR do?

Forces python3 to be used to invoke the downloader regardless of user settings.

### Motivation

We can't support Python2 for the newer versions of the libraries that the downloader depends on. We want to avoid having to maintain two versions (to keep py2 compatibility), and since the downloader script is invoked independently, there's no reason not to use python3 here.
[AITOOLS-77](https://datadoghq.atlassian.net/browse/AITOOLS-77)

### Describe how to test/QA your changes

- Check that the `agent integration install` command keeps working as usual.
- Do the same as in https://github.com/DataDog/datadog-agent/pull/14331#issuecomment-1323315264.
- When a version of the downloader without py2 support is released, check that it works even when the agent is set to use python2 for integrations.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
