### PR TITLE
Improve debug logging in cloud foundry container tagger

### DIFF
--- a/pkg/cloudfoundry/containertagger/container_tagger.go
+++ b/pkg/cloudfoundry/containertagger/container_tagger.go
@@ -90,7 +90,7 @@ func (c *ContainerTagger) processEvent(ctx context.Context, evt workloadmeta.Eve
 	entity := evt.Entity
 	containerID := entity.GetID().ID
 	if evt.Type == workloadmeta.EventTypeSet {
-		log.Tracef("Processing Event %s", entity.String(true))
+		log.Debugf("Processing Event %s", entity.String(true))
 
 		storeContainer := entity.(*workloadmeta.Container)
 

--- a/pkg/cloudfoundry/containertagger/container_tagger.go
+++ b/pkg/cloudfoundry/containertagger/container_tagger.go
@@ -123,7 +123,7 @@ func (c *ContainerTagger) processEvent(ctx context.Context, evt workloadmeta.Eve
 		go func() {
 			var exitCode int
 			var err error
-			for attempt := 1; attempt < c.retryCount; attempt++ {
+			for attempt := 1; attempt <= c.retryCount; attempt++ {
 				log.Infof("Updating tags in container `%s` attempt #%d", containerID, attempt)
 				log.Debugf("Update attempt #%d for event %d", attempt, eventTimestamp)
 				exitCode, err = updateTagsInContainer(container, tags)

--- a/pkg/cloudfoundry/containertagger/container_tagger.go
+++ b/pkg/cloudfoundry/containertagger/container_tagger.go
@@ -87,10 +87,12 @@ func (c *ContainerTagger) Start(ctx context.Context) {
 }
 
 func (c *ContainerTagger) processEvent(ctx context.Context, evt workloadmeta.Event) error {
-	containerID := evt.Entity.GetID().ID
-
+	entity := evt.Entity
+	containerID := entity.GetID().ID
 	if evt.Type == workloadmeta.EventTypeSet {
-		storeContainer := evt.Entity.(*workloadmeta.Container)
+		log.Tracef("Processing Event %s", entity.String(true))
+
+		storeContainer := entity.(*workloadmeta.Container)
 
 		// extract tags
 		hostTags := host.GetHostTags(ctx, true)
@@ -123,7 +125,6 @@ func (c *ContainerTagger) processEvent(ctx context.Context, evt workloadmeta.Eve
 			var err error
 			for retry := 0; retry < c.retryCount; retry++ {
 				log.Infof("Updating tags in container `%s` attempt #%d", containerID, retry+1)
-				log.Infof("Event is %s", evt)
 				exitCode, err = updateTagsInContainer(container, tags)
 				if err != nil {
 					log.Warnf("Error running a process inside container `%s`: %v", containerID, err)

--- a/pkg/cloudfoundry/containertagger/container_tagger.go
+++ b/pkg/cloudfoundry/containertagger/container_tagger.go
@@ -92,7 +92,8 @@ func (c *ContainerTagger) processEvent(ctx context.Context, evt workloadmeta.Eve
 	if evt.Type == workloadmeta.EventTypeSet {
 		eventTimestamp := time.Now().UnixNano()
 		storeContainer := entity.(*workloadmeta.Container)
-		log.Debugf("Processing Event (id %d): %+v", eventTimestamp, storeContainer)
+		eventID := fmt.Sprintf("%s-%d", containerID, eventTimestamp)
+		log.Debugf("Processing Event (id %s): %+v", eventID, storeContainer)
 
 		// extract tags
 		hostTags := host.GetHostTags(ctx, true)
@@ -125,7 +126,7 @@ func (c *ContainerTagger) processEvent(ctx context.Context, evt workloadmeta.Eve
 			var err error
 			for attempt := 1; attempt <= c.retryCount; attempt++ {
 				log.Infof("Updating tags in container `%s` attempt #%d", containerID, attempt)
-				log.Debugf("Update attempt #%d for event %s-%d", attempt, containerID, eventTimestamp)
+				log.Debugf("Update attempt #%d for event %s", attempt, eventID)
 				exitCode, err = updateTagsInContainer(container, tags)
 				if err != nil {
 					log.Warnf("Error running a process inside container `%s`: %v", containerID, err)

--- a/pkg/cloudfoundry/containertagger/container_tagger.go
+++ b/pkg/cloudfoundry/containertagger/container_tagger.go
@@ -92,8 +92,7 @@ func (c *ContainerTagger) processEvent(ctx context.Context, evt workloadmeta.Eve
 	if evt.Type == workloadmeta.EventTypeSet {
 		eventTimestamp := time.Now().UnixNano()
 		storeContainer := entity.(*workloadmeta.Container)
-
-		log.Debugf("Processing Event (id %d): %s", eventTimestamp, storeContainer.String(true))
+		log.Debugf("Processing Event (id %d): %+v", eventTimestamp, storeContainer)
 
 		// extract tags
 		hostTags := host.GetHostTags(ctx, true)

--- a/pkg/cloudfoundry/containertagger/container_tagger.go
+++ b/pkg/cloudfoundry/containertagger/container_tagger.go
@@ -125,12 +125,12 @@ func (c *ContainerTagger) processEvent(ctx context.Context, evt workloadmeta.Eve
 			var err error
 			for attempt := 1; attempt <= c.retryCount; attempt++ {
 				log.Infof("Updating tags in container `%s` attempt #%d", containerID, attempt)
-				log.Debugf("Update attempt #%d for event %d", attempt, eventTimestamp)
+				log.Debugf("Update attempt #%d for event %s-%d", attempt, containerID, eventTimestamp)
 				exitCode, err = updateTagsInContainer(container, tags)
 				if err != nil {
 					log.Warnf("Error running a process inside container `%s`: %v", containerID, err)
 				} else if exitCode == 0 {
-					log.Debugf("Successfully updated tags in container `%s`", containerID)
+					log.Infof("Successfully updated tags in container `%s`", containerID)
 					return
 				}
 				log.Debugf("Process for container '%s' exited with code: %d", containerID, exitCode)

--- a/pkg/cloudfoundry/containertagger/container_tagger.go
+++ b/pkg/cloudfoundry/containertagger/container_tagger.go
@@ -122,7 +122,8 @@ func (c *ContainerTagger) processEvent(ctx context.Context, evt workloadmeta.Eve
 			var exitCode int
 			var err error
 			for retry := 0; retry < c.retryCount; retry++ {
-				log.Infof("Updating tags in container `%s` retry #%d", containerID, retry)
+				log.Infof("Updating tags in container `%s` attempt #%d", containerID, retry+1)
+				log.Infof("Event is %s", evt)
 				exitCode, err = updateTagsInContainer(container, tags)
 				if err != nil {
 					log.Warnf("Error running a process inside container `%s`: %v", containerID, err)

--- a/pkg/cloudfoundry/containertagger/container_tagger.go
+++ b/pkg/cloudfoundry/containertagger/container_tagger.go
@@ -90,10 +90,11 @@ func (c *ContainerTagger) processEvent(ctx context.Context, evt workloadmeta.Eve
 	entity := evt.Entity
 	containerID := entity.GetID().ID
 	if evt.Type == workloadmeta.EventTypeSet {
-		eventTimestamp := time.Now().Unix()
-		log.Debugf("Processing Event (id %d): %s", eventTimestamp, entity.String(true))
-
+		eventTimestamp := time.Now().UnixNano()
 		storeContainer := entity.(*workloadmeta.Container)
+
+		log.Debugf("Processing Event (id %d): %s", eventTimestamp, storeContainer.String(true))
+
 		// extract tags
 		hostTags := host.GetHostTags(ctx, true)
 		tags := storeContainer.CollectorTags

--- a/releasenotes/notes/Improve-container-tagger-logging-e48b0fffbe8563d0.yaml
+++ b/releasenotes/notes/Improve-container-tagger-logging-e48b0fffbe8563d0.yaml
@@ -1,5 +1,0 @@
----
-enhancements:
-  - |
-    Improve debug logging in the Cloud Foundry container tagger.
-

--- a/releasenotes/notes/Improve-container-tagger-logging-e48b0fffbe8563d0.yaml
+++ b/releasenotes/notes/Improve-container-tagger-logging-e48b0fffbe8563d0.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    Improve debug logging in the Cloud Foundry container tagger.
+


### PR DESCRIPTION
### What does this PR do?

Improves the logging in the cloud foundry container tagger

### Motivation

In some cases, it is helpful for debugging to know what event has causes a container tagger retry event. 

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
