### PR TITLE
fix(ad): prometheus endpoints config check

### DIFF
--- a/pkg/autodiscovery/providers/prometheus_services_test.go
+++ b/pkg/autodiscovery/providers/prometheus_services_test.go
@@ -182,7 +182,7 @@ func TestPrometheusServicesCollect(t *testing.T) {
 			},
 		},
 		{
-			name:   "collect services and endpoints",
+			name:   "collect only endpoints",
 			checks: []*types.PrometheusCheck{types.DefaultPrometheusCheck},
 			services: []*v1.Service{
 				{
@@ -230,17 +230,6 @@ func TestPrometheusServicesCollect(t *testing.T) {
 			},
 			collectEndpoints: true,
 			expectConfigs: []integration.Config{
-				{
-					Name:       "openmetrics",
-					InitConfig: integration.Data("{}"),
-					Instances: []integration.Data{
-						integration.Data(`{"namespace":"","metrics":[".*"],"openmetrics_endpoint":"http://%%host%%:1234/mewtrix"}`),
-					},
-					ADIdentifiers: []string{"kube_service://ns/svc"},
-					Provider:      "prometheus-services",
-					ClusterCheck:  true,
-					Source:        "prometheus_services:kube_service://ns/svc",
-				},
 				{
 					Name:       "openmetrics",
 					ServiceID:  "kube_endpoint_uid://ns/svc/10.0.0.1",

--- a/releasenotes/notes/fix-ad-prometheus-scrape-config-8c99b1cd6a4b1fae.yaml
+++ b/releasenotes/notes/fix-ad-prometheus-scrape-config-8c99b1cd6a4b1fae.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Create only endpoints check from prometheus scrape configuration
+    when `prometheus_scrape.service.endpoint` option is enabled.


### PR DESCRIPTION
### What does this PR do?

This PR improves how the configure with "auto-discovery" Service and Endpoints checks from Prometheus Annotations.

The issue is that we configure both "Service" and "Endpoints" for the same Service even if the user has configured `prometheus_scrape.service_endpoints:true`.

The fix consists in not creating a Service check if `prometheus_scrape.service_endpoints:true`.

### Motivation

do not run `Service` and `Endpoints` check on the same prometheus resources.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Deploy the agent with `prometheus_scrape.service_endpoints:true`.
Configure a dummy test application with  prometheus scrape annotation on a service that target pods.
Check in the datadog cluster-agent that only "Endpoints" checks are configured.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
