### PR TITLE
Add CO-RE version of TCP Queue Length check

### DIFF
--- a/.gitlab/binary_build/system_probe.yml
+++ b/.gitlab/binary_build/system_probe.yml
@@ -29,6 +29,7 @@
     - $S3_CP_CMD $CI_PROJECT_DIR/pkg/ebpf/bytecode/build/runtime-security-syscall-wrapper.o $S3_ARTIFACTS_URI/runtime-security-syscall-wrapper.o.$ARCH
     - $S3_CP_CMD $CI_PROJECT_DIR/pkg/ebpf/bytecode/build/runtime-security-offset-guesser.o $S3_ARTIFACTS_URI/runtime-security-offset-guesser.o.$ARCH
     - $S3_CP_CMD $CI_PROJECT_DIR/pkg/ebpf/bytecode/build/co-re/oom-kill.o $S3_ARTIFACTS_URI/oom-kill-co-re.o.$ARCH
+    - $S3_CP_CMD $CI_PROJECT_DIR/pkg/ebpf/bytecode/build/co-re/tcp-queue-length.o $S3_ARTIFACTS_URI/tcp-queue-length-co-re.o.$ARCH
     - $S3_CP_CMD $CI_PROJECT_DIR/pkg/ebpf/bytecode/build/runtime/tracer.c $S3_ARTIFACTS_URI/tracer.c.$ARCH
     - $S3_CP_CMD $CI_PROJECT_DIR/pkg/ebpf/bytecode/build/runtime/http.c $S3_ARTIFACTS_URI/http.c.$ARCH
     - $S3_CP_CMD $CI_PROJECT_DIR/pkg/ebpf/bytecode/build/runtime/runtime-security.c $S3_ARTIFACTS_URI/runtime-security.c.$ARCH

--- a/.gitlab/package_build/deb.yml
+++ b/.gitlab/package_build/deb.yml
@@ -31,6 +31,7 @@
     - $S3_CP_CMD $S3_ARTIFACTS_URI/runtime-security-syscall-wrapper.o.${PACKAGE_ARCH} /tmp/system-probe/runtime-security-syscall-wrapper.o
     - $S3_CP_CMD $S3_ARTIFACTS_URI/runtime-security-offset-guesser.o.${PACKAGE_ARCH} /tmp/system-probe/runtime-security-offset-guesser.o
     - $S3_CP_CMD $S3_ARTIFACTS_URI/oom-kill-co-re.o.${PACKAGE_ARCH} /tmp/system-probe/oom-kill-co-re.o
+    - $S3_CP_CMD $S3_ARTIFACTS_URI/tcp-queue-length-co-re.o.${PACKAGE_ARCH} /tmp/system-probe/tcp-queue-length-co-re.o
     - $S3_CP_CMD $S3_ARTIFACTS_URI/tracer.c.${PACKAGE_ARCH} /tmp/system-probe/tracer.c
     - $S3_CP_CMD $S3_ARTIFACTS_URI/http.c.${PACKAGE_ARCH} /tmp/system-probe/http.c
     - $S3_CP_CMD $S3_ARTIFACTS_URI/runtime-security.c.${PACKAGE_ARCH} /tmp/system-probe/runtime-security.c

--- a/.gitlab/package_build/rpm.yml
+++ b/.gitlab/package_build/rpm.yml
@@ -29,6 +29,7 @@
     - $S3_CP_CMD $S3_ARTIFACTS_URI/runtime-security-syscall-wrapper.o.${PACKAGE_ARCH} /tmp/system-probe/runtime-security-syscall-wrapper.o
     - $S3_CP_CMD $S3_ARTIFACTS_URI/runtime-security-offset-guesser.o.${PACKAGE_ARCH} /tmp/system-probe/runtime-security-offset-guesser.o
     - $S3_CP_CMD $S3_ARTIFACTS_URI/oom-kill-co-re.o.${PACKAGE_ARCH} /tmp/system-probe/oom-kill-co-re.o
