### PR TITLE
[orchestration] detect unified service tags for the orchestrator-explorer

### DIFF
--- a/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/clusterrole.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/clusterrole.go
@@ -10,6 +10,7 @@ package k8s
 
 import (
 	model "github.com/DataDog/agent-payload/v5/process"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/transformers"
 
 	rbacv1 "k8s.io/api/rbac/v1"
 )
@@ -26,6 +27,9 @@ func ExtractClusterRole(cr *rbacv1.ClusterRole) *model.ClusterRole {
 			clusterRole.AggregationRules = append(clusterRole.AggregationRules, extractLabelSelector(&rule)...)
 		}
 	}
+
+	clusterRole.Tags = append(clusterRole.Tags, transformers.RetrieveUnifiedServiceTags(cr.ObjectMeta.Labels)...)
+
 	return clusterRole
 }
 

--- a/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/clusterrolebinding.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/clusterrolebinding.go
@@ -10,6 +10,7 @@ package k8s
 
 import (
 	model "github.com/DataDog/agent-payload/v5/process"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/transformers"
 
 	rbacv1 "k8s.io/api/rbac/v1"
 )
@@ -17,11 +18,15 @@ import (
 // ExtractClusterRoleBinding returns the protobuf model corresponding to a
 // Kubernetes ClusterRoleBinding resource.
 func ExtractClusterRoleBinding(crb *rbacv1.ClusterRoleBinding) *model.ClusterRoleBinding {
-	return &model.ClusterRoleBinding{
+	c := &model.ClusterRoleBinding{
 		Metadata: extractMetadata(&crb.ObjectMeta),
 		RoleRef:  extractRoleRef(&crb.RoleRef),
 		Subjects: extractSubjects(crb.Subjects),
 	}
+
+	c.Tags = append(c.Tags, transformers.RetrieveUnifiedServiceTags(crb.ObjectMeta.Labels)...)
+
+	return c
 }
 
 func extractRoleRef(r *rbacv1.RoleRef) *model.TypedLocalObjectReference {

--- a/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/cronjob_v1.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/cronjob_v1.go
@@ -10,6 +10,7 @@ package k8s
 
 import (
 	model "github.com/DataDog/agent-payload/v5/process"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/transformers"
 
 	batchv1 "k8s.io/api/batch/v1"
 )
@@ -53,6 +54,9 @@ func ExtractCronJobV1(cj *batchv1.CronJob) *model.CronJob {
 			Uid:             string(job.UID),
 		})
 	}
+
+	cronJob.Spec.ResourceRequirements = ExtractPodTemplateResourceRequirements(cj.Spec.JobTemplate.Spec.Template)
+	cronJob.Tags = append(cronJob.Tags, transformers.RetrieveUnifiedServiceTags(cj.ObjectMeta.Labels)...)
 
 	return &cronJob
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/cronjob_v1beta1.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/cronjob_v1beta1.go
@@ -10,6 +10,7 @@ package k8s
 
 import (
 	model "github.com/DataDog/agent-payload/v5/process"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/transformers"
 
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
 )
@@ -55,6 +56,7 @@ func ExtractCronJobV1Beta1(cj *batchv1beta1.CronJob) *model.CronJob {
 	}
 
 	cronJob.Spec.ResourceRequirements = ExtractPodTemplateResourceRequirements(cj.Spec.JobTemplate.Spec.Template)
+	cronJob.Tags = append(cronJob.Tags, transformers.RetrieveUnifiedServiceTags(cj.ObjectMeta.Labels)...)
 
 	return &cronJob
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/daemonset.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/daemonset.go
@@ -9,6 +9,7 @@
 package k8s
 
 import (
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/transformers"
 	appsv1 "k8s.io/api/apps/v1"
 
 	model "github.com/DataDog/agent-payload/v5/process"
@@ -49,6 +50,7 @@ func ExtractDaemonSet(ds *appsv1.DaemonSet) *model.DaemonSet {
 	}
 
 	daemonSet.Spec.ResourceRequirements = ExtractPodTemplateResourceRequirements(ds.Spec.Template)
+	daemonSet.Tags = append(daemonSet.Tags, transformers.RetrieveUnifiedServiceTags(ds.ObjectMeta.Labels)...)
 
 	return &daemonSet
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/deployment.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/deployment.go
@@ -10,6 +10,7 @@ package k8s
 
 import (
 	model "github.com/DataDog/agent-payload/v5/process"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/transformers"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -49,6 +50,7 @@ func ExtractDeployment(d *appsv1.Deployment) *model.Deployment {
 	deploy.ConditionMessage = extractDeploymentConditionMessage(d.Status.Conditions)
 
 	deploy.ResourceRequirements = ExtractPodTemplateResourceRequirements(d.Spec.Template)
+	deploy.Tags = append(deploy.Tags, transformers.RetrieveUnifiedServiceTags(d.ObjectMeta.Labels)...)
 
 	return &deploy
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/ingress.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/ingress.go
@@ -9,6 +9,7 @@
 package k8s
 
 import (
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/transformers"
 	netv1 "k8s.io/api/networking/v1"
 
 	model "github.com/DataDog/agent-payload/v5/process"
@@ -42,6 +43,8 @@ func ExtractIngress(in *netv1.Ingress) *model.Ingress {
 	if len(in.Status.LoadBalancer.Ingress) > 0 {
 		ingress.Status = extractIngressStatus(in.Status)
 	}
+
+	ingress.Tags = append(ingress.Tags, transformers.RetrieveUnifiedServiceTags(in.ObjectMeta.Labels)...)
 
 	return &ingress
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/job.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/job.go
@@ -10,6 +10,7 @@ package k8s
 
 import (
 	model "github.com/DataDog/agent-payload/v5/process"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/transformers"
 
 	batchv1 "k8s.io/api/batch/v1"
 )
@@ -55,6 +56,7 @@ func ExtractJob(j *batchv1.Job) *model.Job {
 	}
 
 	job.Spec.ResourceRequirements = ExtractPodTemplateResourceRequirements(j.Spec.Template)
+	job.Tags = append(job.Tags, transformers.RetrieveUnifiedServiceTags(j.ObjectMeta.Labels)...)
 
 	return &job
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/node.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/node.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	model "github.com/DataDog/agent-payload/v5/process"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/transformers"
 
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes"
 
@@ -87,6 +88,8 @@ func ExtractNode(n *corev1.Node) *model.Node {
 	}
 
 	addAdditionalNodeTags(msg)
+
+	msg.Tags = append(msg.Tags, transformers.RetrieveUnifiedServiceTags(n.ObjectMeta.Labels)...)
 
 	return msg
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/persistentvolume.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/persistentvolume.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	model "github.com/DataDog/agent-payload/v5/process"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/transformers"
 
 	corev1 "k8s.io/api/core/v1"
 )
@@ -81,6 +82,8 @@ func ExtractPersistentVolume(pv *corev1.PersistentVolume) *model.PersistentVolum
 	}
 
 	addAdditionalPersistentVolumeTags(message)
+
+	message.Tags = append(message.Tags, transformers.RetrieveUnifiedServiceTags(pv.ObjectMeta.Labels)...)
 
 	return message
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/persistentvolumeclaim.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/persistentvolumeclaim.go
@@ -10,6 +10,7 @@ package k8s
 
 import (
 	model "github.com/DataDog/agent-payload/v5/process"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/transformers"
 
 	corev1 "k8s.io/api/core/v1"
 )
@@ -30,6 +31,7 @@ func ExtractPersistentVolumeClaim(pvc *corev1.PersistentVolumeClaim) *model.Pers
 	}
 	extractSpec(pvc, message)
 	extractStatus(pvc, message)
+	message.Tags = append(message.Tags, transformers.RetrieveUnifiedServiceTags(pvc.ObjectMeta.Labels)...)
 
 	return message
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/replicaset.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/replicaset.go
@@ -10,7 +10,7 @@ package k8s
 
 import (
 	model "github.com/DataDog/agent-payload/v5/process"
-
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/transformers"
 	appsv1 "k8s.io/api/apps/v1"
 )
 
@@ -36,6 +36,7 @@ func ExtractReplicaSet(rs *appsv1.ReplicaSet) *model.ReplicaSet {
 	replicaSet.AvailableReplicas = rs.Status.AvailableReplicas
 
 	replicaSet.ResourceRequirements = ExtractPodTemplateResourceRequirements(rs.Spec.Template)
+	replicaSet.Tags = append(replicaSet.Tags, transformers.RetrieveUnifiedServiceTags(rs.ObjectMeta.Labels)...)
 
 	return &replicaSet
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/role.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/role.go
@@ -10,6 +10,7 @@ package k8s
 
 import (
 	model "github.com/DataDog/agent-payload/v5/process"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/transformers"
 
 	rbacv1 "k8s.io/api/rbac/v1"
 )
@@ -17,8 +18,12 @@ import (
 // ExtractRole returns the protobuf model corresponding to a Kubernetes Role
 // resource.
 func ExtractRole(r *rbacv1.Role) *model.Role {
-	return &model.Role{
+	msg := &model.Role{
 		Metadata: extractMetadata(&r.ObjectMeta),
 		Rules:    extractPolicyRules(r.Rules),
 	}
+
+	msg.Tags = append(msg.Tags, transformers.RetrieveUnifiedServiceTags(r.ObjectMeta.Labels)...)
+
+	return msg
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/rolebinding.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/rolebinding.go
@@ -10,6 +10,7 @@ package k8s
 
 import (
 	model "github.com/DataDog/agent-payload/v5/process"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/transformers"
 
 	rbacv1 "k8s.io/api/rbac/v1"
 )
@@ -17,9 +18,13 @@ import (
 // ExtractRoleBinding returns the protobuf model corresponding to a Kubernetes
 // RoleBinding resource.
 func ExtractRoleBinding(rb *rbacv1.RoleBinding) *model.RoleBinding {
-	return &model.RoleBinding{
+	msg := &model.RoleBinding{
 		Metadata: extractMetadata(&rb.ObjectMeta),
 		RoleRef:  extractRoleRef(&rb.RoleRef),
 		Subjects: extractSubjects(rb.Subjects),
 	}
+
+	msg.Tags = append(msg.Tags, transformers.RetrieveUnifiedServiceTags(rb.ObjectMeta.Labels)...)
+
+	return msg
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/service.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/service.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	model "github.com/DataDog/agent-payload/v5/process"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/transformers"
 
 	corev1 "k8s.io/api/core/v1"
 )
@@ -78,6 +79,8 @@ func ExtractService(s *corev1.Service) *model.Service {
 			NodePort:   port.NodePort,
 		})
 	}
+
+	message.Tags = append(message.Tags, transformers.RetrieveUnifiedServiceTags(s.ObjectMeta.Labels)...)
 
 	return message
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/serviceaccount.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/serviceaccount.go
@@ -12,6 +12,8 @@ import (
 	model "github.com/DataDog/agent-payload/v5/process"
 
 	corev1 "k8s.io/api/core/v1"
+
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/transformers"
 )
 
 // ExtractServiceAccount returns the protobuf model corresponding to a
@@ -41,5 +43,8 @@ func ExtractServiceAccount(sa *corev1.ServiceAccount) *model.ServiceAccount {
 			Name: imgPullSecret.Name,
 		})
 	}
+
+	serviceAccount.Tags = append(serviceAccount.Tags, transformers.RetrieveUnifiedServiceTags(sa.ObjectMeta.Labels)...)
+
 	return serviceAccount
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/statefulset.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/statefulset.go
@@ -10,6 +10,7 @@ package k8s
 
 import (
 	model "github.com/DataDog/agent-payload/v5/process"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/transformers"
 
 	v1 "k8s.io/api/apps/v1"
 )
@@ -47,6 +48,7 @@ func ExtractStatefulSet(sts *v1.StatefulSet) *model.StatefulSet {
 	}
 
 	statefulSet.Spec.ResourceRequirements = ExtractPodTemplateResourceRequirements(sts.Spec.Template)
+	statefulSet.Tags = append(statefulSet.Tags, transformers.RetrieveUnifiedServiceTags(sts.ObjectMeta.Labels)...)
 
 	return &statefulSet
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/transformers/ust.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/transformers/ust.go
@@ -1,0 +1,51 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver && orchestrator
+// +build kubeapiserver,orchestrator
+
+package transformers
+
+import (
+	"fmt"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes"
+)
+
+const (
+	tagKeyEnv     = "env"
+	tagKeyVersion = "version"
+	tagKeyService = "service"
+)
+
+var labelToTagKeys = map[string]string{
+	kubernetes.EnvTagLabelKey:     tagKeyEnv,
+	kubernetes.VersionTagLabelKey: tagKeyVersion,
+	kubernetes.ServiceTagLabelKey: tagKeyService,
+}
+
+var ustLabelsWithoutFallback = []string{kubernetes.VersionTagLabelKey, kubernetes.ServiceTagLabelKey}
+
+// call retrieveUST for cluster level resources
+// the `env` is handled special because it being a host level tag.
+func retrieveUST(labels map[string]string) []string {
+	var tags []string
+
+	if tagValue, found := labels[kubernetes.EnvTagLabelKey]; found {
+		tags = append(tags, fmt.Sprintf("%s:%s", labelToTagKeys[kubernetes.EnvTagLabelKey], tagValue))
+	} else {
+		if envTag := config.Datadog.GetString("env"); envTag != "" {
+			tags = append(tags, fmt.Sprintf("%s:%s", tagKeyEnv, envTag))
+		}
+	}
+
+	for _, labelKey := range ustLabelsWithoutFallback {
+		if tagValue, found := labels[labelKey]; found {
+			tags = append(tags, fmt.Sprintf("%s:%s", labelToTagKeys[labelKey], tagValue))
+		}
+	}
+	return tags
+}

--- a/pkg/collector/corechecks/cluster/orchestrator/transformers/ust.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/transformers/ust.go
@@ -29,9 +29,9 @@ var labelToTagKeys = map[string]string{
 
 var ustLabelsWithoutFallback = []string{kubernetes.VersionTagLabelKey, kubernetes.ServiceTagLabelKey}
 
-// call retrieveUST for cluster level resources
+// RetrieveUnifiedServiceTags for cluster level resources
 // the `env` is handled special because it being a host level tag.
-func retrieveUST(labels map[string]string) []string {
+func RetrieveUnifiedServiceTags(labels map[string]string) []string {
 	var tags []string
 
 	if tagValue, found := labels[kubernetes.EnvTagLabelKey]; found {

--- a/pkg/collector/corechecks/cluster/orchestrator/transformers/ust_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/transformers/ust_test.go
@@ -1,3 +1,11 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver && orchestrator
+// +build kubeapiserver,orchestrator
+
 package transformers
 
 import (

--- a/pkg/collector/corechecks/cluster/orchestrator/transformers/ust_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/transformers/ust_test.go
@@ -11,7 +11,8 @@ import (
 func TestRetrieveUST(t *testing.T) {
 	cfg := config.Mock(t)
 	cfg.Set("env", "staging")
-	cfg.Set("version", "not-applied")
+	cfg.Set(tagKeyService, "not-applied")
+	cfg.Set(tagKeyVersion, "not-applied")
 
 	tests := []struct {
 		name   string
@@ -31,8 +32,8 @@ func TestRetrieveUST(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := retrieveUST(tt.labels); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("retrieveUST() = %v, want %v", got, tt.want)
+			if got := RetrieveUnifiedServiceTags(tt.labels); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("RetrieveUnifiedServiceTags() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/collector/corechecks/cluster/orchestrator/transformers/ust_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/transformers/ust_test.go
@@ -1,0 +1,39 @@
+package transformers
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes"
+)
+
+func TestRetrieveUST(t *testing.T) {
+	cfg := config.Mock(t)
+	cfg.Set("env", "staging")
+	cfg.Set("version", "not-applied")
+
+	tests := []struct {
+		name   string
+		labels map[string]string
+		want   []string
+	}{
+		{
+			name:   "label contains ust, labels ust takes precedence",
+			labels: map[string]string{kubernetes.EnvTagLabelKey: "prod", kubernetes.VersionTagLabelKey: "123", kubernetes.ServiceTagLabelKey: "app"},
+			want:   []string{"env:prod", "version:123", "service:app"},
+		},
+		{
+			name:   "label does not contain env, takes from config",
+			labels: map[string]string{},
+			want:   []string{"env:staging"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := retrieveUST(tt.labels); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("retrieveUST() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/releasenotes-dca/notes/collect-ust-orchestrator-1a298b291713d2b7.yaml
+++ b/releasenotes-dca/notes/collect-ust-orchestrator-1a298b291713d2b7.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG-DCA.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Collects Unified Service Tags for the orchestrator explorer product.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
- Detect unified service tags for the orchestrator explorer to support unfiied tagging (filtering/grouping)
- Collectors RR for cronjobs, which seems to have been forgotten

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

- code duplication in favor of larger refactorings (introduction of proper interfaces or usage of generics at some point)

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
