### PR TITLE
[snmp] Fix panic for direct ip instance

### DIFF
--- a/pkg/collector/corechecks/snmp/internal/discovery/discovery.go
+++ b/pkg/collector/corechecks/snmp/internal/discovery/discovery.go
@@ -307,8 +307,8 @@ func (d *Discovery) writeCache(subnet *snmpSubnet) {
 }
 
 // NewDiscovery return a new Discovery instance
-func NewDiscovery(config *checkconfig.CheckConfig, sessionFactory session.Factory) Discovery {
-	return Discovery{
+func NewDiscovery(config *checkconfig.CheckConfig, sessionFactory session.Factory) *Discovery {
+	return &Discovery{
 		discoveredDevices: make(map[checkconfig.DeviceDigest]Device),
 		stop:              make(chan struct{}),
 		config:            config,

--- a/pkg/collector/corechecks/snmp/internal/discovery/discovery_test.go
+++ b/pkg/collector/corechecks/snmp/internal/discovery/discovery_test.go
@@ -61,7 +61,7 @@ func TestDiscovery(t *testing.T) {
 	}
 	discovery := NewDiscovery(checkConfig, sessionFactory)
 	discovery.Start()
-	assert.NoError(t, waitForDiscoveredDevices(&discovery, 7, 2*time.Second))
+	assert.NoError(t, waitForDiscoveredDevices(discovery, 7, 2*time.Second))
 	discovery.Stop()
 
 	deviceConfigs := discovery.GetDiscoveredDeviceConfigs()
@@ -111,7 +111,7 @@ func TestDiscoveryCache(t *testing.T) {
 	}
 	discovery := NewDiscovery(checkConfig, sessionFactory)
 	discovery.Start()
-	assert.NoError(t, waitForDiscoveredDevices(&discovery, 4, 2*time.Second))
+	assert.NoError(t, waitForDiscoveredDevices(discovery, 4, 2*time.Second))
 	discovery.Stop()
 
 	deviceConfigs := discovery.GetDiscoveredDeviceConfigs()
@@ -143,7 +143,7 @@ func TestDiscoveryCache(t *testing.T) {
 	}
 	discovery2 := NewDiscovery(checkConfig, sessionFactory)
 	discovery2.Start()
-	assert.NoError(t, waitForDiscoveredDevices(&discovery2, 4, 2*time.Second))
+	assert.NoError(t, waitForDiscoveredDevices(discovery2, 4, 2*time.Second))
 	discovery2.Stop()
 
 	deviceConfigsFromCache := discovery2.GetDiscoveredDeviceConfigs()

--- a/pkg/collector/corechecks/snmp/snmp.go
+++ b/pkg/collector/corechecks/snmp/snmp.go
@@ -156,6 +156,7 @@ func (c *Check) Configure(rawInstance integration.Data, rawInitConfig integratio
 func (c *Check) Cancel() {
 	if c.discovery != nil {
 		c.discovery.Stop()
+		c.discovery = nil
 	}
 }
 

--- a/pkg/collector/corechecks/snmp/snmp.go
+++ b/pkg/collector/corechecks/snmp/snmp.go
@@ -30,7 +30,7 @@ type Check struct {
 	core.CheckBase
 	config         *checkconfig.CheckConfig
 	singleDeviceCk *devicecheck.DeviceCheck
-	discovery      discovery.Discovery
+	discovery      *discovery.Discovery
 	sessionFactory session.Factory
 }
 
@@ -154,7 +154,9 @@ func (c *Check) Configure(rawInstance integration.Data, rawInitConfig integratio
 
 // Cancel is called when check is unscheduled
 func (c *Check) Cancel() {
-	c.discovery.Stop()
+	if c.discovery != nil {
+		c.discovery.Stop()
+	}
 }
 
 // Interval returns the scheduling time for the check

--- a/pkg/collector/corechecks/snmp/snmp_test.go
+++ b/pkg/collector/corechecks/snmp/snmp_test.go
@@ -1645,6 +1645,9 @@ metric_tags:
 	}
 	networkTags := []string{"network:10.10.0.0/30", "autodiscovery_subnet:10.10.0.0/30"}
 	sender.AssertMetric(t, "Gauge", "snmp.discovered_devices_count", 4, "", networkTags)
+
+	chk.Cancel()
+	assert.Nil(t, chk.discovery)
 }
 
 func TestDiscovery_CheckError(t *testing.T) {

--- a/pkg/collector/corechecks/snmp/snmp_test.go
+++ b/pkg/collector/corechecks/snmp/snmp_test.go
@@ -288,6 +288,8 @@ tags:
 	sender.AssertMetricTaggedWith(t, "MonotonicCount", "datadog.snmp.check_interval", telemetryTags)
 	sender.AssertMetricTaggedWith(t, "Gauge", "datadog.snmp.check_duration", telemetryTags)
 	sender.AssertMetric(t, "Gauge", "datadog.snmp.submitted_metrics", 7, "", telemetryTags)
+
+	chk.Cancel()
 }
 
 func TestSupportedMetricTypes(t *testing.T) {
@@ -2070,4 +2072,28 @@ metrics:
 	}
 	networkTags := []string{"network:10.10.0.0/30", "autodiscovery_subnet:10.10.0.0/30"}
 	sender.AssertMetric(t, "Gauge", "snmp.discovered_devices_count", 4, "", networkTags)
+}
+
+func TestCheckCancel(t *testing.T) {
+	checkconfig.SetConfdPathAndCleanProfiles()
+	sess := session.CreateMockSession()
+	sessionFactory := func(*checkconfig.CheckConfig) (session.Session, error) {
+		return sess, nil
+	}
+	chk := Check{sessionFactory: sessionFactory}
+
+	aggregator.InitAndStartAgentDemultiplexer(demuxOpts(), "")
+
+	// language=yaml
+	rawInstanceConfig := []byte(`
+ip_address: 1.2.3.4
+community_string: public
+`)
+
+	err := chk.Configure(rawInstanceConfig, []byte(``), "test")
+	assert.Nil(t, err)
+
+	// check Cancel does not panic when called with single check
+	// it shouldn't try to stop discovery
+	chk.Cancel()
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

[snmp] Fix panic for direct ip instance

snmp integration has 2 modes:
- direct ip instances (`ip_address` config)
- autodiscovery (`network_address` config)

`discovery.Stop()` was called on direct ip instances and can lead to panic

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Panic can happen if Cancel is called for a single device instance:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x1f8 pc=0x105a733dc]

goroutine 251262 [running]:
github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/internal/discovery.(*Discovery).Stop(...)
	/Users/alexandre.yang/go/src/github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/internal/discovery/discovery.go:75
github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp.(*Check).Cancel(0x140000c7450)
	/Users/alexandre.yang/go/src/github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/snmp.go:157 +0x3c
github.com/DataDog/datadog-agent/pkg/collector/internal/middleware.(*CheckWrapper).Cancel(0x1400144afa0)
	/Users/alexandre.yang/go/src/github.com/DataDog/datadog-agent/pkg/collector/internal/middleware/check_wrapper.go:41 +0x34
github.com/DataDog/datadog-agent/pkg/collector.(*Collector).cancelCheck.func1()
	/Users/alexandre.yang/go/src/github.com/DataDog/datadog-agent/pkg/collector/collector.go:195 +0x34
created by github.com/DataDog/datadog-agent/pkg/collector.(*Collector).cancelCheck
	/Users/alexandre.yang/go/src/github.com/DataDog/datadog-agent/pkg/collector/collector.go:194 +0xa4
```

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

1/ Start SNMP Listener with config like this:

```
listeners:
  - name: snmp
snmp_listener:
  discovery_interval: 10  # default is 1h but set it to 10sec for faster QA, a integration instance is unschedule after 3 retry (3x discovery_interval time)
  loader: core  # use core check implementation of SNMP integration. recommended
  use_device_id_as_hostname: true
  configs:
    - network_address: 127.0.0.0/30  # CIDR subnet
      snmp_version: 2
      port: 1161
      community_string: 'public'
```

2/ Start snmpsim from integrations-core repo

```
DATA_DIR=`pwd`/snmp/tests/compose/data/  docker-compose -f snmp/tests/compose/docker-compose.yaml up
```

3/ Waiting 1-2 min for snmp listener to discover the checks

4/ Verify using `datadog-agent configcheck` command that the snmp instance(s) are there

5/ Stop snmpsim

6/ Waiting 1-2 mins for snmp listener to unschedule the checks

7/ Verify using `datadog-agent configcheck` command that the is no snmp instance(s)

8/ everything is fine is the agent didn't panic after steps 5-7 (you can check the agent logs to sure of that)

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
