### PR TITLE
[orchestration] Add Pod Start and Schedule

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	code.cloudfoundry.org/bbs v0.0.0-20200403215808-d7bc971db0db
 	code.cloudfoundry.org/garden v0.0.0-20210208153517-580cadd489d2
 	code.cloudfoundry.org/lager v2.0.0+incompatible
-	github.com/DataDog/agent-payload/v5 v5.0.42
+	github.com/DataDog/agent-payload/v5 v5.0.43
 	github.com/DataDog/datadog-agent/pkg/obfuscate v0.41.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/otlp/model v0.41.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/quantile v0.41.0-rc.3

--- a/go.sum
+++ b/go.sum
@@ -117,8 +117,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/toml v1.1.0 h1:ksErzDEI1khOiGPgpwuI7x2ebx/uXQNw7xJpn9Eq1+I=
 github.com/BurntSushi/toml v1.1.0/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/DataDog/agent-payload/v5 v5.0.42 h1:cDfxKa9aoqm2rzHp6oC1H/d+heNLQYIz8CNo1j0kSSQ=
-github.com/DataDog/agent-payload/v5 v5.0.42/go.mod h1:vhXPNG7eNDOLeW94Z7dLNUBv61kRBHK7vXnQ+RQfckk=
+github.com/DataDog/agent-payload/v5 v5.0.43 h1:CusKXkIlZfVGivojTUVriKs54KNDg7vspQ51qAvBSks=
+github.com/DataDog/agent-payload/v5 v5.0.43/go.mod h1:vhXPNG7eNDOLeW94Z7dLNUBv61kRBHK7vXnQ+RQfckk=
 github.com/DataDog/aptly v1.5.0 h1:Oy6JVRC9iDgnmpeVYa4diXwP/exU7wJ/U1kuI4Zacxg=
 github.com/DataDog/aptly v1.5.0/go.mod h1:KVyvkYXGcFugxadGFZ+u5Fc3M6q/EfzFZyeTD9HVbkY=
 github.com/DataDog/cast v1.3.1-0.20190301154711-1ee8c8bd14a3 h1:SobA9WYm4K/MUtWlbKaomWTmnuYp1KhIm8Wlx3vmpsg=

--- a/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/pod.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/pod.go
@@ -57,6 +57,15 @@ func ExtractPod(p *corev1.Pod) *model.Pod {
 
 	podModel.ResourceRequirements = extractPodResourceRequirements(p.Spec.Containers, p.Spec.InitContainers)
 
+	if p.Status.StartTime != nil {
+		podModel.StartTime = p.Status.StartTime.Unix()
+	}
+	for _, c := range p.Status.Conditions {
+		if c.Type == corev1.PodScheduled && c.Status == corev1.ConditionTrue {
+			podModel.ScheduledTime = c.LastTransitionTime.Unix()
+		}
+	}
+
 	return &podModel
 }
 

--- a/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/pod_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/pod_test.go
@@ -87,6 +87,11 @@ func TestExtractPod(t *testing.T) {
 							Type:   v1.PodReady,
 							Status: v1.ConditionTrue,
 						},
+						{
+							Type:               v1.PodScheduled,
+							Status:             v1.ConditionTrue,
+							LastTransitionTime: timestamp,
+						},
 					},
 					ContainerStatuses: []v1.ContainerStatus{
 						{
@@ -175,6 +180,8 @@ func TestExtractPod(t *testing.T) {
 				NominatedNodeName: "nominated",
 				NodeName:          "node",
 				RestartCount:      42,
+				ScheduledTime:     timestamp.Unix(),
+				StartTime:         timestamp.Unix(),
 				Status:            "chillin",
 				QOSClass:          "Guaranteed",
 				PriorityClass:     "high-priority",

--- a/releasenotes/notes/PodStartSchedule-1bf8b53bf8e79f9c.yaml
+++ b/releasenotes/notes/PodStartSchedule-1bf8b53bf8e79f9c.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Add both the `StartTime` and `ScheduledTime` properties in collector for K8s pods.

--- a/releasenotes/notes/PodStartSchedule-1bf8b53bf8e79f9c.yaml
+++ b/releasenotes/notes/PodStartSchedule-1bf8b53bf8e79f9c.yaml
@@ -8,4 +8,4 @@
 ---
 enhancements:
   - |
-    Add both the `StartTime` and `ScheduledTime` properties in collector for K8s pods.
+    Adds both the `StartTime` and `ScheduledTime` properties in the collector for Kubernetes pods.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
Add the pod start time and pod schedule time to the collector. This will allow us to start collecting those metrics in the agent.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
We want additional metrics for pods specifically, so we're updating the agent to start collecting those metrics
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
