### PR TITLE
[CWS] Add tests for activity dump processes content

### DIFF
--- a/pkg/security/probe/activity_dump_proto_dec_v1.go
+++ b/pkg/security/probe/activity_dump_proto_dec_v1.go
@@ -129,7 +129,7 @@ func protoDecodeProcessNode(p *adproto.ProcessInfo) model.Process {
 
 		Credentials: protoDecodeCredentials(p.Credentials),
 
-		ScrubbedArgv:  make([]string, len(p.Args)),
+		Argv:          make([]string, len(p.Args)),
 		Argv0:         p.Argv0,
 		ArgsTruncated: p.ArgsTruncated,
 
@@ -137,7 +137,7 @@ func protoDecodeProcessNode(p *adproto.ProcessInfo) model.Process {
 		EnvsTruncated: p.EnvsTruncated,
 	}
 
-	copy(mp.ScrubbedArgv, p.Args)
+	copy(mp.Argv, p.Args)
 	copy(mp.Envs, p.Envs)
 	return mp
 }

--- a/pkg/security/tests/activity_dumps_test.go
+++ b/pkg/security/tests/activity_dumps_test.go
@@ -66,6 +66,84 @@ func TestActivityDumps(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	t.Run("activity-dump-cgroup-process", func(t *testing.T) {
+		dockerInstance, dump, err := test.StartADockerGetDump()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer dockerInstance.stop()
+
+		cmd := dockerInstance.Command(syscallTester, []string{"sleep", "1"}, []string{})
+		_, err = cmd.CombinedOutput()
+		if err != nil {
+			t.Fatal(err)
+		}
+		time.Sleep(1 * time.Second) // a quick sleep to let events to be added to the dump
+
+		err = test.StopActivityDump(dump.Name, "", "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		// time.Sleep(time.Second * 60)
+
+		validateActivityDumpOutputs(t, test, expectedFormats, dump.OutputFiles, func(ad *probe.ActivityDump) bool {
+			nodes := ad.FindMatchingNodes("syscall_tester")
+			if nodes == nil {
+				t.Fatalf("Node not found in activity dump: %+v", nodes)
+			}
+			if len(nodes) != 1 {
+				t.Fatalf("Found %d nodes, expected only one.", len(nodes))
+			}
+			node := nodes[0]
+
+			// ProcessActivityNode content1
+			assert.Equal(t, probe.Runtime, node.GenerationType)
+			assert.Equal(t, 0, len(node.Children))
+			assert.Equal(t, 0, len(node.Files))
+			assert.Equal(t, 0, len(node.DNSNames))
+			assert.Equal(t, 0, len(node.Sockets))
+
+			// Process content
+			assert.Equal(t, node.Process.Pid, node.Process.Tid)
+			assert.Equal(t, uint32(0), node.Process.UID)
+			assert.Equal(t, uint32(0), node.Process.GID)
+			assert.Equal(t, "root", node.Process.User)
+			assert.Equal(t, "root", node.Process.Group)
+			assert.Equal(t, node.Process.Pid-1, node.Process.PPid)
+			assert.Equal(t, false, node.Process.IsThread)
+			assert.Equal(t, uint64(0), node.Process.SpanID)
+			assert.Equal(t, uint64(0), node.Process.TraceID)
+			assert.Equal(t, "", node.Process.TTYName)
+			assert.Equal(t, "syscall_tester", node.Process.Comm)
+			assert.Equal(t, false, node.Process.ArgsTruncated)
+			assert.Equal(t, 2, len(node.Process.Argv))
+			if len(node.Process.Argv) >= 2 {
+				assert.Equal(t, "sleep", node.Process.Argv[0])
+				assert.Equal(t, "1", node.Process.Argv[1])
+			}
+			assert.Equal(t, syscallTester, node.Process.Argv0)
+			assert.Equal(t, false, node.Process.ArgsTruncated)
+			assert.Equal(t, false, node.Process.EnvsTruncated)
+			found := false
+			for _, env := range node.Process.Envs {
+				if strings.HasPrefix(env, "PATH=") {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("PATH not present in envs")
+			}
+
+			// Process.FileEvent content
+			if !strings.HasSuffix(node.Process.FileEvent.PathnameStr, "/syscall_tester") {
+				t.Errorf("PathnameStr did not ends with /syscall_tester: %s", node.Process.FileEvent.PathnameStr)
+			}
+			assert.Equal(t, "syscall_tester", node.Process.FileEvent.BasenameStr)
+			return true
+		})
+	})
+
 	t.Run("activity-dump-cgroup-bind", func(t *testing.T) {
 		dockerInstance, dump, err := test.StartADockerGetDump()
 		if err != nil {

--- a/pkg/security/tests/activity_dumps_test.go
+++ b/pkg/security/tests/activity_dumps_test.go
@@ -109,7 +109,9 @@ func TestActivityDumps(t *testing.T) {
 			assert.Equal(t, uint32(0), node.Process.GID)
 			assert.Equal(t, "root", node.Process.User)
 			assert.Equal(t, "root", node.Process.Group)
-			assert.Equal(t, node.Process.Pid-1, node.Process.PPid)
+			if node.Process.Pid < node.Process.PPid {
+				t.Errorf("PID < PPID")
+			}
 			assert.Equal(t, false, node.Process.IsThread)
 			assert.Equal(t, uint64(0), node.Process.SpanID)
 			assert.Equal(t, uint64(0), node.Process.TraceID)


### PR DESCRIPTION
### What does this PR do?

Add tests for activity dump processes content

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
