### PR TITLE
[CWS] generic lru

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -469,6 +469,8 @@ core,github.com/hashicorp/go-multierror,MPL-2.0,"Copyright © 2014-2018 HashiCor
 core,github.com/hashicorp/go-rootcerts,MPL-2.0,"Copyright © 2014-2018 HashiCorp, Inc"
 core,github.com/hashicorp/golang-lru,MPL-2.0,"Copyright © 2014-2018 HashiCorp, Inc"
 core,github.com/hashicorp/golang-lru/simplelru,MPL-2.0,"Copyright © 2014-2018 HashiCorp, Inc"
+core,github.com/hashicorp/golang-lru/v2,MPL-2.0,"Copyright © 2014-2018 HashiCorp, Inc"
+core,github.com/hashicorp/golang-lru/v2/simplelru,MPL-2.0,"Copyright © 2014-2018 HashiCorp, Inc"
 core,github.com/hashicorp/hcl,MPL-2.0,"Copyright © 2014-2018 HashiCorp, Inc"
 core,github.com/hashicorp/hcl/hcl/ast,MPL-2.0,"Copyright © 2014-2018 HashiCorp, Inc"
 core,github.com/hashicorp/hcl/hcl/parser,MPL-2.0,"Copyright © 2014-2018 HashiCorp, Inc"

