### PR TITLE
Emit ebpf helper telemetry as prometheus metrics

### DIFF
--- a/cmd/system-probe/api/server.go
+++ b/cmd/system-probe/api/server.go
@@ -23,8 +23,6 @@ import (
 	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
 )
 
-var expvarServer *http.Server
-
 // StartServer starts the HTTP server for the system-probe, which registers endpoints from all enabled modules.
 func StartServer(cfg *config.Config) error {
 	conn, err := net.NewListener(cfg.SocketAddress)

--- a/cmd/system-probe/api/server.go
+++ b/cmd/system-probe/api/server.go
@@ -19,8 +19,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/process/net"
 	"github.com/DataDog/datadog-agent/pkg/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-
-	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
 )
 
 // StartServer starts the HTTP server for the system-probe, which registers endpoints from all enabled modules.
@@ -50,7 +48,7 @@ func StartServer(cfg *config.Config) error {
 	mux.Handle("/debug/vars", http.DefaultServeMux)
 
 	// Expose telemetry endpoint
-	if ddconfig.Datadog.GetBool("telemetry.enabled") {
+	if cfg.TelemetryEnabled {
 		http.Handle("/telemetry", telemetry.Handler())
 	}
 

--- a/cmd/system-probe/api/server.go
+++ b/cmd/system-probe/api/server.go
@@ -17,8 +17,11 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/system-probe/modules"
 	"github.com/DataDog/datadog-agent/cmd/system-probe/utils"
 	"github.com/DataDog/datadog-agent/pkg/process/net"
+	"github.com/DataDog/datadog-agent/pkg/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
+
+var expvarServer *http.Server
 
 // StartServer starts the HTTP server for the system-probe, which registers endpoints from all enabled modules.
 func StartServer(cfg *config.Config) error {
@@ -32,6 +35,20 @@ func StartServer(cfg *config.Config) error {
 	if err != nil {
 		return fmt.Errorf("failed to create system probe: %s", err)
 	}
+
+	// Setup prometheus server
+	port := cfg.DefaultSystemProbeExpVarPort
+	http.Handle("/telemetry", telemetry.Handler())
+	expvarServer := &http.Server{
+		Addr:    "127.0.0.1:" + port,
+		Handler: http.DefaultServeMux,
+	}
+	go func() {
+		err := expvarServer.ListenAndServe()
+		if err != nil && err != http.ErrServerClosed {
+			log.Errorf("Error creating expvar server on port %v: %v", port, err)
+		}
+	}()
 
 	// Register stats endpoint
 	mux.HandleFunc("/debug/stats", utils.WithConcurrencyLimit(utils.DefaultMaxConcurrentRequests, func(w http.ResponseWriter, req *http.Request) {

--- a/cmd/system-probe/api/server.go
+++ b/cmd/system-probe/api/server.go
@@ -17,7 +17,6 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/system-probe/modules"
 	"github.com/DataDog/datadog-agent/cmd/system-probe/utils"
 	"github.com/DataDog/datadog-agent/pkg/process/net"
-	"github.com/DataDog/datadog-agent/pkg/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -46,11 +45,6 @@ func StartServer(cfg *config.Config) error {
 	mux.HandleFunc("/module-restart/{module-name}", restartModuleHandler).Methods("POST")
 
 	mux.Handle("/debug/vars", http.DefaultServeMux)
-
-	// Expose telemetry endpoint
-	if cfg.TelemetryEnabled {
-		http.Handle("/telemetry", telemetry.Handler())
-	}
 
 	go func() {
 		err = http.Serve(conn.GetListener(), mux)

--- a/cmd/system-probe/api/server.go
+++ b/cmd/system-probe/api/server.go
@@ -42,7 +42,7 @@ func StartServer(cfg *config.Config) error {
 	}
 
 	// Setup telemetry server
-	port := cfg.SystemProbeExpVarPort
+	port := cfg.ExpVarPort
 	if ddconfig.Datadog.GetBool("telemetry.enabled") && isValidPort(port) {
 		http.Handle("/telemetry", telemetry.Handler())
 		expvarServer := &http.Server{

--- a/cmd/system-probe/api/server.go
+++ b/cmd/system-probe/api/server.go
@@ -17,7 +17,10 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/system-probe/modules"
 	"github.com/DataDog/datadog-agent/cmd/system-probe/utils"
 	"github.com/DataDog/datadog-agent/pkg/process/net"
+	"github.com/DataDog/datadog-agent/pkg/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+
+	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
 )
 
 // StartServer starts the HTTP server for the system-probe, which registers endpoints from all enabled modules.
@@ -45,6 +48,11 @@ func StartServer(cfg *config.Config) error {
 	mux.HandleFunc("/module-restart/{module-name}", restartModuleHandler).Methods("POST")
 
 	mux.Handle("/debug/vars", http.DefaultServeMux)
+
+	// Expose telemetry endpoint
+	if ddconfig.Datadog.GetBool("telemetry.enabled") {
+		http.Handle("/telemetry", telemetry.Handler())
+	}
 
 	go func() {
 		err = http.Serve(conn.GetListener(), mux)

--- a/cmd/system-probe/app/run.go
+++ b/cmd/system-probe/app/run.go
@@ -30,6 +30,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/pidfile"
 	"github.com/DataDog/datadog-agent/pkg/process/statsd"
 	ddruntime "github.com/DataDog/datadog-agent/pkg/runtime"
+	"github.com/DataDog/datadog-agent/pkg/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/profiling"
@@ -199,6 +200,10 @@ func StartSystemProbe() error {
 
 	// if a debug port is specified, we expose the default handler to that port
 	if isValidPort(cfg.DebugPort) {
+		// Expose telemetry endpoint
+		if cfg.TelemetryEnabled {
+			http.Handle("/telemetry", telemetry.Handler())
+		}
 		go func() {
 			err := http.ListenAndServe(fmt.Sprintf("localhost:%d", cfg.DebugPort), http.DefaultServeMux)
 			if err != nil && err != http.ErrServerClosed {

--- a/cmd/system-probe/app/run.go
+++ b/cmd/system-probe/app/run.go
@@ -30,7 +30,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/pidfile"
 	"github.com/DataDog/datadog-agent/pkg/process/statsd"
 	ddruntime "github.com/DataDog/datadog-agent/pkg/runtime"
-	"github.com/DataDog/datadog-agent/pkg/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/profiling"
@@ -196,11 +195,6 @@ func StartSystemProbe() error {
 
 	if err := statsd.Configure(cfg.StatsdHost, cfg.StatsdPort); err != nil {
 		return log.Criticalf("Error configuring statsd: %s", err)
-	}
-
-	// Expose telemetry endpoint
-	if ddconfig.Datadog.GetBool("telemetry.enabled") {
-		http.Handle("/telemetry", telemetry.Handler())
 	}
 
 	// if a debug port is specified, we expose the default handler to that port

--- a/cmd/system-probe/config/config.go
+++ b/cmd/system-probe/config/config.go
@@ -65,7 +65,6 @@ type Config struct {
 
 	StatsdHost string
 	StatsdPort int
-	ExpVarPort int
 
 	// Settings for profiling, or nil if not enabled
 	ProfilingSettings *profiling.Settings
@@ -173,7 +172,6 @@ func load(configPath string) (*Config, error) {
 
 		StatsdHost: aconfig.GetBindHost(),
 		StatsdPort: cfg.GetInt("dogstatsd_port"),
-		ExpVarPort: cfg.GetInt(key(spNS, "expvar_port")),
 
 		ProfilingSettings: profSettings,
 	}

--- a/cmd/system-probe/config/config.go
+++ b/cmd/system-probe/config/config.go
@@ -63,8 +63,9 @@ type Config struct {
 	LogLevel  string
 	DebugPort int
 
-	StatsdHost string
-	StatsdPort int
+	StatsdHost                   string
+	StatsdPort                   int
+	DefaultSystemProbeExpVarPort string
 
 	// Settings for profiling, or nil if not enabled
 	ProfilingSettings *profiling.Settings
@@ -170,8 +171,9 @@ func load(configPath string) (*Config, error) {
 		LogLevel:  cfg.GetString(key(spNS, "log_level")),
 		DebugPort: cfg.GetInt(key(spNS, "debug_port")),
 
-		StatsdHost: aconfig.GetBindHost(),
-		StatsdPort: cfg.GetInt("dogstatsd_port"),
+		StatsdHost:                   aconfig.GetBindHost(),
+		StatsdPort:                   cfg.GetInt("dogstatsd_port"),
+		DefaultSystemProbeExpVarPort: cfg.GetString(key(spNS, "expvar_port")),
 
 		ProfilingSettings: profSettings,
 	}

--- a/cmd/system-probe/config/config.go
+++ b/cmd/system-probe/config/config.go
@@ -63,9 +63,9 @@ type Config struct {
 	LogLevel  string
 	DebugPort int
 
-	StatsdHost            string
-	StatsdPort            int
-	SystemProbeExpVarPort int
+	StatsdHost string
+	StatsdPort int
+	ExpVarPort int
 
 	// Settings for profiling, or nil if not enabled
 	ProfilingSettings *profiling.Settings
@@ -171,9 +171,9 @@ func load(configPath string) (*Config, error) {
 		LogLevel:  cfg.GetString(key(spNS, "log_level")),
 		DebugPort: cfg.GetInt(key(spNS, "debug_port")),
 
-		StatsdHost:            aconfig.GetBindHost(),
-		StatsdPort:            cfg.GetInt("dogstatsd_port"),
-		SystemProbeExpVarPort: cfg.GetInt(key(spNS, "expvar_port")),
+		StatsdHost: aconfig.GetBindHost(),
+		StatsdPort: cfg.GetInt("dogstatsd_port"),
+		ExpVarPort: cfg.GetInt(key(spNS, "expvar_port")),
 
 		ProfilingSettings: profSettings,
 	}

--- a/cmd/system-probe/config/config.go
+++ b/cmd/system-probe/config/config.go
@@ -59,9 +59,10 @@ type Config struct {
 	SocketAddress      string
 	MaxConnsPerMessage int
 
-	LogFile   string
-	LogLevel  string
-	DebugPort int
+	LogFile          string
+	LogLevel         string
+	DebugPort        int
+	TelemetryEnabled bool
 
 	StatsdHost string
 	StatsdPort int
@@ -166,9 +167,10 @@ func load(configPath string) (*Config, error) {
 		SocketAddress:      cfg.GetString(key(spNS, "sysprobe_socket")),
 		MaxConnsPerMessage: cfg.GetInt(key(spNS, "max_conns_per_message")),
 
-		LogFile:   cfg.GetString(key(spNS, "log_file")),
-		LogLevel:  cfg.GetString(key(spNS, "log_level")),
-		DebugPort: cfg.GetInt(key(spNS, "debug_port")),
+		LogFile:          cfg.GetString(key(spNS, "log_file")),
+		LogLevel:         cfg.GetString(key(spNS, "log_level")),
+		DebugPort:        cfg.GetInt(key(spNS, "debug_port")),
+		TelemetryEnabled: cfg.GetBool(key(spNS, "telemetry_enabled")),
 
 		StatsdHost: aconfig.GetBindHost(),
 		StatsdPort: cfg.GetInt("dogstatsd_port"),

--- a/cmd/system-probe/config/config.go
+++ b/cmd/system-probe/config/config.go
@@ -63,9 +63,9 @@ type Config struct {
 	LogLevel  string
 	DebugPort int
 
-	StatsdHost                   string
-	StatsdPort                   int
-	DefaultSystemProbeExpVarPort string
+	StatsdHost            string
+	StatsdPort            int
+	SystemProbeExpVarPort int
 
 	// Settings for profiling, or nil if not enabled
 	ProfilingSettings *profiling.Settings
@@ -171,9 +171,9 @@ func load(configPath string) (*Config, error) {
 		LogLevel:  cfg.GetString(key(spNS, "log_level")),
 		DebugPort: cfg.GetInt(key(spNS, "debug_port")),
 
-		StatsdHost:                   aconfig.GetBindHost(),
-		StatsdPort:                   cfg.GetInt("dogstatsd_port"),
-		DefaultSystemProbeExpVarPort: cfg.GetString(key(spNS, "expvar_port")),
+		StatsdHost:            aconfig.GetBindHost(),
+		StatsdPort:            cfg.GetInt("dogstatsd_port"),
+		SystemProbeExpVarPort: cfg.GetInt(key(spNS, "expvar_port")),
 
 		ProfilingSettings: profSettings,
 	}

--- a/pkg/config/system_probe.go
+++ b/pkg/config/system_probe.go
@@ -71,7 +71,6 @@ func InitSystemProbeConfig(cfg Config) {
 
 	cfg.BindEnvAndSetDefault(join(spNS, "dogstatsd_host"), "127.0.0.1")
 	cfg.BindEnvAndSetDefault(join(spNS, "dogstatsd_port"), 8125)
-	cfg.BindEnvAndSetDefault(join(spNS, "expvar_port"), 5020, "DD_SYSTEM_PROBE_EXPVAR_PORT")
 
 	cfg.BindEnvAndSetDefault(join(spNS, "internal_profiling.enabled"), false, "DD_SYSTEM_PROBE_INTERNAL_PROFILING_ENABLED")
 	cfg.BindEnvAndSetDefault(join(spNS, "internal_profiling.site"), DefaultSite, "DD_SYSTEM_PROBE_INTERNAL_PROFILING_SITE", "DD_SITE")

--- a/pkg/config/system_probe.go
+++ b/pkg/config/system_probe.go
@@ -71,6 +71,7 @@ func InitSystemProbeConfig(cfg Config) {
 
 	cfg.BindEnvAndSetDefault(join(spNS, "dogstatsd_host"), "127.0.0.1")
 	cfg.BindEnvAndSetDefault(join(spNS, "dogstatsd_port"), 8125)
+	cfg.BindEnvAndSetDefault(join(spNS, "expvar_port"), "5020", "DD_SYSTEM_PROBE_EXPVAR_PORT")
 
 	cfg.BindEnvAndSetDefault(join(spNS, "internal_profiling.enabled"), false, "DD_SYSTEM_PROBE_INTERNAL_PROFILING_ENABLED")
 	cfg.BindEnvAndSetDefault(join(spNS, "internal_profiling.site"), DefaultSite, "DD_SYSTEM_PROBE_INTERNAL_PROFILING_SITE", "DD_SITE")

--- a/pkg/config/system_probe.go
+++ b/pkg/config/system_probe.go
@@ -68,7 +68,7 @@ func InitSystemProbeConfig(cfg Config) {
 	cfg.BindEnvAndSetDefault(join(spNS, "log_file"), defaultSystemProbeLogFilePath)
 	cfg.BindEnvAndSetDefault(join(spNS, "log_level"), "info", "DD_LOG_LEVEL", "LOG_LEVEL")
 	cfg.BindEnvAndSetDefault(join(spNS, "debug_port"), 0)
-	cfg.BindEnvAndSetDefault(join(spNS, "telemetry_enabled"), true)
+	cfg.BindEnvAndSetDefault(join(spNS, "telemetry_enabled"), true, "DD_TELEMETRY_ENABLED")
 
 	cfg.BindEnvAndSetDefault(join(spNS, "dogstatsd_host"), "127.0.0.1")
 	cfg.BindEnvAndSetDefault(join(spNS, "dogstatsd_port"), 8125)

--- a/pkg/config/system_probe.go
+++ b/pkg/config/system_probe.go
@@ -71,7 +71,7 @@ func InitSystemProbeConfig(cfg Config) {
 
 	cfg.BindEnvAndSetDefault(join(spNS, "dogstatsd_host"), "127.0.0.1")
 	cfg.BindEnvAndSetDefault(join(spNS, "dogstatsd_port"), 8125)
-	cfg.BindEnvAndSetDefault(join(spNS, "expvar_port"), "5020", "DD_SYSTEM_PROBE_EXPVAR_PORT")
+	cfg.BindEnvAndSetDefault(join(spNS, "expvar_port"), 5020, "DD_SYSTEM_PROBE_EXPVAR_PORT")
 
 	cfg.BindEnvAndSetDefault(join(spNS, "internal_profiling.enabled"), false, "DD_SYSTEM_PROBE_INTERNAL_PROFILING_ENABLED")
 	cfg.BindEnvAndSetDefault(join(spNS, "internal_profiling.site"), DefaultSite, "DD_SYSTEM_PROBE_INTERNAL_PROFILING_SITE", "DD_SITE")

--- a/pkg/config/system_probe.go
+++ b/pkg/config/system_probe.go
@@ -68,6 +68,7 @@ func InitSystemProbeConfig(cfg Config) {
 	cfg.BindEnvAndSetDefault(join(spNS, "log_file"), defaultSystemProbeLogFilePath)
 	cfg.BindEnvAndSetDefault(join(spNS, "log_level"), "info", "DD_LOG_LEVEL", "LOG_LEVEL")
 	cfg.BindEnvAndSetDefault(join(spNS, "debug_port"), 0)
+	cfg.BindEnvAndSetDefault(join(spNS, "telemetry_enabled"), true)
 
 	cfg.BindEnvAndSetDefault(join(spNS, "dogstatsd_host"), "127.0.0.1")
 	cfg.BindEnvAndSetDefault(join(spNS, "dogstatsd_port"), 8125)

--- a/pkg/network/telemetry/ebpf_telemetry.go
+++ b/pkg/network/telemetry/ebpf_telemetry.go
@@ -213,24 +213,6 @@ func buildHelperErrTelemetryKeys(mgr *manager.Manager) []manager.ConstantEditor 
 	return keys
 }
 
-//func getErrStrTags() []string {
-//	var tags []string
-//	var tagStr string
-//	for i := 1; i < maxErrno+1; i++ {
-//		if i == maxErrno {
-//			tagStr = maxErrnoStr
-//		} else {
-//			tagStr = syscall.Errno(i).Error()
-//		}
-//
-//		tagStr = strings.ReplaceAll(tagStr, " ", "_")
-//		tagStr = strings.ReplaceAll(tagStr, "/", "_")
-//		tags = append(tags)
-//	}
-//
-//	return tags
-//}
-
 func (b *EBPFTelemetry) initializeMapErrTelemetryMap(maps []*manager.Map) error {
 	z := new(MapErrTelemetry)
 	h := fnv.New64a()

--- a/pkg/network/telemetry/ebpf_telemetry.go
+++ b/pkg/network/telemetry/ebpf_telemetry.go
@@ -131,7 +131,7 @@ func getHelperTelemetry(v *HelperErrTelemetry, probeName string, gauge telemetry
 			helper[helperName] = count
 
 			for errStr, errCount := range count {
-				gauge.Set(float64(errCount), probeName, helperName, errStr)
+				gauge.Set(float64(errCount), helperName, probeName, errStr)
 			}
 		}
 	}

--- a/pkg/network/telemetry/ebpf_telemetry.go
+++ b/pkg/network/telemetry/ebpf_telemetry.go
@@ -39,19 +39,21 @@ var helperNames = map[int]string{readIndx: "bpf_probe_read", readUserIndx: "bpf_
 // EBPFTelemetry struct contains all the maps that
 // are registered to have their telemetry collected.
 type EBPFTelemetry struct {
-	MapErrMap         *ebpf.Map
-	HelperErrMap      *ebpf.Map
-	mapKeys           map[string]uint64
-	probeKeys         map[string]uint64
-	prometheusMetrics map[string]telemetry.Gauge
+	MapErrMap             *ebpf.Map
+	HelperErrMap          *ebpf.Map
+	mapKeys               map[string]uint64
+	probeKeys             map[string]uint64
+	ebpfMapOpsErrorsGauge telemetry.Gauge
+	ebpfHelperErrorsGauge telemetry.Gauge
 }
 
 // NewEBPFTelemetry initializes a new EBPFTelemetry object
 func NewEBPFTelemetry() *EBPFTelemetry {
 	return &EBPFTelemetry{
-		mapKeys:           make(map[string]uint64),
-		probeKeys:         make(map[string]uint64),
-		prometheusMetrics: make(map[string]telemetry.Gauge),
+		mapKeys:               make(map[string]uint64),
+		probeKeys:             make(map[string]uint64),
+		ebpfMapOpsErrorsGauge: telemetry.NewGauge("ebpf_map_ops", "errors", []string{"map_name", "error"}, "Failures of map operations for a specific ebpf map reported per error."),
+		ebpfHelperErrorsGauge: telemetry.NewGauge("ebpf_helpers", "errors", []string{"helper", "probe_name", "error"}, "Failures of bpf helper operations reported per helper per error for each probe."),
 	}
 }
 
@@ -88,9 +90,8 @@ func (b *EBPFTelemetry) GetMapsTelemetry() map[string]interface{} {
 		}
 		if count := getMapErrCount(&val); len(count) > 0 {
 			t[m] = count
-			promGauge := b.prometheusMetrics[m]
 			for errStr, errCount := range count {
-				promGauge.Set(float64(errCount), errStr)
+				b.ebpfMapOpsErrorsGauge.Set(float64(errCount), m, errStr)
 			}
 		}
 	}
@@ -107,31 +108,30 @@ func (b *EBPFTelemetry) GetHelperTelemetry() map[string]interface{} {
 	var val HelperErrTelemetry
 	helperTelemMap := make(map[string]interface{})
 
-	for m, k := range b.probeKeys {
+	for probeName, k := range b.probeKeys {
 		err := b.HelperErrMap.Lookup(&k, &val)
 		if err != nil {
-			log.Debugf("failed to get telemetry for map:key %s:%d\n", m, k)
+			log.Debugf("failed to get telemetry for map:key %s:%d\n", probeName, k)
 			continue
 		}
 
-		promGauge := b.prometheusMetrics[m]
-		if t := getHelperTelemetry(&val, promGauge); len(t) > 0 {
-			helperTelemMap[m] = t
+		if t := getHelperTelemetry(&val, probeName, b.ebpfHelperErrorsGauge); len(t) > 0 {
+			helperTelemMap[probeName] = t
 		}
 	}
 
 	return helperTelemMap
 }
 
-func getHelperTelemetry(v *HelperErrTelemetry, gauge telemetry.Gauge) map[string]interface{} {
+func getHelperTelemetry(v *HelperErrTelemetry, probeName string, gauge telemetry.Gauge) map[string]interface{} {
 	helper := make(map[string]interface{})
 
-	for indx, name := range helperNames {
+	for indx, helperName := range helperNames {
 		if count := getErrCount(v, indx); len(count) > 0 {
-			helper[name] = count
+			helper[helperName] = count
 
 			for errStr, errCount := range count {
-				gauge.Set(float64(errCount), name, errStr)
+				gauge.Set(float64(errCount), probeName, helperName, errStr)
 			}
 		}
 	}
@@ -234,7 +234,6 @@ func (b *EBPFTelemetry) initializeMapErrTelemetryMap(maps []*manager.Map) error 
 
 		b.mapKeys[m.Name] = key
 
-		b.prometheusMetrics[m.Name] = telemetry.NewGauge("map_ops", m.Name, []string{"error"}, "Failures of map operations for a specific ebpf map reported per error.")
 	}
 
 	return nil
@@ -260,7 +259,6 @@ func (b *EBPFTelemetry) initializeHelperErrTelemetryMap(probes []*manager.Probe)
 		h.Reset()
 
 		b.probeKeys[p.EBPFFuncName] = key
-		b.prometheusMetrics[p.EBPFFuncName] = telemetry.NewGauge("ebpf_helpers", p.EBPFFuncName, []string{"helper", "error"}, "Failures of bpf helper operations reported per helper per error for each probe.")
 	}
 
 	return nil


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
This PR exposes ebpf helper telemetry as prometheus metrics.
The associated PR for enabling the agent_telemetry check for system-probe: https://github.com/DataDog/k8s-resources/pull/37994

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation


<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
