### PR TITLE
[SNMP] - Parse snmp config from the snmp_listener

### DIFF
--- a/pkg/snmp/snmpparse/config_snmp.go
+++ b/pkg/snmp/snmpparse/config_snmp.go
@@ -12,6 +12,8 @@ import (
 	yaml "gopkg.in/yaml.v2"
 
 	"github.com/DataDog/datadog-agent/cmd/agent/api/response"
+	snmplistener "github.com/DataDog/datadog-agent/pkg/snmp"
+
 	"github.com/DataDog/datadog-agent/pkg/api/util"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/config"
@@ -59,6 +61,39 @@ func ParseConfigSnmp(c integration.Config) []SNMPConfig {
 
 	return snmpconfigs
 }
+func ParseConfigSnmpMain() []SNMPConfig {
+	snmpconfigs := []SNMPConfig{}
+	configs := []snmplistener.Config{}
+	//the UnmarshalKey stores the result in mapstructures while the snmpconfig is in yaml
+	// we get: unable to get snmp config from snmp_listener: '' expected a map, got 'slice'
+	//so for each result of the Unmarshal key we storre the result in a tmp SNMPConfig{} object
+	err := config.Datadog.UnmarshalKey("snmp_listener.configs", &configs)
+	if err != nil {
+		fmt.Printf("unable to get snmp config from snmp_listener: %v", err)
+	}
+	for c := range configs {
+		snmpconfig := SNMPConfig{}
+
+		snmpconfig.NetAddress = configs[c].Network
+		snmpconfig.Port = configs[c].Port
+		snmpconfig.Version = configs[c].Version
+		snmpconfig.Timeout = configs[c].Timeout
+		snmpconfig.Retries = configs[c].Retries
+		snmpconfig.CommunityString = configs[c].Community
+		snmpconfig.Username = configs[c].User
+		snmpconfig.AuthProtocol = configs[c].AuthProtocol
+		snmpconfig.AuthKey = configs[c].AuthKey
+		snmpconfig.PrivProtocol = configs[c].PrivProtocol
+		snmpconfig.PrivKey = configs[c].PrivKey
+		snmpconfig.Context = configs[c].ContextName
+
+		snmpconfigs = append(snmpconfigs, snmpconfig)
+
+	}
+
+	return snmpconfigs
+
+}
 
 func GetConfigCheckSnmp() ([]SNMPConfig, error) {
 
@@ -91,6 +126,7 @@ func GetConfigCheckSnmp() ([]SNMPConfig, error) {
 			snmpconfigs = append(snmpconfigs, ParseConfigSnmp(c)...)
 		}
 	}
+	snmpconfigs = append(snmpconfigs, ParseConfigSnmpMain()...)
 
 	return snmpconfigs, nil
 

--- a/pkg/snmp/snmpparse/config_snmp.go
+++ b/pkg/snmp/snmpparse/config_snmp.go
@@ -61,7 +61,7 @@ func ParseConfigSnmp(c integration.Config) []SNMPConfig {
 
 	return snmpconfigs
 }
-func ParseConfigSnmpMain() []SNMPConfig {
+func parseConfigSnmpMain() ([]SNMPConfig, error) {
 	snmpconfigs := []SNMPConfig{}
 	configs := []snmplistener.Config{}
 	//the UnmarshalKey stores the result in mapstructures while the snmpconfig is in yaml
@@ -69,6 +69,7 @@ func ParseConfigSnmpMain() []SNMPConfig {
 	err := config.Datadog.UnmarshalKey("snmp_listener.configs", &configs)
 	if err != nil {
 		fmt.Printf("unable to get snmp config from snmp_listener: %v", err)
+		return nil, err
 	}
 	for c := range configs {
 		snmpconfig := SNMPConfig{}
@@ -90,7 +91,7 @@ func ParseConfigSnmpMain() []SNMPConfig {
 
 	}
 
-	return snmpconfigs
+	return snmpconfigs, nil
 
 }
 
@@ -125,7 +126,8 @@ func GetConfigCheckSnmp() ([]SNMPConfig, error) {
 			snmpconfigs = append(snmpconfigs, ParseConfigSnmp(c)...)
 		}
 	}
-	snmpconfigs = append(snmpconfigs, ParseConfigSnmpMain()...)
+	snmpconfigMain, _ := parseConfigSnmpMain()
+	snmpconfigs = append(snmpconfigs, snmpconfigMain...)
 
 	return snmpconfigs, nil
 

--- a/pkg/snmp/snmpparse/config_snmp.go
+++ b/pkg/snmp/snmpparse/config_snmp.go
@@ -65,7 +65,6 @@ func ParseConfigSnmpMain() []SNMPConfig {
 	snmpconfigs := []SNMPConfig{}
 	configs := []snmplistener.Config{}
 	//the UnmarshalKey stores the result in mapstructures while the snmpconfig is in yaml
-	// we get: unable to get snmp config from snmp_listener: '' expected a map, got 'slice'
 	//so for each result of the Unmarshal key we storre the result in a tmp SNMPConfig{} object
 	err := config.Datadog.UnmarshalKey("snmp_listener.configs", &configs)
 	if err != nil {

--- a/pkg/snmp/snmpparse/config_snmp_test.go
+++ b/pkg/snmp/snmpparse/config_snmp_test.go
@@ -257,7 +257,7 @@ snmp_listener:
 `))
 	assert.NoError(t, err)
 
-	Output := ParseConfigSnmpMain()
+	Output, _ := parseConfigSnmpMain()
 	Exoutput := []SNMPConfig{
 		{
 			Version:         "1",

--- a/pkg/snmp/snmpparse/config_snmp_test.go
+++ b/pkg/snmp/snmpparse/config_snmp_test.go
@@ -6,11 +6,13 @@
 package snmpparse
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
+	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
 func TestOneInstance(t *testing.T) {
@@ -236,4 +238,43 @@ func TestGetSNMPConfigEmpty(t *testing.T) {
 func assertIP(t *testing.T, input string, snmpConfigList []SNMPConfig, expectedOutput SNMPConfig) {
 	output := GetIPConfig(input, snmpConfigList)
 	assert.Equal(t, expectedOutput, output)
+}
+
+func TestParseConfigSnmpMain(t *testing.T) {
+	config.Datadog.SetConfigType("yaml")
+	// ReadConfig stores the Yaml in the config.Datadog object
+	err := config.Datadog.ReadConfig(strings.NewReader(`
+snmp_listener:
+  configs:
+   - network_address: 127.0.0.1/30
+     snmp_version: 1
+     community_string: public
+   - network_address: 127.0.0.2/30
+     snmp_version: 2
+     community_string: publicX
+   - network_address: 127.0.0.3/30
+     snmp_version: 3
+`))
+	assert.NoError(t, err)
+
+	Output := ParseConfigSnmpMain()
+	Exoutput := []SNMPConfig{
+		{
+			Version:         "1",
+			CommunityString: "public",
+			NetAddress:      "127.0.0.1/30",
+		},
+		{
+			Version:         "2",
+			CommunityString: "publicX",
+			NetAddress:      "127.0.0.2/30",
+		},
+		{
+			Version:    "3",
+			NetAddress: "127.0.0.3/30",
+		},
+	}
+
+	assert.Equal(t, Exoutput, Output)
+
 }

--- a/pkg/snmp/snmpparse/config_snmp_test.go
+++ b/pkg/snmp/snmpparse/config_snmp_test.go
@@ -252,7 +252,7 @@ snmp_listener:
    - network_address: 127.0.0.2/30
      snmp_version: 2
      community_string: publicX
-   - network_address: 127.0.0.3/30
+   - network_address: 127.0.0.4/30
      snmp_version: 3
 `))
 	assert.NoError(t, err)
@@ -271,7 +271,7 @@ snmp_listener:
 		},
 		{
 			Version:    "3",
-			NetAddress: "127.0.0.3/30",
+			NetAddress: "127.0.0.4/30",
 		},
 	}
 


### PR DESCRIPTION

### What does this PR do?

This PR is a part of the previous PR  #13779  
For now the integrated snmp walk command can only see the snmp config under the integrations directories, after this PR it will also parse the snmp configuration from the snmp_listener section (under the datadog main file), this way the search for the IP Address provided as argument to the integrated snmp walk will include any network addresses set under the snmp_listener.

### Motivation

Make the integrated snmp walk able to run with only one argument provided(the IP address)
This will help us validate the customer snmp configuration set within the agent : if the snmpwalk fails, this would mean their datadog snmp configuration is not valid.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
