### PR TITLE
Restrict flare file from being accessible by other users on Unix

### DIFF
--- a/comp/core/flare/helpers/builder.go
+++ b/comp/core/flare/helpers/builder.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/util/filesystem"
 	"github.com/DataDog/datadog-agent/pkg/util/hostname"
 	"github.com/DataDog/datadog-agent/pkg/util/hostname/validate"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -84,6 +85,15 @@ func NewFlareBuilder() (FlareBuilder, error) {
 	}
 	hostname = validate.CleanHostnameDir(hostname)
 
+	fperm, err := filesystem.NewPermission()
+	if err != nil {
+		return nil, err
+	}
+	err = fperm.RemoveAccessToOtherUsers(tmpDir)
+	if err != nil {
+		return nil, err
+	}
+
 	return newBuilder(tmpDir, hostname)
 }
 
@@ -121,15 +131,30 @@ func (fb *builder) Save() (string, error) {
 	_ = fb.AddFileFromFunc("permissions.log", fb.permsInfos.commit)
 	_ = fb.logFile.Close()
 
-	archivePath := filepath.Join(os.TempDir(), getArchiveName())
+	archiveName := getArchiveName()
+	archiveTmpPath := filepath.Join(fb.tmpDir, archiveName)
+	archiveFinalPath := filepath.Join(os.TempDir(), archiveName)
+
+	// We first create the archive in our fb.tmpDir directory which is only readable by the current user (and
+	// SYSTEM/ADMIN on Windows). Then we retrict the archive permissions before moving it to the system temporary
+	// directory. This prevents other users from being able to read local flares.
 
 	// File format is determined based on archivePath extension, so zip
-	err := archiver.Archive([]string{fb.flareDir}, archivePath)
+	err := archiver.Archive([]string{fb.flareDir}, archiveTmpPath)
 	if err != nil {
 		return "", err
 	}
 
-	return archivePath, nil
+	fperm, err := filesystem.NewPermission()
+	if err != nil {
+		return "", err
+	}
+	err = fperm.RemoveAccessToOtherUsers(archiveTmpPath)
+	if err != nil {
+		return "", err
+	}
+
+	return archiveFinalPath, os.Rename(archiveTmpPath, archiveFinalPath)
 }
 
 func (fb *builder) clean() {

--- a/pkg/util/filesystem/permission_nowindows.go
+++ b/pkg/util/filesystem/permission_nowindows.go
@@ -67,7 +67,7 @@ func (p *Permission) RemoveAccessToOtherUsers(path string) error {
 	if err != nil {
 		return err
 	}
-	// We keep the original 'user' rights but set 'group' and 'use' to zero.
+	// We keep the original 'user' rights but set 'group' and 'other' to zero.
 	newPerm := fperm.Mode().Perm() & 0700
 	return os.Chmod(path, fs.FileMode(newPerm))
 }

--- a/pkg/util/filesystem/permission_nowindows.go
+++ b/pkg/util/filesystem/permission_nowindows.go
@@ -2,6 +2,7 @@
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
+
 //go:build !windows
 // +build !windows
 
@@ -26,7 +27,8 @@ func NewPermission() (*Permission, error) {
 	return &Permission{}, nil
 }
 
-// RestrictAccessToUser restricts the access to a file to the current user and its group
+// RestrictAccessToUser sets the file user and group to the same as 'dd-agent' user. If the function fails to lookup
+// "dd-agent" user it return nil immediately.
 func (p *Permission) RestrictAccessToUser(path string) error {
 	usr, err := user.Lookup("dd-agent")
 	if err != nil {
@@ -53,4 +55,19 @@ func (p *Permission) RestrictAccessToUser(path string) error {
 	}
 
 	return nil
+}
+
+// RemoveAccessToOtherUsers on Unix this calls RestrictAccessToUser and then removes all access to the file for 'group'
+// and 'other'
+func (p *Permission) RemoveAccessToOtherUsers(path string) error {
+	// We first try to set other and group to "dd-agent" when possible
+	_ = p.RestrictAccessToUser(path)
+
+	fperm, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+	// We keep the original 'user' rights but set 'group' and 'use' to zero.
+	newPerm := fperm.Mode().Perm() & 0700
+	return os.Chmod(path, fs.FileMode(newPerm))
 }

--- a/pkg/util/filesystem/permission_nowindows_test.go
+++ b/pkg/util/filesystem/permission_nowindows_test.go
@@ -1,0 +1,45 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !windows
+// +build !windows
+
+package filesystem
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gotest.tools/assert"
+)
+
+func TestRemoveAccessToOtherUsers(t *testing.T) {
+	p, err := NewPermission()
+	require.NoError(t, err)
+
+	root := t.TempDir()
+
+	testFile := filepath.Join(root, "file")
+	testDir := filepath.Join(root, "dir")
+
+	err = os.WriteFile(testFile, []byte("test"), 0777)
+	require.NoError(t, err)
+	err = os.Mkdir(testDir, 0777)
+	require.NoError(t, err)
+
+	err = p.RemoveAccessToOtherUsers(testFile)
+	require.NoError(t, err)
+	stat, err := os.Stat(testFile)
+	require.NoError(t, err)
+	assert.Equal(t, int(stat.Mode().Perm()), 0700)
+
+	err = p.RemoveAccessToOtherUsers(testDir)
+	require.NoError(t, err)
+	stat, err = os.Stat(testDir)
+	require.NoError(t, err)
+	assert.Equal(t, int(stat.Mode().Perm()), 0700)
+}

--- a/pkg/util/filesystem/permission_windows.go
+++ b/pkg/util/filesystem/permission_windows.go
@@ -71,3 +71,8 @@ func (p *Permission) RestrictAccessToUser(path string) error {
 		acl.GrantSid(windows.GENERIC_ALL, p.systemSid),
 		acl.GrantSid(windows.GENERIC_ALL, p.currentUserSid))
 }
+
+// RemoveAccessToOtherUsers on Windows this function calls RestrictAccessToUser
+func (p *Permission) RemoveAccessToOtherUsers(path string) error {
+	return p.RestrictAccessToUser(path)
+}


### PR DESCRIPTION
### What does this PR do?

Restrict flare file from being accessible by other users on Unix

### Describe how to test/QA your changes

Create and send from from both Linux and Windows when the agent is running and not running.

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
