### PR TITLE
[pkg/otlp/model] Move NaN metric test to its own file

### DIFF
--- a/pkg/otlp/model/translator/metrics_translator_test.go
+++ b/pkg/otlp/model/translator/metrics_translator_test.go
@@ -25,10 +25,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
-	"go.uber.org/zap/zaptest/observer"
 
-	"github.com/DataDog/datadog-agent/pkg/otlp/model/attributes"
 	"github.com/DataDog/datadog-agent/pkg/otlp/model/source"
 	"github.com/DataDog/datadog-agent/pkg/quantile"
 	"github.com/DataDog/datadog-agent/pkg/quantile/summary"
@@ -650,32 +647,6 @@ func TestFormatFloat(t *testing.T) {
 	}
 }
 
-func exampleSummaryDataPointSlice(ts pcommon.Timestamp, sum float64, count uint64) pmetric.SummaryDataPointSlice {
-	slice := pmetric.NewSummaryDataPointSlice()
-	point := slice.AppendEmpty()
-	point.SetCount(count)
-	point.SetSum(sum)
-	qSlice := point.QuantileValues()
-
-	qMin := qSlice.AppendEmpty()
-	qMin.SetQuantile(0.0)
-	qMin.SetValue(0)
-
-	qMedian := qSlice.AppendEmpty()
-	qMedian.SetQuantile(0.5)
-	qMedian.SetValue(100)
-
-	q999 := qSlice.AppendEmpty()
-	q999.SetQuantile(0.999)
-	q999.SetValue(500)
-
-	qMax := qSlice.AppendEmpty()
-	qMax.SetQuantile(1)
-	qMax.SetValue(600)
-	point.SetTimestamp(ts)
-	return slice
-}
-
 const (
 	testHostname     = "res-hostname"
 	fallbackHostname = "fallbackHostname"
@@ -737,124 +708,4 @@ func newSketchWithHostname(name string, summary summary.Summary, tags []string) 
 	s := newSketch(dims.AddTags(tags...), 0, summary)
 	s.host = testHostname
 	return s
-}
-
-func createNaNMetrics() pmetric.Metrics {
-	md := pmetric.NewMetrics()
-	rms := md.ResourceMetrics()
-	rm := rms.AppendEmpty()
-
-	attrs := rm.Resource().Attributes()
-	attrs.PutStr(attributes.AttributeDatadogHostname, testHostname)
-	ilms := rm.ScopeMetrics()
-
-	metricsArray := ilms.AppendEmpty().Metrics()
-
-	// DoubleGauge
-	met := metricsArray.AppendEmpty()
-	met.SetName("nan.gauge")
-	met.SetEmptyGauge()
-	dpsDouble := met.Gauge().DataPoints()
-	dpDouble := dpsDouble.AppendEmpty()
-	dpDouble.SetTimestamp(seconds(0))
-	dpDouble.SetDoubleValue(math.NaN())
-
-	// Double Sum (delta)
-	met = metricsArray.AppendEmpty()
-	met.SetName("nan.delta.sum")
-	met.SetEmptySum()
-	met.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityDelta)
-	dpsDouble = met.Sum().DataPoints()
-	dpDouble = dpsDouble.AppendEmpty()
-	dpDouble.SetTimestamp(seconds(0))
-	dpDouble.SetDoubleValue(math.NaN())
-
-	// Double Sum (delta monotonic)
-	met = metricsArray.AppendEmpty()
-	met.SetName("nan.delta.monotonic.sum")
-	met.SetEmptySum()
-	met.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityDelta)
-	dpsDouble = met.Sum().DataPoints()
-	dpDouble = dpsDouble.AppendEmpty()
-	dpDouble.SetTimestamp(seconds(0))
-	dpDouble.SetDoubleValue(math.NaN())
-
-	// Histogram
-	met = metricsArray.AppendEmpty()
-	met.SetName("nan.histogram")
-	met.SetEmptyHistogram()
-	met.Histogram().SetAggregationTemporality(pmetric.AggregationTemporalityDelta)
-	dpsDoubleHist := met.Histogram().DataPoints()
-	dpDoubleHist := dpsDoubleHist.AppendEmpty()
-	dpDoubleHist.SetCount(20)
-	dpDoubleHist.SetSum(math.NaN())
-	dpDoubleHist.BucketCounts().FromRaw([]uint64{2, 18})
-	dpDoubleHist.ExplicitBounds().FromRaw([]float64{0})
-	dpDoubleHist.SetTimestamp(seconds(0))
-
-	// Double Sum (cumulative)
-	met = metricsArray.AppendEmpty()
-	met.SetName("nan.cumulative.sum")
-	met.SetEmptySum()
-	met.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
-	dpsDouble = met.Sum().DataPoints()
-	dpsDouble.EnsureCapacity(2)
-	dpDouble = dpsDouble.AppendEmpty()
-	dpDouble.SetTimestamp(seconds(0))
-	dpDouble.SetDoubleValue(math.NaN())
-
-	// Double Sum (cumulative monotonic)
-	met = metricsArray.AppendEmpty()
-	met.SetName("nan.cumulative.monotonic.sum")
-	met.SetEmptySum()
-	met.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
-	met.Sum().SetIsMonotonic(true)
-	dpsDouble = met.Sum().DataPoints()
-	dpsDouble.EnsureCapacity(2)
-	dpDouble = dpsDouble.AppendEmpty()
-	dpDouble.SetTimestamp(seconds(0))
-	dpDouble.SetDoubleValue(math.NaN())
-
-	// Summary
-	met = metricsArray.AppendEmpty()
-	met.SetName("nan.summary")
-	met.SetEmptySummary()
-	slice := exampleSummaryDataPointSlice(seconds(0), math.NaN(), 1)
-	slice.CopyTo(met.Summary().DataPoints())
-
-	met = metricsArray.AppendEmpty()
-	met.SetName("nan.summary")
-	met.SetEmptySummary()
-	slice = exampleSummaryDataPointSlice(seconds(2), 10_001, 101)
-	slice.CopyTo(met.Summary().DataPoints())
-	return md
-}
-
-func TestNaNMetrics(t *testing.T) {
-	md := createNaNMetrics()
-
-	core, observed := observer.New(zapcore.DebugLevel)
-	testLogger := zap.New(core)
-	ctx := context.Background()
-	tr := newTranslator(t, testLogger)
-	consumer := &mockFullConsumer{}
-	err := tr.MapMetrics(ctx, md, consumer)
-	require.NoError(t, err)
-
-	assert.ElementsMatch(t, consumer.metrics, []metric{
-		newCountWithHostname("nan.summary.count", 100, 2, []string{}),
-	})
-
-	assert.ElementsMatch(t, consumer.sketches, []sketch{
-		newSketchWithHostname("nan.histogram", summary.Summary{
-			Min: 0,
-			Max: 0,
-			Sum: 0,
-			Avg: 0,
-			Cnt: 20,
-		}, []string{}),
-	})
-
-	// One metric type was unknown or unsupported
-	assert.Equal(t, observed.FilterMessage("Unsupported metric value").Len(), 7)
 }

