### PR TITLE
[snmp] Handle metric_tags for detect metrics feature

### DIFF
--- a/pkg/collector/corechecks/snmp/common/oidtrie.go
+++ b/pkg/collector/corechecks/snmp/common/oidtrie.go
@@ -66,6 +66,9 @@ func oidToNumbers(oid string) ([]int, error) {
 }
 
 func (o *OIDTrie) getNode(oid string) (*OIDTrie, error) {
+	if oid == "" {
+		return nil, fmt.Errorf("invalid empty OID")
+	}
 	current := o
 	oid = strings.TrimLeft(oid, ".")
 	digits := strings.Split(oid, ".")

--- a/pkg/collector/corechecks/snmp/common/oidtrie_test.go
+++ b/pkg/collector/corechecks/snmp/common/oidtrie_test.go
@@ -39,14 +39,17 @@ func TestBuildTries(t *testing.T) {
 
 func Test_oidTrie_LeafExist(t *testing.T) {
 	trie := BuildOidTrie([]string{"1.2.3", "1.3.4.5"})
+	assert.Equal(t, false, trie.LeafExist(""))
 	assert.Equal(t, true, trie.LeafExist("1.2.3"))
 	assert.Equal(t, true, trie.LeafExist("1.3.4.5"))
 	assert.Equal(t, false, trie.LeafExist("1.2"))
 	assert.Equal(t, false, trie.LeafExist("1.4"))
+	assert.Equal(t, false, trie.LeafExist("1"))
 }
 
 func Test_oidTrie_NodeExist(t *testing.T) {
 	trie := BuildOidTrie([]string{"1", "1.2.3", "1.3.4.5"})
+	assert.Equal(t, false, trie.NonLeafNodeExist(""))
 	assert.Equal(t, true, trie.NonLeafNodeExist("1.2"))
 	assert.Equal(t, false, trie.NonLeafNodeExist("1.2.3")) // this is a leaf, not a node
 	assert.Equal(t, true, trie.NonLeafNodeExist("1.3.4"))

--- a/pkg/collector/corechecks/snmp/internal/checkconfig/config_test.go
+++ b/pkg/collector/corechecks/snmp/internal/checkconfig/config_test.go
@@ -334,7 +334,7 @@ community_string: abc
 
 	assert.Equal(t, metrics, config.Metrics)
 	assert.Equal(t, metricsTags, config.MetricTags)
-	assert.Equal(t, 1, len(config.Profiles))
+	assert.Equal(t, 2, len(config.Profiles))
 	assert.Equal(t, fixtureProfileDefinitionMap()["f5-big-ip"].Metrics, config.Profiles["f5-big-ip"].Metrics)
 }
 

--- a/pkg/collector/corechecks/snmp/internal/checkconfig/profile_test.go
+++ b/pkg/collector/corechecks/snmp/internal/checkconfig/profile_test.go
@@ -42,120 +42,132 @@ func fixtureProfileDefinitionMap() profileDefinitionMap {
 		},
 		{Symbol: SymbolConfig{OID: "1.2.3.4.5", Name: "someMetric"}},
 	}
-	return profileDefinitionMap{"f5-big-ip": profileDefinition{
-		Metrics:      metrics,
-		Extends:      []string{"_base.yaml", "_generic-if.yaml"},
-		Device:       DeviceMeta{Vendor: "f5"},
-		SysObjectIds: StringArray{"1.3.6.1.4.1.3375.2.1.3.4.*"},
-		StaticTags:   []string{"static_tag:from_profile_root", "static_tag:from_base_profile"},
-		MetricTags: []MetricTagConfig{
-			{
-				OID:     "1.3.6.1.2.1.1.5.0",
-				Name:    "sysName",
-				Match:   "(\\w)(\\w+)",
-				pattern: regexp.MustCompile("(\\w)(\\w+)"),
-				Tags: map[string]string{
-					"some_tag": "some_tag_value",
-					"prefix":   "\\1",
-					"suffix":   "\\2",
-				},
-			},
-			{Tag: "snmp_host", Index: 0x0, Column: SymbolConfig{OID: "", Name: ""}, OID: "1.3.6.1.2.1.1.5.0", Name: "sysName"},
-		},
-		Metadata: MetadataConfig{
-			"device": {
-				Fields: map[string]MetadataField{
-					"vendor": {
-						Value: "f5",
-					},
-					"description": {
-						Symbol: SymbolConfig{
-							OID:  "1.3.6.1.2.1.1.1.0",
-							Name: "sysDescr",
-						},
-					},
-					"name": {
-						Symbol: SymbolConfig{
-							OID:  "1.3.6.1.2.1.1.5.0",
-							Name: "sysName",
-						},
-					},
-					"serial_number": {
-						Symbol: SymbolConfig{
-							OID:  "1.3.6.1.4.1.3375.2.1.3.3.3.0",
-							Name: "sysGeneralChassisSerialNum",
-						},
-					},
-					"sys_object_id": {
-						Symbol: SymbolConfig{
-							OID:  "1.3.6.1.2.1.1.2.0",
-							Name: "sysObjectID",
-						},
+	return profileDefinitionMap{
+		"f5-big-ip": profileDefinition{
+			Metrics:      metrics,
+			Extends:      []string{"_base.yaml", "_generic-if.yaml"},
+			Device:       DeviceMeta{Vendor: "f5"},
+			SysObjectIds: StringArray{"1.3.6.1.4.1.3375.2.1.3.4.*"},
+			StaticTags:   []string{"static_tag:from_profile_root", "static_tag:from_base_profile"},
+			MetricTags: []MetricTagConfig{
+				{
+					OID:     "1.3.6.1.2.1.1.5.0",
+					Name:    "sysName",
+					Match:   "(\\w)(\\w+)",
+					pattern: regexp.MustCompile("(\\w)(\\w+)"),
+					Tags: map[string]string{
+						"some_tag": "some_tag_value",
+						"prefix":   "\\1",
+						"suffix":   "\\2",
 					},
 				},
+				{Tag: "snmp_host", Index: 0x0, Column: SymbolConfig{OID: "", Name: ""}, OID: "1.3.6.1.2.1.1.5.0", Name: "sysName"},
 			},
-			"interface": {
-				Fields: map[string]MetadataField{
-					"admin_status": {
-						Symbol: SymbolConfig{
+			Metadata: MetadataConfig{
+				"device": {
+					Fields: map[string]MetadataField{
+						"vendor": {
+							Value: "f5",
+						},
+						"description": {
+							Symbol: SymbolConfig{
+								OID:  "1.3.6.1.2.1.1.1.0",
+								Name: "sysDescr",
+							},
+						},
+						"name": {
+							Symbol: SymbolConfig{
+								OID:  "1.3.6.1.2.1.1.5.0",
+								Name: "sysName",
+							},
+						},
+						"serial_number": {
+							Symbol: SymbolConfig{
+								OID:  "1.3.6.1.4.1.3375.2.1.3.3.3.0",
+								Name: "sysGeneralChassisSerialNum",
+							},
+						},
+						"sys_object_id": {
+							Symbol: SymbolConfig{
+								OID:  "1.3.6.1.2.1.1.2.0",
+								Name: "sysObjectID",
+							},
+						},
+					},
+				},
+				"interface": {
+					Fields: map[string]MetadataField{
+						"admin_status": {
+							Symbol: SymbolConfig{
 
-							OID:  "1.3.6.1.2.1.2.2.1.7",
-							Name: "ifAdminStatus",
+								OID:  "1.3.6.1.2.1.2.2.1.7",
+								Name: "ifAdminStatus",
+							},
+						},
+						"alias": {
+							Symbol: SymbolConfig{
+								OID:  "1.3.6.1.2.1.31.1.1.1.18",
+								Name: "ifAlias",
+							},
+						},
+						"description": {
+							Symbol: SymbolConfig{
+								OID:                  "1.3.6.1.2.1.31.1.1.1.1",
+								Name:                 "ifName",
+								ExtractValue:         "(Row\\d)",
+								ExtractValueCompiled: regexp.MustCompile("(Row\\d)"),
+							},
+						},
+						"mac_address": {
+							Symbol: SymbolConfig{
+								OID:    "1.3.6.1.2.1.2.2.1.6",
+								Name:   "ifPhysAddress",
+								Format: "mac_address",
+							},
+						},
+						"name": {
+							Symbol: SymbolConfig{
+								OID:  "1.3.6.1.2.1.31.1.1.1.1",
+								Name: "ifName",
+							},
+						},
+						"oper_status": {
+							Symbol: SymbolConfig{
+								OID:  "1.3.6.1.2.1.2.2.1.8",
+								Name: "ifOperStatus",
+							},
 						},
 					},
-					"alias": {
-						Symbol: SymbolConfig{
-							OID:  "1.3.6.1.2.1.31.1.1.1.18",
-							Name: "ifAlias",
+					IDTags: MetricTagConfigList{
+						{
+							Tag: "custom-tag",
+							Column: SymbolConfig{
+								OID:  "1.3.6.1.2.1.31.1.1.1.1",
+								Name: "ifAlias",
+							},
 						},
-					},
-					"description": {
-						Symbol: SymbolConfig{
-							OID:                  "1.3.6.1.2.1.31.1.1.1.1",
-							Name:                 "ifName",
-							ExtractValue:         "(Row\\d)",
-							ExtractValueCompiled: regexp.MustCompile("(Row\\d)"),
-						},
-					},
-					"mac_address": {
-						Symbol: SymbolConfig{
-							OID:    "1.3.6.1.2.1.2.2.1.6",
-							Name:   "ifPhysAddress",
-							Format: "mac_address",
-						},
-					},
-					"name": {
-						Symbol: SymbolConfig{
-							OID:  "1.3.6.1.2.1.31.1.1.1.1",
-							Name: "ifName",
-						},
-					},
-					"oper_status": {
-						Symbol: SymbolConfig{
-							OID:  "1.3.6.1.2.1.2.2.1.8",
-							Name: "ifOperStatus",
-						},
-					},
-				},
-				IDTags: MetricTagConfigList{
-					{
-						Tag: "custom-tag",
-						Column: SymbolConfig{
-							OID:  "1.3.6.1.2.1.31.1.1.1.1",
-							Name: "ifAlias",
-						},
-					},
-					{
-						Tag: "interface",
-						Column: SymbolConfig{
-							OID:  "1.3.6.1.2.1.31.1.1.1.1",
-							Name: "ifName",
+						{
+							Tag: "interface",
+							Column: SymbolConfig{
+								OID:  "1.3.6.1.2.1.31.1.1.1.1",
+								Name: "ifName",
+							},
 						},
 					},
 				},
 			},
 		},
-	}}
+		"another_profile": profileDefinition{
+			Metrics: []MetricsConfig{
+				{Symbol: SymbolConfig{OID: "1.3.6.1.2.1.1.999.0", Name: "someMetric"}, ForcedType: ""},
+			},
+			MetricTags: []MetricTagConfig{
+				{Tag: "snmp_host2", Column: SymbolConfig{OID: "1.3.6.1.2.1.1.5.0", Name: "sysName"}},
+				{Tag: "unknown_symbol", OID: "1.3.6.1.2.1.1.999.0", Name: "unknownSymbol"},
+			},
+			Metadata: MetadataConfig{},
+		},
+	}
 }
 
 func Test_getDefaultProfilesDefinitionFiles(t *testing.T) {
@@ -167,6 +179,9 @@ func Test_getDefaultProfilesDefinitionFiles(t *testing.T) {
 	expectedProfileConfig := profileConfigMap{
 		"f5-big-ip": {
 			DefinitionFile: filepath.Join(confdPath, "snmp.d", "profiles", "f5-big-ip.yaml"),
+		},
+		"another_profile": {
+			DefinitionFile: filepath.Join(confdPath, "snmp.d", "profiles", "another_profile.yaml"),
 		},
 	}
 

--- a/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck.go
+++ b/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck.go
@@ -269,7 +269,7 @@ func (d *DeviceCheck) detectAvailableMetrics() ([]checkconfig.MetricsConfig, []c
 			}
 		}
 		for _, metricTag := range profileDef.MetricTags {
-			if metricTag.Index != 0 || metricTag.OID != "" || metricTag.Column.OID != "" {
+			if root.LeafExist(metricTag.OID) || root.LeafExist(metricTag.Column.OID) {
 				metricTagConfigs = append(metricTagConfigs, metricTag)
 			}
 		}

--- a/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck_test.go
+++ b/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck_test.go
@@ -1063,11 +1063,7 @@ ip_address: 1.2.3.4
 community_string: public
 `)
 	// language=yaml
-	rawInitConfig := []byte(`
-profiles:
- f5-big-ip:
-   definition_file: f5-big-ip.yaml
-`)
+	rawInitConfig := []byte(``)
 
 	config, err := checkconfig.NewCheckConfig(rawInstanceConfig, rawInitConfig)
 	assert.Nil(t, err)
@@ -1081,7 +1077,8 @@ profiles:
 	deviceCk.SetSender(report.NewMetricSender(sender, ""))
 
 	sess.On("GetNext", []string{"1.0"}).Return(&gosnmplib.MockValidReachableGetNextPacket, nil)
-	sess.On("GetNext", []string{"1.3.6.1.2.1.1.2.0"}).Return(session.CreateGetNextPacket("1.3.6.1.2.1.2.2.1.13.1", gosnmp.OctetString, []byte(`123`)), nil)
+	sess.On("GetNext", []string{"1.3.6.1.2.1.1.2.0"}).Return(session.CreateGetNextPacket("1.3.6.1.2.1.1.5.0", gosnmp.OctetString, []byte(`123`)), nil)
+	sess.On("GetNext", []string{"1.3.6.1.2.1.1.5.0"}).Return(session.CreateGetNextPacket("1.3.6.1.2.1.2.2.1.13.1", gosnmp.OctetString, []byte(`123`)), nil)
 	sess.On("GetNext", []string{"1.3.6.1.2.1.2.2.1.14"}).Return(session.CreateGetNextPacket("1.3.6.1.2.1.2.2.1.14.1", gosnmp.OctetString, []byte(`123`)), nil)
 	sess.On("GetNext", []string{"1.3.6.1.2.1.2.2.1.15"}).Return(session.CreateGetNextPacket("1.3.6.1.2.1.2.2.1.15.1", gosnmp.OctetString, []byte(`123`)), nil)
 	sess.On("GetNext", []string{"1.3.6.1.2.1.2.2.1.16"}).Return(session.CreateGetNextPacket("1.3.6.1.4.1.3375.2.1.1.2.1.44.0", gosnmp.OctetString, []byte(`123`)), nil)
@@ -1122,9 +1119,10 @@ profiles:
 			},
 		},
 		{Tag: "snmp_host", OID: "1.3.6.1.2.1.1.5.0", Name: "sysName"},
+		{Tag: "snmp_host2", Column: checkconfig.SymbolConfig{OID: "1.3.6.1.2.1.1.5.0", Name: "sysName"}},
 	}
 
 	checkconfig.ValidateEnrichMetricTags(expectedMetricsTagConfigs)
 
-	assert.Equal(t, expectedMetricsTagConfigs, metricTagConfigs)
+	assert.ElementsMatch(t, expectedMetricsTagConfigs, metricTagConfigs)
 }

--- a/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck_test.go
+++ b/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck_test.go
@@ -1087,7 +1087,7 @@ profiles:
 	sess.On("GetNext", []string{"1.3.6.1.2.1.2.2.1.16"}).Return(session.CreateGetNextPacket("1.3.6.1.4.1.3375.2.1.1.2.1.44.0", gosnmp.OctetString, []byte(`123`)), nil)
 	sess.On("GetNext", []string{"1.3.6.1.4.1.3375.2.1.1.2.1.44.0"}).Return(session.CreateGetNextPacket("", gosnmp.EndOfMibView, nil), nil)
 
-	metricsConfigs := deviceCk.detectAvailableMetrics()
+	metricsConfigs, metricTagConfigs := deviceCk.detectAvailableMetrics()
 
 	expectedMetricsConfigs := []checkconfig.MetricsConfig{
 		{
@@ -1109,4 +1109,22 @@ profiles:
 		},
 	}
 	assert.Equal(t, expectedMetricsConfigs, metricsConfigs)
+
+	expectedMetricsTagConfigs := []checkconfig.MetricTagConfig{
+		{
+			OID:   "1.3.6.1.2.1.1.5.0",
+			Name:  "sysName",
+			Match: "(\\w)(\\w+)",
+			Tags: map[string]string{
+				"some_tag": "some_tag_value",
+				"prefix":   "\\1",
+				"suffix":   "\\2",
+			},
+		},
+		{Tag: "snmp_host", OID: "1.3.6.1.2.1.1.5.0", Name: "sysName"},
+	}
+
+	checkconfig.ValidateEnrichMetricTags(expectedMetricsTagConfigs)
+
+	assert.Equal(t, expectedMetricsTagConfigs, metricTagConfigs)
 }

--- a/pkg/collector/corechecks/snmp/internal/test/conf.d/snmp.d/profiles/another_profile.yaml
+++ b/pkg/collector/corechecks/snmp/internal/test/conf.d/snmp.d/profiles/another_profile.yaml
@@ -1,0 +1,15 @@
+# Another profile
+#
+metrics:
+  - symbol:
+      OID: 1.3.6.1.2.1.1.999.0
+      name: someMetric
+
+metric_tags:
+  - column: # column syntax
+      OID: 1.3.6.1.2.1.1.5.0
+      name: sysName
+    tag: snmp_host2
+  - OID: 1.3.6.1.2.1.1.999.0
+    symbol: unknownSymbol
+    tag: unknown_symbol


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

[snmp] Handle metric_tags for detect metrics feature

Improvement for this initial PR: https://github.com/DataDog/datadog-agent/pull/14401

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Support detection of global metric_tags.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
