### PR TITLE
[fargate] Make hostname resolution more reliable

### DIFF
--- a/cmd/trace-agent/config/config.go
+++ b/cmd/trace-agent/config/config.go
@@ -75,17 +75,12 @@ func prepareConfig(path string) (*config.AgentConfig, error) {
 	cfg.DDAgentBin = defaultDDAgentBin
 	cfg.AgentVersion = version.AgentVersion
 	cfg.GitCommit = version.Commit
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	orch := fargate.GetOrchestrator()
-	cancel()
-	if err := ctx.Err(); err != nil && err != context.Canceled {
-		log.Errorf("Failed to get Fargate orchestrator. This may cause issues if you are in a Fargate instance: %v", err)
-	}
-	cfg.FargateOrchestrator = config.FargateOrchestratorName(orch)
 	coreconfig.Datadog.SetConfigFile(path)
 	if _, err := coreconfig.Load(); err != nil {
 		return cfg, err
 	}
+	orch := fargate.GetOrchestrator() // Needs to be after loading config, because it relies on feature auto-detection
+	cfg.FargateOrchestrator = config.FargateOrchestratorName(orch)
 	if p := coreconfig.GetProxies(); p != nil {
 		cfg.Proxy = httputils.GetProxyTransportFunc(p)
 	}

--- a/cmd/trace-agent/config/config.go
+++ b/cmd/trace-agent/config/config.go
@@ -76,7 +76,7 @@ func prepareConfig(path string) (*config.AgentConfig, error) {
 	cfg.AgentVersion = version.AgentVersion
 	cfg.GitCommit = version.Commit
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	orch := fargate.GetOrchestrator(ctx)
+	orch := fargate.GetOrchestrator()
 	cancel()
 	if err := ctx.Err(); err != nil && err != context.Canceled {
 		log.Errorf("Failed to get Fargate orchestrator. This may cause issues if you are in a Fargate instance: %v", err)

--- a/cmd/trace-agent/config/config_test.go
+++ b/cmd/trace-agent/config/config_test.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"regexp"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -1024,7 +1025,12 @@ func TestFargateConfig(t *testing.T) {
 			t.Setenv(data.envKey, data.envValue)
 			cfg, err := LoadConfigFile("./testdata/no_apm_config.yaml")
 			assert.NoError(err)
-			assert.Equal(data.orchestrator, cfg.FargateOrchestrator)
+
+			if runtime.GOOS == "darwin" {
+				assert.Equal(config.OrchestratorUnknown, cfg.FargateOrchestrator)
+			} else {
+				assert.Equal(data.orchestrator, cfg.FargateOrchestrator)
+			}
 		})
 	}
 }

--- a/cmd/trace-agent/config/config_test.go
+++ b/cmd/trace-agent/config/config_test.go
@@ -990,3 +990,41 @@ func TestLoadEnv(t *testing.T) {
 		}
 	})
 }
+
+func TestFargateConfig(t *testing.T) {
+	assert := assert.New(t)
+	type testData struct {
+		name         string
+		envKey       string
+		envValue     string
+		orchestrator config.FargateOrchestratorName
+	}
+	for _, data := range []testData{
+		{
+			name:         "ecs_fargate",
+			envKey:       "ECS_FARGATE",
+			envValue:     "true",
+			orchestrator: config.OrchestratorECS,
+		},
+		{
+			name:         "eks_fargate",
+			envKey:       "DD_EKS_FARGATE",
+			envValue:     "true",
+			orchestrator: config.OrchestratorEKS,
+		},
+		{
+			name:         "unknown",
+			envKey:       "ECS_FARGATE",
+			envValue:     "",
+			orchestrator: config.OrchestratorUnknown,
+		},
+	} {
+		t.Run("", func(t *testing.T) {
+			defer cleanConfig()()
+			t.Setenv(data.envKey, data.envValue)
+			cfg, err := LoadConfigFile("./testdata/no_apm_config.yaml")
+			assert.NoError(err)
+			assert.Equal(data.orchestrator, cfg.FargateOrchestrator)
+		})
+	}
+}

