### PR TITLE
Monitor samplers configuration

### DIFF
--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -193,6 +193,7 @@ func (a *Agent) loop() {
 				a.obfuscator,
 				a.obfuscator,
 				a.cardObfuscator,
+				a.RemoteConfigHandler,
 			} {
 				stopper.Stop()
 			}

--- a/pkg/trace/remoteconfighandler/mock_samplers.go
+++ b/pkg/trace/remoteconfighandler/mock_samplers.go
@@ -9,74 +9,39 @@ import (
 	gomock "github.com/golang/mock/gomock"
 )
 
-// MockprioritySampler is a mock of prioritySampler interface.
-type MockprioritySampler struct {
+// MocksamplerWithTPS is a mock of samplerWithTPS interface.
+type MocksamplerWithTPS struct {
 	ctrl     *gomock.Controller
-	recorder *MockprioritySamplerMockRecorder
+	recorder *MocksamplerWithTPSMockRecorder
 }
 
-// MockprioritySamplerMockRecorder is the mock recorder for MockprioritySampler.
-type MockprioritySamplerMockRecorder struct {
-	mock *MockprioritySampler
+// MocksamplerWithTPSMockRecorder is the mock recorder for MocksamplerWithTPS.
+type MocksamplerWithTPSMockRecorder struct {
+	mock *MocksamplerWithTPS
 }
 
-// NewMockprioritySampler creates a new mock instance.
-func NewMockprioritySampler(ctrl *gomock.Controller) *MockprioritySampler {
-	mock := &MockprioritySampler{ctrl: ctrl}
-	mock.recorder = &MockprioritySamplerMockRecorder{mock}
+// NewMocksamplerWithTPS creates a new mock instance.
+func NewMocksamplerWithTPS(ctrl *gomock.Controller) *MocksamplerWithTPS {
+	mock := &MocksamplerWithTPS{ctrl: ctrl}
+	mock.recorder = &MocksamplerWithTPSMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockprioritySampler) EXPECT() *MockprioritySamplerMockRecorder {
+func (m *MocksamplerWithTPS) EXPECT() *MocksamplerWithTPSMockRecorder {
 	return m.recorder
 }
 
 // UpdateTargetTPS mocks base method.
-func (m *MockprioritySampler) UpdateTargetTPS(targetTPS float64) {
+func (m *MocksamplerWithTPS) UpdateTargetTPS(targetTPS float64, remotelyConfigured bool) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "UpdateTargetTPS", targetTPS)
+	m.ctrl.Call(m, "UpdateTargetTPS", targetTPS, remotelyConfigured)
 }
 
 // UpdateTargetTPS indicates an expected call of UpdateTargetTPS.
-func (mr *MockprioritySamplerMockRecorder) UpdateTargetTPS(targetTPS interface{}) *gomock.Call {
+func (mr *MocksamplerWithTPSMockRecorder) UpdateTargetTPS(targetTPS, remotelyConfigured interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateTargetTPS", reflect.TypeOf((*MockprioritySampler)(nil).UpdateTargetTPS), targetTPS)
-}
-
-// MockerrorsSampler is a mock of errorsSampler interface.
-type MockerrorsSampler struct {
-	ctrl     *gomock.Controller
-	recorder *MockerrorsSamplerMockRecorder
-}
-
-// MockerrorsSamplerMockRecorder is the mock recorder for MockerrorsSampler.
-type MockerrorsSamplerMockRecorder struct {
-	mock *MockerrorsSampler
-}
-
-// NewMockerrorsSampler creates a new mock instance.
-func NewMockerrorsSampler(ctrl *gomock.Controller) *MockerrorsSampler {
-	mock := &MockerrorsSampler{ctrl: ctrl}
-	mock.recorder = &MockerrorsSamplerMockRecorder{mock}
-	return mock
-}
-
-// EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockerrorsSampler) EXPECT() *MockerrorsSamplerMockRecorder {
-	return m.recorder
-}
-
-// UpdateTargetTPS mocks base method.
-func (m *MockerrorsSampler) UpdateTargetTPS(targetTPS float64) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "UpdateTargetTPS", targetTPS)
-}
-
-// UpdateTargetTPS indicates an expected call of UpdateTargetTPS.
-func (mr *MockerrorsSamplerMockRecorder) UpdateTargetTPS(targetTPS interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateTargetTPS", reflect.TypeOf((*MockerrorsSampler)(nil).UpdateTargetTPS), targetTPS)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateTargetTPS", reflect.TypeOf((*MocksamplerWithTPS)(nil).UpdateTargetTPS), targetTPS, remotelyConfigured)
 }
 
 // MockrareSampler is a mock of rareSampler interface.
