### PR TITLE
[Serverless] Allow some keys to be option in serverless integration tests.

### DIFF
--- a/test/integration/serverless/snapshots/log-proxy
+++ b/test/integration/serverless/snapshots/log-proxy
@@ -178,35 +178,5 @@
     "service": "integration-tests-service",
     "ddsource": "lambda",
     "ddtags": "account_id:425362996713,architecture:XXX,aws_account:425362996713,dd_extension_version:123,env:integration-tests-env,function_arn:arn:aws:lambda:eu-west-1:425362996713:function:integration-tests-extension-XXXXXX-log-proxy,functionname:integration-tests-extension-XXXXXX-log-proxy,memorysize:1024,region:eu-west-1,resource:integration-tests-extension-XXXXXX-log-proxy,runtime:nodejs14.x,service:integration-tests-service,taga:valuea,tagb:valueb,tagc:valuec,tagd:valued,version:integration-tests-version"
-  },
-  {
-    "message": {
-      "message": "TIMESTAMP UTC | DD_EXTENSION | ERROR | could not forward the request context canceled\n",
-      "lambda": {
-        "arn": "arn:aws:lambda:eu-west-1:425362996713:function:integration-tests-extension-XXXXXX-log-proxy",
-        "request_id": "XXX"
-      }
-    },
-    "status": "info",
-    "timestamp": "XXX",
-    "hostname": "arn:aws:lambda:eu-west-1:425362996713:function:integration-tests-extension-XXXXXX-log-proxy",
-    "service": "integration-tests-service",
-    "ddsource": "lambda",
-    "ddtags": "account_id:425362996713,architecture:XXX,aws_account:425362996713,dd_extension_version:123,env:integration-tests-env,function_arn:arn:aws:lambda:eu-west-1:425362996713:function:integration-tests-extension-XXXXXX-log-proxy,functionname:integration-tests-extension-XXXXXX-log-proxy,memorysize:1024,region:eu-west-1,resource:integration-tests-extension-XXXXXX-log-proxy,runtime:nodejs14.x,service:integration-tests-service,taga:valuea,tagb:valueb,tagc:valuec,tagd:valued,version:integration-tests-version"
-  },
-  {
-    "message": {
-      "message": "TIMESTAMP http: proxy error: context canceled\n",
-      "lambda": {
-        "arn": "arn:aws:lambda:eu-west-1:425362996713:function:integration-tests-extension-XXXXXX-log-proxy",
-        "request_id": "XXX"
-      }
-    },
-    "status": "info",
-    "timestamp": "XXX",
-    "hostname": "arn:aws:lambda:eu-west-1:425362996713:function:integration-tests-extension-XXXXXX-log-proxy",
-    "service": "integration-tests-service",
-    "ddsource": "lambda",
-    "ddtags": "account_id:425362996713,architecture:XXX,aws_account:425362996713,dd_extension_version:123,env:integration-tests-env,function_arn:arn:aws:lambda:eu-west-1:425362996713:function:integration-tests-extension-XXXXXX-log-proxy,functionname:integration-tests-extension-XXXXXX-log-proxy,memorysize:1024,region:eu-west-1,resource:integration-tests-extension-XXXXXX-log-proxy,runtime:nodejs14.x,service:integration-tests-service,taga:valuea,tagb:valueb,tagc:valuec,tagd:valued,version:integration-tests-version"
   }
 ]


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Optionally removes items from a list before comparing to the snapshot. This is helpful when a log message is sometimes, but not always, present.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Flaky tests are bad. See https://github.com/DataDog/datadog-agent/actions/runs/3751530055/jobs/6372617090 for an example.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

Note that the two log lines I've removed could actually be an indication of a larger problem with our proxy support. Or it could be a misconfiguration of the test function. Either way, it should be investigated at some point.

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
