### PR TITLE
[CWS] fix cli params commands

### DIFF
--- a/cmd/security-agent/app/subcommands/compliance/command.go
+++ b/cmd/security-agent/app/subcommands/compliance/command.go
@@ -45,7 +45,7 @@ type eventCliParams struct {
 }
 
 func complianceEventCommand(globalParams *common.GlobalParams) *cobra.Command {
-	eventArgs := eventCliParams{
+	eventArgs := &eventCliParams{
 		GlobalParams: globalParams,
 	}
 

--- a/cmd/security-agent/app/subcommands/flare/command.go
+++ b/cmd/security-agent/app/subcommands/flare/command.go
@@ -31,7 +31,7 @@ type flareCliParams struct {
 }
 
 func Commands(globalParams *common.GlobalParams) []*cobra.Command {
-	cliParams := flareCliParams{
+	cliParams := &flareCliParams{
 		GlobalParams: globalParams,
 	}
 

--- a/cmd/security-agent/app/subcommands/runtime/activity_dump.go
+++ b/cmd/security-agent/app/subcommands/runtime/activity_dump.go
@@ -74,7 +74,7 @@ func listCommands(globalParams *common.GlobalParams) []*cobra.Command {
 }
 
 func stopCommands(globalParams *common.GlobalParams) []*cobra.Command {
-	cliParams := activityDumpCliParams{
+	cliParams := &activityDumpCliParams{
 		GlobalParams: globalParams,
 	}
 
@@ -128,7 +128,7 @@ func generateCommands(globalParams *common.GlobalParams) []*cobra.Command {
 }
 
 func generateDumpCommands(globalParams *common.GlobalParams) []*cobra.Command {
-	cliParams := activityDumpCliParams{
+	cliParams := &activityDumpCliParams{
 		GlobalParams: globalParams,
 	}
 
@@ -200,7 +200,7 @@ func generateDumpCommands(globalParams *common.GlobalParams) []*cobra.Command {
 }
 
 func generateEncodingCommands(globalParams *common.GlobalParams) []*cobra.Command {
-	cliParams := activityDumpCliParams{
+	cliParams := &activityDumpCliParams{
 		GlobalParams: globalParams,
 	}
 

--- a/cmd/security-agent/app/subcommands/runtime/command.go
+++ b/cmd/security-agent/app/subcommands/runtime/command.go
@@ -260,7 +260,7 @@ func downloadPolicyCommands(globalParams *common.GlobalParams) []*cobra.Command 
 				fx.Supply(core.BundleParams{
 					SecurityAgentConfigFilePaths: globalParams.ConfPathArray,
 					ConfigLoadSecurityAgent:      true,
-				}.LogForOneShot(common.LoggerName, "info", true)),
+				}.LogForOneShot(common.LoggerName, "off", false)),
 				core.Bundle,
 			)
 		},

--- a/cmd/security-agent/app/subcommands/runtime/command.go
+++ b/cmd/security-agent/app/subcommands/runtime/command.go
@@ -83,7 +83,7 @@ type checkPoliciesCliParams struct {
 }
 
 func checkPoliciesCommands(globalParams *common.GlobalParams) []*cobra.Command {
-	cliParams := checkPoliciesCliParams{
+	cliParams := &checkPoliciesCliParams{
 		GlobalParams: globalParams,
 	}
 
@@ -150,7 +150,7 @@ type evalCliParams struct {
 }
 
 func evalCommands(globalParams *common.GlobalParams) []*cobra.Command {
-	evalArgs := evalCliParams{
+	evalArgs := &evalCliParams{
 		GlobalParams: globalParams,
 	}
 
@@ -180,7 +180,7 @@ func evalCommands(globalParams *common.GlobalParams) []*cobra.Command {
 }
 
 func commonCheckPoliciesCommands(globalParams *common.GlobalParams) []*cobra.Command {
-	cliParams := checkPoliciesCliParams{
+	cliParams := &checkPoliciesCliParams{
 		GlobalParams: globalParams,
 	}
 
@@ -247,7 +247,7 @@ type downloadPolicyCliParams struct {
 }
 
 func downloadPolicyCommands(globalParams *common.GlobalParams) []*cobra.Command {
-	downloadPolicyArgs := downloadPolicyCliParams{
+	downloadPolicyArgs := &downloadPolicyCliParams{
 		GlobalParams: globalParams,
 	}
 
@@ -279,7 +279,7 @@ type processCacheDumpCliParams struct {
 }
 
 func processCacheCommands(globalParams *common.GlobalParams) []*cobra.Command {
-	cliParams := processCacheDumpCliParams{
+	cliParams := &processCacheDumpCliParams{
 		GlobalParams: globalParams,
 	}
 
@@ -315,7 +315,7 @@ type dumpNetworkNamespaceCliParams struct {
 }
 
 func networkNamespaceCommands(globalParams *common.GlobalParams) []*cobra.Command {
-	cliParams := dumpNetworkNamespaceCliParams{
+	cliParams := &dumpNetworkNamespaceCliParams{
 		GlobalParams: globalParams,
 	}
 
@@ -768,8 +768,8 @@ func StartRuntimeSecurity(hostname string, stopper startstop.Stopper, statsdClie
 }
 
 func downloadPolicy(log complog.Component, config compconfig.Component, downloadPolicyArgs *downloadPolicyCliParams) error {
-	apiKey := coreconfig.Datadog.GetString("api_key")
-	appKey := coreconfig.Datadog.GetString("app_key")
+	apiKey := config.GetString("api_key")
+	appKey := config.GetString("app_key")
 
 	if apiKey == "" {
 		return errors.New("API key is empty")
@@ -779,7 +779,7 @@ func downloadPolicy(log complog.Component, config compconfig.Component, download
 		return errors.New("application key is empty")
 	}
 
-	site := coreconfig.Datadog.GetString("site")
+	site := config.GetString("site")
 	if site == "" {
 		site = "datadoghq.com"
 	}


### PR DESCRIPTION
### What does this PR do?

This PR fixes a few things that were broken by https://github.com/DataDog/datadog-agent/pull/14571:
- pointer for CLI params struct 
- no logger for download policy (since it's piped directly to a file in the e2e tests)

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

I put this PR in `skip-qa` because the QA from the original PR should cover what is fixed here

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