@@ -103,13 +68,13 @@ func (m *MockrareSampler) EXPECT() *MockrareSamplerMockRecorder {
 }
 
 // SetEnabled mocks base method.
-func (m *MockrareSampler) SetEnabled(enabled bool) {
+func (m *MockrareSampler) SetEnabled(enabled, remotelyConfigured bool) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetEnabled", enabled)
+	m.ctrl.Call(m, "SetEnabled", enabled, remotelyConfigured)
 }
 
 // SetEnabled indicates an expected call of SetEnabled.
-func (mr *MockrareSamplerMockRecorder) SetEnabled(enabled interface{}) *gomock.Call {
+func (mr *MockrareSamplerMockRecorder) SetEnabled(enabled, remotelyConfigured interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetEnabled", reflect.TypeOf((*MockrareSampler)(nil).SetEnabled), enabled)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetEnabled", reflect.TypeOf((*MockrareSampler)(nil).SetEnabled), enabled, remotelyConfigured)
 }

--- a/pkg/trace/remoteconfighandler/mock_samplers.go
+++ b/pkg/trace/remoteconfighandler/mock_samplers.go
@@ -68,13 +68,13 @@ func (m *MockrareSampler) EXPECT() *MockrareSamplerMockRecorder {
 }
 
 // SetEnabled mocks base method.
-func (m *MockrareSampler) SetEnabled(enabled, remotelyConfigured bool) {
+func (m *MockrareSampler) Configure(enabled, remotelyConfigured bool) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetEnabled", enabled, remotelyConfigured)
+	m.ctrl.Call(m, "Configure", enabled, remotelyConfigured)
 }
 
 // SetEnabled indicates an expected call of SetEnabled.
 func (mr *MockrareSamplerMockRecorder) SetEnabled(enabled, remotelyConfigured interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetEnabled", reflect.TypeOf((*MockrareSampler)(nil).SetEnabled), enabled, remotelyConfigured)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Configure", reflect.TypeOf((*MockrareSampler)(nil).Configure), enabled, remotelyConfigured)
 }

--- a/pkg/trace/remoteconfighandler/remote_config_handler.go
+++ b/pkg/trace/remoteconfighandler/remote_config_handler.go
@@ -18,7 +18,7 @@ type samplerWithTPS interface {
 }
 
 type rareSampler interface {
-	SetEnabled(enabled bool, remotelyConfigured bool)
+	Configure(enabled bool, remotelyConfigured bool)
 }
 
 // RemoteConfigHandler holds pointers to samplers that need to be updated when APM remote config changes
@@ -133,5 +133,5 @@ func (h *RemoteConfigHandler) updateSamplers(config apmsampling.SamplerConfig) {
 		rareSamplerEnabled = h.agentConfig.RareSamplerEnabled
 		rareSamplerRemotelyConfigured = false
 	}
-	h.rareSampler.SetEnabled(rareSamplerEnabled, rareSamplerRemotelyConfigured)
+	h.rareSampler.Configure(rareSamplerEnabled, rareSamplerRemotelyConfigured)
 }

--- a/pkg/trace/remoteconfighandler/remote_config_handler.go
+++ b/pkg/trace/remoteconfighandler/remote_config_handler.go
@@ -57,6 +57,14 @@ func (h *RemoteConfigHandler) Start() {
 	h.remoteClient.RegisterAPMUpdate(h.onUpdate)
 }
 
