### PR TITLE
Adding an option to exclude EC2 instance tags from host tags

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -725,6 +725,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("ec2_prioritize_instance_id_as_hostname", false) // used to bypass the hostname detection logic and force the EC2 instance ID as a hostname.
 	config.BindEnvAndSetDefault("collect_ec2_tags", false)
 	config.BindEnvAndSetDefault("collect_ec2_tags_use_imds", false)
+	config.BindEnvAndSetDefault("exclude_ec2_tags", []string{})
 
 	// ECS
 	config.BindEnvAndSetDefault("ecs_agent_url", "") // Will be autodetected

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -365,6 +365,12 @@ api_key:
 #
 # collect_ec2_tags: false
 
+## @param exclude_ec2_tags - list of strings - optional - default: []
+## @env DD_EXCLUDE_EC2_TAGS - space separated list of strings - optional - default: []
+## EC2 tags to exclude from being converted into host tags -- only applicable when collect_ec2_tags is true.
+#
+# exclude_ec2_tags: []
+
 ## @param collect_ec2_tags_use_imds - boolean - optional - default: false
 ## @env DD_COLLECT_EC2_TAGS_USE_IMDS - boolean - optional - default: false
 ## Use instance metadata service (IMDS) instead of EC2 API to collect AWS EC2 custom tags.

--- a/pkg/util/ec2/ec2_tags_test.go
+++ b/pkg/util/ec2/ec2_tags_test.go
@@ -98,11 +98,13 @@ func TestFetchEc2TagsFromIMDS(t *testing.T) {
 		w.Header().Set("Content-Type", "text/plain")
 		switch r.RequestURI {
 		case "/tags/instance":
-			io.WriteString(w, "Name\nPurpose") // no trailing newline
+			io.WriteString(w, "Name\nPurpose\nExcludedTag") // no trailing newline
 		case "/tags/instance/Name":
 			io.WriteString(w, "some-vm")
 		case "/tags/instance/Purpose":
 			io.WriteString(w, "mining")
+		case "/tags/instance/ExcludedTag":
+			io.WriteString(w, "testing")
 		default:
 			w.WriteHeader(http.StatusNotFound)
 		}
@@ -111,6 +113,9 @@ func TestFetchEc2TagsFromIMDS(t *testing.T) {
 	metadataURL = ts.URL
 	config.Datadog.Set("ec2_metadata_timeout", 1000)
 	defer resetPackageVars()
+
+	confMock := config.Mock(t)
+	confMock.Set("exclude_ec2_tags", []string{"ExcludedTag", "OtherExcludedTag2"})
 
 	tags, err := fetchEc2TagsFromIMDS(ctx)
 	require.Nil(t, err)
@@ -135,12 +140,10 @@ func TestFetchEc2TagsFromIMDSError(t *testing.T) {
 }
 
 func mockFetchTagsSuccess(ctx context.Context) ([]string, error) {
-	fmt.Printf("mockFetchTagsSuccess !!!!!!!!\n")
 	return []string{"tag1", "tag2"}, nil
 }
 
 func mockFetchTagsFailure(ctx context.Context) ([]string, error) {
-	fmt.Printf("mockFetchTagsFailure !!!!!!!!\n")
 	return nil, fmt.Errorf("could not fetch tags")
 }
 

--- a/releasenotes/notes/ec2-exclude-tags-c2b92f1716ef6bee.yaml
+++ b/releasenotes/notes/ec2-exclude-tags-c2b92f1716ef6bee.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Adding a configuration option, ``exclude_ec2_tags``, to exclude EC2 instance tags from being converted into host
+    tags.


### PR DESCRIPTION
### What does this PR do?

New option `exclude_ec2_tags`, allows user to exclude tags from EC2 instances from being converted to host tags. This works in a similar way to `exclude_gce_tags`.

### Motivation

https://github.com/DataDog/datadog-agent/issues/13588

### Describe how to test/QA your changes

Start an EC2 instance with some tags. Enable ec2 tags collection and check that all tags are still collected.
Then add some tags to the exclude list and check that those tags are no longer collected (host tags are shown in the status page).

Test this with both IMDSv1 and IMDSv2.