### PR TITLE
Add an option to force the Agent to trust hostname value retrieved from non-root UTS namespaces

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -355,6 +355,12 @@ func InitConfig(config Config) {
 	// canonical hostname, otherwise the instance-id is used as canonical hostname.
 	config.BindEnvAndSetDefault("hostname_force_config_as_canonical", false)
 
+	// By default the Agent does not trust the hostname value retrieved from non-root UTS namespace.
+	// When enabled, the Agent will trust the value retrieved from non-root UTS namespace instead of failing
+	// hostname resolution.
+	// (Linux only)
+	config.BindEnvAndSetDefault("hostname_trust_uts_namespace", false)
+
 	config.BindEnvAndSetDefault("cluster_name", "")
 	config.BindEnvAndSetDefault("disable_cluster_name_tag_key", false)
 

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -96,6 +96,16 @@ api_key:
 #
 # hostname_fqdn: false
 
+## @param hostname_trust_uts_namespace - boolean - optional - default: false
+## @env DD_HOSTNAME_TRUST_UTS_NAMESPACE - boolean - optional - default: false
+## By default the Agent does not trust the hostname value retrieved from non-root UTS namespace,
+## as it's usually a generated name, unrelated to the host (e.g. when running in a container).
+## When enabled, the Agent will trust the value retrieved from non-root UTS namespace instead of failing
+## hostname resolution.
+## (Linux only)
+#
+# hostname_trust_uts_namespace: false
+
 ## @param host_aliases - list of strings - optional
 ## @env DD_HOST_ALIASES - space separated list of strings - optional
 ## List of host aliases to report in addition to any aliases collected

--- a/pkg/util/hostname/os_hostname_linux.go
+++ b/pkg/util/hostname/os_hostname_linux.go
@@ -11,6 +11,7 @@ package hostname
 import (
 	"context"
 
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/system"
 )
@@ -19,6 +20,10 @@ import (
 // in a non-root UTS namespace because in that case, the OS hostname characterizes the
 // identity of the agent container and not the one of the nodes it is running on.
 func isOSHostnameUsable(ctx context.Context) bool {
+	if config.Datadog.GetBool("hostname_trust_uts_namespace") {
+		return true
+	}
+
 	selfUTSInode, err := system.GetProcessNamespaceInode("/proc", "self", "uts")
 	if err != nil {
 		// If we are not able to gather our own UTS Inode, in doubt, return true.

--- a/releasenotes/notes/add-trust-uts-option-9ce336359bde636a.yaml
+++ b/releasenotes/notes/add-trust-uts-option-9ce336359bde636a.yaml
@@ -1,4 +1,4 @@
 ---
 enhancements:
   - |
-    Add an option (`hostname_trust_uts_namespace`) to force the Agent to trust hostname value retrieved from non-root UTS namespaces (Linux only).
+    Add an option (`hostname_trust_uts_namespace`) to force the Agent to trust the hostname value retrieved from non-root UTS namespaces (Linux only).

--- a/releasenotes/notes/add-trust-uts-option-9ce336359bde636a.yaml
+++ b/releasenotes/notes/add-trust-uts-option-9ce336359bde636a.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Add an option (`hostname_trust_uts_namespace`) to force the Agent to trust hostname value retrieved from non-root UTS namespaces (Linux only).


### PR DESCRIPTION
### What does this PR do?

Add an option to force the Agent to trust hostname value retrieved from non-root UTS namespaces

### Motivation

Give an easy way to trust hostname retrieved from non-root UTS namespaces, which can be especially useful when the Agent runs in containers without container runtimes API (LXC, for instance) on bare-metal or cloud providers for which we are not able to retrieve hostname from any API.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Run the Agent in Docker locally (not AWS, GCP or Azure) without mounting the docker socket but with `-e DD_HOSTNAME_TRUST_UTS_NAMESPACE=true`.
The Agent should start and run with `os` hostname (can be checked in `agent status`).

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
