### PR TITLE
Escape path in get-acl command

### DIFF
--- a/pkg/secrets/check_rights_windows_test.go
+++ b/pkg/secrets/check_rights_windows_test.go
@@ -9,6 +9,7 @@
 package secrets
 
 import (
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"testing"
@@ -35,6 +36,17 @@ func testCheckRightsStub() {
 
 func TestWrongPath(t *testing.T) {
 	require.NotNil(t, checkRights("does not exists", false))
+}
+
+func TestSpaceInPath(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "super temp")
+	require.Nil(t, err)
+	defer os.Remove(tmpDir)
+	tmpFile, err := os.CreateTemp(tmpDir, "agent-collector-test")
+	require.Nil(t, err)
+	defer os.Remove(tmpFile.Name())
+	require.Nil(t, os.Chmod(tmpFile.Name(), 0700))
+	require.Nil(t, checkRights(tmpFile.Name(), false))
 }
 
 func TestCheckRights(t *testing.T) {

--- a/pkg/secrets/check_rights_windows_test.go
+++ b/pkg/secrets/check_rights_windows_test.go
@@ -50,9 +50,6 @@ func TestSpaceInPath(t *testing.T) {
 }
 
 func TestCheckRights(t *testing.T) {
-	_, err := os.CreateTemp("", "agent-collector-test")
-	require.Nil(t, err)
-
 	// default options
 	allowGroupExec := false
 

--- a/pkg/secrets/info_windows.go
+++ b/pkg/secrets/info_windows.go
@@ -12,10 +12,12 @@ import (
 	"bytes"
 	"fmt"
 	"os/exec"
+	"strings"
 )
 
 func (info *SecretInfo) populateRights() {
-	err := checkRights(info.ExecutablePath, secretBackendCommandAllowGroupExec)
+	execPath := fmt.Sprintf("\"%s\"", strings.TrimSpace(info.ExecutablePath))
+	err := checkRights(execPath, secretBackendCommandAllowGroupExec)
 	if err != nil {
 		info.Rights = fmt.Sprintf("Error: %s", err)
 	} else {
@@ -28,7 +30,7 @@ func (info *SecretInfo) populateRights() {
 		return
 	}
 
-	cmd := exec.Command(ps, "get-acl", "-Path", info.ExecutablePath, "|", "format-list")
+	cmd := exec.Command(ps, "get-acl", "-Path", execPath, "|", "format-list")
 
 	stdout := bytes.Buffer{}
 	stderr := bytes.Buffer{}

--- a/releasenotes/notes/Escape-path-in-get-acl-command-b4c123c26759a1e1.yaml
+++ b/releasenotes/notes/Escape-path-in-get-acl-command-b4c123c26759a1e1.yaml
@@ -1,0 +1,3 @@
+---
+fixes:
+  - The secret command now correctly displays the ACL on a path with spaces.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
This PR adds quotes around the space of the executable command for the secret feature.
Note that this affect only the display of ACLs on the executable, and not the checking of the rights, which was working fine.
This PR also updates the unit tests to 1) cover the case where there are spaces in the path and 2) remove an unused temporary file creation.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
[WA-68](https://datadoghq.atlassian.net/browse/WA-68)

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
Set a secret backend command with spaces, check the rights on the executable with `& "$env:ProgramFiles\Datadog\Datadog Agent\bin\agent.exe" secret`. The ACLs should display correctly.

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