--- a/go.mod
+++ b/go.mod
@@ -122,6 +122,7 @@ require (
 	github.com/hashicorp/consul/api v1.13.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/golang-lru v0.5.4
+	github.com/hashicorp/golang-lru/v2 v2.0.1
 	github.com/hectane/go-acl v0.0.0-20190604041725-da78bae5fc95
 	github.com/iceber/iouring-go v0.0.0-20220511091803-99712053f7ec
 	github.com/imdario/mergo v0.3.12
@@ -147,6 +148,7 @@ require (
 	github.com/opencontainers/image-spec v1.0.3-0.20211202183452-c5a74bcca799
 	github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417
 	github.com/openshift/api v3.9.0+incompatible
+	github.com/pahanini/go-grpc-bidirectional-streaming-example v0.0.0-20211027164128-cc6111af44be
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.13.1
@@ -194,6 +196,7 @@ require (
 	golang.org/x/tools v0.3.0
 	google.golang.org/genproto v0.0.0-20221027153422-115e99e71e1c
 	google.golang.org/grpc v1.50.1
+	google.golang.org/grpc/examples v0.0.0-20221020162917-9127159caf5a
 	google.golang.org/protobuf v1.28.1
 	gopkg.in/DataDog/dd-trace-go.v1 v1.37.0
 	gopkg.in/yaml.v2 v2.4.0
@@ -416,10 +419,6 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.1 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
-
-require google.golang.org/grpc/examples v0.0.0-20221020162917-9127159caf5a
-
-require github.com/pahanini/go-grpc-bidirectional-streaming-example v0.0.0-20211027164128-cc6111af44be
 
 replace github.com/pahanini/go-grpc-bidirectional-streaming-example v0.0.0-20211027164128-cc6111af44be => github.com/DataDog/go-grpc-bidirectional-streaming-example v0.0.0-20221024060302-b9cf785c02fe
 

--- a/go.sum
+++ b/go.sum
@@ -942,6 +942,8 @@ github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
+github.com/hashicorp/golang-lru/v2 v2.0.1 h1:5pv5N1lT1fjLg2VQ5KWc7kmucp2x/kvFOnxuVTqZ6x4=
+github.com/hashicorp/golang-lru/v2 v2.0.1/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=

--- a/pkg/security/probe/mount_resolver_test.go
+++ b/pkg/security/probe/mount_resolver_test.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/golang-lru/simplelru"
+	"github.com/hashicorp/golang-lru/v2/simplelru"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
@@ -344,7 +344,7 @@ func TestMountResolver(t *testing.T) {
 }
 
 func TestMountGetParentPath(t *testing.T) {
-	parentPathCache, err := simplelru.NewLRU(256, nil)
+	parentPathCache, err := simplelru.NewLRU[uint32, string](256, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -374,7 +374,7 @@ func TestMountGetParentPath(t *testing.T) {
 }
 
 func TestMountLoop(t *testing.T) {
-	parentPathCache, err := simplelru.NewLRU(256, nil)
+	parentPathCache, err := simplelru.NewLRU[uint32, string](256, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -406,7 +406,7 @@ func TestMountLoop(t *testing.T) {
 }
 
 func BenchmarkGetParentPath(b *testing.B) {
-	parentPathCache, err := simplelru.NewLRU(256, nil)
+	parentPathCache, err := simplelru.NewLRU[uint32, string](256, nil)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/pkg/security/probe/namespace_resolver.go
+++ b/pkg/security/probe/namespace_resolver.go
@@ -20,7 +20,7 @@ import (
 	"github.com/DataDog/datadog-go/v5/statsd"
 	manager "github.com/DataDog/ebpf-manager"
 	"github.com/DataDog/gopsutil/process"
-	"github.com/hashicorp/golang-lru/simplelru"
+	"github.com/hashicorp/golang-lru/v2/simplelru"
 	"github.com/vishvananda/netlink"
 	"go.uber.org/atomic"
 	"golang.org/x/sys/unix"
@@ -196,7 +196,7 @@ type NamespaceResolver struct {
 	probe  *Probe
 	client statsd.ClientInterface
 
-	networkNamespaces *simplelru.LRU
+	networkNamespaces *simplelru.LRU[uint32, *NetworkNamespace]
 }
 
 // NewNamespaceResolver returns a new instance of NamespaceResolver
@@ -207,9 +207,9 @@ func NewNamespaceResolver(probe *Probe) (*NamespaceResolver, error) {
 		client: probe.statsdClient,
 	}
 
-	lru, err := simplelru.NewLRU(1024, func(key interface{}, value interface{}) {
-		nr.flushNetworkNamespace(value.(*NetworkNamespace))
-		nr.probe.flushNetworkNamespace(value.(*NetworkNamespace))
+	lru, err := simplelru.NewLRU(1024, func(key uint32, value *NetworkNamespace) {
+		nr.flushNetworkNamespace(value)
+		nr.probe.flushNetworkNamespace(value)
 	})
 	if err != nil {
 		return nil, err
@@ -239,8 +239,7 @@ func (nr *NamespaceResolver) SaveNetworkNamespaceHandle(nsID uint32, nsPath *uti
 	nr.Lock()
 	defer nr.Unlock()
 
-	var netns *NetworkNamespace
-	value, found := nr.networkNamespaces.Get(nsID)
+	netns, found := nr.networkNamespaces.Get(nsID)
 	if !found {
 		var err error
 		netns, err = NewNetworkNamespaceWithPath(nsID, nsPath)
@@ -250,7 +249,6 @@ func (nr *NamespaceResolver) SaveNetworkNamespaceHandle(nsID uint32, nsPath *uti
 		}
 		nr.networkNamespaces.Add(nsID, netns)
 	} else {
-		netns = value.(*NetworkNamespace)
 		if netns.hasValidHandle() {
 			// we already have a handle for this network namespace, ignore
 			return netns, false
@@ -283,7 +281,7 @@ func (nr *NamespaceResolver) ResolveNetworkNamespace(nsID uint32) *NetworkNamesp
 	defer nr.Unlock()
 
 	if ns, found := nr.networkNamespaces.Get(nsID); found {
-		return ns.(*NetworkNamespace)
+		return ns
 	}
 
 	return nil
@@ -375,13 +373,10 @@ func (nr *NamespaceResolver) QueueNetworkDevice(device model.NetDevice) {
 	nr.Lock()
 	defer nr.Unlock()
 
-	var netns *NetworkNamespace
-	value, found := nr.networkNamespaces.Get(device.NetNS)
+	netns, found := nr.networkNamespaces.Get(device.NetNS)
 	if !found {
 		netns = NewNetworkNamespace(device.NetNS)
 		nr.networkNamespaces.Add(device.NetNS, netns)
-	} else {
-		netns = value.(*NetworkNamespace)
 	}
 
 	netns.queueNetworkDevice(device)
@@ -459,8 +454,7 @@ func (nr *NamespaceResolver) preventNetworkNamespaceDrift(probesCount map[uint32
 
 	// compute the list of network namespaces without any probe
 	for _, nsID := range nr.networkNamespaces.Keys() {
-		value, _ := nr.networkNamespaces.Peek(nsID)
-		netns := value.(*NetworkNamespace)
+		netns, _ := nr.networkNamespaces.Peek(nsID)
 
 		netns.Lock()
 		netnsCount := probesCount[netns.nsID]
@@ -504,8 +498,7 @@ func (nr *NamespaceResolver) SendStats() error {
 	var lonelyNetworkNamespacesCount float64
 
 	for _, nsID := range nr.networkNamespaces.Keys() {
-		value, _ := nr.networkNamespaces.Peek(nsID)
-		netns := value.(*NetworkNamespace)
+		netns, _ := nr.networkNamespaces.Peek(nsID)
 
 		if count := len(netns.networkDevicesQueue); count > 0 {
 			queuedNetworkDevicesCount += float64(count)
@@ -564,9 +557,7 @@ func (nr *NamespaceResolver) dump(params *api.DumpNetworkNamespaceParams) []Netw
 
 	// iterate over the list of network namespaces
 	for _, nsID := range nr.networkNamespaces.Keys() {
-		value, _ := nr.networkNamespaces.Peek(nsID)
-		netns := value.(*NetworkNamespace)
-
+		netns, _ := nr.networkNamespaces.Peek(nsID)
 		netns.Lock()
 
 		netnsDump := NetworkNamespaceDump{

--- a/pkg/security/probe/user_resolver.go
+++ b/pkg/security/probe/user_resolver.go
@@ -12,20 +12,20 @@ import (
 	"os/user"
 	"strconv"
 
-	lru "github.com/hashicorp/golang-lru"
+	lru "github.com/hashicorp/golang-lru/v2"
 )
 
 // UserGroupResolver resolves user and group ids to names
 type UserGroupResolver struct {
-	userCache  *lru.Cache
-	groupCache *lru.Cache
+	userCache  *lru.Cache[int, string]
+	groupCache *lru.Cache[int, string]
 }
 
 // ResolveUser resolves a user id to a username
 func (r *UserGroupResolver) ResolveUser(uid int) (string, error) {
 	cachedEntry, found := r.userCache.Get(uid)
 	if found {
-		return cachedEntry.(string), nil
+		return cachedEntry, nil
 	}
 
 	var username string
@@ -41,7 +41,7 @@ func (r *UserGroupResolver) ResolveUser(uid int) (string, error) {
 func (r *UserGroupResolver) ResolveGroup(gid int) (string, error) {
 	cachedEntry, found := r.groupCache.Get(gid)
 	if found {
-		return cachedEntry.(string), nil
+		return cachedEntry, nil
 	}
 
 	var groupname string
@@ -55,12 +55,12 @@ func (r *UserGroupResolver) ResolveGroup(gid int) (string, error) {
 
 // NewUserGroupResolver instantiates a new user and group resolver
 func NewUserGroupResolver() (*UserGroupResolver, error) {
-	userCache, err := lru.New(64)
+	userCache, err := lru.New[int, string](64)
 	if err != nil {
 		return nil, err
 	}
 
-	groupCache, err := lru.New(64)
+	groupCache, err := lru.New[int, string](64)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/security/secl/go.mod
+++ b/pkg/security/secl/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/fatih/structtag v1.2.0
 	github.com/fsnotify/fsnotify v1.6.0
 	github.com/hashicorp/go-multierror v1.1.1
-	github.com/hashicorp/golang-lru v0.5.4
+	github.com/hashicorp/golang-lru/v2 v2.0.1
 	github.com/skydive-project/go-debouncer v1.0.0
 	github.com/spf13/cast v1.5.0
 	github.com/stretchr/testify v1.8.1

--- a/pkg/security/secl/go.sum
+++ b/pkg/security/secl/go.sum
@@ -23,8 +23,8 @@ github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/U
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
-github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
-github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
+github.com/hashicorp/golang-lru/v2 v2.0.1 h1:5pv5N1lT1fjLg2VQ5KWc7kmucp2x/kvFOnxuVTqZ6x4=
+github.com/hashicorp/golang-lru/v2 v2.0.1/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/huandu/xstrings v1.3.1/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/huandu/xstrings v1.3.2 h1:L18LIDzqlW6xN2rEkpdV8+oL/IXWJ1APd+vsdYy4Wdw=
 github.com/huandu/xstrings v1.3.2/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=

--- a/pkg/security/secl/model/consts_common.go
+++ b/pkg/security/secl/model/consts_common.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 
-	lru "github.com/hashicorp/golang-lru"
+	lru "github.com/hashicorp/golang-lru/v2"
 )
 
 const (
@@ -1008,11 +1008,11 @@ func (f RetValError) String() string {
 	return ""
 }
 
-var capsStringArrayCache *lru.Cache
+var capsStringArrayCache *lru.Cache[KernelCapability, []string]
 
 func init() {
 	initConstants()
-	capsStringArrayCache, _ = lru.New(4)
+	capsStringArrayCache, _ = lru.New[KernelCapability, []string](4)
 }
 
 // KernelCapability represents a kernel capability bitmask value
@@ -1025,7 +1025,7 @@ func (kc KernelCapability) String() string {
 // StringArray returns the kernel capabilities as an array of strings
 func (kc KernelCapability) StringArray() []string {
 	if value, ok := capsStringArrayCache.Get(kc); ok {
-		return value.([]string)
+		return value
 	}
 	computed := bitmaskU64ToStringArray(uint64(kc), kernelCapabilitiesStrings)
 	capsStringArrayCache.Add(kc, computed)


### PR DESCRIPTION
### What does this PR do?

Uses v2 of the `golang-lru` lib for:
- stay up-to-date (fixes https://github.com/DataDog/datadog-agent/pull/14426)
- type safety, for example https://github.com/DataDog/datadog-agent/pull/14433 would not have been possible
- performance (no more `interface{}` casting everywhere)

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
