### PR TITLE
[CI] Fix `kitchen_deploy` stage tests by avoiding race conditions

### DIFF
--- a/.gitlab/kitchen_deploy.yml
+++ b/.gitlab/kitchen_deploy.yml
@@ -43,13 +43,6 @@
 .deploy_deb_resource_group-a7: &deploy_deb_resource_group-a7
   resource_group: deploy_deb_a7
 
-.deploy_rpm_resource_group-a6: &deploy_rpm_resource_group-a6
-  resource_group: deploy_rpm_a6
-
-.deploy_rpm_resource_group-a7: &deploy_rpm_resource_group-a7
-  resource_group: deploy_rpm_a7
-
-
 .deploy_deb_testing-a6:
   stage: kitchen_deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
@@ -138,7 +131,6 @@ deploy_deb_testing-a7_arm64:
   stage: kitchen_deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
   tags: ["runner:main"]
-  <<: *deploy_deb_resource_group-a6
   variables:
     DD_PIPELINE_ID: $CI_PIPELINE_ID-a6
   before_script:
@@ -170,7 +162,6 @@ deploy_rpm_testing-a6_arm64:
   stage: kitchen_deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
   tags: ["runner:main"]
-  <<: *deploy_deb_resource_group-a7
   variables:
     DD_PIPELINE_ID: $CI_PIPELINE_ID-a7
   before_script:

--- a/.gitlab/kitchen_deploy.yml
+++ b/.gitlab/kitchen_deploy.yml
@@ -36,10 +36,25 @@
   - filename=$(ls datadog-signing-keys*.deb); mv $filename datadog-signing-keys_${DD_PIPELINE_ID}.deb
   - popd
 
+# Avoid simultaneous writes on the repo metadata file that made kitchen tests fail before
+.deploy_deb_resource_group-a6: &deploy_deb_resource_group-a6
+  resource_group: deploy_deb_a6
+
+.deploy_deb_resource_group-a7: &deploy_deb_resource_group-a7
+  resource_group: deploy_deb_a7
+
+.deploy_rpm_resource_group-a6: &deploy_rpm_resource_group-a6
+  resource_group: deploy_rpm_a6
+
+.deploy_rpm_resource_group-a7: &deploy_rpm_resource_group-a7
+  resource_group: deploy_rpm_a7
+
+
 .deploy_deb_testing-a6:
   stage: kitchen_deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
   tags: ["runner:main"]
+  <<: *deploy_deb_resource_group-a6
   variables:
     DD_PIPELINE_ID: $CI_PIPELINE_ID-a6
   before_script:
@@ -81,6 +96,7 @@ deploy_deb_testing-a6_arm64:
   stage: kitchen_deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
   tags: ["runner:main"]
+  <<: *deploy_deb_resource_group-a7
   variables:
     DD_PIPELINE_ID: $CI_PIPELINE_ID-a7
   before_script:
@@ -122,6 +138,7 @@ deploy_deb_testing-a7_arm64:
   stage: kitchen_deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
   tags: ["runner:main"]
+  <<: *deploy_deb_resource_group-a6
   variables:
     DD_PIPELINE_ID: $CI_PIPELINE_ID-a6
   before_script:
@@ -153,6 +170,7 @@ deploy_rpm_testing-a6_arm64:
   stage: kitchen_deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
   tags: ["runner:main"]
+  <<: *deploy_deb_resource_group-a7
   variables:
     DD_PIPELINE_ID: $CI_PIPELINE_ID-a7
   before_script:


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This PR adds `resource_group` attribute to the `deploy_deb` and `deploy_yum` jobs to avoid writing simultaneously to the repo metadata file.


<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

We sometimes have issues in kitchen tests because metadata files aren’t correct due 

For instance, [this deploy job](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/191198298) published the arm64 Agent 7 deb package for pipeline 11035730, but the metadata file reads:
```
Codename: pipeline-11035730-a7
Date: Wed, 09 Nov 2022 13:54:18 UTC
Architectures: amd64 i386 armhf x86_64
Components: 7
```

because of two simultaneous writes to the repo metadata file, causing failures in kitchen tests: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/191285322.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Run the pipeline and check that the `Kitchen_deploy` stage tests are not failing. Concerned tests are:
- `deploy_deb_testing-a6_x64` and `deploy_deb_testing-a6_arm64`.
- `deploy_deb_testing-a7_x64` and `deploy_deb_testing-a7_arm64`.
- `deploy_rpm_testing-a6_x64` and `deploy_rpm_testing-a6_arm64`.
- `deploy_rpm_testing-a7_x64` and `deploy_rpm_testing-a7_arm64`.

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
