### PR TITLE
usm: gotls: performance improvement

### DIFF
--- a/pkg/network/go/bininspect/dwarf.go
+++ b/pkg/network/go/bininspect/dwarf.go
@@ -76,12 +76,11 @@ func InspectWithDWARF(elfFile *elf.File, functions []string, structFields []Fiel
 	}
 
 	return &Result{
-		Arch:                 arch,
-		ABI:                  abi,
-		GoVersion:            goVersion,
-		IncludesDebugSymbols: true,
-		Functions:            functionsMetadata,
-		StructOffsets:        structOffsets,
+		Arch:          arch,
+		ABI:           abi,
+		GoVersion:     goVersion,
+		Functions:     functionsMetadata,
+		StructOffsets: structOffsets,
 	}, nil
 
 }

--- a/pkg/network/go/bininspect/symbols.go
+++ b/pkg/network/go/bininspect/symbols.go
@@ -1,0 +1,289 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
+//go:build linux
+// +build linux
+
+package bininspect
+
+import (
+	"debug/elf"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"github.com/DataDog/datadog-agent/pkg/util/common"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"io"
+	"math"
+)
+
+// getSymbolNameByEntry extracts from the string data section the string in the given position.
+// If the symbol name is shorter or longer than the given min and max (==len(buf)) then we return an error.
+func getSymbolNameByEntry(sectionReader io.ReaderAt, startPos, minLength int, buf []byte) (string, bool) {
+	_, err := sectionReader.ReadAt(buf, int64(startPos))
+	if err != nil {
+		return "", false
+	}
+	for i := 0; i < len(buf); i++ {
+		if buf[i] == 0 {
+			if i < minLength {
+				break
+			}
+			return string(buf[0:i]), true
+		}
+	}
+
+	return "", false
+}
+
+// getSymbolBoundaries extracts the minimum and maximum lengths of the symbols.
+func getSymbolBoundaries(set common.StringSet) (int, int) {
+	maxSymbolName := 0
+	minSymbolName := math.MaxInt
+	for k := range set {
+		if len(k) > maxSymbolName {
+			maxSymbolName = len(k)
+		}
+		if len(k) < minSymbolName {
+			minSymbolName = len(k)
+		}
+	}
+
+	return minSymbolName, maxSymbolName
+}
+
+// readSymbolEntryInStringTable reads the first 4 bytes from the symbol section current location, which represents the
+// symbol name entry in the string data section.
+func readSymbolEntryInStringTable(symbolSectionReader io.ReaderAt, byteOrder binary.ByteOrder, readLocation int64, allocatedBufferForRead []byte) (int, bool) {
+	if _, err := symbolSectionReader.ReadAt(allocatedBufferForRead, readLocation); err != nil {
+		return 0, false
+	}
+	return int(byteOrder.Uint32(allocatedBufferForRead)), true
+}
+
+// readRestOfSymbol64 reads the symbol entry from the symbol section with the first 4 bytes of the name entry (which
+// we read using readSymbolEntryInStringTable).
+func readRestOfSymbol64(symbol *elf.Symbol, symbolSectionReader io.ReaderAt, byteOrder binary.ByteOrder, symbolName string, readLocation int64, allocatedBufferForRead []byte) {
+	symbolSectionReader.ReadAt(allocatedBufferForRead, readLocation)
+
+	infoAndOther := byteOrder.Uint16(allocatedBufferForRead[0:2])
+	symbol.Name = symbolName
+	symbol.Info = uint8(infoAndOther >> 8)
+	symbol.Other = uint8(infoAndOther)
+	symbol.Section = elf.SectionIndex(byteOrder.Uint16(allocatedBufferForRead[2:4]))
+	symbol.Value = byteOrder.Uint64(allocatedBufferForRead[4:12])
+	symbol.Size = byteOrder.Uint64(allocatedBufferForRead[12:20])
+}
+
+// readRestOfSymbol32 reads the symbol entry from the symbol section with the first 4 bytes of the name entry (which
+// we read using readSymbolEntryInStringTable).
+func readRestOfSymbol32(symbol *elf.Symbol, symbolSectionReader io.ReaderAt, byteOrder binary.ByteOrder, symbolName string, readLocation int64, allocatedBufferForRead []byte) {
+	symbolSectionReader.ReadAt(allocatedBufferForRead, readLocation)
+
+	symbol.Name = symbolName
+	symbol.Value = uint64(byteOrder.Uint32(allocatedBufferForRead[0:4]))
+	symbol.Size = uint64(byteOrder.Uint32(allocatedBufferForRead[4:8]))
+
+	infoAndOther := byteOrder.Uint16(allocatedBufferForRead[8:10])
+	symbol.Info = uint8(infoAndOther >> 8)
+	symbol.Other = uint8(infoAndOther)
+	symbol.Section = elf.SectionIndex(byteOrder.Uint16(allocatedBufferForRead[10:12]))
+}
+
+// getSymbols64 extracts the given symbol list from the binary.
+func getSymbols64(f *elf.File, typ elf.SectionType, wantedSymbols common.StringSet) ([]elf.Symbol, error) {
+	// Getting the relevant symbol section.
+	symbolSection := f.SectionByType(typ)
+	if symbolSection == nil {
+		return nil, elf.ErrNoSymbols
+	}
+
+	// Checking the symbol section size is aligned to a multiplication of Sym64Size.
+	if symbolSection.Size%elf.Sym64Size != 0 {
+		return nil, errors.New("length of symbol section is not a multiple of Sym64Size")
+	}
+
+	// Checking the symbol section link is valid.
+	if symbolSection.Link <= 0 || symbolSection.Link >= uint32(len(f.Sections)) {
+		return nil, errors.New("section has invalid string table link")
+	}
+
+	// Allocating entries for all wanted symbols.
+	symbols := make([]elf.Symbol, 0, len(wantedSymbols))
+
+	// Copying the wanted symbol set, so we can modify it during runtime.
+	copyOfWantedSymbols := wantedSymbols.Clone()
+	// Extracting the min and max symbol length.
+	minSymbolNameSize, maxSymbolNameSize := getSymbolBoundaries(copyOfWantedSymbols)
+	// Pre-allocating a buffer to read the symbol string into.
+	// The size of the buffer is maxSymbolNameSize + 1, for null termination.
+	symbolNameBuf := make([]byte, maxSymbolNameSize+1)
+	// Pre allocating a buffer for reading the symbol entry in the string table.
+	allocatedBufferForSymbolNameRead := make([]byte, 4)
+	// Pre allocating a buffer for reading the rest of the symbol fields from the symbol section.
+	allocatedBufferForSymbolRead := make([]byte, elf.Sym64Size-len(allocatedBufferForSymbolNameRead))
+
+	// Iterating through the symbol table. We skip the first elf.Sym64Size bytes as they are zeros.
+	for readLocation := int64(elf.Sym64Size); uint64(readLocation) < symbolSection.Size; readLocation += elf.Sym64Size {
+		// Reading the symbol entry in the string table.
+		stringEntry, ok := readSymbolEntryInStringTable(symbolSection.ReaderAt, f.ByteOrder, readLocation, allocatedBufferForSymbolNameRead)
+		if !ok {
+			continue
+		}
+
+		// Trying to get string representation of symbol.
+		// If the symbol name's length is not in the boundaries [minSymbolNameSize, maxSymbolNameSize+1] then we fail,
+		// and continue to the next symbol.
+		symbolName, ok := getSymbolNameByEntry(f.Sections[symbolSection.Link].ReaderAt, stringEntry, minSymbolNameSize, symbolNameBuf)
+		if !ok {
+			continue
+		}
+
+		// Checking the symbol is relevant for us.
+		if _, ok := copyOfWantedSymbols[symbolName]; !ok {
+			continue
+		}
+
+		// If relevant, delete it for optimization purposes.
+		delete(copyOfWantedSymbols, symbolName)
+
+		// Complete the symbol reading.
+		var symbol elf.Symbol
+		readRestOfSymbol64(&symbol, symbolSection.ReaderAt, f.ByteOrder, symbolName, readLocation+4, allocatedBufferForSymbolRead)
+		symbols = append(symbols, symbol)
+		// If no symbols left, stop running.
+		if len(copyOfWantedSymbols) == 0 {
+			break
+		}
+	}
+
+	return symbols, nil
+}
+
+// getSymbols32 extracts the given symbol list from the binary.
+func getSymbols32(f *elf.File, typ elf.SectionType, wantedSymbols common.StringSet) ([]elf.Symbol, error) {
+	// Getting the relevant symbol section.
+	symbolSection := f.SectionByType(typ)
+	if symbolSection == nil {
+		return nil, elf.ErrNoSymbols
+	}
+
+	// Checking the symbol section size is aligned to a multiplication of Sym64Size.
+	if symbolSection.Size%elf.Sym32Size != 0 {
+		return nil, errors.New("length of symbol section is not a multiple of Sym32Size")
+	}
+
+	// Checking the symbol section link is valid.
+	if symbolSection.Link <= 0 || symbolSection.Link >= uint32(len(f.Sections)) {
+		return nil, errors.New("section has invalid string table link")
+	}
+
+	// Allocating entries for all wanted symbols.
+	symbols := make([]elf.Symbol, 0, len(wantedSymbols))
+
+	// Copying the wanted symbol set, so we can modify it during runtime.
+	copyOfWantedSymbols := wantedSymbols.Clone()
+	// Extracting the min and max symbol length.
+	minSymbolNameSize, maxSymbolNameSize := getSymbolBoundaries(copyOfWantedSymbols)
+	// Pre-allocating a buffer to read the symbol string into.
+	// The size of the buffer is maxSymbolNameSize + 1, for null termination.
+	symbolNameBuf := make([]byte, maxSymbolNameSize+1)
+	// Pre allocating a buffer for reading the symbol entry in the string table.
+	allocatedBufferForSymbolNameRead := make([]byte, 4)
+	// Pre allocating a buffer for reading the rest of the symbol fields from the symbol section.
+	allocatedBufferForSymbolRead := make([]byte, elf.Sym32Size-len(allocatedBufferForSymbolNameRead))
+
+	// Iterating through the symbol table. We skip the first elf.Sym32Size bytes as they are zeros.
+	for readLocation := int64(elf.Sym32Size); uint64(readLocation) < symbolSection.Size; readLocation += elf.Sym32Size {
+		// Reading the symbol entry in the string table.
+		stringEntry, ok := readSymbolEntryInStringTable(symbolSection.ReaderAt, f.ByteOrder, readLocation, allocatedBufferForSymbolNameRead)
+		if !ok {
+			continue
+		}
+
+		// Trying to get string representation of symbol.
+		// If the symbol name's length is not in the boundaries [minSymbolNameSize, maxSymbolNameSize+1] then we fail,
+		// and continue to the next symbol.
+		symbolName, ok := getSymbolNameByEntry(f.Sections[symbolSection.Link].ReaderAt, stringEntry, minSymbolNameSize, symbolNameBuf)
+		if !ok {
+			continue
+		}
+
+		// Checking the symbol is relevant for us.
+		if _, ok := copyOfWantedSymbols[symbolName]; !ok {
+			continue
+		}
+
+		// If relevant, delete it for optimization purposes.
+		delete(copyOfWantedSymbols, symbolName)
+
+		// Complete the symbol reading.
+		var symbol elf.Symbol
+		readRestOfSymbol32(&symbol, symbolSection.ReaderAt, f.ByteOrder, symbolName, readLocation+4, allocatedBufferForSymbolRead)
+		symbols = append(symbols, symbol)
+		// If no symbols left, stop running.
+		if len(copyOfWantedSymbols) == 0 {
+			break
+		}
+	}
+
+	return symbols, nil
+}
+
+func getSymbols(f *elf.File, typ elf.SectionType, wanted map[string]struct{}) ([]elf.Symbol, error) {
+	switch f.Class {
+	case elf.ELFCLASS64:
+		return getSymbols64(f, typ, wanted)
+
+	case elf.ELFCLASS32:
+		return getSymbols32(f, typ, wanted)
+	}
+
+	return nil, errors.New("not implemented")
+}
+
+func GetAllSymbolsByName(elfFile *elf.File, symbolSet common.StringSet) (map[string]elf.Symbol, error) {
+	regularSymbols, regularSymbolsErr := getSymbols(elfFile, elf.SHT_SYMTAB, symbolSet)
+	if regularSymbolsErr != nil {
+		log.Debugf("Failed getting regular symbols of elf file: %s", regularSymbolsErr)
+	}
+
+	var dynamicSymbols []elf.Symbol
+	var dynamicSymbolsErr error
+	if len(regularSymbols) != len(symbolSet) {
+		dynamicSymbols, dynamicSymbolsErr = getSymbols(elfFile, elf.SHT_DYNSYM, symbolSet)
+		if dynamicSymbolsErr != nil {
+			log.Debugf("Failed getting dynamic symbols of elf file: %s", dynamicSymbolsErr)
+		}
+	}
+
+	// Only if we failed getting both regular and dynamic symbols - then we abort.
+	if regularSymbolsErr != nil && dynamicSymbolsErr != nil {
+		return nil, fmt.Errorf("could not open symbol sections to resolve symbol offset: %v, %v", regularSymbolsErr, dynamicSymbolsErr)
+	}
+
+	symbolByName := make(map[string]elf.Symbol, len(regularSymbols)+len(dynamicSymbols))
+
+	for _, regularSymbol := range regularSymbols {
+		symbolByName[regularSymbol.Name] = regularSymbol
+	}
+
+	for _, dynamicSymbol := range dynamicSymbols {
+		symbolByName[dynamicSymbol.Name] = dynamicSymbol
+	}
+
+	if len(symbolByName) != len(symbolSet) {
+		missingSymbols := make([]string, 0, len(symbolSet)-len(symbolByName))
+		for symbolName := range symbolSet {
+			if _, ok := symbolByName[symbolName]; !ok {
+				missingSymbols = append(missingSymbols, symbolName)
+			}
+
+		}
+		return nil, fmt.Errorf("failed to find symbols %#v", missingSymbols)
+	}
+
+	return symbolByName, nil
+}

