### PR TITLE
[gitlab] Add team slack channel name to CI JUnit uploads

### DIFF
--- a/tasks/libs/junit_upload.py
+++ b/tasks/libs/junit_upload.py
@@ -9,6 +9,7 @@ import xml.etree.ElementTree as ET
 
 from invoke.exceptions import Exit
 
+from .pipeline_notifications import DEFAULT_SLACK_CHANNEL, GITHUB_SLACK_MAP
 from ..flavor import AgentFlavor
 
 CODEOWNERS_ORG_PREFIX = "@DataDog/"
@@ -78,13 +79,17 @@ def upload_junitxmls(output_dir, owners, flavor, additional_tags=None, job_url="
     process_env = os.environ.copy()
     process_env["CI_JOB_URL"] = job_url
     for owner in owners:
+        codeowner = CODEOWNERS_ORG_PREFIX + owner
+        slack_channel = GITHUB_SLACK_MAP.get(codeowner, DEFAULT_SLACK_CHANNEL)[1:]
         args = [
             "--service",
             "datadog-agent",
             "--tags",
-            'test.codeowners:["' + CODEOWNERS_ORG_PREFIX + owner + '"]',
+            f'test.codeowners:["{codeowner}"]',
             "--tags",
             f"test.flavor:{flavor}",
+            "--tags",
+            f"slack_channel:{slack_channel}",
         ]
         if additional_tags:
             args.extend(additional_tags)

--- a/tasks/libs/junit_upload.py
+++ b/tasks/libs/junit_upload.py
@@ -9,8 +9,8 @@ import xml.etree.ElementTree as ET
 
 from invoke.exceptions import Exit
 
-from .pipeline_notifications import DEFAULT_SLACK_CHANNEL, GITHUB_SLACK_MAP
 from ..flavor import AgentFlavor
+from .pipeline_notifications import DEFAULT_SLACK_CHANNEL, GITHUB_SLACK_MAP
 
 CODEOWNERS_ORG_PREFIX = "@DataDog/"
 REPO_NAME_PREFIX = "github.com/DataDog/datadog-agent/"

--- a/tasks/libs/pipeline_notifications.py
+++ b/tasks/libs/pipeline_notifications.py
@@ -6,7 +6,6 @@ from collections import defaultdict
 from .common.gitlab import Gitlab, get_gitlab_token
 from .types import FailedJobType, Test
 
-
 DEFAULT_SLACK_CHANNEL = "#agent-platform"
 GITHUB_SLACK_MAP = {
     "@DataDog/agent-platform": DEFAULT_SLACK_CHANNEL,

--- a/tasks/libs/pipeline_notifications.py
+++ b/tasks/libs/pipeline_notifications.py
@@ -7,6 +7,32 @@ from .common.gitlab import Gitlab, get_gitlab_token
 from .types import FailedJobType, Test
 
 
+DEFAULT_SLACK_CHANNEL = "#agent-platform"
+GITHUB_SLACK_MAP = {
+    "@DataDog/agent-platform": DEFAULT_SLACK_CHANNEL,
+    "@DataDog/container-integrations": "#container-integrations",
+    "@DataDog/platform-integrations": "#platform-integrations",
+    "@DataDog/agent-network": "#network-agent",
+    "@DataDog/agent-security": "#security-and-compliance-agent-ops",
+    "@DataDog/agent-apm": "#apm-agent",
+    "@DataDog/infrastructure-integrations": "#infrastructure-integrations",
+    "@DataDog/processes": "#process-agent-ops",
+    "@DataDog/agent-core": "#agent-core",
+    "@DataDog/agent-metrics-logs": "#agent-metrics-logs",
+    "@DataDog/agent-shared-components": "#agent-shared-components",
+    "@DataDog/container-app": "#container-app",
+    "@DataDog/metrics-aggregation": "#metrics-aggregation",
+    "@DataDog/serverless": "#serverless-agent",
+    "@DataDog/remote-config": "#remote-config-monitoring",
+    "@DataDog/agent-all": "#datadog-agent-pipelines",
+    "@DataDog/ebpf-platform": "#ebpf-platform",
+    "@DataDog/Networks": "#networks",
+    "@DataDog/universal-service-monitoring": "#universal-service-monitoring",
+    "@DataDog/windows-kernel-integrations": "#windows-kernel-integrations",
+    "@DataDog/opentelemetry": "#opentelemetry-ops",
+}
+
+
 def read_owners(owners_file):
     from codeowners import CodeOwners
 

--- a/tasks/pipeline.py
+++ b/tasks/pipeline.py
@@ -15,11 +15,11 @@ from .libs.common.gitlab import Gitlab, get_gitlab_bot_token, get_gitlab_token
 from .libs.datadog_api import create_count, send_metrics
 from .libs.pipeline_data import get_failed_jobs
 from .libs.pipeline_notifications import (
+    GITHUB_SLACK_MAP,
     base_message,
     find_job_owners,
     get_failed_tests,
     send_slack_message,
-    GITHUB_SLACK_MAP,
 )
 from .libs.pipeline_stats import get_failed_jobs_stats
 from .libs.pipeline_tools import (

--- a/tasks/pipeline.py
+++ b/tasks/pipeline.py
@@ -14,7 +14,13 @@ from .libs.common.color import color_message
 from .libs.common.gitlab import Gitlab, get_gitlab_bot_token, get_gitlab_token
 from .libs.datadog_api import create_count, send_metrics
 from .libs.pipeline_data import get_failed_jobs
-from .libs.pipeline_notifications import base_message, find_job_owners, get_failed_tests, send_slack_message
+from .libs.pipeline_notifications import (
+    base_message,
+    find_job_owners,
+    get_failed_tests,
+    send_slack_message,
+    GITHUB_SLACK_MAP,
+)
 from .libs.pipeline_stats import get_failed_jobs_stats
 from .libs.pipeline_tools import (
     FilteredOutException,
@@ -319,30 +325,6 @@ def wait_for_pipeline_from_ref(gitlab, ref):
 
 
 # Tasks to trigger pipeline notifications
-
-GITHUB_SLACK_MAP = {
-    "@DataDog/agent-platform": "#agent-platform",
-    "@DataDog/container-integrations": "#container-integrations",
-    "@DataDog/platform-integrations": "#platform-integrations",
-    "@DataDog/agent-network": "#network-agent",
-    "@DataDog/agent-security": "#security-and-compliance-agent-ops",
-    "@DataDog/agent-apm": "#apm-agent",
-    "@DataDog/infrastructure-integrations": "#infrastructure-integrations",
-    "@DataDog/processes": "#process-agent-ops",
-    "@DataDog/agent-core": "#agent-core",
-    "@DataDog/agent-metrics-logs": "#agent-metrics-logs",
-    "@DataDog/agent-shared-components": "#agent-shared-components",
-    "@DataDog/container-app": "#container-app",
-    "@DataDog/metrics-aggregation": "#metrics-aggregation",
-    "@DataDog/serverless": "#serverless-agent",
-    "@DataDog/remote-config": "#remote-config-monitoring",
-    "@DataDog/agent-all": "#datadog-agent-pipelines",
-    "@DataDog/ebpf-platform": "#ebpf-platform",
-    "@DataDog/Networks": "#networks",
-    "@DataDog/universal-service-monitoring": "#universal-service-monitoring",
-    "@DataDog/windows-kernel-integrations": "#windows-kernel-integrations",
-    "@DataDog/opentelemetry": "#opentelemetry-ops",
-}
 
 UNKNOWN_OWNER_TEMPLATE = """The owner `{owner}` is not mapped to any slack channel.
 Please check for typos in the JOBOWNERS file and/or add them to the Github <-> Slack map.


### PR DESCRIPTION
### What does this PR do?

Adds `slack_channel` tag to all JUnit uploads through `datadog-ci`.

### Motivation

Being able to send messages about failing/flaky tests to the correct channel.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
