### PR TITLE
[agent] Support for running secrets backends with sha256 verification

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -371,6 +371,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("secret_backend_timeout", 30)
 	config.BindEnvAndSetDefault("secret_backend_command_allow_group_exec_perm", false)
 	config.BindEnvAndSetDefault("secret_backend_skip_checks", false)
+	config.BindEnvAndSetDefault("secret_backend_command_sha256", "")
 
 	// Use to output logs in JSON format
 	config.BindEnvAndSetDefault("log_format_json", false)
@@ -1610,6 +1611,8 @@ func ResolveSecrets(config Config, origin string) error {
 		config.GetInt("secret_backend_timeout"),
 		config.GetInt("secret_backend_output_max_size"),
 		config.GetBool("secret_backend_command_allow_group_exec_perm"),
+		config.GetString("secret_backend_command_sha256"),
+		config.ConfigFileUsed(),
 	)
 
 	if config.GetString("secret_backend_command") != "" {

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -711,6 +711,15 @@ api_key:
 #
 # secret_backend_skip_checks: false
 
+## @param secret_backend_command_sha256 - string - optional
+## @env DD_SECRET_BACKEND_COMMAND_SHA256 - string - optional
+## `secret_backend_command_sha256` is the SHA256 of the backend command executable.
+## The executable for `secret_backend_command` must be an absolute path if `secret_backend_command_sha256` is used.
+##
+## For more information see: https://github.com/DataDog/datadog-agent/blob/main/docs/agent/secrets.md
+#
+# secret_backend_command_sha256: <SHA256>
+
 ## @param snmp_listener - custom object - optional
 ## Creates and schedules a listener to automatically discover your SNMP devices.
 ## Discovered devices can then be monitored with the SNMP integration by using

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -713,10 +713,12 @@ api_key:
 
 ## @param secret_backend_command_sha256 - string - optional
 ## @env DD_SECRET_BACKEND_COMMAND_SHA256 - string - optional
-## `secret_backend_command_sha256` is the SHA256 of the backend command executable.
+## `secret_backend_command_sha256` is the expected SHA256 of the backend command executable.
 ## If `secret_backend_command_sha256` is used, the following restrictions are in place:
 ## - Value specified in the `secret_backend_command` setting must be an absolute path.
 ## - Permissions for the datadog.yaml config file must disallow write access by unprivileged accounts.
+## The agent will refuse to start if the actual SHA256 of 'secret_backend_command' executable is different
+## from the one specified by `secret_backend_command_sha256`.
 #
 # secret_backend_command_sha256: <SHA256>
 

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -714,9 +714,9 @@ api_key:
 ## @param secret_backend_command_sha256 - string - optional
 ## @env DD_SECRET_BACKEND_COMMAND_SHA256 - string - optional
 ## `secret_backend_command_sha256` is the SHA256 of the backend command executable.
-## The executable for `secret_backend_command` must be an absolute path if `secret_backend_command_sha256` is used.
-##
-## For more information see: https://github.com/DataDog/datadog-agent/blob/main/docs/agent/secrets.md
+## If `secret_backend_command_sha256` is used, the following restrictions are in place:
+## - Value specified in the `secret_backend_command` setting must be an absolute path.
+## - Permissions for the datadog.yaml config file must disallow write access by unprivileged accounts.
 #
 # secret_backend_command_sha256: <SHA256>
 

--- a/pkg/secrets/check_rights_nix.go
+++ b/pkg/secrets/check_rights_nix.go
@@ -111,12 +111,6 @@ var checkConfigFilePermissions = func(path string) error {
 	return nil
 }
 
-// hashIsRequired returns true if we consider the hash to be required for verification of the secret backend
-var hashIsRequired = func() (bool, error) {
-	// Do not perform elevation check on Linux
-	return false, nil
-}
-
 // lockOpenFile opens the file and prevents overwrite and delete by another process
 func lockOpenFile(path string) (*os.File, error) {
 	fd, err := syscall.Open(path, syscall.O_CREAT|syscall.O_RDONLY, 0600)

--- a/pkg/secrets/check_rights_nix.go
+++ b/pkg/secrets/check_rights_nix.go
@@ -93,8 +93,8 @@ func checkGroupPermission(stat *syscall.Stat_t, usr *user.User, userGroups []str
 	return nil
 }
 
-// checkConfigRights validates that a config file has supported permissions when using secret_backend_command_sha256 hash
-var checkConfigRights = func(path string) error {
+// checkConfigFilePermissions validates that a config file has supported permissions when using secret_backend_command_sha256 hash
+var checkConfigFilePermissions = func(path string) error {
 	var stat syscall.Stat_t
 	if err := syscall.Stat(path, &stat); err != nil {
 		return fmt.Errorf("unable to check permissions for '%s': can't stat it: %s", path, err)
@@ -118,7 +118,7 @@ var hashIsRequired = func() (bool, error) {
 }
 
 // lockOpenFile opens the file and prevents overwrite and delete by another process
-var lockOpenFile = func(path string) (*os.File, error) {
+func lockOpenFile(path string) (*os.File, error) {
 	fd, err := syscall.Open(path, syscall.O_CREAT|syscall.O_RDONLY, 0600)
 	if err != nil {
 		return nil, err

--- a/pkg/secrets/check_rights_windows.go
+++ b/pkg/secrets/check_rights_windows.go
@@ -178,8 +178,8 @@ var getDDAgentUserSID = func() (*windows.SID, error) {
 	return sid, err
 }
 
-// checkConfigRights validates that a config file has supported permissions when using secret_backend_command_sha256 hash
-var checkConfigRights = func(filename string) error {
+// checkConfigFilePermissions validates that a config file has supported permissions when using secret_backend_command_sha256 hash
+var checkConfigFilePermissions = func(filename string) error {
 	if _, err := os.Stat(filename); err != nil {
 		if os.IsNotExist(err) {
 			return fmt.Errorf("config file '%s' does not exist", filename)

--- a/pkg/secrets/check_rights_windows.go
+++ b/pkg/secrets/check_rights_windows.go
@@ -250,7 +250,7 @@ var checkConfigFilePermissions = func(filename string) error {
 			allowedAccountForWrite := compareIsLocalSystem || compareIsAdministrators || compareIsSecretUser
 			hasOnlyAllowForRead := pAce.AccessMask&^(windows.FILE_GENERIC_READ) == 0
 			if !allowedAccountForWrite && !hasOnlyAllowForRead {
-				return fmt.Errorf("invalid permissions for config file '%s': users/groups other than LOCAL_SYSTEM and Administrators have rights on it", filename)
+				return fmt.Errorf("invalid permissions for config file '%s': users/groups other than LOCAL_SYSTEM, Administrators or %s have rights on it", filename, secretUser)
 			}
 		}
 	}

--- a/pkg/secrets/check_rights_windows_test.go
+++ b/pkg/secrets/check_rights_windows_test.go
@@ -37,6 +37,11 @@ func TestWrongPath(t *testing.T) {
 	require.NotNil(t, checkRights("does not exists", false))
 }
 
+func testCheckRightsStub() {
+	// Stub for CI since running as Administrator and no installer data
+	getDDAgentUserSID = winutil.GetSidFromUser
+}
+
 func TestCheckRights(t *testing.T) {
 	_, err := os.CreateTemp("", "agent-collector-test")
 	require.Nil(t, err)

--- a/pkg/secrets/check_rights_windows_test.go
+++ b/pkg/secrets/check_rights_windows_test.go
@@ -37,11 +37,6 @@ func TestWrongPath(t *testing.T) {
 	require.NotNil(t, checkRights("does not exists", false))
 }
 
-func testCheckRightsStub() {
-	// Stub for CI since running as Administrator and no installer data
-	getDDAgentUserSID = winutil.GetSidFromUser
-}
-
 func TestCheckRights(t *testing.T) {
 	_, err := os.CreateTemp("", "agent-collector-test")
 	require.Nil(t, err)

--- a/pkg/secrets/fetch_secret.go
+++ b/pkg/secrets/fetch_secret.go
@@ -64,7 +64,7 @@ func execCommand(inputPayload string) ([]byte, error) {
 			return nil, fmt.Errorf("error while running '%s': absolute path required with SHA256", secretBackendCommand)
 		}
 
-		if err := checkConfigRights(configFileUsed); err != nil {
+		if err := checkConfigFilePermissions(configFileUsed); err != nil {
 			return nil, err
 		}
 

--- a/pkg/secrets/fetch_secret.go
+++ b/pkg/secrets/fetch_secret.go
@@ -59,7 +59,7 @@ func execCommand(inputPayload string) ([]byte, error) {
 	}
 	defer done()
 
-	if len(secretBackendCommandSHA256) != 0 {
+	if secretBackendCommandSHA256 != "" {
 		if !filepath.IsAbs(secretBackendCommand) {
 			return nil, fmt.Errorf("error while running '%s': absolute path required with SHA256", secretBackendCommand)
 		}

--- a/pkg/secrets/fetch_secret.go
+++ b/pkg/secrets/fetch_secret.go
@@ -83,14 +83,6 @@ func execCommand(inputPayload string) ([]byte, error) {
 			return nil, fmt.Errorf("error while running '%s': SHA256 mismatch, actual '%s' expected '%s'", secretBackendCommand, sha256, secretBackendCommandSHA256)
 		}
 
-	} else {
-		requireHash, err := hashIsRequired()
-		if err != nil {
-			return nil, fmt.Errorf("error while running '%s': %s", secretBackendCommand, err)
-		}
-		if requireHash {
-			return nil, fmt.Errorf("error while running '%s': running elevated and 'secret_backend_command_sha256' is not set", secretBackendCommand)
-		}
 	}
 
 	if err = checkRights(cmd.Path, secretBackendCommandAllowGroupExec); err != nil {

--- a/pkg/secrets/fetch_secret.go
+++ b/pkg/secrets/fetch_secret.go
@@ -11,10 +11,15 @@ package secrets
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"hash"
+	"io"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -54,7 +59,35 @@ func execCommand(inputPayload string) ([]byte, error) {
 	}
 	defer done()
 
-	if err := checkRights(cmd.Path, secretBackendCommandAllowGroupExec); err != nil {
+	if len(secretBackendCommandSHA256) != 0 {
+		if !filepath.IsAbs(secretBackendCommand) {
+			return nil, fmt.Errorf("error while running '%s': absolute path required with SHA256", secretBackendCommand)
+		}
+
+		if err := checkConfigRights(configFileUsed); err != nil {
+			return nil, err
+		}
+
+		f, err := lockOpenFile(secretBackendCommand)
+		if err != nil {
+			return nil, err
+		}
+		defer f.Close() //nolint:errcheck
+
+		sha256, err := fileHashSHA256(f)
+		if err != nil {
+			return nil, err
+		}
+
+		if !strings.EqualFold(sha256, secretBackendCommandSHA256) {
+			return nil, fmt.Errorf("error while running '%s': SHA256 mismatch", secretBackendCommand)
+		}
+
+	} else if hashIsRequired() {
+		return nil, fmt.Errorf("error while running '%s': running elevated and no configured SHA256", secretBackendCommand)
+	}
+
+	if err = checkRights(cmd.Path, secretBackendCommandAllowGroupExec); err != nil {
 		return nil, err
 	}
 
@@ -161,4 +194,42 @@ func fetchSecret(secretsHandle []string, origin string) (map[string]string, erro
 		res[sec] = v.Value
 	}
 	return res, nil
+}
+
+func fileHashSHA256(f *os.File) (string, error) {
+	stat, err := f.Stat()
+	if err != nil {
+		return "", err
+	}
+
+	h := sha256.New()
+
+	fileSize := stat.Size()
+	if fileSize == 0 {
+		return formatHash(h), nil
+	}
+
+	var bufSize int64 = 102400
+	if fileSize < bufSize {
+		bufSize = fileSize
+	}
+
+	buffer := make([]byte, bufSize)
+
+	for {
+		read, err := f.Read(buffer)
+		if err != nil {
+			if err != io.EOF {
+				return "", err
+			}
+			break
+		}
+		h.Write(buffer[:read])
+	}
+
+	return formatHash(h), nil
+}
+
+func formatHash(h hash.Hash) string {
+	return fmt.Sprintf("%x", h.Sum(nil))
 }

--- a/pkg/secrets/fetch_secret.go
+++ b/pkg/secrets/fetch_secret.go
@@ -80,11 +80,17 @@ func execCommand(inputPayload string) ([]byte, error) {
 		}
 
 		if !strings.EqualFold(sha256, secretBackendCommandSHA256) {
-			return nil, fmt.Errorf("error while running '%s': SHA256 mismatch", secretBackendCommand)
+			return nil, fmt.Errorf("error while running '%s': SHA256 mismatch, actual '%s' expected '%s'", secretBackendCommand, sha256, secretBackendCommandSHA256)
 		}
 
-	} else if hashIsRequired() {
-		return nil, fmt.Errorf("error while running '%s': running elevated and no configured SHA256", secretBackendCommand)
+	} else {
+		requireHash, err := hashIsRequired()
+		if err != nil {
+			return nil, fmt.Errorf("error while running '%s': %s", secretBackendCommand, err)
+		}
+		if requireHash {
+			return nil, fmt.Errorf("error while running '%s': running elevated and 'secret_backend_command_sha256' is not set", secretBackendCommand)
+		}
 	}
 
 	if err = checkRights(cmd.Path, secretBackendCommandAllowGroupExec); err != nil {

--- a/pkg/secrets/fetch_secret_test.go
+++ b/pkg/secrets/fetch_secret_test.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"testing"
 
@@ -85,10 +86,15 @@ func TestLimitBuffer(t *testing.T) {
 }
 
 func TestExecCommandError(t *testing.T) {
+	prevHashIsRequired := hashIsRequired
+	hashIsRequired = func() bool { return false }
+
 	defer func() {
 		secretBackendCommand = ""
 		secretBackendArguments = []string{}
-		secretBackendTimeout = 0
+		secretBackendTimeout = defaultSecretBackendTimeout
+		SecretBackendOutputMaxSize = defaultSecretBackendOutputMaxSize
+		hashIsRequired = prevHashIsRequired
 	}()
 
 	inputPayload := "{\"version\": \"" + PayloadVersion + "\" , \"secrets\": [\"sec1\", \"sec2\"]}"
@@ -144,6 +150,76 @@ func TestExecCommandError(t *testing.T) {
 	_, err = execCommand(inputPayload)
 	require.NotNil(t, err)
 	assert.Equal(t, "error while running './test/response_too_long/response_too_long"+binExtension+"': command output was too long: exceeded 20 bytes", err.Error())
+}
+
+func TestExecCommandWithHash(t *testing.T) {
+	prevCheckConfigRights := checkConfigRights
+	checkConfigRights = func(string) error { return nil }
+	defer func() {
+		secretBackendCommand = ""
+		secretBackendArguments = []string{}
+		secretBackendTimeout = defaultSecretBackendTimeout
+		secretBackendCommandSHA256 = ""
+		SecretBackendOutputMaxSize = defaultSecretBackendOutputMaxSize
+		checkConfigRights = prevCheckConfigRights
+	}()
+
+	inputPayload := "{\"version\": \"" + PayloadVersion + "\" , \"secrets\": [\"sec1\", \"sec2\"]}"
+
+	// test simple with hash (no error)
+	secretBackendCommand, _ = filepath.Abs("./test/simple/simple" + binExtension)
+	setCorrectRight(secretBackendCommand)
+	f, err := os.Open(secretBackendCommand)
+	require.NoError(t, err)
+	hash, err := fileHashSHA256(f)
+	_ = f.Close()
+	require.NoError(t, err)
+	secretBackendCommandSHA256 = hash
+	resp, err := execCommand(inputPayload)
+	require.NoError(t, err)
+	require.Equal(t, []byte("{\"handle1\":{\"value\":\"simple_password\"}}"), resp)
+}
+
+func TestExecCommandErrorElevatedNoHash(t *testing.T) {
+	prevHashIsRequired := hashIsRequired
+	defer func() { hashIsRequired = prevHashIsRequired }()
+	hashIsRequired = func() bool { return true }
+	secretBackendCommand = "foo"
+	defer func() {
+		secretBackendCommand = ""
+	}()
+	resp, err := execCommand("")
+	assert.Nil(t, resp)
+	assert.EqualError(t, err, `error while running 'foo': running elevated and no configured SHA256`)
+}
+
+func TestExecCommandErrorNotAbsPath(t *testing.T) {
+	secretBackendCommand = "test/simple/simple.go"
+	secretBackendCommandSHA256 = "foo"
+	defer func() {
+		secretBackendCommand = ""
+		secretBackendCommandSHA256 = ""
+	}()
+	resp, err := execCommand("")
+	assert.Nil(t, resp)
+	assert.EqualError(t, err, `error while running 'test/simple/simple.go': absolute path required with SHA256`)
+}
+
+func TestExecCommandErrorHashMismatch(t *testing.T) {
+	var err error
+	secretBackendCommand, err = filepath.Abs("./test/simple/simple.go")
+	require.NoError(t, err)
+	secretBackendCommandSHA256 = "foo"
+	prevCheckConfigRights := checkConfigRights
+	checkConfigRights = func(string) error { return nil }
+	defer func() {
+		secretBackendCommand = ""
+		secretBackendCommandSHA256 = ""
+		checkConfigRights = prevCheckConfigRights
+	}()
+	resp, err := execCommand("")
+	assert.Nil(t, resp)
+	assert.EqualError(t, err, `error while running '`+secretBackendCommand+`': SHA256 mismatch`)
 }
 
 func TestFetchSecretExecError(t *testing.T) {
@@ -245,4 +321,13 @@ func TestFetchSecret(t *testing.T) {
 		"handle2": "p2",
 	}, secretCache)
 	assert.Equal(t, map[string]common.StringSet{"handle1": common.NewStringSet("test"), "handle2": common.NewStringSet("test")}, secretOrigin)
+}
+
+func TestCheckHash(t *testing.T) {
+	f, err := os.Open("test/simple/simple.go")
+	assert.NoError(t, err)
+	defer f.Close() //nolint:errcheck
+	hash, err := fileHashSHA256(f)
+	assert.NoError(t, err)
+	assert.Equal(t, "0e47e4f4749aa31a8d0c92607b75c251efdf9602fec15f060a18ad4aabbf0d1f", hash)
 }

--- a/pkg/secrets/fetch_secret_test.go
+++ b/pkg/secrets/fetch_secret_test.go
@@ -86,15 +86,11 @@ func TestLimitBuffer(t *testing.T) {
 }
 
 func TestExecCommandError(t *testing.T) {
-	prevHashIsRequired := hashIsRequired
-	hashIsRequired = func() (bool, error) { return false, nil }
-
 	defer func() {
 		secretBackendCommand = ""
 		secretBackendArguments = []string{}
 		secretBackendTimeout = defaultSecretBackendTimeout
 		SecretBackendOutputMaxSize = defaultSecretBackendOutputMaxSize
-		hashIsRequired = prevHashIsRequired
 	}()
 
 	inputPayload := "{\"version\": \"" + PayloadVersion + "\" , \"secrets\": [\"sec1\", \"sec2\"]}"
@@ -178,19 +174,6 @@ func TestExecCommandWithHash(t *testing.T) {
 	resp, err := execCommand(inputPayload)
 	require.NoError(t, err)
 	require.Equal(t, []byte(`{"handle1":{"value":"simple_password"}}`), resp)
-}
-
-func TestExecCommandErrorElevatedNoHash(t *testing.T) {
-	prevHashIsRequired := hashIsRequired
-	defer func() { hashIsRequired = prevHashIsRequired }()
-	hashIsRequired = func() (bool, error) { return true, nil }
-	secretBackendCommand = "foo"
-	defer func() {
-		secretBackendCommand = ""
-	}()
-	resp, err := execCommand("")
-	assert.Nil(t, resp)
-	assert.EqualError(t, err, `error while running 'foo': running elevated and 'secret_backend_command_sha256' is not set`)
 }
 
 func TestExecCommandErrorNotAbsPath(t *testing.T) {

--- a/pkg/secrets/fetch_secret_test.go
+++ b/pkg/secrets/fetch_secret_test.go
@@ -153,15 +153,15 @@ func TestExecCommandError(t *testing.T) {
 }
 
 func TestExecCommandWithHash(t *testing.T) {
-	prevCheckConfigRights := checkConfigRights
-	checkConfigRights = func(string) error { return nil }
+	prevCheckConfigFilePermissions := checkConfigFilePermissions
+	checkConfigFilePermissions = func(string) error { return nil }
 	defer func() {
 		secretBackendCommand = ""
 		secretBackendArguments = []string{}
 		secretBackendTimeout = defaultSecretBackendTimeout
 		secretBackendCommandSHA256 = ""
 		SecretBackendOutputMaxSize = defaultSecretBackendOutputMaxSize
-		checkConfigRights = prevCheckConfigRights
+		checkConfigFilePermissions = prevCheckConfigFilePermissions
 	}()
 
 	inputPayload := `{"version": ""` + PayloadVersion + `" , "secrets": ["sec1", "sec2"]}`
@@ -210,12 +210,12 @@ func TestExecCommandErrorHashMismatch(t *testing.T) {
 	secretBackendCommand, err = filepath.Abs("./test/simple/simple.go")
 	require.NoError(t, err)
 	secretBackendCommandSHA256 = "foo"
-	prevCheckConfigRights := checkConfigRights
-	checkConfigRights = func(string) error { return nil }
+	prevCheckConfigFilePermissions := checkConfigFilePermissions
+	checkConfigFilePermissions = func(string) error { return nil }
 	defer func() {
 		secretBackendCommand = ""
 		secretBackendCommandSHA256 = ""
-		checkConfigRights = prevCheckConfigRights
+		checkConfigFilePermissions = prevCheckConfigFilePermissions
 	}()
 	resp, err := execCommand("")
 	assert.Nil(t, resp)

--- a/pkg/secrets/info.go
+++ b/pkg/secrets/info.go
@@ -14,18 +14,25 @@ import (
 
 // SecretInfo export troubleshooting information about the decrypted secrets
 type SecretInfo struct {
-	ExecutablePath string
-	Rights         string
-	RightDetails   string
-	UnixOwner      string
-	UnixGroup      string
-	SecretsHandles map[string][]string
+	ExecutablePath       string
+	ExecutablePathSHA256 string
+	Rights               string
+	RightDetails         string
+	UnixOwner            string
+	UnixGroup            string
+	SecretsHandles       map[string][]string
 }
 
 // Print output a SecretInfo to a io.Writer
 func (si *SecretInfo) Print(w io.Writer) {
 	fmt.Fprintf(w, "=== Checking executable rights ===\n")
 	fmt.Fprintf(w, "Executable path: %s\n", si.ExecutablePath)
+
+	sha256 := si.ExecutablePathSHA256
+	if si.ExecutablePathSHA256 == "" {
+		sha256 = "Not configured"
+	}
+	fmt.Fprintf(w, "Executable path SHA256: %s\n", sha256)
 
 	fmt.Fprintf(w, "Check Rights: %s\n", si.Rights)
 

--- a/pkg/secrets/no_secrets.go
+++ b/pkg/secrets/no_secrets.go
@@ -18,7 +18,8 @@ import (
 var SecretBackendOutputMaxSize = 1024 * 1024
 
 // Init placeholder when compiled without the 'secrets' build tag
-func Init(command string, arguments []string, timeout int, maxSize int, groupExecPerm bool) {}
+func Init(command string, arguments []string, timeout int, maxSize int, groupExecPerm bool, sha256 string, configFile string) {
+}
 
 // Decrypt encrypted secrets are not available on windows
 func Decrypt(data []byte, origin string) ([]byte, error) {
@@ -27,5 +28,5 @@ func Decrypt(data []byte, origin string) ([]byte, error) {
 
 // GetDebugInfo exposes debug informations about secrets to be included in a flare
 func GetDebugInfo() (*SecretInfo, error) {
-	return nil, fmt.Errorf("Secret feature is not available in this version of the agent")
+	return nil, fmt.Errorf("secret feature is not available in this version of the agent")
 }

--- a/pkg/secrets/secrets.go
+++ b/pkg/secrets/secrets.go
@@ -18,6 +18,11 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
+const (
+	defaultSecretBackendTimeout       = 5
+	defaultSecretBackendOutputMaxSize = 1024 * 1024
+)
+
 var (
 	secretCache map[string]string
 	// list of handles and where they were found
@@ -25,11 +30,13 @@ var (
 
 	secretBackendCommand               string
 	secretBackendArguments             []string
-	secretBackendTimeout               = 5
+	secretBackendTimeout               = defaultSecretBackendTimeout
 	secretBackendCommandAllowGroupExec bool
+	secretBackendCommandSHA256         string
+	configFileUsed                     string
 
 	// SecretBackendOutputMaxSize defines max size of the JSON output from a secrets reader backend
-	SecretBackendOutputMaxSize = 1024 * 1024
+	SecretBackendOutputMaxSize = defaultSecretBackendOutputMaxSize
 )
 
 func init() {
@@ -40,12 +47,14 @@ func init() {
 // Init initializes the command and other options of the secrets package. Since
 // this package is used by the 'config' package to decrypt itself we can't
 // directly use it.
-func Init(command string, arguments []string, timeout int, maxSize int, groupExecPerm bool) {
+func Init(command string, arguments []string, timeout int, maxSize int, groupExecPerm bool, sha256 string, configFile string) {
 	secretBackendCommand = command
 	secretBackendArguments = arguments
 	secretBackendTimeout = timeout
 	SecretBackendOutputMaxSize = maxSize
 	secretBackendCommandAllowGroupExec = groupExecPerm
+	secretBackendCommandSHA256 = sha256
+	configFileUsed = configFile
 	if secretBackendCommandAllowGroupExec {
 		log.Warnf("Agent configuration relax permissions constraint on the secret backend cmd, Group can read and exec")
 	}

--- a/pkg/secrets/secrets.go
+++ b/pkg/secrets/secrets.go
@@ -212,7 +212,10 @@ func GetDebugInfo() (*SecretInfo, error) {
 	if secretBackendCommand == "" {
 		return nil, fmt.Errorf("No secret_backend_command set: secrets feature is not enabled")
 	}
-	info := &SecretInfo{ExecutablePath: secretBackendCommand}
+	info := &SecretInfo{
+		ExecutablePath:       secretBackendCommand,
+		ExecutablePathSHA256: secretBackendCommandSHA256,
+	}
 	info.populateRights()
 
 	info.SecretsHandles = map[string][]string{}

--- a/releasenotes/notes/secret_backend_command_sha256-b322140f976f02e1.yaml
+++ b/releasenotes/notes/secret_backend_command_sha256-b322140f976f02e1.yaml
@@ -1,7 +1,11 @@
 ---
 features:
   - |
-    Adds support for secret_backend_command_sha256
+    Adds support for `secret_backend_command_sha256` SHA for the `secret_backend_command` executable. If `secret_backend_command_sha256` is used,
+    the following restrictions are in place:
+    - Value specified in the `secret_backend_command` setting must be an absolute path.
+    - Permissions for the datadog.yaml config file must disallow write access by unprivileged accounts.
+    The agent will refuse to start if the actual SHA256 of 'secret_backend_command' executable is different from the one specified by `secret_backend_command_sha256`.
 
 enhancements:
   - |

--- a/releasenotes/notes/secret_backend_command_sha256-b322140f976f02e1.yaml
+++ b/releasenotes/notes/secret_backend_command_sha256-b322140f976f02e1.yaml
@@ -1,12 +1,13 @@
 ---
 features:
   - |
-    Adds support for `secret_backend_command_sha256` SHA for the `secret_backend_command` executable. If `secret_backend_command_sha256` is used,
+    Adds support for ``secret_backend_command_sha256`` SHA for the ``secret_backend_command`` executable. If ``secret_backend_command_sha256`` is used,
     the following restrictions are in place:
-    - Value specified in the `secret_backend_command` setting must be an absolute path.
-    - Permissions for the datadog.yaml config file must disallow write access by unprivileged accounts.
-    The agent will refuse to start if the actual SHA256 of 'secret_backend_command' executable is different from the one specified by `secret_backend_command_sha256`.
+    - Value specified in the ``secret_backend_command`` setting must be an absolute path.
+    - Permissions for the ``datadog.yaml`` config file must disallow write access by unprivileged accounts.
+    The agent will refuse to start if the actual SHA256 of the ``secret_backend_command`` executable is different from the one specified by ``secret_backend_command_sha256``.
+    The ``secret_backend_command`` file is locked during verification of SHA256 and subsequent run of the secret backend executable.
 
 enhancements:
   - |
-    Allows running secrets in the process-agent on Windows as long as the user provides secret_backend_command_sha256 and restricts access to the datadog.yaml config file.
+    Allows running secrets in the process-agent on Windows as long as the user provides ``secret_backend_command_sha256`` and restricts access to the ``datadog.yaml`` config file.

--- a/releasenotes/notes/secret_backend_command_sha256-b322140f976f02e1.yaml
+++ b/releasenotes/notes/secret_backend_command_sha256-b322140f976f02e1.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    Adds support for secret_backend_command_sha256
+
+enhancements:
+  - |
+    Allows running secrets in the process-agent on Windows as long as the user provides secret_backend_command_sha256 and restricts access to the datadog.yaml config file.

--- a/releasenotes/notes/secret_backend_command_sha256-b322140f976f02e1.yaml
+++ b/releasenotes/notes/secret_backend_command_sha256-b322140f976f02e1.yaml
@@ -4,10 +4,7 @@ features:
     Adds support for ``secret_backend_command_sha256`` SHA for the ``secret_backend_command`` executable. If ``secret_backend_command_sha256`` is used,
     the following restrictions are in place:
     - Value specified in the ``secret_backend_command`` setting must be an absolute path.
-    - Permissions for the ``datadog.yaml`` config file must disallow write access by unprivileged accounts.
+    - Permissions for the ``datadog.yaml`` config file must disallow write access by users other than ``ddagentuser`` or ``Administrators`` on Windows or root on Linux.
     The agent will refuse to start if the actual SHA256 of the ``secret_backend_command`` executable is different from the one specified by ``secret_backend_command_sha256``.
     The ``secret_backend_command`` file is locked during verification of SHA256 and subsequent run of the secret backend executable.
 
-enhancements:
-  - |
-    Allows running secrets in the process-agent on Windows as long as the user provides ``secret_backend_command_sha256`` and restricts access to the ``datadog.yaml`` config file.

--- a/tasks/process_agent.py
+++ b/tasks/process_agent.py
@@ -65,6 +65,11 @@ def build(
 
     build_tags = get_build_tags(build_include, build_exclude)
 
+    ## secrets is not supported on windows because the process agent still runs as
+    ## root.  No matter what `get_default_build_tags()` returns, take secrets out.
+    if sys.platform == 'win32' and "secrets" in build_tags:
+        build_tags.remove("secrets")
+
     # TODO static option
     cmd = 'go build -mod={go_mod} {race_opt} {build_type} -tags "{go_build_tags}" '
     cmd += '-o {agent_bin} -gcflags="{gcflags}" -ldflags="{ldflags}" {REPO_PATH}/cmd/process-agent'


### PR DESCRIPTION
### What does this PR do?

- Adds support for `secret_backend_command_sha256` that enforces SHA256 of the secret backend binary.

Note that when `secret_backend_command_sha256` is used the `datadog.yaml` config has to be restricted as follows:
- Must be owned by root and cannot have writable others' permissions on *nix.
- Cannot be writable by principals other than `Local System`, `Administrators` or `ddagentuser` on Windows.

### Motivation

- Provide cross platform way to enforce the validity of the `secret_backend_command` binary.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

- Validate existing secrets backend functionality still works as expected.
- Validate configuration of `secret_backend_command_sha256` works correctly on Linux and Windows.

In order to validate this functionality on Windows the datadog.yaml file has to be configured to disallow writes by principals other than `Local System`, `Administrators`, or `ddagentuser`.

The secret backend binary should have access by the account running the agent.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
