### PR TITLE
Auto compute timeWindow on external metrics based on DatadogMetrics maxAge

### DIFF
--- a/pkg/clusteragent/externalmetrics/metrics_retriever_test.go
+++ b/pkg/clusteragent/externalmetrics/metrics_retriever_test.go
@@ -9,6 +9,7 @@
 package externalmetrics
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -29,7 +30,7 @@ func (p *mockedProcessor) UpdateExternalMetrics(emList map[string]custommetrics.
 	return nil
 }
 
-func (p *mockedProcessor) QueryExternalMetric(queries []string) (map[string]autoscalers.Point, error) {
+func (p *mockedProcessor) QueryExternalMetric(queries []string, timeWindow time.Duration) (map[string]autoscalers.Point, error) {
 	return p.points, p.err
 }
 
@@ -341,6 +342,7 @@ func TestRetrieveMetricsErrorCases(t *testing.T) {
 					Value:     0,
 					Timestamp: defaultPreviousUpdateTime.Unix(),
 					Valid:     false,
+					Error:     errors.New("some err"),
 				},
 			},
 			queryError: nil,
@@ -362,7 +364,7 @@ func TestRetrieveMetricsErrorCases(t *testing.T) {
 						Active: true,
 						Value:  11.0,
 						Valid:  false,
-						Error:  fmt.Errorf(invalidMetricBackendErrorMessage, "query-metric1"),
+						Error:  fmt.Errorf(invalidMetricErrorMessage, errors.New("some err"), "query-metric1"),
 						// UpdateTime not set as it will not be compared directly
 					},
 					query: "query-metric1",
@@ -476,7 +478,7 @@ func TestRetrieveMetricsErrorCases(t *testing.T) {
 						Active: true,
 						Value:  2.0,
 						Valid:  false,
-						Error:  fmt.Errorf(invalidMetricNoDataErrorMessage, "query-metric1"),
+						Error:  fmt.Errorf(invalidMetricNotFoundErrorMessage, "query-metric1"),
 						// UpdateTime not set as it will not be compared directly
 					},
 					query: "query-metric1",

--- a/pkg/clusteragent/externalmetrics/provider.go
+++ b/pkg/clusteragent/externalmetrics/provider.go
@@ -135,14 +135,14 @@ func (p *datadogMetricProvider) getExternalMetric(namespace string, metricSelect
 		parsed = true
 	}
 	if !parsed {
-		return nil, log.Errorf("ExternalMetric does not follow DatadogMetric format: %s", info.Metric)
+		return nil, log.Warnf("ExternalMetric does not follow DatadogMetric format: %s", info.Metric)
 	}
 
 	datadogMetric := p.store.Get(datadogMetricID)
 	log.Tracef("DatadogMetric from store: %v", datadogMetric)
 
 	if datadogMetric == nil {
-		return nil, log.Errorf("DatadogMetric not found for metric name: %s, datadogmetricid: %s", info.Metric, datadogMetricID)
+		return nil, log.Warnf("DatadogMetric not found for metric name: %s, datadogmetricid: %s", info.Metric, datadogMetricID)
 	}
 
 	externalMetric, err := datadogMetric.ToExternalMetricFormat(info.Metric)

