### PR TITLE
[dogstatsd] introduce the OriginTelemetryTracker to report some telemetry per origin

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -517,6 +517,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("dogstatsd_origin_optout_enabled", true)
 	config.BindEnvAndSetDefault("dogstatsd_so_rcvbuf", 0)
 	config.BindEnvAndSetDefault("dogstatsd_metrics_stats_enable", false)
+	config.BindEnvAndSetDefault("dogstatsd_origin_telemetry", "") // possible values: simple or complete
 	config.BindEnvAndSetDefault("dogstatsd_tags", []string{})
 	config.BindEnvAndSetDefault("dogstatsd_mapper_cache_size", 1000)
 	config.BindEnvAndSetDefault("dogstatsd_string_interner_size", 4096)

--- a/pkg/dogstatsd/listeners/origin_telemetry.go
+++ b/pkg/dogstatsd/listeners/origin_telemetry.go
@@ -1,0 +1,125 @@
+package listeners
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/telemetry"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+var (
+	tlmOriginBytes = telemetry.NewCounter("dogstatsd", "origin_bytes",
+		[]string{"origin"}, "Bytes count per origin")
+	tlmOriginPackets = telemetry.NewCounter("dogstatsd", "origin_packets",
+		[]string{"origin"}, "Packets count per origin")
+	tlmOriginTags = telemetry.NewCounter("dogstatsd", "origin_tags",
+		[]string{"origin"}, "Tags count per origin")
+	tlmOriginMetrics = telemetry.NewCounter("dogstatsd", "origin_metrics",
+		[]string{"origin"}, "Metrics count per origin")
+)
+
+type OriginTelemetryMode string
+
+const OriginTelemetrySimple OriginTelemetryMode = "simple"
+const OriginTelemetryComplete OriginTelemetryMode = "complete"
+
+// OriginTelemetryEntry is created while processing a packet, meaning we have
+// one OriginTelemetryEntry per packet.
+type OriginTelemetryEntry struct {
+	Origin       string
+	BytesCount   uint
+	TagsCount    uint
+	MetricsCount uint
+}
+
+type OriginTelemetryTracker struct {
+	Mode         OriginTelemetryMode
+	ch           chan OriginTelemetryEntry
+	stopChan     chan bool
+	packetsCount map[string]uint
+	bytesCount   map[string]uint
+	tagsCount    map[string]uint
+	metricsCount map[string]uint
+}
+
+// StartOriginTelemetry reports origin telemetry using the internal telemetry system.
+// We can consider storing a per origin rate in order to implement rate-limit
+// in the future.
+func StartOriginTelemetry(stopChan chan bool, mode OriginTelemetryMode) *OriginTelemetryTracker {
+	trackingCh := make(chan OriginTelemetryEntry, 8192)
+	tracker := &OriginTelemetryTracker{
+		ch:           trackingCh,
+		stopChan:     stopChan,
+		packetsCount: make(map[string]uint),
+		bytesCount:   make(map[string]uint),
+		tagsCount:    make(map[string]uint),
+		metricsCount: make(map[string]uint),
+		Mode:         mode,
+	}
+	go func() {
+		tracker.run(trackingCh)
+	}()
+	return tracker
+}
+
+func (t *OriginTelemetryTracker) processEntry(entry OriginTelemetryEntry) {
+	tlmOriginBytes.Add(float64(entry.BytesCount), entry.Origin)
+	tlmOriginPackets.Inc(entry.Origin)
+
+	if t.Mode == OriginTelemetryComplete {
+		tlmOriginTags.Add(float64(entry.TagsCount), entry.Origin)
+		tlmOriginMetrics.Add(float64(entry.MetricsCount), entry.Origin)
+	}
+}
+
+func countMetricsAndTags(b []byte) (uint, uint) {
+	// results
+	var metrics uint = 0
+	var tags uint = 0
+
+	// parser states
+	var countingTag = false
+	var enteringNew = true
+
+	for _, c := range b {
+		if enteringNew {
+			// resets the parser and count a metric
+			enteringNew = false
+			countingTag = false
+			metrics += 1
+		}
+
+		if c == '#' {
+			// we're parsing a metric and we start parsing its tags
+			countingTag = true
+			// there is at least one (that's a simplification, there could be
+			// an immediate | and no tags to count. Let's not mind about this
+			// edge case to avoid a new parser state.
+			tags += 1
+		} else if countingTag && c == ',' {
+			// we're currently couting tags and we parsed a ',', means we'll
+			// start seeing a next one. Counts one (same simplification as above).
+			tags += 1
+		} else if c == '|' {
+			// We're leaving a part of the metrics parsing, in all cases, it means
+			// we are not counting tags anymore.
+			countingTag = false
+		} else if c == '\n' {
+			// We're done with current metric
+			enteringNew = true
+		}
+	}
+
+	return metrics, tags
+}
+
+func (t *OriginTelemetryTracker) run(trackingCh chan OriginTelemetryEntry) {
+	log.Debug("Starting the origin telemetry tracker")
+	for {
+		select {
+		case entry := <-trackingCh:
+			t.processEntry(entry)
+		case <-t.stopChan:
+			log.Debug("Closing the origin telemetry tracker")
+			return
+		}
+	}
+}