--- a/pkg/network/go/bininspect/symbols.go
+++ b/pkg/network/go/bininspect/symbols.go
@@ -13,10 +13,11 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"github.com/DataDog/datadog-agent/pkg/util/common"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"io"
 	"math"
+
+	"github.com/DataDog/datadog-agent/pkg/util/common"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // getSymbolNameByEntry extracts from the string data section the string in the given position.

--- a/pkg/network/go/bininspect/types.go
+++ b/pkg/network/go/bininspect/types.go
@@ -54,13 +54,12 @@ type elfMetadata struct {
 
 // Result is the result of the binary inspection process.
 type Result struct {
-	Arch                 GoArch
-	ABI                  GoABI
-	GoVersion            goversion.GoVersion
-	IncludesDebugSymbols bool
-	Functions            map[string]FunctionMetadata
-	StructOffsets        map[FieldIdentifier]uint64
-	GoroutineIDMetadata  GoroutineIDMetadata
+	Arch                GoArch
+	ABI                 GoABI
+	GoVersion           goversion.GoVersion
+	Functions           map[string]FunctionMetadata
+	StructOffsets       map[FieldIdentifier]uint64
+	GoroutineIDMetadata GoroutineIDMetadata
 }
 
 // GoArch only includes supported architectures,

--- a/pkg/network/go/bininspect/utils.go
+++ b/pkg/network/go/bininspect/utils.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/network/go/asmscan"
 	"github.com/DataDog/datadog-agent/pkg/network/go/binversion"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/go-delve/delve/pkg/goversion"
 )
 
