### PR TITLE
Add windows_counter_init_failure_limit option

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1193,6 +1193,27 @@ func InitConfig(config Config) {
 	// Windows Performance Counter refresh interval
 	// Controls if and how often Performance Counters need to be refreshed by the agent. This is mainly used in integrations that rely on Performance Counters.
 	config.BindEnvAndSetDefault("windows_counter_refresh_interval", 60)
+	// Added in Agent version 7.42
+	// Limits the number of times a check will attempt to initialize a performance pounter before ceasing
+	// attempts to initialize the counter.
+	// Typically there is one attempt per check run.
+	// This allows the Agent to stop incurring the overhead of trying to initialize a counter that
+	// will probably never succeed. For example, when the performance counter database needs to be rebuilt,
+	// or the counter is disabled.
+	//
+	// The value of this option should be chosen in consideration with the windows_counter_refresh_interval option.
+	// The performance counter cache is refreshed during subsequent attempts to intiialize a counter that failed
+	// the first time (with consideration of the windows_counter_refresh_interval value).
+	// It is unknown if it is possible for a counter that failed to initialize to later succeed without a refresh
+	// in between the attempts. Consequently, if windows_counter_refresh_interval is 0 (disabled), then this option should
+	// be 1. If this option is too small compared to the windows_counter_refresh_interval, it is possible to reach the limit
+	// before a refresh occurs. Typically there is one attempt per check run, and check runs are 15 seconds apart by default.
+	//
+	// Increasing this value may help in the rare instance where counters are not available for some time after host boot.
+	//
+	// Setting this option to 0 disables the limit and the Agent will attempt to initialize the counter forever.
+	// The default value of 20 means the Agent will retry counter intialization for roughly 5 minutes.
+	config.BindEnvAndSetDefault("windows_counter_init_failure_limit", 20)
 
 	// Vector integration
 	bindVectorOptions(config, Metrics)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1199,6 +1199,7 @@ func InitConfig(config Config) {
 	// attempts to initialize the counter. This allows the Agent to stop incurring the overhead of trying
 	// to initialize a counter that will probably never succeed. For example, when the performance counter
 	// database needs to be rebuilt or the counter is disabled.
+	// https://learn.microsoft.com/en-us/troubleshoot/windows-server/performance/manually-rebuild-performance-counters
 	//
 	// The value of this option should be chosen in consideration with the windows_counter_refresh_interval option.
 	// The performance counter cache is refreshed during subsequent attempts to intiialize a counter that failed

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1195,7 +1195,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("windows_counter_refresh_interval", 60)
 
 	// Added in Agent version 7.42
-	// Limits the number of times a check will attempt to initialize a performance pounter before ceasing
+	// Limits the number of times a check will attempt to initialize a performance counter before ceasing
 	// attempts to initialize the counter. This allows the Agent to stop incurring the overhead of trying
 	// to initialize a counter that will probably never succeed. For example, when the performance counter
 	// database needs to be rebuilt or the counter is disabled.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1196,9 +1196,9 @@ func InitConfig(config Config) {
 
 	// Added in Agent version 7.42
 	// Limits the number of times a check will attempt to initialize a performance pounter before ceasing
-	// attempts to initialize the counter. Typically there is one attempt per check run. This allows the Agent
-	// to stop incurring the overhead of trying to initialize a counter that will probably never succeed.
-	// For example, when the performance counter database needs to be rebuilt, or the counter is disabled.
+	// attempts to initialize the counter. This allows the Agent to stop incurring the overhead of trying
+	// to initialize a counter that will probably never succeed. For example, when the performance counter
+	// database needs to be rebuilt or the counter is disabled.
 	//
 	// The value of this option should be chosen in consideration with the windows_counter_refresh_interval option.
 	// The performance counter cache is refreshed during subsequent attempts to intiialize a counter that failed

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1193,13 +1193,12 @@ func InitConfig(config Config) {
 	// Windows Performance Counter refresh interval
 	// Controls if and how often Performance Counters need to be refreshed by the agent. This is mainly used in integrations that rely on Performance Counters.
 	config.BindEnvAndSetDefault("windows_counter_refresh_interval", 60)
+
 	// Added in Agent version 7.42
 	// Limits the number of times a check will attempt to initialize a performance pounter before ceasing
-	// attempts to initialize the counter.
-	// Typically there is one attempt per check run.
-	// This allows the Agent to stop incurring the overhead of trying to initialize a counter that
-	// will probably never succeed. For example, when the performance counter database needs to be rebuilt,
-	// or the counter is disabled.
+	// attempts to initialize the counter. Typically there is one attempt per check run. This allows the Agent
+	// to stop incurring the overhead of trying to initialize a counter that will probably never succeed.
+	// For example, when the performance counter database needs to be rebuilt, or the counter is disabled.
 	//
 	// The value of this option should be chosen in consideration with the windows_counter_refresh_interval option.
 	// The performance counter cache is refreshed during subsequent attempts to intiialize a counter that failed

--- a/pkg/util/winutil/pdhutil/pdhcounter.go
+++ b/pkg/util/winutil/pdhutil/pdhcounter.go
@@ -83,7 +83,7 @@ type pdhCounter struct {
 	InstanceName string
 	CounterName  string
 
-	initError error
+	initError     error
 	initFailCount int
 }
 

--- a/pkg/util/winutil/pdhutil/pdhcounter.go
+++ b/pkg/util/winutil/pdhutil/pdhcounter.go
@@ -306,6 +306,9 @@ func CreatePdhQuery() (*PdhQuery, error) {
 }
 
 // Close closes the query handle, freeing the underlying windows resources.
+// It is not necessary to remove the counters from the query before calling this function.
+// PdhCloseQuery closes all counter handles associated with the query.
+// https://learn.microsoft.com/en-us/windows/win32/perfctrs/creating-a-query
 func (query *PdhQuery) Close() {
 	pfnPdhCloseQuery(query.handle)
 }

--- a/releasenotes/notes/limit-pdh-init-failures-a4918705f55936fd.yaml
+++ b/releasenotes/notes/limit-pdh-init-failures-a4918705f55936fd.yaml
@@ -1,0 +1,6 @@
+---
+enhancements:
+  - |
+    Adds the ``windows_counter_init_failure_limit`` option.
+    This option limits the number of times a check will attempt to initialize
+    a performance counter before ceasing attempts to initialize the counter.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Adds the `windows_counter_init_failure_limit` option to limit the number of times a check will attempt to initialize a performance counter.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
If the counter initialization fails this many times it is not likely to ever succeed. So we can stop trying and incurring the overhead of refresh (if enabled, default).

https://datadoghq.atlassian.net/browse/WA-166

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
Did not add to the agent config template because the value should only need to be modified in rare circumstances (see comments in config.go).

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
* [Disable performance counters ](https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2003/cc784382(v=ws.10)), one or more of the Perf* counters will do
* Start the agent, ensure the failures are logged and counted `(Failure X/X)`
* Ensure the message about the limit being exceeded prints.
* Ensure the "add counter" failure messages stop after that. (The check.Warnf message `Failed to collect query data` doesn't count, that should still appear).

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
