### PR TITLE
DogStatsD subcommand

### DIFF
--- a/cmd/agent/subcommands/configcheck/command.go
+++ b/cmd/agent/subcommands/configcheck/command.go
@@ -17,6 +17,7 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/agent/command"
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/log"
 	"github.com/DataDog/datadog-agent/pkg/flare"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/DataDog/datadog-agent/pkg/util/scrubber"
@@ -43,7 +44,9 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(run,
 				fx.Supply(cliParams),
-				fx.Supply(core.CreateAgentBundleParams(globalParams.ConfFilePath, true, core.WithLogForOneShot("CORE", "off", true))),
+				fx.Supply(core.BundleParams{
+					ConfigParams: config.NewAgentParams(globalParams.ConfFilePath, true),
+					LogParams:    log.LogForOneShot("CORE", "off", true)}),
 				core.Bundle,
 			)
 		},

--- a/cmd/agent/subcommands/configcheck/command.go
+++ b/cmd/agent/subcommands/configcheck/command.go
@@ -45,7 +45,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 			return fxutil.OneShot(run,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewAgentParams(globalParams.ConfFilePath, true),
+					ConfigParams: config.NewAgentParamsWithSecrets(globalParams.ConfFilePath),
 					LogParams:    log.LogForOneShot("CORE", "off", true)}),
 				core.Bundle,
 			)

--- a/cmd/agent/subcommands/configcheck/command_test.go
+++ b/cmd/agent/subcommands/configcheck/command_test.go
@@ -22,6 +22,6 @@ func TestCommand(t *testing.T) {
 		run,
 		func(cliParams *cliParams, coreParams core.BundleParams) {
 			require.Equal(t, true, cliParams.verbose)
-			require.Equal(t, true, coreParams.ConfigLoadSecrets)
+			require.Equal(t, true, coreParams.ConfigLoadSecrets())
 		})
 }

--- a/cmd/agent/subcommands/diagnose/command.go
+++ b/cmd/agent/subcommands/diagnose/command.go
@@ -54,7 +54,9 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(runAll,
 				fx.Supply(cliParams),
-				fx.Supply(core.CreateAgentBundleParams(globalParams.ConfFilePath, false, core.WithLogForOneShot("CORE", "info", true))),
+				fx.Supply(core.BundleParams{
+					ConfigParams: config.NewAgentParams(globalParams.ConfFilePath, false),
+					LogParams:    log.LogForOneShot("CORE", "info", true)}),
 				core.Bundle,
 			)
 		},
@@ -67,7 +69,9 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(runDatadogConnectivityDiagnose,
 				fx.Supply(cliParams),
-				fx.Supply(core.CreateAgentBundleParams(globalParams.ConfFilePath, false, core.WithLogForOneShot("CORE", "info", true))),
+				fx.Supply(core.BundleParams{
+					ConfigParams: config.NewAgentParams(globalParams.ConfFilePath, false),
+					LogParams:    log.LogForOneShot("CORE", "info", true)}),
 				core.Bundle,
 			)
 		},
@@ -94,7 +98,9 @@ This command print the V5 metadata payload for the Agent. This payload is used t
 			cliParams.payloadName = "v5"
 			return fxutil.OneShot(printPayload,
 				fx.Supply(cliParams),
-				fx.Supply(core.CreateAgentBundleParams(globalParams.ConfFilePath, false, core.WithLogForOneShot("CORE", "off", true))),
+				fx.Supply(core.BundleParams{
+					ConfigParams: config.NewAgentParams(globalParams.ConfFilePath, false),
+					LogParams:    log.LogForOneShot("CORE", "off", true)}),
 				core.Bundle,
 			)
 		},
@@ -109,7 +115,9 @@ This command print the last Inventory metadata payload sent by the Agent. This p
 			cliParams.payloadName = "inventory"
 			return fxutil.OneShot(printPayload,
 				fx.Supply(cliParams),
-				fx.Supply(core.CreateAgentBundleParams(globalParams.ConfFilePath, false, core.WithLogForOneShot("CORE", "off", true))),
+				fx.Supply(core.BundleParams{
+					ConfigParams: config.NewAgentParams(globalParams.ConfFilePath, false),
+					LogParams:    log.LogForOneShot("CORE", "off", true)}),
 				core.Bundle,
 			)
 		},

--- a/cmd/agent/subcommands/diagnose/command.go
+++ b/cmd/agent/subcommands/diagnose/command.go
@@ -55,7 +55,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 			return fxutil.OneShot(runAll,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewAgentParams(globalParams.ConfFilePath, false),
+					ConfigParams: config.NewAgentParamsWithoutSecrets(globalParams.ConfFilePath),
 					LogParams:    log.LogForOneShot("CORE", "info", true)}),
 				core.Bundle,
 			)
@@ -70,7 +70,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 			return fxutil.OneShot(runDatadogConnectivityDiagnose,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewAgentParams(globalParams.ConfFilePath, false),
+					ConfigParams: config.NewAgentParamsWithoutSecrets(globalParams.ConfFilePath),
 					LogParams:    log.LogForOneShot("CORE", "info", true)}),
 				core.Bundle,
 			)
@@ -99,7 +99,7 @@ This command print the V5 metadata payload for the Agent. This payload is used t
 			return fxutil.OneShot(printPayload,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewAgentParams(globalParams.ConfFilePath, false),
+					ConfigParams: config.NewAgentParamsWithoutSecrets(globalParams.ConfFilePath),
 					LogParams:    log.LogForOneShot("CORE", "off", true)}),
 				core.Bundle,
 			)
@@ -116,7 +116,7 @@ This command print the last Inventory metadata payload sent by the Agent. This p
 			return fxutil.OneShot(printPayload,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewAgentParams(globalParams.ConfFilePath, false),
+					ConfigParams: config.NewAgentParamsWithoutSecrets(globalParams.ConfFilePath),
 					LogParams:    log.LogForOneShot("CORE", "off", true)}),
 				core.Bundle,
 			)

--- a/cmd/agent/subcommands/diagnose/command_test.go
+++ b/cmd/agent/subcommands/diagnose/command_test.go
@@ -21,7 +21,7 @@ func TestDiagnoseCommand(t *testing.T) {
 		[]string{"diagnose"},
 		runAll,
 		func(cliParams *cliParams, coreParams core.BundleParams) {
-			require.Equal(t, false, coreParams.ConfigLoadSecrets)
+			require.Equal(t, false, coreParams.ConfigLoadSecrets())
 		})
 }
 
@@ -31,7 +31,7 @@ func TestMetadataAvailabilityCommand(t *testing.T) {
 		[]string{"diagnose", "metadata-availability"},
 		runAll,
 		func(cliParams *cliParams, coreParams core.BundleParams) {
-			require.Equal(t, false, coreParams.ConfigLoadSecrets)
+			require.Equal(t, false, coreParams.ConfigLoadSecrets())
 		})
 }
 
@@ -41,7 +41,7 @@ func TestShowMetadataV5Command(t *testing.T) {
 		[]string{"diagnose", "show-metadata", "v5"},
 		printPayload,
 		func(cliParams *cliParams, coreParams core.BundleParams) {
-			require.Equal(t, false, coreParams.ConfigLoadSecrets)
+			require.Equal(t, false, coreParams.ConfigLoadSecrets())
 			require.Equal(t, "v5", cliParams.payloadName)
 		})
 }
@@ -52,7 +52,7 @@ func TestShowMetadataInventoryCommand(t *testing.T) {
 		[]string{"diagnose", "show-metadata", "inventory"},
 		printPayload,
 		func(cliParams *cliParams, coreParams core.BundleParams) {
-			require.Equal(t, false, coreParams.ConfigLoadSecrets)
+			require.Equal(t, false, coreParams.ConfigLoadSecrets())
 			require.Equal(t, "inventory", cliParams.payloadName)
 		})
 }
@@ -63,7 +63,7 @@ func TestDatadogConnectivityCommand(t *testing.T) {
 		[]string{"diagnose", "datadog-connectivity", "--no-trace"},
 		runDatadogConnectivityDiagnose,
 		func(cliParams *cliParams, coreParams core.BundleParams) {
-			require.Equal(t, false, coreParams.ConfigLoadSecrets)
+			require.Equal(t, false, coreParams.ConfigLoadSecrets())
 			require.Equal(t, true, cliParams.noTrace)
 		})
 }

--- a/cmd/agent/subcommands/dogstatsdcapture/command.go
+++ b/cmd/agent/subcommands/dogstatsdcapture/command.go
@@ -58,7 +58,9 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(dogstatsdCapture,
 				fx.Supply(cliParams),
-				fx.Supply(core.CreateAgentBundleParams(globalParams.ConfFilePath, false, core.WithLogForOneShot("CORE", "off", true))),
+				fx.Supply(core.BundleParams{
+					ConfigParams: config.NewAgentParams(globalParams.ConfFilePath, false),
+					LogParams:    log.LogForOneShot("CORE", "off", true)}),
 				core.Bundle,
 			)
 		},

--- a/cmd/agent/subcommands/dogstatsdcapture/command.go
+++ b/cmd/agent/subcommands/dogstatsdcapture/command.go
@@ -59,7 +59,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 			return fxutil.OneShot(dogstatsdCapture,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewAgentParams(globalParams.ConfFilePath, false),
+					ConfigParams: config.NewAgentParamsWithoutSecrets(globalParams.ConfFilePath),
 					LogParams:    log.LogForOneShot("CORE", "off", true)}),
 				core.Bundle,
 			)

--- a/cmd/agent/subcommands/dogstatsdcapture/command_test.go
+++ b/cmd/agent/subcommands/dogstatsdcapture/command_test.go
@@ -24,6 +24,6 @@ func TestCommand(t *testing.T) {
 		func(cliParams *cliParams, coreParams core.BundleParams) {
 			require.Equal(t, 10*time.Second, cliParams.dsdCaptureDuration)
 			require.True(t, cliParams.dsdCaptureCompressed)
-			require.Equal(t, false, coreParams.ConfigLoadSecrets)
+			require.Equal(t, false, coreParams.ConfigLoadSecrets())
 		})
 }

--- a/cmd/agent/subcommands/dogstatsdreplay/command.go
+++ b/cmd/agent/subcommands/dogstatsdreplay/command.go
@@ -62,7 +62,9 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(dogstatsdReplay,
 				fx.Supply(cliParams),
-				fx.Supply(core.CreateAgentBundleParams(globalParams.ConfFilePath, false, core.WithLogForOneShot("CORE", "off", true))),
+				fx.Supply(core.BundleParams{
+					ConfigParams: config.NewAgentParams(globalParams.ConfFilePath, false),
+					LogParams:    log.LogForOneShot("CORE", "off", true)}),
 				core.Bundle,
 			)
 		},

--- a/cmd/agent/subcommands/dogstatsdreplay/command.go
+++ b/cmd/agent/subcommands/dogstatsdreplay/command.go
@@ -63,7 +63,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 			return fxutil.OneShot(dogstatsdReplay,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewAgentParams(globalParams.ConfFilePath, false),
+					ConfigParams: config.NewAgentParamsWithoutSecrets(globalParams.ConfFilePath),
 					LogParams:    log.LogForOneShot("CORE", "off", true)}),
 				core.Bundle,
 			)

--- a/cmd/agent/subcommands/dogstatsdreplay/command_test.go
+++ b/cmd/agent/subcommands/dogstatsdreplay/command_test.go
@@ -22,6 +22,6 @@ func TestCommand(t *testing.T) {
 		dogstatsdReplay,
 		func(cliParams *cliParams, coreParams core.BundleParams) {
 			require.True(t, cliParams.dsdVerboseReplay)
-			require.Equal(t, false, coreParams.ConfigLoadSecrets)
+			require.Equal(t, false, coreParams.ConfigLoadSecrets())
 		})
 }

--- a/cmd/agent/subcommands/dogstatsdstats/command.go
+++ b/cmd/agent/subcommands/dogstatsdstats/command.go
@@ -52,7 +52,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 			return fxutil.OneShot(requestDogstatsdStats,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewAgentParams(globalParams.ConfFilePath, false),
+					ConfigParams: config.NewAgentParamsWithoutSecrets(globalParams.ConfFilePath),
 					LogParams:    log.LogForOneShot("CORE", "off", true)}),
 				core.Bundle,
 			)

--- a/cmd/agent/subcommands/dogstatsdstats/command.go
+++ b/cmd/agent/subcommands/dogstatsdstats/command.go
@@ -51,7 +51,9 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(requestDogstatsdStats,
 				fx.Supply(cliParams),
-				fx.Supply(core.CreateAgentBundleParams(globalParams.ConfFilePath, false, core.WithLogForOneShot("CORE", "off", true))),
+				fx.Supply(core.BundleParams{
+					ConfigParams: config.NewAgentParams(globalParams.ConfFilePath, false),
+					LogParams:    log.LogForOneShot("CORE", "off", true)}),
 				core.Bundle,
 			)
 		},

--- a/cmd/agent/subcommands/dogstatsdstats/command_test.go
+++ b/cmd/agent/subcommands/dogstatsdstats/command_test.go
@@ -22,6 +22,6 @@ func TestCommand(t *testing.T) {
 		requestDogstatsdStats,
 		func(cliParams *cliParams, coreParams core.BundleParams) {
 			require.True(t, cliParams.jsonStatus)
-			require.Equal(t, false, coreParams.ConfigLoadSecrets)
+			require.Equal(t, false, coreParams.ConfigLoadSecrets())
 		})
 }

--- a/cmd/agent/subcommands/flare/command.go
+++ b/cmd/agent/subcommands/flare/command.go
@@ -61,7 +61,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		Long:  ``,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cliParams.args = args
-			config := config.NewAgentParams(globalParams.ConfFilePath, true,
+			config := config.NewAgentParamsWithSecrets(globalParams.ConfFilePath,
 				config.WithSecurityAgentConfigFilePaths([]string{
 					path.Join(common.DefaultConfPath, "security-agent.yaml"),
 				}),

--- a/cmd/agent/subcommands/flare/command.go
+++ b/cmd/agent/subcommands/flare/command.go
@@ -61,17 +61,20 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		Long:  ``,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cliParams.args = args
-			bundleParams := core.CreateAgentBundleParams(globalParams.ConfFilePath, true, core.WithLogForOneShot("CORE", "off", false))
-			bundleParams.SecurityAgentConfigFilePaths = []string{
+			config := config.NewAgentParams(globalParams.ConfFilePath, true)
+			config.SecurityAgentConfigFilePaths = []string{
 				path.Join(common.DefaultConfPath, "security-agent.yaml"),
 			}
-			bundleParams.ConfigLoadSecurityAgent = true
-			bundleParams.SysProbeConfFilePath = globalParams.SysProbeConfFilePath
-			bundleParams.ConfigLoadSysProbe = true
+			config.ConfigLoadSecurityAgent = true
+			config.SysProbeConfFilePath = globalParams.SysProbeConfFilePath
+			config.ConfigLoadSysProbe = true
 
 			return fxutil.OneShot(makeFlare,
 				fx.Supply(cliParams),
-				fx.Supply(bundleParams),
+				fx.Supply(core.BundleParams{
+					ConfigParams: config,
+					LogParams:    log.LogForOneShot("CORE", "off", false),
+				}),
 				core.Bundle,
 			)
 		},

--- a/cmd/agent/subcommands/flare/command.go
+++ b/cmd/agent/subcommands/flare/command.go
@@ -61,13 +61,13 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		Long:  ``,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cliParams.args = args
-			config := config.NewAgentParams(globalParams.ConfFilePath, true)
-			config.SecurityAgentConfigFilePaths = []string{
-				path.Join(common.DefaultConfPath, "security-agent.yaml"),
-			}
-			config.ConfigLoadSecurityAgent = true
-			config.SysProbeConfFilePath = globalParams.SysProbeConfFilePath
-			config.ConfigLoadSysProbe = true
+			config := config.NewAgentParams(globalParams.ConfFilePath, true,
+				config.WithSecurityAgentConfigFilePaths([]string{
+					path.Join(common.DefaultConfPath, "security-agent.yaml"),
+				}),
+				config.WithConfigLoadSecurityAgent(true),
+				config.WithSysProbeConfFilePath(globalParams.SysProbeConfFilePath),
+				config.WithConfigLoadSysProbe(true))
 
 			return fxutil.OneShot(makeFlare,
 				fx.Supply(cliParams),

--- a/cmd/agent/subcommands/flare/command_test.go
+++ b/cmd/agent/subcommands/flare/command_test.go
@@ -105,6 +105,6 @@ func TestCommand(t *testing.T) {
 		makeFlare,
 		func(cliParams *cliParams, coreParams core.BundleParams) {
 			require.Equal(t, []string{"1234"}, cliParams.args)
-			require.Equal(t, true, coreParams.ConfigLoadSecrets)
+			require.Equal(t, true, coreParams.ConfigLoadSecrets())
 		})
 }

--- a/cmd/agent/subcommands/hostname/command.go
+++ b/cmd/agent/subcommands/hostname/command.go
@@ -38,7 +38,9 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(getHostname,
 				fx.Supply(cliParams),
-				fx.Supply(core.CreateAgentBundleParams(globalParams.ConfFilePath, false, core.WithLogForOneShot("CORE", "off", false))), // never output anything but hostname
+				fx.Supply(core.BundleParams{
+					ConfigParams: config.NewAgentParams(globalParams.ConfFilePath, false),
+					LogParams:    log.LogForOneShot("CORE", "off", false)}), // never output anything but hostname
 				core.Bundle,
 			)
 		},

--- a/cmd/agent/subcommands/hostname/command.go
+++ b/cmd/agent/subcommands/hostname/command.go
@@ -39,7 +39,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 			return fxutil.OneShot(getHostname,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewAgentParams(globalParams.ConfFilePath, false),
+					ConfigParams: config.NewAgentParamsWithoutSecrets(globalParams.ConfFilePath),
 					LogParams:    log.LogForOneShot("CORE", "off", false)}), // never output anything but hostname
 				core.Bundle,
 			)

--- a/cmd/agent/subcommands/hostname/command_test.go
+++ b/cmd/agent/subcommands/hostname/command_test.go
@@ -21,6 +21,6 @@ func TestCommand(t *testing.T) {
 		[]string{"hostname"},
 		getHostname,
 		func(cliParams *cliParams, coreParams core.BundleParams) {
-			require.Equal(t, false, coreParams.ConfigLoadSecrets)
+			require.Equal(t, false, coreParams.ConfigLoadSecrets())
 		})
 }

--- a/cmd/agent/subcommands/integrations/command.go
+++ b/cmd/agent/subcommands/integrations/command.go
@@ -103,7 +103,8 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 	runOneShot := func(callback interface{}) error {
 		return fxutil.OneShot(callback,
 			fx.Supply(cliParams),
-			fx.Supply(core.CreateAgentBundleParams(globalParams.ConfFilePath, false, core.WithConfigMissingOK(true))),
+			fx.Supply(core.BundleParams{
+				ConfigParams: config.NewAgentParams(globalParams.ConfFilePath, false, config.WithConfigMissingOK(true))}),
 			core.Bundle,
 		)
 	}

--- a/cmd/agent/subcommands/integrations/command.go
+++ b/cmd/agent/subcommands/integrations/command.go
@@ -104,7 +104,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		return fxutil.OneShot(callback,
 			fx.Supply(cliParams),
 			fx.Supply(core.BundleParams{
-				ConfigParams: config.NewAgentParams(globalParams.ConfFilePath, false, config.WithConfigMissingOK(true))}),
+				ConfigParams: config.NewAgentParamsWithoutSecrets(globalParams.ConfFilePath, config.WithConfigMissingOK(true))}),
 			core.Bundle,
 		)
 	}

--- a/cmd/agent/subcommands/integrations/command_test.go
+++ b/cmd/agent/subcommands/integrations/command_test.go
@@ -26,8 +26,8 @@ func TestInstallCommand(t *testing.T) {
 		func(cliParams *cliParams, coreParams core.BundleParams) {
 			require.Equal(t, []string{"foo==1.0"}, cliParams.args)
 			require.Equal(t, 1, cliParams.verbose)
-			require.Equal(t, false, coreParams.ConfigLoadSecrets)
-			require.Equal(t, true, coreParams.ConfigMissingOK)
+			require.Equal(t, false, coreParams.ConfigLoadSecrets())
+			require.Equal(t, true, coreParams.ConfigMissingOK())
 		})
 }
 
@@ -39,8 +39,8 @@ func TestRemoveCommand(t *testing.T) {
 		func(cliParams *cliParams, coreParams core.BundleParams) {
 			require.Equal(t, []string{"foo"}, cliParams.args)
 			require.Equal(t, 0, cliParams.verbose)
-			require.Equal(t, false, coreParams.ConfigLoadSecrets)
-			require.Equal(t, true, coreParams.ConfigMissingOK)
+			require.Equal(t, false, coreParams.ConfigLoadSecrets())
+			require.Equal(t, true, coreParams.ConfigMissingOK())
 		})
 }
 
@@ -52,8 +52,8 @@ func TestFreezeCommand(t *testing.T) {
 		func(cliParams *cliParams, coreParams core.BundleParams) {
 			require.Equal(t, []string{}, cliParams.args)
 			require.Equal(t, 0, cliParams.verbose)
-			require.Equal(t, false, coreParams.ConfigLoadSecrets)
-			require.Equal(t, true, coreParams.ConfigMissingOK)
+			require.Equal(t, false, coreParams.ConfigLoadSecrets())
+			require.Equal(t, true, coreParams.ConfigMissingOK())
 		})
 }
 
@@ -65,7 +65,7 @@ func TestShowCommand(t *testing.T) {
 		func(cliParams *cliParams, coreParams core.BundleParams) {
 			require.Equal(t, []string{"foo"}, cliParams.args)
 			require.Equal(t, 0, cliParams.verbose)
-			require.Equal(t, false, coreParams.ConfigLoadSecrets)
-			require.Equal(t, true, coreParams.ConfigMissingOK)
+			require.Equal(t, false, coreParams.ConfigLoadSecrets())
+			require.Equal(t, true, coreParams.ConfigMissingOK())
 		})
 }

--- a/cmd/agent/subcommands/jmx/command.go
+++ b/cmd/agent/subcommands/jmx/command.go
@@ -87,7 +87,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		params := core.CreateAgentBundleParams(globalParams.ConfFilePath, true, core.WithLogForOneShot("CORE", cliParams.jmxLogLevel, false))
 
 		if cliParams.logFile != "" {
-			params = params.LogToFile(cliParams.logFile)
+			params.LogParams.LogToFile(cliParams.logFile)
 		}
 
 		return fxutil.OneShot(callback,

--- a/cmd/agent/subcommands/jmx/command.go
+++ b/cmd/agent/subcommands/jmx/command.go
@@ -84,7 +84,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 			cliParams.jmxLogLevel = "debug"
 		}
 		params := core.BundleParams{
-			ConfigParams: config.NewAgentParams(globalParams.ConfFilePath, true),
+			ConfigParams: config.NewAgentParamsWithSecrets(globalParams.ConfFilePath),
 			LogParams:    log.LogForOneShot("CORE", cliParams.jmxLogLevel, false)}
 		if cliParams.logFile != "" {
 			params.LogParams.LogToFile(cliParams.logFile)

--- a/cmd/agent/subcommands/jmx/command.go
+++ b/cmd/agent/subcommands/jmx/command.go
@@ -83,9 +83,9 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		if cliParams.jmxLogLevel == "" {
 			cliParams.jmxLogLevel = "debug"
 		}
-
-		params := core.CreateAgentBundleParams(globalParams.ConfFilePath, true, core.WithLogForOneShot("CORE", cliParams.jmxLogLevel, false))
-
+		params := core.BundleParams{
+			ConfigParams: config.NewAgentParams(globalParams.ConfFilePath, true),
+			LogParams:    log.LogForOneShot("CORE", cliParams.jmxLogLevel, false)}
 		if cliParams.logFile != "" {
 			params.LogParams.LogToFile(cliParams.logFile)
 		}

--- a/cmd/agent/subcommands/jmx/command_test.go
+++ b/cmd/agent/subcommands/jmx/command_test.go
@@ -34,8 +34,8 @@ func TestCollectCommand(t *testing.T) {
 				require.Equal(t, "debug", coreParams.LogLevelFn(nil))
 				require.Equal(t, "", cliParams.logFile)
 				require.Equal(t, "", coreParams.LogFileFn(nil))
-				require.Equal(t, "CORE", coreParams.LoggerName)
-				require.Equal(t, true, coreParams.ConfigLoadSecrets)
+				require.Equal(t, "CORE", coreParams.LoggerName())
+				require.Equal(t, true, coreParams.ConfigLoadSecrets())
 			})
 	})
 
