### PR TITLE
[CWS][SEC-6381] Update template configuration file to add activity dumps and network detection parameters

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1616,7 +1616,7 @@ api_key:
   #   - HISTFILESIZE
 
   ## @param activity_dump - custom object - optional
-  ## Activity dumps section to configure if/how the agent sends activity dumps to the backend for security profiles learning.
+  ## Activity dump section configures if/how the Agent sends activity dumps to Datadog
   #
   # activity_dump:
 
@@ -1639,7 +1639,7 @@ api_key:
     #  cgroup_dump_timeout: 30
 
   ## @param network - custom object - optional
-  ## Network section to configure CWS network features.
+  ## Network section is used to configure Cloud Workload Security (CWS) network features.
   #
   # network:
 

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1615,6 +1615,40 @@ api_key:
   #   - HISTSIZE
   #   - HISTFILESIZE
 
+  ## @param activity_dump - custom object - optional
+  ## Activity dumps section to configure if/how the agent sends activity dumps to the backend for security profiles learning.
+  #
+  # activity_dump:
+
+    ## @param enabled - boolean - optional - default: false
+    ## @env DD_RUNTIME_SECURITY_CONFIG_ACTIVITY_DUMP_ENABLED - boolean - optional - default: false
+    ## Set to true to activate the security profiles feature.
+    #
+    #  enabled: false
+
+    ## @param traced_cgroups_count - integer - optional - default: 5
+    ## @env DD_RUNTIME_SECURITY_CONFIG_ACTIVITY_DUMP_TRACED_CGROUPS_COUNT - integer - optional - default: 5
+    ## Defines the number of concurrent cgroups to be learned.
+    #
+    #  traced_cgroups_count: 5
+
+    ## @param cgroup_dump_timeout - integer - optional - default: 30
+    ## @env DD_RUNTIME_SECURITY_CONFIG_ACTIVITY_DUMP_CGROUP_DUMP_TIMEOUT - integer - optional - default: 30
+    ## Defines the duration of cgroups learning phase in minutes. Minimum value is 10.
+    #
+    #  cgroup_dump_timeout: 30
+
+  ## @param network - custom object - optional
+  ## Network section to configure CWS network features.
+  #
+  # network:
+
+    ## @param enabled - boolean - optional - default: true
+    ## @env DD_RUNTIME_SECURITY_CONFIG_NETWORK_ENABLED - boolean - optional - default: true
+    ## Set to true to activate the CWS network detections.
+    #
+    #  enabled: true
+
 {{ end -}}
 {{ end -}}
 

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1628,7 +1628,7 @@ api_key:
 
     ## @param traced_cgroups_count - integer - optional - default: 5
     ## @env DD_RUNTIME_SECURITY_CONFIG_ACTIVITY_DUMP_TRACED_CGROUPS_COUNT - integer - optional - default: 5
-    ## Defines the number of concurrent cgroups to be learned.
+    ## Defines the number of concurrent cgroups to be traced.
     #
     #  traced_cgroups_count: 5
 


### PR DESCRIPTION
### What does this PR do?

This PR adds the more useful/basic parameters to configure the new security profile feature.
It adds also the parameter to enable/disable CWS network detections.

### Motivation

Add some guidelines for customers who want to use security profiles feature.

### Additional Notes

There are plenty more parameters but, more cryptic/internal. I'm not sure about the parameter list to expose here.
Two others configs that may be also exposed could be:
```
runtime_security_config.activity_dump.traced_event_types
runtime_security_config.activity_dump.local_storage.formats
```

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
