### PR TITLE
Fix small typo in install XML.

### DIFF
--- a/omnibus/resources/agent/msi/localization-en-us.wxl.erb
+++ b/omnibus/resources/agent/msi/localization-en-us.wxl.erb
@@ -21,7 +21,7 @@
   <String Id="FeaturesDlgDescription">{\WixUI_Font_Normal_White}Select the way you want features to be installed.</String>
 
   <String Id="FilesInUseTitle">{\WixUI_Font_Title_White}Files in Use</String>
-  <String Id="FilesInUseDescription">WixUI_Font_Normal_White}Some files that need to be updated are currently in use.</String>
+  <String Id="FilesInUseDescription">{\WixUI_Font_Normal_White}Some files that need to be updated are currently in use.</String>
 
   <String Id="InstallDirDlgTitle">{\WixUI_Font_Title_White}Destination Folder</String>
   <String Id="InstallDirDlgDescription">{\WixUI_Font_Normal_White}Click Next to install to the default folder or click Change to choose another.</String>


### PR DESCRIPTION
Causes Wix to throw error (although apparently non-fatal)

### Motivation

noticed error during unrelated development

### Additional Notes
### Possible Drawbacks / Trade-offs
### Describe how to test/QA your changes

### Reviewer's Checklist
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
