### PR TITLE
Fix missing cgroup in CO-RE oomkill probe

### DIFF
--- a/pkg/collector/corechecks/ebpf/c/co-re/bpf-common.h
+++ b/pkg/collector/corechecks/ebpf/c/co-re/bpf-common.h
@@ -14,7 +14,8 @@ static __always_inline int get_cgroup_name(char *buf, size_t sz) {
 
     struct task_struct *cur_tsk = (struct task_struct *)bpf_get_current_task();
 
-    if (BPF_CORE_READ_STR_INTO(buf, cur_tsk, cgroups, subsys[0], cgroup, kn, name)) {
+    const char *name = BPF_CORE_READ(cur_tsk, cgroups, subsys[0], cgroup, kn, name);
+    if (bpf_probe_read_kernel_str(buf, sz, name) < 0) {
         return -1;
     }
 

--- a/pkg/collector/corechecks/ebpf/c/co-re/bpf-common.h
+++ b/pkg/collector/corechecks/ebpf/c/co-re/bpf-common.h
@@ -5,6 +5,10 @@
 #include "bpf_core_read.h"
 #include "bpf_helpers.h"
 
+enum cgroup_subsys_id___local {
+		memory_cgrp_id___local = 123, /* value doesn't matter */
+};
+
 static __always_inline int get_cgroup_name(char *buf, size_t sz) {
     __builtin_memset(buf, 0, sz);
 
@@ -14,7 +18,8 @@ static __always_inline int get_cgroup_name(char *buf, size_t sz) {
 
     struct task_struct *cur_tsk = (struct task_struct *)bpf_get_current_task();
 
-    const char *name = BPF_CORE_READ(cur_tsk, cgroups, subsys[0], cgroup, kn, name);
+    int cgrp_id = bpf_core_enum_value(enum cgroup_subsys_id___local, memory_cgrp_id___local);
+    const char *name = BPF_CORE_READ(cur_tsk, cgroups, subsys[cgrp_id], cgroup, kn, name);
     if (bpf_probe_read_kernel_str(buf, sz, name) < 0) {
         return -1;
     }

--- a/pkg/collector/corechecks/ebpf/c/runtime/bpf-common.h
+++ b/pkg/collector/corechecks/ebpf/c/runtime/bpf-common.h
@@ -14,7 +14,7 @@ static __always_inline int get_cgroup_name(char *buf, size_t sz) {
         return -1;
 
     struct cgroup_subsys_state *css;
-    if (bpf_probe_read(&css, sizeof(css), &css_set->subsys[0]) < 0)
+    if (bpf_probe_read(&css, sizeof(css), &css_set->subsys[memory_cgrp_id]) < 0)
         return -1;
 
     struct cgroup *cgrp;

--- a/pkg/collector/corechecks/ebpf/probe/oom_kill_test.go
+++ b/pkg/collector/corechecks/ebpf/probe/oom_kill_test.go
@@ -13,10 +13,12 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"regexp"
 	"syscall"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sys/unix"
 
@@ -125,6 +127,13 @@ func TestOOMKillProbe(t *testing.T) {
 	for _, result := range results {
 		if result.TPid == uint32(cmd.Process.Pid) {
 			found = true
+
+			assert.Regexp(t, regexp.MustCompile("run-([0-9|a-z]*).scope"), result.CgroupName)
+			assert.Equal(t, result.TPid, result.Pid)
+			assert.Equal(t, "python3", result.FComm)
+			assert.Equal(t, "python3", result.TComm)
+			assert.NotZero(t, result.Pages)
+			assert.Equal(t, uint32(1), result.MemCgOOM)
 			break
 		}
 	}

--- a/pkg/config/system_probe.go
+++ b/pkg/config/system_probe.go
@@ -93,7 +93,7 @@ func InitSystemProbeConfig(cfg Config) {
 	cfg.BindEnvAndSetDefault(join(spNS, "bpf_dir"), defaultSystemProbeBPFDir, "DD_SYSTEM_PROBE_BPF_DIR")
 	cfg.BindEnvAndSetDefault(join(spNS, "excluded_linux_versions"), []string{})
 	cfg.BindEnvAndSetDefault(join(spNS, "enable_tracepoints"), false)
-	cfg.BindEnvAndSetDefault(join(spNS, "enable_co_re"), false, "DD_ENABLE_CO_RE")
+	cfg.BindEnvAndSetDefault(join(spNS, "enable_co_re"), true, "DD_ENABLE_CO_RE")
 	cfg.BindEnvAndSetDefault(join(spNS, "btf_path"), "", "DD_SYSTEM_PROBE_BTF_PATH")
 	cfg.BindEnv(join(spNS, "enable_runtime_compiler"), "DD_ENABLE_RUNTIME_COMPILER")
 	cfg.BindEnvAndSetDefault(join(spNS, "allow_precompiled_fallback"), true, "DD_ALLOW_PRECOMPILED_FALLBACK")

--- a/pkg/config/system_probe.go
+++ b/pkg/config/system_probe.go
@@ -93,7 +93,7 @@ func InitSystemProbeConfig(cfg Config) {
 	cfg.BindEnvAndSetDefault(join(spNS, "bpf_dir"), defaultSystemProbeBPFDir, "DD_SYSTEM_PROBE_BPF_DIR")
 	cfg.BindEnvAndSetDefault(join(spNS, "excluded_linux_versions"), []string{})
 	cfg.BindEnvAndSetDefault(join(spNS, "enable_tracepoints"), false)
-	cfg.BindEnvAndSetDefault(join(spNS, "enable_co_re"), true, "DD_ENABLE_CO_RE")
+	cfg.BindEnvAndSetDefault(join(spNS, "enable_co_re"), false, "DD_ENABLE_CO_RE")
 	cfg.BindEnvAndSetDefault(join(spNS, "btf_path"), "", "DD_SYSTEM_PROBE_BTF_PATH")
 	cfg.BindEnv(join(spNS, "enable_runtime_compiler"), "DD_ENABLE_RUNTIME_COMPILER")
 	cfg.BindEnvAndSetDefault(join(spNS, "allow_precompiled_fallback"), true, "DD_ALLOW_PRECOMPILED_FALLBACK")

--- a/pkg/ebpf/bytecode/runtime/oom-kill.go
+++ b/pkg/ebpf/bytecode/runtime/oom-kill.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var OomKill = newAsset("oom-kill.c", "5dcb629bf0dfe63368846ce069813f797015c76dfb9a5b2ffa8ec060dc4c75fb")
+var OomKill = newAsset("oom-kill.c", "22f55aa9a693adbcd396973a59e9395109b4b2d38fa907f1bbb882bf3440a7ff")

--- a/pkg/ebpf/bytecode/runtime/tcp-queue-length.go
+++ b/pkg/ebpf/bytecode/runtime/tcp-queue-length.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var TcpQueueLength = newAsset("tcp-queue-length.c", "aa298d8b67da8a6b56e7307696ae68114b5411cd6e0ac6f2e1413f095972051d")
+var TcpQueueLength = newAsset("tcp-queue-length.c", "9fd146b7f51386efd5df66614ba2a704351697b3bbb3a5fe20b0f36b6a3f2613")


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Fixes the `CgroupName` field which was not being read correctly by the CO-RE version of the OOM-kill probe + updates the OOM Kill test to be more comprehensive.

Also modifies oom kill check (both the CO-RE version and the runtime compiled version) to read `CgroupName` from the `memory` cgroup subsystem instead of the `cpuset` subsystem. This fixes a bug which caused `CgroupName` to be blank for certain processes on systems which use cgroupv1 instead of cgroupv2. (The bug comes from certain programs not supporting the `cpuset` subsystem when cgroupv1 is used - so when the oom kill probe tries to read the cgroup name from that subsystem, it ends up being blank.)

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
