### PR TITLE
[kitchen] Work around bundler and ruby version issue in verifier

### DIFF
--- a/test/kitchen/drivers/azure-driver.yml
+++ b/test/kitchen/drivers/azure-driver.yml
@@ -175,6 +175,14 @@ platforms:
     username: <%= vm_username %>
     password: <%= vm_password %>
 
+  lifecycle:
+    pre_verify:
+      <% if windows %>
+      - remote: C:/opscode/chef/embedded/bin/gem install rexml --install-dir C:/Users/<%= vm_username %>/AppData/Local/Temp/verifier/gems
+      <% else %>
+      - remote: /opt/chef/embedded/bin/gem install rexml --install-dir /tmp/verifier/gems
+      <% end %>
+
   transport:
     <% if windows %>
     name: winrm

--- a/test/kitchen/drivers/azure-driver.yml
+++ b/test/kitchen/drivers/azure-driver.yml
@@ -176,9 +176,12 @@ platforms:
     password: <%= vm_password %>
 
   lifecycle:
+    # HACK: this is needed to install rexml for system-probe tests without using bundler, which cannot be used for now
+    # (see the explanation in tasks/run-test-kitchen.sh).
     pre_verify:
+      - local: echo 'Installing rexml gem for the system-probe-test suite'
       <% if windows %>
-      - remote: C:/opscode/chef/embedded/bin/gem install rexml --install-dir C:/Users/<%= vm_username %>/AppData/Local/Temp/verifier/gems
+      - remote: C:/opscode/chef/embedded/bin/gem.bat install rexml --install-dir C:/Users/<%= vm_username %>/AppData/Local/Temp/verifier/gems
       <% else %>
       - remote: /opt/chef/embedded/bin/gem install rexml --install-dir /tmp/verifier/gems
       <% end %>

--- a/test/kitchen/drivers/ec2-driver.yml
+++ b/test/kitchen/drivers/ec2-driver.yml
@@ -143,6 +143,12 @@ platforms:
           let i+=${wait};
         done;
   <% end %>
+    pre_verify:
+      <% if windows %>
+      - remote: C:/opscode/chef/embedded/bin/gem install rexml --install-dir C:/Users/ec2-user/AppData/Local/Temp/verifier/gems
+      <% else %>
+      - remote: /opt/chef/embedded/bin/gem install rexml --install-dir /tmp/verifier/gems
+      <% end %>
   verifier:
     downloads:
       "/tmp/junit.tar.gz": kitchen-junit-<%= platform_name %>.tar.gz

--- a/test/kitchen/drivers/ec2-driver.yml
+++ b/test/kitchen/drivers/ec2-driver.yml
@@ -143,9 +143,12 @@ platforms:
           let i+=${wait};
         done;
   <% end %>
+    # HACK: this is needed to install rexml for system-probe tests without using bundler, which cannot be used for now
+    # (see the explanation in tasks/run-test-kitchen.sh).
     pre_verify:
+      - local: echo 'Installing rexml gem for the system-probe-test suite'
       <% if windows %>
-      - remote: C:/opscode/chef/embedded/bin/gem install rexml --install-dir C:/Users/ec2-user/AppData/Local/Temp/verifier/gems
+      - remote: C:/opscode/chef/embedded/bin/gem.bat install rexml --install-dir C:/Users/ec2-user/AppData/Local/Temp/verifier/gems
       <% else %>
       - remote: /opt/chef/embedded/bin/gem install rexml --install-dir /tmp/verifier/gems
       <% end %>

--- a/test/kitchen/tasks/run-test-kitchen.sh
+++ b/test/kitchen/tasks/run-test-kitchen.sh
@@ -156,12 +156,12 @@ for attempt in $(seq 0 "${KITCHEN_INFRASTRUCTURE_FLAKES_RETRY:-2}"); do
   # version issue at the start of the verifier.
   # The kitchen verifier uses the latest version of busser (0.8.0). busser detects that we have rspec tests,
   # and therefore installs the latest version of the busser-rspec gem (0.7.6).
-  # The busser-rspec, has a postinstall hook that installs the latest versions of the rspec and bundler gems.
+  # The busser-rspec gem has a postinstall hook that installs the latest versions of the rspec and bundler gems.
   # The rspec install goes fine, but the bundler install fails since December 24, 2022, when 2.4.0 of bundler
   # was released, which drops support for ruby < 2.6.
