### PR TITLE
Remove reference to windows_counter_refresh_interval configuration from config template

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1190,8 +1190,9 @@ func InitConfig(config Config) {
 	// command line options
 	config.SetKnown("cmd.check.fullsketches")
 
-	// Windows Performance Counter refresh interval
-	// Controls if and how often Performance Counters need to be refreshed by the agent. This is mainly used in integrations that rely on Performance Counters.
+	// Windows Performance Counter refresh interval in seconds (introduced in 7.40, narrowed down
+	// in 7.42). Additional information can be found where it is used (refreshPdhObjectCache())
+	// The refresh can be disabled by setting the interval to 0.
 	config.BindEnvAndSetDefault("windows_counter_refresh_interval", 60)
 
 	// Vector integration

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -895,17 +895,6 @@ api_key:
     #
     # oid_batch_size: 5
 
-{{- if (eq .OS "windows")}}
-  ## @param windows_counter_refresh_interval - number - optional - default: 60
-  ## This controls the interval in seconds for which windows performance counters are refreshed by the agent.
-  ## Refreshes are necessary for the discovery of new counters/countersets and instances for integrations that
-  ## rely on performance counters. Checks include active_directory, aspdotnet, dotnetclr, exchange_server, hyperv,
-  ## iis and windows_performance_counters.
-  ## Refresh can be disabled by setting the interval to 0.
-  #
-  # windows_counter_refresh_interval: 60
-{{ end }}
-
 
 {{- if .InternalProfiling -}}
 ## @param profiling - custom object - optional

--- a/pkg/util/winutil/pdhutil/pdhhelper.go
+++ b/pkg/util/winutil/pdhutil/pdhhelper.go
@@ -64,6 +64,24 @@ func refreshPdhObjectCache(forceRefresh bool) (didrefresh bool, err error) {
 	//
 	// returns didrefresh=true if the refresh operation was successful
 	//
+	// Background information
+	// -----------------------
+	// Controls the minimum number of seconds that must have elapsed before the
+	// cached performance counters objects list can be refreshed again. Starting
+	// in 7.40 it had been used for all Windows Performance Counters based
+	// checks (all the time for Python checks and only to initialize Go checks).
+	// Starting from 7.42 it is not used anymore for Python Performance Counters
+	// based checks due to its side effects (for details see integrations-core PR
+	// https://github.com/DataDog/integrations-core/pull/13243). It is still used
+	// for Go Performance Counters based checks because it may be useful in rare
+	// cases when their initialization fails.
+	//
+	// A higher value will have lower performance impact and create fewer perflib
+	// Windows Event log warnings and errors but will increase the time before the
+	// failing counters have a chance to initialize successfully. A lower value
+	// will have higher performance impact and create more perflib Windows Event
+	// log perflib Windows Event log warnings but will decrease the time before
+	// the failing counters have a chance to initialize successfully.
 
 	var len uint32
 

--- a/pkg/util/winutil/pdhutil/pdhhelper.go
+++ b/pkg/util/winutil/pdhutil/pdhhelper.go
@@ -64,8 +64,8 @@ func refreshPdhObjectCache(forceRefresh bool) (didrefresh bool, err error) {
 	//
 	// returns didrefresh=true if the refresh operation was successful
 	//
-	// Background information
-	// -----------------------
+	// Background information for 'windows_counter_refresh_interval' config
+	// --------------------------------------------------------------------
 	// Controls the minimum number of seconds that must have elapsed before the
 	// cached performance counters objects list can be refreshed again. Starting
 	// in 7.40 it had been used for all Windows Performance Counters based
@@ -77,11 +77,11 @@ func refreshPdhObjectCache(forceRefresh bool) (didrefresh bool, err error) {
 	// cases when their initialization fails.
 	//
 	// A higher value will have lower performance impact and create fewer perflib
-	// Windows Event log warnings and errors but will increase the time before the
+	// Windows Event log errors and warnings but will increase the time before the
 	// failing counters have a chance to initialize successfully. A lower value
 	// will have higher performance impact and create more perflib Windows Event
-	// log perflib Windows Event log warnings but will decrease the time before
-	// the failing counters have a chance to initialize successfully.
+	// log errors and warnings but will decrease the time before the failing
+	// counters have a chance to initialize successfully.
 
 	var len uint32
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
To reflect that the configuration will not be used in Python Windows performance counters based checks (per integrations-core PR https://github.com/DataDog/integrations-core/pull/13243) and that its scope become useful mostly for troubleshooting scenarios and hence does not need to be exposed directly in the configuration template.
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
