### PR TITLE
[gitlab] Fix glob that finds JUnit results to upload

### DIFF
--- a/tasks/libs/junit_upload.py
+++ b/tasks/libs/junit_upload.py
@@ -131,7 +131,7 @@ def junit_upload_from_tgz(junit_tgz, codeowners_path=".github/CODEOWNERS"):
 
     empty_tgzs = []
     for tgz, count in xmlcounts.items():
-        print(f"Submitted results for {filecount} JUnit XML files from {tgz}")
+        print(f"Submitted results for {count} JUnit XML files from {tgz}")
         if count == 0:
             empty_tgzs.append(tgz)
 

--- a/tasks/libs/junit_upload.py
+++ b/tasks/libs/junit_upload.py
@@ -117,7 +117,8 @@ def junit_upload_from_tgz(junit_tgz, codeowners_path=".github/CODEOWNERS"):
             job_url = jf.read()
 
         # for each unpacked xml file, split it and submit all parts
-        for xmlfile in glob.glob(f"{unpack_dir}/**/*.xml"):
+        # NOTE: recursive=True is necessary for "**" to unpack into 0-n dirs, not just 1
+        for xmlfile in glob.glob(f"{unpack_dir}/**/*.xml", recursive=True):
             with tempfile.TemporaryDirectory() as output_dir:
                 written_owners, flavor = split_junitxml(xmlfile, codeowners, output_dir)
                 upload_junitxmls(output_dir, written_owners, flavor, tags, job_url)


### PR DESCRIPTION
### What does this PR do?

Using `glob.glob("dir/**/*.xml")` in Python literally only looks one directory deep. If we want to take all xml files from all subdirectories including `dir` directly, the `recursive=True` argument must be passed.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
