### PR TITLE
[pkg/otlp] Rewrite sumnmary tests to use only public API

### DIFF
--- a/pkg/otlp/model/translator/summary_test.go
+++ b/pkg/otlp/model/translator/summary_test.go
@@ -8,7 +8,6 @@ package translator
 import (
 	"testing"
 
-	gocache "github.com/patrickmn/go-cache"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 )
@@ -58,20 +57,6 @@ func TestSummaryMetrics(t *testing.T) {
 	for _, testinstance := range tests {
 		t.Run(testinstance.name, func(t *testing.T) {
 			translator, err := New(zap.NewNop(), testinstance.options...)
-			c := newTestCache()
-			c.cache.Set((&Dimensions{
-				name:     "summary.example.count",
-				tags:     testinstance.tags,
-				host:     "hostname",
-				originID: "",
-			}).String(), numberCounter{0, 0, 1}, gocache.NoExpiration)
-			c.cache.Set((&Dimensions{
-				name:     "summary.example.sum",
-				tags:     testinstance.tags,
-				host:     "hostname",
-				originID: "",
-			}).String(), numberCounter{0, 0, 1}, gocache.NoExpiration)
-			translator.prevPts = c
 			require.NoError(t, err)
 			AssertTranslatorMap(t, translator, testinstance.otlpfile, testinstance.ddogfile)
 		})

--- a/pkg/otlp/model/translator/testdata/datadogdata/summary/simple_summary-with-quantile.json
+++ b/pkg/otlp/model/translator/testdata/datadogdata/summary/simple_summary-with-quantile.json
@@ -7,7 +7,7 @@
       "Host": "hostname",
       "OriginID": "",
       "Type": "count",
-      "Timestamp": 1667560641226420924,
+      "Timestamp": 1669802350921840070,
       "Value": 10
     },
     {
@@ -16,7 +16,7 @@
       "Host": "hostname",
       "OriginID": "",
       "Type": "count",
-      "Timestamp": 1667560641226420924,
+      "Timestamp": 1669802350921840070,
       "Value": 100
     },
     {
@@ -27,7 +27,7 @@
       "Host": "hostname",
       "OriginID": "",
       "Type": "gauge",
-      "Timestamp": 1667560641226420924,
+      "Timestamp": 1669802350921840070,
       "Value": 0
     },
     {
@@ -38,7 +38,7 @@
       "Host": "hostname",
       "OriginID": "",
       "Type": "gauge",
-      "Timestamp": 1667560641226420924,
+      "Timestamp": 1669802350921840070,
       "Value": 100
     },
     {
@@ -49,7 +49,7 @@
       "Host": "hostname",
       "OriginID": "",
       "Type": "gauge",
-      "Timestamp": 1667560641226420924,
+      "Timestamp": 1669802350921840070,
       "Value": 500
     },
     {
@@ -60,7 +60,7 @@
       "Host": "hostname",
       "OriginID": "",
       "Type": "gauge",
-      "Timestamp": 1667560641226420924,
+      "Timestamp": 1669802350921840070,
       "Value": 600
     }
   ]

--- a/pkg/otlp/model/translator/testdata/datadogdata/summary/simple_summary.json
+++ b/pkg/otlp/model/translator/testdata/datadogdata/summary/simple_summary.json
@@ -7,7 +7,7 @@
       "Host": "hostname",
       "OriginID": "",
       "Type": "count",
-      "Timestamp": 1667560641226420924,
+      "Timestamp": 1669802350921840070,
       "Value": 10
     },
     {
@@ -16,7 +16,7 @@
       "Host": "hostname",
       "OriginID": "",
       "Type": "count",
-      "Timestamp": 1667560641226420924,
+      "Timestamp": 1669802350921840070,
       "Value": 100
     }
   ]

--- a/pkg/otlp/model/translator/testdata/datadogdata/summary/with-attributes-quantile_summary.json
+++ b/pkg/otlp/model/translator/testdata/datadogdata/summary/with-attributes-quantile_summary.json
@@ -9,7 +9,7 @@
       "Host": "hostname",
       "OriginID": "",
       "Type": "count",
