### PR TITLE
[security-agent] Use `core.CreateBundleParams` instead of struct literal

### DIFF
--- a/cmd/security-agent/app/subcommands/check/command.go
+++ b/cmd/security-agent/app/subcommands/check/command.go
@@ -45,10 +45,11 @@ type checkCliParams struct {
 }
 
 func SecAgentCommands(globalParams *common.GlobalParams) []*cobra.Command {
-	bp := core.BundleParams{
-		SecurityAgentConfigFilePaths: globalParams.ConfPathArray,
-		ConfigLoadSecurityAgent:      true,
-	}.LogForOneShot(common.LoggerName, "info", true)
+	bp := core.CreateBundleParams(
+		"",
+		core.WithSecurityAgentConfigFilePaths(globalParams.ConfPathArray),
+		core.WithConfigLoadSecurityAgent(true),
+	).LogForOneShot(common.LoggerName, "info", true)
 
 	return Commands(bp)
 }

--- a/cmd/security-agent/app/subcommands/compliance/command.go
+++ b/cmd/security-agent/app/subcommands/compliance/command.go
@@ -55,10 +55,11 @@ func complianceEventCommand(globalParams *common.GlobalParams) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(eventRun,
 				fx.Supply(eventArgs),
-				fx.Supply(core.BundleParams{
-					SecurityAgentConfigFilePaths: globalParams.ConfPathArray,
-					ConfigLoadSecurityAgent:      true,
-				}.LogForOneShot(common.LoggerName, "info", true)),
+				fx.Supply(core.CreateBundleParams(
+					"",
+					core.WithSecurityAgentConfigFilePaths(globalParams.ConfPathArray),
+					core.WithConfigLoadSecurityAgent(true),
+				).LogForOneShot(common.LoggerName, "info", true)),
 				core.Bundle,
 			)
 		},

--- a/cmd/security-agent/app/subcommands/runtime/activity_dump.go
+++ b/cmd/security-agent/app/subcommands/runtime/activity_dump.go
@@ -61,10 +61,11 @@ func listCommands(globalParams *common.GlobalParams) []*cobra.Command {
 		Short: "get the list of running activity dumps",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(listActivityDumps,
-				fx.Supply(core.BundleParams{
-					SecurityAgentConfigFilePaths: globalParams.ConfPathArray,
-					ConfigLoadSecurityAgent:      true,
-				}.LogForOneShot(common.LoggerName, "info", true)),
+				fx.Supply(core.CreateBundleParams(
+					"",
+					core.WithSecurityAgentConfigFilePaths(globalParams.ConfPathArray),
+					core.WithConfigLoadSecurityAgent(true),
+				).LogForOneShot(common.LoggerName, "info", true)),
 				core.Bundle,
 			)
 		},
@@ -84,10 +85,11 @@ func stopCommands(globalParams *common.GlobalParams) []*cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(stopActivityDump,
 				fx.Supply(cliParams),
-				fx.Supply(core.BundleParams{
-					SecurityAgentConfigFilePaths: globalParams.ConfPathArray,
-					ConfigLoadSecurityAgent:      true,
-				}.LogForOneShot(common.LoggerName, "info", true)),
+				fx.Supply(core.CreateBundleParams(
+					"",
+					core.WithSecurityAgentConfigFilePaths(globalParams.ConfPathArray),
+					core.WithConfigLoadSecurityAgent(true),
+				).LogForOneShot(common.LoggerName, "info", true)),
 				core.Bundle,
 			)
 		},
@@ -138,10 +140,11 @@ func generateDumpCommands(globalParams *common.GlobalParams) []*cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(generateActivityDump,
 				fx.Supply(cliParams),
-				fx.Supply(core.BundleParams{
-					SecurityAgentConfigFilePaths: globalParams.ConfPathArray,
-					ConfigLoadSecurityAgent:      true,
-				}.LogForOneShot(common.LoggerName, "info", true)),
+				fx.Supply(core.CreateBundleParams(
+					"",
+					core.WithSecurityAgentConfigFilePaths(globalParams.ConfPathArray),
+					core.WithConfigLoadSecurityAgent(true),
+				).LogForOneShot(common.LoggerName, "info", true)),
 				core.Bundle,
 			)
 		},
