### PR TITLE
NDM: Add snmp.device.[un]reachable metrics

### DIFF
--- a/pkg/collector/corechecks/snmp/common/utils.go
+++ b/pkg/collector/corechecks/snmp/common/utils.go
@@ -42,3 +42,11 @@ func CopyStrings(tags []string) []string {
 func GetAgentVersionTag() string {
 	return "agent_version:" + version.AgentVersion
 }
+
+// BoolToFloat64 converts a true/false boolean into a 1.0 or 0.0 float
+func BoolToFloat64(val bool) float64 {
+	if val {
+		return 1.
+	}
+	return 0.
+}

--- a/pkg/collector/corechecks/snmp/common/utils_test.go
+++ b/pkg/collector/corechecks/snmp/common/utils_test.go
@@ -106,3 +106,9 @@ func Test_CopyStrings(t *testing.T) {
 	assert.NotEqual(t, fmt.Sprintf("%p", tags), fmt.Sprintf("%p", newTags))
 	assert.NotEqual(t, fmt.Sprintf("%p", &tags[0]), fmt.Sprintf("%p", &newTags[0]))
 }
+
+func Test_BoolToFloat64(t *testing.T) {
+	assert.Equal(t, BoolToFloat64(true), 1.0)
+	assert.Equal(t, BoolToFloat64(false), 0.0)
+
+}

--- a/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck.go
+++ b/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck.go
@@ -34,6 +34,7 @@ import (
 const (
 	snmpLoaderTag        = "loader:core"
 	serviceCheckName     = "snmp.can_check"
+	deviceUpMetric       = "snmp.device_up"
 	deviceHostnamePrefix = "device:"
 )
 
@@ -109,10 +110,12 @@ func (d *DeviceCheck) Run(collectionTime time.Time) error {
 	if checkErr != nil {
 		tags = append(tags, d.savedDynamicTags...)
 		d.sender.ServiceCheck(serviceCheckName, metrics.ServiceCheckCritical, tags, checkErr.Error())
+		d.sender.Gauge(deviceUpMetric, 0., tags)
 	} else {
 		d.savedDynamicTags = dynamicTags
 		tags = append(tags, dynamicTags...)
 		d.sender.ServiceCheck(serviceCheckName, metrics.ServiceCheckOK, tags, "")
+		d.sender.Gauge(deviceUpMetric, 1., tags)
 	}
 	if values != nil {
 		d.sender.ReportMetrics(d.config.Metrics, values, tags)

--- a/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck.go
+++ b/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck.go
@@ -116,12 +116,8 @@ func (d *DeviceCheck) Run(collectionTime time.Time) error {
 		tags = append(tags, dynamicTags...)
 		d.sender.ServiceCheck(serviceCheckName, metrics.ServiceCheckOK, tags, "")
 	}
-	deviceReachableFloat := 0.
-	if deviceReachable {
-		deviceReachableFloat = 1
-	}
-	d.sender.Gauge(deviceReachableMetric, deviceReachableFloat, tags)
-	d.sender.Gauge(deviceUnreachableMetric, 1-deviceReachableFloat, tags)
+	d.sender.Gauge(deviceReachableMetric, common.BoolToFloat64(deviceReachable), tags)
+	d.sender.Gauge(deviceUnreachableMetric, common.BoolToFloat64(!deviceReachable), tags)
 
 	if values != nil {
 		d.sender.ReportMetrics(d.config.Metrics, values, tags)

--- a/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck_test.go
+++ b/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck_test.go
@@ -12,6 +12,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/metrics"
+
 	"github.com/gosnmp/gosnmp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -1051,13 +1053,15 @@ profiles:
 		"static_tag:from_profile_root", "some_tag:some_tag_value", "prefix:f", "suffix:oo_sys_name"}
 
 	sender.AssertServiceCheck(t, "snmp.can_check", metrics.ServiceCheckOK, "", snmpTags, "")
+	sender.AssertMetric(t, "Gauge", deviceUpMetric, 1., "", snmpTags)
 	assert.Equal(t, false, deviceCk.config.AutodetectProfile)
-
+	sender.ResetCalls()
 	sess.ConnectErr = fmt.Errorf("some error")
 	err = deviceCk.Run(time.Now())
 
 	assert.Error(t, err, "some error")
 	sender.Mock.AssertCalled(t, "ServiceCheck", "snmp.can_check", metrics.ServiceCheckCritical, "", mocksender.MatchTagsContains(snmpTags), "snmp connection error: some error")
+	sender.AssertMetric(t, "Gauge", deviceUpMetric, 0., "", snmpTags)
 }
 
 func TestRun_sessionCloseError(t *testing.T) {

--- a/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck_test.go
+++ b/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck_test.go
@@ -1053,7 +1053,8 @@ profiles:
 		"static_tag:from_profile_root", "some_tag:some_tag_value", "prefix:f", "suffix:oo_sys_name"}
 
 	sender.AssertServiceCheck(t, "snmp.can_check", metrics.ServiceCheckOK, "", snmpTags, "")
-	sender.AssertMetric(t, "Gauge", deviceUpMetric, 1., "", snmpTags)
+	sender.AssertMetric(t, "Gauge", deviceReachableMetric, 1., "", snmpTags)
+	sender.AssertMetric(t, "Gauge", deviceUnreachableMetric, 0., "", snmpTags)
 	assert.Equal(t, false, deviceCk.config.AutodetectProfile)
 	sender.ResetCalls()
 	sess.ConnectErr = fmt.Errorf("some error")
@@ -1061,7 +1062,8 @@ profiles:
 
 	assert.Error(t, err, "some error")
 	sender.Mock.AssertCalled(t, "ServiceCheck", "snmp.can_check", metrics.ServiceCheckCritical, "", mocksender.MatchTagsContains(snmpTags), "snmp connection error: some error")
-	sender.AssertMetric(t, "Gauge", deviceUpMetric, 0., "", snmpTags)
+	sender.AssertMetric(t, "Gauge", deviceUnreachableMetric, 1., "", snmpTags)
+	sender.AssertMetric(t, "Gauge", deviceReachableMetric, 0., "", snmpTags)
 }
 
 func TestRun_sessionCloseError(t *testing.T) {

--- a/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck_test.go
+++ b/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck_test.go
@@ -12,8 +12,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/metrics"
-
 	"github.com/gosnmp/gosnmp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"

--- a/releasenotes/notes/NDM---Add-snmp.device_up-metric-65a7855a959af675.yaml
+++ b/releasenotes/notes/NDM---Add-snmp.device_up-metric-65a7855a959af675.yaml
@@ -7,4 +7,4 @@
 # Each section note must be formatted as reStructuredText.
 ---
 features:
-  - NDM: Add snmp.device_up metric to all monitored devices.
+  - NDM: Add snmp.device.reachable/unreachable metrics to all monitored devices.

--- a/releasenotes/notes/NDM---Add-snmp.device_up-metric-65a7855a959af675.yaml
+++ b/releasenotes/notes/NDM---Add-snmp.device_up-metric-65a7855a959af675.yaml
@@ -1,0 +1,10 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - NDM: Add snmp.device_up metric to all monitored devices.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Add two simple metrics `snmp.device.reachable` & `snmp.device.unreachable` to track the stability of devices over time and easier setup of monitors.

### Motivation

Tracking device stability over time.

### Additional Notes

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Install on a simulated environment with devices and assert that you:
- See two new metric context per monitored devices.
- "Up" devices should report 1 for `snmp.device.reachable` and 0 for `snmp.device.unreachable`
- "Down" devices should report 0 for `snmp.device.reachable` and 1 for `snmp.device.unreachable`

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
