### PR TITLE
[process-agent] Fix secrets build flag omission in process-agent

### DIFF
--- a/tasks/process_agent.py
+++ b/tasks/process_agent.py
@@ -65,11 +65,6 @@ def build(
 
     build_tags = get_build_tags(build_include, build_exclude)
 
-    ## secrets is not supported on windows because the process agent still runs as
-    ## root.  No matter what `get_default_build_tags()` returns, take secrets out.
-    if sys.platform == 'win32' and "secrets" in build_tags:
-        build_tags.remove("secrets")
-
     # TODO static option
     cmd = 'go build -mod={go_mod} {race_opt} {build_type} -tags "{go_build_tags}" '
     cmd += '-o {agent_bin} -gcflags="{gcflags}" -ldflags="{ldflags}" {REPO_PATH}/cmd/process-agent'


### PR DESCRIPTION
### What does this PR do?

- This corrects the `secrets` backend omission handling in https://github.com/DataDog/datadog-agent/pull/14529
- Process agent supports `secrets` as of https://github.com/DataDog/datadog-agent/pull/14628 (merged before the above PR)

### Motivation

Fix secrets handling in the `process-agent`, secrets were erroneously compiled out due to a rebase issue.

### Describe how to test/QA your changes

Validate changes per instructions in:
- https://github.com/DataDog/datadog-agent/pull/14529
- https://github.com/DataDog/datadog-agent/pull/14628

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
