### PR TITLE
[workloadmeta/collectors/containerd] Collect image metadata

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1085,6 +1085,9 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("inventories_max_interval", DefaultInventoriesMaxInterval) // integer seconds
 	config.BindEnvAndSetDefault("inventories_min_interval", DefaultInventoriesMinInterval) // integer seconds
 
+	// workloadmeta
+	config.BindEnvAndSetDefault("workloadmeta.image_metadata_collection.enabled", false)
+
 	// Datadog security agent (common)
 	config.BindEnvAndSetDefault("security_agent.cmd_port", 5010)
 	config.BindEnvAndSetDefault("security_agent.expvar_port", 5011)

--- a/pkg/util/containerd/containerd_util.go
+++ b/pkg/util/containerd/containerd_util.go
@@ -46,7 +46,7 @@ type ContainerdItf interface {
 	Labels(namespace string, ctn containerd.Container) (map[string]string, error)
 	LabelsWithContext(ctx context.Context, namespace string, ctn containerd.Container) (map[string]string, error)
 	ListImages(namespace string) ([]containerd.Image, error)
-	Image(namespace string, ctn containerd.Container) (containerd.Image, error)
+	ImageOfContainer(namespace string, ctn containerd.Container) (containerd.Image, error)
 	ImageSize(namespace string, ctn containerd.Container) (int64, error)
 	Spec(namespace string, ctn containerd.Container) (*oci.Spec, error)
 	SpecWithContext(ctx context.Context, namespace string, ctn containerd.Container) (*oci.Spec, error)
@@ -230,8 +230,8 @@ func (c *ContainerdUtil) ListImages(namespace string) ([]containerd.Image, error
 	return c.cl.ListImages(ctxNamespace)
 }
 
-// Image interfaces with the containerd api to get an image
-func (c *ContainerdUtil) Image(namespace string, ctn containerd.Container) (containerd.Image, error) {
+// ImageOfContainer interfaces with the containerd api to get an image
+func (c *ContainerdUtil) ImageOfContainer(namespace string, ctn containerd.Container) (containerd.Image, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), c.queryTimeout)
 	defer cancel()
 	ctxNamespace := namespaces.WithNamespace(ctx, namespace)

--- a/pkg/util/containerd/containerd_util.go
+++ b/pkg/util/containerd/containerd_util.go
@@ -46,6 +46,7 @@ type ContainerdItf interface {
 	Labels(namespace string, ctn containerd.Container) (map[string]string, error)
 	LabelsWithContext(ctx context.Context, namespace string, ctn containerd.Container) (map[string]string, error)
 	ListImages(namespace string) ([]containerd.Image, error)
+	Image(namespace string, name string) (containerd.Image, error)
 	ImageOfContainer(namespace string, ctn containerd.Container) (containerd.Image, error)
 	ImageSize(namespace string, ctn containerd.Container) (int64, error)
 	Spec(namespace string, ctn containerd.Container) (*oci.Spec, error)
@@ -228,6 +229,15 @@ func (c *ContainerdUtil) ListImages(namespace string) ([]containerd.Image, error
 	ctxNamespace := namespaces.WithNamespace(ctx, namespace)
 
 	return c.cl.ListImages(ctxNamespace)
+}
+
+// Image interfaces with the containerd api to get an image
+func (c *ContainerdUtil) Image(namespace string, name string) (containerd.Image, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), c.queryTimeout)
+	defer cancel()
+	ctxNamespace := namespaces.WithNamespace(ctx, namespace)
+
+	return c.cl.GetImage(ctxNamespace, name)
 }
 
 // ImageOfContainer interfaces with the containerd api to get an image

--- a/pkg/util/containerd/containerd_util_test.go
+++ b/pkg/util/containerd/containerd_util_test.go
@@ -147,7 +147,7 @@ func TestInfo(t *testing.T) {
 	require.Equal(t, "foo", c.Image)
 }
 