--- a/pkg/autodiscovery/providers/config_reader.go
+++ b/pkg/autodiscovery/providers/config_reader.go
@@ -6,7 +6,6 @@
 package providers
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -381,7 +380,7 @@ func GetIntegrationConfigFromFile(name, fpath string) (integration.Config, error
 		// at this point the Yaml was already parsed, no need to check the error
 		rawConf, _ := yaml.Marshal(instance)
 		dataConf := (integration.Data)(rawConf)
-		if fargate.IsFargateInstance(context.TODO()) {
+		if fargate.IsFargateInstance() {
 			// In Fargate, since no host tags are applied in the backend,
 			// add the configured DD_TAGS/DD_EXTRA_TAGS to the instance tags.
 			tags := config.GetConfiguredTags(false)

--- a/pkg/config/environment.go
+++ b/pkg/config/environment.go
@@ -46,7 +46,7 @@ func IsKubernetes() bool {
 
 // IsECSFargate returns whether the Agent is running in ECS Fargate
 func IsECSFargate() bool {
-	return os.Getenv("ECS_FARGATE") != ""
+	return os.Getenv("ECS_FARGATE") != "" || os.Getenv("AWS_EXECUTION_ENV") == "AWS_ECS_FARGATE"
 }
 
 // IsHostProcAvailable returns whether host proc is available or not

--- a/pkg/dogstatsd/server_test.go
+++ b/pkg/dogstatsd/server_test.go
@@ -47,6 +47,9 @@ func getAvailableUDPPort() (int, error) {
 }
 
 func TestNewServer(t *testing.T) {
+	config.SetDetectedFeatures(config.FeatureMap{})
+	defer config.SetDetectedFeatures(nil)
+
 	port, err := getAvailableUDPPort()
 	require.NoError(t, err)
 	config.Datadog.SetDefault("dogstatsd_port", port)
@@ -62,6 +65,9 @@ func TestNewServer(t *testing.T) {
 }
 
 func TestStopServer(t *testing.T) {
+	config.SetDetectedFeatures(config.FeatureMap{})
+	defer config.SetDetectedFeatures(nil)
+
 	port, err := getAvailableUDPPort()
 	require.NoError(t, err)
 	config.Datadog.SetDefault("dogstatsd_port", port)
@@ -112,6 +118,9 @@ func TestNoRaceOriginTagMaps(t *testing.T) {
 }
 
 func TestUDPReceive(t *testing.T) {
+	config.SetDetectedFeatures(config.FeatureMap{})
+	defer config.SetDetectedFeatures(nil)
+
 	port, err := getAvailableUDPPort()
 	require.NoError(t, err)
 	config.Datadog.SetDefault("dogstatsd_port", port)
@@ -389,6 +398,9 @@ func TestUDPReceive(t *testing.T) {
 }
 
 func TestUDPForward(t *testing.T) {
+	config.SetDetectedFeatures(config.FeatureMap{})
+	defer config.SetDetectedFeatures(nil)
+
 	fport, err := getAvailableUDPPort()
 	require.NoError(t, err)
 
@@ -433,6 +445,9 @@ func TestUDPForward(t *testing.T) {
 }
 
 func TestHistToDist(t *testing.T) {
+	config.SetDetectedFeatures(config.FeatureMap{})
+	defer config.SetDetectedFeatures(nil)
+
 	port, err := getAvailableUDPPort()
 	require.NoError(t, err)
 	defaultPort := config.Datadog.GetInt("dogstatsd_port")
@@ -531,6 +546,9 @@ func TestEOLParsing(t *testing.T) {
 }
 
 func TestE2EParsing(t *testing.T) {
+	config.SetDetectedFeatures(config.FeatureMap{})
+	defer config.SetDetectedFeatures(nil)
+
 	port, err := getAvailableUDPPort()
 	require.NoError(t, err)
 	config.Datadog.SetDefault("dogstatsd_port", port)
@@ -573,6 +591,9 @@ func TestE2EParsing(t *testing.T) {
 }
 
 func TestExtraTags(t *testing.T) {
+	config.SetDetectedFeatures(config.FeatureMap{})
+	defer config.SetDetectedFeatures(nil)
+
 	port, err := getAvailableUDPPort()
 	require.NoError(t, err)
 	config.Datadog.SetDefault("dogstatsd_port", port)
@@ -607,11 +628,11 @@ func TestStaticTags(t *testing.T) {
 	require.NoError(t, err)
 	config.Datadog.SetDefault("dogstatsd_port", port)
 	config.Datadog.SetDefault("dogstatsd_tags", []string{"sometag3:somevalue3"})
-	config.Datadog.SetDefault("eks_fargate", true) // triggers DD_TAGS in static_tags
 	config.Datadog.SetDefault("tags", []string{"from:dd_tags"})
-	config.SetDetectedFeatures(config.FeatureMap{})
 	defer config.Datadog.SetDefault("dogstatsd_tags", []string{})
-	defer config.Datadog.SetDefault("eks_fargate", false)
+
+	config.SetDetectedFeatures(config.FeatureMap{config.EKSFargate: struct{}{}})
+	defer config.SetDetectedFeatures(nil)
 
 	demux := aggregator.InitTestAgentDemultiplexerWithFlushInterval(10 * time.Millisecond)
 	s, err := NewServer(demux, false)
@@ -642,6 +663,9 @@ func TestStaticTags(t *testing.T) {
 }
 
 func TestDebugStatsSpike(t *testing.T) {
+	config.SetDetectedFeatures(config.FeatureMap{})
+	defer config.SetDetectedFeatures(nil)
+
 	assert := assert.New(t)
 	demux := mockDemultiplexer()
 	defer demux.Stop(false)
@@ -702,6 +726,9 @@ func TestDebugStatsSpike(t *testing.T) {
 }
 
 func TestDebugStats(t *testing.T) {
+	config.SetDetectedFeatures(config.FeatureMap{})
+	defer config.SetDetectedFeatures(nil)
+
 	demux := mockDemultiplexer()
 	defer demux.Stop(false)
 	s, err := NewServer(demux, false)
@@ -777,6 +804,9 @@ func TestDebugStats(t *testing.T) {
 }
 
 func TestNoMappingsConfig(t *testing.T) {
+	config.SetDetectedFeatures(config.FeatureMap{})
+	defer config.SetDetectedFeatures(nil)
+
 	datadogYaml := ``
 	samples := []metrics.MetricSample{}
 
@@ -894,6 +924,9 @@ dogstatsd_mapper_profiles:
 	samples := []metrics.MetricSample{}
 	for _, scenario := range scenarios {
 		t.Run(scenario.name, func(t *testing.T) {
+			config.SetDetectedFeatures(config.FeatureMap{})
+			defer config.SetDetectedFeatures(nil)
+
 			config.Datadog.SetConfigType("yaml")
 			err := config.Datadog.ReadConfig(strings.NewReader(scenario.config))
 			assert.NoError(t, err, "Case `%s` failed. ReadConfig should not return error %v", scenario.name, err)
@@ -931,6 +964,9 @@ dogstatsd_mapper_profiles:
 }
 
 func TestNewServerExtraTags(t *testing.T) {
+	config.SetDetectedFeatures(config.FeatureMap{})
+	defer config.SetDetectedFeatures(nil)
+
 	// restore env/config after having runned the test
 	p := config.Datadog.Get("dogstatsd_port")
 	defer func() {
@@ -1049,6 +1085,9 @@ func testProcessedMetricsOrigin(t *testing.T) {
 }
 
 func TestProcessedMetricsOrigin(t *testing.T) {
+	config.SetDetectedFeatures(config.FeatureMap{})
+	defer config.SetDetectedFeatures(nil)
+
 	v := config.Datadog.GetBool("dogstatsd_origin_optout_enabled")
 	defer config.Datadog.Set("dogstatsd_origin_optout_enabled", v)
 	for _, enabled := range []bool{true, false} {
@@ -1087,6 +1126,9 @@ func testContainerIDParsing(t *testing.T) {
 }
 
 func TestContainerIDParsing(t *testing.T) {
+	config.SetDetectedFeatures(config.FeatureMap{})
+	defer config.SetDetectedFeatures(nil)
+
 	v := config.Datadog.GetBool("dogstatsd_origin_optout_enabled")
 	defer config.Datadog.Set("dogstatsd_origin_optout_enabled", v)
 	for _, enabled := range []bool{true, false} {
@@ -1137,6 +1179,9 @@ func testOriginOptout(t *testing.T, enabled bool) {
 }
 
 func TestOriginOptout(t *testing.T) {
+	config.SetDetectedFeatures(config.FeatureMap{})
+	defer config.SetDetectedFeatures(nil)
+
 	v := config.Datadog.GetBool("dogstatsd_origin_optout_enabled")
 	defer config.Datadog.Set("dogstatsd_origin_optout_enabled", v)
 	for _, enabled := range []bool{true, false} {

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 
+	coreConfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/network"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
@@ -46,6 +47,12 @@ var (
 	payloadSizesTCP   = []int{2 << 5, 2 << 8, 2 << 10, 2 << 12, 2 << 14, 2 << 15}
 	payloadSizesUDP   = []int{2 << 5, 2 << 8, 2 << 12, 2 << 14}
 )
+
+// Some tests try to detect if they're running on Fargate. We'll get a panic
+// when checking that if the auto-detected features have not been initialized.
+func init() {
+	coreConfig.SetDetectedFeatures(coreConfig.FeatureMap{})
+}
 
 func TestMain(m *testing.M) {
 	logLevel := os.Getenv("DD_LOG_LEVEL")

--- a/pkg/otlp/internal/serializerexporter/exporter_test.go
+++ b/pkg/otlp/internal/serializerexporter/exporter_test.go
@@ -77,6 +77,12 @@ func Test_ConsumeMetrics_Tags(t *testing.T) {
 				n.SetIntValue(777)
 				return newMetrics(histogramMetricName, h, numberMetricName, n)
 			},
+			setConfig: func(t *testing.T) {
+				config.SetDetectedFeatures(config.FeatureMap{})
+				t.Cleanup(func() {
+					defer config.SetDetectedFeatures(nil)
+				})
+			},
 			wantSketchTags: tagset.NewCompositeTags([]string{}, nil),
 			wantSerieTags:  tagset.NewCompositeTags([]string{}, nil),
 		},
@@ -101,10 +107,10 @@ func Test_ConsumeMetrics_Tags(t *testing.T) {
 				return newMetrics(histogramMetricName, h, numberMetricName, n)
 			},
 			setConfig: func(t *testing.T) {
-				config.Datadog.SetDefault("eks_fargate", true)
+				config.SetDetectedFeatures(config.FeatureMap{config.EKSFargate: struct{}{}})
 				config.Datadog.SetDefault("tags", []string{"serverless_tag1:test1", "serverless_tag2:test2", "serverless_tag3:test3"})
 				t.Cleanup(func() {
-					config.Datadog.SetDefault("eks_fargate", false)
+					defer config.SetDetectedFeatures(nil)
 					config.Datadog.SetDefault("tags", []string{})
 				})
 			},

--- a/pkg/otlp/internal/serializerexporter/factory_test.go
+++ b/pkg/otlp/internal/serializerexporter/factory_test.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/component/componenttest"
 
@@ -27,6 +28,9 @@ func TestNewFactory(t *testing.T) {
 }
 
 func TestNewMetricsExporter(t *testing.T) {
+	config.SetDetectedFeatures(config.FeatureMap{})
+	defer config.SetDetectedFeatures(nil)
+
 	factory := NewFactory(&serializer.MockSerializer{})
 	cfg := factory.CreateDefaultConfig()
 	set := componenttest.NewNopExporterCreateSettings()
@@ -36,6 +40,9 @@ func TestNewMetricsExporter(t *testing.T) {
 }
 
 func TestNewMetricsExporterInvalid(t *testing.T) {
+	config.SetDetectedFeatures(config.FeatureMap{})
+	defer config.SetDetectedFeatures(nil)
+
 	factory := NewFactory(&serializer.MockSerializer{})
 	cfg := factory.CreateDefaultConfig()
 

--- a/pkg/process/config/config.go
+++ b/pkg/process/config/config.go
@@ -257,7 +257,7 @@ func InitRuntimeSettings() {
 
 // getContainerHostType uses the fargate library to detect container environment and returns the protobuf version of it
 func getContainerHostType() model.ContainerHostType {
-	switch fargate.GetOrchestrator(context.TODO()) {
+	switch fargate.GetOrchestrator() {
 	case fargate.ECS:
 		return model.ContainerHostType_fargateECS
 	case fargate.EKS:
@@ -307,7 +307,7 @@ func IsBlacklisted(cmdline []string, blacklist []*regexp.Regexp) bool {
 // via cli and lastly falling back to os.Hostname() if it is unavailable
 func getHostname(ctx context.Context, ddAgentBin string, grpcConnectionTimeout time.Duration) (string, error) {
 	// Fargate is handled as an exceptional case (there is no concept of a host, so we use the ARN in-place).
-	if fargate.IsFargateInstance(ctx) {
+	if fargate.IsFargateInstance() {
 		hostname, err := fargate.GetFargateHost(ctx)
 		if err == nil {
 			return hostname, nil

--- a/pkg/util/fargate/detection.go
+++ b/pkg/util/fargate/detection.go
@@ -13,23 +13,18 @@ import (
 
 // IsFargateInstance returns whether the Agent is running in Fargate.
 func IsFargateInstance() bool {
-	return config.IsFeaturePresent(config.ECSFargate) || IsEKSFargateInstance()
+	return config.IsFeaturePresent(config.ECSFargate) || config.IsFeaturePresent(config.EKSFargate)
 }
 
 // GetOrchestrator returns whether the Agent is running on ECS or EKS.
 func GetOrchestrator() OrchestratorName {
-	if IsEKSFargateInstance() {
+	if config.IsFeaturePresent(config.EKSFargate) {
 		return EKS
 	}
 	if config.IsFeaturePresent(config.ECSFargate) {
 		return ECS
 	}
 	return Unknown
-}
-
-// IsEKSFargateInstance returns whether the Agent is running in EKS Fargate.
-func IsEKSFargateInstance() bool {
-	return config.Datadog.GetBool("eks_fargate")
 }
 
 // GetEKSFargateNodename returns the node name in EKS Fargate

--- a/pkg/util/fargate/detection.go
+++ b/pkg/util/fargate/detection.go
@@ -6,24 +6,22 @@
 package fargate
 
 import (
-	"context"
 	"errors"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
-	"github.com/DataDog/datadog-agent/pkg/util/ecs"
 )
 
 // IsFargateInstance returns whether the Agent is running in Fargate.
-func IsFargateInstance(ctx context.Context) bool {
-	return ecs.IsFargateInstance(ctx) || IsEKSFargateInstance()
+func IsFargateInstance() bool {
+	return config.IsFeaturePresent(config.ECSFargate) || IsEKSFargateInstance()
 }
 
 // GetOrchestrator returns whether the Agent is running on ECS or EKS.
-func GetOrchestrator(ctx context.Context) OrchestratorName {
+func GetOrchestrator() OrchestratorName {
 	if IsEKSFargateInstance() {
 		return EKS
 	}
-	if ecs.IsFargateInstance(ctx) {
+	if config.IsFeaturePresent(config.ECSFargate) {
 		return ECS
 	}
 	return Unknown

--- a/pkg/util/fargate/hostname_process.go
+++ b/pkg/util/fargate/hostname_process.go
@@ -22,7 +22,7 @@ import (
 // - ECS: fargate_task:<TaskARN>
 // - EKS: value of kubernetes_kubelet_nodename
 func GetFargateHost(ctx context.Context) (string, error) {
-	return getFargateHost(ctx, GetOrchestrator(ctx), getECSHost, getEKSHost)
+	return getFargateHost(ctx, GetOrchestrator(), getECSHost, getEKSHost)
 }
 
 // getFargateHost is separated from GetFargateHost for testing purpose

--- a/pkg/util/hostname/common.go
+++ b/pkg/util/hostname/common.go
@@ -71,9 +71,9 @@ func fromHostnameFile(ctx context.Context, _ string) (string, error) {
 	return hostname, nil
 }
 
-func fromFargate(ctx context.Context, _ string) (string, error) {
+func fromFargate(_ context.Context, _ string) (string, error) {
 	// If we're running on fargate we strip the hostname
-	if isFargateInstance(ctx) {
+	if isFargateInstance() {
 		return "", nil
 	}
 	return "", fmt.Errorf("agent is not runnning on Fargate")

--- a/pkg/util/hostname/common_test.go
+++ b/pkg/util/hostname/common_test.go
@@ -90,12 +90,12 @@ func TestFromHostnameFileInvalid(t *testing.T) {
 func TestFromFargate(t *testing.T) {
 	defer func() { isFargateInstance = fargate.IsFargateInstance }()
 
-	isFargateInstance = func(context.Context) bool { return true }
+	isFargateInstance = func() bool { return true }
 	hostname, err := fromFargate(context.TODO(), "")
 	require.NoError(t, err)
 	assert.Equal(t, "", hostname)
 
-	isFargateInstance = func(context.Context) bool { return false }
+	isFargateInstance = func() bool { return false }
 	_, err = fromFargate(context.TODO(), "")
 	assert.Error(t, err)
 }

--- a/pkg/util/hostname/providers_test.go
+++ b/pkg/util/hostname/providers_test.go
@@ -71,9 +71,9 @@ func setupHostnameTest(t *testing.T, tc testCase) {
 		setupHostnameFile(t, "hostname-from-file")
 	}
 	if tc.fargate {
-		isFargateInstance = func(context.Context) bool { return true }
+		isFargateInstance = func() bool { return true }
 	} else {
-		isFargateInstance = func(context.Context) bool { return false }
+		isFargateInstance = func() bool { return false }
 	}
 
 	if tc.GCE {

--- a/pkg/util/kernel/fs.go
+++ b/pkg/util/kernel/fs.go
@@ -9,7 +9,6 @@
 package kernel
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -88,7 +87,7 @@ func IsDebugFSMounted() (bool, error) {
 	}
 
 	// on fargate, kprobe_events is mounted as ro
-	if !fargate.IsFargateInstance(context.Background()) {
+	if !fargate.IsFargateInstance() {
 		options := strings.Split(mi.Options, ",")
 		for _, option := range options {
 			if option == "ro" {

--- a/pkg/util/static_tags.go
+++ b/pkg/util/static_tags.go
@@ -34,7 +34,7 @@ func GetStaticTagsSlice(ctx context.Context) []string {
 	tags = append(tags, config.GetConfiguredTags(false)...)
 
 	// EKS Fargate specific tags
-	if fargate.IsEKSFargateInstance() {
+	if config.IsFeaturePresent(config.EKSFargate) {
 		// eks_fargate_node
 		node, err := fargate.GetEKSFargateNodename()
 		if err != nil {

--- a/pkg/util/static_tags.go
+++ b/pkg/util/static_tags.go
@@ -24,7 +24,7 @@ func GetStaticTagsSlice(ctx context.Context) []string {
 	// fargate (ECS or EKS) does not have host tags, so we need to
 	// add static tags to each container manually
 
-	if !fargate.IsFargateInstance(ctx) {
+	if !fargate.IsFargateInstance() {
 		return nil
 	}
 

--- a/pkg/util/static_tags_test.go
+++ b/pkg/util/static_tags_test.go
@@ -16,10 +16,11 @@ import (
 
 func TestStaticTags(t *testing.T) {
 	mockConfig := config.Mock(t)
-	mockConfig.Set("eks_fargate", true) // pretend this is a hostless environment
 	mockConfig.Set("kubernetes_kubelet_nodename", "eksnode")
-	defer mockConfig.Set("eks_fargate", false)
 	defer mockConfig.Set("kubernetes_kubelet_nodename", "")
+
+	config.SetDetectedFeatures(config.FeatureMap{config.EKSFargate: struct{}{}})
+	defer config.SetDetectedFeatures(nil)
 
 	t.Run("just tags", func(t *testing.T) {
 		mockConfig.Set("tags", []string{"some:tag", "another:tag", "nocolon"})
@@ -58,10 +59,11 @@ func TestStaticTags(t *testing.T) {
 
 func TestStaticTagsSlice(t *testing.T) {
 	mockConfig := config.Mock(t)
-	mockConfig.Set("eks_fargate", true) // pretend this is a hostless environment
 	mockConfig.Set("kubernetes_kubelet_nodename", "eksnode")
-	defer mockConfig.Set("eks_fargate", false)
 	defer mockConfig.Set("kubernetes_kubelet_nodename", "")
+
+	config.SetDetectedFeatures(config.FeatureMap{config.EKSFargate: struct{}{}})
+	defer config.SetDetectedFeatures(nil)
 
 	t.Run("just tags", func(t *testing.T) {
 		mockConfig.Set("tags", []string{"some:tag", "another:tag", "nocolon"})

--- a/releasenotes/notes/improve-ecs-fargate-hostname-detection-0a468e1c3a53b3df.yaml
+++ b/releasenotes/notes/improve-ecs-fargate-hostname-detection-0a468e1c3a53b3df.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    The agent no longer wrongly resolves its hostname on ECS Fargate when
+    requests to the Fargate API timeout.


### PR DESCRIPTION
### What does this PR do?

Makes hostname resolution more reliable when running on ECS Fargate.

Currently, hostname resolution on ECS Fargate queries the `/metadata` endpoint. This is a bit problematic because when there's a timeout, the Agent assumes that is not running on ECS Fargate and tries to resolve the hostname as if it was running on a different environment.

Checking `ECS_FARGATE` and `AWS_EXECUTION_ENV` should be enough to detect if the Agent is running on ECS Fargate. This PR adapts the code that auto-detects features to take that into account (`pkg/config/environment.go`). This PR also changes the code that hostname resolution uses to detect if it's running on ECS Fargate (`pkg/util/fargate/detection.go`) to rely on autodetected features instead of performing its own checks.


### Describe how to test/QA your changes

Hostname should always be empty when running on ECS Fargate. Before this change, it can be non-empty when there's a problem querying `/metadata`.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
