### PR TITLE
kafka: split structs to spare 320 bytes for every kafka transcation o…

### DIFF
--- a/pkg/ebpf/bytecode/runtime/kafka.go
+++ b/pkg/ebpf/bytecode/runtime/kafka.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var Kafka = NewAsset("kafka.c", "860bad1823e957239bc034dd9ce0e923672234b5d724c1c94d0cec188d2188fe")
+var Kafka = NewAsset("kafka.c", "62daffe292ea41c8eb46285d066231c016d1880de50912e5d36e87f63e5da192")

--- a/pkg/ebpf/bytecode/runtime/kafka.go
+++ b/pkg/ebpf/bytecode/runtime/kafka.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var Kafka = NewAsset("kafka.c", "62daffe292ea41c8eb46285d066231c016d1880de50912e5d36e87f63e5da192")
+var Kafka = NewAsset("kafka.c", "962732e2578cca8d0e0e01fbb05684eef6821691499fafb2f3376f2d65b26d6b")

--- a/pkg/network/ebpf/c/kafka/kafka-types.h
+++ b/pkg/network/ebpf/c/kafka/kafka-types.h
@@ -42,7 +42,6 @@ typedef struct {
     __u32 page_num;
 } kafka_batch_key_t;
 
-// Kafka transaction information associated to a certain socket (tuple_t)
 typedef struct {
     conn_tuple_t tup;
 
@@ -55,8 +54,13 @@ typedef struct {
     __u32 tcp_seq;
 
     __u32 current_offset_in_request_fragment;
-    char request_fragment[KAFKA_BUFFER_SIZE] __attribute__ ((aligned (8)));
     char topic_name[TOPIC_NAME_MAX_STRING_SIZE] __attribute__ ((aligned (8)));
+} kafka_transaction_batch_entry_t;
+
+// Kafka transaction information associated to a certain socket (tuple_t)
+typedef struct {
+    kafka_transaction_batch_entry_t base;
+    char request_fragment[KAFKA_BUFFER_SIZE] __attribute__ ((aligned (8)));
 
 } kafka_transaction_t;
 
@@ -75,7 +79,7 @@ typedef struct {
 typedef struct {
     __u64 idx;
     __u8 pos;
-    kafka_transaction_t txs[KAFKA_BATCH_SIZE];
+    kafka_transaction_batch_entry_t txs[KAFKA_BATCH_SIZE];
 } kafka_batch_t;
 
 #endif

--- a/pkg/network/ebpf/c/kafka/kafka-types.h
+++ b/pkg/network/ebpf/c/kafka/kafka-types.h
@@ -54,14 +54,13 @@ typedef struct {
     __u32 tcp_seq;
 
     __u32 current_offset_in_request_fragment;
-    char topic_name[TOPIC_NAME_MAX_STRING_SIZE] __attribute__ ((aligned (8)));
+    char topic_name[TOPIC_NAME_MAX_STRING_SIZE];
 } kafka_transaction_batch_entry_t;
 
 // Kafka transaction information associated to a certain socket (tuple_t)
 typedef struct {
+    char request_fragment[KAFKA_BUFFER_SIZE];
     kafka_transaction_batch_entry_t base;
-    char request_fragment[KAFKA_BUFFER_SIZE] __attribute__ ((aligned (8)));
-
 } kafka_transaction_t;
 
 typedef struct {

--- a/pkg/network/ebpf/c/kafka/kafka.h
+++ b/pkg/network/ebpf/c/kafka/kafka.h
@@ -92,7 +92,7 @@ static __always_inline bool kafka_seen_before(kafka_transaction_t *kafka, skb_in
     // check if we've seen this TCP segment before. this can happen in the
     // context of localhost traffic where the same TCP segment can be seen
     // multiple times coming in and out from different interfaces
-    return kafka->tcp_seq == skb_info->tcp_seq;
+    return kafka->base.tcp_seq == skb_info->tcp_seq;
 }
 //
 static __always_inline void kafka_update_seen_before(kafka_transaction_t *kafka_transaction, skb_info_t *skb_info) {
@@ -100,8 +100,8 @@ static __always_inline void kafka_update_seen_before(kafka_transaction_t *kafka_
         return;
     }
 
-    log_debug("kafka: kafka_update_seen_before: ktx=%llx old_seq=%llu seq=%llu\n", kafka_transaction, kafka_transaction->tcp_seq, skb_info->tcp_seq);
-    kafka_transaction->tcp_seq = skb_info->tcp_seq;
+    log_debug("kafka: kafka_update_seen_before: ktx=%llx old_seq=%llu seq=%llu\n", kafka_transaction, kafka_transaction->base.tcp_seq, skb_info->tcp_seq);
+    kafka_transaction->base.tcp_seq = skb_info->tcp_seq;
 }
 
 static __always_inline int kafka_process(kafka_transaction_t *kafka_transaction) {
@@ -111,7 +111,7 @@ static __always_inline int kafka_process(kafka_transaction_t *kafka_transaction)
     if (!try_parse_request(kafka_transaction)) {
         return 0;
     }
-    log_debug("kafka: topic name is %s", kafka_transaction->topic_name);
+    log_debug("kafka: topic name is %s", kafka_transaction->base.topic_name);
 
     kafka_enqueue(kafka_transaction);
     return 0;
@@ -123,7 +123,7 @@ static __always_inline int kafka_process(kafka_transaction_t *kafka_transaction)
 // of interest such as empty ACKs, UDP data or encrypted traffic.
 static __always_inline bool kafka_allow_packet(kafka_transaction_t *kafka, struct __sk_buff* skb, skb_info_t *skb_info) {
     // we're only interested in TCP traffic
-    if (!(kafka->tup.metadata&CONN_TYPE_TCP)) {
+    if (!(kafka->base.tup.metadata&CONN_TYPE_TCP)) {
         return false;
     }
 
@@ -137,12 +137,12 @@ static __always_inline bool kafka_allow_packet(kafka_transaction_t *kafka, struc
     // Check that we didn't see this tcp segment before so we won't process
     // the same traffic twice
     log_debug("kafka: Current tcp sequence: %lu", skb_info->tcp_seq);
-    __u32 *last_tcp_seq = bpf_map_lookup_elem(&kafka_last_tcp_seq_per_connection, &kafka->tup);
+    __u32 *last_tcp_seq = bpf_map_lookup_elem(&kafka_last_tcp_seq_per_connection, &kafka->base.tup);
     if (last_tcp_seq != NULL && *last_tcp_seq == skb_info->tcp_seq) {
         log_debug("kafka: already seen this tcp sequence: %lu", *last_tcp_seq);
         return false;
     }
-    bpf_map_update_elem(&kafka_last_tcp_seq_per_connection, &kafka->tup, &skb_info->tcp_seq, BPF_ANY);
+    bpf_map_update_elem(&kafka_last_tcp_seq_per_connection, &kafka->base.tup, &skb_info->tcp_seq, BPF_ANY);
     return true;
 }
 

--- a/pkg/network/ebpf/c/kafka/kafka.h
+++ b/pkg/network/ebpf/c/kafka/kafka.h
@@ -71,7 +71,7 @@ static __always_inline void kafka_enqueue(kafka_transaction_t *kafka_transaction
         return;
     }
 
-    __builtin_memcpy(&batch->txs[batch->pos], kafka_transaction, sizeof(kafka_transaction_t));
+    __builtin_memcpy(&batch->txs[batch->pos], &kafka_transaction->base, sizeof(kafka_transaction_batch_entry_t));
     log_debug("kafka: kafka_enqueue: ktx=%llx path=%s\n", kafka_transaction, kafka_transaction->request_fragment);
     log_debug("kafka: kafka transaction enqueued: cpu: %d batch_idx: %d pos: %d\n", key.cpu, batch_state->idx, batch->pos);
     batch->pos++;

--- a/pkg/network/ebpf/c/prebuilt/kafka.c
+++ b/pkg/network/ebpf/c/prebuilt/kafka.c
@@ -28,7 +28,7 @@ int socket__kafka_filter(struct __sk_buff* skb) {
     }
     __builtin_memset(kafka, 0, sizeof(kafka_transaction_t));
 
-    if (!read_conn_tuple_skb(skb, &skb_info, &kafka->tup)) {
+    if (!read_conn_tuple_skb(skb, &skb_info, &kafka->base.tup)) {
         return 0;
     }
 
@@ -36,7 +36,7 @@ int socket__kafka_filter(struct __sk_buff* skb) {
         return 0;
     }
 
-    normalize_tuple(&kafka->tup);
+    normalize_tuple(&kafka->base.tup);
 
     read_into_buffer_skb((char *)kafka->request_fragment, skb, &skb_info);
     kafka_process(kafka);

--- a/pkg/network/ebpf/c/runtime/kafka.c
+++ b/pkg/network/ebpf/c/runtime/kafka.c
@@ -29,7 +29,7 @@ int socket__kafka_filter(struct __sk_buff* skb) {
     }
     __builtin_memset(kafka, 0, sizeof(kafka_transaction_t));
 
-    if (!read_conn_tuple_skb(skb, &skb_info, &kafka->tup)) {
+    if (!read_conn_tuple_skb(skb, &skb_info, &kafka->base.tup)) {
         return 0;
     }
 
@@ -37,7 +37,7 @@ int socket__kafka_filter(struct __sk_buff* skb) {
         return 0;
     }
 
-    normalize_tuple(&kafka->tup);
+    normalize_tuple(&kafka->base.tup);
 
     read_into_buffer_skb((char *)kafka->request_fragment, skb, &skb_info);
     kafka_process(kafka);

--- a/pkg/network/kafka/kafka_types.go
+++ b/pkg/network/kafka/kafka_types.go
@@ -16,7 +16,7 @@ import "C"
 
 type kafkaConnTuple C.conn_tuple_t
 
-type ebpfKafkaTx C.kafka_transaction_t
+type ebpfKafkaTx C.kafka_transaction_batch_entry_t
 type kafkaBatch C.kafka_batch_t
 type kafkaBatchKey C.kafka_batch_key_t
 

--- a/pkg/network/kafka/kafka_types_linux.go
+++ b/pkg/network/kafka/kafka_types_linux.go
@@ -22,7 +22,6 @@ type ebpfKafkaTx struct {
 	Correlation_id                     uint32
 	Tcp_seq                            uint32
 	Current_offset_in_request_fragment uint32
-	Request_fragment                   [320]byte
 	Topic_name                         [80]int8
 }
 type kafkaBatch struct {


### PR DESCRIPTION
…bject

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Removes the fragment from being sent to the user mode.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

the fragment is not used in the usermode, thus not needed to be sent

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
