### PR TITLE
Fix alt_dir kitchen tests

### DIFF
--- a/test/kitchen/site-cookbooks/dd-agent-install/recipes/_install_windows_base.rb
+++ b/test/kitchen/site-cookbooks/dd-agent-install/recipes/_install_windows_base.rb
@@ -92,6 +92,7 @@ ruby_block "Print install logs" do
 end
 
 ruby_block "Check install sucess" do
+  not_if agent_install_options.include?('WIXFAILWHENDEFERRED')
   block do
     raise "Could not find installation log file, did the installer run ?" if !File.file?(log_file_name)
     logfile = File.open(log_file_name, "rb:UTF-16LE", &:read).encode('UTF-8')

--- a/test/kitchen/site-cookbooks/dd-agent-install/recipes/_install_windows_base.rb
+++ b/test/kitchen/site-cookbooks/dd-agent-install/recipes/_install_windows_base.rb
@@ -92,7 +92,7 @@ ruby_block "Print install logs" do
 end
 
 ruby_block "Check install sucess" do
-  not_if agent_install_options.include?('WIXFAILWHENDEFERRED')
+  not_if { agent_install_options.include?('WIXFAILWHENDEFERRED') }
   block do
     raise "Could not find installation log file, did the installer run ?" if !File.file?(log_file_name)
     logfile = File.open(log_file_name, "rb:UTF-16LE", &:read).encode('UTF-8')

--- a/test/kitchen/test/integration/win-alt-dir/rspec/win-alt-dir_spec.rb
+++ b/test/kitchen/test/integration/win-alt-dir/rspec/win-alt-dir_spec.rb
@@ -50,9 +50,8 @@ shared_examples_for 'an Agent with valid permissions' do
     expected_sddl = "O:SYG:SYD:PAI(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)(A;OICI;WD;;;BU)(A;OICI;FA;;;#{dd_user_sid})"
     expected_sddl_2016 = "O:SYG:SYD:(A;ID;WD;;;BU)(A;ID;FA;;;BA)(A;ID;FA;;;SY)(A;ID;FA;;;#{dd_user_sid})"
     actual_sddl = get_sddl_for_object(configuration_path)
-    equal_base = equal_sddl?(expected_sddl, actual_sddl)
-    equal_2016 = equal_sddl?(expected_sddl_2016, actual_sddl)
-    expect(equal_base | equal_2016).to be_truthy
+    expect(actual_sddl).to have_sddl_equal_to(expected_sddl)
+                       .or have_sddl_equal_to(expected_sddl_2016)
   end
   it 'has proper permissions on datadog.yaml' do
     # should have a sddl like so 
@@ -64,9 +63,8 @@ shared_examples_for 'an Agent with valid permissions' do
     expected_sddl = "O:SYG:SYD:PAI(A;;FA;;;SY)(A;;FA;;;BA)(A;;WD;;;BU)(A;;FA;;;#{dd_user_sid})"
     expected_sddl_2016 = "O:SYG:SYD:(A;ID;WD;;;BU)(A;ID;FA;;;BA)(A;ID;FA;;;SY)(A;ID;FA;;;#{dd_user_sid})"
     actual_sddl = get_sddl_for_object("#{configuration_path}\\datadog.yaml")
-    equal_base = equal_sddl?(expected_sddl, actual_sddl)
-    equal_2016 = equal_sddl?(expected_sddl_2016, actual_sddl)
-    expect(equal_base | equal_2016).to be_truthy
+    expect(actual_sddl).to have_sddl_equal_to(expected_sddl)
+                       .or have_sddl_equal_to(expected_sddl_2016)
   end
   it 'has proper permissions on the conf.d directory' do
     # A,OICI;FA;;;SY = Allows Object Inheritance (OI) container inherit (CI); File All Access to LocalSystem
@@ -78,8 +76,7 @@ shared_examples_for 'an Agent with valid permissions' do
     expected_sddl =      "O:SYG:SYD:PAI(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)(A;OICI;WD;;;BU)(A;OICI;FA;;;#{dd_user_sid})"
     actual_sddl = get_sddl_for_object("#{configuration_path}\\conf.d")
 
-    sddl_result = equal_sddl?(expected_sddl, actual_sddl)
-    expect(sddl_result).to be_truthy
+    expect(actual_sddl).to have_sddl_equal_to(expected_sddl)
   end
 
   it 'has the proper permissions on the DataDog registry key' do
@@ -113,10 +110,9 @@ shared_examples_for 'an Agent with valid permissions' do
 
     actual_sddl = get_sddl_for_object("HKLM:Software\\Datadog\\Datadog Agent")
 
-    sddl_result = equal_sddl?(expected_sddl, actual_sddl)
-    equal_2008 = equal_sddl?(expected_sddl_2008, actual_sddl)
-    edge_result = equal_sddl?(expected_sddl_with_edge, actual_sddl)
-    expect(sddl_result | equal_2008 | edge_result).to be_truthy
+    expect(actual_sddl).to have_sddl_equal_to(expected_sddl)
+                       .or have_sddl_equal_to(expected_sddl_2008)
+                       .or have_sddl_equal_to(expected_sddl_with_edge)
   end
 
   it 'has agent.exe running as ddagentuser' do


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
Fix the alt_dir kitchen tests following #14550 

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Kitchen tests that pass.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
