### PR TITLE
Store/retrieve properties from registry

### DIFF
--- a/tools/windows/DatadogAgentInstaller/CustomActions/UserCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/UserCustomActions.cs
@@ -157,7 +157,7 @@ namespace Datadog.CustomActions
         {
             try
             {
-                if (!string.IsNullOrEmpty(session["DDAGENTUSER_FQ_NAME"]))
+                if (!string.IsNullOrEmpty(session["DDAGENTUSER_PROCESSED_FQ_NAME"]))
                 {
                   // This function has already executed succesfully
                   return ActionResult.Success;
@@ -198,12 +198,12 @@ namespace Datadog.CustomActions
                 {
                     domain = GetDefaultDomainPart();
                 }
-                session.Log($"Installing with DDAGENTUSER_USERNAME={userName} and DDAGENTUSER_DOMAIN={domain}");
-                // Create new DDAGENTUSER_USERNAME property so we don't modify the property containing
+                session.Log($"Installing with DDAGENTUSER_PROCESSED_NAME={userName} and DDAGENTUSER_PROCESSED_DOMAIN={domain}");
+                // Create new DDAGENTUSER_PROCESSED_NAME property so we don't modify the property containing
                 // the user provided value DDAGENTUSER_NAME
-                session["DDAGENTUSER_USERNAME"] = userName;
-                session["DDAGENTUSER_DOMAIN"] = domain;
-                session["DDAGENTUSER_FQ_NAME"] = $"{domain}\\{userName}";
+                session["DDAGENTUSER_PROCESSED_NAME"] = userName;
+                session["DDAGENTUSER_PROCESSED_DOMAIN"] = domain;
+                session["DDAGENTUSER_PROCESSED_FQ_NAME"] = $"{domain}\\{userName}";
 
                 var ddAgentUserPassword = session["DDAGENTUSER_PASSWORD"];
 
@@ -217,7 +217,7 @@ namespace Datadog.CustomActions
                     ddAgentUserPassword = null;
                 }
 
-                session["DDAGENTUSER_PASSWORD"] = ddAgentUserPassword;
+                session["DDAGENTUSER_PROCESSED_PASSWORD"] = ddAgentUserPassword;
             }
             catch (Exception e)
             {
@@ -240,7 +240,7 @@ namespace Datadog.CustomActions
                 SecurityIdentifier securityIdentifier;
                 if (string.IsNullOrEmpty(session.Property("DDAGENTUSER_SID")))
                 {
-                    var ddAgentUserName = $"{session.Property("DDAGENTUSER_FQ_NAME")}";
+                    var ddAgentUserName = $"{session.Property("DDAGENTUSER_PROCESSED_FQ_NAME")}";
                     var userFound = LookupAccountName(ddAgentUserName,
                         out _,
                         out _,

--- a/tools/windows/DatadogAgentInstaller/CustomActions/UserCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/UserCustomActions.cs
@@ -177,6 +177,8 @@ namespace Datadog.CustomActions
                     domain = GetDefaultDomainPart();
                 }
                 session.Log($"Installing with DDAGENTUSER_USERNAME={userName} and DDAGENTUSER_DOMAIN={domain}");
+                // Create new DDAGENTUSER_USERNAME property so we don't modify the property containing
+                // the user provided value DDAGENTUSER_NAME
                 session["DDAGENTUSER_USERNAME"] = userName;
                 session["DDAGENTUSER_DOMAIN"] = domain;
                 session["DDAGENTUSER_FQ_NAME"] = $"{domain}\\{userName}";

--- a/tools/windows/DatadogAgentInstaller/CustomActions/UserCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/UserCustomActions.cs
@@ -69,7 +69,8 @@ namespace Datadog.CustomActions
                 try
                 {
                     var propertyVal = handler(session);
-                    if (!string.IsNullOrEmpty(propertyVal)) {
+                    if (!string.IsNullOrEmpty(propertyVal))
+                    {
                         session[propertyName] = propertyVal;
                         session.Log($"Found {propertyName} in registry {session[propertyName]}");
                     }
@@ -125,10 +126,11 @@ namespace Datadog.CustomActions
                             {
                                 var domain = subkey.GetValue("installedDomain").ToString();
                                 var user = subkey.GetValue("installedUser").ToString();
-                                if (!string.IsNullOrEmpty(domain) && !string.IsNullOrEmpty(user)) {
+                                if (!string.IsNullOrEmpty(domain) && !string.IsNullOrEmpty(user))
+                                {
                                     return $"{domain}\\{user}";
                                 }
-                                return "";
+                                return string.Empty;
                             });
 
                         // PROJECTLOCATION

--- a/tools/windows/DatadogAgentInstaller/CustomActions/UserCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/UserCustomActions.cs
@@ -75,7 +75,10 @@ namespace Datadog.CustomActions
                         session.Log($"Found {propertyName} in registry {session[propertyName]}");
                     }
                 }
-                catch { }
+                catch (Exception e)
+                {
+                    session.Log($"Exception processing registry value for {propertyName}: {e}");
+                }
             }
             else
             {

--- a/tools/windows/DatadogAgentInstaller/CustomActions/UserCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/UserCustomActions.cs
@@ -87,34 +87,38 @@ namespace Datadog.CustomActions
             // This CA runs (only once) in either the InstallUISequence or the InstallExecuteSequence.
             try
             {
-                using (var subkey = Microsoft.Win32.Registry.LocalMachine.OpenSubKey(@"Software\Datadog\Datadog Agent")) {
-                    // DDAGENTUSER_NAME
-                    //
-                    // The user account can be provided to the installer by
-                    // * The registry
-                    // * The command line
-                    // * The agent user dialog
-                    // The user account domain and name are stored separetely in the registry
-                    // but are passed together on the command line and the agent user dialog.
-                    // This function will combine the registry properties if they exist.
-                    // Preference is given to creds provided on the command line and the agent user dialog.
-                    // For UI installs it ensures that the agent user dialog is pre-populated.
-                    RegistryProperty(session, "DDAGENTUSER_NAME",
-                        RegistryPropertyHandler =>
-                        {
-                            var domain = subkey.GetValue("installedDomain").ToString();
-                            var user = subkey.GetValue("installedUser").ToString();
-                            if (!string.IsNullOrEmpty(domain) && !string.IsNullOrEmpty(user)) {
-                                return $"{domain}\\{user}";
-                            }
-                            return "";
-                        });
+                using (var subkey = Microsoft.Win32.Registry.LocalMachine.OpenSubKey(@"Software\Datadog\Datadog Agent"))
+                {
+                    if (subkey != null)
+                    {
+                        // DDAGENTUSER_NAME
+                        //
+                        // The user account can be provided to the installer by
+                        // * The registry
+                        // * The command line
+                        // * The agent user dialog
+                        // The user account domain and name are stored separetely in the registry
+                        // but are passed together on the command line and the agent user dialog.
+                        // This function will combine the registry properties if they exist.
+                        // Preference is given to creds provided on the command line and the agent user dialog.
+                        // For UI installs it ensures that the agent user dialog is pre-populated.
+                        RegistryProperty(session, "DDAGENTUSER_NAME",
+                            RegistryPropertyHandler =>
+                            {
+                                var domain = subkey.GetValue("installedDomain").ToString();
+                                var user = subkey.GetValue("installedUser").ToString();
+                                if (!string.IsNullOrEmpty(domain) && !string.IsNullOrEmpty(user)) {
+                                    return $"{domain}\\{user}";
+                                }
+                                return "";
+                            });
 
-                    // PROJECTLOCATION
-                    RegistryValueProperty(session, "PROJECTLOCATION", subkey, "InstallPath");
+                        // PROJECTLOCATION
+                        RegistryValueProperty(session, "PROJECTLOCATION", subkey, "InstallPath");
 
-                    // APPLICATIONDATADIRECTORY
-                    RegistryValueProperty(session, "APPLICATIONDATADIRECTORY", subkey, "ConfigRoot");
+                        // APPLICATIONDATADIRECTORY
+                        RegistryValueProperty(session, "APPLICATIONDATADIRECTORY", subkey, "ConfigRoot");
+                    }
                 }
             }
             catch (Exception e)

--- a/tools/windows/DatadogAgentInstaller/WixSetup/CustomAction.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/CustomAction.cs
@@ -48,6 +48,19 @@ namespace WixSetup
             CustomActionMethod action,
             Return returnType,
             When when,
+            Step step,
+            Condition condition,
+            Sequence sequence)
+            : base(id, action, typeof(T).Assembly.Location, returnType, when, step, condition, sequence)
+        {
+            RefAssemblies = typeof(T).GetReferencesAssembliesPaths().ToArray();
+        }
+
+        public CustomAction(
+            Id id,
+            CustomActionMethod action,
+            Return returnType,
+            When when,
             Step step)
             : base(id, action, typeof(T).Assembly.Location, returnType, when, step, Condition.Always)
         {

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentCustomActions.cs
@@ -9,6 +9,8 @@ namespace WixSetup.Datadog
 
         public ManagedAction WriteConfig { get; }
 
+        public ManagedAction ReadRegistryProperties { get; }
+
         public ManagedAction ProcessDdAgentUserCredentials { get; }
 
         public ManagedAction DecompressPythonDistributions { get; }
@@ -23,11 +25,22 @@ namespace WixSetup.Datadog
                     new Id("ReadConfigCustomAction"),
                     ConfigCustomActions.ReadConfig,
                     Return.ignore,
-                    When.Before,
-                    Step.InstallInitialize,
-                    Condition.NOT_BeingRemoved
+                    When.After,
+                    Step.AppSearch,
+                    Condition.NOT_BeingRemoved,
+                    Sequence.InstallUISequence
                 )
                 .SetProperties("APPLICATIONDATADIRECTORY=[APPLICATIONDATADIRECTORY]");
+
+            ReadRegistryProperties = new CustomAction<UserCustomActions>(
+                    new Id("ReadRegistryProperties"),
+                    UserCustomActions.ReadRegistryProperties,
+                    Return.ignore,
+                    When.After,
+                    Step.AppSearch,
+                    Condition.NOT_BeingRemoved,
+                    Sequence.InstallUISequence
+                );
 
             WriteConfig = new CustomAction<ConfigCustomActions>(
                     new Id("WriteConfigCustomAction"),
@@ -75,7 +88,7 @@ namespace WixSetup.Datadog
                     Return.check,
                     When.Before,
                     Step.InstallInitialize,
-                    Condition.NOT_Installed & Condition.NOT_BeingRemoved
+                    Condition.NOT_BeingRemoved
                 )
                 .SetProperties("DDAGENTUSER_NAME=[DDAGENTUSER_NAME], DDAGENTUSER_PASSWORD=[DDAGENTUSER_PASSWORD]")
                 .HideTarget(true);

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentCustomActions.cs
@@ -28,8 +28,11 @@ namespace WixSetup.Datadog
                     When.After,
                     Step.AppSearch,
                     Condition.NOT_BeingRemoved,
-                    Sequence.InstallUISequence
+                    Sequence.InstallExecuteSequence | Sequence.InstallUISequence
                 )
+                {
+                    Execute = Execute.firstSequence
+                }
                 .SetProperties("APPLICATIONDATADIRECTORY=[APPLICATIONDATADIRECTORY]");
 
             ReadRegistryProperties = new CustomAction<UserCustomActions>(
@@ -39,8 +42,11 @@ namespace WixSetup.Datadog
                     When.After,
                     Step.AppSearch,
                     Condition.NOT_BeingRemoved,
-                    Sequence.InstallUISequence
-                );
+                    Sequence.InstallExecuteSequence | Sequence.InstallUISequence
+                )
+                {
+                    Execute = Execute.firstSequence
+                };
 
             WriteConfig = new CustomAction<ConfigCustomActions>(
                     new Id("WriteConfigCustomAction"),

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentCustomActions.cs
@@ -133,7 +133,7 @@ namespace WixSetup.Datadog
                 {
                     Execute = Execute.deferred
                 }
-                .SetProperties("DDAGENTUSER_FQ_NAME=[DDAGENTUSER_FQ_NAME], DDAGENTUSER_SID=[DDAGENTUSER_SID]");
+                .SetProperties("DDAGENTUSER_PROCESSED_FQ_NAME=[DDAGENTUSER_PROCESSED_FQ_NAME], DDAGENTUSER_SID=[DDAGENTUSER_SID]");
         }
     }
 }

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentCustomActions.cs
@@ -25,7 +25,7 @@ namespace WixSetup.Datadog
                     Return.ignore,
                     // AppSearch is when RegistrySearch is run, so that will overwrite
                     // any command line values.