@@ -50,8 +50,8 @@ func TestCollectCommand(t *testing.T) {
 				require.Equal(t, "info", coreParams.LogLevelFn(nil))
 				require.Equal(t, "", cliParams.logFile)
 				require.Equal(t, "", coreParams.LogFileFn(nil))
-				require.Equal(t, "CORE", coreParams.LoggerName)
-				require.Equal(t, true, coreParams.ConfigLoadSecrets)
+				require.Equal(t, "CORE", coreParams.LoggerName())
+				require.Equal(t, true, coreParams.ConfigLoadSecrets())
 			})
 	})
 
@@ -66,8 +66,8 @@ func TestCollectCommand(t *testing.T) {
 				require.Equal(t, "debug", coreParams.LogLevelFn(nil)) // overrides --log-level
 				require.True(t, strings.HasPrefix(cliParams.logFile, common.DefaultJMXFlareDirectory))
 				require.Equal(t, cliParams.logFile, coreParams.LogFileFn(nil))
-				require.Equal(t, "CORE", coreParams.LoggerName)
-				require.Equal(t, true, coreParams.ConfigLoadSecrets)
+				require.Equal(t, "CORE", coreParams.LoggerName())
+				require.Equal(t, true, coreParams.ConfigLoadSecrets())
 			})
 	})
 }

--- a/cmd/agent/subcommands/launchgui/command.go
+++ b/cmd/agent/subcommands/launchgui/command.go
@@ -39,7 +39,8 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(launchGui,
 				fx.Supply(cliParams),
-				fx.Supply(core.CreateAgentBundleParams(globalParams.ConfFilePath, false)),
+				fx.Supply(core.BundleParams{
+					ConfigParams: config.NewAgentParams(globalParams.ConfFilePath, false)}),
 				core.Bundle,
 			)
 		},

--- a/cmd/agent/subcommands/launchgui/command.go
+++ b/cmd/agent/subcommands/launchgui/command.go
@@ -40,7 +40,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 			return fxutil.OneShot(launchGui,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewAgentParams(globalParams.ConfFilePath, false)}),
+					ConfigParams: config.NewAgentParamsWithoutSecrets(globalParams.ConfFilePath)}),
 				core.Bundle,
 			)
 		},

--- a/cmd/agent/subcommands/launchgui/command_test.go
+++ b/cmd/agent/subcommands/launchgui/command_test.go
@@ -21,6 +21,6 @@ func TestCommand(t *testing.T) {
 		[]string{"launch-gui"},
 		launchGui,
 		func(cliParams *cliParams, coreParams core.BundleParams) {
-			require.Equal(t, false, coreParams.ConfigLoadSecrets)
+			require.Equal(t, false, coreParams.ConfigLoadSecrets())
 		})
 }

--- a/cmd/agent/subcommands/remoteconfig/command.go
+++ b/cmd/agent/subcommands/remoteconfig/command.go
@@ -44,7 +44,8 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(state,
 				fx.Supply(cliParams),
-				fx.Supply(core.CreateAgentBundleParams(globalParams.ConfFilePath, false)),
+				fx.Supply(core.BundleParams{
+					ConfigParams: config.NewAgentParams(globalParams.ConfFilePath, false)}),
 				core.Bundle,
 			)
 		},

--- a/cmd/agent/subcommands/remoteconfig/command.go
+++ b/cmd/agent/subcommands/remoteconfig/command.go
@@ -45,7 +45,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 			return fxutil.OneShot(state,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewAgentParams(globalParams.ConfFilePath, false)}),
+					ConfigParams: config.NewAgentParamsWithoutSecrets(globalParams.ConfFilePath)}),
 				core.Bundle,
 			)
 		},

--- a/cmd/agent/subcommands/remoteconfig/command_test.go
+++ b/cmd/agent/subcommands/remoteconfig/command_test.go
@@ -21,6 +21,6 @@ func TestCommand(t *testing.T) {
 		[]string{"remote-config"},
 		state,
 		func(cliParams *cliParams, coreParams core.BundleParams) {
-			require.Equal(t, false, coreParams.ConfigLoadSecrets)
+			require.Equal(t, false, coreParams.ConfigLoadSecrets())
 		})
 }

--- a/cmd/agent/subcommands/run/command.go
+++ b/cmd/agent/subcommands/run/command.go
@@ -115,7 +115,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		return fxutil.OneShot(run,
 			fx.Supply(cliParams),
 			fx.Supply(core.BundleParams{
-				ConfigParams: config.NewAgentParams(globalParams.ConfFilePath, true),
+				ConfigParams: config.NewAgentParamsWithSecrets(globalParams.ConfFilePath),
 				LogParams:    log.LogForDaemon("CORE", "log_file", common.DefaultLogFile)}),
 			core.Bundle,
 		)
@@ -201,7 +201,7 @@ func StartAgentWithDefaults() error {
 	},
 		// no config file path specification in this situation
 		fx.Supply(core.BundleParams{
-			ConfigParams: config.NewAgentParams("", true),
+			ConfigParams: config.NewAgentParamsWithSecrets(""),
 			LogParams:    log.LogForDaemon("CORE", "log_file", common.DefaultLogFile)}),
 		core.Bundle,
 	)

--- a/cmd/agent/subcommands/run/command.go
+++ b/cmd/agent/subcommands/run/command.go
@@ -114,7 +114,9 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		// this will use `fxutil.Run` instead of `fxutil.OneShot`.
 		return fxutil.OneShot(run,
 			fx.Supply(cliParams),
-			fx.Supply(core.CreateAgentBundleParams(globalParams.ConfFilePath, true).LogForDaemon("CORE", "log_file", common.DefaultLogFile)),
+			fx.Supply(core.BundleParams{
+				ConfigParams: config.NewAgentParams(globalParams.ConfFilePath, true),
+				LogParams:    log.LogForDaemon("CORE", "log_file", common.DefaultLogFile)}),
 			core.Bundle,
 		)
 	}
@@ -198,7 +200,9 @@ func StartAgentWithDefaults() error {
 		return startAgent(&cliParams{GlobalParams: &command.GlobalParams{}})
 	},
 		// no config file path specification in this situation
-		fx.Supply(core.CreateAgentBundleParams("", true).LogForDaemon("CORE", "log_file", common.DefaultLogFile)),
+		fx.Supply(core.BundleParams{
+			ConfigParams: config.NewAgentParams("", true),
+			LogParams:    log.LogForDaemon("CORE", "log_file", common.DefaultLogFile)}),
 		core.Bundle,
 	)
 }

--- a/cmd/agent/subcommands/run/command_test.go
+++ b/cmd/agent/subcommands/run/command_test.go
@@ -21,7 +21,7 @@ func TestCommand(t *testing.T) {
 		[]string{"run"},
 		run,
 		func(cliParams *cliParams, coreParams core.BundleParams) {
-			require.Equal(t, true, coreParams.ConfigLoadSecrets)
+			require.Equal(t, true, coreParams.ConfigLoadSecrets())
 		})
 }
 
@@ -32,6 +32,6 @@ func TestCommandPidfile(t *testing.T) {
 		run,
 		func(cliParams *cliParams, coreParams core.BundleParams) {
 			require.Equal(t, "/pid/file", cliParams.pidfilePath)
-			require.Equal(t, true, coreParams.ConfigLoadSecrets)
+			require.Equal(t, true, coreParams.ConfigLoadSecrets())
 		})
 }

--- a/cmd/agent/subcommands/secret/command.go
+++ b/cmd/agent/subcommands/secret/command.go
@@ -41,7 +41,9 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(secret,
 				fx.Supply(cliParams),
-				fx.Supply(core.CreateAgentBundleParams(globalParams.ConfFilePath, false, core.WithLogForOneShot("CORE", "off", true))),
+				fx.Supply(core.BundleParams{
+					ConfigParams: config.NewAgentParams(globalParams.ConfFilePath, false),
+					LogParams:    log.LogForOneShot("CORE", "off", true)}),
 				core.Bundle,
 			)
 		},

--- a/cmd/agent/subcommands/secret/command.go
+++ b/cmd/agent/subcommands/secret/command.go
@@ -42,7 +42,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 			return fxutil.OneShot(secret,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewAgentParams(globalParams.ConfFilePath, false),
+					ConfigParams: config.NewAgentParamsWithoutSecrets(globalParams.ConfFilePath),
 					LogParams:    log.LogForOneShot("CORE", "off", true)}),
 				core.Bundle,
 			)

--- a/cmd/agent/subcommands/secret/command_test.go
+++ b/cmd/agent/subcommands/secret/command_test.go
@@ -21,6 +21,6 @@ func TestCommand(t *testing.T) {
 		[]string{"secret"},
 		secret,
 		func(cliParams *cliParams, coreParams core.BundleParams) {
-			require.Equal(t, false, coreParams.ConfigLoadSecrets)
+			require.Equal(t, false, coreParams.ConfigLoadSecrets())
 		})
 }

--- a/cmd/agent/subcommands/snmp/command.go
+++ b/cmd/agent/subcommands/snmp/command.go
@@ -94,7 +94,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 			return fxutil.OneShot(snmpwalk,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewAgentParams(globalParams.ConfFilePath, true),
+					ConfigParams: config.NewAgentParamsWithSecrets(globalParams.ConfFilePath),
 					LogParams:    log.LogForOneShot("CORE", "off", true)}),
 				core.Bundle,
 			)

--- a/cmd/agent/subcommands/snmp/command.go
+++ b/cmd/agent/subcommands/snmp/command.go
@@ -21,6 +21,7 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/agent/command"
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/log"
 	utilFunc "github.com/DataDog/datadog-agent/pkg/snmp/gosnmplib"
 	parse "github.com/DataDog/datadog-agent/pkg/snmp/snmpparse"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
@@ -92,7 +93,9 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 			cliParams.cmd = cmd
 			return fxutil.OneShot(snmpwalk,
 				fx.Supply(cliParams),
-				fx.Supply(core.CreateAgentBundleParams(globalParams.ConfFilePath, true, core.WithLogForOneShot("CORE", "off", true))),
+				fx.Supply(core.BundleParams{
+					ConfigParams: config.NewAgentParams(globalParams.ConfFilePath, true),
+					LogParams:    log.LogForOneShot("CORE", "off", true)}),
 				core.Bundle,
 			)
 		},

--- a/cmd/agent/subcommands/status/command.go
+++ b/cmd/agent/subcommands/status/command.go
@@ -63,7 +63,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 			return fxutil.OneShot(statusCmd,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewAgentParams(globalParams.ConfFilePath, false, config.WithConfigLoadSysProbe(true)),
+					ConfigParams: config.NewAgentParamsWithoutSecrets(globalParams.ConfFilePath, config.WithConfigLoadSysProbe(true)),
 					LogParams:    log.LogForOneShot("CORE", "off", true)}),
 				core.Bundle,
 			)
@@ -89,7 +89,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 			return fxutil.OneShot(componentStatusCmd,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewAgentParams(globalParams.ConfFilePath, false),
+					ConfigParams: config.NewAgentParamsWithoutSecrets(globalParams.ConfFilePath),
 					LogParams:    log.LogForOneShot("CORE", "off", true)}),
 				core.Bundle,
 			)

--- a/cmd/agent/subcommands/status/command.go
+++ b/cmd/agent/subcommands/status/command.go
@@ -62,7 +62,9 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 
 			return fxutil.OneShot(statusCmd,
 				fx.Supply(cliParams),
-				fx.Supply(core.CreateAgentBundleParams(globalParams.ConfFilePath, false, core.WithConfigLoadSysProbe(true), core.WithLogForOneShot("CORE", "off", true))),
+				fx.Supply(core.BundleParams{
+					ConfigParams: config.NewAgentParams(globalParams.ConfFilePath, false, config.WithConfigLoadSysProbe(true)),
+					LogParams:    log.LogForOneShot("CORE", "off", true)}),
 				core.Bundle,
 			)
 		},
@@ -86,7 +88,9 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 
 			return fxutil.OneShot(componentStatusCmd,
 				fx.Supply(cliParams),
-				fx.Supply(core.CreateAgentBundleParams(globalParams.ConfFilePath, false, core.WithLogForOneShot("CORE", "off", true))),
+				fx.Supply(core.BundleParams{
+					ConfigParams: config.NewAgentParams(globalParams.ConfFilePath, false),
+					LogParams:    log.LogForOneShot("CORE", "off", true)}),
 				core.Bundle,
 			)
 		},

--- a/cmd/agent/subcommands/status/command_test.go
+++ b/cmd/agent/subcommands/status/command_test.go
@@ -25,8 +25,8 @@ func TestStatusCommand(t *testing.T) {
 		func(cliParams *cliParams, coreParams core.BundleParams) {
 			require.Equal(t, []string{}, cliParams.args)
 			require.Equal(t, true, cliParams.jsonStatus)
-			require.Equal(t, false, coreParams.ConfigLoadSecrets)
-			require.Equal(t, true, coreParams.ConfigLoadSysProbe)
+			require.Equal(t, false, coreParams.ConfigLoadSecrets())
+			require.Equal(t, true, coreParams.ConfigLoadSysProbe())
 		})
 }
 
@@ -39,7 +39,7 @@ func TestComponentStatusCommand(t *testing.T) {
 		func(cliParams *cliParams, coreParams core.BundleParams) {
 			require.Equal(t, []string{"abc"}, cliParams.args)
 			require.Equal(t, false, cliParams.jsonStatus)
-			require.Equal(t, false, coreParams.ConfigLoadSecrets)
-			require.Equal(t, false, coreParams.ConfigLoadSysProbe)
+			require.Equal(t, false, coreParams.ConfigLoadSecrets())
+			require.Equal(t, false, coreParams.ConfigLoadSysProbe())
 		})
 }

--- a/cmd/agent/subcommands/stop/command.go
+++ b/cmd/agent/subcommands/stop/command.go
@@ -19,6 +19,7 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/agent/command"
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/log"
 	"github.com/DataDog/datadog-agent/pkg/api/util"
 	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
@@ -41,7 +42,9 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(stop,
 				fx.Supply(cliParams),
-				fx.Supply(core.CreateAgentBundleParams(globalParams.ConfFilePath, false, core.WithLogForOneShot("CORE", "off", true))),
+				fx.Supply(core.BundleParams{
+					ConfigParams: config.NewAgentParams(globalParams.ConfFilePath, false),
+					LogParams:    log.LogForOneShot("CORE", "off", true)}),
 				core.Bundle,
 			)
 		},

--- a/cmd/agent/subcommands/stop/command.go
+++ b/cmd/agent/subcommands/stop/command.go
@@ -43,7 +43,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 			return fxutil.OneShot(stop,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewAgentParams(globalParams.ConfFilePath, false),
+					ConfigParams: config.NewAgentParamsWithoutSecrets(globalParams.ConfFilePath),
 					LogParams:    log.LogForOneShot("CORE", "off", true)}),
 				core.Bundle,
 			)

--- a/cmd/agent/subcommands/stop/command_test.go
+++ b/cmd/agent/subcommands/stop/command_test.go
@@ -24,6 +24,6 @@ func TestCommand(t *testing.T) {
 		[]string{"stop"},
 		stop,
 		func(cliParams *cliParams, coreParams core.BundleParams) {
-			require.Equal(t, false, coreParams.ConfigLoadSecrets)
+			require.Equal(t, false, coreParams.ConfigLoadSecrets())
 		})
 }

--- a/cmd/agent/subcommands/streamlogs/command.go
+++ b/cmd/agent/subcommands/streamlogs/command.go
@@ -46,7 +46,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 			return fxutil.OneShot(streamLogs,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewAgentParams(globalParams.ConfFilePath, false),
+					ConfigParams: config.NewAgentParamsWithoutSecrets(globalParams.ConfFilePath),
 					LogParams:    log.LogForOneShot("CORE", "off", true)}),
 				core.Bundle,
 			)

--- a/cmd/agent/subcommands/streamlogs/command.go
+++ b/cmd/agent/subcommands/streamlogs/command.go
@@ -45,7 +45,9 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(streamLogs,
 				fx.Supply(cliParams),
-				fx.Supply(core.CreateAgentBundleParams(globalParams.ConfFilePath, false, core.WithLogForOneShot("CORE", "off", true))),
+				fx.Supply(core.BundleParams{
+					ConfigParams: config.NewAgentParams(globalParams.ConfFilePath, false),
+					LogParams:    log.LogForOneShot("CORE", "off", true)}),
 				core.Bundle,
 			)
 		},

--- a/cmd/agent/subcommands/streamlogs/command_test.go
+++ b/cmd/agent/subcommands/streamlogs/command_test.go
@@ -21,7 +21,7 @@ func TestCommand(t *testing.T) {
 		[]string{"stream-logs", "--type", "foo"},
 		streamLogs,
 		func(cliParams *cliParams, coreParams core.BundleParams) {
-			require.Equal(t, false, coreParams.ConfigLoadSecrets)
+			require.Equal(t, false, coreParams.ConfigLoadSecrets())
 			require.Equal(t, "foo", cliParams.filters.Type)
 		})
 }

--- a/cmd/agent/subcommands/taggerlist/command.go
+++ b/cmd/agent/subcommands/taggerlist/command.go
@@ -41,7 +41,9 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(taggerList,
 				fx.Supply(cliParams),
-				fx.Supply(core.CreateAgentBundleParams(globalParams.ConfFilePath, false, core.WithLogForOneShot("CORE", "off", true))),
+				fx.Supply(core.BundleParams{
+					ConfigParams: config.NewAgentParams(globalParams.ConfFilePath, false),
+					LogParams:    log.LogForOneShot("CORE", "off", true)}),
 				core.Bundle,
 			)
 		},

--- a/cmd/agent/subcommands/taggerlist/command.go
+++ b/cmd/agent/subcommands/taggerlist/command.go
@@ -42,7 +42,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 			return fxutil.OneShot(taggerList,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewAgentParams(globalParams.ConfFilePath, false),
+					ConfigParams: config.NewAgentParamsWithoutSecrets(globalParams.ConfFilePath),
 					LogParams:    log.LogForOneShot("CORE", "off", true)}),
 				core.Bundle,
 			)

--- a/cmd/agent/subcommands/taggerlist/command_test.go
+++ b/cmd/agent/subcommands/taggerlist/command_test.go
@@ -21,6 +21,6 @@ func TestCommand(t *testing.T) {
 		[]string{"tagger-list"},
 		taggerList,
 		func(cliParams *cliParams, coreParams core.BundleParams) {
-			require.Equal(t, false, coreParams.ConfigLoadSecrets)
+			require.Equal(t, false, coreParams.ConfigLoadSecrets())
 		})
 }

--- a/cmd/agent/subcommands/workloadlist/command.go
+++ b/cmd/agent/subcommands/workloadlist/command.go
@@ -45,7 +45,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 			return fxutil.OneShot(workloadList,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewAgentParams(globalParams.ConfFilePath, false),
+					ConfigParams: config.NewAgentParamsWithoutSecrets(globalParams.ConfFilePath),
 					LogParams:    log.LogForOneShot("CORE", "off", true)}),
 				core.Bundle,
 			)

--- a/cmd/agent/subcommands/workloadlist/command.go
+++ b/cmd/agent/subcommands/workloadlist/command.go
@@ -44,7 +44,9 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(workloadList,
 				fx.Supply(cliParams),
-				fx.Supply(core.CreateAgentBundleParams(globalParams.ConfFilePath, false, core.WithLogForOneShot("CORE", "off", true))),
+				fx.Supply(core.BundleParams{
+					ConfigParams: config.NewAgentParams(globalParams.ConfFilePath, false),
+					LogParams:    log.LogForOneShot("CORE", "off", true)}),
 				core.Bundle,
 			)
 		},

--- a/cmd/agent/subcommands/workloadlist/command_test.go
+++ b/cmd/agent/subcommands/workloadlist/command_test.go
@@ -22,6 +22,6 @@ func TestCommand(t *testing.T) {
 		workloadList,
 		func(cliParams *cliParams, coreParams core.BundleParams) {
 			require.Equal(t, true, cliParams.verboseList)
-			require.Equal(t, false, coreParams.ConfigLoadSecrets)
+			require.Equal(t, false, coreParams.ConfigLoadSecrets())
 		})
 }

