### PR TITLE
feat(dockerfile): Add base image labels

### DIFF
--- a/Dockerfiles/agent/amd64/Dockerfile
+++ b/Dockerfiles/agent/amd64/Dockerfile
@@ -1,4 +1,7 @@
 FROM ubuntu:22.04 AS baseimage
+LABEL baseimage.os "ubuntu jammy LTS"
+LABEL baseimage.name "ubuntu:22.04"
+
 ARG CIBUILD
 # NOTE about APT mirrorlists:
 # It seems that this feature could use some improvement. If you just get mirrorlist

--- a/Dockerfiles/agent/arm64/Dockerfile
+++ b/Dockerfiles/agent/arm64/Dockerfile
@@ -1,4 +1,7 @@
 FROM ubuntu:22.04 AS baseimage
+LABEL baseimage.os "ubuntu jammy LTS"
+LABEL baseimage.name "ubuntu:22.04"
+
 ARG CIBUILD
 # NOTE about APT mirrorlists:
 # It seems that this feature could use some improvement. If you just get mirrorlist

--- a/Dockerfiles/agent/windows/amd64/Dockerfile
+++ b/Dockerfiles/agent/windows/amd64/Dockerfile
@@ -1,5 +1,7 @@
 ARG BASE_IMAGE=mcr.microsoft.com/powershell:lts-windowsservercore-1809
 FROM ${BASE_IMAGE}
+LABEL baseimage.os "windows server core"
+LABEL baseimage.name "${BASE_IMAGE}"
 
 ARG WITH_JMX="false"
 ARG VARIANT="unknown"

--- a/Dockerfiles/cluster-agent/amd64/Dockerfile
+++ b/Dockerfiles/cluster-agent/amd64/Dockerfile
@@ -3,6 +3,8 @@
 ########################################
 
 FROM ubuntu:22.04 as builder
+LABEL baseimage.os "ubuntu jammy LTS"
+LABEL baseimage.name "ubuntu:22.04"
 
 WORKDIR /output
 

--- a/Dockerfiles/cluster-agent/arm64/Dockerfile
+++ b/Dockerfiles/cluster-agent/arm64/Dockerfile
@@ -3,6 +3,8 @@
 ########################################
 
 FROM ubuntu:22.04 as builder
+LABEL baseimage.os "ubuntu jammy LTS"
+LABEL baseimage.name "ubuntu:22.04"
 
 WORKDIR /output
 

--- a/Dockerfiles/dogstatsd/alpine/amd64/Dockerfile
+++ b/Dockerfiles/dogstatsd/alpine/amd64/Dockerfile
@@ -1,5 +1,7 @@
 FROM alpine:3.12
 
+LABEL baseimage.os "alpine"
+LABEL baseimage.name "alpine:3.12"
 LABEL maintainer "Datadog <package@datadoghq.com>"
 
 ENV DOCKER_DD_AGENT=true

--- a/Dockerfiles/dogstatsd/alpine/arm64/Dockerfile
+++ b/Dockerfiles/dogstatsd/alpine/arm64/Dockerfile
@@ -1,5 +1,7 @@
 FROM alpine:3.12
 
+LABEL baseimage.os "alpine"
+LABEL baseimage.name "alpine:3.12"
 LABEL maintainer "Datadog <package@datadoghq.com>"
 
 ENV DOCKER_DD_AGENT=true


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Add `baseimage.*` labels in Agent, Cluster-Agent and Dogstatsd dockerfiles to ease track of which versions are use to build the agents images.

### Motivation

ease base image version tracking

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

run a command like `crane config gcr.io/datadoghq/agent:7.42.0-rc.1 | jq .` and check the labels

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
