### PR TITLE
[CWS] probe code base reorga v1

### DIFF
--- a/cmd/security-agent/app/activity_dump.go
+++ b/cmd/security-agent/app/activity_dump.go
@@ -14,8 +14,8 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/security-agent/app/common"
 	secagent "github.com/DataDog/datadog-agent/pkg/security/agent"
 	"github.com/DataDog/datadog-agent/pkg/security/api"
+	"github.com/DataDog/datadog-agent/pkg/security/config"
 	sprobe "github.com/DataDog/datadog-agent/pkg/security/probe"
-	"github.com/DataDog/datadog-agent/pkg/security/probe/dump"
 	"github.com/spf13/cobra"
 )
 
@@ -155,7 +155,7 @@ func generateDumpCommands(globalParams *common.GlobalParams) []*cobra.Command {
 		&cliParams.localStorageFormats,
 		"format",
 		[]string{},
-		fmt.Sprintf("local storage output formats. Available options are %v.", dump.AllStorageFormats()),
+		fmt.Sprintf("local storage output formats. Available options are %v.", config.AllStorageFormats()),
 	)
 	activityDumpGenerateDumpCmd.Flags().BoolVar(
 		&cliParams.remoteStorageCompression,
@@ -167,7 +167,7 @@ func generateDumpCommands(globalParams *common.GlobalParams) []*cobra.Command {
 		&cliParams.remoteStorageFormats,
 		"remote-format",
 		[]string{},
-		fmt.Sprintf("remote storage output formats. Available options are %v.", dump.AllStorageFormats()),
+		fmt.Sprintf("remote storage output formats. Available options are %v.", config.AllStorageFormats()),
 	)
 
 	return []*cobra.Command{activityDumpGenerateDumpCmd}
@@ -209,7 +209,7 @@ func generateEncodingCommands(globalParams *common.GlobalParams) []*cobra.Comman
 		&cliParams.localStorageFormats,
 		"format",
 		[]string{},
-		fmt.Sprintf("local storage output formats. Available options are %v.", dump.AllStorageFormats()),
+		fmt.Sprintf("local storage output formats. Available options are %v.", config.AllStorageFormats()),
 	)
 	activityDumpGenerateEncodingCmd.Flags().BoolVar(
 		&cliParams.remoteStorageCompression,
@@ -221,7 +221,7 @@ func generateEncodingCommands(globalParams *common.GlobalParams) []*cobra.Comman
 		&cliParams.remoteStorageFormats,
 		"remote-format",
 		[]string{},
-		fmt.Sprintf("remote storage output formats. Available options are %v.", dump.AllStorageFormats()),
+		fmt.Sprintf("remote storage output formats. Available options are %v.", config.AllStorageFormats()),
 	)
 	activityDumpGenerateEncodingCmd.Flags().BoolVar(
 		&cliParams.remoteRequest,
@@ -300,7 +300,7 @@ func generateEncodingFromActivityDump(activityDumpArgs *activityDumpCliParams) e
 			return err
 		}
 
-		storageRequests, err := dump.ParseStorageRequests(parsedRequests)
+		storageRequests, err := config.ParseStorageRequests(parsedRequests)
 		if err != nil {
 			return fmt.Errorf("couldn't parse transcoding request for [%s]: %v", ad.GetSelectorStr(), err)
 		}
@@ -364,13 +364,13 @@ func listActivityDumps() error {
 
 func parseStorageRequest(activityDumpArgs *activityDumpCliParams) (*api.StorageRequestParams, error) {
 	// parse local storage formats
-	_, err := dump.ParseStorageFormats(activityDumpArgs.localStorageFormats)
+	_, err := config.ParseStorageFormats(activityDumpArgs.localStorageFormats)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't parse local storage formats %v: %v", activityDumpArgs.localStorageFormats, err)
 	}
 
 	// parse remote storage formats
-	_, err = dump.ParseStorageFormats(activityDumpArgs.remoteStorageFormats)
+	_, err = config.ParseStorageFormats(activityDumpArgs.remoteStorageFormats)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't parse remote storage formats %v: %v", activityDumpArgs.remoteStorageFormats, err)
 	}