+    - $S3_CP_CMD $S3_ARTIFACTS_URI/tcp-queue-length-co-re.o.${PACKAGE_ARCH} /tmp/system-probe/tcp-queue-length-co-re.o
     - $S3_CP_CMD $S3_ARTIFACTS_URI/tracer.c.${PACKAGE_ARCH} /tmp/system-probe/tracer.c
     - $S3_CP_CMD $S3_ARTIFACTS_URI/http.c.${PACKAGE_ARCH} /tmp/system-probe/http.c
     - $S3_CP_CMD $S3_ARTIFACTS_URI/runtime-security.c.${PACKAGE_ARCH} /tmp/system-probe/runtime-security.c

--- a/.gitlab/package_build/suse_rpm.yml
+++ b/.gitlab/package_build/suse_rpm.yml
@@ -28,6 +28,7 @@
     - $S3_CP_CMD $S3_ARTIFACTS_URI/runtime-security-syscall-wrapper.o.${PACKAGE_ARCH} /tmp/system-probe/runtime-security-syscall-wrapper.o
     - $S3_CP_CMD $S3_ARTIFACTS_URI/runtime-security-offset-guesser.o.${PACKAGE_ARCH} /tmp/system-probe/runtime-security-offset-guesser.o
     - $S3_CP_CMD $S3_ARTIFACTS_URI/oom-kill-co-re.o.${PACKAGE_ARCH} /tmp/system-probe/oom-kill-co-re.o
+    - $S3_CP_CMD $S3_ARTIFACTS_URI/tcp-queue-length-co-re.o.${PACKAGE_ARCH} /tmp/system-probe/tcp-queue-length-co-re.o
     - $S3_CP_CMD $S3_ARTIFACTS_URI/tracer.c.${PACKAGE_ARCH} /tmp/system-probe/tracer.c
     - $S3_CP_CMD $S3_ARTIFACTS_URI/http.c.${PACKAGE_ARCH} /tmp/system-probe/http.c
     - $S3_CP_CMD $S3_ARTIFACTS_URI/runtime-security.c.${PACKAGE_ARCH} /tmp/system-probe/runtime-security.c

--- a/.gitlab/package_deps_build.yml
+++ b/.gitlab/package_deps_build.yml
@@ -12,7 +12,7 @@
     - tar -xf btfs-$ARCH.tar.gz
     - $S3_CP_CMD $S3_ARTIFACTS_URI/oom-kill-co-re.o.$ARCH oom-kill.o
     - $S3_CP_CMD $S3_ARTIFACTS_URI/tcp-queue-length-co-re.o.$ARCH tcp-queue-length.o
-    - inv -e system-probe.generate-minimized-btfs --source-dir "$CI_PROJECT_DIR/btfs-$ARCH" --output-dir "$CI_PROJECT_DIR/minimized-btfs" --input-bpf-programs "$CI_PROJECT_DIR/oom-kill.o" "$CI_PROJECT_DIR/tcp-queue-length.o"
+    - inv -e system-probe.generate-minimized-btfs --source-dir "$CI_PROJECT_DIR/btfs-$ARCH" --output-dir "$CI_PROJECT_DIR/minimized-btfs" --input-bpf-programs "$CI_PROJECT_DIR/oom-kill.o $CI_PROJECT_DIR/tcp-queue-length.o"
     - cd minimized-btfs
     - tar -cJf minimized-btfs.tar.xz *
     - $S3_CP_CMD minimized-btfs.tar.xz $S3_ARTIFACTS_URI/minimized-btfs-$ARCH.tar.xz

--- a/.gitlab/package_deps_build.yml
+++ b/.gitlab/package_deps_build.yml
@@ -11,7 +11,8 @@
     - $S3_CP_CMD $S3_PERMANENT_ARTIFACTS_URI/btfs-$ARCH.tar.gz .
     - tar -xf btfs-$ARCH.tar.gz
     - $S3_CP_CMD $S3_ARTIFACTS_URI/oom-kill-co-re.o.$ARCH oom-kill.o
