### PR TITLE
Add netlink process monitor

### DIFF
--- a/pkg/network/protocols/http/ebpf_gotls.go
+++ b/pkg/network/protocols/http/ebpf_gotls.go
@@ -248,7 +248,12 @@ func (p *GoTLSProgram) Start() {
 	}
 	return
 failed:
-	p.procMonitor.cleanupExec()
+	if p.procMonitor.cleanupExec != nil {
+		p.procMonitor.cleanupExec()
+	}
+	if p.procMonitor.cleanupExit != nil {
+		p.procMonitor.cleanupExit()
+	}
 	return
 }
 

--- a/pkg/network/protocols/http/ebpf_gotls.go
+++ b/pkg/network/protocols/http/ebpf_gotls.go
@@ -244,8 +244,12 @@ func (p *GoTLSProgram) Start() {
 	})
 	if err != nil {
 		log.Errorf("failed to subscribe Exit process monitor error: %s", err)
-		return
+		goto failed
 	}
+	return
+failed:
+	p.procMonitor.cleanupExec()
+	return
 }
 
 func (p *GoTLSProgram) Stop() {

--- a/pkg/network/protocols/http/ebpf_gotls.go
+++ b/pkg/network/protocols/http/ebpf_gotls.go
@@ -234,7 +234,7 @@ func (p *GoTLSProgram) Start() {
 		Callback: p.handleProcessStart,
 	})
 	if err != nil {
-		log.Errorf("process monitor Subscribe() error: %s", err)
+		log.Errorf("failed to subscribe Exec process monitor error: %s", err)
 		return
 	}
 	p.procMonitor.cleanupExit, err = mon.Subscribe(&monitor.ProcessCallback{
@@ -243,7 +243,7 @@ func (p *GoTLSProgram) Start() {
 		Callback: p.handleProcessStop,
 	})
 	if err != nil {
-		log.Errorf("process monitor Subscribe() error: %s", err)
+		log.Errorf("failed to subscribe Exit process monitor error: %s", err)
 		return
 	}
 }

--- a/pkg/network/protocols/http/ebpf_gotls.go
+++ b/pkg/network/protocols/http/ebpf_gotls.go
@@ -227,9 +227,9 @@ func (p *GoTLSProgram) Start() {
 		return
 	}
 
