### PR TITLE
Use URI.parse for installopts specs instead of string compare

### DIFF
--- a/test/kitchen/test/integration/win-installopts/rspec/win-installopts_spec.rb
+++ b/test/kitchen/test/integration/win-installopts/rspec/win-installopts_spec.rb
@@ -42,15 +42,15 @@ shared_examples_for 'a configured Agent' do
 
       expect(confYaml).to have_key("logs_config")
       expect(confYaml["logs_config"]).to have_key("logs_dd_url")
-      expect(URI.parse(confYaml["logs_config"]["logs_dd_url"]).to eq(URI.parse("https://logs.someurl.datadoghq.com"))
+      expect(URI.parse(confYaml["logs_config"]["logs_dd_url"])).to eq(URI.parse("https://logs.someurl.datadoghq.com"))
 
       expect(confYaml).to have_key("process_config")
       expect(confYaml["process_config"]).to have_key("process_dd_url")
-      expect(URI.parse(confYaml["process_config"]["process_dd_url"]).to eq(URI.parse("https://process.someurl.datadoghq.com"))
+      expect(URI.parse(confYaml["process_config"]["process_dd_url"])).to eq(URI.parse("https://process.someurl.datadoghq.com"))
 
       expect(confYaml).to have_key("apm_config")
       expect(confYaml["apm_config"]).to have_key("apm_dd_url")
-      expect(URI.parse(confYaml["apm_config"]["apm_dd_url"]).to eq(URI.parse("https://trace.someurl.datadoghq.com"))
+      expect(URI.parse(confYaml["apm_config"]["apm_dd_url"])).to eq(URI.parse("https://trace.someurl.datadoghq.com"))
 
     end
 end

--- a/test/kitchen/test/integration/win-installopts/rspec/win-installopts_spec.rb
+++ b/test/kitchen/test/integration/win-installopts/rspec/win-installopts_spec.rb
@@ -31,26 +31,26 @@ shared_examples_for 'a configured Agent' do
     it 'has proxy settings' do 
      expect(confYaml).to have_key("proxy")
      expect(confYaml["proxy"]).to have_key("https")
-     expect(confYaml["proxy"]["https"]).to eq("http://puser:ppass@proxy.foo.com:1234")
+     expect(URI.parse(confYaml["proxy"]["https"])).to eq(URI.parse("http://puser:ppass@proxy.foo.com:1234"))
     end
     it 'has site settings' do
       expect(confYaml).to have_key("site")
       expect(confYaml["site"]).to eq("eu")
 
       expect(confYaml).to have_key("dd_url")
-      expect(confYaml["dd_url"]).to eq("https://someurl.datadoghq.com")
+      expect(URI.parse(confYaml["dd_url"])).to eq(URI.parse("https://someurl.datadoghq.com"))
 
       expect(confYaml).to have_key("logs_config")
       expect(confYaml["logs_config"]).to have_key("logs_dd_url")
-      expect(confYaml["logs_config"]["logs_dd_url"]).to eq("https://logs.someurl.datadoghq.com")
+      expect(URI.parse(confYaml["logs_config"]["logs_dd_url"]).to eq(URI.parse("https://logs.someurl.datadoghq.com"))
 
       expect(confYaml).to have_key("process_config")
       expect(confYaml["process_config"]).to have_key("process_dd_url")
-      expect(confYaml["process_config"]["process_dd_url"]).to eq("https://process.someurl.datadoghq.com")
+      expect(URI.parse(confYaml["process_config"]["process_dd_url"]).to eq(URI.parse("https://process.someurl.datadoghq.com"))
 
       expect(confYaml).to have_key("apm_config")
       expect(confYaml["apm_config"]).to have_key("apm_dd_url")
-      expect(confYaml["apm_config"]["apm_dd_url"]).to eq("https://trace.someurl.datadoghq.com")
+      expect(URI.parse(confYaml["apm_config"]["apm_dd_url"]).to eq(URI.parse("https://trace.someurl.datadoghq.com"))
 
     end
 end


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
This PR changes the `installopts` rspec expecations to use `URI.parse` and compare the resulting objects, rather than doing string comparison which are prone to failure.
For instance:
```
6) win-installopts behaves like a configured Agent has proxy settings
            Failure/Error: expect(confYaml["proxy"]["https"]).to eq("http://puser:ppass@proxy.foo.com:1234")

       expected: "http://puser:ppass@proxy.foo.com:1234"
            got: "http://puser:ppass@proxy.foo.com:1234/"

       (compared using ==)
            Shared Example Group: "a configured Agent" called from ./win-installopts_spec.rb:62
            # ./win-installopts_spec.rb:34:in `block (2 levels) in <top (required)>'
            # C:/Users/vagrant/AppData/Local/Temp/verifier/gems/gems/busser-rspec-0.7.6/lib/busser/rspec/runner.rb:23:in `<main>'
```

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Better kitchen tests

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