--- a/pkg/otlp/model/translator/nan_metrics_test.go
+++ b/pkg/otlp/model/translator/nan_metrics_test.go
@@ -1,0 +1,178 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package translator
+
+import (
+	"context"
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+
+	"github.com/DataDog/datadog-agent/pkg/otlp/model/attributes"
+	"github.com/DataDog/datadog-agent/pkg/quantile/summary"
+)
+
+func exampleSummaryDataPointSlice(ts pcommon.Timestamp, sum float64, count uint64) pmetric.SummaryDataPointSlice {
+	slice := pmetric.NewSummaryDataPointSlice()
+	point := slice.AppendEmpty()
+	point.SetCount(count)
+	point.SetSum(sum)
+	qSlice := point.QuantileValues()
+
+	qMin := qSlice.AppendEmpty()
+	qMin.SetQuantile(0.0)
+	qMin.SetValue(0)
+
+	qMedian := qSlice.AppendEmpty()
+	qMedian.SetQuantile(0.5)
+	qMedian.SetValue(100)
+
+	q999 := qSlice.AppendEmpty()
+	q999.SetQuantile(0.999)
+	q999.SetValue(500)
+
+	qMax := qSlice.AppendEmpty()
+	qMax.SetQuantile(1)
+	qMax.SetValue(600)
+	point.SetTimestamp(ts)
+	return slice
+}
+
+func createNaNMetrics() pmetric.Metrics {
+	md := pmetric.NewMetrics()
+	rms := md.ResourceMetrics()
+	rm := rms.AppendEmpty()
+
+	attrs := rm.Resource().Attributes()
+	attrs.PutStr(attributes.AttributeDatadogHostname, testHostname)
+	ilms := rm.ScopeMetrics()
+
+	metricsArray := ilms.AppendEmpty().Metrics()
+
+	// DoubleGauge
+	met := metricsArray.AppendEmpty()
+	met.SetName("nan.gauge")
+	met.SetEmptyGauge()
+	dpsDouble := met.Gauge().DataPoints()
+	dpDouble := dpsDouble.AppendEmpty()
+	dpDouble.SetTimestamp(seconds(0))
+	dpDouble.SetDoubleValue(math.NaN())
+
+	// Double Sum (delta)
+	met = metricsArray.AppendEmpty()
+	met.SetName("nan.delta.sum")
+	met.SetEmptySum()
+	met.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityDelta)
+	dpsDouble = met.Sum().DataPoints()
+	dpDouble = dpsDouble.AppendEmpty()
+	dpDouble.SetTimestamp(seconds(0))
+	dpDouble.SetDoubleValue(math.NaN())
+
+	// Double Sum (delta monotonic)
+	met = metricsArray.AppendEmpty()
+	met.SetName("nan.delta.monotonic.sum")
+	met.SetEmptySum()
+	met.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityDelta)
+	dpsDouble = met.Sum().DataPoints()
+	dpDouble = dpsDouble.AppendEmpty()
+	dpDouble.SetTimestamp(seconds(0))
+	dpDouble.SetDoubleValue(math.NaN())
+
+	// Histogram
+	met = metricsArray.AppendEmpty()
+	met.SetName("nan.histogram")
+	met.SetEmptyHistogram()
+	met.Histogram().SetAggregationTemporality(pmetric.AggregationTemporalityDelta)
+	dpsDoubleHist := met.Histogram().DataPoints()
+	dpDoubleHist := dpsDoubleHist.AppendEmpty()
+	dpDoubleHist.SetCount(20)
+	dpDoubleHist.SetSum(math.NaN())
+	dpDoubleHist.BucketCounts().FromRaw([]uint64{2, 18})
+	dpDoubleHist.ExplicitBounds().FromRaw([]float64{0})
+	dpDoubleHist.SetTimestamp(seconds(0))
+
+	// Double Sum (cumulative)
+	met = metricsArray.AppendEmpty()
+	met.SetName("nan.cumulative.sum")
+	met.SetEmptySum()
+	met.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+	dpsDouble = met.Sum().DataPoints()
+	dpsDouble.EnsureCapacity(2)
+	dpDouble = dpsDouble.AppendEmpty()
+	dpDouble.SetTimestamp(seconds(0))
+	dpDouble.SetDoubleValue(math.NaN())
+
+	// Double Sum (cumulative monotonic)
+	met = metricsArray.AppendEmpty()
+	met.SetName("nan.cumulative.monotonic.sum")
+	met.SetEmptySum()
+	met.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+	met.Sum().SetIsMonotonic(true)
+	dpsDouble = met.Sum().DataPoints()
+	dpsDouble.EnsureCapacity(2)
+	dpDouble = dpsDouble.AppendEmpty()
+	dpDouble.SetTimestamp(seconds(0))
+	dpDouble.SetDoubleValue(math.NaN())
+
+	// Summary
+	met = metricsArray.AppendEmpty()
+	met.SetName("nan.summary")
+	met.SetEmptySummary()
+	slice := exampleSummaryDataPointSlice(seconds(0), math.NaN(), 1)
+	slice.CopyTo(met.Summary().DataPoints())
+
+	met = metricsArray.AppendEmpty()
+	met.SetName("nan.summary")
+	met.SetEmptySummary()
+	slice = exampleSummaryDataPointSlice(seconds(2), 10_001, 101)
+	slice.CopyTo(met.Summary().DataPoints())
+	return md
+}
+
+func TestNaNMetrics(t *testing.T) {
+	md := createNaNMetrics()
+
+	core, observed := observer.New(zapcore.DebugLevel)
+	testLogger := zap.New(core)
+	ctx := context.Background()
+	tr := newTranslator(t, testLogger)
+	consumer := &mockFullConsumer{}
+	err := tr.MapMetrics(ctx, md, consumer)
+	require.NoError(t, err)
+
+	assert.ElementsMatch(t, consumer.metrics, []metric{
+		newCountWithHostname("nan.summary.count", 100, 2, []string{}),
+	})
+
+	assert.ElementsMatch(t, consumer.sketches, []sketch{
+		newSketchWithHostname("nan.histogram", summary.Summary{
+			Min: 0,
+			Max: 0,
+			Sum: 0,
+			Avg: 0,
+			Cnt: 20,
+		}, []string{}),
+	})
+
+	// One metric type was unknown or unsupported
+	assert.Equal(t, observed.FilterMessage("Unsupported metric value").Len(), 7)
+}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Move OTLP metric translator test TestNaNMetrics and its related helper function to its own test file.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Better test structure and more descriptive test file names.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

TestNaNMetrics cannot be converted to JSON tests because JSON doesn't support NaN.

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
