### PR TITLE
[gitlab] Update MSI RC urls for Choco and Winget

### DIFF
--- a/tasks/winbuildscripts/Generate-Chocolatey-Package.ps1
+++ b/tasks/winbuildscripts/Generate-Chocolatey-Package.ps1
@@ -36,7 +36,7 @@ if ($rawAgentVersion -match $releaseCandidatePattern) {
     $agentVersion = "{0}-rc-{1}" -f $agentVersionMatches.Matches.Groups[1], $agentVersionMatches.Matches.Groups[2].Value
     # We don't have release notes for RCs but this way the user can always see what commits are included in this RC
     $releaseNotes = "https://github.com/DataDog/datadog-agent/releases/tag/{0}-rc.{1}" -f $agentVersionMatches.Matches.Groups[1], $agentVersionMatches.Matches.Groups[2]
-    $url = "https://s3.amazonaws.com/dd-agent-mstesting/builds/beta/datadog-agent-$($agentVersionMatches.Matches.Groups[1])-rc.$($agentVersionMatches.Matches.Groups[2])-1-x86_64.msi"
+    $url = "https://s3.amazonaws.com/dd-agent-mstesting/builds/beta/ddagent-cli-$($agentVersionMatches.Matches.Groups[1])-rc.$($agentVersionMatches.Matches.Groups[2]).msi"
 } elseif ($rawAgentVersion -match $develPattern) {
     if ($installMethod -eq "online") {
         # We don't publish online chocolatey packages for dev branches, error out

--- a/tasks/winbuildscripts/Generate-Chocolatey-Package.ps1
+++ b/tasks/winbuildscripts/Generate-Chocolatey-Package.ps1
@@ -33,10 +33,10 @@ if ($installMethod -eq "offline") {
 
 if ($rawAgentVersion -match $releaseCandidatePattern) {
     $agentVersionMatches = $rawAgentVersion | Select-String -Pattern $releaseCandidatePattern
-    $agentVersion = "{0}-rc-{1}" -f $agentVersionMatches.Matches.Groups[1], $agentVersionMatches.Matches.Groups[2].Value
+    $agentVersion = "{0}-rc.{1}" -f $agentVersionMatches.Matches.Groups[1], $agentVersionMatches.Matches.Groups[2].Value
     # We don't have release notes for RCs but this way the user can always see what commits are included in this RC
     $releaseNotes = "https://github.com/DataDog/datadog-agent/releases/tag/{0}-rc.{1}" -f $agentVersionMatches.Matches.Groups[1], $agentVersionMatches.Matches.Groups[2]
-    $url = "https://s3.amazonaws.com/dd-agent-mstesting/builds/beta/ddagent-cli-$($agentVersionMatches.Matches.Groups[1])-rc.$($agentVersionMatches.Matches.Groups[2]).msi"
+    $url = "https://s3.amazonaws.com/dd-agent-mstesting/builds/beta/ddagent-cli-$(agentVersion).msi"
 } elseif ($rawAgentVersion -match $develPattern) {
     if ($installMethod -eq "online") {
         # We don't publish online chocolatey packages for dev branches, error out

--- a/tasks/winbuildscripts/Generate-Chocolatey-Package.ps1
+++ b/tasks/winbuildscripts/Generate-Chocolatey-Package.ps1
@@ -33,10 +33,10 @@ if ($installMethod -eq "offline") {
 
 if ($rawAgentVersion -match $releaseCandidatePattern) {
     $agentVersionMatches = $rawAgentVersion | Select-String -Pattern $releaseCandidatePattern
-    $agentVersion = "{0}-rc.{1}" -f $agentVersionMatches.Matches.Groups[1], $agentVersionMatches.Matches.Groups[2].Value
+    $agentVersion = "{0}-rc-{1}" -f $agentVersionMatches.Matches.Groups[1], $agentVersionMatches.Matches.Groups[2].Value
     # We don't have release notes for RCs but this way the user can always see what commits are included in this RC
     $releaseNotes = "https://github.com/DataDog/datadog-agent/releases/tag/{0}-rc.{1}" -f $agentVersionMatches.Matches.Groups[1], $agentVersionMatches.Matches.Groups[2]
-    $url = "https://s3.amazonaws.com/dd-agent-mstesting/builds/beta/ddagent-cli-$(agentVersion).msi"
+    $url = "https://s3.amazonaws.com/dd-agent-mstesting/builds/beta/ddagent-cli-$($agentVersionMatches.Matches.Groups[1])-rc.$($agentVersionMatches.Matches.Groups[2]).msi"
 } elseif ($rawAgentVersion -match $develPattern) {
     if ($installMethod -eq "online") {
         # We don't publish online chocolatey packages for dev branches, error out

--- a/tasks/winbuildscripts/Update-Winget.ps1
+++ b/tasks/winbuildscripts/Update-Winget.ps1
@@ -16,7 +16,7 @@ if ($m) {
 }
 if ($rc) {
     Write-Host ("Updating Winget manifest for Agent version ${agentVersion}-rc.${rc}")
-    wingetcreate.exe update --urls "https://s3.amazonaws.com/dd-agent-mstesting/builds/beta/datadog-agent-${agentVersion}-rc.${rc}-1-x86_64.msi" --version "${agentVersion}-rc.${rc}" --submit --token "${env:WINGET_GITHUB_ACCESS_TOKEN}" "Datadog.Agent"
+    wingetcreate.exe update --urls "https://s3.amazonaws.com/dd-agent-mstesting/builds/beta/ddagent-cli-${agentVersion}-rc.${rc}.msi" --version "${agentVersion}-rc.${rc}" --submit --token "${env:WINGET_GITHUB_ACCESS_TOKEN}" "Datadog.Agent"
 } else {
     Write-Host ("Updating Winget manifest for Agent version ${agentVersion}.1")
     wingetcreate.exe update --urls "https://s3.amazonaws.com/ddagent-windows-stable/ddagent-cli-${agentVersion}.msi" --version "${agentVersion}.1" --submit --token "${env:WINGET_GITHUB_ACCESS_TOKEN}" "Datadog.Agent"


### PR DESCRIPTION
### What does this PR do?

Updates URLs to MSI RC packages in staging after changes done in https://github.com/DataDog/datadog-agent/pull/14392

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
