### PR TITLE
Print MSI install logs even when install fails.

### DIFF
--- a/test/kitchen/site-cookbooks/dd-agent-install/recipes/_install_windows_base.rb
+++ b/test/kitchen/site-cookbooks/dd-agent-install/recipes/_install_windows_base.rb
@@ -72,7 +72,6 @@ windows_package 'Datadog Agent' do
   # but we need to print the install logs.
   ignore_failure true
 end
-end
 
 # This runs during the converge phase and will return a non-zero exit
 # code if the service doesn't run. While it can be useful to quickly

--- a/test/kitchen/site-cookbooks/dd-agent-install/recipes/_install_windows_base.rb
+++ b/test/kitchen/site-cookbooks/dd-agent-install/recipes/_install_windows_base.rb
@@ -68,6 +68,10 @@ windows_package 'Datadog Agent' do
     :path => temp_file
   })
   returns expected_msi_result_code
+  # It's ok to ignore failure, the kitchen test will fail anyway
+  # but we need to print the install logs.
+  ignore_failure true
+end
 end
 
 # This runs during the converge phase and will return a non-zero exit
@@ -85,5 +89,13 @@ ruby_block "Print install logs" do
     # Use warn, because Chef's default "log" is too chatty
     # and the kitchen tests default to "warn"
     Chef::Log.warn(File.open(log_file_name, "rb:UTF-16LE", &:read).encode('UTF-8'))
+  end
+end
+
+ruby_block "Check install sucess" do
+  block do
+    raise "Could not find installation log file, did the installer run ?" if !File.file?(log_file_name)
+    logfile = File.open(log_file_name, "rb:UTF-16LE", &:read).encode('UTF-8')
+    raise "The Agent failed to install" if logfile.include? "Product: Datadog Agent -- Installation failed."
   end
 end


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
This PR lets the install recipe for the kitchen test to print the MSI install logs even in the event of an install failure.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Better kitchen tests.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