-  # For most kitchen test suites, running kitchen verify another time does work, because the postinstall hook isn't run again,
-  # and we don't actually need bundler in the test suites (because we don't have custom Gemfile for the verifier tests).
-  # At present, the only test suite this doesn't fix is the system-probe-test suite.
+  # Running kitchen verify another time does work, because the postinstall hook isn't run again,
+  # and we don't actually need bundler in the test suites (for suites that do have depedencies, we install them
+  # manually with lifecycle hooks in the platform definitions).
   bundle exec kitchen verify "$test_suites" --no-log-overwrite -c -d always 2>&1 || true
 
   bundle exec kitchen verify "$test_suites" --no-log-overwrite -c -d always 2>&1 | tee -a "/tmp/runlog${attempt}"

--- a/test/kitchen/tasks/run-test-kitchen.sh
+++ b/test/kitchen/tasks/run-test-kitchen.sh
@@ -149,8 +149,24 @@ set +o pipefail
 test_suites=".*"
 # This for loop retries kitchen tests failing because of infrastructure/networking issues
 for attempt in $(seq 0 "${KITCHEN_INFRASTRUCTURE_FLAKES_RETRY:-2}"); do
-  bundle exec kitchen verify "$test_suites" -c -d always 2>&1 | tee "/tmp/runlog${attempt}"
-  result=${PIPESTATUS[0]}
+  bundle exec kitchen converge "$test_suites" -c -d always 2>&1 | tee "/tmp/runlog${attempt}"
+  converge_result=${PIPESTATUS[0]}
+
+  # HACK: Since December 24, 2022, the first verify attempt always fails, due to a bundler <-> ruby
+  # version issue at the start of the verifier.
+  # The kitchen verifier uses the latest version of busser (0.8.0). busser detects that we have rspec tests,
+  # and therefore installs the latest version of the busser-rspec gem (0.7.6).
+  # The busser-rspec, has a postinstall hook that installs the latest versions of the rspec and bundler gems.
+  # The rspec install goes fine, but the bundler install fails since December 24, 2022, when 2.4.0 of bundler
+  # was released, which drops support for ruby < 2.6.
+  # For most kitchen test suites, running kitchen verify another time does work, because the postinstall hook isn't run again,
+  # and we don't actually need bundler in the test suites (because we don't have custom Gemfile for the verifier tests).
+  # At present, the only test suite this doesn't fix is the system-probe-test suite.
+  bundle exec kitchen verify "$test_suites" --no-log-overwrite -c -d always 2>&1 || true
+
+  bundle exec kitchen verify "$test_suites" --no-log-overwrite -c -d always 2>&1 | tee -a "/tmp/runlog${attempt}"
+  verify_result=${PIPESTATUS[0]}
+
   # Before destroying the kitchen machines, get the list of failed suites,
   # as their status will be reset to non-failing once they're destroyed.
   # failing_test_suites is a newline-separated list of the failing test suite names.
@@ -170,7 +186,7 @@ for attempt in $(seq 0 "${KITCHEN_INFRASTRUCTURE_FLAKES_RETRY:-2}"); do
     break
   fi
 
-  if [ "$result" -eq 0 ]; then
+  if [ "$converge_result" -eq 0 ] && [ "$verify_result" -eq 0 ]; then
       # if kitchen test succeeded, exit with 0
       exit 0
   else

--- a/test/kitchen/test/integration/system-probe-test/rspec/Gemfile
+++ b/test/kitchen/test/integration/system-probe-test/rspec/Gemfile
@@ -1,4 +1,0 @@
-source 'https://rubygems.org'
-
-gem 'rspec'
-gem 'rexml'


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Modifies the script used to run kitchen tests to run the verify phase twice, and adds a `pre_verify` lifecycle hook to install the dependency needed for system-probe kitchen tests.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Work around an issue (version mismatch between ruby and bundler) that started happening after the release of version 2.4.0 of bundler.
As long as this workaround is needed, we can't have Gemfiles in test suites, and instead need to manually install gems whenever needed.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

This is a temporary workaround. It's far from perfect, and can have some side effects (eg. converge-phase failures get retried twice now, because we run kitchen three times in total).

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

n/a

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

All kitchen tests, except system-probe tests, pass.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
