### PR TITLE
Only log warning about "max files" reached in once per state

### DIFF
--- a/pkg/logs/internal/launchers/file/provider/file_provider.go
+++ b/pkg/logs/internal/launchers/file/provider/file_provider.go
@@ -226,7 +226,7 @@ func (p *FileProvider) FilesToTail(validatePodContainerID bool, inputSources []*
 	}
 
 	if len(filesToTail) == p.filesLimit {
-		log.Warn("Reached the limit on the maximum number of files in use: ", p.filesLimit)
+		log.Debug("Reached the limit on the maximum number of files in use: ", p.filesLimit)
 	}
 
 	return filesToTail

--- a/pkg/logs/internal/launchers/file/provider/file_provider.go
+++ b/pkg/logs/internal/launchers/file/provider/file_provider.go
@@ -74,10 +74,11 @@ const (
 
 // FileProvider implements the logic to retrieve at most filesLimit Files defined in sources
 type FileProvider struct {
-	filesLimit      int
-	wildcardOrder   wildcardOrdering
-	selectionMode   selectionStrategy
-	shouldLogErrors bool
+	filesLimit          int
+	wildcardOrder       wildcardOrdering
+	selectionMode       selectionStrategy
+	shouldLogErrors     bool
+	reachedNumFileLimit bool
 }
 
 // NewFileProvider returns a new Provider
@@ -90,10 +91,11 @@ func NewFileProvider(filesLimit int, wildcardSelection WildcardSelectionStrategy
 	}
 
 	return &FileProvider{
-		filesLimit:      filesLimit,
-		wildcardOrder:   wildcardOrder,
-		selectionMode:   selectionMode,
-		shouldLogErrors: true,
+		filesLimit:          filesLimit,
+		wildcardOrder:       wildcardOrder,
+		selectionMode:       selectionMode,
+		shouldLogErrors:     true,
+		reachedNumFileLimit: false,
 	}
 }
 
@@ -225,8 +227,11 @@ func (p *FileProvider) FilesToTail(validatePodContainerID bool, inputSources []*
 		source.Messages.AddMessage(source.Config.Path, fmt.Sprintf("%d files tailed out of %d files matching", matchCnt.tracked, matchCnt.total))
 	}
 
-	if len(filesToTail) == p.filesLimit {
-		log.Debug("Reached the limit on the maximum number of files in use: ", p.filesLimit)
+	if !p.reachedNumFileLimit && len(filesToTail) == p.filesLimit {
+		log.Warn("Reached the limit on the maximum number of files in use: ", p.filesLimit)
+		p.reachedNumFileLimit = true
+	} else if len(filesToTail) < p.filesLimit {
+		p.reachedNumFileLimit = false
 	}
 
 	return filesToTail


### PR DESCRIPTION
### What does this PR do?
Logs a warning when the `file_provider` transitions into the "max files reached" state only once per state, rather than every time the logs on disk are scanned.

### Motivation
Customers that run at the limit have un-necessary log spam, however at the same time this is a useful log for customers who may be unaware that their agent is in this state.


### Additional Notes
This "file limit reached" message is also displayed prominently on the status page.

### Possible Drawbacks / Trade-offs


### Describe how to test/QA your changes
1. Configure the agent to monitor a local folder with a wildcard pattern. (example below)
2. Set the `logs_config.open_files_limit: 2` and `logs_config.file_scan_period: 1`
3. Run the agent with an empty local log folder.
4. Create 2 files in the log folder, ensure that you see the warning log `Reached the limit on the maximum number of files in use`
5. Wait for a few seconds to ensure only you don't see more warning logs.
6. Remove one file, wait a few seconds, then re-add one file (for a total of 2 files) and ensure you see a new warning log `Reached the limit on the maximum number of files in use`
7. Done.

Example local log config:
```
# conf.d/local-logs/conf.yaml
logs:
  - type: file
    path: "/tmp/mylogdir/*.log"
    service: "myservice"
    source: "mysource"
```
### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
