### PR TITLE
[CWS] add discarders eBPF unit test

### DIFF
--- a/.gitlab/source_test/ebpf.yml
+++ b/.gitlab/source_test/ebpf.yml
@@ -49,6 +49,7 @@
     - inv -e system-probe.object-files
     - invoke -e golangci-lint --build system-probe ./pkg
     - !reference [.build_sysprobe_artifacts]
+    - invoke -e security-agent.run-ebpf-unit-tests --verbose
     - invoke -e security-agent.kitchen-prepare
     - cp /tmp/clang-bpf $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files/clang-bpf
     - cp /tmp/llc-bpf $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files/llc-bpf

--- a/go.mod
+++ b/go.mod
@@ -452,6 +452,8 @@ require (
 	mellium.im/sasl v0.3.1 // indirect
 )
 
+require github.com/safchain/baloum v0.0.0-20221206135539-a3b4d52f28b4
+
 replace github.com/pahanini/go-grpc-bidirectional-streaming-example v0.0.0-20211027164128-cc6111af44be => github.com/DataDog/go-grpc-bidirectional-streaming-example v0.0.0-20221024060302-b9cf785c02fe
 
 // Fixing a CVE on a transitive dep of k8s/etcd, should be cleaned-up once k8s.io/apiserver dep is removed (but double-check with `go mod why` that no other dep pulls it)