--- a/pkg/dogstatsd/listeners/origin_telemetry_test.go
+++ b/pkg/dogstatsd/listeners/origin_telemetry_test.go
@@ -1,0 +1,30 @@
+package listeners
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCountMetricsAndTags(t *testing.T) {
+	require := require.New(t)
+
+	metrics, tags := countMetricsAndTags([]byte("♬†øU†øU¥ºuT0♪:61|g|#intitulé:T0µ,another:tag|TT1657100540|@0.21"))
+	require.Equal(uint(1), metrics)
+	require.Equal(uint(2), tags)
+
+	metrics, tags = countMetricsAndTags([]byte("♬†øU†øU¥ºuT0♪:61|g|#intitulé:T0µ,another:tag,yetanother|TT1657100540|@0.21"))
+	require.Equal(uint(1), metrics)
+	require.Equal(uint(3), tags)
+
+	metrics, tags = countMetricsAndTags([]byte("♬†øU†øU¥ºuT0♪:61|g|#intitulé:T0µ,another:tag,yetanother|TT1657100540|@0.21\n"))
+	require.Equal(uint(1), metrics)
+	require.Equal(uint(3), tags)
+
+	metrics, tags = countMetricsAndTags([]byte("♬†øU†øU¥ºuT0♪:61|g|#intitulé:T0µ,another:tag,yetanother|TT1657100540|@0.21\nmetric_name:1:g"))
+	require.Equal(uint(2), metrics)
+	require.Equal(uint(3), tags)
+	metrics, tags = countMetricsAndTags([]byte("♬†øU†øU¥ºuT0♪:61|g|#intitulé:T0µ,another:tag,yetanother|TT1657100540|@0.21\nmetric_name:1:g|#hello:world"))
+	require.Equal(uint(2), metrics)
+	require.Equal(uint(4), tags)
+}

--- a/pkg/dogstatsd/listeners/uds_common_test.go
+++ b/pkg/dogstatsd/listeners/uds_common_test.go
@@ -33,7 +33,7 @@ func testFileExistsNewUDSListener(t *testing.T, socketPath string) {
 	_, err := os.Create(socketPath)
 	assert.Nil(t, err)
 	defer os.Remove(socketPath)
-	_, err = NewUDSListener(nil, packetPoolManagerUDS, nil)
+	_, err = NewUDSListener(nil, packetPoolManagerUDS, nil, nil)
 	assert.Error(t, err)
 }
 
