### PR TITLE
Set `ec2_prefer_imdsv2: true` by default

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -729,7 +729,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("ec2_use_windows_prefix_detection", false)
 	config.BindEnvAndSetDefault("ec2_metadata_timeout", 300)          // value in milliseconds
 	config.BindEnvAndSetDefault("ec2_metadata_token_lifetime", 21600) // value in seconds
-	config.BindEnvAndSetDefault("ec2_prefer_imdsv2", false)
+	config.BindEnvAndSetDefault("ec2_prefer_imdsv2", true)
 	config.BindEnvAndSetDefault("ec2_prioritize_instance_id_as_hostname", false) // used to bypass the hostname detection logic and force the EC2 instance ID as a hostname.
 	config.BindEnvAndSetDefault("collect_ec2_tags", false)
 	config.BindEnvAndSetDefault("collect_ec2_tags_use_imds", false)

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -394,8 +394,8 @@ api_key:
 #
 # ec2_metadata_timeout: 300
 
-## @param ec2_prefer_imdsv2 - boolean - optional - default: false
-## @env DD_EC2_PREFER_IMDSV2 - boolean - optional - default: false
+## @param ec2_prefer_imdsv2 - boolean - optional - default: true
+## @env DD_EC2_PREFER_IMDSV2 - boolean - optional - default: true
 ## If this flag is true then the agent will request EC2 metadata using IMDS v2,
 ## which offers additional security for accessing metadata. However, in some
 ## situations (such as a containerized agent on a plain EC2 instance) it may
@@ -403,7 +403,7 @@ api_key:
 ## for further details:
 ## https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html#instance-metadata-transition-to-version-2
 #
-# ec2_prefer_imdsv2: false
+# ec2_prefer_imdsv2: true
 
 ## @param collect_gce_tags - boolean - optional - default: true
 ## @env DD_COLLECT_GCE_TAGS - boolean - optional - default: true

--- a/pkg/util/ec2/ec2.go
+++ b/pkg/util/ec2/ec2.go
@@ -275,7 +275,7 @@ func doHTTPRequest(ctx context.Context, url string) (string, error) {
 	if config.Datadog.GetBool("ec2_prefer_imdsv2") {
 		tokenValue, err := token.Get(ctx)
 		if err != nil {
-			log.Warnf("ec2_prefer_imdsv2 is set to true in the configuration but the agent was unable to proceed: %s", err)
+			log.Debugf("ec2_prefer_imdsv2 is set to true in the configuration but the agent was unable to proceed: %s", err)
 		} else {
 			headers["X-aws-ec2-metadata-token"] = tokenValue
 		}

--- a/releasenotes/notes/set-ec2_prefer_imdsv2-true-by-default-37f01c4b33a1d8e0.yaml
+++ b/releasenotes/notes/set-ec2_prefer_imdsv2-true-by-default-37f01c4b33a1d8e0.yaml
@@ -1,0 +1,4 @@
+---
+upgrade:
+  - |
+    Set ``ec2_prefer_imdsv2: true`` by default.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Set `ec2_prefer_imdsv2: true` by default, which means that Agent [use IMDSv2](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html) by default. When Agent fails to get a token by any reasons, Agent try to request to IMDSv1.

### Motivation

#### FRAGENT-1317

Background

Upon AWS' Security Hub recommendations the client enabled IMDsV2 on their EC2 instances, but noticed that they could no longer collect default metadata using the Datadog Agent.

User Story

Have ec2_prefer_imdsv2 enabled by default rather than have the client do so manually.

Related internal FRs
- FRAGENT-1029
- FRAGENT-1321
- FRAGENT-1520

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

1 ) Build the Agent.

```bash
vagrant@vagrant:~/go/src/github.com/DataDog/datadog-agent$ sudo bin/agent/agent version
Agent 7.42.0-rc.2 - Meta: git.2.f6066e9 - Commit: f6066e9e75 - Serialization version: v5.0.46 - Go version: go1.19.4
```

2 ) Prepare `datadog.yaml`.
3 ) Run commands to check a default value.

```bash
vagrant@vagrant:~/go/src/github.com/DataDog/datadog-agent$ echo 'api_key: <DD_API_KEY>' > datadog.yaml
vagrant@vagrant:~/go/src/github.com/DataDog/datadog-agent$ sudo bin/agent/agent run --cfgpath datadog.yaml  > /dev/null 2>&1
[1] 154004
vagrant@vagrant:~/go/src/github.com/DataDog/datadog-agent$ sudo bin/agent/agent config --cfgpath datadog.yaml | grep prefer
ec2_prefer_imdsv2: true
```


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