-                    // Prefer using our CA over RegsitrySearch.
+                    // Prefer using our CA over RegistrySearch.
                     // It is executed on the Welcome screen of the installer.
                     When.After,
                     Step.AppSearch,
@@ -102,8 +102,11 @@ namespace WixSetup.Datadog
                     new Id("ProcessDdAgentUserCredentials"),
                     UserCustomActions.ProcessDdAgentUserCredentials,
                     Return.check,
+                    // Run at end of "config phase", right before the "make changes" phase.
                     When.Before,
                     Step.InstallInitialize,
+                    // Run unless we are being uninstalled.
+                    // This CA produces properties used for services, accounts, and permissions.
                     Condition.NOT_BeingRemoved
                 )
                 .SetProperties("DDAGENTUSER_NAME=[DDAGENTUSER_NAME], DDAGENTUSER_PASSWORD=[DDAGENTUSER_PASSWORD]")

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentInstaller.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentInstaller.cs
@@ -94,6 +94,8 @@ namespace WixSetup.Datadog
                 new RegKey(
                     _agentFeatures.MainApplication,
                     RegistryHive.LocalMachine, @"Software\Datadog\Datadog Agent",
+                    // Store these properties in the registry for retrieval by future
+                    // installer runs via the ReadRegistryProperties CA.
                     new RegValue("InstallPath", "[PROJECTLOCATION]") { Win64 = true },
                     new RegValue("ConfigRoot", "[APPLICATIONDATADIRECTORY]") { Win64 = true },
                     new RegValue("installedDomain", "[DDAGENTUSER_DOMAIN]") { Win64 = true },

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentInstaller.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentInstaller.cs
@@ -71,43 +71,17 @@ namespace WixSetup.Datadog
                 {
                     AttributesDefinition = "Hidden=yes;Secure=yes"
                 },
-                new RegValueProperty("DDAGENTUSER_DOMAIN",
-                        RegistryHive.LocalMachine,
-                        @"Software\Datadog\Datadog Agent",
-                        "installedDomain"
-                )
-                {
-                    Win64 = true
-                },
-                new RegValueProperty("DDAGENTUSER_USERNAME",
-                        RegistryHive.LocalMachine,
-                        @"Software\Datadog\Datadog Agent",
-                        "installedUser"
-                )
-                {
-                    Win64 = true
-                },
                 new Property("DDAGENTUSER_PASSWORD")
                 {
                     AttributesDefinition = "Hidden=yes;Secure=yes"
                 },
-                new RegValueProperty("PROJECTLOCATION",
-                    RegistryHive.LocalMachine,
-                    "SOFTWARE\\Datadog\\Datadog Agent",
-                    "InstallPath"
-                )
+                new Property("PROJECTLOCATION")
                 {
                     AttributesDefinition = "Secure=yes",
-                    Win64 = true
                 },
-                new RegValueProperty("APPLICATIONDATADIRECTORY",
-                    RegistryHive.LocalMachine,
-                    "SOFTWARE\\Datadog\\Datadog Agent",
-                    "ConfigRoot"
-                )
+                new Property("APPLICATIONDATADIRECTORY")
                 {
                     AttributesDefinition = "Secure=yes",
-                    Win64 = true
                 },
                 new CloseApplication(new Id("CloseTrayApp"),
                     Path.GetFileName(_agentBinaries.Tray),

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentInstallerUI.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentInstallerUI.cs
@@ -25,8 +25,7 @@ namespace WixSetup.Datadog
 
             CustomUI.On(NativeDialogs.CustomizeDlg, Buttons.Back, new ShowDialog(NativeDialogs.MaintenanceTypeDlg, Condition.Installed) { Order = 1 });
             CustomUI.On(NativeDialogs.CustomizeDlg, Buttons.Back, new ShowDialog(NativeDialogs.LicenseAgreementDlg, Condition.NOT_Installed) { Order = 2 });
-            CustomUI.On(NativeDialogs.CustomizeDlg, Buttons.Next, new ExecuteCustomAction(agentCustomActions.ReadConfig.Id) { Order = 1 });
-            CustomUI.On(NativeDialogs.CustomizeDlg, Buttons.Next, new ShowDialog(Dialogs.ApiKeyDialog) { Order = 2 });
+            CustomUI.On(NativeDialogs.CustomizeDlg, Buttons.Next, new ShowDialog(Dialogs.ApiKeyDialog) { Order = 1 });
 
             CustomUI.On(Dialogs.ApiKeyDialog, Buttons.Next, new ShowDialog(Dialogs.SiteSelectionDialog));
             CustomUI.On(Dialogs.ApiKeyDialog, Buttons.Back, new ShowDialog(NativeDialogs.CustomizeDlg, Condition.NOT_Installed));

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentInstallerUI.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentInstallerUI.cs
@@ -16,6 +16,9 @@ namespace WixSetup.Datadog
             wixProjectEvents.WixSourceGenerated += OnWixSourceGenerated;
 
             CustomUI = new CustomUI();
+            // NOTE: CustomActions called from dialog Controls will not be able to add messages to the log.
+            //       If possible, prefer adding the custom action to an install sequence.
+            //       https://learn.microsoft.com/en-us/windows/win32/msi/doaction-controlevent
 
             CustomUI.On(NativeDialogs.WelcomeDlg, Buttons.Next, new ShowDialog(NativeDialogs.LicenseAgreementDlg, Condition.NOT_Installed));
             CustomUI.On(NativeDialogs.WelcomeDlg, Buttons.Next, new ShowDialog(NativeDialogs.VerifyReadyDlg, Conditions.Installed_AND_PATCH));


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Adds a custom action to retrieve properties from the registry, giving precedence to command line properties.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
feature parity https://datadoghq.atlassian.net/browse/WA-146

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
