### PR TITLE
[corechecks/helm] Set event type to Error when status is "failed"

### DIFF
--- a/pkg/collector/corechecks/cluster/helm/events.go
+++ b/pkg/collector/corechecks/cluster/helm/events.go
@@ -18,7 +18,8 @@ import (
 )
 
 const (
-	eventTitle = "Event on Helm release"
+	eventTitle       = "Event on Helm release"
+	helmStatusFailed = "failed"
 )
 
 type eventsManager struct {
@@ -64,6 +65,11 @@ func (em *eventsManager) storeEvent(event coreMetrics.Event) {
 }
 
 func eventForRelease(rel *release, text string, tags []string) coreMetrics.Event {
+	status := ""
+	if rel.Info != nil {
+		status = rel.Info.Status
+	}
+
 	return coreMetrics.Event{
 		Title:          eventTitle,
 		Text:           text,
@@ -73,6 +79,7 @@ func eventForRelease(rel *release, text string, tags []string) coreMetrics.Event
 		EventType:      checkName,
 		AggregationKey: fmt.Sprintf("helm_release:%s", rel.namespacedName()),
 		Tags:           tags,
+		AlertType:      alertType(status),
 	}
 }
 
@@ -107,4 +114,12 @@ func textForChangedStatus(previousRelStatus string, updatedRelease *release) str
 		updatedRelease.Namespace,
 		previousRelStatus,
 		updatedRelease.Info.Status)
+}
+
+func alertType(releaseStatus string) coreMetrics.EventAlertType {
+	if releaseStatus == helmStatusFailed {
+		return coreMetrics.EventAlertTypeError
+	}
+
+	return coreMetrics.EventAlertTypeInfo
 }

--- a/pkg/collector/corechecks/cluster/helm/events_test.go
+++ b/pkg/collector/corechecks/cluster/helm/events_test.go
@@ -53,6 +53,7 @@ func TestAddEventForNewRelease(t *testing.T) {
 			EventType:      "helm",
 			AggregationKey: "helm_release:default/my_datadog",
 			Tags:           testTags(),
+			AlertType:      coreMetrics.EventAlertTypeInfo,
 		},
 		storedEvent,
 	)
@@ -73,6 +74,7 @@ func TestAddEventForNewRelease(t *testing.T) {
 			EventType:      "helm",
 			AggregationKey: "helm_release:default/my_datadog",
 			Tags:           testTags(),
+			AlertType:      coreMetrics.EventAlertTypeInfo,
 		},
 		storedEvent,
 	)
@@ -112,6 +114,7 @@ func TestAddEventForDeletedRelease(t *testing.T) {
 			EventType:      "helm",
 			AggregationKey: "helm_release:default/my_datadog",
 			Tags:           testTags(),
+			AlertType:      coreMetrics.EventAlertTypeInfo,
 		},
 		storedEvent,
 	)
@@ -150,6 +153,22 @@ func TestAddEventForUpdatedRelease(t *testing.T) {
 		Namespace: "default",
 	}
 
+	exampleReleaseWithNonFailedStatus := release{
+		Name: "my_datadog",
+		Info: &info{
+			Status: "uninstalling",
+		},
+		Chart: &chart{
+			Metadata: &metadata{
+				Name:       "datadog",
+				Version:    "2.30.5",
+				AppVersion: "7",
+			},
+		},
+		Version:   1,
+		Namespace: "default",
+	}
+
 	releaseWithoutInfo := release{
 		Name: "my_datadog",
 		Info: nil,
@@ -171,7 +190,7 @@ func TestAddEventForUpdatedRelease(t *testing.T) {
 		expectedEvent  *coreMetrics.Event
 	}{
 		{
-			name:           "The status changed",
+			name:           "The status changed to \"failed\"",
 			oldRelease:     &exampleRelease,
 			updatedRelease: &exampleReleaseWithFailedStatus,
 			expectedEvent: &coreMetrics.Event{
@@ -183,6 +202,23 @@ func TestAddEventForUpdatedRelease(t *testing.T) {
 				EventType:      "helm",
 				AggregationKey: "helm_release:default/my_datadog",
 				Tags:           testTags(),
+				AlertType:      coreMetrics.EventAlertTypeError, // Because the new status is "failed"
+			},
+		},
+		{
+			name:           "The status changed and it is not \"failed\"",
+			oldRelease:     &exampleRelease,
+			updatedRelease: &exampleReleaseWithNonFailedStatus,
+			expectedEvent: &coreMetrics.Event{
+				Title:          "Event on Helm release",
+				Text:           "Helm release \"my_datadog\" (revision 1) in \"default\" namespace changed its status from \"deployed\" to \"uninstalling\".",
+				Ts:             0,
+				Priority:       coreMetrics.EventPriorityNormal,
+				SourceTypeName: "helm",
+				EventType:      "helm",
+				AggregationKey: "helm_release:default/my_datadog",
+				Tags:           testTags(),
+				AlertType:      coreMetrics.EventAlertTypeInfo, // Because the new status is not "failed"
 			},
 		},
 		{
@@ -258,6 +294,7 @@ func TestSendEvents(t *testing.T) {
 			EventType:      "helm",
 			AggregationKey: "helm_release:default/my_datadog",
 			Tags:           testTags(),
+			AlertType:      coreMetrics.EventAlertTypeInfo,
 		},
 		10*time.Second,
 	)

--- a/releasenotes/notes/helm-check-events-error-status-77fdf0f5b3a6a726.yaml
+++ b/releasenotes/notes/helm-check-events-error-status-77fdf0f5b3a6a726.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Events emitted by the Helm check now have "Error" status when the release fails.


### PR DESCRIPTION
### What does this PR do?

Sets the status to "Error" in the events emitted by the Helm check when the release status is "failed".

### Motivation

Useful to detect errors in the Events UI.


### Describe how to test/QA your changes

- Deploy the agent with the helm check enabled and events enabled. When using the helm chart:
```
datadog:
  helmCheck:
    enabled: true
    collectEvents: true
```
- Force an error in a release and verify in the Events UI that the event has status "Error" instead of "Info".

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
