### PR TITLE
[CWS] fix envs LRU entry not removed and avoid double pool Put

### DIFF
--- a/pkg/security/probe/activity_dump.go
+++ b/pkg/security/probe/activity_dump.go
@@ -1008,10 +1008,10 @@ func (pan *ProcessActivityNode) debug(w io.Writer, prefix string) {
 }
 
 func (pan *ProcessActivityNode) retain() {
-	if pan.Process.ArgsEntry != nil && pan.Process.ArgsEntry.ArgsEnvsCacheEntry != nil {
+	if pan.Process.ArgsEntry != nil {
 		pan.Process.ArgsEntry.Retain()
 	}
-	if pan.Process.EnvsEntry != nil && pan.Process.EnvsEntry.ArgsEnvsCacheEntry != nil {
+	if pan.Process.EnvsEntry != nil {
 		pan.Process.EnvsEntry.Retain()
 	}
 }
@@ -1024,10 +1024,10 @@ func (pan *ProcessActivityNode) scrubAndReleaseArgsEnvs(resolver *ProcessResolve
 	pan.Process.EnvsTruncated = envsTruncated
 	pan.Process.Argv0, _ = resolver.GetProcessArgv0(&pan.Process)
 
-	if pan.Process.ArgsEntry != nil && pan.Process.ArgsEntry.ArgsEnvsCacheEntry != nil {
+	if pan.Process.ArgsEntry != nil {
 		pan.Process.ArgsEntry.Release()
 	}
-	if pan.Process.EnvsEntry != nil && pan.Process.EnvsEntry.ArgsEnvsCacheEntry != nil {
+	if pan.Process.EnvsEntry != nil {
 		pan.Process.EnvsEntry.Release()
 	}
 	pan.Process.ArgsEntry = nil

--- a/pkg/security/probe/process_resolver.go
+++ b/pkg/security/probe/process_resolver.go
@@ -219,11 +219,11 @@ func NewProcessCacheEntryPool(p *ProcessResolver) *ProcessCacheEntryPool {
 				pce.Ancestor.Release()
 			}
 
-			if pce.ArgsEntry != nil && pce.ArgsEntry.ArgsEnvsCacheEntry != nil {
-				pce.ArgsEntry.ArgsEnvsCacheEntry.Release()
+			if pce.ArgsEntry != nil {
+				pce.ArgsEntry.Release()
 			}
-			if pce.EnvsEntry != nil && pce.EnvsEntry.ArgsEnvsCacheEntry != nil {
-				pce.EnvsEntry.ArgsEnvsCacheEntry.Release()
+			if pce.EnvsEntry != nil {
+				pce.EnvsEntry.Release()
 			}
 
 			p.cacheSize.Dec()
@@ -868,7 +868,7 @@ func (p *ProcessResolver) SetProcessArgs(pce *model.ProcessCacheEntry) {
 		// attach to a process thus retain the head of the chain
 		// note: only the head of the list is retained and when released
 		// the whole list will be released
-		pce.ArgsEntry.ArgsEnvsCacheEntry.Retain()
+		pce.ArgsEntry.Retain()
 
 		// no need to keep it in LRU now as attached to a process
 		p.argsEnvsCache.Remove(pce.ArgsID)
@@ -939,10 +939,10 @@ func (p *ProcessResolver) SetProcessEnvs(pce *model.ProcessCacheEntry) {
 		// attach to a process thus retain the head of the chain
 		// note: only the head of the list is retained and when released
 		// the whole list will be released
-		pce.EnvsEntry.ArgsEnvsCacheEntry.Retain()
+		pce.EnvsEntry.Retain()
 
 		// no need to keep it in LRU now as attached to a process
-		p.argsEnvsCache.Remove(pce.ArgsID)
+		p.argsEnvsCache.Remove(pce.EnvsID)
 	}
 }
 

--- a/pkg/security/secl/model/process_cache_entry.go
+++ b/pkg/security/secl/model/process_cache_entry.go
@@ -89,12 +89,12 @@ func (pc *ProcessCacheEntry) Exec(entry *ProcessCacheEntry) {
 // ShareArgsEnvs share args and envs between the current entry and the given child entry
 func (pc *ProcessCacheEntry) ShareArgsEnvs(childEntry *ProcessCacheEntry) {
 	childEntry.ArgsEntry = pc.ArgsEntry
-	if childEntry.ArgsEntry != nil && childEntry.ArgsEntry.ArgsEnvsCacheEntry != nil {
-		childEntry.ArgsEntry.ArgsEnvsCacheEntry.Retain()
+	if childEntry.ArgsEntry != nil {
+		childEntry.ArgsEntry.Retain()
 	}
 	childEntry.EnvsEntry = pc.EnvsEntry
-	if childEntry.EnvsEntry != nil && childEntry.EnvsEntry.ArgsEnvsCacheEntry != nil {
-		childEntry.EnvsEntry.ArgsEnvsCacheEntry.Retain()
+	if childEntry.EnvsEntry != nil {
+		childEntry.EnvsEntry.Retain()
 	}
 }
 
@@ -149,7 +149,7 @@ type ArgsEnvsCacheEntry struct {
 }
 
 // Reset the entry
-func (p *ArgsEnvsCacheEntry) release() {
+func (p *ArgsEnvsCacheEntry) forceReleaseAll() {
 	entry := p
 	for entry != nil {
 		next := entry.next
@@ -187,18 +187,20 @@ func (p *ArgsEnvsCacheEntry) Append(entry *ArgsEnvsCacheEntry) {
 }
 
 // Retain increment ref counter
-func (p *ArgsEnvsCacheEntry) Retain() {
+func (p *ArgsEnvsCacheEntry) retain() {
 	p.refCount++
 }
 
 // Release decrement and eventually release the entry
-func (p *ArgsEnvsCacheEntry) Release() {
+func (p *ArgsEnvsCacheEntry) release() bool {
 	p.refCount--
 	if p.refCount > 0 {
-		return
+		return false
 	}
 
-	p.release()
+	p.forceReleaseAll()
+
+	return true
 }
 
 // NewArgsEnvsCacheEntry returns a new args/env cache entry
@@ -244,6 +246,20 @@ type ArgsEntry struct {
 	parsed bool
 }
 
+// Retain increment ref counter
+func (p *ArgsEntry) Retain() {
+	if p.ArgsEnvsCacheEntry != nil {
+		p.ArgsEnvsCacheEntry.retain()
+	}
+}
+
+// Release decrement and eventually release the entry
+func (p *ArgsEntry) Release() {
+	if p.ArgsEnvsCacheEntry != nil && p.ArgsEnvsCacheEntry.release() {
+		p.ArgsEnvsCacheEntry = nil
+	}
+}
+
 // ToArray returns args as array
 func (p *ArgsEntry) ToArray() ([]string, bool) {
 	if len(p.Values) > 0 || p.parsed {
@@ -252,9 +268,9 @@ func (p *ArgsEntry) ToArray() ([]string, bool) {
 	p.Values, p.Truncated = p.toArray()
 	p.parsed = true
 
-	// now we have the cache we can free
+	// now we have the cache we can force the free without having to check the refcount
 	if p.ArgsEnvsCacheEntry != nil {
-		p.Release()
+		p.ArgsEnvsCacheEntry.forceReleaseAll()
 		p.ArgsEnvsCacheEntry = nil
 	}
 
@@ -287,6 +303,20 @@ type EnvsEntry struct {
 	kv           map[string]string
 }
 
+// Retain increment ref counter
+func (p *EnvsEntry) Retain() {
+	if p.ArgsEnvsCacheEntry != nil {
+		p.ArgsEnvsCacheEntry.retain()
+	}
+}
+
+// Release decrement and eventually release the entry
+func (p *EnvsEntry) Release() {
+	if p.ArgsEnvsCacheEntry != nil && p.ArgsEnvsCacheEntry.release() {
+		p.ArgsEnvsCacheEntry = nil
+	}
+}
+
 // ToArray returns envs as an array
 func (p *EnvsEntry) ToArray() ([]string, bool) {
 	if p.parsed {
@@ -296,9 +326,9 @@ func (p *EnvsEntry) ToArray() ([]string, bool) {
 	p.Values, p.Truncated = p.toArray()
 	p.parsed = true
 
-	// now we have the cache we can free
+	// now we have the cache we can force the free without having to check the refcount
 	if p.ArgsEnvsCacheEntry != nil {
-		p.Release()
+		p.ArgsEnvsCacheEntry.forceReleaseAll()
 		p.ArgsEnvsCacheEntry = nil
 	}
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This PR does two things:

- it fixes a critical bug causing a memory leak. The envs entry was not remove from the initial LRU because of a typo. This is a problem if the same entry ID is generated multiple time by the eBPF code and if the previous entry in the LRU hasn't been evicted. In that particular case a same entry is reference multiple times and can be accessed by multiple entry cache list.
- It reworks the functions around the args/envs cache entries to avoid putting multiple time the same node.


<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
