### PR TITLE
Refactor `agent integration` command for easier testing

### DIFF
--- a/cmd/agent/subcommands/integrations/command.go
+++ b/cmd/agent/subcommands/integrations/command.go
@@ -103,6 +103,12 @@ func (cp *cliParams) python() *pythonRunner {
 	}
 }
 
+func (cp *cliParams) fallbackVersion(configValue string) {
+	if cp.pythonMajorVersion == "" {
+		cp.pythonMajorVersion = configValue
+	}
+}
+
 // Commands returns a slice of subcommands for the 'agent' command.
 func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 	cliParams := &cliParams{}
@@ -211,10 +217,6 @@ func loadPythonInfo(config config.Component, cliParams *cliParams) error {
 		}
 
 		rootDir = parentDir
-	}
-
-	if cliParams.pythonMajorVersion == "" {
-		cliParams.pythonMajorVersion = config.GetString("python_version")
 	}
 
 	constraintsPath = filepath.Join(rootDir, fmt.Sprintf("final_constraints-py%s.txt", cliParams.pythonMajorVersion))
@@ -333,6 +335,7 @@ func pip(python *pythonRunner, cmd string, args []string, verbose int) error {
 }
 
 func install(config config.Component, cliParams *cliParams) error {
+	cliParams.fallbackVersion(config.GetString("python_version"))
 	if err := loadPythonInfo(config, cliParams); err != nil {
 		return err
 	}
@@ -784,6 +787,7 @@ func moveConfigurationFiles(srcFolder string, dstFolder string) error {
 }
 
 func remove(config config.Component, cliParams *cliParams) error {
+	cliParams.fallbackVersion(config.GetString("python_version"))
 	if err := loadPythonInfo(config, cliParams); err != nil {
 		return err
 	}
@@ -808,6 +812,7 @@ func remove(config config.Component, cliParams *cliParams) error {
 }
 
 func list(config config.Component, cliParams *cliParams) error {
+	cliParams.fallbackVersion(config.GetString("python_version"))
 	if err := loadPythonInfo(config, cliParams); err != nil {
 		return err
 	}
@@ -835,6 +840,7 @@ func list(config config.Component, cliParams *cliParams) error {
 }
 
 func show(config config.Component, cliParams *cliParams) error {
+	cliParams.fallbackVersion(config.GetString("python_version"))
 	if err := loadPythonInfo(config, cliParams); err != nil {
 		return err
 	}

--- a/cmd/agent/subcommands/integrations/command.go
+++ b/cmd/agent/subcommands/integrations/command.go
@@ -46,6 +46,7 @@ try:
 except pkg_resources.DistributionNotFound:
 	pass
 `
+	sitePackagesPathScript = "import site; print(site.getsitepackages()[0])"
 )
 
 var (
@@ -705,6 +706,15 @@ func getVersionFromReqLine(integration string, lines string) (*semver.Version, b
 	return version, true, nil
 }
 
+func getRelChecksPath(cliParams *cliParams) (string, error) {
+	sitePackagesPath, err := cliParams.python().runCommand(sitePackagesPathScript)
+	if err != nil {
+		return "", err
+	}
+	sitePackagesPath = strings.TrimSpace(string(sitePackagesPath))
+	return filepath.Join(sitePackagesPath, "datadog_checks"), nil
+}
+
 func moveConfigurationFilesOf(cliParams *cliParams, integration string) error {
 	confFolder := pkgconfig.Datadog.GetString("confd_path")
 	check := getIntegrationName(integration)
@@ -717,7 +727,7 @@ func moveConfigurationFilesOf(cliParams *cliParams, integration string) error {
 	if err != nil {
 		return err
 	}
-	confFileSrc := filepath.Join(rootDir, relChecksPath, check, "data")
+	confFileSrc := filepath.Join(relChecksPath, check, "data")
 
 	return moveConfigurationFiles(confFileSrc, confFileDest)
 }

--- a/cmd/agent/subcommands/integrations/command.go
+++ b/cmd/agent/subcommands/integrations/command.go
@@ -76,6 +76,8 @@ type cliParams struct {
 	localWheel         bool
 	thirdParty         bool
 	pythonMajorVersion string
+	python2Path        string
+	python3Path        string
 }
 
 func (cp *cliParams) python() *pythonRunner {
@@ -84,6 +86,13 @@ func (cp *cliParams) python() *pythonRunner {
 		pyPath = sysPythonPath()
 	} else {
 		pyPath = defaultPythonPath()
+	}
+
+	if cp.python2Path != "" {
+		pyPath.py2 = cp.python2Path
+	}
+	if cp.python3Path != "" {
+		pyPath.py3 = cp.python3Path
 	}
 
 	if cp.pythonMajorVersion == "2" {
@@ -107,9 +116,13 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 	integrationCmd.PersistentFlags().BoolVarP(&cliParams.allowRoot, "allow-root", "r", false, "flag to enable root to install packages")
 	integrationCmd.PersistentFlags().BoolVarP(&cliParams.useSysPython, "use-sys-python", "p", false, "use system python instead [dev flag]")
 	integrationCmd.PersistentFlags().StringVarP(&cliParams.pythonMajorVersion, "python", "", "", "the version of Python to act upon (2 or 3). defaults to the python_version setting in datadog.yaml")
+	integrationCmd.PersistentFlags().StringVarP(&cliParams.python2Path, "python2-path", "", "", "use python executable at path as python2[dev flag]")
+	integrationCmd.PersistentFlags().StringVarP(&cliParams.python3Path, "python3-path", "", "", "use python executable at path as python3[dev flag]")
 
 	// Power user flags - mark as hidden
 	integrationCmd.PersistentFlags().MarkHidden("use-sys-python") //nolint:errcheck
+	integrationCmd.PersistentFlags().MarkHidden("python2-path")   //nolint:errcheck
+	integrationCmd.PersistentFlags().MarkHidden("python3-path")   //nolint:errcheck
 
 	// all subcommands use the same provided components, with a different oneShot callback
 	runOneShot := func(callback interface{}) error {

--- a/cmd/agent/subcommands/integrations/command.go
+++ b/cmd/agent/subcommands/integrations/command.go
@@ -201,7 +201,7 @@ You must specify a version of the package to install using the syntax: <package>
 	return []*cobra.Command{integrationCmd}
 }
 
-func loadPythonInfo(config config.Component, cliParams *cliParams) error {
+func findAndSetRootDir(config config.Component, cliParams *cliParams) error {
 	rootDir, _ = executable.Folder()
 	for {
 		agentReleaseFile := filepath.Join(rootDir, reqAgentReleaseFile)
@@ -338,7 +338,7 @@ func getConstraintsPath(version string, rootDir string) (string, error) {
 
 func install(config config.Component, cliParams *cliParams) error {
 	cliParams.fallbackVersion(config.GetString("python_version"))
-	if err := loadPythonInfo(config, cliParams); err != nil {
+	if err := findAndSetRootDir(config, cliParams); err != nil {
 		return err
 	}
 
@@ -795,7 +795,7 @@ func moveConfigurationFiles(srcFolder string, dstFolder string) error {
 
 func remove(config config.Component, cliParams *cliParams) error {
 	cliParams.fallbackVersion(config.GetString("python_version"))
-	if err := loadPythonInfo(config, cliParams); err != nil {
+	if err := findAndSetRootDir(config, cliParams); err != nil {
 		return err
 	}
 
@@ -820,7 +820,7 @@ func remove(config config.Component, cliParams *cliParams) error {
 
 func list(config config.Component, cliParams *cliParams) error {
 	cliParams.fallbackVersion(config.GetString("python_version"))
-	if err := loadPythonInfo(config, cliParams); err != nil {
+	if err := findAndSetRootDir(config, cliParams); err != nil {
 		return err
 	}
 
@@ -848,7 +848,7 @@ func list(config config.Component, cliParams *cliParams) error {
 
 func show(config config.Component, cliParams *cliParams) error {
 	cliParams.fallbackVersion(config.GetString("python_version"))
-	if err := loadPythonInfo(config, cliParams); err != nil {
+	if err := findAndSetRootDir(config, cliParams); err != nil {
 		return err
 	}
 

--- a/cmd/agent/subcommands/integrations/command_runner.go
+++ b/cmd/agent/subcommands/integrations/command_runner.go
@@ -21,10 +21,22 @@ type commandRunner interface {
 	StderrPipe() (io.ReadCloser, error)
 	StdoutPipe() (io.ReadCloser, error)
 	Wait() error
+	// We need this additional method to wrap access to the `.Env` field
+	SetEnv([]string)
 }
 
 type commandConstructor func(name string, arg ...string) commandRunner
 
+type defaultRunner struct {
+	*exec.Cmd
+}
+
+func (c *defaultRunner) SetEnv(newEnv []string) {
+	c.Cmd.Env = newEnv
+}
+
 func execCommand(name string, arg ...string) commandRunner {
-	return commandRunner(exec.Command(name, arg...))
+	cmd := &defaultRunner{}
+	cmd.Cmd = exec.Command(name, arg...)
+	return commandRunner(cmd)
 }

--- a/cmd/agent/subcommands/integrations/command_runner.go
+++ b/cmd/agent/subcommands/integrations/command_runner.go
@@ -1,0 +1,30 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build python
+// +build python
+
+package integrations
+
+import (
+	"io"
+	"os/exec"
+)
+
+// Interface to run external commands.
+// This lets us inject a custom runner (e.g. for tests)
+type commandRunner interface {
+	Output() ([]byte, error)
+	Start() error
+	StderrPipe() (io.ReadCloser, error)
+	StdoutPipe() (io.ReadCloser, error)
+	Wait() error
+}
+
+type commandConstructor func(name string, arg ...string) commandRunner
+
+func execCommand(name string, arg ...string) commandRunner {
+	return commandRunner(exec.Command(name, arg...))
+}

--- a/cmd/agent/subcommands/integrations/command_test.go
+++ b/cmd/agent/subcommands/integrations/command_test.go
@@ -76,6 +76,22 @@ func TestShowCommand(t *testing.T) {
 		})
 }
 
+func TestCliParamsFallbackVersion(t *testing.T) {
+	tests := map[string]struct {
+		cp              cliParams
+		configValue     string
+		expectedVersion string
+	}{
+		"falls back to config": {cliParams{}, "2", "2"},
+		"overrides config":     {cliParams{pythonMajorVersion: "3"}, "2", "3"},
+	}
+	for name, test := range tests {
+		t.Logf("Running test %s", name)
+		test.cp.fallbackVersion(test.configValue)
+		assert.Equal(t, test.expectedVersion, test.cp.pythonMajorVersion)
+	}
+}
+
 // A minimal mock for a command that lets us control its output and make assertions
 type CmdMock struct {
 	name             string

--- a/cmd/agent/subcommands/integrations/command_test.go
+++ b/cmd/agent/subcommands/integrations/command_test.go
@@ -199,3 +199,22 @@ func TestDownloadWheel(t *testing.T) {
 	_, err = downloadWheel(py, "datadog-integration", "3.1.4", "core", 0)
 	assert.Equal(t, fmt.Sprintf("wheel %s does not exist", packagePath), err.Error())
 }
+
+func TestInstalledVersion(t *testing.T) {
+	cmdMock := &CmdMock{}
+	cmdMock.stdout = "3.1.4"
+
+	newCommand := func(name string, arg ...string) commandRunner {
+		cmdMock.name = name
+		cmdMock.arg = arg
+		return cmdMock
+	}
+
+	py := python(defaultPythonPath().py3)
+	py.cmdConstructor = newCommand
+
+	version, found, err := installedVersion(py, "datadog-integration")
+	assert.Equal(t, "3.1.4", version.String())
+	assert.Equal(t, true, found)
+	assert.Nil(t, err)
+}

--- a/cmd/agent/subcommands/integrations/command_test.go
+++ b/cmd/agent/subcommands/integrations/command_test.go
@@ -141,10 +141,15 @@ func TestPip(t *testing.T) {
 		return cmdMock
 	}
 
-	err := pip("my/python", 0, "freeze", []string{}, stdout, stderr, newCommand)
+	py := python(defaultPythonPath().py3)
+	py.stdout = stdout
+	py.stderr = stderr
+	py.cmdConstructor = newCommand
+
+	err := pip(py, "freeze", []string{}, 0)
 	assert.Equal(t, nil, err)
-	assert.Equal(t, "my/python", cmdMock.name)
-	assert.Equal(t, []string{"-mpip", "freeze", "--disable-pip-version-check"}, cmdMock.arg)
+	assert.Equal(t, defaultPythonPath().py3, cmdMock.name)
+	assert.Equal(t, []string{"-m", "pip", "freeze", "--disable-pip-version-check"}, cmdMock.arg)
 
 	assert.Equal(t, cmdMock.stdout, string(stdout.Bytes()))
 	assert.Equal(t, cmdMock.stderr, string(stderr.Bytes()))
@@ -174,9 +179,14 @@ func TestDownloadWheel(t *testing.T) {
 		return cmdMock
 	}
 
-	wheelPath, err := downloadWheel("my/python", 0, "datadog-integration", "3.1.4", "core", stdout, stderr, newCommand)
+	py := python(defaultPythonPath().py3)
+	py.stdout = stdout
+	py.stderr = stderr
+	py.cmdConstructor = newCommand
+
+	wheelPath, err := downloadWheel(py, "datadog-integration", "3.1.4", "core", 0)
 	assert.Equal(t, nil, err)
-	assert.Equal(t, "my/python", cmdMock.name)
+	assert.Equal(t, defaultPythonPath().py3, cmdMock.name)
 	assert.Equal(t, []string{"-m", downloaderModule, "datadog-integration", "--version", "3.1.4", "--type", "core"}, cmdMock.arg)
 
 	assert.Equal(t, cmdMock.stdout, string(stdout.Bytes()))
@@ -186,6 +196,6 @@ func TestDownloadWheel(t *testing.T) {
 	// Test that we get an error when the downloader exists but we can't find the wheel
 	packagePath = filepath.Join(tempdir, "non-existing-wheel")
 	cmdMock.stdout = fmt.Sprintf("%s\n", packagePath)
-	_, err = downloadWheel("my/python", 0, "datadog-integration", "3.1.4", "core", stdout, stderr, newCommand)
+	_, err = downloadWheel(py, "datadog-integration", "3.1.4", "core", 0)
 	assert.Equal(t, fmt.Sprintf("wheel %s does not exist", packagePath), err.Error())
 }

--- a/cmd/agent/subcommands/integrations/command_test.go
+++ b/cmd/agent/subcommands/integrations/command_test.go
@@ -92,6 +92,28 @@ func TestCliParamsFallbackVersion(t *testing.T) {
 	}
 }
 
+func TestGetConstraintsPath(t *testing.T) {
+	// File existing returns expected path
+	tempdir := t.TempDir()
+	dir := filepath.Join(tempdir, "root-dir")
+	expectedPath := filepath.Join(dir, "final_constraints-py3.txt")
+	os.MkdirAll(filepath.Dir(expectedPath), 0777)
+	f, err := os.Create(expectedPath)
+	if err != nil {
+		t.Errorf("failed to create: %s", err)
+		return
+	}
+	f.Close()
+
+	path, err := getConstraintsPath("3", dir)
+	assert.Equal(t, expectedPath, path)
+	assert.Nil(t, err)
+
+	// File not existing returns error
+	_, err = getConstraintsPath("2", dir)
+	assert.NotNil(t, err)
+}
+
 // A minimal mock for a command that lets us control its output and make assertions
 type CmdMock struct {
 	name             string

--- a/cmd/agent/subcommands/integrations/integrations_nix_helpers.go
+++ b/cmd/agent/subcommands/integrations/integrations_nix_helpers.go
@@ -24,8 +24,8 @@ var (
 	pythonMinorVersion string
 )
 
-func getRelPyPath(cliParams *cliParams) string {
-	return filepath.Join("embedded", "bin", fmt.Sprintf("%s%s", pythonBin, cliParams.pythonMajorVersion))
+func getRelPyPath(version string) string {
+	return filepath.Join("embedded", "bin", fmt.Sprintf("%s%s", pythonBin, version))
 }
 
 func getRelChecksPath(cliParams *cliParams) (string, error) {

--- a/cmd/agent/subcommands/integrations/integrations_nix_helpers.go
+++ b/cmd/agent/subcommands/integrations/integrations_nix_helpers.go
@@ -11,33 +11,12 @@ package integrations
 import (
 	"fmt"
 	"path/filepath"
-	"strings"
 )
 
 const (
-	pythonBin                = "python"
-	pythonMinorVersionScript = "import sys;print(sys.version_info[1])"
+	pythonBin = "python"
 )
 
 func getRelPyPath(version string) string {
 	return filepath.Join("embedded", "bin", fmt.Sprintf("%s%s", pythonBin, version))
-}
-
-func getRelChecksPath(cliParams *cliParams) (string, error) {
-	pythonMinorVersion, err := detectPythonMinorVersion(cliParams)
-	if err != nil {
-		return "", err
-	}
-
-	pythonDir := fmt.Sprintf("%s%s.%s", pythonBin, cliParams.pythonMajorVersion, pythonMinorVersion)
-	return filepath.Join("embedded", "lib", pythonDir, "site-packages", "datadog_checks"), nil
-}
-
-func detectPythonMinorVersion(cliParams *cliParams) (string, error) {
-	minorVersion, err := cliParams.python().runCommand(pythonMinorVersionScript)
-
-	if err != nil {
-		return "", err
-	}
-	return strings.TrimSpace(string(minorVersion)), nil
 }

--- a/cmd/agent/subcommands/integrations/integrations_test.go
+++ b/cmd/agent/subcommands/integrations/integrations_test.go
@@ -84,21 +84,22 @@ func TestGetVersionFromReqLine(t *testing.T) {
 func TestValidateArgs(t *testing.T) {
 	// No args
 	args := []string{}
-	err := validateArgs(args, false)
+	_, err := validateArgs(args, false)
 	assert.NotNil(t, err)
 
 	// Too many args
 	args = []string{"arg1", "arg2"}
-	err = validateArgs(args, true)
+	_, err = validateArgs(args, true)
 	assert.NotNil(t, err)
 
 	// Not local => name starts with datadog
 	args = []string{"foo"}
-	err = validateArgs(args, false)
+	_, err = validateArgs(args, false)
 	assert.NotNil(t, err)
 	args = []string{"datadog-foo"}
-	err = validateArgs(args, false)
+	pkg, err := validateArgs(args, false)
 	assert.Nil(t, err)
+	assert.Equal(t, "datadog-foo", pkg)
 }
 
 func TestValidateRequirement(t *testing.T) {

--- a/cmd/agent/subcommands/integrations/integrations_windows.go
+++ b/cmd/agent/subcommands/integrations/integrations_windows.go
@@ -23,10 +23,6 @@ func getRelPyPath(version string) string {
 	return filepath.Join(fmt.Sprintf("embedded%s", version), pythonBin)
 }
 
-func getRelChecksPath(cliParams *cliParams) (string, error) {
-	return filepath.Join(fmt.Sprintf("embedded%s", cliParams.pythonMajorVersion), "Lib", "site-packages", "datadog_checks"), nil
-}
-
 func validateUser(allowRoot bool) error {
 	elevated, _ := winutil.IsProcessElevated()
 	if !elevated {

--- a/cmd/agent/subcommands/integrations/integrations_windows.go
+++ b/cmd/agent/subcommands/integrations/integrations_windows.go
@@ -19,8 +19,8 @@ const (
 	pythonBin = "python.exe"
 )
 
-func getRelPyPath(cliParams *cliParams) string {
-	return filepath.Join(fmt.Sprintf("embedded%s", cliParams.pythonMajorVersion), pythonBin)
+func getRelPyPath(version string) string {
+	return filepath.Join(fmt.Sprintf("embedded%s", version), pythonBin)
 }
 
 func getRelChecksPath(cliParams *cliParams) (string, error) {

--- a/cmd/agent/subcommands/integrations/python.go
+++ b/cmd/agent/subcommands/integrations/python.go
@@ -37,6 +37,7 @@ func python(path string) *pythonRunner {
 	}
 }
 
+// Creates a copy of the runner with the environment set to newEnv
 func (p *pythonRunner) withEnv(newEnv []string) *pythonRunner {
 	newRunner := *p
 	newRunner.env = newEnv

--- a/cmd/agent/subcommands/integrations/python.go
+++ b/cmd/agent/subcommands/integrations/python.go
@@ -1,0 +1,123 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build python
+// +build python
+
+package integrations
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/fatih/color"
+)
+
+type pythonRunner struct {
+	path           string
+	stdout         io.Writer
+	stderr         io.Writer
+	cmdConstructor commandConstructor
+	env            []string
+}
+
+func python(path string) *pythonRunner {
+	return &pythonRunner{
+		path:           path,
+		stdout:         os.Stdout,
+		stderr:         os.Stderr,
+		cmdConstructor: execCommand,
+	}
+}
+
+func (p *pythonRunner) withEnv(newEnv []string) *pythonRunner {
+	newRunner := *p
+	newRunner.env = newEnv
+	return &newRunner
+}
+
+// Runs a python module with the interpreter, piping to stdout and stderr
+func (p *pythonRunner) runModule(module string, args []string) error {
+	return p.runModuleWithCallback(module, args, func(_s string) {})
+}
+
+// Runs a python module with the interpreter, calling a callback on every stdout line
+func (p *pythonRunner) runModuleWithCallback(module string, args []string, callback func(string)) error {
+	args = append([]string{"-m", module}, args...)
+	pipCmd := p.cmdConstructor(p.path, args...)
+	pipCmd.SetEnv(p.env)
+
+	// Create a waitgroup for waiting for piping goroutines
+	var wg sync.WaitGroup
+
+	// forward the standard output to stdout
+	pipStdout, err := pipCmd.StdoutPipe()
+	if err != nil {
+		return err
+	}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		in := bufio.NewScanner(pipStdout)
+		for in.Scan() {
+			line := in.Text()
+			fmt.Fprintf(p.stdout, "%s\n", line)
+			callback(line)
+		}
+	}()
+
+	// forward the standard error to stderr
+	pipStderr, err := pipCmd.StderrPipe()
+	if err != nil {
+		return err
+	}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		in := bufio.NewScanner(pipStderr)
+		for in.Scan() {
+			fmt.Fprintf(p.stderr, "%s\n", color.RedString(in.Text()))
+		}
+	}()
+
+	if err = pipCmd.Start(); err != nil {
+		wg.Wait()
+		return fmt.Errorf("error running command: %v", err)
+	}
+
+	// Wait for both piping goroutines to complete to ensure pipes are exhausted
+	wg.Wait()
+
+	err = pipCmd.Wait()
+	if err != nil {
+		return fmt.Errorf("error running command: %v", err)
+	}
+
+	return nil
+}
+
+// Holds paths for both versions of Python
+type pythonPath struct {
+	py2 string
+	py3 string
+}
+
+func defaultPythonPath() pythonPath {
+	return pythonPath{
+		py2: filepath.Join(rootDir, getRelPyPath("2")),
+		py3: filepath.Join(rootDir, getRelPyPath("3")),
+	}
+}
+
+func sysPythonPath() pythonPath {
+	return pythonPath{
+		py2: pythonBin,
+		py3: pythonBin,
+	}
+}

--- a/cmd/agent/subcommands/integrations/python.go
+++ b/cmd/agent/subcommands/integrations/python.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"sync"
 
@@ -100,6 +101,25 @@ func (p *pythonRunner) runModuleWithCallback(module string, args []string, callb
 	}
 
 	return nil
+}
+
+// Runs a python command (python literal program) and returns its output
+func (p *pythonRunner) runCommand(cmd string) (string, error) {
+	pythonCmd := p.cmdConstructor(p.path, "-c", cmd)
+	output, err := pythonCmd.Output()
+
+	if err != nil {
+		errMsg := ""
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			errMsg = string(exitErr.Stderr)
+		} else {
+			errMsg = err.Error()
+		}
+
+		return "", fmt.Errorf("error executing python: %s", errMsg)
+	}
+
+	return string(output), nil
 }
 
 // Holds paths for both versions of Python

--- a/cmd/agent/subcommands/integrations/python.go
+++ b/cmd/agent/subcommands/integrations/python.go
@@ -51,14 +51,14 @@ func (p *pythonRunner) runModule(module string, args []string) error {
 // Runs a python module with the interpreter, calling a callback on every stdout line
 func (p *pythonRunner) runModuleWithCallback(module string, args []string, callback func(string)) error {
 	args = append([]string{"-m", module}, args...)
-	pipCmd := p.cmdConstructor(p.path, args...)
-	pipCmd.SetEnv(p.env)
+	pythonCmd := p.cmdConstructor(p.path, args...)
+	pythonCmd.SetEnv(p.env)
 
 	// Create a waitgroup for waiting for piping goroutines
 	var wg sync.WaitGroup
 
 	// forward the standard output to stdout
-	pipStdout, err := pipCmd.StdoutPipe()
+	pipStdout, err := pythonCmd.StdoutPipe()
 	if err != nil {
 		return err
 	}
@@ -74,7 +74,7 @@ func (p *pythonRunner) runModuleWithCallback(module string, args []string, callb
 	}()
 
 	// forward the standard error to stderr
-	pipStderr, err := pipCmd.StderrPipe()
+	pipStderr, err := pythonCmd.StderrPipe()
 	if err != nil {
 		return err
 	}
@@ -87,7 +87,7 @@ func (p *pythonRunner) runModuleWithCallback(module string, args []string, callb
 		}
 	}()
 
-	if err = pipCmd.Start(); err != nil {
+	if err = pythonCmd.Start(); err != nil {
 		wg.Wait()
 		return fmt.Errorf("error running command: %v", err)
 	}
@@ -95,7 +95,7 @@ func (p *pythonRunner) runModuleWithCallback(module string, args []string, callb
 	// Wait for both piping goroutines to complete to ensure pipes are exhausted
 	wg.Wait()
 
-	err = pipCmd.Wait()
+	err = pythonCmd.Wait()
 	if err != nil {
 		return fmt.Errorf("error running command: %v", err)
 	}


### PR DESCRIPTION
### What does this PR do?

- Improves test coverage of code in the `integrations` package (from ~30% to ~50%).
- It applies various code improvements, simplifying code, removing repetition and removing global variables.
  - Part of this includes unifying the way we were calling python modules and scripts, where testing also helped me find a race condition with the output redirection that we do there.
- Adds a couple of dev flags (`--python2-path`, `--python3-path`) that would let me test #14331 without needing a full omnibus build.
- It simplifies how the path to the checks folder is found, which also makes it possible for the code to work when using an arbitrary python (e.g. via the above flags).

### Motivation

As I was working on #14331 recently I was:

- Struggling to test my little change locally.
- Surprised at the low test coverage of the code (~30 %)
- Finding that overall the code could use some improvements.

So I used my Hackathon time to work on this.

### Additional Notes

- I tried to make commits in a way that it should aid reviewing commit-by-commit.
- I'm not too familiar Go and its ecosystem which may show in places (e.g. the tests should probably be split in different ways).
- There's still room for improvement but 1) the PR is already pretty big and 2) hackathon's over and this is probably not a priority.
- It looks like it would be nice if we could reuse the same logic that the agent uses to find python instead of rolling our own here, but I was not familiar enough with the codebase to attempt that.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Check that all `agent integration` subcommands work as expected.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
