### PR TITLE
Updates document discussing the API endpoints exposed by the core agent

### DIFF
--- a/docs/dev/agent_api.md
+++ b/docs/dev/agent_api.md
@@ -1,22 +1,17 @@
 # Endpoints exposed by the Agent
-The core Agent exposes a variety of HTTP and GRPC endpoints that can be grouped into 2
+The core Agent exposes a variety of HTTP and GRPC endpoints that can be organized into two
 groups:
-1) Control
-    - These endpoints are used to send commands that can control and inspect the state of the running Agent
-2) Telemetry
-    - These expose some internal telemetry that is useful for profiling and
-      debugging.
+1. **Control**: These endpoints are used to send commands that can control and inspect the state of the running Agent.
+2. **Telemetry**: These expose some internal telemetry that is useful for profiling and debugging.
 
 ## Control API
 This API is accessible via HTTPS only and listens by default on the `localhost` interface on port `5001`. The listening interface and port can be configured using the `cmd_host` and `cmd_port` config options.
 
 ### Authentication
 To avoid unprivileged users accessing the Agent control API, authentication is required and based on a generated token.
-The token is written to a file (`auth_token`) that's only readable by the user that the Agent runs as.
+The token is written to a file (`auth_token`) that's only readable by the user that is running the Agent.
 
-The `auth_token` file is written to the same directory that the config was read
-from by default, or the config option `auth_token_file_path` can be used to set
-a custom location.
+By default, the `auth_token` file is written to the same directory where the config is located. To specify a custom location, use the config option `auth_token_file_path`.
 
 ### Example
 ```
@@ -24,11 +19,11 @@ $ curl -qs -H "authorization: Bearer $(cat /path/to/auth_token)" -k https://loca
 {"Major":7,"Minor":41,"Patch":0,"Pre":"rc.3","Meta":"git.238.453e769","Commit":"453e7695a4"}%
 ```
 
-### Full Endpoint List
+### Full endpoint list
 https://github.com/DataDog/datadog-agent/blob/453e7695a43fa3c162e1240863999c9ddc91fbdd/cmd/agent/api/internal/agent/agent.go#L49-L73
 
 ## Telemetry API
-By default, there are 3 different systems exposing data on the same port but at
+There are 3 different systems exposing data on the same port but at
 different endpoints. The default port is 5000 and can be configured by changing
 `expvar_port`.
 
@@ -55,8 +50,8 @@ $ curl -s http://localhost:5000/debug/vars | jq '.scheduler'
 }
 ```
 
-### Prometheus-style Telemetry
-Prometheus style telemetry is exposed at `/telemetry` if and only if the config option
+### Prometheus-style telemetry
+Prometheus style telemetry is exposed at `/telemetry` if the config option
 `telemetry.enabled` is set to true.
 
 ```
@@ -75,14 +70,14 @@ aggregator_tags_store__hits_total{cache_instance_name="timesampler #0"} 0
 
 ### Pprof
 Pprof is available at `/debug/pprof`. This endpoint has an index that lists the
-different pprof endpoints and the official go pprof docs can also be referenced.
+different pprof endpoints and the official go [pprof docs](https://pkg.go.dev/net/http/pprof) can also be referenced.
 
 ```
 $ curl -s http://localhost:5000/debug/pprof/profile?seconds=60 > ./cpu.out
 ```
 
 # Not documented here
-- non-core agent endpoints (ie, what do the security, process, and cluster agents expose)
+- non-core agent endpoints (i.e., what do the security, process, and cluster agents expose)
 - GRPC endpoints
 
 

--- a/docs/dev/agent_api.md
+++ b/docs/dev/agent_api.md
@@ -1,17 +1,88 @@
-# IPC (Inter Process Communication) API
+# Endpoints exposed by the Agent
+The core Agent exposes a variety of HTTP and GRPC endpoints that can be grouped into 2
+groups:
+1) Control
+    - These endpoints are used to send commands that can control and inspect the state of the running Agent
+2) Telemetry
+    - These expose some internal telemetry that is useful for profiling and
+      debugging.
 
