### PR TITLE
[Serverless] Fix race condition in `TestHandleInvocationShouldNotSIGSEGVWhenTimedOut`

### DIFF
--- a/pkg/serverless/daemon/daemon.go
+++ b/pkg/serverless/daemon/daemon.go
@@ -65,8 +65,8 @@ type Daemon struct {
 	// It should be reset when we start a new invocation, as we may start a new invocation before hearing that the last one finished.
 	RuntimeWg *sync.WaitGroup
 
-	// FlushWg is used to keep track of whether there is currently a flush in progress
-	FlushWg *sync.WaitGroup
+	// FlushLock is used to keep track of whether there is currently a flush in progress
+	FlushLock sync.Mutex
 
 	ExtraTags *serverlessLog.Tags
 
@@ -104,7 +104,7 @@ func StartDaemon(addr string) *Daemon {
 		httpServer:        &http.Server{Addr: addr, Handler: mux},
 		mux:               mux,
 		RuntimeWg:         &sync.WaitGroup{},
-		FlushWg:           &sync.WaitGroup{},
+		FlushLock:         sync.Mutex{},
 		lastInvocations:   make([]time.Time, 0),
 		useAdaptiveFlush:  true,
 		flushStrategy:     &flush.AtTheEnd{},
@@ -201,8 +201,8 @@ func (d *Daemon) UseAdaptiveFlush(enabled bool) {
 // flush may be continued on the next invocation.
 // In some circumstances, it may switch to another flush strategy after the flush.
 func (d *Daemon) TriggerFlush(isLastFlushBeforeShutdown bool) {
-	d.FlushWg.Add(1)
-	defer d.FlushWg.Done()
+	d.FlushLock.Lock()
+	defer d.FlushLock.Unlock()
 
 	ctx, cancel := context.WithTimeout(context.Background(), FlushTimeout)
 
@@ -340,7 +340,8 @@ func (d *Daemon) TellDaemonRuntimeDone() {
 // WaitForDaemon waits until the daemon has finished handling the current invocation
 func (d *Daemon) WaitForDaemon() {
 	// We always want to wait for any in-progress flush to complete
-	d.FlushWg.Wait()
+	d.FlushLock.Lock()
+	d.FlushLock.Unlock()
 
 	// If we are flushing at the end of the invocation, we need to wait for the invocation itself to end
 	// before we finish handling it. Otherwise, the daemon does not actually need to wait for the runtime to

--- a/pkg/serverless/daemon/daemon.go
+++ b/pkg/serverless/daemon/daemon.go
@@ -341,7 +341,7 @@ func (d *Daemon) TellDaemonRuntimeDone() {
 func (d *Daemon) WaitForDaemon() {
 	// We always want to wait for any in-progress flush to complete
 	d.FlushLock.Lock()
-	d.FlushLock.Unlock()
+	d.FlushLock.Unlock() //nolint:staticcheck
 
 	// If we are flushing at the end of the invocation, we need to wait for the invocation itself to end
 	// before we finish handling it. Otherwise, the daemon does not actually need to wait for the runtime to

--- a/pkg/serverless/daemon/daemon_test.go
+++ b/pkg/serverless/daemon/daemon_test.go
@@ -82,13 +82,14 @@ func TestTellDaemonRuntimeDoneIfLocalTest(t *testing.T) {
 	request, err := http.NewRequest(http.MethodPost, fmt.Sprintf("http://127.0.0.1:%d/lambda/flush", port), nil)
 	assert.Nil(err)
 	response, err := client.Do(request)
+	response.Body.Close()
 	if err != nil {
 		// retry once in case the daemon wasn't ready to accept requests
 		time.Sleep(100 * time.Millisecond)
 		response, err = client.Do(request)
+		response.Body.Close()
 	}
 	assert.Nil(err)
-	response.Body.Close()
 	select {
 	case <-wrapWait(d.RuntimeWg):
 		// all good

--- a/pkg/serverless/daemon/daemon_test.go
+++ b/pkg/serverless/daemon/daemon_test.go
@@ -82,6 +82,11 @@ func TestTellDaemonRuntimeDoneIfLocalTest(t *testing.T) {
 	request, err := http.NewRequest(http.MethodPost, fmt.Sprintf("http://127.0.0.1:%d/lambda/flush", port), nil)
 	assert.Nil(err)
 	response, err := client.Do(request)
+	if err != nil {
+		// retry once in case the daemon wasn't ready to accept requests
+		time.Sleep(100 * time.Millisecond)
+		response, err = client.Do(request)
+	}
 	assert.Nil(err)
 	response.Body.Close()
 	select {

--- a/pkg/serverless/daemon/interval_test.go
+++ b/pkg/serverless/daemon/interval_test.go
@@ -29,7 +29,6 @@ func TestAutoSelectStrategy(t *testing.T) {
 		d.StoreInvocationTime(now.Add(time.Second * time.Duration(i)))
 	}
 
-	fmt.Print(len(d.lastInvocations))
 	// when not enough data, the flush at the end strategy should be selected
 	// -----
 
@@ -55,7 +54,6 @@ func TestAutoSelectStrategy(t *testing.T) {
 	assert.Equal((&flush.AtTheEnd{}).String(), d.AutoSelectStrategy().String(), "not the good strategy has been selected")
 	assert.True(d.StoreInvocationTime(now.Add(-time.Minute * 6)))
 	// because of the interval, we should kept the "flush at the end" strategy
-	fmt.Println(d.InvocationInterval())
 	assert.Equal((&flush.AtTheEnd{}).String(), d.AutoSelectStrategy().String(), "not the good strategy has been selected")
 }
 

--- a/test/integration/serverless/snapshots/trace-csharp
+++ b/test/integration/serverless/snapshots/trace-csharp
@@ -48,7 +48,6 @@
             "metrics": {
               "_dd.top_level": 1,
               "_dd.tracer_kr": 0,
-              "_sampling_priority_rate_v1": 1,
               "_sampling_priority_v1": 1,
               "_top_level": 1,
               "process_id": null
@@ -114,7 +113,6 @@
             "metrics": {
               "_dd.top_level": 1,
               "_dd.tracer_kr": 1,
-              "_sampling_priority_rate_v1": 1,
               "_sampling_priority_v1": 1,
               "_top_level": 1,
               "process_id": null

--- a/test/integration/serverless/snapshots/trace-go
+++ b/test/integration/serverless/snapshots/trace-go
@@ -40,7 +40,6 @@
               "version": "integration-tests-version"
             },
             "metrics": {
-              "_sampling_priority_rate_v1": 1,
               "_top_level": 1
             },
             "type": ""

--- a/test/integration/serverless/snapshots/trace-java
+++ b/test/integration/serverless/snapshots/trace-java
@@ -40,7 +40,6 @@
               "version": "integration-tests-version"
             },
             "metrics": {
-              "_sampling_priority_rate_v1": 1,
               "_top_level": 1
             },
             "type": ""

--- a/test/integration/serverless/snapshots/trace-node
+++ b/test/integration/serverless/snapshots/trace-node
@@ -40,7 +40,6 @@
               "version": "integration-tests-version"
             },
             "metrics": {
-              "_sampling_priority_rate_v1": 1,
               "_top_level": 1
             },
             "type": ""

--- a/test/integration/serverless/snapshots/trace-python
+++ b/test/integration/serverless/snapshots/trace-python
@@ -40,7 +40,6 @@
               "version": "integration-tests-version"
             },
             "metrics": {
-              "_sampling_priority_rate_v1": 1,
               "_top_level": 1
             },
             "type": ""


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

The race detector has been consistently failing at `TestHandleInvocationShouldNotSIGSEGVWhenTimedOut`. This PR fixes the race condition.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Race conditions are bad.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

Note that this makes one small change to the functionality of the daemon. Now it is no longer possible to trigger two flushes at the same time. The second flush will now always wait until any preceding flushes have completed before executing.

This makes it easier for the `WaitForDaemon` to determine if it needs to wait or not. Instead of needing to wait for any variable number of flushes, it now only needs to wait for either one or zero flushes. In the case where there are zero active flushes, it continues without waiting. In the case where there is an executing flush, it will wait until it completes.

The `WaitForDaemon` determines if there is an active flush using a simple `sync.Mutex`. When the mutex is locked, we assume there is an active flush. When the mutex is unlocked, there is no active flush. The `WaitForDaemon` method simply needs to attempt to acquire the lock to determine if there is a running flush.

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

Disallowing concurrent flushes _could_ add additional overhead to the flush process. If flushes are requested in rapid succession, each flush must now wait until all others have completed. I believe this should be fine and possibly cut down on future errors due to concurrency issues. However, we should be sure to look for this when running the extension during QA.

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Ensure that no significant additional overhead is added when the extension is running on an very busy lambda function.

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
