### PR TITLE
WMS: add image ID for containerd and ecs fargate collectors

### DIFF
--- a/pkg/workloadmeta/collectors/internal/containerd/container_builder.go
+++ b/pkg/workloadmeta/collectors/internal/containerd/container_builder.go
@@ -36,6 +36,11 @@ func buildWorkloadMetaContainer(namespace string, container containerd.Container
 		return workloadmeta.Container{}, err
 	}
 
+	containerImage, err := containerdClient.Image(namespace, container)
+	if err != nil {
+		return workloadmeta.Container{}, err
+	}
+
 	envs, err := cutil.EnvVarsFromSpec(spec)
 	if err != nil {
 		return workloadmeta.Container{}, err
@@ -45,6 +50,7 @@ func buildWorkloadMetaContainer(namespace string, container containerd.Container
 	if err != nil {
 		log.Debugf("cannot split image name %q: %s", info.Image, err)
 	}
+	image.ID = containerImage.Target().Digest.String()
 
 	status, err := containerdClient.Status(namespace, container)
 	if err != nil {

--- a/pkg/workloadmeta/collectors/internal/ecsfargate/ecsfargate.go
+++ b/pkg/workloadmeta/collectors/internal/ecsfargate/ecsfargate.go
@@ -168,6 +168,7 @@ func (c *collector) parseTaskContainers(
 		if err != nil {
 			log.Debugf("cannot split image name %q: %s", container.Image, err)
 		}
+		image.ID = container.ImageID
 
 		ips := make(map[string]string)
 


### PR DESCRIPTION
### What does this PR do?

The workload meta container image struct already accept an ID, but this field is only filled for the kubelet collector. This PR collects this data for fargate and containerd (I was not able to found this digest for podman).

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