--- a/cmd/cluster-agent/app/compliance_cmd.go
+++ b/cmd/cluster-agent/app/compliance_cmd.go
@@ -24,8 +24,10 @@ var (
 
 func init() {
 	bundleParams := core.BundleParams{
-		ConfFilePath: confPath,
-		ConfigName:   "datadog-cluster",
+		ConfigParams: core.ConfigParams{
+			ConfFilePath: confPath,
+			ConfigName:   "datadog-cluster",
+		},
 	}.LogForOneShot(string(loggerName), "off", true)
 
 	complianceCmd.AddCommand(check.Commands(bundleParams)...)

--- a/cmd/cluster-agent/app/compliance_cmd.go
+++ b/cmd/cluster-agent/app/compliance_cmd.go
@@ -26,10 +26,11 @@ var (
 
 func init() {
 	bundleParams := core.BundleParams{
-		ConfigParams: config.Params{
-			ConfFilePath: confPath,
-			ConfigName:   "datadog-cluster",
-		},
+		ConfigParams: config.NewParams(
+			"",
+			config.WithConfFilePath(confPath),
+			config.WithConfigName("datadog-cluster"),
+		),
 		LogParams: log.LogForOneShot(string(loggerName), "off", true),
 	}
 

--- a/cmd/cluster-agent/app/compliance_cmd.go
+++ b/cmd/cluster-agent/app/compliance_cmd.go
@@ -13,6 +13,8 @@ import (
 
 	"github.com/DataDog/datadog-agent/cmd/security-agent/app/subcommands/check"
 	"github.com/DataDog/datadog-agent/comp/core"
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/log"
 )
 
 var (
@@ -24,11 +26,12 @@ var (
 
 func init() {
 	bundleParams := core.BundleParams{
-		ConfigParams: core.ConfigParams{
+		ConfigParams: config.Params{
 			ConfFilePath: confPath,
 			ConfigName:   "datadog-cluster",
 		},
-	}.LogForOneShot(string(loggerName), "off", true)
+		LogParams: log.LogForOneShot(string(loggerName), "off", true),
+	}
 
 	complianceCmd.AddCommand(check.Commands(bundleParams)...)
 	ClusterAgentCmd.AddCommand(complianceCmd)

--- a/cmd/dogstatsd/command/command.go
+++ b/cmd/dogstatsd/command/command.go
@@ -8,55 +8,19 @@
 package command
 
 import (
-	"context"
 	_ "expvar"
 	"fmt"
-	"net/http"
 	_ "net/http/pprof"
-	"os"
-	"os/signal"
 	"runtime"
-	"syscall"
 
 	"github.com/spf13/cobra"
-	"go.uber.org/fx"
 
-	"github.com/DataDog/datadog-agent/comp/core"
-	"github.com/DataDog/datadog-agent/comp/core/config"
-	"github.com/DataDog/datadog-agent/pkg/aggregator"
-	"github.com/DataDog/datadog-agent/pkg/api/healthprobe"
-	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
-	"github.com/DataDog/datadog-agent/pkg/dogstatsd"
-	"github.com/DataDog/datadog-agent/pkg/forwarder"
-	"github.com/DataDog/datadog-agent/pkg/metadata"
+	"github.com/DataDog/datadog-agent/cmd/dogstatsd/subcommands/start"
 	"github.com/DataDog/datadog-agent/pkg/serializer"
-	"github.com/DataDog/datadog-agent/pkg/status/health"
-	"github.com/DataDog/datadog-agent/pkg/tagger"
-	"github.com/DataDog/datadog-agent/pkg/tagger/local"
-	"github.com/DataDog/datadog-agent/pkg/util"
-	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
-	"github.com/DataDog/datadog-agent/pkg/util/hostname"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/version"
-	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 
 	// register all workloadmeta collectors
 	_ "github.com/DataDog/datadog-agent/pkg/workloadmeta/collectors"
-)
-
-var (
-	metaScheduler  *metadata.Scheduler
-	statsd         *dogstatsd.Server
-	dogstatsdStats *http.Server
-)
-
-type cliParams struct {
-	confPath string
-}
-
-const (
-	// loggerName is the name of the dogstatsd logger
-	loggerName pkgconfig.LoggerName = "DSD"
 )
 
 func MakeRootCommand(defaultLogFile string) *cobra.Command {
@@ -79,16 +43,6 @@ extensions for special Datadog features.`,
 }
 
 func makeCommands(defaultLogFile string) []*cobra.Command {
-	cliParams := &cliParams{}
-	startCmd := &cobra.Command{
-		Use:   "start",
-		Short: "Start DogStatsD",
-		Long:  `Runs DogStatsD in the foreground`,
-		RunE: func(*cobra.Command, []string) error {
-			return runDogstatsdFct(cliParams, "", defaultLogFile, start)
-		},
-	}
-
 	versionCmd := &cobra.Command{
 		Use:   "version",
 		Short: "Print the version number",
@@ -100,222 +54,5 @@ func makeCommands(defaultLogFile string) []*cobra.Command {
 		},
 	}
 
-	// local flags
-	startCmd.Flags().StringVarP(&cliParams.confPath, "cfgpath", "c", "", "path to folder containing dogstatsd.yaml")
-	pkgconfig.Datadog.BindPFlag("conf_path", startCmd.Flags().Lookup("cfgpath")) //nolint:errcheck
-	var socketPath string
-	startCmd.Flags().StringVarP(&socketPath, "socket", "s", "", "listen to this socket instead of UDP")
-	pkgconfig.Datadog.BindPFlag("dogstatsd_socket", startCmd.Flags().Lookup("socket")) //nolint:errcheck
-
-	return []*cobra.Command{startCmd, versionCmd}
-}
-
-func runDogstatsdFct(cliParams *cliParams, defaultConfPath string, defaultLogFile string, fct interface{}) error {
-	params := &Params{
-		defaultLogFile: defaultLogFile,
-	}
-	return fxutil.OneShot(fct,
-		fx.Supply(cliParams),
-		fx.Supply(params),
-		fx.Supply(core.BundleParams{
-			ConfigParams: config.NewParams(
-				defaultConfPath,
-				config.WithConfFilePath(cliParams.confPath),
-				config.WithConfigLoadSecrets(true),
-				config.WithConfigMissingOK(true),
-				config.WithConfigName("dogstatsd")),
-		}),
-		core.Bundle,
-	)
-}
-
-type Params struct {
-	defaultLogFile string
-}
-
-func start(cliParams *cliParams, config config.Component, params *Params) error {
-	// Main context passed to components
-	ctx, cancel := context.WithCancel(context.Background())
-	defer stopAgent(cancel)
-
-	stopCh := make(chan struct{})
-	go handleSignals(stopCh)
-
-	err := runAgent(ctx, cliParams, config, params)
-	if err != nil {
-		return err
-	}
-
-	// Block here until we receive a stop signal
-	<-stopCh
-
-	return nil
-}
-
-func runAgent(ctx context.Context, cliParams *cliParams, config config.Component, params *Params) (err error) {
-	if len(cliParams.confPath) == 0 {
-		log.Infof("Config will be read from env variables")
-	}
-
-	// go_expvar server
-	port := config.GetInt("dogstatsd_stats_port")
-	dogstatsdStats = &http.Server{
-		Addr:    fmt.Sprintf("127.0.0.1:%d", port),
-		Handler: http.DefaultServeMux,
-	}
-	go func() {
-		if err := dogstatsdStats.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			log.Errorf("Error creating dogstatsd stats server on port %d: %s", port, err)
-		}
-	}()
-
-	// Setup logger
-	syslogURI := pkgconfig.GetSyslogURI()
-	logFile := config.GetString("log_file")
-	if logFile == "" {
-		logFile = params.defaultLogFile
-	}
-
-	if config.GetBool("disable_file_logging") {
-		// this will prevent any logging on file
-		logFile = ""
-	}
-
-	err = pkgconfig.SetupLogger(
-		loggerName,
-		config.GetString("log_level"),
-		logFile,
-		syslogURI,
-		config.GetBool("syslog_rfc"),
-		config.GetBool("log_to_console"),
-		config.GetBool("log_format_json"),
-	)
-	if err != nil {
-		log.Criticalf("Unable to setup logger: %s", err)
-		return
-	}
-
-	if err := util.SetupCoreDump(); err != nil {
-		log.Warnf("Can't setup core dumps: %v, core dumps might not be available after a crash", err)
-	}
-
-	if !config.IsSet("api_key") {
-		err = log.Critical("no API key configured, exiting")
-		return
-	}
-
-	// Setup healthcheck port
-	var healthPort = config.GetInt("health_port")
-	if healthPort > 0 {
-		err = healthprobe.Serve(ctx, healthPort)
-		if err != nil {
-			err = log.Errorf("Error starting health port, exiting: %v", err)
-			return
-		}
-		log.Debugf("Health check listening on port %d", healthPort)
-	}
-
-	// setup the demultiplexer
-	keysPerDomain, err := pkgconfig.GetMultipleEndpoints()
-	if err != nil {
-		log.Error("Misconfiguration of agent endpoints: ", err)
-	}
-
-	forwarderOpts := forwarder.NewOptions(keysPerDomain)
-	opts := aggregator.DefaultAgentDemultiplexerOptions(forwarderOpts)
-	opts.UseOrchestratorForwarder = false
-	opts.UseEventPlatformForwarder = false
-	opts.UseContainerLifecycleForwarder = false
-	opts.EnableNoAggregationPipeline = config.GetBool("dogstatsd_no_aggregation_pipeline")
-	hname, err := hostname.Get(context.TODO())
-	if err != nil {
-		log.Warnf("Error getting hostname: %s", err)
-		hname = ""
-	}
-	log.Debugf("Using hostname: %s", hname)
-	demux := aggregator.InitAndStartAgentDemultiplexer(opts, hname)
-	demux.AddAgentStartupTelemetry(version.AgentVersion)
-
-	// setup the metadata collector
-	metaScheduler = metadata.NewScheduler(demux)
-	if err = metadata.SetupMetadataCollection(metaScheduler, []string{"host"}); err != nil {
-		metaScheduler.Stop()
-		return
-	}
-
-	if err = metadata.SetupInventories(metaScheduler, nil); err != nil {
-		return
-	}
-
-	// container tagging initialisation if origin detection is on
-	if config.GetBool("dogstatsd_origin_detection") {
-		store := workloadmeta.CreateGlobalStore(workloadmeta.NodeAgentCatalog)
-		store.Start(ctx)
-
-		tagger.SetDefaultTagger(local.NewTagger(store))
-		if err := tagger.Init(ctx); err != nil {
-			log.Errorf("failed to start the tagger: %s", err)
-		}
-	}
-
-	statsd, err = dogstatsd.NewServer(demux, false)
-	if err != nil {
-		log.Criticalf("Unable to start dogstatsd: %s", err)
-		return
-	}
-	return
-}
-
-// handleSignals handles OS signals, and sends a message on stopCh when an interrupt
-// signal is received.
-func handleSignals(stopCh chan struct{}) {
-	// Setup a channel to catch OS signals
-	signalCh := make(chan os.Signal, 1)
-	signal.Notify(signalCh, os.Interrupt, syscall.SIGTERM, syscall.SIGPIPE)
-
-	// Block here until we receive the interrupt signal
-	for signo := range signalCh {
-		switch signo {
-		case syscall.SIGPIPE:
-			// By default systemd redirects the stdout to journald. When journald is stopped or crashes we receive a SIGPIPE signal.
-			// Go ignores SIGPIPE signals unless it is when stdout or stdout is closed, in this case the agent is stopped.
-			// We never want dogstatsd to stop upon receiving SIGPIPE, so we intercept the SIGPIPE signals and just discard them.
-		default:
-			log.Infof("Received signal '%s', shutting down...", signo)
-			stopCh <- struct{}{}
-			return
-		}
-	}
-}
-
-func stopAgent(cancel context.CancelFunc) {
-	// retrieve the agent health before stopping the components
-	// GetReadyNonBlocking has a 100ms timeout to avoid blocking
-	health, err := health.GetReadyNonBlocking()
-	if err != nil {
-		log.Warnf("Dogstatsd health unknown: %s", err)
-	} else if len(health.Unhealthy) > 0 {
-		log.Warnf("Some components were unhealthy: %v", health.Unhealthy)
-	}
-
-	// gracefully shut down any component
-	cancel()
-
-	// stop metaScheduler and statsd if they are instantiated
-	if metaScheduler != nil {
-		metaScheduler.Stop()
-	}
-
-	if dogstatsdStats != nil {
-		if err := dogstatsdStats.Shutdown(context.Background()); err != nil {
-			log.Errorf("Error shutting down dogstatsd stats server: %s", err)
-		}
-	}
-
-	if statsd != nil {
-		statsd.Stop()
-	}
-
-	log.Info("See ya!")
-	log.Flush()
+	return []*cobra.Command{start.Command(defaultLogFile), versionCmd}
 }

--- a/cmd/dogstatsd/command/command.go
+++ b/cmd/dogstatsd/command/command.go
@@ -9,15 +9,12 @@ package command
 
 import (
 	_ "expvar"
-	"fmt"
 	_ "net/http/pprof"
-	"runtime"
 
 	"github.com/spf13/cobra"
 
 	"github.com/DataDog/datadog-agent/cmd/dogstatsd/subcommands/start"
-	"github.com/DataDog/datadog-agent/pkg/serializer"
-	"github.com/DataDog/datadog-agent/pkg/version"
+	"github.com/DataDog/datadog-agent/pkg/cli/subcommands/version"
 
 	// register all workloadmeta collectors
 	_ "github.com/DataDog/datadog-agent/pkg/workloadmeta/collectors"
@@ -43,16 +40,5 @@ extensions for special Datadog features.`,
 }
 
 func makeCommands(defaultLogFile string) []*cobra.Command {
-	versionCmd := &cobra.Command{
-		Use:   "version",
-		Short: "Print the version number",
-		Long:  ``,
-		Run: func(cmd *cobra.Command, args []string) {
-			av, _ := version.Agent()
-			fmt.Println(fmt.Sprintf("DogStatsD from Agent %s - Codename: %s - Commit: %s - Serialization version: %s - Go version: %s",
-				av.GetNumber(), av.Meta, av.Commit, serializer.AgentPayloadVersion, runtime.Version()))
-		},
-	}
-
-	return []*cobra.Command{start.Command(defaultLogFile), versionCmd}
+	return []*cobra.Command{start.Command(defaultLogFile), version.MakeCommand("DogStatsD")}
 }

--- a/cmd/dogstatsd/command/command.go
+++ b/cmd/dogstatsd/command/command.go
@@ -5,7 +5,7 @@
 
 //go:generate go run ../../pkg/config/render_config.go dogstatsd ../../pkg/config/config_template.yaml ./dist/dogstatsd.yaml
 
-package main
+package command
 
 import (
 	"context"

--- a/cmd/dogstatsd/command/command_test.go
+++ b/cmd/dogstatsd/command/command_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-package main
+package command
 
 import (
 	"testing"

--- a/cmd/dogstatsd/main.go
+++ b/cmd/dogstatsd/main.go
@@ -113,13 +113,14 @@ func makeCommands() []*cobra.Command {
 func runDogstatsdFct(cliParams *cliParams, defaultConfPath string, fct interface{}) error {
 	return fxutil.OneShot(fct,
 		fx.Supply(cliParams),
-		fx.Supply(core.CreateBundleParams(
-			defaultConfPath,
-			core.WithConfFilePath(cliParams.confPath),
-			core.WithConfigLoadSecrets(true),
-			core.WithConfigMissingOK(true),
-			core.WithConfigName("dogstatsd"),
-		)),
+		fx.Supply(core.BundleParams{
+			ConfigParams: config.NewParams(
+				defaultConfPath,
+				config.WithConfFilePath(cliParams.confPath),
+				config.WithConfigLoadSecrets(true),
+				config.WithConfigMissingOK(true),
+				config.WithConfigName("dogstatsd")),
+		}),
 		core.Bundle,
 	)
 }

--- a/cmd/dogstatsd/main_nix.go
+++ b/cmd/dogstatsd/main_nix.go
@@ -21,7 +21,7 @@ const defaultLogFile = "/var/log/datadog/dogstatsd.log"
 func main() {
 	flavor.SetFlavor(flavor.Dogstatsd)
 
-	if err := MakeRootCommand().Execute(); err != nil {
+	if err := MakeRootCommand(defaultLogFile).Execute(); err != nil {
 		log.Error(err)
 		os.Exit(-1)
 	}

--- a/cmd/dogstatsd/main_nix.go
+++ b/cmd/dogstatsd/main_nix.go
@@ -12,6 +12,7 @@ import (
 	_ "net/http/pprof"
 	"os"
 
+	"github.com/DataDog/datadog-agent/cmd/dogstatsd/command"
 	"github.com/DataDog/datadog-agent/pkg/util/flavor"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -21,7 +22,7 @@ const defaultLogFile = "/var/log/datadog/dogstatsd.log"
 func main() {
 	flavor.SetFlavor(flavor.Dogstatsd)
 
-	if err := MakeRootCommand(defaultLogFile).Execute(); err != nil {
+	if err := command.MakeRootCommand(defaultLogFile).Execute(); err != nil {
 		log.Error(err)
 		os.Exit(-1)
 	}

--- a/cmd/dogstatsd/main_test.go
+++ b/cmd/dogstatsd/main_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestStartCommand(t *testing.T) {
 	fxutil.TestOneShotSubcommand(t,
-		makeCommands(),
+		makeCommands("defaultLogFile"),
 		[]string{"start", "--cfgpath", "PATH"},
 		start,
 		func(cliParams *cliParams, coreParams core.BundleParams) {

--- a/cmd/dogstatsd/main_windows.go
+++ b/cmd/dogstatsd/main_windows.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/DataDog/datadog-agent/cmd/dogstatsd/command"
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/flavor"
@@ -62,7 +63,7 @@ func main() {
 	}
 	defer log.Flush()
 
-	if err = MakeRootCommand(defaultLogFile).Execute(); err != nil {
+	if err = command.MakeRootCommand(defaultLogFile).Execute(); err != nil {
 		log.Error(err)
 		os.Exit(-1)
 	}

--- a/cmd/dogstatsd/main_windows.go
+++ b/cmd/dogstatsd/main_windows.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/cmd/dogstatsd/command"
+	"github.com/DataDog/datadog-agent/cmd/dogstatsd/subcommands/start"
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/flavor"
@@ -80,7 +81,7 @@ func (m *myservice) Execute(args []string, r <-chan svc.ChangeRequest, changes c
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cliParams := &cliParams{}
-	err := runDogstatsdFct(
+	err := start.RunDogstatsdFct(
 		cliParams,
 		DefaultConfPath,
 		func(config config.Component) error { return runAgent(ctx, cliParams, config) })

--- a/cmd/dogstatsd/main_windows.go
+++ b/cmd/dogstatsd/main_windows.go
@@ -62,7 +62,7 @@ func main() {
 	}
 	defer log.Flush()
 
-	if err = MakeRootCommand().Execute(); err != nil {
+	if err = MakeRootCommand(defaultLogFile).Execute(); err != nil {
 		log.Error(err)
 		os.Exit(-1)
 	}

--- a/cmd/dogstatsd/subcommands/start/command.go
+++ b/cmd/dogstatsd/subcommands/start/command.go
@@ -1,0 +1,282 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package start
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/DataDog/datadog-agent/comp/core"
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/pkg/aggregator"
+	"github.com/DataDog/datadog-agent/pkg/api/healthprobe"
+	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/dogstatsd"
+	"github.com/DataDog/datadog-agent/pkg/forwarder"
+	"github.com/DataDog/datadog-agent/pkg/metadata"
+	"github.com/DataDog/datadog-agent/pkg/status/health"
+	"github.com/DataDog/datadog-agent/pkg/tagger"
+	"github.com/DataDog/datadog-agent/pkg/tagger/local"
+	"github.com/DataDog/datadog-agent/pkg/util"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+	"github.com/DataDog/datadog-agent/pkg/util/hostname"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/version"
+	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
+	"github.com/spf13/cobra"
+	"go.uber.org/fx"
+)
+
+var (
+	metaScheduler  *metadata.Scheduler
+	statsd         *dogstatsd.Server
+	dogstatsdStats *http.Server
+)
+
+type cliParams struct {
+	confPath string
+}
+
+const (
+	// loggerName is the name of the dogstatsd logger
+	loggerName pkgconfig.LoggerName = "DSD"
+)
+
+// Command returns the start subcommand for the 'dogstatsd' command.
+func Command(defaultLogFile string) *cobra.Command {
+	cliParams := &cliParams{}
+	startCmd := &cobra.Command{
+		Use:   "start",
+		Short: "Start DogStatsD",
+		Long:  `Runs DogStatsD in the foreground`,
+		RunE: func(*cobra.Command, []string) error {
+			return RunDogstatsdFct(cliParams, "", defaultLogFile, start)
+		},
+	}
+
+	// local flags
+	startCmd.Flags().StringVarP(&cliParams.confPath, "cfgpath", "c", "", "path to folder containing dogstatsd.yaml")
+	pkgconfig.Datadog.BindPFlag("conf_path", startCmd.Flags().Lookup("cfgpath")) //nolint:errcheck
+	var socketPath string
+	startCmd.Flags().StringVarP(&socketPath, "socket", "s", "", "listen to this socket instead of UDP")
+	pkgconfig.Datadog.BindPFlag("dogstatsd_socket", startCmd.Flags().Lookup("socket")) //nolint:errcheck
+
+	return startCmd
+}
+
+type Params struct {
+	defaultLogFile string
+}
+
+func RunDogstatsdFct(cliParams *cliParams, defaultConfPath string, defaultLogFile string, fct interface{}) error {
+	params := &Params{
+		defaultLogFile: defaultLogFile,
+	}
+	return fxutil.OneShot(fct,
+		fx.Supply(cliParams),
+		fx.Supply(params),
+		fx.Supply(core.BundleParams{
+			ConfigParams: config.NewParams(
+				defaultConfPath,
+				config.WithConfFilePath(cliParams.confPath),
+				config.WithConfigLoadSecrets(true),
+				config.WithConfigMissingOK(true),
+				config.WithConfigName("dogstatsd")),
+		}),
+		core.Bundle,
+	)
+}
+
+func start(cliParams *cliParams, config config.Component, params *Params) error {
+	// Main context passed to components
+	ctx, cancel := context.WithCancel(context.Background())
+	defer stopAgent(cancel)
+
+	stopCh := make(chan struct{})
+	go handleSignals(stopCh)
+
+	err := runAgent(ctx, cliParams, config, params)
+	if err != nil {
+		return err
+	}
+
+	// Block here until we receive a stop signal
+	<-stopCh
+
+	return nil
+}
+
+func runAgent(ctx context.Context, cliParams *cliParams, config config.Component, params *Params) (err error) {
+	if len(cliParams.confPath) == 0 {
+		log.Infof("Config will be read from env variables")
+	}
+
+	// go_expvar server
+	port := config.GetInt("dogstatsd_stats_port")
+	dogstatsdStats = &http.Server{
+		Addr:    fmt.Sprintf("127.0.0.1:%d", port),
+		Handler: http.DefaultServeMux,
+	}
+	go func() {
+		if err := dogstatsdStats.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Errorf("Error creating dogstatsd stats server on port %d: %s", port, err)
+		}
+	}()
+
+	// Setup logger
+	syslogURI := pkgconfig.GetSyslogURI()
+	logFile := config.GetString("log_file")
+	if logFile == "" {
+		logFile = params.defaultLogFile
+	}
+
+	if config.GetBool("disable_file_logging") {
+		// this will prevent any logging on file
+		logFile = ""
+	}
+
+	err = pkgconfig.SetupLogger(
+		loggerName,
+		config.GetString("log_level"),
+		logFile,
+		syslogURI,
+		config.GetBool("syslog_rfc"),
+		config.GetBool("log_to_console"),
+		config.GetBool("log_format_json"),
+	)
+	if err != nil {
+		log.Criticalf("Unable to setup logger: %s", err)
+		return
+	}
+
+	if err := util.SetupCoreDump(); err != nil {
+		log.Warnf("Can't setup core dumps: %v, core dumps might not be available after a crash", err)
+	}
+
+	if !config.IsSet("api_key") {
+		err = log.Critical("no API key configured, exiting")
+		return
+	}
+
+	// Setup healthcheck port
+	var healthPort = config.GetInt("health_port")
+	if healthPort > 0 {
+		err = healthprobe.Serve(ctx, healthPort)
+		if err != nil {
+			err = log.Errorf("Error starting health port, exiting: %v", err)
+			return
+		}
+		log.Debugf("Health check listening on port %d", healthPort)
+	}
+
+	// setup the demultiplexer
+	keysPerDomain, err := pkgconfig.GetMultipleEndpoints()
+	if err != nil {
+		log.Error("Misconfiguration of agent endpoints: ", err)
+	}
+
+	forwarderOpts := forwarder.NewOptions(keysPerDomain)
+	opts := aggregator.DefaultAgentDemultiplexerOptions(forwarderOpts)
+	opts.UseOrchestratorForwarder = false
+	opts.UseEventPlatformForwarder = false
+	opts.UseContainerLifecycleForwarder = false
+	opts.EnableNoAggregationPipeline = config.GetBool("dogstatsd_no_aggregation_pipeline")
+	hname, err := hostname.Get(context.TODO())
+	if err != nil {
+		log.Warnf("Error getting hostname: %s", err)
+		hname = ""
+	}
+	log.Debugf("Using hostname: %s", hname)
+	demux := aggregator.InitAndStartAgentDemultiplexer(opts, hname)
+	demux.AddAgentStartupTelemetry(version.AgentVersion)
+
+	// setup the metadata collector
+	metaScheduler = metadata.NewScheduler(demux)
+	if err = metadata.SetupMetadataCollection(metaScheduler, []string{"host"}); err != nil {
+		metaScheduler.Stop()
+		return
+	}
+
+	if err = metadata.SetupInventories(metaScheduler, nil); err != nil {
+		return
+	}
+
+	// container tagging initialisation if origin detection is on
+	if config.GetBool("dogstatsd_origin_detection") {
+		store := workloadmeta.CreateGlobalStore(workloadmeta.NodeAgentCatalog)
+		store.Start(ctx)
+
+		tagger.SetDefaultTagger(local.NewTagger(store))
+		if err := tagger.Init(ctx); err != nil {
+			log.Errorf("failed to start the tagger: %s", err)
+		}
+	}
+
+	statsd, err = dogstatsd.NewServer(demux, false)
+	if err != nil {
+		log.Criticalf("Unable to start dogstatsd: %s", err)
+		return
+	}
+	return
+}
+
+// handleSignals handles OS signals, and sends a message on stopCh when an interrupt
+// signal is received.
+func handleSignals(stopCh chan struct{}) {
+	// Setup a channel to catch OS signals
+	signalCh := make(chan os.Signal, 1)
+	signal.Notify(signalCh, os.Interrupt, syscall.SIGTERM, syscall.SIGPIPE)
+
+	// Block here until we receive the interrupt signal
+	for signo := range signalCh {
+		switch signo {
+		case syscall.SIGPIPE:
+			// By default systemd redirects the stdout to journald. When journald is stopped or crashes we receive a SIGPIPE signal.
+			// Go ignores SIGPIPE signals unless it is when stdout or stdout is closed, in this case the agent is stopped.
+			// We never want dogstatsd to stop upon receiving SIGPIPE, so we intercept the SIGPIPE signals and just discard them.
+		default:
+			log.Infof("Received signal '%s', shutting down...", signo)
+			stopCh <- struct{}{}
+			return
+		}
+	}
+}
+
+func stopAgent(cancel context.CancelFunc) {
+	// retrieve the agent health before stopping the components
+	// GetReadyNonBlocking has a 100ms timeout to avoid blocking
+	health, err := health.GetReadyNonBlocking()
+	if err != nil {
+		log.Warnf("Dogstatsd health unknown: %s", err)
+	} else if len(health.Unhealthy) > 0 {
+		log.Warnf("Some components were unhealthy: %v", health.Unhealthy)
+	}
+
+	// gracefully shut down any component
+	cancel()
+
+	// stop metaScheduler and statsd if they are instantiated
+	if metaScheduler != nil {
+		metaScheduler.Stop()
+	}
+
+	if dogstatsdStats != nil {
+		if err := dogstatsdStats.Shutdown(context.Background()); err != nil {
+			log.Errorf("Error shutting down dogstatsd stats server: %s", err)
+		}
+	}
+
+	if statsd != nil {
+		statsd.Stop()
+	}
+
+	log.Info("See ya!")
+	log.Flush()
+}

--- a/cmd/dogstatsd/subcommands/start/command.go
+++ b/cmd/dogstatsd/subcommands/start/command.go
@@ -62,8 +62,8 @@ func Command(defaultLogFile string) *cobra.Command {
 	}
 
 	// local flags
-	startCmd.Flags().StringVarP(&cliParams.confPath, "cfgpath", "c", "", "path to folder containing dogstatsd.yaml")
-	pkgconfig.Datadog.BindPFlag("conf_path", startCmd.Flags().Lookup("cfgpath")) //nolint:errcheck
+	startCmd.PersistentFlags().StringVarP(&cliParams.confPath, "cfgpath", "c", "", "path to directory containing datadog.yaml")
+
 	var socketPath string
 	startCmd.Flags().StringVarP(&socketPath, "socket", "s", "", "listen to this socket instead of UDP")
 	pkgconfig.Datadog.BindPFlag("dogstatsd_socket", startCmd.Flags().Lookup("socket")) //nolint:errcheck

--- a/cmd/dogstatsd/subcommands/start/command_test.go
+++ b/cmd/dogstatsd/subcommands/start/command_test.go
@@ -3,19 +3,20 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-package command
+package start
 
 import (
 	"testing"
 
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 )
 
 func TestStartCommand(t *testing.T) {
 	fxutil.TestOneShotSubcommand(t,
-		makeCommands("defaultLogFile"),
+		[]*cobra.Command{Command("defaultLogFile")},
 		[]string{"start", "--cfgpath", "PATH"},
 		start,
 		func(cliParams *cliParams, coreParams core.BundleParams) {

--- a/cmd/process-agent/subcommands/workloadlist/command.go
+++ b/cmd/process-agent/subcommands/workloadlist/command.go
@@ -41,7 +41,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 			return fxutil.OneShot(workloadList,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewAgentParams(globalParams.ConfFilePath, false),
+					ConfigParams: config.NewAgentParamsWithoutSecrets(globalParams.ConfFilePath),
 					LogParams:    log.LogForOneShot("PROCESS", "off", true)}),
 				core.Bundle,
 			)

--- a/cmd/process-agent/subcommands/workloadlist/command.go
+++ b/cmd/process-agent/subcommands/workloadlist/command.go
@@ -40,7 +40,9 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(workloadList,
 				fx.Supply(cliParams),
-				fx.Supply(core.CreateAgentBundleParams(globalParams.ConfFilePath, false).LogForOneShot("PROCESS", "off", true)),
+				fx.Supply(core.BundleParams{
+					ConfigParams: config.NewAgentParams(globalParams.ConfFilePath, false),
+					LogParams:    log.LogForOneShot("PROCESS", "off", true)}),
 				core.Bundle,
 			)
 		},

--- a/cmd/security-agent/app/subcommands/check/command.go
+++ b/cmd/security-agent/app/subcommands/check/command.go
@@ -46,12 +46,8 @@ type checkCliParams struct {
 
 func SecAgentCommands(globalParams *common.GlobalParams) []*cobra.Command {
 	bp := core.BundleParams{
-		ConfigParams: core.ConfigParams{
-			SecurityAgentConfigFilePaths: globalParams.ConfPathArray,
-			ConfigLoadSecurityAgent:      true,
-		},
-	}.LogForOneShot(common.LoggerName, "info", true)
-
+		ConfigParams: core.ConfigParams{SecurityAgentConfigFilePaths: globalParams.ConfPathArray, ConfigLoadSecurityAgent: true},
+		LogParams:    log.LogForOneShot(common.LoggerName, "info", true)}
 	return Commands(bp)
 }
 

--- a/cmd/security-agent/app/subcommands/check/command.go
+++ b/cmd/security-agent/app/subcommands/check/command.go
@@ -46,7 +46,7 @@ type checkCliParams struct {
 
 func SecAgentCommands(globalParams *common.GlobalParams) []*cobra.Command {
 	bp := core.BundleParams{
-		ConfigParams: config.NewSecurityAgentParams(globalParams.ConfPathArray, true),
+		ConfigParams: config.NewSecurityAgentParams(globalParams.ConfPathArray),
 		LogParams:    log.LogForOneShot(common.LoggerName, "info", true)}
 	return Commands(bp)
 }

--- a/cmd/security-agent/app/subcommands/check/command.go
+++ b/cmd/security-agent/app/subcommands/check/command.go
@@ -46,7 +46,7 @@ type checkCliParams struct {
 
 func SecAgentCommands(globalParams *common.GlobalParams) []*cobra.Command {
 	bp := core.BundleParams{
-		ConfigParams: core.ConfigParams{SecurityAgentConfigFilePaths: globalParams.ConfPathArray, ConfigLoadSecurityAgent: true},
+		ConfigParams: config.NewSecurityAgentParams(globalParams.ConfPathArray, true),
 		LogParams:    log.LogForOneShot(common.LoggerName, "info", true)}
 	return Commands(bp)
 }

--- a/cmd/security-agent/app/subcommands/check/command.go
+++ b/cmd/security-agent/app/subcommands/check/command.go
@@ -45,11 +45,12 @@ type checkCliParams struct {
 }
 
 func SecAgentCommands(globalParams *common.GlobalParams) []*cobra.Command {
-	bp := core.CreateBundleParams(
-		"",
-		core.WithSecurityAgentConfigFilePaths(globalParams.ConfPathArray),
-		core.WithConfigLoadSecurityAgent(true),
-	).LogForOneShot(common.LoggerName, "info", true)
+	bp := core.BundleParams{
+		ConfigParams: core.ConfigParams{
+			SecurityAgentConfigFilePaths: globalParams.ConfPathArray,
+			ConfigLoadSecurityAgent:      true,
+		},
+	}.LogForOneShot(common.LoggerName, "info", true)
 
 	return Commands(bp)
 }

--- a/cmd/security-agent/app/subcommands/compliance/command.go
+++ b/cmd/security-agent/app/subcommands/compliance/command.go
@@ -16,6 +16,7 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/security-agent/app/subcommands/check"
 	"github.com/DataDog/datadog-agent/comp/core"
 	compconfig "github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/log"
 	complog "github.com/DataDog/datadog-agent/comp/core/log"
 	"github.com/DataDog/datadog-agent/pkg/compliance/event"
 	coreconfig "github.com/DataDog/datadog-agent/pkg/config"
@@ -56,11 +57,8 @@ func complianceEventCommand(globalParams *common.GlobalParams) *cobra.Command {
 			return fxutil.OneShot(eventRun,
 				fx.Supply(eventArgs),
 				fx.Supply(core.BundleParams{
-					ConfigParams: core.ConfigParams{
-						SecurityAgentConfigFilePaths: globalParams.ConfPathArray,
-						ConfigLoadSecurityAgent:      true,
-					},
-				}.LogForOneShot(common.LoggerName, "info", true)),
+					ConfigParams: core.ConfigParams{SecurityAgentConfigFilePaths: globalParams.ConfPathArray, ConfigLoadSecurityAgent: true},
+					LogParams:    log.LogForOneShot(common.LoggerName, "info", true)}),
 				core.Bundle,
 			)
 		},

--- a/cmd/security-agent/app/subcommands/compliance/command.go
+++ b/cmd/security-agent/app/subcommands/compliance/command.go
@@ -58,7 +58,7 @@ func complianceEventCommand(globalParams *common.GlobalParams) *cobra.Command {
 			return fxutil.OneShot(eventRun,
 				fx.Supply(eventArgs),
 				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewSecurityAgentParams(globalParams.ConfPathArray, true),
+					ConfigParams: config.NewSecurityAgentParams(globalParams.ConfPathArray),
 					LogParams:    log.LogForOneShot(common.LoggerName, "info", true)}),
 				core.Bundle,
 			)

--- a/cmd/security-agent/app/subcommands/compliance/command.go
+++ b/cmd/security-agent/app/subcommands/compliance/command.go
@@ -55,11 +55,12 @@ func complianceEventCommand(globalParams *common.GlobalParams) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(eventRun,
 				fx.Supply(eventArgs),
-				fx.Supply(core.CreateBundleParams(
-					"",
-					core.WithSecurityAgentConfigFilePaths(globalParams.ConfPathArray),
-					core.WithConfigLoadSecurityAgent(true),
-				).LogForOneShot(common.LoggerName, "info", true)),
+				fx.Supply(core.BundleParams{
+					ConfigParams: core.ConfigParams{
+						SecurityAgentConfigFilePaths: globalParams.ConfPathArray,
+						ConfigLoadSecurityAgent:      true,
+					},
+				}.LogForOneShot(common.LoggerName, "info", true)),
 				core.Bundle,
 			)
 		},

--- a/cmd/security-agent/app/subcommands/compliance/command.go
+++ b/cmd/security-agent/app/subcommands/compliance/command.go
@@ -15,6 +15,7 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/security-agent/app/common"
 	"github.com/DataDog/datadog-agent/cmd/security-agent/app/subcommands/check"
 	"github.com/DataDog/datadog-agent/comp/core"
+	"github.com/DataDog/datadog-agent/comp/core/config"
 	compconfig "github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/log"
 	complog "github.com/DataDog/datadog-agent/comp/core/log"
@@ -57,7 +58,7 @@ func complianceEventCommand(globalParams *common.GlobalParams) *cobra.Command {
 			return fxutil.OneShot(eventRun,
 				fx.Supply(eventArgs),
 				fx.Supply(core.BundleParams{
-					ConfigParams: core.ConfigParams{SecurityAgentConfigFilePaths: globalParams.ConfPathArray, ConfigLoadSecurityAgent: true},
+					ConfigParams: config.NewSecurityAgentParams(globalParams.ConfPathArray, true),
 					LogParams:    log.LogForOneShot(common.LoggerName, "info", true)}),
 				core.Bundle,
 			)

--- a/cmd/security-agent/app/subcommands/flare/command.go
+++ b/cmd/security-agent/app/subcommands/flare/command.go
@@ -16,6 +16,7 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/security-agent/app/common"
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/log"
 	"github.com/DataDog/datadog-agent/pkg/api/util"
 	"github.com/DataDog/datadog-agent/pkg/flare"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
@@ -47,11 +48,9 @@ func Commands(globalParams *common.GlobalParams) []*cobra.Command {
 			// The flare command should not log anything, all errors should be reported directly to the console without the log format
 			return fxutil.OneShot(requestFlare,
 				fx.Supply(cliParams),
-				fx.Supply(core.CreateBundleParams(
-					"",
-					core.WithSecurityAgentConfigFilePaths(globalParams.ConfPathArray),
-					core.WithConfigLoadSecurityAgent(true),
-				).LogForOneShot(common.LoggerName, "off", true)),
+				fx.Supply(core.BundleParams{
+					ConfigParams: config.NewParams("", config.WithSecurityAgentConfigFilePaths(globalParams.ConfPathArray), config.WithConfigLoadSecurityAgent(true)),
+					LogParams:    log.LogForOneShot(common.LoggerName, "off", true)}),
 				core.Bundle,
 			)
 		},

--- a/cmd/security-agent/app/subcommands/runtime/activity_dump.go
+++ b/cmd/security-agent/app/subcommands/runtime/activity_dump.go
@@ -61,8 +61,9 @@ func listCommands(globalParams *common.GlobalParams) []*cobra.Command {
 		Short: "get the list of running activity dumps",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(listActivityDumps,
-				fx.Supply(core.BundleParams{ConfigParams: core.ConfigParams{SecurityAgentConfigFilePaths: globalParams.ConfPathArray, ConfigLoadSecurityAgent: true}}.
-					LogForOneShot(common.LoggerName, "info", true)),
+				fx.Supply(core.BundleParams{
+					ConfigParams: core.ConfigParams{SecurityAgentConfigFilePaths: globalParams.ConfPathArray, ConfigLoadSecurityAgent: true},
+					LogParams:    log.LogForOneShot(common.LoggerName, "info", true)}),
 				core.Bundle,
 			)
 		},
@@ -82,8 +83,9 @@ func stopCommands(globalParams *common.GlobalParams) []*cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(stopActivityDump,
 				fx.Supply(cliParams),
-				fx.Supply(core.BundleParams{ConfigParams: core.ConfigParams{SecurityAgentConfigFilePaths: globalParams.ConfPathArray, ConfigLoadSecurityAgent: true}}.
-					LogForOneShot(common.LoggerName, "info", true)),
+				fx.Supply(core.BundleParams{
+					ConfigParams: core.ConfigParams{SecurityAgentConfigFilePaths: globalParams.ConfPathArray, ConfigLoadSecurityAgent: true},
+					LogParams:    log.LogForOneShot(common.LoggerName, "info", true)}),
 				core.Bundle,
 			)
 		},
@@ -134,8 +136,9 @@ func generateDumpCommands(globalParams *common.GlobalParams) []*cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(generateActivityDump,
 				fx.Supply(cliParams),
-				fx.Supply(core.BundleParams{ConfigParams: core.ConfigParams{SecurityAgentConfigFilePaths: globalParams.ConfPathArray, ConfigLoadSecurityAgent: true}}.
-					LogForOneShot(common.LoggerName, "info", true)),
+				fx.Supply(core.BundleParams{
+					ConfigParams: core.ConfigParams{SecurityAgentConfigFilePaths: globalParams.ConfPathArray, ConfigLoadSecurityAgent: true},
+					LogParams:    log.LogForOneShot(common.LoggerName, "info", true)}),
 				core.Bundle,
 			)
 		},
@@ -204,8 +207,9 @@ func generateEncodingCommands(globalParams *common.GlobalParams) []*cobra.Comman
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(generateEncodingFromActivityDump,
 				fx.Supply(cliParams),
-				fx.Supply(core.BundleParams{ConfigParams: core.ConfigParams{SecurityAgentConfigFilePaths: globalParams.ConfPathArray, ConfigLoadSecurityAgent: true}}.
-					LogForOneShot(common.LoggerName, "info", true)),
+				fx.Supply(core.BundleParams{
+					ConfigParams: core.ConfigParams{SecurityAgentConfigFilePaths: globalParams.ConfPathArray, ConfigLoadSecurityAgent: true},
+					LogParams:    log.LogForOneShot(common.LoggerName, "info", true)}),
 				core.Bundle,
 			)
 		},

--- a/cmd/security-agent/app/subcommands/runtime/activity_dump.go
+++ b/cmd/security-agent/app/subcommands/runtime/activity_dump.go
@@ -62,7 +62,7 @@ func listCommands(globalParams *common.GlobalParams) []*cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(listActivityDumps,
 				fx.Supply(core.BundleParams{
-					ConfigParams: core.ConfigParams{SecurityAgentConfigFilePaths: globalParams.ConfPathArray, ConfigLoadSecurityAgent: true},
+					ConfigParams: core.NewSecurityAgentParams(globalParams.ConfPathArray, true),
 					LogParams:    log.LogForOneShot(common.LoggerName, "info", true)}),
 				core.Bundle,
 			)
@@ -84,7 +84,7 @@ func stopCommands(globalParams *common.GlobalParams) []*cobra.Command {
 			return fxutil.OneShot(stopActivityDump,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams: core.ConfigParams{SecurityAgentConfigFilePaths: globalParams.ConfPathArray, ConfigLoadSecurityAgent: true},
+					ConfigParams: core.NewSecurityAgentParams(globalParams.ConfPathArray, true),
 					LogParams:    log.LogForOneShot(common.LoggerName, "info", true)}),
 				core.Bundle,
 			)
@@ -137,7 +137,7 @@ func generateDumpCommands(globalParams *common.GlobalParams) []*cobra.Command {
 			return fxutil.OneShot(generateActivityDump,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams: core.ConfigParams{SecurityAgentConfigFilePaths: globalParams.ConfPathArray, ConfigLoadSecurityAgent: true},
+					ConfigParams: core.NewSecurityAgentParams(globalParams.ConfPathArray, true),
 					LogParams:    log.LogForOneShot(common.LoggerName, "info", true)}),
 				core.Bundle,
 			)
@@ -208,7 +208,7 @@ func generateEncodingCommands(globalParams *common.GlobalParams) []*cobra.Comman
 			return fxutil.OneShot(generateEncodingFromActivityDump,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams: core.ConfigParams{SecurityAgentConfigFilePaths: globalParams.ConfPathArray, ConfigLoadSecurityAgent: true},
+					ConfigParams: core.NewSecurityAgentParams(globalParams.ConfPathArray, true),
 					LogParams:    log.LogForOneShot(common.LoggerName, "info", true)}),
 				core.Bundle,
 			)

--- a/cmd/security-agent/app/subcommands/runtime/activity_dump.go
+++ b/cmd/security-agent/app/subcommands/runtime/activity_dump.go
@@ -61,11 +61,8 @@ func listCommands(globalParams *common.GlobalParams) []*cobra.Command {
 		Short: "get the list of running activity dumps",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(listActivityDumps,
-				fx.Supply(core.CreateBundleParams(
-					"",
-					core.WithSecurityAgentConfigFilePaths(globalParams.ConfPathArray),
-					core.WithConfigLoadSecurityAgent(true),
-				).LogForOneShot(common.LoggerName, "info", true)),
+				fx.Supply(core.BundleParams{ConfigParams: core.ConfigParams{SecurityAgentConfigFilePaths: globalParams.ConfPathArray, ConfigLoadSecurityAgent: true}}.
+					LogForOneShot(common.LoggerName, "info", true)),
 				core.Bundle,
 			)
 		},
@@ -85,11 +82,8 @@ func stopCommands(globalParams *common.GlobalParams) []*cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(stopActivityDump,
 				fx.Supply(cliParams),
-				fx.Supply(core.CreateBundleParams(
-					"",
-					core.WithSecurityAgentConfigFilePaths(globalParams.ConfPathArray),
-					core.WithConfigLoadSecurityAgent(true),
-				).LogForOneShot(common.LoggerName, "info", true)),
+				fx.Supply(core.BundleParams{ConfigParams: core.ConfigParams{SecurityAgentConfigFilePaths: globalParams.ConfPathArray, ConfigLoadSecurityAgent: true}}.
+					LogForOneShot(common.LoggerName, "info", true)),
 				core.Bundle,
 			)
 		},
@@ -140,11 +134,8 @@ func generateDumpCommands(globalParams *common.GlobalParams) []*cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(generateActivityDump,
 				fx.Supply(cliParams),
-				fx.Supply(core.CreateBundleParams(
-					"",
-					core.WithSecurityAgentConfigFilePaths(globalParams.ConfPathArray),
-					core.WithConfigLoadSecurityAgent(true),
-				).LogForOneShot(common.LoggerName, "info", true)),
+				fx.Supply(core.BundleParams{ConfigParams: core.ConfigParams{SecurityAgentConfigFilePaths: globalParams.ConfPathArray, ConfigLoadSecurityAgent: true}}.
+					LogForOneShot(common.LoggerName, "info", true)),
 				core.Bundle,
 			)
 		},
@@ -213,11 +204,8 @@ func generateEncodingCommands(globalParams *common.GlobalParams) []*cobra.Comman
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(generateEncodingFromActivityDump,
 				fx.Supply(cliParams),
-				fx.Supply(core.CreateBundleParams(
-					"",
-					core.WithSecurityAgentConfigFilePaths(globalParams.ConfPathArray),
-					core.WithConfigLoadSecurityAgent(true),
-				).LogForOneShot(common.LoggerName, "info", true)),
+				fx.Supply(core.BundleParams{ConfigParams: core.ConfigParams{SecurityAgentConfigFilePaths: globalParams.ConfPathArray, ConfigLoadSecurityAgent: true}}.
+					LogForOneShot(common.LoggerName, "info", true)),
 				core.Bundle,
 			)
 		},

--- a/cmd/security-agent/app/subcommands/runtime/activity_dump.go
+++ b/cmd/security-agent/app/subcommands/runtime/activity_dump.go
@@ -62,7 +62,7 @@ func listCommands(globalParams *common.GlobalParams) []*cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(listActivityDumps,
 				fx.Supply(core.BundleParams{
-					ConfigParams: compconfig.NewSecurityAgentParams(globalParams.ConfPathArray, true),
+					ConfigParams: compconfig.NewSecurityAgentParams(globalParams.ConfPathArray),
 					LogParams:    complog.LogForOneShot(common.LoggerName, "info", true)}),
 				core.Bundle,
 			)
@@ -84,7 +84,7 @@ func stopCommands(globalParams *common.GlobalParams) []*cobra.Command {
 			return fxutil.OneShot(stopActivityDump,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams: compconfig.NewSecurityAgentParams(globalParams.ConfPathArray, true),
+					ConfigParams: compconfig.NewSecurityAgentParams(globalParams.ConfPathArray),
 					LogParams:    complog.LogForOneShot(common.LoggerName, "info", true)}),
 				core.Bundle,
 			)
@@ -137,7 +137,7 @@ func generateDumpCommands(globalParams *common.GlobalParams) []*cobra.Command {
 			return fxutil.OneShot(generateActivityDump,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams: compconfig.NewSecurityAgentParams(globalParams.ConfPathArray, true),
+					ConfigParams: compconfig.NewSecurityAgentParams(globalParams.ConfPathArray),
 					LogParams:    complog.LogForOneShot(common.LoggerName, "info", true)}),
 				core.Bundle,
 			)
@@ -208,7 +208,7 @@ func generateEncodingCommands(globalParams *common.GlobalParams) []*cobra.Comman
 			return fxutil.OneShot(generateEncodingFromActivityDump,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams: compconfig.NewSecurityAgentParams(globalParams.ConfPathArray, true),
+					ConfigParams: compconfig.NewSecurityAgentParams(globalParams.ConfPathArray),
 					LogParams:    complog.LogForOneShot(common.LoggerName, "info", true)}),
 				core.Bundle,
 			)

--- a/cmd/security-agent/app/subcommands/runtime/activity_dump.go
+++ b/cmd/security-agent/app/subcommands/runtime/activity_dump.go
@@ -62,8 +62,8 @@ func listCommands(globalParams *common.GlobalParams) []*cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(listActivityDumps,
 				fx.Supply(core.BundleParams{
-					ConfigParams: core.NewSecurityAgentParams(globalParams.ConfPathArray, true),
-					LogParams:    log.LogForOneShot(common.LoggerName, "info", true)}),
+					ConfigParams: compconfig.NewSecurityAgentParams(globalParams.ConfPathArray, true),
+					LogParams:    complog.LogForOneShot(common.LoggerName, "info", true)}),
 				core.Bundle,
 			)
 		},
@@ -84,8 +84,8 @@ func stopCommands(globalParams *common.GlobalParams) []*cobra.Command {
 			return fxutil.OneShot(stopActivityDump,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams: core.NewSecurityAgentParams(globalParams.ConfPathArray, true),
-					LogParams:    log.LogForOneShot(common.LoggerName, "info", true)}),
+					ConfigParams: compconfig.NewSecurityAgentParams(globalParams.ConfPathArray, true),
+					LogParams:    complog.LogForOneShot(common.LoggerName, "info", true)}),
 				core.Bundle,
 			)
 		},
