### PR TITLE
Fix `logs_config.close_time` value display in INFO log

### DIFF
--- a/pkg/logs/internal/tailers/file/tailer.go
+++ b/pkg/logs/internal/tailers/file/tailer.go
@@ -213,12 +213,12 @@ func (t *Tailer) StopAfterFileRotation() {
 	go func() {
 		time.Sleep(t.closeTimeout)
 		if newBytesRead := t.Source().BytesRead.Get() - bytesReadAtRotationTime; newBytesRead > 0 {
-			log.Infof("After rotation close timeout (%ds), an additional %d bytes were read from file %q", t.closeTimeout, newBytesRead, t.file.Path)
+			log.Infof("After rotation close timeout (%s), an additional %d bytes were read from file %q", t.closeTimeout, newBytesRead, t.file.Path)
 			fileStat, err := t.osFile.Stat()
 			if err != nil {
 				log.Warnf("During rotation close, unable to determine total file size for %q, err: %v", t.file.Path, err)
 			} else if remainingBytes := fileStat.Size() - t.lastReadOffset.Load(); remainingBytes > 0 {
-				log.Warnf("After rotation close timeout (%ds), there were %d bytes remaining unread for file %q. These unread logs are now lost. Consider increasing DD_LOGS_CONFIG_CLOSE_TIMEOUT", t.closeTimeout, remainingBytes, t.file.Path)
+				log.Warnf("After rotation close timeout (%s), there were %d bytes remaining unread for file %q. These unread logs are now lost. Consider increasing DD_LOGS_CONFIG_CLOSE_TIMEOUT", t.closeTimeout, remainingBytes, t.file.Path)
 			}
 		}
 		t.stopForward()


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Fix `close_time` value display in INFO log.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Agent writes `logs_config.close_time` value in INFO logs, but a printed value looks bigger than configured. This is because closeTimeout's type is [time.Duration](https://github.com/DataDog/datadog-agent/blob/4bbee1655c05db184e26a3c14bb5bd8750c58a2a/pkg/logs/internal/tailers/file/tailer.go#L80).

```
2022-12-14 08:19:54 UTC | CORE | INFO | (pkg/logs/internal/tailers/file/tailer.go:216 in func1) | After rotation close timeout (1000000000s), an additional 98613 bytes were read from file "/var/log/datadog/agent.log"
```

Now Agent writes a correct duration.

```
2022-12-14 08:26:14 UTC | CORE | INFO | (pkg/logs/internal/tailers/file/tailer.go:216 in func1) | After rotation close timeout (1s), an additional 513 bytes were read from file "/var/log/datadog/agent.log"
```


### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

1 ) Build the Agent.
2 ) Set these configuration in `datadog.yaml`.

```yaml
api_key: <API_KEY>
logs_enabled: true
logs_config:
  close_timeout: 1
log_to_console: false # Disable stdout logs
log_file_max_size: 3072 # Easily a log rotation happens
```

3 ) Set this configuration in `conf.d/agent.d/conf.yaml`.

```yaml
logs:
  - type: file
    path: /var/log/datadog/agent.log
    service: agent
    source: file
```

4 ) Run the Agent and see INFO logs.

```bash
sudo bin/agent/agent run --cfgpath bin/agent/dist/datadog.yaml &
```

```
2022-12-14 08:26:14 UTC | CORE | INFO | (pkg/logs/internal/tailers/file/tailer.go:216 in func1) | After rotation close timeout (1s), an additional 513 bytes were read from file "/var/log/datadog/agent.log"
```


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
