### PR TITLE
fix remote config gogo proto / api v2 interaction

### DIFF
--- a/pkg/config/remote/api/http.go
+++ b/pkg/config/remote/api/http.go
@@ -13,7 +13,7 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/gogo/protobuf/proto"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/proto/pbgo"


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This PR fixes the gogo protobuf/protobuf api v2 interaction resulting in:
```
panic: protobuf tag not enough fields in LatestConfigsResponse.state:

goroutine 339 [running]:
github.com/gogo/protobuf/proto.(*unmarshalInfo).computeUnmarshalInfo(0xc0012b14a0)
	/go/pkg/mod/github.com/gogo/protobuf@v1.3.2/proto/table_unmarshal.go:341 +0x138a
github.com/gogo/protobuf/proto.(*unmarshalInfo).unmarshal(0xc0012b14a0, {0x4cd16c0?}, {0xc0014e4000, 0x15404, 0x18000})
	/go/pkg/mod/github.com/gogo/protobuf@v1.3.2/proto/table_unmarshal.go:138 +0x67
github.com/gogo/protobuf/proto.(*InternalMessageInfo).Unmarshal(0xc0012d77c0?, {0x57fa1d0, 0xc001333130}, {0xc0014e4000?, 0x15404?, 0x18000?})
	/go/pkg/mod/github.com/gogo/protobuf@v1.3.2/proto/table_unmarshal.go:63 +0xd0
github.com/gogo/protobuf/proto.(*Buffer).Unmarshal(0xc0010b9b70, {0x57fa1d0, 0xc001333130})
	/go/pkg/mod/github.com/gogo/protobuf@v1.3.2/proto/decode.go:424 +0x153
github.com/gogo/protobuf/proto.Unmarshal({0xc0014e4000, 0x15404, 0x18000}, {0x57fa1d0, 0xc001333130})
	/go/pkg/mod/github.com/gogo/protobuf@v1.3.2/proto/decode.go:342 +0xe6
github.com/DataDog/datadog-agent/pkg/config/remote/api.(*HTTPClient).Fetch(0xc0009aeac0, {0x5810e50, 0xc000134000}, 0xc0001f82d0)
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/config/remote/api/http.go:115 +0x670
github.com/DataDog/datadog-agent/pkg/config/remote/service.(*Service).refresh(0xc0005f7d00)
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/config/remote/service/service.go:273 +0x3f2
github.com/DataDog/datadog-agent/pkg/config/remote/service.(*Service).Start.func1()
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/config/remote/service/service.go:217 +0x6e
created by github.com/DataDog/datadog-agent/pkg/config/remote/service.(*Service).Start
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/config/remote/service/service.go:214 +0xc5
```
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