@@ -137,8 +137,8 @@ func generateDumpCommands(globalParams *common.GlobalParams) []*cobra.Command {
 			return fxutil.OneShot(generateActivityDump,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams: core.NewSecurityAgentParams(globalParams.ConfPathArray, true),
-					LogParams:    log.LogForOneShot(common.LoggerName, "info", true)}),
+					ConfigParams: compconfig.NewSecurityAgentParams(globalParams.ConfPathArray, true),
+					LogParams:    complog.LogForOneShot(common.LoggerName, "info", true)}),
 				core.Bundle,
 			)
 		},
@@ -208,8 +208,8 @@ func generateEncodingCommands(globalParams *common.GlobalParams) []*cobra.Comman
 			return fxutil.OneShot(generateEncodingFromActivityDump,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams: core.NewSecurityAgentParams(globalParams.ConfPathArray, true),
-					LogParams:    log.LogForOneShot(common.LoggerName, "info", true)}),
+					ConfigParams: compconfig.NewSecurityAgentParams(globalParams.ConfPathArray, true),
+					LogParams:    complog.LogForOneShot(common.LoggerName, "info", true)}),
 				core.Bundle,
 			)
 		},

--- a/cmd/security-agent/app/subcommands/runtime/command.go
+++ b/cmd/security-agent/app/subcommands/runtime/command.go
@@ -93,7 +93,9 @@ func checkPoliciesCommands(globalParams *common.GlobalParams) []*cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(checkPolicies,
 				fx.Supply(cliParams),
-				fx.Supply(core.BundleParams{ConfigParams: core.ConfigParams{SecurityAgentConfigFilePaths: globalParams.ConfPathArray, ConfigLoadSecurityAgent: true}}.LogForOneShot(common.LoggerName, "off", false)),
+				fx.Supply(core.BundleParams{
+					ConfigParams: core.ConfigParams{SecurityAgentConfigFilePaths: globalParams.ConfPathArray, ConfigLoadSecurityAgent: true},
+					LogParams:    log.LogForOneShot(common.LoggerName, "off", false)}),
 				core.Bundle,
 			)
 		},
