### PR TITLE
APM: add trace-agent.benchmarks to invoke scripts, fix frozen BenchmarkAgentTraceProcessing

### DIFF
--- a/tasks/trace_agent.py
+++ b/tasks/trace_agent.py
@@ -123,3 +123,15 @@ def cross_compile(ctx, tag=""):
     ctx.run("git checkout -")
 
     print(f"Done! Binaries are located in ./bin/trace-agent/{tag}")
+
+
+@task
+def benchmarks(ctx, bench, output="./trace-agent.benchmarks.out"):
+    """
+    Runs the benchmarks. Use "--bench=X" to specify benchmarks to run. Use the "--output=X" argument to specify where to output results.
+    """
+    if not bench:
+        print("Argument --bench=<bench_regex> is required.")
+        return
+    with ctx.cd("./pkg/trace"):
+        ctx.run(f"go test -run=XXX -bench \"{bench}\" -benchmem -count 10 -benchtime 2s ./... | tee {output}")


### PR DESCRIPTION

### What does this PR do?
We need trace-agent.benchmarks available on the `main` branch so we can run comparisons as we work on adding automated comparative benchmarks. Also the BenchmarkAgentTraceProcessing has been broken for quite some time it seems as it needs the test agent to be `Run` so stats payloads are retrieved from the channel.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
To have benchmarks available for the APM Benchmarking Platform work.
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs
None?
<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
