### PR TITLE
[CSPM] Send failed report first

### DIFF
--- a/pkg/compliance/checks/check.go
+++ b/pkg/compliance/checks/check.go
@@ -6,6 +6,7 @@
 package checks
 
 import (
+	"sort"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
@@ -126,6 +127,8 @@ func (c *complianceCheck) Run() error {
 	var err error
 
 	reports := c.checkable.Check(c)
+	sort.Sort(reports)
+
 	resourceQuadIDs := make(map[resourceQuadID]bool)
 
 	for _, report := range reports {

--- a/pkg/compliance/checks/checkable.go
+++ b/pkg/compliance/checks/checkable.go
@@ -12,5 +12,5 @@ import (
 
 // Checkable abstracts a resource check
 type Checkable interface {
-	Check(env env.Env) []*compliance.Report
+	Check(env env.Env) compliance.Reports
 }

--- a/pkg/compliance/checks/mock_checkable_test.go
+++ b/pkg/compliance/checks/mock_checkable_test.go
@@ -16,7 +16,7 @@ type mockCheckable struct {
 	mock.Mock
 }
 
-func (m *mockCheckable) Check(env env.Env) []*compliance.Report {
+func (m *mockCheckable) Check(env env.Env) compliance.Reports {
 	args := m.Called(env)
 	reports := args.Get(0).([]*compliance.Report)
 	return reports

--- a/pkg/compliance/rego/rego_check.go
+++ b/pkg/compliance/rego/rego_check.go
@@ -514,7 +514,7 @@ func findingsToReports(findings []regoFinding) []*compliance.Report {
 	return reports
 }
 
-func (r *regoCheck) Check(env env.Env) []*compliance.Report {
+func (r *regoCheck) Check(env env.Env) compliance.Reports {
 	r.evalLock.Lock()
 	defer r.evalLock.Unlock()
 

--- a/pkg/compliance/rego/rego_check_test.go
+++ b/pkg/compliance/rego/rego_check_test.go
@@ -25,7 +25,7 @@ type regoFixture struct {
 	findings string
 
 	processes     processutils.Processes
-	expectReports []*compliance.Report
+	expectReports compliance.Reports
 }
 
 func (f *regoFixture) newRegoCheck() (*regoCheck, error) {
@@ -116,7 +116,7 @@ func TestRegoCheck(t *testing.T) {
 				}
 			`,
 			findings: "data.test.findings",
-			expectReports: []*compliance.Report{
+			expectReports: compliance.Reports{
 				{
 					Passed: true,
 					Data: event.Data{
@@ -178,7 +178,7 @@ func TestRegoCheck(t *testing.T) {
 			processes: processutils.Processes{
 				42: processutils.NewCheckedFakeProcess(42, "proc1", []string{"arg1", "--path=foo"}),
 			},
-			expectReports: []*compliance.Report{
+			expectReports: compliance.Reports{
 				{
 					Passed: true,
 					Data: event.Data{
@@ -232,7 +232,7 @@ func TestRegoCheck(t *testing.T) {
 			processes: processutils.Processes{
 				42: processutils.NewCheckedFakeProcess(42, "proc1", []string{"arg1", "--path=foo"}),
 			},
-			expectReports: []*compliance.Report{
+			expectReports: compliance.Reports{
 				{
 					Passed: false,
 					Data: event.Data{
@@ -277,7 +277,7 @@ func TestRegoCheck(t *testing.T) {
 			processes: processutils.Processes{
 				42: processutils.NewCheckedFakeProcess(42, "proc1", []string{"arg1", "--path=foo"}),
 			},
-			expectReports: []*compliance.Report{
+			expectReports: compliance.Reports{
 				{
 					Passed: false,
 					Data:   nil,

--- a/pkg/compliance/report.go
+++ b/pkg/compliance/report.go
@@ -32,3 +32,10 @@ type ReportResource struct {
 	ID   string
 	Type string
 }
+
+// Reports aggregates compliance reports
+type Reports []*Report
+
+func (r Reports) Len() int           { return len(r) }
+func (r Reports) Less(i, j int) bool { return !r[i].Passed && r[i].Error == nil }
+func (r Reports) Swap(i, j int)      { r[i], r[j] = r[j], r[i] }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

When multiple findings are generated for the same resource ID/Type tuple, only one
is sent. When one is in "passed" state and an other one is in "failed" state, we should send
the latter.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
