### PR TITLE
[process-agent] Allow using secret backends in Process Agent on Windows

### DIFF
--- a/pkg/secrets/check_rights_nix_test.go
+++ b/pkg/secrets/check_rights_nix_test.go
@@ -21,6 +21,10 @@ func setCorrectRight(path string) {
 	os.Chmod(path, 0700)
 }
 
+// testCheckRightsStub is a dummy checkRights stub for *nix
+func testCheckRightsStub() {
+}
+
 func TestWrongPath(t *testing.T) {
 	require.NotNil(t, checkRights("does not exists", false))
 }

--- a/pkg/secrets/check_rights_windows.go
+++ b/pkg/secrets/check_rights_windows.go
@@ -14,6 +14,7 @@ import (
 	"unsafe"
 
 	"golang.org/x/sys/windows"
+	"golang.org/x/sys/windows/registry"
 
 	"github.com/DataDog/datadog-agent/pkg/util/winutil"
 )
@@ -28,82 +29,64 @@ func checkRights(filename string, allowGroupExec bool) error {
 	}
 	if _, err := os.Stat(filename); err != nil {
 		if os.IsNotExist(err) {
-			return fmt.Errorf("secretBackendCommand %s does not exist", filename)
+			return fmt.Errorf("secretBackendCommand '%s' does not exist", filename)
 		}
+		return fmt.Errorf("unable to check permissions for secretBackendCommand '%s': %s", filename, err)
 	}
 
-	var fileDacl *winutil.Acl
-	err := winutil.GetNamedSecurityInfo(filename,
-		winutil.SE_FILE_OBJECT,
-		winutil.DACL_SECURITY_INFORMATION,
-		nil,
-		nil,
-		&fileDacl,
-		nil,
-		nil)
+	fileDacl, err := getACL(filename)
 	if err != nil {
-		return fmt.Errorf("could not query ACLs for %s: %s", filename, err)
+		return fmt.Errorf("could not query ACLs for '%s': %s", filename, err)
 	}
 
 	var aclSizeInfo winutil.AclSizeInformation
 	err = winutil.GetAclInformation(fileDacl, &aclSizeInfo, winutil.AclSizeInformationEnum)
 	if err != nil {
-		return fmt.Errorf("could not query ACLs for %s: %s", filename, err)
+		return fmt.Errorf("could not query ACLs for '%s': %s", filename, err)
 	}
 
 	// create the sids that are acceptable to us (local system account and
 	// administrators group)
-	var localSystem *windows.SID
-	err = windows.AllocateAndInitializeSid(&windows.SECURITY_NT_AUTHORITY,
-		1, // local system has 1 valid subauth
-		windows.SECURITY_LOCAL_SYSTEM_RID,
-		0, 0, 0, 0, 0, 0, 0,
-		&localSystem)
+	localSystem, err := getLocalSystemSID()
 	if err != nil {
 		return fmt.Errorf("could not query Local System SID: %s", err)
 	}
 	defer windows.FreeSid(localSystem)
 
-	var administrators *windows.SID
-	err = windows.AllocateAndInitializeSid(&windows.SECURITY_NT_AUTHORITY,
-		2, // administrators group has 2 valid subauths
-		windows.SECURITY_BUILTIN_DOMAIN_RID,
-		windows.DOMAIN_ALIAS_RID_ADMINS,
-		0, 0, 0, 0, 0, 0,
-		&administrators)
+	administrators, err := getAdministratorsSID()
 	if err != nil {
 		return fmt.Errorf("could not query Administrator SID: %s", err)
 	}
 	defer windows.FreeSid(administrators)
 