--- a/go.mod
+++ b/go.mod
@@ -430,6 +430,7 @@ require (
 require (
 	github.com/DataDog/go-libddwaf v0.0.0-20221118110754-0372d7c76b8a
 	github.com/go-redis/redis/v9 v9.0.0-rc.2
+	github.com/safchain/baloum v0.0.0-20221229104256-b1fc8f70a86b
 	github.com/streadway/amqp v1.0.0
 	github.com/uptrace/bun v1.1.9
 	github.com/uptrace/bun/dialect/pgdialect v1.1.9
@@ -451,8 +452,6 @@ require (
 	gomodules.xyz/jsonpatch/v2 v2.2.0 // indirect
 	mellium.im/sasl v0.3.1 // indirect
 )
-
-require github.com/safchain/baloum v0.0.0-20221206135539-a3b4d52f28b4
 
 replace github.com/pahanini/go-grpc-bidirectional-streaming-example v0.0.0-20211027164128-cc6111af44be => github.com/DataDog/go-grpc-bidirectional-streaming-example v0.0.0-20221024060302-b9cf785c02fe
 

--- a/go.sum
+++ b/go.sum
@@ -1528,8 +1528,8 @@ github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/ryanuber/columnize v2.1.0+incompatible/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/ryanuber/go-glob v1.0.0/go.mod h1:807d1WSdnB0XRJzKNil9Om6lcp/3a0v4qIHxIXzX/Yc=
-github.com/safchain/baloum v0.0.0-20221206135539-a3b4d52f28b4 h1:AUa6BxTG3rp0tQFCQ+cfeXJd9jwI2x62S9FaYsybXzU=
-github.com/safchain/baloum v0.0.0-20221206135539-a3b4d52f28b4/go.mod h1:1+GWOH32bsIEAHknYja6/H1efcDs+/Q2XrtYMM200Ho=
+github.com/safchain/baloum v0.0.0-20221229104256-b1fc8f70a86b h1:cTiH46CYvPhgOlE0t82N+rgQw44b7vB39ay+P+wiVz8=
+github.com/safchain/baloum v0.0.0-20221229104256-b1fc8f70a86b/go.mod h1:1+GWOH32bsIEAHknYja6/H1efcDs+/Q2XrtYMM200Ho=
 github.com/safchain/ethtool v0.0.0-20190326074333-42ed695e3de8/go.mod h1:Z0q5wiBQGYcxhMZ6gUqHn6pYNLypFAvaL3UvgZLR0U4=
 github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da h1:p3Vo3i64TCLY7gIfzeQaUJ+kppEO5WQG3cL8iE8tGHU=
 github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da/go.mod h1:gi+0XIa01GRL2eRQVjQkKGqKF3SF9vZR/HnPullcV2E=

--- a/go.sum
+++ b/go.sum
@@ -1528,6 +1528,8 @@ github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/ryanuber/columnize v2.1.0+incompatible/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/ryanuber/go-glob v1.0.0/go.mod h1:807d1WSdnB0XRJzKNil9Om6lcp/3a0v4qIHxIXzX/Yc=
+github.com/safchain/baloum v0.0.0-20221206135539-a3b4d52f28b4 h1:AUa6BxTG3rp0tQFCQ+cfeXJd9jwI2x62S9FaYsybXzU=
+github.com/safchain/baloum v0.0.0-20221206135539-a3b4d52f28b4/go.mod h1:1+GWOH32bsIEAHknYja6/H1efcDs+/Q2XrtYMM200Ho=
 github.com/safchain/ethtool v0.0.0-20190326074333-42ed695e3de8/go.mod h1:Z0q5wiBQGYcxhMZ6gUqHn6pYNLypFAvaL3UvgZLR0U4=
 github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da h1:p3Vo3i64TCLY7gIfzeQaUJ+kppEO5WQG3cL8iE8tGHU=
 github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da/go.mod h1:gi+0XIa01GRL2eRQVjQkKGqKF3SF9vZR/HnPullcV2E=

--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var RuntimeSecurity = newAsset("runtime-security.c", "371ee4726c29eb13a0eaddf72636bd72a28cebd88d537718f7ccd72d7e3d13b3")
+var RuntimeSecurity = newAsset("runtime-security.c", "5d0851c4f57bf54d9e4053d970d6f955f37bacb3ad3a50f12d389d507a9aac8a")

--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var RuntimeSecurity = newAsset("runtime-security.c", "5d0851c4f57bf54d9e4053d970d6f955f37bacb3ad3a50f12d389d507a9aac8a")
+var RuntimeSecurity = newAsset("runtime-security.c", "284489038bc6dfaa1850e06eb8e909c91bcd6a6a1eaf29233b344f8413361b8e")

--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var RuntimeSecurity = newAsset("runtime-security.c", "5561235e358dae918931ad84862a6b6e92bed10c6d56a1b17137005d915e4dd2")
+var RuntimeSecurity = newAsset("runtime-security.c", "371ee4726c29eb13a0eaddf72636bd72a28cebd88d537718f7ccd72d7e3d13b3")

--- a/pkg/security/ebpf/c/baloum.h
+++ b/pkg/security/ebpf/c/baloum.h
@@ -1,0 +1,78 @@
+#ifdef __BALOUM__
+
+#ifndef _BALOUM_H__
+#define _BALOUM_H__
+
+struct baloum_ctx
+{
+    __u64 arg0;
+    __u64 arg1;
+    __u64 arg2;
+    __u64 arg3;
+    __u64 arg4;
+};
+static void *(*baloum_malloc)(__u32 size) = (void *)0xffff;
+static int (*baloum_call)(struct baloum_ctx *ctx, const char *section) = (void *)0xfffe;
+static int (*baloum_strcmp)(const char *s1, const char *s2) = (void *)0xfffd;
+static int (*baloum_memcmp)(const void *b1, const void *b2, __u32 size) = (void *)0xfffc;
+static int (*baloum_sleep)(__u64 ns) = (void *)0xfffb;
+
+#define assert_memcmp(b1, b2, s, msg)                                \
+    if (baloum_memcmp(b1, b2, s) != 0)                               \
+    {                                                                \
+        bpf_printk("assert line %d : b1 != b2 : %s", __LINE__, msg); \
+        return -1;                                                   \
+    }
+
+#define assert_strcmp(s1, s2, msg)                                   \
+    if (baloum_strcmp(s1, s2) != 0)                                  \
+    {                                                                \
+        bpf_printk("assert line %d : s1 != s2 : %s", __LINE__, msg); \
+        return -1;                                                   \
+    }
+
+#define assert_equals(v1, v2, msg)                                   \
+    if (v1 != v2)                                                    \
+    {                                                                \
+        bpf_printk("assert line %d : v1 != v2 : %s", __LINE__, msg); \
+        return -1;                                                   \
+    }
+
+#define assert_zero(v1, msg)                                           \
+    if (v1 != 0)                                                       \
+    {                                                                  \
+        bpf_printk("assert line %d : v1 == 0 : %s", __LINE__, msg);    \
+        return -1;                                                     \
+    }
+
+#define assert_not_zero(v1, msg)                                       \
+    if (v1 == 0)                                                       \
+    {                                                                  \
+        bpf_printk("assert line %d : v1 != 0 : %s", __LINE__, msg);    \
+        return -1;                                                     \
+    }
+
+#define assert_not_equals(v1, v2, msg)                               \
+    if (v1 == v2)                                                    \
+    {                                                                \
+        bpf_printk("assert line %d : v1 == v2 : %s", __LINE__, msg); \
+        return -1;                                                   \
+    }
+
+#define assert_not_null(v1, msg)                                       \
+    if (v1 == NULL)                                                    \
+    {                                                                  \
+        bpf_printk("assert line %d : v1 == NULL : %s", __LINE__, msg); \
+        return -1;                                                     \
+    }
+
+#define assert_null(v1, msg)                                           \
+    if (v1 != NULL)                                                    \
+    {                                                                  \
+        bpf_printk("assert line %d : v1 != NULL : %s", __LINE__, msg); \
+        return -1;                                                     \
+    }
+
+#endif
+
+#endif

--- a/pkg/security/ebpf/c/dentry_resolver.h
+++ b/pkg/security/ebpf/c/dentry_resolver.h
@@ -125,6 +125,7 @@ int __attribute__((always_inline)) resolve_dentry_tail_call(void *ctx, struct de
     }
     *params = (struct is_discarded_by_inode_t){
         .discarder_type = input->discarder_type,
+        // TODO(safchain) do we need the pid ?????
         .tgid = bpf_get_current_pid_tgid() >> 32,
         .now = bpf_ktime_get_ns(),
         .ad_state = input->ad_state,

--- a/pkg/security/ebpf/c/discarders.h
+++ b/pkg/security/ebpf/c/discarders.h
@@ -43,9 +43,9 @@ struct bpf_map_def SEC("maps/discarders_revision") discarders_revision = {
 };
 
 u64 __attribute__((always_inline)) get_discarder_retention() {
-    u64 retention;
+    u64 retention = 0;
     LOAD_CONSTANT("discarder_retention", retention);
-    return retention;
+    return retention ? retention : SEC_TO_NS(5);
 }
 
 int __attribute__((always_inline)) monitor_discarder_added(u64 event_type) {

--- a/pkg/security/ebpf/c/discarders.h
+++ b/pkg/security/ebpf/c/discarders.h
@@ -162,7 +162,7 @@ u64* __attribute__((always_inline)) get_discarder_timestamp(struct discarder_par
 // This function is doing the same thing as the one before, but can only work if `params` is a pointer to a map value
 // and not a pointer to the stack since kernels < 4.15 does not allow this. On the other hand it is faster and needs less
 // instructions.
-u64* __attribute__((always_inline)) get_discarder_timestamp_from_map(struct discarder_params_t *params, u64 event_type) {
+u64 * __attribute__((always_inline)) get_discarder_timestamp_from_map(struct discarder_params_t *params, u64 event_type) {
     if (EVENT_FIRST_DISCARDER <= event_type && event_type < EVENT_LAST_DISCARDER) {
         return &params->timestamps[event_type-EVENT_FIRST_DISCARDER];
     }
@@ -212,6 +212,18 @@ struct bpf_map_def SEC("maps/inode_discarders") inode_discarders = {
 
 
 int __attribute__((always_inline)) expire_inode_discarders(u32 mount_id, u64 inode);
+
+struct inode_discarder_params_t * __attribute__((always_inline)) get_inode_discarder_params(u32 mount_id, u64 inode, u32 is_leaf) {
+    struct inode_discarder_t key = {
+        .path_key = {
+            .ino = inode,
+            .mount_id = mount_id,
+        },
+        .is_leaf = is_leaf,
+    };
+
+    return bpf_map_lookup_elem(&inode_discarders, &key);
+}
 
 int __attribute__((always_inline)) discard_inode(u64 event_type, u32 mount_id, u64 inode, u64 timeout, u32 is_leaf) {
     if (!mount_id || !inode) {

--- a/pkg/security/ebpf/c/discarders_test.h
+++ b/pkg/security/ebpf/c/discarders_test.h
@@ -1,0 +1,71 @@
+#ifndef _DISCARDERS_TEST_H
+#define _DISCARDERS_TEST_H
+
+#include "defs.h"
+#include "discarders.h"
+#include "baloum.h"
+
+SEC("test/discarders_retention")
+int test_discarders_retention()
+{
+    u32 mount_id = 123;
+    u64 inode = 456;
+
+    int ret = discard_inode(EVENT_OPEN, mount_id, inode, 0, 0);
+    assert_zero(ret, "failed to discard the inode");
+
+    struct inode_discarder_t key = {
+        .path_key = {
+            .ino = inode,
+            .mount_id = mount_id,
+        }
+    };
+
+    struct inode_discarder_params_t *inode_params = bpf_map_lookup_elem(&inode_discarders, &key);
+    assert_not_null(inode_params, "unable to find the inode discarder entry");
+
+    struct is_discarded_by_inode_t params = {
+        .discarder_type = EVENT_OPEN,
+        .discarder = {
+            .path_key.ino = inode,
+            .path_key.mount_id = mount_id,
+        }
+    };
+
+    ret = is_discarded_by_inode(&params);
+    assert_not_zero(ret, "inode should be discarded");
+
+    // expire the discarder
+    expire_inode_discarders(mount_id, inode);
+
+    // the entry should still be there
+    inode_params = bpf_map_lookup_elem(&inode_discarders, &key);
+    assert_not_null(inode_params, "unable to find the inode discarder entry");
+
+    // but should be discarded anymore
+    ret = is_discarded_by_inode(&params);
+    assert_zero(ret, "inode shouldn't be discarded");
+
+    // we shouldn't be able to add a new discarder for the same inode during the retention period
+    // TODO(safchain) should return an error value
+    ret = discard_inode(EVENT_OPEN, mount_id, inode, 0, 0);
+    assert_zero(ret, "failed to discard the inode");
+
+    // shouldn't still be discarded
+    ret = is_discarded_by_inode(&params);
+    assert_zero(ret, "inode shouldn't be discarded");
+
+    // wait the retention period
+    baloum_sleep(get_discarder_retention() + 1);
+
+    // the retention period is now over, we should be able to add a discarder
+    ret = discard_inode(EVENT_OPEN, mount_id, inode, 0, 0);
+    assert_zero(ret, "failed to discard the inode");
+
+    ret = is_discarded_by_inode(&params);
+    assert_not_zero(ret, "inode should be discarded");
+
+    return 0;
+}
+
+#endif

--- a/pkg/security/ebpf/c/discarders_test.h
+++ b/pkg/security/ebpf/c/discarders_test.h
@@ -5,6 +5,64 @@
 #include "discarders.h"
 #include "baloum.h"
 
+SEC("test/discarders_event_mask")
+int test_discarders_event_mask()
+{
+    u32 mount_id = 123;
+    u64 inode = 456;
+
+    int ret = discard_inode(EVENT_OPEN, mount_id, inode, 0, 0);
+    assert_zero(ret, "failed to discard the inode");
+
+    struct inode_discarder_t key = {
+        .path_key = {
+            .ino = inode,
+            .mount_id = mount_id,
+        }
+    };
+
+    struct inode_discarder_params_t *inode_params = bpf_map_lookup_elem(&inode_discarders, &key);
+    assert_not_null(inode_params, "unable to find the inode discarder entry");
+
+    ret = mask_has_event(inode_params->params.event_mask, EVENT_OPEN);
+    assert_not_zero(ret, "event not found in mask");
+
+    struct is_discarded_by_inode_t params = {
+        .discarder_type = EVENT_OPEN,
+        .discarder = {
+            .path_key.ino = inode,
+            .path_key.mount_id = mount_id,
+        }
+    };
+
+    ret = is_discarded_by_inode(&params);
+    assert_not_zero(ret, "inode should be discarded");
+
+    // add another event type
+    ret = discard_inode(EVENT_CHMOD, mount_id, inode, 0, 0);
+    assert_zero(ret, "failed to discard the inode");
+
+    // check that we have now both open and chmod event discarded
+    inode_params = bpf_map_lookup_elem(&inode_discarders, &key);
+    assert_not_null(inode_params, "unable to find the inode discarder entry");
+
+    ret = mask_has_event(inode_params->params.event_mask, EVENT_OPEN);
+    assert_not_zero(ret, "event not found in mask");
+
+    ret = mask_has_event(inode_params->params.event_mask, EVENT_CHMOD);
+    assert_not_zero(ret, "event not found in mask");
+
+    ret = is_discarded_by_inode(&params);
+    assert_not_zero(ret, "inode should be discarded");
+
+    params.discarder_type = EVENT_CHMOD;
+
+    ret = is_discarded_by_inode(&params);
+    assert_not_zero(ret, "inode should be discarded");
+
+    return 0;
+}
+
 SEC("test/discarders_retention")
 int test_discarders_retention()
 {

--- a/pkg/security/ebpf/c/prebuilt/probe.c
+++ b/pkg/security/ebpf/c/prebuilt/probe.c
@@ -105,6 +105,11 @@ void __attribute__((always_inline)) invalidate_inode(struct pt_regs *ctx, u32 mo
     }
 }
 
+// unit tests
+#ifdef __BALOUM__
+#include "tests.h"
+#endif
+
 __u32 _version SEC("version") = 0xFFFFFFFE;
 
 char LICENSE[] SEC("license") = "GPL";

--- a/pkg/security/ebpf/c/tests.h
+++ b/pkg/security/ebpf/c/tests.h
@@ -1,0 +1,6 @@
+#ifndef _TESTS_H
+#define _TESTS_H
+
+#include "discarders_test.h"
+
+#endif

--- a/pkg/security/ebpf/loader.go
+++ b/pkg/security/ebpf/loader.go
@@ -9,10 +9,13 @@
 package ebpf
 
 import (
+	"strings"
+
 	"github.com/DataDog/datadog-agent/pkg/ebpf/bytecode"
 	"github.com/DataDog/datadog-agent/pkg/security/config"
 	"github.com/DataDog/datadog-agent/pkg/security/seclog"
 	"github.com/DataDog/datadog-go/v5/statsd"
+	manager "github.com/DataDog/ebpf-manager"
 )
 
 // ProbeLoader defines an eBPF ProbeLoader
@@ -94,4 +97,14 @@ func (l *OffsetGuesserLoader) Close() error {
 // Load eBPF programs
 func (l *OffsetGuesserLoader) Load() (bytecode.AssetReader, error) {
 	return bytecode.GetReader(l.config.BPFDir, "runtime-security-offset-guesser.o")
+}
+
+// IsSyscallWrapperRequired checks whether the wrapper is required
+func IsSyscallWrapperRequired() (bool, error) {
+	openSyscall, err := manager.GetSyscallFnName("open")
+	if err != nil {
+		return false, err
+	}
+
+	return !strings.HasPrefix(openSyscall, "SyS_") && !strings.HasPrefix(openSyscall, "sys_"), nil
 }

--- a/pkg/security/ebpf/tests/discarders_test.go
+++ b/pkg/security/ebpf/tests/discarders_test.go
@@ -11,71 +11,11 @@ package tests
 import (
 	"testing"
 
-	"github.com/DataDog/datadog-agent/pkg/security/config"
-	secebpf "github.com/DataDog/datadog-agent/pkg/security/ebpf"
-	"github.com/DataDog/datadog-go/v5/statsd"
-	"github.com/cilium/ebpf"
 	"github.com/safchain/baloum/pkg/baloum"
 )
 
-type testLogger struct {
-	t *testing.T
-}
-
-func (l *testLogger) Info(params ...interface{}) {
-	l.t.Log(params...)
-}
-
-func (l *testLogger) Infof(format string, params ...interface{}) {
-	l.t.Logf(format, params...)
-}
-
-func (l *testLogger) Debug(params ...interface{}) {
-	l.t.Log(params...)
-}
-
-func (l *testLogger) Debugf(format string, params ...interface{}) {
-	l.t.Logf(format, params...)
-}
-
-func (l *testLogger) Error(params ...interface{}) {
-	l.t.Error(params...)
-}
-
-func (l *testLogger) Errorf(format string, params ...interface{}) {
-	l.t.Errorf(format, params...)
-}
-
-func newVM(t *testing.T) *baloum.VM {
-	useSyscallWrapper, err := secebpf.IsSyscallWrapperRequired()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	loader := secebpf.NewProbeLoader(&config.Config{}, useSyscallWrapper, &statsd.NoOpClient{})
-	reader, _, err := loader.Load()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	spec, err := ebpf.LoadCollectionSpecFromReader(reader)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	fncs := baloum.Fncs{
-		TracePrintk: func(vm *baloum.VM, format string, args ...interface{}) error {
-			t.Logf(format, args...)
-			return nil
-		},
-	}
-
-	return baloum.NewVM(spec, baloum.Opts{Fncs: fncs, Logger: &testLogger{t: t}})
-}
-
 func TestDiscarderEventMask(t *testing.T) {
 	var ctx baloum.Context
-
 	code, err := newVM(t).RunProgram(ctx, "test/discarders_event_mask")
 	if err != nil || code != 0 {
 		t.Errorf("unexpected error: %v, %d", err, code)
@@ -84,7 +24,6 @@ func TestDiscarderEventMask(t *testing.T) {
 
 func TestDiscarderRetention(t *testing.T) {
 	var ctx baloum.Context
-
 	code, err := newVM(t).RunProgram(ctx, "test/discarders_retention")
 	if err != nil || code != 0 {
 		t.Errorf("unexpected error: %v, %d", err, code)

--- a/pkg/security/ebpf/tests/discarders_test.go
+++ b/pkg/security/ebpf/tests/discarders_test.go
@@ -15,16 +15,16 @@ import (
 )
 
 func TestDiscarderEventMask(t *testing.T) {
-	var ctx baloum.Context
-	code, err := newVM(t).RunProgram(ctx, "test/discarders_event_mask")
+	var ctx baloum.StdContext
+	code, err := newVM(t).RunProgram(&ctx, "test/discarders_event_mask")
 	if err != nil || code != 0 {
 		t.Errorf("unexpected error: %v, %d", err, code)
 	}
 }
 
 func TestDiscarderRetention(t *testing.T) {
-	var ctx baloum.Context
-	code, err := newVM(t).RunProgram(ctx, "test/discarders_retention")
+	var ctx baloum.StdContext
+	code, err := newVM(t).RunProgram(&ctx, "test/discarders_retention")
 	if err != nil || code != 0 {
 		t.Errorf("unexpected error: %v, %d", err, code)
 	}

--- a/pkg/security/ebpf/tests/discarders_test.go
+++ b/pkg/security/ebpf/tests/discarders_test.go
@@ -1,0 +1,63 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux && ebpf_bindata
+// +build linux,ebpf_bindata
+
+package tests
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/security/config"
+	secebpf "github.com/DataDog/datadog-agent/pkg/security/ebpf"
+	"github.com/DataDog/datadog-go/v5/statsd"
+	"github.com/cilium/ebpf"
+	"github.com/safchain/baloum/pkg/baloum"
+	"go.uber.org/zap"
+)
+
+func TestDiscarderRetention(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	defer logger.Sync()
+
+	suggar := logger.Sugar()
+
+	useSyscallWrapper, err := secebpf.IsSyscallWrapperRequired()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	loader := secebpf.NewProbeLoader(&config.Config{}, useSyscallWrapper, &statsd.NoOpClient{})
+	reader, _, err := loader.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	spec, err := ebpf.LoadCollectionSpecFromReader(reader)
+	if err != nil {
+		suggar.Fatal(err)
+	}
+
+	tgid := uint64(33)
+
+	fncs := baloum.Fncs{
+		GetCurrentPidTgid: func(vm *baloum.VM) (uint64, error) {
+			return tgid, nil
+		},
+		TracePrintk: func(vm *baloum.VM, format string, args ...interface{}) {
+			suggar.Debugf(format, args...)
+		},
+	}
+
+	vm := baloum.NewVM(spec, baloum.Opts{Fncs: fncs, Logger: suggar})
+
+	var ctx baloum.Context
+
+	code, err := vm.RunProgram(ctx, "test/discarders_retention")
+	if err != nil || code != 0 {
+		suggar.Fatalf("unexpected error: %v, %d", err, code)
+	}
+}

--- a/pkg/security/ebpf/tests/discarders_test.go
+++ b/pkg/security/ebpf/tests/discarders_test.go
@@ -29,3 +29,19 @@ func TestDiscarderRetention(t *testing.T) {
 		t.Errorf("unexpected error: %v, %d", err, code)
 	}
 }
+
+func TestDiscarderRevision(t *testing.T) {
+	var ctx baloum.StdContext
+	code, err := newVM(t).RunProgram(&ctx, "test/discarders_revision")
+	if err != nil || code != 0 {
+		t.Errorf("unexpected error: %v, %d", err, code)
+	}
+}
+
+func TestDiscarderMountRevision(t *testing.T) {
+	var ctx baloum.StdContext
+	code, err := newVM(t).RunProgram(&ctx, "test/discarders_mount_revision")
+	if err != nil || code != 0 {
+		t.Errorf("unexpected error: %v, %d", err, code)
+	}
+}

--- a/pkg/security/ebpf/tests/helpers_test.go
+++ b/pkg/security/ebpf/tests/helpers_test.go
@@ -1,0 +1,89 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux && ebpf_bindata
+// +build linux,ebpf_bindata
+
+package tests
+
+import (
+	"flag"
+	"os"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/security/config"
+	secebpf "github.com/DataDog/datadog-agent/pkg/security/ebpf"
+	"github.com/DataDog/datadog-go/v5/statsd"
+	"github.com/cilium/ebpf"
+	"github.com/safchain/baloum/pkg/baloum"
+)
+
+type testLogger struct {
+	t     *testing.T
+	trace bool
+}
+
+func (l *testLogger) Info(params ...interface{}) {
+	l.t.Log(params...)
+}
+
+func (l *testLogger) Infof(format string, params ...interface{}) {
+	l.t.Logf(format, params...)
+}
+
+func (l *testLogger) Debug(params ...interface{}) {
+	if l.trace {
+		l.t.Log(params...)
+	}
+}
+
+func (l *testLogger) Debugf(format string, params ...interface{}) {
+	if l.trace {
+		l.t.Logf(format, params...)
+	}
+}
+
+func (l *testLogger) Error(params ...interface{}) {
+	l.t.Error(params...)
+}
+
+func (l *testLogger) Errorf(format string, params ...interface{}) {
+	l.t.Errorf(format, params...)
+}
+
+var trace bool
+
+func newVM(t *testing.T) *baloum.VM {
+	useSyscallWrapper, err := secebpf.IsSyscallWrapperRequired()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	loader := secebpf.NewProbeLoader(&config.Config{}, useSyscallWrapper, &statsd.NoOpClient{})
+	reader, _, err := loader.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	spec, err := ebpf.LoadCollectionSpecFromReader(reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fncs := baloum.Fncs{
+		TracePrintk: func(vm *baloum.VM, format string, args ...interface{}) error {
+			t.Logf(format, args...)
+			return nil
+		},
+	}
+
+	return baloum.NewVM(spec, baloum.Opts{Fncs: fncs, Logger: &testLogger{t: t, trace: trace}})
+}
+
+func TestMain(m *testing.M) {
+	flag.BoolVar(&trace, "trace", false, "enable eBPF VM instruction tracing")
+	flag.Parse()
+	os.Exit(m.Run())
+}

--- a/pkg/security/ebpf/tests/helpers_test.go
+++ b/pkg/security/ebpf/tests/helpers_test.go
@@ -12,6 +12,7 @@ import (
 	"flag"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/security/config"
 	secebpf "github.com/DataDog/datadog-agent/pkg/security/ebpf"
@@ -72,9 +73,19 @@ func newVM(t *testing.T) *baloum.VM {
 		t.Fatal(err)
 	}
 
+	var now time.Time
+
 	fncs := baloum.Fncs{
 		TracePrintk: func(vm *baloum.VM, format string, args ...interface{}) error {
 			t.Logf(format, args...)
+			return nil
+		},
+		// fake the time duration to speed up the tests
+		KtimeGetNS: func(vm *baloum.VM) (uint64, error) {
+			return uint64(now.UnixNano()), nil
+		},
+		Sleep: func(vm *baloum.VM, duration time.Duration) error {
+			now = now.Add(duration)
 			return nil
 		},
 	}

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -15,7 +15,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"strings"
 	"sync"
 	"time"
 
@@ -221,20 +220,11 @@ func (p *Probe) VerifyEnvironment() *multierror.Error {
 	return err
 }
 
-func isSyscallWrapperRequired() (bool, error) {
-	openSyscall, err := manager.GetSyscallFnName("open")
-	if err != nil {
-		return false, err
-	}
-
-	return !strings.HasPrefix(openSyscall, "SyS_") && !strings.HasPrefix(openSyscall, "sys_"), nil
-}
-
 // Init initializes the probe
 func (p *Probe) Init() error {
 	p.startTime = time.Now()
 
-	useSyscallWrapper, err := isSyscallWrapperRequired()
+	useSyscallWrapper, err := ebpf.IsSyscallWrapperRequired()
 	if err != nil {
 		return err
 	}

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -707,3 +707,20 @@ def kitchen_prepare(ctx):
     ctx.run(f"mkdir -p {ebpf_runtime_dir}")
     ctx.run(f"cp {bytecode_build_dir}/runtime-security* {ebpf_bytecode_dir}")
     ctx.run(f"cp {bytecode_build_dir}/runtime/runtime-security* {ebpf_runtime_dir}")
+
+
+@task
+def run_ebpf_unit_tests(ctx, verbose=False):
+    build_cws_object_files(
+        ctx,
+        major_version='7',
+        arch=CURRENT_ARCH,
+        kernel_release=None,
+        with_unit_test=True,
+    )
+
+    flags = '-tags ebpf_bindata'
+    if verbose:
+        flags += " -test.v"
+
+    ctx.run(f"go test {flags} ./pkg/security/ebpf/tests/...")

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -710,7 +710,7 @@ def kitchen_prepare(ctx):
 
 
 @task
-def run_ebpf_unit_tests(ctx, verbose=False):
+def run_ebpf_unit_tests(ctx, verbose=False, trace=False):
     build_cws_object_files(
         ctx,
         major_version='7',
@@ -723,4 +723,8 @@ def run_ebpf_unit_tests(ctx, verbose=False):
     if verbose:
         flags += " -test.v"
 
-    ctx.run(f"go test {flags} ./pkg/security/ebpf/tests/...")
+    args = '-args'
+    if trace:
+        args += " -trace"
+
+    ctx.run(f"go test {flags} ./pkg/security/ebpf/tests/... {args}")

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -68,7 +68,7 @@ def ninja_define_windows_resources(ctx, nw, major_version):
 
 def ninja_define_ebpf_compiler(nw, strip_object_files=False, kernel_release=None):
     nw.variable("target", "-emit-llvm")
-    nw.variable("ebpfflags", get_ebpf_build_flags())
+    nw.variable("ebpfflags", get_ebpf_build_flags(True))
     nw.variable("kheaders", get_kernel_headers_flags(kernel_release))
 
     nw.rule(
@@ -893,7 +893,7 @@ def get_linux_header_dirs(kernel_release=None, minimal_kernel_release=None):
     return dirs
 
 
-def get_ebpf_build_flags():
+def get_ebpf_build_flags(test=False):
     flags = []
     flags.extend(
         [
@@ -904,6 +904,8 @@ def get_ebpf_build_flags():
             '-DCOMPILE_PREBUILT',
         ]
     )
+    if test:
+        flags.extend(['-D__BALOUM__'])
     flags.extend(
         [
             '-Wno-unused-value',

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -1098,7 +1098,7 @@ def build_cws_object_files(
         debug=debug,
         strip_object_files=strip_object_files,
         kernel_release=kernel_release,
-        unit_test=with_unit_test,
+        with_unit_test=with_unit_test,
     )
 
 

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -398,7 +398,7 @@ def build(
     debug=False,
     strip_object_files=False,
     strip_binary=False,
-    with_unit_test=False
+    with_unit_test=False,
 ):
     """
     Build the system-probe
@@ -991,7 +991,9 @@ def run_ninja(
 ):
     check_for_ninja(ctx)
     nf_path = os.path.join(ctx.cwd, 'system-probe.ninja')
-    ninja_generate(ctx, nf_path, windows, major_version, arch, debug, strip_object_files, kernel_release, with_unit_test)
+    ninja_generate(
+        ctx, nf_path, windows, major_version, arch, debug, strip_object_files, kernel_release, with_unit_test
+    )
     explain_opt = "-d explain" if explain else ""
     if task:
         ctx.run(f"ninja {explain_opt} -f {nf_path} -t {task}")
@@ -1088,7 +1090,13 @@ def build_object_files(
 
 
 def build_cws_object_files(
-    ctx, major_version='7', arch=CURRENT_ARCH, kernel_release=None, debug=False, strip_object_files=False, with_unit_test=False
+    ctx,
+    major_version='7',
+    arch=CURRENT_ARCH,
+    kernel_release=None,
+    debug=False,
+    strip_object_files=False,
+    with_unit_test=False,
 ):
     run_ninja(
         ctx,


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Some parts of the cws eBPF code are difficult to test through functional tests. Some parts rely on timestamp, unpredictable data (pid, inode, mount id, noisy neighbor). This PR uses an eBPF VM with some extra helper in order to be able to add unit tests for this specific pieces of code. The eBPF VM covers only a subset of the eBPF feature and doesn't aim to mimic perfectly the kernel. The purpose of it is testing.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