+func (h *RemoteConfigHandler) Stop() {
+	if h == nil {
+		return
+	}
+
+	h.remoteClient.Close()
+}
+
 func (h *RemoteConfigHandler) onUpdate(update map[string]state.APMSamplingConfig) {
 	if len(update) == 0 {
 		log.Debugf("no samplers configuration in remote config update payload")

--- a/pkg/trace/remoteconfighandler/remote_config_handler.go
+++ b/pkg/trace/remoteconfighandler/remote_config_handler.go
@@ -93,45 +93,27 @@ func (h *RemoteConfigHandler) updateSamplers(config apmsampling.SamplerConfig) {
 		}
 	}
 
-	var prioritySamplerTargetTPS float64
-	var prioritySamplerRemotelyConfigured bool
 	if confForEnv != nil && confForEnv.PrioritySamplerTargetTPS != nil {
-		prioritySamplerTargetTPS = *confForEnv.PrioritySamplerTargetTPS
-		prioritySamplerRemotelyConfigured = true
+		h.prioritySampler.UpdateTargetTPS(*confForEnv.PrioritySamplerTargetTPS, true)
 	} else if config.AllEnvs.PrioritySamplerTargetTPS != nil {
-		prioritySamplerTargetTPS = *config.AllEnvs.PrioritySamplerTargetTPS
-		prioritySamplerRemotelyConfigured = true
+		h.prioritySampler.UpdateTargetTPS(*config.AllEnvs.PrioritySamplerTargetTPS, true)
 	} else {
-		prioritySamplerTargetTPS = h.agentConfig.TargetTPS
-		prioritySamplerRemotelyConfigured = false
+		h.prioritySampler.UpdateTargetTPS(h.agentConfig.TargetTPS, false)
 	}
-	h.prioritySampler.UpdateTargetTPS(prioritySamplerTargetTPS, prioritySamplerRemotelyConfigured)
 
-	var errorsSamplerTargetTPS float64
-	var errorsSamplerRemotelyConfigured bool
 	if confForEnv != nil && confForEnv.ErrorsSamplerTargetTPS != nil {
-		errorsSamplerTargetTPS = *confForEnv.ErrorsSamplerTargetTPS
-		errorsSamplerRemotelyConfigured = true
+		h.errorsSampler.UpdateTargetTPS(*confForEnv.ErrorsSamplerTargetTPS, true)
 	} else if config.AllEnvs.ErrorsSamplerTargetTPS != nil {
-		errorsSamplerTargetTPS = *config.AllEnvs.ErrorsSamplerTargetTPS
-		errorsSamplerRemotelyConfigured = true
+		h.errorsSampler.UpdateTargetTPS(*config.AllEnvs.ErrorsSamplerTargetTPS, true)
 	} else {
-		errorsSamplerTargetTPS = h.agentConfig.ErrorTPS
-		errorsSamplerRemotelyConfigured = false
+		h.errorsSampler.UpdateTargetTPS(h.agentConfig.ErrorTPS, false)
 	}
-	h.errorsSampler.UpdateTargetTPS(errorsSamplerTargetTPS, errorsSamplerRemotelyConfigured)
 
-	var rareSamplerEnabled bool
-	var rareSamplerRemotelyConfigured bool
 	if confForEnv != nil && confForEnv.RareSamplerEnabled != nil {
-		rareSamplerEnabled = *confForEnv.RareSamplerEnabled
-		rareSamplerRemotelyConfigured = true
+		h.rareSampler.Configure(*confForEnv.RareSamplerEnabled, true)
 	} else if config.AllEnvs.RareSamplerEnabled != nil {
-		rareSamplerEnabled = *config.AllEnvs.RareSamplerEnabled
-		rareSamplerRemotelyConfigured = true
+		h.rareSampler.Configure(*config.AllEnvs.RareSamplerEnabled, true)
 	} else {
-		rareSamplerEnabled = h.agentConfig.RareSamplerEnabled
-		rareSamplerRemotelyConfigured = false
+		h.rareSampler.Configure(h.agentConfig.RareSamplerEnabled, false)
 	}
-	h.rareSampler.Configure(rareSamplerEnabled, rareSamplerRemotelyConfigured)
 }

