### PR TITLE
[CSPM] downgrade the process fetch error log to a warn log

### DIFF
--- a/pkg/compliance/checks/process_utils.go
+++ b/pkg/compliance/checks/process_utils.go
@@ -57,7 +57,7 @@ func (p *CheckedProcess) Name() string {
 
 	innerName, err := p.inner.Name()
 	if err != nil {
-		log.Infof("failed to fetch process (pid=%d) name: %v", p.pid, err)
+		log.Warnf("failed to fetch process (pid=%d) name: %v", p.pid, err)
 		return ""
 	}
 	p.name = innerName
@@ -72,7 +72,7 @@ func (p *CheckedProcess) Exe() string {
 
 	innerExe, err := p.inner.Exe()
 	if err != nil {
-		log.Infof("failed to fetch process (pid=%d) exe: %v", p.pid, err)
+		log.Warnf("failed to fetch process (pid=%d) exe: %v", p.pid, err)
 		return ""
 	}
 	p.exe = innerExe
@@ -87,7 +87,7 @@ func (p *CheckedProcess) CmdlineSlice() []string {
 
 	innerCmdLine, err := p.inner.CmdlineSlice()
 	if err != nil {
-		log.Infof("failed to fetch process (pid=%d) cmdline: %v", p.pid, err)
+		log.Warnf("failed to fetch process (pid=%d) cmdline: %v", p.pid, err)
 		return nil
 	}
 	p.cmdLineSlice = innerCmdLine

--- a/pkg/compliance/checks/process_utils.go
+++ b/pkg/compliance/checks/process_utils.go
@@ -57,7 +57,7 @@ func (p *CheckedProcess) Name() string {
 
 	innerName, err := p.inner.Name()
 	if err != nil {
-		log.Errorf("failed to fetch process (pid=%d) name: %v", p.pid, err)
+		log.Infof("failed to fetch process (pid=%d) name: %v", p.pid, err)
 		return ""
 	}
 	p.name = innerName
@@ -72,7 +72,7 @@ func (p *CheckedProcess) Exe() string {
 
 	innerExe, err := p.inner.Exe()
 	if err != nil {
-		log.Errorf("failed to fetch process (pid=%d) exe: %v", p.pid, err)
+		log.Infof("failed to fetch process (pid=%d) exe: %v", p.pid, err)
 		return ""
 	}
 	p.exe = innerExe
@@ -87,7 +87,7 @@ func (p *CheckedProcess) CmdlineSlice() []string {
 
 	innerCmdLine, err := p.inner.CmdlineSlice()
 	if err != nil {
-		log.Errorf("failed to fetch process (pid=%d) cmdline: %v", p.pid, err)
+		log.Infof("failed to fetch process (pid=%d) cmdline: %v", p.pid, err)
 		return nil
 	}
 	p.cmdLineSlice = innerCmdLine

--- a/pkg/compliance/checks/process_utils.go
+++ b/pkg/compliance/checks/process_utils.go
@@ -6,6 +6,8 @@
 package checks
 
 import (
+	"errors"
+	"io/fs"
 	"strings"
 	"time"
 
@@ -72,7 +74,11 @@ func (p *CheckedProcess) Exe() string {
 
 	innerExe, err := p.inner.Exe()
 	if err != nil {
-		log.Warnf("failed to fetch process (pid=%d) exe: %v", p.pid, err)
+		if errors.Is(err, fs.ErrPermission) {
+			log.Debugf("failed to fetch process (pid=%d) exe: %v", p.pid, err)
+		} else {
+			log.Warnf("failed to fetch process (pid=%d) exe: %v", p.pid, err)
+		}
 		return ""
 	}
 	p.exe = innerExe


### PR DESCRIPTION
### What does this PR do?

Since https://github.com/DataDog/datadog-agent/pull/12429 the listing of the processes and the fetching of interesting fields is done in 2 separate steps, and lazily on request of the field. In some cases it can happen that the process doesn't exist anymore. In other cases the old fetching process mechanism was failing silently if the readlink to fetch the exe name was not allowed.

This PR downgrades the logs to warn instead of error and even debug for the exe case where permission is denied (a common case, and the exe field is not used in CSPM rules).

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