-	secretuser, err := winutil.GetSidFromUser()
+	secretUser, err := getSecretUserSID()
 	if err != nil {
-		return fmt.Errorf("could not get SID for current user: %s", err)
+		return err
 	}
 
 	bSecretUserExplicitlyAllowed := false
 	for i := uint32(0); i < aclSizeInfo.AceCount; i++ {
 		var pAce *winutil.AccessAllowedAce
 		if err := winutil.GetAce(fileDacl, i, &pAce); err != nil {
-			return fmt.Errorf("Could not query a ACE on %s: %s", filename, err)
+			return fmt.Errorf("could not query a ACE on '%s': %s", filename, err)
 		}
 
 		compareSid := (*windows.SID)(unsafe.Pointer(&pAce.SidStart))
 		compareIsLocalSystem := windows.EqualSid(compareSid, localSystem)
 		compareIsAdministrators := windows.EqualSid(compareSid, administrators)
-		compareIsSecretUser := windows.EqualSid(compareSid, secretuser)
+		compareIsSecretUser := windows.EqualSid(compareSid, secretUser)
 
 		if pAce.AceType == winutil.ACCESS_DENIED_ACE_TYPE {
 			// if we're denying access to local system or administrators,
 			// it's wrong. Otherwise, any explicit access denied is OK
 			if compareIsLocalSystem || compareIsAdministrators || compareIsSecretUser {
-				return fmt.Errorf("Invalid executable '%s': Can't deny access LOCAL_SYSTEM, Administrators or %s", filename, secretuser)
+				return fmt.Errorf("invalid executable '%s': explicit deny access for LOCAL_SYSTEM, Administrators or %s", filename, secretUser)
 			}
 			// otherwise, it's fine; deny access to whomever
 		}
 		if pAce.AceType == winutil.ACCESS_ALLOWED_ACE_TYPE {
 			if !(compareIsLocalSystem || compareIsAdministrators || compareIsSecretUser) {
-				return fmt.Errorf("Invalid executable '%s': other users/groups than LOCAL_SYSTEM, Administrators or %s have rights on it", filename, secretuser)
+				return fmt.Errorf("invalid executable '%s': other users/groups than LOCAL_SYSTEM, Administrators or %s have rights on it", filename, secretUser)
 			}
 			if compareIsSecretUser {
 				bSecretUserExplicitlyAllowed = true
@@ -113,7 +96,98 @@ func checkRights(filename string, allowGroupExec bool) error {
 
 	if !bSecretUserExplicitlyAllowed {
 		// there was never an ACE explicitly allowing the secret user, so we can't use it
-		return fmt.Errorf("'%s' user is not allowed to execute secretBackendCommand '%s'", secretuser, filename)
+		return fmt.Errorf("'%s' user is not allowed to execute secretBackendCommand '%s'", secretUser, filename)
 	}
 	return nil
+}
+
+// getACL retrieves the DACL for the file at filename path
+func getACL(filename string) (*winutil.Acl, error) {
+	var fileDacl *winutil.Acl
+	err := winutil.GetNamedSecurityInfo(filename,
+		winutil.SE_FILE_OBJECT,
+		winutil.DACL_SECURITY_INFORMATION,
+		nil,
+		nil,
+		&fileDacl,
+		nil,
+		nil)
+
+	return fileDacl, err
+}
+
+// getLocalSystemSID returns the SID of the Local System account
+func getLocalSystemSID() (*windows.SID, error) {
+	var localSystem *windows.SID
+	err := windows.AllocateAndInitializeSid(&windows.SECURITY_NT_AUTHORITY,
+		1, // local system has 1 valid subauth
+		windows.SECURITY_LOCAL_SYSTEM_RID,
+		0, 0, 0, 0, 0, 0, 0,
+		&localSystem)
+
+	return localSystem, err
+}
+
+// getAdministratorsSID returns the SID of the built-in Administrators group principal
+func getAdministratorsSID() (*windows.SID, error) {
+	var administrators *windows.SID
+	err := windows.AllocateAndInitializeSid(&windows.SECURITY_NT_AUTHORITY,
+		2, // administrators group has 2 valid subauths
+		windows.SECURITY_BUILTIN_DOMAIN_RID,
+		windows.DOMAIN_ALIAS_RID_ADMINS,
+		0, 0, 0, 0, 0, 0,
+		&administrators)
+	return administrators, err
+}
+
+// getSecretUserSID returns the SID of the user running the secret backend
+func getSecretUserSID() (*windows.SID, error) {
+	localSystem, err := getLocalSystemSID()
+	if err != nil {
+		return nil, fmt.Errorf("could not query Local System SID: %s", err)
+	}
+	defer windows.FreeSid(localSystem)
+
+	currentUser, err := winutil.GetSidFromUser()
+	if err != nil {
+		return nil, fmt.Errorf("could not get SID for current user: %s", err)
+	}
+
+	secretUser := currentUser
+
+	elevated, err := winutil.IsProcessElevated()
+	if err != nil {
+		return nil, fmt.Errorf("unable to determine if running elevated: %s", err)
+	}
+
+	if elevated || currentUser.Equals(localSystem) {
+		ddUser, err := getDDAgentUserSID()
+		if err != nil {
+			return nil, fmt.Errorf("could not resolve SID for ddagentuser user: %s", err)
+		}
+		secretUser = ddUser
+	}
+	return secretUser, nil
+}
+
+// getDDAgentUserSID returns the SID of the ddagentuser configured at installation time
+var getDDAgentUserSID = func() (*windows.SID, error) {
+	k, err := registry.OpenKey(registry.LOCAL_MACHINE, `SOFTWARE\Datadog\Datadog Agent`, registry.QUERY_VALUE)
+	if err != nil {
+		return nil, fmt.Errorf("could not open installer registry key: %s", err)
+	}
+	defer k.Close()
+
+	user, _, err := k.GetStringValue("installedUser")
+	if err != nil {
+		return nil, fmt.Errorf("could not read installedUser in registry: %s", err)
+	}
+
+	domain, _, err := k.GetStringValue("installedDomain")
+	if err != nil {
+		return nil, fmt.Errorf("could not read installedDomain in registry: %s", err)
+	}
+
+	sid, _, _, err := windows.LookupSID(domain, user)
+	return sid, err
 }

--- a/pkg/secrets/check_rights_windows_test.go
+++ b/pkg/secrets/check_rights_windows_test.go
@@ -15,6 +15,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/util/winutil"
 )
 
 func setCorrectRight(path string) {
@@ -24,6 +26,11 @@ func setCorrectRight(path string) {
 		"-removeAdmin", "0",
 		"-removeLocalSystem", "0",
 		"-addDDuser", "1").Run()
+}
+
+func testCheckRightsStub() {
+	// Stub for CI since running as Administrator and no installer data
+	getDDAgentUserSID = winutil.GetSidFromUser
 }
 
 func TestWrongPath(t *testing.T) {

--- a/pkg/secrets/exec_nix.go
+++ b/pkg/secrets/exec_nix.go
@@ -1,0 +1,19 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build secrets && !windows
+// +build secrets,!windows
+
+package secrets
+
+import (
+	"context"
+	"os/exec"
+)
+
+// commandContext sets up an exec.Cmd for running with a context
+func commandContext(ctx context.Context, name string, arg ...string) (*exec.Cmd, func(), error) {
+	return exec.CommandContext(ctx, name, arg...), func() {}, nil
+}

--- a/pkg/secrets/exec_windows.go
+++ b/pkg/secrets/exec_windows.go
@@ -1,0 +1,120 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018-present Datadog, Inc.
+
+//go:build secrets && windows
+// +build secrets,windows
+
+package secrets
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"syscall"
+
+	"golang.org/x/sys/windows"
+	"golang.org/x/sys/windows/svc/mgr"
+
+	"github.com/DataDog/datadog-agent/pkg/util/winutil"
+)
+
+// commandContext sets up an exec.Cmd for running with a context
+func commandContext(ctx context.Context, name string, arg ...string) (*exec.Cmd, func(), error) {
+	cmd := exec.CommandContext(ctx, name, arg...)
+	done := func() {}
+	localSystem, err := getLocalSystemSID()
+	if err != nil {
+		return nil, nil, fmt.Errorf("could not query Local System SID: %s", err)
+	}
+	defer windows.FreeSid(localSystem)
+
+	currentUser, err := winutil.GetSidFromUser()
+	if err != nil {
+		return nil, nil, fmt.Errorf("could not get SID for current user: %s", err)
+	}
+
+	// If we are running as Local System we need to "sandbox" execution to "ddagentuser"
+	if currentUser.Equals(localSystem) {
+		// Retrieve token from the running Datadog Agent service
+		token, err := getDDAgentServiceToken()
+		if err != nil {
+			return nil, nil, err
+		}
+
+		done = func() {
+			defer windows.CloseHandle(windows.Handle(token))
+		}
+
+		// Configure the token to run with
+		cmd.SysProcAttr = &syscall.SysProcAttr{Token: syscall.Token(token)}
+	}
+
+	return cmd, done, nil
+}
+
+// getDDAgentServiceToken retrieves token from the running Datadog Agent service
+func getDDAgentServiceToken() (windows.Token, error) {
+	var token, duplicatedToken windows.Token
+	pid, err := getServicePid("datadogagent")
+	if err != nil {
+		return windows.Token(0), fmt.Errorf("could not get pid of datadogagent service: %s", err)
+	}
+
+	procHandle, err := windows.OpenProcess(windows.PROCESS_QUERY_INFORMATION, false, pid)
+	if err != nil {
+		return windows.Token(0), fmt.Errorf("could not get pid of datadogagent service: %s", err)
+	}
+
+	defer windows.CloseHandle(procHandle)
+
+	if err = windows.OpenProcessToken(procHandle, windows.TOKEN_ALL_ACCESS, &token); err != nil {
+		return windows.Token(0), err
+	}
+
+	defer windows.CloseHandle(windows.Handle(token))
+
+	if err := windows.DuplicateTokenEx(token, windows.MAXIMUM_ALLOWED, nil, windows.SecurityDelegation, windows.TokenPrimary, &duplicatedToken); err != nil {
+		return windows.Token(0), fmt.Errorf("error while DuplicateTokenEx: %w", err)
+	}
+
+	return duplicatedToken, nil
+}
+
+// getServicePid gets the PID of a running service
+func getServicePid(serviceName string) (uint32, error) {
+	h, err := windows.OpenSCManager(nil, nil, windows.SC_MANAGER_CONNECT)
+	if err != nil {
+		return 0, fmt.Errorf("could not connect to SCM: %s", err)
+	}
+
+	m := &mgr.Mgr{Handle: h}
+	defer m.Disconnect()
+
+	hSvc, err := windows.OpenService(m.Handle, syscall.StringToUTF16Ptr(serviceName),
+		windows.SERVICE_QUERY_STATUS)
+	if err != nil {
+		return 0, fmt.Errorf("could not access service %s: %v", serviceName, err)
+	}
+
+	service := &mgr.Service{Name: serviceName, Handle: hSvc}
+	defer service.Close()
+	status, err := service.Query()
+	if err != nil {
+		return 0, fmt.Errorf("could not query service %s: %v", serviceName, err)
+	}
+	return status.ProcessId, nil
+}
+
+// getLocalSystemSID returns the SID of the Local System account
+func getLocalSystemSID() (*windows.SID, error) {
+	var localSystem *windows.SID
+	err := windows.AllocateAndInitializeSid(&windows.SECURITY_NT_AUTHORITY,
+		1, // local system has 1 valid subauth
+		windows.SECURITY_LOCAL_SYSTEM_RID,
+		0, 0, 0, 0, 0, 0, 0,
+		&localSystem)
+
+	return localSystem, err
+}

--- a/pkg/secrets/exec_windows.go
+++ b/pkg/secrets/exec_windows.go
@@ -108,15 +108,3 @@ func getServicePid(serviceName string) (uint32, error) {
 	}
 	return status.ProcessId, nil
 }
-
-// getLocalSystemSID returns the SID of the Local System account
-func getLocalSystemSID() (*windows.SID, error) {
-	var localSystem *windows.SID
-	err := windows.AllocateAndInitializeSid(&windows.SECURITY_NT_AUTHORITY,
-		1, // local system has 1 valid subauth
-		windows.SECURITY_LOCAL_SYSTEM_RID,
-		0, 0, 0, 0, 0, 0, 0,
-		&localSystem)
-
-	return localSystem, err
-}

--- a/pkg/secrets/fetch_secret.go
+++ b/pkg/secrets/fetch_secret.go
@@ -48,7 +48,12 @@ func execCommand(inputPayload string) ([]byte, error) {
 		time.Duration(secretBackendTimeout)*time.Second)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, secretBackendCommand, secretBackendArguments...)
