### PR TITLE
[CWS] remove args entry cache

### DIFF
--- a/pkg/security/module/process_monitor.go
+++ b/pkg/security/module/process_monitor.go
@@ -34,7 +34,7 @@ func (p *ProcessMonitoring) HandleEvent(event *sprobe.Event) {
 	var cmdline []string
 	if entry.ArgsEntry != nil {
 		// ignore if the args have been truncated
-		cmdline, _ = entry.ArgsEntry.ToArray()
+		cmdline = entry.ArgsEntry.Values
 	}
 
 	e := &model.ProcessEvent{

--- a/pkg/security/probe/activity_dump.go
+++ b/pkg/security/probe/activity_dump.go
@@ -979,7 +979,6 @@ func NewProcessActivityNode(entry *model.ProcessCacheEntry, generationType NodeG
 		Files:          make(map[string]*FileActivityNode),
 		DNSNames:       make(map[string]*DNSNode),
 	}
-	pan.retain()
 	return &pan
 }
 
@@ -1008,15 +1007,6 @@ func (pan *ProcessActivityNode) debug(w io.Writer, prefix string) {
 	}
 }
 
-func (pan *ProcessActivityNode) retain() {
-	if pan.Process.ArgsEntry != nil {
-		pan.Process.ArgsEntry.Retain()
-	}
-	if pan.Process.EnvsEntry != nil {
-		pan.Process.EnvsEntry.Retain()
-	}
-}
-
 // scrubAndReleaseArgsEnvs scrubs the process args and envs, and then releases them
 func (pan *ProcessActivityNode) scrubAndReleaseArgsEnvs(resolver *ProcessResolver) {
 	_, _ = resolver.GetProcessScrubbedArgv(&pan.Process)
@@ -1025,12 +1015,6 @@ func (pan *ProcessActivityNode) scrubAndReleaseArgsEnvs(resolver *ProcessResolve
 	pan.Process.EnvsTruncated = envsTruncated
 	pan.Process.Argv0, _ = resolver.GetProcessArgv0(&pan.Process)
 
-	if pan.Process.ArgsEntry != nil {
-		pan.Process.ArgsEntry.Release()
-	}
-	if pan.Process.EnvsEntry != nil {
-		pan.Process.EnvsEntry.Release()
-	}
 	pan.Process.ArgsEntry = nil
 	pan.Process.EnvsEntry = nil
 }

--- a/pkg/security/probe/process_resolver.go
+++ b/pkg/security/probe/process_resolver.go
@@ -122,7 +122,7 @@ type ProcessResolver struct {
 	envsSize       *atomic.Int64
 
 	entryCache    map[uint32]*model.ProcessCacheEntry
-	argsEnvsCache *simplelru.LRU[uint32, *model.ArgsEnvsCacheEntry]
+	argsEnvsCache *simplelru.LRU[uint32, *argsEnvsCacheEntry]
 
 	processCacheEntryPool *ProcessCacheEntryPool
 
@@ -303,8 +303,7 @@ func (e *argsEnvsCacheEntry) extend(event *model.ArgsEnvsEvent) {
 
 // UpdateArgsEnvs updates arguments or environment variables of the given id
 func (p *ProcessResolver) UpdateArgsEnvs(event *model.ArgsEnvsEvent) {
-	if e, found := p.argsEnvsCache.Get(event.ID); found {
-		list := e.(*argsEnvsCacheEntry)
+	if list, found := p.argsEnvsCache.Get(event.ID); found {
 		list.extend(event)
 	} else {
 		p.argsEnvsCache.Add(event.ID, newArgsEnvsCacheEntry(event))
@@ -1217,7 +1216,7 @@ func (p *ProcessResolver) NewProcessVariables(scoper func(ctx *eval.Context) uns
 // NewProcessResolver returns a new process resolver
 func NewProcessResolver(manager *manager.Manager, config *config.Config, statsdClient statsd.ClientInterface,
 	scrubber *pconfig.DataScrubber, resolvers *Resolvers, opts ProcessResolverOpts) (*ProcessResolver, error) {
-	argsEnvsCache, err := simplelru.NewLRU[uint32, *model.ArgsEnvsCacheEntry](maxParallelArgsEnvs, nil)
+	argsEnvsCache, err := simplelru.NewLRU[uint32, *argsEnvsCacheEntry](maxParallelArgsEnvs, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/security/probe/process_resolver.go
+++ b/pkg/security/probe/process_resolver.go
@@ -828,12 +828,12 @@ func (p *ProcessResolver) GetProcessArgv(pr *model.Process) ([]string, bool) {
 		return nil, false
 	}
 
-	argv, truncated := pr.ArgsEntry.ToArray()
+	argv := pr.ArgsEntry.Values
 	if len(argv) > 0 {
 		argv = argv[1:]
 	}
 
-	return argv, pr.ArgsTruncated || truncated
+	return argv, pr.ArgsTruncated || pr.ArgsEntry.Truncated
 }
 
 // GetProcessArgv0 returns the first arg of the event
@@ -842,12 +842,12 @@ func (p *ProcessResolver) GetProcessArgv0(pr *model.Process) (string, bool) {
 		return "", false
 	}
 
-	argv, truncated := pr.ArgsEntry.ToArray()
+	argv := pr.ArgsEntry.Values
 	if len(argv) > 0 {
-		return argv[0], pr.ArgsTruncated || truncated
+		return argv[0], pr.ArgsTruncated || pr.ArgsEntry.Truncated
 	}
 
-	return "", pr.ArgsTruncated || truncated
+	return "", pr.ArgsTruncated || pr.ArgsEntry.Truncated
 }
 
 // GetProcessScrubbedArgv returns the scrubbed args of the event as an array
@@ -905,9 +905,7 @@ func (p *ProcessResolver) GetProcessEnvp(pr *model.Process) ([]string, bool) {
 		return nil, false
 	}
 
-	envp, truncated := pr.EnvsEntry.ToArray()
-
-	return envp, pr.EnvsTruncated || truncated
+	return pr.EnvsEntry.Values, pr.EnvsTruncated || pr.EnvsEntry.Truncated
 }
 
 // SetProcessTTY resolves TTY and cache the result

--- a/pkg/security/probe/process_resolver.go
+++ b/pkg/security/probe/process_resolver.go
@@ -53,7 +53,6 @@ const (
 
 const (
 	procResolveMaxDepth = 16
-	maxArgsEnvResidents = 1024
 	maxParallelArgsEnvs = 512 // == number of parallel starting processes
 )
 

--- a/pkg/security/secl/model/process_cache_entry.go
+++ b/pkg/security/secl/model/process_cache_entry.go
@@ -125,11 +125,6 @@ type ArgsEntry struct {
 	Truncated bool
 }
 
-// ToArray returns args as array
-func (p *ArgsEntry) ToArray() ([]string, bool) {
-	return p.Values, p.Truncated
-}
-
 // Equals compares two ArgsEntry
 func (p *ArgsEntry) Equals(o *ArgsEntry) bool {
 	if p == o {
@@ -148,11 +143,6 @@ type EnvsEntry struct {
 
 	filteredEnvs []string
 	kv           map[string]string
-}
-
-// ToArray returns envs as an array
-func (p *EnvsEntry) ToArray() ([]string, bool) {
-	return p.Values, p.Truncated
 }
 
 // FilterEnvs returns an array of envs, only the name of each variable is returned unless the variable name is part of the provided filter

--- a/pkg/security/secl/model/process_cache_entry.go
+++ b/pkg/security/secl/model/process_cache_entry.go
@@ -138,10 +138,7 @@ func (p *ArgsEntry) Equals(o *ArgsEntry) bool {
 		return false
 	}
 
-	pa, _ := p.ToArray()
-	oa, _ := o.ToArray()
-
-	return slices.Equal(pa, oa)
+	return slices.Equal(p.Values, o.Values)
 }
 
 // EnvsEntry defines a args cache entry
@@ -164,15 +161,14 @@ func (p *EnvsEntry) FilterEnvs(envsWithValue map[string]bool) ([]string, bool) {
 		return p.filteredEnvs, p.Truncated
 	}
 
-	values, _ := p.ToArray()
-	if len(values) == 0 {
+	if len(p.Values) == 0 {
 		return nil, p.Truncated
 	}
 
-	p.filteredEnvs = make([]string, len(values))
+	p.filteredEnvs = make([]string, len(p.Values))
 
 	var i int
-	for _, value := range values {
+	for _, value := range p.Values {
 		k, _, found := strings.Cut(value, "=")
 		if !found {
 			continue
@@ -194,10 +190,9 @@ func (p *EnvsEntry) toMap() {
 		return
 	}
 
-	values, _ := p.ToArray()
-	p.kv = make(map[string]string, len(values))
+	p.kv = make(map[string]string, len(p.Values))
 
-	for _, value := range values {
+	for _, value := range p.Values {
 		k, v, found := strings.Cut(value, "=")
 		if found {
 			p.kv[k] = v
@@ -219,8 +214,5 @@ func (p *EnvsEntry) Equals(o *EnvsEntry) bool {
 		return false
 	}
 
-	pa, _ := p.ToArray()
-	oa, _ := o.ToArray()
-
-	return slices.Equal(pa, oa)
+	return slices.Equal(p.Values, o.Values)
 }


### PR DESCRIPTION
### What does this PR do?

The goal of this PR is to re-evaluate the wins provided by the args entry cache. This cache is very complex, and was required by poor performance of the go GC. Multiple bumps of the go toolchain later, the argument between the difficulty to keep this cache bug-free (made even harder with the activity dumps) against the win in performance can be made again.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