--- a/pkg/trace/remoteconfighandler/remote_config_handler_test.go
+++ b/pkg/trace/remoteconfighandler/remote_config_handler_test.go
@@ -20,8 +20,8 @@ func TestStart(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	remoteClient := NewMockRemoteClient(ctrl)
 	agentConfig := config.AgentConfig{RemoteSamplingClient: remoteClient}
-	prioritySampler := NewMockprioritySampler(ctrl)
-	errorsSampler := NewMockerrorsSampler(ctrl)
+	prioritySampler := NewMocksamplerWithTPS(ctrl)
+	errorsSampler := NewMocksamplerWithTPS(ctrl)
 	rareSampler := NewMockrareSampler(ctrl)
 
 	h := New(&agentConfig, prioritySampler, rareSampler, errorsSampler)
@@ -42,8 +42,8 @@ func TestStartNoRemoteClient(t *testing.T) {
 func TestPrioritySampler(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	remoteClient := NewMockRemoteClient(ctrl)
-	prioritySampler := NewMockprioritySampler(ctrl)
-	errorsSampler := NewMockerrorsSampler(ctrl)
+	prioritySampler := NewMocksamplerWithTPS(ctrl)
+	errorsSampler := NewMocksamplerWithTPS(ctrl)
 	rareSampler := NewMockrareSampler(ctrl)
 
 	agentConfig := config.AgentConfig{RemoteSamplingClient: remoteClient, TargetTPS: 41, ErrorTPS: 41, RareSamplerEnabled: true}
@@ -60,9 +60,9 @@ func TestPrioritySampler(t *testing.T) {
 		Config: raw,
 	}
 
-	prioritySampler.EXPECT().UpdateTargetTPS(float64(42)).Times(1)
-	errorsSampler.EXPECT().UpdateTargetTPS(float64(41)).Times(1)
-	rareSampler.EXPECT().SetEnabled(true).Times(1)
+	prioritySampler.EXPECT().UpdateTargetTPS(float64(42), true).Times(1)
+	errorsSampler.EXPECT().UpdateTargetTPS(float64(41), false).Times(1)
+	rareSampler.EXPECT().SetEnabled(true, false).Times(1)
 
 	h.onUpdate(map[string]state.APMSamplingConfig{"datadog/2/APM_SAMPLING/samplerconfig/config": config})
 
@@ -72,8 +72,8 @@ func TestPrioritySampler(t *testing.T) {
 func TestErrorsSampler(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	remoteClient := NewMockRemoteClient(ctrl)
-	prioritySampler := NewMockprioritySampler(ctrl)
-	errorsSampler := NewMockerrorsSampler(ctrl)
+	prioritySampler := NewMocksamplerWithTPS(ctrl)
+	errorsSampler := NewMocksamplerWithTPS(ctrl)
 	rareSampler := NewMockrareSampler(ctrl)
 
 	agentConfig := config.AgentConfig{RemoteSamplingClient: remoteClient, TargetTPS: 41, ErrorTPS: 41, RareSamplerEnabled: true}
@@ -90,9 +90,9 @@ func TestErrorsSampler(t *testing.T) {
 		Config: raw,
 	}
 
-	prioritySampler.EXPECT().UpdateTargetTPS(float64(41)).Times(1)
-	errorsSampler.EXPECT().UpdateTargetTPS(float64(42)).Times(1)
-	rareSampler.EXPECT().SetEnabled(true).Times(1)
+	prioritySampler.EXPECT().UpdateTargetTPS(float64(41), false).Times(1)
+	errorsSampler.EXPECT().UpdateTargetTPS(float64(42), true).Times(1)
+	rareSampler.EXPECT().SetEnabled(true, false).Times(1)
 
 	h.onUpdate(map[string]state.APMSamplingConfig{"datadog/2/APM_SAMPLING/samplerconfig/config": config})
 
@@ -102,8 +102,8 @@ func TestErrorsSampler(t *testing.T) {
 func TestRareSampler(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	remoteClient := NewMockRemoteClient(ctrl)
-	prioritySampler := NewMockprioritySampler(ctrl)
-	errorsSampler := NewMockerrorsSampler(ctrl)
+	prioritySampler := NewMocksamplerWithTPS(ctrl)
+	errorsSampler := NewMocksamplerWithTPS(ctrl)
 	rareSampler := NewMockrareSampler(ctrl)
 
 	agentConfig := config.AgentConfig{RemoteSamplingClient: remoteClient, TargetTPS: 41, ErrorTPS: 41, RareSamplerEnabled: true}
@@ -120,9 +120,9 @@ func TestRareSampler(t *testing.T) {
 		Config: raw,
 	}
 
-	prioritySampler.EXPECT().UpdateTargetTPS(float64(41)).Times(1)
-	errorsSampler.EXPECT().UpdateTargetTPS(float64(41)).Times(1)
-	rareSampler.EXPECT().SetEnabled(false).Times(1)
+	prioritySampler.EXPECT().UpdateTargetTPS(float64(41), false).Times(1)
+	errorsSampler.EXPECT().UpdateTargetTPS(float64(41), false).Times(1)
+	rareSampler.EXPECT().SetEnabled(false, true).Times(1)
 
 	h.onUpdate(map[string]state.APMSamplingConfig{"datadog/2/APM_SAMPLING/samplerconfig/config": config})
 
@@ -132,8 +132,8 @@ func TestRareSampler(t *testing.T) {
 func TestEnvPrecedence(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	remoteClient := NewMockRemoteClient(ctrl)
-	prioritySampler := NewMockprioritySampler(ctrl)
-	errorsSampler := NewMockerrorsSampler(ctrl)
+	prioritySampler := NewMocksamplerWithTPS(ctrl)
+	errorsSampler := NewMocksamplerWithTPS(ctrl)
 	rareSampler := NewMockrareSampler(ctrl)
 
 	agentConfig := config.AgentConfig{RemoteSamplingClient: remoteClient, TargetTPS: 41, ErrorTPS: 41, RareSamplerEnabled: true, DefaultEnv: "agent-env"}
@@ -160,9 +160,9 @@ func TestEnvPrecedence(t *testing.T) {
 		Config: raw,
 	}
 
-	prioritySampler.EXPECT().UpdateTargetTPS(float64(43)).Times(1)
-	errorsSampler.EXPECT().UpdateTargetTPS(float64(43)).Times(1)
-	rareSampler.EXPECT().SetEnabled(false).Times(1)
+	prioritySampler.EXPECT().UpdateTargetTPS(float64(43), true).Times(1)
+	errorsSampler.EXPECT().UpdateTargetTPS(float64(43), true).Times(1)
+	rareSampler.EXPECT().SetEnabled(false, true).Times(1)
 
 	h.onUpdate(map[string]state.APMSamplingConfig{"datadog/2/APM_SAMPLING/samplerconfig/config": config})
 

--- a/pkg/trace/sampler/config_watcher.go
+++ b/pkg/trace/sampler/config_watcher.go
@@ -1,0 +1,49 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package sampler
+
+import (
+	"fmt"
+	"github.com/DataDog/datadog-agent/pkg/trace/metrics"
+	"time"
+)
+
+type ConfigWatcher struct {
+	prioritySampler *PrioritySampler
+	errorsSampler   *ErrorsSampler
+	rareSampler     *RareSampler
+	stop            chan struct{}
+}
+
+func NewConfigWatcher(prioritySampler *PrioritySampler, errorsSampler *ErrorsSampler, rareSampler *RareSampler) *ConfigWatcher {
+	return &ConfigWatcher{
+		prioritySampler: prioritySampler,
+		errorsSampler:   errorsSampler,
+		rareSampler:     rareSampler,
+		stop:            make(chan struct{}),
+	}
+}
+
+func (w *ConfigWatcher) Start() {
+	go func() {
+		ticker := time.NewTicker(10 * time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				metrics.Gauge("datadog.trace_agent.sampler.priority_sampler_target_tps", w.prioritySampler.sampler.GetTargetTps(), []string{fmt.Sprintf("remotely_configured:%v", w.prioritySampler.RemotelyConfigured)}, 1)
+				metrics.Gauge("datadog.trace_agent.sampler.errors_sampler_target_tps", w.errorsSampler.GetTargetTps(), []string{fmt.Sprintf("remotely_configured:%v", w.errorsSampler.RemotelyConfigured)}, 1)
+				metrics.Gauge("datadog.trace_agent.sampler.rare_sampler_target_tps", float64(w.rareSampler.limiter.Limit()), []string{fmt.Sprintf("enabled:%v", w.rareSampler.GetEnabled()), fmt.Sprintf("remotely_configured:%v", w.rareSampler.RemotelyConfigured)}, 1)
+			case <-w.stop:
+				return
+			}
+		}
+	}()
+}
+
+func (w *ConfigWatcher) Stop() {
+	close(w.stop)
+}

--- a/pkg/trace/sampler/coresampler.go
+++ b/pkg/trace/sampler/coresampler.go
@@ -76,6 +76,10 @@ func newSampler(extraRate float64, targetTPS float64, tags []string) *Sampler {
 	return s
 }
 
+func (s *Sampler) GetTargetTps() float64 {
+	return s.targetTPS.Load()
+}
+
 // updateTargetTPS updates the targetTPS and all rates
 func (s *Sampler) updateTargetTPS(targetTPS float64) {
 	previousTargetTPS := s.targetTPS.Load()

--- a/pkg/trace/sampler/errorssampler.go
+++ b/pkg/trace/sampler/errorssampler.go
@@ -1,0 +1,32 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package sampler
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/trace/config"
+)
+
+// ErrorsSampler is dedicated to catching traces containing spans with errors.
+type ErrorsSampler struct {
+	ScoreSampler
+	RemotelyConfigured bool
+}
+
+// NewErrorsSampler returns an initialized Sampler dedicated to errors. It behaves
+// just like the the normal ScoreEngine except for its GetType method (useful
+// for reporting).
+func NewErrorsSampler(conf *config.AgentConfig) *ErrorsSampler {
+	s := newSampler(conf.ExtraSampleRate, conf.ErrorTPS, []string{"sampler:error"})
+	return &ErrorsSampler{
+		ScoreSampler:       ScoreSampler{Sampler: s, samplingRateKey: errorsRateKey, disabled: conf.ErrorTPS == 0},
+		RemotelyConfigured: false,
+	}
+}
+
+func (e *ErrorsSampler) UpdateTargetTPS(targetTPS float64, remotelyConfigured bool) {
+	e.Sampler.updateTargetTPS(targetTPS)
+	e.RemotelyConfigured = remotelyConfigured
+}

--- a/pkg/trace/sampler/rare_sampler.go
+++ b/pkg/trace/sampler/rare_sampler.go
@@ -96,7 +96,7 @@ func (e *RareSampler) Stop() {
 	e.tickStats.Stop()
 }
 
-func (e *RareSampler) SetEnabled(enabled bool, remotelyConfigured bool) {
+func (e *RareSampler) Configure(enabled bool, remotelyConfigured bool) {
 	e.enabled.Store(enabled)
 	e.RemotelyConfigured.Store(remotelyConfigured)
 }

--- a/pkg/trace/sampler/scoresampler.go
+++ b/pkg/trace/sampler/scoresampler.go
@@ -20,9 +20,6 @@ const (
 	shrinkCardinality = 200
 )
 
-// ErrorsSampler is dedicated to catching traces containing spans with errors.
-type ErrorsSampler struct{ ScoreSampler }
-
 // NoPrioritySampler is dedicated to catching traces with no priority set.
 type NoPrioritySampler struct{ ScoreSampler }
 
@@ -45,14 +42,6 @@ func NewNoPrioritySampler(conf *config.AgentConfig) *NoPrioritySampler {
 	return &NoPrioritySampler{ScoreSampler{Sampler: s, samplingRateKey: noPriorityRateKey}}
 }
 
-// NewErrorsSampler returns an initialized Sampler dedicate to errors. It behaves
-// just like the the normal ScoreEngine except for its GetType method (useful
-// for reporting).
-func NewErrorsSampler(conf *config.AgentConfig) *ErrorsSampler {
-	s := newSampler(conf.ExtraSampleRate, conf.ErrorTPS, []string{"sampler:error"})
-	return &ErrorsSampler{ScoreSampler{Sampler: s, samplingRateKey: errorsRateKey, disabled: conf.ErrorTPS == 0}}
-}
-
 // Sample counts an incoming trace and tells if it is a sample which has to be kept
 func (s *ScoreSampler) Sample(now time.Time, trace pb.Trace, root *pb.Span, env string) bool {
 	if s.disabled {
@@ -71,10 +60,6 @@ func (s *ScoreSampler) Sample(now time.Time, trace pb.Trace, root *pb.Span, env 
 	rate := s.getSignatureSampleRate(signature)
 
 	return s.applySampleRate(root, rate)
-}
-
-func (e *ErrorsSampler) UpdateTargetTPS(targetTPS float64) {
-	e.ScoreSampler.Sampler.updateTargetTPS(targetTPS)
 }
 
 func (s *ScoreSampler) applySampleRate(root *pb.Span, rate float64) bool {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

We previously made agent samplers remotely configurable. This PR gives us some visibility on what the configuration is for every agent, and on whether or not these configurations are remote or local.

https://datadoghq.atlassian.net/jira/software/projects/ATI/boards/105?selectedIssue=ATI-2346

![image](https://user-images.githubusercontent.com/103181765/205324162-bccc1b09-430a-4917-b204-1882d3aa5350.png)


<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
