### PR TITLE
[backport] [kitchen] Work around bundler and ruby version issue in verifier

### DIFF
--- a/test/kitchen/drivers/azure-driver.yml
+++ b/test/kitchen/drivers/azure-driver.yml
@@ -160,6 +160,17 @@ platforms:
     username: <%= vm_username %>
     password: <%= vm_password %>
 
+  lifecycle:
+    # HACK: this is needed to install rexml for system-probe tests without using bundler, which cannot be used for now
+    # (see the explanation in tasks/run-test-kitchen.sh).
+    pre_verify:
+      - local: echo 'Installing rexml gem for the system-probe-test suite'
+      <% if windows %>
+      - remote: C:/opscode/chef/embedded/bin/gem.bat install rexml --install-dir C:/Users/<%= vm_username %>/AppData/Local/Temp/verifier/gems
+      <% else %>
+      - remote: /opt/chef/embedded/bin/gem install rexml --install-dir /tmp/verifier/gems
+      <% end %>
+
   transport:
     <% if windows %>
     name: winrm

--- a/test/kitchen/drivers/ec2-driver.yml
+++ b/test/kitchen/drivers/ec2-driver.yml
@@ -143,6 +143,15 @@ platforms:
           let i+=${wait};
         done;
   <% end %>
+    # HACK: this is needed to install rexml for system-probe tests without using bundler, which cannot be used for now
+    # (see the explanation in tasks/run-test-kitchen.sh).
+    pre_verify:
+      - local: echo 'Installing rexml gem for the system-probe-test suite'
+      <% if windows %>
+      - remote: C:/opscode/chef/embedded/bin/gem.bat install rexml --install-dir C:/Users/ec2-user/AppData/Local/Temp/verifier/gems
+      <% else %>
+      - remote: /opt/chef/embedded/bin/gem install rexml --install-dir /tmp/verifier/gems
+      <% end %>
   verifier:
     downloads:
       "/tmp/junit.tar.gz": kitchen-junit-<%= platform_name %>.tar.gz

--- a/test/kitchen/test/integration/system-probe-test/rspec/Gemfile
+++ b/test/kitchen/test/integration/system-probe-test/rspec/Gemfile
@@ -1,4 +1,0 @@
-source 'https://rubygems.org'
-
-gem 'rspec'
-gem 'rexml'


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Backport of #14851.

Modifies the script used to run kitchen tests to run the verify phase twice, and adds a pre_verify lifecycle hook to install the dependency needed for system-probe kitchen tests.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Works around an issue (version mismatch between ruby and bundler) that started happening after the release of version 2.4.0 of bundler. As long as this workaround is needed, we can't have Gemfiles in test suites, and instead need to manually install gems whenever needed.


### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

n/a

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

n/a

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

n/a

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
