### PR TITLE
Bump python in github workflows to 3.8.14

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Python3
         uses: actions/setup-python@v4
         with:
-          python-version: '3.8.10'
+          python-version: '3.8.14'
 
       - name: Install Python requirements
         run: |

--- a/.github/workflows/cws-btfhub-sync.yml
+++ b/.github/workflows/cws-btfhub-sync.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.8.10'
+          python-version: '3.8.14'
           cache: 'pip'
 
       - name: Install go

--- a/.github/workflows/go_mod_tidy.yml
+++ b/.github/workflows/go_mod_tidy.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Install python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.8.10'
+        python-version: '3.8.14'
     - name: Install python requirements.txt
       run: python3 -m pip install -r requirements.txt
     - name: Go mod tidy

--- a/.github/workflows/windows-unittests.yml
+++ b/.github/workflows/windows-unittests.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.8.10'
+          python-version: '3.8.14'
 
       - name: Install go
         uses: actions/setup-go@v3


### PR DESCRIPTION
### What does this PR do?

As can be seen in https://github.com/DataDog/datadog-agent/actions/runs/3532902485/jobs/5927837520, python 3.8.10 is not available for ubuntu 22.04. This is related to the fact that `ubuntu-latest` recently move to point to 22.04 while it was pointing to 20.04 before.

To fix this issue we now use python 3.8.14 (available for both 20.04 and 22.04)

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
