### PR TITLE
flare: Added /opt/datadog-agent directory permissions to permissions.log

### DIFF
--- a/comp/core/flare/helpers/builder.go
+++ b/comp/core/flare/helpers/builder.go
@@ -255,3 +255,12 @@ func (fb *builder) PrepareFilePath(path string) (string, error) {
 func (fb *builder) RegisterFilePerm(path string) {
 	fb.permsInfos.add(path)
 }
+
+func (fb *builder) RegisterDirPerm(srcDir string) {
+	_ = filepath.Walk(srcDir, func(src string, f os.FileInfo, err error) error {
+		if f != nil && !f.IsDir() {
+			fb.RegisterFilePerm(src)
+		}
+		return nil
+	})
+}

--- a/comp/core/flare/helpers/builder.go
+++ b/comp/core/flare/helpers/builder.go
@@ -256,9 +256,9 @@ func (fb *builder) RegisterFilePerm(path string) {
 	fb.permsInfos.add(path)
 }
 
-func (fb *builder) RegisterDirPerm(srcDir string) {
-	_ = filepath.Walk(srcDir, func(src string, f os.FileInfo, err error) error {
-		if f != nil && !f.IsDir() {
+func (fb *builder) RegisterDirPerm(path string) {
+	_ = filepath.Walk(path, func(src string, f os.FileInfo, err error) error {
+		if f != nil {
 			fb.RegisterFilePerm(src)
 		}
 		return nil

--- a/comp/core/flare/helpers/builder_test.go
+++ b/comp/core/flare/helpers/builder_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/DataDog/datadog-agent/pkg/util/common"
 	"github.com/DataDog/datadog-agent/pkg/util/hostname"
 	"github.com/DataDog/datadog-agent/pkg/util/hostname/validate"
 )
@@ -250,19 +249,18 @@ func TestRegisterDirPerm(t *testing.T) {
 
 	fb.RegisterDirPerm(root)
 
-	expectedPaths := common.StringSet{
-		fmt.Sprintf("%s", root):                     struct{}{},
-		fmt.Sprintf("%s/test1", root):               struct{}{},
-		fmt.Sprintf("%s/test2", root):               struct{}{},
-		fmt.Sprintf("%s/depth1", root):              struct{}{},
-		fmt.Sprintf("%s/depth1/test3", root):        struct{}{},
-		fmt.Sprintf("%s/depth1/depth2", root):       struct{}{},
-		fmt.Sprintf("%s/depth1/depth2/test4", root): struct{}{},
+	expectedPaths := []string{
+		fmt.Sprintf("%s", root),
+		fmt.Sprintf("%s/test1", root),
+		fmt.Sprintf("%s/test2", root),
+		fmt.Sprintf("%s/depth1", root),
+		fmt.Sprintf("%s/depth1/test3", root),
+		fmt.Sprintf("%s/depth1/depth2", root),
+		fmt.Sprintf("%s/depth1/depth2/test4", root),
 	}
 
 	require.Len(t, fb.permsInfos, len(expectedPaths))
-	for path := range expectedPaths {
-		_, exist := fb.permsInfos[path]
-		require.True(t, exist)
+	for _, path := range expectedPaths {
+		assert.Contains(t, fb.permsInfos, path)
 	}
 }

--- a/comp/core/flare/helpers/helpers.go
+++ b/comp/core/flare/helpers/helpers.go
@@ -109,10 +109,10 @@ type FlareBuilder interface {
 	// RegisterFilePerm add the current permissions for a file to the flare's permissions.log.
 	RegisterFilePerm(srcDir string)
 
-	// RegisterDirPerm add the current permissions for a directory and its content to the flare's permissions.log.
+	// RegisterDirPerm add the current permissions for all the files in a directory to the flare's permissions.log.
 	RegisterDirPerm(path string)
 
-	// Save archives all the data added to the to the flare, cleanup all the temporary directories and return the path to
+	// Save archives all the data added to the flare, cleanup all the temporary directories and return the path to
 	// the archive file. Upon error the cleanup is still done.
 	// Error or not, once Save as been called the FlareBuilder is no longer capable of receiving new data. It is the caller
 	// responsibility to make sure of this.

--- a/comp/core/flare/helpers/helpers.go
+++ b/comp/core/flare/helpers/helpers.go
@@ -107,7 +107,7 @@ type FlareBuilder interface {
 	PrepareFilePath(path string) (string, error)
 
 	// RegisterFilePerm add the current permissions for a file to the flare's permissions.log.
-	RegisterFilePerm(srcDir string)
+	RegisterFilePerm(path string)
 
 	// RegisterDirPerm add the current permissions for all the files in a directory to the flare's permissions.log.
 	RegisterDirPerm(path string)

--- a/comp/core/flare/helpers/helpers.go
+++ b/comp/core/flare/helpers/helpers.go
@@ -107,7 +107,10 @@ type FlareBuilder interface {
 	PrepareFilePath(path string) (string, error)
 
 	// RegisterFilePerm add the current permissions for a file to the flare's permissions.log.
-	RegisterFilePerm(path string)
+	RegisterFilePerm(srcDir string)
+
+	// RegisterDirPerm add the current permissions for a directory and its content to the flare's permissions.log.
+	RegisterDirPerm(path string)
 
 	// Save archives all the data added to the to the flare, cleanup all the temporary directories and return the path to
 	// the archive file. Upon error the cleanup is still done.

--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -16,6 +16,7 @@ import (
 	"net/http"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"sort"
 	"strings"
 	"time"
@@ -157,7 +158,9 @@ func createArchive(fb flarehelpers.FlareBuilder, confSearchPaths SearchPaths, lo
 
 	fb.RegisterFilePerm(security.GetAuthTokenFilepath())
 
-	fb.RegisterDirPerm(filepath.Dir(config.Datadog.GetString("system_probe_config.sysprobe_socket")))
+	if runtime.GOOS == "linux" {
+		fb.RegisterDirPerm(filepath.Dir(config.Datadog.GetString("system_probe_config.sysprobe_socket")))
+	}
 	fb.RegisterDirPerm(config.Datadog.GetString("system_probe_config.bpf_dir"))
 
 	if config.Datadog.GetBool("system_probe_config.enabled") {

--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -144,7 +144,7 @@ func createArchive(fb flarehelpers.FlareBuilder, confSearchPaths SearchPaths, lo
 			fb.AddFile("config-check.log", []byte("unable to get loaded checks config, is the agent running?"))
 		}
 	} else {
-		// Status informations are available, add them as the agent is running.
+		// Status information are available, add them as the agent is running.
 
 		fb.AddFileFromFunc("status.log", status.GetAndFormatStatus)
 		fb.AddFileFromFunc("config-check.log", getConfigCheck)
@@ -156,6 +156,8 @@ func createArchive(fb flarehelpers.FlareBuilder, confSearchPaths SearchPaths, lo
 	}
 
 	fb.RegisterFilePerm(security.GetAuthTokenFilepath())
+
+	fb.RegisterDirPerm("/opt/datadog-agent")
 
 	if config.Datadog.GetBool("system_probe_config.enabled") {
 		fb.AddFileFromFunc(filepath.Join("expvar", "system-probe"), getSystemProbeStats)

--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -16,7 +16,6 @@ import (
 	"net/http"
 	"path/filepath"
 	"regexp"
-	"runtime"
 	"sort"
 	"strings"
 	"time"
@@ -158,10 +157,8 @@ func createArchive(fb flarehelpers.FlareBuilder, confSearchPaths SearchPaths, lo
 
 	fb.RegisterFilePerm(security.GetAuthTokenFilepath())
 
-	if runtime.GOOS == "linux" {
-		fb.RegisterDirPerm(filepath.Dir(config.Datadog.GetString("system_probe_config.sysprobe_socket")))
-	}
 	fb.RegisterDirPerm(config.Datadog.GetString("system_probe_config.bpf_dir"))
+	addSystemProbePlatformSpecificEntries(fb)
 
 	if config.Datadog.GetBool("system_probe_config.enabled") {
 		fb.AddFileFromFunc(filepath.Join("expvar", "system-probe"), getSystemProbeStats)

--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -157,7 +157,8 @@ func createArchive(fb flarehelpers.FlareBuilder, confSearchPaths SearchPaths, lo
 
 	fb.RegisterFilePerm(security.GetAuthTokenFilepath())
 
-	fb.RegisterDirPerm("/opt/datadog-agent")
+	fb.RegisterDirPerm(filepath.Dir(config.Datadog.GetString("system_probe_config.sysprobe_socket")))
+	fb.RegisterDirPerm(config.Datadog.GetString("system_probe_config.bpf_dir"))
 
 	if config.Datadog.GetBool("system_probe_config.enabled") {
 		fb.AddFileFromFunc(filepath.Join("expvar", "system-probe"), getSystemProbeStats)

--- a/pkg/flare/archive_linux.go
+++ b/pkg/flare/archive_linux.go
@@ -12,11 +12,17 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"path/filepath"
 	"regexp"
 	"syscall"
 
 	flarehelpers "github.com/DataDog/datadog-agent/comp/core/flare/helpers"
+	"github.com/DataDog/datadog-agent/pkg/config"
 )
+
+func addSystemProbePlatformSpecificEntries(fb flarehelpers.FlareBuilder) {
+	fb.RegisterDirPerm(filepath.Dir(config.Datadog.GetString("system_probe_config.sysprobe_socket")))
+}
 
 func getLinuxKernelSymbols(fb flarehelpers.FlareBuilder) error {
 	return fb.CopyFile("/proc/kallsyms")

--- a/pkg/flare/archive_nolinux.go
+++ b/pkg/flare/archive_nolinux.go
@@ -12,6 +12,8 @@ import (
 	flarehelpers "github.com/DataDog/datadog-agent/comp/core/flare/helpers"
 )
 
+func addSystemProbePlatformSpecificEntries(fb flarehelpers.FlareBuilder) {}
+
 func getLinuxKernelSymbols(fb flarehelpers.FlareBuilder) error {
 	return nil
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

List permissions of files under `/opt/datadog-agent` directory in the flare `permissions.log` file

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

system-probe internal files (sysprobe.socket, runtime compilation source files, prebuilt version, etc.) are located in /opt/datadog-agent when getting a flare, we cannot know those files permissions (and if they exist).

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

1. Deploy agent
2. Trigger flare creation
3. Ensure the `/opt/datadog-agent` files (including subdirectories) exists in the `permissions.log` file in the flare
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
