### PR TITLE
Revert #14367 and use nano timestamp instead

### DIFF
--- a/pkg/autodiscovery/providers/clusterchecks.go
+++ b/pkg/autodiscovery/providers/clusterchecks.go
@@ -123,7 +123,7 @@ func (c *ClusterChecksConfigProvider) IsUpToDate(ctx context.Context) (bool, err
 	if reply.IsUpToDate {
 		log.Tracef("Up to date with change %d", c.lastChange)
 	} else {
-		log.Tracef("Not up to date with change %d", c.lastChange)
+		log.Infof("Not up to date with change %d", c.lastChange)
 	}
 	return reply.IsUpToDate, nil
 }

--- a/pkg/clusteragent/clusterchecks/dispatcher_nodes.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_nodes.go
@@ -66,6 +66,7 @@ func (d *dispatcher) processNodeStatus(nodeName, clientIP string, status types.N
 	}
 
 	// Node-agent needs to pull updated configs
+	log.Infof("Node %s needs to poll config, cluster config version: %d, node config version: %d", nodeName, node.lastConfigChange, status.LastChange)
 	return false, nil
 }
 

--- a/pkg/clusteragent/clusterchecks/dispatcher_nodes.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_nodes.go
@@ -33,7 +33,7 @@ func (d *dispatcher) getClusterCheckConfigs(nodeName string) ([]integration.Conf
 
 	node.RLock()
 	defer node.RUnlock()
-	return makeConfigArray(node.digestToConfig), node.configVersion.Load(), nil
+	return makeConfigArray(node.digestToConfig), node.lastConfigChange, nil
 }
 
 // processNodeStatus keeps the node's status in the store, and returns true
