### PR TITLE
[CWS][SEC-6508] use tail call limit to increase the number of args/envs

### DIFF
--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var RuntimeSecurity = newAsset("runtime-security.c", "871228962c5fcbc5e86eee892dbbe5a729a3189c8bae3f9f77db3f9732ab56c6")
+var RuntimeSecurity = newAsset("runtime-security.c", "e504cfb15c5360a1f4fb07cf2d578af776e89e18b307f9141fa1155bb095ac22")

--- a/pkg/security/ebpf/c/syscalls.h
+++ b/pkg/security/ebpf/c/syscalls.h
@@ -14,7 +14,7 @@ enum {
 
 struct str_array_ref_t {
     u32 id;
-    u8 index;
+    u32 index;
     u8 truncated;
     const char **array;
 };
@@ -141,7 +141,6 @@ struct syscall_cache_t {
             struct str_array_ref_t envs;
             struct span_context_t span_context;
             struct linux_binprm_t linux_binprm;
-            u32 next_tail;
             u8 is_parsed;
         } exec;
 

--- a/pkg/security/ebpf/probes/exec.go
+++ b/pkg/security/ebpf/probes/exec.go
@@ -227,19 +227,14 @@ func getExecProbes() []*manager.Probe {
 }
 
 func getExecTailCallRoutes() []manager.TailCallRoute {
-	var routes []manager.TailCallRoute
-
-	for i := uint32(0); i != 10; i++ {
-		route := manager.TailCallRoute{
+	return []manager.TailCallRoute{
+		{
 			ProgArrayName: "args_envs_progs",
-			Key:           i,
+			Key:           0,
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
 				EBPFSection:  "kprobe/parse_args_envs",
 				EBPFFuncName: "kprobe_parse_args_envs",
 			},
-		}
-		routes = append(routes, route)
+		},
 	}
-
-	return routes
 }

--- a/pkg/security/probe/serializers.go
+++ b/pkg/security/probe/serializers.go
@@ -611,7 +611,7 @@ func newCredentialsSerializer(ce *model.Credentials) *CredentialsSerializer {
 
 func newProcessSerializer(ps *model.Process, e *Event) *ProcessSerializer {
 	if ps.IsNotKworker() {
-		argv, argvTruncated := e.resolvers.ProcessResolver.GetProcessScrubbedArgv(ps)
+		argv, argvTruncated := e.resolvers.ProcessResolver.GetProcessArgv(ps)
 		envs, EnvsTruncated := e.resolvers.ProcessResolver.GetProcessEnvs(ps)
 		argv0, _ := e.resolvers.ProcessResolver.GetProcessArgv0(ps)
 

--- a/pkg/security/probe/serializers.go
+++ b/pkg/security/probe/serializers.go
@@ -611,7 +611,7 @@ func newCredentialsSerializer(ce *model.Credentials) *CredentialsSerializer {
 
 func newProcessSerializer(ps *model.Process, e *Event) *ProcessSerializer {
 	if ps.IsNotKworker() {
-		argv, argvTruncated := e.resolvers.ProcessResolver.GetProcessArgv(ps)
+		argv, argvTruncated := e.resolvers.ProcessResolver.GetProcessScrubbedArgv(ps)
 		envs, EnvsTruncated := e.resolvers.ProcessResolver.GetProcessEnvs(ps)
 		argv0, _ := e.resolvers.ProcessResolver.GetProcessArgv0(ps)
 

--- a/pkg/security/tests/process_test.go
+++ b/pkg/security/tests/process_test.go
@@ -102,7 +102,7 @@ func TestProcessContext(t *testing.T) {
 		},
 		{
 			ID:         "test_rule_args_envs",
-			Expression: `exec.file.name == "ls" && exec.args in [~"*-al*"] && exec.envs in [~"LD_*"]`,
+			Expression: `exec.file.name == "ls" && exec.args =~ "-al*" && exec.envs =~ "LD_*"`,
 		},
 		{
 			ID:         "test_rule_argv",
@@ -421,9 +421,9 @@ func TestProcessContext(t *testing.T) {
 			}
 
 			argv := strings.Split(execArgs.(string), " ")
-			assert.Equal(t, 132, len(argv), "incorrect number of args: %s", argv)
+			assert.Equal(t, 379, len(argv), "incorrect number of args: %s", argv)
 
-			for i := 0; i != 132; i++ {
+			for i := 0; i != 379; i++ {
 				assert.Equal(t, args[i], argv[i], "expected arg not found")
 			}
 
@@ -462,9 +462,9 @@ func TestProcessContext(t *testing.T) {
 			}
 
 			argv := strings.Split(execArgs.(string), " ")
-			assert.Equal(t, 159, len(argv), "incorrect number of args: %s", argv)
+			assert.Equal(t, 389, len(argv), "incorrect number of args: %s", argv)
 
-			for i := 0; i != 159; i++ {
+			for i := 0; i != 389; i++ {
 				expected := args[i]
 				if len(expected) > model.MaxArgEnvSize {
 					expected = args[i][:model.MaxArgEnvSize-4] + "..." // 4 is the size number of the string
@@ -564,9 +564,9 @@ func TestProcessContext(t *testing.T) {
 			}
 
 			envp := (execEnvp.([]string))
-			assert.Equal(t, 57, len(envp), "incorrect number of envs: %s", envp)
+			assert.Equal(t, 380, len(envp), "incorrect number of envs: %s", envp)
 
-			for i := 0; i != 57; i++ {
+			for i := 0; i != 380; i++ {
 				assert.Equal(t, envs[i], envp[i], "expected env not found")
 			}
 
@@ -615,9 +615,9 @@ func TestProcessContext(t *testing.T) {
 			}
 
 			envp := (execEnvp.([]string))
-			assert.Equal(t, 68, len(envp), "incorrect number of envs: %s", envp)
+			assert.Equal(t, 390, len(envp), "incorrect number of envs: %s", envp)
 
-			for i := 0; i != 68; i++ {
+			for i := 0; i != 390; i++ {
 				expected := envs[i]
 				if len(expected) > model.MaxArgEnvSize {
 					expected = envs[i][:model.MaxArgEnvSize-4] + "..." // 4 is the size number of the string


### PR DESCRIPTION
This PR increases the maximum number of tail calls used to parse arguments and environment variables. The maximum number of tail calls is increased from 10 to 32 (16 for each args and envs).

Relevant functional tests:
`inv -e security-agent.functional-tests --testflags "-test.v -test.run TestProcessContext"`

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