--- a/pkg/security/config/config.go
+++ b/pkg/security/config/config.go
@@ -16,7 +16,6 @@ import (
 	logshttp "github.com/DataDog/datadog-agent/pkg/logs/client/http"
 	logsconfig "github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
-	"github.com/DataDog/datadog-agent/pkg/security/probe/dump"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/seclog"
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
@@ -137,14 +136,14 @@ type Config struct {
 	// this field empty to prevent writing any output to disk.
 	ActivityDumpLocalStorageDirectory string
 	// ActivityDumpLocalStorageFormats defines the formats that should be used to persist the activity dumps locally.
-	ActivityDumpLocalStorageFormats []dump.StorageFormat
+	ActivityDumpLocalStorageFormats []StorageFormat
 	// ActivityDumpLocalStorageCompression defines if the local storage should compress the persisted data.
 	ActivityDumpLocalStorageCompression bool
 	// ActivityDumpLocalStorageMaxDumpsCount defines the maximum count of activity dumps that should be kept locally.
 	// When the limit is reached, the oldest dumps will be deleted first.
 	ActivityDumpLocalStorageMaxDumpsCount int
 	// ActivityDumpRemoteStorageFormats defines the formats that should be used to persist the activity dumps remotely.
-	ActivityDumpRemoteStorageFormats []dump.StorageFormat
+	ActivityDumpRemoteStorageFormats []StorageFormat
 	// ActivityDumpRemoteStorageCompression defines if the remote storage should compress the persisted data.
 	ActivityDumpRemoteStorageCompression bool
 	// ActivityDumpSyscallMonitorPeriod defines the minimum amount of time to wait between 2 syscalls event for the same
@@ -386,14 +385,14 @@ func (c *Config) sanitizeRuntimeSecurityConfigActivityDump() error {
 
 	if formats := coreconfig.Datadog.GetStringSlice("runtime_security_config.activity_dump.local_storage.formats"); len(formats) > 0 {
 		var err error
-		c.ActivityDumpLocalStorageFormats, err = dump.ParseStorageFormats(formats)
+		c.ActivityDumpLocalStorageFormats, err = ParseStorageFormats(formats)
 		if err != nil {
 			return fmt.Errorf("invalid value for runtime_security_config.activity_dump.local_storage.formats: %w", err)
 		}
 	}
 	if formats := coreconfig.Datadog.GetStringSlice("runtime_security_config.activity_dump.remote_storage.formats"); len(formats) > 0 {
 		var err error
-		c.ActivityDumpRemoteStorageFormats, err = dump.ParseStorageFormats(formats)
+		c.ActivityDumpRemoteStorageFormats, err = ParseStorageFormats(formats)
 		if err != nil {
 			return fmt.Errorf("invalid value for runtime_security_config.activity_dump.remote_storage.formats: %w", err)
 		}

--- a/pkg/security/config/dump.go
+++ b/pkg/security/config/dump.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-package dump
+package config
 
 import (
 	"fmt"

--- a/pkg/security/probe/activity_dump.go
+++ b/pkg/security/probe/activity_dump.go
@@ -41,6 +41,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/ebpf/probes"
 	"github.com/DataDog/datadog-agent/pkg/security/metrics"
 	"github.com/DataDog/datadog-agent/pkg/security/probe/dump"
+	"github.com/DataDog/datadog-agent/pkg/security/probe/resolvers"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/seclog"
@@ -126,7 +127,7 @@ type ActivityDump struct {
 }
 
 // NewActivityDumpLoadConfig returns a new instance of ActivityDumpLoadConfig
-func NewActivityDumpLoadConfig(evt []model.EventType, timeout time.Duration, waitListTimeout time.Duration, rate int, start time.Time, resolver *TimeResolver) *model.ActivityDumpLoadConfig {
+func NewActivityDumpLoadConfig(evt []model.EventType, timeout time.Duration, waitListTimeout time.Duration, rate int, start time.Time, resolver *resolvers.TimeResolver) *model.ActivityDumpLoadConfig {
 	adlc := &model.ActivityDumpLoadConfig{
 		TracedEventTypes: evt,
 		Timeout:          timeout,

--- a/pkg/security/probe/activity_dump_graph.go
+++ b/pkg/security/probe/activity_dump_graph.go
@@ -111,8 +111,8 @@ func (ad *ActivityDump) prepareGraphData(title string) graph {
 
 func (ad *ActivityDump) prepareProcessActivityNode(p *ProcessActivityNode, data *graph) GraphID {
 	var args string
-	if ad.adm != nil && ad.adm.probe != nil {
-		if argv, _ := ad.adm.probe.resolvers.ProcessResolver.GetProcessScrubbedArgv(&p.Process); len(argv) > 0 {
+	if ad.adm != nil && ad.adm.resolvers != nil {
+		if argv, _ := ad.adm.resolvers.ProcessResolver.GetProcessScrubbedArgv(&p.Process); len(argv) > 0 {
 			args = strings.ReplaceAll(strings.Join(argv, " "), "\"", "\\\"")
 			args = strings.ReplaceAll(args, "\n", " ")
 			args = strings.ReplaceAll(args, ">", "\\>")

--- a/pkg/security/probe/activity_dump_graph.go
+++ b/pkg/security/probe/activity_dump_graph.go
@@ -15,9 +15,9 @@ import (
 	"text/template"
 	"unsafe"
 
+	"github.com/DataDog/datadog-agent/pkg/security/config"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
-	"github.com/DataDog/datadog-agent/pkg/security/config"
 )
 
 var (

--- a/pkg/security/probe/activity_dump_graph.go
+++ b/pkg/security/probe/activity_dump_graph.go
@@ -15,9 +15,9 @@ import (
 	"text/template"
 	"unsafe"
 
-	"github.com/DataDog/datadog-agent/pkg/security/probe/dump"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+	"github.com/DataDog/datadog-agent/pkg/security/config"
 )
 
 var (
@@ -91,7 +91,7 @@ func (ad *ActivityDump) EncodeDOT() (*bytes.Buffer, error) {
 	t := template.Must(template.New("tmpl").Parse(GraphTemplate))
 	raw := bytes.NewBuffer(nil)
 	if err := t.Execute(raw, data); err != nil {
-		return nil, fmt.Errorf("couldn't encode %s in %s: %w", ad.getSelectorStr(), dump.DOT, err)
+		return nil, fmt.Errorf("couldn't encode %s in %s: %w", ad.getSelectorStr(), config.DOT, err)
 	}
 	return raw, nil
 }

--- a/pkg/security/probe/activity_dump_load_controller.go
+++ b/pkg/security/probe/activity_dump_load_controller.go
@@ -14,8 +14,8 @@ import (
 
 	"github.com/cilium/ebpf"
 
+	"github.com/DataDog/datadog-agent/pkg/security/config"
 	"github.com/DataDog/datadog-agent/pkg/security/metrics"
-	"github.com/DataDog/datadog-agent/pkg/security/probe/dump"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/seclog"
 )
@@ -81,7 +81,7 @@ func (lc *ActivityDumpLoadController) NextPartialDump(ad *ActivityDump) *Activit
 	// copy storage requests
 	for _, reqList := range ad.StorageRequests {
 		for _, req := range reqList {
-			newDump.AddStorageRequest(dump.NewStorageRequest(
+			newDump.AddStorageRequest(config.NewStorageRequest(
 				req.Type,
 				req.Format,
 				req.Compression,

--- a/pkg/security/probe/activity_dump_load_controller.go
+++ b/pkg/security/probe/activity_dump_load_controller.go
@@ -37,7 +37,7 @@ type ActivityDumpLoadController struct {
 
 // NewActivityDumpLoadController returns a new activity dump load controller
 func NewActivityDumpLoadController(adm *ActivityDumpManager) (*ActivityDumpLoadController, error) {
-	activityDumpConfigDefaultsMap, found, err := adm.probe.manager.GetMap("activity_dump_config_defaults")
+	activityDumpConfigDefaultsMap, found, err := adm.manager.GetMap("activity_dump_config_defaults")
 	if err != nil {
 		return nil, err
 	}
@@ -55,14 +55,14 @@ func NewActivityDumpLoadController(adm *ActivityDumpManager) (*ActivityDumpLoadC
 func (lc *ActivityDumpLoadController) PushCurrentConfig() error {
 	// push default load config values
 	defaults := NewActivityDumpLoadConfig(
-		lc.adm.probe.config.ActivityDumpTracedEventTypes,
-		lc.adm.probe.config.ActivityDumpCgroupDumpTimeout,
+		lc.adm.config.ActivityDumpTracedEventTypes,
+		lc.adm.config.ActivityDumpCgroupDumpTimeout,
 		0,
-		lc.adm.probe.config.ActivityDumpRateLimiter,
+		lc.adm.config.ActivityDumpRateLimiter,
 		time.Now(),
-		lc.adm.probe.resolvers.TimeResolver,
+		lc.adm.resolvers.TimeResolver,
 	)
-	defaults.WaitListTimestampRaw = uint64(lc.adm.probe.config.ActivityDumpCgroupWaitListTimeout)
+	defaults.WaitListTimestampRaw = uint64(lc.adm.config.ActivityDumpCgroupWaitListTimeout)
 	if err := lc.activityDumpConfigDefaults.Put(uint32(0), defaults); err != nil {
 		return fmt.Errorf("couldn't update default activity dump load config: %w", err)
 	}
@@ -173,7 +173,7 @@ func (lc *ActivityDumpLoadController) reduceDumpTimeout(new *ActivityDump) error
 }
 
 func (lc *ActivityDumpLoadController) sendLoadControllerTriggeredMetric(tags []string) error {
-	if err := lc.adm.probe.statsdClient.Count(metrics.MetricActivityDumpLoadControllerTriggered, 1, tags, 1.0); err != nil {
+	if err := lc.adm.statsdClient.Count(metrics.MetricActivityDumpLoadControllerTriggered, 1, tags, 1.0); err != nil {
 		return fmt.Errorf("couldn't send %s metric: %v", metrics.MetricActivityDumpLoadControllerTriggered, err)
 	}
 	return nil

--- a/pkg/security/probe/activity_dump_local_storage.go
+++ b/pkg/security/probe/activity_dump_local_storage.go
@@ -21,7 +21,7 @@ import (
 	"github.com/hashicorp/golang-lru/v2/simplelru"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
-	"github.com/DataDog/datadog-agent/pkg/security/probe/dump"
+	"github.com/DataDog/datadog-agent/pkg/security/config"
 	"github.com/DataDog/datadog-agent/pkg/security/seclog"
 )
 
@@ -100,7 +100,7 @@ func NewActivityDumpLocalStorage(p *Probe) (ActivityDumpStorage, error) {
 		for _, f := range files {
 			// check if the extension of the file is known
 			ext := filepath.Ext(f.Name())
-			if _, err = dump.ParseStorageFormat(ext); err != nil && ext != ".gz" {
+			if _, err = config.ParseStorageFormat(ext); err != nil && ext != ".gz" {
 				// ignore this file
 				continue
 			}
@@ -140,12 +140,12 @@ func NewActivityDumpLocalStorage(p *Probe) (ActivityDumpStorage, error) {
 }
 
 // GetStorageType returns the storage type of the ActivityDumpLocalStorage
-func (storage *ActivityDumpLocalStorage) GetStorageType() dump.StorageType {
-	return dump.LocalStorage
+func (storage *ActivityDumpLocalStorage) GetStorageType() config.StorageType {
+	return config.LocalStorage
 }
 
 // Persist saves the provided buffer to the persistent storage
-func (storage *ActivityDumpLocalStorage) Persist(request dump.StorageRequest, ad *ActivityDump, raw *bytes.Buffer) error {
+func (storage *ActivityDumpLocalStorage) Persist(request config.StorageRequest, ad *ActivityDump, raw *bytes.Buffer) error {
 	outputPath := request.GetOutputPath(ad.DumpMetadata.Name)
 
 	if request.Compression {

--- a/pkg/security/probe/activity_dump_local_storage.go
+++ b/pkg/security/probe/activity_dump_local_storage.go
@@ -67,7 +67,7 @@ func NewActivityDumpLocalStorage(p *Probe) (ActivityDumpStorage, error) {
 		return &ActivityDumpLocalStorage{}, nil
 	}
 
-	lru, err := simplelru.NewLRU(p.config.ActivityDumpLocalStorageMaxDumpsCount, func(name string, files []string) {
+	lru, err := simplelru.NewLRU(p.Config.ActivityDumpLocalStorageMaxDumpsCount, func(name string, files []string) {
 		if len(files) == 0 {
 			return
 		}
@@ -81,13 +81,13 @@ func NewActivityDumpLocalStorage(p *Probe) (ActivityDumpStorage, error) {
 	}
 
 	// snapshot the dumps in the default output directory
-	if len(p.config.ActivityDumpLocalStorageDirectory) > 0 {
+	if len(p.Config.ActivityDumpLocalStorageDirectory) > 0 {
 		// list all the files in the activity dump output directory
-		files, err := os.ReadDir(p.config.ActivityDumpLocalStorageDirectory)
+		files, err := os.ReadDir(p.Config.ActivityDumpLocalStorageDirectory)
 		if err != nil {
 			if os.IsNotExist(err) {
 				files = make([]os.DirEntry, 0)
-				if err = os.MkdirAll(p.config.ActivityDumpLocalStorageDirectory, 0400); err != nil {
+				if err = os.MkdirAll(p.Config.ActivityDumpLocalStorageDirectory, 0400); err != nil {
 					return nil, fmt.Errorf("couldn't create output directory for cgroup activity dumps: %w", err)
 				}
 			} else {

--- a/pkg/security/probe/activity_dump_manager.go
+++ b/pkg/security/probe/activity_dump_manager.go
@@ -21,7 +21,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/api"
 	"github.com/DataDog/datadog-agent/pkg/security/config"
 	"github.com/DataDog/datadog-agent/pkg/security/metrics"
-	"github.com/DataDog/datadog-agent/pkg/security/probe/dump"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/seclog"
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
@@ -315,8 +314,8 @@ func (adm *ActivityDumpManager) HandleCgroupTracingEvent(event *model.CgroupTrac
 
 	// add local storage requests
 	for _, format := range adm.probe.config.ActivityDumpLocalStorageFormats {
-		newDump.AddStorageRequest(dump.NewStorageRequest(
-			dump.LocalStorage,
+		newDump.AddStorageRequest(config.NewStorageRequest(
+			config.LocalStorage,
 			format,
 			adm.probe.config.ActivityDumpLocalStorageCompression,
 			adm.probe.config.ActivityDumpLocalStorageDirectory,
@@ -325,8 +324,8 @@ func (adm *ActivityDumpManager) HandleCgroupTracingEvent(event *model.CgroupTrac
 
 	// add remote storage requests
 	for _, format := range adm.probe.config.ActivityDumpRemoteStorageFormats {
-		newDump.AddStorageRequest(dump.NewStorageRequest(
-			dump.RemoteStorage,
+		newDump.AddStorageRequest(config.NewStorageRequest(
+			config.RemoteStorage,
 			format,
 			adm.probe.config.ActivityDumpRemoteStorageCompression,
 			"",
@@ -351,7 +350,7 @@ func (adm *ActivityDumpManager) DumpActivity(params *api.ActivityDumpParams) (*a
 	})
 
 	// add local storage requests
-	storageRequests, err := dump.ParseStorageRequests(params.GetStorage())
+	storageRequests, err := config.ParseStorageRequests(params.GetStorage())
 	if err != nil {
 		errMsg := fmt.Errorf("couldn't start tracing [%s]: %v", newDump.GetSelectorStr(), err)
 		return &api.ActivityDumpMessage{Error: errMsg.Error()}, errMsg
@@ -477,7 +476,7 @@ func (adm *ActivityDumpManager) TranscodingRequest(params *api.TranscodingReques
 	}
 
 	// add transcoding requests
-	storageRequests, err := dump.ParseStorageRequests(params.GetStorage())
+	storageRequests, err := config.ParseStorageRequests(params.GetStorage())
 	if err != nil {
 		errMsg := fmt.Errorf("couldn't parse transcoding request for [%s]: %v", ad.GetSelectorStr(), err)
 		return &api.TranscodingRequestMessage{Error: errMsg.Error()}, errMsg

--- a/pkg/security/probe/activity_dump_manager_test.go
+++ b/pkg/security/probe/activity_dump_manager_test.go
@@ -346,17 +346,19 @@ func TestActivityDumpManager_getOverweightDumps(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		probe := &Probe{
+			StatsdClient: &statsd.NoOpClient{},
+			Config: &config.Config{
+				ActivityDumpMaxDumpSize: func() int {
+					return 2048
+				},
+			}}
 		t.Run(tt.name, func(t *testing.T) {
 			adm := &ActivityDumpManager{
-				activeDumps: tt.fields.activeDumps,
-				probe: &Probe{
-					statsdClient: &statsd.NoOpClient{},
-					config: &config.Config{
-						ActivityDumpMaxDumpSize: func() int {
-							return 2048
-						},
-					},
-				},
+				activeDumps:        tt.fields.activeDumps,
+				probe:              probe,
+				config:             probe.Config,
+				statsdClient:       probe.StatsdClient,
 				ignoreFromSnapshot: make(map[string]bool),
 			}
 

--- a/pkg/security/probe/activity_dump_proto_dec_v1.go
+++ b/pkg/security/probe/activity_dump_proto_dec_v1.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	adproto "github.com/DataDog/datadog-agent/pkg/security/adproto/v1"
-	"github.com/DataDog/datadog-agent/pkg/security/probe/dump"
+	"github.com/DataDog/datadog-agent/pkg/security/config"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 )
 
@@ -29,7 +29,7 @@ func protoToActivityDump(dest *ActivityDump, ad *adproto.ActivityDump) {
 	dest.Tags = make([]string, len(ad.Tags))
 	copy(dest.Tags, ad.Tags)
 	dest.ProcessActivityTree = make([]*ProcessActivityNode, 0, len(ad.Tree))
-	dest.StorageRequests = make(map[dump.StorageFormat][]dump.StorageRequest)
+	dest.StorageRequests = make(map[config.StorageFormat][]config.StorageRequest)
 
 	for _, tree := range ad.Tree {
 		dest.ProcessActivityTree = append(dest.ProcessActivityTree, protoDecodeProcessActivityNode(tree))

--- a/pkg/security/probe/activity_dump_remote_storage.go
+++ b/pkg/security/probe/activity_dump_remote_storage.go
@@ -24,7 +24,6 @@ import (
 	logsconfig "github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/security/config"
 	"github.com/DataDog/datadog-agent/pkg/security/metrics"
-	"github.com/DataDog/datadog-agent/pkg/security/probe/dump"
 	"github.com/DataDog/datadog-agent/pkg/security/seclog"
 	ddhttputil "github.com/DataDog/datadog-agent/pkg/util/http"
 )
@@ -47,7 +46,7 @@ func getEndpointURL(endpoint logsconfig.Endpoint, uri string) string {
 }
 
 type tooLargeEntityStatsEntry struct {
-	storageFormat dump.StorageFormat
+	storageFormat config.StorageFormat
 	compression   bool
 }
 
@@ -69,7 +68,7 @@ func NewActivityDumpRemoteStorage() (ActivityDumpStorage, error) {
 		},
 	}
 
-	for _, format := range dump.AllStorageFormats() {
+	for _, format := range config.AllStorageFormats() {
 		for _, compression := range []bool{true, false} {
 			entry := tooLargeEntityStatsEntry{
 				storageFormat: format,
@@ -92,8 +91,8 @@ func NewActivityDumpRemoteStorage() (ActivityDumpStorage, error) {
 }
 
 // GetStorageType returns the storage type of the ActivityDumpLocalStorage
-func (storage *ActivityDumpRemoteStorage) GetStorageType() dump.StorageType {
-	return dump.RemoteStorage
+func (storage *ActivityDumpRemoteStorage) GetStorageType() config.StorageType {
+	return config.RemoteStorage
 }
 
 func (storage *ActivityDumpRemoteStorage) writeEventMetadata(writer *multipart.Writer, ad *ActivityDump) error {
@@ -126,7 +125,7 @@ func (storage *ActivityDumpRemoteStorage) writeEventMetadata(writer *multipart.W
 	return err
 }
 
-func (storage *ActivityDumpRemoteStorage) writeDump(writer *multipart.Writer, request dump.StorageRequest, raw *bytes.Buffer) error {
+func (storage *ActivityDumpRemoteStorage) writeDump(writer *multipart.Writer, request config.StorageRequest, raw *bytes.Buffer) error {
 	h := make(textproto.MIMEHeader)
 	h.Set("Content-Disposition", fmt.Sprintf(`form-data; name="dump"; filename="dump.%s"`, request.Format.String()))
 	h.Set("Content-Type", "application/json")
@@ -141,7 +140,7 @@ func (storage *ActivityDumpRemoteStorage) writeDump(writer *multipart.Writer, re
 	return nil
 }
 
-func (storage *ActivityDumpRemoteStorage) buildBody(request dump.StorageRequest, ad *ActivityDump, raw *bytes.Buffer) (*multipart.Writer, *bytes.Buffer, error) {
+func (storage *ActivityDumpRemoteStorage) buildBody(request config.StorageRequest, ad *ActivityDump, raw *bytes.Buffer) (*multipart.Writer, *bytes.Buffer, error) {
 	body := bytes.NewBuffer(nil)
 	var multipartWriter *multipart.Writer
 
@@ -167,7 +166,7 @@ func (storage *ActivityDumpRemoteStorage) buildBody(request dump.StorageRequest,
 	return multipartWriter, body, nil
 }
 
-func (storage *ActivityDumpRemoteStorage) sendToEndpoint(url string, apiKey string, request dump.StorageRequest, writer *multipart.Writer, body *bytes.Buffer) error {
+func (storage *ActivityDumpRemoteStorage) sendToEndpoint(url string, apiKey string, request config.StorageRequest, writer *multipart.Writer, body *bytes.Buffer) error {
 	r, err := http.NewRequest("POST", url, bytes.NewBuffer(body.Bytes()))
 	if err != nil {
 		return err
@@ -198,7 +197,7 @@ func (storage *ActivityDumpRemoteStorage) sendToEndpoint(url string, apiKey stri
 }
 
 // Persist saves the provided buffer to the persistent storage
-func (storage *ActivityDumpRemoteStorage) Persist(request dump.StorageRequest, ad *ActivityDump, raw *bytes.Buffer) error {
+func (storage *ActivityDumpRemoteStorage) Persist(request config.StorageRequest, ad *ActivityDump, raw *bytes.Buffer) error {
 	writer, body, err := storage.buildBody(request, ad, raw)
 	if err != nil {
 		return fmt.Errorf("couldn't build request: %w", err)

--- a/pkg/security/probe/activity_dump_remote_storage_forwarder.go
+++ b/pkg/security/probe/activity_dump_remote_storage_forwarder.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/security/api"
-	"github.com/DataDog/datadog-agent/pkg/security/probe/dump"
+	"github.com/DataDog/datadog-agent/pkg/security/config"
 	"github.com/DataDog/datadog-agent/pkg/security/seclog"
 )
 
@@ -30,12 +30,12 @@ func NewActivityDumpRemoteStorageForwarder(p *Probe) (ActivityDumpStorage, error
 }
 
 // GetStorageType returns the storage type of the ActivityDumpRemoteStorage
-func (storage *ActivityDumpRemoteStorageForwarder) GetStorageType() dump.StorageType {
-	return dump.RemoteStorage
+func (storage *ActivityDumpRemoteStorageForwarder) GetStorageType() config.StorageType {
+	return config.RemoteStorage
 }
 
 // Persist saves the provided buffer to the persistent storage
-func (storage *ActivityDumpRemoteStorageForwarder) Persist(request dump.StorageRequest, ad *ActivityDump, raw *bytes.Buffer) error {
+func (storage *ActivityDumpRemoteStorageForwarder) Persist(request config.StorageRequest, ad *ActivityDump, raw *bytes.Buffer) error {
 	// set activity dump size for current encoding
 	ad.DumpMetadata.Size = uint64(raw.Len())
 

--- a/pkg/security/probe/activity_dump_storage_manager.go
+++ b/pkg/security/probe/activity_dump_storage_manager.go
@@ -68,7 +68,7 @@ func NewActivityDumpStorageManager(p *Probe) (*ActivityDumpStorageManager, error
 
 	manager := &ActivityDumpStorageManager{
 		storages:     make(map[config.StorageType]ActivityDumpStorage),
-		statsdClient: p.statsdClient,
+		statsdClient: p.StatsdClient,
 	}
 	for _, factory := range storageFactory {
 		storage, err := factory(p)

--- a/pkg/security/probe/activity_dump_storage_manager.go
+++ b/pkg/security/probe/activity_dump_storage_manager.go
@@ -13,17 +13,17 @@ import (
 	"fmt"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
+	"github.com/DataDog/datadog-agent/pkg/security/config"
 	"github.com/DataDog/datadog-agent/pkg/security/metrics"
-	"github.com/DataDog/datadog-agent/pkg/security/probe/dump"
 	"github.com/DataDog/datadog-agent/pkg/security/seclog"
 )
 
 // ActivityDumpStorage defines the interface implemented by all activity dump storages
 type ActivityDumpStorage interface {
 	// GetStorageType returns the storage type
-	GetStorageType() dump.StorageType
+	GetStorageType() config.StorageType
 	// Persist saves the provided buffer to the persistent storage
-	Persist(request dump.StorageRequest, ad *ActivityDump, raw *bytes.Buffer) error
+	Persist(request config.StorageRequest, ad *ActivityDump, raw *bytes.Buffer) error
 	// SendTelemetry sends metrics using the provided metrics sender
 	SendTelemetry(sender aggregator.Sender)
 }
@@ -31,7 +31,7 @@ type ActivityDumpStorage interface {
 // ActivityDumpStorageManager is used to manage activity dump storages
 type ActivityDumpStorageManager struct {
 	probe    *Probe
-	storages map[dump.StorageType]ActivityDumpStorage
+	storages map[config.StorageType]ActivityDumpStorage
 
 	metricsSender aggregator.Sender
 }
@@ -39,7 +39,7 @@ type ActivityDumpStorageManager struct {
 // NewSecurityAgentStorageManager returns a new instance of ActivityDumpStorageManager
 func NewSecurityAgentStorageManager() (*ActivityDumpStorageManager, error) {
 	manager := &ActivityDumpStorageManager{
-		storages: make(map[dump.StorageType]ActivityDumpStorage),
+		storages: make(map[config.StorageType]ActivityDumpStorage),
 	}
 
 	sender, err := aggregator.GetDefaultSender()
@@ -66,7 +66,7 @@ func NewActivityDumpStorageManager(p *Probe) (*ActivityDumpStorageManager, error
 	}
 
 	manager := &ActivityDumpStorageManager{
-		storages: make(map[dump.StorageType]ActivityDumpStorage),
+		storages: make(map[config.StorageType]ActivityDumpStorage),
 		probe:    p,
 	}
 	for _, factory := range storageFactory {
@@ -103,7 +103,7 @@ func (manager *ActivityDumpStorageManager) Persist(ad *ActivityDump) error {
 }
 
 // PersistRaw saves the provided dump to the requested storages
-func (manager *ActivityDumpStorageManager) PersistRaw(requests []dump.StorageRequest, ad *ActivityDump, raw *bytes.Buffer) error {
+func (manager *ActivityDumpStorageManager) PersistRaw(requests []config.StorageRequest, ad *ActivityDump, raw *bytes.Buffer) error {
 	for _, request := range requests {
 		storage, ok := manager.storages[request.Type]
 		if !ok || storage == nil {

--- a/pkg/security/probe/activity_dump_storage_manager_unsupported.go
+++ b/pkg/security/probe/activity_dump_storage_manager_unsupported.go
@@ -13,14 +13,14 @@ import (
 	"fmt"
 
 	"github.com/DataDog/datadog-agent/pkg/security/api"
-	"github.com/DataDog/datadog-agent/pkg/security/probe/dump"
+	"github.com/DataDog/datadog-agent/pkg/security/config"
 )
 
 // ActivityDumpStorageManager is defined for unsupported platforms
 type ActivityDumpStorageManager struct{}
 
 // PersistRaw is defined for unsupported platforms
-func (manager *ActivityDumpStorageManager) PersistRaw(requests []dump.StorageRequest, ad *ActivityDump, raw *bytes.Buffer) error {
+func (manager *ActivityDumpStorageManager) PersistRaw(requests []config.StorageRequest, ad *ActivityDump, raw *bytes.Buffer) error {
 	return nil
 }
 
@@ -34,7 +34,7 @@ func NewSecurityAgentStorageManager() (*ActivityDumpStorageManager, error) {
 
 // ActivityDump is defined for unsupported platforms
 type ActivityDump struct {
-	StorageRequests map[dump.StorageFormat][]dump.StorageRequest
+	StorageRequests map[config.StorageFormat][]config.StorageRequest
 }
 
 // NewActivityDumpFromMessage returns a new ActivityDump from a SecurityActivityDumpMessage

--- a/pkg/security/probe/approvers.go
+++ b/pkg/security/probe/approvers.go
@@ -17,7 +17,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
 )
 
-type onApproverHandler func(probe *Probe, approvers rules.Approvers) (activeApprovers, error)
+type onApproverHandler func(approvers rules.Approvers) (activeApprovers, error)
 type activeApprover = activeKFilter
 type activeApprovers = activeKFilters
 
@@ -66,7 +66,7 @@ func approveFlags(tableName string, flags ...int) (activeApprover, error) {
 	return setFlagsFilter(tableName, flags...)
 }
 
-func onNewBasenameApprovers(probe *Probe, eventType model.EventType, field string, approvers rules.Approvers) ([]activeApprover, error) {
+func onNewBasenameApprovers(eventType model.EventType, field string, approvers rules.Approvers) ([]activeApprover, error) {
 	stringValues := func(fvs rules.FilterValues) []string {
 		var values []string
 		for _, v := range fvs {
@@ -106,8 +106,8 @@ func onNewBasenameApprovers(probe *Probe, eventType model.EventType, field strin
 }
 
 func onNewBasenameApproversWrapper(event model.EventType) onApproverHandler {
-	return func(probe *Probe, approvers rules.Approvers) (activeApprovers, error) {
-		basenameApprovers, err := onNewBasenameApprovers(probe, event, "file", approvers)
+	return func(approvers rules.Approvers) (activeApprovers, error) {
+		basenameApprovers, err := onNewBasenameApprovers(event, "file", approvers)
 		if err != nil {
 			return nil, err
 		}
@@ -116,12 +116,12 @@ func onNewBasenameApproversWrapper(event model.EventType) onApproverHandler {
 }
 
 func onNewTwoBasenamesApproversWrapper(event model.EventType, field1, field2 string) onApproverHandler {
-	return func(probe *Probe, approvers rules.Approvers) (activeApprovers, error) {
-		basenameApprovers, err := onNewBasenameApprovers(probe, event, field1, approvers)
+	return func(approvers rules.Approvers) (activeApprovers, error) {
+		basenameApprovers, err := onNewBasenameApprovers(event, field1, approvers)
 		if err != nil {
 			return nil, err
 		}
-		basenameApprovers2, err := onNewBasenameApprovers(probe, event, field2, approvers)
+		basenameApprovers2, err := onNewBasenameApprovers(event, field2, approvers)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/security/probe/bpf.go
+++ b/pkg/security/probe/bpf.go
@@ -12,11 +12,11 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/ebpf/kernel"
 )
 
-func getCheckHelperCallInputType(probe *Probe) uint64 {
+func getCheckHelperCallInputType(kernelVersion *kernel.Version) uint64 {
 	input := uint64(1)
 
 	switch {
-	case probe.kernelVersion.Code != 0 && probe.kernelVersion.Code >= kernel.Kernel5_13:
+	case kernelVersion.Code != 0 && kernelVersion.Code >= kernel.Kernel5_13:
 		input = uint64(2)
 	}
 

--- a/pkg/security/probe/custom_events.go
+++ b/pkg/security/probe/custom_events.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/mailru/easyjson"
 
+	"github.com/DataDog/datadog-agent/pkg/security/probe/resolvers"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
@@ -271,7 +272,7 @@ func NewNoisyProcessEvent(count uint64,
 
 func resolutionErrorToEventType(err error) model.EventType {
 	switch err.(type) {
-	case ErrTruncatedParents, ErrTruncatedParentsERPC:
+	case resolvers.ErrTruncatedParents, resolvers.ErrTruncatedParentsERPC:
 		return model.CustomTruncatedParentsEventType
 	default:
 		return model.UnknownEventType

--- a/pkg/security/probe/discarder_monitor.go
+++ b/pkg/security/probe/discarder_monitor.go
@@ -12,11 +12,13 @@ import (
 	"fmt"
 
 	"github.com/DataDog/datadog-go/v5/statsd"
+	manager "github.com/DataDog/ebpf-manager"
 
 	lib "github.com/cilium/ebpf"
 
 	"github.com/DataDog/datadog-agent/pkg/security/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/security/metrics"
+	"github.com/DataDog/datadog-agent/pkg/security/probe/managerhelper"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
 )
@@ -80,31 +82,31 @@ func (d *DiscarderMonitor) SendStats() error {
 }
 
 // NewDiscarderMonitor returns a new DiscarderMonitor
-func NewDiscarderMonitor(p *Probe) (*DiscarderMonitor, error) {
+func NewDiscarderMonitor(manager *manager.Manager, statsdClient statsd.ClientInterface) (*DiscarderMonitor, error) {
 	numCPU, err := utils.NumCPU()
 	if err != nil {
 		return nil, fmt.Errorf("couldn't fetch the host CPU count: %w", err)
 	}
 
 	d := &DiscarderMonitor{
-		statsdClient: p.statsdClient,
+		statsdClient: statsdClient,
 		statsZero:    make([]DiscarderStats, numCPU),
 		numCPU:       numCPU,
 	}
 
-	statsFB, err := p.Map("discarder_stats_fb")
+	statsFB, err := managerhelper.Map(manager, "discarder_stats_fb")
 	if err != nil {
 		return nil, err
 	}
 	d.stats[0] = statsFB
 
-	statsBB, err := p.Map("discarder_stats_bb")
+	statsBB, err := managerhelper.Map(manager, "discarder_stats_bb")
 	if err != nil {
 		return nil, err
 	}
 	d.stats[1] = statsBB
 
-	bufferSelector, err := p.Map("buffer_selector")
+	bufferSelector, err := managerhelper.Map(manager, "buffer_selector")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/security/probe/discarders.go
+++ b/pkg/security/probe/discarders.go
@@ -19,6 +19,8 @@ import (
 	manager "github.com/DataDog/ebpf-manager"
 	"github.com/cilium/ebpf"
 
+	"github.com/DataDog/datadog-agent/pkg/security/probe/erpc"
+	"github.com/DataDog/datadog-agent/pkg/security/probe/resolvers"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
@@ -107,13 +109,13 @@ var InvalidDiscarders = map[eval.Field][]interface{}{
 }
 
 // bumpDiscardersRevision sends an eRPC request to bump the discarders revisionr
-func bumpDiscardersRevision(erpc *ERPC) error {
-	var req ERPCRequest
-	req.OP = BumpDiscardersRevision
-	return erpc.Request(&req)
+func bumpDiscardersRevision(e *erpc.ERPC) error {
+	var req erpc.ERPCRequest
+	req.OP = erpc.BumpDiscardersRevision
+	return e.Request(&req)
 }
 
-func marshalDiscardHeader(req *ERPCRequest, eventType model.EventType, timeout uint64) int {
+func marshalDiscardHeader(req *erpc.ERPCRequest, eventType model.EventType, timeout uint64) int {
 	model.ByteOrder.PutUint64(req.Data[0:8], uint64(eventType))
 	model.ByteOrder.PutUint64(req.Data[8:16], timeout)
 
@@ -121,24 +123,24 @@ func marshalDiscardHeader(req *ERPCRequest, eventType model.EventType, timeout u
 }
 
 type pidDiscarders struct {
-	erpc *ERPC
+	erpc *erpc.ERPC
 }
 
-func (p *pidDiscarders) discardWithTimeout(req *ERPCRequest, eventType model.EventType, pid uint32, timeout int64) error {
-	req.OP = DiscardPidOp
+func (p *pidDiscarders) discardWithTimeout(req *erpc.ERPCRequest, eventType model.EventType, pid uint32, timeout int64) error {
+	req.OP = erpc.DiscardPidOp
 	offset := marshalDiscardHeader(req, eventType, uint64(timeout))
 	model.ByteOrder.PutUint32(req.Data[offset:offset+4], pid)
 
 	return p.erpc.Request(req)
 }
 
-func newPidDiscarders(erpc *ERPC) *pidDiscarders {
+func newPidDiscarders(erpc *erpc.ERPC) *pidDiscarders {
 	return &pidDiscarders{erpc: erpc}
 }
 
 // InodeDiscarderMapEntry describes a map entry
 type InodeDiscarderMapEntry struct {
-	PathKey PathKey
+	PathKey resolvers.PathKey
 	IsLeaf  uint32
 	Padding uint32
 }
@@ -176,8 +178,8 @@ func recentlyAddedIndex(mountID uint32, inode uint64) uint64 {
 
 // inodeDiscarders is used to issue eRPC discarder requests
 type inodeDiscarders struct {
-	erpc           *ERPC
-	dentryResolver *DentryResolver
+	erpc           *erpc.ERPC
+	dentryResolver *resolvers.DentryResolver
 	rs             *rules.RuleSet
 	discarderEvent *Event
 	evalCtx        *eval.Context
@@ -188,7 +190,7 @@ type inodeDiscarders struct {
 	recentlyAddedEntries [maxRecentlyAddedCacheSize]InodeDiscarderEntry
 }
 
-func newInodeDiscarders(erpc *ERPC, dentryResolver *DentryResolver) *inodeDiscarders {
+func newInodeDiscarders(erpc *erpc.ERPC, dentryResolver *resolvers.DentryResolver) *inodeDiscarders {
 	event := NewEvent(nil, nil, nil)
 	ctx := eval.NewContext(event.GetPointer())
 
@@ -224,13 +226,13 @@ func (id *inodeDiscarders) recentlyAdded(mountID uint32, inode uint64, timestamp
 	entry.Timestamp = timestamp
 }
 
-func (id *inodeDiscarders) discardInode(req *ERPCRequest, eventType model.EventType, mountID uint32, inode uint64, isLeaf bool) error {
+func (id *inodeDiscarders) discardInode(req *erpc.ERPCRequest, eventType model.EventType, mountID uint32, inode uint64, isLeaf bool) error {
 	var isLeafInt uint32
 	if isLeaf {
 		isLeafInt = 1
 	}
 
-	req.OP = DiscardInodeOp
+	req.OP = erpc.DiscardInodeOp
 
 	offset := marshalDiscardHeader(req, eventType, 0)
 	model.ByteOrder.PutUint64(req.Data[offset:offset+8], inode)
@@ -422,7 +424,7 @@ func (id *inodeDiscarders) isParentPathDiscarder(rs *rules.RuleSet, eventType mo
 	return true, nil
 }
 
-func (id *inodeDiscarders) discardParentInode(req *ERPCRequest, rs *rules.RuleSet, eventType model.EventType, field eval.Field, filename string, mountID uint32, inode uint64, pathID uint32, timestamp uint64) (bool, uint32, uint64, error) {
+func (id *inodeDiscarders) discardParentInode(req *erpc.ERPCRequest, rs *rules.RuleSet, eventType model.EventType, field eval.Field, filename string, mountID uint32, inode uint64, pathID uint32, timestamp uint64) (bool, uint32, uint64, error) {
 	var discarderDepth int
 	var isDiscarder bool
 	var err error
@@ -440,7 +442,7 @@ func (id *inodeDiscarders) discardParentInode(req *ERPCRequest, rs *rules.RuleSe
 
 	for i := 0; i < discarderDepth; i++ {
 		parentMountID, parentInode, err := id.dentryResolver.GetParent(mountID, inode, pathID)
-		if err != nil || IsFakeInode(parentInode) {
+		if err != nil || resolvers.IsFakeInode(parentInode) {
 			if i == 0 {
 				return false, 0, 0, err
 			}
@@ -492,8 +494,8 @@ func filenameDiscarderWrapper(eventType model.EventType, getter inodeEventGetter
 
 			isDiscarded, _, parentInode, err := probe.inodeDiscarders.discardParentInode(probe.erpcRequest, rs, eventType, field, filename, mountID, inode, pathID, event.TimestampRaw)
 			if !isDiscarded && !isDeleted {
-				if _, ok := err.(*ErrInvalidKeyPath); !ok {
-					if !IsFakeInode(inode) {
+				if _, ok := err.(*resolvers.ErrInvalidKeyPath); !ok {
+					if !resolvers.IsFakeInode(inode) {
 						seclog.Tracef("Apply `%s.file.path` inode discarder for event `%s`, inode: %d(%s)", eventType, eventType, inode, filename)
 
 						// not able to discard the parent then only discard the filename
@@ -566,7 +568,7 @@ type DiscardersDump struct {
 	Stats  map[string]DiscarderStats `yaml:"stats"`
 }
 
-func dumpPidDiscarders(resolver *DentryResolver, pidMap *ebpf.Map) ([]PidDiscarderDump, error) {
+func dumpPidDiscarders(resolver *resolvers.DentryResolver, pidMap *ebpf.Map) ([]PidDiscarderDump, error) {
 	var dumps []PidDiscarderDump
 
 	info, err := pidMap.Info()
@@ -597,7 +599,7 @@ func dumpPidDiscarders(resolver *DentryResolver, pidMap *ebpf.Map) ([]PidDiscard
 	return dumps, nil
 }
 
-func dumpInodeDiscarders(resolver *DentryResolver, inodeMap *ebpf.Map) ([]InodeDiscarderDump, error) {
+func dumpInodeDiscarders(resolver *resolvers.DentryResolver, inodeMap *ebpf.Map) ([]InodeDiscarderDump, error) {
 	var dumps []InodeDiscarderDump
 
 	info, err := inodeMap.Info()
@@ -670,7 +672,7 @@ func dumpDiscarderStats(buffers ...*ebpf.Map) (map[string]DiscarderStats, error)
 }
 
 // DumpDiscarders removes all the discarders
-func dumpDiscarders(resolver *DentryResolver, pidMap, inodeMap, statsFB, statsBB *ebpf.Map) (DiscardersDump, error) {
+func dumpDiscarders(resolver *resolvers.DentryResolver, pidMap, inodeMap, statsFB, statsBB *ebpf.Map) (DiscardersDump, error) {
 	seclog.Debugf("Dumping discarders")
 
 	dump := DiscardersDump{

--- a/pkg/security/probe/erpc/erpc.go
+++ b/pkg/security/probe/erpc/erpc.go
@@ -6,7 +6,7 @@
 //go:build linux
 // +build linux
 
-package probe
+package erpc
 
 import (
 	"errors"

--- a/pkg/security/probe/kfilters_bpf.go
+++ b/pkg/security/probe/kfilters_bpf.go
@@ -8,9 +8,14 @@
 
 package probe
 
+import (
+	"github.com/DataDog/datadog-agent/pkg/security/probe/managerhelper"
+	manager "github.com/DataDog/ebpf-manager"
+)
+
 type activeKFilter interface {
-	Remove(*Probe) error
-	Apply(*Probe) error
+	Remove(*manager.Manager) error
+	Apply(*manager.Manager) error
 	Key() interface{}
 }
 
@@ -64,16 +69,16 @@ func (e *arrayEntry) Key() interface{} {
 	}
 }
 
-func (e *arrayEntry) Remove(probe *Probe) error {
-	table, err := probe.Map(e.tableName)
+func (e *arrayEntry) Remove(manager *manager.Manager) error {
+	table, err := managerhelper.Map(manager, e.tableName)
 	if err != nil {
 		return err
 	}
 	return table.Put(e.index, e.zeroValue)
 }
 
-func (e *arrayEntry) Apply(probe *Probe) error {
-	table, err := probe.Map(e.tableName)
+func (e *arrayEntry) Apply(manager *manager.Manager) error {
+	table, err := managerhelper.Map(manager, e.tableName)
 	if err != nil {
 		return err
 	}
@@ -94,8 +99,8 @@ func (e *mapEventMask) Key() interface{} {
 	}
 }
 
-func (e *mapEventMask) Remove(probe *Probe) error {
-	table, err := probe.Map(e.tableName)
+func (e *mapEventMask) Remove(manager *manager.Manager) error {
+	table, err := managerhelper.Map(manager, e.tableName)
 	if err != nil {
 		return err
 	}
@@ -109,8 +114,8 @@ func (e *mapEventMask) Remove(probe *Probe) error {
 	return table.Put(e.tableKey, eventMask)
 }
 
-func (e *mapEventMask) Apply(probe *Probe) error {
-	table, err := probe.Map(e.tableName)
+func (e *mapEventMask) Apply(manager *manager.Manager) error {
+	table, err := managerhelper.Map(manager, e.tableName)
 	if err != nil {
 		return err
 	}

--- a/pkg/security/probe/load_controller.go
+++ b/pkg/security/probe/load_controller.go
@@ -19,6 +19,7 @@ import (
 	"golang.org/x/time/rate"
 
 	"github.com/DataDog/datadog-agent/pkg/security/metrics"
+	"github.com/DataDog/datadog-agent/pkg/security/probe/erpc"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/seclog"
 )
@@ -133,7 +134,7 @@ func (lc *LoadController) discardNoisiestProcess() {
 		return
 	}
 
-	var erpcRequest ERPCRequest
+	var erpcRequest erpc.ERPCRequest
 
 	// push a temporary discarder on the noisiest process & event type tuple
 	seclog.Tracef("discarding events from pid %d for %s seconds", maxKey.Pid, lc.DiscarderTimeout)

--- a/pkg/security/probe/load_controller.go
+++ b/pkg/security/probe/load_controller.go
@@ -51,7 +51,7 @@ type LoadController struct {
 
 // NewLoadController instantiates a new load controller
 func NewLoadController(probe *Probe) (*LoadController, error) {
-	lru, err := simplelru.NewLRU[eventCounterLRUKey, *atomic.Uint64](probe.config.PIDCacheSize, nil)
+	lru, err := simplelru.NewLRU[eventCounterLRUKey, *atomic.Uint64](probe.Config.PIDCacheSize, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -63,9 +63,9 @@ func NewLoadController(probe *Probe) (*LoadController, error) {
 		eventsCounters:     lru,
 		pidDiscardersCount: atomic.NewInt64(0),
 
-		EventsCountThreshold: probe.config.LoadControllerEventsCountThreshold,
-		DiscarderTimeout:     probe.config.LoadControllerDiscarderTimeout,
-		ControllerPeriod:     probe.config.LoadControllerControlPeriod,
+		EventsCountThreshold: probe.Config.LoadControllerEventsCountThreshold,
+		DiscarderTimeout:     probe.Config.LoadControllerDiscarderTimeout,
+		ControllerPeriod:     probe.Config.LoadControllerControlPeriod,
 
 		NoisyProcessCustomEventRate: rate.NewLimiter(rate.Every(time.Second), defaultRateLimit),
 	}
@@ -76,7 +76,7 @@ func NewLoadController(probe *Probe) (*LoadController, error) {
 func (lc *LoadController) SendStats() error {
 	// send load_controller.pids_discarder metric
 	if count := lc.pidDiscardersCount.Swap(0); count > 0 {
-		if err := lc.probe.statsdClient.Count(metrics.MetricLoadControllerPidDiscarder, count, []string{}, 1.0); err != nil {
+		if err := lc.probe.StatsdClient.Count(metrics.MetricLoadControllerPidDiscarder, count, []string{}, 1.0); err != nil {
 			return fmt.Errorf("couldn't send load_controller.pids_discarder metric: %w", err)
 		}
 	}

--- a/pkg/security/probe/managerhelper/managerhelper.go
+++ b/pkg/security/probe/managerhelper/managerhelper.go
@@ -1,0 +1,30 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+// +build linux
+
+package managerhelper
+
+import (
+	"fmt"
+
+	manager "github.com/DataDog/ebpf-manager"
+	lib "github.com/cilium/ebpf"
+)
+
+// Map returns a map by its name
+func Map(manager *manager.Manager, name string) (*lib.Map, error) {
+	if manager == nil {
+		return nil, fmt.Errorf("failed to get map '%s', manager is null", name)
+	}
+	m, ok, err := manager.GetMap(name)
+	if err != nil {
+		return nil, err
+	} else if !ok {
+		return nil, fmt.Errorf("failed to get map '%s'", name)
+	}
+	return m, nil
+}

--- a/pkg/security/probe/mmap.go
+++ b/pkg/security/probe/mmap.go
@@ -36,7 +36,7 @@ var mmapCapabilities = Capabilities{
 	},
 }
 
-func mmapOnNewApprovers(probe *Probe, approvers rules.Approvers) (activeApprovers, error) {
+func mmapOnNewApprovers(approvers rules.Approvers) (activeApprovers, error) {
 	intValues := func(fvs rules.FilterValues) []int {
 		var values []int
 		for _, v := range fvs {
@@ -45,7 +45,7 @@ func mmapOnNewApprovers(probe *Probe, approvers rules.Approvers) (activeApprover
 		return values
 	}
 
-	mmapApprovers, err := onNewBasenameApprovers(probe, model.MMapEventType, "file", approvers)
+	mmapApprovers, err := onNewBasenameApprovers(model.MMapEventType, "file", approvers)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/security/probe/model_test.go
+++ b/pkg/security/probe/model_test.go
@@ -15,8 +15,12 @@ import (
 	"sort"
 	"testing"
 
+	pconfig "github.com/DataDog/datadog-agent/pkg/process/config"
+	"github.com/DataDog/datadog-agent/pkg/security/config"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+	"github.com/DataDog/datadog-go/v5/statsd"
+	manager "github.com/DataDog/ebpf-manager"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -78,7 +82,8 @@ func TestProcessArgsFlags(t *testing.T) {
 		},
 	}
 
-	resolver, _ := NewProcessResolver(&Probe{}, nil, NewProcessResolverOpts(nil))
+	resolver, _ := NewProcessResolver(&manager.Manager{}, &config.Config{}, &statsd.NoOpClient{},
+		&pconfig.DataScrubber{}, nil, NewProcessResolverOpts(nil))
 	e.resolvers = &Resolvers{
 		ProcessResolver: resolver,
 	}
@@ -137,7 +142,8 @@ func TestProcessArgsOptions(t *testing.T) {
 		},
 	}
 
-	resolver, _ := NewProcessResolver(&Probe{}, nil, NewProcessResolverOpts(nil))
+	resolver, _ := NewProcessResolver(&manager.Manager{}, &config.Config{}, &statsd.NoOpClient{},
+		&pconfig.DataScrubber{}, nil, NewProcessResolverOpts(nil))
 	e.resolvers = &Resolvers{
 		ProcessResolver: resolver,
 	}

--- a/pkg/security/probe/mprotect.go
+++ b/pkg/security/probe/mprotect.go
@@ -26,7 +26,7 @@ var mprotectCapabilities = Capabilities{
 	},
 }
 
-func mprotectOnNewApprovers(probe *Probe, approvers rules.Approvers) (activeApprovers, error) {
+func mprotectOnNewApprovers(approvers rules.Approvers) (activeApprovers, error) {
 	intValues := func(fvs rules.FilterValues) []int {
 		var values []int
 		for _, v := range fvs {

--- a/pkg/security/probe/namespace_resolver.go
+++ b/pkg/security/probe/namespace_resolver.go
@@ -207,9 +207,9 @@ func NewNamespaceResolver(probe *Probe) (*NamespaceResolver, error) {
 	nr := &NamespaceResolver{
 		state:   atomic.NewInt64(0),
 		probe:   probe,
-		client:  probe.statsdClient,
-		config:  probe.config,
-		manager: probe.manager,
+		client:  probe.StatsdClient,
+		config:  probe.Config,
+		manager: probe.Manager,
 	}
 
 	lru, err := simplelru.NewLRU(1024, func(key uint32, value *NetworkNamespace) {
@@ -586,7 +586,7 @@ func (nr *NamespaceResolver) dump(params *api.DumpNetworkNamespaceParams) []Netw
 				continue
 			}
 
-			ntl, err = nr.probe.manager.GetNetlinkSocket(uint64(handle.Fd()), netns.nsID)
+			ntl, err = nr.probe.Manager.GetNetlinkSocket(uint64(handle.Fd()), netns.nsID)
 			if err == nil {
 				links, err = ntl.Sock.LinkList()
 				if err == nil {

--- a/pkg/security/probe/namespace_resolver.go
+++ b/pkg/security/probe/namespace_resolver.go
@@ -26,6 +26,7 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/DataDog/datadog-agent/pkg/security/api"
+	"github.com/DataDog/datadog-agent/pkg/security/config"
 	"github.com/DataDog/datadog-agent/pkg/security/ebpf/kernel"
 	"github.com/DataDog/datadog-agent/pkg/security/metrics"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
@@ -192,9 +193,11 @@ func (nn *NetworkNamespace) hasValidHandle() bool {
 // NamespaceResolver is used to store namespace handles
 type NamespaceResolver struct {
 	sync.Mutex
-	state  *atomic.Int64
-	probe  *Probe
-	client statsd.ClientInterface
+	state   *atomic.Int64
+	probe   *Probe
+	client  statsd.ClientInterface
+	config  *config.Config
+	manager *manager.Manager
 
 	networkNamespaces *simplelru.LRU[uint32, *NetworkNamespace]
 }
@@ -202,9 +205,11 @@ type NamespaceResolver struct {
 // NewNamespaceResolver returns a new instance of NamespaceResolver
 func NewNamespaceResolver(probe *Probe) (*NamespaceResolver, error) {
 	nr := &NamespaceResolver{
-		state:  atomic.NewInt64(0),
-		probe:  probe,
-		client: probe.statsdClient,
+		state:   atomic.NewInt64(0),
+		probe:   probe,
+		client:  probe.statsdClient,
+		config:  probe.config,
+		manager: probe.manager,
 	}
 
 	lru, err := simplelru.NewLRU(1024, func(key uint32, value *NetworkNamespace) {
@@ -232,7 +237,7 @@ func (nr *NamespaceResolver) GetState() int64 {
 // SaveNetworkNamespaceHandle inserts the provided process network namespace in the list of tracked network. Returns
 // true if a new entry was added.
 func (nr *NamespaceResolver) SaveNetworkNamespaceHandle(nsID uint32, nsPath *utils.NetNSPath) (*NetworkNamespace, bool) {
-	if !nr.probe.config.NetworkEnabled || nsID == 0 || nsPath == nil {
+	if !nr.config.NetworkEnabled || nsID == 0 || nsPath == nil {
 		return nil, false
 	}
 
@@ -273,7 +278,7 @@ func (nr *NamespaceResolver) SaveNetworkNamespaceHandle(nsID uint32, nsPath *uti
 // close this file descriptor when it is done using it. Do not forget to close this file descriptor, otherwise we might
 // exhaust the host IPs by keeping all network namespaces alive.
 func (nr *NamespaceResolver) ResolveNetworkNamespace(nsID uint32) *NetworkNamespace {
-	if !nr.probe.config.NetworkEnabled || nsID == 0 {
+	if !nr.config.NetworkEnabled || nsID == 0 {
 		return nil
 	}
 
@@ -296,7 +301,7 @@ func (nr *NamespaceResolver) snapshotNetworkDevices(netns *NetworkNamespace) int
 	}
 	defer handle.Close()
 
-	ntl, err := nr.probe.manager.GetNetlinkSocket(uint64(handle.Fd()), netns.nsID)
+	ntl, err := nr.manager.GetNetlinkSocket(uint64(handle.Fd()), netns.nsID)
 	if err != nil {
 		seclog.Errorf("couldn't open netlink socket: %s", err)
 		return 0
@@ -334,7 +339,7 @@ func (nr *NamespaceResolver) snapshotNetworkDevices(netns *NetworkNamespace) int
 // IsLazyDeletionInterface returns true if an interface name is in the list of interfaces that aren't explicitly deleted by the
 // container runtime when a container is deleted.
 func (nr *NamespaceResolver) IsLazyDeletionInterface(name string) bool {
-	for _, lazyPrefix := range nr.probe.config.NetworkLazyInterfacePrefixes {
+	for _, lazyPrefix := range nr.config.NetworkLazyInterfacePrefixes {
 		if strings.HasPrefix(name, lazyPrefix) {
 			return true
 		}
@@ -344,7 +349,7 @@ func (nr *NamespaceResolver) IsLazyDeletionInterface(name string) bool {
 
 // SyncCache snapshots /proc for the provided pid. This method returns true if it updated the namespace cache.
 func (nr *NamespaceResolver) SyncCache(proc *process.Process) bool {
-	if !nr.probe.config.NetworkEnabled {
+	if !nr.config.NetworkEnabled {
 		return false
 	}
 
@@ -362,7 +367,7 @@ func (nr *NamespaceResolver) SyncCache(proc *process.Process) bool {
 // of the device is resolved, a new TC classifier will automatically be added to the device. The queue is cleaned up
 // periodically if a namespace do not own any process.
 func (nr *NamespaceResolver) QueueNetworkDevice(device model.NetDevice) {
-	if !nr.probe.config.NetworkEnabled {
+	if !nr.config.NetworkEnabled {
 		return
 	}
 
@@ -384,7 +389,7 @@ func (nr *NamespaceResolver) QueueNetworkDevice(device model.NetDevice) {
 
 // Start starts the namespace flush goroutine
 func (nr *NamespaceResolver) Start(ctx context.Context) error {
-	if !nr.probe.config.NetworkEnabled {
+	if !nr.config.NetworkEnabled {
 		return nil
 	}
 
@@ -434,14 +439,14 @@ func (nr *NamespaceResolver) flushNetworkNamespace(netns *NetworkNamespace) {
 	handle, err := netns.getNamespaceHandleDup()
 	if err == nil {
 		defer handle.Close()
-		_, _ = nr.probe.manager.GetNetlinkSocket(uint64(handle.Fd()), netns.nsID)
+		_, _ = nr.manager.GetNetlinkSocket(uint64(handle.Fd()), netns.nsID)
 	}
 
 	// close network namespace handle to release the namespace
 	netns.close()
 
 	// remove all references to this network namespace from the manager
-	_ = nr.probe.manager.CleanupNetworkNamespace(netns.nsID)
+	_ = nr.manager.CleanupNetworkNamespace(netns.nsID)
 }
 
 // preventNetworkNamespaceDrift ensures that we do not keep network namespace handles indefinitely

--- a/pkg/security/probe/open.go
+++ b/pkg/security/probe/open.go
@@ -34,7 +34,7 @@ var openCapabilities = Capabilities{
 	},
 }
 
-func openOnNewApprovers(probe *Probe, approvers rules.Approvers) (activeApprovers, error) {
+func openOnNewApprovers(approvers rules.Approvers) (activeApprovers, error) {
 	intValues := func(fvs rules.FilterValues) []int {
 		var values []int
 		for _, v := range fvs {
@@ -43,7 +43,7 @@ func openOnNewApprovers(probe *Probe, approvers rules.Approvers) (activeApprover
 		return values
 	}
 
-	openApprovers, err := onNewBasenameApprovers(probe, model.FileOpenEventType, "file", approvers)
+	openApprovers, err := onNewBasenameApprovers(model.FileOpenEventType, "file", approvers)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/security/probe/perf_buffer_monitor.go
+++ b/pkg/security/probe/perf_buffer_monitor.go
@@ -90,8 +90,8 @@ type PerfBufferMonitor struct {
 func NewPerfBufferMonitor(p *Probe) (*PerfBufferMonitor, error) {
 	pbm := PerfBufferMonitor{
 		probe:               p,
-		config:              p.config,
-		statsdClient:        p.statsdClient,
+		config:              p.Config,
+		statsdClient:        p.StatsdClient,
 		perfBufferStatsMaps: make(map[string]*lib.Map),
 		perfBufferSize:      make(map[string]float64),
 
@@ -118,7 +118,7 @@ func NewPerfBufferMonitor(p *Probe) (*PerfBufferMonitor, error) {
 
 	// Select perf buffer statistics maps
 	for perfMapName, statsMapName := range pbm.perfBufferMapNameToStatsMapsName {
-		stats, ok, err := p.manager.GetMap(statsMapName)
+		stats, ok, err := p.Manager.GetMap(statsMapName)
 		if !ok {
 			return nil, fmt.Errorf("map %s not found", statsMapName)
 		}
@@ -135,12 +135,12 @@ func NewPerfBufferMonitor(p *Probe) (*PerfBufferMonitor, error) {
 		}
 	}
 
-	maps := make(map[string]int, len(p.manager.PerfMaps)+len(p.manager.RingBuffers))
-	for _, pm := range p.manager.PerfMaps {
+	maps := make(map[string]int, len(p.Manager.PerfMaps)+len(p.Manager.RingBuffers))
+	for _, pm := range p.Manager.PerfMaps {
 		maps[pm.Name] = pm.PerfRingBufferSize
 	}
 
-	for _, rb := range p.manager.RingBuffers {
+	for _, rb := range p.Manager.RingBuffers {
 		maps[rb.Name] = rb.RingBufferSize
 	}
 

--- a/pkg/security/probe/perf_buffer_monitor.go
+++ b/pkg/security/probe/perf_buffer_monitor.go
@@ -15,6 +15,7 @@ import (
 	lib "github.com/cilium/ebpf"
 	"go.uber.org/atomic"
 
+	"github.com/DataDog/datadog-agent/pkg/security/config"
 	"github.com/DataDog/datadog-agent/pkg/security/ebpf/probes"
 	"github.com/DataDog/datadog-agent/pkg/security/metrics"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
@@ -53,7 +54,9 @@ func (s *PerfMapStats) UnmarshalBinary(data []byte) error {
 //nolint:structcheck,unused
 type PerfBufferMonitor struct {
 	// probe is a pointer to the Probe
-	probe *Probe
+	probe        *Probe
+	config       *config.Config
+	statsdClient statsd.ClientInterface
 	// numCPU holds the current count of CPU
 	numCPU int
 	// perfBufferStatsMaps holds the pointers to the statistics kernel maps
@@ -87,6 +90,8 @@ type PerfBufferMonitor struct {
 func NewPerfBufferMonitor(p *Probe) (*PerfBufferMonitor, error) {
 	pbm := PerfBufferMonitor{
 		probe:               p,
+		config:              p.config,
+		statsdClient:        p.statsdClient,
 		perfBufferStatsMaps: make(map[string]*lib.Map),
 		perfBufferSize:      make(map[string]float64),
 
@@ -380,7 +385,7 @@ func (pbm *PerfBufferMonitor) CountEvent(eventType model.EventType, timestamp ui
 func (pbm *PerfBufferMonitor) sendEventsAndBytesReadStats(client statsd.ClientInterface) error {
 	var count int64
 	var err error
-	tags := []string{pbm.probe.config.StatsTagsCardinality, "", ""}
+	tags := []string{pbm.config.StatsTagsCardinality, "", ""}
 
 	for m := range pbm.stats {
 		tags[1] = fmt.Sprintf("map:%s", m)
@@ -402,7 +407,7 @@ func (pbm *PerfBufferMonitor) sendEventsAndBytesReadStats(client statsd.ClientIn
 				}
 
 				if count = pbm.getAndResetSortingErrorCount(evtType, m); count > 0 {
-					if err = pbm.probe.statsdClient.Count(metrics.MetricPerfBufferSortingError, count, tags, 1.0); err != nil {
+					if err = pbm.statsdClient.Count(metrics.MetricPerfBufferSortingError, count, tags, 1.0); err != nil {
 						return err
 					}
 				}
@@ -413,7 +418,7 @@ func (pbm *PerfBufferMonitor) sendEventsAndBytesReadStats(client statsd.ClientIn
 }
 
 func (pbm *PerfBufferMonitor) sendLostEventsReadStats(client statsd.ClientInterface) error {
-	tags := []string{pbm.probe.config.StatsTagsCardinality, ""}
+	tags := []string{pbm.config.StatsTagsCardinality, ""}
 
 	for m := range pbm.readLostEvents {
 		var total float64
@@ -450,7 +455,7 @@ func (pbm *PerfBufferMonitor) collectAndSendKernelStats(client statsd.ClientInte
 		cpuStats[i] = NewPerfMapStats()
 	}
 
-	tags := []string{pbm.probe.config.StatsTagsCardinality, "", ""}
+	tags := []string{pbm.config.StatsTagsCardinality, "", ""}
 
 	// loop through the statistics buffers of each perf map
 	for perfMapName, statsMap := range pbm.perfBufferStatsMaps {
@@ -522,7 +527,7 @@ func (pbm *PerfBufferMonitor) collectAndSendKernelStats(client statsd.ClientInte
 			)
 
 			// snapshot traced cgroups if a CgroupTracing event was lost
-			if pbm.probe.config.ActivityDumpEnabled && perEvent[model.CgroupTracingEventType.String()] > 0 {
+			if pbm.config.ActivityDumpEnabled && perEvent[model.CgroupTracingEventType.String()] > 0 {
 				pbm.probe.monitor.activityDumpManager.snapshotTracedCgroups()
 			}
 		}
@@ -554,7 +559,7 @@ func (pbm *PerfBufferMonitor) sendKernelStats(client statsd.ClientInterface, sta
 
 // SendStats send event stats using the provided statsd client
 func (pbm *PerfBufferMonitor) SendStats() error {
-	if err := pbm.collectAndSendKernelStats(pbm.probe.statsdClient); err != nil {
+	if err := pbm.collectAndSendKernelStats(pbm.statsdClient); err != nil {
 		return err
 	}
 
@@ -562,9 +567,9 @@ func (pbm *PerfBufferMonitor) SendStats() error {
 		pbm.probe.resolvers.DentryResolver.BumpCacheGenerations()
 	}
 
-	if err := pbm.sendEventsAndBytesReadStats(pbm.probe.statsdClient); err != nil {
+	if err := pbm.sendEventsAndBytesReadStats(pbm.statsdClient); err != nil {
 		return err
 	}
 
-	return pbm.sendLostEventsReadStats(pbm.probe.statsdClient)
+	return pbm.sendLostEventsReadStats(pbm.statsdClient)
 }

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -40,6 +40,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/ebpf/probes"
 	"github.com/DataDog/datadog-agent/pkg/security/metrics"
 	"github.com/DataDog/datadog-agent/pkg/security/probe/constantfetch"
+	"github.com/DataDog/datadog-agent/pkg/security/probe/resolvers"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
@@ -1351,7 +1352,7 @@ func NewProbe(config *config.Config, statsdClient statsd.ClientInterface) (*Prob
 		},
 		manager.ConstantEditor{
 			Name:  "mount_id_offset",
-			Value: getMountIDOffset(p),
+			Value: resolvers.GetMountIDOffset(p.kernelVersion),
 		},
 		manager.ConstantEditor{
 			Name:  "getattr2",
@@ -1359,27 +1360,27 @@ func NewProbe(config *config.Config, statsdClient statsd.ClientInterface) (*Prob
 		},
 		manager.ConstantEditor{
 			Name:  "vfs_unlink_dentry_position",
-			Value: getVFSLinkDentryPosition(p),
+			Value: resolvers.GetVFSLinkDentryPosition(p.kernelVersion),
 		},
 		manager.ConstantEditor{
 			Name:  "vfs_mkdir_dentry_position",
-			Value: getVFSMKDirDentryPosition(p),
+			Value: resolvers.GetVFSMKDirDentryPosition(p.kernelVersion),
 		},
 		manager.ConstantEditor{
 			Name:  "vfs_link_target_dentry_position",
-			Value: getVFSLinkTargetDentryPosition(p),
+			Value: resolvers.GetVFSLinkTargetDentryPosition(p.kernelVersion),
 		},
 		manager.ConstantEditor{
 			Name:  "vfs_setxattr_dentry_position",
-			Value: getVFSSetxattrDentryPosition(p),
+			Value: resolvers.GetVFSSetxattrDentryPosition(p.kernelVersion),
 		},
 		manager.ConstantEditor{
 			Name:  "vfs_removexattr_dentry_position",
-			Value: getVFSRemovexattrDentryPosition(p),
+			Value: resolvers.GetVFSRemovexattrDentryPosition(p.kernelVersion),
 		},
 		manager.ConstantEditor{
 			Name:  "vfs_rename_input_type",
-			Value: getVFSRenameInputType(p),
+			Value: resolvers.GetVFSRenameInputType(p.kernelVersion),
 		},
 		manager.ConstantEditor{
 			Name:  "check_helper_call_input",

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -39,6 +39,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/ebpf/probes"
 	"github.com/DataDog/datadog-agent/pkg/security/metrics"
 	"github.com/DataDog/datadog-agent/pkg/security/probe/constantfetch"
+	"github.com/DataDog/datadog-agent/pkg/security/probe/erpc"
 	"github.com/DataDog/datadog-agent/pkg/security/probe/managerhelper"
 	"github.com/DataDog/datadog-agent/pkg/security/probe/resolvers"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
@@ -98,8 +99,8 @@ type Probe struct {
 	activityDumpHandler ActivityDumpHandler
 
 	// Approvers / discarders section
-	erpc                               *ERPC
-	erpcRequest                        *ERPCRequest
+	erpc                               *erpc.ERPC
+	erpcRequest                        *erpc.ERPCRequest
 	pidDiscarders                      *pidDiscarders
 	inodeDiscarders                    *inodeDiscarders
 	approvers                          map[eval.EventType]activeApprovers
@@ -1243,7 +1244,7 @@ func (p *Probe) flushInactiveProbes() map[uint32]int {
 
 // NewProbe instantiates a new runtime security agent probe
 func NewProbe(config *config.Config, statsdClient statsd.ClientInterface) (*Probe, error) {
-	erpc, err := NewERPC()
+	nerpc, err := erpc.NewERPC()
 	if err != nil {
 		return nil, err
 	}
@@ -1256,8 +1257,8 @@ func NewProbe(config *config.Config, statsdClient statsd.ClientInterface) (*Prob
 		managerOptions:       ebpf.NewDefaultOptions(),
 		ctx:                  ctx,
 		cancelFnc:            cancel,
-		erpc:                 erpc,
-		erpcRequest:          &ERPCRequest{},
+		erpc:                 nerpc,
+		erpcRequest:          &erpc.ERPCRequest{},
 		tcPrograms:           make(map[NetDeviceKey]*manager.Probe),
 		statsdClient:         statsdClient,
 		discarderRateLimiter: rate.NewLimiter(rate.Every(time.Second/5), 100),

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -1427,14 +1427,14 @@ func NewProbe(config *config.Config, statsdClient statsd.ClientInterface) (*Prob
 		p.managerOptions.ExcludedFunctions = append(p.managerOptions.ExcludedFunctions, probes.GetAllTCProgramFunctions()...)
 	}
 
+	p.scrubber = pconfig.NewDefaultDataScrubber()
+	p.scrubber.AddCustomSensitiveWords(config.CustomSensitiveWords)
+
 	resolvers, err := NewResolvers(config, p)
 	if err != nil {
 		return nil, err
 	}
 	p.resolvers = resolvers
-
-	p.scrubber = pconfig.NewDefaultDataScrubber()
-	p.scrubber.AddCustomSensitiveWords(config.CustomSensitiveWords)
 
 	p.event = NewEvent(p.resolvers, p.scrubber, p)
 

--- a/pkg/security/probe/probe_monitor.go
+++ b/pkg/security/probe/probe_monitor.go
@@ -53,18 +53,18 @@ func NewMonitor(p *Probe) (*Monitor, error) {
 		return nil, fmt.Errorf("couldn't create the events statistics monitor: %w", err)
 	}
 
-	if p.config.ActivityDumpEnabled {
-		m.activityDumpManager, err = NewActivityDumpManager(p, p.config, p.statsdClient, p.resolvers, p.kernelVersion, p.scrubber, p.manager)
+	if p.Config.ActivityDumpEnabled {
+		m.activityDumpManager, err = NewActivityDumpManager(p, p.Config, p.StatsdClient, p.resolvers, p.kernelVersion, p.scrubber, p.Manager)
 		if err != nil {
 			return nil, fmt.Errorf("couldn't create the activity dump manager: %w", err)
 		}
 	}
 
-	if p.config.RuntimeMonitor {
-		m.runtimeMonitor = NewRuntimeMonitor(p.statsdClient)
+	if p.Config.RuntimeMonitor {
+		m.runtimeMonitor = NewRuntimeMonitor(p.StatsdClient)
 	}
 
-	m.discarderMonitor, err = NewDiscarderMonitor(p.manager, p.statsdClient)
+	m.discarderMonitor, err = NewDiscarderMonitor(p.Manager, p.StatsdClient)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't create the discarder monitor: %w", err)
 	}
@@ -136,7 +136,7 @@ func (m *Monitor) SendStats() error {
 		}
 	}
 
-	if m.probe.config.RuntimeMonitor {
+	if m.probe.Config.RuntimeMonitor {
 		if err := m.runtimeMonitor.SendStats(); err != nil {
 			return fmt.Errorf("failed to send runtime monitor stats: %w", err)
 		}
@@ -176,7 +176,7 @@ func (m *Monitor) ReportRuleSetLoaded(ruleSet *rules.RuleSet, err *multierror.Er
 	r, ev := NewRuleSetLoadedEvent(ruleSet, err)
 	report := RuleSetLoadedReport{Rule: r, Event: ev}
 
-	if err := m.probe.statsdClient.Count(metrics.MetricRuleSetLoaded, 1, []string{}, 1.0); err != nil {
+	if err := m.probe.StatsdClient.Count(metrics.MetricRuleSetLoaded, 1, []string{}, 1.0); err != nil {
 		log.Error(fmt.Errorf("failed to send ruleset_loaded metric: %w", err))
 	}
 
@@ -196,7 +196,7 @@ func (m *Monitor) ReportSelfTest(success []string, fails []string) {
 		fmt.Sprintf("success:%d", len(success)),
 		fmt.Sprintf("fails:%d", len(fails)),
 	}
-	if err := m.probe.statsdClient.Count(metrics.MetricSelfTest, 1, tags, 1.0); err != nil {
+	if err := m.probe.StatsdClient.Count(metrics.MetricSelfTest, 1, tags, 1.0); err != nil {
 		log.Error(fmt.Errorf("failed to send self_test metric: %w", err))
 	}
 
@@ -211,7 +211,7 @@ var ErrActivityDumpManagerDisabled = errors.New("ActivityDumpManager is disabled
 
 // DumpActivity handles an activity dump request
 func (m *Monitor) DumpActivity(params *api.ActivityDumpParams) (*api.ActivityDumpMessage, error) {
-	if !m.probe.config.ActivityDumpEnabled {
+	if !m.probe.Config.ActivityDumpEnabled {
 		return &api.ActivityDumpMessage{
 			Error: ErrActivityDumpManagerDisabled.Error(),
 		}, ErrActivityDumpManagerDisabled
@@ -221,7 +221,7 @@ func (m *Monitor) DumpActivity(params *api.ActivityDumpParams) (*api.ActivityDum
 
 // ListActivityDumps returns the list of active dumps
 func (m *Monitor) ListActivityDumps(params *api.ActivityDumpListParams) (*api.ActivityDumpListMessage, error) {
-	if !m.probe.config.ActivityDumpEnabled {
+	if !m.probe.Config.ActivityDumpEnabled {
 		return &api.ActivityDumpListMessage{
 			Error: ErrActivityDumpManagerDisabled.Error(),
 		}, ErrActivityDumpManagerDisabled
@@ -231,7 +231,7 @@ func (m *Monitor) ListActivityDumps(params *api.ActivityDumpListParams) (*api.Ac
 
 // StopActivityDump stops an active activity dump
 func (m *Monitor) StopActivityDump(params *api.ActivityDumpStopParams) (*api.ActivityDumpStopMessage, error) {
-	if !m.probe.config.ActivityDumpEnabled {
+	if !m.probe.Config.ActivityDumpEnabled {
 		return &api.ActivityDumpStopMessage{
 			Error: ErrActivityDumpManagerDisabled.Error(),
 		}, ErrActivityDumpManagerDisabled
@@ -241,7 +241,7 @@ func (m *Monitor) StopActivityDump(params *api.ActivityDumpStopParams) (*api.Act
 
 // GenerateTranscoding encodes an activity dump following the input parameters
 func (m *Monitor) GenerateTranscoding(params *api.TranscodingRequestParams) (*api.TranscodingRequestMessage, error) {
-	if !m.probe.config.ActivityDumpEnabled {
+	if !m.probe.Config.ActivityDumpEnabled {
 		return &api.TranscodingRequestMessage{
 			Error: ErrActivityDumpManagerDisabled.Error(),
 		}, ErrActivityDumpManagerDisabled

--- a/pkg/security/probe/probe_monitor.go
+++ b/pkg/security/probe/probe_monitor.go
@@ -54,7 +54,7 @@ func NewMonitor(p *Probe) (*Monitor, error) {
 	}
 
 	if p.config.ActivityDumpEnabled {
-		m.activityDumpManager, err = NewActivityDumpManager(p)
+		m.activityDumpManager, err = NewActivityDumpManager(p, p.config, p.statsdClient, p.resolvers, p.kernelVersion, p.scrubber, p.manager)
 		if err != nil {
 			return nil, fmt.Errorf("couldn't create the activity dump manager: %w", err)
 		}
@@ -64,7 +64,7 @@ func NewMonitor(p *Probe) (*Monitor, error) {
 		m.runtimeMonitor = NewRuntimeMonitor(p.statsdClient)
 	}
 
-	m.discarderMonitor, err = NewDiscarderMonitor(p)
+	m.discarderMonitor, err = NewDiscarderMonitor(p.manager, p.statsdClient)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't create the discarder monitor: %w", err)
 	}

--- a/pkg/security/probe/process_resolver.go
+++ b/pkg/security/probe/process_resolver.go
@@ -22,14 +22,18 @@ import (
 	"time"
 	"unsafe"
 
+	"github.com/DataDog/datadog-go/v5/statsd"
 	manager "github.com/DataDog/ebpf-manager"
 	"github.com/DataDog/gopsutil/process"
 	lib "github.com/cilium/ebpf"
 	"github.com/hashicorp/golang-lru/v2/simplelru"
 	"go.uber.org/atomic"
 
+	pconfig "github.com/DataDog/datadog-agent/pkg/process/config"
+	"github.com/DataDog/datadog-agent/pkg/security/config"
 	"github.com/DataDog/datadog-agent/pkg/security/ebpf/kernel"
 	"github.com/DataDog/datadog-agent/pkg/security/metrics"
+	"github.com/DataDog/datadog-agent/pkg/security/probe/managerhelper"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
@@ -53,16 +57,16 @@ const (
 	maxParallelArgsEnvs = 512 // == number of parallel starting processes
 )
 
-func getAttr2(probe *Probe) uint64 {
-	if probe.kernelVersion.IsRH7Kernel() {
+func getAttr2(kernelVersion *kernel.Version) uint64 {
+	if kernelVersion.IsRH7Kernel() {
 		return 1
 	}
 	return 0
 }
 
 // getDoForkInput returns the expected input type of _do_fork, do_fork and kernel_clone
-func getDoForkInput(probe *Probe) uint64 {
-	if probe.kernelVersion.Code != 0 && probe.kernelVersion.Code >= kernel.Kernel5_3 {
+func getDoForkInput(kernelVersion *kernel.Version) uint64 {
+	if kernelVersion.Code != 0 && kernelVersion.Code >= kernel.Kernel5_3 {
 		return doForkStructInput
 	}
 	return doForkListInput
@@ -93,8 +97,13 @@ type ProcessResolverOpts struct {
 // ProcessResolver resolved process context
 type ProcessResolver struct {
 	sync.RWMutex
-	state            *atomic.Int64
-	probe            *Probe
+	state *atomic.Int64
+
+	manager      *manager.Manager
+	config       *config.Config
+	statsdClient statsd.ClientInterface
+	scrubber     *pconfig.DataScrubber
+
 	resolvers        *Resolvers
 	execFileCacheMap *lib.Map
 	procCacheMap     *lib.Map
@@ -274,66 +283,66 @@ func (p *ProcessResolver) NewProcessCacheEntry(pidContext model.PIDContext) *mod
 
 // SendStats sends process resolver metrics
 func (p *ProcessResolver) SendStats() error {
-	if err := p.probe.statsdClient.Gauge(metrics.MetricProcessResolverCacheSize, p.GetCacheSize(), []string{}, 1.0); err != nil {
+	if err := p.statsdClient.Gauge(metrics.MetricProcessResolverCacheSize, p.GetCacheSize(), []string{}, 1.0); err != nil {
 		return fmt.Errorf("failed to send process_resolver cache_size metric: %w", err)
 	}
 
-	if err := p.probe.statsdClient.Gauge(metrics.MetricProcessResolverReferenceCount, p.GetEntryCacheSize(), []string{}, 1.0); err != nil {
+	if err := p.statsdClient.Gauge(metrics.MetricProcessResolverReferenceCount, p.GetEntryCacheSize(), []string{}, 1.0); err != nil {
 		return fmt.Errorf("failed to send process_resolver reference_count metric: %w", err)
 	}
 
 	for _, resolutionType := range metrics.AllTypesTags {
 		if count := p.hitsStats[resolutionType].Swap(0); count > 0 {
-			if err := p.probe.statsdClient.Count(metrics.MetricProcessResolverHits, count, []string{resolutionType}, 1.0); err != nil {
+			if err := p.statsdClient.Count(metrics.MetricProcessResolverHits, count, []string{resolutionType}, 1.0); err != nil {
 				return fmt.Errorf("failed to send process_resolver with `%s` metric: %w", resolutionType, err)
 			}
 		}
 	}
 
 	if count := p.missStats.Swap(0); count > 0 {
-		if err := p.probe.statsdClient.Count(metrics.MetricProcessResolverMiss, count, []string{}, 1.0); err != nil {
+		if err := p.statsdClient.Count(metrics.MetricProcessResolverMiss, count, []string{}, 1.0); err != nil {
 			return fmt.Errorf("failed to send process_resolver misses metric: %w", err)
 		}
 	}
 
 	if count := p.addedEntries.Swap(0); count > 0 {
-		if err := p.probe.statsdClient.Count(metrics.MetricProcessResolverAdded, count, []string{}, 1.0); err != nil {
+		if err := p.statsdClient.Count(metrics.MetricProcessResolverAdded, count, []string{}, 1.0); err != nil {
 			return fmt.Errorf("failed to send process_resolver added entries metric: %w", err)
 		}
 	}
 
 	if count := p.flushedEntries.Swap(0); count > 0 {
-		if err := p.probe.statsdClient.Count(metrics.MetricProcessResolverFlushed, count, []string{}, 1.0); err != nil {
+		if err := p.statsdClient.Count(metrics.MetricProcessResolverFlushed, count, []string{}, 1.0); err != nil {
 			return fmt.Errorf("failed to send process_resolver flushed entries metric: %w", err)
 		}
 	}
 
 	if count := p.pathErrStats.Swap(0); count > 0 {
-		if err := p.probe.statsdClient.Count(metrics.MetricProcessResolverPathError, count, []string{}, 1.0); err != nil {
+		if err := p.statsdClient.Count(metrics.MetricProcessResolverPathError, count, []string{}, 1.0); err != nil {
 			return fmt.Errorf("failed to send process_resolver path error metric: %w", err)
 		}
 	}
 
 	if count := p.argsTruncated.Swap(0); count > 0 {
-		if err := p.probe.statsdClient.Count(metrics.MetricProcessResolverArgsTruncated, count, []string{}, 1.0); err != nil {
+		if err := p.statsdClient.Count(metrics.MetricProcessResolverArgsTruncated, count, []string{}, 1.0); err != nil {
 			return fmt.Errorf("failed to send args truncated metric: %w", err)
 		}
 	}
 
 	if count := p.argsSize.Swap(0); count > 0 {
-		if err := p.probe.statsdClient.Count(metrics.MetricProcessResolverArgsSize, count, []string{}, 1.0); err != nil {
+		if err := p.statsdClient.Count(metrics.MetricProcessResolverArgsSize, count, []string{}, 1.0); err != nil {
 			return fmt.Errorf("failed to send args size metric: %w", err)
 		}
 	}
 
 	if count := p.envsTruncated.Swap(0); count > 0 {
-		if err := p.probe.statsdClient.Count(metrics.MetricProcessResolverEnvsTruncated, count, []string{}, 1.0); err != nil {
+		if err := p.statsdClient.Count(metrics.MetricProcessResolverEnvsTruncated, count, []string{}, 1.0); err != nil {
 			return fmt.Errorf("failed to send envs truncated metric: %w", err)
 		}
 	}
 
 	if count := p.envsSize.Swap(0); count > 0 {
-		if err := p.probe.statsdClient.Count(metrics.MetricProcessResolverEnvsSize, count, []string{}, 1.0); err != nil {
+		if err := p.statsdClient.Count(metrics.MetricProcessResolverEnvsSize, count, []string{}, 1.0); err != nil {
 			return fmt.Errorf("failed to send envs size metric: %w", err)
 		}
 	}
@@ -486,7 +495,7 @@ func (p *ProcessResolver) enrichEventFromProc(entry *model.ProcessCacheEntry, pr
 	// add netns
 	entry.NetNS, _ = utils.NetNSPathFromPid(pid).GetProcessNetworkNamespace()
 
-	if p.probe.config.NetworkEnabled {
+	if p.config.NetworkEnabled {
 		// snapshot pid routes in kernel space
 		_, _ = proc.OpenFiles()
 	}
@@ -909,8 +918,8 @@ func (p *ProcessResolver) GetProcessScrubbedArgv(pr *model.Process) ([]string, b
 
 	argv, truncated := p.GetProcessArgv(pr)
 
-	if p.probe.scrubber != nil {
-		argv, _ = p.probe.scrubber.ScrubCommand(argv)
+	if p.scrubber != nil {
+		argv, _ = p.scrubber.ScrubCommand(argv)
 	}
 
 	pr.ScrubbedArgv = argv
@@ -1048,15 +1057,15 @@ func (p *ProcessResolver) UpdateCapset(pid uint32, e *Event) {
 // Start starts the resolver
 func (p *ProcessResolver) Start(ctx context.Context) error {
 	var err error
-	if p.execFileCacheMap, err = p.probe.Map("exec_file_cache"); err != nil {
+	if p.execFileCacheMap, err = managerhelper.Map(p.manager, "exec_file_cache"); err != nil {
 		return err
 	}
 
-	if p.procCacheMap, err = p.probe.Map("proc_cache"); err != nil {
+	if p.procCacheMap, err = managerhelper.Map(p.manager, "proc_cache"); err != nil {
 		return err
 	}
 
-	if p.pidCacheMap, err = p.probe.Map("pid_cache"); err != nil {
+	if p.pidCacheMap, err = managerhelper.Map(p.manager, "pid_cache"); err != nil {
 		return err
 	}
 
@@ -1269,14 +1278,18 @@ func (p *ProcessResolver) NewProcessVariables(scoper func(ctx *eval.Context) uns
 }
 
 // NewProcessResolver returns a new process resolver
-func NewProcessResolver(probe *Probe, resolvers *Resolvers, opts ProcessResolverOpts) (*ProcessResolver, error) {
+func NewProcessResolver(manager *manager.Manager, config *config.Config, statsdClient statsd.ClientInterface,
+	scrubber *pconfig.DataScrubber, resolvers *Resolvers, opts ProcessResolverOpts) (*ProcessResolver, error) {
 	argsEnvsCache, err := simplelru.NewLRU[uint32, *model.ArgsEnvsCacheEntry](maxParallelArgsEnvs, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	p := &ProcessResolver{
-		probe:          probe,
+		manager:        manager,
+		config:         config,
+		statsdClient:   statsdClient,
+		scrubber:       scrubber,
 		resolvers:      resolvers,
 		entryCache:     make(map[uint32]*model.ProcessCacheEntry),
 		opts:           opts,

--- a/pkg/security/probe/process_resolver.go
+++ b/pkg/security/probe/process_resolver.go
@@ -34,6 +34,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/ebpf/kernel"
 	"github.com/DataDog/datadog-agent/pkg/security/metrics"
 	"github.com/DataDog/datadog-agent/pkg/security/probe/managerhelper"
+	"github.com/DataDog/datadog-agent/pkg/security/probe/resolvers"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
@@ -637,7 +638,7 @@ func (p *ProcessResolver) SetProcessPath(fileEvent *model.FileEvent, ctx *model.
 		fileEvent.SetBasenameStr("")
 
 		p.pathErrStats.Inc()
-		return "", &ErrInvalidKeyPath{Inode: fileEvent.Inode, MountID: fileEvent.MountID}
+		return "", &resolvers.ErrInvalidKeyPath{Inode: fileEvent.Inode, MountID: fileEvent.MountID}
 	}
 
 	pathnameStr, err := p.resolvers.resolveFileFieldsPath(&fileEvent.FileFields, ctx)
@@ -647,7 +648,7 @@ func (p *ProcessResolver) SetProcessPath(fileEvent *model.FileEvent, ctx *model.
 
 		p.pathErrStats.Inc()
 
-		return "", &ErrInvalidKeyPath{Inode: fileEvent.Inode, MountID: fileEvent.MountID}
+		return "", &resolvers.ErrInvalidKeyPath{Inode: fileEvent.Inode, MountID: fileEvent.MountID}
 	}
 
 	fileEvent.SetPathnameStr(pathnameStr)

--- a/pkg/security/probe/process_resolver_test.go
+++ b/pkg/security/probe/process_resolver_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+	"github.com/DataDog/datadog-go/v5/statsd"
 )
 
 func testCacheSize(t *testing.T, resolver *ProcessResolver) {
@@ -33,7 +34,7 @@ func testCacheSize(t *testing.T, resolver *ProcessResolver) {
 }
 
 func TestFork1st(t *testing.T) {
-	resolver, err := NewProcessResolver(nil, nil, NewProcessResolverOpts(nil))
+	resolver, err := NewProcessResolver(nil, nil, &statsd.NoOpClient{}, nil, nil, NewProcessResolverOpts(nil))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -72,7 +73,7 @@ func TestFork1st(t *testing.T) {
 }
 
 func TestFork2nd(t *testing.T) {
-	resolver, err := NewProcessResolver(nil, nil, NewProcessResolverOpts(nil))
+	resolver, err := NewProcessResolver(nil, nil, &statsd.NoOpClient{}, nil, nil, NewProcessResolverOpts(nil))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -113,7 +114,7 @@ func TestFork2nd(t *testing.T) {
 }
 
 func TestForkExec(t *testing.T) {
-	resolver, err := NewProcessResolver(nil, nil, NewProcessResolverOpts(nil))
+	resolver, err := NewProcessResolver(nil, nil, &statsd.NoOpClient{}, nil, nil, NewProcessResolverOpts(nil))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -168,7 +169,7 @@ func TestForkExec(t *testing.T) {
 }
 
 func TestOrphanExec(t *testing.T) {
-	resolver, err := NewProcessResolver(nil, nil, NewProcessResolverOpts(nil))
+	resolver, err := NewProcessResolver(nil, nil, &statsd.NoOpClient{}, nil, nil, NewProcessResolverOpts(nil))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -223,7 +224,7 @@ func TestOrphanExec(t *testing.T) {
 }
 
 func TestForkExecExec(t *testing.T) {
-	resolver, err := NewProcessResolver(nil, nil, NewProcessResolverOpts(nil))
+	resolver, err := NewProcessResolver(nil, nil, &statsd.NoOpClient{}, nil, nil, NewProcessResolverOpts(nil))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -292,7 +293,7 @@ func TestForkExecExec(t *testing.T) {
 }
 
 func TestForkReuse(t *testing.T) {
-	resolver, err := NewProcessResolver(nil, nil, NewProcessResolverOpts(nil))
+	resolver, err := NewProcessResolver(nil, nil, &statsd.NoOpClient{}, nil, nil, NewProcessResolverOpts(nil))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -386,7 +387,7 @@ func TestForkReuse(t *testing.T) {
 }
 
 func TestForkForkExec(t *testing.T) {
-	resolver, err := NewProcessResolver(nil, nil, NewProcessResolverOpts(nil))
+	resolver, err := NewProcessResolver(nil, nil, &statsd.NoOpClient{}, nil, nil, NewProcessResolverOpts(nil))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/probe/resolvers.go
+++ b/pkg/security/probe/resolvers.go
@@ -39,7 +39,7 @@ type Resolvers struct {
 
 // NewResolvers creates a new instance of Resolvers
 func NewResolvers(config *config.Config, probe *Probe) (*Resolvers, error) {
-	dentryResolver, err := resolvers.NewDentryResolver(probe.config, probe.statsdClient, probe.erpc)
+	dentryResolver, err := resolvers.NewDentryResolver(probe.Config, probe.StatsdClient, probe.Erpc)
 	if err != nil {
 		return nil, err
 	}
@@ -54,7 +54,7 @@ func NewResolvers(config *config.Config, probe *Probe) (*Resolvers, error) {
 		return nil, err
 	}
 
-	mountResolver, err := resolvers.NewMountResolver(probe.statsdClient)
+	mountResolver, err := resolvers.NewMountResolver(probe.StatsdClient)
 	if err != nil {
 		return nil, err
 	}
@@ -75,8 +75,8 @@ func NewResolvers(config *config.Config, probe *Probe) (*Resolvers, error) {
 		NamespaceResolver: namespaceResolver,
 	}
 
-	processResolver, err := NewProcessResolver(probe.manager, probe.config, probe.statsdClient,
-		probe.scrubber, resolvers, NewProcessResolverOpts(probe.config.EnvsWithValue))
+	processResolver, err := NewProcessResolver(probe.Manager, probe.Config, probe.StatsdClient,
+		probe.scrubber, resolvers, NewProcessResolverOpts(probe.Config.EnvsWithValue))
 	if err != nil {
 		return nil, err
 	}
@@ -197,7 +197,7 @@ func (r *Resolvers) Start(ctx context.Context) error {
 		return err
 	}
 
-	if err := r.DentryResolver.Start(r.probe.manager); err != nil {
+	if err := r.DentryResolver.Start(r.probe.Manager); err != nil {
 		return err
 	}
 
@@ -213,7 +213,7 @@ func (r *Resolvers) Snapshot() error {
 	r.ProcessResolver.SetState(snapshotted)
 	r.NamespaceResolver.SetState(snapshotted)
 
-	selinuxStatusMap, err := managerhelper.Map(r.probe.manager, "selinux_enforce_status")
+	selinuxStatusMap, err := managerhelper.Map(r.probe.Manager, "selinux_enforce_status")
 	if err != nil {
 		return fmt.Errorf("unable to snapshot SELinux: %w", err)
 	}

--- a/pkg/security/probe/resolvers.go
+++ b/pkg/security/probe/resolvers.go
@@ -32,14 +32,14 @@ type Resolvers struct {
 	TimeResolver      *resolvers.TimeResolver
 	UserGroupResolver *resolvers.UserGroupResolver
 	TagsResolver      *resolvers.TagsResolver
-	DentryResolver    *DentryResolver
+	DentryResolver    *resolvers.DentryResolver
 	ProcessResolver   *ProcessResolver
 	NamespaceResolver *NamespaceResolver
 }
 
 // NewResolvers creates a new instance of Resolvers
 func NewResolvers(config *config.Config, probe *Probe) (*Resolvers, error) {
-	dentryResolver, err := NewDentryResolver(probe.config, probe.statsdClient, probe.erpc)
+	dentryResolver, err := resolvers.NewDentryResolver(probe.config, probe.statsdClient, probe.erpc)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/security/probe/resolvers/container_resolver.go
+++ b/pkg/security/probe/resolvers/container_resolver.go
@@ -6,7 +6,7 @@
 //go:build linux
 // +build linux
 
-package probe
+package resolvers
 
 import (
 	"github.com/DataDog/datadog-agent/pkg/security/utils"

--- a/pkg/security/probe/resolvers/dentry_resolver.go
+++ b/pkg/security/probe/resolvers/dentry_resolver.go
@@ -23,16 +23,16 @@ import (
 	"go.uber.org/atomic"
 	"golang.org/x/sys/unix"
 
-	"strings"
 	manager "github.com/DataDog/ebpf-manager"
+	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/security/config"
 	"github.com/DataDog/datadog-agent/pkg/security/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/security/metrics"
-	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
-	"github.com/DataDog/datadog-agent/pkg/security/utils"
 	"github.com/DataDog/datadog-agent/pkg/security/probe/erpc"
 	"github.com/DataDog/datadog-agent/pkg/security/probe/managerhelper"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+	"github.com/DataDog/datadog-agent/pkg/security/utils"
 )
 
 var (

--- a/pkg/security/probe/resolvers/dentry_resolver_test.go
+++ b/pkg/security/probe/resolvers/dentry_resolver_test.go
@@ -6,7 +6,7 @@
 //go:build linux
 // +build linux
 
-package probe
+package resolvers
 
 import (
 	"testing"

--- a/pkg/security/probe/resolvers/mount_resolver.go
+++ b/pkg/security/probe/resolvers/mount_resolver.go
@@ -6,7 +6,7 @@
 //go:build linux
 // +build linux
 
-package probe
+package resolvers
 
 import (
 	"context"
@@ -394,73 +394,73 @@ func (mr *MountResolver) ResolveMountPaths(mountID, pid uint32) (string, string,
 	return parentPath, mount.RootStr, nil
 }
 
-func getMountIDOffset(probe *Probe) uint64 {
+func GetMountIDOffset(kernelVersion *skernel.Version) uint64 {
 	offset := uint64(284)
 
 	switch {
-	case probe.kernelVersion.IsSuseKernel() || probe.kernelVersion.Code >= skernel.Kernel5_12:
+	case kernelVersion.IsSuseKernel() || kernelVersion.Code >= skernel.Kernel5_12:
 		offset = 292
-	case probe.kernelVersion.Code != 0 && probe.kernelVersion.Code < skernel.Kernel4_13:
+	case kernelVersion.Code != 0 && kernelVersion.Code < skernel.Kernel4_13:
 		offset = 268
 	}
 
 	return offset
 }
 
-func getVFSLinkDentryPosition(probe *Probe) uint64 {
+func GetVFSLinkDentryPosition(kernelVersion *skernel.Version) uint64 {
 	position := uint64(2)
 
-	if probe.kernelVersion.Code != 0 && probe.kernelVersion.Code >= skernel.Kernel5_12 {
+	if kernelVersion.Code != 0 && kernelVersion.Code >= skernel.Kernel5_12 {
 		position = 3
 	}
 
 	return position
 }
 
-func getVFSMKDirDentryPosition(probe *Probe) uint64 {
+func GetVFSMKDirDentryPosition(kernelVersion *skernel.Version) uint64 {
 	position := uint64(2)
 
-	if probe.kernelVersion.Code != 0 && probe.kernelVersion.Code >= skernel.Kernel5_12 {
+	if kernelVersion.Code != 0 && kernelVersion.Code >= skernel.Kernel5_12 {
 		position = 3
 	}
 
 	return position
 }
 
-func getVFSLinkTargetDentryPosition(probe *Probe) uint64 {
+func GetVFSLinkTargetDentryPosition(kernelVersion *skernel.Version) uint64 {
 	position := uint64(3)
 
-	if probe.kernelVersion.Code != 0 && probe.kernelVersion.Code >= skernel.Kernel5_12 {
+	if kernelVersion.Code != 0 && kernelVersion.Code >= skernel.Kernel5_12 {
 		position = 4
 	}
 
 	return position
 }
 
-func getVFSSetxattrDentryPosition(probe *Probe) uint64 {
+func GetVFSSetxattrDentryPosition(kernelVersion *skernel.Version) uint64 {
 	position := uint64(1)
 
-	if probe.kernelVersion.Code != 0 && probe.kernelVersion.Code >= skernel.Kernel5_12 {
+	if kernelVersion.Code != 0 && kernelVersion.Code >= skernel.Kernel5_12 {
 		position = 2
 	}
 
 	return position
 }
 
-func getVFSRemovexattrDentryPosition(probe *Probe) uint64 {
+func GetVFSRemovexattrDentryPosition(kernelVersion *skernel.Version) uint64 {
 	position := uint64(1)
 
-	if probe.kernelVersion.Code != 0 && probe.kernelVersion.Code >= skernel.Kernel5_12 {
+	if kernelVersion.Code != 0 && kernelVersion.Code >= skernel.Kernel5_12 {
 		position = 2
 	}
 
 	return position
 }
 
-func getVFSRenameInputType(probe *Probe) uint64 {
+func GetVFSRenameInputType(kernelVersion *skernel.Version) uint64 {
 	inputType := uint64(1)
 
-	if probe.kernelVersion.Code != 0 && probe.kernelVersion.Code >= skernel.Kernel5_12 {
+	if kernelVersion.Code != 0 && kernelVersion.Code >= skernel.Kernel5_12 {
 		inputType = 2
 	}
 

--- a/pkg/security/probe/resolvers/mount_resolver_test.go
+++ b/pkg/security/probe/resolvers/mount_resolver_test.go
@@ -6,7 +6,7 @@
 //go:build linux
 // +build linux
 
-package probe
+package resolvers
 
 import (
 	"fmt"

--- a/pkg/security/probe/resolvers/selinux_resolver.go
+++ b/pkg/security/probe/resolvers/selinux_resolver.go
@@ -6,7 +6,7 @@
 //go:build linux
 // +build linux
 
-package probe
+package resolvers
 
 import (
 	"os/exec"
@@ -24,7 +24,7 @@ const (
 	SELinuxStatusEnforceKey uint32 = 1
 )
 
-func snapshotSELinux(selinuxStatusMap *ebpf.Map) error {
+func SnapshotSELinux(selinuxStatusMap *ebpf.Map) error {
 	currentStatus := func() string {
 		output, err := exec.Command("getenforce").Output()
 		if err != nil {

--- a/pkg/security/probe/resolvers/tags_resolver.go
+++ b/pkg/security/probe/resolvers/tags_resolver.go
@@ -6,7 +6,7 @@
 //go:build linux
 // +build linux
 
-package probe
+package resolvers
 
 import (
 	"context"

--- a/pkg/security/probe/resolvers/time_resolver.go
+++ b/pkg/security/probe/resolvers/time_resolver.go
@@ -6,7 +6,7 @@
 //go:build linux
 // +build linux
 
-package probe
+package resolvers
 
 import (
 	"fmt"

--- a/pkg/security/probe/resolvers/user_resolver.go
+++ b/pkg/security/probe/resolvers/user_resolver.go
@@ -6,7 +6,7 @@
 //go:build linux
 // +build linux
 
-package probe
+package resolvers
 
 import (
 	"os/user"

--- a/pkg/security/probe/splice.go
+++ b/pkg/security/probe/splice.go
@@ -36,7 +36,7 @@ var spliceCapabilities = Capabilities{
 	},
 }
 
-func spliceOnNewApprovers(probe *Probe, approvers rules.Approvers) (activeApprovers, error) {
+func spliceOnNewApprovers(approvers rules.Approvers) (activeApprovers, error) {
 	intValues := func(fvs rules.FilterValues) []int {
 		var values []int
 		for _, v := range fvs {
@@ -45,7 +45,7 @@ func spliceOnNewApprovers(probe *Probe, approvers rules.Approvers) (activeApprov
 		return values
 	}
 
-	spliceApprovers, err := onNewBasenameApprovers(probe, model.SpliceEventType, "file", approvers)
+	spliceApprovers, err := onNewBasenameApprovers(model.SpliceEventType, "file", approvers)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/security/tests/activity_dumps_encoding_test.go
+++ b/pkg/security/tests/activity_dumps_encoding_test.go
@@ -15,8 +15,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/DataDog/datadog-agent/pkg/security/config"
 	"github.com/DataDog/datadog-agent/pkg/security/probe"
-	"github.com/DataDog/datadog-agent/pkg/security/probe/dump"
 )
 
 //go:embed testdata/adv1.protobuf
@@ -24,7 +24,7 @@ var v1testdata []byte
 
 func getTestDataActivityDump(tb testing.TB) *probe.ActivityDump {
 	ad := probe.NewEmptyActivityDump()
-	if err := ad.DecodeFromReader(bytes.NewReader(v1testdata), dump.PROTOBUF); err != nil {
+	if err := ad.DecodeFromReader(bytes.NewReader(v1testdata), config.PROTOBUF); err != nil {
 		tb.Fatal(err)
 	}
 	return ad

--- a/pkg/security/tests/dentry_test.go
+++ b/pkg/security/tests/dentry_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/ebpf/kernel"
 	"github.com/DataDog/datadog-agent/pkg/security/metrics"
 	sprobe "github.com/DataDog/datadog-agent/pkg/security/probe"
+	"github.com/DataDog/datadog-agent/pkg/security/probe/resolvers"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
 )
@@ -216,12 +217,12 @@ func BenchmarkERPCDentryResolutionSegment(b *testing.B) {
 	}
 
 	// create a new dentry resolver to avoid concurrent map access errors
-	resolver, err := sprobe.NewDentryResolver(test.probe)
+	resolver, err := resolvers.NewDentryResolver(test.probe.Config, test.probe.StatsdClient, test.probe.Erpc)
 	if err != nil {
 		b.Fatal(err)
 	}
 
-	if err := resolver.Start(test.probe); err != nil {
+	if err := resolver.Start(test.probe.Manager); err != nil {
 		b.Fatal(err)
 	}
 	name, err := resolver.ResolveNameFromERPC(mountID, inode, pathID)
@@ -285,12 +286,12 @@ func BenchmarkERPCDentryResolutionPath(b *testing.B) {
 	}
 
 	// create a new dentry resolver to avoid concurrent map access errors
-	resolver, err := sprobe.NewDentryResolver(test.probe)
+	resolver, err := resolvers.NewDentryResolver(test.probe.Config, test.probe.StatsdClient, test.probe.Erpc)
 	if err != nil {
 		b.Fatal(err)
 	}
 
-	if err := resolver.Start(test.probe); err != nil {
+	if err := resolver.Start(test.probe.Manager); err != nil {
 		b.Fatal(err)
 	}
 	f, err := resolver.ResolveFromERPC(mountID, inode, pathID, true)
@@ -354,12 +355,12 @@ func BenchmarkMapDentryResolutionSegment(b *testing.B) {
 	}
 
 	// create a new dentry resolver to avoid concurrent map access errors
-	resolver, err := sprobe.NewDentryResolver(test.probe)
+	resolver, err := resolvers.NewDentryResolver(test.probe.Config, test.probe.StatsdClient, test.probe.Erpc)
 	if err != nil {
 		b.Fatal(err)
 	}
 
-	if err := resolver.Start(test.probe); err != nil {
+	if err := resolver.Start(test.probe.Manager); err != nil {
 		b.Fatal(err)
 	}
 	name, err := resolver.ResolveNameFromMap(mountID, inode, pathID)
@@ -423,12 +424,12 @@ func BenchmarkMapDentryResolutionPath(b *testing.B) {
 	}
 
 	// create a new dentry resolver to avoid concurrent map access errors
-	resolver, err := sprobe.NewDentryResolver(test.probe)
+	resolver, err := resolvers.NewDentryResolver(test.probe.Config, test.probe.StatsdClient, test.probe.Erpc)
 	if err != nil {
 		b.Fatal(err)
 	}
 
-	if err := resolver.Start(test.probe); err != nil {
+	if err := resolver.Start(test.probe.Manager); err != nil {
 		b.Fatal(err)
 	}
 	f, err := resolver.ResolveFromMap(mountID, inode, pathID, true)

--- a/pkg/security/tests/schemas.go
+++ b/pkg/security/tests/schemas.go
@@ -17,6 +17,7 @@ import (
 	"github.com/xeipuuv/gojsonschema"
 
 	sprobe "github.com/DataDog/datadog-agent/pkg/security/probe"
+	"github.com/DataDog/datadog-agent/pkg/security/probe/resolvers"
 )
 
 //nolint:deadcode,unused
@@ -45,7 +46,7 @@ func (v ValidInodeFormatChecker) IsFormat(input interface{}) bool {
 	default:
 		return false
 	}
-	return !sprobe.IsFakeInode(inode)
+	return !resolvers.IsFakeInode(inode)
 }
 
 //nolint:deadcode,unused

--- a/tasks/libs/copyright.py
+++ b/tasks/libs/copyright.py
@@ -37,7 +37,6 @@ PATH_EXCLUSION_REGEX = [
     '/pkg/security/probe/custom_events_easyjson.go',
     '/pkg/security/probe/fields_resolver.go',
     '/pkg/security/probe/serializers_easyjson.go',
-    '/pkg/security/probe/dump/.*_gen(_test){,1}.go',
     '/pkg/security/secl/model/.*_gen(_test){,1}.go',
     '/pkg/security/secl/model/accessors.go',
     '/pkg/trace/pb/.*_gen(_test){,1}.go',

--- a/tasks/libs/copyright.py
+++ b/tasks/libs/copyright.py
@@ -37,6 +37,7 @@ PATH_EXCLUSION_REGEX = [
     '/pkg/security/probe/custom_events_easyjson.go',
     '/pkg/security/probe/fields_resolver.go',
     '/pkg/security/probe/serializers_easyjson.go',
+    '/pkg/security/probe/dump/.*_gen(_test){,1}.go',
     '/pkg/security/secl/model/.*_gen(_test){,1}.go',
     '/pkg/security/secl/model/accessors.go',
     '/pkg/trace/pb/.*_gen(_test){,1}.go',


### PR DESCRIPTION
### What does this PR do?

First "tiny" PR to start the reorganization of the probe code base into different sub packages.
This first step do:
* Move some resolvers to a dedicated package
* Move probe/dump/model.go to config/, to prepare the move of activity_dump stuff to probe/dump/ by avoiding a circle dependency
* Remove Probe references where it's simple to do so (and package its Map method to probe/managerhelper/)
* Move ERPC stuff to a dedicated packege

### Motivation

The initial goal was to move all activity dumps stuff into a dedicated package, but due to all the entanglement, .. sadly we'll have to process step by step instead.


### Additional Notes

Here are some notes on the more complicated entanglement to solve in order to continue the code base reorga

#### Resolvers

I moved the simplest ones to a dedicated package, but there is still:
* process_resolver: dependent to Resolvers and Event (which depends on serializer, tcProgram etc)
* namespace_resolver and resolvers: dependent on probe directly, and other stuff..

#### Activity dumps

Some dependencies hard to extract:
* probe/resolvers*
* probe/Event, which depends on:
* probe/serializer
* probe/tcPrograms


### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
