### PR TITLE
[process-agent] Change the tag emitted by the process based service inference

### DIFF
--- a/pkg/process/checks/net.go
+++ b/pkg/process/checks/net.go
@@ -304,8 +304,8 @@ func batchConnections(
 			remapDNSStatsByDomainByQueryType(c, namemap, &namedb, domains)
 
 			// tags remap
-			serviceTag := serviceExtractor.GetServiceTag(c.Pid)
-			tagsStr := convertAndEnrichWithServiceTags(tags, c.Tags, serviceTag)
+			serviceCtx := serviceExtractor.GetServiceContext(c.Pid)
+			tagsStr := convertAndEnrichWithServiceCtx(tags, c.Tags, serviceCtx)
 
 			if len(tagsStr) > 0 {
 				c.Tags = nil
@@ -413,15 +413,15 @@ func groupSize(total, maxBatchSize int) int32 {
 	return int32(groupSize)
 }
 
-// converts the tags based on the tagOffsets for encoding. It also enriches it with service tags if any
-func convertAndEnrichWithServiceTags(tags []string, tagOffsets []uint32, serviceTag string) []string {
-	tagCount := len(tagOffsets) + len(serviceTag)
+// converts the tags based on the tagOffsets for encoding. It also enriches it with service context if any
+func convertAndEnrichWithServiceCtx(tags []string, tagOffsets []uint32, serviceCtx string) []string {
+	tagCount := len(tagOffsets) + len(serviceCtx)
 	tagsStr := make([]string, 0, tagCount)
 	for _, t := range tagOffsets {
 		tagsStr = append(tagsStr, tags[t])
 	}
-	if serviceTag != "" {
-		tagsStr = append(tagsStr, serviceTag)
+	if serviceCtx != "" {
+		tagsStr = append(tagsStr, serviceCtx)
 	}
 
 	return tagsStr

--- a/pkg/process/checks/net_test.go
+++ b/pkg/process/checks/net_test.go
@@ -614,7 +614,7 @@ func TestNetworkConnectionTagsWithService(t *testing.T) {
 	tags := []string{"tag0"}
 	conns[0].Tags = []uint32{0}
 
-	expectedTags := []string{"tag0", "service:my-server"}
+	expectedTags := []string{"tag0", "process_context:my-server"}
 
 	procsByPid := map[int32]*procutil.Process{
 		conns[0].Pid: {
@@ -661,19 +661,19 @@ func TestConvertAndEnrichWithServiceTags(t *testing.T) {
 		{
 			name:       "convert service tag only",
 			tagOffsets: nil,
-			serviceTag: "service:dogfood",
-			expected:   []string{"service:dogfood"},
+			serviceTag: "process_context:dogfood",
+			expected:   []string{"process_context:dogfood"},
 		},
 		{
 			name:       "convert tags with service tag",
 			tagOffsets: []uint32{0, 2},
-			serviceTag: "service:doge",
-			expected:   []string{"tag0", "tag2", "service:doge"},
+			serviceTag: "process_context:doge",
+			expected:   []string{"tag0", "tag2", "process_context:doge"},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expected, convertAndEnrichWithServiceTags(tags, tt.tagOffsets, tt.serviceTag))
+			assert.Equal(t, tt.expected, convertAndEnrichWithServiceCtx(tags, tt.tagOffsets, tt.serviceTag))
 		})
 	}
 }

--- a/pkg/process/metadata/parser/service.go
+++ b/pkg/process/metadata/parser/service.go
@@ -46,8 +46,8 @@ type ServiceExtractor struct {
 }
 
 type serviceMetadata struct {
-	cmdline    []string
-	serviceTag string
+	cmdline        []string
+	serviceContext string
 }
 
 // NewServiceExtractor instantiates a new service discovery extractor
@@ -86,12 +86,12 @@ func (d *ServiceExtractor) Extract(processes map[int32]*procutil.Process) {
 	d.serviceByPID = serviceByPID
 }
 
-func (d *ServiceExtractor) GetServiceTag(pid int32) string {
+func (d *ServiceExtractor) GetServiceContext(pid int32) string {
 	if !d.enabled {
 		return ""
 	}
 	if meta, ok := d.serviceByPID[pid]; ok {
-		return meta.serviceTag
+		return meta.serviceContext
 	}
 	return ""
 }
@@ -124,8 +124,8 @@ func extractServiceMetadata(cmd []string) *serviceMetadata {
 	if contextFn, ok := binsWithContext[exe]; ok {
 		tag := contextFn(cmd[1:])
 		return &serviceMetadata{
-			cmdline:    cmd,
-			serviceTag: "service:" + tag,
+			cmdline:        cmd,
+			serviceContext: "process_context:" + tag,
 		}
 	}
 
@@ -135,8 +135,8 @@ func extractServiceMetadata(cmd []string) *serviceMetadata {
 	}
 
 	return &serviceMetadata{
-		cmdline:    cmd,
-		serviceTag: "service:" + exe,
+		cmdline:        cmd,
+		serviceContext: "process_context:" + exe,
 	}
 }
 

--- a/pkg/process/metadata/parser/service_test.go
+++ b/pkg/process/metadata/parser/service_test.go
@@ -35,70 +35,70 @@ func TestExtractServiceMetadata(t *testing.T) {
 			cmdline: []string{
 				"./my-server.sh",
 			},
-			expectedServiceTag: "service:my-server",
+			expectedServiceTag: "process_context:my-server",
 		},
 		{
 			name: "sudo",
 			cmdline: []string{
 				"sudo", "-E", "-u", "dog", "/usr/local/bin/myApp", "-items=0,1,2,3", "-foo=bar",
 			},
-			expectedServiceTag: "service:myApp",
+			expectedServiceTag: "process_context:myApp",
 		},
 		{
 			name: "python flask argument",
 			cmdline: []string{
 				"/opt/python/2.7.11/bin/python2.7", "flask", "run", "--host=0.0.0.0",
 			},
-			expectedServiceTag: "service:flask",
+			expectedServiceTag: "process_context:flask",
 		},
 		{
 			name: "python - flask argument in path",
 			cmdline: []string{
 				"/opt/python/2.7.11/bin/python2.7", "/opt/dogweb/bin/flask", "run", "--host=0.0.0.0", "--without-threads",
 			},
-			expectedServiceTag: "service:flask",
+			expectedServiceTag: "process_context:flask",
 		},
 		{
 			name: "python flask in single argument",
 			cmdline: []string{
 				"/opt/python/2.7.11/bin/python2.7 flask run --host=0.0.0.0",
 			},
-			expectedServiceTag: "service:flask",
+			expectedServiceTag: "process_context:flask",
 		},
 		{
 			name: "python - module hello",
 			cmdline: []string{
 				"python3", "-m", "hello",
 			},
-			expectedServiceTag: "service:hello",
+			expectedServiceTag: "process_context:hello",
 		},
 		{
 			name: "ruby - td-agent",
 			cmdline: []string{
 				"ruby", "/usr/sbin/td-agent", "--log", "/var/log/td-agent/td-agent.log", "--daemon", "/var/run/td-agent/td-agent.pid",
 			},
-			expectedServiceTag: "service:td-agent",
+			expectedServiceTag: "process_context:td-agent",
 		},
 		{
 			name: "java using the -jar flag to define the service",
 			cmdline: []string{
 				"java", "-Xmx4000m", "-Xms4000m", "-XX:ReservedCodeCacheSize=256m", "-jar", "/opt/sheepdog/bin/myservice.jar",
 			},
-			expectedServiceTag: "service:myservice",
+			expectedServiceTag: "process_context:myservice",
 		},
 		{
 			name: "java class name as service",
 			cmdline: []string{
 				"java", "-Xmx4000m", "-Xms4000m", "-XX:ReservedCodeCacheSize=256m", "com.datadog.example.HelloWorld",
 			},
-			expectedServiceTag: "service:HelloWorld",
+			expectedServiceTag: "process_context:HelloWorld",
 		},
 		{
 			name: "java kafka",
 			cmdline: []string{
 				"java", "-Xmx4000m", "-Xms4000m", "-XX:ReservedCodeCacheSize=256m", "kafka.Kafka",
 			},
-			expectedServiceTag: "service:Kafka",
+			expectedServiceTag: "process_context:Kafka",
 		},
 		{
 			name: "java parsing for org.apache projects with cassandra as the service",
@@ -108,14 +108,14 @@ func TestExtractServiceMetadata(t *testing.T) {
 				"-cp", "/etc/cassandra:/usr/share/cassandra/lib/HdrHistogram-2.1.9.jar:/usr/share/cassandra/lib/cassandra-driver-core-3.0.1-shaded.jar",
 				"org.apache.cassandra.service.CassandraDaemon",
 			},
-			expectedServiceTag: "service:cassandra",
+			expectedServiceTag: "process_context:cassandra",
 		},
 		{
 			name: "java space in java executable path",
 			cmdline: []string{
 				"/home/dd/my java dir/java", "com.dog.cat",
 			},
-			expectedServiceTag: "service:cat",
+			expectedServiceTag: "process_context:cat",
 		},
 	}
 
@@ -132,7 +132,7 @@ func TestExtractServiceMetadata(t *testing.T) {
 
 			se := NewServiceExtractor()
 			se.Extract(procsByPid)
-			assert.Equal(t, tt.expectedServiceTag, se.GetServiceTag(proc.Pid))
+			assert.Equal(t, tt.expectedServiceTag, se.GetServiceContext(proc.Pid))
 		})
 	}
 }
@@ -148,5 +148,5 @@ func TestExtractServiceMetadataDisabled(t *testing.T) {
 	procsByPid := map[int32]*procutil.Process{proc.Pid: &proc}
 	se := NewServiceExtractor()
 	se.Extract(procsByPid)
-	assert.Empty(t, se.GetServiceTag(proc.Pid))
+	assert.Empty(t, se.GetServiceContext(proc.Pid))
 }

--- a/pkg/process/metadata/parser/service_windows_test.go
+++ b/pkg/process/metadata/parser/service_windows_test.go
@@ -28,28 +28,28 @@ func TestWindowsExtractServiceMetadata(t *testing.T) {
 			cmdline: []string{
 				"C:\\Windows\\system32\\svchost.exe", "-k", "LocalService", "-p", "-s", "CDPSvc",
 			},
-			expectedServiceTag: "service:svchost",
+			expectedServiceTag: "process_context:svchost",
 		},
 		{
 			name: "nginx",
 			cmdline: []string{
 				"C:\\nginx-1.23.2\\nginx.exe",
 			},
-			expectedServiceTag: "service:nginx",
+			expectedServiceTag: "process_context:nginx",
 		},
 		{
 			name: "java using the -jar flag",
 			cmdline: []string{
 				"\"C:\\Program Files\\Java\\jdk-17.0.1\\bin\\java\"", "-Xmx4000m", "-Xms4000m", "-XX:ReservedCodeCacheSize=256m", "-jar", "myService.jar",
 			},
-			expectedServiceTag: "service:myService",
+			expectedServiceTag: "process_context:myService",
 		},
 		{
 			name: "java with exe extension",
 			cmdline: []string{
 				"C:\\Program Files\\Java\\jdk-17.0.1\\bin\\java.exe", "com.dog.myService",
 			},
-			expectedServiceTag: "service:myService",
+			expectedServiceTag: "process_context:myService",
 		},
 	}
 
@@ -66,7 +66,7 @@ func TestWindowsExtractServiceMetadata(t *testing.T) {
 
 			se := NewServiceExtractor()
 			se.Extract(procsByPid)
-			assert.Equal(t, tt.expectedServiceTag, se.GetServiceTag(proc.Pid))
+			assert.Equal(t, tt.expectedServiceTag, se.GetServiceContext(proc.Pid))
 		})
 	}
 }