-    - inv -e system-probe.generate-minimized-btfs --source-dir "$CI_PROJECT_DIR/btfs-$ARCH" --output-dir "$CI_PROJECT_DIR/minimized-btfs" --input-bpf-programs "$CI_PROJECT_DIR/oom-kill.o"
+    - $S3_CP_CMD $S3_ARTIFACTS_URI/tcp-queue-length-co-re.o.$ARCH tcp-queue-length.o
+    - inv -e system-probe.generate-minimized-btfs --source-dir "$CI_PROJECT_DIR/btfs-$ARCH" --output-dir "$CI_PROJECT_DIR/minimized-btfs" --input-bpf-programs "$CI_PROJECT_DIR/oom-kill.o" "$CI_PROJECT_DIR/tcp-queue-length.o"
     - cd minimized-btfs
     - tar -cJf minimized-btfs.tar.xz *
     - $S3_CP_CMD minimized-btfs.tar.xz $S3_ARTIFACTS_URI/minimized-btfs-$ARCH.tar.xz

--- a/.gitlab/source_test/ebpf.yml
+++ b/.gitlab/source_test/ebpf.yml
@@ -21,6 +21,7 @@
   - cp $CI_PROJECT_DIR/pkg/ebpf/bytecode/build/dns.o $CI_PROJECT_DIR/.tmp/binary-ebpf/dns.o
   - cp $CI_PROJECT_DIR/pkg/ebpf/bytecode/build/dns-debug.o $CI_PROJECT_DIR/.tmp/binary-ebpf/dns-debug.o
   - cp $CI_PROJECT_DIR/pkg/ebpf/bytecode/build/co-re/oom-kill.o $CI_PROJECT_DIR/.tmp/binary-ebpf/co-re/oom-kill.o
+  - cp $CI_PROJECT_DIR/pkg/ebpf/bytecode/build/co-re/tcp-queue-length.o $CI_PROJECT_DIR/.tmp/binary-ebpf/co-re/tcp-queue-length.o
   - cp $CI_PROJECT_DIR/pkg/ebpf/bytecode/build/runtime/tracer.c $CI_PROJECT_DIR/.tmp/binary-ebpf/tracer.c
   - cp $CI_PROJECT_DIR/pkg/ebpf/bytecode/build/runtime/http.c $CI_PROJECT_DIR/.tmp/binary-ebpf/http.c
   - cp $CI_PROJECT_DIR/pkg/ebpf/bytecode/build/runtime/runtime-security.c $CI_PROJECT_DIR/.tmp/binary-ebpf/runtime-security.c

--- a/omnibus/config/software/datadog-agent-finalize.rb
+++ b/omnibus/config/software/datadog-agent-finalize.rb
@@ -197,6 +197,7 @@ build do
             strip_exclude("*runtime-security*")
             strip_exclude("*dns*")
             strip_exclude("*oom-kill*")
+            strip_exclude("*tcp-queue-length*")
         end
 
         if osx?

--- a/omnibus/config/software/system-probe.rb
+++ b/omnibus/config/software/system-probe.rb
@@ -32,6 +32,7 @@ build do
     copy "#{ENV['SYSTEM_PROBE_BIN']}/runtime-security-syscall-wrapper.o", "#{install_dir}/embedded/share/system-probe/ebpf/"
     copy "#{ENV['SYSTEM_PROBE_BIN']}/runtime-security-offset-guesser.o", "#{install_dir}/embedded/share/system-probe/ebpf/"
     copy "#{ENV['SYSTEM_PROBE_BIN']}/oom-kill-co-re.o", "#{install_dir}/embedded/share/system-probe/ebpf/co-re/oom-kill.o"
+    copy "#{ENV['SYSTEM_PROBE_BIN']}/tcp-queue-length-co-re.o", "#{install_dir}/embedded/share/system-probe/ebpf/co-re/tcp-queue-length.o"
     copy "#{ENV['SYSTEM_PROBE_BIN']}/tracer.c", "#{install_dir}/embedded/share/system-probe/ebpf/runtime/"
     copy "#{ENV['SYSTEM_PROBE_BIN']}/http.c", "#{install_dir}/embedded/share/system-probe/ebpf/runtime/"
     copy "#{ENV['SYSTEM_PROBE_BIN']}/runtime-security.c", "#{install_dir}/embedded/share/system-probe/ebpf/runtime/"

