### PR TITLE
[cmd/process-agent] Add workload-list command

### DIFF
--- a/cmd/process-agent/api/server.go
+++ b/cmd/process-agent/api/server.go
@@ -24,6 +24,8 @@ func setupHandlers(r *mux.Router) {
 	r.HandleFunc("/config/{setting}", settingshttp.Server.SetValue).Methods("POST")
 	r.HandleFunc("/agent/status", statusHandler).Methods("GET")
 	r.HandleFunc("/agent/tagger-list", getTaggerList).Methods("GET")
+	r.HandleFunc("/agent/workload-list/short", getShortWorkloadList).Methods("GET")
+	r.HandleFunc("/agent/workload-list/verbose", getVerboseWorkloadList).Methods("GET")
 	r.HandleFunc("/check/{check}", checkHandler).Methods("GET")
 }
 

--- a/cmd/process-agent/api/workload_list.go
+++ b/cmd/process-agent/api/workload_list.go
@@ -1,0 +1,33 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
+)
+
+func getVerboseWorkloadList(w http.ResponseWriter, r *http.Request) {
+	workloadList(w, true)
+}
+
+func getShortWorkloadList(w http.ResponseWriter, r *http.Request) {
+	workloadList(w, false)
+}
+
+func workloadList(w http.ResponseWriter, verbose bool) {
+	response := workloadmeta.GetGlobalStore().Dump(verbose)
+	jsonDump, err := json.Marshal(response)
+	if err != nil {
+		setJSONError(w, log.Errorf("Unable to marshal workload list response: %v", err), 500)
+		return
+	}
+
+	w.Write(jsonDump)
+}

--- a/cmd/process-agent/app/subcommands/workloadlist/command.go
+++ b/cmd/process-agent/app/subcommands/workloadlist/command.go
@@ -1,0 +1,100 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package workloadlist
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+	"go.uber.org/fx"
+
+	"github.com/DataDog/datadog-agent/cmd/agent/command"
+	"github.com/DataDog/datadog-agent/comp/core"
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/log"
+	"github.com/DataDog/datadog-agent/pkg/api/util"
+	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
+)
+
+type cliParams struct {
+	*command.GlobalParams
+	verboseList bool
+}
+
+// Commands returns a slice of subcommands for the 'process-agent' command.
+func Commands(globalParams *command.GlobalParams) []*cobra.Command {
+	cliParams := &cliParams{
+		GlobalParams: globalParams,
+	}
+	workloadListCommand := &cobra.Command{
+		Use:   "workload-list",
+		Short: "Print the workload content of a running agent",
+		Long:  ``,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return fxutil.OneShot(workloadList,
+				fx.Supply(cliParams),
+				fx.Supply(core.CreateAgentBundleParams(globalParams.ConfFilePath, false).LogForOneShot("PROCESS", "off", true)),
+				core.Bundle,
+			)
+		},
+	}
+	workloadListCommand.Flags().BoolVarP(&cliParams.verboseList, "verbose", "", false, "print out a full dump of the workload store")
+
+	return []*cobra.Command{workloadListCommand}
+}
+
+func workloadList(_ log.Component, _ config.Component, cliParams *cliParams) error {
+	c := util.GetClient(false) // FIX: get certificates right then make this true
+
+	// Set session token
+	err := util.SetAuthToken()
+	if err != nil {
+		return err
+	}
+
+	url, err := workloadURL(cliParams.verboseList)
+	if err != nil {
+		return err
+	}
+
+	r, err := util.DoGet(c, url, util.LeaveConnectionOpen)
+	if err != nil {
+		if r != nil && string(r) != "" {
+			fmt.Fprintf(color.Output, "The agent ran into an error while getting the workload store information: %s\n", string(r))
+		} else {
+			fmt.Fprintf(color.Output, "Failed to query the agent (running?): %s\n", err)
+		}
+	}
+
+	workload := workloadmeta.WorkloadDumpResponse{}
+	err = json.Unmarshal(r, &workload)
+	if err != nil {
+		return err
+	}
+
+	workload.Write(color.Output)
+
+	return nil
+}
+
+func workloadURL(verbose bool) (string, error) {
+	addressPort, err := ddconfig.GetProcessAPIAddressPort()
+	if err != nil {
+		return "", fmt.Errorf("config error: %s", err.Error())
+	}
+
+	url := fmt.Sprintf("http://%s/agent/workload-list", addressPort)
+
+	if verbose {
+		return url + "/verbose", nil
+	}
+
+	return url + "/short", nil
+}

--- a/cmd/process-agent/main_common.go
+++ b/cmd/process-agent/main_common.go
@@ -15,10 +15,12 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/DataDog/datadog-agent/cmd/agent/command"
 	"github.com/DataDog/datadog-agent/cmd/agent/common/misconfig"
 	"github.com/DataDog/datadog-agent/cmd/manager"
 	"github.com/DataDog/datadog-agent/cmd/process-agent/api"
 	"github.com/DataDog/datadog-agent/cmd/process-agent/app"
+	cmdworkloadlist "github.com/DataDog/datadog-agent/cmd/process-agent/app/subcommands/workloadlist"
 	cmdconfig "github.com/DataDog/datadog-agent/cmd/process-agent/commands/config"
 	sysconfig "github.com/DataDog/datadog-agent/cmd/system-probe/config"
 	apiutil "github.com/DataDog/datadog-agent/pkg/api/util"
@@ -95,6 +97,18 @@ func getSettingsClient(_ *cobra.Command, _ []string) (settings.Client, error) {
 
 func init() {
 	rootCmd.AddCommand(configCommand, app.StatusCmd, app.VersionCmd, app.CheckCmd, app.EventsCmd, app.TaggerCmd)
+
+	globalParams := command.GlobalParams{}
+
+	factories := []command.SubcommandFactory{
+		cmdworkloadlist.Commands,
+	}
+
+	for _, factory := range factories {
+		for _, subcmd := range factory(&globalParams) {
+			rootCmd.AddCommand(subcmd)
+		}
+	}
 }
 
 const (

--- a/releasenotes/notes/process-agent-cmd-workload-list-5b0535968ee5163f.yaml
+++ b/releasenotes/notes/process-agent-cmd-workload-list-5b0535968ee5163f.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Added the `workload-list` command to the process agent. It lists the entities stored in workloadmeta.


### PR DESCRIPTION
### What does this PR do?

Adds the `workload-list` command to the process-agent. It's the same command that already exists in the core agent.

I used the new way of defining subcommands already used in the core agent and others.

### Motivation

It's useful for debugging.

### Describe how to test/QA your changes

Run `process-agent workload-list` and `process-agent workload-list verbose` and check that they work.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