--- a/releasenotes/notes/process-agent-service-tag-extraction-3fb97205155ed1a4.yaml
+++ b/releasenotes/notes/process-agent-service-tag-extraction-3fb97205155ed1a4.yaml
@@ -1,6 +1,6 @@
 ---
 enhancements:
   - |
-    Add process_context tag extraction based on a process's command line arguments for service monitoring.
-    This feature is configured in the `system-probe.yaml` with the following configuration
+    Add `process_context` tag extraction based on a process's command line arguments for service monitoring.
+    This feature is configured in the `system-probe.yaml` with the following configuration:
     `service_monitoring_config.process_service_inference.enabled`.

--- a/releasenotes/notes/process-agent-service-tag-extraction-3fb97205155ed1a4.yaml
+++ b/releasenotes/notes/process-agent-service-tag-extraction-3fb97205155ed1a4.yaml
@@ -1,5 +1,6 @@
 ---
 enhancements:
   - |
-    Add service tag extraction based on a process's command line arguments for service monitoring. This feature is configured
-    in the `system-probe.yaml` with the following configuration `service_monitoring_config.process_service_inference.enabled`.
+    Add process_context tag extraction based on a process's command line arguments for service monitoring.
+    This feature is configured in the `system-probe.yaml` with the following configuration
+    `service_monitoring_config.process_service_inference.enabled`.


### PR DESCRIPTION
### What does this PR do?
Updates the tag created when doing process based service inferencing introduced in https://github.com/DataDog/datadog-agent/pull/14287 to be `process_context` instead of `service`. This is to avoid overloading the `service` tag. The `process_context` tag will provide a possible service tag for a given connection and will implicitly provide the source of service discovery, which will be the service extraction based on a process's command line args.


### Motivation
Add additional context for service inferencing to USM.

### Additional Notes


### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Perform the same tests as documented in: https://github.com/DataDog/datadog-agent/pull/14287, but expect the `process_context` tag instead of `service`

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