--- a/pkg/clusteragent/externalmetrics/provider.go
+++ b/pkg/clusteragent/externalmetrics/provider.go
@@ -113,7 +113,6 @@ func NewDatadogMetricProvider(ctx context.Context, apiCl *apiserver.APIClient) (
 func (p *datadogMetricProvider) GetExternalMetric(ctx context.Context, namespace string, metricSelector labels.Selector, info provider.ExternalMetricInfo) (*external_metrics.ExternalMetricValueList, error) {
 	res, err := p.getExternalMetric(namespace, metricSelector, info)
 	if err != nil {
-		log.Errorf("ExternalMetric query failed with error: %v", err)
 		convErr := apierr.NewInternalError(err)
 		if convErr != nil {
 			err = convErr
@@ -136,14 +135,14 @@ func (p *datadogMetricProvider) getExternalMetric(namespace string, metricSelect
 		parsed = true
 	}
 	if !parsed {
-		return nil, fmt.Errorf("ExternalMetric does not follow DatadogMetric format")
+		return nil, log.Errorf("ExternalMetric does not follow DatadogMetric format: %s", info.Metric)
 	}
 
 	datadogMetric := p.store.Get(datadogMetricID)
-	log.Debugf("DatadogMetric from store: %v", datadogMetric)
+	log.Tracef("DatadogMetric from store: %v", datadogMetric)
 
 	if datadogMetric == nil {
-		return nil, fmt.Errorf("DatadogMetric not found for metric name: %s, datadogmetricid: %s", info.Metric, datadogMetricID)
+		return nil, log.Errorf("DatadogMetric not found for metric name: %s, datadogmetricid: %s", info.Metric, datadogMetricID)
 	}
 
 	externalMetric, err := datadogMetric.ToExternalMetricFormat(info.Metric)

--- a/pkg/clusteragent/externalmetrics/provider_test.go
+++ b/pkg/clusteragent/externalmetrics/provider_test.go
@@ -175,7 +175,7 @@ func TestGetExternalMetrics(t *testing.T) {
 			},
 			queryMetricName:         "datadogmetric@metric1",
 			expectedExternalMetrics: nil,
-			expectedError:           fmt.Errorf("ExternalMetric does not follow DatadogMetric format"),
+			expectedError:           fmt.Errorf("ExternalMetric does not follow DatadogMetric format: datadogmetric@metric1"),
 		},
 		{
 			desc: "Test ExternalMetric does not use DatadogMetric format",

--- a/pkg/util/kubernetes/apiserver/hpa_controller_test.go
+++ b/pkg/util/kubernetes/apiserver/hpa_controller_test.go
@@ -124,13 +124,15 @@ func (h *fakeProcessor) UpdateExternalMetrics(emList map[string]custommetrics.Ex
 	}
 	return nil
 }
+
 func (h *fakeProcessor) ProcessEMList(metrics []custommetrics.ExternalMetricValue) map[string]custommetrics.ExternalMetricValue {
 	if h.processFunc != nil {
 		return h.processFunc(metrics)
 	}
 	return nil
 }
-func (h *fakeProcessor) QueryExternalMetric(queries []string) (map[string]autoscalers.Point, error) {
+
+func (h *fakeProcessor) QueryExternalMetric(queries []string, timeWindow time.Duration) (map[string]autoscalers.Point, error) {
 	return nil, nil
 }
 
@@ -292,7 +294,6 @@ func TestUpdate(t *testing.T) {
 			require.True(t, reflect.DeepEqual(m.Labels, map[string]string{"foo": "baz"}))
 		}
 	}
-
 }
 
 // TestAutoscalerController is an integration test of the AutoscalerController

--- a/pkg/util/kubernetes/autoscalers/datadogexternal_test.go
+++ b/pkg/util/kubernetes/autoscalers/datadogexternal_test.go
@@ -37,22 +37,13 @@ func TestDatadogExternalQuery(t *testing.T) {
 			nil,
 		},
 		{
-			"metricName yields empty response from Datadog",
-			func(from, to int64, query string) ([]datadog.Series, error) {
-				return nil, nil
-			},
-			[]string{"mymetric{foo:bar}"},
-			map[string]Point{"mymetric{foo:bar}": {Value: 0, Valid: false}},
-			fmt.Errorf("none of the queries mymetric{foo:bar} returned any point, there might be an issue with them"),
-		},
-		{
 			"metricName yields rate limiting error response from Datadog",
 			func(int64, int64, string) ([]datadog.Series, error) {
 				return nil, fmt.Errorf("Rate limit of 300 requests in 3600 seconds")
 			},
 			[]string{"avg:mymetric{foo:bar}.rollup(30)"},
 			nil,
-			fmt.Errorf("Error while executing metric query avg:mymetric{foo:bar}.rollup(30): Rate limit of 300 requests in 3600 seconds"),
+			fmt.Errorf("error while executing metric query avg:mymetric{foo:bar}.rollup(30): Rate limit of 300 requests in 3600 seconds"),
 		},
 		{
 			"metrics with different granularities Datadog",
@@ -259,7 +250,7 @@ func TestDatadogExternalQuery(t *testing.T) {
 				queryMetricsFunc: test.queryfunc,
 			}
 			p := Processor{datadogClient: cl}
-			points, err := p.queryDatadogExternal(test.metricName, config.Datadog.GetInt64("external_metrics_provider.bucket_size"))
+			points, err := p.queryDatadogExternal(test.metricName, time.Duration(config.Datadog.GetInt64("external_metrics_provider.bucket_size"))*time.Second)
 			if test.err != nil {
 				require.EqualError(t, test.err, err.Error())
 			}

--- a/pkg/util/kubernetes/autoscalers/processor.go
+++ b/pkg/util/kubernetes/autoscalers/processor.go
@@ -34,7 +34,7 @@ const (
 	// extraQueryCharacters accounts for the extra characters added to form a query to Datadog's API (e.g.: `avg:`, `.rollup(X)` ...)
 	extraQueryCharacters = 16
 	// maxTimeWindow is a safeguard to prevent the Cluster Agent from making queries on a large time window
-	maxTimeWindow = 1 * time.Hour
+	maxTimeWindow = 24 * time.Hour
 )
 
 // DatadogClient abstracts the dependency on the Datadog api
@@ -134,6 +134,7 @@ func (p *Processor) UpdateExternalMetrics(emList map[string]custommetrics.Extern
 		}
 	}
 
+	// In non-DatadogMetric path, we don't have any custom maxAge possible, passing 0 as custom time window to QueryExternalMetric
 	metrics, err := p.QueryExternalMetric(batch, 0)
 	if len(metrics) == 0 && err != nil {
 		log.Errorf("Error getting metrics from Datadog: %v", err.Error())
@@ -184,7 +185,7 @@ func (p *Processor) QueryExternalMetric(queries []string, timeWindow time.Durati
 
 	// Safeguard against large time window
 	if timeWindow > maxTimeWindow {
-		log.Errorf("Querying external metrics with a time window larger than: %v is not allowed, ceiling value", maxTimeWindow)
+		log.Warnf("Querying external metrics with a time window larger than: %v is not allowed, ceiling value", maxTimeWindow)
 		timeWindow = maxTimeWindow
 	}
 

--- a/pkg/util/kubernetes/autoscalers/processor.go
+++ b/pkg/util/kubernetes/autoscalers/processor.go
@@ -33,6 +33,8 @@ const (
 	maxCharactersPerChunk = 7000
 	// extraQueryCharacters accounts for the extra characters added to form a query to Datadog's API (e.g.: `avg:`, `.rollup(X)` ...)
 	extraQueryCharacters = 16
+	// maxTimeWindow is a safeguard to prevent the Cluster Agent from making queries on a large time window
+	maxTimeWindow = 1 * time.Hour
 )
 
 // DatadogClient abstracts the dependency on the Datadog api
@@ -44,7 +46,7 @@ type DatadogClient interface {
 // ProcessorInterface is used to easily mock the interface for testing
 type ProcessorInterface interface {
 	UpdateExternalMetrics(emList map[string]custommetrics.ExternalMetricValue) map[string]custommetrics.ExternalMetricValue
-	QueryExternalMetric(queries []string) (map[string]Point, error)
+	QueryExternalMetric(queries []string, timeWindow time.Duration) (map[string]Point, error)
 	ProcessEMList(emList []custommetrics.ExternalMetricValue) map[string]custommetrics.ExternalMetricValue
 }
 
@@ -132,7 +134,7 @@ func (p *Processor) UpdateExternalMetrics(emList map[string]custommetrics.Extern
 		}
 	}
 
-	metrics, err := p.QueryExternalMetric(batch)
+	metrics, err := p.QueryExternalMetric(batch, 0)
 	if len(metrics) == 0 && err != nil {
 		log.Errorf("Error getting metrics from Datadog: %v", err.Error())
 		// If no metrics can be retrieved from Datadog in a given list, we need to invalidate them
@@ -164,13 +166,28 @@ func (p *Processor) UpdateExternalMetrics(emList map[string]custommetrics.Extern
 
 // QueryExternalMetric queries Datadog to validate the availability and value of one or more external metrics
 // Also updates the rate limits statistics as a result of the query.
-func (p *Processor) QueryExternalMetric(queries []string) (processed map[string]Point, err error) {
+func (p *Processor) QueryExternalMetric(queries []string, timeWindow time.Duration) (processed map[string]Point, err error) {
 	processed = make(map[string]Point)
 	if len(queries) == 0 {
 		return processed, nil
 	}
 
-	bucketSize := config.Datadog.GetInt64("external_metrics_provider.bucket_size")
+	configMaxAge := time.Duration(config.Datadog.GetInt64("external_metrics_provider.max_age")) * time.Second
+	if configMaxAge > timeWindow {
+		timeWindow = configMaxAge
+	}
+
+	configTimeWindow := time.Duration(config.Datadog.GetInt64("external_metrics_provider.bucket_size")) * time.Second
+	if configTimeWindow > timeWindow {
+		timeWindow = configTimeWindow
+	}
+
+	// Safeguard against large time window
+	if timeWindow > maxTimeWindow {
+		log.Errorf("Querying external metrics with a time window larger than: %v is not allowed, ceiling value", maxTimeWindow)
+		timeWindow = maxTimeWindow
+	}
+
 	chunks := makeChunks(queries)
 	log.Tracef("List of batches %v", chunks)
 
@@ -182,7 +199,7 @@ func (p *Processor) QueryExternalMetric(queries []string) (processed map[string]
 	for _, c := range chunks {
 		go func(chunk []string) {
 			defer waitResp.Done()
-			resp, err := p.queryDatadogExternal(chunk, bucketSize)
+			resp, err := p.queryDatadogExternal(chunk, timeWindow)
 			responses <- queryResponse{resp, err}
 		}(c)
 	}

--- a/pkg/util/kubernetes/autoscalers/processor_test.go
+++ b/pkg/util/kubernetes/autoscalers/processor_test.go
@@ -228,7 +228,6 @@ func TestProcessor_UpdateExternalMetrics(t *testing.T) {
 	for _, i := range invList {
 		require.False(t, i.Valid)
 	}
-
 }
 
 var ASCIIRunes = []rune("qwertyuiopasdfghjklzxcvbnm1234567890")
@@ -256,7 +255,8 @@ func TestValidateExternalMetricsBatching(t *testing.T) {
 			desc: "one batch",
 			in: lambdaMakeChunks(14, custommetrics.ExternalMetricValue{
 				MetricName: "foo",
-				Labels:     map[string]string{"foo": "bar"}}),
+				Labels:     map[string]string{"foo": "bar"},
+			}),
 			out: []datadog.Series{
 				{
 					Metric: &metricName,
@@ -276,7 +276,8 @@ func TestValidateExternalMetricsBatching(t *testing.T) {
 			desc: "several batches",
 			in: lambdaMakeChunks(158, custommetrics.ExternalMetricValue{
 				MetricName: "foo",
-				Labels:     map[string]string{"foo": "bar"}}),
+				Labels:     map[string]string{"foo": "bar"},
+			}),
 			out: []datadog.Series{
 				{
 					Metric: &metricName,
@@ -296,7 +297,8 @@ func TestValidateExternalMetricsBatching(t *testing.T) {
 			desc: "Overspilling queries",
 			in: lambdaMakeChunks(20, custommetrics.ExternalMetricValue{
 				MetricName: randStringRune(4000),
-				Labels:     map[string]string{"foo": "bar"}}),
+				Labels:     map[string]string{"foo": "bar"},
+			}),
 			out: []datadog.Series{
 				{
 					Metric: &metricName,
@@ -316,7 +318,8 @@ func TestValidateExternalMetricsBatching(t *testing.T) {
 			desc: "Overspilling single query",
 			in: lambdaMakeChunks(0, custommetrics.ExternalMetricValue{
 				MetricName: randStringRune(7000),
-				Labels:     map[string]string{"foo": "bar"}}),
+				Labels:     map[string]string{"foo": "bar"},
+			}),
 			out: []datadog.Series{
 				{
 					Metric: &metricName,
@@ -336,7 +339,8 @@ func TestValidateExternalMetricsBatching(t *testing.T) {
 			desc: "several batches, one error",
 			in: lambdaMakeChunks(158, custommetrics.ExternalMetricValue{
 				MetricName: "foo",
-				Labels:     map[string]string{"foo": "bar"}}),
+				Labels:     map[string]string{"foo": "bar"},
+			}),
 			out: []datadog.Series{
 				{
 					Metric: &metricName,
@@ -389,7 +393,7 @@ func TestValidateExternalMetricsBatching(t *testing.T) {
 			}
 			p := &Processor{datadogClient: datadogClient}
 
-			_, err := p.QueryExternalMetric(tt.in)
+			_, err := p.QueryExternalMetric(tt.in, 0)
 			if err != nil || tt.err != nil {
 				assert.Contains(t, err.Error(), tt.err.Error())
 			}

--- a/releasenotes/notes/add-automatic-time-window-ffed100742f51246.yaml
+++ b/releasenotes/notes/add-automatic-time-window-ffed100742f51246.yaml
@@ -1,4 +1,4 @@
 ---
 enhancements:
   - |
-    The external metrics server now automatically adjust query time window based on DatadogMetrics `MaxAge` attribute.
+    The external metrics server now automatically adjusts the query time window based on the Datadog metrics `MaxAge` attribute.

--- a/releasenotes/notes/add-automatic-time-window-ffed100742f51246.yaml
+++ b/releasenotes/notes/add-automatic-time-window-ffed100742f51246.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    The external metrics server now automatically adjust query time window based on DatadogMetrics `MaxAge` attribute.


### PR DESCRIPTION
### What does this PR do?

We currently offer `maxAge` property in `DatadogMetric` but we do not allow to configure `bucket_size` as multiple queries are batched together.

If `maxAge > bucket_size`, the query will fail from time to time (when last point timestamp is between `bucket_size` and `max_age` old), which means that `bucket_size` needs to be increased as well (requires a config change in the Cluster Agent)

To improve the user experience, this PR introduce automatic calculation of `timeWindow` (i.e. `bucket_size`) based on DatadogMetrics `maxAge` and configuration. It uses the maximum value of `[DatadogMetrics, bucket_size, maxAge]` limited to `60 minutes` (hardcoded, as a safeguard).

This PR was also the occasion to simplify and improve the logging around external metrics.

### Motivation

Improve user experience.

### Additional Notes

### Possible Drawbacks / Trade-offs

With the default configuration (`maxAge: 120s, bucket_size=300s`), nothing changes.
If `maxAge` goes above default `bucket_size (300s)`, then `bucket_size` will be adjusted automatically.
There's one caveat to this if `maxAge` is close to metric `interval`: the last point will be used instead of the penultimate point. I believe that using last point instead of penultimate point makes sense in this case as otherwise it'd delay scaling by `interval`.

### Describe how to test/QA your changes

Deploy the Cluster Agent with DatadogMetrics. Create an HPA scaling on a `DatadogMetric` based on a metric with a long interval (larger than 5m: can be generated through Dogstatsd for instance).
Set the DatadogMetric `maxAge to interval + ~10%`.
Observe that autoscaling works without changing any other setting.

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
