### PR TITLE
Update `agent-payload` to the version of DataDog/agent-payload#213

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	code.cloudfoundry.org/bbs v0.0.0-20200403215808-d7bc971db0db
 	code.cloudfoundry.org/garden v0.0.0-20210208153517-580cadd489d2
 	code.cloudfoundry.org/lager v2.0.0+incompatible
-	github.com/DataDog/agent-payload/v5 v5.0.46
+	github.com/DataDog/agent-payload/v5 v5.0.50-0.20221223171725-20d994c6b841
 	github.com/DataDog/datadog-agent/pkg/obfuscate v0.42.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/otlp/model v0.42.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/quantile v0.42.0-rc.3

--- a/go.sum
+++ b/go.sum
@@ -119,8 +119,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/toml v1.1.0 h1:ksErzDEI1khOiGPgpwuI7x2ebx/uXQNw7xJpn9Eq1+I=
 github.com/BurntSushi/toml v1.1.0/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/DataDog/agent-payload/v5 v5.0.46 h1:flmDbLb7QFTLNvbfjkL0BiwFfwP5umS17tQ4ZUeJ9r8=
-github.com/DataDog/agent-payload/v5 v5.0.46/go.mod h1:vhXPNG7eNDOLeW94Z7dLNUBv61kRBHK7vXnQ+RQfckk=
+github.com/DataDog/agent-payload/v5 v5.0.50-0.20221223171725-20d994c6b841 h1:0xlMKUDOwdWXi2l05TX9KkVRGLkNW8q+gnbJEZ4rOlQ=
+github.com/DataDog/agent-payload/v5 v5.0.50-0.20221223171725-20d994c6b841/go.mod h1:67tjAtRyRuPmkHqj/35eGLb8Ea76zJBGmF+MYYHvbCM=
 github.com/DataDog/aptly v1.5.0 h1:Oy6JVRC9iDgnmpeVYa4diXwP/exU7wJ/U1kuI4Zacxg=
 github.com/DataDog/aptly v1.5.0/go.mod h1:KVyvkYXGcFugxadGFZ+u5Fc3M6q/EfzFZyeTD9HVbkY=
 github.com/DataDog/cast v1.3.1-0.20190301154711-1ee8c8bd14a3 h1:SobA9WYm4K/MUtWlbKaomWTmnuYp1KhIm8Wlx3vmpsg=

--- a/pkg/process/checks/chunking.go
+++ b/pkg/process/checks/chunking.go
@@ -9,6 +9,7 @@ import (
 	model "github.com/DataDog/agent-payload/v5/process"
 
 	"github.com/DataDog/datadog-agent/pkg/process/util"
+	"google.golang.org/protobuf/proto"
 )
 
 // chunkProcessesBySizeAndWeight chunks `model.Process` payloads by max allowed size and max allowed weight of a chunk
@@ -154,7 +155,7 @@ var (
 		Networks: &model.ProcessNetworks{},
 	}
 	// procSizeofProto is a size of the empty process
-	procSizeofProto = procSizeofSampleProcess.Size()
+	procSizeofProto = proto.Size(procSizeofSampleProcess)
 )
 
 // weighProcess weighs `model.Process` payloads using an approximation of a serialized size of the proto message

--- a/pkg/process/net/resolver/resolver.go
+++ b/pkg/process/net/resolver/resolver.go
@@ -48,7 +48,7 @@ func (l *LocalResolver) LoadAddrs(containers []*model.Container, pidToCid map[in
 			if parsedAddr.IsLoopback() {
 				continue
 			}
-			l.addrToCtrID[*networkAddr] = ctr.Id
+			l.addrToCtrID[networkAddr.Clean()] = ctr.Id
 		}
 	}
 }

--- a/pkg/process/util/api/payload.go
+++ b/pkg/process/util/api/payload.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 
 	model "github.com/DataDog/agent-payload/v5/process"
-	"github.com/gogo/protobuf/proto"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/DataDog/datadog-agent/pkg/telemetry"
 )
@@ -29,7 +29,7 @@ func EncodePayload(m model.MessageBody) ([]byte, error) {
 	}
 
 	typeTag := "type:" + msgType.String()
-	tlmBytesIn.Add(float64(m.Size()), typeTag)
+	tlmBytesIn.Add(float64(proto.Size(m)), typeTag)
 
 	var encoded []byte
 	if msgType == model.TypeCollectorProcEvent {

--- a/pkg/process/util/containers.go
+++ b/pkg/process/util/containers.go
@@ -239,15 +239,15 @@ func computeContainerNetworkStats(inStats *metrics.ContainerNetworkStats, previo
 	outStats.NetSentPs = float32(rateValue(outPreviousStats.NetworkSentPackets, previousStats.NetworkSentPackets, inStats.Timestamp, previousStats.NetworkStatsTimestamp))
 }
 
-func computeContainerAddrs(container *workloadmeta.Container) []*model.ContainerAddr {
+func computeContainerAddrs(container *workloadmeta.Container) []*model.ContainerAddrP {
 	if len(container.NetworkIPs) == 0 || len(container.Ports) == 0 {
 		return nil
 	}
 
-	addrs := make([]*model.ContainerAddr, 0, len(container.NetworkIPs)*len(container.Ports))
+	addrs := make([]*model.ContainerAddrP, 0, len(container.NetworkIPs)*len(container.Ports))
 	for _, containerIP := range container.NetworkIPs {
 		for _, port := range container.Ports {
-			addrs = append(addrs, &model.ContainerAddr{
+			addrs = append(addrs, &model.ContainerAddrP{
 				Ip:       containerIP,
 				Port:     int32(port.Port),
 				Protocol: model.ConnectionType(model.ConnectionType_value[port.Protocol]),


### PR DESCRIPTION
### What does this PR do?

Update the version of `agent-payload` to the one provided by DataDog/agent-payload#213.

### Motivation

End-to-end validation of the ProtocolBuffer compiler upgrade done in DataDog/agent-payload#213.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Validate that the agent is still able to submit data to the intakes.

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
