### PR TITLE
Add custom service extraction support for java processes

### DIFF
--- a/pkg/process/metadata/parser/service.go
+++ b/pkg/process/metadata/parser/service.go
@@ -33,6 +33,7 @@ var binsWithContext = map[string]serviceExtractorFn{
 	"ruby2.3":   parseCommandContext,
 	"ruby":      parseCommandContext,
 	"java":      parseCommandContextJava,
+	"java.exe":  parseCommandContextJava,
 	"sudo":      parseCommandContext,
 }
 
@@ -104,10 +105,15 @@ func extractServiceMetadata(cmd []string) *serviceMetadata {
 
 	exe := cmd[0]
 	// check if all args are packed into the first argument
-	if idx := strings.IndexRune(exe, ' '); idx != -1 {
-		exe = exe[0:idx]
-		cmd = strings.Split(cmd[0], " ")
+	if len(cmd) == 1 {
+		if idx := strings.IndexRune(exe, ' '); idx != -1 {
+			exe = exe[0:idx]
+			cmd = strings.Split(cmd[0], " ")
+		}
 	}
+
+	// trim quotes from string
+	exe = strings.Trim(exe, "\"")
 
 	// Extract executable from commandline args
 	exe = trimColonRight(removeFilePath(exe))

--- a/pkg/process/metadata/parser/service.go
+++ b/pkg/process/metadata/parser/service.go
@@ -112,7 +112,7 @@ func extractServiceMetadata(cmd []string) *serviceMetadata {
 		}
 	}
 
-	// trim quotes from string
+	// trim any quotes from the executable
 	exe = strings.Trim(exe, "\"")
 
 	// Extract executable from commandline args

--- a/pkg/process/metadata/parser/service_test.go
+++ b/pkg/process/metadata/parser/service_test.go
@@ -79,6 +79,37 @@ func TestExtractServiceMetadata(t *testing.T) {
 			},
 			expectedServiceTag: "service:td-agent",
 		},
