### PR TITLE
correction to resulting hostname/aliases

### DIFF
--- a/pkg/util/hostname/README.md
+++ b/pkg/util/hostname/README.md
@@ -92,15 +92,15 @@ The results are as follows:
 | none      | false                 | 1         | os            | none          |
 | none      | true                  | 1         | os            | none          |
 | v2 only   | false                 | 1         | os            | none          |
-| v2 only   | true                  | 1         | aws (i-..)    | aws (i-..)    |
+| v2 only   | true                  | 1         | os            | none          |
 | v1+v2     | false                 | 1         | aws (i-..)    | aws (i-..)    |
 | v1+v2     | true                  | 1         | aws (i-..)    | aws (i-..)    |
 | none      | false                 | 2+        | os            | none          |
 | none      | true                  | 2+        | os            | none          |
 | v2 only   | false                 | 2+        | os            | none          |
-| v2 only   | true                  | 2+        | os            | none          |
-| v1+v2     | false                 | 2+        | os            | aws (i-..)    |
-| v1+v2     | true                  | 2+        | os            | aws (i-..)    |
+| v2 only   | true                  | 2+        | aws (i-..)    | aws (i-..)    |
+| v1+v2     | false                 | 2+        | aws (i-..)    | aws (i-..)    |
+| v1+v2     | true                  | 2+        | aws (i-..)    | aws (i-..)    |
 
  * The first column describes the EC2 IMDS configuration: "none" means IMDS is entirely disabled; "v2 only" means that IMDSv1 is disabled, and "v1+v2" is the default setting with both versions available
  * The second column is the `ec2_prefer_imdsv2` configuration value.


### PR DESCRIPTION
### What does this PR do?

Corrects the resulting hostname.
- Anything with IMDSv1 enabled regardless of `ec2_prefer_imdsv2` would result in aws instance-id being used
- IMDSv2-only with incorrect hop count of 1 will always fail and result in using `os`
- IMDSv2-only with proper hop count `2+` and `ec2_prefer_imdsv2: true` results in aws instance-id.
- IMDSv2-only with proper hop count `2+` and `ec2_prefer_imdsv2: false` results in `os`

### Motivation

AGENT-9030

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
