### PR TITLE
pkg/trace/config: Lower max tracer payload to 25 MB to better align with backend limits

### DIFF
--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -464,7 +464,7 @@ func New() *AgentConfig {
 
 		ReceiverHost:           "localhost",
 		ReceiverPort:           8126,
-		MaxRequestBytes:        50 * 1024 * 1024, // 50MB
+		MaxRequestBytes:        25 * 1024 * 1024, // 25MB
 		PipeBufferSize:         1_000_000,
 		PipeSecurityDescriptor: "D:AI(A;;GA;;;WD)",
 		GUIPort:                "5002",

--- a/releasenotes/notes/LowerTraceLimit-839236eacc69d87a.yaml
+++ b/releasenotes/notes/LowerTraceLimit-839236eacc69d87a.yaml
@@ -8,4 +8,4 @@
 ---
 fixes:
   - |
-    APM: Lower incoming trace payload limit to 25MB. This more closely aligns with the backend limit. Some users may see traces rejected by the Agent that the agent would have previously accepted, but would have subsequently been rejected by the trace intake.
+    APM: Lower incoming trace payload limit to 25MB. This more closely aligns with the backend limit. Some users may see traces rejected by the Agent that the Agent would have previously accepted, but would have subsequently been rejected by the trace intake.

--- a/releasenotes/notes/LowerTraceLimit-839236eacc69d87a.yaml
+++ b/releasenotes/notes/LowerTraceLimit-839236eacc69d87a.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    APM: Lower incoming trace payload limit to 25MB. This more closely aligns with the backend limit. Some users may see traces rejected by the Agent that the agent would have previously accepted, but would have subsequently been rejected by the trace intake.

--- a/releasenotes/notes/LowerTraceLimit-839236eacc69d87a.yaml
+++ b/releasenotes/notes/LowerTraceLimit-839236eacc69d87a.yaml
@@ -8,4 +8,4 @@
 ---
 fixes:
   - |
-    APM: Lower incoming trace payload limit to 25MB. This more closely aligns with the backend limit. Some users may see traces rejected by the Agent that the Agent would have previously accepted, but would have subsequently been rejected by the trace intake.
+    APM: Lower default incoming trace payload limit to 25MB. This more closely aligns with the backend limit. Some users may see traces rejected by the Agent that the Agent would have previously accepted, but would have subsequently been rejected by the trace intake. The Agent limit can still be configured via `apm_config.max_payload_size`.


### PR DESCRIPTION

### What does this PR do?
Lower the limit for incoming trace payloads to 25MB from 50MB.

### Motivation
There have been a couple customer escalations where they saw errors from the agent indicating a `413` and that the payloads were too large to be accepted by the APM backend. Due to the late nature of these rejections it was difficult to determine the source of these excessively-large traces. By rejecting these payloads earlier it will push the error closer to the true source of the issue (the error will appear at the tracer level and not the agent). It will also improve performance for agents that are receiving these overly-large payloads as the agent will no longer process payloads that would nearly-always be rejected by the backend.

### Possible Drawbacks / Trade-offs
It is unlikely, but possible that _some_ previously accepted and processed payloads will now be rejected. Example: A payload that is 30MB when it enters the agent, but due to a large amount of Tag replacements becomes smaller than the backend limit.
I believe the improved visibility and performance are well worth this risk as trace chunks that are near these limits are difficult to reason about / view in the user-interface. They almost always represent an issue where an integration is connecting work that _should_ be separate traces, or a bug generating a significant number of garbage traces or tags.

### Describe how to test/QA your changes
Send a trace payload that is larger than 25 MB. See that it is rejected by the agent.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
