### PR TITLE
[workloadmeta/store] Retry collectors with exp backoff

### DIFF
--- a/releasenotes/notes/workloadmeta-store-retry-collectors-backoff-129359ac8b33bdc3.yaml
+++ b/releasenotes/notes/workloadmeta-store-retry-collectors-backoff-129359ac8b33bdc3.yaml
@@ -1,0 +1,14 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Changes the retry mechanism of starting workloadmeta collectors so that
+    instead of retrying every 30 seconds, it retries following an exponential
+    backoff with initial interval of 1s and max of 30s. In general, this should
+    help start sooner the collectors that failed on the first try.


### PR DESCRIPTION

### What does this PR do?

Changes the retry mechanism of starting workloadmeta collectors so that instead of retrying every 30 seconds, it retries following an exponential backoff with initial interval of 1s and max of 30s. In general, this should help start sooner the collectors that failed on the first try.

### Describe how to test/QA your changes

One of the workloadmeta collectors that fail some times at start is the "kube_metadata" one because, by default, it waits until the DCA is ready.

A possible way of testing this PR consists of killing the DCA pod while the agent is starting to force an error in the "kube_metadata" collector start. Before this change, you should see in the logs that the collector tries to start every 30s. With this PR, it should retry with an exponential backoff.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
