### PR TITLE
Kacper murzyn/7.40.1 changelog backport

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,37 @@
 Release Notes
 =============
 
+.. _Release Notes_7.40.1:
+
+7.40.1
+======
+
+.. _Release Notes_7.40.1_Prelude:
+
+Prelude
+-------
+
+Release on: 2022-11-09
+
+- Please refer to the `7.40.1 tag on integrations-core <https://github.com/DataDog/integrations-core/blob/master/AGENT_CHANGELOG.md#datadog-agent-version-7401>`_ for the list of changes on the Core Checks
+
+
+.. _Release Notes_7.40.1_Enhancement Notes:
+
+Enhancement Notes
+-----------------
+
+- Agents are now built with Go 1.18.8.
+
+
+.. _Release Notes_7.40.1_Bug Fixes:
+
+Bug Fixes
+---------
+
+- Fix log collection on Kubernetes distributions using ``cri-o`` like OpenShift, which
+  began failing in 7.40.0.
+
 .. _Release Notes_7.40.0:
 
 7.40.0 / 6.40.0

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -68,9 +68,7 @@ New Features
 - Add a username and password dialog window to the Windows Installer
 
 - APM: DogStatsD data can now be proxied through the "/dogstatsd/v1/proxy" endpoint
-  over UDS or UDP. If a socket is provided with dogstatsd_socket, the proxy will
-  default to proxying over UDS. Otherwise, UDP will be used. See
-  https://docs.datadoghq.com/developers/dogstatsd#setup for configuration details.
+  over UDP. See https://docs.datadoghq.com/developers/dogstatsd#setup for configuration details.
 
 - Cloud Workload Security now has Agent version constraints for Macros in SECL expressions.
 
@@ -163,6 +161,8 @@ Known Issues
 ------------
 
 - APM: OTLP Ingest: resource attributes such as service.name are correctly picked up by spans.
+- APM: The "/dogstatsd/v1/proxy" endpoint can only accept a single payload at a time. This will
+  be fixed in the v2 endpoint which will split payloads by newline.
 
 
 .. _Release Notes_7.40.0_Deprecation Notes:


### PR DESCRIPTION
Backporting the 7.40.1 bugfix release changelog to 7.41.x branch.