### PR TITLE
[CWS] remove useless mount resolver code

### DIFF
--- a/pkg/security/probe/mount_resolver.go
+++ b/pkg/security/probe/mount_resolver.go
@@ -85,13 +85,12 @@ type deleteRequest struct {
 
 // MountResolver represents a cache for mountpoints and the corresponding file systems
 type MountResolver struct {
-	statsdClient     statsd.ClientInterface
-	lock             sync.RWMutex
-	mounts           map[uint32]*model.MountEvent
-	devices          map[uint32]map[uint32]*model.MountEvent
-	deleteQueue      []deleteRequest
-	overlayPathCache *simplelru.LRU[uint32, string]
-	parentPathCache  *simplelru.LRU[uint32, string]
+	statsdClient    statsd.ClientInterface
+	lock            sync.RWMutex
+	mounts          map[uint32]*model.MountEvent
+	devices         map[uint32]map[uint32]*model.MountEvent
+	deleteQueue     []deleteRequest
+	parentPathCache *simplelru.LRU[uint32, string]
 
 	// stats
 	cacheHitsStats *atomic.Int64
@@ -291,55 +290,6 @@ func (mr *MountResolver) getParentPath(mountID uint32) (string, error) {
 	return path, nil
 }
 
-func (mr *MountResolver) _getAncestor(mount *model.MountEvent, cache map[uint32]bool) *model.MountEvent {
-	if _, exists := cache[mount.MountID]; exists {
-		return nil
-	}
-	cache[mount.MountID] = true
-
-	parent, ok := mr.mounts[mount.ParentMountID]
-	if !ok {
-		return nil
-	}
-
-	if grandParent := mr._getAncestor(parent, cache); grandParent != nil {
-		return grandParent
-	}
-
-	return parent
-}
-
-func (mr *MountResolver) getAncestor(mount *model.MountEvent) *model.MountEvent {
-	return mr._getAncestor(mount, map[uint32]bool{})
-}
-
-// getOverlayPath uses deviceID to find overlay path
-func (mr *MountResolver) getOverlayPath(mount *model.MountEvent) (string, error) {
-	if entry, found := mr.overlayPathCache.Get(mount.MountID); found {
-		return entry, nil
-	}
-
-	if ancestor := mr.getAncestor(mount); ancestor != nil {
-		mount = ancestor
-	}
-
-	for _, deviceMount := range mr.devices[mount.Device] {
-		if mount.MountID != deviceMount.MountID && deviceMount.IsOverlayFS() {
-			p, err := mr.getParentPath(deviceMount.MountID)
-			if err != nil {
-				return "", err
-			}
-
-			if p != "" {
-				mr.overlayPathCache.Add(mount.MountID, p)
-				return p, nil
-			}
-		}
-	}
-
-	return "", nil
-}
-
 func (mr *MountResolver) dequeue(now time.Time) {
 	mr.lock.Lock()
 
@@ -374,7 +324,6 @@ func (mr *MountResolver) dequeue(now time.Time) {
 
 func (mr *MountResolver) clearCacheForMountID(mountID uint32) {
 	mr.parentPathCache.Remove(mountID)
-	mr.overlayPathCache.Remove(mountID)
 }
 
 // Start starts the resolver
@@ -426,28 +375,23 @@ func (mr *MountResolver) resolveMount(mountID, pid uint32) (*model.MountEvent, e
 	return mount, nil
 }
 
-// GetMountPath returns the path of a mount identified by its mount ID. The first path is the container mount path if
-// it exists, the second parameter is the mount point path, and the third parameter is the root path.
-func (mr *MountResolver) GetMountPath(mountID, pid uint32) (string, string, string, error) {
+// ResolveMountPaths returns the path of a mount identified by its mount ID.
+// The first parameter is the mount point path, and the third parameter is the root path.
+func (mr *MountResolver) ResolveMountPaths(mountID, pid uint32) (string, string, error) {
 	mr.lock.Lock()
 	defer mr.lock.Unlock()
 
 	mount, err := mr.resolveMount(mountID, pid)
 	if err != nil {
-		return "", "", "", ErrMountNotFound
-	}
-
-	overlayPath, err := mr.getOverlayPath(mount)
-	if err != nil {
-		return "", "", "", err
+		return "", "", ErrMountNotFound
 	}
 
 	parentPath, err := mr.getParentPath(mountID)
 	if err != nil {
-		return "", "", "", err
+		return "", "", err
 	}
 
-	return overlayPath, parentPath, mount.RootStr, nil
+	return parentPath, mount.RootStr, nil
 }
 
 func getMountIDOffset(probe *Probe) uint64 {
@@ -549,26 +493,20 @@ func (mr *MountResolver) SendStats() error {
 
 // NewMountResolver instantiates a new mount resolver
 func NewMountResolver(statsdClient statsd.ClientInterface) (*MountResolver, error) {
-	overlayPathCache, err := simplelru.NewLRU[uint32, string](256, nil)
-	if err != nil {
-		return nil, err
-	}
-
 	parentPathCache, err := simplelru.NewLRU[uint32, string](256, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	return &MountResolver{
-		statsdClient:     statsdClient,
-		lock:             sync.RWMutex{},
-		devices:          make(map[uint32]map[uint32]*model.MountEvent),
-		mounts:           make(map[uint32]*model.MountEvent),
-		overlayPathCache: overlayPathCache,
-		parentPathCache:  parentPathCache,
-		cacheHitsStats:   atomic.NewInt64(0),
-		procHitsStats:    atomic.NewInt64(0),
-		cacheMissStats:   atomic.NewInt64(0),
-		procMissStats:    atomic.NewInt64(0),
+		statsdClient:    statsdClient,
+		lock:            sync.RWMutex{},
+		devices:         make(map[uint32]map[uint32]*model.MountEvent),
+		mounts:          make(map[uint32]*model.MountEvent),
+		parentPathCache: parentPathCache,
+		cacheHitsStats:  atomic.NewInt64(0),
+		procHitsStats:   atomic.NewInt64(0),
+		cacheMissStats:  atomic.NewInt64(0),
+		procMissStats:   atomic.NewInt64(0),
 	}, nil
 }

--- a/pkg/security/probe/mount_resolver_test.go
+++ b/pkg/security/probe/mount_resolver_test.go
@@ -328,7 +328,7 @@ func TestMountResolver(t *testing.T) {
 			mr.dequeue(time.Now().Add(1 * time.Minute))
 
 			for _, testC := range tt.args.cases {
-				_, p, _, err := mr.GetMountPath(testC.mountID, 0)
+				p, _, err := mr.ResolveMountPaths(testC.mountID, 0)
 				if err != nil {
 					if testC.expectedError != nil {
 						assert.Equal(t, testC.expectedError.Error(), err.Error())

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -533,7 +533,7 @@ func (p *Probe) handleEvent(CPU int, data []byte) {
 
 		if event.Mount.GetFSType() == "nsfs" {
 			nsid := uint32(event.Mount.RootInode)
-			_, mountPath, _, err := p.resolvers.MountResolver.GetMountPath(event.Mount.MountID, event.PIDContext.Pid)
+			mountPath, _, err := p.resolvers.MountResolver.ResolveMountPaths(event.Mount.MountID, event.PIDContext.Pid)
 			if err != nil {
 				seclog.Debugf("failed to get mount path: %v", err)
 			} else {

--- a/pkg/security/probe/resolvers.go
+++ b/pkg/security/probe/resolvers.go
@@ -95,7 +95,7 @@ func (r *Resolvers) resolveFileFieldsPath(e *model.FileFields, ctx *model.PIDCon
 		return pathStr, err
 	}
 
-	_, mountPath, rootPath, mountErr := r.MountResolver.GetMountPath(e.MountID, ctx.Pid)
+	mountPath, rootPath, mountErr := r.MountResolver.ResolveMountPaths(e.MountID, ctx.Pid)
 	if mountErr != nil {
 		return pathStr, mountErr
 	}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Remove useless cache and function from the mount resolver.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