@@ -111,7 +113,9 @@ func reloadPoliciesCommands(globalParams *common.GlobalParams) []*cobra.Command 
 		Short: "Reload policies",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(reloadRuntimePolicies,
-				fx.Supply(core.BundleParams{ConfigParams: core.ConfigParams{SecurityAgentConfigFilePaths: globalParams.ConfPathArray, ConfigLoadSecurityAgent: true}}.LogForOneShot(common.LoggerName, "info", true)),
+				fx.Supply(core.BundleParams{
+					ConfigParams: core.ConfigParams{SecurityAgentConfigFilePaths: globalParams.ConfPathArray, ConfigLoadSecurityAgent: true},
+					LogParams:    log.LogForOneShot(common.LoggerName, "info", true)}),
 				core.Bundle,
 			)
 		},
@@ -154,7 +158,9 @@ func evalCommands(globalParams *common.GlobalParams) []*cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(evalRule,
 				fx.Supply(evalArgs),
-				fx.Supply(core.BundleParams{ConfigParams: core.ConfigParams{SecurityAgentConfigFilePaths: globalParams.ConfPathArray, ConfigLoadSecurityAgent: true}}.LogForOneShot(common.LoggerName, "off", false)),
+				fx.Supply(core.BundleParams{
+					ConfigParams: core.ConfigParams{SecurityAgentConfigFilePaths: globalParams.ConfPathArray, ConfigLoadSecurityAgent: true},
+					LogParams:    log.LogForOneShot(common.LoggerName, "off", false)}),
 				core.Bundle,
 			)
 		},
@@ -181,7 +187,9 @@ func commonCheckPoliciesCommands(globalParams *common.GlobalParams) []*cobra.Com
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(checkPolicies,
 				fx.Supply(cliParams),
-				fx.Supply(core.BundleParams{ConfigParams: core.ConfigParams{SecurityAgentConfigFilePaths: globalParams.ConfPathArray, ConfigLoadSecurityAgent: true}}.LogForOneShot(common.LoggerName, "off", false)),
+				fx.Supply(core.BundleParams{
+					ConfigParams: core.ConfigParams{SecurityAgentConfigFilePaths: globalParams.ConfPathArray, ConfigLoadSecurityAgent: true},
+					LogParams:    log.LogForOneShot(common.LoggerName, "off", false)}),
 				core.Bundle,
 			)
 		},
@@ -198,7 +206,9 @@ func commonReloadPoliciesCommands(globalParams *common.GlobalParams) []*cobra.Co
 		Short: "Reload policies",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(reloadRuntimePolicies,
-				fx.Supply(core.BundleParams{ConfigParams: core.ConfigParams{SecurityAgentConfigFilePaths: globalParams.ConfPathArray, ConfigLoadSecurityAgent: true}}.LogForOneShot(common.LoggerName, "info", true)),
+				fx.Supply(core.BundleParams{
+					ConfigParams: core.ConfigParams{SecurityAgentConfigFilePaths: globalParams.ConfPathArray, ConfigLoadSecurityAgent: true},
+					LogParams:    log.LogForOneShot(common.LoggerName, "info", true)}),
 				core.Bundle,
 			)
 		},
@@ -212,7 +222,9 @@ func selfTestCommands(globalParams *common.GlobalParams) []*cobra.Command {
 		Short: "Run runtime self test",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(runRuntimeSelfTest,
-				fx.Supply(core.BundleParams{ConfigParams: core.ConfigParams{SecurityAgentConfigFilePaths: globalParams.ConfPathArray, ConfigLoadSecurityAgent: true}}.LogForOneShot(common.LoggerName, "info", true)),
+				fx.Supply(core.BundleParams{
+					ConfigParams: core.ConfigParams{SecurityAgentConfigFilePaths: globalParams.ConfPathArray, ConfigLoadSecurityAgent: true},
+					LogParams:    log.LogForOneShot(common.LoggerName, "info", true)}),
 				core.Bundle,
 			)
 		},
@@ -239,7 +251,9 @@ func downloadPolicyCommands(globalParams *common.GlobalParams) []*cobra.Command 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(downloadPolicy,
 				fx.Supply(downloadPolicyArgs),
-				fx.Supply(core.BundleParams{ConfigParams: core.ConfigParams{SecurityAgentConfigFilePaths: globalParams.ConfPathArray, ConfigLoadSecurityAgent: true}}.LogForOneShot(common.LoggerName, "off", false)),
+				fx.Supply(core.BundleParams{
+					ConfigParams: core.ConfigParams{SecurityAgentConfigFilePaths: globalParams.ConfPathArray, ConfigLoadSecurityAgent: true},
+					LogParams:    log.LogForOneShot(common.LoggerName, "off", false)}),
 				core.Bundle,
 			)
 		},
@@ -268,7 +282,9 @@ func processCacheCommands(globalParams *common.GlobalParams) []*cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(dumpProcessCache,
 				fx.Supply(cliParams),
-				fx.Supply(core.BundleParams{ConfigParams: core.ConfigParams{SecurityAgentConfigFilePaths: globalParams.ConfPathArray, ConfigLoadSecurityAgent: true}}.LogForOneShot(common.LoggerName, "info", true)),
+				fx.Supply(core.BundleParams{
+					ConfigParams: core.ConfigParams{SecurityAgentConfigFilePaths: globalParams.ConfPathArray, ConfigLoadSecurityAgent: true},
+					LogParams:    log.LogForOneShot(common.LoggerName, "info", true)}),
 				core.Bundle,
 			)
 		},
@@ -301,7 +317,9 @@ func networkNamespaceCommands(globalParams *common.GlobalParams) []*cobra.Comman
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(dumpNetworkNamespace,
 				fx.Supply(cliParams),
-				fx.Supply(core.BundleParams{ConfigParams: core.ConfigParams{SecurityAgentConfigFilePaths: globalParams.ConfPathArray, ConfigLoadSecurityAgent: true}}.LogForOneShot(common.LoggerName, "info", true)),
+				fx.Supply(core.BundleParams{
+					ConfigParams: core.ConfigParams{SecurityAgentConfigFilePaths: globalParams.ConfPathArray, ConfigLoadSecurityAgent: true},
+					LogParams:    log.LogForOneShot(common.LoggerName, "info", true)}),
 				core.Bundle,
 			)
 		},
@@ -324,7 +342,9 @@ func discardersCommands(globalParams *common.GlobalParams) []*cobra.Command {
 		Short: "dump discarders",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(dumpDiscarders,
-				fx.Supply(core.BundleParams{ConfigParams: core.ConfigParams{SecurityAgentConfigFilePaths: globalParams.ConfPathArray, ConfigLoadSecurityAgent: true}}.LogForOneShot(common.LoggerName, "info", true)),
+				fx.Supply(core.BundleParams{
+					ConfigParams: core.ConfigParams{SecurityAgentConfigFilePaths: globalParams.ConfPathArray, ConfigLoadSecurityAgent: true},
+					LogParams:    log.LogForOneShot(common.LoggerName, "info", true)}),
 				core.Bundle,
 			)
 		},

--- a/cmd/security-agent/app/subcommands/runtime/command.go
+++ b/cmd/security-agent/app/subcommands/runtime/command.go
@@ -94,8 +94,8 @@ func checkPoliciesCommands(globalParams *common.GlobalParams) []*cobra.Command {
 			return fxutil.OneShot(checkPolicies,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams: core.NewSecurityAgentParams(globalParams.ConfPathArray, true),
-					LogParams:    log.LogForOneShot(common.LoggerName, "off", false)}),
+					ConfigParams: compconfig.NewSecurityAgentParams(globalParams.ConfPathArray, true),
+					LogParams:    complog.LogForOneShot(common.LoggerName, "off", false)}),
 				core.Bundle,
 			)
 		},
@@ -114,8 +114,8 @@ func reloadPoliciesCommands(globalParams *common.GlobalParams) []*cobra.Command 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(reloadRuntimePolicies,
 				fx.Supply(core.BundleParams{
-					ConfigParams: core.NewSecurityAgentParams(globalParams.ConfPathArray, true),
-					LogParams:    log.LogForOneShot(common.LoggerName, "info", true)}),
+					ConfigParams: compconfig.NewSecurityAgentParams(globalParams.ConfPathArray, true),
+					LogParams:    complog.LogForOneShot(common.LoggerName, "info", true)}),
 				core.Bundle,
 			)
 		},
@@ -159,8 +159,8 @@ func evalCommands(globalParams *common.GlobalParams) []*cobra.Command {
 			return fxutil.OneShot(evalRule,
 				fx.Supply(evalArgs),
 				fx.Supply(core.BundleParams{
-					ConfigParams: core.NewSecurityAgentParams(globalParams.ConfPathArray, true),
-					LogParams:    log.LogForOneShot(common.LoggerName, "off", false)}),
+					ConfigParams: compconfig.NewSecurityAgentParams(globalParams.ConfPathArray, true),
+					LogParams:    complog.LogForOneShot(common.LoggerName, "off", false)}),
 				core.Bundle,
 			)
 		},
@@ -188,8 +188,8 @@ func commonCheckPoliciesCommands(globalParams *common.GlobalParams) []*cobra.Com
 			return fxutil.OneShot(checkPolicies,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams: core.NewSecurityAgentParams(globalParams.ConfPathArray, true),
-					LogParams:    log.LogForOneShot(common.LoggerName, "off", false)}),
+					ConfigParams: compconfig.NewSecurityAgentParams(globalParams.ConfPathArray, true),
+					LogParams:    complog.LogForOneShot(common.LoggerName, "off", false)}),
 				core.Bundle,
 			)
 		},
@@ -207,8 +207,8 @@ func commonReloadPoliciesCommands(globalParams *common.GlobalParams) []*cobra.Co
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(reloadRuntimePolicies,
 				fx.Supply(core.BundleParams{
-					ConfigParams: core.NewSecurityAgentParams(globalParams.ConfPathArray, true),
-					LogParams:    log.LogForOneShot(common.LoggerName, "info", true)}),
+					ConfigParams: compconfig.NewSecurityAgentParams(globalParams.ConfPathArray, true),
+					LogParams:    complog.LogForOneShot(common.LoggerName, "info", true)}),
 				core.Bundle,
 			)
 		},
@@ -223,8 +223,8 @@ func selfTestCommands(globalParams *common.GlobalParams) []*cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(runRuntimeSelfTest,
 				fx.Supply(core.BundleParams{
-					ConfigParams: core.NewSecurityAgentParams(globalParams.ConfPathArray, true),
-					LogParams:    log.LogForOneShot(common.LoggerName, "info", true)}),
+					ConfigParams: compconfig.NewSecurityAgentParams(globalParams.ConfPathArray, true),
+					LogParams:    complog.LogForOneShot(common.LoggerName, "info", true)}),
 				core.Bundle,
 			)
 		},
@@ -252,8 +252,8 @@ func downloadPolicyCommands(globalParams *common.GlobalParams) []*cobra.Command 
 			return fxutil.OneShot(downloadPolicy,
 				fx.Supply(downloadPolicyArgs),
 				fx.Supply(core.BundleParams{
-					ConfigParams: core.NewSecurityAgentParams(globalParams.ConfPathArray, true),
-					LogParams:    log.LogForOneShot(common.LoggerName, "off", false)}),
+					ConfigParams: compconfig.NewSecurityAgentParams(globalParams.ConfPathArray, true),
+					LogParams:    complog.LogForOneShot(common.LoggerName, "off", false)}),
 				core.Bundle,
 			)
 		},
@@ -283,8 +283,8 @@ func processCacheCommands(globalParams *common.GlobalParams) []*cobra.Command {
 			return fxutil.OneShot(dumpProcessCache,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams: core.NewSecurityAgentParams(globalParams.ConfPathArray, true),
-					LogParams:    log.LogForOneShot(common.LoggerName, "info", true)}),
+					ConfigParams: compconfig.NewSecurityAgentParams(globalParams.ConfPathArray, true),
+					LogParams:    complog.LogForOneShot(common.LoggerName, "info", true)}),
 				core.Bundle,
 			)
 		},
@@ -318,8 +318,8 @@ func networkNamespaceCommands(globalParams *common.GlobalParams) []*cobra.Comman
 			return fxutil.OneShot(dumpNetworkNamespace,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams: core.NewSecurityAgentParams(globalParams.ConfPathArray, true),
-					LogParams:    log.LogForOneShot(common.LoggerName, "info", true)}),
+					ConfigParams: compconfig.NewSecurityAgentParams(globalParams.ConfPathArray, true),
+					LogParams:    complog.LogForOneShot(common.LoggerName, "info", true)}),
 				core.Bundle,
 			)
 		},
@@ -343,8 +343,8 @@ func discardersCommands(globalParams *common.GlobalParams) []*cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(dumpDiscarders,
 				fx.Supply(core.BundleParams{
-					ConfigParams: core.NewSecurityAgentParams(globalParams.ConfPathArray, true),
-					LogParams:    log.LogForOneShot(common.LoggerName, "info", true)}),
+					ConfigParams: compconfig.NewSecurityAgentParams(globalParams.ConfPathArray, true),
+					LogParams:    complog.LogForOneShot(common.LoggerName, "info", true)}),
 				core.Bundle,
 			)
 		},

--- a/cmd/security-agent/app/subcommands/runtime/command.go
+++ b/cmd/security-agent/app/subcommands/runtime/command.go
@@ -94,7 +94,7 @@ func checkPoliciesCommands(globalParams *common.GlobalParams) []*cobra.Command {
 			return fxutil.OneShot(checkPolicies,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams: core.ConfigParams{SecurityAgentConfigFilePaths: globalParams.ConfPathArray, ConfigLoadSecurityAgent: true},
+					ConfigParams: core.NewSecurityAgentParams(globalParams.ConfPathArray, true),
 					LogParams:    log.LogForOneShot(common.LoggerName, "off", false)}),
 				core.Bundle,
 			)
@@ -114,7 +114,7 @@ func reloadPoliciesCommands(globalParams *common.GlobalParams) []*cobra.Command 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(reloadRuntimePolicies,
 				fx.Supply(core.BundleParams{
-					ConfigParams: core.ConfigParams{SecurityAgentConfigFilePaths: globalParams.ConfPathArray, ConfigLoadSecurityAgent: true},
+					ConfigParams: core.NewSecurityAgentParams(globalParams.ConfPathArray, true),
 					LogParams:    log.LogForOneShot(common.LoggerName, "info", true)}),
 				core.Bundle,
 			)
@@ -159,7 +159,7 @@ func evalCommands(globalParams *common.GlobalParams) []*cobra.Command {
 			return fxutil.OneShot(evalRule,
 				fx.Supply(evalArgs),
 				fx.Supply(core.BundleParams{
-					ConfigParams: core.ConfigParams{SecurityAgentConfigFilePaths: globalParams.ConfPathArray, ConfigLoadSecurityAgent: true},
+					ConfigParams: core.NewSecurityAgentParams(globalParams.ConfPathArray, true),
 					LogParams:    log.LogForOneShot(common.LoggerName, "off", false)}),
 				core.Bundle,
 			)
@@ -188,7 +188,7 @@ func commonCheckPoliciesCommands(globalParams *common.GlobalParams) []*cobra.Com
 			return fxutil.OneShot(checkPolicies,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams: core.ConfigParams{SecurityAgentConfigFilePaths: globalParams.ConfPathArray, ConfigLoadSecurityAgent: true},
+					ConfigParams: core.NewSecurityAgentParams(globalParams.ConfPathArray, true),
 					LogParams:    log.LogForOneShot(common.LoggerName, "off", false)}),
 				core.Bundle,
 			)
@@ -207,7 +207,7 @@ func commonReloadPoliciesCommands(globalParams *common.GlobalParams) []*cobra.Co
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(reloadRuntimePolicies,
 				fx.Supply(core.BundleParams{
-					ConfigParams: core.ConfigParams{SecurityAgentConfigFilePaths: globalParams.ConfPathArray, ConfigLoadSecurityAgent: true},
+					ConfigParams: core.NewSecurityAgentParams(globalParams.ConfPathArray, true),
 					LogParams:    log.LogForOneShot(common.LoggerName, "info", true)}),
 				core.Bundle,
 			)
@@ -223,7 +223,7 @@ func selfTestCommands(globalParams *common.GlobalParams) []*cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(runRuntimeSelfTest,
 				fx.Supply(core.BundleParams{
-					ConfigParams: core.ConfigParams{SecurityAgentConfigFilePaths: globalParams.ConfPathArray, ConfigLoadSecurityAgent: true},
+					ConfigParams: core.NewSecurityAgentParams(globalParams.ConfPathArray, true),
 					LogParams:    log.LogForOneShot(common.LoggerName, "info", true)}),
 				core.Bundle,
 			)
@@ -252,7 +252,7 @@ func downloadPolicyCommands(globalParams *common.GlobalParams) []*cobra.Command 
 			return fxutil.OneShot(downloadPolicy,
 				fx.Supply(downloadPolicyArgs),
 				fx.Supply(core.BundleParams{
-					ConfigParams: core.ConfigParams{SecurityAgentConfigFilePaths: globalParams.ConfPathArray, ConfigLoadSecurityAgent: true},
+					ConfigParams: core.NewSecurityAgentParams(globalParams.ConfPathArray, true),
 					LogParams:    log.LogForOneShot(common.LoggerName, "off", false)}),
 				core.Bundle,
 			)
@@ -283,7 +283,7 @@ func processCacheCommands(globalParams *common.GlobalParams) []*cobra.Command {
 			return fxutil.OneShot(dumpProcessCache,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams: core.ConfigParams{SecurityAgentConfigFilePaths: globalParams.ConfPathArray, ConfigLoadSecurityAgent: true},
+					ConfigParams: core.NewSecurityAgentParams(globalParams.ConfPathArray, true),
 					LogParams:    log.LogForOneShot(common.LoggerName, "info", true)}),
 				core.Bundle,
 			)
@@ -318,7 +318,7 @@ func networkNamespaceCommands(globalParams *common.GlobalParams) []*cobra.Comman
 			return fxutil.OneShot(dumpNetworkNamespace,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams: core.ConfigParams{SecurityAgentConfigFilePaths: globalParams.ConfPathArray, ConfigLoadSecurityAgent: true},
+					ConfigParams: core.NewSecurityAgentParams(globalParams.ConfPathArray, true),
 					LogParams:    log.LogForOneShot(common.LoggerName, "info", true)}),
 				core.Bundle,
 			)
@@ -343,7 +343,7 @@ func discardersCommands(globalParams *common.GlobalParams) []*cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(dumpDiscarders,
 				fx.Supply(core.BundleParams{
-					ConfigParams: core.ConfigParams{SecurityAgentConfigFilePaths: globalParams.ConfPathArray, ConfigLoadSecurityAgent: true},
+					ConfigParams: core.NewSecurityAgentParams(globalParams.ConfPathArray, true),
 					LogParams:    log.LogForOneShot(common.LoggerName, "info", true)}),
 				core.Bundle,
 			)

--- a/cmd/security-agent/app/subcommands/runtime/command.go
+++ b/cmd/security-agent/app/subcommands/runtime/command.go
@@ -93,11 +93,7 @@ func checkPoliciesCommands(globalParams *common.GlobalParams) []*cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(checkPolicies,
 				fx.Supply(cliParams),
-				fx.Supply(core.CreateBundleParams(
-					"",
-					core.WithSecurityAgentConfigFilePaths(globalParams.ConfPathArray),
-					core.WithConfigLoadSecurityAgent(true),
-				).LogForOneShot(common.LoggerName, "off", false)),
+				fx.Supply(core.BundleParams{ConfigParams: core.ConfigParams{SecurityAgentConfigFilePaths: globalParams.ConfPathArray, ConfigLoadSecurityAgent: true}}.LogForOneShot(common.LoggerName, "off", false)),
 				core.Bundle,
 			)
 		},
@@ -115,11 +111,7 @@ func reloadPoliciesCommands(globalParams *common.GlobalParams) []*cobra.Command 
 		Short: "Reload policies",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(reloadRuntimePolicies,
-				fx.Supply(core.CreateBundleParams(
-					"",
-					core.WithSecurityAgentConfigFilePaths(globalParams.ConfPathArray),
-					core.WithConfigLoadSecurityAgent(true),
-				).LogForOneShot(common.LoggerName, "info", true)),
+				fx.Supply(core.BundleParams{ConfigParams: core.ConfigParams{SecurityAgentConfigFilePaths: globalParams.ConfPathArray, ConfigLoadSecurityAgent: true}}.LogForOneShot(common.LoggerName, "info", true)),
 				core.Bundle,
 			)
 		},
@@ -162,11 +154,7 @@ func evalCommands(globalParams *common.GlobalParams) []*cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(evalRule,
 				fx.Supply(evalArgs),
-				fx.Supply(core.CreateBundleParams(
-					"",
-					core.WithSecurityAgentConfigFilePaths(globalParams.ConfPathArray),
-					core.WithConfigLoadSecurityAgent(true),
-				).LogForOneShot(common.LoggerName, "off", false)),
+				fx.Supply(core.BundleParams{ConfigParams: core.ConfigParams{SecurityAgentConfigFilePaths: globalParams.ConfPathArray, ConfigLoadSecurityAgent: true}}.LogForOneShot(common.LoggerName, "off", false)),
 				core.Bundle,
 			)
 		},
@@ -193,11 +181,7 @@ func commonCheckPoliciesCommands(globalParams *common.GlobalParams) []*cobra.Com
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(checkPolicies,
 				fx.Supply(cliParams),
-				fx.Supply(core.CreateBundleParams(
-					"",
-					core.WithSecurityAgentConfigFilePaths(globalParams.ConfPathArray),
-					core.WithConfigLoadSecurityAgent(true),
-				).LogForOneShot(common.LoggerName, "off", false)),
+				fx.Supply(core.BundleParams{ConfigParams: core.ConfigParams{SecurityAgentConfigFilePaths: globalParams.ConfPathArray, ConfigLoadSecurityAgent: true}}.LogForOneShot(common.LoggerName, "off", false)),
 				core.Bundle,
 			)
 		},
@@ -214,11 +198,7 @@ func commonReloadPoliciesCommands(globalParams *common.GlobalParams) []*cobra.Co
 		Short: "Reload policies",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(reloadRuntimePolicies,
-				fx.Supply(core.CreateBundleParams(
-					"",
-					core.WithSecurityAgentConfigFilePaths(globalParams.ConfPathArray),
-					core.WithConfigLoadSecurityAgent(true),
-				).LogForOneShot(common.LoggerName, "info", true)),
+				fx.Supply(core.BundleParams{ConfigParams: core.ConfigParams{SecurityAgentConfigFilePaths: globalParams.ConfPathArray, ConfigLoadSecurityAgent: true}}.LogForOneShot(common.LoggerName, "info", true)),
 				core.Bundle,
 			)
 		},
@@ -232,11 +212,7 @@ func selfTestCommands(globalParams *common.GlobalParams) []*cobra.Command {
 		Short: "Run runtime self test",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(runRuntimeSelfTest,
-				fx.Supply(core.CreateBundleParams(
-					"",
-					core.WithSecurityAgentConfigFilePaths(globalParams.ConfPathArray),
-					core.WithConfigLoadSecurityAgent(true),
-				).LogForOneShot(common.LoggerName, "info", true)),
+				fx.Supply(core.BundleParams{ConfigParams: core.ConfigParams{SecurityAgentConfigFilePaths: globalParams.ConfPathArray, ConfigLoadSecurityAgent: true}}.LogForOneShot(common.LoggerName, "info", true)),
 				core.Bundle,
 			)
 		},
