### PR TITLE
[WIP] Add nightly job for system tests

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -89,7 +89,7 @@ jobs:
             variant: rails70
 
     env:
-      DD_API_KEY: ${{ secrets.DD_API_KEY }}
+      DD_API_KEY: XXXX # ${{ secrets.DD_API_KEY }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -20,76 +20,22 @@ jobs:
           - library: cpp
             variant: nginx
           - library: golang
-            variant: net-http
-          - library: golang
-            variant: gorilla
-          - library: golang
             variant: echo
-          - library: golang
-            variant: chi
-          - library: golang
-            variant: gin
           - library: nodejs
             variant: express4
-          - library: nodejs
-            variant: express4-typescript
           - library: dotnet
             variant: poc
-
           - library: java
             variant: spring-boot
-          - library: java
-            variant: spring-boot-jetty
-          - library: java
-            variant: jersey-grizzly2
-          - library: java
-            variant: resteasy-netty3
-          - library: java
-            variant: ratpack
-          - library: java
-            variant: vertx3
-
           - library: php
             variant: apache-mod-8.0
-          - library: php
-            variant: php-fpm-8.0
-          - library: python
-            variant: django-poc
           - library: python
             variant: flask-poc
-          - library: python
-            variant: uwsgi-poc
-          - library: ruby
-            variant: rack
-          - library: ruby
-            variant: sinatra14
-          - library: ruby
-            variant: sinatra20
           - library: ruby
             variant: sinatra21
-          - library: ruby
-            variant: rails32
-          - library: ruby
-            variant: rails40
-          - library: ruby
-            variant: rails41
-          - library: ruby
-            variant: rails42
-          - library: ruby
-            variant: rails50
-          - library: ruby
-            variant: rails51
-          - library: ruby
-            variant: rails52
-          - library: ruby
-            variant: rails60
-          - library: ruby
-            variant: rails61
-          - library: ruby
-            variant: rails70
 
     env:
-      DD_API_KEY: XXXX # ${{ secrets.DD_API_KEY }}
+      DD_API_KEY: ${{ secrets.DD_API_KEY }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -120,26 +66,3 @@ jobs:
         with:
           name: logs_${{ matrix.weblog.library }}_${{ matrix.weblog.variant }}
           path: artifact.tar.gz
-
-      - name: Upload results CI Visibility
-        if: ${{ always() }}
-        run: ./utils/scripts/upload_results_CI_visibility.sh dev nightly-agent ${{ github.run_id }}-${{ github.run_attempt }}
-        env:
-          DD_API_KEY: ${{ secrets.DD_CI_API_KEY }}
-
-  post_system-tests:
-    runs-on: ubuntu-latest
-    if: always() && github.ref == 'refs/heads/main'
-    needs: [system-tests]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          repository: 'DataDog/system-tests'
-          token: ${{ secrets.GH_TOKEN }}
-
-      - name: Update CI Dashboard..
-        run: ./utils/scripts/update_dashboard_CI_visibility.sh nightly-agent ${{ github.run_id }}-${{ github.run_attempt }}
-        env:
-          DD_API_KEY: ${{ secrets.DD_CI_API_KEY }}
-          DD_APP_KEY: ${{ secrets.DD_CI_APP_KEY }}

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -1,0 +1,145 @@
+name: System tests
+
+on:
+  workflow_dispatch: {}
+  schedule:
+    - cron:  '00 05 * * 2-6'
+  pull_request:  # temporary, checking the job works fine
+    branches:
+      - "**"
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  system-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        weblog:
+          - library: cpp
+            variant: nginx
+          - library: golang
+            variant: net-http
+          - library: golang
+            variant: gorilla
+          - library: golang
+            variant: echo
+          - library: golang
+            variant: chi
+          - library: golang
+            variant: gin
+          - library: nodejs
+            variant: express4
+          - library: nodejs
+            variant: express4-typescript
+          - library: dotnet
+            variant: poc
+
+          - library: java
+            variant: spring-boot
+          - library: java
+            variant: spring-boot-jetty
+          - library: java
+            variant: jersey-grizzly2
+          - library: java
+            variant: resteasy-netty3
+          - library: java
+            variant: ratpack
+          - library: java
+            variant: vertx3
+
+          - library: php
+            variant: apache-mod-8.0
+          - library: php
+            variant: php-fpm-8.0
+          - library: python
+            variant: django-poc
+          - library: python
+            variant: flask-poc
+          - library: python
+            variant: uwsgi-poc
+          - library: ruby
+            variant: rack
+          - library: ruby
+            variant: sinatra14
+          - library: ruby
+            variant: sinatra20
+          - library: ruby
+            variant: sinatra21
+          - library: ruby
+            variant: rails32
+          - library: ruby
+            variant: rails40
+          - library: ruby
+            variant: rails41
+          - library: ruby
+            variant: rails42
+          - library: ruby
+            variant: rails50
+          - library: ruby
+            variant: rails51
+          - library: ruby
+            variant: rails52
+          - library: ruby
+            variant: rails60
+          - library: ruby
+            variant: rails61
+          - library: ruby
+            variant: rails70
+
+    env:
+      DD_API_KEY: ${{ secrets.DD_API_KEY }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          repository: 'DataDog/system-tests'
+
+      - name: Load agent binary
+        run: ./utils/scripts/load-binary.sh agent
+
+      - name: Log in to the Container registry
+        if: ${{ matrix.weblog.library == 'ruby' }}
+        run: |
+          echo ${{ github.token }} | docker login ${{ env.REGISTRY }} -u ${{ github.actor }} --password-stdin
+
+      - name: Build
+        run: ./build.sh ${{ matrix.weblog.library }} -w ${{ matrix.weblog.variant }}
+
+      - name: Run default scenario
+        run: ./run.sh
+
+      - name: Compress artifact
+        if: ${{ always() }}
+        run: tar -czvf artifact.tar.gz $(ls | grep logs)
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        if: ${{ always() }}
+        with:
+          name: logs_${{ matrix.weblog.library }}_${{ matrix.weblog.variant }}
+          path: artifact.tar.gz
+
+      - name: Upload results CI Visibility
+        if: ${{ always() }}
+        run: ./utils/scripts/upload_results_CI_visibility.sh dev nightly-agent ${{ github.run_id }}-${{ github.run_attempt }}
+        env:
+          DD_API_KEY: ${{ secrets.DD_CI_API_KEY }}
+
+  post_system-tests:
+    runs-on: ubuntu-latest
+    if: always() && github.ref == 'refs/heads/main'
+    needs: [system-tests]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          repository: 'DataDog/system-tests'
+          token: ${{ secrets.GH_TOKEN }}
+
+      - name: Update CI Dashboard..
+        run: ./utils/scripts/update_dashboard_CI_visibility.sh nightly-agent ${{ github.run_id }}-${{ github.run_attempt }}
+        env:
+          DD_API_KEY: ${{ secrets.DD_CI_API_KEY }}
+          DD_APP_KEY: ${{ secrets.DD_CI_APP_KEY }}


### PR DESCRIPTION

### What does this PR do?

This PR adds a nightly job for [system tests](https://github.com/DataDog/system-tests), checking that the very last commit on `main` branch of DataDog/datadog-agent passes the functional test suite using released version of every other components (mostly tracers).

### Motivation

Increase the functional test coverage.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
NA

### Possible Drawbacks / Trade-offs

The test is totally isolated, and won't have any side effect on any part of this repo

### Describe how to test/QA your changes

Run the test 😄  The GH action job inslude a manual launch button.

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
