### PR TITLE
rename configMissingOK field to baseConfigMissingOK

### DIFF
--- a/comp/core/config/params.go
+++ b/comp/core/config/params.go
@@ -28,7 +28,7 @@ type Params struct {
 	// the component's config data.
 	configLoadSysProbe bool
 
-	// securityAgentConfigFilePaths are the paths at which to look for security-aegnt
+	// securityAgentConfigFilePaths are the paths at which to look for security-agent
 	// configuration, usually given by the --cfgpath command-line flag.
 	securityAgentConfigFilePaths []string
 
@@ -40,9 +40,9 @@ type Params struct {
 	// should be evaluated.  This is typically false for one-shot commands.
 	configLoadSecrets bool
 
-	// configMissingOK determines whether it is a fatal error if the config
+	// baseConfigMissingOK determines whether it is a fatal error if the base Datadog config
 	// file does not exist.
-	configMissingOK bool
+	baseConfigMissingOK bool
 
 	// defaultConfPath determines the default configuration path.
 	// if defaultConfPath is empty, then no default configuration path is used.
@@ -82,6 +82,7 @@ func NewSecurityAgentParams(securityAgentConfigFilePaths []string, options ...fu
 	params := NewParams("", options...)
 	params.securityAgentConfigFilePaths = securityAgentConfigFilePaths
 	params.configLoadSecurityAgent = true
+	params.baseConfigMissingOK = true
 	return params
 }
 
@@ -93,7 +94,7 @@ func WithConfigName(name string) func(*Params) {
 
 func WithConfigMissingOK(v bool) func(*Params) {
 	return func(b *Params) {
-		b.configMissingOK = v
+		b.baseConfigMissingOK = v
 	}
 }
 
@@ -144,7 +145,7 @@ func (p Params) ConfigLoadSecrets() bool {
 // ConfigMissingOK determines whether it is a fatal error if the config
 // file does not exist.
 func (p Params) ConfigMissingOK() bool {
-	return p.configMissingOK
+	return p.baseConfigMissingOK
 }
 
 // ConfigLoadSysProbe determines whether to read the system-probe.yaml into

--- a/comp/core/config/setup.go
+++ b/comp/core/config/setup.go
@@ -24,7 +24,7 @@ func setupConfig(deps dependencies) (*config.Warnings, error) {
 	confFilePath := deps.Params.confFilePath
 	configName := deps.Params.configName
 	withoutSecrets := !deps.Params.configLoadSecrets
-	failOnMissingFile := !deps.Params.configMissingOK
+	failOnMissingFile := !deps.Params.baseConfigMissingOK
 	defaultConfPath := deps.Params.defaultConfPath
 
 	if configName != "" {
@@ -109,7 +109,7 @@ func MergeConfigurationFiles(configName string, configurationFilesArray []string
 			deps.Params.confFilePath = configurationFilename
 			deps.Params.configName = ""
 			deps.Params.configLoadSecrets = true
-			deps.Params.configMissingOK = false
+			deps.Params.baseConfigMissingOK = false
 			deps.Params.defaultConfPath = ""
 
 			w, err := setupConfig(deps)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
