### PR TITLE
Track EC2 Spot related errors on e2e tests as infra failures

### DIFF
--- a/tasks/libs/pipeline_data.py
+++ b/tasks/libs/pipeline_data.py
@@ -100,6 +100,15 @@ infra_failure_logs = [
         re.compile(r'ERROR: The kitchen tests failed due to infrastructure failures\.'),
         FailedJobReason.KITCHEN,
     ),
+    # End to end tests EC2 Spot instances allocation failures
+    (
+        re.compile(r'Failed to allocate end to end test EC2 Spot instance after [0-9]+ attempts'),
+        FailedJobReason.EC2_SPOT,
+    ),
+    (
+        re.compile(r'Connection to [0-9]+\.[0-9]+\.[0-9]+\.[0-9]+ closed by remote host\.'),
+        FailedJobReason.EC2_SPOT,
+    ),
 ]
 
 

--- a/tasks/libs/types.py
+++ b/tasks/libs/types.py
@@ -49,6 +49,7 @@ class FailedJobReason(Enum):
     FAILED_JOB_SCRIPT = 5
     GITLAB = 6
     KITCHEN = 7
+    EC2_SPOT = 8
 
 
 class SlackMessage:


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Add EC2 Spot allocation failures as infra failures, to avoid notifications and track frequency.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

EC2 Spot allocation failures are not actionable and create very flaky notifications.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

I did not add exponential backoff to describe because I am not sure as to how the EC2 Spot instance allocation works and I don't want to accidentally increase the failure rate

CONT-3573 tracks improvements on allocation

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
