### PR TITLE
protocols: refactor tests to allow pre-post setups

### DIFF
--- a/pkg/network/tracer/tracer_classification_test.go
+++ b/pkg/network/tracer/tracer_classification_test.go
@@ -39,6 +39,7 @@ type testContext struct {
 	expectedProtocol network.ProtocolType
 	// A channel to mark goroutines (like servers) to halt.
 	done chan struct{}
+	//nolint:unused
 	// A dynamic map that allows extending the context easily between phases of the test.
 	extras map[string]interface{}
 }
@@ -69,6 +70,7 @@ func defaultTeardown(_ *testing.T, ctx testContext) {
 	close(ctx.done)
 }
 
+//nolint:deadcode,unused
 // skipIfNotLinux skips the test if we are not on a linux machine
 func skipIfNotLinux(_ testContext) (bool, string) {
 	if runtime.GOOS != "linux" {
@@ -78,6 +80,7 @@ func skipIfNotLinux(_ testContext) (bool, string) {
 	return false, ""
 }
 
+//nolint:deadcode,unused
 // skipIfUsingNAT skips the test if we have a NAT rules applied.
 func skipIfUsingNAT(ctx testContext) (bool, string) {
 	if ctx.targetAddress != ctx.serverAddress {

--- a/pkg/network/tracer/tracer_classification_test.go
+++ b/pkg/network/tracer/tracer_classification_test.go
@@ -15,6 +15,7 @@ import (
 	"io"
 	"net"
 	nethttp "net/http"
+	"runtime"
 	"testing"
 	"time"
 
@@ -24,12 +25,32 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func testProtocolClassification(t *testing.T, cfg *config.Config, clientHost, targetHost, serverHost string) {
+// testContext shares the context of a given test.
+// It contains common variable used by all tests, and allows extending the context dynamically by setting more
+// attributes to the `extras` map.
+type testContext struct {
+	// The address of the server to listen on.
+	serverAddress string
+	serverPort    string
+	// The address for the client to communicate with.
+	targetAddress string
+	// optional - A custom dialer to set the ip/port/socket attributes for the client.
+	clientDialer     *net.Dialer
+	expectedProtocol network.ProtocolType
+	// A channel to mark goroutines (like servers) to halt.
+	done chan struct{}
+	// A dynamic map that allows extending the context easily between phases of the test.
+	extras map[string]interface{}
+}
+
+func setupTracer(t *testing.T, cfg *config.Config) *Tracer {
 	tr, err := NewTracer(cfg)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer tr.Stop()
+	t.Cleanup(func() {
+		tr.Stop()
+	})
 
 	initTracerState(t, tr)
 	require.NoError(t, err)
@@ -37,7 +58,37 @@ func testProtocolClassification(t *testing.T, cfg *config.Config, clientHost, ta
 	// Giving the tracer time to run
 	time.Sleep(time.Second)
 
-	dialer := &net.Dialer{
+	return tr
+}
+
+func validateProtocolConnection(t *testing.T, ctx testContext, tr *Tracer) {
+	waitForConnectionsWithProtocol(t, tr, ctx.targetAddress, ctx.serverAddress, ctx.expectedProtocol)
+}
+
+func defaultTeardown(_ *testing.T, ctx testContext) {
+	close(ctx.done)
+}
+
+// skipIfNotLinux skips the test if we are not on a linux machine
+func skipIfNotLinux(_ testContext) (bool, string) {
+	if runtime.GOOS != "linux" {
+		return true, "test is supported on linux machine only"
+	}
+
+	return false, ""
+}
+
+// skipIfUsingNAT skips the test if we have a NAT rules applied.
+func skipIfUsingNAT(ctx testContext) (bool, string) {
+	if ctx.targetAddress != ctx.serverAddress {
+		return true, "test is supported when NAT is applied"
+	}
+
+	return false, ""
+}
+
+func testProtocolClassification(t *testing.T, cfg *config.Config, clientHost, targetHost, serverHost string) {
+	defaultDialer := &net.Dialer{
 		LocalAddr: &net.TCPAddr{
 			IP:   net.ParseIP(clientHost),
 			Port: 0,
@@ -45,42 +96,44 @@ func testProtocolClassification(t *testing.T, cfg *config.Config, clientHost, ta
 	}
 
 	tests := []struct {
-		name      string
-		clientRun func(t *testing.T, serverAddr string)
-		serverRun func(t *testing.T, serverAddr string, done chan struct{}) string
-		want      network.ProtocolType
+		name            string
+		context         testContext
+		shouldSkip      func(context testContext) (bool, string)
+		preTracerSetup  func(t *testing.T, context testContext)
+		postTracerSetup func(t *testing.T, context testContext)
+		validation      func(t *testing.T, context testContext, tr *Tracer)
+		teardown        func(t *testing.T, context testContext)
 	}{
 		{
 			name: "tcp client without sending data",
-			clientRun: func(t *testing.T, serverAddr string) {
+			context: testContext{
+				serverPort:       "8080",
+				clientDialer:     defaultDialer,
+				expectedProtocol: network.ProtocolUnknown,
+			},
+			postTracerSetup: func(t *testing.T, ctx testContext) {
+				server := NewTCPServerOnAddress(ctx.serverAddress, func(c net.Conn) {
+					c.Close()
+				})
+				require.NoError(t, server.Run(ctx.done))
 				timedContext, cancel := context.WithTimeout(context.Background(), time.Second)
-				c, err := dialer.DialContext(timedContext, "tcp", serverAddr)
+				c, err := ctx.clientDialer.DialContext(timedContext, "tcp", ctx.targetAddress)
 				cancel()
 				require.NoError(t, err)
 				defer c.Close()
 			},
-			serverRun: func(t *testing.T, serverAddr string, done chan struct{}) string {
-				server := NewTCPServerOnAddress(serverAddr, func(c net.Conn) {
-					c.Close()
-				})
-				require.NoError(t, server.Run(done))
-				return server.address
-			},
-			want: network.ProtocolUnknown,
+			teardown:   defaultTeardown,
+			validation: validateProtocolConnection,
 		},
 		{
 			name: "tcp client with sending random data",
-			clientRun: func(t *testing.T, serverAddr string) {
-				timedContext, cancel := context.WithTimeout(context.Background(), time.Second)
-				c, err := dialer.DialContext(timedContext, "tcp", serverAddr)
-				cancel()
-				require.NoError(t, err)
-				defer c.Close()
-				c.Write([]byte("hello\n"))
-				io.ReadAll(c)
+			context: testContext{
+				serverPort:       "8080",
+				clientDialer:     defaultDialer,
+				expectedProtocol: network.ProtocolUnknown,
 			},
-			serverRun: func(t *testing.T, serverAddr string, done chan struct{}) string {
-				server := NewTCPServerOnAddress(serverAddr, func(c net.Conn) {
+			postTracerSetup: func(t *testing.T, ctx testContext) {
+				server := NewTCPServerOnAddress(ctx.serverAddress, func(c net.Conn) {
 					r := bufio.NewReader(c)
 					input, err := r.ReadBytes(byte('\n'))
 					if err == nil {
@@ -88,26 +141,28 @@ func testProtocolClassification(t *testing.T, cfg *config.Config, clientHost, ta
 					}
 					c.Close()
 				})
-				require.NoError(t, server.Run(done))
-				return server.address
+				require.NoError(t, server.Run(ctx.done))
+
+				timedContext, cancel := context.WithTimeout(context.Background(), time.Second)
+				c, err := ctx.clientDialer.DialContext(timedContext, "tcp", ctx.targetAddress)
+				cancel()
+				require.NoError(t, err)
+				defer c.Close()
+				c.Write([]byte("hello\n"))
+				io.ReadAll(c)
 			},
-			want: network.ProtocolUnknown,
+			teardown:   defaultTeardown,
+			validation: validateProtocolConnection,
 		},
 		{
 			name: "tcp client with sending HTTP request",
-			clientRun: func(t *testing.T, serverAddr string) {
-				client := nethttp.Client{
-					Transport: &nethttp.Transport{
-						DialContext: dialer.DialContext,
-					},
-				}
-				resp, err := client.Get("http://" + serverAddr + "/test")
-				require.NoError(t, err)
-				io.Copy(io.Discard, resp.Body)
-				resp.Body.Close()
+			context: testContext{
+				serverPort:       "8080",
+				clientDialer:     defaultDialer,
+				expectedProtocol: network.ProtocolHTTP,
 			},
-			serverRun: func(t *testing.T, serverAddr string, done chan struct{}) string {
-				ln, err := net.Listen("tcp", serverAddr)
+			postTracerSetup: func(t *testing.T, ctx testContext) {
+				ln, err := net.Listen("tcp", ctx.serverAddress)
 				require.NoError(t, err)
 
 				srv := &nethttp.Server{
@@ -124,64 +179,97 @@ func testProtocolClassification(t *testing.T, cfg *config.Config, clientHost, ta
 					_ = srv.Serve(ln)
 				}()
 				go func() {
-					<-done
+					<-ctx.done
 					srv.Shutdown(context.Background())
 				}()
-				return srv.Addr
+
+				client := nethttp.Client{
+					Transport: &nethttp.Transport{
+						DialContext: ctx.clientDialer.DialContext,
+					},
+				}
+				resp, err := client.Get("http://" + ctx.targetAddress + "/test")
+				require.NoError(t, err)
+				io.Copy(io.Discard, resp.Body)
+				resp.Body.Close()
 			},
-			want: network.ProtocolHTTP,
+			teardown:   defaultTeardown,
+			validation: validateProtocolConnection,
 		},
 		{
-			name: "gRPC traffic - unary call",
-			clientRun: func(t *testing.T, serverAddr string) {
-				c, err := grpc.NewClient(serverAddr, grpc.Options{
-					CustomDialer: dialer,
+			name: "http2 traffic using gRPC - unary call",
+			context: testContext{
+				serverPort:       "8080",
+				clientDialer:     defaultDialer,
+				expectedProtocol: network.ProtocolHTTP2,
+			},
+			postTracerSetup: func(t *testing.T, ctx testContext) {
+				server, err := grpc.NewServer(ctx.serverAddress)
+				require.NoError(t, err)
+				server.Run()
+				go func() {
+					<-ctx.done
+					server.Stop()
+				}()
+
+				c, err := grpc.NewClient(ctx.targetAddress, grpc.Options{
+					CustomDialer: ctx.clientDialer,
 				})
 				require.NoError(t, err)
 				defer c.Close()
 				require.NoError(t, c.HandleUnary(context.Background(), "test"))
 			},
-			serverRun: func(t *testing.T, serverAddr string, done chan struct{}) string {
-				server, err := grpc.NewServer(serverAddr)
+			teardown:   defaultTeardown,
+			validation: validateProtocolConnection,
+		},
+		{
+			name: "http2 traffic using gRPC - stream call",
+			context: testContext{
+				serverPort:       "8080",
+				clientDialer:     defaultDialer,
+				expectedProtocol: network.ProtocolHTTP2,
+			},
+			postTracerSetup: func(t *testing.T, ctx testContext) {
+				server, err := grpc.NewServer(ctx.serverAddress)
 				require.NoError(t, err)
 				server.Run()
 				go func() {
-					<-done
+					<-ctx.done
 					server.Stop()
 				}()
-				return server.Address
-			},
-			want: network.ProtocolHTTP2,
-		},
-		{
-			name: "gRPC traffic - stream call",
-			clientRun: func(t *testing.T, serverAddr string) {
-				c, err := grpc.NewClient(serverAddr, grpc.Options{
-					CustomDialer: dialer,
+
+				c, err := grpc.NewClient(ctx.targetAddress, grpc.Options{
+					CustomDialer: ctx.clientDialer,
 				})
 				require.NoError(t, err)
 				defer c.Close()
 				require.NoError(t, c.HandleStream(context.Background(), 5))
 			},
-			serverRun: func(t *testing.T, serverAddr string, done chan struct{}) string {
-				server, err := grpc.NewServer(serverAddr)
-				require.NoError(t, err)
-				server.Run()
-				go func() {
-					<-done
-					server.Stop()
-				}()
-				return server.Address
-			},
-			want: network.ProtocolHTTP2,
+			teardown:   defaultTeardown,
+			validation: validateProtocolConnection,
 		},
 		{
 			// A case where we see multiple protocols on the same socket. In that case, we expect to classify the connection
 			// with the first protocol we've found.
 			name: "mixed protocols",
-			clientRun: func(t *testing.T, serverAddr string) {
+			context: testContext{
+				serverPort:       "8080",
+				clientDialer:     defaultDialer,
+				expectedProtocol: network.ProtocolHTTP,
+			},
+			postTracerSetup: func(t *testing.T, ctx testContext) {
+				server := NewTCPServerOnAddress(ctx.serverAddress, func(c net.Conn) {
+					r := bufio.NewReader(c)
+					input, err := r.ReadBytes(byte('\n'))
+					if err == nil {
+						c.Write(input)
+					}
+					c.Close()
+				})
+				require.NoError(t, server.Run(ctx.done))
+
 				timedContext, cancel := context.WithTimeout(context.Background(), time.Second)
-				c, err := dialer.DialContext(timedContext, "tcp", serverAddr)
+				c, err := ctx.clientDialer.DialContext(timedContext, "tcp", ctx.targetAddress)
 				cancel()
 				require.NoError(t, err)
 				defer c.Close()
@@ -191,35 +279,29 @@ func testProtocolClassification(t *testing.T, cfg *config.Config, clientHost, ta
 				c.Write([]byte("PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n"))
 				io.ReadAll(c)
 			},
-			serverRun: func(t *testing.T, serverAddr string, done chan struct{}) string {
-				server := NewTCPServerOnAddress(serverAddr, func(c net.Conn) {
-					r := bufio.NewReader(c)
-					input, err := r.ReadBytes(byte('\n'))
-					if err == nil {
-						c.Write(input)
-					}
-					c.Close()
-				})
-				require.NoError(t, server.Run(done))
-				return server.address
-			},
-			want: network.ProtocolHTTP,
+			teardown:   defaultTeardown,
+			validation: validateProtocolConnection,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			done := make(chan struct{})
-			defer close(done)
-			serverAddr := tt.serverRun(t, serverHost, done)
-			_, port, err := net.SplitHostPort(serverAddr)
-			require.NoError(t, err)
-			targetAddr := net.JoinHostPort(targetHost, port)
-
-			// Letting the server time to start
-			time.Sleep(500 * time.Millisecond)
-			tt.clientRun(t, targetAddr)
-
-			waitForConnectionsWithProtocol(t, tr, targetAddr, serverAddr, tt.want)
+			if tt.shouldSkip != nil {
+				if skip, msg := tt.shouldSkip(tt.context); skip {
+					t.Skip(msg)
+				}
+			}
+			tt.context.serverAddress = net.JoinHostPort(serverHost, tt.context.serverPort)
+			tt.context.targetAddress = net.JoinHostPort(targetHost, tt.context.serverPort)
+			tt.context.done = make(chan struct{})
+			t.Cleanup(func() {
+				tt.teardown(t, tt.context)
+			})
+			if tt.preTracerSetup != nil {
+				tt.preTracerSetup(t, tt.context)
+			}
+			tr := setupTracer(t, cfg)
+			tt.postTracerSetup(t, tt.context)
+			tt.validation(t, tt.context, tr)
 		})
 	}
 }

--- a/pkg/network/tracer/tracer_classification_windows_test.go
+++ b/pkg/network/tracer/tracer_classification_windows_test.go
@@ -16,6 +16,6 @@ func TestProtocolClassification(t *testing.T) {
 		t.Skip("Classification is not supported")
 	}
 	t.Run("without nat", func(t *testing.T) {
-		testProtocolClassification(t, cfg, "localhost", "127.0.0.1", "127.0.0.1:0")
+		testProtocolClassification(t, cfg, "localhost", "127.0.0.1", "127.0.0.1")
 	})
 }

--- a/pkg/network/tracer/tracer_usm_linux_test.go
+++ b/pkg/network/tracer/tracer_usm_linux_test.go
@@ -492,19 +492,19 @@ func TestProtocolClassification(t *testing.T) {
 	t.Run("with dnat", func(t *testing.T) {
 		// SetupDNAT sets up a NAT translation from 2.2.2.2 to 1.1.1.1
 		netlink.SetupDNAT(t)
-		testProtocolClassification(t, cfg, "localhost", "2.2.2.2", "1.1.1.1:0")
+		testProtocolClassification(t, cfg, "localhost", "2.2.2.2", "1.1.1.1")
 		testProtocolClassificationMapCleanup(t, cfg, "localhost", "2.2.2.2", "1.1.1.1:0")
 	})
 
 	t.Run("with snat", func(t *testing.T) {
 		// SetupDNAT sets up a NAT translation from 6.6.6.6 to 7.7.7.7
 		netlink.SetupSNAT(t)
-		testProtocolClassification(t, cfg, "6.6.6.6", "127.0.0.1", "127.0.0.1:0")
+		testProtocolClassification(t, cfg, "6.6.6.6", "127.0.0.1", "127.0.0.1")
 		testProtocolClassificationMapCleanup(t, cfg, "6.6.6.6", "127.0.0.1", "127.0.0.1:0")
 	})
 
 	t.Run("without nat", func(t *testing.T) {
-		testProtocolClassification(t, cfg, "localhost", "127.0.0.1", "127.0.0.1:0")
+		testProtocolClassification(t, cfg, "localhost", "127.0.0.1", "127.0.0.1")
 		testProtocolClassificationMapCleanup(t, cfg, "localhost", "127.0.0.1", "127.0.0.1:0")
 	})
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Refactor of protocol classification UT to allow more complex tests scenarios.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Setting the foundations for tests in which we should have setup without having the tracer running.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
