### PR TITLE
{pkg/trace/api,cmd/trace-agent}: use container's procfs for pid-cid mapping

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -739,7 +739,7 @@ core,github.com/tinylib/msgp/gen,MIT,Copyright (c) 2009 The Go Authors (license 
 core,github.com/tinylib/msgp/msgp,MIT,Copyright (c) 2009 The Go Authors (license at http://golang.org) where indicated | Copyright (c) 2014 Philip Hofer
 core,github.com/tinylib/msgp/parse,MIT,Copyright (c) 2009 The Go Authors (license at http://golang.org) where indicated | Copyright (c) 2014 Philip Hofer
 core,github.com/tinylib/msgp/printer,MIT,Copyright (c) 2009 The Go Authors (license at http://golang.org) where indicated | Copyright (c) 2014 Philip Hofer
-core,github.com/tklauser/go-sysconf,BSD-3-Clause,"Copyright (c) 2018-2021, Tobias Klauser"
+core,github.com/tklauser/go-sysconf,BSD-3-Clause,"Copyright (c) 2018-2022, Tobias Klauser"
 core,github.com/tklauser/numcpus,Apache-2.0,Copyright 2018 Tobias Klauser
 core,github.com/twmb/murmur3,BSD-3-Clause,"Copyright 2013, Sébastien Paolacci | Copyright 2018, Travis Bischel"
 core,github.com/ugorji/go/codec,MIT,Copyright (c) 2012-2020 Ugorji Nwoke

--- a/cmd/trace-agent/remote_config.go
+++ b/cmd/trace-agent/remote_config.go
@@ -41,7 +41,7 @@ func putBuffer(buffer *bytes.Buffer) {
 }
 
 func remoteConfigHandler(r *api.HTTPReceiver, client pbgo.AgentSecureClient, token string, cfg *config.AgentConfig) http.Handler {
-	cidProvider := api.NewIDProvider(cfg.ContainerProcRoot)
+	cidProvider := api.NewIDProvider("/proc")
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		defer timing.Since("datadog.trace_agent.receiver.config_process_ms", time.Now())
 		tags := r.TagStats(api.V07, req.Header).AsTags()

--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -98,7 +98,7 @@ func NewHTTPReceiver(conf *config.AgentConfig, dynConf *sampler.DynamicConfig, o
 		statsProcessor:      statsProcessor,
 		conf:                conf,
 		dynConf:             dynConf,
-		containerIDProvider: NewIDProvider(conf.ContainerProcRoot),
+		containerIDProvider: NewIDProvider("/proc"),
 
 		rateLimiterResponse: rateLimiterResponse,
 

--- a/pkg/trace/api/debugger.go
+++ b/pkg/trace/api/debugger.go
@@ -62,7 +62,7 @@ func debuggerErrorHandler(err error) http.Handler {
 // newDebuggerProxy returns a new httputil.ReverseProxy proxying and augmenting requests with headers containing the tags.
 func newDebuggerProxy(conf *config.AgentConfig, target *url.URL, key string, tags string) *httputil.ReverseProxy {
 	logger := log.NewThrottled(5, 10*time.Second) // limit to 5 messages every 10 seconds
-	cidProvider := NewIDProvider(conf.ContainerProcRoot)
+	cidProvider := NewIDProvider("/proc")
 	director := func(req *http.Request) {
 		ddtags := tags
 		containerID := cidProvider.GetContainerID(req.Context(), req.Header)

--- a/pkg/trace/api/otlp.go
+++ b/pkg/trace/api/otlp.go
@@ -59,7 +59,7 @@ type OTLPReceiver struct {
 
 // NewOTLPReceiver returns a new OTLPReceiver which sends any incoming traces down the out channel.
 func NewOTLPReceiver(out chan<- *Payload, cfg *config.AgentConfig) *OTLPReceiver {
-	return &OTLPReceiver{out: out, conf: cfg, cidProvider: NewIDProvider(cfg.ContainerProcRoot)}
+	return &OTLPReceiver{out: out, conf: cfg, cidProvider: NewIDProvider("/proc")}
 }
 
 // Start starts the OTLPReceiver, if any of the servers were configured as active.

--- a/pkg/trace/api/pipeline_stats.go
+++ b/pkg/trace/api/pipeline_stats.go
@@ -62,7 +62,7 @@ func pipelineStatsErrorHandler(err error) http.Handler {
 // newPipelineStatsProxy creates an http.ReverseProxy which forwards requests to the pipeline stats intake.
 // The tags will be added as a header to all proxied requests.
 func newPipelineStatsProxy(conf *config.AgentConfig, target *url.URL, key string, tags string) *httputil.ReverseProxy {
-	cidProvider := NewIDProvider(conf.ContainerProcRoot)
+	cidProvider := NewIDProvider("/proc")
 	director := func(req *http.Request) {
 		req.Header.Set("Via", fmt.Sprintf("trace-agent %s", conf.AgentVersion))
 		if _, ok := req.Header["User-Agent"]; !ok {

--- a/pkg/trace/api/profiles.go
+++ b/pkg/trace/api/profiles.go
@@ -100,7 +100,7 @@ func errorHandler(err error) http.Handler {
 // The tags will be added as a header to all proxied requests.
 // For more details please see multiTransport.
 func newProfileProxy(conf *config.AgentConfig, targets []*url.URL, keys []string, tags string) *httputil.ReverseProxy {
-	cidProvider := NewIDProvider(conf.ContainerProcRoot)
+	cidProvider := NewIDProvider("/proc")
 	director := func(req *http.Request) {
 		req.Header.Set("Via", fmt.Sprintf("trace-agent %s", conf.AgentVersion))
 		if _, ok := req.Header["User-Agent"]; !ok {


### PR DESCRIPTION

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
This commit causes the agent to always use its own procfs (/proc) to map PIDs to container IDs.

### Motivation

Previously, the ID Provider was using the host's procfs (/host/proc) when available. This does not work with UDS, since the PID we receive is always in the agent's pid namespace. Instead, the agent must always read its own procfs, otherwise it will get wrong data.

This will specifically affect deployments where the agent is not in the host's PID namespace, but shares a PID namespace with the application.


### Additional Notes

https://github.com/DataDog/datadog-agent/pull/13224
https://github.com/DataDog/integrations-core/pull/13183

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

This change affects container tagging under k8s and docker. In order to test these changes, we should:

1. do a standard deployment of the agent to k8s and docker on a host running only cgroup v2, with the agent container running in the host's PID namespace (this should be default now). We should then ensure that the agent is correctly adding container tags to the container.
2. do a deployment of the agent to k8s and docker with an application, where the agent is in the same PID namespace as the application. This can be accomplished in multiple ways, by putting them in the same container, or by following the following: https://kubernetes.io/docs/tasks/configure-pod-container/share-process-namespace/. After the deploy, ensure that the agent is correctly adding container tags to the container.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