@@ -46,7 +46,7 @@ func testSocketExistsNewUSDListener(t *testing.T, socketPath string) {
 }
 
 func testWorkingNewUDSListener(t *testing.T, socketPath string) {
-	s, err := NewUDSListener(nil, packetPoolManagerUDS, nil)
+	s, err := NewUDSListener(nil, packetPoolManagerUDS, nil, nil)
 	defer s.Stop()
 
 	assert.Nil(t, err)
@@ -80,7 +80,7 @@ func TestStartStopUDSListener(t *testing.T) {
 	mockConfig := config.Mock(t)
 	mockConfig.Set("dogstatsd_socket", socketPath)
 	mockConfig.Set("dogstatsd_origin_detection", false)
-	s, err := NewUDSListener(nil, packetPoolManagerUDS, nil)
+	s, err := NewUDSListener(nil, packetPoolManagerUDS, nil, nil)
 	assert.Nil(t, err)
 	assert.NotNil(t, s)
 
@@ -105,7 +105,7 @@ func TestUDSReceive(t *testing.T) {
 	var contents = []byte("daemon:666|g|#sometag1:somevalue1,sometag2:somevalue2")
 
 	packetsChannel := make(chan packets.Packets)
-	s, err := NewUDSListener(packetsChannel, packetPoolManagerUDS, nil)
+	s, err := NewUDSListener(packetsChannel, packetPoolManagerUDS, nil, nil)
 	assert.Nil(t, err)
 	assert.NotNil(t, s)
 

--- a/pkg/dogstatsd/listeners/uds_linux_test.go
+++ b/pkg/dogstatsd/listeners/uds_linux_test.go
@@ -36,7 +36,7 @@ func TestUDSPassCred(t *testing.T) {
 
 	pool := packets.NewPool(512)
 	poolManager := packets.NewPoolManager(pool)
-	s, err := NewUDSListener(nil, poolManager, nil)
+	s, err := NewUDSListener(nil, poolManager, nil, nil)
 	defer s.Stop()
 
 	assert.Nil(t, err)

--- a/test/integration/dogstatsd/origin_detection.go
+++ b/test/integration/dogstatsd/origin_detection.go
@@ -60,7 +60,7 @@ func testUDSOriginDetection(t *testing.T) {
 	packetsChannel := make(chan packets.Packets)
 	sharedPacketPool := packets.NewPool(32)
 	sharedPacketPoolManager := packets.NewPoolManager(sharedPacketPool)
-	s, err := listeners.NewUDSListener(packetsChannel, sharedPacketPoolManager, nil)
+	s, err := listeners.NewUDSListener(packetsChannel, sharedPacketPoolManager, nil, nil)
 	require.Nil(t, err)
 
 	go s.Listen()


### PR DESCRIPTION
When enabled with `dogstatsd_origin_telemetry: simple`, a goroutine reports telemetry for bytes per origin and packets per origin for message received by DogStatsD.
When enabled with `dogstatsd_origin_telemetry: complete`, this goroutine also reports telemetry metrics per origin and tags per origin.

In order to not be intrusive with the DogStatsD server, this implementation emphases on using the CPU instead of the RAM, thus it can have an impact on the CPU usage but should have none on the RAM usage. It has an impact on the CPU usage only when configured to use the `complete` mode. The CPU usage depends on the amount of metrics processed (null if no metrics processed, 100 mcores when 100k metrics processed per second, 250 mcores when 300k metrics processed per second, ...) 

### Motivation

While running on nodes where a lot of various apps are sending traffic to DogStatsD, it could be interesting to report metric per origin.

### Possible Drawbacks / Trade-offs

When enabled in mode `complete`, could have an impact on CPU, but none on RAM.

### Describe how to test/QA your changes

* Enable DogStatsD origin detection (`dogstatsd_origin_detection: true `).
* Enable `dogstatsd_origin_telemetry: simple`
    * Validate that the internal telemetry of the Agent reports counts with sane values for `dogstatsd.origin_bytes` and `dogstatsd.origin_packets` per origin. 
* Enable `dogstatsd_origin_telemetry: complete`
    * Validate that the internal telemetry of the Agent reports counts with sane values for `dogstatsd.origin_tags` and `dogstatsd.origin_metrics` per origin. 

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
