### PR TITLE
[CWS] extract probe from event and activity dump manager

### DIFF
--- a/pkg/security/probe/activity_dump.go
+++ b/pkg/security/probe/activity_dump.go
@@ -1173,7 +1173,7 @@ func (ad *ActivityDump) snapshotProcess(pan *ProcessActivityNode) error {
 }
 
 func (ad *ActivityDump) insertSnapshotedSocket(pan *ProcessActivityNode, p *process.Process, family uint16, ip net.IP, port uint16) {
-	evt := NewEvent(ad.adm.resolvers, ad.adm.scrubber, ad.adm.probe)
+	evt := NewEvent(ad.adm.resolvers, ad.adm.scrubber, ad.adm.probe.tcResolver)
 	evt.Event.Type = uint32(model.BindEventType)
 
 	evt.Bind.SyscallEvent.Retval = 0
@@ -1315,7 +1315,7 @@ func (pan *ProcessActivityNode) snapshotFiles(p *process.Process, ad *ActivityDu
 			continue
 		}
 
-		evt := NewEvent(ad.adm.resolvers, ad.adm.scrubber, ad.adm.probe)
+		evt := NewEvent(ad.adm.resolvers, ad.adm.scrubber, ad.adm.probe.tcResolver)
 		evt.Event.Type = uint32(model.FileOpenEventType)
 
 		resolvedPath, err = filepath.EvalSymlinks(f)

--- a/pkg/security/probe/activity_dump.go
+++ b/pkg/security/probe/activity_dump.go
@@ -1173,7 +1173,7 @@ func (ad *ActivityDump) snapshotProcess(pan *ProcessActivityNode) error {
 }
 
 func (ad *ActivityDump) insertSnapshotedSocket(pan *ProcessActivityNode, p *process.Process, family uint16, ip net.IP, port uint16) {
-	evt := NewEvent(ad.adm.resolvers, ad.adm.scrubber, ad.adm.probe.tcResolver)
+	evt := NewEvent(ad.adm.resolvers, ad.adm.scrubber)
 	evt.Event.Type = uint32(model.BindEventType)
 
 	evt.Bind.SyscallEvent.Retval = 0
@@ -1315,7 +1315,7 @@ func (pan *ProcessActivityNode) snapshotFiles(p *process.Process, ad *ActivityDu
 			continue
 		}
 
-		evt := NewEvent(ad.adm.resolvers, ad.adm.scrubber, ad.adm.probe.tcResolver)
+		evt := NewEvent(ad.adm.resolvers, ad.adm.scrubber)
 		evt.Event.Type = uint32(model.FileOpenEventType)
 
 		resolvedPath, err = filepath.EvalSymlinks(f)

--- a/pkg/security/probe/activity_dump_manager.go
+++ b/pkg/security/probe/activity_dump_manager.go
@@ -38,7 +38,6 @@ func areCGroupADsEnabled(c *config.Config) bool {
 // ActivityDumpManager is used to manage ActivityDumps
 type ActivityDumpManager struct {
 	sync.RWMutex
-	probe         *Probe
 	config        *config.Config
 	statsdClient  statsd.ClientInterface
 	resolvers     *Resolvers

--- a/pkg/security/probe/activity_dump_manager_test.go
+++ b/pkg/security/probe/activity_dump_manager_test.go
@@ -346,19 +346,15 @@ func TestActivityDumpManager_getOverweightDumps(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		probe := &Probe{
-			StatsdClient: &statsd.NoOpClient{},
-			Config: &config.Config{
-				ActivityDumpMaxDumpSize: func() int {
-					return 2048
-				},
-			}}
 		t.Run(tt.name, func(t *testing.T) {
 			adm := &ActivityDumpManager{
-				activeDumps:        tt.fields.activeDumps,
-				probe:              probe,
-				config:             probe.Config,
-				statsdClient:       probe.StatsdClient,
+				activeDumps: tt.fields.activeDumps,
+				config: &config.Config{
+					ActivityDumpMaxDumpSize: func() int {
+						return 2048
+					},
+				},
+				statsdClient:       &statsd.NoOpClient{},
 				ignoreFromSnapshot: make(map[string]bool),
 			}
 

--- a/pkg/security/probe/discarders.go
+++ b/pkg/security/probe/discarders.go
@@ -191,7 +191,7 @@ type inodeDiscarders struct {
 }
 
 func newInodeDiscarders(erpc *erpc.ERPC, dentryResolver *resolvers.DentryResolver) *inodeDiscarders {
-	event := NewEvent(nil, nil, nil)
+	event := NewEvent(nil, nil)
 	ctx := eval.NewContext(event.GetPointer())
 
 	id := &inodeDiscarders{

--- a/pkg/security/probe/model.go
+++ b/pkg/security/probe/model.go
@@ -73,7 +73,7 @@ type Event struct {
 	resolvers           *Resolvers
 	pathResolutionError error
 	scrubber            *procutil.DataScrubber
-	probe               *Probe
+	tcResolver          *resolvers.TCResolver
 }
 
 // Retain the event
@@ -604,14 +604,14 @@ func bestGuessServiceTag(serviceValues []string) string {
 
 // ResolveNetworkDeviceIfName returns the network iterface name from the network context
 func (ev *Event) ResolveNetworkDeviceIfName(device *model.NetworkDeviceContext) string {
-	if len(device.IfName) == 0 && ev.probe != nil {
+	if len(device.IfName) == 0 && ev.tcResolver != nil {
 		key := resolvers.NetDeviceKey{
 			NetNS:            device.NetNS,
 			IfIndex:          device.IfIndex,
 			NetworkDirection: manager.Egress,
 		}
 
-		tcProbe := ev.probe.tcResolver.GetTCProbeForKey(key)
+		tcProbe := ev.tcResolver.GetTCProbeForKey(key)
 		if tcProbe != nil {
 			device.IfName = tcProbe.IfName
 		}
@@ -621,11 +621,11 @@ func (ev *Event) ResolveNetworkDeviceIfName(device *model.NetworkDeviceContext) 
 }
 
 // NewEvent returns a new event
-func NewEvent(resolvers *Resolvers, scrubber *procutil.DataScrubber, probe *Probe) *Event {
+func NewEvent(resolvers *Resolvers, scrubber *procutil.DataScrubber, tcResolver *resolvers.TCResolver) *Event {
 	return &Event{
-		Event:     model.Event{},
-		resolvers: resolvers,
-		scrubber:  scrubber,
-		probe:     probe,
+		Event:      model.Event{},
+		resolvers:  resolvers,
+		scrubber:   scrubber,
+		tcResolver: tcResolver,
 	}
 }

--- a/pkg/security/probe/model.go
+++ b/pkg/security/probe/model.go
@@ -73,7 +73,6 @@ type Event struct {
 	resolvers           *Resolvers
 	pathResolutionError error
 	scrubber            *procutil.DataScrubber
-	tcResolver          *resolvers.TCResolver
 }
 
 // Retain the event
@@ -604,14 +603,14 @@ func bestGuessServiceTag(serviceValues []string) string {
 
 // ResolveNetworkDeviceIfName returns the network iterface name from the network context
 func (ev *Event) ResolveNetworkDeviceIfName(device *model.NetworkDeviceContext) string {
-	if len(device.IfName) == 0 && ev.tcResolver != nil {
+	if len(device.IfName) == 0 && ev.resolvers.TCResolver != nil {
 		key := resolvers.NetDeviceKey{
 			NetNS:            device.NetNS,
 			IfIndex:          device.IfIndex,
 			NetworkDirection: manager.Egress,
 		}
 
-		tcProbe := ev.tcResolver.GetTCProbeForKey(key)
+		tcProbe := ev.resolvers.TCResolver.GetTCProbeForKey(key)
 		if tcProbe != nil {
 			device.IfName = tcProbe.IfName
 		}
@@ -621,11 +620,10 @@ func (ev *Event) ResolveNetworkDeviceIfName(device *model.NetworkDeviceContext) 
 }
 
 // NewEvent returns a new event
-func NewEvent(resolvers *Resolvers, scrubber *procutil.DataScrubber, tcResolver *resolvers.TCResolver) *Event {
+func NewEvent(resolvers *Resolvers, scrubber *procutil.DataScrubber) *Event {
 	return &Event{
-		Event:      model.Event{},
-		resolvers:  resolvers,
-		scrubber:   scrubber,
-		tcResolver: tcResolver,
+		Event:     model.Event{},
+		resolvers: resolvers,
+		scrubber:  scrubber,
 	}
 }

--- a/pkg/security/probe/model.go
+++ b/pkg/security/probe/model.go
@@ -602,9 +602,9 @@ func bestGuessServiceTag(serviceValues []string) string {
 // ResolveNetworkDeviceIfName returns the network iterface name from the network context
 func (ev *Event) ResolveNetworkDeviceIfName(device *model.NetworkDeviceContext) string {
 	if len(device.IfName) == 0 && ev.resolvers.TCResolver != nil {
-		tcProbe := ev.resolvers.TCResolver.GetTCProbeForKey(device.IfIndex, device.NetNS)
-		if tcProbe != nil {
-			device.IfName = tcProbe.IfName
+		ifName, ok := ev.resolvers.TCResolver.ResolveNetworkDeviceIfName(device.IfIndex, device.NetNS)
+		if ok {
+			device.IfName = ifName
 		}
 	}
 

--- a/pkg/security/probe/model.go
+++ b/pkg/security/probe/model.go
@@ -16,13 +16,11 @@ import (
 	"syscall"
 	"time"
 
-	manager "github.com/DataDog/ebpf-manager"
 	"github.com/cilium/ebpf/perf"
 	"github.com/mailru/easyjson/jwriter"
 
 	"github.com/DataDog/datadog-agent/pkg/process/procutil"
 	"github.com/DataDog/datadog-agent/pkg/security/probe/constantfetch"
-	"github.com/DataDog/datadog-agent/pkg/security/probe/resolvers"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 )
@@ -604,13 +602,7 @@ func bestGuessServiceTag(serviceValues []string) string {
 // ResolveNetworkDeviceIfName returns the network iterface name from the network context
 func (ev *Event) ResolveNetworkDeviceIfName(device *model.NetworkDeviceContext) string {
 	if len(device.IfName) == 0 && ev.resolvers.TCResolver != nil {
-		key := resolvers.NetDeviceKey{
-			NetNS:            device.NetNS,
-			IfIndex:          device.IfIndex,
-			NetworkDirection: manager.Egress,
-		}
-
-		tcProbe := ev.resolvers.TCResolver.GetTCProbeForKey(key)
+		tcProbe := ev.resolvers.TCResolver.GetTCProbeForKey(device.IfIndex, device.NetNS)
 		if tcProbe != nil {
 			device.IfName = tcProbe.IfName
 		}

--- a/pkg/security/probe/namespace_resolver.go
+++ b/pkg/security/probe/namespace_resolver.go
@@ -165,7 +165,7 @@ func (nn *NetworkNamespace) dequeueNetworkDevices(probe *Probe) {
 	defer handle.Close()
 
 	for _, queuedDevice := range nn.networkDevicesQueue {
-		_ = probe.setupNewTCClassifierWithNetNSHandle(queuedDevice, handle)
+		_ = probe.tcResolver.SetupNewTCClassifierWithNetNSHandle(queuedDevice, handle, probe.Manager)
 	}
 	nn.flushNetworkDevicesQueue()
 }
@@ -214,7 +214,7 @@ func NewNamespaceResolver(probe *Probe) (*NamespaceResolver, error) {
 
 	lru, err := simplelru.NewLRU(1024, func(key uint32, value *NetworkNamespace) {
 		nr.flushNetworkNamespace(value)
-		nr.probe.flushNetworkNamespace(value)
+		nr.probe.tcResolver.FlushNetworkNamespaceID(value.nsID, nr.probe.Manager)
 	})
 	if err != nil {
 		return nil, err
@@ -326,7 +326,7 @@ func (nr *NamespaceResolver) snapshotNetworkDevices(netns *NetworkNamespace) int
 			NetNS:   netns.nsID,
 		}
 
-		if err = nr.probe.setupNewTCClassifierWithNetNSHandle(device, handle); err == nil {
+		if err = nr.probe.tcResolver.SetupNewTCClassifierWithNetNSHandle(device, handle, nr.probe.Manager); err == nil {
 			// ignore interfaces that are lazily deleted
 			if !nr.IsLazyDeletionInterface(device.Name) && attrs.HardwareAddr.String() != "" {
 				attachedDeviceCountNoLazyDeletion++
@@ -406,7 +406,7 @@ func (nr *NamespaceResolver) flushNamespaces(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			probesCount := nr.probe.flushInactiveProbes()
+			probesCount := nr.probe.tcResolver.FlushInactiveProbes(nr.probe.Manager, nr.IsLazyDeletionInterface)
 
 			// There is a possible race condition if we lose all network device creations but do notice the new network
 			// namespace: we will create a handle that will never be flushed by `nr.probe.flushInactiveNamespaces()`.
@@ -472,7 +472,7 @@ func (nr *NamespaceResolver) preventNetworkNamespaceDrift(probesCount map[uint32
 				deviceCountNoLoopbackNoDummy := nr.snapshotNetworkDevices(netns)
 				if deviceCountNoLoopbackNoDummy == 0 {
 					nr.flushNetworkNamespace(netns)
-					nr.probe.flushNetworkNamespace(netns)
+					nr.probe.tcResolver.FlushNetworkNamespaceID(netns.nsID, nr.probe.Manager)
 					netns.Unlock()
 					continue
 				}

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -23,7 +23,6 @@ import (
 	manager "github.com/DataDog/ebpf-manager"
 	"github.com/hashicorp/go-multierror"
 	"github.com/moby/sys/mountinfo"
-	"github.com/vishvananda/netlink"
 	"golang.org/x/exp/slices"
 	"golang.org/x/sys/unix"
 	"golang.org/x/time/rate"
@@ -38,7 +37,6 @@ import (
 	kernel "github.com/DataDog/datadog-agent/pkg/security/ebpf/kernel"
 	"github.com/DataDog/datadog-agent/pkg/security/ebpf/probes"
 	"github.com/DataDog/datadog-agent/pkg/security/events"
-	"github.com/DataDog/datadog-agent/pkg/security/metrics"
 	"github.com/DataDog/datadog-agent/pkg/security/probe/constantfetch"
 	"github.com/DataDog/datadog-agent/pkg/security/probe/erpc"
 	"github.com/DataDog/datadog-agent/pkg/security/probe/managerhelper"
@@ -113,8 +111,7 @@ type Probe struct {
 	runtimeCompiled bool
 
 	// network section
-	tcProgramsLock sync.RWMutex
-	tcPrograms     map[NetDeviceKey]*manager.Probe
+	tcResolver *resolvers.TCResolver
 
 	isRuntimeDiscarded bool
 }
@@ -359,18 +356,9 @@ func (p *Probe) DispatchCustomEvent(rule *rules.Rule, event *events.CustomEvent)
 	}
 }
 
-func (p *Probe) sendTCProgramsStats() {
-	p.tcProgramsLock.RLock()
-	defer p.tcProgramsLock.RUnlock()
-
-	if val := float64(len(p.tcPrograms)); val > 0 {
-		_ = p.StatsdClient.Gauge(metrics.MetricTCProgram, val, []string{}, 1.0)
-	}
-}
-
 // SendStats sends statistics about the probe to Datadog
 func (p *Probe) SendStats() error {
-	p.sendTCProgramsStats()
+	p.tcResolver.SendTCProgramsStats(p.StatsdClient)
 
 	return p.monitor.SendStats()
 }
@@ -904,28 +892,6 @@ func (p *Probe) SetApprovers(eventType eval.EventType, approvers rules.Approvers
 	return nil
 }
 
-func (p *Probe) selectTCProbes() manager.ProbesSelector {
-	p.tcProgramsLock.RLock()
-	defer p.tcProgramsLock.RUnlock()
-
-	// Although unlikely, a race is still possible with the umount event of a network namespace:
-	//   - a reload event is triggered
-	//   - selectTCProbes is invoked and the list of currently running probes is generated
-	//   - a container exits and the umount event of its network namespace is handled now (= its TC programs are stopped)
-	//   - the manager executes UpdateActivatedProbes
-	// In this setup, if we didn't use the best effort selector, the manager would try to init & attach a program that
-	// was deleted when the container exited.
-	var activatedProbes manager.BestEffort
-	for _, tcProbe := range p.tcPrograms {
-		if tcProbe.IsRunning() {
-			activatedProbes.Selectors = append(activatedProbes.Selectors, &manager.ProbeSelector{
-				ProbeIdentificationPair: tcProbe.ProbeIdentificationPair,
-			})
-		}
-	}
-	return &activatedProbes
-}
-
 func (p *Probe) isNeededForActivityDump(eventType eval.EventType) bool {
 	if p.Config.ActivityDumpEnabled {
 		for _, e := range p.Config.ActivityDumpTracedEventTypes {
@@ -963,7 +929,7 @@ func (p *Probe) SelectProbes(eventTypes []eval.EventType) error {
 		}
 	}
 
-	activatedProbes = append(activatedProbes, p.selectTCProbes())
+	activatedProbes = append(activatedProbes, p.tcResolver.SelectTCProbes())
 
 	// Add syscall monitor probes
 	if p.Config.ActivityDumpEnabled {
@@ -1157,60 +1123,7 @@ func (p *Probe) setupNewTCClassifier(device model.NetDevice) error {
 		return QueuedNetworkDeviceError{msg: fmt.Sprintf("device %s is queued until %d is resolved", device.Name, device.NetNS)}
 	}
 	defer handle.Close()
-	return p.setupNewTCClassifierWithNetNSHandle(device, handle)
-}
-
-// setupNewTCClassifierWithNetNSHandle creates and attaches TC probes on the provided device. WARNING: this function
-// will not close the provided netns handle, so the caller of this function needs to take care of it.
-func (p *Probe) setupNewTCClassifierWithNetNSHandle(device model.NetDevice, netnsHandle *os.File) error {
-	p.tcProgramsLock.Lock()
-	defer p.tcProgramsLock.Unlock()
-
-	var combinedErr multierror.Error
-	for _, tcProbe := range probes.GetTCProbes() {
-		// make sure we're not overriding an existing network probe
-		deviceKey := NetDeviceKey{IfIndex: device.IfIndex, NetNS: device.NetNS, NetworkDirection: tcProbe.NetworkDirection}
-		_, ok := p.tcPrograms[deviceKey]
-		if ok {
-			continue
-		}
-
-		newProbe := tcProbe.Copy()
-		newProbe.CopyProgram = true
-		newProbe.UID = probes.SecurityAgentUID + device.GetKey()
-		newProbe.IfIndex = int(device.IfIndex)
-		newProbe.IfIndexNetns = uint64(netnsHandle.Fd())
-		newProbe.IfIndexNetnsID = device.NetNS
-		newProbe.KeepProgramSpec = false
-		newProbe.TCFilterPrio = p.Config.NetworkClassifierPriority
-		newProbe.TCFilterHandle = netlink.MakeHandle(0, p.Config.NetworkClassifierHandle)
-
-		netnsEditor := []manager.ConstantEditor{
-			{
-				Name:  "netns",
-				Value: uint64(device.NetNS),
-			},
-		}
-
-		if err := p.Manager.CloneProgram(probes.SecurityAgentUID, newProbe, netnsEditor, nil); err != nil {
-			_ = multierror.Append(&combinedErr, fmt.Errorf("couldn't clone %s: %v", tcProbe.ProbeIdentificationPair, err))
-		} else {
-			p.tcPrograms[deviceKey] = newProbe
-		}
-	}
-	return combinedErr.ErrorOrNil()
-}
-
-// flushNetworkNamespace thread unsafe version of FlushNetworkNamespace
-func (p *Probe) flushNetworkNamespace(namespace *NetworkNamespace) {
-	p.tcProgramsLock.Lock()
-	defer p.tcProgramsLock.Unlock()
-	for tcKey, tcProbe := range p.tcPrograms {
-		if tcKey.NetNS == namespace.nsID {
-			_ = p.Manager.DetachHook(tcProbe.ProbeIdentificationPair)
-			delete(p.tcPrograms, tcKey)
-		}
-	}
+	return p.tcResolver.SetupNewTCClassifierWithNetNSHandle(device, handle, p.Manager)
 }
 
 // FlushNetworkNamespace removes all references and stops all TC programs in the provided network namespace. This method
@@ -1219,37 +1132,7 @@ func (p *Probe) FlushNetworkNamespace(namespace *NetworkNamespace) {
 	p.resolvers.NamespaceResolver.FlushNetworkNamespace(namespace)
 
 	// cleanup internal structures
-	p.flushNetworkNamespace(namespace)
-}
-
-// flushInactiveProbes detaches and deletes inactive probes. This function returns a map containing the count of interfaces
-// per network namespace (ignoring the interfaces that are lazily deleted).
-func (p *Probe) flushInactiveProbes() map[uint32]int {
-	p.tcProgramsLock.Lock()
-	defer p.tcProgramsLock.Unlock()
-
-	probesCountNoLazyDeletion := make(map[uint32]int)
-
-	var linkName string
-	for tcKey, tcProbe := range p.tcPrograms {
-		if !tcProbe.IsTCFilterActive() {
-			_ = p.Manager.DetachHook(tcProbe.ProbeIdentificationPair)
-			delete(p.tcPrograms, tcKey)
-		} else {
-			link, err := tcProbe.ResolveLink()
-			if err == nil {
-				linkName = link.Attrs().Name
-			} else {
-				linkName = ""
-			}
-			// ignore interfaces that are lazily deleted
-			if link.Attrs().HardwareAddr.String() != "" && !p.resolvers.NamespaceResolver.IsLazyDeletionInterface(linkName) {
-				probesCountNoLazyDeletion[tcKey.NetNS]++
-			}
-		}
-	}
-
-	return probesCountNoLazyDeletion
+	p.tcResolver.FlushNetworkNamespaceID(namespace.nsID, p.Manager)
 }
 
 func (p *Probe) handleNewMount(event *Event, m *model.Mount) error {
@@ -1290,6 +1173,8 @@ func NewProbe(config *config.Config, statsdClient statsd.ClientInterface) (*Prob
 
 	ctx, cancel := context.WithCancel(context.Background())
 
+	tcResolver := resolvers.NewTCResolver(config)
+
 	p := &Probe{
 		Config:               config,
 		approvers:            make(map[eval.EventType]activeApprovers),
@@ -1298,7 +1183,7 @@ func NewProbe(config *config.Config, statsdClient statsd.ClientInterface) (*Prob
 		cancelFnc:            cancel,
 		Erpc:                 nerpc,
 		erpcRequest:          &erpc.ERPCRequest{},
-		tcPrograms:           make(map[NetDeviceKey]*manager.Probe),
+		tcResolver:           tcResolver,
 		StatsdClient:         statsdClient,
 		discarderRateLimiter: rate.NewLimiter(rate.Every(time.Second/5), 100),
 		isRuntimeDiscarded:   os.Getenv("RUNTIME_SECURITY_TESTSUITE") != "true",

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -1092,7 +1092,7 @@ func (p *Probe) GetDebugStats() map[string]interface{} {
 // NewRuleSet returns a new rule set
 func (p *Probe) NewRuleSet(opts *rules.Opts, evalOpts *eval.Opts, macroStore *eval.MacroStore) *rules.RuleSet {
 	eventCtor := func() eval.Event {
-		return NewEvent(p.resolvers, p.scrubber, p)
+		return NewEvent(p.resolvers, p.scrubber, p.tcResolver)
 	}
 	opts.WithLogger(seclog.DefaultLogger)
 
@@ -1360,11 +1360,11 @@ func NewProbe(config *config.Config, statsdClient statsd.ClientInterface) (*Prob
 	}
 	p.resolvers = resolvers
 
-	p.event = NewEvent(p.resolvers, p.scrubber, p)
+	p.event = NewEvent(p.resolvers, p.scrubber, p.tcResolver)
 
 	eventZero.resolvers = p.resolvers
 	eventZero.scrubber = p.scrubber
-	eventZero.probe = p
+	eventZero.tcResolver = p.tcResolver
 
 	if useRingBuffers {
 		p.eventStream = NewRingBuffer(p.handleEvent)

--- a/pkg/security/probe/resolvers.go
+++ b/pkg/security/probe/resolvers.go
@@ -37,6 +37,7 @@ type Resolvers struct {
 	ProcessResolver   *ProcessResolver
 	NamespaceResolver *NamespaceResolver
 	CgroupsResolver   *resolvers.CgroupsResolver
+	TCResolver        *resolvers.TCResolver
 }
 
 // NewResolvers creates a new instance of Resolvers
@@ -71,6 +72,8 @@ func NewResolvers(config *config.Config, probe *Probe) (*Resolvers, error) {
 		return nil, err
 	}
 
+	tcResolver := resolvers.NewTCResolver(config)
+
 	resolvers := &Resolvers{
 		probe:             probe,
 		MountResolver:     mountResolver,
@@ -81,6 +84,7 @@ func NewResolvers(config *config.Config, probe *Probe) (*Resolvers, error) {
 		DentryResolver:    dentryResolver,
 		NamespaceResolver: namespaceResolver,
 		CgroupsResolver:   cgroupsResolver,
+		TCResolver:        tcResolver,
 	}
 
 	processResolver, err := NewProcessResolver(probe.Manager, probe.Config, probe.StatsdClient,

--- a/pkg/security/probe/resolvers/tc_resolver.go
+++ b/pkg/security/probe/resolvers/tc_resolver.go
@@ -1,0 +1,172 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+// +build linux
+
+package resolvers
+
+import (
+	"fmt"
+	"os"
+	"sync"
+
+	"github.com/DataDog/datadog-agent/pkg/security/config"
+	"github.com/DataDog/datadog-agent/pkg/security/ebpf/probes"
+	"github.com/DataDog/datadog-agent/pkg/security/metrics"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+	"github.com/DataDog/datadog-go/v5/statsd"
+	manager "github.com/DataDog/ebpf-manager"
+	"github.com/hashicorp/go-multierror"
+	"github.com/vishvananda/netlink"
+)
+
+// NetDeviceKey is used to uniquely identify a network device
+type NetDeviceKey struct {
+	IfIndex          uint32
+	NetNS            uint32
+	NetworkDirection manager.TrafficType
+}
+
+type TCResolver struct {
+	sync.RWMutex
+	config   *config.Config
+	programs map[NetDeviceKey]*manager.Probe
+}
+
+func NewTCResolver(config *config.Config) *TCResolver {
+	return &TCResolver{
+		config:   config,
+		programs: make(map[NetDeviceKey]*manager.Probe),
+	}
+}
+
+func (tcr *TCResolver) SendTCProgramsStats(statsdClient statsd.ClientInterface) {
+	tcr.RLock()
+	defer tcr.RUnlock()
+
+	if val := float64(len(tcr.programs)); val > 0 {
+		_ = statsdClient.Gauge(metrics.MetricTCProgram, val, []string{}, 1.0)
+	}
+}
+
+func (tcr *TCResolver) SelectTCProbes() manager.ProbesSelector {
+	tcr.RLock()
+	defer tcr.RUnlock()
+
+	// Although unlikely, a race is still possible with the umount event of a network namespace:
+	//   - a reload event is triggered
+	//   - selectTCProbes is invoked and the list of currently running probes is generated
+	//   - a container exits and the umount event of its network namespace is handled now (= its TC programs are stopped)
+	//   - the manager executes UpdateActivatedProbes
+	// In this setup, if we didn't use the best effort selector, the manager would try to init & attach a program that
+	// was deleted when the container exited.
+	var activatedProbes manager.BestEffort
+	for _, tcProbe := range tcr.programs {
+		if tcProbe.IsRunning() {
+			activatedProbes.Selectors = append(activatedProbes.Selectors, &manager.ProbeSelector{
+				ProbeIdentificationPair: tcProbe.ProbeIdentificationPair,
+			})
+		}
+	}
+	return &activatedProbes
+}
+
+// SetupNewTCClassifierWithNetNSHandle creates and attaches TC probes on the provided device. WARNING: this function
+// will not close the provided netns handle, so the caller of this function needs to take care of it.
+func (tcr *TCResolver) SetupNewTCClassifierWithNetNSHandle(device model.NetDevice, netnsHandle *os.File, m *manager.Manager) error {
+	tcr.Lock()
+	defer tcr.Unlock()
+
+	var combinedErr multierror.Error
+	for _, tcProbe := range probes.GetTCProbes() {
+		// make sure we're not overriding an existing network probe
+		deviceKey := NetDeviceKey{IfIndex: device.IfIndex, NetNS: device.NetNS, NetworkDirection: tcProbe.NetworkDirection}
+		_, ok := tcr.programs[deviceKey]
+		if ok {
+			continue
+		}
+
+		newProbe := tcProbe.Copy()
+		newProbe.CopyProgram = true
+		newProbe.UID = probes.SecurityAgentUID + device.GetKey()
+		newProbe.IfIndex = int(device.IfIndex)
+		newProbe.IfIndexNetns = uint64(netnsHandle.Fd())
+		newProbe.IfIndexNetnsID = device.NetNS
+		newProbe.KeepProgramSpec = false
+		newProbe.TCFilterPrio = tcr.config.NetworkClassifierPriority
+		newProbe.TCFilterHandle = netlink.MakeHandle(0, tcr.config.NetworkClassifierHandle)
+
+		netnsEditor := []manager.ConstantEditor{
+			{
+				Name:  "netns",
+				Value: uint64(device.NetNS),
+			},
+		}
+
+		if err := m.CloneProgram(probes.SecurityAgentUID, newProbe, netnsEditor, nil); err != nil {
+			_ = multierror.Append(&combinedErr, fmt.Errorf("couldn't clone %s: %v", tcProbe.ProbeIdentificationPair, err))
+		} else {
+			tcr.programs[deviceKey] = newProbe
+		}
+	}
+	return combinedErr.ErrorOrNil()
+}
+
+// flushNetworkNamespace thread unsafe version of FlushNetworkNamespace
+func (tcr *TCResolver) FlushNetworkNamespaceID(namespaceID uint32, m *manager.Manager) {
+	tcr.Lock()
+	defer tcr.Unlock()
+
+	for tcKey, tcProbe := range tcr.programs {
+		if tcKey.NetNS == namespaceID {
+			_ = m.DetachHook(tcProbe.ProbeIdentificationPair)
+			delete(tcr.programs, tcKey)
+		}
+	}
+}
+
+// FlushInactiveProbes detaches and deletes inactive probes. This function returns a map containing the count of interfaces
+// per network namespace (ignoring the interfaces that are lazily deleted).
+func (tcr *TCResolver) FlushInactiveProbes(m *manager.Manager, isLazy func(string) bool) map[uint32]int {
+	tcr.Lock()
+	defer tcr.Unlock()
+
+	probesCountNoLazyDeletion := make(map[uint32]int)
+
+	var linkName string
+	for tcKey, tcProbe := range tcr.programs {
+		if !tcProbe.IsTCFilterActive() {
+			_ = m.DetachHook(tcProbe.ProbeIdentificationPair)
+			delete(tcr.programs, tcKey)
+		} else {
+			link, err := tcProbe.ResolveLink()
+			if err == nil {
+				linkName = link.Attrs().Name
+			} else {
+				linkName = ""
+			}
+			// ignore interfaces that are lazily deleted
+			if link.Attrs().HardwareAddr.String() != "" && !isLazy(linkName) {
+				probesCountNoLazyDeletion[tcKey.NetNS]++
+			}
+		}
+	}
+
+	return probesCountNoLazyDeletion
+}
+
+func (tcr *TCResolver) GetTCProbeForKey(key NetDeviceKey) *manager.Probe {
+	tcr.RLock()
+	defer tcr.RUnlock()
+
+	tcProbe, ok := tcr.programs[key]
+	if ok {
+		return tcProbe
+	}
+
+	key.NetworkDirection = manager.Ingress
+	return tcr.programs[key]
+}

--- a/pkg/security/probe/resolvers/tc_resolver.go
+++ b/pkg/security/probe/resolvers/tc_resolver.go
@@ -158,7 +158,7 @@ func (tcr *TCResolver) FlushInactiveProbes(m *manager.Manager, isLazy func(strin
 	return probesCountNoLazyDeletion
 }
 
-func (tcr *TCResolver) GetTCProbeForKey(ifIndex, netNS uint32) *manager.Probe {
+func (tcr *TCResolver) ResolveNetworkDeviceIfName(ifIndex, netNS uint32) (string, bool) {
 	tcr.RLock()
 	defer tcr.RUnlock()
 
@@ -171,8 +171,8 @@ func (tcr *TCResolver) GetTCProbeForKey(ifIndex, netNS uint32) *manager.Probe {
 
 		tcProbe, ok := tcr.programs[key]
 		if ok {
-			return tcProbe
+			return tcProbe.IfName, true
 		}
 	}
-	return nil
+	return "", false
 }

--- a/pkg/security/probe/resolvers/tc_resolver.go
+++ b/pkg/security/probe/resolvers/tc_resolver.go
@@ -158,15 +158,21 @@ func (tcr *TCResolver) FlushInactiveProbes(m *manager.Manager, isLazy func(strin
 	return probesCountNoLazyDeletion
 }
 
-func (tcr *TCResolver) GetTCProbeForKey(key NetDeviceKey) *manager.Probe {
+func (tcr *TCResolver) GetTCProbeForKey(ifIndex, netNS uint32) *manager.Probe {
 	tcr.RLock()
 	defer tcr.RUnlock()
 
-	tcProbe, ok := tcr.programs[key]
-	if ok {
-		return tcProbe
-	}
+	for _, direction := range []manager.TrafficType{manager.Egress, manager.Ingress} {
+		key := NetDeviceKey{
+			IfIndex:          ifIndex,
+			NetNS:            netNS,
+			NetworkDirection: direction,
+		}
 
-	key.NetworkDirection = manager.Ingress
-	return tcr.programs[key]
+		tcProbe, ok := tcr.programs[key]
+		if ok {
+			return tcProbe
+		}
+	}
+	return nil
 }

--- a/pkg/security/probe/serializers.go
+++ b/pkg/security/probe/serializers.go
@@ -708,7 +708,7 @@ func newProcessContextSerializer(pc *model.ProcessContext, e *Event, r *Resolver
 
 	if e == nil {
 		// custom events create an empty event
-		e = NewEvent(r, nil, nil)
+		e = NewEvent(r, nil)
 		e.ProcessContext = pc
 	}
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This PR is a potential next step in the `pkg/security/probe` reorg, moving `model.Event` and `ActivityDumpManager` away from accessing `*Probe` directly. To this end, it extract the TC managment to a new TCResolver.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
