### PR TITLE
[netflow] Try fix flaky test `TestAggragator`

### DIFF
--- a/pkg/netflow/flowaggregator/aggregator.go
+++ b/pkg/netflow/flowaggregator/aggregator.go
@@ -146,8 +146,8 @@ func (agg *FlowAggregator) flush() int {
 	agg.sender.Gauge("datadog.netflow.aggregator.input_buffer.capacity", float64(cap(agg.flowIn)), "", nil)
 	agg.sender.Gauge("datadog.netflow.aggregator.input_buffer.length", float64(len(agg.flowIn)), "", nil)
 
-	// Increase `flushedFlowCount` at the end to be sure that the metrics are submitted before.
-	// Tests wait for `flushedFlowCount` to be increased before asserting the metrics.
+	// We increase `flushedFlowCount` at the end to be sure that the metrics are submitted before hand.
+	// Tests will wait for `flushedFlowCount` to be increased before asserting the metrics.
 	agg.flushedFlowCount.Add(uint64(flushCount))
 
 	return len(flowsToFlush)

--- a/pkg/netflow/flowaggregator/aggregator.go
+++ b/pkg/netflow/flowaggregator/aggregator.go
@@ -135,11 +135,11 @@ func (agg *FlowAggregator) flush() int {
 		agg.sendFlows(flowsToFlush)
 	}
 
-	flushCount := uint64(len(flowsToFlush))
+	flushCount := len(flowsToFlush)
 
 	agg.sender.MonotonicCount("datadog.netflow.aggregator.hash_collisions", float64(agg.flowAcc.hashCollisionFlowCount.Load()), "", nil)
 	agg.sender.MonotonicCount("datadog.netflow.aggregator.flows_received", float64(agg.receivedFlowCount.Load()), "", nil)
-	agg.sender.MonotonicCount("datadog.netflow.aggregator.flows_flushed", float64(agg.flushedFlowCount.Load()+flushCount), "", nil)
+	agg.sender.Count("datadog.netflow.aggregator.flows_flushed", float64(flushCount), "", nil)
 	agg.sender.Gauge("datadog.netflow.aggregator.flows_contexts", float64(flowsContexts), "", nil)
 	agg.sender.Gauge("datadog.netflow.aggregator.port_rollup.current_store_size", float64(agg.flowAcc.portRollup.GetCurrentStoreSize()), "", nil)
 	agg.sender.Gauge("datadog.netflow.aggregator.port_rollup.new_store_size", float64(agg.flowAcc.portRollup.GetNewStoreSize()), "", nil)
@@ -148,7 +148,7 @@ func (agg *FlowAggregator) flush() int {
 
 	// Increase `flushedFlowCount` at the end to be sure that the metrics are submitted before.
 	// Tests wait for `flushedFlowCount` to be increased before asserting the metrics.
-	agg.flushedFlowCount.Add(flushCount)
+	agg.flushedFlowCount.Add(uint64(flushCount))
 
 	return len(flowsToFlush)
 }

--- a/pkg/netflow/flowaggregator/aggregator.go
+++ b/pkg/netflow/flowaggregator/aggregator.go
@@ -135,9 +135,11 @@ func (agg *FlowAggregator) flush() int {
 		agg.sendFlows(flowsToFlush)
 	}
 
+	flushCount := uint64(len(flowsToFlush))
+
 	agg.sender.MonotonicCount("datadog.netflow.aggregator.hash_collisions", float64(agg.flowAcc.hashCollisionFlowCount.Load()), "", nil)
 	agg.sender.MonotonicCount("datadog.netflow.aggregator.flows_received", float64(agg.receivedFlowCount.Load()), "", nil)
-	agg.sender.MonotonicCount("datadog.netflow.aggregator.flows_flushed", float64(agg.flushedFlowCount.Load()), "", nil)
+	agg.sender.MonotonicCount("datadog.netflow.aggregator.flows_flushed", float64(agg.flushedFlowCount.Load()+flushCount), "", nil)
 	agg.sender.Gauge("datadog.netflow.aggregator.flows_contexts", float64(flowsContexts), "", nil)
 	agg.sender.Gauge("datadog.netflow.aggregator.port_rollup.current_store_size", float64(agg.flowAcc.portRollup.GetCurrentStoreSize()), "", nil)
 	agg.sender.Gauge("datadog.netflow.aggregator.port_rollup.new_store_size", float64(agg.flowAcc.portRollup.GetNewStoreSize()), "", nil)
@@ -146,7 +148,7 @@ func (agg *FlowAggregator) flush() int {
 
 	// Increase `flushedFlowCount` at the end to be sure that the metrics are submitted before.
 	// Tests wait for `flushedFlowCount` to be increased before asserting the metrics.
-	agg.flushedFlowCount.Add(uint64(len(flowsToFlush)))
+	agg.flushedFlowCount.Add(flushCount)
 
 	return len(flowsToFlush)
 }

--- a/pkg/netflow/flowaggregator/aggregator_test.go
+++ b/pkg/netflow/flowaggregator/aggregator_test.go
@@ -26,6 +26,7 @@ func TestAggregator(t *testing.T) {
 
 	sender := mocksender.NewMockSender("")
 	sender.On("Gauge", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+	sender.On("Count", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 	sender.On("MonotonicCount", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 	sender.On("EventPlatformEvent", mock.Anything, mock.Anything).Return()
 	sender.On("Commit").Return()
@@ -131,7 +132,7 @@ func TestAggregator(t *testing.T) {
 	assert.NoError(t, err)
 
 	sender.AssertEventPlatformEvent(t, compactEvent.String(), "network-devices-netflow")
-	sender.AssertMetric(t, "MonotonicCount", "datadog.netflow.aggregator.flows_flushed", 1, "", nil)
+	sender.AssertMetric(t, "Count", "datadog.netflow.aggregator.flows_flushed", 1, "", nil)
 	sender.AssertMetric(t, "MonotonicCount", "datadog.netflow.aggregator.flows_received", 1, "", nil)
 	sender.AssertMetric(t, "Gauge", "datadog.netflow.aggregator.flows_contexts", 1, "", nil)
 	sender.AssertMetric(t, "Gauge", "datadog.netflow.aggregator.port_rollup.current_store_size", 2, "", nil)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

https://github.com/DataDog/datadog-agent/pull/14346

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

The test TestAggregator waits for `flushedFlowCount` but the metrics are sent after `flushedFlowCount` is increased, so that might lead to metrics assertions fail (`sender.AssertMetric()`):

https://github.com/DataDog/datadog-agent/blob/2aad19b5b762689276b7ac8e54510cb3ad404134/pkg/netflow/flowaggregator/aggregator_test.go#L131-L141

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes


<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

`datadog.netflow.aggregator.flows_flushed` submission type changed from MonotonicCount to Count, but backend type is `count` for both cases, verify that the metric behaviour the same way as before.

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
