### PR TITLE
Backport #14332 to `7.41.x`: Fix the scheduling of `oom_kill` and `tcp_queue_length` check with Datadog operator 1.0

### DIFF
--- a/Dockerfiles/agent/cont-init.d/60-sysprobe-check.sh
+++ b/Dockerfiles/agent/cont-init.d/60-sysprobe-check.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-if grep -Eq '^ *enable_tcp_queue_length *: *true' /etc/datadog-agent/system-probe.yaml; then
+if grep -Eq '^ *enable_tcp_queue_length *: *true' /etc/datadog-agent/system-probe.yaml || [[ "$DD_SYSTEM_PROBE_CONFIG_ENABLE_TCP_QUEUE_LENGTH" == "true" ]]; then
     mv /etc/datadog-agent/conf.d/tcp_queue_length.d/conf.yaml.example \
        /etc/datadog-agent/conf.d/tcp_queue_length.d/conf.yaml.default
 fi
 
-if grep -Eq '^ *enable_oom_kill *: *true' /etc/datadog-agent/system-probe.yaml; then
+if grep -Eq '^ *enable_oom_kill *: *true' /etc/datadog-agent/system-probe.yaml || [[ "$DD_SYSTEM_PROBE_CONFIG_ENABLE_OOM_KILL" == "true" ]]; then
     mv /etc/datadog-agent/conf.d/oom_kill.d/conf.yaml.example \
        /etc/datadog-agent/conf.d/oom_kill.d/conf.yaml.default
 fi


### PR DESCRIPTION
### What does this PR do?

The `oom_kill` and `tcp_queue_length` checks split in two parts: the data extractor runs inside `system-probe` whereas the formatting of the data, the decoration with tags and the data submission happens in the core agent.

The `system-probe` part is activated via dedicated settings.
Those settings can be set either via a `system-probe.yaml` config file or via environment variables.

For the core agent part, the activation is triggered by a script run inside an init container which reads only the `system-probe.yaml` config file.
Whereas this used to work with the Helm chart and with old versions of the operator, this is broken with the operator 1.0 because it only sets environment variables and doesn’t create any `system-probe.yaml` file.


### Motivation

Fix `oom_kill` and `tcp_queue_length` checks with the operator 1.0

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Spawn a datadog operator 1.0 and try to enable `oom_kill` and `tcp_queue_length` checks with the following CR:
```yaml
apiVersion: datadoghq.com/v2alpha1
kind: DatadogAgent
metadata:
  name: datadog
spec:
  global:
    credentials:
      apiSecret:
        secretName: datadog-secret
        keyName: api-key
      appSecret:
        secretName: datadog-secret
        keyName: app-key
  features:
    oomKill:
      enabled: true
    tcpQueueLength:
      enabled: true
```
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
