### PR TITLE
[gitlab] Send more environment variables to macOS build pipeline

### DIFF
--- a/tasks/github.py
+++ b/tasks/github.py
@@ -24,6 +24,10 @@ def trigger_macos_build(
         release_version=release_version,
         major_version=major_version,
         python_runtimes=python_runtimes,
+        # Send pipeline id and bucket branch so that the package version
+        # can be constructed properly for nightlies.
+        gitlab_pipeline_id=env.get("CI_PIPELINE_ID", None),
+        bucket_branch=env.get("BUCKET_BRANCH", None),
     )
 
     follow_workflow_run(run_id)

--- a/tasks/libs/github_actions_tools.py
+++ b/tasks/libs/github_actions_tools.py
@@ -31,6 +31,8 @@ def trigger_macos_workflow(
     release_version=None,
     major_version=None,
     python_runtimes="3",
+    gitlab_pipeline_id=None,
+    bucket_branch=None,
 ):
     """
     Trigger a workflow to build a MacOS Agent.
@@ -48,6 +50,12 @@ def trigger_macos_workflow(
 
     if python_runtimes is not None:
         inputs["python_runtimes"] = python_runtimes
+
+    if gitlab_pipeline_id is not None:
+        inputs["gitlab_pipeline_id"] = gitlab_pipeline_id
+
+    if bucket_branch is not None:
+        inputs["bucket_branch"] = bucket_branch
 
     print(
         "Creating workflow on datadog-agent-macos-build on commit {} with args:\n{}".format(  # noqa: FS002


### PR DESCRIPTION
### What does this PR do?

Up until now, the nightly names didn't contain the `.pipeline.<ID>` like nightly packages for other systems. So now we have datadog-agent-7.41.0-rc.3.git.80.6a3d555-1.dmg but we want to have datadog-agent-7.41.0-rc.3.git.80.6a3d555.pipeline.11191346-1.dmg. Related datadog-agent-macos-build PR: https://github.com/DataDog/datadog-agent-macos-build/pull/122

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
