### PR TITLE
pkg/trace/api: prioritize service name from span local "peer.service"

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -193,6 +193,7 @@
 /pkg/version/                           @DataDog/agent-shared-components
 /pkg/obfuscate/                         @DataDog/agent-apm
 /pkg/trace/                             @DataDog/agent-apm
+/pkg/trace/api/otlp*.go                 @DataDog/opentelemetry
 /pkg/autodiscovery/                     @DataDog/container-integrations @DataDog/agent-metrics-logs
 /pkg/autodiscovery/listeners/           @DataDog/container-integrations
 /pkg/autodiscovery/listeners/cloudfoundry*.go  @DataDog/platform-integrations

--- a/releasenotes/notes/apm-otlp-fix-service-precedence-916d72f88d1a2a52.yaml
+++ b/releasenotes/notes/apm-otlp-fix-service-precedence-916d72f88d1a2a52.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    APM: OTLP Ingest: Fix an issue where a span local "peer.service" attribute would not override a resource attribute-level service.

--- a/releasenotes/notes/apm-otlp-fix-service-precedence-916d72f88d1a2a52.yaml
+++ b/releasenotes/notes/apm-otlp-fix-service-precedence-916d72f88d1a2a52.yaml
@@ -8,4 +8,4 @@
 ---
 fixes:
   - |
-    APM: OTLP Ingest: Fix an issue where a span local "peer.service" attribute would not override a resource attribute-level service.
+    APM OTLP: Fix an issue where a span's local "peer.service" attribute would not override a resource attribute-level service.


### PR DESCRIPTION
This change fixes a bug where a span-local "peer.service" would not override the service name set from resource attributes.