### PR TITLE
[secrets] Fix config permissions check for Linux and macOS hosts

### DIFF
--- a/pkg/secrets/check_rights_nix.go
+++ b/pkg/secrets/check_rights_nix.go
@@ -119,19 +119,13 @@ var checkConfigFilePermissions = func(path string) error {
 		return fmt.Errorf("invalid config file permissions for '%s': not owned by %s", path, usr.Uid)
 	}
 
-	ownedByUserGroup := false
-
 	for _, g := range groups {
 		if strconv.FormatInt(int64(stat.Gid), 10) == g {
-			ownedByUserGroup = true
+			return nil
 		}
 	}
 
-	if !ownedByUserGroup {
-		return fmt.Errorf("invalid config file permissions for '%s': not owned by any groups for user %s", path, usr.Uid)
-	}
-
-	return nil
+	return fmt.Errorf("invalid config file permissions for '%s': not owned by any groups for user %s", path, usr.Uid)
 }
 
 // lockOpenFile opens the file and prevents overwrite and delete by another process

--- a/pkg/secrets/check_rights_nix_test.go
+++ b/pkg/secrets/check_rights_nix_test.go
@@ -144,3 +144,22 @@ func Test_checkGroupPermission(t *testing.T) {
 		})
 	}
 }
+
+func TestCheckConfigFilePermissionsOtherRights(t *testing.T) {
+	tmpfile, err := os.CreateTemp("", "agent-config-file")
+	require.Nil(t, err)
+	defer os.Remove(tmpfile.Name())
+
+	// file exists
+	require.Error(t, checkConfigFilePermissions("/does not exists"))
+
+	require.NoError(t, os.Chmod(tmpfile.Name(), 0660))
+	require.NoError(t, checkConfigFilePermissions(tmpfile.Name()))
+
+	// other should have no write right
+	require.NoError(t, os.Chmod(tmpfile.Name(), 0664))
+	require.NoError(t, checkConfigFilePermissions(tmpfile.Name()))
+
+	require.NoError(t, os.Chmod(tmpfile.Name(), 0666))
+	require.Error(t, checkConfigFilePermissions(tmpfile.Name()))
+}

--- a/releasenotes/notes/secret_backend_command_sha256-b322140f976f02e1.yaml
+++ b/releasenotes/notes/secret_backend_command_sha256-b322140f976f02e1.yaml
@@ -4,7 +4,7 @@ features:
     Adds support for ``secret_backend_command_sha256`` SHA for the ``secret_backend_command`` executable. If ``secret_backend_command_sha256`` is used,
     the following restrictions are in place:
     - Value specified in the ``secret_backend_command`` setting must be an absolute path.
-    - Permissions for the ``datadog.yaml`` config file must disallow write access by users other than ``ddagentuser`` or ``Administrators`` on Windows or root on Linux.
+    - Permissions for the ``datadog.yaml`` config file must disallow write access by users other than ``ddagentuser`` or ``Administrators`` on Windows or the user running the Agent on Linux and macOS.
     The agent will refuse to start if the actual SHA256 of the ``secret_backend_command`` executable is different from the one specified by ``secret_backend_command_sha256``.
     The ``secret_backend_command`` file is locked during verification of SHA256 and subsequent run of the secret backend executable.
 


### PR DESCRIPTION
### What does this PR do?

- Fixes issues on non-container installs where the file isn't owned by root.
- Make the permission check closer to that of the secret backend - ensure the file is owned by the running Agent user.

### Motivation

- Properly support `secret_backend_command_sha256` on host-based installations in Linux and macOS.

### Describe how to test/QA your changes

Validate the feature in https://github.com/DataDog/datadog-agent/pull/14529 works when Agent is installed on Linux (non-container) hosts and macOS.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
