### PR TITLE
[dogstatsd] origin telemetry can be enabled without having to enable the DSD debug mode

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1011,6 +1011,7 @@ func InitConfig(config Config) {
 	// Enable telemetry metrics on the internals of the Agent.
 	// This create a lot of billable custom metrics.
 	config.BindEnvAndSetDefault("telemetry.enabled", false)
+	config.BindEnvAndSetDefault("telemetry.dogstatsd_origin", false)
 	config.BindEnv("telemetry.checks")
 	// We're using []string as a default instead of []float64 because viper can only parse list of string from the environment
 	//


### PR DESCRIPTION
### What does this PR do?

In some environments, it is interesting to report per origin the telemetry of processed DogStatsD metrics. This origin tracked is only the one available in the UDS ancillary data (i.e. not resolving the special tag `dd.internal.entity_id `).

Plus some renaming to make this a bit clearer.

### Describe how to test/QA your changes

* Runs the Agent with telemetry + set `telemetry.dogstatsd_origin: true`.
* Enable DogStatsD origin detection (`dogstatsd_origin_detection: true` ).
* Use an UDS client to sends metrics to DogStatsD with an origin attached.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