-      "Timestamp": 1667560641226420924,
+      "Timestamp": 1669802350921840070,
       "Value": 10
     },
     {
@@ -20,7 +20,7 @@
       "Host": "hostname",
       "OriginID": "",
       "Type": "count",
-      "Timestamp": 1667560641226420924,
+      "Timestamp": 1669802350921840070,
       "Value": 100
     },
     {
@@ -32,7 +32,7 @@
       "Host": "hostname",
       "OriginID": "",
       "Type": "gauge",
-      "Timestamp": 1667560641226420924,
+      "Timestamp": 1669802350921840070,
       "Value": 0
     },
     {
@@ -44,7 +44,7 @@
       "Host": "hostname",
       "OriginID": "",
       "Type": "gauge",
-      "Timestamp": 1667560641226420924,
+      "Timestamp": 1669802350921840070,
       "Value": 100
     },
     {
@@ -56,7 +56,7 @@
       "Host": "hostname",
       "OriginID": "",
       "Type": "gauge",
-      "Timestamp": 1667560641226420924,
+      "Timestamp": 1669802350921840070,
       "Value": 500
     },
     {
@@ -68,7 +68,7 @@
       "Host": "hostname",
       "OriginID": "",
       "Type": "gauge",
-      "Timestamp": 1667560641226420924,
+      "Timestamp": 1669802350921840070,
       "Value": 600
     }
   ]

--- a/pkg/otlp/model/translator/testdata/datadogdata/summary/with-attributes_summary.json
+++ b/pkg/otlp/model/translator/testdata/datadogdata/summary/with-attributes_summary.json
@@ -9,7 +9,7 @@
       "Host": "hostname",
       "OriginID": "",
       "Type": "count",
-      "Timestamp": 1667560641226420924,
+      "Timestamp": 1669802350921840070,
       "Value": 10
     },
     {
@@ -20,7 +20,7 @@
       "Host": "hostname",
       "OriginID": "",
       "Type": "count",
-      "Timestamp": 1667560641226420924,
+      "Timestamp": 1669802350921840070,
       "Value": 100
     }
   ]

--- a/pkg/otlp/model/translator/testdata/otlpdata/summary/simple.json
+++ b/pkg/otlp/model/translator/testdata/otlpdata/summary/simple.json
@@ -20,7 +20,21 @@
                 "summary": {
                   "dataPoints": [
                     {
-                      "timeUnixNano": "1667560641226420924",
+                      "timeUnixNano": "1669802348455623075",
+                      "count": 1,
+                      "sum": 1,
+                      "quantileValues": [
+                      ]
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "summary.example",
+                "summary": {
+                  "dataPoints": [
+                    {
+                      "timeUnixNano": "1669802350921840070",
                       "count": 11,
                       "sum": 101,
                       "quantileValues": [

--- a/pkg/otlp/model/translator/testdata/otlpdata/summary/with-attributes.json
+++ b/pkg/otlp/model/translator/testdata/otlpdata/summary/with-attributes.json
@@ -28,7 +28,29 @@
                           }
                         }
                       ],
-                      "timeUnixNano": "1667560641226420924",
+                      "timeUnixNano": "1669802348455623075",
+                      "count": 1,
+                      "sum": 1,
+                      "quantileValues": [
+                      ]
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "summary.example",
+                "summary": {
+                  "dataPoints": [
+                    {
+                      "attributes": [
+                        {
+                          "key": "attribute_tag",
+                          "value": {
+                            "stringValue": "attribute_value"
+                          }
+                        }
+                      ],
+                      "timeUnixNano": "1669802350921840070",
                       "count": 11,
                       "sum": 101,
                       "quantileValues": [


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Rewrite unit tests without explicitly setting cache

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Make unit tests more realistic, avoid depending on private APIs for unit tests.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
