### PR TITLE
[process-agent] Log an error when `hidepid=invisible` is set

### DIFF
--- a/cmd/agent/common/misconfig/mounts.go
+++ b/cmd/agent/common/misconfig/mounts.go
@@ -27,6 +27,16 @@ func init() {
 	registerCheck("proc mount", procMount, map[AgentType]struct{}{CoreAgent: {}, ProcessAgent: {}})
 }
 
+func isHidePid2Set(mountsOptsLookup map[string]struct{}) (setting string, isSet bool) {
+	if _, hidepid2Set := mountsOptsLookup["hidepid=2"]; hidepid2Set {
+		return "hidepid=2", true
+	}
+	if _, hidepidInvisibleSet := mountsOptsLookup["hidepid=invisible"]; hidepidInvisibleSet {
+		return "hidepid=invisible", true
+	}
+	return "", false
+}
+
 func procMount() error {
 
 	if os.Geteuid() == 0 {
@@ -91,9 +101,10 @@ func checkProcMountHidePid(path string, uid int, groups []int) error {
 			mountOptsLookup[opt] = struct{}{}
 		}
 
-		if _, ok := mountOptsLookup["hidepid=2"]; !ok {
+		hidepidSetting, hidepid2Set := isHidePid2Set(mountOptsLookup)
+		if hidepid2Set {
 			// hidepid is not set, no further checks necessary
-			log.Tracef("Proc mounts hidepid=2 option is not set")
+			log.Tracef("Proc mounts hidepid=2 or hidepid=invisible option is not set")
 			return nil
 		}
 
@@ -107,13 +118,13 @@ func checkProcMountHidePid(path string, uid int, groups []int) error {
 			gidList = append(gidList, strconv.Itoa(gid))
 			if _, ok := mountOptsLookup[gidOpt]; ok {
 				// While hidepid=2 is set, one of the groups is enabled
-				log.Tracef("Proc mounts hidepid=2 with %s - proc fs inspection is enabled", gidOpt)
+				log.Tracef("Proc mounts %s with %s - proc fs inspection is enabled", hidepidSetting, gidOpt)
 				return nil
 			}
 		}
 
-		return fmt.Errorf("hidepid=2 option detected in %s (options=%s) - proc fs inspection may not work (uid=%d, groups=[%s])",
-			path, fields[3], uid, strings.Join(gidList, ","))
+		return fmt.Errorf("%s option detected in %s (options=%s) - proc fs inspection may not work (uid=%d, groups=[%s])",
+			hidepidSetting, path, fields[3], uid, strings.Join(gidList, ","))
 	}
 
 	return errors.Wrapf(scanner.Err(), "failed to scan %s", path)

--- a/cmd/agent/common/misconfig/mounts.go
+++ b/cmd/agent/common/misconfig/mounts.go
@@ -27,7 +27,7 @@ func init() {
 	registerCheck("proc mount", procMount, map[AgentType]struct{}{CoreAgent: {}, ProcessAgent: {}})
 }
 
-func isHidePid2Set(mountsOptsLookup map[string]struct{}) (setting string, isSet bool) {
+func isHidepid2Set(mountsOptsLookup map[string]struct{}) (setting string, isSet bool) {
 	if _, hidepid2Set := mountsOptsLookup["hidepid=2"]; hidepid2Set {
 		return "hidepid=2", true
 	}
@@ -101,7 +101,7 @@ func checkProcMountHidePid(path string, uid int, groups []int) error {
 			mountOptsLookup[opt] = struct{}{}
 		}
 
-		hidepidSetting, hidepid2Set := isHidePid2Set(mountOptsLookup)
+		hidepidSetting, hidepid2Set := isHidepid2Set(mountOptsLookup)
 		if !hidepid2Set {
 			// hidepid is not set, no further checks necessary
 			log.Tracef("Proc mounts hidepid=2 or hidepid=invisible option is not set")

--- a/cmd/agent/common/misconfig/mounts.go
+++ b/cmd/agent/common/misconfig/mounts.go
@@ -102,7 +102,7 @@ func checkProcMountHidePid(path string, uid int, groups []int) error {
 		}
 
 		hidepidSetting, hidepid2Set := isHidePid2Set(mountOptsLookup)
-		if hidepid2Set {
+		if !hidepid2Set {
 			// hidepid is not set, no further checks necessary
 			log.Tracef("Proc mounts hidepid=2 or hidepid=invisible option is not set")
 			return nil

--- a/cmd/agent/common/misconfig/mounts_test.go
+++ b/cmd/agent/common/misconfig/mounts_test.go
@@ -15,8 +15,6 @@ import (
 )
 
 func TestCheckProcMountHidePid(t *testing.T) {
-	assert := assert.New(t)
-
 	tests := []struct {
 		name        string
 		file        string
@@ -35,13 +33,29 @@ func TestCheckProcMountHidePid(t *testing.T) {
 			expectError: "hidepid=2 option detected in ./tests/proc-mounts-hidepid-2 (options=defaults,hidepid=2) - proc fs inspection may not work (uid=1001, groups=[1,2,3])",
 		},
 		{
+			name:        "hidepid=invisible without groups",
+			file:        "./tests/proc-mounts-hidepid-invisible",
+			groups:      []int{1, 2, 3},
+			expectError: "hidepid=invisible option detected in ./tests/proc-mounts-hidepid-invisible (options=defaults,hidepid=invisible) - proc fs inspection may not work (uid=1001, groups=[1,2,3])",
+		},
+		{
 			name:   "hidepid without groups user has root group",
 			file:   "./tests/proc-mounts-hidepid-2",
 			groups: []int{0},
 		},
 		{
+			name:   "hidepid=invisible without groups user has root group",
+			file:   "./tests/proc-mounts-hidepid-invisible",
+			groups: []int{0},
+		},
+		{
 			name:   "hidepid and groups",
 			file:   "./tests/proc-mounts-hidepid-2-groups",
+			groups: []int{234, 4242},
+		},
+		{
+			name:   "hidepid=invisible and groups",
+			file:   "./tests/proc-mounts-hidepid-invisible-groups",
 			groups: []int{234, 4242},
 		},
 		{
@@ -52,6 +66,8 @@ func TestCheckProcMountHidePid(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			assert := assert.New(t)
+
 			err := checkProcMountHidePid(test.file, 1001, test.groups)
 			if test.expectError != "" {
 				assert.EqualError(err, test.expectError)

--- a/cmd/agent/common/misconfig/tests/proc-mounts-hidepid-invisible
+++ b/cmd/agent/common/misconfig/tests/proc-mounts-hidepid-invisible
@@ -1,0 +1,1 @@
+proc	/proc	proc	defaults,hidepid=invisible	0 0

--- a/cmd/agent/common/misconfig/tests/proc-mounts-hidepid-invisible-groups
+++ b/cmd/agent/common/misconfig/tests/proc-mounts-hidepid-invisible-groups
@@ -1,0 +1,1 @@
+proc	/proc	proc	defaults,hidepid=2,gid=4242	0 0

--- a/releasenotes/notes/hidepid-invisible-235607d4fbfe25f9.yaml
+++ b/releasenotes/notes/hidepid-invisible-235607d4fbfe25f9.yaml
@@ -1,0 +1,3 @@
+---
+fixes:
+  - Fix a bug where a misconfig error does not show when `hidepid=invisible` instead

--- a/releasenotes/notes/hidepid-invisible-235607d4fbfe25f9.yaml
+++ b/releasenotes/notes/hidepid-invisible-235607d4fbfe25f9.yaml
@@ -1,3 +1,3 @@
 ---
 fixes:
-  - Fix a bug where a misconfig error does not show when `hidepid=invisible` instead
+  - Fix a bug where a misconfig error does not show when `hidepid=invisible`


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
In kernels 5.10+, `hidepid=2` can sometimes show up as `hidepid=invisible`. This PR allows the process-agent to detect `hidepid=invisible` as well as `hidepid=2` so that we can properly show an error.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
https://datadoghq.atlassian.net/browse/PROC-2083?atlOrigin=eyJpIjoiYTZhNGJmMjg4ZGJlNDY2NDhmMGQyNjYxYzRhY2Q4MTIiLCJwIjoiaiJ9

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
- Using a linux box with kernel version >5.10, run `sudo mount -o remount,rw,hidepid=invisible /proc`. I did this by downloading a brand new Ubuntu image into parallels, but you should also be able to do this in ec2.
- Run `mount | grep proc` and ensure that `/proc` is mounted with `hidepid=invisible`.
- Run the process agent and check to see if the WARN is logged for `hidepid=invisible`

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