@@ -48,36 +47,6 @@ func HasDwarfInfo(elfFile *elf.File) (*dwarf.Data, bool) {
 	}
 
 	return nil, false
-}
-
-// GetAllSymbolsByName returns all the elf file's symbols mapped by their name.
-func GetAllSymbolsByName(elfFile *elf.File) (map[string]elf.Symbol, error) {
-	regularSymbols, regularSymbolsErr := elfFile.Symbols()
-	if regularSymbolsErr != nil {
-		log.Debugf("Failed getting regular symbols of elf file: %s", regularSymbolsErr)
-	}
-
-	dynamicSymbols, dynamicSymbolsErr := elfFile.DynamicSymbols()
-	if dynamicSymbolsErr != nil {
-		log.Debugf("Failed getting dynamic symbols of elf file: %s", dynamicSymbolsErr)
-	}
-
-	// Only if we failed getting both regular and dynamic symbols - then we abort.
-	if regularSymbolsErr != nil && dynamicSymbolsErr != nil {
-		return nil, fmt.Errorf("could not open symbol sections to resolve symbol offset: %v, %v", regularSymbolsErr, dynamicSymbolsErr)
-	}
-
-	symbolByName := make(map[string]elf.Symbol, len(regularSymbols)+len(dynamicSymbols))
-
-	for _, regularSymbol := range regularSymbols {
-		symbolByName[regularSymbol.Name] = regularSymbol
-	}
-
-	for _, dynamicSymbol := range dynamicSymbols {
-		symbolByName[dynamicSymbol.Name] = dynamicSymbol
-	}
-
-	return symbolByName, nil
 }
 
 // FindGoVersion attempts to determine the Go version