@@ -210,10 +213,11 @@ func generateEncodingCommands(globalParams *common.GlobalParams) []*cobra.Comman
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(generateEncodingFromActivityDump,
 				fx.Supply(cliParams),
-				fx.Supply(core.BundleParams{
-					SecurityAgentConfigFilePaths: globalParams.ConfPathArray,
-					ConfigLoadSecurityAgent:      true,
-				}.LogForOneShot(common.LoggerName, "info", true)),
+				fx.Supply(core.CreateBundleParams(
+					"",
+					core.WithSecurityAgentConfigFilePaths(globalParams.ConfPathArray),
+					core.WithConfigLoadSecurityAgent(true),
+				).LogForOneShot(common.LoggerName, "info", true)),
 				core.Bundle,
 			)
 		},

--- a/cmd/security-agent/app/subcommands/runtime/command.go
+++ b/cmd/security-agent/app/subcommands/runtime/command.go
@@ -93,10 +93,11 @@ func checkPoliciesCommands(globalParams *common.GlobalParams) []*cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(checkPolicies,
 				fx.Supply(cliParams),
-				fx.Supply(core.BundleParams{
-					SecurityAgentConfigFilePaths: globalParams.ConfPathArray,
-					ConfigLoadSecurityAgent:      true,
-				}.LogForOneShot(common.LoggerName, "off", false)),
+				fx.Supply(core.CreateBundleParams(
+					"",
+					core.WithSecurityAgentConfigFilePaths(globalParams.ConfPathArray),
+					core.WithConfigLoadSecurityAgent(true),
+				).LogForOneShot(common.LoggerName, "off", false)),
 				core.Bundle,
 			)
 		},
@@ -114,10 +115,11 @@ func reloadPoliciesCommands(globalParams *common.GlobalParams) []*cobra.Command 
 		Short: "Reload policies",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(reloadRuntimePolicies,
-				fx.Supply(core.BundleParams{
-					SecurityAgentConfigFilePaths: globalParams.ConfPathArray,
-					ConfigLoadSecurityAgent:      true,
-				}.LogForOneShot(common.LoggerName, "info", true)),
+				fx.Supply(core.CreateBundleParams(
+					"",
+					core.WithSecurityAgentConfigFilePaths(globalParams.ConfPathArray),
+					core.WithConfigLoadSecurityAgent(true),
+				).LogForOneShot(common.LoggerName, "info", true)),
 				core.Bundle,
 			)
 		},
@@ -160,10 +162,11 @@ func evalCommands(globalParams *common.GlobalParams) []*cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(evalRule,
 				fx.Supply(evalArgs),
-				fx.Supply(core.BundleParams{
-					SecurityAgentConfigFilePaths: globalParams.ConfPathArray,
-					ConfigLoadSecurityAgent:      true,
-				}.LogForOneShot(common.LoggerName, "off", false)),
+				fx.Supply(core.CreateBundleParams(
+					"",
+					core.WithSecurityAgentConfigFilePaths(globalParams.ConfPathArray),
+					core.WithConfigLoadSecurityAgent(true),
+				).LogForOneShot(common.LoggerName, "off", false)),
 				core.Bundle,
 			)
 		},
@@ -190,10 +193,11 @@ func commonCheckPoliciesCommands(globalParams *common.GlobalParams) []*cobra.Com
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(checkPolicies,
 				fx.Supply(cliParams),
-				fx.Supply(core.BundleParams{
-					SecurityAgentConfigFilePaths: globalParams.ConfPathArray,
-					ConfigLoadSecurityAgent:      true,
-				}.LogForOneShot(common.LoggerName, "off", false)),
+				fx.Supply(core.CreateBundleParams(
+					"",
+					core.WithSecurityAgentConfigFilePaths(globalParams.ConfPathArray),
+					core.WithConfigLoadSecurityAgent(true),
+				).LogForOneShot(common.LoggerName, "off", false)),
 				core.Bundle,
 			)
 		},
@@ -210,10 +214,11 @@ func commonReloadPoliciesCommands(globalParams *common.GlobalParams) []*cobra.Co
 		Short: "Reload policies",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(reloadRuntimePolicies,
-				fx.Supply(core.BundleParams{
-					SecurityAgentConfigFilePaths: globalParams.ConfPathArray,
-					ConfigLoadSecurityAgent:      true,
-				}.LogForOneShot(common.LoggerName, "info", true)),
+				fx.Supply(core.CreateBundleParams(
+					"",
+					core.WithSecurityAgentConfigFilePaths(globalParams.ConfPathArray),
+					core.WithConfigLoadSecurityAgent(true),
+				).LogForOneShot(common.LoggerName, "info", true)),
 				core.Bundle,
 			)
 		},
