### PR TITLE
pkg/trace/{api,otlp,sampler}: enable priority sampling for OTLP Ingest

### DIFF
--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -36,9 +36,6 @@ const (
 
 	// manualSampling is the value for _dd.p.dm when user sets sampling priority directly in code.
 	manualSampling = "-4"
-
-	// tagDecisionMaker specifies the sampling decision maker
-	tagDecisionMaker = "_dd.p.dm"
 )
 
 // Agent struct holds all the sub-routines structs and make the data flow between them
@@ -109,7 +106,7 @@ func NewAgent(ctx context.Context, conf *config.AgentConfig) *Agent {
 		ctx:                   ctx,
 	}
 	agnt.Receiver = api.NewHTTPReceiver(conf, dynConf, in, agnt)
-	agnt.OTLPReceiver = api.NewOTLPReceiver(in, conf)
+	agnt.OTLPReceiver = api.NewOTLPReceiver(in, dynConf, conf)
 	agnt.RemoteConfigHandler = remoteconfighandler.New(conf, agnt.PrioritySampler, agnt.RareSampler, agnt.ErrorsSampler)
 	return agnt
 }
@@ -463,7 +460,7 @@ func isManualUserDrop(priority sampler.SamplingPriority, pt traceutil.ProcessedT
 	if priority != sampler.PriorityUserDrop {
 		return false
 	}
-	dm, hasDm := pt.Root.Meta[tagDecisionMaker]
+	dm, hasDm := pt.Root.Meta[sampler.KeyDecisionMaker]
 	if !hasDm {
 		return false
 	}

--- a/pkg/trace/api/otlp_test.go
+++ b/pkg/trace/api/otlp_test.go
@@ -101,7 +101,7 @@ func TestOTLPReceiverSamplingPriority(t *testing.T) {
 	mkspan := func(traceID uint64, service, env string) *pb.Span {
 		return &pb.Span{
 			TraceID: traceID,
-			Service: "a",
+			Service: service,
 			Meta:    map[string]string{"env": env},
 			Metrics: make(map[string]float64),
 		}

--- a/pkg/trace/sampler/prioritysampler.go
+++ b/pkg/trace/sampler/prioritysampler.go
@@ -27,7 +27,6 @@ import (
 
 const (
 	deprecatedRateKey = "_sampling_priority_rate_v1"
-	agentRateKey      = "_dd.agent_psr"
 	ruleRateKey       = "_dd.rule_psr"
 )
 
@@ -129,8 +128,8 @@ func (s *PrioritySampler) applyRate(root *pb.Span, signature Signature) float64 
 		return 1.0
 	}
 	// recent tracers annotate roots with applied priority rate
-	// agentRateKey is set when the agent computed rate is applied
-	if rate, ok := getMetric(root, agentRateKey); ok {
+	// KeyAgentRate is set when the agent computed rate is applied
+	if rate, ok := getMetric(root, KeyAgentRate); ok {
 		return rate
 	}
 	// ruleRateKey is set when a tracer rule rate is applied

--- a/pkg/trace/sampler/prioritysampler_test.go
+++ b/pkg/trace/sampler/prioritysampler_test.go
@@ -52,7 +52,7 @@ func getTestTraceWithService(service string, s *PrioritySampler) (*pb.TraceChunk
 	if r <= rate {
 		priority = PriorityAutoKeep
 	}
-	spans[0].Metrics[agentRateKey] = rate
+	spans[0].Metrics[KeyAgentRate] = rate
 	return &pb.TraceChunk{
 		Priority: int32(priority),
 		Spans:    spans,
@@ -187,7 +187,7 @@ func TestPrioritySamplerTPSFeedbackLoop(t *testing.T) {
 				// skipping clientDrop as the feedback loop is different when client drops
 				// seen is actually the last rate sent
 				if !tc.clientDrop {
-					appliedRate := root.Metrics[agentRateKey]
+					appliedRate := root.Metrics[KeyAgentRate]
 					assert.InEpsilon(tc.expectedTPS/tc.generatedTPS, appliedRate, 0.0000001)
 				}
 

--- a/pkg/trace/sampler/sampler.go
+++ b/pkg/trace/sampler/sampler.go
@@ -40,6 +40,13 @@ const (
 
 	// KeySpanSamplingMechanism is the metric key holding a span sampling rule that a span was kept on.
 	KeySpanSamplingMechanism = "_dd.span_sampling.mechanism"
+
+	// KeyAgentRate specifies the metric key used to store the rate at which the sampling
+	// priority for a given span was computed.
+	KeyAgentRate = "_dd.agent_psr"
+
+	// KeyDecisionMaker specifies the sampling decision maker.
+	KeyDecisionMaker = "_dd.p.dm"
 )
 
 // SamplingPriority is the type encoding a priority sampling decision.

--- a/releasenotes/notes/apm-otlp-ingestion-controls-c46a248768afa6f9.yaml
+++ b/releasenotes/notes/apm-otlp-ingestion-controls-c46a248768afa6f9.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    APM OTLP: Agent-level ingestion controls are now supported via the "Ingestion Controls" web UI. Settings such as DD_APM_MAX_TPS, DD_APM_ERROR_TPS, etc. are now followed by the OTLP Ingest as well.


### PR DESCRIPTION
This change ensures that the priority sampler rates are used in OTLP as well, following user-set TPS rates, such as DD_APM_MAX_TPS, DD_APM_ERROR_TPS, etc. just like the Datadog tracing libraries.