### PR TITLE
Revert sampling priority metric accidental deletion

### DIFF
--- a/pkg/trace/sampler/prioritysampler.go
+++ b/pkg/trace/sampler/prioritysampler.go
@@ -26,7 +26,9 @@ import (
 )
 
 const (
-	agentRateKey = "_dd.agent_psr"
+	deprecatedRateKey = "_sampling_priority_rate_v1"
+	agentRateKey      = "_dd.agent_psr"
+	ruleRateKey       = "_dd.rule_psr"
 )
 
 // PrioritySampler computes priority rates per tracerEnv, service to apply in a feedback loop with trace-agent clients.
@@ -116,9 +118,35 @@ func (s *PrioritySampler) Sample(now time.Time, trace *pb.TraceChunk, root *pb.S
 	s.countSignature(now, root, signature, clientDroppedP0sWeight)
 
 	if sampled {
+		s.applyRate(root, signature)
 		s.sampler.countSample()
 	}
 	return sampled
+}
+
+func (s *PrioritySampler) applyRate(root *pb.Span, signature Signature) float64 {
+	if root.ParentID != 0 {
+		return 1.0
+	}
+	// recent tracers annotate roots with applied priority rate
+	// agentRateKey is set when the agent computed rate is applied
+	if rate, ok := getMetric(root, agentRateKey); ok {
+		return rate
+	}
+	// ruleRateKey is set when a tracer rule rate is applied
+	if rate, ok := getMetric(root, ruleRateKey); ok {
+		return rate
+	}
+	// slow path used by older tracer versions
+	// dd-trace-go used to set the rate in deprecatedRateKey
+	if rate, ok := getMetric(root, deprecatedRateKey); ok {
+		return rate
+	}
+	rate := s.sampler.getSignatureSampleRate(signature)
+
+	setMetric(root, deprecatedRateKey, rate)
+
+	return rate
 }
 
 // countSignature counts all chunks received with local chunk root signature.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Revert part of this PR: https://github.com/DataDog/datadog-agent/pull/14011

There was no reason to remove the part that sets  a metric on some spans.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

The general idea is:

 1. Send a trace to the agent, WITHOUT `_dd.agent_psr` in the metrics
 2. Assuming that this trace was sampled by the agent, check that `_sampling_priority_rate_v1` was added to the metrics of the root span

<img width="930" alt="image" src="https://user-images.githubusercontent.com/103181765/206409960-23dbc2a2-4e84-42a0-b75e-28ea54b8d65a.png">

However step 1 is quite hard, since newer agents are supposed to set this metric. See here for one way to send custom traces to an agent: https://datadoghq.atlassian.net/l/cp/4xs6VxMC


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
