### PR TITLE
[process-agent] Set HintMask in CollectorProc during process checks.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	code.cloudfoundry.org/bbs v0.0.0-20200403215808-d7bc971db0db
 	code.cloudfoundry.org/garden v0.0.0-20210208153517-580cadd489d2
 	code.cloudfoundry.org/lager v2.0.0+incompatible
-	github.com/DataDog/agent-payload/v5 v5.0.61
+	github.com/DataDog/agent-payload/v5 v5.0.64
 	github.com/DataDog/datadog-agent/pkg/obfuscate v0.42.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/otlp/model v0.42.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/quantile v0.42.0-rc.3

--- a/go.sum
+++ b/go.sum
@@ -121,8 +121,8 @@ github.com/BurntSushi/toml v1.1.0/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbi
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/CycloneDX/cyclonedx-go v0.7.0 h1:jNxp8hL7UpcvPDFXjY+Y1ibFtsW+e5zyF9QoSmhK/zg=
 github.com/CycloneDX/cyclonedx-go v0.7.0/go.mod h1:W5Z9w8pTTL+t+yG3PCiFRGlr8PUlE0pGWzKSJbsyXkg=
-github.com/DataDog/agent-payload/v5 v5.0.61 h1:3HC4B1NpHgAedZHmM9/oCJvFo6pu/ugDAjrISK5AJsk=
-github.com/DataDog/agent-payload/v5 v5.0.61/go.mod h1:oQZi1VZp1e3QvlSUX4iphZCpJaFepUxWq0hNXxihKBM=
+github.com/DataDog/agent-payload/v5 v5.0.64 h1:UEjYFRbuqjOlh6tz6NtUB5O4Pc2Xcgrsp3lGZ5zvz34=
+github.com/DataDog/agent-payload/v5 v5.0.64/go.mod h1:oQZi1VZp1e3QvlSUX4iphZCpJaFepUxWq0hNXxihKBM=
 github.com/DataDog/aptly v1.5.0 h1:Oy6JVRC9iDgnmpeVYa4diXwP/exU7wJ/U1kuI4Zacxg=
 github.com/DataDog/aptly v1.5.0/go.mod h1:KVyvkYXGcFugxadGFZ+u5Fc3M6q/EfzFZyeTD9HVbkY=
 github.com/DataDog/cast v1.3.1-0.20190301154711-1ee8c8bd14a3 h1:SobA9WYm4K/MUtWlbKaomWTmnuYp1KhIm8Wlx3vmpsg=

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -61,8 +61,9 @@ func TestDefaults(t *testing.T) {
 
 	// Testing process-agent defaults
 	assert.Equal(t, map[string]interface{}{
-		"enabled":  true,
-		"interval": 4 * time.Hour,
+		"enabled":        true,
+		"hint_frequency": 60,
+		"interval":       4 * time.Hour,
 	}, config.GetStringMap("process_config.process_discovery"))
 }
 

--- a/pkg/config/process.go
+++ b/pkg/config/process.go
@@ -176,6 +176,8 @@ func setupProcesses(config Config) {
 	)
 	procBindEnvAndSetDefault(config, "process_config.process_discovery.interval", 4*time.Hour)
 
+	procBindEnvAndSetDefault(config, "process_config.checks_between_hints", 60)
+
 	procBindEnvAndSetDefault(config, "process_config.drop_check_payloads", []string{})
 
 	// Process Lifecycle Events

--- a/pkg/config/process.go
+++ b/pkg/config/process.go
@@ -67,6 +67,9 @@ const (
 
 	// DefaultProcessEventsCheckInterval is the default interval used by the process_events check
 	DefaultProcessEventsCheckInterval = 10 * time.Second
+
+	// DefaultProcessDiscoveryHintFrequency is the default frequency in terms of number of checks which we send a process discovery hint
+	DefaultProcessDiscoveryHintFrequency = 60
 )
 
 // setupProcesses is meant to be called multiple times for different configs, but overrides apply to all configs, so
@@ -176,7 +179,7 @@ func setupProcesses(config Config) {
 	)
 	procBindEnvAndSetDefault(config, "process_config.process_discovery.interval", 4*time.Hour)
 
-	procBindEnvAndSetDefault(config, "process_config.checks_between_hints", 60)
+	procBindEnvAndSetDefault(config, "process_config.process_discovery.hint_frequency", DefaultProcessDiscoveryHintFrequency)
 
 	procBindEnvAndSetDefault(config, "process_config.drop_check_payloads", []string{})
 

