### PR TITLE
Fix cpu check in Windows containers

### DIFF
--- a/pkg/collector/corechecks/system/cpu/cpu_windows.go
+++ b/pkg/collector/corechecks/system/cpu/cpu_windows.go
@@ -113,14 +113,10 @@ func (counter *processorPDHCounter) addToQueryWithExtraChecks(query *pdhutil.Pdh
 
 	// Add succeeded, check if the counter is working (see above comment)
 	// Must call PdhCollectQueryData() twice before GetValue() will succeed.
-	// This call may fail for the first counter added to the query. Once at least one Processor
-	// counter is successfully added this call will succeed and we must depend on the GetValue() call.
-	for i := 0; i < 2; i++ {
-		err = pdhutil.PdhCollectQueryData(query.Handle)
-		if err != nil {
-			return err
-		}
-	}
+	// Ignoring PdhCollectQueryData() return value because its success is determined by the query
+	// and not specifically this counter, additonally if either call fails then GetValue() will too.
+	_ = pdhutil.PdhCollectQueryData(query.Handle)
+	_ = pdhutil.PdhCollectQueryData(query.Handle)
 	_, err = counter.GetValue()
 	return err
 }

--- a/pkg/collector/corechecks/system/cpu/cpu_windows.go
+++ b/pkg/collector/corechecks/system/cpu/cpu_windows.go
@@ -116,9 +116,9 @@ func (counter *processorPDHCounter) addToQueryWithExtraChecks(query *pdhutil.Pdh
 	// This call may fail for the first counter added to the query. Once at least one Processor
 	// counter is successfully added this call will succeed and we must depend on the GetValue() call.
 	for i := 0; i < 2; i++ {
-		pdherror := pdhutil.PdhCollectQueryData(query.Handle)
-		if 0 != pdherror {
-			return fmt.Errorf("Failed to collect query data: %#x.", pdherror)
+		err = pdhutil.PdhCollectQueryData(query.Handle)
+		if err != nil {
+			return err
 		}
 	}
 	_, err = counter.GetValue()

--- a/pkg/collector/corechecks/system/cpu/cpu_windows.go
+++ b/pkg/collector/corechecks/system/cpu/cpu_windows.go
@@ -21,6 +21,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/winutil/pdhutil"
 )
 
@@ -77,24 +78,65 @@ type processorPDHCounter struct {
 	pdhutil.PdhEnglishSingleInstanceCounter
 }
 
-func (counter *processorPDHCounter) AddToQuery(query *pdhutil.PdhQuery) error {
-	// Configure the PDH counter according to the running environment.
-	// We had a support ticket where a container did not have the "Processor Information" counterset
+func (counter *processorPDHCounter) addToQueryWithExtraChecks(query *pdhutil.PdhQuery, objectName string) (err error) {
+	// addToQueryWithExtraChecks wraps the base counter's AddToQuery to add additional error checks
+	// to work around a possible Microsoft PDH issue.
+	//
+	// The "Processor Information" counterset does not work in Windows containers.
+	// The counterset exists but has no instances and always returns "PDH_NO_DATA" error.
+	// So we have to fallback to the old "Processor" counterset.
 	// see https://github.com/DataDog/datadog-agent/pull/8881
-	// On machines with more than 1 NUMA node, it uses "Processor Information",
-	// otherwise it uses "Processor" (e.g. in containers).
-	// Note we use "processor information" instead of "processor" because on multi-processor machines the later only gives
-	// you visibility about other applications running on the same processor as you
-	err := counter.PdhEnglishSingleInstanceCounter.AddToQuery(query)
-	if err != nil {
-		counter.ObjectName = "Processor"
-		err = counter.PdhEnglishSingleInstanceCounter.AddToQuery(query)
-		if err != nil {
-			// Processor failed, too. Restore default objectName so we can try it again next time.
-			counter.ObjectName = "Processor Information"
+	// Unfortunately, since the counterset exists checking the PdhAddEnglishCounter result
+	// alone is insufficient. We must perform additional checks to ensure the counterset
+	// is functioning properly.
 
+	// Add counter to the Query
+	var origObjectName = counter.ObjectName
+	counter.ObjectName = objectName
+	err = counter.PdhEnglishSingleInstanceCounter.AddToQuery(query)
+	if err != nil {
+		// PdhAddEnglishCounter failed, restore original object name and return
+		counter.ObjectName = origObjectName
+		return err
+	}
+	defer func() {
+		if err != nil {
+			// PdhAddEnglishCounter failed, restore original object name
+			counter.ObjectName = origObjectName
+			// Remove the counter from the query
+			tmpErr := counter.Remove()
+			if tmpErr != nil {
+				log.Warnf("cpu.Check: Failed to remove counter \\%s(%s)\\%s from query. %v", objectName, counter.InstanceName, counter.CounterName, tmpErr)
+			}
+		}
+	}()
+
+	// Add succeeded, check if the counter is working (see above comment)
+	// Must call PdhCollectQueryData() twice before GetValue() will succeed.
+	// This call may fail for the first counter added to the query. Once at least one Processor
+	// counter is successfully added this call will succeed and we must depend on the GetValue() call.
+	for i := 0; i < 2; i++ {
+		pdherror := pdhutil.PdhCollectQueryData(query.Handle)
+		if 0 != pdherror {
+			return fmt.Errorf("Failed to collect query data: %#x.", pdherror)
 		}
 	}
+	_, err = counter.GetValue()
+	return err
+}
+
+func (counter *processorPDHCounter) AddToQuery(query *pdhutil.PdhQuery) error {
+	// Configure the PDH counter according to the running environment.
+	// This check defaults to using the "Processor Information" counterset when it is available,
+	// as it is the newer version of the "Processor" counterset and has support for more features.
+	// https://techcommunity.microsoft.com/t5/running-sap-applications-on-the/windows-2008-r2-performance-monitor-8211-processor-information/ba-p/367007
+	// See addToQueryWithExtraChecks for more details.
+	err := counter.addToQueryWithExtraChecks(query, "Processor Information")
+	if err != nil {
+		log.Warnf("cpu.Check: Error initializing counter \\%s(%s)\\%s: %v. This error is expected in Windows containers. Trying Processor counterset as a fallback.", counter.ObjectName, counter.InstanceName, counter.CounterName, err)
+		err = counter.addToQueryWithExtraChecks(query, "Processor")
+	}
+
 	return err
 }
 

--- a/pkg/collector/corechecks/system/cpu/cpu_windows.go
+++ b/pkg/collector/corechecks/system/cpu/cpu_windows.go
@@ -114,7 +114,7 @@ func (counter *processorPDHCounter) addToQueryWithExtraChecks(query *pdhutil.Pdh
 	// Add succeeded, check if the counter is working (see above comment)
 	// Must call PdhCollectQueryData() twice before GetValue() will succeed.
 	// Ignoring PdhCollectQueryData() return value because its success is determined by the query
-	// and not specifically this counter, additonally if either call fails then GetValue() will too.
+	// and not specifically this counter, additionally if either call fails then GetValue() will too.
 	_ = pdhutil.PdhCollectQueryData(query.Handle)
 	_ = pdhutil.PdhCollectQueryData(query.Handle)
 	_, err = counter.GetValue()

--- a/pkg/collector/corechecks/system/cpu/cpu_windows.go
+++ b/pkg/collector/corechecks/system/cpu/cpu_windows.go
@@ -101,7 +101,7 @@ func (counter *processorPDHCounter) addToQueryWithExtraChecks(query *pdhutil.Pdh
 	}
 	defer func() {
 		if err != nil {
-			// PdhAddEnglishCounter failed, restore original object name
+			// failed, restore original object name
 			counter.ObjectName = origObjectName
 			// Remove the counter from the query
 			tmpErr := counter.Remove()

--- a/pkg/collector/corechecks/system/cpu/cpu_windows_test.go
+++ b/pkg/collector/corechecks/system/cpu/cpu_windows_test.go
@@ -27,10 +27,14 @@ func CPUInfo() (map[string]string, error) {
 func TestCPUCheckWindows(t *testing.T) {
 	cpuInfo = CPUInfo
 	pdhtest.SetupTesting("..\\testfiles\\counter_indexes_en-us.txt", "..\\testfiles\\allcounters_en-us.txt")
-	pdhtest.SetQueryReturnValue("\\\\.\\Processor Information(_Total)\\% Interrupt Time", 0.1)
-	pdhtest.SetQueryReturnValue("\\\\.\\Processor Information(_Total)\\% Idle Time", 80.1)
-	pdhtest.SetQueryReturnValue("\\\\.\\Processor Information(_Total)\\% User Time", 11.3)
-	pdhtest.SetQueryReturnValue("\\\\.\\Processor Information(_Total)\\% Privileged Time", 8.5)
+	// The counters will have GetValue called twice because of the "Processor Information" issue workaround
+	// see AddToQuery() in cpu_windows.go
+	for i := 0; i < 2; i++ {
+		pdhtest.SetQueryReturnValue("\\\\.\\Processor Information(_Total)\\% Interrupt Time", 0.1)
+		pdhtest.SetQueryReturnValue("\\\\.\\Processor Information(_Total)\\% Idle Time", 80.1)
+		pdhtest.SetQueryReturnValue("\\\\.\\Processor Information(_Total)\\% User Time", 11.3)
+		pdhtest.SetQueryReturnValue("\\\\.\\Processor Information(_Total)\\% Privileged Time", 8.5)
+	}
 
 	cpuCheck := new(Check)
 	cpuCheck.Configure(integration.FakeConfigHash, nil, nil, "test")

--- a/pkg/process/procutil/process_windows.go
+++ b/pkg/process/procutil/process_windows.go
@@ -86,9 +86,8 @@ func (p *probe) init() {
 	}
 
 	// Need to run PdhCollectQueryData once so that we have meaningful metrics on the first run
-	status = pdhutil.PdhCollectQueryData(p.hQuery)
-	if status != 0 {
-		err = fmt.Errorf("PdhCollectQueryData failed with 0x%x", status)
+	err = pdhutil.PdhCollectQueryData(p.hQuery)
+	if err != nil {
 		return
 	}
 
@@ -257,9 +256,9 @@ func (p *probe) enumCounters(collectMeta bool, collectStats bool) error {
 		delete(p.instanceToPID, k)
 	}
 
-	status := pdhutil.PdhCollectQueryData(p.hQuery)
-	if status != 0 {
-		return fmt.Errorf("PdhCollectQueryData failed with 0x%x", status)
+	err := pdhutil.PdhCollectQueryData(p.hQuery)
+	if err != nil {
+		return err
 	}
 
 	ignored := []string{
@@ -267,7 +266,7 @@ func (p *probe) enumCounters(collectMeta bool, collectStats bool) error {
 		"Idle",   // System Idle process
 	}
 
-	err := p.formatter.Enum(pdhutil.CounterAllProcessPID, p.counters[pdhutil.CounterAllProcessPID], pdhutil.PDH_FMT_LARGE, ignored, valueToUint64(p.mapPID))
+	err = p.formatter.Enum(pdhutil.CounterAllProcessPID, p.counters[pdhutil.CounterAllProcessPID], pdhutil.PDH_FMT_LARGE, ignored, valueToUint64(p.mapPID))
 
 	if err != nil {
 		return err

--- a/pkg/util/winutil/pdhutil/pdh.go
+++ b/pkg/util/winutil/pdhutil/pdh.go
@@ -226,13 +226,13 @@ func PdhAddEnglishCounter(hQuery PDH_HQUERY, szFullCounterPath string, dwUserDat
 	return uint32(ret)
 }
 
-/* PdhCollectQueryData
+/* pdhCollectQueryData
    Collects the current raw data value for all counters in the specified query and updates the status code of each counter.
 Parameters
 hQuery [in, out]
 Handle of the query for which you want to collect data. The PdhOpenQuery function returns this handle.
 */
-func PdhCollectQueryData(hQuery PDH_HQUERY) uint32 {
+func pdhCollectQueryData(hQuery PDH_HQUERY) uint32 {
 	ret, _, _ := procPdhCollectQueryData.Call(uintptr(hQuery))
 
 	return uint32(ret)

--- a/pkg/util/winutil/pdhutil/pdhcounter.go
+++ b/pkg/util/winutil/pdhutil/pdhcounter.go
@@ -57,7 +57,7 @@ type PdhCounter interface {
 	AddToQuery(*PdhQuery) error
 
 	// Given the result of PdhCounter.AddToQuery, should update initError and initFailCount
-	CheckInitError(error) error
+	SetInitError(error) error
 
 	// Calls PdhRemoveCounter and updates internal state (handle field)
 	Remove() error
@@ -126,7 +126,7 @@ func (counter *pdhCounter) ShouldInit() bool {
 	return true
 }
 
-func (counter *pdhCounter) CheckInitError(err error) error {
+func (counter *pdhCounter) SetInitError(err error) error {
 	if err == nil {
 		counter.initError = nil
 		return nil
@@ -176,7 +176,7 @@ func (counter *pdhEnglishCounter) AddToQuery(query *PdhQuery) error {
 // Counters should implement PdhCounter.AddToQuery to override init logic
 func AddToQuery(query *PdhQuery, counter PdhCounter) error {
 	err := counter.AddToQuery(query)
-	return counter.CheckInitError(err)
+	return counter.SetInitError(err)
 }
 
 func (query *PdhQuery) AddCounter(counter PdhCounter) {

--- a/pkg/util/winutil/pdhutil/pdhcounter.go
+++ b/pkg/util/winutil/pdhutil/pdhcounter.go
@@ -342,11 +342,16 @@ func CreatePdhQuery() (*PdhQuery, error) {
 // PdhCloseQuery closes all counter handles associated with the query.
 // https://learn.microsoft.com/en-us/windows/win32/perfctrs/creating-a-query
 func (query *PdhQuery) Close() {
-	pfnPdhCloseQuery(query.Handle)
-	query.Handle = PDH_HQUERY(0)
+	if query.Handle != PDH_HQUERY(0) {
+		pfnPdhCloseQuery(query.Handle)
+		query.Handle = PDH_HQUERY(0)
+	}
 }
 
 func PdhCollectQueryData(hQuery PDH_HQUERY) error {
+	if hQuery == PDH_HQUERY(0) {
+		return fmt.Errorf("Invalid query handle")
+	}
 	pdherror := pfnPdhCollectQueryData(hQuery)
 	if ERROR_SUCCESS != pdherror {
 		return fmt.Errorf("Failed to collect query data %#x", pdherror)

--- a/pkg/util/winutil/pdhutil/pdhcounter.go
+++ b/pkg/util/winutil/pdhutil/pdhcounter.go
@@ -150,7 +150,7 @@ func (counter *pdhCounter) Remove() error {
 		return fmt.Errorf("Counter is not initialized")
 	}
 
-	pdherror := PdhRemoveCounter(counter.handle)
+	pdherror := pfnPdhRemoveCounter(counter.handle)
 	if ERROR_SUCCESS != pdherror {
 		return fmt.Errorf("RemoveCounter failed: %#x", pdherror)
 	}

--- a/pkg/util/winutil/pdhutil/pdhcounter.go
+++ b/pkg/util/winutil/pdhutil/pdhcounter.go
@@ -26,6 +26,7 @@ var (
 	pfnPdhCollectQueryData              = PdhCollectQueryData
 	pfnPdhGetFormattedCounterValueFloat = pdhGetFormattedCounterValueFloat
 	pfnPdhGetFormattedCounterArray      = pdhGetFormattedCounterArray
+	pfnPdhRemoveCounter                 = PdhRemoveCounter
 	pfnPdhCloseQuery                    = PdhCloseQuery
 	pfnPdhMakeCounterPath               = pdhMakeCounterPath
 )
@@ -39,7 +40,7 @@ type CounterInstanceVerify func(string) bool
 // https://learn.microsoft.com/en-us/windows/win32/perfctrs/creating-a-query
 // https://learn.microsoft.com/en-us/windows/win32/api/pdh/nf-pdh-pdhopenqueryw
 type PdhQuery struct {
-	handle   PDH_HQUERY
+	Handle   PDH_HQUERY
 	counters []PdhCounter
 }
 
@@ -50,10 +51,16 @@ type PdhCounter interface {
 	// Return false if a query must not attempt to initialize this counter.
 	ShouldInit() bool
 
-	// Called during (*PdhQuery).CollectQueryData for counters that return true from ShouldInit()
+	// Called during (*PdhQuery).CollectQueryData via AddToQuery() for counters that return true from ShouldInit()
 	// Must call the appropriate PdhAddCounter/PdhAddEnglishCounter function to add the
 	// counter to the query.
 	AddToQuery(*PdhQuery) error
+
+	// Given the result of PdhCounter.AddToQuery, should update initError and initFailCount
+	CheckInitError(error) error
+
+	// Calls PdhRemoveCounter and updates internal state (handle field)
+	Remove() error
 }
 
 // Manages a PDH counter with no instance or for a specific instance
@@ -119,7 +126,12 @@ func (counter *pdhCounter) ShouldInit() bool {
 	return true
 }
 
-func (counter *pdhCounter) countInitError(err error) error {
+func (counter *pdhCounter) CheckInitError(err error) error {
+	if err == nil {
+		counter.initError = nil
+		return nil
+	}
+
 	counter.initFailCount += 1
 	var initFailLimit = config.Datadog.GetInt("windows_counter_init_failure_limit")
 	if initFailLimit > 0 && counter.initFailCount >= initFailLimit {
@@ -133,18 +145,38 @@ func (counter *pdhCounter) countInitError(err error) error {
 	return counter.initError
 }
 
+func (counter *pdhCounter) Remove() error {
+	if counter.handle == PDH_HCOUNTER(0) {
+		return fmt.Errorf("Counter is not initialized")
+	}
+
+	pdherror := PdhRemoveCounter(counter.handle)
+	if ERROR_SUCCESS != pdherror {
+		return fmt.Errorf("RemoveCounter failed: %#x", pdherror)
+	}
+
+	counter.handle = PDH_HCOUNTER(0)
+	return nil
+}
+
 // Implements PdhCounter.AddToQuery for english counters.
 func (counter *pdhEnglishCounter) AddToQuery(query *PdhQuery) error {
 	path, err := pfnPdhMakeCounterPath("", counter.ObjectName, counter.InstanceName, counter.CounterName)
 	if err != nil {
-		return counter.countInitError(fmt.Errorf("Failed to make counter path (\\%s(%s)\\%s): %v", counter.ObjectName, counter.InstanceName, counter.CounterName, err))
+		return fmt.Errorf("Failed to make counter path (\\%s(%s)\\%s): %v", counter.ObjectName, counter.InstanceName, counter.CounterName, err)
 	}
-	pdherror := pfnPdhAddEnglishCounter(query.handle, path, uintptr(0), &counter.handle)
+	pdherror := pfnPdhAddEnglishCounter(query.Handle, path, uintptr(0), &counter.handle)
 	if ERROR_SUCCESS != pdherror {
-		return counter.countInitError(fmt.Errorf("Failed to add english counter (%s): %#x", path, pdherror))
+		return fmt.Errorf("Failed to add english counter (%s): %#x", path, pdherror)
 	}
-	counter.initError = nil
 	return nil
+}
+
+// Calls PdhCounter.AddToQuery and handles initError logic
+// Counters should implement PdhCounter.AddToQuery to override init logic
+func AddToQuery(query *PdhQuery, counter PdhCounter) error {
+	err := counter.AddToQuery(query)
+	return counter.CheckInitError(err)
 }
 
 func (query *PdhQuery) AddCounter(counter PdhCounter) {
@@ -157,7 +189,7 @@ func (query *PdhQuery) AddCounter(counter PdhCounter) {
 // https://learn.microsoft.com/en-us/windows/win32/api/pdh/nf-pdh-pdhaddenglishcounterw
 //
 // Implementation detail: This function does not actually call the Windows API PdhAddEnglishCounter. That happens
-//   when (*PdhQuery).CollectQueryData calls PdhCounter.AddToQuery. This function only links our pdhCounter struct
+//   when (*PdhQuery).CollectQueryData calls AddToQuery. This function only links our pdhCounter struct
 //   to our PdhQuery struct.
 //   We do this so we can handle several PDH error cases and their recovery behind the scenes to reduce
 //   duplicate/error prone code in the checks that uses this package.
@@ -211,7 +243,7 @@ func (query *PdhQuery) CollectQueryData() error {
 			// https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2003/cc784382(v=ws.10)
 			_, _ = tryRefreshPdhObjectCache()
 
-			err := counter.AddToQuery(query)
+			err := AddToQuery(query, counter)
 			if err == nil {
 				addedNewCounter = true
 			} else {
@@ -223,14 +255,14 @@ func (query *PdhQuery) CollectQueryData() error {
 		// if we added a new counter then we need an additional call to
 		// PdhCollectQuery data because some counters require two datapoints
 		// before they can return a value.
-		pdherror := pfnPdhCollectQueryData(query.handle)
+		pdherror := pfnPdhCollectQueryData(query.Handle)
 		if ERROR_SUCCESS != pdherror {
 			return fmt.Errorf("Failed to collect query data %#x. This error indicates that the Windows performance counter database may need to be rebuilt.", pdherror)
 		}
 	}
 
 	// Update the counters
-	pdherror := pfnPdhCollectQueryData(query.handle)
+	pdherror := pfnPdhCollectQueryData(query.Handle)
 	if ERROR_SUCCESS != pdherror {
 		return fmt.Errorf("Failed to collect query data %#x. This error indicates that the Windows performance counter database may need to be rebuilt.", pdherror)
 	}
@@ -297,7 +329,7 @@ func (counter *PdhEnglishSingleInstanceCounter) GetValue() (float64, error) {
 func CreatePdhQuery() (*PdhQuery, error) {
 	var q PdhQuery
 
-	pdherror := pfnPdhOpenQuery(uintptr(0), uintptr(0), &q.handle)
+	pdherror := pfnPdhOpenQuery(uintptr(0), uintptr(0), &q.Handle)
 	if ERROR_SUCCESS != pdherror {
 		err := fmt.Errorf("Failed to open PDH query handle %#x", pdherror)
 		return nil, err
@@ -310,5 +342,6 @@ func CreatePdhQuery() (*PdhQuery, error) {
 // PdhCloseQuery closes all counter handles associated with the query.
 // https://learn.microsoft.com/en-us/windows/win32/perfctrs/creating-a-query
 func (query *PdhQuery) Close() {
-	pfnPdhCloseQuery(query.handle)
+	pfnPdhCloseQuery(query.Handle)
+	query.Handle = PDH_HQUERY(0)
 }

--- a/pkg/util/winutil/pdhutil/pdhcounter.go
+++ b/pkg/util/winutil/pdhutil/pdhcounter.go
@@ -147,7 +147,7 @@ func (counter *pdhCounter) SetInitError(err error) error {
 
 func (counter *pdhCounter) Remove() error {
 	if counter.handle == PDH_HCOUNTER(0) {
-		return fmt.Errorf("Counter is not initialized")
+		return fmt.Errorf("counter is not initialized")
 	}
 
 	pdherror := pfnPdhRemoveCounter(counter.handle)
@@ -285,7 +285,7 @@ func (counter *PdhEnglishMultiInstanceCounter) GetAllValues() (values map[string
 		if counter.initError != nil {
 			return nil, counter.initError
 		}
-		return nil, fmt.Errorf("Counter is not initialized")
+		return nil, fmt.Errorf("counter is not initialized")
 	}
 	// fetch data
 	items, err := pfnPdhGetFormattedCounterArray(counter.handle, PDH_FMT_DOUBLE)
@@ -319,7 +319,7 @@ func (counter *PdhEnglishSingleInstanceCounter) GetValue() (float64, error) {
 		if counter.initError != nil {
 			return 0, counter.initError
 		}
-		return 0, fmt.Errorf("Counter is not initialized")
+		return 0, fmt.Errorf("counter is not initialized")
 	}
 	// fetch data
 	return pfnPdhGetFormattedCounterValueFloat(counter.handle)
@@ -331,7 +331,7 @@ func CreatePdhQuery() (*PdhQuery, error) {
 
 	pdherror := pfnPdhOpenQuery(uintptr(0), uintptr(0), &q.Handle)
 	if ERROR_SUCCESS != pdherror {
-		err := fmt.Errorf("Failed to open PDH query handle %#x", pdherror)
+		err := fmt.Errorf("failed to open PDH query handle %#x", pdherror)
 		return nil, err
 	}
 	return &q, nil
@@ -350,11 +350,11 @@ func (query *PdhQuery) Close() {
 
 func PdhCollectQueryData(hQuery PDH_HQUERY) error {
 	if hQuery == PDH_HQUERY(0) {
-		return fmt.Errorf("Invalid query handle")
+		return fmt.Errorf("invalid query handle")
 	}
 	pdherror := pfnPdhCollectQueryData(hQuery)
 	if ERROR_SUCCESS != pdherror {
-		return fmt.Errorf("Failed to collect query data %#x", pdherror)
+		return fmt.Errorf("failed to collect query data %#x", pdherror)
 	}
 	return nil
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Fix a bug that was re-introduced by https://github.com/DataDog/datadog-agent/pull/14630


### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
Checking `PdhAddEnglishCounter` result is not enough to determine if the "Processor Information" counterset is/isn't available in a countainer. https://datadoghq.atlassian.net/browse/WA-177

original bugfix https://github.com/DataDog/datadog-agent/pull/8881

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
Example warnings for first check run when running in a container
```
2022-12-12 18:51:53 EST | CORE | DEBUG | (pkg/collector/scheduler.go:182 in getChecks) | Core Check Loader: successfully loaded check 'cpu'
2022-12-12 18:51:53 EST | CORE | WARN | (pkg/collector/corechecks/system/cpu/cpu_windows.go:136 in AddToQuery) | cpu.Check: Error initializing counter \Processor Information(_Total)\% Interrupt Time: Failed to collect query data 0x800007d5. This error is expected in Windows containers.
 Trying Processor counterset as a fallback.
2022-12-12 18:51:53 EST | CORE | WARN | (pkg/collector/corechecks/system/cpu/cpu_windows.go:136 in AddToQuery) | cpu.Check: Error initializing counter \Processor Information(_Total)\% Idle Time: Error retrieving float value 0xc0000bc6 0xc0000bc6. This error is expected in Windows conta
iners. Trying Processor counterset as a fallback.
2022-12-12 18:51:53 EST | CORE | WARN | (pkg/collector/corechecks/system/cpu/cpu_windows.go:136 in AddToQuery) | cpu.Check: Error initializing counter \Processor Information(_Total)\% User Time: Error retrieving float value 0xc0000bc6 0xc0000bc6. This error is expected in Windows conta
iners. Trying Processor counterset as a fallback.
2022-12-12 18:51:53 EST | CORE | WARN | (pkg/collector/corechecks/system/cpu/cpu_windows.go:136 in AddToQuery) | cpu.Check: Error initializing counter \Processor Information(_Total)\% Privileged Time: Error retrieving float value 0xc0000bc6 0xc0000bc6. This error is expected in Windows
 containers. Trying Processor counterset as a fallback.
```

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
