### PR TITLE
Disable by default remote-tagger in clc-runner mode

### DIFF
--- a/cmd/agent/common/loader.go
+++ b/cmd/agent/common/loader.go
@@ -42,6 +42,10 @@ func LoadComponents(ctx context.Context, confdPath string) {
 		options, err := remote.CLCRunnerOptions()
 		if err != nil {
 			log.Errorf("unable to configure the remote tagger: %s", err)
+			t = local.NewFakeTagger()
+		} else if options.Disabled {
+			log.Info("remote tagger disabled")
+			t = local.NewFakeTagger()
 		} else {
 			t = remote.NewTagger(options)
 		}

--- a/cmd/agent/common/loader.go
+++ b/cmd/agent/common/loader.go
@@ -44,7 +44,7 @@ func LoadComponents(ctx context.Context, confdPath string) {
 			log.Errorf("unable to configure the remote tagger: %s", err)
 			t = local.NewFakeTagger()
 		} else if options.Disabled {
-			log.Info("remote tagger disabled")
+			log.Info("remote tagger is disabled")
 			t = local.NewFakeTagger()
 		} else {
 			t = remote.NewTagger(options)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -988,6 +988,8 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("clc_runner_port", 5005)
 	config.BindEnvAndSetDefault("clc_runner_server_write_timeout", 15)
 	config.BindEnvAndSetDefault("clc_runner_server_readheader_timeout", 10)
+	config.BindEnvAndSetDefault("clc_runner_remote_tagger_enabled", false)
+
 	// Admission controller
 	config.BindEnvAndSetDefault("admission_controller.enabled", false)
 	config.BindEnvAndSetDefault("admission_controller.mutate_unlabelled", false)


### PR DESCRIPTION
### What does this PR do?

Add a new option `clc_runner_remote_tagger_enabled` to enable the remote-tagger when the agent is configured as clc-runner.

### Motivation

Disable by default `remote-tagger` in CLC-runner since this feature is not yet used by cluster-checks.

### Additional Notes

This feature is not yet use in the CLC-runner so no impact on current cluster-checks. Also this is not yet a feature that we are documenting to customer since we still need to work a bit more on optimisation.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Deploy the cluster-agent and clc-runner. check that the clc-runner pod doesn't try to communicate with the cluster-agent.
the log `remote tagger is disabled` should be present in the CLC-runner logs.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
