### PR TITLE
[CSPM] Remove unused prepared rego queries

### DIFF
--- a/pkg/compliance/rego/rego_check.go
+++ b/pkg/compliance/rego/rego_check.go
@@ -33,7 +33,6 @@ import (
 )
 
 const regoEvaluator = "rego"
-const regoParseTimeout = 20 * time.Second
 const regoEvalTimeout = 20 * time.Second
 
 var (
@@ -46,17 +45,16 @@ var (
 
 type regoInput struct {
 	compliance.RegoInput
-	preparedTransformQuery rego.PreparedEvalQuery
+	regoModuleArgs []func(*rego.Rego)
 }
 
 type regoCheck struct {
 	evalLock sync.Mutex
 
-	ruleID            string
-	ruleScope         compliance.RuleScope
-	inputs            []regoInput
-	regoModuleArgs    []func(*rego.Rego)
-	preparedEvalQuery rego.PreparedEvalQuery
+	ruleID         string
+	ruleScope      compliance.RuleScope
+	inputs         []regoInput
+	regoModuleArgs []func(*rego.Rego)
 }
 
 // NewCheck returns a new rego based check
@@ -194,7 +192,7 @@ func computeRuleTransform(rule *compliance.RegoRule, res compliance.RegoInput, m
 	return append(options, ruleModules...), query, nil
 }
 
-func (r *regoCheck) prepareQuery(moduleArgs []func(*rego.Rego), query string) (rego.PreparedEvalQuery, []func(*rego.Rego), error) {
+func (r *regoCheck) createQuery(moduleArgs []func(*rego.Rego), query string) []func(*rego.Rego) {
 	log.Debugf("rego query: %v", query)
 	moduleArgs = append(moduleArgs, rego.Query(query))
 
@@ -207,14 +205,7 @@ func (r *regoCheck) prepareQuery(moduleArgs []func(*rego.Rego), query string) (r
 		rego.PrintHook(&regoPrintHook{}),
 	)
 
-	ctx, cancel := context.WithTimeout(context.Background(), regoParseTimeout)
-	defer cancel()
-
-	preparedEvalQuery, err := rego.New(
-		moduleArgs...,
-	).PrepareForEval(ctx)
-
-	return preparedEvalQuery, moduleArgs, err
+	return moduleArgs
 }
 
 func (r *regoCheck) CompileRule(rule *compliance.RegoRule, ruleScope compliance.RuleScope, meta *compliance.SuiteMeta, metrics metrics.Metrics) error {
@@ -232,14 +223,8 @@ func (r *regoCheck) CompileRule(rule *compliance.RegoRule, ruleScope compliance.
 
 	moduleArgs = append(moduleArgs, ruleModules...)
 
-	preparedEvalQuery, moduleArgs, err := r.prepareQuery(moduleArgs, query)
-	if err != nil {
-		return err
-	}
-
-	r.preparedEvalQuery = preparedEvalQuery
+	r.regoModuleArgs = r.createQuery(moduleArgs, query)
 	r.ruleScope = ruleScope
-	r.regoModuleArgs = moduleArgs
 
 	// resource transformers
 	for i, input := range r.inputs {
@@ -255,12 +240,7 @@ func (r *regoCheck) CompileRule(rule *compliance.RegoRule, ruleScope compliance.
 		}
 		moduleArgs = append(moduleArgs, ruleModules...)
 
-		preparedTransformQuery, _, err := r.prepareQuery(moduleArgs, query)
-		if err != nil {
-			return err
-		}
-
-		r.inputs[i].preparedTransformQuery = preparedTransformQuery
+		r.inputs[i].regoModuleArgs = r.createQuery(moduleArgs, query)
 	}
 
 	return nil
@@ -307,7 +287,8 @@ func (r *regoCheck) buildNormalInput(env env.Env) (eval.RegoInputMap, error) {
 			ctx, cancel := context.WithTimeout(context.Background(), regoEvalTimeout)
 			defer cancel()
 
-			results, err := regoInput.preparedTransformQuery.Eval(ctx, rego.EvalInput(input))
+			regoMod := rego.New(append(regoInput.regoModuleArgs, rego.Input(input))...)
+			results, err := regoMod.Eval(ctx)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

An error in rebase in #13265 caused Rego queries to be precompiled again, restoring the memory
impact fixed by #13609


<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
