### PR TITLE
[CWS] add inode to pid context to detect exec loss

### DIFF
--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var RuntimeSecurity = newAsset("runtime-security.c", "8fc17b02b607a474aa111cd15319ccf7571093c358ca44e3b8a9d413ec8fc7fd")
+var RuntimeSecurity = newAsset("runtime-security.c", "6f6112c597d1e92032379514af0f019bab38e39e095402bcc0501de502fd445a")

--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var RuntimeSecurity = newAsset("runtime-security.c", "6f6112c597d1e92032379514af0f019bab38e39e095402bcc0501de502fd445a")
+var RuntimeSecurity = newAsset("runtime-security.c", "1e551a249259dfdc98b380b64d91c7ba1e34039b6e2fae669015a60e6bbfb22d")

--- a/pkg/security/ebpf/c/defs.h
+++ b/pkg/security/ebpf/c/defs.h
@@ -251,6 +251,8 @@ struct process_context_t {
     u32 tid;
     u32 netns;
     u32 is_kworker;
+    u32 revision;
+    u32 padding;
 };
 
 struct container_context_t {

--- a/pkg/security/ebpf/c/defs.h
+++ b/pkg/security/ebpf/c/defs.h
@@ -251,8 +251,7 @@ struct process_context_t {
     u32 tid;
     u32 netns;
     u32 is_kworker;
-    u32 revision;
-    u32 padding;
+    u64 inode;
 };
 
 struct container_context_t {

--- a/pkg/security/ebpf/c/exec.h
+++ b/pkg/security/ebpf/c/exec.h
@@ -484,8 +484,6 @@ int sched_process_fork(struct _tracepoint_sched_process_fork *args) {
     // [activity_dump] inherit tracing state
     inherit_traced_state(args, ppid, pid, event->container.container_id, event->proc_entry.comm);
 
-    update_pid_revision_cache(pid);
-
     // send the entry to maintain userspace cache
     send_event_ptr(args, EVENT_FORK, event);
 
@@ -516,8 +514,6 @@ int kprobe_do_exit(struct pt_regs *ctx) {
 
     // delete netns entry
     bpf_map_delete_elem(&netns_cache, &pid);
-
-    del_pid_revision(pid);
 
     u64 *pid_tgid_execing = (u64 *)bpf_map_lookup_elem(&exec_pid_transfer, &tgid);
 
@@ -935,8 +931,6 @@ int __attribute__((always_inline)) send_exec_event(struct pt_regs *ctx) {
     u64 pid_tgid = bpf_get_current_pid_tgid();
     u64 now = bpf_ktime_get_ns();
     u32 tgid = pid_tgid >> 32;
-
-    update_pid_revision_cache(tgid);
 
     bpf_map_delete_elem(&exec_pid_transfer, &tgid);
 

--- a/pkg/security/ebpf/c/process.h
+++ b/pkg/security/ebpf/c/process.h
@@ -48,33 +48,6 @@ struct bpf_map_def SEC("maps/proc_cache") proc_cache = {
     .max_entries = 16384,
 };
 
-struct bpf_map_def SEC("maps/pid_revisions") pid_revisions = {
-    .type = BPF_MAP_TYPE_HASH,
-    .key_size = sizeof(u32),
-    .value_size = sizeof(u32),
-    .max_entries = 16384,
-};
-
-void __attribute__((always_inline)) update_pid_revision_cache(u32 pid) {
-    u32 *revision = bpf_map_lookup_elem(&pid_revisions, &pid);
-    if (revision) {
-        __sync_fetch_and_add(revision, 1);
-    } else {
-        u32 value = 1;
-        bpf_map_update_elem(&pid_revisions, &pid, &value, BPF_ANY);
-    }
-}
-
-u32 __attribute__((always_inline)) get_pid_revision(u32 pid) {
-    u32 *revision = bpf_map_lookup_elem(&pid_revisions, &pid);
-    return revision ? *revision : 0;
-}
-
-void __attribute__((always_inline)) del_pid_revision(u32 pid) {
-    bpf_map_delete_elem(&pid_revisions, &pid);
-}
-
-
 static void __attribute__((always_inline)) fill_container_context(struct proc_cache_t *entry, struct container_context_t *context) {
     if (entry) {
         copy_container_id(entry->container.container_id, context->container_id);
@@ -165,9 +138,12 @@ static struct proc_cache_t * __attribute__((always_inline)) fill_process_context
         data->is_kworker = 1;
     }
 
-    data->revision = get_pid_revision(pid);
+    struct proc_cache_t *pc = get_proc_cache(tgid);
+    if (pc) {
+        data->inode = pc->entry.executable.path_key.ino;
+    }
 
-    return get_proc_cache(tgid);
+    return pc;
 }
 
 static struct proc_cache_t * __attribute__((always_inline)) fill_process_context(struct process_context_t *data) {

--- a/pkg/security/probe/field_handlers.go
+++ b/pkg/security/probe/field_handlers.go
@@ -355,7 +355,7 @@ func (fh *FieldHandlers) ResolveProcessCacheEntry(ev *model.Event) (*model.Proce
 	}
 
 	if ev.ProcessCacheEntry == nil {
-		ev.ProcessCacheEntry = fh.resolvers.ProcessResolver.Resolve(ev.PIDContext.Pid, ev.PIDContext.Tid)
+		ev.ProcessCacheEntry = fh.resolvers.ProcessResolver.Resolve(ev.PIDContext.Pid, ev.PIDContext.Tid, ev.PIDContext.Revision)
 	}
 
 	if ev.ProcessCacheEntry == nil {

--- a/pkg/security/probe/field_handlers.go
+++ b/pkg/security/probe/field_handlers.go
@@ -355,7 +355,7 @@ func (fh *FieldHandlers) ResolveProcessCacheEntry(ev *model.Event) (*model.Proce
 	}
 
 	if ev.ProcessCacheEntry == nil {
-		ev.ProcessCacheEntry = fh.resolvers.ProcessResolver.Resolve(ev.PIDContext.Pid, ev.PIDContext.Tid, ev.PIDContext.Revision)
+		ev.ProcessCacheEntry = fh.resolvers.ProcessResolver.Resolve(ev.PIDContext.Pid, ev.PIDContext.Tid, ev.PIDContext.Inode)
 	}
 
 	if ev.ProcessCacheEntry == nil {

--- a/pkg/security/probe/load_controller.go
+++ b/pkg/security/probe/load_controller.go
@@ -152,7 +152,7 @@ func (lc *LoadController) discardNoisiestProcess() {
 	lc.pidDiscardersCount.Inc()
 
 	if lc.NoisyProcessCustomEventRate.Allow() {
-		process := lc.probe.resolvers.ProcessResolver.Resolve(maxKey.Pid, maxKey.Pid)
+		process := lc.probe.resolvers.ProcessResolver.Resolve(maxKey.Pid, maxKey.Pid, 0)
 		if process == nil {
 			seclog.Warnf("Unable to resolve process with pid: %d", maxKey.Pid)
 			return

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -709,7 +709,7 @@ func (p *Probe) handleEvent(CPU int, data []byte) {
 			return
 		}
 		// resolve tracee process context
-		cacheEntry := p.resolvers.ProcessResolver.Resolve(event.PTrace.PID, event.PTrace.PID)
+		cacheEntry := p.resolvers.ProcessResolver.Resolve(event.PTrace.PID, event.PTrace.PID, 0)
 		if cacheEntry != nil {
 			event.PTrace.Tracee = &cacheEntry.ProcessContext
 		}
@@ -750,7 +750,7 @@ func (p *Probe) handleEvent(CPU int, data []byte) {
 			return
 		}
 		// resolve target process context
-		cacheEntry := p.resolvers.ProcessResolver.Resolve(event.Signal.PID, event.Signal.PID)
+		cacheEntry := p.resolvers.ProcessResolver.Resolve(event.Signal.PID, event.Signal.PID, 0)
 		if cacheEntry != nil {
 			event.Signal.Target = &cacheEntry.ProcessContext
 		}

--- a/pkg/security/probe/process_resolver.go
+++ b/pkg/security/probe/process_resolver.go
@@ -559,7 +559,7 @@ func (p *ProcessResolver) insertForkEntry(entry *model.ProcessCacheEntry) {
 
 	parent := p.entryCache[entry.PPid]
 	if parent == nil && entry.PPid >= 1 {
-		parent = p.resolve(entry.PPid, entry.PPid, entry.Revision)
+		parent = p.resolve(entry.PPid, entry.PPid, entry.Inode)
 	}
 
 	if parent != nil {
@@ -608,15 +608,15 @@ func (p *ProcessResolver) DeleteEntry(pid uint32, exitTime time.Time) {
 }
 
 // Resolve returns the cache entry for the given pid
-func (p *ProcessResolver) Resolve(pid, tid, revision uint32) *model.ProcessCacheEntry {
+func (p *ProcessResolver) Resolve(pid, tid uint32, inode uint64) *model.ProcessCacheEntry {
 	p.Lock()
 	defer p.Unlock()
 
-	return p.resolve(pid, tid, revision)
+	return p.resolve(pid, tid, inode)
 }
 
-func (p *ProcessResolver) resolve(pid, tid, revision uint32) *model.ProcessCacheEntry {
-	if entry := p.resolveFromCache(pid, tid, revision); entry != nil {
+func (p *ProcessResolver) resolve(pid, tid uint32, inode uint64) *model.ProcessCacheEntry {
+	if entry := p.resolveFromCache(pid, tid, inode); entry != nil {
 		p.hitsStats[metrics.CacheTag].Inc()
 		return entry
 	}
@@ -710,15 +710,22 @@ func (p *ProcessResolver) ApplyBootTime(entry *model.ProcessCacheEntry) {
 }
 
 // ResolveFromCache resolves cache entry from the cache
-func (p *ProcessResolver) ResolveFromCache(pid, tid, revision uint32) *model.ProcessCacheEntry {
+func (p *ProcessResolver) ResolveFromCache(pid, tid uint32, inode uint64) *model.ProcessCacheEntry {
 	p.Lock()
 	defer p.Unlock()
-	return p.resolveFromCache(pid, tid, revision)
+	return p.resolveFromCache(pid, tid, inode)
 }
 
-func (p *ProcessResolver) resolveFromCache(pid, tid, revision uint32) *model.ProcessCacheEntry {
+func (p *ProcessResolver) resolveFromCache(pid, tid uint32, inode uint64) *model.ProcessCacheEntry {
 	entry, exists := p.entryCache[pid]
-	if !exists || (revision != 0 && entry.Revision != revision) {
+	if !exists {
+		return nil
+	}
+
+	// Compare inode to ensure that the cache is up-to-date.
+	// Be sure to compare with the file inode and not the pidcontext which can be empty
+	// if the entry originates from procfs.
+	if inode != 0 && inode != entry.Process.FileEvent.Inode {
 		return nil
 	}
 

--- a/pkg/security/probe/process_resolver.go
+++ b/pkg/security/probe/process_resolver.go
@@ -559,7 +559,7 @@ func (p *ProcessResolver) insertForkEntry(entry *model.ProcessCacheEntry) {
 
 	parent := p.entryCache[entry.PPid]
 	if parent == nil && entry.PPid >= 1 {
-		parent = p.resolve(entry.PPid, entry.PPid)
+		parent = p.resolve(entry.PPid, entry.PPid, entry.Revision)
 	}
 
 	if parent != nil {
@@ -608,15 +608,15 @@ func (p *ProcessResolver) DeleteEntry(pid uint32, exitTime time.Time) {
 }
 
 // Resolve returns the cache entry for the given pid
-func (p *ProcessResolver) Resolve(pid, tid uint32) *model.ProcessCacheEntry {
+func (p *ProcessResolver) Resolve(pid, tid, revision uint32) *model.ProcessCacheEntry {
 	p.Lock()
 	defer p.Unlock()
 
-	return p.resolve(pid, tid)
+	return p.resolve(pid, tid, revision)
 }
 
-func (p *ProcessResolver) resolve(pid, tid uint32) *model.ProcessCacheEntry {
-	if entry := p.resolveFromCache(pid, tid); entry != nil {
+func (p *ProcessResolver) resolve(pid, tid, revision uint32) *model.ProcessCacheEntry {
+	if entry := p.resolveFromCache(pid, tid, revision); entry != nil {
 		p.hitsStats[metrics.CacheTag].Inc()
 		return entry
 	}
@@ -710,15 +710,15 @@ func (p *ProcessResolver) ApplyBootTime(entry *model.ProcessCacheEntry) {
 }
 
 // ResolveFromCache resolves cache entry from the cache
-func (p *ProcessResolver) ResolveFromCache(pid, tid uint32) *model.ProcessCacheEntry {
+func (p *ProcessResolver) ResolveFromCache(pid, tid, revision uint32) *model.ProcessCacheEntry {
 	p.Lock()
 	defer p.Unlock()
-	return p.resolveFromCache(pid, tid)
+	return p.resolveFromCache(pid, tid, revision)
 }
 
-func (p *ProcessResolver) resolveFromCache(pid, tid uint32) *model.ProcessCacheEntry {
+func (p *ProcessResolver) resolveFromCache(pid, tid, revision uint32) *model.ProcessCacheEntry {
 	entry, exists := p.entryCache[pid]
-	if !exists {
+	if !exists || (revision != 0 && entry.Revision != revision) {
 		return nil
 	}
 

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -747,7 +747,7 @@ type PIDContext struct {
 	Tid       uint32 `field:"tid"` // Thread ID of the thread
 	NetNS     uint32 `field:"-"`
 	IsKworker bool   `field:"is_kworker"` // Indicates whether the process is a kworker
-	Revision  uint32 `field:"-"`          // used to track exec
+	Inode     uint64 `field:"-"`          // used to track exec and event loss
 }
 
 // RenameEvent represents a rename event

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -747,6 +747,7 @@ type PIDContext struct {
 	Tid       uint32 `field:"tid"` // Thread ID of the thread
 	NetNS     uint32 `field:"-"`
 	IsKworker bool   `field:"is_kworker"` // Indicates whether the process is a kworker
+	Revision  uint32 `field:"-"`          // used to track exec
 }
 
 // RenameEvent represents a rename event

--- a/pkg/security/secl/model/unmarshallers.go
+++ b/pkg/security/secl/model/unmarshallers.go
@@ -479,7 +479,7 @@ func (e *SELinuxEvent) UnmarshalBinary(data []byte) (int, error) {
 
 // UnmarshalBinary unmarshalls a binary representation of itself, process_context_t kernel side
 func (p *PIDContext) UnmarshalBinary(data []byte) (int, error) {
-	if len(data) < 16 {
+	if len(data) < 24 {
 		return 0, ErrNotEnoughData
 	}
 
@@ -487,8 +487,10 @@ func (p *PIDContext) UnmarshalBinary(data []byte) (int, error) {
 	p.Tid = ByteOrder.Uint32(data[4:8])
 	p.NetNS = ByteOrder.Uint32(data[8:12])
 	p.IsKworker = ByteOrder.Uint32(data[12:16]) > 0
+	p.Revision = ByteOrder.Uint32(data[16:20])
+	// padding
 
-	return 16, nil
+	return 24, nil
 }
 
 // UnmarshalBinary unmarshalls a binary representation of itself

--- a/pkg/security/secl/model/unmarshallers.go
+++ b/pkg/security/secl/model/unmarshallers.go
@@ -487,8 +487,7 @@ func (p *PIDContext) UnmarshalBinary(data []byte) (int, error) {
 	p.Tid = ByteOrder.Uint32(data[4:8])
 	p.NetNS = ByteOrder.Uint32(data[8:12])
 	p.IsKworker = ByteOrder.Uint32(data[12:16]) > 0
-	p.Revision = ByteOrder.Uint32(data[16:20])
-	// padding
+	p.Inode = ByteOrder.Uint64(data[16:24])
 
 	return 24, nil
 }

--- a/pkg/security/tests/process_test.go
+++ b/pkg/security/tests/process_test.go
@@ -2025,6 +2025,12 @@ func TestProcessResolution(t *testing.T) {
 		}
 		pid := uint32(value.(int))
 
+		value, err = event.GetFieldValue("process.file.inode")
+		if err != nil {
+			t.Errorf("not able to get pid")
+		}
+		inode := uint64(value.(int))
+
 		resolvers := test.probe.GetResolvers()
 
 		// compare only few fields as the hierarchy fields(pointers, etc) are modified by the resolution function calls
@@ -2038,7 +2044,7 @@ func TestProcessResolution(t *testing.T) {
 			assert.Equal(t, entry1.ContainerID, entry2.ContainerID)
 		}
 
-		cacheEntry := resolvers.ProcessResolver.ResolveFromCache(pid, pid)
+		cacheEntry := resolvers.ProcessResolver.ResolveFromCache(pid, pid, inode)
 		if cacheEntry == nil {
 			t.Errorf("not able to resolve the entry")
 		}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Add inode in the pidcontext in order to detect exec event loss. This should trigger a procfs fallback instead of attaching open/chmod/etc event to the wrong process context.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
