### PR TITLE
Improve kitchen windows install recipe

### DIFF
--- a/test/kitchen/site-cookbooks/dd-agent-install/recipes/_install_windows_base.rb
+++ b/test/kitchen/site-cookbooks/dd-agent-install/recipes/_install_windows_base.rb
@@ -29,8 +29,11 @@ else
   end
 end
 
+temp_file_basename = ::File.join(Chef::Config[:file_cache_path], 'ddagent-cli').gsub(File::SEPARATOR, File::ALT_SEPARATOR || File::SEPARATOR)
+
 dd_agent_installer = "#{dd_agent_installer_basename}.msi"
 source_url += dd_agent_installer
+temp_file = "#{temp_file_basename}.msi"
 
 log_file_name = ::File.join(Chef::Config[:file_cache_path], 'install.log').gsub(File::SEPARATOR, File::ALT_SEPARATOR || File::SEPARATOR)
 # Delete the log file in case it exists (in case of multiple converge runs for example)
@@ -57,6 +60,9 @@ windows_package 'Datadog Agent' do
   retry_delay package_retry_delay unless package_retry_delay.nil?
   options install_options
   action :install
+  remote_file_attributes ({
+    :path => temp_file
+  })
 end
 
 # This runs during the converge phase and will return a non-zero exit

--- a/test/kitchen/site-cookbooks/dd-agent-install/recipes/_install_windows_base.rb
+++ b/test/kitchen/site-cookbooks/dd-agent-install/recipes/_install_windows_base.rb
@@ -43,7 +43,7 @@ end
 
 # Agent >= 5.12.0 installs per-machine by default, but specifying ALLUSERS=1 shouldn't affect the install
 agent_install_options = node['dd-agent-install']['agent_install_options']
-install_options = "/log #{log_file_name} /norestart ALLUSERS=1  #{agent_install_options}"
+install_options = "/log #{log_file_name} /norestart ALLUSERS=1 #{agent_install_options}"
 
 # This fake package resource serves only to trigger the Datadog Agent uninstall.
 # If the checksum is not provided, assume we need to reinstall the Agent.
@@ -52,6 +52,10 @@ package 'Datadog Agent removal' do
   package_name 'Datadog Agent'
   action :remove
 end
+
+# When WIXFAILWHENDEFERRED is present, we expect the installer to fail.
+expected_msi_result_code = [0, 3010]
+expected_msi_result_code.append(1603) if agent_install_options.include?('WIXFAILWHENDEFERRED')
 
 windows_package 'Datadog Agent' do
   source source_url
@@ -63,6 +67,7 @@ windows_package 'Datadog Agent' do
   remote_file_attributes ({
     :path => temp_file
   })
+  returns expected_msi_result_code
 end
 
 # This runs during the converge phase and will return a non-zero exit

--- a/test/kitchen/site-cookbooks/dd-agent-install/recipes/_install_windows_base.rb
+++ b/test/kitchen/site-cookbooks/dd-agent-install/recipes/_install_windows_base.rb
@@ -29,36 +29,50 @@ else
   end
 end
 
-temp_file_basename = ::File.join(Chef::Config[:file_cache_path], 'ddagent-cli').gsub(File::SEPARATOR, File::ALT_SEPARATOR || File::SEPARATOR)
-
 dd_agent_installer = "#{dd_agent_installer_basename}.msi"
 source_url += dd_agent_installer
 
-temp_file = "#{temp_file_basename}.msi"
+log_file_name = ::File.join(Chef::Config[:file_cache_path], 'install.log').gsub(File::SEPARATOR, File::ALT_SEPARATOR || File::SEPARATOR)
+# Delete the log file in case it exists (in case of multiple converge runs for example)
+file log_file_name do
+  action :delete
+end
 
 # Agent >= 5.12.0 installs per-machine by default, but specifying ALLUSERS=1 shouldn't affect the install
 agent_install_options = node['dd-agent-install']['agent_install_options']
-install_options = "/norestart ALLUSERS=1  #{agent_install_options}"
+install_options = "/log #{log_file_name} /norestart ALLUSERS=1  #{agent_install_options}"
 
+# This fake package resource serves only to trigger the Datadog Agent uninstall.
+# If the checksum is not provided, assume we need to reinstall the Agent.
 package 'Datadog Agent removal' do
+  only_if { node['dd-agent-install']['windows_agent_checksum'].nil? }
   package_name 'Datadog Agent'
-  action :nothing
+  action :remove
 end
 
-# Download the installer to a temp location
-remote_file temp_file do
+windows_package 'Datadog Agent' do
   source source_url
   checksum node['dd-agent-install']['windows_agent_checksum'] if node['dd-agent-install']['windows_agent_checksum']
   retries package_retries unless package_retries.nil?
   retry_delay package_retry_delay unless package_retry_delay.nil?
-  # As of v1.37, the windows cookbook doesn't upgrade the package if a newer version is downloaded
-  # As a workaround uninstall the package first if a new MSI is downloaded
-  notifies :remove, 'package[Datadog Agent removal]', :immediately
+  options install_options
+  action :install
 end
 
-execute "install-agent" do
-  command "echo %TIME% && start /wait msiexec /q /i #{temp_file} #{install_options} && echo %TIME% && sc interrogate datadogagent 2>&1"
-  status_out = `sc interrogate datadogagent 2>&1`
-  puts status_out
-  action :run
+# This runs during the converge phase and will return a non-zero exit
+# code if the service doesn't run. While it can be useful to quickly
+# test locally if the Datadog Agent service is running after a converge phase
+# it defeats the purpose of the kitchen tests, so keep it commented unless debugging the installer.
+#execute "check-agent-service" do
+#  command "sc interrogate datadogagent 2>&1"
+#  action :run
+#end
+
+ruby_block "Print install logs" do
+  only_if { ::File.exists?(log_file_name) }
+  block do
+    # Use warn, because Chef's default "log" is too chatty
+    # and the kitchen tests default to "warn"
+    Chef::Log.warn(File.open(log_file_name, "rb:UTF-16LE", &:read).encode('UTF-8'))
+  end
 end


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
This PR refactors the `_install_windows_base` kitchen recipe to:
- Use a single `windows_package` resource to install the Agent, instead of a `remote_file` and an `execute` block.
  - This results in simpler code, and more importantly, an idempotent recipe. 
- Use a `ruby_block` to print out the install log so that they are not lost.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Better kitchen tests.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
