### PR TITLE
Update URL regexp to detect for Datadog's URL

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1229,7 +1229,9 @@ func InitConfig(config Config) {
 	setupProcesses(config)
 }
 
-var ddURLRegexp = regexp.MustCompile(`^app(\.(us|eu)\d)?\.(datad(oghq|0g)\.(com|eu)|ddog-gov\.com)$`)
+// ddURLRegexp determines if an URL belongs to Datadog or not. If the URL belongs to Datadog it's prefixed with the Agent
+// version (see AddAgentVersionToDomain).
+var ddURLRegexp = regexp.MustCompile(`^app(\.[a-z]{2}\d)?\.(datad(oghq|0g)\.(com|eu)|ddog-gov\.com)$`)
 
 // GetProxies returns the proxy settings from the configuration
 func GetProxies() *Proxy {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -558,82 +558,80 @@ additional_endpoints:
 }
 
 func TestAddAgentVersionToDomain(t *testing.T) {
-	// US
-	newURL, err := AddAgentVersionToDomain("https://app.datadoghq.com", "app")
-	require.Nil(t, err)
-	assert.Equal(t, "https://"+getDomainPrefix("app")+".datadoghq.com", newURL)
+	appVersionPrefix := getDomainPrefix("app")
+	flareVersionPrefix := getDomainPrefix("flare")
 
-	newURL, err = AddAgentVersionToDomain("https://app.datadoghq.com", "flare")
-	require.Nil(t, err)
-	assert.Equal(t, "https://"+getDomainPrefix("flare")+".datadoghq.com", newURL)
+	versionURLTests := []struct {
+		url                 string
+		expectedURL         string
+		shouldAppendVersion bool
+	}{
+		{ // US
+			"https://app.datadoghq.com",
+			".datadoghq.com",
+			true,
+		},
+		{ // EU
+			"https://app.datadoghq.eu",
+			".datadoghq.eu",
+			true,
+		},
+		{ // Gov
+			"https://app.ddog-gov.com",
+			".ddog-gov.com",
+			true,
+		},
+		{ // Additional site
+			"https://app.us2.datadoghq.com",
+			".us2.datadoghq.com",
+			true,
+		},
+		{ // arbitrary site
+			"https://app.xx9.datadoghq.com",
+			".xx9.datadoghq.com",
+			true,
+		},
+		{ // Custom DD URL: leave unchanged
+			"https://custom.datadoghq.com",
+			"custom.datadoghq.com",
+			false,
+		},
+		{ // Custom DD URL with 'agent' subdomain: leave unchanged
+			"https://custom.agent.datadoghq.com",
+			"custom.agent.datadoghq.com",
+			false,
+		},
+		{ // Custom DD URL: unclear if anyone is actually using such a URL, but for now leave unchanged
+			"https://app.custom.datadoghq.com",
+			"app.custom.datadoghq.com",
+			false,
+		},
+		{ // Custom top-level domain: unclear if anyone is actually using this, but for now leave unchanged
+			"https://app.datadoghq.internal",
+			"app.datadoghq.internal",
+			false,
+		},
+		{ // DD URL set to proxy, leave unchanged
+			"https://app.myproxy.com",
+			"app.myproxy.com",
+			false,
+		},
+	}
 
-	// EU
-	newURL, err = AddAgentVersionToDomain("https://app.datadoghq.eu", "app")
-	require.Nil(t, err)
-	assert.Equal(t, "https://"+getDomainPrefix("app")+".datadoghq.eu", newURL)
+	for _, testCase := range versionURLTests {
+		appURL, err := AddAgentVersionToDomain(testCase.url, "app")
+		require.Nil(t, err)
+		flareURL, err := AddAgentVersionToDomain(testCase.url, "flare")
+		require.Nil(t, err)
 
-	newURL, err = AddAgentVersionToDomain("https://app.datadoghq.eu", "flare")
-	require.Nil(t, err)
-	assert.Equal(t, "https://"+getDomainPrefix("flare")+".datadoghq.eu", newURL)
-
-	// Gov
-	newURL, err = AddAgentVersionToDomain("https://app.ddog-gov.com", "app")
-	require.Nil(t, err)
-	assert.Equal(t, "https://"+getDomainPrefix("app")+".ddog-gov.com", newURL)
-
-	newURL, err = AddAgentVersionToDomain("https://app.ddog-gov.com", "flare")
-	require.Nil(t, err)
-	assert.Equal(t, "https://"+getDomainPrefix("flare")+".ddog-gov.com", newURL)
-
-	// Additional site
-	newURL, err = AddAgentVersionToDomain("https://app.us2.datadoghq.com", "app")
-	require.Nil(t, err)
-	assert.Equal(t, "https://"+getDomainPrefix("app")+".us2.datadoghq.com", newURL)
-
-	newURL, err = AddAgentVersionToDomain("https://app.us2.datadoghq.com", "flare")
-	require.Nil(t, err)
-	assert.Equal(t, "https://"+getDomainPrefix("flare")+".us2.datadoghq.com", newURL)
-
-	// Custom DD URL: leave unchanged
-	newURL, err = AddAgentVersionToDomain("https://custom.datadoghq.com", "app")
-	require.Nil(t, err)
-	assert.Equal(t, "https://custom.datadoghq.com", newURL)
-
-	newURL, err = AddAgentVersionToDomain("https://custom.datadoghq.com", "flare")
-	require.Nil(t, err)
-	assert.Equal(t, "https://custom.datadoghq.com", newURL)
-
-	// Custom DD URL with 'agent' subdomain: leave unchanged
-	newURL, err = AddAgentVersionToDomain("https://custom.agent.datadoghq.com", "app")
-	require.Nil(t, err)
-	assert.Equal(t, "https://custom.agent.datadoghq.com", newURL)
-
-	newURL, err = AddAgentVersionToDomain("https://custom.agent.datadoghq.com", "flare")
-	require.Nil(t, err)
-	assert.Equal(t, "https://custom.agent.datadoghq.com", newURL)
-
-	// Custom DD URL: unclear if anyone is actually using such a URL, but for now leave unchanged
-	newURL, err = AddAgentVersionToDomain("https://app.custom.datadoghq.com", "app")
-	require.Nil(t, err)
-	assert.Equal(t, "https://app.custom.datadoghq.com", newURL)
-
-	newURL, err = AddAgentVersionToDomain("https://app.custom.datadoghq.com", "flare")
-	require.Nil(t, err)
-	assert.Equal(t, "https://app.custom.datadoghq.com", newURL)
-
-	// Custom top-level domain: unclear if anyone is actually using this, but for now leave unchanged
-	newURL, err = AddAgentVersionToDomain("https://app.datadoghq.internal", "app")
-	require.Nil(t, err)
-	assert.Equal(t, "https://app.datadoghq.internal", newURL)
-
-	newURL, err = AddAgentVersionToDomain("https://app.datadoghq.internal", "flare")
-	require.Nil(t, err)
-	assert.Equal(t, "https://app.datadoghq.internal", newURL)
-
-	// DD URL set to proxy, leave unchanged
-	newURL, err = AddAgentVersionToDomain("https://app.myproxy.com", "app")
-	require.Nil(t, err)
-	assert.Equal(t, "https://app.myproxy.com", newURL)
+		if testCase.shouldAppendVersion {
+			assert.Equal(t, "https://"+appVersionPrefix+testCase.expectedURL, appURL)
+			assert.Equal(t, "https://"+flareVersionPrefix+testCase.expectedURL, flareURL)
+		} else {
+			assert.Equal(t, "https://"+testCase.expectedURL, appURL)
+			assert.Equal(t, "https://"+testCase.expectedURL, flareURL)
+		}
+	}
 }
 
 func TestIsCloudProviderEnabled(t *testing.T) {

--- a/pkg/forwarder/forwarder_health_test.go
+++ b/pkg/forwarder/forwarder_health_test.go
@@ -48,6 +48,7 @@ func TestComputeDomainsURL(t *testing.T) {
 		"https://custom.agent.datadoghq.com":     {"api_key3"},
 		"https://app.datadoghq.eu":               {"api_key4"},
 		"https://app.us2.datadoghq.com":          {"api_key5"},
+		"https://app.xx9.datadoghq.com":          {"api_key5"},
 		"https://custom.agent.us2.datadoghq.com": {"api_key6"},
 		// debatable whether the next one should be changed to `api.`, preserve pre-existing behavior for now
 		"https://app.datadoghq.internal": {"api_key7"},
@@ -60,6 +61,7 @@ func TestComputeDomainsURL(t *testing.T) {
 		"https://api.datadoghq.com":      {"api_key1", "api_key2", "api_key3"},
 		"https://api.datadoghq.eu":       {"api_key4"},
 		"https://api.us2.datadoghq.com":  {"api_key5", "api_key6"},
+		"https://api.xx9.datadoghq.com":  {"api_key5"},
 		"https://api.datadoghq.internal": {"api_key7"},
 		"https://app.myproxy.com":        {"api_key8"},
 		"https://api.ddog-gov.com":       {"api_key9", "api_key10"},


### PR DESCRIPTION
### What does this PR do?

In the past we use to edit the regexp everytime Datadog would open a new location. This commit allow the agent to detect for all present and future locations as long as they follow the format of 2 letters + 1
digit. Example: `us3.datadoghq.com`.

### Motivation

Avoid editing the agent code when we open a new location. Since we release the agent every 6 weeks this also decouple agent release from new location opening.

### Describe how to test/QA your changes

Test that we can still send data, send flares and check for API key validity on:
- datadoghq.com
- datadoghq.eu
- us3.datadoghq.com or us5.datadoghq.com
- ddog-gov.com

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
