### PR TITLE
update profiling endpoint when the fips is enabled to avoid 404

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1596,6 +1596,7 @@ func setupFipsEndpoints(config Config) error {
 
 	// APM
 	config.Set("apm_config.apm_dd_url", protocol+urlFor(traces))
+	// Adding "/api/v2/profile" because it's not added to the 'apm_config.profiling_dd_url' value by the Agent
 	config.Set("apm_config.profiling_dd_url", protocol+urlFor(profiles)+"/api/v2/profile")
 	config.Set("apm_config.telemetry.dd_url", protocol+urlFor(instrumentationTelemetry))
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1596,7 +1596,7 @@ func setupFipsEndpoints(config Config) error {
 
 	// APM
 	config.Set("apm_config.apm_dd_url", protocol+urlFor(traces))
-	config.Set("apm_config.profiling_dd_url", protocol+urlFor(profiles))
+	config.Set("apm_config.profiling_dd_url", protocol+urlFor(profiles)+"/api/v2/profile")
 	config.Set("apm_config.telemetry.dd_url", protocol+urlFor(instrumentationTelemetry))
 
 	// Processes

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1235,7 +1235,7 @@ func assertFipsProxyExpectedConfig(t *testing.T, expectedBaseHTTPURL, expectedBa
 	if rng {
 		assert.Equal(t, expectedBaseHTTPURL+"01", c.GetString("dd_url"))
 		assert.Equal(t, expectedBaseHTTPURL+"02", c.GetString("apm_config.apm_dd_url"))
-		assert.Equal(t, expectedBaseHTTPURL+"03", c.GetString("apm_config.profiling_dd_url"))
+		assert.Equal(t, expectedBaseHTTPURL+"03"+"/api/v2/profile", c.GetString("apm_config.profiling_dd_url"))
 		assert.Equal(t, expectedBaseHTTPURL+"10", c.GetString("apm_config.telemetry.dd_url"))
 		assert.Equal(t, expectedBaseHTTPURL+"04", c.GetString("process_config.process_dd_url"))
 		assert.Equal(t, expectedBaseURL+"05", c.GetString("logs_config.logs_dd_url"))
@@ -1246,7 +1246,7 @@ func assertFipsProxyExpectedConfig(t *testing.T, expectedBaseHTTPURL, expectedBa
 	} else {
 		assert.Equal(t, expectedBaseHTTPURL, c.GetString("dd_url"))
 		assert.Equal(t, expectedBaseHTTPURL, c.GetString("apm_config.apm_dd_url"))
-		assert.Equal(t, expectedBaseHTTPURL, c.GetString("apm_config.profiling_dd_url"))
+		assert.Equal(t, expectedBaseHTTPURL, c.GetString("apm_config.profiling_dd_url")) // Omitting "/api/v2/profile" as the config is not overwritten
 		assert.Equal(t, expectedBaseHTTPURL, c.GetString("apm_config.telemetry.dd_url"))
 		assert.Equal(t, expectedBaseHTTPURL, c.GetString("process_config.process_dd_url"))
 		assert.Equal(t, expectedBaseURL, c.GetString("logs_config.logs_dd_url"))


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This PR adds `/api/v2/profile` to `apm_config.profiling_dd_url` when fips is enabled

### Motivation

`/api/v2/profile` is not automatically added to `profiling_dd_url` (see [code](https://github.com/DataDog/datadog-agent/blob/main/pkg/trace/api/profiles.go#L38-L43)) while the [real endpoint](https://github.com/DataDog/datadog-agent/blob/main/pkg/trace/api/profiles.go#L26) contains it. This leads to a 404 when communicating with the proxy.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

- Unit tests should be sufficient
- Otherwise you can launch the Agent, a proxy and verify that you can send profiles through the proxy.
    - You can use the following repository https://github.com/DataDog/haproxy-dd-profiling
    - Replace the agent image in https://github.com/DataDog/haproxy-dd-profiling/blob/main/docker-compose.yml
    - Either set `DD_FIPS_PORT_RANGE_START=3834` for the agent in `docker-compose.yml` or modify the [port on the config](https://github.com/DataDog/haproxy-dd-profiling/blob/main/docker-compose.yml#L19) for 9806 + [expose](https://github.com/DataDog/haproxy-dd-profiling/blob/main/docker-compose.yml#L10) port 9806 .
    - Launch `docker-compose up` and wait about a minute. Then verify that there is no error in the logs (watch carefully after `pyfib_1_9f41eb2990e2 | DEBUG:ddtrace.profiling.scheduler:Flushing events` logs), and that you can see profiles in the UI.

**Notes**: you can set `DD_PROFILING_UPLOAD_INTERVAL: 5` variable in `pyfib` [environment](https://github.com/DataDog/haproxy-dd-profiling/blob/main/docker-compose.yml#L33) to avoid waiting too much time.


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