@@ -263,11 +239,7 @@ func downloadPolicyCommands(globalParams *common.GlobalParams) []*cobra.Command 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(downloadPolicy,
 				fx.Supply(downloadPolicyArgs),
-				fx.Supply(core.CreateBundleParams(
-					"",
-					core.WithSecurityAgentConfigFilePaths(globalParams.ConfPathArray),
-					core.WithConfigLoadSecurityAgent(true),
-				).LogForOneShot(common.LoggerName, "off", false)),
+				fx.Supply(core.BundleParams{ConfigParams: core.ConfigParams{SecurityAgentConfigFilePaths: globalParams.ConfPathArray, ConfigLoadSecurityAgent: true}}.LogForOneShot(common.LoggerName, "off", false)),
 				core.Bundle,
 			)
 		},
@@ -296,11 +268,7 @@ func processCacheCommands(globalParams *common.GlobalParams) []*cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(dumpProcessCache,
 				fx.Supply(cliParams),
-				fx.Supply(core.CreateBundleParams(
-					"",
-					core.WithSecurityAgentConfigFilePaths(globalParams.ConfPathArray),
-					core.WithConfigLoadSecurityAgent(true),
-				).LogForOneShot(common.LoggerName, "info", true)),
+				fx.Supply(core.BundleParams{ConfigParams: core.ConfigParams{SecurityAgentConfigFilePaths: globalParams.ConfPathArray, ConfigLoadSecurityAgent: true}}.LogForOneShot(common.LoggerName, "info", true)),
 				core.Bundle,
 			)
 		},
@@ -333,11 +301,7 @@ func networkNamespaceCommands(globalParams *common.GlobalParams) []*cobra.Comman
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(dumpNetworkNamespace,
 				fx.Supply(cliParams),
-				fx.Supply(core.CreateBundleParams(
-					"",
-					core.WithSecurityAgentConfigFilePaths(globalParams.ConfPathArray),
-					core.WithConfigLoadSecurityAgent(true),
-				).LogForOneShot(common.LoggerName, "info", true)),
+				fx.Supply(core.BundleParams{ConfigParams: core.ConfigParams{SecurityAgentConfigFilePaths: globalParams.ConfPathArray, ConfigLoadSecurityAgent: true}}.LogForOneShot(common.LoggerName, "info", true)),
 				core.Bundle,
 			)
 		},
@@ -360,11 +324,7 @@ func discardersCommands(globalParams *common.GlobalParams) []*cobra.Command {
 		Short: "dump discarders",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(dumpDiscarders,
-				fx.Supply(core.CreateBundleParams(
-					"",
-					core.WithSecurityAgentConfigFilePaths(globalParams.ConfPathArray),
-					core.WithConfigLoadSecurityAgent(true),
-				).LogForOneShot(common.LoggerName, "info", true)),
+				fx.Supply(core.BundleParams{ConfigParams: core.ConfigParams{SecurityAgentConfigFilePaths: globalParams.ConfPathArray, ConfigLoadSecurityAgent: true}}.LogForOneShot(common.LoggerName, "info", true)),
 				core.Bundle,
 			)
 		},

--- a/cmd/security-agent/app/subcommands/runtime/command.go
+++ b/cmd/security-agent/app/subcommands/runtime/command.go
@@ -94,7 +94,7 @@ func checkPoliciesCommands(globalParams *common.GlobalParams) []*cobra.Command {
 			return fxutil.OneShot(checkPolicies,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams: compconfig.NewSecurityAgentParams(globalParams.ConfPathArray, true),
+					ConfigParams: compconfig.NewSecurityAgentParams(globalParams.ConfPathArray),
 					LogParams:    complog.LogForOneShot(common.LoggerName, "off", false)}),
 				core.Bundle,
 			)
@@ -114,7 +114,7 @@ func reloadPoliciesCommands(globalParams *common.GlobalParams) []*cobra.Command 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(reloadRuntimePolicies,
 				fx.Supply(core.BundleParams{
-					ConfigParams: compconfig.NewSecurityAgentParams(globalParams.ConfPathArray, true),
+					ConfigParams: compconfig.NewSecurityAgentParams(globalParams.ConfPathArray),
 					LogParams:    complog.LogForOneShot(common.LoggerName, "info", true)}),
 				core.Bundle,
 			)
@@ -159,7 +159,7 @@ func evalCommands(globalParams *common.GlobalParams) []*cobra.Command {
 			return fxutil.OneShot(evalRule,
 				fx.Supply(evalArgs),
 				fx.Supply(core.BundleParams{
-					ConfigParams: compconfig.NewSecurityAgentParams(globalParams.ConfPathArray, true),
+					ConfigParams: compconfig.NewSecurityAgentParams(globalParams.ConfPathArray),
 					LogParams:    complog.LogForOneShot(common.LoggerName, "off", false)}),
 				core.Bundle,
 			)
@@ -188,7 +188,7 @@ func commonCheckPoliciesCommands(globalParams *common.GlobalParams) []*cobra.Com
 			return fxutil.OneShot(checkPolicies,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams: compconfig.NewSecurityAgentParams(globalParams.ConfPathArray, true),
+					ConfigParams: compconfig.NewSecurityAgentParams(globalParams.ConfPathArray),
 					LogParams:    complog.LogForOneShot(common.LoggerName, "off", false)}),
 				core.Bundle,
 			)
@@ -207,7 +207,7 @@ func commonReloadPoliciesCommands(globalParams *common.GlobalParams) []*cobra.Co
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(reloadRuntimePolicies,
 				fx.Supply(core.BundleParams{
-					ConfigParams: compconfig.NewSecurityAgentParams(globalParams.ConfPathArray, true),
+					ConfigParams: compconfig.NewSecurityAgentParams(globalParams.ConfPathArray),
 					LogParams:    complog.LogForOneShot(common.LoggerName, "info", true)}),
 				core.Bundle,
 			)
@@ -223,7 +223,7 @@ func selfTestCommands(globalParams *common.GlobalParams) []*cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(runRuntimeSelfTest,
 				fx.Supply(core.BundleParams{
-					ConfigParams: compconfig.NewSecurityAgentParams(globalParams.ConfPathArray, true),
+					ConfigParams: compconfig.NewSecurityAgentParams(globalParams.ConfPathArray),
 					LogParams:    complog.LogForOneShot(common.LoggerName, "info", true)}),
 				core.Bundle,
 			)
@@ -252,7 +252,7 @@ func downloadPolicyCommands(globalParams *common.GlobalParams) []*cobra.Command 
 			return fxutil.OneShot(downloadPolicy,
 				fx.Supply(downloadPolicyArgs),
 				fx.Supply(core.BundleParams{
-					ConfigParams: compconfig.NewSecurityAgentParams(globalParams.ConfPathArray, true),
+					ConfigParams: compconfig.NewSecurityAgentParams(globalParams.ConfPathArray),
 					LogParams:    complog.LogForOneShot(common.LoggerName, "off", false)}),
 				core.Bundle,
 			)
@@ -283,7 +283,7 @@ func processCacheCommands(globalParams *common.GlobalParams) []*cobra.Command {
 			return fxutil.OneShot(dumpProcessCache,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams: compconfig.NewSecurityAgentParams(globalParams.ConfPathArray, true),
+					ConfigParams: compconfig.NewSecurityAgentParams(globalParams.ConfPathArray),
 					LogParams:    complog.LogForOneShot(common.LoggerName, "info", true)}),
 				core.Bundle,
 			)
@@ -318,7 +318,7 @@ func networkNamespaceCommands(globalParams *common.GlobalParams) []*cobra.Comman
 			return fxutil.OneShot(dumpNetworkNamespace,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams: compconfig.NewSecurityAgentParams(globalParams.ConfPathArray, true),
+					ConfigParams: compconfig.NewSecurityAgentParams(globalParams.ConfPathArray),
 					LogParams:    complog.LogForOneShot(common.LoggerName, "info", true)}),
 				core.Bundle,
 			)
@@ -343,7 +343,7 @@ func discardersCommands(globalParams *common.GlobalParams) []*cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(dumpDiscarders,
 				fx.Supply(core.BundleParams{
-					ConfigParams: compconfig.NewSecurityAgentParams(globalParams.ConfPathArray, true),
+					ConfigParams: compconfig.NewSecurityAgentParams(globalParams.ConfPathArray),
 					LogParams:    complog.LogForOneShot(common.LoggerName, "info", true)}),
 				core.Bundle,
 			)

--- a/cmd/security-agent/app/subcommands/status/command.go
+++ b/cmd/security-agent/app/subcommands/status/command.go
@@ -43,11 +43,9 @@ func Commands(globalParams *common.GlobalParams) []*cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(runStatus,
 				fx.Supply(cliParams),
-				fx.Supply(core.CreateBundleParams(
-					"",
-					core.WithSecurityAgentConfigFilePaths(globalParams.ConfPathArray),
-					core.WithConfigLoadSecurityAgent(true),
-				).LogForOneShot(common.LoggerName, "off", true)),
+				fx.Supply(core.BundleParams{
+					ConfigParams: config.NewParams("", config.WithSecurityAgentConfigFilePaths(globalParams.ConfPathArray), config.WithConfigLoadSecurityAgent(true)),
+					LogParams:    log.LogForOneShot(common.LoggerName, "off", true)}),
 				core.Bundle,
 			)
 		},