--- a/pkg/process/checks/host_info_test.go
+++ b/pkg/process/checks/host_info_test.go
@@ -24,6 +24,9 @@ import (
 )
 
 func TestGetHostname(t *testing.T) {
+	config.SetDetectedFeatures(config.FeatureMap{})
+	defer config.SetDetectedFeatures(nil)
+
 	ctx := context.Background()
 	h, err := getHostname(ctx, config.Datadog.GetString("process_config.dd_agent_bin"), 0)
 	assert.Nil(t, err)
@@ -80,6 +83,9 @@ func TestGetHostnameFromCmd(t *testing.T) {
 }
 
 func TestInvalidHostname(t *testing.T) {
+	config.SetDetectedFeatures(config.FeatureMap{})
+	defer config.SetDetectedFeatures(nil)
+
 	// Lower the GRPC timeout, otherwise the test will time out in CI
 	config.Datadog.Set("process_config.grpc_connection_timeout_secs", 1)
 	config.Datadog.Set("hostname", "localhost")

--- a/pkg/process/checks/process.go
+++ b/pkg/process/checks/process.go
@@ -45,7 +45,7 @@ func NewProcessCheck() Check {
 var errEmptyCPUTime = errors.New("empty CPU time information returned")
 
 const (
-	ProcessDiscoveryHintPosition = 0
+	ProcessDiscoveryHint int32 = 1 << iota // 1
 )
 
 // ProcessCheck collects full state, including cmdline args and related metadata,
@@ -279,17 +279,11 @@ func (p *ProcessCheck) run(groupID int32, collectRealTime bool) (RunResult, erro
 	return result, nil
 }
 
-// Sets the bit at pos in the integer n.
-func setBit(n int32, pos uint) int32 {
-	n |= (1 << pos)
-	return n
-}
-
 func (p *ProcessCheck) generateHints() int32 {
-	var hints int32 = 0
+	var hints int32
 
 	if p.checkCount%p.skipAmount == 0 {
-		hints = setBit(hints, ProcessDiscoveryHintPosition)
+		hints |= ProcessDiscoveryHint
 	}
 	return hints
 }
@@ -341,7 +335,7 @@ func createProcCtrMessages(
 		m.Info = hostInfo.SystemInfo
 		m.GroupId = groupID
 		m.ContainerHostType = hostInfo.ContainerHostType
-		m.HintMask = hints
+		m.Hints = &model.CollectorProc_HintMask{HintMask: hints}
 
 		messages = append(messages, m)
 	}

--- a/pkg/process/checks/process_nix_test.go
+++ b/pkg/process/checks/process_nix_test.go
@@ -122,7 +122,7 @@ func TestBasicProcessMessages(t *testing.T) {
 			}
 
 			procs := fmtProcesses(procutil.NewDefaultDataScrubber(), disallowList, tc.processes, tc.processes, tc.pidToCid, syst2, syst1, lastRun, nil)
-			messages, totalProcs, totalContainers := createProcCtrMessages(hostInfo, procs, tc.containers, tc.maxSize, maxBatchBytes, int32(i), "nid")
+			messages, totalProcs, totalContainers := createProcCtrMessages(hostInfo, procs, tc.containers, tc.maxSize, maxBatchBytes, int32(i), "nid", 0)
 
 			assert.Equal(t, tc.expectedChunks, len(messages))
 
@@ -233,7 +233,7 @@ func TestContainerProcessChunking(t *testing.T) {
 			hostInfo := &HostInfo{SystemInfo: sysInfo}
 
 			processes := fmtProcesses(procutil.NewDefaultDataScrubber(), nil, procsByPid, procsByPid, pidToCid, syst2, syst1, lastRun, nil)
-			messages, totalProcs, totalContainers := createProcCtrMessages(hostInfo, processes, ctrs, tc.maxSize, maxBatchBytes, int32(i), "nid")
+			messages, totalProcs, totalContainers := createProcCtrMessages(hostInfo, processes, ctrs, tc.maxSize, maxBatchBytes, int32(i), "nid", 0)
 
 			assert.Equal(t, tc.expectedProcCount, totalProcs)
 			assert.Equal(t, tc.expectedCtrCount, totalContainers)

--- a/pkg/process/checks/process_test.go
+++ b/pkg/process/checks/process_test.go
@@ -122,31 +122,31 @@ func TestProcessCheckSecondRun(t *testing.T) {
 			Processes: []*model.Process{makeProcessModel(t, proc1)},
 			GroupSize: int32(len(processesByPid)),
 			Info:      processCheck.hostInfo.SystemInfo,
-			HintMask:  0b1,
+			Hints:     &model.CollectorProc_HintMask{HintMask: 0b1},
 		},
 		&model.CollectorProc{
 			Processes: []*model.Process{makeProcessModel(t, proc2)},
 			GroupSize: int32(len(processesByPid)),
 			Info:      processCheck.hostInfo.SystemInfo,
-			HintMask:  0b1,
+			Hints:     &model.CollectorProc_HintMask{HintMask: 0b1},
 		},
 		&model.CollectorProc{
 			Processes: []*model.Process{makeProcessModel(t, proc3)},
 			GroupSize: int32(len(processesByPid)),
 			Info:      processCheck.hostInfo.SystemInfo,
-			HintMask:  0b1,
+			Hints:     &model.CollectorProc_HintMask{HintMask: 0b1},
 		},
 		&model.CollectorProc{
 			Processes: []*model.Process{makeProcessModel(t, proc4)},
 			GroupSize: int32(len(processesByPid)),
 			Info:      processCheck.hostInfo.SystemInfo,
-			HintMask:  0b1,
+			Hints:     &model.CollectorProc_HintMask{HintMask: 0b1},
 		},
 		&model.CollectorProc{
 			Processes: []*model.Process{makeProcessModel(t, proc5)},
 			GroupSize: int32(len(processesByPid)),
 			Info:      processCheck.hostInfo.SystemInfo,
-			HintMask:  0b1,
+			Hints:     &model.CollectorProc_HintMask{HintMask: 0b1},
 		},
 	}
 	actual, err := processCheck.run(0, false)
@@ -178,26 +178,31 @@ func TestProcessCheckWithRealtime(t *testing.T) {
 			Processes: []*model.Process{makeProcessModel(t, proc1)},
 			GroupSize: int32(len(processesByPid)),
 			Info:      processCheck.hostInfo.SystemInfo,
+			Hints:     &model.CollectorProc_HintMask{HintMask: 0b1},
 		},
 		&model.CollectorProc{
 			Processes: []*model.Process{makeProcessModel(t, proc2)},
 			GroupSize: int32(len(processesByPid)),
 			Info:      processCheck.hostInfo.SystemInfo,
+			Hints:     &model.CollectorProc_HintMask{HintMask: 0b1},
 		},
 		&model.CollectorProc{
 			Processes: []*model.Process{makeProcessModel(t, proc3)},
 			GroupSize: int32(len(processesByPid)),
 			Info:      processCheck.hostInfo.SystemInfo,
+			Hints:     &model.CollectorProc_HintMask{HintMask: 0b1},
 		},
 		&model.CollectorProc{
 			Processes: []*model.Process{makeProcessModel(t, proc4)},
 			GroupSize: int32(len(processesByPid)),
 			Info:      processCheck.hostInfo.SystemInfo,
+			Hints:     &model.CollectorProc_HintMask{HintMask: 0b1},
 		},
 		&model.CollectorProc{
 			Processes: []*model.Process{makeProcessModel(t, proc5)},
 			GroupSize: int32(len(processesByPid)),
 			Info:      processCheck.hostInfo.SystemInfo,
+			Hints:     &model.CollectorProc_HintMask{HintMask: 0b1},
 		},
 	}
 
@@ -347,7 +352,7 @@ func TestProcessCheckHints(t *testing.T) {
 		Return(processesByPid, nil)
 
 	// The first run returns nothing because processes must be observed on two consecutive runs
-	first, err := processCheck.run(config.NewDefaultAgentConfig(), 0, false)
+	first, err := processCheck.run(0, false)
 	require.NoError(t, err)
 	assert.Equal(t, &RunResult{}, first)
 
@@ -355,11 +360,11 @@ func TestProcessCheckHints(t *testing.T) {
 		&model.CollectorProc{
 			Processes: []*model.Process{makeProcessModel(t, proc1)},
 			GroupSize: int32(len(processesByPid)),
-			Info:      processCheck.sysInfo,
-			HintMask:  0b1,
+			Info:      processCheck.hostInfo.SystemInfo,
+			Hints:     &model.CollectorProc_HintMask{HintMask: 0b1},
 		},
 	}
-	actual, err := processCheck.run(config.NewDefaultAgentConfig(), 0, false)
+	actual, err := processCheck.run(0, false)
 	require.NoError(t, err)
 	assert.ElementsMatch(t, expected, actual.Standard) // ordering is not guaranteed
 	assert.Nil(t, actual.RealTime)
@@ -368,12 +373,12 @@ func TestProcessCheckHints(t *testing.T) {
 		&model.CollectorProc{
 			Processes: []*model.Process{makeProcessModel(t, proc1)},
 			GroupSize: int32(len(processesByPid)),
-			Info:      processCheck.sysInfo,
-			HintMask:  0b0,
+			Info:      processCheck.hostInfo.SystemInfo,
+			Hints:     &model.CollectorProc_HintMask{HintMask: 0},
 		},
 	}
 
-	actual, err = processCheck.run(config.NewDefaultAgentConfig(), 0, false)
+	actual, err = processCheck.run(0, false)
 	require.NoError(t, err)
 	assert.ElementsMatch(t, expectedUnspecified, actual.Standard) // ordering is not guaranteed
 
@@ -381,12 +386,12 @@ func TestProcessCheckHints(t *testing.T) {
 		&model.CollectorProc{
 			Processes: []*model.Process{makeProcessModel(t, proc1)},
 			GroupSize: int32(len(processesByPid)),
-			Info:      processCheck.sysInfo,
-			HintMask:  0b1,
+			Info:      processCheck.hostInfo.SystemInfo,
+			Hints:     &model.CollectorProc_HintMask{HintMask: 0b1},
 		},
 	}
 
-	actual, err = processCheck.run(config.NewDefaultAgentConfig(), 0, false)
+	actual, err = processCheck.run(0, false)
 	require.NoError(t, err)
 	assert.ElementsMatch(t, expectedDiscovery, actual.Standard) // ordering is not guaranteed
 }
@@ -405,7 +410,7 @@ func BenchmarkProcessCheck(b *testing.B) {
 	probe.On("ProcessesByPID", mock.Anything, mock.Anything).Return(processesByPid, nil)
 
 	for n := 0; n < b.N; n++ {
-		_, err := processCheck.run(config.NewDefaultAgentConfig(), 0, false)
+		_, err := processCheck.run(0, false)
 		require.NoError(b, err)
 	}
 }

--- a/pkg/process/checks/process_test.go
+++ b/pkg/process/checks/process_test.go
@@ -354,7 +354,7 @@ func TestProcessCheckHints(t *testing.T) {
 	// The first run returns nothing because processes must be observed on two consecutive runs
 	first, err := processCheck.run(0, false)
 	require.NoError(t, err)
-	assert.Equal(t, &RunResult{}, first)
+	assert.Equal(t, CombinedRunResult{}, first)
 
 	expected := []model.MessageBody{
 		&model.CollectorProc{
@@ -366,8 +366,8 @@ func TestProcessCheckHints(t *testing.T) {
 	}
 	actual, err := processCheck.run(0, false)
 	require.NoError(t, err)
-	assert.ElementsMatch(t, expected, actual.Standard) // ordering is not guaranteed
-	assert.Nil(t, actual.RealTime)
+	assert.ElementsMatch(t, expected, actual.Payloads()) // ordering is not guaranteed
+	assert.Nil(t, actual.RealtimePayloads())
 
 	expectedUnspecified := []model.MessageBody{
 		&model.CollectorProc{
@@ -380,7 +380,8 @@ func TestProcessCheckHints(t *testing.T) {
 
 	actual, err = processCheck.run(0, false)
 	require.NoError(t, err)
-	assert.ElementsMatch(t, expectedUnspecified, actual.Standard) // ordering is not guaranteed
+	assert.ElementsMatch(t, expectedUnspecified, actual.Payloads()) // ordering is not guaranteed
+	assert.Nil(t, actual.RealtimePayloads())
 
 	expectedDiscovery := []model.MessageBody{
 		&model.CollectorProc{
@@ -393,7 +394,7 @@ func TestProcessCheckHints(t *testing.T) {
 
 	actual, err = processCheck.run(0, false)
 	require.NoError(t, err)
-	assert.ElementsMatch(t, expectedDiscovery, actual.Standard) // ordering is not guaranteed
+	assert.ElementsMatch(t, expectedDiscovery, actual.Payloads()) // ordering is not guaranteed
 }
 
 func BenchmarkProcessCheck(b *testing.B) {

--- a/releasenotes/notes/process-discovery-hints-e6d255090fdbe65f.yaml
+++ b/releasenotes/notes/process-discovery-hints-e6d255090fdbe65f.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Adds a new process discovery hint in the process agent when the regular process and container checks run.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
Process check can now populate the hints field added into the payload. The process discovery hint will be added every certain amount of checks done. This is a configurable setting that is currently set at every 60 checks.

### Motivation


### Additional Notes


### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
1. Enable the process check 
2. Set log level to trace
3. check for the log line:
```
2023-01-18 05:32:56 PST | PROCESS | TRACE | (pkg/process/checks/process.go:291 in generateHints) | generated a process discovery hint on check #60
```

**Run the process check**
```
/opt/datadog-agent/embedded/bin/process-agent check process --json 
```
Verify the check contains the hint
```
...
  "Hints": {
    "HintMask": 1
  }
```


<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
