### PR TITLE
[CSPM] disable e2e CSPM aggregate hacks

### DIFF
--- a/test/e2e/cws-tests/tests/test_e2e_cspm_docker.py
+++ b/test/e2e/cws-tests/tests/test_e2e_cspm_docker.py
@@ -130,8 +130,9 @@ class TestE2EDocker(unittest.TestCase):
         with Step(msg="wait for datadog.security_agent.compliance.running metric", emoji="\N{beer mug}"):
             self.app.wait_for_metric("datadog.security_agent.compliance.running", host=socket.gethostname())
 
-        with Step(msg="check app compliance event", emoji=":SOON_arrow:"):
-            wait_for_compliance_event(f"resource_id:*{self.container_id}")
+        ## Disabled while no CSPM API is available
+        # with Step(msg="check app compliance event", emoji=":SOON_arrow:"):
+        #    wait_for_compliance_event(f"resource_id:*{self.container_id}")
 
         with Step(msg="wait for finding generation (~1m)", emoji=":alarm_clock:"):
             time.sleep(1 * 60)
@@ -141,8 +142,9 @@ class TestE2EDocker(unittest.TestCase):
                 "datadog.security_agent.compliance.containers_running", container_id=self.container_id
             )
 
-        with Step(msg="check app finding", emoji=":chart_increasing_with_yen:"):
-            wait_for_findings(f"@resource_type:docker_container @container_id:{self.container_id}")
+        ## Disabled while no CSPM API is available
+        # with Step(msg="check app finding", emoji=":chart_increasing_with_yen:"):
+        #    wait_for_findings(f"@resource_type:docker_container @container_id:{self.container_id}")
 
 
 def main():

--- a/test/e2e/cws-tests/tests/test_e2e_cspm_docker.py
+++ b/test/e2e/cws-tests/tests/test_e2e_cspm_docker.py
@@ -8,7 +8,7 @@ import warnings
 
 from lib.config import gen_datadog_agent_config
 from lib.const import CSPM_START_LOG
-from lib.cspm.api import App, wait_for_compliance_event, wait_for_findings
+from lib.cspm.api import App
 from lib.docker import DockerHelper
 from lib.log import wait_agent_log
 from lib.stepper import Step

--- a/test/e2e/cws-tests/tests/test_e2e_cspm_kubernetes.py
+++ b/test/e2e/cws-tests/tests/test_e2e_cspm_kubernetes.py
@@ -221,8 +221,9 @@ class TestE2EKubernetes(unittest.TestCase):
         with Step(msg="wait for datadog.security_agent.compliance.running metric", emoji="\N{beer mug}"):
             self.app.wait_for_metric("datadog.security_agent.compliance.running", host=TestE2EKubernetes.hostname)
 
-        with Step(msg="check app compliance event", emoji=":SOON_arrow:"):
-            wait_for_compliance_event(f"resource_id:{self.resource_id}")
+        ## Disabled while no CSPM API is available
+        # with Step(msg="check app compliance event", emoji=":SOON_arrow:"):
+        #     wait_for_compliance_event(f"resource_id:{self.resource_id}")
 
         with Step(msg="wait for finding generation (~1m)", emoji=":alarm_clock:"):
             time.sleep(1 * 60)
@@ -232,8 +233,9 @@ class TestE2EKubernetes(unittest.TestCase):
                 "datadog.security_agent.compliance.containers_running", host=TestE2EKubernetes.hostname
             )
 
-        with Step(msg="check app findings", emoji=":chart_increasing_with_yen:"):
-            wait_for_findings(f"@resource_type:kubernetes_*_node @resource:{self.resource_id}")
+        ## Disabled while no CSPM API is available
+        # with Step(msg="check app findings", emoji=":chart_increasing_with_yen:"):
+        #     wait_for_findings(f"@resource_type:kubernetes_*_node @resource:{self.resource_id}")
 
         print(emoji.emojize(":heart_on_fire:"), flush=True)
 

--- a/test/e2e/cws-tests/tests/test_e2e_cspm_kubernetes.py
+++ b/test/e2e/cws-tests/tests/test_e2e_cspm_kubernetes.py
@@ -6,7 +6,7 @@ import warnings
 
 import emoji
 from lib.const import CSPM_START_LOG
-from lib.cspm.api import App, wait_for_compliance_event, wait_for_findings
+from lib.cspm.api import App
 from lib.kubernetes import KubernetesHelper
 from lib.log import wait_agent_log
 from lib.stepper import Step


### PR DESCRIPTION
### What does this PR do?

The aggregate API now only supports LOGS track. This PR disable our usage of this API while we find another solution

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