--- a/cmd/security-agent/app/subcommands/version/command.go
+++ b/cmd/security-agent/app/subcommands/version/command.go
@@ -10,7 +10,9 @@ import (
 
 	"github.com/DataDog/datadog-agent/cmd/security-agent/app/common"
 	"github.com/DataDog/datadog-agent/comp/core"
+	"github.com/DataDog/datadog-agent/comp/core/config"
 	compconfig "github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/log"
 	complog "github.com/DataDog/datadog-agent/comp/core/log"
 	"github.com/DataDog/datadog-agent/pkg/serializer"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
@@ -27,11 +29,9 @@ func Commands(globalParams *common.GlobalParams) []*cobra.Command {
 		Long:  ``,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(displayVersion,
-				fx.Supply(core.CreateBundleParams(
-					"",
-					core.WithSecurityAgentConfigFilePaths(globalParams.ConfPathArray),
-					core.WithConfigLoadSecurityAgent(true),
-				).LogForOneShot(common.LoggerName, "off", true)),
+				fx.Supply(core.BundleParams{
+					ConfigParams: config.NewParams("", config.WithSecurityAgentConfigFilePaths(globalParams.ConfPathArray), config.WithConfigLoadSecurityAgent(true)),
+					LogParams:    log.LogForOneShot(common.LoggerName, "off", true)}),
 				core.Bundle,
 			)
 		},

--- a/comp/core/bundle.go
+++ b/comp/core/bundle.go
@@ -23,6 +23,7 @@ import (
 
 // Bundle defines the fx options for this bundle.
 var Bundle = fxutil.Bundle(
+	// As `config.Module` expects `config.Params` as a parameter, it is require to define how to get `config.Params` from `BundleParams`.
 	fx.Provide(func(params BundleParams) config.Params { return params.ConfigParams }),
 	config.Module,
 	fx.Provide(func(params BundleParams) log.Params { return params.LogParams }),

--- a/comp/core/bundle.go
+++ b/comp/core/bundle.go
@@ -16,18 +16,23 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/log"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+	"go.uber.org/fx"
 )
 
 // team: agent-shared-components
 
 // Bundle defines the fx options for this bundle.
 var Bundle = fxutil.Bundle(
+	fx.Provide(func(params BundleParams) config.Params { return params.ConfigParams }),
 	config.Module,
+	fx.Provide(func(params BundleParams) log.Params { return params.LogParams }),
 	log.Module,
 )
 
 // MockBundle defines the mock fx options for this bundle.
 var MockBundle = fxutil.Bundle(
-	config.MockModule,
+	fx.Provide(func(params BundleParams) config.Params { return params.ConfigParams }),
+	config.Module,
+	fx.Provide(func(params BundleParams) log.Params { return params.LogParams }),
 	log.Module,
 )

--- a/comp/core/bundle_params.go
+++ b/comp/core/bundle_params.go
@@ -6,7 +6,6 @@
 package core
 
 import (
-	"github.com/DataDog/datadog-agent/cmd/agent/common"
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/log"
 )
@@ -24,99 +23,3 @@ type BundleParams struct {
 
 type ConfigParams = config.Params
 type LogParams = log.Params
-
-// CreateAgentBundleParams creates a new BundleParams for the Core Agent
-func CreateAgentBundleParams(confFilePath string, configLoadSecrets bool, options ...func(*BundleParams)) BundleParams {
-	params := CreateBundleParams(common.DefaultConfPath, options...)
-	params.ConfFilePath = confFilePath
-	params.ConfigLoadSecrets = configLoadSecrets
-	return params
-}
-
-// CreateBundleParams creates a new BundleParams
-func CreateBundleParams(defaultConfPath string, options ...func(*BundleParams)) BundleParams {
-	bundleParams := BundleParams{
-		ConfigParams: config.Params{DefaultConfPath: defaultConfPath},
-	}
-	for _, o := range options {
-		o(&bundleParams)
-	}
-	return bundleParams
-}
-
-func WithConfigName(name string) func(*BundleParams) {
-	return func(b *BundleParams) {
-		b.ConfigName = name
-	}
-}
-
-func WithConfigMissingOK(v bool) func(*BundleParams) {
-	return func(b *BundleParams) {
-		b.ConfigMissingOK = v
-	}
-}
-
-func WithConfigLoadSysProbe(v bool) func(*BundleParams) {
-	return func(b *BundleParams) {
-		b.ConfigLoadSysProbe = v
-	}
-}
-
-func WithSecurityAgentConfigFilePaths(securityAgentConfigFilePaths []string) func(*BundleParams) {
-	return func(b *BundleParams) {
-		b.SecurityAgentConfigFilePaths = securityAgentConfigFilePaths
-	}
-}
-
-func WithConfigLoadSecurityAgent(configLoadSecurityAgent bool) func(*BundleParams) {
-	return func(b *BundleParams) {
-		b.ConfigLoadSecurityAgent = configLoadSecurityAgent
-	}
-}
-
-func WithConfFilePath(confFilePath string) func(*BundleParams) {
-	return func(b *BundleParams) {
-		b.ConfFilePath = confFilePath
-	}
-}
-
-func WithConfigLoadSecrets(configLoadSecrets bool) func(*BundleParams) {
-	return func(b *BundleParams) {
-		b.ConfigLoadSecrets = configLoadSecrets
-	}
-}
-
-func WithLogForOneShot(loggerName, level string, overrideFromEnv bool) func(*BundleParams) {
-	return func(b *BundleParams) {
-		b.LogParams = b.LogParams.LogForOneShot(loggerName, level, overrideFromEnv)
-	}
-}
-
-func WithLogForDaemon(loggerName, logFileConfig, defaultLogFile string) func(*BundleParams) {
-	return func(b *BundleParams) {
-		b.LogParams = b.LogParams.LogForDaemon(loggerName, logFileConfig, defaultLogFile)
-	}
-}
-
-func WithLogToFile(logFile string) func(*BundleParams) {
-	return func(b *BundleParams) {
-		b.LogParams.LogToFile(logFile)
-	}
-}
-
-// These functions are temporary. They are there to supply `BundleParams“ and not `log.Params“ in the following line.
-//
-//	fx.Supply(core.CreateAgentBundleParams(globalParams.ConfFilePath, false).LogForOneShot(globalParams.LoggerName, "off", true)),
-func (params BundleParams) LogForOneShot(loggerName, level string, overrideFromEnv bool) BundleParams {
-	params.LogParams = params.LogParams.LogForOneShot(loggerName, level, overrideFromEnv)
-	return params
-}
-
-func (params BundleParams) LogForDaemon(loggerName, logFileConfig, defaultLogFile string) BundleParams {
-	params.LogParams = params.LogParams.LogForDaemon(loggerName, logFileConfig, defaultLogFile)
-	return params
-}
-
-func (params *BundleParams) LogToFile(logFile string) {
-	params.LogParams.LogToFile(logFile)
-}

--- a/comp/core/bundle_params.go
+++ b/comp/core/bundle_params.go
@@ -12,6 +12,8 @@ import (
 
 // BundleParams defines the parameters for this bundle.
 type BundleParams = internal.BundleParams
+type ConfigParams = internal.ConfigParams
+type LogParams = internal.LogParams
 
 // CreateAgentBundleParams creates a new BundleParams for the Core Agent
 func CreateAgentBundleParams(confFilePath string, configLoadSecrets bool, options ...func(*BundleParams)) BundleParams {
@@ -24,7 +26,7 @@ func CreateAgentBundleParams(confFilePath string, configLoadSecrets bool, option
 // CreateBundleParams creates a new BundleParams
 func CreateBundleParams(defaultConfPath string, options ...func(*BundleParams)) BundleParams {
 	bundleParams := BundleParams{
-		DefaultConfPath: defaultConfPath,
+		ConfigParams: internal.ConfigParams{DefaultConfPath: defaultConfPath},
 	}
 	for _, o := range options {
 		o(&bundleParams)

--- a/comp/core/config/config.go
+++ b/comp/core/config/config.go
@@ -35,24 +35,24 @@ type dependencies struct {
 
 func newConfig(deps dependencies) (Component, error) {
 	warnings, err := setupConfig(
-		deps.Params.ConfFilePath,
-		deps.Params.ConfigName,
-		!deps.Params.ConfigLoadSecrets,
-		!deps.Params.ConfigMissingOK,
-		deps.Params.DefaultConfPath)
+		deps.Params.confFilePath,
+		deps.Params.configName,
+		!deps.Params.configLoadSecrets,
+		!deps.Params.configMissingOK,
+		deps.Params.defaultConfPath)
 	if err != nil {
 		return nil, err
 	}
 
-	if deps.Params.ConfigLoadSysProbe {
-		_, err := sysconfig.Merge(deps.Params.SysProbeConfFilePath)
+	if deps.Params.configLoadSysProbe {
+		_, err := sysconfig.Merge(deps.Params.sysProbeConfFilePath)
 		if err != nil {
 			return &cfg{warnings}, err
 		}
 	}
 
-	if deps.Params.ConfigLoadSecurityAgent {
-		if err := secconfig.Merge(deps.Params.SecurityAgentConfigFilePaths); err != nil {
+	if deps.Params.configLoadSecurityAgent {
+		if err := secconfig.Merge(deps.Params.securityAgentConfigFilePaths); err != nil {
 			return &cfg{warnings}, err
 		}
 	}

--- a/comp/core/config/config.go
+++ b/comp/core/config/config.go
@@ -15,7 +15,6 @@ import (
 
 	secconfig "github.com/DataDog/datadog-agent/cmd/security-agent/config"
 	sysconfig "github.com/DataDog/datadog-agent/cmd/system-probe/config"
-	"github.com/DataDog/datadog-agent/comp/core/internal"
 	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
@@ -31,7 +30,7 @@ type cfg struct {
 type dependencies struct {
 	fx.In
 
-	Params internal.BundleParams
+	Params Params
 }
 
 func newConfig(deps dependencies) (Component, error) {

--- a/comp/core/config/config_test.go
+++ b/comp/core/config/config_test.go
@@ -27,10 +27,11 @@ func TestRealConfig(t *testing.T) {
 	defer func() { os.Unsetenv("DD_DD_URL") }()
 
 	fxutil.Test(t, fx.Options(
-		fx.Supply(Params{
-			ConfigMissingOK: true,
-			ConfFilePath:    dir,
-		}),
+		fx.Supply(NewParams(
+			"",
+			WithConfigMissingOK(true),
+			WithConfFilePath(dir),
+		)),
 		Module,
 	), func(config Component) {
 		require.Equal(t, "https://example.com", config.GetString("dd_url"))

--- a/comp/core/config/config_test.go
+++ b/comp/core/config/config_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/DataDog/datadog-agent/comp/core/internal"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
@@ -28,7 +27,7 @@ func TestRealConfig(t *testing.T) {
 	defer func() { os.Unsetenv("DD_DD_URL") }()
 
 	fxutil.Test(t, fx.Options(
-		fx.Supply(internal.ConfigParams{
+		fx.Supply(Params{
 			ConfigMissingOK: true,
 			ConfFilePath:    dir,
 		}),
@@ -46,7 +45,7 @@ func TestMockConfig(t *testing.T) {
 	defer func() { os.Unsetenv("DD_DD_URL") }()
 
 	fxutil.Test(t, fx.Options(
-		fx.Supply(internal.BundleParams{}),
+		fx.Supply(Params{}),
 		MockModule,
 	), func(config Component) {
 		// values aren't set from env..

--- a/comp/core/config/config_test.go
+++ b/comp/core/config/config_test.go
@@ -28,7 +28,7 @@ func TestRealConfig(t *testing.T) {
 	defer func() { os.Unsetenv("DD_DD_URL") }()
 
 	fxutil.Test(t, fx.Options(
-		fx.Supply(internal.BundleParams{
+		fx.Supply(internal.ConfigParams{
 			ConfigMissingOK: true,
 			ConfFilePath:    dir,
 		}),

--- a/comp/core/config/params.go
+++ b/comp/core/config/params.go
@@ -60,8 +60,17 @@ func NewParams(defaultConfPath string, options ...func(*Params)) Params {
 	return params
 }
 
-// NewAgentParams creates a new instance of Params for the Agent.
-func NewAgentParams(confFilePath string, configLoadSecrets bool, options ...func(*Params)) Params {
+// NewAgentParamsWithSecrets creates a new instance of Params using secrets for the Agent.
+func NewAgentParamsWithSecrets(confFilePath string, options ...func(*Params)) Params {
+	return newAgentParams(confFilePath, true, options...)
+}
+
+// NewAgentParamsWithoutSecrets creates a new instance of Params without using secrets for the Agent.
+func NewAgentParamsWithoutSecrets(confFilePath string, options ...func(*Params)) Params {
+	return newAgentParams(confFilePath, false, options...)
+}
+
+func newAgentParams(confFilePath string, configLoadSecrets bool, options ...func(*Params)) Params {
 	params := NewParams(common.DefaultConfPath, options...)
 	params.confFilePath = confFilePath
 	params.configLoadSecrets = configLoadSecrets

--- a/comp/core/config/params.go
+++ b/comp/core/config/params.go
@@ -5,6 +5,8 @@
 
 package config
 
+import "github.com/DataDog/datadog-agent/cmd/agent/common"
+
 // Params defines the parameters for the config component.
 type Params struct {
 	// ConfFilePath is the path at which to look for configuration, usually
@@ -45,4 +47,65 @@ type Params struct {
 	// DefaultConfPath determines the default configuration path.
 	// if DefaultConfPath is empty, then no default configuration path is used.
 	DefaultConfPath string
+}
+
+// NewParams creates a new instance of Params
+func NewParams(defaultConfPath string, options ...func(*Params)) Params {
+	params := Params{
+		DefaultConfPath: defaultConfPath,
+	}
+	for _, o := range options {
+		o(&params)
+	}
+	return params
+}
+
+// NewParams creates a new instance of Params for the Agent.
+func NewAgentParams(confFilePath string, configLoadSecrets bool, options ...func(*Params)) Params {
+	params := NewParams(common.DefaultConfPath, options...)
+	params.ConfFilePath = confFilePath
+	params.ConfigLoadSecrets = configLoadSecrets
+	return params
+}
+
+func WithConfigName(name string) func(*Params) {
+	return func(b *Params) {
+		b.ConfigName = name
+	}
+}
+
+func WithConfigMissingOK(v bool) func(*Params) {
+	return func(b *Params) {
+		b.ConfigMissingOK = v
+	}
+}
+
+func WithConfigLoadSysProbe(v bool) func(*Params) {
+	return func(b *Params) {
+		b.ConfigLoadSysProbe = v
+	}
+}
+
+func WithSecurityAgentConfigFilePaths(securityAgentConfigFilePaths []string) func(*Params) {
+	return func(b *Params) {
+		b.SecurityAgentConfigFilePaths = securityAgentConfigFilePaths
+	}
+}
+
+func WithConfigLoadSecurityAgent(configLoadSecurityAgent bool) func(*Params) {
+	return func(b *Params) {
+		b.ConfigLoadSecurityAgent = configLoadSecurityAgent
+	}
+}
+
+func WithConfFilePath(confFilePath string) func(*Params) {
+	return func(b *Params) {
+		b.ConfFilePath = confFilePath
+	}
+}
+
+func WithConfigLoadSecrets(configLoadSecrets bool) func(*Params) {
+	return func(b *Params) {
+		b.ConfigLoadSecrets = configLoadSecrets
+	}
 }

--- a/comp/core/config/params.go
+++ b/comp/core/config/params.go
@@ -9,50 +9,50 @@ import "github.com/DataDog/datadog-agent/cmd/agent/common"
 
 // Params defines the parameters for the config component.
 type Params struct {
-	// ConfFilePath is the path at which to look for configuration, usually
+	// confFilePath is the path at which to look for configuration, usually
 	// given by the --cfgpath command-line flag.
-	ConfFilePath string
+	confFilePath string
 
-	// ConfigName is the root of the name of the configuration file.  The
+	// configName is the root of the name of the configuration file.  The
 	// comp/core/config component will search for a file with this name
 	// in ConfFilePath, using a variety of extensions.  The default is
 	// "datadog".
-	ConfigName string
+	configName string
 
-	// SysProbeConfFilePath is the path at which to look for system-probe
+	// sysProbeConfFilePath is the path at which to look for system-probe
 	// configuration, usually given by --sysprobecfgpath.  This is not used
 	// unless ConfigLoadSysProbe is true.
-	SysProbeConfFilePath string
+	sysProbeConfFilePath string
 
 	// ConfigLoadSysProbe determines whether to read the system-probe.yaml into
 	// the component's config data.
-	ConfigLoadSysProbe bool
+	configLoadSysProbe bool
 
-	// SecurityAgentConfigFilePaths are the paths at which to look for security-aegnt
+	// securityAgentConfigFilePaths are the paths at which to look for security-aegnt
 	// configuration, usually given by the --cfgpath command-line flag.
-	SecurityAgentConfigFilePaths []string
+	securityAgentConfigFilePaths []string
 
-	// ConfigLoadSecurityAgent determines whether to read the config from
+	// configLoadSecurityAgent determines whether to read the config from
 	// SecurityAgentConfigFilePaths or from ConfFilePath.
-	ConfigLoadSecurityAgent bool
+	configLoadSecurityAgent bool
 
 	// ConfigLoadSecrets determines whether secrets in the configuration file
 	// should be evaluated.  This is typically false for one-shot commands.
-	ConfigLoadSecrets bool
+	configLoadSecrets bool
 
-	// ConfigMissingOK determines whether it is a fatal error if the config
+	// configMissingOK determines whether it is a fatal error if the config
 	// file does not exist.
-	ConfigMissingOK bool
+	configMissingOK bool
 
-	// DefaultConfPath determines the default configuration path.
-	// if DefaultConfPath is empty, then no default configuration path is used.
-	DefaultConfPath string
+	// defaultConfPath determines the default configuration path.
+	// if defaultConfPath is empty, then no default configuration path is used.
+	defaultConfPath string
 }
 
 // NewParams creates a new instance of Params
 func NewParams(defaultConfPath string, options ...func(*Params)) Params {
 	params := Params{
-		DefaultConfPath: defaultConfPath,
+		defaultConfPath: defaultConfPath,
 	}
 	for _, o := range options {
 		o(&params)
@@ -63,57 +63,83 @@ func NewParams(defaultConfPath string, options ...func(*Params)) Params {
 // NewAgentParams creates a new instance of Params for the Agent.
 func NewAgentParams(confFilePath string, configLoadSecrets bool, options ...func(*Params)) Params {
 	params := NewParams(common.DefaultConfPath, options...)
-	params.ConfFilePath = confFilePath
-	params.ConfigLoadSecrets = configLoadSecrets
+	params.confFilePath = confFilePath
+	params.configLoadSecrets = configLoadSecrets
 	return params
 }
 
 // NewSecurityAgentParams creates a new instance of Params for the Security Agent.
 func NewSecurityAgentParams(securityAgentConfigFilePaths []string, configLoadSecurityAgent bool, options ...func(*Params)) Params {
 	params := NewParams("", options...)
-	params.SecurityAgentConfigFilePaths = securityAgentConfigFilePaths
-	params.ConfigLoadSecurityAgent = configLoadSecurityAgent
+	params.securityAgentConfigFilePaths = securityAgentConfigFilePaths
+	params.configLoadSecurityAgent = configLoadSecurityAgent
 	return params
 }
 
 func WithConfigName(name string) func(*Params) {
 	return func(b *Params) {
-		b.ConfigName = name
+		b.configName = name
 	}
 }
 
 func WithConfigMissingOK(v bool) func(*Params) {
 	return func(b *Params) {
-		b.ConfigMissingOK = v
+		b.configMissingOK = v
 	}
 }
 
 func WithConfigLoadSysProbe(v bool) func(*Params) {
 	return func(b *Params) {
-		b.ConfigLoadSysProbe = v
+		b.configLoadSysProbe = v
 	}
 }
 
 func WithSecurityAgentConfigFilePaths(securityAgentConfigFilePaths []string) func(*Params) {
 	return func(b *Params) {
-		b.SecurityAgentConfigFilePaths = securityAgentConfigFilePaths
+		b.securityAgentConfigFilePaths = securityAgentConfigFilePaths
 	}
 }
 
 func WithConfigLoadSecurityAgent(configLoadSecurityAgent bool) func(*Params) {
 	return func(b *Params) {
-		b.ConfigLoadSecurityAgent = configLoadSecurityAgent
+		b.configLoadSecurityAgent = configLoadSecurityAgent
 	}
 }
 
 func WithConfFilePath(confFilePath string) func(*Params) {
 	return func(b *Params) {
-		b.ConfFilePath = confFilePath
+		b.confFilePath = confFilePath
 	}
 }
 
 func WithConfigLoadSecrets(configLoadSecrets bool) func(*Params) {
 	return func(b *Params) {
-		b.ConfigLoadSecrets = configLoadSecrets
+		b.configLoadSecrets = configLoadSecrets
 	}
+}
+
+func WithSysProbeConfFilePath(sysProbeConfFilePath string) func(*Params) {
+	return func(b *Params) {
+		b.sysProbeConfFilePath = sysProbeConfFilePath
+	}
+}
+
+// These functions are used in unit tests.
+
+// ConfigLoadSecrets determines whether secrets in the configuration file
+// should be evaluated.  This is typically false for one-shot commands.
+func (p Params) ConfigLoadSecrets() bool {
+	return p.configLoadSecrets
+}
+
+// ConfigMissingOK determines whether it is a fatal error if the config
+// file does not exist.
+func (p Params) ConfigMissingOK() bool {
+	return p.configMissingOK
+}
+
+// ConfigLoadSysProbe determines whether to read the system-probe.yaml into
+// the component's config data.
+func (p Params) ConfigLoadSysProbe() bool {
+	return p.configLoadSysProbe
 }

--- a/comp/core/config/params.go
+++ b/comp/core/config/params.go
@@ -69,10 +69,10 @@ func NewAgentParams(confFilePath string, configLoadSecrets bool, options ...func
 }
 
 // NewSecurityAgentParams creates a new instance of Params for the Security Agent.
-func NewSecurityAgentParams(securityAgentConfigFilePaths []string, configLoadSecurityAgent bool, options ...func(*Params)) Params {
+func NewSecurityAgentParams(securityAgentConfigFilePaths []string, options ...func(*Params)) Params {
 	params := NewParams("", options...)
 	params.securityAgentConfigFilePaths = securityAgentConfigFilePaths
-	params.configLoadSecurityAgent = configLoadSecurityAgent
+	params.configLoadSecurityAgent = true
 	return params
 }
 

--- a/comp/core/config/params.go
+++ b/comp/core/config/params.go
@@ -1,0 +1,48 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package config
+
+// Params defines the parameters for the config component.
+type Params struct {
+	// ConfFilePath is the path at which to look for configuration, usually
+	// given by the --cfgpath command-line flag.
+	ConfFilePath string
+
+	// ConfigName is the root of the name of the configuration file.  The
+	// comp/core/config component will search for a file with this name
+	// in ConfFilePath, using a variety of extensions.  The default is
+	// "datadog".
+	ConfigName string
+
+	// SysProbeConfFilePath is the path at which to look for system-probe
+	// configuration, usually given by --sysprobecfgpath.  This is not used
+	// unless ConfigLoadSysProbe is true.
+	SysProbeConfFilePath string
+
+	// ConfigLoadSysProbe determines whether to read the system-probe.yaml into
+	// the component's config data.
+	ConfigLoadSysProbe bool
+
+	// SecurityAgentConfigFilePaths are the paths at which to look for security-aegnt
+	// configuration, usually given by the --cfgpath command-line flag.
+	SecurityAgentConfigFilePaths []string
+
+	// ConfigLoadSecurityAgent determines whether to read the config from
+	// SecurityAgentConfigFilePaths or from ConfFilePath.
+	ConfigLoadSecurityAgent bool
+
+	// ConfigLoadSecrets determines whether secrets in the configuration file
+	// should be evaluated.  This is typically false for one-shot commands.
+	ConfigLoadSecrets bool
+
+	// ConfigMissingOK determines whether it is a fatal error if the config
+	// file does not exist.
+	ConfigMissingOK bool
+
+	// DefaultConfPath determines the default configuration path.
+	// if DefaultConfPath is empty, then no default configuration path is used.
+	DefaultConfPath string
+}

--- a/comp/core/config/params.go
+++ b/comp/core/config/params.go
@@ -60,11 +60,19 @@ func NewParams(defaultConfPath string, options ...func(*Params)) Params {
 	return params
 }
 
-// NewParams creates a new instance of Params for the Agent.
+// NewAgentParams creates a new instance of Params for the Agent.
 func NewAgentParams(confFilePath string, configLoadSecrets bool, options ...func(*Params)) Params {
 	params := NewParams(common.DefaultConfPath, options...)
 	params.ConfFilePath = confFilePath
 	params.ConfigLoadSecrets = configLoadSecrets
+	return params
+}
+
+// NewSecurityAgentParams creates a new instance of Params for the Security Agent.
+func NewSecurityAgentParams(securityAgentConfigFilePaths []string, configLoadSecurityAgent bool, options ...func(*Params)) Params {
+	params := NewParams("", options...)
+	params.SecurityAgentConfigFilePaths = securityAgentConfigFilePaths
+	params.ConfigLoadSecurityAgent = configLoadSecurityAgent
 	return params
 }
 

--- a/comp/core/internal/params.go
+++ b/comp/core/internal/params.go
@@ -18,6 +18,12 @@ import (
 // return the updated BundleParams.  One of `LogForOneShot` or `LogForDaemon`
 // must be called.
 type BundleParams struct {
+	ConfigParams
+	LogParams
+}
+
+// ConfigParams defines the parameters for the config component.
+type ConfigParams struct {
 	// ConfFilePath is the path at which to look for configuration, usually
 	// given by the --cfgpath command-line flag.
 	ConfFilePath string
@@ -53,12 +59,20 @@ type BundleParams struct {
 	// file does not exist.
 	ConfigMissingOK bool
 
-	// LoggerName is the name that appears in the logfile
-	LoggerName string
-
 	// DefaultConfPath determines the default configuration path.
 	// if DefaultConfPath is empty, then no default configuration path is used.
 	DefaultConfPath string
+}
+
+// LogParams defines the parameters for this log component.
+//
+// Logs-related parameters are implemented as unexported fields containing
+// callbacks.  These fields can be set with the `LogXxx()` methods, which
+// return the updated LogParams.  One of `LogForOneShot` or `LogForDaemon`
+// must be called.
+type LogParams struct {
+	// LoggerName is the name that appears in the logfile
+	LoggerName string
 
 	// LogLevelFn returns the log level. This field is set by methods on this
 	// type.
@@ -84,7 +98,7 @@ type BundleParams struct {
 }
 
 // configGetter is a subset of the comp/core/config component, able to get
-// config values for the xxxFn fields in BundleParams.  comp/core/log uses
+// config values for the xxxFn fields in LogParams.  comp/core/log uses
 // this interface to get parameters that may depend on a configuration value.
 type configGetter interface {
 	GetString(key string) string

--- a/comp/core/log/logger.go
+++ b/comp/core/log/logger.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
-	"github.com/DataDog/datadog-agent/comp/core/internal"
 	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -20,7 +19,7 @@ type logger struct {
 	// pkg/util/log, and uses globals in that package.
 }
 
-func newLogger(params internal.BundleParams, config config.Component) (Component, error) {
+func newLogger(params Params, config config.Component) (Component, error) {
 	if params.LogLevelFn == nil {
 		return nil, errors.New("must call one of core.BundleParams.LogForOneShot or LogForDaemon")
 	}

--- a/comp/core/log/logger.go
+++ b/comp/core/log/logger.go
@@ -20,17 +20,17 @@ type logger struct {
 }
 
 func newLogger(params Params, config config.Component) (Component, error) {
-	if params.LogLevelFn == nil {
+	if params.logLevelFn == nil {
 		return nil, errors.New("must call one of core.BundleParams.LogForOneShot or LogForDaemon")
 	}
 	err := pkgconfig.SetupLogger(
-		pkgconfig.LoggerName(params.LoggerName),
-		params.LogLevelFn(config),
-		params.LogFileFn(config),
-		params.LogSyslogURIFn(config),
-		params.LogSyslogRFCFn(config),
-		params.LogToConsoleFn(config),
-		params.LogFormatJSONFn(config))
+		pkgconfig.LoggerName(params.loggerName),
+		params.logLevelFn(config),
+		params.logFileFn(config),
+		params.logSyslogURIFn(config),
+		params.logSyslogRFCFn(config),
+		params.logToConsoleFn(config),
+		params.logFormatJSONFn(config))
 	if err != nil {
 		return nil, err
 	}

--- a/comp/core/log/logger_test.go
+++ b/comp/core/log/logger_test.go
@@ -11,13 +11,13 @@ import (
 	"go.uber.org/fx"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
-	"github.com/DataDog/datadog-agent/comp/core/internal"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
 func TestLogging(t *testing.T) {
 	fxutil.Test(t, fx.Options(
-		fx.Supply(internal.BundleParams{}.LogForOneShot("TEST", "debug", false)),
+		fx.Supply(Params{}.LogForOneShot("TEST", "debug", false)),
+		fx.Supply(config.Params{}),
 		config.MockModule,
 		Module,
 	), func(log Component) {

--- a/comp/core/log/logger_test.go
+++ b/comp/core/log/logger_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestLogging(t *testing.T) {
 	fxutil.Test(t, fx.Options(
-		fx.Supply(Params{}.LogForOneShot("TEST", "debug", false)),
+		fx.Supply(LogForOneShot("TEST", "debug", false)),
 		fx.Supply(config.Params{}),
 		config.MockModule,
 		Module,

--- a/comp/core/log/mock_test.go
+++ b/comp/core/log/mock_test.go
@@ -11,13 +11,12 @@ import (
 	"go.uber.org/fx"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
-	"github.com/DataDog/datadog-agent/comp/core/internal"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
 func TestMockLogging(t *testing.T) {
 	fxutil.Test(t, fx.Options(
-		fx.Supply(internal.BundleParams{}),
+		fx.Supply(Params{}),
 		config.MockModule,
 		MockModule,
 	), func(log Component) {

--- a/comp/core/log/params.go
+++ b/comp/core/log/params.go
@@ -130,3 +130,20 @@ func LogForDaemon(loggerName, logFileConfig, defaultLogFile string) Params {
 func (params *Params) LogToFile(logFile string) {
 	params.logFileFn = func(configGetter) string { return logFile }
 }
+
+// These functions are used in unit tests.
+
+// LogLevelFn returns the log level
+func (params Params) LogLevelFn(c configGetter) string {
+	return params.logLevelFn(c)
+}
+
+// LogFileFn returns the log file
+func (params Params) LogFileFn(c configGetter) string {
+	return params.logFileFn(c)
+}
+
+// LoggerName is the name that appears in the logfile
+func (params Params) LoggerName() string {
+	return params.loggerName
+}

--- a/comp/core/log/params.go
+++ b/comp/core/log/params.go
@@ -18,30 +18,30 @@ import (
 // return the updated LogParams.  One of `LogForOneShot` or `LogForDaemon`
 // must be called.
 type Params struct {
-	// LoggerName is the name that appears in the logfile
-	LoggerName string
+	// loggerName is the name that appears in the logfile
+	loggerName string
 
-	// LogLevelFn returns the log level. This field is set by methods on this
+	// logLevelFn returns the log level. This field is set by methods on this
 	// type.
-	LogLevelFn func(configGetter) string
+	logLevelFn func(configGetter) string
 
-	// LogFileFn returns the log file. This field is set by methods on this type.
-	LogFileFn func(configGetter) string
+	// logFileFn returns the log file. This field is set by methods on this type.
+	logFileFn func(configGetter) string
 
-	// LogSyslogURIFn returns the syslog URI. This field is set by methods on this type.
-	LogSyslogURIFn func(configGetter) string
+	// logSyslogURIFn returns the syslog URI. This field is set by methods on this type.
+	logSyslogURIFn func(configGetter) string
 
-	// LogSyslogRFCFn returns a boolean determining whether to use syslog RFC
+	// logSyslogRFCFn returns a boolean determining whether to use syslog RFC
 	// 5424. This field is set by methods on this type.
-	LogSyslogRFCFn func(configGetter) bool
+	logSyslogRFCFn func(configGetter) bool
 
-	// LogToConsoleFn returns a boolean determining whether to write logs to
+	// logToConsoleFn returns a boolean determining whether to write logs to
 	// the console. This field is set by methods on this type.
-	LogToConsoleFn func(configGetter) bool
+	logToConsoleFn func(configGetter) bool
 
-	// LogFormatJSONFn returns a boolean determining whether logs should be
+	// logFormatJSONFn returns a boolean determining whether logs should be
 	// written in JSON format.
-	LogFormatJSONFn func(configGetter) bool
+	logFormatJSONFn func(configGetter) bool
 }
 
 // configGetter is a subset of the comp/core/config component, able to get
@@ -60,17 +60,17 @@ type configGetter interface {
 // enabled, and JSON formatting is disabled.
 func LogForOneShot(loggerName, level string, overrideFromEnv bool) Params {
 	params := Params{}
-	params.LoggerName = loggerName
+	params.loggerName = loggerName
 	if overrideFromEnv {
-		params.LogLevelFn = func(configGetter) string { return config.GetEnvDefault("DD_LOG_LEVEL", level) }
+		params.logLevelFn = func(configGetter) string { return config.GetEnvDefault("DD_LOG_LEVEL", level) }
 	} else {
-		params.LogLevelFn = func(configGetter) string { return level }
+		params.logLevelFn = func(configGetter) string { return level }
 	}
-	params.LogFileFn = func(configGetter) string { return "" }
-	params.LogSyslogURIFn = func(configGetter) string { return "" }
-	params.LogSyslogRFCFn = func(configGetter) bool { return false }
-	params.LogToConsoleFn = func(configGetter) bool { return true }
-	params.LogFormatJSONFn = func(configGetter) bool { return false }
+	params.logFileFn = func(configGetter) string { return "" }
+	params.logSyslogURIFn = func(configGetter) string { return "" }
+	params.logSyslogRFCFn = func(configGetter) bool { return false }
+	params.logToConsoleFn = func(configGetter) bool { return true }
+	params.logFormatJSONFn = func(configGetter) bool { return false }
 	return params
 }
 
@@ -90,9 +90,9 @@ func LogForOneShot(loggerName, level string, overrideFromEnv bool) Params {
 // as JSON if `log_format_json` is set.
 func LogForDaemon(loggerName, logFileConfig, defaultLogFile string) Params {
 	params := Params{}
-	params.LoggerName = loggerName
-	params.LogLevelFn = func(g configGetter) string { return g.GetString("log_level") }
-	params.LogFileFn = func(g configGetter) string {
+	params.loggerName = loggerName
+	params.logLevelFn = func(g configGetter) string { return g.GetString("log_level") }
+	params.logFileFn = func(g configGetter) string {
 		if g.GetBool("disable_file_logging") {
 			return ""
 		}
@@ -102,7 +102,7 @@ func LogForDaemon(loggerName, logFileConfig, defaultLogFile string) Params {
 		}
 		return logFile
 	}
-	params.LogSyslogURIFn = func(g configGetter) string {
+	params.logSyslogURIFn = func(g configGetter) string {
 		if runtime.GOOS == "windows" {
 			return "" // syslog not supported on Windows
 		}
@@ -119,14 +119,14 @@ func LogForDaemon(loggerName, logFileConfig, defaultLogFile string) Params {
 
 		return uri
 	}
-	params.LogSyslogRFCFn = func(g configGetter) bool { return g.GetBool("syslog_rfc") }
-	params.LogToConsoleFn = func(g configGetter) bool { return g.GetBool("log_to_console") }
-	params.LogFormatJSONFn = func(g configGetter) bool { return g.GetBool("log_format_json") }
+	params.logSyslogRFCFn = func(g configGetter) bool { return g.GetBool("syslog_rfc") }
+	params.logToConsoleFn = func(g configGetter) bool { return g.GetBool("log_to_console") }
+	params.logFormatJSONFn = func(g configGetter) bool { return g.GetBool("log_format_json") }
 	return params
 }
 
 // LogToFile modifies the parameters to set the destination log file, overriding any
 // previous logfile parameter.
 func (params *Params) LogToFile(logFile string) {
-	params.LogFileFn = func(configGetter) string { return logFile }
+	params.logFileFn = func(configGetter) string { return logFile }
 }

--- a/comp/core/log/params.go
+++ b/comp/core/log/params.go
@@ -58,7 +58,8 @@ type configGetter interface {
 //
 // Otherwise, file logging is disabled, syslog is disabled, console logging is
 // enabled, and JSON formatting is disabled.
-func (params Params) LogForOneShot(loggerName, level string, overrideFromEnv bool) Params {
+func LogForOneShot(loggerName, level string, overrideFromEnv bool) Params {
+	params := Params{}
 	params.LoggerName = loggerName
 	if overrideFromEnv {
 		params.LogLevelFn = func(configGetter) string { return config.GetEnvDefault("DD_LOG_LEVEL", level) }
@@ -87,7 +88,8 @@ func (params Params) LogForOneShot(loggerName, level string, overrideFromEnv boo
 //
 // Console logging is enabled if `log_to_console` is set.  Lots are formatted
 // as JSON if `log_format_json` is set.
-func (params Params) LogForDaemon(loggerName, logFileConfig, defaultLogFile string) Params {
+func LogForDaemon(loggerName, logFileConfig, defaultLogFile string) Params {
+	params := Params{}
 	params.LoggerName = loggerName
 	params.LogLevelFn = func(g configGetter) string { return g.GetString("log_level") }
 	params.LogFileFn = func(g configGetter) string {

--- a/comp/core/log/params_test.go
+++ b/comp/core/log/params_test.go
@@ -26,7 +26,7 @@ func (g *getter) GetBool(k string) bool {
 }
 
 func TestLogForOneShot_noOverride(t *testing.T) {
-	params := Params{}.LogForOneShot("TEST", "trace", false)
+	params := LogForOneShot("TEST", "trace", false)
 	g := &getter{}
 	t.Setenv("DD_LOG_LEVEL", "debug")
 
@@ -40,7 +40,7 @@ func TestLogForOneShot_noOverride(t *testing.T) {
 }
 
 func TestLogForOneShot_override(t *testing.T) {
-	params := Params{}.LogForOneShot("TEST", "trace", true)
+	params := LogForOneShot("TEST", "trace", true)
 	g := &getter{}
 	t.Setenv("DD_LOG_LEVEL", "debug")
 
@@ -57,7 +57,7 @@ func TestLogForDaemon_windows(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Skip()
 	}
-	params := Params{}.LogForDaemon("TEST", "unused", "unused")
+	params := LogForDaemon("TEST", "unused", "unused")
 	g := &getter{
 		strs: map[string]string{
 			"log_level": "trace",
@@ -98,7 +98,7 @@ func TestLogForDaemon_linux(t *testing.T) {
 	}
 
 	t.Run("log_file config", func(t *testing.T) {
-		params := Params{}.LogForDaemon("TEST", "log_file", "unused")
+		params := LogForDaemon("TEST", "log_file", "unused")
 		g := makeGetter()
 		g.strs["log_file"] = "/foo/bar"
 		require.Equal(t, "TEST", params.LoggerName)
@@ -111,7 +111,7 @@ func TestLogForDaemon_linux(t *testing.T) {
 	})
 
 	t.Run("log_file default", func(t *testing.T) {
-		params := Params{}.LogForDaemon("TEST", "log_file", "/default/log")
+		params := LogForDaemon("TEST", "log_file", "/default/log")
 		g := makeGetter()
 		g.strs["log_file"] = ""
 		require.Equal(t, "TEST", params.LoggerName)
@@ -124,7 +124,7 @@ func TestLogForDaemon_linux(t *testing.T) {
 	})
 
 	t.Run("disable_file_logging", func(t *testing.T) {
-		params := Params{}.LogForDaemon("TEST", "log_file", "/default/log")
+		params := LogForDaemon("TEST", "log_file", "/default/log")
 		g := makeGetter()
 		g.bools["disable_file_logging"] = true
 		require.Equal(t, "TEST", params.LoggerName)
@@ -137,7 +137,7 @@ func TestLogForDaemon_linux(t *testing.T) {
 	})
 
 	t.Run("log to syslog", func(t *testing.T) {
-		params := Params{}.LogForDaemon("TEST", "log_file", "/default/log")
+		params := LogForDaemon("TEST", "log_file", "/default/log")
 		g := makeGetter()
 		g.bools["log_to_syslog"] = true
 		require.Equal(t, "TEST", params.LoggerName)
@@ -150,7 +150,7 @@ func TestLogForDaemon_linux(t *testing.T) {
 	})
 
 	t.Run("log to syslog with uri", func(t *testing.T) {
-		params := Params{}.LogForDaemon("TEST", "log_file", "/default/log")
+		params := LogForDaemon("TEST", "log_file", "/default/log")
 		g := makeGetter()
 		g.bools["log_to_syslog"] = true
 		g.strs["syslog_uri"] = "test:///"
@@ -165,7 +165,7 @@ func TestLogForDaemon_linux(t *testing.T) {
 }
 
 func TestLogToFile(t *testing.T) {
-	params := Params{}.LogForOneShot("TEST", "trace", true)
+	params := LogForOneShot("TEST", "trace", true)
 	params.LogToFile("/some/file")
 	g := &getter{}
 

--- a/comp/core/log/params_test.go
+++ b/comp/core/log/params_test.go
@@ -30,13 +30,13 @@ func TestLogForOneShot_noOverride(t *testing.T) {
 	g := &getter{}
 	t.Setenv("DD_LOG_LEVEL", "debug")
 
-	require.Equal(t, "TEST", params.LoggerName)
-	require.Equal(t, "trace", params.LogLevelFn(g))
-	require.Equal(t, "", params.LogFileFn(g))
-	require.Equal(t, "", params.LogSyslogURIFn(g))
-	require.Equal(t, false, params.LogSyslogRFCFn(g))
-	require.Equal(t, true, params.LogToConsoleFn(g))
-	require.Equal(t, false, params.LogFormatJSONFn(g))
+	require.Equal(t, "TEST", params.loggerName)
+	require.Equal(t, "trace", params.logLevelFn(g))
+	require.Equal(t, "", params.logFileFn(g))
+	require.Equal(t, "", params.logSyslogURIFn(g))
+	require.Equal(t, false, params.logSyslogRFCFn(g))
+	require.Equal(t, true, params.logToConsoleFn(g))
+	require.Equal(t, false, params.logFormatJSONFn(g))
 }
 
 func TestLogForOneShot_override(t *testing.T) {
@@ -44,13 +44,13 @@ func TestLogForOneShot_override(t *testing.T) {
 	g := &getter{}
 	t.Setenv("DD_LOG_LEVEL", "debug")
 
-	require.Equal(t, "TEST", params.LoggerName)
-	require.Equal(t, "debug", params.LogLevelFn(g))
-	require.Equal(t, "", params.LogFileFn(g))
-	require.Equal(t, "", params.LogSyslogURIFn(g))
-	require.Equal(t, false, params.LogSyslogRFCFn(g))
-	require.Equal(t, true, params.LogToConsoleFn(g))
-	require.Equal(t, false, params.LogFormatJSONFn(g))
+	require.Equal(t, "TEST", params.loggerName)
+	require.Equal(t, "debug", params.logLevelFn(g))
+	require.Equal(t, "", params.logFileFn(g))
+	require.Equal(t, "", params.logSyslogURIFn(g))
+	require.Equal(t, false, params.logSyslogRFCFn(g))
+	require.Equal(t, true, params.logToConsoleFn(g))
+	require.Equal(t, false, params.logFormatJSONFn(g))
 }
 
 func TestLogForDaemon_windows(t *testing.T) {
@@ -67,13 +67,13 @@ func TestLogForDaemon_windows(t *testing.T) {
 		},
 	}
 
-	require.Equal(t, "TEST", params.LoggerName)
-	require.Equal(t, "trace", params.LogLevelFn(g))
-	require.Equal(t, "", params.LogFileFn(g))
-	require.Equal(t, "", params.LogSyslogURIFn(g)) // still empty
-	require.Equal(t, false, params.LogSyslogRFCFn(g))
-	require.Equal(t, true, params.LogToConsoleFn(g))
-	require.Equal(t, false, params.LogFormatJSONFn(g))
+	require.Equal(t, "TEST", params.loggerName)
+	require.Equal(t, "trace", params.logLevelFn(g))
+	require.Equal(t, "", params.logFileFn(g))
+	require.Equal(t, "", params.logSyslogURIFn(g)) // still empty
+	require.Equal(t, false, params.logSyslogRFCFn(g))
+	require.Equal(t, true, params.logToConsoleFn(g))
+	require.Equal(t, false, params.logFormatJSONFn(g))
 }
 
 func TestLogForDaemon_linux(t *testing.T) {
@@ -101,52 +101,52 @@ func TestLogForDaemon_linux(t *testing.T) {
 		params := LogForDaemon("TEST", "log_file", "unused")
 		g := makeGetter()
 		g.strs["log_file"] = "/foo/bar"
-		require.Equal(t, "TEST", params.LoggerName)
-		require.Equal(t, "trace", params.LogLevelFn(g))
-		require.Equal(t, "/foo/bar", params.LogFileFn(g))
-		require.Equal(t, "", params.LogSyslogURIFn(g))
-		require.Equal(t, true, params.LogSyslogRFCFn(g))
-		require.Equal(t, false, params.LogToConsoleFn(g))
-		require.Equal(t, true, params.LogFormatJSONFn(g))
+		require.Equal(t, "TEST", params.loggerName)
+		require.Equal(t, "trace", params.logLevelFn(g))
+		require.Equal(t, "/foo/bar", params.logFileFn(g))
+		require.Equal(t, "", params.logSyslogURIFn(g))
+		require.Equal(t, true, params.logSyslogRFCFn(g))
+		require.Equal(t, false, params.logToConsoleFn(g))
+		require.Equal(t, true, params.logFormatJSONFn(g))
 	})
 
 	t.Run("log_file default", func(t *testing.T) {
 		params := LogForDaemon("TEST", "log_file", "/default/log")
 		g := makeGetter()
 		g.strs["log_file"] = ""
-		require.Equal(t, "TEST", params.LoggerName)
-		require.Equal(t, "trace", params.LogLevelFn(g))
-		require.Equal(t, "/default/log", params.LogFileFn(g))
-		require.Equal(t, "", params.LogSyslogURIFn(g))
-		require.Equal(t, true, params.LogSyslogRFCFn(g))
-		require.Equal(t, false, params.LogToConsoleFn(g))
-		require.Equal(t, true, params.LogFormatJSONFn(g))
+		require.Equal(t, "TEST", params.loggerName)
+		require.Equal(t, "trace", params.logLevelFn(g))
+		require.Equal(t, "/default/log", params.logFileFn(g))
+		require.Equal(t, "", params.logSyslogURIFn(g))
+		require.Equal(t, true, params.logSyslogRFCFn(g))
+		require.Equal(t, false, params.logToConsoleFn(g))
+		require.Equal(t, true, params.logFormatJSONFn(g))
 	})
 
 	t.Run("disable_file_logging", func(t *testing.T) {
 		params := LogForDaemon("TEST", "log_file", "/default/log")
 		g := makeGetter()
 		g.bools["disable_file_logging"] = true
-		require.Equal(t, "TEST", params.LoggerName)
-		require.Equal(t, "trace", params.LogLevelFn(g))
-		require.Equal(t, "", params.LogFileFn(g))
-		require.Equal(t, "", params.LogSyslogURIFn(g))
-		require.Equal(t, true, params.LogSyslogRFCFn(g))
-		require.Equal(t, false, params.LogToConsoleFn(g))
-		require.Equal(t, true, params.LogFormatJSONFn(g))
+		require.Equal(t, "TEST", params.loggerName)
+		require.Equal(t, "trace", params.logLevelFn(g))
+		require.Equal(t, "", params.logFileFn(g))
+		require.Equal(t, "", params.logSyslogURIFn(g))
+		require.Equal(t, true, params.logSyslogRFCFn(g))
+		require.Equal(t, false, params.logToConsoleFn(g))
+		require.Equal(t, true, params.logFormatJSONFn(g))
 	})
 
 	t.Run("log to syslog", func(t *testing.T) {
 		params := LogForDaemon("TEST", "log_file", "/default/log")
 		g := makeGetter()
 		g.bools["log_to_syslog"] = true
-		require.Equal(t, "TEST", params.LoggerName)
-		require.Equal(t, "trace", params.LogLevelFn(g))
-		require.Equal(t, "/default/log", params.LogFileFn(g))
-		require.Equal(t, "unixgram:///dev/log", params.LogSyslogURIFn(g))
-		require.Equal(t, true, params.LogSyslogRFCFn(g))
-		require.Equal(t, false, params.LogToConsoleFn(g))
-		require.Equal(t, true, params.LogFormatJSONFn(g))
+		require.Equal(t, "TEST", params.loggerName)
+		require.Equal(t, "trace", params.logLevelFn(g))
+		require.Equal(t, "/default/log", params.logFileFn(g))
+		require.Equal(t, "unixgram:///dev/log", params.logSyslogURIFn(g))
+		require.Equal(t, true, params.logSyslogRFCFn(g))
+		require.Equal(t, false, params.logToConsoleFn(g))
+		require.Equal(t, true, params.logFormatJSONFn(g))
 	})
 
 	t.Run("log to syslog with uri", func(t *testing.T) {
@@ -154,13 +154,13 @@ func TestLogForDaemon_linux(t *testing.T) {
 		g := makeGetter()
 		g.bools["log_to_syslog"] = true
 		g.strs["syslog_uri"] = "test:///"
-		require.Equal(t, "TEST", params.LoggerName)
-		require.Equal(t, "trace", params.LogLevelFn(g))
-		require.Equal(t, "/default/log", params.LogFileFn(g))
-		require.Equal(t, "test:///", params.LogSyslogURIFn(g))
-		require.Equal(t, true, params.LogSyslogRFCFn(g))
-		require.Equal(t, false, params.LogToConsoleFn(g))
-		require.Equal(t, true, params.LogFormatJSONFn(g))
+		require.Equal(t, "TEST", params.loggerName)
+		require.Equal(t, "trace", params.logLevelFn(g))
+		require.Equal(t, "/default/log", params.logFileFn(g))
+		require.Equal(t, "test:///", params.logSyslogURIFn(g))
+		require.Equal(t, true, params.logSyslogRFCFn(g))
+		require.Equal(t, false, params.logToConsoleFn(g))
+		require.Equal(t, true, params.logFormatJSONFn(g))
 	})
 }
 
@@ -169,5 +169,5 @@ func TestLogToFile(t *testing.T) {
 	params.LogToFile("/some/file")
 	g := &getter{}
 
-	require.Equal(t, "/some/file", params.LogFileFn(g))
+	require.Equal(t, "/some/file", params.logFileFn(g))
 }

--- a/comp/core/log/params_test.go
+++ b/comp/core/log/params_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-package internal
+package log
 
 import (
 	"runtime"
@@ -26,7 +26,7 @@ func (g *getter) GetBool(k string) bool {
 }
 
 func TestLogForOneShot_noOverride(t *testing.T) {
-	params := BundleParams{}.LogForOneShot("TEST", "trace", false)
+	params := Params{}.LogForOneShot("TEST", "trace", false)
 	g := &getter{}
 	t.Setenv("DD_LOG_LEVEL", "debug")
 
@@ -40,7 +40,7 @@ func TestLogForOneShot_noOverride(t *testing.T) {
 }
 
 func TestLogForOneShot_override(t *testing.T) {
-	params := BundleParams{}.LogForOneShot("TEST", "trace", true)
+	params := Params{}.LogForOneShot("TEST", "trace", true)
 	g := &getter{}
 	t.Setenv("DD_LOG_LEVEL", "debug")
 
@@ -57,7 +57,7 @@ func TestLogForDaemon_windows(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Skip()
 	}
-	params := BundleParams{}.LogForDaemon("TEST", "unused", "unused")
+	params := Params{}.LogForDaemon("TEST", "unused", "unused")
 	g := &getter{
 		strs: map[string]string{
 			"log_level": "trace",
@@ -98,7 +98,7 @@ func TestLogForDaemon_linux(t *testing.T) {
 	}
 
 	t.Run("log_file config", func(t *testing.T) {
-		params := BundleParams{}.LogForDaemon("TEST", "log_file", "unused")
+		params := Params{}.LogForDaemon("TEST", "log_file", "unused")
 		g := makeGetter()
 		g.strs["log_file"] = "/foo/bar"
 		require.Equal(t, "TEST", params.LoggerName)
@@ -111,7 +111,7 @@ func TestLogForDaemon_linux(t *testing.T) {
 	})
 
 	t.Run("log_file default", func(t *testing.T) {
-		params := BundleParams{}.LogForDaemon("TEST", "log_file", "/default/log")
+		params := Params{}.LogForDaemon("TEST", "log_file", "/default/log")
 		g := makeGetter()
 		g.strs["log_file"] = ""
 		require.Equal(t, "TEST", params.LoggerName)
@@ -124,7 +124,7 @@ func TestLogForDaemon_linux(t *testing.T) {
 	})
 
 	t.Run("disable_file_logging", func(t *testing.T) {
-		params := BundleParams{}.LogForDaemon("TEST", "log_file", "/default/log")
+		params := Params{}.LogForDaemon("TEST", "log_file", "/default/log")
 		g := makeGetter()
 		g.bools["disable_file_logging"] = true
 		require.Equal(t, "TEST", params.LoggerName)
@@ -137,7 +137,7 @@ func TestLogForDaemon_linux(t *testing.T) {
 	})
 
 	t.Run("log to syslog", func(t *testing.T) {
-		params := BundleParams{}.LogForDaemon("TEST", "log_file", "/default/log")
+		params := Params{}.LogForDaemon("TEST", "log_file", "/default/log")
 		g := makeGetter()
 		g.bools["log_to_syslog"] = true
 		require.Equal(t, "TEST", params.LoggerName)
@@ -150,7 +150,7 @@ func TestLogForDaemon_linux(t *testing.T) {
 	})
 
 	t.Run("log to syslog with uri", func(t *testing.T) {
-		params := BundleParams{}.LogForDaemon("TEST", "log_file", "/default/log")
+		params := Params{}.LogForDaemon("TEST", "log_file", "/default/log")
 		g := makeGetter()
 		g.bools["log_to_syslog"] = true
 		g.strs["syslog_uri"] = "test:///"
@@ -165,7 +165,8 @@ func TestLogForDaemon_linux(t *testing.T) {
 }
 
 func TestLogToFile(t *testing.T) {
-	params := BundleParams{}.LogForOneShot("TEST", "trace", true).LogToFile("/some/file")
+	params := Params{}.LogForOneShot("TEST", "trace", true)
+	params.LogToFile("/some/file")
 	g := &getter{}
 
 	require.Equal(t, "/some/file", params.LogFileFn(g))

--- a/pkg/cli/subcommands/check/command.go
+++ b/pkg/cli/subcommands/check/command.go
@@ -105,8 +105,9 @@ func MakeCommand(globalParamsGetter func() GlobalParams) *cobra.Command {
 			disableCmdPort()
 			return fxutil.OneShot(run,
 				fx.Supply(cliParams),
-				fx.Supply(core.CreateAgentBundleParams(globalParams.ConfFilePath, true, core.WithConfigName(globalParams.ConfigName)).
-					LogForOneShot(globalParams.LoggerName, "off", true)),
+				fx.Supply(core.BundleParams{
+					ConfigParams: config.NewAgentParams(globalParams.ConfFilePath, true, config.WithConfigName(globalParams.ConfigName)),
+					LogParams:    log.LogForOneShot(globalParams.LoggerName, "off", true)}),
 				core.Bundle,
 			)
 		},

--- a/pkg/cli/subcommands/check/command.go
+++ b/pkg/cli/subcommands/check/command.go
@@ -106,7 +106,7 @@ func MakeCommand(globalParamsGetter func() GlobalParams) *cobra.Command {
 			return fxutil.OneShot(run,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewAgentParams(globalParams.ConfFilePath, true, config.WithConfigName(globalParams.ConfigName)),
+					ConfigParams: config.NewAgentParamsWithSecrets(globalParams.ConfFilePath, config.WithConfigName(globalParams.ConfigName)),
 					LogParams:    log.LogForOneShot(globalParams.LoggerName, "off", true)}),
 				core.Bundle,
 			)

--- a/pkg/cli/subcommands/check/command_test.go
+++ b/pkg/cli/subcommands/check/command_test.go
@@ -31,6 +31,6 @@ func TestCommand(t *testing.T) {
 			require.Equal(t, []string{"cleopatra"}, cliParams.args)
 			require.Equal(t, 1, cliParams.checkDelay)
 			require.True(t, cliParams.saveFlare)
-			require.Equal(t, true, coreParams.ConfigLoadSecrets)
+			require.Equal(t, true, coreParams.ConfigLoadSecrets())
 		})
 }

--- a/pkg/cli/subcommands/config/command.go
+++ b/pkg/cli/subcommands/config/command.go
@@ -51,7 +51,7 @@ func MakeCommand(globalParamsGetter func() GlobalParams) *cobra.Command {
 			return fxutil.OneShot(callback,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewAgentParams(globalParams.ConfFilePath, false, config.WithConfigName(globalParams.ConfigName)),
+					ConfigParams: config.NewAgentParamsWithoutSecrets(globalParams.ConfFilePath, config.WithConfigName(globalParams.ConfigName)),
 					LogParams:    log.LogForOneShot(globalParams.LoggerName, "off", true)}),
 				core.Bundle,
 			)

--- a/pkg/cli/subcommands/config/command.go
+++ b/pkg/cli/subcommands/config/command.go
@@ -50,8 +50,9 @@ func MakeCommand(globalParamsGetter func() GlobalParams) *cobra.Command {
 
 			return fxutil.OneShot(callback,
 				fx.Supply(cliParams),
-				fx.Supply(core.CreateAgentBundleParams(globalParams.ConfFilePath, false, core.WithConfigName(globalParams.ConfigName)).
-					LogForOneShot(globalParams.LoggerName, "off", true)),
+				fx.Supply(core.BundleParams{
+					ConfigParams: config.NewAgentParams(globalParams.ConfFilePath, false, config.WithConfigName(globalParams.ConfigName)),
+					LogParams:    log.LogForOneShot(globalParams.LoggerName, "off", true)}),
 				core.Bundle,
 			)
 		}

--- a/pkg/cli/subcommands/config/command_test.go
+++ b/pkg/cli/subcommands/config/command_test.go
@@ -28,7 +28,7 @@ func TestConfigCommand(t *testing.T) {
 		showRuntimeConfiguration,
 		func(cliParams *cliParams, coreParams core.BundleParams) {
 			require.Equal(t, []string{}, cliParams.args)
-			require.Equal(t, false, coreParams.ConfigLoadSecrets)
+			require.Equal(t, false, coreParams.ConfigLoadSecrets())
 		})
 }
 
@@ -45,7 +45,7 @@ func TestConfigListRuntimeCommand(t *testing.T) {
 		listRuntimeConfigurableValue,
 		func(cliParams *cliParams, coreParams core.BundleParams) {
 			require.Equal(t, []string{}, cliParams.args)
-			require.Equal(t, false, coreParams.ConfigLoadSecrets)
+			require.Equal(t, false, coreParams.ConfigLoadSecrets())
 		})
 }
 
@@ -62,7 +62,7 @@ func TestConfigSetCommand(t *testing.T) {
 		setConfigValue,
 		func(cliParams *cliParams, coreParams core.BundleParams) {
 			require.Equal(t, []string{"foo", "bar"}, cliParams.args)
-			require.Equal(t, false, coreParams.ConfigLoadSecrets)
+			require.Equal(t, false, coreParams.ConfigLoadSecrets())
 		})
 }
 
@@ -79,6 +79,6 @@ func TestConfigGetCommand(t *testing.T) {
 		getConfigValue,
 		func(cliParams *cliParams, coreParams core.BundleParams) {
 			require.Equal(t, []string{"foo"}, cliParams.args)
-			require.Equal(t, false, coreParams.ConfigLoadSecrets)
+			require.Equal(t, false, coreParams.ConfigLoadSecrets())
 		})
 }

--- a/pkg/cli/subcommands/health/command.go
+++ b/pkg/cli/subcommands/health/command.go
@@ -45,7 +45,7 @@ func MakeCommand(globalParamsGetter func() GlobalParams) *cobra.Command {
 
 			return fxutil.OneShot(requestHealth,
 				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewAgentParams(globalParams.ConfFilePath, false, config.WithConfigName(globalParams.ConfigName)),
+					ConfigParams: config.NewAgentParamsWithoutSecrets(globalParams.ConfFilePath, config.WithConfigName(globalParams.ConfigName)),
 					LogParams:    log.LogForOneShot(globalParams.LoggerName, "off", true)}),
 				core.Bundle,
 			)

--- a/pkg/cli/subcommands/health/command.go
+++ b/pkg/cli/subcommands/health/command.go
@@ -44,8 +44,9 @@ func MakeCommand(globalParamsGetter func() GlobalParams) *cobra.Command {
 			globalParams := globalParamsGetter()
 
 			return fxutil.OneShot(requestHealth,
-				fx.Supply(core.CreateAgentBundleParams(globalParams.ConfFilePath, false, core.WithConfigName(globalParams.ConfigName)).
-					LogForOneShot(globalParams.LoggerName, "off", true)),
+				fx.Supply(core.BundleParams{
+					ConfigParams: config.NewAgentParams(globalParams.ConfFilePath, false, config.WithConfigName(globalParams.ConfigName)),
+					LogParams:    log.LogForOneShot(globalParams.LoggerName, "off", true)}),
 				core.Bundle,
 			)
 		},

--- a/pkg/cli/subcommands/health/command_test.go
+++ b/pkg/cli/subcommands/health/command_test.go
@@ -27,6 +27,6 @@ func TestCommand(t *testing.T) {
 		[]string{"health"},
 		requestHealth,
 		func(coreParams core.BundleParams) {
-			require.Equal(t, false, coreParams.ConfigLoadSecrets)
+			require.Equal(t, false, coreParams.ConfigLoadSecrets())
 		})
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
This PR moves the DogStatsd `start` command to its own folder for consistency with the Agent commands.
Also DogStatsd `version` uses the shared implementation in `pkg/cli/subcommands/version/command.go`.

Before:
```
DogStatsD from Agent 7.42.0 - Codename: git.349.7dcd5dd - Commit: 7dcd5ddf12 - Serialization version: v5.0.46 - Go version: go1.19.3
```
After:
```
DogStatsD 7.42.0-devel - Meta: git.350.71db951 - Commit: 71db951840 - Serialization version: v5.0.46 - Go version: go1.19.3
```
`--cfgpath` is handled in the same way for DogstatsD as for the main agent.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

https://github.com/DataDog/datadog-agent/pull/13842#pullrequestreview-1149752249

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
- Makes sure DogStatsD start command works on both Linux and Windows.
- Check that `version` command still works.
- Check `--cfgpath` works

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