-The agent communicates with the outside world through an HTTP API to ease the
-development of 3rd party tools and interfaces. The API is available from `localhost`
-and through HTTPS only. It listens on port `5001` by default but can be configured differently.
+## Control API
+This API is accessible via HTTPS only and listens by default on the `localhost` interface on port `5001`. The listening interface and port can be configured using the `cmd_host` and `cmd_port` config options.
 
-## Security and Authentication
+### Authentication
+To avoid unprivileged users accessing the Agent control API, authentication is required and based on a generated token.
+The token is written to a file (`auth_token`) that's only readable by the user that the Agent runs as.
 
-To avoid unprivileged users to access the API, authentication is required and based on a token.
-The token is written to a file that's only readable by the user that the Agent runs as.
+The `auth_token` file is written to the same directory that the config was read
+from by default, or the config option `auth_token_file_path` can be used to set
+a custom location.
 
-## Endpoints
+### Example
+```
+$ curl -qs -H "authorization: Bearer $(cat /path/to/auth_token)" -k https://localhost:5001/agent/version
+{"Major":7,"Minor":41,"Patch":0,"Pre":"rc.3","Meta":"git.238.453e769","Commit":"453e7695a4"}%
+```
 
-Please refer to the [`cmd/agent/api`](https://github.com/DataDog/datadog-agent/tree/main/cmd/agent/api)
-package for a list of endpoints implemented so far.
+### Full Endpoint List
+https://github.com/DataDog/datadog-agent/blob/453e7695a43fa3c162e1240863999c9ddc91fbdd/cmd/agent/api/internal/agent/agent.go#L49-L73
 
-TODO: generate a list of endpoints with [swagger](http://swagger.io/)
+## Telemetry API
+By default, there are 3 different systems exposing data on the same port but at
+different endpoints. The default port is 5000 and can be configured by changing
+`expvar_port`.
+
+### ExpVar
+Expvar is at `/debug/vars`
+
+```
+$ curl -s http://localhost:5000/debug/vars | jq '.scheduler'
+{
+  "ChecksEntered": 8,
+  "Queues": [
+    {
+      "Buckets": 900,
+      "Interval": 900,
+      "Size": 1
+    },
+    {
+      "Buckets": 15,
+      "Interval": 15,
+      "Size": 7
+    }
+  ],
+  "QueuesCount": 2
+}
+```
+
+### Prometheus-style Telemetry
+Prometheus style telemetry is exposed at `/telemetry` if and only if the config option
+`telemetry.enabled` is set to true.
+
+```
+$ curl -s http://localhost:5000/telemetry | head
+# HELP aggregator__processed Amount of metrics/services_checks/events processed by the aggregator
+# TYPE aggregator__processed counter
+aggregator__processed{data_type="dogstatsd_metrics"} 1
+aggregator__processed{data_type="events"} 1
+aggregator__processed{data_type="metrics"} 102
+aggregator__processed{data_type="service_checks"} 6
+# HELP aggregator_tags_store__hits_total number of times cache already contained the tags
+# TYPE aggregator_tags_store__hits_total counter
+aggregator_tags_store__hits_total{cache_instance_name="aggregator"} 171
+aggregator_tags_store__hits_total{cache_instance_name="timesampler #0"} 0
+```
+
+### Pprof
+Pprof is available at `/debug/pprof`. This endpoint has an index that lists the
+different pprof endpoints and the official go pprof docs can also be referenced.
+
+```
+$ curl -s http://localhost:5000/debug/pprof/profile?seconds=60 > ./cpu.out
+```
+
+# Not documented here
+- non-core agent endpoints (ie, what do the security, process, and cluster agents expose)
+- GRPC endpoints
+
+


### PR DESCRIPTION
### What does this PR do?
Adds more complete documentation of API endpoints with examples.

### Motivation


### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