--- a/pkg/collector/corechecks/ebpf/c/runtime/cgroup.h
+++ b/pkg/collector/corechecks/ebpf/c/runtime/cgroup.h
@@ -10,7 +10,7 @@
 
 static __always_inline int get_cgroup_name(char *buf, size_t sz) {
     if (!bpf_helper_exists(BPF_FUNC_get_current_task)) {
-        return -1;
+        return 0;
     }
     __builtin_memset(buf, 0, sz);
     struct task_struct *cur_tsk = (struct task_struct *)bpf_get_current_task();
@@ -25,10 +25,10 @@ static __always_inline int get_cgroup_name(char *buf, size_t sz) {
 #endif
     const char *name = BPF_CORE_READ(cur_tsk, cgroups, subsys[cgrp_id], cgroup, kn, name);
     if (bpf_probe_read_kernel_str(buf, sz, name) < 0) {
-        return -1;
+        return 0;
     }
 
-    return 0;
+    return 1;
 }
 
 #endif /* defined(BPF_CGROUP_H) */

--- a/pkg/collector/corechecks/ebpf/c/runtime/tcp-queue-length-kern-user.h
+++ b/pkg/collector/corechecks/ebpf/c/runtime/tcp-queue-length-kern-user.h
@@ -1,7 +1,7 @@
 #ifndef TCP_QUEUE_LENGTH_KERN_USER_H
 #define TCP_QUEUE_LENGTH_KERN_USER_H
 
-#include <linux/types.h>
+#include "ktypes.h"
 
 struct stats_key {
     char cgroup_name[129];

--- a/pkg/collector/corechecks/ebpf/c/runtime/tcp-queue-length-kern.c
+++ b/pkg/collector/corechecks/ebpf/c/runtime/tcp-queue-length-kern.c
@@ -1,16 +1,21 @@
-#include "kconfig.h"
 #include "ktypes.h"
-#include <linux/tcp.h>
 
-#include "bpf_helpers.h"
-#include "map-defs.h"
-#include "cgroup.h"
-#include "tcp-queue-length-kern-user.h"
+#ifdef COMPILE_RUNTIME
+#include "kconfig.h"
+#include <linux/tcp.h>
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4, 8, 0)
 // 4.8 is the first version where `bpf_get_current_task` is available
 #error Versions of Linux previous to 4.8.0 are not supported by this probe
 #endif
+#endif
+
+#include "tcp-queue-length-kern-user.h"
+#include "cgroup.h"
+
+#include "bpf_tracing.h"
+#include "bpf_core_read.h"
+#include "map-defs.h"
 
 /*
  * The `tcp_queue_stats` map is used to share with the userland program system-probe
@@ -26,7 +31,6 @@ BPF_HASH_MAP(who_recvmsg, u64, struct sock *, 100)
 
 BPF_HASH_MAP(who_sendmsg, u64, struct sock *, 100)
 
-// TODO: replace all `bpf_probe_read` by `bpf_probe_read_kernel` once we can assume that we have at least kernel 5.5
 static __always_inline int check_sock(struct sock *sk) {
     struct stats_value zero = {
         .read_buffer_max_usage = 0,
@@ -34,7 +38,9 @@ static __always_inline int check_sock(struct sock *sk) {
     };
 
     struct stats_key k;
-    get_cgroup_name(k.cgroup_name, sizeof(k.cgroup_name));
+    if (!get_cgroup_name(k.cgroup_name, sizeof(k.cgroup_name))) {
+        return 0;
+    }
 
     bpf_map_update_elem(&tcp_queue_stats, &k, &zero, BPF_NOEXIST);
     struct stats_value *v = bpf_map_lookup_elem(&tcp_queue_stats, &k);
@@ -42,55 +48,55 @@ static __always_inline int check_sock(struct sock *sk) {
         return 0;
     }
 
-    int rqueue_size, wqueue_size;
-    bpf_probe_read(&rqueue_size, sizeof(rqueue_size), (void *)&sk->sk_rcvbuf);
-    bpf_probe_read(&wqueue_size, sizeof(wqueue_size), (void *)&sk->sk_sndbuf);
+    int rqueue_size = BPF_CORE_READ(sk, sk_rcvbuf);
+    int wqueue_size = BPF_CORE_READ(sk, sk_sndbuf);
 
-    const struct tcp_sock *tp = tcp_sk(sk);
-    u32 rcv_nxt, copied_seq, write_seq, snd_una;
-    bpf_probe_read(&rcv_nxt, sizeof(rcv_nxt), (void *)&tp->rcv_nxt); // What we want to receive next
-    bpf_probe_read(&copied_seq, sizeof(copied_seq), (void *)&tp->copied_seq); // Head of yet unread data
-    bpf_probe_read(&write_seq, sizeof(write_seq), (void *)&tp->write_seq); // Tail(+1) of data held in tcp send buffer
-    bpf_probe_read(&snd_una, sizeof(snd_una), (void *)&tp->snd_una); // First byte we want an ack for
+    const struct tcp_sock *tp = (struct tcp_sock *)sk;
+    u32 rcv_nxt = BPF_CORE_READ(tp, rcv_nxt); // What we want to receive next
+    u32 copied_seq = BPF_CORE_READ(tp, copied_seq); // Head of yet unread data
+    u32 write_seq = BPF_CORE_READ(tp, write_seq); // Tail(+1) of data held in tcp send buffer
+    u32 snd_una = BPF_CORE_READ(tp, snd_una); // First byte we want an ack for
 
     u32 rqueue = rcv_nxt < copied_seq ? 0 : rcv_nxt - copied_seq;
-    if (rqueue < 0)
+    if (rqueue < 0) {
         rqueue = 0;
+    }
     u32 wqueue = write_seq - snd_una;
 
     u32 rqueue_usage = 1000 * rqueue / rqueue_size;
     u32 wqueue_usage = 1000 * wqueue / wqueue_size;
 
-    if (rqueue_usage > v->read_buffer_max_usage)
+    if (rqueue_usage > v->read_buffer_max_usage) {
         v->read_buffer_max_usage = rqueue_usage;
-    if (wqueue_usage > v->write_buffer_max_usage)
+    }
+    if (wqueue_usage > v->write_buffer_max_usage) {
         v->write_buffer_max_usage = wqueue_usage;
+    }
 
     return 0;
 }
 
 SEC("kprobe/tcp_recvmsg")
-int kprobe__tcp_recvmsg(struct pt_regs *ctx) {
-    struct sock *sk = (struct sock*)PT_REGS_PARM1(ctx);
+int BPF_KPROBE(kprobe__tcp_recvmsg, struct sock *sk) {
     u64 pid_tgid = bpf_get_current_pid_tgid();
     bpf_map_update_elem(&who_recvmsg, &pid_tgid, &sk, BPF_ANY);
     return check_sock(sk);
 }
 
 SEC("kretprobe/tcp_recvmsg")
-int kretprobe__tcp_recvmsg(struct pt_regs *ctx) {
+int BPF_KRETPROBE(kretprobe__tcp_recvmsg) {
     u64 pid_tgid = bpf_get_current_pid_tgid();
     struct sock **sk = bpf_map_lookup_elem(&who_recvmsg, &pid_tgid);
     bpf_map_delete_elem(&who_recvmsg, &pid_tgid);
 
-    if (sk)
+    if (sk) {
         return check_sock(*sk);
+    }
     return 0;
 }
 
 SEC("kprobe/tcp_sendmsg")
-int kprobe__tcp_sendmsg(struct pt_regs *ctx) {
-    struct sock *sk = (struct sock*)PT_REGS_PARM1(ctx);
+int BPF_KPROBE(kprobe__tcp_sendmsg, struct sock *sk) {
     u64 pid_tgid = bpf_get_current_pid_tgid();
     bpf_map_update_elem(&who_sendmsg, &pid_tgid, &sk, BPF_ANY);
 
@@ -98,17 +104,16 @@ int kprobe__tcp_sendmsg(struct pt_regs *ctx) {
 }
 
 SEC("kretprobe/tcp_sendmsg")
-int kretprobe__tcp_sendmsg(struct pt_regs *ctx) {
+int BPF_KRETPROBE(kretprobe__tcp_sendmsg) {
     u64 pid_tgid = bpf_get_current_pid_tgid();
     struct sock **sk = bpf_map_lookup_elem(&who_sendmsg, &pid_tgid);
     bpf_map_delete_elem(&who_sendmsg, &pid_tgid);
 
-    if (sk)
+    if (sk) {
         return check_sock(*sk);
+    }
     return 0;
 }
 
-// This number will be interpreted by elf-loader to set the current running kernel version
-__u32 _version SEC("version") = 0xFFFFFFFE; // NOLINT(bugprone-reserved-identifier)
-
-char _license[] SEC("license") = "GPL"; // NOLINT(bugprone-reserved-identifier)
+__u32 _version SEC("version") = 0xFFFFFFFE;
+char _license[] SEC("license") = "GPL";

--- a/pkg/collector/corechecks/ebpf/probe/oom_kill.go
+++ b/pkg/collector/corechecks/ebpf/probe/oom_kill.go
@@ -45,21 +45,21 @@ type OOMKillProbe struct {
 
 func NewOOMKillProbe(cfg *ebpf.Config) (*OOMKillProbe, error) {
 	if cfg.EnableCORE {
-		probe, err := loadCOREProbe(cfg)
+		probe, err := loadOOMKillCOREProbe(cfg)
 		if err == nil {
-			return probe, err
+			return probe, nil
 		}
 
 		if !cfg.AllowRuntimeCompiledFallback {
-			return nil, fmt.Errorf("error loading CO-RE oom-kill probe: %s. set system_probe_config.allow_runtime_compiled_fallback to true to allow fallback to runtime compilation.", err)
+			return nil, fmt.Errorf("error loading CO-RE oom-kill probe: %s. set system_probe_config.allow_runtime_compiled_fallback to true to allow fallback to runtime compilation", err)
 		}
 		log.Warnf("error loading CO-RE oom-kill probe: %s. falling back to runtime compiled probe", err)
 	}
 
-	return loadRuntimeCompiledProbe(cfg)
+	return loadOOMKillRuntimeCompiledProbe(cfg)
 }
 
-func loadCOREProbe(cfg *ebpf.Config) (*OOMKillProbe, error) {
+func loadOOMKillCOREProbe(cfg *ebpf.Config) (*OOMKillProbe, error) {
 	kv, err := kernel.HostVersion()
 	if err != nil {
 		return nil, fmt.Errorf("error detecting kernel version: %s", err)
@@ -81,7 +81,7 @@ func loadCOREProbe(cfg *ebpf.Config) (*OOMKillProbe, error) {
 	return probe, nil
 }
 
-func loadRuntimeCompiledProbe(cfg *ebpf.Config) (*OOMKillProbe, error) {
+func loadOOMKillRuntimeCompiledProbe(cfg *ebpf.Config) (*OOMKillProbe, error) {
 	buf, err := runtime.OomKill.Compile(cfg, getCFlags(cfg), statsd.Client)
 	if err != nil {
 		return nil, err

--- a/pkg/collector/corechecks/ebpf/probe/oom_kill_test.go
+++ b/pkg/collector/corechecks/ebpf/probe/oom_kill_test.go
@@ -79,7 +79,7 @@ func TestOOMKillProbe(t *testing.T) {
 	cfg := testConfig()
 
 	fullKV := host.GetStatusInformation().KernelVersion
-	if cfg.EnableCORE && (fullKV == "4.18.0-1018-azure" || fullKV == "4.18.0-147.43.1.el8_1.x86_64") {
+	if cfg.EnableCORE && isMissingBTF(fullKV) {
 		t.Skipf("Skipping CO-RE tests for kernel version %v due to missing BTFs", fullKV)
 	}
 

--- a/pkg/collector/corechecks/ebpf/probe/tcp_queue_length.go
+++ b/pkg/collector/corechecks/ebpf/probe/tcp_queue_length.go
@@ -161,7 +161,7 @@ func loadTCPQueueLengthCOREProbe(cfg *ebpf.Config) (*TCPQueueLengthTracer, error
 	if err != nil {
 		return nil, fmt.Errorf("error detecting kernel version: %s", err)
 	}
-	if kv < kernel.VersionCode(4, 9, 0) {
+	if kv < kernel.VersionCode(4, 8, 0) {
 		return nil, fmt.Errorf("detected kernel version %s, but tcp-queue-length probe requires a kernel version of at least 4.8.0", kv)
 	}
 

--- a/pkg/collector/corechecks/ebpf/probe/tcp_queue_length.go
+++ b/pkg/collector/corechecks/ebpf/probe/tcp_queue_length.go
@@ -48,14 +48,14 @@ type TCPQueueLengthTracer struct {
 func NewTCPQueueLengthTracer(cfg *ebpf.Config) (*TCPQueueLengthTracer, error) {
 	if cfg.EnableCORE {
 		probe, err := loadTCPQueueLengthCOREProbe(cfg)
-		if err == nil {
+		if err != nil {
+			if !cfg.AllowRuntimeCompiledFallback {
+				return nil, fmt.Errorf("error loading CO-RE tcp-queue-length probe: %s. set system_probe_config.allow_runtime_compiled_fallback to true to allow fallback to runtime compilation", err)
+			}
+			log.Warnf("error loading CO-RE tcp-queue-length probe: %s. falling back to runtime compiled probe", err)
+		} else {
 			return probe, nil
 		}
-
-		if !cfg.AllowRuntimeCompiledFallback {
-			return nil, fmt.Errorf("error loading CO-RE tcp-queue-length probe: %s. set system_probe_config.allow_runtime_compiled_fallback to true to allow fallback to runtime compilation", err)
-		}
-		log.Warnf("error loading CO-RE tcp-queue-length probe: %s. falling back to runtime compiled probe", err)
 	}
 
 	return loadTCPQueueLengthRuntimeCompiledProbe(cfg)

--- a/pkg/collector/corechecks/ebpf/probe/tcp_queue_length_test.go
+++ b/pkg/collector/corechecks/ebpf/probe/tcp_queue_length_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/ebpf/bytecode/runtime"
+	"github.com/DataDog/datadog-agent/pkg/metadata/host"
 	"github.com/DataDog/datadog-agent/pkg/process/statsd"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 )
@@ -47,6 +48,11 @@ func TestTCPQueueLengthTracer(t *testing.T) {
 	}
 
 	cfg := ebpf.NewConfig()
+
+	fullKV := host.GetStatusInformation().KernelVersion
+	if cfg.EnableCORE && (fullKV == "4.18.0-1018-azure" || fullKV == "4.18.0-147.43.1.el8_1.x86_64") {
+		t.Skipf("Skipping CO-RE tests for kernel version %v due to missing BTFs", fullKV)
+	}
 
 	tcpTracer, err := NewTCPQueueLengthTracer(cfg)
 	if err != nil {

--- a/pkg/collector/corechecks/ebpf/probe/tcp_queue_length_test.go
+++ b/pkg/collector/corechecks/ebpf/probe/tcp_queue_length_test.go
@@ -23,6 +23,18 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 )
 
+var (
+	missingBTFS = map[string]struct{}{
+		"4.18.0-1018-azure":            {},
+		"4.18.0-147.43.1.el8_1.x86_64": {},
+	}
+)
+
+func isMissingBTF(kv string) bool {
+	_, ok := missingBTFS[kv]
+	return ok
+}
+
 func TestTCPQueueLengthCompile(t *testing.T) {
 	kv, err := kernel.HostVersion()
 	if err != nil {
@@ -50,7 +62,7 @@ func TestTCPQueueLengthTracer(t *testing.T) {
 	cfg := ebpf.NewConfig()
 
 	fullKV := host.GetStatusInformation().KernelVersion
-	if cfg.EnableCORE && (fullKV == "4.18.0-1018-azure" || fullKV == "4.18.0-147.43.1.el8_1.x86_64") {
+	if cfg.EnableCORE && isMissingBTF(fullKV) {
 		t.Skipf("Skipping CO-RE tests for kernel version %v due to missing BTFs", fullKV)
 	}
 

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -229,7 +229,7 @@ def ninja_network_ebpf_programs(nw, build_dir, co_re_build_dir):
 def ninja_container_integrations_ebpf_programs(nw, co_re_build_dir):
     container_integrations_co_re_dir = os.path.join("pkg", "collector", "corechecks", "ebpf", "c", "runtime")
     container_integrations_co_re_flags = f"-I{container_integrations_co_re_dir}"
-    container_integrations_co_re_programs = ["oom-kill"]
+    container_integrations_co_re_programs = ["oom-kill", "tcp-queue-length"]
 
     for prog in container_integrations_co_re_programs:
         infile = os.path.join(container_integrations_co_re_dir, f"{prog}-kern.c")


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Updates the TCP Queue Length check to support CO-RE.

### Motivation

Support CO-RE version.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
