### PR TITLE
Fix `agent stream-logs` command

### DIFF
--- a/cmd/agent/api/internal/agent/agent.go
+++ b/cmd/agent/api/internal/agent/agent.go
@@ -37,6 +37,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/status/health"
 	"github.com/DataDog/datadog-agent/pkg/tagger"
 	"github.com/DataDog/datadog-agent/pkg/tagger/collectors"
+	"github.com/DataDog/datadog-agent/pkg/util/grpc"
 	"github.com/DataDog/datadog-agent/pkg/util/hostname"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/scrubber"
@@ -46,9 +47,6 @@ import (
 type contextKey struct {
 	key string
 }
-
-// ConnContextKey key to reference the http connection from the request context
-var ConnContextKey = &contextKey{"http-connection"}
 
 // SetupHandlers adds the specific handlers for /agent endpoints
 func SetupHandlers(r *mux.Router) *mux.Router {
@@ -463,5 +461,5 @@ func max(a, b int) int {
 
 // GetConnection returns the connection for the request
 func GetConnection(r *http.Request) net.Conn {
-	return r.Context().Value(ConnContextKey).(net.Conn)
+	return r.Context().Value(grpc.ConnContextKey).(net.Conn)
 }

--- a/cmd/agent/api/internal/agent/agent.go
+++ b/cmd/agent/api/internal/agent/agent.go
@@ -44,10 +44,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 )
 
-type contextKey struct {
-	key string
-}
-
 // SetupHandlers adds the specific handlers for /agent endpoints
 func SetupHandlers(r *mux.Router) *mux.Router {
 	r.HandleFunc("/version", common.GetVersion).Methods("GET")

--- a/pkg/util/grpc/server.go
+++ b/pkg/util/grpc/server.go
@@ -20,7 +20,7 @@ type contextKey struct {
 	key string
 }
 
-var connContextKey = &contextKey{"http-connection"}
+var ConnContextKey = &contextKey{"http-connection"}
 
 // NewMuxedGRPCServer returns an http.Server that multiplexes connections
 // between a gRPC server and an HTTP handler.
@@ -35,7 +35,7 @@ func NewMuxedGRPCServer(addr string, tlsConfig *tls.Config, grpcServer *grpc.Ser
 		TLSConfig: tlsConfig,
 		ConnContext: func(ctx context.Context, c net.Conn) context.Context {
 			// Store the connection in the context so requests can reference it if needed
-			return context.WithValue(ctx, connContextKey, c)
+			return context.WithValue(ctx, ConnContextKey, c)
 		},
 	}
 }
@@ -47,7 +47,7 @@ func TimeoutHandlerFunc(httpHandler http.Handler, timeout time.Duration) http.Ha
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		deadline := time.Now().Add(timeout)
 
-		conn := r.Context().Value(connContextKey).(net.Conn)
+		conn := r.Context().Value(ConnContextKey).(net.Conn)
 		_ = conn.SetWriteDeadline(deadline)
 
 		httpHandler.ServeHTTP(w, r)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

`agent stream-logs` is broken. [This change](https://github.com/DataDog/datadog-agent/pull/13844) introduced 2 definitions of `ConnContextKey`. The key used to store the connection was different than the one that tried to look it up. 

This PR ensure the same key is used in both cases. 

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Bug Fix

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Ensure `agent stream-logs` works. Test other agent commands as well. 

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
