### PR TITLE
[CWS][SEC-6252] remote workloadmeta in security agent

### DIFF
--- a/cmd/security-agent/app/app.go
+++ b/cmd/security-agent/app/app.go
@@ -232,14 +232,13 @@ func RunAgent(ctx context.Context, pidfilePath string) (err error) {
 		return log.Criticalf("Error creating statsd Client: %s", err)
 	}
 
+	workloadmetaCollectors := workloadmeta.NodeAgentCatalog
 	if coreconfig.Datadog.GetBool("security_agent.remote_workloadmeta") {
-		if err = workloadmeta.ConfigureAsRemote(); err != nil {
-			log.Errorf("Can't configure workloadmeta as remote, will use a local one. err: %s", err)
-		}
+		workloadmetaCollectors = workloadmeta.RemoteCatalog
 	}
 
 	// Start workloadmeta store
-	store := workloadmeta.CreateGlobalStore(workloadmeta.NodeAgentCatalog)
+	store := workloadmeta.CreateGlobalStore(workloadmetaCollectors)
 	store.Start(ctx)
 
 	// Initialize the remote tagger

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1084,6 +1084,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("security_agent.expvar_port", 5011)
 	config.BindEnvAndSetDefault("security_agent.log_file", defaultSecurityAgentLogFile)
 	config.BindEnvAndSetDefault("security_agent.remote_tagger", true)
+	config.BindEnvAndSetDefault("security_agent.remote_workloadmeta", false) // TODO(paulcacheux): switch this to true when ready
 
 	config.BindEnvAndSetDefault("security_agent.internal_profiling.enabled", false, "DD_SECURITY_AGENT_INTERNAL_PROFILING_ENABLED")
 	config.BindEnvAndSetDefault("security_agent.internal_profiling.site", DefaultSite, "DD_SECURITY_AGENT_INTERNAL_PROFILING_SITE", "DD_SITE")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1084,7 +1084,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("security_agent.expvar_port", 5011)
 	config.BindEnvAndSetDefault("security_agent.log_file", defaultSecurityAgentLogFile)
 	config.BindEnvAndSetDefault("security_agent.remote_tagger", true)
-	config.BindEnvAndSetDefault("security_agent.remote_workloadmeta", false) // TODO(paulcacheux): switch this to true when ready
+	config.BindEnvAndSetDefault("security_agent.remote_workloadmeta", false) // TODO: switch this to true when ready
 
 	config.BindEnvAndSetDefault("security_agent.internal_profiling.enabled", false, "DD_SECURITY_AGENT_INTERNAL_PROFILING_ENABLED")
 	config.BindEnvAndSetDefault("security_agent.internal_profiling.site", DefaultSite, "DD_SECURITY_AGENT_INTERNAL_PROFILING_SITE", "DD_SITE")

--- a/test/e2e/cws-tests/tests/lib/config.py
+++ b/test/e2e/cws-tests/tests/lib/config.py
@@ -25,7 +25,7 @@ def gen_datadog_agent_config(hostname="myhost", log_level="INFO", tags=None):
     if not tags:
         tags = []
 
-    data = {"log_level": log_level, "hostname": hostname, "tags": tags}
+    data = {"log_level": log_level, "hostname": hostname, "tags": tags, "security_agent.remote_workloadmeta": True}
     yaml.dump(data, fp)
     fp.close()
 


### PR DESCRIPTION
### What does this PR do?

Depends on: https://github.com/DataDog/datadog-agent/pull/14482

This PR adds support for using the remote workloadmeta in the security agent. This is currently disabled by default but is tested by the e2e tests.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
