### PR TITLE
Add the 'test' build tag to the 'unit-tests' flavor

### DIFF
--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -41,6 +41,7 @@ ALL_TAGS = {
     "systemd",
     "zk",
     "zlib",
+    "test",  # used for unit-tests
 }
 
 ### Tag inclusion lists
@@ -136,6 +137,9 @@ DARWIN_EXCLUDED_TAGS = {"docker", "containerd", "cri"}
 # List of tags to always remove when building on Windows 32-bits
 WINDOWS_32BIT_EXCLUDE_TAGS = {"docker", "kubeapiserver", "kubelet", "orchestrator"}
 
+# Unit test build tags
+UNIT_TEST_TAGS = {"test"}
+
 # Build type: maps flavor to build tags map
 build_tags = {
     AgentFlavor.base: {
@@ -150,22 +154,26 @@ build_tags = {
         "trace-agent": TRACE_AGENT_TAGS,
         # Test setups
         "test": AGENT_TEST_TAGS,
-        "unit-tests": AGENT_TEST_TAGS.union(PROCESS_AGENT_TAGS),
+        "lint": AGENT_TEST_TAGS.union(PROCESS_AGENT_TAGS),
+        "unit-tests": AGENT_TEST_TAGS.union(PROCESS_AGENT_TAGS).union(UNIT_TEST_TAGS),
     },
     AgentFlavor.heroku: {
         "agent": AGENT_HEROKU_TAGS,
         "process-agent": PROCESS_AGENT_HEROKU_TAGS,
         "trace-agent": TRACE_AGENT_HEROKU_TAGS,
-        "unit-tests": AGENT_HEROKU_TAGS,
+        "lint": AGENT_HEROKU_TAGS,
+        "unit-tests": AGENT_HEROKU_TAGS.union(UNIT_TEST_TAGS),
     },
     AgentFlavor.iot: {
         "agent": IOT_AGENT_TAGS,
-        "unit-tests": IOT_AGENT_TAGS,
+        "lint": IOT_AGENT_TAGS,
+        "unit-tests": IOT_AGENT_TAGS.union(UNIT_TEST_TAGS),
     },
     AgentFlavor.dogstatsd: {
         "dogstatsd": DOGSTATSD_TAGS,
         "system-tests": AGENT_TAGS,
-        "unit-tests": DOGSTATSD_TAGS,
+        "lint": DOGSTATSD_TAGS,
+        "unit-tests": DOGSTATSD_TAGS.union(UNIT_TEST_TAGS),
     },
 }
 

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -161,7 +161,7 @@ def test_flavor(
     failed_modules = []
     junit_files = []
 
-    args["go_build_tags"] = " ".join(build_tags + ["test"])
+    args["go_build_tags"] = " ".join(build_tags)
 
     junit_file_flag = ""
     junit_file = f"junit-out-{flavor.name}.xml"
@@ -327,7 +327,13 @@ def test(
 
     modules, flavors = process_input_args(module, targets, flavors)
 
-    flavors_build_tags = {
+    linter_tags = {
+        f: compute_build_tags_for_flavor(
+            flavor=f, build="lint", arch=arch, build_include=build_include, build_exclude=build_exclude
+        )
+        for f in flavors
+    }
+    unit_tests_tags = {
         f: compute_build_tags_for_flavor(
             flavor=f, build="unit-tests", arch=arch, build_include=build_include, build_exclude=build_exclude
         )
@@ -341,7 +347,7 @@ def test(
     if skip_linters:
         print("--- [skipping Go linters]")
     else:
-        for flavor, build_tags in flavors_build_tags.items():
+        for flavor, build_tags in linter_tags.items():
             lint_flavor(
                 ctx, modules=modules, flavor=flavor, build_tags=build_tags, arch=arch, rtloader_root=rtloader_root
             )
@@ -422,7 +428,7 @@ def test(
 
     failed_modules = {}
     junit_files = []
-    for flavor, build_tags in flavors_build_tags.items():
+    for flavor, build_tags in unit_tests_tags.items():
         junit_files_for_flavor, failed_modules_for_flavor = test_flavor(
             ctx,
             flavor=flavor,


### PR DESCRIPTION
### What does this PR do?

This tag is needed to run unit-test but was not printed by 'inv print-default-build-tags -b unit-tests'. When running tests from a IDE or other we need the correct list of tags to be returned.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