@@ -53,7 +53,7 @@ func (d *dispatcher) processNodeStatus(nodeName, clientIP string, status types.N
 	node.lastStatus = status
 	node.heartbeat = timestampNow()
 
-	if node.configVersion.Load() == status.LastChange {
+	if node.lastConfigChange == status.LastChange {
 		// Node-agent is up to date
 		return true, nil
 	}

--- a/pkg/clusteragent/clusterchecks/dispatcher_test.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_test.go
@@ -212,7 +212,7 @@ func TestProcessNodeStatus(t *testing.T) {
 	assert.False(t, upToDate)
 
 	// Give changes
-	node1.lastConfigChange = timestampNow()
+	node1.lastConfigChange = timestampNowNano()
 	node1.heartbeat = node1.heartbeat - 50
 	status2 := types.NodeStatus{LastChange: node1.lastConfigChange - 2}
 	upToDate, err = dispatcher.processNodeStatus("node1", "10.0.0.1", status2)
@@ -300,7 +300,8 @@ func TestRescheduleDanglingFromExpiredNodes(t *testing.T) {
 	// Register a node with a correct status & schedule a Check
 	dispatcher.processNodeStatus("nodeA", "10.0.0.1", types.NodeStatus{})
 	dispatcher.Schedule([]integration.Config{
-		generateIntegration("A")})
+		generateIntegration("A"),
+	})
 
 	// Ensure it's dispatch correctly
 	allConfigs, err := dispatcher.getAllConfigs()

--- a/pkg/clusteragent/clusterchecks/dispatcher_test.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_test.go
@@ -212,9 +212,9 @@ func TestProcessNodeStatus(t *testing.T) {
 	assert.False(t, upToDate)
 
 	// Give changes
-	node1.configVersion.Inc()
+	node1.lastConfigChange = timestampNow()
 	node1.heartbeat = node1.heartbeat - 50
-	status2 := types.NodeStatus{LastChange: node1.configVersion.Load() - 2}
+	status2 := types.NodeStatus{LastChange: node1.lastConfigChange - 2}
 	upToDate, err = dispatcher.processNodeStatus("node1", "10.0.0.1", status2)
 	assert.NoError(t, err)
 	assert.False(t, upToDate)
@@ -222,7 +222,7 @@ func TestProcessNodeStatus(t *testing.T) {
 	assert.True(t, timestampNow() <= node1.heartbeat+1)
 
 	// No change
-	status3 := types.NodeStatus{LastChange: node1.configVersion.Load()}
+	status3 := types.NodeStatus{LastChange: node1.lastConfigChange}
 	upToDate, err = dispatcher.processNodeStatus("node1", "10.0.0.1", status3)
 	assert.NoError(t, err)
 	assert.True(t, upToDate)
@@ -300,8 +300,7 @@ func TestRescheduleDanglingFromExpiredNodes(t *testing.T) {
 	// Register a node with a correct status & schedule a Check
 	dispatcher.processNodeStatus("nodeA", "10.0.0.1", types.NodeStatus{})
 	dispatcher.Schedule([]integration.Config{
-		generateIntegration("A"),
-	})
+		generateIntegration("A")})
 
 	// Ensure it's dispatch correctly
 	allConfigs, err := dispatcher.getAllConfigs()

--- a/pkg/clusteragent/clusterchecks/helpers.go
+++ b/pkg/clusteragent/clusterchecks/helpers.go
@@ -32,6 +32,10 @@ func makeConfigArray(configMap map[string]integration.Config) []integration.Conf
 	return configSlice
 }
 
+func timestampNowNano() int64 {
+	return time.Now().UnixNano()
+}
+
 // timestampNow provides a consistent way to keep a seconds timestamp
 func timestampNow() int64 {
 	return time.Now().Unix()

--- a/pkg/clusteragent/clusterchecks/stores.go
+++ b/pkg/clusteragent/clusterchecks/stores.go
@@ -103,7 +103,7 @@ func newNodeStore(name, clientIP string) *nodeStore {
 }
 
 func (s *nodeStore) addConfig(config integration.Config) {
-	s.lastConfigChange = timestampNow()
+	s.lastConfigChange = timestampNowNano()
 	s.digestToConfig[config.Digest()] = config
 	dispatchedConfigs.Inc(s.name, le.JoinLeaderValue)
 }
@@ -114,7 +114,7 @@ func (s *nodeStore) removeConfig(digest string) {
 		log.Debugf("unknown digest %s, skipping", digest)
 		return
 	}
-	s.lastConfigChange = timestampNow()
+	s.lastConfigChange = timestampNowNano()
 	delete(s.digestToConfig, digest)
 	dispatchedConfigs.Dec(s.name, le.JoinLeaderValue)
 }

--- a/pkg/clusteragent/clusterchecks/stores.go
+++ b/pkg/clusteragent/clusterchecks/stores.go
@@ -17,8 +17,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	le "github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/leaderelection/metrics"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-
-	"go.uber.org/atomic"
 )
 
 // clusterStore holds the state of cluster-check management.
@@ -84,20 +82,19 @@ func (s *clusterStore) clearDangling() {
 // Lock is to be held by the user (dispatcher)
 type nodeStore struct {
 	sync.RWMutex
-	name           string
-	heartbeat      int64
-	lastStatus     types.NodeStatus
-	configVersion  *atomic.Int64
-	digestToConfig map[string]integration.Config
-	clientIP       string
-	clcRunnerStats types.CLCRunnersStats
-	busyness       int
+	name             string
+	heartbeat        int64
+	lastStatus       types.NodeStatus
+	lastConfigChange int64
+	digestToConfig   map[string]integration.Config
+	clientIP         string
+	clcRunnerStats   types.CLCRunnersStats
+	busyness         int
 }
 
 func newNodeStore(name, clientIP string) *nodeStore {
 	return &nodeStore{
 		name:           name,
-		configVersion:  atomic.NewInt64(0),
 		clientIP:       clientIP,
 		digestToConfig: make(map[string]integration.Config),
 		clcRunnerStats: types.CLCRunnersStats{},
@@ -106,8 +103,8 @@ func newNodeStore(name, clientIP string) *nodeStore {
 }
 
 func (s *nodeStore) addConfig(config integration.Config) {
+	s.lastConfigChange = timestampNow()
 	s.digestToConfig[config.Digest()] = config
-	s.configVersion.Inc()
 	dispatchedConfigs.Inc(s.name, le.JoinLeaderValue)
 }
 
@@ -117,8 +114,8 @@ func (s *nodeStore) removeConfig(digest string) {
 		log.Debugf("unknown digest %s, skipping", digest)
 		return
 	}
+	s.lastConfigChange = timestampNow()
 	delete(s.digestToConfig, digest)
-	s.configVersion.Inc()
 	dispatchedConfigs.Dec(s.name, le.JoinLeaderValue)
 }
 


### PR DESCRIPTION
### What does this PR do?

Revert #14367 and use nano timestamp instead.
The issue is that the `configVersion` is now reset everytime the Cluster Agent restarts.
Thus, the `configVersion` can be reused across Cluster Agent restarts while the config content may have changed.

### Motivation

Bugfix.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Similarly to #14367, the issue is not really possible to replicate. It will validated in internal deployments

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
