### PR TITLE
Replace timestamp by increasing id to avoid configVersion matching different config changed in the same second

### DIFF
--- a/pkg/clusteragent/clusterchecks/dispatcher_nodes.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_nodes.go
@@ -33,7 +33,7 @@ func (d *dispatcher) getClusterCheckConfigs(nodeName string) ([]integration.Conf
 
 	node.RLock()
 	defer node.RUnlock()
-	return makeConfigArray(node.digestToConfig), node.lastConfigChange, nil
+	return makeConfigArray(node.digestToConfig), node.configVersion.Load(), nil
 }
 
 // processNodeStatus keeps the node's status in the store, and returns true
@@ -53,7 +53,7 @@ func (d *dispatcher) processNodeStatus(nodeName, clientIP string, status types.N
 	node.lastStatus = status
 	node.heartbeat = timestampNow()
 
-	if node.lastConfigChange == status.LastChange {
+	if node.configVersion.Load() == status.LastChange {
 		// Node-agent is up to date
 		return true, nil
 	}

--- a/pkg/clusteragent/clusterchecks/dispatcher_test.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_test.go
@@ -212,9 +212,9 @@ func TestProcessNodeStatus(t *testing.T) {
 	assert.False(t, upToDate)
 
 	// Give changes
-	node1.lastConfigChange = timestampNow()
+	node1.configVersion.Inc()
 	node1.heartbeat = node1.heartbeat - 50
-	status2 := types.NodeStatus{LastChange: node1.lastConfigChange - 2}
+	status2 := types.NodeStatus{LastChange: node1.configVersion.Load() - 2}
 	upToDate, err = dispatcher.processNodeStatus("node1", "10.0.0.1", status2)
 	assert.NoError(t, err)
 	assert.False(t, upToDate)
@@ -222,7 +222,7 @@ func TestProcessNodeStatus(t *testing.T) {
 	assert.True(t, timestampNow() <= node1.heartbeat+1)
 
 	// No change
-	status3 := types.NodeStatus{LastChange: node1.lastConfigChange}
+	status3 := types.NodeStatus{LastChange: node1.configVersion.Load()}
 	upToDate, err = dispatcher.processNodeStatus("node1", "10.0.0.1", status3)
 	assert.NoError(t, err)
 	assert.True(t, upToDate)
@@ -300,7 +300,8 @@ func TestRescheduleDanglingFromExpiredNodes(t *testing.T) {
 	// Register a node with a correct status & schedule a Check
 	dispatcher.processNodeStatus("nodeA", "10.0.0.1", types.NodeStatus{})
 	dispatcher.Schedule([]integration.Config{
-		generateIntegration("A")})
+		generateIntegration("A"),
+	})
 
 	// Ensure it's dispatch correctly
 	allConfigs, err := dispatcher.getAllConfigs()

--- a/pkg/clusteragent/clusterchecks/stores.go
+++ b/pkg/clusteragent/clusterchecks/stores.go
@@ -17,6 +17,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	le "github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/leaderelection/metrics"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+
+	"go.uber.org/atomic"
 )
 
 // clusterStore holds the state of cluster-check management.
@@ -82,19 +84,20 @@ func (s *clusterStore) clearDangling() {
 // Lock is to be held by the user (dispatcher)
 type nodeStore struct {
 	sync.RWMutex
-	name             string
-	heartbeat        int64
-	lastStatus       types.NodeStatus
-	lastConfigChange int64
-	digestToConfig   map[string]integration.Config
-	clientIP         string
-	clcRunnerStats   types.CLCRunnersStats
-	busyness         int
+	name           string
+	heartbeat      int64
+	lastStatus     types.NodeStatus
+	configVersion  *atomic.Int64
+	digestToConfig map[string]integration.Config
+	clientIP       string
+	clcRunnerStats types.CLCRunnersStats
+	busyness       int
 }
 
 func newNodeStore(name, clientIP string) *nodeStore {
 	return &nodeStore{
 		name:           name,
+		configVersion:  atomic.NewInt64(0),
 		clientIP:       clientIP,
 		digestToConfig: make(map[string]integration.Config),
 		clcRunnerStats: types.CLCRunnersStats{},
@@ -103,8 +106,8 @@ func newNodeStore(name, clientIP string) *nodeStore {
 }
 
 func (s *nodeStore) addConfig(config integration.Config) {
-	s.lastConfigChange = timestampNow()
 	s.digestToConfig[config.Digest()] = config
+	s.configVersion.Inc()
 	dispatchedConfigs.Inc(s.name, le.JoinLeaderValue)
 }
 
@@ -114,8 +117,8 @@ func (s *nodeStore) removeConfig(digest string) {
 		log.Debugf("unknown digest %s, skipping", digest)
 		return
 	}
-	s.lastConfigChange = timestampNow()
 	delete(s.digestToConfig, digest)
+	s.configVersion.Inc()
 	dispatchedConfigs.Dec(s.name, le.JoinLeaderValue)
 }
 


### PR DESCRIPTION
### What does this PR do?

Change the config version tracker in the cluster checks dispatching to allow multiple config changes in the same second.

### Motivation

Bugfix.

### Additional Notes

If a cluster checks runner would poll between 2 config changes that happened within the same second, it would ignore the newly added configs.
If you wonder, the `int64` will not overflow before end of time with 10 config changes / second.

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

The bug is not really reproducible, so the idea is simply to perform a non-regression test on the Cluster Checks dispatching.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