+		{
+			name: "java using the -jar flag to define the service",
+			cmdline: []string{
+				"java", "-Xmx4000m", "-Xms4000m", "-XX:ReservedCodeCacheSize=256m", "-jar", "/opt/sheepdog/bin/myservice.jar",
+			},
+			expectedServiceTag: "service:myservice",
+		},
+		{
+			name: "java class name as service",
+			cmdline: []string{
+				"java", "-Xmx4000m", "-Xms4000m", "-XX:ReservedCodeCacheSize=256m", "-jar", "com.datadog.example.HelloWorld",
+			},
+			expectedServiceTag: "service:HelloWorld",
+		},
+		{
+			name: "java kafka",
+			cmdline: []string{
+				"java", "-Xmx4000m", "-Xms4000m", "-XX:ReservedCodeCacheSize=256m", "kafka.Kafka",
+			},
+			expectedServiceTag: "service:Kafka",
+		},
+		{
+			name: "java parsing for org.apache projects with cassandra as the service",
+			cmdline: []string{
+				"/usr/bin/java", "-Xloggc:/usr/share/cassandra/logs/gc.log", "-ea", "-XX:+HeapDumpOnOutOfMemoryError", "-Xss256k", "-Dlogback.configurationFile=logback.xml",
+				"-Dcassandra.logdir=/var/log/cassandra", "-Dcassandra.storagedir=/data/cassandra",
+				"-cp", "/etc/cassandra:/usr/share/cassandra/lib/HdrHistogram-2.1.9.jar:/usr/share/cassandra/lib/cassandra-driver-core-3.0.1-shaded.jar",
+				"org.apache.cassandra.service.CassandraDaemon",
+			},
+			expectedServiceTag: "service:cassandra",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/process/metadata/parser/service_test.go
+++ b/pkg/process/metadata/parser/service_test.go
@@ -89,7 +89,7 @@ func TestExtractServiceMetadata(t *testing.T) {
 		{
 			name: "java class name as service",
 			cmdline: []string{
-				"java", "-Xmx4000m", "-Xms4000m", "-XX:ReservedCodeCacheSize=256m", "-jar", "com.datadog.example.HelloWorld",
+				"java", "-Xmx4000m", "-Xms4000m", "-XX:ReservedCodeCacheSize=256m", "com.datadog.example.HelloWorld",
 			},
 			expectedServiceTag: "service:HelloWorld",
 		},

--- a/pkg/process/metadata/parser/service_test.go
+++ b/pkg/process/metadata/parser/service_test.go
@@ -110,6 +110,13 @@ func TestExtractServiceMetadata(t *testing.T) {
 			},
 			expectedServiceTag: "service:cassandra",
 		},
+		{
+			name: "java space in java executable path",
+			cmdline: []string{
+				"/home/dd/my java dir/java", "com.dog.cat",
+			},
+			expectedServiceTag: "service:cat",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/process/metadata/parser/service_windows_test.go
+++ b/pkg/process/metadata/parser/service_windows_test.go
@@ -40,7 +40,7 @@ func TestWindowsExtractServiceMetadata(t *testing.T) {
 		{
 			name: "java using the -jar flag",
 			cmdline: []string{
-				"\"C:\\Program Files\\Java\\j2re1.4.2_04\\bin\\javaw.exe\"", "-Xmx4000m", "-Xms4000m", "-XX:ReservedCodeCacheSize=256m", "-jar", "myService.jar",
+				"\"C:\\Program Files\\Java\\jdk-17.0.1\\bin\\java\"", "-Xmx4000m", "-Xms4000m", "-XX:ReservedCodeCacheSize=256m", "-jar", "myService.jar",
 			},
 			expectedServiceTag: "service:myservice",
 		},

--- a/pkg/process/metadata/parser/service_windows_test.go
+++ b/pkg/process/metadata/parser/service_windows_test.go
@@ -37,6 +37,13 @@ func TestWindowsExtractServiceMetadata(t *testing.T) {
 			},
 			expectedServiceTag: "service:nginx",
 		},
+		{
+			name: "java using the -jar flag",
+			cmdline: []string{
+				"java", "-Xmx4000m", "-Xms4000m", "-XX:ReservedCodeCacheSize=256m", "-jar", "\"C:\\Program Files\\datadog\\myService.jar\"",
+			},
+			expectedServiceTag: "service:myservice",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/process/metadata/parser/service_windows_test.go
+++ b/pkg/process/metadata/parser/service_windows_test.go
@@ -42,7 +42,14 @@ func TestWindowsExtractServiceMetadata(t *testing.T) {
 			cmdline: []string{
 				"\"C:\\Program Files\\Java\\jdk-17.0.1\\bin\\java\"", "-Xmx4000m", "-Xms4000m", "-XX:ReservedCodeCacheSize=256m", "-jar", "myService.jar",
 			},
-			expectedServiceTag: "service:myservice",
+			expectedServiceTag: "service:myService",
+		},
+		{
+			name: "java with exe extension",
+			cmdline: []string{
+				"C:\\Program Files\\Java\\jdk-17.0.1\\bin\\java.exe", "com.dog.myService",
+			},
+			expectedServiceTag: "service:myService",
 		},
 	}
 

--- a/pkg/process/metadata/parser/service_windows_test.go
+++ b/pkg/process/metadata/parser/service_windows_test.go
@@ -40,7 +40,7 @@ func TestWindowsExtractServiceMetadata(t *testing.T) {
 		{
 			name: "java using the -jar flag",
 			cmdline: []string{
-				"java", "-Xmx4000m", "-Xms4000m", "-XX:ReservedCodeCacheSize=256m", "-jar", "\"C:\\Program Files\\datadog\\myService.jar\"",
+				"\"C:\\Program Files\\Java\\j2re1.4.2_04\\bin\\javaw.exe\"", "-Xmx4000m", "-Xms4000m", "-XX:ReservedCodeCacheSize=256m", "-jar", "myService.jar",
 			},
 			expectedServiceTag: "service:myservice",
 		},


### PR DESCRIPTION
### What does this PR do?

An extension of the service tag extraction work done in: https://github.com/DataDog/datadog-agent/pull/14287

#### Service tag extraction examples

| Command line   | Service tag       |
|----------------|-------------------|
| java -Xmx4g -Xms2g -jar /opt/dd/bin/myserver.jar  | my-server |
| java kafka.Kafka | Kafka  | 
| /usr/bin/java org.apache.cassandra.service.CassandraDaemon | cassandra            |
| java -cp /some/path/foo.jar:/some/path/bar.jar com.example.HelloWorld | HelloWorld |

### Motivation


### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
1. Enable the system probe service monitoring (system-probe.yaml)
```
service_monitoring_config:
  enabled: true
  process_service_inference:
    enabled: true
```

2. Run a java process with active network connections. (ex. kafka, cassandra, zookeeper, etc)
3. Run a connections check from the process agent with trace logging enabled
```
DD_LOG_LEVEL=TRACE process-agent check connections
``` 

### Reviewer's Checklist
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
