### PR TITLE
[process-agent] Remove unused properties from AgentConfig

### DIFF
--- a/pkg/process/config/config.go
+++ b/pkg/process/config/config.go
@@ -33,10 +33,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-// defaultProxyPort is the default port used for proxies.
-// This mirrors the configuration for the infrastructure agent.
-const defaultProxyPort = 3128
-
 // Name for check performed by process-agent or system-probe
 const (
 	ProcessCheckName       = "process"

--- a/pkg/process/config/config.go
+++ b/pkg/process/config/config.go
@@ -12,11 +12,9 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"net/url"
 	"os"
 	"os/exec"
 	"regexp"
-	"strconv"
 	"strings"
 	"time"
 
@@ -60,8 +58,6 @@ const (
 	ProcessDiscoveryCheckDefaultInterval = 4 * time.Hour
 )
 
-type proxyFunc func(*http.Request) (*url.URL, error)
-
 type cmdFunc = func(name string, arg ...string) *exec.Cmd
 
 // AgentConfig is the global config for the process-agent. This information
@@ -74,13 +70,11 @@ type AgentConfig struct {
 	Blacklist          []*regexp.Regexp
 	Scrubber           *DataScrubber
 	MaxConnsPerMessage int
-	Transport          *http.Transport `json:"-"`
 
 	// host type of the agent, used to populate container payload with additional host information
 	ContainerHostType model.ContainerHostType
 
 	// System probe collection configuration
-	EnableSystemProbe  bool
 	SystemProbeAddress string
 
 	// Orchestrator config
@@ -88,9 +82,6 @@ type AgentConfig struct {
 
 	// Check config
 	CheckIntervals map[string]time.Duration
-
-	// Internal store of a proxy used for generating the Transport
-	proxy proxyFunc
 }
 
 // CheckInterval returns the interval for the given check name, defaulting to 10s if not found.
@@ -123,12 +114,10 @@ func NewDefaultAgentConfig() *AgentConfig {
 	ac := &AgentConfig{
 		MaxConnsPerMessage: 600,
 		HostName:           "",
-		Transport:          NewDefaultTransport(),
 
 		ContainerHostType: model.ContainerHostType_notSpecified,
 
 		// System probe collection configuration
-		EnableSystemProbe:  false,
 		SystemProbeAddress: defaultSystemProbeAddress,
 
 		// Orchestrator config
@@ -189,8 +178,6 @@ func LoadConfigIfExists(path string) error {
 // NewAgentConfig returns an AgentConfig using a configuration file. It can be nil
 // if there is no file available. In this case we'll configure only via environment.
 func NewAgentConfig(loggerName config.LoggerName, yamlPath string, syscfg *sysconfig.Config) (*AgentConfig, error) {
-	var err error
-
 	cfg := NewDefaultAgentConfig()
 	if err := cfg.LoadAgentConfig(yamlPath); err != nil {
 		return nil, err
@@ -208,15 +195,8 @@ func NewAgentConfig(loggerName config.LoggerName, yamlPath string, syscfg *sysco
 	}
 
 	if syscfg.Enabled {
-		cfg.EnableSystemProbe = true
 		cfg.MaxConnsPerMessage = syscfg.MaxConnsPerMessage
 		cfg.SystemProbeAddress = syscfg.SocketAddress
-	}
-
-	// TODO: Once proxies have been moved to common config util, remove this
-	if cfg.proxy, err = proxyFromEnv(cfg.proxy); err != nil {
-		log.Errorf("error parsing environment proxy settings, not using a proxy: %s", err)
-		cfg.proxy = nil
 	}
 
 	if err := validate.ValidHostname(cfg.HostName); err != nil {
@@ -231,10 +211,6 @@ func NewAgentConfig(loggerName config.LoggerName, yamlPath string, syscfg *sysco
 	}
 
 	cfg.ContainerHostType = getContainerHostType()
-
-	if cfg.proxy != nil {
-		cfg.Transport.Proxy = cfg.proxy
-	}
 
 	return cfg, nil
 }
@@ -374,73 +350,6 @@ func getHostnameFromGRPC(ctx context.Context, grpcClientFn func(ctx context.Cont
 
 	log.Debugf("retrieved hostname:%s from datadog agent via grpc", reply.Hostname)
 	return reply.Hostname, nil
-}
-
-// proxyFromEnv parses out the proxy configuration from the ENV variables in a
-// similar way to getProxySettings and, if enough values are available, returns
-// a new proxy URL value. If the environment is not set for this then the
-// `defaultVal` is returned.
-func proxyFromEnv(defaultVal proxyFunc) (proxyFunc, error) {
-	var host string
-	scheme := "http"
-	if v := os.Getenv("PROXY_HOST"); v != "" {
-		// accept either http://myproxy.com or myproxy.com
-		if i := strings.Index(v, "://"); i != -1 {
-			// when available, parse the scheme from the url
-			scheme = v[0:i]
-			host = v[i+3:]
-		} else {
-			host = v
-		}
-	}
-
-	if host == "" {
-		return defaultVal, nil
-	}
-
-	port := defaultProxyPort
-	if v := os.Getenv("PROXY_PORT"); v != "" {
-		port, _ = strconv.Atoi(v)
-	}
-	var user, password string
-	if v := os.Getenv("PROXY_USER"); v != "" {
-		user = v
-	}
-	if v := os.Getenv("PROXY_PASSWORD"); v != "" {
-		password = v
-	}
-
-	return constructProxy(host, scheme, port, user, password)
-}
-
-// constructProxy constructs a *url.Url for a proxy given the parts of a
-// Note that we assume we have at least a non-empty host for this call but
-// all other values can be their defaults (empty string or 0).
-func constructProxy(host, scheme string, port int, user, password string) (proxyFunc, error) {
-	var userpass *url.Userinfo
-	if user != "" {
-		if password != "" {
-			userpass = url.UserPassword(user, password)
-		} else {
-			userpass = url.User(user)
-		}
-	}
-
-	var path string
-	if userpass != nil {
-		path = fmt.Sprintf("%s@%s:%v", userpass.String(), host, port)
-	} else {
-		path = fmt.Sprintf("%s:%v", host, port)
-	}
-	if scheme != "" {
-		path = fmt.Sprintf("%s://%s", scheme, path)
-	}
-
-	u, err := url.Parse(path)
-	if err != nil {
-		return nil, err
-	}
-	return http.ProxyURL(u), nil
 }
 
 func setupLogger(loggerName config.LoggerName, logFile string) error {

--- a/pkg/process/config/yaml_config.go
+++ b/pkg/process/config/yaml_config.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
-	httputils "github.com/DataDog/datadog-agent/pkg/util/http"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -110,10 +109,6 @@ func (a *AgentConfig) LoadAgentConfig(path string) error {
 		log.Debug("Strip all process arguments enabled")
 		a.Scrubber.StripAllArguments = true
 	}
-
-	// Build transport (w/ proxy if needed)
-	a.Transport = httputils.CreateHTTPTransport()
-
 	return nil
 }
 


### PR DESCRIPTION
### What does this PR do?

Removes a number of unused properties from the `AgentConfig` struct. 

### Motivation

Cleanup before further refactoring of config usage in the proces-agent.

### Describe how to test/QA your changes

Non-functional change - properties not used.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