-func TestImage(t *testing.T) {
+func TestImageOfContainer(t *testing.T) {
 	mockUtil := ContainerdUtil{}
 
 	image := &mockImage{
@@ -160,7 +160,7 @@ func TestImage(t *testing.T) {
 		},
 	}
 
-	resultImage, err := mockUtil.Image(TestNamespace, container)
+	resultImage, err := mockUtil.ImageOfContainer(TestNamespace, container)
 	require.NoError(t, err)
 	require.Equal(t, resultImage, image)
 }

--- a/pkg/util/containerd/fake/containerd_util.go
+++ b/pkg/util/containerd/fake/containerd_util.go
@@ -31,7 +31,7 @@ type MockedContainerdClient struct {
 	MockEnvVars               func(namespace string, ctn containerd.Container) (map[string]string, error)
 	MockMetadata              func() (containerd.Version, error)
 	MockListImages            func(namespace string) ([]containerd.Image, error)
-	MockImage                 func(namespace string, ctn containerd.Container) (containerd.Image, error)
+	MockImageOfContainer      func(namespace string, ctn containerd.Container) (containerd.Image, error)
 	MockImageSize             func(namespace string, ctn containerd.Container) (int64, error)
 	MockTaskMetrics           func(namespace string, ctn containerd.Container) (*types.Metric, error)
 	MockTaskPids              func(namespace string, ctn containerd.Container) ([]containerd.ProcessInfo, error)
@@ -62,9 +62,9 @@ func (client *MockedContainerdClient) ListImages(namespace string) ([]containerd
 	return client.MockListImages(namespace)
 }
 
-// Image is a mock method
-func (client *MockedContainerdClient) Image(namespace string, ctn containerd.Container) (containerd.Image, error) {
-	return client.MockImage(namespace, ctn)
+// ImageOfContainer is a mock method
+func (client *MockedContainerdClient) ImageOfContainer(namespace string, ctn containerd.Container) (containerd.Image, error) {
+	return client.MockImageOfContainer(namespace, ctn)
 }
 
 // ImageSize is a mock method

--- a/pkg/util/containerd/fake/containerd_util.go
+++ b/pkg/util/containerd/fake/containerd_util.go
@@ -31,6 +31,7 @@ type MockedContainerdClient struct {
 	MockEnvVars               func(namespace string, ctn containerd.Container) (map[string]string, error)
 	MockMetadata              func() (containerd.Version, error)
 	MockListImages            func(namespace string) ([]containerd.Image, error)
+	MockImage                 func(namespace string, name string) (containerd.Image, error)
 	MockImageOfContainer      func(namespace string, ctn containerd.Container) (containerd.Image, error)
 	MockImageSize             func(namespace string, ctn containerd.Container) (int64, error)
 	MockTaskMetrics           func(namespace string, ctn containerd.Container) (*types.Metric, error)
@@ -60,6 +61,11 @@ func (client *MockedContainerdClient) CheckConnectivity() *retry.Error {
 // ListImages is a mock method
 func (client *MockedContainerdClient) ListImages(namespace string) ([]containerd.Image, error) {
 	return client.MockListImages(namespace)
+}
+
+// Image is a mock method
+func (client *MockedContainerdClient) Image(namespace string, name string) (containerd.Image, error) {
+	return client.MockImage(namespace, name)
 }
 
 // ImageOfContainer is a mock method

--- a/pkg/workloadmeta/collectors/internal/containerd/containerd.go
+++ b/pkg/workloadmeta/collectors/internal/containerd/containerd.go
@@ -87,18 +87,18 @@ type collector struct {
 	// contToExitInfo caches the exit info of a task to enrich the container deletion event when it's received later.
 	contToExitInfo map[string]*exitInfo
 
-	// Stores a map of image name => image ID.
-	// Events from containerd contain an image name, but not IDs. When a delete
-	// event arrives it'll contain a name, but we won't be able to access the ID
-	// because the image is already gone, that's why we need this map.
-	knownImages map[string]string
+	knownImages *knownImages
+
+	// Map of image ID => array of repo tags
+	repoTags map[string][]string
 }
 
 func init() {
 	workloadmeta.RegisterCollector(collectorID, func() workloadmeta.Collector {
 		return &collector{
 			contToExitInfo: make(map[string]*exitInfo),
-			knownImages:    make(map[string]string),
+			knownImages:    newKnownImages(),
+			repoTags:       make(map[string][]string),
 		}
 	})
 }

--- a/pkg/workloadmeta/collectors/internal/containerd/event_builder_test.go
+++ b/pkg/workloadmeta/collectors/internal/containerd/event_builder_test.go
@@ -290,7 +290,7 @@ func containerdClient(container containerd.Container) fake.MockedContainerdClien
 		MockLabels: func(namespace string, ctn containerd.Container) (map[string]string, error) {
 			return labels, nil
 		},
-		MockImage: func(namespace string, ctn containerd.Container) (containerd.Image, error) {
+		MockImageOfContainer: func(namespace string, ctn containerd.Container) (containerd.Image, error) {
 			return &mockedImage{
 				mockName: func() string {
 					return imgName

--- a/pkg/workloadmeta/collectors/internal/containerd/image.go
+++ b/pkg/workloadmeta/collectors/internal/containerd/image.go
@@ -14,8 +14,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
-	log "github.com/cihub/seelog"
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/api/events"
 	"github.com/containerd/containerd/content"
@@ -24,9 +22,60 @@ import (
 	"github.com/containerd/containerd/namespaces"
 	"github.com/gogo/protobuf/proto"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 )
 
 const imageTopicPrefix = "/images/"
+
+// Events from containerd contain an image name, but not IDs. When a delete
+// event arrives it'll contain a name, but we won't be able to access the ID
+// because the image is already gone, that's why we need to keep the IDs =>
+// names relationships.
+type knownImages struct {
+	// Store IDs and names in both directions for efficient access
+	idsByName map[string]string              // map name => ID
+	namesByID map[string]map[string]struct{} // map ID => set of names
+}
+
+func newKnownImages() *knownImages {
+	return &knownImages{
+		idsByName: make(map[string]string),
+		namesByID: make(map[string]map[string]struct{}),
+	}
+}
+
+func (images *knownImages) addAssociation(imageName string, imageID string) {
+	images.idsByName[imageName] = imageID
+
+	if images.namesByID[imageID] == nil {
+		images.namesByID[imageID] = make(map[string]struct{})
+	}
+	images.namesByID[imageID][imageName] = struct{}{}
+}
+
+func (images *knownImages) deleteAssociation(imageName string, imageID string) {
+	delete(images.idsByName, imageName)
+
+	if images.namesByID[imageID] == nil {
+		return
+	}
+
+	delete(images.namesByID[imageID], imageName)
+	if len(images.namesByID[imageID]) == 0 {
+		delete(images.namesByID, imageID)
+	}
+}
+
+func (images *knownImages) getImageID(imageName string) (string, bool) {
+	id, found := images.idsByName[imageName]
+	return id, found
+}
+
+func (images *knownImages) isReferenced(imageID string) bool {
+	return len(images.namesByID[imageID]) > 0
+}
 
 func isImageTopic(topic string) bool {
 	return strings.HasPrefix(topic, imageTopicPrefix)
@@ -56,11 +105,17 @@ func (c *collector) handleImageEvent(ctx context.Context, containerdEvent *conta
 			return fmt.Errorf("error unmarshaling containerd event: %w", err)
 		}
 
-		imageID, found := c.knownImages[event.Name]
+		imageID, found := c.knownImages.getImageID(event.Name)
 		if !found {
-			// Not necessarily an error. If an image had multiple names, it
-			// could have already been deleted using other name
 			return nil
+		}
+
+		c.knownImages.deleteAssociation(event.Name, imageID)
+
+		if c.knownImages.isReferenced(imageID) {
+			// Image is still referenced by a different name. Don't delete the
+			// image, but update its repo tags.
+			return c.deleteRepoTagOfImage(ctx, containerdEvent.Namespace, imageID, event.Name)
 		}
 
 		c.store.Notify([]workloadmeta.CollectorEvent{
@@ -75,8 +130,6 @@ func (c *collector) handleImageEvent(ctx context.Context, containerdEvent *conta
 				},
 			},
 		})
-
-		delete(c.knownImages, event.Name)
 
 		return nil
 	default:
@@ -103,7 +156,7 @@ func (c *collector) notifyEventForImage(ctx context.Context, namespace string, i
 
 	layers, err := getLayersWithHistory(ctxWithNamespace, img.ContentStore(), manifest)
 	if err != nil {
-		_ = log.Warnf("error while getting layers with history: %s", err)
+		log.Warnf("error while getting layers with history: %s", err)
 
 		// Not sure if the layers and history are always available. Instead of
 		// returning an error, collect the image without this information.
@@ -115,6 +168,15 @@ func (c *collector) notifyEventForImage(ctx context.Context, namespace string, i
 	}
 
 	imageName := img.Name()
+	shortName := ""
+	parsedImg, err := workloadmeta.NewContainerImage(imageName)
+	if err == nil {
+		// Don't set a short name. We know that some images handled here contain
+		// "sha256" in the name, and those don't have a short name.
+	} else {
+		shortName = parsedImg.ShortName
+	}
+
 	imageID := manifest.Config.Digest.String()
 
 	// We can get "create" events for images that already exist. That happens
@@ -125,41 +187,35 @@ func (c *collector) notifyEventForImage(ctx context.Context, namespace string, i
 	// name is a digest, in other is something with the same format as
 	// datadog/agent:7, and sometimes there's a temporary name prefixed with
 	// "import-".
+	// When that happens, give precedence to the name with repo and tag instead
+	// of the name that includes a digest. This is just to show names that are
+	// more user-friendly (the digests are already present in other attributes
+	// like ID, and repo digest).
 	existingImg, err := c.store.GetImage(imageID)
 	if err == nil {
-		updatedImg := existingImg.DeepCopy().(*workloadmeta.ContainerImageMetadata) // Avoid race conditions
-		changed := c.updateContainerImageMetadata(updatedImg, imageName)
-
-		if changed {
-			c.store.Notify([]workloadmeta.CollectorEvent{
-				{
-					Type:   workloadmeta.EventTypeSet,
-					Source: workloadmeta.SourceRuntime,
-					Entity: updatedImg,
-				},
-			})
-
-			c.updateKnownImages(imageName, imageID)
+		if strings.Contains(imageName, "sha256:") && !strings.Contains(existingImg.Name, "sha256:") {
+			imageName = existingImg.Name
+			shortName = existingImg.ShortName
 		}
-
-		return nil
-	}
-
-	shortName := ""
-	parsedImg, err := workloadmeta.NewContainerImage(imageName)
-	if err != nil {
-		_ = log.Warn("Can't get image short name")
-	} else {
-		shortName = parsedImg.ShortName
 	}
 
 	var repoDigests []string
-	var repoTags []string
 	if strings.Contains(imageName, "@sha256:") {
 		repoDigests = append(repoDigests, imageName)
 	} else {
 		repoDigests = append(repoDigests, imageName+"@"+img.Target().Digest.String())
-		repoTags = append(repoTags, imageName)
+
+		repoTagAlreadyPresent := false
+		for _, repoTag := range c.repoTags[imageID] {
+			if repoTag == imageName {
+				repoTagAlreadyPresent = true
+				break
+			}
+		}
+
+		if !repoTagAlreadyPresent {
+			c.repoTags[imageID] = append(c.repoTags[imageID], imageName)
+		}
 	}
 
 	var totalSizeBytes int64 = 0
@@ -187,7 +243,7 @@ func (c *collector) notifyEventForImage(ctx context.Context, namespace string, i
 			Labels:    img.Labels(),
 		},
 		ShortName:    shortName,
-		RepoTags:     repoTags,
+		RepoTags:     c.repoTags[imageID],
 		RepoDigests:  repoDigests,
 		MediaType:    manifest.MediaType,
 		SizeBytes:    totalSizeBytes,
@@ -206,39 +262,45 @@ func (c *collector) notifyEventForImage(ctx context.Context, namespace string, i
 		},
 	})
 
-	c.updateKnownImages(imageName, imageID)
+	return c.updateKnownImages(ctx, namespace, imageName, imageID)
+}
+
+// Updates the map with the image name => image ID relationships and also the repo tags
+func (c *collector) updateKnownImages(ctx context.Context, namespace string, imageName string, newImageID string) error {
+	oldImageID, found := c.knownImages.getImageID(imageName)
+	c.knownImages.addAssociation(imageName, newImageID)
+
+	// If the image name is already pointing to an ID, we need to delete the name from
+	// the repo tags of the image with that ID.
+	if found && newImageID != oldImageID {
+		c.knownImages.deleteAssociation(imageName, oldImageID)
+		return c.deleteRepoTagOfImage(ctx, namespace, oldImageID, imageName)
+	}
 
 	return nil
 }
 
-func (c *collector) updateKnownImages(imageName string, newImageID string) {
-	currentImageID, found := c.knownImages[imageName]
+func (c *collector) deleteRepoTagOfImage(ctx context.Context, namespace string, imageID string, repoTagToDelete string) error {
+	repoTagDeleted := false
 
-	// If the image name is already pointing to an ID, we need to delete it from
-	// the repo tags of the image with that ID.
-	if found {
-		existingImg, err := c.store.GetImage(currentImageID)
-		if err == nil {
-			existingImgCopy := existingImg.DeepCopy().(*workloadmeta.ContainerImageMetadata) // Avoid race conditions
-			for i, repoTag := range existingImgCopy.RepoTags {
-				if repoTag == imageName {
-					existingImgCopy.RepoTags = append(existingImgCopy.RepoTags[:i], existingImgCopy.RepoTags[i+1:]...)
-
-					c.store.Notify([]workloadmeta.CollectorEvent{
-						{
-							Type:   workloadmeta.EventTypeSet,
-							Source: workloadmeta.SourceRuntime,
-							Entity: existingImgCopy,
-						},
-					})
-
-					break
-				}
-			}
+	for i, repoTag := range c.repoTags[imageID] {
+		if repoTag == repoTagToDelete {
+			c.repoTags[imageID] = append(c.repoTags[imageID][:i], c.repoTags[imageID][i+1:]...)
+			repoTagDeleted = true
+			break
 		}
 	}
 
-	c.knownImages[imageName] = newImageID
+	if repoTagDeleted && len(c.repoTags[imageID]) > 0 {
+		// We need to notify to workloadmeta that the image has changed.
+		// Updating workloadmeta entities directly is not thread-safe, that's
+		// why we generate an update event here instead.
+		if err := c.handleImageCreateOrUpdate(ctx, namespace, c.repoTags[imageID][len(c.repoTags[imageID])-1]); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func getLayersWithHistory(ctx context.Context, store content.Store, manifest ocispec.Manifest) ([]workloadmeta.ContainerImageLayer, error) {
@@ -293,52 +355,4 @@ func getLayersWithHistory(ctx context.Context, store content.Store, manifest oci
 	}
 
 	return layers, nil
-}
-
-// updateContainerImageMetadata Updates the given container image metadata so
-// that it takes into account the new image name that refers to it. Returns a
-// boolean that indicates if the image metadata was updated.
-// There are 2 possible changes to be made:
-//  1. Some environments refer to the same image with multiple names. When
-//     that's the case, give precedence to the name with repo and tag instead of
-//     the name that includes a digest. This is just to show names that are more
-//     user-friendly (the digests are already present in other attributes like ID,
-//     and repo digest).
-//  2. Add the new name to the repo tags of the image. Notice that repo names
-//     are not digests.
-func (c *collector) updateContainerImageMetadata(imageMetadata *workloadmeta.ContainerImageMetadata, newName string) bool {
-	if strings.Contains(newName, "sha256:") {
-		// Nothing to do. It's not going to replace the current name, and it's
-		// not a repo tag.
-		return false
-	}
-
-	changed := false
-
-	// If the current name is a digest and the new one is not, replace.
-	if strings.Contains(imageMetadata.Name, "sha256:") {
-		imageMetadata.Name = newName
-
-		parsedName, err := workloadmeta.NewContainerImage(newName)
-		if err == nil {
-			imageMetadata.ShortName = parsedName.ShortName
-		}
-
-		changed = true
-	}
-
-	// Add new repo tag if not already present.
-	addNewRepoTag := true
-	for _, existingRepoTag := range imageMetadata.RepoTags {
-		if existingRepoTag == newName {
-			addNewRepoTag = false
-			break
-		}
-	}
-	if addNewRepoTag {
-		imageMetadata.RepoTags = append(imageMetadata.RepoTags, newName)
-		changed = true
-	}
-
-	return changed
 }

--- a/pkg/workloadmeta/collectors/internal/containerd/image.go
+++ b/pkg/workloadmeta/collectors/internal/containerd/image.go
@@ -1,0 +1,344 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build containerd
+// +build containerd
+
+package containerd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
+	log "github.com/cihub/seelog"
+	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/api/events"
+	"github.com/containerd/containerd/content"
+	containerdevents "github.com/containerd/containerd/events"
+	"github.com/containerd/containerd/images"
+	"github.com/containerd/containerd/namespaces"
+	"github.com/gogo/protobuf/proto"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+const imageTopicPrefix = "/images/"
+
+func isImageTopic(topic string) bool {
+	return strings.HasPrefix(topic, imageTopicPrefix)
+}
+
+func (c *collector) handleImageEvent(ctx context.Context, containerdEvent *containerdevents.Envelope) error {
+	switch containerdEvent.Topic {
+	case imageCreationTopic:
+		event := &events.ImageCreate{}
+		if err := proto.Unmarshal(containerdEvent.Event.Value, event); err != nil {
+			return fmt.Errorf("error unmarshaling containerd event: %w", err)
+		}
+
+		return c.handleImageCreateOrUpdate(ctx, containerdEvent.Namespace, event.Name)
+
+	case imageUpdateTopic:
+		event := &events.ImageUpdate{}
+		if err := proto.Unmarshal(containerdEvent.Event.Value, event); err != nil {
+			return fmt.Errorf("error unmarshaling containerd event: %w", err)
+		}
+
+		return c.handleImageCreateOrUpdate(ctx, containerdEvent.Namespace, event.Name)
+
+	case imageDeletionTopic:
+		event := &events.ImageDelete{}
+		if err := proto.Unmarshal(containerdEvent.Event.Value, event); err != nil {
+			return fmt.Errorf("error unmarshaling containerd event: %w", err)
+		}
+
+		imageID, found := c.knownImages[event.Name]
+		if !found {
+			// Not necessarily an error. If an image had multiple names, it
+			// could have already been deleted using other name
+			return nil
+		}
+
+		c.store.Notify([]workloadmeta.CollectorEvent{
+			{
+				Type:   workloadmeta.EventTypeUnset,
+				Source: workloadmeta.SourceRuntime,
+				Entity: &workloadmeta.ContainerImageMetadata{
+					EntityID: workloadmeta.EntityID{
+						Kind: workloadmeta.KindContainerImageMetadata,
+						ID:   imageID,
+					},
+				},
+			},
+		})
+
+		delete(c.knownImages, event.Name)
+
+		return nil
+	default:
+		return fmt.Errorf("unknown containerd image event topic %s, ignoring", containerdEvent.Topic)
+	}
+}
+
+func (c *collector) handleImageCreateOrUpdate(ctx context.Context, namespace string, imageName string) error {
+	img, err := c.containerdClient.Image(namespace, imageName)
+	if err != nil {
+		return fmt.Errorf("error getting image: %w", err)
+	}
+
+	return c.notifyEventForImage(ctx, namespace, img)
+}
+
+func (c *collector) notifyEventForImage(ctx context.Context, namespace string, img containerd.Image) error {
+	ctxWithNamespace := namespaces.WithNamespace(ctx, namespace)
+
+	manifest, err := images.Manifest(ctxWithNamespace, img.ContentStore(), img.Target(), img.Platform())
+	if err != nil {
+		return fmt.Errorf("error getting image manifest: %w", err)
+	}
+
+	layers, err := getLayersWithHistory(ctxWithNamespace, img.ContentStore(), manifest)
+	if err != nil {
+		_ = log.Warnf("error while getting layers with history: %s", err)
+
+		// Not sure if the layers and history are always available. Instead of
+		// returning an error, collect the image without this information.
+	}
+
+	platforms, err := images.Platforms(ctxWithNamespace, img.ContentStore(), manifest.Config)
+	if err != nil {
+		return fmt.Errorf("error getting image platforms: %w", err)
+	}
+
+	imageName := img.Name()
+	imageID := manifest.Config.Digest.String()
+
+	// We can get "create" events for images that already exist. That happens
+	// when the same image is referenced with different names. For example,
+	// datadog/agent:latest and datadog/agent:7 might refer to the same image.
+	// Also, in some environments (at least with Kind), pulling an image like
+	// datadog/agent:latest creates several events: in one of them the image
+	// name is a digest, in other is something with the same format as
+	// datadog/agent:7, and sometimes there's a temporary name prefixed with
+	// "import-".
+	existingImg, err := c.store.GetImage(imageID)
+	if err == nil {
+		updatedImg := existingImg.DeepCopy().(*workloadmeta.ContainerImageMetadata) // Avoid race conditions
+		changed := c.updateContainerImageMetadata(updatedImg, imageName)
+
+		if changed {
+			c.store.Notify([]workloadmeta.CollectorEvent{
+				{
+					Type:   workloadmeta.EventTypeSet,
+					Source: workloadmeta.SourceRuntime,
+					Entity: updatedImg,
+				},
+			})
+
+			c.updateKnownImages(imageName, imageID)
+		}
+
+		return nil
+	}
+
+	shortName := ""
+	parsedImg, err := workloadmeta.NewContainerImage(imageName)
+	if err != nil {
+		_ = log.Warn("Can't get image short name")
+	} else {
+		shortName = parsedImg.ShortName
+	}
+
+	var repoDigests []string
+	var repoTags []string
+	if strings.Contains(imageName, "@sha256:") {
+		repoDigests = append(repoDigests, imageName)
+	} else {
+		repoDigests = append(repoDigests, imageName+"@"+img.Target().Digest.String())
+		repoTags = append(repoTags, imageName)
+	}
+
+	var totalSizeBytes int64 = 0
+	for _, layer := range manifest.Layers {
+		totalSizeBytes += layer.Size
+	}
+
+	var os, osVersion, architecture, variant string
+	// If there are multiple platforms, return the info about the first one
+	if len(platforms) >= 1 {
+		os = platforms[0].OS
+		osVersion = platforms[0].OSVersion
+		architecture = platforms[0].Architecture
+		variant = platforms[0].Variant
+	}
+
+	workloadmetaImg := workloadmeta.ContainerImageMetadata{
+		EntityID: workloadmeta.EntityID{
+			Kind: workloadmeta.KindContainerImageMetadata,
+			ID:   imageID,
+		},
+		EntityMeta: workloadmeta.EntityMeta{
+			Name:      imageName,
+			Namespace: namespace,
+			Labels:    img.Labels(),
+		},
+		ShortName:    shortName,
+		RepoTags:     repoTags,
+		RepoDigests:  repoDigests,
+		MediaType:    manifest.MediaType,
+		SizeBytes:    totalSizeBytes,
+		OS:           os,
+		OSVersion:    osVersion,
+		Architecture: architecture,
+		Variant:      variant,
+		Layers:       layers,
+	}
+
+	c.store.Notify([]workloadmeta.CollectorEvent{
+		{
+			Type:   workloadmeta.EventTypeSet,
+			Source: workloadmeta.SourceRuntime,
+			Entity: &workloadmetaImg,
+		},
+	})
+
+	c.updateKnownImages(imageName, imageID)
+
+	return nil
+}
+
+func (c *collector) updateKnownImages(imageName string, newImageID string) {
+	currentImageID, found := c.knownImages[imageName]
+
+	// If the image name is already pointing to an ID, we need to delete it from
+	// the repo tags of the image with that ID.
+	if found {
+		existingImg, err := c.store.GetImage(currentImageID)
+		if err == nil {
+			existingImgCopy := existingImg.DeepCopy().(*workloadmeta.ContainerImageMetadata) // Avoid race conditions
+			for i, repoTag := range existingImgCopy.RepoTags {
+				if repoTag == imageName {
+					existingImgCopy.RepoTags = append(existingImgCopy.RepoTags[:i], existingImgCopy.RepoTags[i+1:]...)
+
+					c.store.Notify([]workloadmeta.CollectorEvent{
+						{
+							Type:   workloadmeta.EventTypeSet,
+							Source: workloadmeta.SourceRuntime,
+							Entity: existingImgCopy,
+						},
+					})
+
+					break
+				}
+			}
+		}
+	}
+
+	c.knownImages[imageName] = newImageID
+}
+
+func getLayersWithHistory(ctx context.Context, store content.Store, manifest ocispec.Manifest) ([]workloadmeta.ContainerImageLayer, error) {
+	blob, err := content.ReadBlob(ctx, store, manifest.Config)
+	if err != nil {
+		return nil, fmt.Errorf("error while getting image contents: %w", err)
+	}
+
+	var ocispecImage ocispec.Image
+	if err = json.Unmarshal(blob, &ocispecImage); err != nil {
+		return nil, fmt.Errorf("error while unmarshaling image: %w", err)
+	}
+
+	var layers []workloadmeta.ContainerImageLayer
+
+	// The layers in the manifest don't include the history, and the only way to
+	// match the history with each layer is to rely on the order and take into
+	// account that some history objects don't have an associated layer
+	// (emptyLayer = true).
+
+	history := ocispecImage.History
+	manifestLayersIdx := 0
+
+	for _, historyPoint := range history {
+		layer := workloadmeta.ContainerImageLayer{
+			History: historyPoint,
+		}
+
+		if !historyPoint.EmptyLayer {
+			if manifestLayersIdx >= len(manifest.Layers) {
+				// This should never happen. len(manifest.Layers) should equal
+				// len(history) minus the number of history points with
+				// emptyLayer = false.
+				return nil, fmt.Errorf("error while extracting image layer history")
+			}
+
+			manifestLayer := manifest.Layers[manifestLayersIdx]
+			manifestLayersIdx += 1
+
+			layer.MediaType = manifestLayer.MediaType
+			layer.Digest = manifestLayer.Digest.String()
+			layer.SizeBytes = manifestLayer.Size
+			layer.URLs = manifestLayer.URLs
+		}
+
+		layers = append(layers, layer)
+	}
+
+	if manifestLayersIdx != len(manifest.Layers) {
+		// This should never happen. Same case as above.
+		return nil, fmt.Errorf("error while extracting image layer history")
+	}
+
+	return layers, nil
+}
+
+// updateContainerImageMetadata Updates the given container image metadata so
+// that it takes into account the new image name that refers to it. Returns a
+// boolean that indicates if the image metadata was updated.
+// There are 2 possible changes to be made:
+//  1. Some environments refer to the same image with multiple names. When
+//     that's the case, give precedence to the name with repo and tag instead of
+//     the name that includes a digest. This is just to show names that are more
+//     user-friendly (the digests are already present in other attributes like ID,
+//     and repo digest).
+//  2. Add the new name to the repo tags of the image. Notice that repo names
+//     are not digests.
+func (c *collector) updateContainerImageMetadata(imageMetadata *workloadmeta.ContainerImageMetadata, newName string) bool {
+	if strings.Contains(newName, "sha256:") {
+		// Nothing to do. It's not going to replace the current name, and it's
+		// not a repo tag.
+		return false
+	}
+
+	changed := false
+
+	// If the current name is a digest and the new one is not, replace.
+	if strings.Contains(imageMetadata.Name, "sha256:") {
+		imageMetadata.Name = newName
+
+		parsedName, err := workloadmeta.NewContainerImage(newName)
+		if err == nil {
+			imageMetadata.ShortName = parsedName.ShortName
+		}
+
+		changed = true
+	}
+
+	// Add new repo tag if not already present.
+	addNewRepoTag := true
+	for _, existingRepoTag := range imageMetadata.RepoTags {
+		if existingRepoTag == newName {
+			addNewRepoTag = false
+			break
+		}
+	}
+	if addNewRepoTag {
+		imageMetadata.RepoTags = append(imageMetadata.RepoTags, newName)
+		changed = true
+	}
+
+	return changed
+}

--- a/pkg/workloadmeta/collectors/internal/containerd/image_test.go
+++ b/pkg/workloadmeta/collectors/internal/containerd/image_test.go
@@ -1,0 +1,90 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build containerd
+// +build containerd
+
+package containerd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
+)
+
+func TestUpdateContainerImageMetadata(t *testing.T) {
+	tests := []struct {
+		name                         string
+		imageMetadata                workloadmeta.ContainerImageMetadata
+		newName                      string
+		expectedUpdatedImageMetadata workloadmeta.ContainerImageMetadata
+		expectsUpdate                bool
+	}{
+		{
+			name: "new name is a digest",
+			imageMetadata: workloadmeta.ContainerImageMetadata{
+				EntityID: workloadmeta.EntityID{
+					Kind: workloadmeta.KindContainerImageMetadata,
+					ID:   "sha256:12345",
+				},
+				EntityMeta: workloadmeta.EntityMeta{
+					Name: "gcr.io/datadoghq/cluster-agent:7.40.1",
+				},
+				ShortName: "cluster-agent",
+				RepoTags: []string{
+					"gcr.io/datadoghq/cluster-agent:7.40.1",
+				},
+			},
+			newName:       "sha256:123",
+			expectsUpdate: false,
+		},
+		{
+			name: "new name replaces old and is added as repo tag",
+			imageMetadata: workloadmeta.ContainerImageMetadata{
+				EntityID: workloadmeta.EntityID{
+					Kind: workloadmeta.KindContainerImageMetadata,
+					ID:   "sha256:12345",
+				},
+				EntityMeta: workloadmeta.EntityMeta{
+					Name: "sha256:12345",
+				},
+				ShortName: "",
+				RepoTags:  []string{},
+			},
+			newName: "gcr.io/datadoghq/cluster-agent:7.40.1",
+			expectedUpdatedImageMetadata: workloadmeta.ContainerImageMetadata{
+				EntityID: workloadmeta.EntityID{
+					Kind: workloadmeta.KindContainerImageMetadata,
+					ID:   "sha256:12345",
+				},
+				EntityMeta: workloadmeta.EntityMeta{
+					Name: "gcr.io/datadoghq/cluster-agent:7.40.1",
+				},
+				ShortName: "cluster-agent",
+				RepoTags: []string{
+					"gcr.io/datadoghq/cluster-agent:7.40.1",
+				},
+			},
+			expectsUpdate: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			testCollector := collector{}
+
+			changed := testCollector.updateContainerImageMetadata(&test.imageMetadata, test.newName)
+
+			if test.expectsUpdate {
+				assert.True(t, changed)
+				assert.Equal(t, test.expectedUpdatedImageMetadata, test.imageMetadata)
+			} else {
+				assert.False(t, changed)
+			}
+		})
+	}
+}

--- a/pkg/workloadmeta/store.go
+++ b/pkg/workloadmeta/store.go
@@ -323,6 +323,16 @@ func (s *store) ListImages() []*ContainerImageMetadata {
 	return images
 }
 
+// GetImage implements Store#GetImage
+func (s *store) GetImage(id string) (*ContainerImageMetadata, error) {
+	entity, err := s.getEntityByKind(KindContainerImageMetadata, id)
+	if err != nil {
+		return nil, err
+	}
+
+	return entity.(*ContainerImageMetadata), nil
+}
+
 // Notify implements Store#Notify
 func (s *store) Notify(events []CollectorEvent) {
 	if len(events) > 0 {

--- a/pkg/workloadmeta/testing/store.go
+++ b/pkg/workloadmeta/testing/store.go
@@ -117,6 +117,16 @@ func (s *Store) ListImages() []*workloadmeta.ContainerImageMetadata {
 	return images
 }
 
+// GetImage implements Store#GetImage
+func (s *Store) GetImage(id string) (*workloadmeta.ContainerImageMetadata, error) {
+	entity, err := s.getEntityByKind(workloadmeta.KindContainerImageMetadata, id)
+	if err != nil {
+		return nil, err
+	}
+
+	return entity.(*workloadmeta.ContainerImageMetadata), nil
+}
+
 // Set sets an entity in the store.
 func (s *Store) Set(entity workloadmeta.Entity) {
 	s.mu.Lock()

--- a/pkg/workloadmeta/types.go
+++ b/pkg/workloadmeta/types.go
@@ -78,6 +78,10 @@ type Store interface {
 	// entities with kind KindContainerImageMetadata.
 	ListImages() []*ContainerImageMetadata
 
+	// GetImage returns metadata about a container image. It fetches the entity
+	// with kind KindContainerImageMetadata and the given ID.
+	GetImage(id string) (*ContainerImageMetadata, error)
+
 	// Notify notifies the store with a slice of events.  It should only be
 	// used by workloadmeta collectors.
 	Notify(events []CollectorEvent)


### PR DESCRIPTION
### What does this PR do?

Updates the containerd workloadmeta collector so it also collects container image metadata.

This feature is disabled by default. It can be enabled setting `workloadmeta.image_metadata_collection.enabled=true`

### Describe how to test/QA your changes

Deploy the agent in a containerd environment. Ideally kubernetes and also bare containerd to cover more cases. Run `workload-list --verbose` and check that the "container_image_metadata" objects shown have the correct information. Also, try to pull and delete images and verify that the output of `workload-list --verbose` reflects the changes.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
