### PR TITLE
Add "View Log" button to fatal error dialog

### DIFF
--- a/tools/windows/DatadogAgentInstaller/CustomActions/UserCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/UserCustomActions.cs
@@ -437,5 +437,32 @@ namespace Datadog.CustomActions
         {
             return ConfigureUser(new SessionWrapper(session));
         }
+
+        private static ActionResult OpenMsiLog(ISession session)
+        {
+            try
+            {
+                var wixLogLocation = session["MsiLogFileLocation"];
+                if (!string.IsNullOrEmpty(wixLogLocation)) {
+                    System.Diagnostics.Process.Start(wixLogLocation);
+                    // TODO: pop a message box on error?
+                } else {
+                    // not found
+                    // TODO: pop a message box?
+                }
+            }
+            catch (Exception e)
+            {
+                session.Log($"Failed to open Wix log: {e}");
+                return ActionResult.Failure;
+            }
+            return ActionResult.Success;
+        }
+
+        [CustomAction]
+        public static ActionResult OpenMsiLog(Session session)
+        {
+            return OpenMsiLog(new SessionWrapper(session));
+        }
     }
 }

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentCustomActions.cs
@@ -17,6 +17,8 @@ namespace WixSetup.Datadog
 
         public ManagedAction ConfigureUser { get; }
 
+        public ManagedAction OpenMsiLog { get; }
+
         public AgentCustomActions()
         {
             ReadRegistryProperties = new CustomAction<UserCustomActions>(
@@ -140,6 +142,14 @@ namespace WixSetup.Datadog
                 )
                 .SetProperties("DDAGENTUSER_NAME=[DDAGENTUSER_NAME], DDAGENTUSER_PASSWORD=[DDAGENTUSER_PASSWORD]")
                 .HideTarget(true);
+
+            OpenMsiLog = new CustomAction<UserCustomActions>(
+                new Id("OpenMsiLog"),
+                UserCustomActions.OpenMsiLog
+                )
+                {
+                    Sequence = Sequence.NotInSequence
+                };
         }
     }
 }

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentInstaller.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentInstaller.cs
@@ -101,6 +101,7 @@ namespace WixSetup.Datadog
                 _agentCustomActions.ProcessDdAgentUserCredentials,
                 _agentCustomActions.DecompressPythonDistributions,
                 _agentCustomActions.ConfigureUser,
+                _agentCustomActions.OpenMsiLog,
                 new Property("MsiLogging", "iwearucmop!"),
                 new Property("APIKEY")
                 {

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentInstallerUI.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentInstallerUI.cs
@@ -65,6 +65,8 @@ namespace WixSetup.Datadog
             On(NativeDialogs.MaintenanceTypeDlg, Buttons.Back, new ShowDialog(NativeDialogs.MaintenanceWelcomeDlg));
 
             On(NativeDialogs.ExitDialog, Buttons.Finish, new CloseDialog { Order = 9999 });
+
+            On(Dialogs.FatalErrorDialog, "OpenMsiLog", new ExecuteCustomAction(agentCustomActions.OpenMsiLog));
         }
 
         public void OnWixSourceGenerated(XDocument document)

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Dialogs.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Dialogs.cs
@@ -1,9 +1,10 @@
-﻿namespace WixSetup
+namespace WixSetup
 {
     public static class Dialogs
     {
         public const string ApiKeyDialog = "ApiKeyDlg";
         public const string SiteSelectionDialog = "SiteDlg";
         public const string AgentUserDialog = "DDAgentUserDlg";
+        public const string FatalErrorDialog = "Custom_FatalError";
     }
 }

--- a/tools/windows/DatadogAgentInstaller/WixSetup/dialogs/fatalError.wxi
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/dialogs/fatalError.wxi
@@ -9,7 +9,9 @@
     <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17" Disabled="yes" Text="!(loc.WixUIBack)" />
     <Control Id="BottomLine" Type="Line" X="0" Y="234" Width="370" Height="0" />
     <Control Id="Title" Type="Text" X="135" Y="20" Width="220" Height="60" Transparent="yes" NoPrefix="yes" Text="!(loc.FatalErrorTitle)" />
