### PR TITLE
Reduce PDH overhead in go core checks

### DIFF
--- a/pkg/collector/corechecks/system/cpu/cpu_windows.go
+++ b/pkg/collector/corechecks/system/cpu/cpu_windows.go
@@ -51,11 +51,11 @@ func (c *Check) Run() error {
 	err = c.pdhQuery.CollectQueryData()
 	if err == nil {
 		// Get values for PDH counters
-		for metricname, cset := range c.counters {
+		for metricname, counter := range c.counters {
 			var val float64
-			val, err = cset.GetValue()
+			val, err = counter.GetValue()
 			if err == nil {
-				sender.Gauge(metricname, float64(val), "", nil)
+				sender.Gauge(metricname, val, "", nil)
 			} else {
 				c.Warnf("cpu.Check: Could not retrieve value for %v: %v", metricname, err)
 			}
@@ -89,7 +89,11 @@ func (counter *processorPDHCounter) AddToQuery(query *pdhutil.PdhQuery) error {
 	if err != nil {
 		counter.ObjectName = "Processor"
 		err = counter.PdhEnglishSingleInstanceCounter.AddToQuery(query)
-		counter.ObjectName = "Processor Information"
+		if err != nil {
+			// Processor failed, too. Restore default objectName so we can try it again next time.
+			counter.ObjectName = "Processor Information"
+
+		}
 	}
 	return err
 }

--- a/pkg/collector/corechecks/system/disk/iostats_pdh_windows.go
+++ b/pkg/collector/corechecks/system/disk/iostats_pdh_windows.go
@@ -43,8 +43,10 @@ type IOCheck struct {
 	core.CheckBase
 	blacklist          *regexp.Regexp
 	lowercaseDeviceTag bool
-	counters           map[string]*pdhutil.PdhMultiInstanceCounterSet
-	counternames       map[string]string
+	pdhQuery           *pdhutil.PdhQuery
+	// maps metric to counter object
+	counters     map[string]pdhutil.PdhMultiInstanceCounter
+	counternames map[string]string
 }
 
 var pfnGetDriveType = getDriveType
@@ -76,6 +78,12 @@ func (c *IOCheck) Configure(integrationConfigDigest uint64, data integration.Dat
 		return err
 	}
 
+	// Create PDH query
+	c.pdhQuery, err = pdhutil.CreatePdhQuery()
+	if err != nil {
+		return err
+	}
+
 	c.counternames = map[string]string{
 		"Disk Write Bytes/sec":      "system.io.wkb_s",
 		"Disk Writes/sec":           "system.io.w_s",
@@ -86,9 +94,9 @@ func (c *IOCheck) Configure(integrationConfigDigest uint64, data integration.Dat
 		"Avg. Disk sec/Write":       "system.io.w_await",
 	}
 
-	c.counters = make(map[string]*pdhutil.PdhMultiInstanceCounterSet)
+	c.counters = make(map[string]pdhutil.PdhMultiInstanceCounter)
 	for name := range c.counternames {
-		c.counters[name] = nil
+		c.counters[name] = c.pdhQuery.AddEnglishMultiInstanceCounter("LogicalDisk", name, isDrive)
 	}
 
 	return nil
@@ -100,56 +108,55 @@ func (c *IOCheck) Run() error {
 	if err != nil {
 		return err
 	}
-	// Try to initialize any nil counters
-	for name := range c.counternames {
-		if c.counters[name] == nil {
-			c.counters[name], err = pdhutil.GetEnglishMultiInstanceCounter("LogicalDisk", name, isDrive)
-			if err != nil {
-				c.Warnf("io.Check: could not establish LogicalDisk '%v' counter: %v", name, err)
-			}
-		}
-	}
-	var tagbuff bytes.Buffer
-	for cname, cset := range c.counters {
-		if cset == nil {
-			// counter is not yet initialized
-			continue
-		}
-		// get counter values
-		vals, err := cset.GetAllValues()
-		if err != nil {
-			c.Warnf("io.Check: Error getting values for %v: %v", cname, err)
-			continue
-		}
-		for inst, val := range vals {
-			if c.blacklist != nil && c.blacklist.MatchString(inst) {
-				log.Debugf("matched drive %s against blacklist; skipping", inst)
+
+	// Fetch PDH query values
+	err = c.pdhQuery.CollectQueryData()
+	if err == nil {
+		// Get values for PDH counters
+		var tagbuff bytes.Buffer
+		for cname, cset := range c.counters {
+			if cset == nil {
+				// counter is not yet initialized
 				continue
 			}
-			tagbuff.Reset()
-			tagbuff.WriteString("device:")
-			if c.lowercaseDeviceTag {
-				inst = strings.ToLower(inst)
+			// get counter values
+			vals, err := cset.GetAllValues()
+			if err != nil {
+				c.Warnf("io.Check: Error getting values for %v: %v", cname, err)
+				continue
 			}
-			tagbuff.WriteString(inst)
-			tags := []string{tagbuff.String()}
+			for inst, val := range vals {
+				if c.blacklist != nil && c.blacklist.MatchString(inst) {
+					log.Debugf("matched drive %s against blacklist; skipping", inst)
+					continue
+				}
+				tagbuff.Reset()
+				tagbuff.WriteString("device:")
+				if c.lowercaseDeviceTag {
+					inst = strings.ToLower(inst)
+				}
+				tagbuff.WriteString(inst)
+				tags := []string{tagbuff.String()}
 
-			if !driveLetterPattern.MatchString(inst) {
-				// if this is not a drive letter, add device_name to tags
-				tags = append(tags, "device_name:"+inst)
-			}
+				if !driveLetterPattern.MatchString(inst) {
+					// if this is not a drive letter, add device_name to tags
+					tags = append(tags, "device_name:"+inst)
+				}
 
-			if cname == "Disk Write Bytes/sec" || cname == "Disk Read Bytes/sec" {
-				val /= kB
-			}
-			if cname == "Avg. Disk sec/Read" || cname == "Avg. Disk sec/Write" {
-				// r_await/w_await are in milliseconds, but the performance counter
-				// is (obviously) in seconds.  Normalize:
-				val *= 1000
-			}
+				if cname == "Disk Write Bytes/sec" || cname == "Disk Read Bytes/sec" {
+					val /= kB
+				}
+				if cname == "Avg. Disk sec/Read" || cname == "Avg. Disk sec/Write" {
+					// r_await/w_await are in milliseconds, but the performance counter
+					// is (obviously) in seconds.  Normalize:
+					val *= 1000
+				}
 
-			sender.Gauge(c.counternames[cname], val, "", tags)
+				sender.Gauge(c.counternames[cname], val, "", tags)
+			}
 		}
+	} else {
+		c.Warnf("file_handle.Check: Could not collect performance counter data: %v", err)
 	}
 
 	sender.Commit()

--- a/pkg/collector/corechecks/system/disk/iostats_pdh_windows.go
+++ b/pkg/collector/corechecks/system/disk/iostats_pdh_windows.go
@@ -114,13 +114,13 @@ func (c *IOCheck) Run() error {
 	if err == nil {
 		// Get values for PDH counters
 		var tagbuff bytes.Buffer
-		for cname, cset := range c.counters {
-			if cset == nil {
+		for cname, counter := range c.counters {
+			if counter == nil {
 				// counter is not yet initialized
 				continue
 			}
 			// get counter values
-			vals, err := cset.GetAllValues()
+			vals, err := counter.GetAllValues()
 			if err != nil {
 				c.Warnf("io.Check: Error getting values for %v: %v", cname, err)
 				continue

--- a/pkg/collector/corechecks/system/filehandles/file_handles_windows.go
+++ b/pkg/collector/corechecks/system/filehandles/file_handles_windows.go
@@ -35,11 +35,11 @@ func (c *fhCheck) Run() error {
 	err = c.pdhQuery.CollectQueryData()
 	if err == nil {
 		// Get values for PDH counters
-		for metricname, cset := range c.counters {
+		for metricname, counter := range c.counters {
 			var val float64
-			val, err = cset.GetValue()
+			val, err = counter.GetValue()
 			if err == nil {
-				sender.Gauge(metricname, float64(val), "", nil)
+				sender.Gauge(metricname, val, "", nil)
 			} else {
 				c.Warnf("file_handle.Check: Error getting process handle count: %v", err)
 			}

--- a/pkg/collector/corechecks/system/filehandles/file_handles_windows.go
+++ b/pkg/collector/corechecks/system/filehandles/file_handles_windows.go
@@ -11,7 +11,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/winutil/pdhutil"
 )
 
@@ -19,7 +18,9 @@ const fileHandlesCheckName = "file_handle"
 
 type fhCheck struct {
 	core.CheckBase
-	counter *pdhutil.PdhSingleInstanceCounterSet
+	pdhQuery *pdhutil.PdhQuery
+	// maps metric to counter object
+	counters map[string]pdhutil.PdhSingleInstanceCounter
 }
 
 // Run executes the check
@@ -30,20 +31,21 @@ func (c *fhCheck) Run() error {
 		return err
 	}
 
-	var val float64
-
-	// counter ("Process", "Handle count")
-	if c.counter == nil {
-		c.counter, err = pdhutil.GetEnglishCounterInstance("Process", "Handle Count", "_Total")
-	}
-	if c.counter != nil {
-		val, err = c.counter.GetValue()
-	}
-	if err != nil {
-		c.Warnf("file_handle.Check: Error getting process handle count: %v", err)
+	// Fetch PDH query values
+	err = c.pdhQuery.CollectQueryData()
+	if err == nil {
+		// Get values for PDH counters
+		for metricname, cset := range c.counters {
+			var val float64
+			val, err = cset.GetValue()
+			if err == nil {
+				sender.Gauge(metricname, float64(val), "", nil)
+			} else {
+				c.Warnf("file_handle.Check: Error getting process handle count: %v", err)
+			}
+		}
 	} else {
-		log.Debugf("Submitting system.fs.file_handles_in_use %v", val)
-		sender.Gauge("system.fs.file_handles.in_use", float64(val), "", nil)
+		c.Warnf("file_handle.Check: Could not collect performance counter data: %v", err)
 	}
 
 	sender.Commit()
@@ -54,6 +56,16 @@ func (c *fhCheck) Run() error {
 func (c *fhCheck) Configure(integrationConfigDigest uint64, data integration.Data, initConfig integration.Data, source string) (err error) {
 	if err := c.CommonConfigure(integrationConfigDigest, initConfig, data, source); err != nil {
 		return err
+	}
+
+	// Create PDH query
+	c.pdhQuery, err = pdhutil.CreatePdhQuery()
+	if err != nil {
+		return err
+	}
+
+	c.counters = map[string]pdhutil.PdhSingleInstanceCounter{
+		"system.fs.file_handles.in_use": c.pdhQuery.AddEnglishCounterInstance("Process", "Handle Count", "_Total"),
 	}
 
 	return err

--- a/pkg/collector/corechecks/system/memory/memory_windows.go
+++ b/pkg/collector/corechecks/system/memory/memory_windows.go
@@ -26,17 +26,33 @@ var (
 // Check doesn't need additional fields
 type Check struct {
 	core.CheckBase
-	cacheBytes     *pdhutil.PdhSingleInstanceCounterSet
-	committedBytes *pdhutil.PdhSingleInstanceCounterSet
-	pagedBytes     *pdhutil.PdhSingleInstanceCounterSet
-	nonpagedBytes  *pdhutil.PdhSingleInstanceCounterSet
+	pdhQuery *pdhutil.PdhQuery
+	// maps metric to counter object
+	counters map[string]pdhutil.PdhSingleInstanceCounter
 }
 
 const mbSize float64 = 1024 * 1024
 
 // Configure handles initial configuration/initialization of the check
-func (c *Check) Configure(integrationConfigDigest uint64, data integration.Data, initConfig integration.Data, source string) error {
-	return c.CommonConfigure(integrationConfigDigest, initConfig, data, source)
+func (c *Check) Configure(integrationConfigDigest uint64, data integration.Data, initConfig integration.Data, source string) (err error) {
+	if err := c.CommonConfigure(integrationConfigDigest, initConfig, data, source); err != nil {
+		return err
+	}
+
+	// Create PDH query
+	c.pdhQuery, err = pdhutil.CreatePdhQuery()
+	if err != nil {
+		return err
+	}
+
+	c.counters = map[string]pdhutil.PdhSingleInstanceCounter{
+		"system.mem.cached":    c.pdhQuery.AddEnglishSingleInstanceCounter("Memory", "Cache Bytes"),
+		"system.mem.committed": c.pdhQuery.AddEnglishSingleInstanceCounter("Memory", "Committed Bytes"),
+		"system.mem.paged":     c.pdhQuery.AddEnglishSingleInstanceCounter("Memory", "Pool Paged Bytes"),
+		"system.mem.nonpaged":  c.pdhQuery.AddEnglishSingleInstanceCounter("Memory", "Pool Nonpaged Bytes"),
+	}
+
+	return err
 }
 
 // Run executes the check
@@ -46,58 +62,21 @@ func (c *Check) Run() error {
 		return err
 	}
 
-	var val float64
-
-	// counter ("Memory", "Cache Bytes")
-	if c.cacheBytes == nil {
-		c.cacheBytes, err = pdhutil.GetEnglishSingleInstanceCounter("Memory", "Cache Bytes")
-	}
-	if c.cacheBytes != nil {
-		val, err = c.cacheBytes.GetValue()
-	}
+	// Fetch PDH query values
+	err = c.pdhQuery.CollectQueryData()
 	if err == nil {
-		sender.Gauge("system.mem.cached", float64(val)/mbSize, "", nil)
+		// Get values for PDH counters
+		for metricname, cset := range c.counters {
+			var val float64
+			val, err = cset.GetValue()
+			if err == nil {
+				sender.Gauge(metricname, float64(val)/mbSize, "", nil)
+			} else {
+				c.Warnf("memory.Check: Could not retrieve value for %v: %v", metricname, err)
+			}
+		}
 	} else {
-		c.Warnf("memory.Check: Could not retrieve value for system.mem.cached: %v", err)
-	}
-
-	// counter ("Memory", "Committed Bytes")
-	if c.committedBytes == nil {
-		c.committedBytes, err = pdhutil.GetEnglishSingleInstanceCounter("Memory", "Committed Bytes")
-	}
-	if c.committedBytes != nil {
-		val, err = c.committedBytes.GetValue()
-	}
-	if err == nil {
-		sender.Gauge("system.mem.committed", float64(val)/mbSize, "", nil)
-	} else {
-		c.Warnf("memory.Check: Could not retrieve value for system.mem.committed: %v", err)
-	}
-
-	// counter ("Memory", "Pool Paged Bytes")
-	if c.pagedBytes == nil {
-		c.pagedBytes, err = pdhutil.GetEnglishSingleInstanceCounter("Memory", "Pool Paged Bytes")
-	}
-	if c.pagedBytes != nil {
-		val, err = c.pagedBytes.GetValue()
-	}
-	if err == nil {
-		sender.Gauge("system.mem.paged", float64(val)/mbSize, "", nil)
-	} else {
-		c.Warnf("memory.Check: Could not retrieve value for system.mem.paged: %v", err)
-	}
-
-	// counter ("Memory", "Pool Nonpaged Bytes")
-	if c.nonpagedBytes == nil {
-		c.nonpagedBytes, err = pdhutil.GetEnglishSingleInstanceCounter("Memory", "Pool Nonpaged Bytes")
-	}
-	if c.nonpagedBytes != nil {
-		val, err = c.nonpagedBytes.GetValue()
-	}
-	if err == nil {
-		sender.Gauge("system.mem.nonpaged", float64(val)/mbSize, "", nil)
-	} else {
-		c.Warnf("memory.Check: Could not retrieve value for system.mem.nonpaged: %v", err)
+		c.Warnf("memory.Check: Could not collect performance counter data: %v", err)
 	}
 
 	v, errVirt := virtualMemory()

--- a/pkg/collector/corechecks/system/memory/memory_windows.go
+++ b/pkg/collector/corechecks/system/memory/memory_windows.go
@@ -66,11 +66,11 @@ func (c *Check) Run() error {
 	err = c.pdhQuery.CollectQueryData()
 	if err == nil {
 		// Get values for PDH counters
-		for metricname, cset := range c.counters {
+		for metricname, counter := range c.counters {
 			var val float64
-			val, err = cset.GetValue()
+			val, err = counter.GetValue()
 			if err == nil {
-				sender.Gauge(metricname, float64(val)/mbSize, "", nil)
+				sender.Gauge(metricname, val/mbSize, "", nil)
 			} else {
 				c.Warnf("memory.Check: Could not retrieve value for %v: %v", metricname, err)
 			}

--- a/pkg/collector/corechecks/system/winproc/winproc_windows.go
+++ b/pkg/collector/corechecks/system/winproc/winproc_windows.go
@@ -18,8 +18,9 @@ const winprocCheckName = "winproc"
 
 type processChk struct {
 	core.CheckBase
-	numprocs *pdhutil.PdhSingleInstanceCounterSet
-	pql      *pdhutil.PdhSingleInstanceCounterSet
+	pdhQuery *pdhutil.PdhQuery
+	// maps metric to counter object
+	counters map[string]pdhutil.PdhSingleInstanceCounter
 }
 
 // Run executes the check
@@ -29,32 +30,21 @@ func (c *processChk) Run() error {
 		return err
 	}
 
-	var val float64
-
-	// counter ("System", "Processes")
-	if c.numprocs == nil {
-		c.numprocs, err = pdhutil.GetEnglishSingleInstanceCounter("System", "Processes")
-	}
-	if c.numprocs != nil {
-		val, err = c.numprocs.GetValue()
-	}
+	// Fetch PDH query values
+	err = c.pdhQuery.CollectQueryData()
 	if err == nil {
-		sender.Gauge("system.proc.count", val, "", nil)
+		// Get values for PDH counters
+		for metricname, cset := range c.counters {
+			var val float64
+			val, err = cset.GetValue()
+			if err == nil {
+				sender.Gauge(metricname, val, "", nil)
+			} else {
+				c.Warnf("winproc.Check: Could not retrieve value for %v: %v", metricname, err)
+			}
+		}
 	} else {
-		c.Warnf("winproc.Check: Error getting number of processes: %v", err)
-	}
-
-	// counter ("System", "Processor Queue Length")
-	if c.pql == nil {
-		c.pql, err = pdhutil.GetEnglishSingleInstanceCounter("System", "Processor Queue Length")
-	}
-	if c.pql != nil {
-		val, err = c.pql.GetValue()
-	}
-	if err == nil {
-		sender.Gauge("system.proc.queue_length", val, "", nil)
-	} else {
-		c.Warnf("winproc.Check: Error getting processor queue length: %v", err)
+		c.Warnf("winproc.Check: Could not collect performance counter data: %v", err)
 	}
 
 	sender.Commit()
@@ -65,6 +55,17 @@ func (c *processChk) Configure(integrationConfigDigest uint64, data integration.
 	err := c.CommonConfigure(integrationConfigDigest, initConfig, data, source)
 	if err != nil {
 		return err
+	}
+
+	// Create PDH query
+	c.pdhQuery, err = pdhutil.CreatePdhQuery()
+	if err != nil {
+		return err
+	}
+
+	c.counters = map[string]pdhutil.PdhSingleInstanceCounter{
+		"system.proc.count":        c.pdhQuery.AddEnglishSingleInstanceCounter("System", "Processes"),
+		"system.proc.queue_length": c.pdhQuery.AddEnglishSingleInstanceCounter("System", "Processor Queue Length"),
 	}
 
 	return err

--- a/pkg/collector/corechecks/system/winproc/winproc_windows.go
+++ b/pkg/collector/corechecks/system/winproc/winproc_windows.go
@@ -34,9 +34,9 @@ func (c *processChk) Run() error {
 	err = c.pdhQuery.CollectQueryData()
 	if err == nil {
 		// Get values for PDH counters
-		for metricname, cset := range c.counters {
+		for metricname, counter := range c.counters {
 			var val float64
-			val, err = cset.GetValue()
+			val, err = counter.GetValue()
 			if err == nil {
 				sender.Gauge(metricname, val, "", nil)
 			} else {

--- a/pkg/util/winutil/pdhutil/pdhcounter.go
+++ b/pkg/util/winutil/pdhutil/pdhcounter.go
@@ -13,6 +13,11 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
+// NOTE TO DEVELOPER
+//
+// This package uses terminology defined by the following MSDN article
+// https://learn.microsoft.com/en-us/windows/win32/perfctrs/about-performance-counters
+
 // For testing
 var (
 	pfnPdhOpenQuery                     = PdhOpenQuery
@@ -24,123 +29,218 @@ var (
 	pfnPdhMakeCounterPath               = pdhMakeCounterPath
 )
 
-// CounterInstanceVerify is a callback function called by GetCounterSet for each
+// CounterInstanceVerify is a callback function called by GetAllValues for each
 // instance of the counter.  Implementation should return true if that instance
 // should be included, false otherwise
 type CounterInstanceVerify func(string) bool
 
-// PdhCounterSet is the object which represents a pdh counter set.
-type PdhCounterSet struct {
-	className string
-	query     PDH_HQUERY
-	counter   PDH_HCOUNTER
-
-	counterName string
+// Manages a PDH Query
+// https://learn.microsoft.com/en-us/windows/win32/perfctrs/creating-a-query
+// https://learn.microsoft.com/en-us/windows/win32/api/pdh/nf-pdh-pdhopenqueryw
+type PdhQuery struct {
+	handle   PDH_HQUERY
+	counters []PdhCounter
 }
 
-// PdhSingleInstanceCounterSet is a specialization for single instance counters
-type PdhSingleInstanceCounterSet struct {
-	PdhCounterSet
+// Manages behavior common to all types of PDH counters
+// https://learn.microsoft.com/en-us/windows/win32/api/pdh/nf-pdh-pdhaddenglishcounterw
+type PdhCounter interface {
+	// Return true if a query should attempt to initialize this counter.
+	// Return false if a query must not attempt to initialize this counter.
+	ShouldInit() bool
+
+	// Called during (*PdhQuery).CollectQueryData for counters that return true from ShouldInit()
+	// Must call the appropriate PdhAddCounter/PdhAddEnglishCounter function to add the
+	// counter to the query.
+	AddToQuery(*PdhQuery) error
 }
 
-// PdhMultiInstanceCounterSet is a specialization for a multiple instance counter
-type PdhMultiInstanceCounterSet struct {
-	PdhCounterSet
+// Manages a PDH counter with no instance or for a specific instance
+// Only a single value is returned.
+// https://learn.microsoft.com/en-us/windows/win32/perfctrs/specifying-a-counter-path
+type PdhSingleInstanceCounter interface {
+	PdhCounter
+	// Return the counter value formatted as a float
+	GetValue() (float64, error)
+}
+
+// Manages a PDH counter that can have multiple instances
+// Returns a value for every instance
+// https://learn.microsoft.com/en-us/windows/win32/perfctrs/specifying-a-counter-path
+type PdhMultiInstanceCounter interface {
+	PdhCounter
+	// Return a map of instance name -> counter value formatted as a float
+	GetAllValues() (map[string]float64, error)
+}
+
+// pdhCounter contains info that is common to all counter types
+type pdhCounter struct {
+	handle PDH_HCOUNTER
+
+	// Parts of PDH counter path
+	objectName   string // also referred to by Microsoft as a counterset, class, or performance object
+	instanceName string
+	counterName  string
+
+	initError error
+}
+
+// pdhEnglishCounter implements AddToQuery for both single and multi instance english counters
+type pdhEnglishCounter struct {
+	pdhCounter
+}
+
+// pdhEnglishSingleInstanceCounter is a specialization for single-instance counters
+// https://learn.microsoft.com/en-us/windows/win32/perfctrs/about-performance-counters
+type pdhEnglishSingleInstanceCounter struct {
+	pdhEnglishCounter
+}
+
+// pdhMultiInstanceCounterSet is a specialization for a multi-instance counters
+// https://learn.microsoft.com/en-us/windows/win32/perfctrs/about-performance-counters
+type pdhEnglishMultiInstanceCounter struct {
+	pdhEnglishCounter
 	verifyfn CounterInstanceVerify
 }
 
-// Initialize initializes a counter set object
-func (p *PdhCounterSet) Initialize(className string, counterName string) error {
+func (counter *pdhCounter) ShouldInit() bool {
+	if counter.handle != PDH_HCOUNTER(0) {
+		// already initialized
+		return false
+	}
+	return true
+}
 
-	// refresh PDH object cache (refresh will only occur periodically)
-	_, _ = tryRefreshPdhObjectCache()
-
-	p.className = className
-	p.counterName = counterName
-
-	pdherror := pfnPdhOpenQuery(uintptr(0), uintptr(0), &p.query)
+// Implements PdhCounter.AddToQuery for english counters.
+func (counter *pdhEnglishCounter) AddToQuery(query *PdhQuery) error {
+	path, err := pfnPdhMakeCounterPath("", counter.objectName, counter.instanceName, counter.counterName)
+	if err != nil {
+		counter.initError = fmt.Errorf("Failed to make counter path (\\%s(%s)\\%s): %v", counter.objectName, counter.instanceName, counter.counterName, err)
+		return counter.initError
+	}
+	pdherror := pfnPdhAddEnglishCounter(query.handle, path, uintptr(0), &counter.handle)
 	if ERROR_SUCCESS != pdherror {
-		err := fmt.Errorf("Failed to open PDH query handle %#x", pdherror)
-		return err
+		counter.initError = fmt.Errorf("Failed to add english counter (\\%s(%s)\\%s): %#x", counter.objectName, counter.instanceName, counter.counterName, pdherror)
+		return counter.initError
+	}
+	counter.initError = nil
+	return nil
+}
+
+// AddEnglishCounterInstance returns a PdhSingleInstanceCounter that will fetch the value of a given instance of the given counter.
+// the objectName and counterName must be in English.
+// See PdhAddEnglishCounter docs for details
+// https://learn.microsoft.com/en-us/windows/win32/api/pdh/nf-pdh-pdhaddenglishcounterw
+//
+// Implementation detail: This function does not actually call the Windows API PdhAddEnglishCounter. That happens
+//   when (*PdhQuery).CollectQueryData calls PdhCounter.AddToQuery. This function only links our pdhCounter struct
+//   to our PdhQuery struct.
+//   We do this so we can handle several PDH error cases and their recovery behind the scenes to reduce
+//   duplicate/error prone code in the checks that uses this package.
+//   For example, see tryRefreshPdhObjectCache().
+//   This function cannot fail, if it does then the checks that use it will need to be
+//   restructured so that their Configure() call does not fail if the counter is not available
+//   right away on host boot (see https://github.com/DataDog/datadog-agent/pull/13101).
+//   All errors related to the counter are returned from the GetValue()/GetAllValues() function.
+//
+func (query *PdhQuery) AddEnglishCounterInstance(objectName string, counterName string, instanceName string) PdhSingleInstanceCounter {
+	var p pdhEnglishSingleInstanceCounter
+	p.Initialize(objectName, counterName, instanceName)
+	query.counters = append(query.counters, &p)
+	return &p
+}
+
+// AddEnglishSingleInstanceCounter returns a PdhSingleInstanceCounter that will fetch a single instance counter value.
+// the objectName and counterName must be in English.
+// See PdhAddEnglishCounter docs for details
+// https://learn.microsoft.com/en-us/windows/win32/api/pdh/nf-pdh-pdhaddenglishcounterw
+//
+// Implementation detail: See AddEnglishCounterInstance()
+func (query *PdhQuery) AddEnglishSingleInstanceCounter(objectName string, counterName string) PdhSingleInstanceCounter {
+	return query.AddEnglishCounterInstance(objectName, counterName, "")
+}
+
+// AddMultiInstanceCounter returns a PdhMultiInstanceCounter that will fetch values for all instances of a counter.
+// This uses a '*' wildcard to collect values for all instances of a counter.
+// Instances/values can be filtered manually once returned from GetAllValues() or with verifyfn (see CounterInstanceVerify)
+//
+// Implementation detail: See AddEnglishCounterInstance()
+func (query *PdhQuery) AddEnglishMultiInstanceCounter(objectName string, counterName string, verifyfn CounterInstanceVerify) PdhMultiInstanceCounter {
+	var p pdhEnglishMultiInstanceCounter
+	// Use the * wildcard to collect all instances
+	p.Initialize(objectName, counterName, "*")
+	p.verifyfn = verifyfn
+	query.counters = append(query.counters, &p)
+	return &p
+}
+
+// Must be called before GetValue/GetAllValues to make new counter values available.
+// https://learn.microsoft.com/en-us/windows/win32/api/pdh/nf-pdh-pdhcollectquerydata
+func (query *PdhQuery) CollectQueryData() error {
+	// iterate each of the counters and try to add them to the query
+	var addedNewCounter = false
+	for _, counter := range query.counters {
+		if counter.ShouldInit() {
+			// refresh PDH object cache (refresh will only occur periodically)
+			// This will update Windows PDH internals and make any newly
+			// initialized (during host boot) or newly enabled counters available to us.
+			// https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2003/cc784382(v=ws.10)
+			_, _ = tryRefreshPdhObjectCache()
+
+			err := counter.AddToQuery(query)
+			if err == nil {
+				addedNewCounter = true
+			} else {
+				log.Warnf("Failed to add counter to query: %v. This error indicates that the Windows performance counter database may need to be rebuilt", err)
+			}
+		}
+	}
+	if addedNewCounter {
+		// if we added a new counter then we need an additional call to
+		// PdhCollectQuery data because some counters require two datapoints
+		// before they can return a value.
+		pdherror := pfnPdhCollectQueryData(query.handle)
+		if ERROR_SUCCESS != pdherror {
+			return fmt.Errorf("Failed to collect query data %#x. This error indicates that the Windows performance counter database may need to be rebuilt.", pdherror)
+		}
+	}
+
+	// Update the counters
+	pdherror := pfnPdhCollectQueryData(query.handle)
+	if ERROR_SUCCESS != pdherror {
+		return fmt.Errorf("Failed to collect query data %#x. This error indicates that the Windows performance counter database may need to be rebuilt.", pdherror)
 	}
 	return nil
 }
 
-// GetEnglishCounterInstance returns a specific instance of the given counter
-// the className and counterName must be in English.
-// See PdhAddEnglishCounter docs for details
-// https://learn.microsoft.com/en-us/windows/win32/api/pdh/nf-pdh-pdhaddenglishcountera
-func GetEnglishCounterInstance(className string, counterName string, instance string) (*PdhSingleInstanceCounterSet, error) {
+// Initialize initializes a pdhCounter object
+func (counter *pdhCounter) Initialize(objectName string, counterName string, instanceName string) {
 
-	var p PdhSingleInstanceCounterSet
-	if err := p.Initialize(className, counterName); err != nil {
-		return nil, err
-	}
-
-	path, err := pfnPdhMakeCounterPath("", className, instance, counterName)
-	if err != nil {
-		return nil, fmt.Errorf("Failed to make counter path %s: %v", counterName, err)
-	}
-	pdherror := pfnPdhAddEnglishCounter(p.query, path, uintptr(0), &p.counter)
-	if ERROR_SUCCESS != pdherror {
-		return nil, fmt.Errorf("Failed to add english counter %#x", pdherror)
-	}
-	pdherror = pfnPdhCollectQueryData(p.query)
-	if ERROR_SUCCESS != pdherror {
-		return nil, fmt.Errorf("Failed to collect query data %#x", pdherror)
-	}
-	return &p, nil
+	counter.objectName = objectName
+	counter.counterName = counterName
+	counter.instanceName = instanceName
 }
 
-// GetEnglishSingleInstanceCounter returns a single instance counter object for the given counter class
-// the className and counterName must be in English.
-// See PdhAddEnglishCounter docs for details
-// https://learn.microsoft.com/en-us/windows/win32/api/pdh/nf-pdh-pdhaddenglishcountera
-func GetEnglishSingleInstanceCounter(className string, counterName string) (*PdhSingleInstanceCounterSet, error) {
-	return GetEnglishCounterInstance(className, counterName, "")
-}
-
-// GetMultiInstanceCounter returns a multi-instance counter object for the given counter class
-func GetEnglishMultiInstanceCounter(className string, counterName string, verifyfn CounterInstanceVerify) (*PdhMultiInstanceCounterSet, error) {
-	var p PdhMultiInstanceCounterSet
-	if err := p.Initialize(className, counterName); err != nil {
-		return nil, err
-	}
-
-	p.verifyfn = verifyfn
-
-	// Use the * wildcard to collect all instances
-	path, err := pfnPdhMakeCounterPath("", className, "*", counterName)
-	if err != nil {
-		return nil, fmt.Errorf("Failed to make counter path %s: %v", counterName, err)
-	}
-	pdherror := pfnPdhAddEnglishCounter(p.query, path, uintptr(0), &p.counter)
-	if ERROR_SUCCESS != pdherror {
-		return nil, fmt.Errorf("Failed to add english counter %#x", pdherror)
-	}
-	pdherror = pfnPdhCollectQueryData(p.query)
-	if ERROR_SUCCESS != pdherror {
-		return nil, fmt.Errorf("Failed to collect query data %#x", pdherror)
-	}
-
-	return &p, nil
-}
-
-// GetAllValues returns the data associated with each instance in a query.
+// GetAllValues returns the data associated with each instance in a counter.
 // verifyfn is used to filter out instance names that are returned
 // instance:value pairs are not returned for items whose CStatus contains an error
-func (p *PdhMultiInstanceCounterSet) GetAllValues() (values map[string]float64, err error) {
-	// update data
-	pfnPdhCollectQueryData(p.query)
+func (counter *pdhEnglishMultiInstanceCounter) GetAllValues() (values map[string]float64, err error) {
+	if counter.handle == PDH_HCOUNTER(0) {
+		// If there was an error initializing this counter, return it here
+		if counter.initError != nil {
+			return nil, counter.initError
+		}
+		return nil, fmt.Errorf("Counter is not initialized")
+	}
 	// fetch data
-	items, err := pfnPdhGetFormattedCounterArray(p.counter, PDH_FMT_DOUBLE)
+	items, err := pfnPdhGetFormattedCounterArray(counter.handle, PDH_FMT_DOUBLE)
 	if err != nil {
 		return nil, err
 	}
 	values = make(map[string]float64)
 	for _, item := range items {
-		if p.verifyfn != nil {
-			if p.verifyfn(item.instance) == false {
+		if counter.verifyfn != nil {
+			if counter.verifyfn(item.instance) == false {
 				// not interested, moving on
 				continue
 			}
@@ -149,7 +249,7 @@ func (p *PdhMultiInstanceCounterSet) GetAllValues() (values map[string]float64, 
 			item.value.CStatus != PDH_CSTATUS_NEW_DATA {
 			// Does not necessarily indicate the problem, e.g. the process may have
 			// exited by the time the formatting of its counter values happened
-			log.Debugf("Counter value not valid for %s[%s]: %#x", p.counterName, item.instance, item.value.CStatus)
+			log.Debugf("Counter value not valid for %s[%s]: %#x", counter.counterName, item.instance, item.value.CStatus)
 			continue
 		}
 		values[item.instance] = item.value.Double
@@ -158,16 +258,31 @@ func (p *PdhMultiInstanceCounterSet) GetAllValues() (values map[string]float64, 
 }
 
 // GetValue returns the data associated with a single-value counter
-func (p *PdhSingleInstanceCounterSet) GetValue() (val float64, err error) {
-	if p.counter == PDH_HCOUNTER(0) {
-		return 0, fmt.Errorf("Not a single-value counter")
+func (counter *pdhEnglishSingleInstanceCounter) GetValue() (float64, error) {
+	if counter.handle == PDH_HCOUNTER(0) {
+		// If there was an error initializing this counter, return it here
+		if counter.initError != nil {
+			return 0, counter.initError
+		}
+		return 0, fmt.Errorf("Counter is not initialized")
 	}
-	pfnPdhCollectQueryData(p.query)
-	return pfnPdhGetFormattedCounterValueFloat(p.counter)
+	// fetch data
+	return pfnPdhGetFormattedCounterValueFloat(counter.handle)
+}
 
+// Create a query that can have counters added to it
+func CreatePdhQuery() (*PdhQuery, error) {
+	var q PdhQuery
+
+	pdherror := pfnPdhOpenQuery(uintptr(0), uintptr(0), &q.handle)
+	if ERROR_SUCCESS != pdherror {
+		err := fmt.Errorf("Failed to open PDH query handle %#x", pdherror)
+		return nil, err
+	}
+	return &q, nil
 }
 
 // Close closes the query handle, freeing the underlying windows resources.
-func (p *PdhCounterSet) Close() {
-	pfnPdhCloseQuery(p.query)
+func (query *PdhQuery) Close() {
+	pfnPdhCloseQuery(query.handle)
 }

--- a/pkg/util/winutil/pdhutil/pdhcounter.go
+++ b/pkg/util/winutil/pdhutil/pdhcounter.go
@@ -120,7 +120,7 @@ func (counter *pdhEnglishCounter) AddToQuery(query *PdhQuery) error {
 	}
 	pdherror := pfnPdhAddEnglishCounter(query.handle, path, uintptr(0), &counter.handle)
 	if ERROR_SUCCESS != pdherror {
-		counter.initError = fmt.Errorf("Failed to add english counter (\\%s(%s)\\%s): %#x", counter.ObjectName, counter.InstanceName, counter.CounterName, pdherror)
+		counter.initError = fmt.Errorf("Failed to add english counter (%s): %#x", path, pdherror)
 		return counter.initError
 	}
 	counter.initError = nil
@@ -195,7 +195,7 @@ func (query *PdhQuery) CollectQueryData() error {
 			if err == nil {
 				addedNewCounter = true
 			} else {
-				log.Warnf("Failed to add counter to query: %v. This error indicates that the Windows performance counter database may need to be rebuilt", err)
+				log.Warnf("Failed to add counter to query: %v. This error indicates that the Windows performance counter database may need to be rebuilt.", err)
 			}
 		}
 	}
@@ -219,7 +219,6 @@ func (query *PdhQuery) CollectQueryData() error {
 
 // Initialize initializes a pdhCounter object
 func (counter *pdhCounter) Initialize(objectName string, counterName string, instanceName string) {
-
 	counter.ObjectName = objectName
 	counter.CounterName = counterName
 	counter.InstanceName = instanceName

--- a/releasenotes/notes/reduce-pdh-overhead-9e915f2ac9deb085.yaml
+++ b/releasenotes/notes/reduce-pdh-overhead-9e915f2ac9deb085.yaml
@@ -1,0 +1,7 @@
+---
+enhancements:
+  - |
+    Reduce the overhead of using Windows Performance Counters / PDH in checks.
+fixes:
+  - |
+    Fix a PDH query handle leak that occurred when a counter failed to add to a query.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Reorganizes the go PDH library so that each check can use a single PDH query for all counters. This reduces PDH overhead by reducing the number of query handles as well as the number of calls to `PdhCollectQueryData`.

Also fixes a PDH query handle leak that occurred in the `Get*Counter()` constructors if the query was succesfully created by `Initialize()` but then adding the counter to the query fails.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

PDH Query handle leak
https://datadoghq.atlassian.net/browse/WA-173
Reduce PdhCollectQueryData calls
https://datadoghq.atlassian.net/browse/WA-133

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

ensure that the metrics supplied by the checks are available.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
