### PR TITLE
[CWS] fix fork/child cgroups release

### DIFF
--- a/pkg/security/probe/process_resolver.go
+++ b/pkg/security/probe/process_resolver.go
@@ -587,7 +587,12 @@ func (p *ProcessResolver) deleteEntry(pid uint32, exitTime time.Time) {
 	entry.Exit(exitTime)
 
 	if entry.IsContainerInit() {
-		p.resolvers.CgroupsResolver.DelPID1(entry.ContainerID)
+		p.resolvers.CgroupsResolver.Release(entry.ContainerID)
+	}
+
+	// Release also the parent if the entry is a fork child. The parent could have increased the ref counter too
+	if entry.IsThread && entry.Ancestor.IsContainerInit() {
+		p.resolvers.CgroupsResolver.Release(entry.Ancestor.ContainerID)
 	}
 
 	delete(p.entryCache, entry.Pid)

--- a/pkg/security/probe/resolvers/cgroups_resolver.go
+++ b/pkg/security/probe/resolvers/cgroups_resolver.go
@@ -54,8 +54,22 @@ func (cr *CgroupsResolver) GetPID1(id string) (uint32, bool) {
 	return entry.pid, true
 }
 
-// DelPID1 removes the entry
-func (cr *CgroupsResolver) DelPID1(id string) {
+// DelByPID1 force removes the entry
+func (cr *CgroupsResolver) DelByPID1(pid uint32) {
+	cr.Lock()
+	defer cr.Unlock()
+
+	for _, id := range cr.pids.Keys() {
+		entry, exists := cr.pids.Get(id)
+		if exists && entry.pid == pid {
+			cr.pids.Remove(id)
+			break
+		}
+	}
+}
+
+// Release decrement usage
+func (cr *CgroupsResolver) Release(id string) {
 	cr.Lock()
 	defer cr.Unlock()
 

--- a/pkg/security/probe/resolvers/mount_resolver.go
+++ b/pkg/security/probe/resolvers/mount_resolver.go
@@ -145,6 +145,7 @@ func (mr *MountResolver) SyncCache(pid uint32) error {
 func (mr *MountResolver) syncCache(pid uint32) error {
 	mnts, err := kernel.ParseMountInfoFile(int32(pid))
 	if err != nil {
+		mr.cgroupsResolver.DelByPID1(pid)
 		return err
 	}
 

--- a/pkg/security/probe/resolvers/mount_resolver_test.go
+++ b/pkg/security/probe/resolvers/mount_resolver_test.go
@@ -11,7 +11,6 @@ package resolvers
 import (
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -448,13 +447,13 @@ func TestMountResolver(t *testing.T) {
 					mr.insert(&evt.mount.Mount)
 				}
 				if evt.umount != nil {
-					if err := mr.Delete(evt.umount.MountID); err != nil {
+					mount, err := mr.ResolveMount(evt.umount.MountID, pid, "")
+					if err != nil {
 						t.Fatal(err)
 					}
+					mr.finalize(mount)
 				}
 			}
-
-			mr.dequeue(time.Now().Add(1 * time.Minute))
 
 			for _, testC := range tt.args.cases {
 				p, err := mr.ResolveMountPath(testC.mountID, pid, "")


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Fix the cgroups ref count for fork child/parent entry. The parent and the child could have incremented the counter thus we need to decrement for both.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
