### PR TITLE
[gitlab] Repack macOS JUnit tarball to include correct name and job URL

### DIFF
--- a/.gitlab/source_test/macos.yml
+++ b/.gitlab/source_test/macos.yml
@@ -14,9 +14,10 @@ tests_macos:
     - export GITHUB_INSTALLATION_ID=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.macos_github_installation_id --with-decryption --query "Parameter.Value" --out text)
     - python3 -m pip install -r tasks/libs/requirements-github.txt
     - inv -e github.trigger-macos-test --datadog-agent-ref "$CI_COMMIT_SHA" --python-runtimes "$PYTHON_RUNTIMES"
+    - inv -e junit-macos-repack --infile junit-tests_macos.tgz --outfile junit-tests_macos-repacked.tgz
   artifacts:
     expire_in: 2 weeks
     when: always
     paths:
       - test_output.json
-      - junit-*.tgz
+      - junit-*-repacked.tgz

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -49,6 +49,7 @@ from .test import (
     install_shellcheck,
     install_tools,
     integration_tests,
+    junit_macos_repack,
     junit_upload,
     lint_copyrights,
     lint_filenames,
@@ -92,6 +93,7 @@ ns.add_task(tidy_all)
 ns.add_task(check_go_version)
 ns.add_task(generate_config)
 ns.add_task(junit_upload)
+ns.add_task(junit_macos_repack)
 ns.add_task(fuzz)
 
 # add namespaced tasks to the root

--- a/tasks/libs/junit_upload.py
+++ b/tasks/libs/junit_upload.py
@@ -193,7 +193,8 @@ def repack_macos_junit_tar(infile, outfile):
             fp.write(os.environ.get("CI_JOB_URL", ""))
         with open(os.path.join(tempd, TAGS_FILE_NAME)) as fp:
             tags = fp.read()
-        tags = tags.replace("ci.job.name:", "ci.job.name:{}".format(os.environ.get("CI_JOB_NAME", "")))
+        job_name = os.environ.get("CI_JOB_NAME", "")
+        tags = tags.replace("ci.job.name:", f"ci.job.name:{job_name}")
         with open(os.path.join(tempd, TAGS_FILE_NAME), "w") as fp:
             fp.write(tags)
 

--- a/tasks/libs/junit_upload.py
+++ b/tasks/libs/junit_upload.py
@@ -182,3 +182,21 @@ def produce_junit_tar(files, result_path):
         job_url_info.size = job_url_file.getbuffer().nbytes
         job_url_file.seek(0)
         tgz.addfile(job_url_info, job_url_file)
+
+
+def repack_macos_junit_tar(infile, outfile):
+    with tarfile.open(infile) as infp, tarfile.open(outfile, "w:gz") as outfp, tempfile.TemporaryDirectory() as tempd:
+        infp.extractall(tempd)
+
+        # write the proper job url and job name
+        with open(os.path.join(tempd, JOB_URL_FILE_NAME), "w") as fp:
+            fp.write(os.environ.get("CI_JOB_URL", ""))
+        with open(os.path.join(tempd, TAGS_FILE_NAME)) as fp:
+            tags = fp.read()
+        tags = tags.replace("ci.job.name:", "ci.job.name:{}".format(os.environ.get("CI_JOB_NAME", "")))
+        with open(os.path.join(tempd, TAGS_FILE_NAME), "w") as fp:
+            fp.write(tags)
+
+        # pack all files to a new tarball
+        for f in os.listdir(tempd):
+            outfp.add(os.path.join(tempd, f), arcname=f)

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -23,7 +23,7 @@ from .dogstatsd import integration_tests as dsd_integration_tests
 from .flavor import AgentFlavor
 from .go import golangci_lint
 from .libs.copyright import CopyrightLinter
-from .libs.junit_upload import add_flavor_to_junitxml, junit_upload_from_tgz, produce_junit_tar
+from .libs.junit_upload import add_flavor_to_junitxml, junit_upload_from_tgz, produce_junit_tar, repack_macos_junit_tar
 from .modules import DEFAULT_MODULES, GoModule
 from .trace_agent import integration_tests as trace_integration_tests
 from .utils import DEFAULT_BRANCH, get_build_flags
@@ -731,3 +731,12 @@ def junit_upload(_, tgz_path):
     """
 
     junit_upload_from_tgz(tgz_path)
+
+
+@task
+def junit_macos_repack(_, infile, outfile):
+    """
+    Repacks JUnit tgz file from macOS Github Action run, so it would
+    containt correct job name and job URL.
+    """
+    repack_macos_junit_tar(infile, outfile)


### PR DESCRIPTION
### What does this PR do?

Adds a new task to repack the macOS JUnit tarball, so it would contain proper job name and job URL. They aren't included in the file as we download it from the Github Action results. Github Actions don't know anything about Gitlab job name and url.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