-	mon := monitor.GetProcessMonitor()
-	if mon == nil {
-		log.Errorf("can't register process monitor callbacks")
+	mon, err := monitor.GetProcessMonitor()
+	if err != nil {
+		log.Errorf("couldn't get process monitor: %w", err)
 		return
 	}
 	p.procMonitor.cleanupExec, err = mon.Subscribe(&monitor.ProcessCallback{

--- a/pkg/network/protocols/http/ebpf_gotls.go
+++ b/pkg/network/protocols/http/ebpf_gotls.go
@@ -232,16 +232,24 @@ func (p *GoTLSProgram) Start() {
 		log.Errorf("can't register process monitor callbacks")
 		return
 	}
-	p.procMonitor.cleanupExec = mon.Subscribe(&monitor.ProcessCallback{
+	p.procMonitor.cleanupExec, err = mon.Subscribe(&monitor.ProcessCallback{
 		Event:    monitor.EXEC,
 		Metadata: monitor.ANY,
 		Callback: p.handleProcessStart,
 	})
-	p.procMonitor.cleanupExit = mon.Subscribe(&monitor.ProcessCallback{
+	if err != nil {
+		log.Errorf("process monitor Subscribe() error: %s", err)
+		return
+	}
+	p.procMonitor.cleanupExit, err = mon.Subscribe(&monitor.ProcessCallback{
 		Event:    monitor.EXIT,
 		Metadata: monitor.ANY,
 		Callback: p.handleProcessStop,
 	})
+	if err != nil {
+		log.Errorf("process monitor Subscribe() error: %s", err)
+		return
+	}
 }
 
 func (p *GoTLSProgram) Stop() {

--- a/pkg/network/protocols/http/ebpf_gotls.go
+++ b/pkg/network/protocols/http/ebpf_gotls.go
@@ -227,11 +227,7 @@ func (p *GoTLSProgram) Start() {
 		return
 	}
 
-	mon, err := monitor.GetProcessMonitor()
-	if err != nil {
-		log.Errorf("couldn't get process monitor: %w", err)
-		return
-	}
+	mon := monitor.GetProcessMonitor()
 	p.procMonitor.cleanupExec, err = mon.Subscribe(&monitor.ProcessCallback{
 		Event:    monitor.EXEC,
 		Metadata: monitor.ANY,

--- a/pkg/network/protocols/http/monitor.go
+++ b/pkg/network/protocols/http/monitor.go
@@ -96,10 +96,7 @@ func NewMonitor(c *config.Config, offsets []manager.ConstantEditor, sockFD *ebpf
 		return nil, fmt.Errorf("couldn't instantiate batch manager: %w", err)
 	}
 
-	processMonitor, err := monitor.GetProcessMonitor()
-	if err != nil {
-		return nil, fmt.Errorf("couldn't instantiate process monitor: %w", err)
-	}
+	processMonitor := monitor.GetProcessMonitor()
 
 	return &Monitor{
 		handler:                handler,

--- a/pkg/network/protocols/http/monitor.go
+++ b/pkg/network/protocols/http/monitor.go
@@ -96,7 +96,7 @@ func NewMonitor(c *config.Config, offsets []manager.ConstantEditor, sockFD *ebpf
 		return nil, fmt.Errorf("couldn't instantiate batch manager: %w", err)
 	}
 
-	processMonitor := monitor.GetProcessMonitor(c)
+	processMonitor := monitor.GetProcessMonitor()
 
 	return &Monitor{
 		handler:                handler,

--- a/pkg/network/protocols/http/monitor.go
+++ b/pkg/network/protocols/http/monitor.go
@@ -155,7 +155,7 @@ func (m *Monitor) Start() error {
 	}()
 
 	if m.processMonitor != nil {
-		m.processMonitor.InitWithAllCurrentProcess()
+		m.processMonitor.Initialize()
 	}
 
 	return nil

--- a/pkg/network/protocols/http/monitor.go
+++ b/pkg/network/protocols/http/monitor.go
@@ -157,11 +157,7 @@ func (m *Monitor) Start() error {
 		}
 	}()
 
-	if err := m.processMonitor.Initialize(); err != nil {
-		return err
-	}
-
-	return nil
+	return m.processMonitor.Initialize()
 }
 
 // GetHTTPStats returns a map of HTTP stats stored in the following format:

--- a/pkg/network/protocols/http/monitor.go
+++ b/pkg/network/protocols/http/monitor.go
@@ -96,7 +96,10 @@ func NewMonitor(c *config.Config, offsets []manager.ConstantEditor, sockFD *ebpf
 		return nil, fmt.Errorf("couldn't instantiate batch manager: %w", err)
 	}
 
-	processMonitor := monitor.GetProcessMonitor()
+	processMonitor, err := monitor.GetProcessMonitor()
+	if err != nil {
+		return nil, fmt.Errorf("couldn't instantiate process monitor: %w", err)
+	}
 
 	return &Monitor{
 		handler:                handler,
@@ -154,10 +157,8 @@ func (m *Monitor) Start() error {
 		}
 	}()
 
-	if m.processMonitor != nil {
-		if err := m.processMonitor.Initialize(); err != nil {
-			return err
-		}
+	if err := m.processMonitor.Initialize(); err != nil {
+		return err
 	}
 
 	return nil

--- a/pkg/network/protocols/http/monitor.go
+++ b/pkg/network/protocols/http/monitor.go
@@ -155,7 +155,9 @@ func (m *Monitor) Start() error {
 	}()
 
 	if m.processMonitor != nil {
-		m.processMonitor.Initialize()
+		if err := m.processMonitor.Initialize(); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/pkg/process/monitor/process_monitor.go
+++ b/pkg/process/monitor/process_monitor.go
@@ -144,7 +144,7 @@ func (p *ProcessMonitor) evalEXECCallback(c *ProcessCallback, pid uint32) {
 	case NAME:
 		pname, err := proc.Name()
 		if err != nil {
-			log.Errorf("process %d name parsing failed %s", pid, err)
+			log.Warnf("process %d name parsing failed %s", pid, err)
 			return
 		}
 		if c.Regex.MatchString(pname) {
@@ -168,7 +168,7 @@ func (pm *ProcessMonitor) Initialize() error {
 	pm.errors = make(chan error)
 
 	if err := netlink.ProcEventMonitor(pm.events, pm.done, pm.errors); err != nil {
-		return fmt.Errorf("could not create process monitor: %s", err)
+		return fmt.Errorf("couldn't initialize process monitor: %s", err)
 	}
 
 	pm.callbackRunnerDone = make(chan struct{}, runtime.NumCPU())

--- a/pkg/process/monitor/process_monitor.go
+++ b/pkg/process/monitor/process_monitor.go
@@ -42,6 +42,8 @@ var (
 // Multiple team can use the same ProcessMonitor,
 // the callers need to guarantee calling each Initialize() Stop() one single time
 // this maintain an internal reference counter
+//
+// ProcessMonitor require root or CAP_NET_ADMIN capabilities
 type ProcessMonitor struct {
 	m        sync.Mutex
 	wg       sync.WaitGroup

--- a/pkg/process/monitor/process_monitor.go
+++ b/pkg/process/monitor/process_monitor.go
@@ -133,9 +133,9 @@ func (p *ProcessMonitor) evalEXECCallback(c *ProcessCallback, pid uint32) {
 
 	var err error
 	var proc *process.Process
+	// We receive the Exec event first and /proc could be slow to update
 	end := time.Now().Add(10 * time.Millisecond)
 	for end.After(time.Now()) {
-		// /proc could be slow to update
 		proc, err = process.NewProcess(int32(pid))
 		if err == nil {
 			break
@@ -143,7 +143,9 @@ func (p *ProcessMonitor) evalEXECCallback(c *ProcessCallback, pid uint32) {
 		time.Sleep(time.Millisecond)
 	}
 	if err != nil {
-		log.Errorf("process %d parsing failed %s", pid, err)
+		// short living process can hit here (or later proc.Name() parsing)
+		// as they already exited when we try to find them in /proc
+		// so let's be quiet on the logs as there not much to do here
 		return
 	}
 

--- a/pkg/process/monitor/process_monitor.go
+++ b/pkg/process/monitor/process_monitor.go
@@ -160,7 +160,7 @@ func (p *ProcessMonitor) evalEXECCallback(c *ProcessCallback, pid uint32) {
 	case NAME:
 		pname, err := proc.Name()
 		if err != nil {
-			log.Warnf("process %d name parsing failed %s", pid, err)
+			log.Debugf("process %d name parsing failed %s", pid, err)
 			return
 		}
 		if c.Regex.MatchString(pname) {

--- a/pkg/process/monitor/process_monitor.go
+++ b/pkg/process/monitor/process_monitor.go
@@ -162,9 +162,25 @@ func (pm *ProcessMonitor) Stop() {
 	processMonitorLock.Unlock()
 }
 
+// GetProcessMonitor() create a monitor (only once) that register to netlink process events.
+//
+// This monitor can monitor.Subscribe(callback, filter) callback on particual event
+// like process EXEC, EXIT. The callback will be called when the filter will match.
+// Filter can be applied on :
+//   process name (NAME)
+//   /proc/pid/smaps file (MAPFILE)
+//   by default ANY is applied
+//
+// Typical initialization:
+// mon := GetProcessMonitor()
+// mon.Subcribe(callback)
+// mon.InitWithAllCurrentProcess()
+//
+// note: o GetProcessMonitor() will always return the same instance
+//         as we can only regiter once with netlink process event
+//       o mon.Subcribe() can be called at anytime, event later
+//
 func GetProcessMonitor() *ProcessMonitor {
-	// we want only one instance as
-	// netlink.ProcEventMonitor() netlink doesn't support multiple connections
 	processMonitorLock.RLock()
 	if processMonitor != nil {
 		defer processMonitorLock.RUnlock()

--- a/pkg/process/monitor/process_monitor.go
+++ b/pkg/process/monitor/process_monitor.go
@@ -127,6 +127,7 @@ func (p *ProcessMonitor) evalEXECCallback(c *ProcessCallback, pid uint32) {
 		for _, mmap := range *mmaps {
 			if c.Regex.MatchString(mmap.Path) {
 				p.enqueueCallback(c, pid)
+				break
 			}
 		}
 	}

--- a/pkg/process/monitor/process_monitor.go
+++ b/pkg/process/monitor/process_monitor.go
@@ -67,7 +67,6 @@ type ProcessMetadataField int
 const (
 	ANY ProcessMetadataField = iota
 	NAME
-	MAPFILE
 )
 
 type ProcessCallback struct {
@@ -122,21 +121,6 @@ func (p *ProcessMonitor) evalEXECCallback(c *ProcessCallback, pid uint32) {
 		}
 		if c.Regex.MatchString(pname) {
 			p.enqueueCallback(c, pid)
-		}
-	case MAPFILE:
-		mmaps, err := proc.MemoryMaps(true)
-		if err != nil {
-			log.Errorf("process %d maps parsing failed %s", pid, err)
-			return
-		}
-		if mmaps == nil {
-			return
-		}
-		for _, mmap := range *mmaps {
-			if c.Regex.MatchString(mmap.Path) {
-				p.enqueueCallback(c, pid)
-				break
-			}
 		}
 	}
 }

--- a/pkg/process/monitor/process_monitor.go
+++ b/pkg/process/monitor/process_monitor.go
@@ -306,7 +306,7 @@ func (pm *ProcessMonitor) Subscribe(callback *ProcessCallback) (UnSubscribe func
 
 	for _, c := range pm.procEventCallbacks[callback.Event] {
 		if c == callback {
-			return func() {}, errors.New("same callback can't be registred twice")
+			return nil, errors.New("same callback can't be registred twice")
 		}
 	}
 
@@ -320,7 +320,7 @@ func (pm *ProcessMonitor) Subscribe(callback *ProcessCallback) (UnSubscribe func
 			}
 		}
 		if !foundSibling {
-			return func() {}, errors.New("no Exec callback has been found with the same Metadata and Regex, please Subscribe(Exec callback, Metadata) first")
+			return nil, errors.New("no Exec callback has been found with the same Metadata and Regex, please Subscribe(Exec callback, Metadata) first")
 		}
 	}
 

--- a/pkg/process/monitor/process_monitor.go
+++ b/pkg/process/monitor/process_monitor.go
@@ -78,14 +78,14 @@ func (pm *ProcessMonitor) enqueueCallback(callback *ProcessCallback, pid uint32)
 
 func (pm *ProcessMonitor) InitWithAllCurrentProcess() {
 	fn := func(pid int) error {
-		pm.m.Lock()
 		for _, c := range pm.procEventCallbacks[EXEC] {
 			pm.evalEXECCallback(c, uint32(pid))
 		}
-		pm.m.Unlock()
 		return nil
 	}
 
+	pm.m.Lock()
+	defer pm.m.Unlock()
 	if err := util.WithAllProcs(util.HostProc(), fn); err != nil {
 		log.Errorf("process monitor init, scanning all process failed %s", err)
 	}

--- a/pkg/process/monitor/process_monitor_test.go
+++ b/pkg/process/monitor/process_monitor_test.go
@@ -29,11 +29,8 @@ func TestProcessMonitorBasics(t *testing.T) {
 	}
 
 	// Making sure we get the same process monitor if we call it twice.
-	pm, err := GetProcessMonitor()
-	require.NoError(t, err)
-
-	pm2, err := GetProcessMonitor()
-	require.NoError(t, err)
+	pm := GetProcessMonitor()
+	pm2 := GetProcessMonitor()
 
 	require.Equal(t, pm, pm2)
 
@@ -71,8 +68,7 @@ func TestProcessMonitorCallbacks(t *testing.T) {
 		t.Skip("require CAP_NET_ADMIN capabilities")
 	}
 
-	pm, err := GetProcessMonitor()
-	require.NoError(t, err)
+	pm := GetProcessMonitor()
 
 	numberOfExecs := 0
 	numberOfExits := 0

--- a/pkg/process/monitor/process_monitor_test.go
+++ b/pkg/process/monitor/process_monitor_test.go
@@ -24,10 +24,6 @@ import (
 )
 
 func TestProcessMonitorBasics(t *testing.T) {
-	if os.Geteuid() != 0 {
-		t.Skip("require CAP_NET_ADMIN capabilities")
-	}
-
 	// Making sure we get the same process monitor if we call it twice.
 	pm := GetProcessMonitor()
 	pm2 := GetProcessMonitor()
@@ -64,10 +60,6 @@ func TestProcessMonitorBasics(t *testing.T) {
 }
 
 func TestProcessMonitorCallbacks(t *testing.T) {
-	if os.Geteuid() != 0 {
-		t.Skip("require CAP_NET_ADMIN capabilities")
-	}
-
 	pm := GetProcessMonitor()
 
 	numberOfExecs := 0
@@ -125,10 +117,6 @@ func TestProcessMonitorCallbacks(t *testing.T) {
 }
 
 func TestProcessMonitorRefcount(t *testing.T) {
-	if os.Geteuid() != 0 {
-		t.Skip("require CAP_NET_ADMIN capabilities")
-	}
-
 	pm := GetProcessMonitor()
 	require.Equal(t, pm.refcount, 0)
 	err := pm.Initialize()

--- a/pkg/process/monitor/process_monitor_test.go
+++ b/pkg/process/monitor/process_monitor_test.go
@@ -76,7 +76,7 @@ func TestProcessMonitorCallbacks(t *testing.T) {
 	tmpFile, err := ioutil.TempFile("", "echo")
 	require.NoError(t, err)
 	defer os.Remove(tmpFile.Name())
-	err = util.CopyFile("/usr/bin/echo", tmpFile.Name())
+	err = util.CopyFile("/bin/echo", tmpFile.Name())
 	require.NoError(t, err)
 
 	require.NoError(t, os.Chmod(tmpFile.Name(), 0500))

--- a/pkg/process/monitor/process_monitor_test.go
+++ b/pkg/process/monitor/process_monitor_test.go
@@ -24,6 +24,10 @@ import (
 )
 
 func TestProcessMonitorBasics(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("require CAP_NET_ADMIN capabilities")
+	}
+
 	// Making sure we get the same process monitor if we call it twice.
 	pm, err := GetProcessMonitor()
 	require.NoError(t, err)
@@ -63,6 +67,10 @@ func TestProcessMonitorBasics(t *testing.T) {
 }
 
 func TestProcessMonitorCallbacks(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("require CAP_NET_ADMIN capabilities")
+	}
+
 	pm, err := GetProcessMonitor()
 	require.NoError(t, err)
 

--- a/pkg/process/monitor/process_monitor_test.go
+++ b/pkg/process/monitor/process_monitor_test.go
@@ -1,0 +1,120 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+// +build linux
+
+package monitor
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/util"
+)
+
+func TestProcessMonitorBasics(t *testing.T) {
+	// Making sure we get the same process monitor if we call it twice.
+	pm, err := GetProcessMonitor()
+	require.NoError(t, err)
+
+	pm2, err := GetProcessMonitor()
+	require.NoError(t, err)
+
+	require.Equal(t, pm, pm2)
+
+	// Sanity subscribing a callback.
+	callback := &ProcessCallback{
+		Event:    EXEC,
+		Metadata: ANY,
+		Callback: func(pid uint32) {},
+	}
+	unsubscribe, err := pm.Subscribe(callback)
+	require.NoError(t, err)
+
+	// Sanity subscribing a callback.
+	callback2 := &ProcessCallback{
+		Event:    EXEC,
+		Metadata: ANY,
+		Callback: func(pid uint32) {},
+	}
+	unsubscribe2, err := pm.Subscribe(callback2)
+	require.NoError(t, err)
+
+	// duplicated subscription should fail.
+	_, err = pm.Subscribe(callback)
+	require.Error(t, err)
+
+	// making sure unsubscribe works and does not panic for the second unsubscription.
+	unsubscribe()
+	require.NotPanics(t, unsubscribe)
+	unsubscribe2()
+	require.NotPanics(t, unsubscribe2)
+}
+
+func TestProcessMonitorCallbacks(t *testing.T) {
+	pm, err := GetProcessMonitor()
+	require.NoError(t, err)
+
+	numberOfExecs := 0
+	numberOfExits := 0
+
+	tmpFile, err := ioutil.TempFile("", "echo")
+	require.NoError(t, err)
+	defer os.Remove(tmpFile.Name())
+	err = util.CopyFile("/usr/bin/echo", tmpFile.Name())
+	require.NoError(t, err)
+
+	require.NoError(t, os.Chmod(tmpFile.Name(), 0500))
+
+	require.NoError(t, pm.Initialize())
+	callbackExec := &ProcessCallback{
+		Event:    EXEC,
+		Metadata: NAME,
+		Regex:    regexp.MustCompile(path.Base(tmpFile.Name())),
+		Callback: func(pid uint32) {
+			numberOfExecs++
+		},
+	}
+	callbackExit := &ProcessCallback{
+		Event:    EXIT,
+		Metadata: NAME, // we want only the captured Exec process
+		Regex:    regexp.MustCompile(path.Base(tmpFile.Name())),
+		Callback: func(pid uint32) {
+			numberOfExits++
+		},
+	}
+
+	unsubscribeExec, err := pm.Subscribe(callbackExec)
+	require.NoError(t, err)
+	unsubscribeExit, err := pm.Subscribe(callbackExit)
+	require.NoError(t, err)
+
+	require.NoError(t, exec.Command(tmpFile.Name(), "test").Run())
+	require.Eventuallyf(t, func() bool {
+		return numberOfExecs == 1 && numberOfExits == 1
+	}, time.Second, time.Millisecond*200, fmt.Sprintf("didn't capture exec %d and exit %d", numberOfExecs, numberOfExits))
+
+	unsubscribeExit()
+	require.NoError(t, exec.Command(tmpFile.Name()).Run())
+	require.Eventuallyf(t, func() bool {
+		return numberOfExecs == 2 && numberOfExits == 1
+	}, time.Second, time.Millisecond*200, fmt.Sprintf("didn't capture exec %d and exit %d", numberOfExecs, numberOfExits))
+
+	unsubscribeExec()
+	require.NoError(t, exec.Command(tmpFile.Name()).Run())
+	require.Eventuallyf(t, func() bool {
+		return numberOfExecs == 2 && numberOfExits == 1
+	}, time.Second, time.Millisecond*200, fmt.Sprintf("didn't capture exec %d and exit %d", numberOfExecs, numberOfExits))
+
+}

--- a/pkg/process/monitor/process_monitor_test.go
+++ b/pkg/process/monitor/process_monitor_test.go
@@ -3,8 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build linux
-// +build linux
+//go:build linux_bpf
+// +build linux_bpf
 
 package monitor
 


### PR DESCRIPTION
### What does this PR do?

 * Add a netlink process montior (require root or CAP_NET_ADMIN) priviledges
 * Subscribe() to process event Exec, Exit
    *  with or without metadata process filter by Name

### Motivation

Notes : 
 * Netlink process subscription is allowed only by one PID running on the system
 * This monitor will read the netlink socket process events queue and run it on parallel worker (map to n cpu cores)

### Describe how to test/QA your changes

The main change here is GoTLS subscribe process Exec and Exit callbacks.

1/ add `enable_go_tls_support: true` to sysprobe configuration
2/ create a https GoTLS client application (like in unit tests) 
3/ verify sysprobe seen the request(s) `sudo curl --unix-socket /opt/datadog-agent/run/sysprobe.sock "http://unix/network_tracer/debug/http_monitoring" | jq`


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
