### PR TITLE
Revert "Update Chocolatey NuSpec"

### DIFF
--- a/chocolatey/datadog-agent-offline.nuspec
+++ b/chocolatey/datadog-agent-offline.nuspec
@@ -4,7 +4,7 @@
     <id>datadog-agent-offline</id>
     <version>$package_version$</version>
     <packageSourceUrl>https://github.com/DataDog/datadog-agent/tree/main/chocolatey</packageSourceUrl>
-    <owners>package@datadoghq.com</owners>
+    <owners>Datadog</owners>
     <title>Datadog Agent Offline Install</title>
     <authors>Datadog</authors>
     <projectUrl>https://github.com/DataDog/datadog-agent</projectUrl>

--- a/chocolatey/datadog-agent-offline.nuspec
+++ b/chocolatey/datadog-agent-offline.nuspec
@@ -4,12 +4,13 @@
     <id>datadog-agent-offline</id>
     <version>$package_version$</version>
     <packageSourceUrl>https://github.com/DataDog/datadog-agent/tree/main/chocolatey</packageSourceUrl>
+    <owners>package@datadoghq.com</owners>
     <title>Datadog Agent Offline Install</title>
     <authors>Datadog</authors>
     <projectUrl>https://github.com/DataDog/datadog-agent</projectUrl>
     <iconUrl>https://datadog-prod.imgix.net/img/dd_logo_70x75.png</iconUrl>
     <copyright>$copyright$</copyright>
-    <license type="expression">Apache-2.0</license>
+    <licenseUrl>https://raw.githubusercontent.com/DataDog/datadog-agent/main/LICENSE</licenseUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <docsUrl>https://docs.datadoghq.com</docsUrl>
     <tags>datadog agent monitoring admin</tags>

--- a/chocolatey/datadog-agent-online.nuspec
+++ b/chocolatey/datadog-agent-online.nuspec
@@ -4,7 +4,7 @@
     <id>datadog-agent</id>
     <version>$package_version$</version>
     <packageSourceUrl>https://github.com/DataDog/datadog-agent/tree/main/chocolatey</packageSourceUrl>
-    <owners>package@datadoghq.com</owners>
+    <owners>Datadog</owners>
     <title>Datadog Agent</title>
     <authors>Datadog</authors>
     <projectUrl>https://github.com/DataDog/datadog-agent</projectUrl>

--- a/chocolatey/datadog-agent-online.nuspec
+++ b/chocolatey/datadog-agent-online.nuspec
@@ -4,12 +4,13 @@
     <id>datadog-agent</id>
     <version>$package_version$</version>
     <packageSourceUrl>https://github.com/DataDog/datadog-agent/tree/main/chocolatey</packageSourceUrl>
+    <owners>package@datadoghq.com</owners>
     <title>Datadog Agent</title>
     <authors>Datadog</authors>
     <projectUrl>https://github.com/DataDog/datadog-agent</projectUrl>
     <iconUrl>https://datadog-prod.imgix.net/img/dd_logo_70x75.png</iconUrl>
     <copyright>$copyright$</copyright>
-    <license type="expression">Apache-2.0</license>
+    <licenseUrl>https://raw.githubusercontent.com/DataDog/datadog-agent/main/LICENSE</licenseUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <docsUrl>https://docs.datadoghq.com</docsUrl>
     <tags>datadog agent monitoring admin</tags>


### PR DESCRIPTION
# What does this PR do?
Reverts DataDog/datadog-agent#14300. Since Chocolatey use their own NuSpec, #14300 actually broke the Chocolatey publishing. This also updates the `<owners />` field to match what Chocolatey expects.

# Motivation
Working Chocolatey publishing.