### PR TITLE
[RCM] Include TUF versions in error when config repo updates fail

### DIFF
--- a/pkg/config/remote/uptane/client.go
+++ b/pkg/config/remote/uptane/client.go
@@ -8,6 +8,7 @@ package uptane
 import (
 	"bytes"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -213,7 +214,8 @@ func (c *Client) updateRepos(response *pbgo.LatestConfigsResponse) error {
 	}
 	_, err = c.configTUFClient.Update()
 	if err != nil {
-		return errors.Wrap(err, "could not update config repository")
+		e := fmt.Sprintf("could not update config repository [%s]", configMetasUpdateSummary(response.ConfigMetas))
+		return errors.Wrap(err, e)
 	}
 	return nil
 }
@@ -359,4 +361,34 @@ func (c *Client) verifyUptane() error {
 		}
 	}
 	return nil
+}
+
+func configMetasUpdateSummary(metas *pbgo.ConfigMetas) string {
+	if metas == nil {
+		return "no metas in update"
+	}
+
+	var b strings.Builder
+
+	if len(metas.Roots) != 0 {
+		b.WriteString("roots=")
+		for i := 0; i < len(metas.Roots)-2; i++ {
+			b.WriteString(fmt.Sprintf("%d,", metas.Roots[i].Version))
+		}
+		b.WriteString(fmt.Sprintf("%d ", metas.Roots[len(metas.Roots)-1].Version))
+	}
+
+	if metas.TopTargets != nil {
+		b.WriteString(fmt.Sprintf("targets=%d ", metas.TopTargets.Version))
+	}
+
+	if metas.Snapshot != nil {
+		b.WriteString(fmt.Sprintf("snapshot=%d ", metas.Snapshot.Version))
+	}
+
+	if metas.Timestamp != nil {
+		b.WriteString(fmt.Sprintf("timestamp=%d", metas.Timestamp.Version))
+	}
+
+	return b.String()
 }


### PR DESCRIPTION
If we know the versions of the TUF metadata the agent is trying to apply we can pull that data down and investigate what went wrong. This adds that context to the error message which will help immensely when debugging in the future.

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