@@ -146,14 +115,9 @@ func FindReturnLocations(elfFile *elf.File, sym elf.Symbol, functionOffset uint6
 }
 
 // SymbolToOffset returns the offset of the given symbol name in the given elf file.
-func SymbolToOffset(f *elf.File, symbol string) (uint32, error) {
+func SymbolToOffset(f *elf.File, symbol elf.Symbol) (uint32, error) {
 	if f == nil {
 		return 0, errors.New("got nil elf file")
-	}
-
-	syms, err := GetAllSymbolsByName(f)
-	if err != nil {
-		return 0, fmt.Errorf("failed to get all symbols from file: %w", err)
 	}
 
 	var sectionsToSearchForSymbol []*elf.Section
@@ -170,25 +134,20 @@ func SymbolToOffset(f *elf.File, symbol string) (uint32, error) {
 
 	var executableSection *elf.Section
 
-	for symbolName, symbolData := range syms {
-		if symbolName == symbol {
-			// Find what section the symbol is in by checking the executable section's
-			// addr space.
-			for m := range sectionsToSearchForSymbol {
-				if symbolData.Value > sectionsToSearchForSymbol[m].Addr &&
-					symbolData.Value < sectionsToSearchForSymbol[m].Addr+sectionsToSearchForSymbol[m].Size {
-					executableSection = sectionsToSearchForSymbol[m]
-					break
-				}
-			}
-
-			if executableSection == nil {
-				return 0, errors.New("could not find symbol in executable sections of binary")
-			}
-
-			return uint32(symbolData.Value - executableSection.Addr + executableSection.Offset), nil
+	// Find what section the symbol is in by checking the executable section's
+	// addr space.
+	for m := range sectionsToSearchForSymbol {
+		if symbol.Value > sectionsToSearchForSymbol[m].Addr &&
+			symbol.Value < sectionsToSearchForSymbol[m].Addr+sectionsToSearchForSymbol[m].Size {
+			executableSection = sectionsToSearchForSymbol[m]
+			break
 		}
 	}
 
-	return 0, fmt.Errorf("symbol %s not found in file", symbol)
+	if executableSection == nil {
+		return 0, errors.New("could not find symbol in executable sections of binary")
+	}
+
+	return uint32(symbol.Value - executableSection.Addr + executableSection.Offset), nil
+
 }

--- a/pkg/network/go/bininspect/utils.go
+++ b/pkg/network/go/bininspect/utils.go
@@ -137,8 +137,9 @@ func SymbolToOffset(f *elf.File, symbol elf.Symbol) (uint32, error) {
 	// Find what section the symbol is in by checking the executable section's
 	// addr space.
 	for m := range sectionsToSearchForSymbol {
-		if symbol.Value > sectionsToSearchForSymbol[m].Addr &&
-			symbol.Value < sectionsToSearchForSymbol[m].Addr+sectionsToSearchForSymbol[m].Size {
+		sectionStart := sectionsToSearchForSymbol[m].Addr
+		sectionEnd := sectionStart + sectionsToSearchForSymbol[m].Size
+		if symbol.Value >= sectionStart && symbol.Value < sectionEnd {
 			executableSection = sectionsToSearchForSymbol[m]
 			break
 		}

--- a/pkg/util/common/common.go
+++ b/pkg/util/common/common.go
@@ -22,7 +22,7 @@ func NewStringSet(initItems ...string) StringSet {
 	return newSet
 }
 
-// Add adds a item to the set
+// Add adds an item to the set
 func (s StringSet) Add(item string) {
 	s[item] = struct{}{}
 }
@@ -34,6 +34,16 @@ func (s StringSet) GetAll() []string {
 		res = append(res, item)
 	}
 	return res
+}
+
+// Clone returns a duplication of the set.
+func (s StringSet) Clone() StringSet {
+	clone := make(StringSet, len(s))
+	for entry := range s {
+		clone[entry] = struct{}{}
+	}
+
+	return clone
 }
 
 // StructToMap converts a struct to a map[string]interface{} based on `json` annotations defaulting to field names

--- a/pkg/util/common/common.go
+++ b/pkg/util/common/common.go
@@ -36,16 +36,6 @@ func (s StringSet) GetAll() []string {
 	return res
 }
 
-// Clone returns a duplication of the set.
-func (s StringSet) Clone() StringSet {
-	clone := make(StringSet, len(s))
-	for entry := range s {
-		clone[entry] = struct{}{}
-	}
-
-	return clone
-}
-
 // StructToMap converts a struct to a map[string]interface{} based on `json` annotations defaulting to field names
 func StructToMap(obj interface{}) map[string]interface{} {
 	rt, rv := reflect.TypeOf(obj), reflect.ValueOf(obj)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Major refactor in the goTLS inspection code.
The changes are divied into 2 changes:
1. Reimplementing GetAllSymbolsByName to be more effificent in memory and runtime. The new version is getting the list of wanted symbols to fetch, and returns the relevant symbols only.
2. Removing irrelevant call to HasDwarfInfo which allocated a lot of memory without any purpose

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Solve memory and runtime overhead

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

Run 2 benchmarks on `main` and this branch.
The first benchmark tried to inpsect `docker` binary which has the relevant symbols, and trying to inpsect the test binary which has many symbols but none are tls.

on `main` branch 

```
BenchmarkGetSymbolsByNameDocker-16    	      10	 100817750 ns/op	132288267 B/op	  530289 allocs/op
BenchmarkGetSymbolsByNameTest-16     	      25	  43744169 ns/op	22586734 B/op	   63665 allocs/op

BenchmarkGetSymbolsByNameDocker-16    	      14	  83114233 ns/op	132287389 B/op	  530286 allocs/op
BenchmarkGetSymbolsByNameTest-16     	      28	  39570493 ns/op	22586641 B/op	   63664 allocs/op
```

On this branch

```
BenchmarkGetSymbolsByNameDocker-16    	     334	   3493458 ns/op	   93019 B/op	    1037 allocs/op
BenchmarkGetSymbolsByNameTest-16     	     475	   2537140 ns/op	   88113 B/op	     861 allocs/op

BenchmarkGetSymbolsByNameDocker-16    	     312	   3520427 ns/op	   93015 B/op	    1037 allocs/op
BenchmarkGetSymbolsByNameTest-16     	     470	   2588324 ns/op	   88120 B/op	     861 allocs/op
```
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
