### PR TITLE
[single-machine-performance] Allow Regression Detector pipeline to fail

### DIFF
--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -18,6 +18,16 @@ single-machine-performance-regression_detector:
     REPLICAS: 10
     CPUS: 7
     MEMORY: "30g"
+  # At present we require two artifacts to exist for the 'baseline' and the
+  # 'comparison'. We are guaranteed by the structure of the pipeline that
+  # 'comparison' exists, not so much with 'baseline' as it has to come from main
+  # merge pipeline run. This is solved in Vector by building Vector twice each
+  # Regression Detector run but remains an unsolved problem for
+  # datadog-agent. So, we allow failure for now.
+  #
+  # _Unfortunately_ this also means that if the Regression Detector finds a
+  # performance issue with a PR it will not be flagged.
+  allow_failure: true
   script:
     # Setup AWS credentials for single-machine-performance AWS account
     - AWS_NAMED_PROFILE="single-machine-performance"


### PR DESCRIPTION
### What does this PR do?

This PR sets the Regression Detector job to allow failures.

### Motivation

At present there's a race condition in the CI pipeline with regard to Regression Detector: we rely on an artifact to be created by main pipeline merge but have no way of making a hard dependency on that artifact. If that artifact is not present then the Regression Detection job will be submitted and then immediately fail.  Absent a solution we allow the Regression Detector job to fail, unfortunately making any actual regressions caught but also not contributing to alert blindness in the meanwhile.

Signed-off-by: Brian L. Troutwine <brian.troutwine@datadoghq.com>