+	cmd, done, err := commandContext(ctx, secretBackendCommand, secretBackendArguments...)
+	if err != nil {
+		return nil, err
+	}
+	defer done()
+
 	if err := checkRights(cmd.Path, secretBackendCommandAllowGroupExec); err != nil {
 		return nil, err
 	}
@@ -73,7 +78,7 @@ func execCommand(inputPayload string) ([]byte, error) {
 	// datadog.yaml.
 	log.Debugf("%s | calling secret_backend_command with payload: '%s'", time.Now().String(), inputPayload)
 	start := time.Now()
-	err := cmd.Run()
+	err = cmd.Run()
 	elapsed := time.Since(start)
 	log.Debugf("%s | secret_backend_command '%s' completed in %s", time.Now().String(), secretBackendCommand, elapsed)
 

--- a/pkg/secrets/fetch_secret_test.go
+++ b/pkg/secrets/fetch_secret_test.go
@@ -35,6 +35,8 @@ func build(m *testing.M, outBin, pkg string) {
 }
 
 func TestMain(m *testing.M) {
+	testCheckRightsStub()
+
 	if runtime.GOOS == "windows" {
 		binExtension = ".exe"
 	}

--- a/releasenotes/notes/process-agent-on-win-secret-backend-a2f4668bc6bc07dc.yaml
+++ b/releasenotes/notes/process-agent-on-win-secret-backend-a2f4668bc6bc07dc.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    Allows running secrets in the Process Agent on Windows by sandboxing
+    ``secret_backend_command`` execution to the ``ddagentuser`` account used by the Core Agent service.

--- a/tasks/process_agent.py
+++ b/tasks/process_agent.py
@@ -65,11 +65,6 @@ def build(
 
     build_tags = get_build_tags(build_include, build_exclude)
 
-    ## secrets is not supported on windows because the process agent still runs as
-    ## root.  No matter what `get_default_build_tags()` returns, take secrets out.
-    if sys.platform == 'win32' and "secrets" in build_tags:
-        build_tags.remove("secrets")
-
     # TODO static option
     cmd = 'go build -mod={go_mod} {race_opt} {build_type} -tags "{go_build_tags}" '
     cmd += '-o {agent_bin} -gcflags="{gcflags}" -ldflags="{ldflags}" {REPO_PATH}/cmd/process-agent'


### PR DESCRIPTION
### What does this PR do?

Allows execution of secret backends in the Process Agent on Windows by sandboxing the execution to the same account as the Core Agent service. 

<img width="525" alt="Screen Shot 2022-12-06 at 12 14 27 PM" src="https://user-images.githubusercontent.com/30147836/206041776-db3acd02-aec7-4013-b61d-7d2bffc79395.png">

### Motivation

Allow using secret backends in the Process Agent running elevated as Local System.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

- Ensure it is possible to configure secrets on Windows using the `ENC[]` syntax and Process Agent can retrieve the secrets using a secret backend.
- Ensure execution of the secret backend is owned by `ddagentuser`.

Example of a backend to validate execution with expected principal - `secret_backend.bat`
```
@echo off
timeout /t 10 /nobreak > NUL
echo {"api_key":{"value": "KEY"}}
```

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