@@ -227,10 +232,11 @@ func selfTestCommands(globalParams *common.GlobalParams) []*cobra.Command {
 		Short: "Run runtime self test",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(runRuntimeSelfTest,
-				fx.Supply(core.BundleParams{
-					SecurityAgentConfigFilePaths: globalParams.ConfPathArray,
-					ConfigLoadSecurityAgent:      true,
-				}.LogForOneShot(common.LoggerName, "info", true)),
+				fx.Supply(core.CreateBundleParams(
+					"",
+					core.WithSecurityAgentConfigFilePaths(globalParams.ConfPathArray),
+					core.WithConfigLoadSecurityAgent(true),
+				).LogForOneShot(common.LoggerName, "info", true)),
 				core.Bundle,
 			)
 		},
@@ -257,10 +263,11 @@ func downloadPolicyCommands(globalParams *common.GlobalParams) []*cobra.Command 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(downloadPolicy,
 				fx.Supply(downloadPolicyArgs),
-				fx.Supply(core.BundleParams{
-					SecurityAgentConfigFilePaths: globalParams.ConfPathArray,
-					ConfigLoadSecurityAgent:      true,
-				}.LogForOneShot(common.LoggerName, "off", false)),
+				fx.Supply(core.CreateBundleParams(
+					"",
+					core.WithSecurityAgentConfigFilePaths(globalParams.ConfPathArray),
+					core.WithConfigLoadSecurityAgent(true),
+				).LogForOneShot(common.LoggerName, "off", false)),
 				core.Bundle,
 			)
 		},
@@ -289,10 +296,11 @@ func processCacheCommands(globalParams *common.GlobalParams) []*cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(dumpProcessCache,
 				fx.Supply(cliParams),
-				fx.Supply(core.BundleParams{
-					SecurityAgentConfigFilePaths: globalParams.ConfPathArray,
-					ConfigLoadSecurityAgent:      true,
-				}.LogForOneShot(common.LoggerName, "info", true)),
+				fx.Supply(core.CreateBundleParams(
+					"",
+					core.WithSecurityAgentConfigFilePaths(globalParams.ConfPathArray),
+					core.WithConfigLoadSecurityAgent(true),
+				).LogForOneShot(common.LoggerName, "info", true)),
 				core.Bundle,
 			)
 		},
@@ -325,10 +333,11 @@ func networkNamespaceCommands(globalParams *common.GlobalParams) []*cobra.Comman
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(dumpNetworkNamespace,
 				fx.Supply(cliParams),
-				fx.Supply(core.BundleParams{
-					SecurityAgentConfigFilePaths: globalParams.ConfPathArray,
-					ConfigLoadSecurityAgent:      true,
-				}.LogForOneShot(common.LoggerName, "info", true)),
+				fx.Supply(core.CreateBundleParams(
+					"",
+					core.WithSecurityAgentConfigFilePaths(globalParams.ConfPathArray),
+					core.WithConfigLoadSecurityAgent(true),
+				).LogForOneShot(common.LoggerName, "info", true)),
 				core.Bundle,
 			)
 		},
@@ -351,10 +360,11 @@ func discardersCommands(globalParams *common.GlobalParams) []*cobra.Command {
 		Short: "dump discarders",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(dumpDiscarders,
-				fx.Supply(core.BundleParams{
-					SecurityAgentConfigFilePaths: globalParams.ConfPathArray,
-					ConfigLoadSecurityAgent:      true,
-				}.LogForOneShot(common.LoggerName, "info", true)),
+				fx.Supply(core.CreateBundleParams(
+					"",
+					core.WithSecurityAgentConfigFilePaths(globalParams.ConfPathArray),
+					core.WithConfigLoadSecurityAgent(true),
+				).LogForOneShot(common.LoggerName, "info", true)),
 				core.Bundle,
 			)
 		},


### PR DESCRIPTION
### What does this PR do?

This PR makes use of the `core.CreateBundleParams` function instead of the raw struct literal to synchronize on usage with other fx apps

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