-    <Control Id="Description" Type="Text" X="135" Y="70" Width="220" Height="80" Transparent="yes" NoPrefix="yes" Text="WOLOLOLOLOLOLOLOL" />
+    <Control Id="Description" Type="Text" X="135" Y="70" Width="220" Height="40" Transparent="yes" NoPrefix="yes" Text="!(loc.FatalErrorDescription1)" />
+    <Control Id="ViewLogDescription" Type="Text" X="135" Y="110" Width="220" Height="40" Transparent="yes" NoPrefix="yes" Text="!(loc.FatalErrorDialog_ViewLogDescription)" />
+    <Control Id="FinishDescription" Type="Text" X="135" Y="150" Width="220" Height="20" Transparent="yes" NoPrefix="yes" Text="!(loc.FatalErrorDescription2)" />
   </Dialog>
 
   <InstallUISequence>

--- a/tools/windows/DatadogAgentInstaller/WixSetup/dialogs/fatalError.wxi
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/dialogs/fatalError.wxi
@@ -3,6 +3,7 @@
     <Control Id="Finish" Type="PushButton" X="236" Y="243" Width="56" Height="17" Default="yes" Cancel="yes" Text="!(loc.WixUIFinish)">
       <Publish Event="EndDialog" Value="Exit">1</Publish>
     </Control>
+    <Control Id="OpenMsiLog" Type="PushButton" X="20" Y="243" Width="56" Height="17" Disabled="no" Text="!(loc.FatalErrorDialog_ViewLog)" />
     <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Disabled="yes" Text="!(loc.WixUICancel)" />
     <Control Id="Bitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="234" TabSkip="no" Text="!(loc.FatalErrorBitmap)" />
     <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17" Disabled="yes" Text="!(loc.WixUIBack)" />

--- a/tools/windows/DatadogAgentInstaller/WixSetup/localization-en-us.wxl
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/localization-en-us.wxl
@@ -48,6 +48,9 @@
   <String Id ="DDAgentUserDialogUserNameLabel" Overridable="yes" Localizable="yes">Please enter the username (leave blank to use ddagentuser):</String>
   <String Id ="DDAgentUserDialogPasswordLabel" Overridable="yes" Localizable="yes">Please enter the password (leave blank to use random password):</String>
 
+  <!-- these strings for the FatalError dialog -->
+  <String Id ="FatalErrorDialog_ViewLog" Overridable="yes" Localizable="yes">View Log</String>
+
   <String Id="MsiRMFilesInUse_Title" Overridable="yes">[ProductName] Setup</String>
   <String Id="MsiRMFilesInUseExit" Overridable="yes">E&amp;xit</String>
   <String Id="MsiRMFilesInUseBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>

--- a/tools/windows/DatadogAgentInstaller/WixSetup/localization-en-us.wxl
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/localization-en-us.wxl
@@ -50,6 +50,7 @@
 
   <!-- these strings for the FatalError dialog -->
   <String Id ="FatalErrorDialog_ViewLog" Overridable="yes" Localizable="yes">View Log</String>
+  <String Id ="FatalErrorDialog_ViewLogDescription" Overridable="yes" Localizable="yes">Detailed information on the error can be found in the installation log file. Click the View Log button to view the installation log.</String>
 
   <String Id="MsiRMFilesInUse_Title" Overridable="yes">[ProductName] Setup</String>
   <String Id="MsiRMFilesInUseExit" Overridable="yes">E&amp;xit</String>


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Add a 'View Log" button to the installer's fatal error dialog

![image](https://user-images.githubusercontent.com/2266830/204910060-639db35f-02be-484a-ad40-bf401197bd6b.png)

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
