### PR TITLE
Running dockers in the kitchen test

### DIFF
--- a/.gitlab/JOBOWNERS
+++ b/.gitlab/JOBOWNERS
@@ -51,6 +51,7 @@ deploy_containers*                   @DataDog/container-integrations
 kitchen_*_system_probe*                        @DataDog/ebpf-platform
 kitchen_*_security_agent*                      @DataDog/agent-security
 kitchen_*_process_agent*                       @DataDog/processes
+pull_test_dockers                              @DataDog/universal-service-monitoring
 cleanup_kitchen_functional_test                @DataDog/ebpf-platform @DataDog/agent-security
 serverless_cold_start_performance-deb_x64      @DataDog/serverless
 

--- a/.gitlab/functional_test/system_probe.yml
+++ b/.gitlab/functional_test/system_probe.yml
@@ -57,7 +57,7 @@ pull_test_dockers_arm64:
 
 .retrieve_test_dockers:
   - mkdir -p $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files/dockers
-  - mv kitchen-dockers $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files/dockers
+  - mv kitchen-dockers/* $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files/dockers
   - ls -lh $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files/dockers
 
 .retrieve_minimized_btfs:

--- a/.gitlab/functional_test/system_probe.yml
+++ b/.gitlab/functional_test/system_probe.yml
@@ -5,6 +5,31 @@
 # include:
 #   - /.gitlab/kitchen_common/testing.yml
 
+.pull_test_dockers:
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/docker_x64:$DATADOG_AGENT_BUILDIMAGES
+  needs: []
+  tags: ["runner:docker"]
+  stage: functional_test
+  script:
+    # DockerHub login for build to limit rate limit when pulling base images
+    - DOCKER_REGISTRY_LOGIN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.$DOCKER_REGISTRY_LOGIN_SSM_KEY --with-decryption --query "Parameter.Value" --out text)
+    - aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.$DOCKER_REGISTRY_PWD_SSM_KEY --with-decryption --query "Parameter.Value" --out text | docker login --username "$DOCKER_REGISTRY_LOGIN" --password-stdin "$DOCKER_REGISTRY_URL"
+    # Pull base images
+    - mkdir -p /tmp/dockers
+    - pip install pyyaml
+    - inv -e system-probe.save-test-dockers --output-dir /tmp/dockers --arch $ARCH
+    - $S3_CP_CMD --recursive --exclude "*" --include "*.tar" /tmp/dockers $S3_ARTIFACTS_URI/kitchen-dockers/$ARCH
+
+pull_test_dockers_x64:
+  extends: .pull_test_dockers
+  variables:
+    ARCH: amd64
+
+pull_test_dockers_arm64:
+  extends: .pull_test_dockers
+  variables:
+    ARCH: arm64
+
 .kitchen_test_system_probe:
   extends:
     - .kitchen_common
@@ -28,6 +53,11 @@
     paths:
       - $DD_AGENT_TESTING_DIR/kitchen-junit-*.tar.gz
 
+.retrieve_test_dockers:
+  - mkdir -p $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files/dockers
+  - mkdir -p /tmp/kitchen-dockers
+  - $S3_CP_CMD --recursive --exclude "*" --include "*.tar" $S3_ARTIFACTS_URI/kitchen-dockers/$ARCH /tmp/kitchen-dockers
+  - cp -r /tmp/kitchen-dockers $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files/dockers
 
 .retrieve_minimized_btfs:
   - $S3_CP_CMD $S3_ARTIFACTS_URI/minimized-btfs-${ARCH}.tar.xz /tmp/minimized-btfs.tar.xz
@@ -39,12 +69,15 @@ kitchen_test_system_probe_linux_x64:
     - .kitchen_test_system_probe
     - .kitchen_azure_x64
     - .kitchen_azure_location_north_central_us
-  needs: [ "tests_ebpf_x64", "generate_minimized_btfs_x64" ]
+  needs: [ "tests_ebpf_x64", "generate_minimized_btfs_x64", "pull_test_dockers_x64" ]
   variables:
     ARCH: amd64
     KITCHEN_ARCH: x86_64
     KITCHEN_IMAGE_SIZE: Standard_D2_v2
+    AZURE_KITCHEN_MOUNT_DIR: /mnt/kitchen_mount
+    AZURE_KITCHEN_TARGET_MOUNT_DIR: /tmp/kitchen_mount
   before_script:
+    - !reference [.retrieve_test_dockers]
     - !reference [.retrieve_minimized_btfs]
     - pushd $DD_AGENT_TESTING_DIR
     - bash -l tasks/kitchen_setup.sh
@@ -57,18 +90,18 @@ kitchen_test_system_probe_linux_x64:
       - KITCHEN_PLATFORM: "centos"
         KITCHEN_OSVERS: "centos-76,rhel-81"
 
-
 kitchen_test_system_probe_linux_x64_ec2:
   extends:
     - .kitchen_test_system_probe
     - .kitchen_ec2_location_us_east_1
     - .kitchen_ec2
-  needs: [ "tests_ebpf_x64", "generate_minimized_btfs_x64" ]
+  needs: [ "tests_ebpf_x64", "generate_minimized_btfs_x64", "pull_test_dockers_x64" ]
   variables:
     ARCH: amd64
     KITCHEN_ARCH: x86_64
     KITCHEN_EC2_INSTANCE_TYPE: "t2.xlarge"
   before_script:
+    - !reference [.retrieve_test_dockers]
     - !reference [.retrieve_minimized_btfs]
     - pushd $DD_AGENT_TESTING_DIR
     - bash -l tasks/kitchen_setup.sh
@@ -83,12 +116,13 @@ kitchen_test_system_probe_linux_arm64:
     - .kitchen_test_system_probe
     - .kitchen_ec2_location_us_east_1
     - .kitchen_ec2_spot_instances
-  needs: [ "tests_ebpf_arm64", "generate_minimized_btfs_arm64" ]
+  needs: [ "tests_ebpf_arm64", "generate_minimized_btfs_arm64", "pull_test_dockers_arm64" ]
   variables:
     ARCH: arm64
     KITCHEN_ARCH: arm64
     KITCHEN_EC2_INSTANCE_TYPE: "t4g.xlarge"
   before_script:
+    - !reference [.retrieve_test_dockers]
     - !reference [.retrieve_minimized_btfs]
     - pushd $DD_AGENT_TESTING_DIR
     - bash -l tasks/kitchen_setup.sh
@@ -98,10 +132,12 @@ kitchen_test_system_probe_linux_arm64:
         KITCHEN_OSVERS: "ubuntu-18-04,ubuntu-20-04,ubuntu-22-04"
       - KITCHEN_PLATFORM: "debian"
         KITCHEN_OSVERS: "debian-10,debian-11"
+        KITCHEN_EC2_DEVICE_NAME: "/dev/xvda"
       - KITCHEN_PLATFORM: "centos"
         KITCHEN_OSVERS: "centos-78,rhel-83"
       - KITCHEN_PLATFORM: "amazonlinux"
         KITCHEN_OSVERS: "amazonlinux2-4-14,amazonlinux2-5-10,amazonlinux2022-5-15"
+        KITCHEN_EC2_DEVICE_NAME: "/dev/xvda"
 
 kitchen_test_system_probe_windows_x64:
   extends:

--- a/.gitlab/functional_test/system_probe.yml
+++ b/.gitlab/functional_test/system_probe.yml
@@ -56,10 +56,8 @@ pull_test_dockers_arm64:
       - $DD_AGENT_TESTING_DIR/kitchen-junit-*.tar.gz
 
 .retrieve_test_dockers:
-  - ls -lh kitchen-dockers
   - mkdir -p $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files/dockers
   - mv kitchen-dockers $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files/dockers
-  - ls -lh kitchen-dockers
   - ls -lh $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files/dockers
 
 .retrieve_minimized_btfs:

--- a/.gitlab/functional_test/system_probe.yml
+++ b/.gitlab/functional_test/system_probe.yml
@@ -18,6 +18,7 @@
     - mkdir kitchen-dockers
     - inv -e system-probe.save-test-dockers --output-dir kitchen-dockers --arch $ARCH
   artifacts:
+    expire_in: 1 day
     paths:
       - kitchen-dockers
 
@@ -55,7 +56,11 @@ pull_test_dockers_arm64:
       - $DD_AGENT_TESTING_DIR/kitchen-junit-*.tar.gz
 
 .retrieve_test_dockers:
+  - ls -lh kitchen-dockers
+  - ls -lh $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files/dockers
   - mv kitchen-dockers $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files/dockers
+  - ls -lh kitchen-dockers
+  - ls -lh $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files/dockers
 
 .retrieve_minimized_btfs:
   - $S3_CP_CMD $S3_ARTIFACTS_URI/minimized-btfs-${ARCH}.tar.xz /tmp/minimized-btfs.tar.xz

--- a/.gitlab/functional_test/system_probe.yml
+++ b/.gitlab/functional_test/system_probe.yml
@@ -15,10 +15,11 @@
     - DOCKER_REGISTRY_LOGIN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.$DOCKER_REGISTRY_LOGIN_SSM_KEY --with-decryption --query "Parameter.Value" --out text)
     - aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.$DOCKER_REGISTRY_PWD_SSM_KEY --with-decryption --query "Parameter.Value" --out text | docker login --username "$DOCKER_REGISTRY_LOGIN" --password-stdin "$DOCKER_REGISTRY_URL"
     # Pull base images
-    - mkdir -p /tmp/dockers
-    - pip install pyyaml
-    - inv -e system-probe.save-test-dockers --output-dir /tmp/dockers --arch $ARCH
-    - $S3_CP_CMD --recursive --exclude "*" --include "*.tar" /tmp/dockers $S3_ARTIFACTS_URI/kitchen-dockers/$ARCH
+    - mkdir kitchen-dockers
+    - inv -e system-probe.save-test-dockers --output-dir kitchen-dockers --arch $ARCH
+  artifacts:
+    paths:
+      - kitchen-dockers
 
 pull_test_dockers_x64:
   extends: .pull_test_dockers
@@ -54,10 +55,7 @@ pull_test_dockers_arm64:
       - $DD_AGENT_TESTING_DIR/kitchen-junit-*.tar.gz
 
 .retrieve_test_dockers:
-  - mkdir -p $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files/dockers
-  - mkdir -p /tmp/kitchen-dockers
-  - $S3_CP_CMD --recursive --exclude "*" --include "*.tar" $S3_ARTIFACTS_URI/kitchen-dockers/$ARCH /tmp/kitchen-dockers
-  - cp -r /tmp/kitchen-dockers $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files/dockers
+  - mv kitchen-dockers $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files/dockers
 
 .retrieve_minimized_btfs:
   - $S3_CP_CMD $S3_ARTIFACTS_URI/minimized-btfs-${ARCH}.tar.xz /tmp/minimized-btfs.tar.xz
@@ -70,6 +68,7 @@ kitchen_test_system_probe_linux_x64:
     - .kitchen_azure_x64
     - .kitchen_azure_location_north_central_us
   needs: [ "tests_ebpf_x64", "generate_minimized_btfs_x64", "pull_test_dockers_x64" ]
+  dependencies: ["pull_test_dockers_x64"]
   variables:
     ARCH: amd64
     KITCHEN_ARCH: x86_64
@@ -96,6 +95,7 @@ kitchen_test_system_probe_linux_x64_ec2:
     - .kitchen_ec2_location_us_east_1
     - .kitchen_ec2
   needs: [ "tests_ebpf_x64", "generate_minimized_btfs_x64", "pull_test_dockers_x64" ]
+  dependencies: [ "pull_test_dockers_x64" ]
   variables:
     ARCH: amd64
     KITCHEN_ARCH: x86_64
@@ -117,6 +117,7 @@ kitchen_test_system_probe_linux_arm64:
     - .kitchen_ec2_location_us_east_1
     - .kitchen_ec2_spot_instances
   needs: [ "tests_ebpf_arm64", "generate_minimized_btfs_arm64", "pull_test_dockers_arm64" ]
+  dependencies: [ "pull_test_dockers_arm64" ]
   variables:
     ARCH: arm64
     KITCHEN_ARCH: arm64

--- a/.gitlab/functional_test/system_probe.yml
+++ b/.gitlab/functional_test/system_probe.yml
@@ -15,9 +15,12 @@
     - DOCKER_REGISTRY_LOGIN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.$DOCKER_REGISTRY_LOGIN_SSM_KEY --with-decryption --query "Parameter.Value" --out text)
     - aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.$DOCKER_REGISTRY_PWD_SSM_KEY --with-decryption --query "Parameter.Value" --out text | docker login --username "$DOCKER_REGISTRY_LOGIN" --password-stdin "$DOCKER_REGISTRY_URL"
     # Pull base images
-    - mkdir /tmp/dockers
-    - inv -e system-probe.save-test-dockers --output-dir /tmp/dockers --arch $ARCH
-    - $S3_CP_CMD --recursive --exclude "*" --include "*.tar" /tmp/dockers $S3_ARTIFACTS_URI/kitchen-dockers/$ARCH
+    - mkdir kitchen-dockers
+    - inv -e system-probe.save-test-dockers --output-dir kitchen-dockers --arch $ARCH
+  artifacts:
+    expire_in: 1 day
+    paths:
+      - kitchen-dockers
 
 pull_test_dockers_x64:
   extends: .pull_test_dockers
@@ -54,9 +57,8 @@ pull_test_dockers_arm64:
 
 .retrieve_test_dockers:
   - mkdir -p $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files/dockers
-  - mkdir -p /tmp/kitchen-dockers
-  - $S3_CP_CMD --recursive --exclude "*" --include "*.tar" $S3_ARTIFACTS_URI/kitchen-dockers/$ARCH /tmp/kitchen-dockers
-  - cp -r /tmp/kitchen-dockers $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files/dockers
+  - mv kitchen-dockers/* $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files/dockers
+  - ls -lh $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files/dockers
 
 .retrieve_minimized_btfs:
   - $S3_CP_CMD $S3_ARTIFACTS_URI/minimized-btfs-${ARCH}.tar.xz /tmp/minimized-btfs.tar.xz

--- a/.gitlab/functional_test/system_probe.yml
+++ b/.gitlab/functional_test/system_probe.yml
@@ -15,12 +15,9 @@
     - DOCKER_REGISTRY_LOGIN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.$DOCKER_REGISTRY_LOGIN_SSM_KEY --with-decryption --query "Parameter.Value" --out text)
     - aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.$DOCKER_REGISTRY_PWD_SSM_KEY --with-decryption --query "Parameter.Value" --out text | docker login --username "$DOCKER_REGISTRY_LOGIN" --password-stdin "$DOCKER_REGISTRY_URL"
     # Pull base images
-    - mkdir kitchen-dockers
-    - inv -e system-probe.save-test-dockers --output-dir kitchen-dockers --arch $ARCH
-  artifacts:
-    expire_in: 1 day
-    paths:
-      - kitchen-dockers
+    - mkdir /tmp/dockers
+    - inv -e system-probe.save-test-dockers --output-dir /tmp/dockers --arch $ARCH
+    - $S3_CP_CMD --recursive --exclude "*" --include "*.tar" /tmp/dockers $S3_ARTIFACTS_URI/kitchen-dockers/$ARCH
 
 pull_test_dockers_x64:
   extends: .pull_test_dockers
@@ -57,13 +54,13 @@ pull_test_dockers_arm64:
 
 .retrieve_test_dockers:
   - mkdir -p $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files/dockers
-  - mv kitchen-dockers/* $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files/dockers
-  - ls -lh $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files/dockers
+  - mkdir -p /tmp/kitchen-dockers
+  - $S3_CP_CMD --recursive --exclude "*" --include "*.tar" $S3_ARTIFACTS_URI/kitchen-dockers/$ARCH /tmp/kitchen-dockers
+  - cp -r /tmp/kitchen-dockers $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files/dockers
 
 .retrieve_minimized_btfs:
   - $S3_CP_CMD $S3_ARTIFACTS_URI/minimized-btfs-${ARCH}.tar.xz /tmp/minimized-btfs.tar.xz
   - cp /tmp/minimized-btfs.tar.xz $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files/minimized-btfs.tar.xz
-
 
 kitchen_test_system_probe_linux_x64:
   extends:
@@ -71,7 +68,6 @@ kitchen_test_system_probe_linux_x64:
     - .kitchen_azure_x64
     - .kitchen_azure_location_north_central_us
   needs: [ "tests_ebpf_x64", "generate_minimized_btfs_x64", "pull_test_dockers_x64" ]
-  dependencies: ["pull_test_dockers_x64"]
   variables:
     ARCH: amd64
     KITCHEN_ARCH: x86_64
@@ -98,7 +94,6 @@ kitchen_test_system_probe_linux_x64_ec2:
     - .kitchen_ec2_location_us_east_1
     - .kitchen_ec2
   needs: [ "tests_ebpf_x64", "generate_minimized_btfs_x64", "pull_test_dockers_x64" ]
-  dependencies: [ "pull_test_dockers_x64" ]
   variables:
     ARCH: amd64
     KITCHEN_ARCH: x86_64
@@ -120,7 +115,6 @@ kitchen_test_system_probe_linux_arm64:
     - .kitchen_ec2_location_us_east_1
     - .kitchen_ec2_spot_instances
   needs: [ "tests_ebpf_arm64", "generate_minimized_btfs_arm64", "pull_test_dockers_arm64" ]
-  dependencies: [ "pull_test_dockers_arm64" ]
   variables:
     ARCH: arm64
     KITCHEN_ARCH: arm64

--- a/.gitlab/functional_test/system_probe.yml
+++ b/.gitlab/functional_test/system_probe.yml
@@ -58,7 +58,6 @@ pull_test_dockers_arm64:
 .retrieve_test_dockers:
   - mkdir -p $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files/dockers
   - mv kitchen-dockers/* $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files/dockers
-  - ls -lh $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files/dockers
 
 .retrieve_minimized_btfs:
   - $S3_CP_CMD $S3_ARTIFACTS_URI/minimized-btfs-${ARCH}.tar.xz /tmp/minimized-btfs.tar.xz

--- a/.gitlab/functional_test/system_probe.yml
+++ b/.gitlab/functional_test/system_probe.yml
@@ -57,7 +57,7 @@ pull_test_dockers_arm64:
 
 .retrieve_test_dockers:
   - ls -lh kitchen-dockers
-  - ls -lh $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files/dockers
+  - mkdir -p $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files/dockers
   - mv kitchen-dockers $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files/dockers
   - ls -lh kitchen-dockers
   - ls -lh $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files/dockers

--- a/pkg/network/protocols/dockers/dockers_test.go
+++ b/pkg/network/protocols/dockers/dockers_test.go
@@ -1,0 +1,81 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf || (windows && npm)
+// +build linux_bpf windows,npm
+
+package dockers
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/network/protocols/http/testutil"
+)
+
+func tryConnectingKafka(addr string) bool {
+	conn, err := net.DialTimeout("tcp", addr, time.Second)
+	if err != nil {
+		return false
+	}
+	defer conn.Close()
+
+	return true
+}
+
+func waitForKafka(ctx context.Context, zookeeperAddr string) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+			if tryConnectingKafka(zookeeperAddr) {
+				return nil
+			}
+			time.Sleep(time.Second)
+			continue
+		}
+	}
+}
+
+func TestDockersInCI(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		return
+	}
+
+	envs := []string{
+		fmt.Sprintf("KAFKA_ADDR=%s", "127.0.0.1"),
+		"KAFKA_PORT=9092",
+	}
+	dir, _ := testutil.CurDir()
+	cmd := exec.Command("docker-compose", "-f", dir+"/testdata/docker-compose.yml", "up")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stdout
+	cmd.Env = append(cmd.Env, envs...)
+	go func() {
+		if err := cmd.Run(); err != nil {
+			fmt.Println("error", err)
+		}
+	}()
+
+	t.Cleanup(func() {
+		c := exec.Command("docker-compose", "-f", dir+"/testdata/docker-compose.yml", "down", "--remove-orphans")
+		c.Stdout = os.Stdout
+		c.Stderr = os.Stdout
+		c.Env = append(c.Env, envs...)
+		_ = c.Run()
+	})
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	require.NoError(t, waitForKafka(ctx, fmt.Sprintf("%s:9092", "127.0.0.1")))
+	cancel()
+}

--- a/pkg/network/protocols/dockers/testdata/docker-compose.yml
+++ b/pkg/network/protocols/dockers/testdata/docker-compose.yml
@@ -1,0 +1,39 @@
+# Taken from https://github.com/conduktor/kafka-stack-docker-compose/blob/master/zk-single-kafka-single.yml
+
+version: '3'
+
+services:
+  zoo1:
+    image: confluentinc/cp-zookeeper:7.2.1
+    hostname: zoo1
+    container_name: zoo1
+    ports:
+      - "2181:2181"
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_SERVER_ID: 1
+      ZOOKEEPER_SERVERS: zoo1:2888:3888
+      KAFKA_OPTS: "-Dzookeeper.4lw.commands.whitelist=*"
+
+  kafka1:
+    image: confluentinc/cp-kafka:7.2.1
+    hostname: kafka1
+    container_name: kafka1
+    ports:
+      - "${KAFKA_ADDR}:${KAFKA_PORT}:9092"
+    environment:
+      KAFKA_ADVERTISED_LISTENERS: INTERNAL://kafka1:19092,EXTERNAL://${KAFKA_ADDR}:${KAFKA_PORT}
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: INTERNAL
+      KAFKA_ZOOKEEPER_CONNECT: "zoo1:2181"
+      KAFKA_BROKER_ID: 1
+      KAFKA_LOG4J_LOGGERS: "kafka.controller=INFO,kafka.producer.async.DefaultEventHandler=INFO,state.change.logger=INFO"
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_JMX_PORT: 9999
+      KAFKA_JMX_HOSTNAME: ${KAFKA_ADDR}
+      KAFKA_AUTHORIZER_CLASS_NAME: kafka.security.authorizer.AclAuthorizer
+      KAFKA_ALLOW_EVERYONE_IF_NO_ACL_FOUND: "true"
+    depends_on:
+      - zoo1

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -5,6 +5,7 @@ import os
 import platform
 import re
 import shutil
+import string
 import sys
 import tarfile
 import tempfile
@@ -1217,3 +1218,26 @@ def print_failed_tests(_, output_dir):
 
     if fail_count > 0:
         raise Exit(code=1)
+
+
+@task
+def save_test_dockers(ctx, output_dir, arch, windows=is_windows):
+    import yaml
+
+    if windows:
+        return
+
+    docker_compose_paths = [
+        "./pkg/network/protocols/dockers/testdata/docker-compose.yml",
+    ]
+    images = set()
+    for docker_compose_path in docker_compose_paths:
+        with open(docker_compose_path, "r") as f:
+            docker_compose = yaml.safe_load(f.read())
+        for component in docker_compose["services"]:
+            images.add(docker_compose["services"][component]["image"])
+
+    for image in images:
+        output_path = image.translate(str.maketrans('', '', string.punctuation))
+        ctx.run(f"docker pull --platform linux/{arch} {image}")
+        ctx.run(f"docker save {image} > {os.path.join(output_dir, output_path)}.tar")

--- a/test/kitchen/drivers/azure-driver.yml
+++ b/test/kitchen/drivers/azure-driver.yml
@@ -15,6 +15,7 @@
   vm_tags = {
     'dd_agent_testing': 'dd_agent_testing'
   }
+  vm_username = ENV['VM_USERNAME'] ? ENV['VM_USERNAME'] : "datadog"
   if ENV['DD_PIPELINE_ID']
     vm_tags['pipeline_id'] = ENV['DD_PIPELINE_ID']
   else
@@ -62,7 +63,7 @@ driver_config:
       - ln -s <%= mount_dir %> <%= target_mount_dir %>
       <% if change_mount_dir %>
       - mkdir <%= mount_dir %>/kitchen
-      - chown -R <%= ENV['VM_USERNAME'] ||= "datadog" %>:<%= ENV['VM_USERNAME'] ||= "datadog" %> <%= target_mount_dir %>/kitchen
+      - chown -R <%=  vm_username %>:<%= vm_username %> <%= target_mount_dir %>/kitchen
       <% end %>
 
 platforms:
@@ -135,7 +136,6 @@ platforms:
       ed25519_platforms = []
       use_ed25519 = ed25519_platforms.any? { |p| platform_name.include?(p) }
 
-      vm_username = ENV['VM_USERNAME'] ? ENV['VM_USERNAME'] : "datadog"
       vm_password = ENV['SERVER_PASSWORD']
 
 %>

--- a/test/kitchen/drivers/azure-driver.yml
+++ b/test/kitchen/drivers/azure-driver.yml
@@ -1,6 +1,14 @@
 <%
   ENV['AZURE_LOCATION'] ||= "North Central US"
   location = ENV['AZURE_LOCATION']
+
+  chang_mount_dir = ENV['AZURE_KITCHEN_MOUNT_DIR']
+  ENV['AZURE_KITCHEN_MOUNT_DIR'] ||= "/mnt/kitchen"
+  mount_dir = ENV['AZURE_KITCHEN_MOUNT_DIR']
+
+  chang_target_mount_dir = ENV['AZURE_KITCHEN_TARGET_MOUNT_DIR']
+  ENV['AZURE_KITCHEN_TARGET_MOUNT_DIR'] ||= "/tmp/kitchen"
+  target_mount_dir = ENV['AZURE_KITCHEN_TARGET_MOUNT_DIR']
 %>
 
 <%
@@ -16,6 +24,9 @@
 
 provisioner:
   name: chef_solo
+  <% if chang_target_mount_dir %>
+  root_path: <%= ENV['AZURE_KITCHEN_TARGET_MOUNT_DIR'] %>/kitchen
+  <% end %>
   product_name: chef
   # There is no arm64 distribution of Chef 14 for Debian. Use the Ubuntu package instead
   <% if ENV['KITCHEN_PLATFORM'] == "debian" && ENV['KITCHEN_ARCH'] == "arm64" %>
@@ -46,9 +57,13 @@ driver_config:
   custom_data: |
     #cloud-config
     runcmd:
-      - mkdir /mnt/kitchen
-      - chmod a+rwx /mnt/kitchen
-      - ln -s /mnt/kitchen /tmp/kitchen
+      - mkdir <%= mount_dir %>
+      - chmod -R a+rwx <%= mount_dir %>
+      - ln -s <%= mount_dir %> <%= target_mount_dir %>
+      <% if chang_mount_dir %>
+      - mkdir <%= mount_dir %>/kitchen
+      - chown -R <%= ENV['VM_USERNAME'] ||= "datadog" %>:<%= ENV['VM_USERNAME'] ||= "datadog" %> <%= target_mount_dir %>/kitchen
+      <% end %>
 
 platforms:
 # Loop through two lists and output a total matrix of all possible platform + chef versions,

--- a/test/kitchen/drivers/azure-driver.yml
+++ b/test/kitchen/drivers/azure-driver.yml
@@ -2,11 +2,11 @@
   ENV['AZURE_LOCATION'] ||= "North Central US"
   location = ENV['AZURE_LOCATION']
 
-  chang_mount_dir = ENV['AZURE_KITCHEN_MOUNT_DIR']
+  change_mount_dir = ENV['AZURE_KITCHEN_MOUNT_DIR']
   ENV['AZURE_KITCHEN_MOUNT_DIR'] ||= "/mnt/kitchen"
   mount_dir = ENV['AZURE_KITCHEN_MOUNT_DIR']
 
-  chang_target_mount_dir = ENV['AZURE_KITCHEN_TARGET_MOUNT_DIR']
+  change_target_mount_dir = ENV['AZURE_KITCHEN_TARGET_MOUNT_DIR']
   ENV['AZURE_KITCHEN_TARGET_MOUNT_DIR'] ||= "/tmp/kitchen"
   target_mount_dir = ENV['AZURE_KITCHEN_TARGET_MOUNT_DIR']
 %>
@@ -24,7 +24,7 @@
 
 provisioner:
   name: chef_solo
-  <% if chang_target_mount_dir %>
+  <% if change_target_mount_dir %>
   root_path: <%= ENV['AZURE_KITCHEN_TARGET_MOUNT_DIR'] %>/kitchen
   <% end %>
   product_name: chef
@@ -60,7 +60,7 @@ driver_config:
       - mkdir <%= mount_dir %>
       - chmod -R a+rwx <%= mount_dir %>
       - ln -s <%= mount_dir %> <%= target_mount_dir %>
-      <% if chang_mount_dir %>
+      <% if change_mount_dir %>
       - mkdir <%= mount_dir %>/kitchen
       - chown -R <%= ENV['VM_USERNAME'] ||= "datadog" %>:<%= ENV['VM_USERNAME'] ||= "datadog" %> <%= target_mount_dir %>/kitchen
       <% end %>

--- a/test/kitchen/drivers/ec2-driver.yml
+++ b/test/kitchen/drivers/ec2-driver.yml
@@ -102,13 +102,13 @@ platforms:
     image_id: <%= platform[1] %>
     block_device_mappings:
       <% if ENV['KITCHEN_ARCH'] == "arm64" %>
-      - device_name: /dev/sda1
+      - device_name: <%= ENV['KITCHEN_EC2_DEVICE_NAME'] || "/dev/sda1" %>
       <% else %>
-      - device_name: /dev/xvda
+      - device_name: <%= ENV['KITCHEN_EC2_DEVICE_NAME'] || "/dev/xvda" %>
       <% end %>
         ebs:
           volume_type: gp2
-          volume_size: 40
+          volume_size: 45
           delete_on_termination: true
     <% if allow_rsa_key || al2022 %>
     user_data: |

--- a/test/kitchen/site-cookbooks/dd-system-probe-check/metadata.rb
+++ b/test/kitchen/site-cookbooks/dd-system-probe-check/metadata.rb
@@ -4,3 +4,4 @@ description      "Executes system-probe (eBPF) integration tests"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          "0.1.0"
 depends "yum-centos", "~> 5.0.0"
+depends 'docker'

--- a/test/kitchen/site-cookbooks/dd-system-probe-check/recipes/docker_installation.rb
+++ b/test/kitchen/site-cookbooks/dd-system-probe-check/recipes/docker_installation.rb
@@ -1,0 +1,58 @@
+case node[:platform]
+when 'ubuntu', 'debian'
+    package 'gnupg'
+
+    package 'unattended-upgrades' do
+      action :remove
+    end
+
+    package 'xfsprogs'
+when 'centos'
+    package 'xfsprogs'
+when 'redhat'
+    execute 'install docker-compose' do
+        command <<-EOF
+            dnf config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
+            dnf install -y docker-ce-19.03.13
+        EOF
+        user "root"
+        live_stream true
+    end
+end
+
+
+case node[:platform]
+when 'amazon'
+    docker_installation_package 'default' do
+        action :create
+        package_name 'docker'
+        package_options %q|-y|
+    end
+
+    service 'docker' do
+        action [ :enable, :start ]
+    end
+when 'ubuntu'
+    docker_installation_package 'default' do
+        action :create
+        package_name 'docker.io'
+    end
+when 'redhat'
+    docker_service 'default' do
+        action [:start]
+    end
+else
+    docker_service 'default' do
+        action [:create, :start]
+    end
+end
+
+
+execute 'install docker-compose' do
+    command <<-EOF
+        curl -SL https://github.com/docker/compose/releases/download/v2.12.2/docker-compose-$(uname -s | awk '{print tolower($0)}')-$(uname -m) -o /usr/bin/docker-compose
+        chmod 0755 /usr/bin/docker-compose
+    EOF
+    user "root"
+    live_stream true
+end

--- a/test/kitchen/site-cookbooks/dd-system-probe-check/recipes/docker_installation.rb
+++ b/test/kitchen/site-cookbooks/dd-system-probe-check/recipes/docker_installation.rb
@@ -1,58 +1,56 @@
 case node[:platform]
 when 'ubuntu', 'debian'
-    package 'gnupg'
+  package 'gnupg'
 
-    package 'unattended-upgrades' do
-      action :remove
-    end
+  package 'unattended-upgrades' do
+    action :remove
+  end
 
-    package 'xfsprogs'
+  package 'xfsprogs'
 when 'centos'
-    package 'xfsprogs'
+  package 'xfsprogs'
 when 'redhat'
-    execute 'install docker-compose' do
-        command <<-EOF
-            dnf config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
-            dnf install -y docker-ce-19.03.13
-        EOF
-        user "root"
-        live_stream true
-    end
-end
-
-
-case node[:platform]
-when 'amazon'
-    docker_installation_package 'default' do
-        action :create
-        package_name 'docker'
-        package_options %q|-y|
-    end
-
-    service 'docker' do
-        action [ :enable, :start ]
-    end
-when 'ubuntu'
-    docker_installation_package 'default' do
-        action :create
-        package_name 'docker.io'
-    end
-when 'redhat'
-    docker_service 'default' do
-        action [:start]
-    end
-else
-    docker_service 'default' do
-        action [:create, :start]
-    end
-end
-
-
-execute 'install docker-compose' do
+  execute 'install docker-compose' do
     command <<-EOF
-        curl -SL https://github.com/docker/compose/releases/download/v2.12.2/docker-compose-$(uname -s | awk '{print tolower($0)}')-$(uname -m) -o /usr/bin/docker-compose
-        chmod 0755 /usr/bin/docker-compose
+      dnf config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
+      dnf install -y docker-ce-19.03.13
     EOF
     user "root"
     live_stream true
+  end
+end
+
+case node[:platform]
+when 'amazon'
+  docker_installation_package 'default' do
+    action :create
+    package_name 'docker'
+    package_options %q|-y|
+  end
+
+  service 'docker' do
+    action [ :enable, :start ]
+  end
+when 'ubuntu'
+  docker_installation_package 'default' do
+    action :create
+    package_name 'docker.io'
+  end
+when 'redhat'
+  docker_service 'default' do
+    action [:start]
+  end
+else
+  docker_service 'default' do
+    action [:create, :start]
+  end
+end
+
+execute 'install docker-compose' do
+  command <<-EOF
+    curl -SL https://github.com/docker/compose/releases/download/v2.12.2/docker-compose-$(uname -s | awk '{print tolower($0)}')-$(uname -m) -o /usr/bin/docker-compose
+    chmod 0755 /usr/bin/docker-compose
+  EOF
+  user "root"
+  live_stream true
 end

--- a/test/kitchen/site-cookbooks/dd-system-probe-check/recipes/linux.rb
+++ b/test/kitchen/site-cookbooks/dd-system-probe-check/recipes/linux.rb
@@ -189,7 +189,7 @@ end
 include_recipe "::docker_installation"
 
 remote_directory "/tmp/kitchen-dockers" do
-  source 'dockers/kitchen-dockers'
+  source 'dockers'
   files_owner 'root'
   files_group 'root'
   files_mode '0750'

--- a/test/kitchen/site-cookbooks/dd-system-probe-check/recipes/linux.rb
+++ b/test/kitchen/site-cookbooks/dd-system-probe-check/recipes/linux.rb
@@ -81,25 +81,25 @@ execute 'ensure conntrack is enabled' do
 end
 
 if Chef::SystemProbeHelpers::arm?(node) and node[:platform] == 'centos'
-    package 'cloud-utils-growpart'
-    package 'gdisk'
+  package 'cloud-utils-growpart'
+  package 'gdisk'
 
-    execute 'increase space' do
-        command <<-EOF
-            df -h /tmp
+  execute 'increase space' do
+    command <<-EOF
+      df -h /tmp
 
-            dev_name=$(df -h / | tail -n1 | awk '{print $1}')
-            dev_name=$(python3 -c "print(' '.join('$dev_name'.rsplit('p', 1)))")
-            dev_name_array=($dev_name)
+      dev_name=$(df -h / | tail -n1 | awk '{print $1}')
+      dev_name=$(python3 -c "print(' '.join('$dev_name'.rsplit('p', 1)))")
+      dev_name_array=($dev_name)
 
-            growpart ${dev_name_array[0]} ${dev_name_array[1]}
-            xfs_growfs -d /
-            df -h /tmp
-        EOF
-        user "root"
-        live_stream true
-        ignore_failure true
-    end
+      growpart ${dev_name_array[0]} ${dev_name_array[1]}
+      xfs_growfs -d /
+      df -h /tmp
+    EOF
+    user "root"
+    live_stream true
+    ignore_failure true
+  end
 end
 
 execute 'disable firewalld on redhat' do
@@ -199,14 +199,14 @@ end
 
 # Load docker images
 execute 'install docker-compose' do
-    cwd '/tmp/kitchen-dockers'
-    command <<-EOF
-        for docker_file in $(ls); do
-            echo docker load -i $docker_file
-            docker load -i $docker_file
-            rm -rf $docker_file
-        done
-    EOF
-    user "root"
-    live_stream true
+  cwd '/tmp/kitchen-dockers'
+  command <<-EOF
+    for docker_file in $(ls); do
+      echo docker load -i $docker_file
+      docker load -i $docker_file
+      rm -rf $docker_file
+    done
+  EOF
+  user "root"
+  live_stream true
 end

--- a/test/kitchen/site-cookbooks/dd-system-probe-check/recipes/linux.rb
+++ b/test/kitchen/site-cookbooks/dd-system-probe-check/recipes/linux.rb
@@ -80,6 +80,28 @@ execute 'ensure conntrack is enabled' do
   action :run
 end
 
+if Chef::SystemProbeHelpers::arm?(node) and node[:platform] == 'centos'
+    package 'cloud-utils-growpart'
+    package 'gdisk'
+
+    execute 'increase space' do
+        command <<-EOF
+            df -h /tmp
+
+            dev_name=$(df -h / | tail -n1 | awk '{print $1}')
+            dev_name=$(python3 -c "print(' '.join('$dev_name'.rsplit('p', 1)))")
+            dev_name_array=($dev_name)
+
+            growpart ${dev_name_array[0]} ${dev_name_array[1]}
+            xfs_growfs -d /
+            df -h /tmp
+        EOF
+        user "root"
+        live_stream true
+        ignore_failure true
+    end
+end
+
 execute 'disable firewalld on redhat' do
   command "systemctl disable --now firewalld"
   user "root"
@@ -161,4 +183,30 @@ end
 
 directory "/tmp/pkgjson" do
   recursive true
+end
+
+# Install relevant packages for docker
+include_recipe "::docker_installation"
+
+remote_directory "/tmp/kitchen-dockers" do
+  source 'dockers/kitchen-dockers'
+  files_owner 'root'
+  files_group 'root'
+  files_mode '0750'
+  action :create
+  recursive true
+end
+
+# Load docker images
+execute 'install docker-compose' do
+    cwd '/tmp/kitchen-dockers'
+    command <<-EOF
+        for docker_file in $(ls); do
+            echo docker load -i $docker_file
+            docker load -i $docker_file
+            rm -rf $docker_file
+        done
+    EOF
+    user "root"
+    live_stream true
 end


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Allow running dockers in kitchen test, and extend the filesystem

The PR introduce a way to run external dockers in the kitchen tests, without pulling them
As we cannot authenticate in the kitchen machines to dockerhub, we had to work around that
and we are pulling and saving the dockers in gitlab, uploading them to the remote machine
using kitchen, and then loading those dockers on the remote machine so they are available
for usage.

In the PR we added steps to install docker and docker compose on the kitchen machines.

The PR introduce an example test that runs dockers.

During the PR we faced the problem of "no space left on the device", to solve those errors
we have to extend the filesystem of the remote machines.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

The need to run dockers for protocol classification feature as part of our kitchen CI.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
