### PR TITLE
pkg/obfuscate: fix panic due to missing logger

### DIFF
--- a/pkg/obfuscate/obfuscate.go
+++ b/pkg/obfuscate/obfuscate.go
@@ -176,6 +176,7 @@ func NewObfuscator(cfg Config) *Obfuscator {
 		opts:              &cfg,
 		queryCache:        newMeasuredCache(cacheOptions{On: cfg.SQL.Cache, Statsd: cfg.Statsd}),
 		sqlLiteralEscapes: atomic.NewBool(false),
+		log:               cfg.Logger,
 	}
 	if cfg.ES.Enabled {
 		o.es = newJSONObfuscator(&cfg.ES, &o)

--- a/releasenotes/notes/fix-obfuscator-logger-8c6a4debbf3a0bf6.yaml
+++ b/releasenotes/notes/fix-obfuscator-logger-8c6a4debbf3a0bf6.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix panic due to uninitialized Obfuscator logger


### PR DESCRIPTION
Obfuscator.log was uninitialized which was causing agent panic

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
In this MR I tried to fix a problem I faced using the dbm with mariadb.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
The agent was in a loop of constant restarts as it was crashing with panic

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
I was not able to build the full project so I'm not sure that I've fixed the problem, however I want to use this PR to have your attention on this.

I have a datadog support case with my agent flare №1046589.

#### What is going on in there?
1. Python checks call an agent to obfuscate an explain of sql query (mariadb)
2. Agent fails to parse sql and calls `o.log.Debugf` (`pkg/obfuscate/json.go:81`)
3. `o.log` is undefined -> agent panics

![dlv screenshot](https://user-images.githubusercontent.com/5867379/209588985-cec0645e-6f78-43bf-8d2d-2330f1d72444.png)

Example of an explain result:
```json
{
  "query_block": {
    "select_id": 1,
    "table": {
      "table_name": "<subquery3>",
      "access_type": "ALL",
      "possible_keys": ["distinct_key"],
      "rows": 206,
      "filtered": 100,
      "materialized": {
        "unique": 1,
        "query_block": {
          "select_id": 3,
          "table": {
            "table_name": "c2_",
            "access_type": "ALL",
            "possible_keys": ["IDX_6DEB6ACA19EB6921"],
            "rows": 206,
            "filtered": 100,
            "attached_condition": "c2_.client_id is not null"
          }
        }
      }
    },
    "table": {
      "table_name": "c0_",
      "access_type": "eq_ref",
      "possible_keys": ["PRIMARY"],
      "key": "PRIMARY",
      "key_length": "108",
      "used_key_parts": ["id"],
      "ref": ["dd.c2_.client_id"],
      "rows": 1,
      "filtered": 100,
      "attached_condition": "!<in_optimizer>(c0_.`id`,c0_.`id` in (subquery#2))"
    },
    "subqueries": [
      {
        "query_block": {
          "select_id": 2,
          "table": {
            "table_name": "c1_",
            "access_type": "range",
            "possible_keys": ["IDX_F6442ECA1B901A92"],
            "key": "IDX_F6442ECA1B901A92",
            "key_length": "109",
            "used_key_parts": ["client_id"],
            "rows": 49,
            "filtered": 100,
            "index_condition": "c1_.client_id is not null",
            "attached_condition": "c1_.start_date <= <cache>(current_timestamp())"
          }
        }
      }
    ]
  }
}
```


### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
