### PR TITLE
pkg/trace/filters: write an error when regex compile error

### DIFF
--- a/pkg/trace/filters/blacklister.go
+++ b/pkg/trace/filters/blacklister.go
@@ -50,7 +50,7 @@ func compileRules(exprs []string) []*regexp.Regexp {
 	for _, entry := range exprs {
 		rule, err := regexp.Compile(entry)
 		if err != nil {
-			log.Errorf("Invalid resource filter: %q", entry)
+			log.Errorf("Invalid resource filter: %s: %s", entry, err)
 			continue
 		}
 		list = append(list, rule)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

- write an error when regex compile error
- `%q` safely escaped a filter string, so escaped string looks a different value from a value they set.
  - https://pkg.go.dev/fmt

Go playground: https://go.dev/play/p/P6df2bp6-3z


```
BEFORE
Invalid resource filter: "App\\Http\\Actions\\HealthAction health"

AFTER
Invalid resource filter: App\Http\Actions\HealthAction health: error parsing regexp: invalid escape sequence: `\H`
```

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Kind log message for users.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

1 ) Build trace-agent.
```bash
ubuntu@ip-172-31-4-166:~/go/src/github.com/DataDog/datadog-agent$ python3 -m invoke trace-agent.build --build-exclude=systemd
--- Setting rtloader paths to lib:/home/ubuntu/go/src/github.com/DataDog/datadog-agent/dev/lib | header:/home/ubuntu/go/src/github.com/DataDog/datadog-agent/dev/include | common headers:
```

2 ) Prepare `datadog.yaml`
```yaml
api_key: <API_KEY>
apm_config:
  enabled: true
  ignore_resources:
  - App\Http\Actions\HealthAction health
```

3 ) Run trace-agent.
```
ubuntu@ip-172-31-4-166:~/go/src/github.com/DataDog/datadog-agent$ ./bin/trace-agent/trace-agent -config ./bin/datadog.yaml
...
2022-12-08 14:43:31 UTC | TRACE | ERROR | (run.go:275 in Errorf) | Invalid resource filter: App\Http\Actions\HealthAction health: error parsing regexp: invalid escape sequence: `\H`
```

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
