### PR TITLE
[pkg/trace][otlp] do not mark payloads to avoid races

### DIFF
--- a/pkg/trace/api/otlp.go
+++ b/pkg/trace/api/otlp.go
@@ -359,14 +359,7 @@ func (o *OTLPReceiver) ReceiveResourceSpans(ctx context.Context, rspans ptrace.R
 	}
 	select {
 	case o.out <- &p:
-		// Stats will be computed for p. Mark the original resource spans to ensure that they don't
-		// get computed twice in case these spans pass through here again.
-		//
-		// Spans can pass through here multiple times because this code path gets used by the:
-		//  - OpenTelemetry Collector Datadog processor, when computing stats.
-		//  - OpenTelemetry Collector Datadog exporter, when flushing.
-		//  - Datadog Agent OTLP Ingest, when used in conjunction with an SDK or a Collector.
-		rspans.Resource().Attributes().PutBool(keyStatsComputed, true)
+		// Do nothing
 	default:
 		log.Warn("Payload in channel full. Dropped 1 payload.")
 	}

--- a/pkg/trace/api/otlp.go
+++ b/pkg/trace/api/otlp.go
@@ -359,7 +359,7 @@ func (o *OTLPReceiver) ReceiveResourceSpans(ctx context.Context, rspans ptrace.R
 	}
 	select {
 	case o.out <- &p:
-		// Do nothing
+		// success
 	default:
 		log.Warn("Payload in channel full. Dropped 1 payload.")
 	}

--- a/pkg/trace/api/otlp_test.go
+++ b/pkg/trace/api/otlp_test.go
@@ -363,8 +363,6 @@ func TestOTLPReceiveResourceSpans(t *testing.T) {
 				},
 			},
 		}).Traces().ResourceSpans().At(0)
-		_, ok := rspans.Resource().Attributes().Get(keyStatsComputed)
-		require.False(ok)
 		rcv.ReceiveResourceSpans(context.Background(), rspans, http.Header{}, "agent_tests")
 		timeout := time.After(500 * time.Millisecond)
 		select {
@@ -373,19 +371,6 @@ func TestOTLPReceiveResourceSpans(t *testing.T) {
 		case p := <-out:
 			// stats are computed this time
 			require.False(p.ClientComputedStats)
-		}
-		// after the first receive, the keyStatsComputed attribute has to be applied,
-		// so that on the second run stats are skipped
-		v, ok := rspans.Resource().Attributes().Get(keyStatsComputed)
-		require.True(ok)
-		require.Equal("true", v.AsString())
-		rcv.ReceiveResourceSpans(context.Background(), rspans, http.Header{}, "agent_tests")
-		select {
-		case <-timeout:
-			t.Fatal("timed out")
-		case p := <-out:
-			// stats are not computed the second time
-			require.True(p.ClientComputedStats)
 		}
 	})
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Do not mark OTLP payloads as inspected for stats.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

This causes a data race with the metadata pusher. A better solution is to mark these on the Datadog processor.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

This blocks open-telemetry/opentelemetry-collector-contrib/pull/17044

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Will be QAed by bumping the commit on the Collector and ensuring the tests pass.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
