### PR TITLE
cmd/trace-agent: set gomemlimit based on cgroups

### DIFF
--- a/cmd/trace-agent/main_nix.go
+++ b/cmd/trace-agent/main_nix.go
@@ -12,8 +12,10 @@ import (
 	"context"
 	"flag"
 
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/runtime"
 	"github.com/DataDog/datadog-agent/pkg/trace/watchdog"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // main is the main application entry point
@@ -22,6 +24,9 @@ func main() {
 
 	// prepare go runtime
 	runtime.SetMaxProcs()
+	if err := runtime.SetGoMemLimit(config.IsContainerized()); err != nil {
+		log.Debugf("Couldn't set Go memory limit: %s", err)
+	}
 
 	// Handle stops properly
 	go func() {

--- a/pkg/runtime/gomemlimit.go
+++ b/pkg/runtime/gomemlimit.go
@@ -1,0 +1,18 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !linux
+// +build !linux
+
+package runtime
+
+import (
+	"errors"
+)
+
+// SetGoMemLimit configures Go memory limit based on cgroups. Only supported on Linux.
+func SetGoMemLimit(isContainerized bool) error {
+	return errors.New("unsupported on non-linux")
+}

--- a/pkg/runtime/gomemlimit.go
+++ b/pkg/runtime/gomemlimit.go
@@ -3,8 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build !linux
-// +build !linux
+//go:build !linux || !go1.19
 
 package runtime
 
@@ -14,5 +13,5 @@ import (
 
 // SetGoMemLimit configures Go memory limit based on cgroups. Only supported on Linux.
 func SetGoMemLimit(isContainerized bool) error {
-	return errors.New("unsupported on non-linux")
+	return errors.New("unsupported")
 }

--- a/pkg/runtime/gomemlimit_linux.go
+++ b/pkg/runtime/gomemlimit_linux.go
@@ -1,0 +1,52 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+// +build linux
+
+package runtime
+
+import (
+	"errors"
+	"os"
+	"runtime/debug"
+
+	"github.com/DataDog/datadog-agent/pkg/util/cgroups"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// SetGoMemLimit configures Go memory soft limit based on cgroups.
+// The soft limit is set to 90% of the cgroup memory hard limit.
+// The function is noop if
+//   - GOMEMLIMIT is set already
+//   - There is no cgroup limit
+//
+// Read more about Go memory limit in https://tip.golang.org/doc/gc-guide#Memory_limit
+func SetGoMemLimit(isContainerized bool) error {
+	if _, ok := os.LookupEnv("GOMEMLIMIT"); ok {
+		log.Debug("GOMEMLIMIT is set already, doing nothing")
+		return nil
+	}
+	selfReader, err := cgroups.NewSelfReader("/proc", isContainerized)
+	if err != nil {
+		return err
+	}
+	cgroup := selfReader.GetCgroup(cgroups.SelfCgroupIdentifier)
+	if cgroup == nil {
+		return errors.New("cannot get cgroup")
+	}
+	var stats cgroups.MemoryStats
+	if err := cgroup.GetMemoryStats(&stats); err != nil {
+		return err
+	}
+	if stats.Limit == nil {
+		log.Debug("Cgroup memory limit not found, doing nothing")
+		return nil
+	}
+	softLimit := int64(0.9 * float64(*stats.Limit))
+	log.Infof("Cgroup memory limit is %d, setting gomemlimit to %d", *stats.Limit, softLimit)
+	debug.SetMemoryLimit(softLimit)
+	return nil
+}

--- a/pkg/runtime/gomemlimit_linux.go
+++ b/pkg/runtime/gomemlimit_linux.go
@@ -3,8 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build linux
-// +build linux
+//go:build linux && go1.19
 
 package runtime
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

- Adds a util `SetGoMemLimit` in `pkg/runtime` to set the Go memory limit to 90% of the cgroup limit
- Call `SetGoMemLimit` in the trace-agent's entrypoint

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

- Leverage Go memory soft limit for a better memory management. The feature that was released in Go 1.19.
- `SetGoMemLimit` is in `pkg/runtime` so any other agent can import it in the future.

![image](https://user-images.githubusercontent.com/38987709/213513350-5e016ace-a86b-46f6-9b7b-2fb5dcd46629.png)


<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

- This requires Go 1.19+
- Go [proposal](https://go.googlesource.com/proposal/+/master/design/48409-soft-memory-limit.md) and [guide](https://tip.golang.org/doc/gc-guide#Memory_limit)

- The trace agent has been load-tested with and without gomemlimit in a Kuberentes environment.
With gomemlimit:
  - The OOM kills happen less frequently
  - No noticeable CPU overhead

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

- Linux only
<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

- Monitor the CPU and memory usage of the trace agent, make sure there are no perf regressions (although this has been tested already)
- Enable debug logs, run the trace-agent with and without cgroup limits, make sure the logs correspond to the expectations
- When the cgroup limit is set, ensure the info log shows the expected values, e.g
```
Cgroup memory limit is 136314880, setting gomemlimit to 122683392
```

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
