### PR TITLE
pkg/trace: do not set _dd.tags.container tag

### DIFF
--- a/pkg/otlp/model/attributes/attributes.go
+++ b/pkg/otlp/model/attributes/attributes.go
@@ -16,7 +16,6 @@ package attributes
 
 import (
 	"fmt"
-	"strings"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
@@ -174,19 +173,14 @@ func OriginIDFromAttributes(attrs pcommon.Map) (originID string) {
 
 // ContainerTagFromAttributes extracts the value of _dd.tags.container from the given
 // set of attributes.
-func ContainerTagFromAttributes(attr map[string]string) string {
-	var str strings.Builder
+func ContainerTagFromAttributes(attr map[string]string) map[string]string {
+	ddtags := make(map[string]string)
 	for _, key := range containerTagsAttributes {
 		val, ok := attr[key]
 		if !ok {
 			continue
 		}
-		if str.Len() > 0 {
-			str.WriteByte(',')
-		}
-		str.WriteString(conventionsMapping[key])
-		str.WriteByte(':')
-		str.WriteString(val)
+		ddtags[conventionsMapping[key]] = val
 	}
-	return str.String()
+	return ddtags
 }

--- a/pkg/otlp/model/attributes/attributes_test.go
+++ b/pkg/otlp/model/attributes/attributes_test.go
@@ -73,14 +73,24 @@ func TestContainerTagFromAttributes(t *testing.T) {
 		"empty_string_val":                         "",
 	}
 
-	assert.Equal(t, "container_name:sample_app,image_tag:sample_app_image_tag,kube_container_name:kube_sample_app,kube_replica_set:sample_replica_set,kube_daemon_set:sample_daemonset_name,pod_name:sample_pod_name,cloud_provider:sample_cloud_provider,region:sample_region,zone:sample_zone,task_family:sample_task_family,ecs_cluster_name:sample_ecs_cluster_name,ecs_container_name:sample_ecs_container_name", ContainerTagFromAttributes(attributeMap))
+	assert.Equal(t, map[string]string{
+		"container_name":      "sample_app",
+		"image_tag":           "sample_app_image_tag",
+		"kube_container_name": "kube_sample_app",
+		"kube_replica_set":    "sample_replica_set",
+		"kube_daemon_set":     "sample_daemonset_name",
+		"pod_name":            "sample_pod_name",
+		"cloud_provider":      "sample_cloud_provider",
+		"region":              "sample_region",
+		"zone":                "sample_zone",
+		"task_family":         "sample_task_family",
+		"ecs_cluster_name":    "sample_ecs_cluster_name",
+		"ecs_container_name":  "sample_ecs_container_name",
+	}, ContainerTagFromAttributes(attributeMap))
 }
 
 func TestContainerTagFromAttributesEmpty(t *testing.T) {
-	var empty string
-	attributeMap := map[string]string{}
-
-	assert.Equal(t, empty, ContainerTagFromAttributes(attributeMap))
+	assert.Empty(t, ContainerTagFromAttributes(map[string]string{}))
 }
 
 func TestOriginIDFromAttributes(t *testing.T) {

--- a/pkg/trace/api/otlp.go
+++ b/pkg/trace/api/otlp.go
@@ -490,8 +490,11 @@ func (o *OTLPReceiver) convertSpan(rattr map[string]string, lib pcommon.Instrume
 		}
 		return true
 	})
-	if ctags := attributes.ContainerTagFromAttributes(span.Meta); ctags != "" {
-		setMetaOTLP(span, tagContainersTags, ctags)
+	for k, v := range attributes.ContainerTagFromAttributes(span.Meta) {
+		if _, ok := span.Meta[k]; !ok {
+			// overwrite only if it does not exist
+			setMetaOTLP(span, k, v)
+		}
 	}
 	if _, ok := span.Meta["env"]; !ok {
 		if env := span.Meta[string(semconv.AttributeDeploymentEnvironment)]; env != "" {

--- a/pkg/trace/api/otlp_test.go
+++ b/pkg/trace/api/otlp_test.go
@@ -1007,7 +1007,8 @@ func TestOTLPConvertSpan(t *testing.T) {
 				Duration: 200000000,
 				Meta: map[string]string{
 					"env":                             "staging",
-					"_dd.tags.container":              "container_id:cid,kube_container_name:k8s-container",
+					"container_id":                    "cid",
+					"kube_container_name":             "k8s-container",
 					semconv.AttributeContainerID:      "cid",
 					semconv.AttributeK8SContainerName: "k8s-container",
 					"http.method":                     "GET",

--- a/releasenotes/notes/apm-otlp-fix-container-tagging-override-835fa1d828681e21.yaml
+++ b/releasenotes/notes/apm-otlp-fix-container-tagging-override-835fa1d828681e21.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    APM: Fix an issue where container tags weren't working because of overwriting an essential tag on spans.


### PR DESCRIPTION
Setting the _dd.tags.container tag on spans will stop the intake from applying the correct container tags to the span. As a result, container tagging will be incorrect.