### PR TITLE
[process-agent] Move data scrubber/disallow-list from pkg/process/config

### DIFF
--- a/pkg/process/checks/process.go
+++ b/pkg/process/checks/process.go
@@ -8,11 +8,14 @@ package checks
 import (
 	"context"
 	"errors"
+	"regexp"
+	"strings"
 	"time"
 
 	model "github.com/DataDog/agent-payload/v5/process"
 	"github.com/DataDog/gopsutil/cpu"
 
+	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/process/config"
 	"github.com/DataDog/datadog-agent/pkg/process/net"
 	"github.com/DataDog/datadog-agent/pkg/process/procutil"
@@ -22,10 +25,19 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-const emptyCtrID = ""
+const (
+	emptyCtrID                 = ""
+	configPrefix               = "process_config."
+	configCustomSensitiveWords = configPrefix + "custom_sensitive_words"
+	configScrubArgs            = configPrefix + "scrub_args"
+	configStripProcArgs        = configPrefix + "strip_proc_arguments"
+	configDisallowList         = configPrefix + "blacklist_patterns"
+)
 
 // Process is a singleton ProcessCheck.
-var Process = &ProcessCheck{}
+var Process = &ProcessCheck{
+	scrubber: procutil.NewDefaultDataScrubber(),
+}
 
 var _ CheckWithRealTime = (*ProcessCheck)(nil)
 
@@ -36,6 +48,11 @@ var errEmptyCPUTime = errors.New("empty CPU time information returned")
 // checks that will be used for rates, cpu calculations, etc.
 type ProcessCheck struct {
 	probe procutil.Probe
+	// scrubber is a DataScrubber to hide command line sensitive words
+	scrubber *procutil.DataScrubber
+
+	// disallowList to hide processes
+	disallowList []*regexp.Regexp
 
 	sysInfo                    *model.SystemInfo
 	lastCPUTime                cpu.TimesStat
@@ -79,6 +96,11 @@ func (p *ProcessCheck) Init(_ *config.AgentConfig, info *model.SystemInfo) {
 
 	p.maxBatchSize = getMaxBatchSize()
 	p.maxBatchBytes = getMaxBatchBytes()
+
+	initScrubber(p.scrubber)
+
+	p.disallowList = initDisallowList()
+
 }
 
 // Name returns the name of the ProcessCheck.
@@ -170,7 +192,7 @@ func (p *ProcessCheck) run(cfg *config.AgentConfig, groupID int32, collectRealTi
 	}
 
 	connsByPID := Connections.getLastConnectionsByPID()
-	procsByCtr := fmtProcesses(cfg, procs, p.lastProcs, pidToCid, cpuTimes[0], p.lastCPUTime, p.lastRun, connsByPID)
+	procsByCtr := fmtProcesses(cfg, p.scrubber, p.disallowList, procs, p.lastProcs, pidToCid, cpuTimes[0], p.lastCPUTime, p.lastRun, connsByPID)
 	messages, totalProcs, totalContainers := createProcCtrMessages(procsByCtr, containers, cfg, p.maxBatchSize, p.maxBatchBytes, p.sysInfo, groupID, p.networkID)
 
 	// Store the last state for comparison on the next run.
@@ -298,6 +320,8 @@ func chunkProcessesAndContainers(
 // non-container processes would be in a single group with key as empty string ""
 func fmtProcesses(
 	cfg *config.AgentConfig,
+	scrubber *procutil.DataScrubber,
+	disallowList []*regexp.Regexp,
 	procs, lastProcs map[int32]*procutil.Process,
 	ctrByProc map[int]string,
 	syst2, syst1 cpu.TimesStat,
@@ -308,12 +332,12 @@ func fmtProcesses(
 	connCheckIntervalS := int(cfg.CheckIntervals[config.ConnectionsCheckName] / time.Second)
 
 	for _, fp := range procs {
-		if skipProcess(cfg, fp, lastProcs) {
+		if skipProcess(disallowList, fp, lastProcs) {
 			continue
 		}
 
-		// Hide blacklisted args if the Scrubber is enabled
-		fp.Cmdline = cfg.Scrubber.ScrubProcessCommand(fp)
+		// Hide disallow-listed args if the Scrubber is enabled
+		fp.Cmdline = scrubber.ScrubProcessCommand(fp)
 
 		proc := &model.Process{
 			Pid:                    fp.Pid,
@@ -338,7 +362,7 @@ func fmtProcesses(
 		procsByCtr[proc.ContainerId] = append(procsByCtr[proc.ContainerId], proc)
 	}
 
-	cfg.Scrubber.IncrementCacheAge()
+	scrubber.IncrementCacheAge()
 
 	return procsByCtr
 }
@@ -442,17 +466,17 @@ func formatCPU(statsNow, statsBefore *procutil.Stats, syst2, syst1 cpu.TimesStat
 	return formatCPUTimes(statsNow, statsNow.CPUTime, statsBefore.CPUTime, syst2, syst1)
 }
 
-// skipProcess will skip a given process if it's blacklisted or hasn't existed
+// skipProcess will skip a given process if it's disallow-listed or hasn't existed
 // for multiple collections.
 func skipProcess(
-	cfg *config.AgentConfig,
+	disallowList []*regexp.Regexp,
 	fp *procutil.Process,
 	lastProcs map[int32]*procutil.Process,
 ) bool {
 	if len(fp.Cmdline) == 0 {
 		return true
 	}
-	if config.IsBlacklisted(fp.Cmdline, cfg.Blacklist) {
+	if isDisallowListed(fp.Cmdline, disallowList) {
 		return true
 	}
 	if _, ok := lastProcs[fp.Pid]; !ok {
@@ -496,4 +520,55 @@ func mergeProcWithSysprobeStats(pids []int32, procs map[int32]*procutil.Process,
 	} else {
 		log.Debugf("cannot do GetProcStats from system-probe for process check: %s", err)
 	}
+}
+
+func initScrubber(scrubber *procutil.DataScrubber) {
+	// Enable/Disable the DataScrubber to obfuscate process args
+	if ddconfig.Datadog.IsSet(configScrubArgs) {
+		scrubber.Enabled = ddconfig.Datadog.GetBool(configScrubArgs)
+	}
+
+	if scrubber.Enabled { // Scrubber is enabled by default when it's created
+		log.Debug("Starting process collection with Scrubber enabled")
+	}
+
+	// A custom word list to enhance the default one used by the DataScrubber
+	if ddconfig.Datadog.IsSet(configCustomSensitiveWords) {
+		words := ddconfig.Datadog.GetStringSlice(configCustomSensitiveWords)
+		scrubber.AddCustomSensitiveWords(words)
+		log.Debug("Adding custom sensitives words to Scrubber:", words)
+	}
+
+	// Strips all process arguments
+	if ddconfig.Datadog.GetBool(configStripProcArgs) {
+		log.Debug("Strip all process arguments enabled")
+		scrubber.StripAllArguments = true
+	}
+}
+
+func initDisallowList() []*regexp.Regexp {
+	var disallowList []*regexp.Regexp
+	// A list of regex patterns that will exclude a process if matched.
+	if ddconfig.Datadog.IsSet(configDisallowList) {
+		for _, b := range ddconfig.Datadog.GetStringSlice(configDisallowList) {
+			r, err := regexp.Compile(b)
+			if err != nil {
+				log.Warnf("Ignoring invalid disallow list pattern: %s", b)
+				continue
+			}
+			disallowList = append(disallowList, r)
+		}
+	}
+	return disallowList
+}
+
+// isDisallowListed returns a boolean indicating if the given command is disallow-listed by our config.
+func isDisallowListed(cmdline []string, disallowList []*regexp.Regexp) bool {
+	cmd := strings.Join(cmdline, " ")
+	for _, b := range disallowList {
+		if b.MatchString(cmd) {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/process/checks/process_nix_test.go
+++ b/pkg/process/checks/process_nix_test.go
@@ -55,7 +55,7 @@ func TestBasicProcessMessages(t *testing.T) {
 		containers         []*model.Container
 		pidToCid           map[int]string
 		maxSize            int
-		blacklist          []string
+		disallowList       []string
 		expectedChunks     int
 		expectedProcs      int
 		expectedContainers int
@@ -66,7 +66,7 @@ func TestBasicProcessMessages(t *testing.T) {
 			maxSize:            2,
 			containers:         []*model.Container{},
 			pidToCid:           nil,
-			blacklist:          []string{},
+			disallowList:       []string{},
 			expectedChunks:     2,
 			expectedProcs:      3,
 			expectedContainers: 0,
@@ -77,7 +77,7 @@ func TestBasicProcessMessages(t *testing.T) {
 			maxSize:            2,
 			containers:         []*model.Container{c[0]},
 			pidToCid:           map[int]string{1: "foo", 2: "foo"},
-			blacklist:          []string{},
+			disallowList:       []string{},
 			expectedChunks:     2,
 			expectedProcs:      3,
 			expectedContainers: 1,
@@ -88,7 +88,7 @@ func TestBasicProcessMessages(t *testing.T) {
 			maxSize:            1,
 			containers:         []*model.Container{c[1]},
 			pidToCid:           map[int]string{3: "bar"},
-			blacklist:          []string{},
+			disallowList:       []string{},
 			expectedChunks:     3,
 			expectedProcs:      3,
 			expectedContainers: 1,
@@ -99,7 +99,7 @@ func TestBasicProcessMessages(t *testing.T) {
 			maxSize:            2,
 			containers:         []*model.Container{c[0], c[1]},
 			pidToCid:           map[int]string{1: "foo", 2: "foo", 3: "bar"},
-			blacklist:          []string{},
+			disallowList:       []string{},
 			expectedChunks:     2,
 			expectedProcs:      3,
 			expectedContainers: 2,
@@ -110,21 +110,20 @@ func TestBasicProcessMessages(t *testing.T) {
 			maxSize:            2,
 			containers:         []*model.Container{c[1]},
 			pidToCid:           map[int]string{3: "bar"},
-			blacklist:          []string{"foo"},
+			disallowList:       []string{"foo"},
 			expectedChunks:     1,
 			expectedProcs:      2,
 			expectedContainers: 1,
 		},
 	} {
 		t.Run(tc.testName, func(t *testing.T) {
-			bl := make([]*regexp.Regexp, 0, len(tc.blacklist))
-			for _, s := range tc.blacklist {
-				bl = append(bl, regexp.MustCompile(s))
+			disallowList := make([]*regexp.Regexp, 0, len(tc.disallowList))
+			for _, s := range tc.disallowList {
+				disallowList = append(disallowList, regexp.MustCompile(s))
 			}
-			cfg.Blacklist = bl
 			networks := make(map[int32][]*model.Connection)
 
-			procs := fmtProcesses(cfg, tc.processes, tc.processes, tc.pidToCid, syst2, syst1, lastRun, networks)
+			procs := fmtProcesses(cfg, procutil.NewDefaultDataScrubber(), disallowList, tc.processes, tc.processes, tc.pidToCid, syst2, syst1, lastRun, networks)
 			messages, totalProcs, totalContainers := createProcCtrMessages(procs, tc.containers, cfg, tc.maxSize, maxBatchBytes, sysInfo, int32(i), "nid")
 
 			assert.Equal(t, tc.expectedChunks, len(messages))
@@ -236,7 +235,7 @@ func TestContainerProcessChunking(t *testing.T) {
 			cfg := config.NewDefaultAgentConfig()
 			sysInfo := &model.SystemInfo{}
 
-			processes := fmtProcesses(cfg, procsByPid, procsByPid, pidToCid, syst2, syst1, lastRun, networks)
+			processes := fmtProcesses(cfg, procutil.NewDefaultDataScrubber(), nil, procsByPid, procsByPid, pidToCid, syst2, syst1, lastRun, networks)
 			messages, totalProcs, totalContainers := createProcCtrMessages(processes, ctrs, cfg, tc.maxSize, maxBatchBytes, sysInfo, int32(i), "nid")
 
 			assert.Equal(t, tc.expectedProcCount, totalProcs)

--- a/pkg/process/config/config.go
+++ b/pkg/process/config/config.go
@@ -14,7 +14,6 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
-	"regexp"
 	"strings"
 	"time"
 
@@ -63,8 +62,6 @@ type cmdFunc = func(name string, arg ...string) *exec.Cmd
 // For any other setting, use `pkg/config`.
 type AgentConfig struct {
 	HostName           string
-	Blacklist          []*regexp.Regexp
-	Scrubber           *DataScrubber
 	MaxConnsPerMessage int
 
 	// host type of the agent, used to populate container payload with additional host information
@@ -130,10 +127,6 @@ func NewDefaultAgentConfig() *AgentConfig {
 			DiscoveryCheckName:     ProcessDiscoveryCheckDefaultInterval,
 			ProcessEventsCheckName: config.DefaultProcessEventsCheckInterval,
 		},
-
-		// DataScrubber to hide command line sensitive words
-		Scrubber:  NewDefaultDataScrubber(),
-		Blacklist: make([]*regexp.Regexp, 0),
 	}
 
 	// Set default values for proc/sys paths if unset.
@@ -262,17 +255,6 @@ func loadEnvVariables() {
 			config.Datadog.Set("orchestrator_explorer.orchestrator_additional_endpoints", endpoints)
 		}
 	}
-}
-
-// IsBlacklisted returns a boolean indicating if the given command is blacklisted by our config.
-func IsBlacklisted(cmdline []string, blacklist []*regexp.Regexp) bool {
-	cmd := strings.Join(cmdline, " ")
-	for _, b := range blacklist {
-		if b.MatchString(cmd) {
-			return true
-		}
-	}
-	return false
 }
 
 // getHostname attempts to resolve the hostname in the following order: the main datadog agent via grpc, the main agent

--- a/pkg/process/config/yaml_config.go
+++ b/pkg/process/config/yaml_config.go
@@ -7,7 +7,6 @@ package config
 
 import (
 	"path/filepath"
-	"regexp"
 	"strings"
 	"time"
 
@@ -77,38 +76,6 @@ func (a *AgentConfig) LoadAgentConfig(path string) error {
 		a.CheckIntervals[RTProcessCheckName] = RTProcessCheckDefaultInterval
 	}
 
-	// A list of regex patterns that will exclude a process if matched.
-	if k := key(ns, "blacklist_patterns"); config.Datadog.IsSet(k) {
-		for _, b := range config.Datadog.GetStringSlice(k) {
-			r, err := regexp.Compile(b)
-			if err != nil {
-				log.Warnf("Ignoring invalid blacklist pattern: %s", b)
-				continue
-			}
-			a.Blacklist = append(a.Blacklist, r)
-		}
-	}
-
-	// Enable/Disable the DataScrubber to obfuscate process args
-	if scrubArgsKey := key(ns, "scrub_args"); config.Datadog.IsSet(scrubArgsKey) {
-		a.Scrubber.Enabled = config.Datadog.GetBool(scrubArgsKey)
-	}
-	if a.Scrubber.Enabled { // Scrubber is enabled by default when it's created
-		log.Debug("Starting process-agent with Scrubber enabled")
-	}
-
-	// A custom word list to enhance the default one used by the DataScrubber
-	if k := key(ns, "custom_sensitive_words"); config.Datadog.IsSet(k) {
-		words := config.Datadog.GetStringSlice(k)
-		a.Scrubber.AddCustomSensitiveWords(words)
-		log.Debug("Adding custom sensitives words to Scrubber:", words)
-	}
-
-	// Strips all process arguments
-	if config.Datadog.GetBool(key(ns, "strip_proc_arguments")) {
-		log.Debug("Strip all process arguments enabled")
-		a.Scrubber.StripAllArguments = true
-	}
 	return nil
 }
 

--- a/pkg/process/procutil/data_scrubber.go
+++ b/pkg/process/procutil/data_scrubber.go
@@ -3,16 +3,14 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-package config
+package procutil
 
 import (
 	"bytes"
-	"fmt"
 	"regexp"
 	"strconv"
 	"strings"
 
-	"github.com/DataDog/datadog-agent/pkg/process/procutil"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -28,7 +26,7 @@ const (
 	defaultCacheMaxCycles = 25
 )
 
-// DataScrubber allows the agent to blacklist cmdline arguments that match
+// DataScrubber allows the agent to disallow-list cmdline arguments that match
 // a list of predefined and custom words
 type DataScrubber struct {
 	Enabled           bool
@@ -87,7 +85,7 @@ func CompileStringsToRegex(words []string) []*regexp.Regexp {
 					valid = false
 					break
 				} else {
-					enhancedWord.WriteString(fmt.Sprintf("[^\\s=:$/]*"))
+					enhancedWord.WriteString("[^\\s=:$/]*")
 				}
 			} else {
 				enhancedWord.WriteString(string(rune))
@@ -111,7 +109,7 @@ func CompileStringsToRegex(words []string) []*regexp.Regexp {
 }
 
 // createProcessKey returns an unique identifier for a given process
-func createProcessKey(p *procutil.Process) string {
+func createProcessKey(p *Process) string {
 	var b bytes.Buffer
 	b.WriteString("p:")
 	b.WriteString(strconv.Itoa(int(p.Pid)))
@@ -123,7 +121,7 @@ func createProcessKey(p *procutil.Process) string {
 
 // ScrubProcessCommand uses a cache memory to avoid scrubbing already known
 // process' cmdlines
-func (ds *DataScrubber) ScrubProcessCommand(p *procutil.Process) []string {
+func (ds *DataScrubber) ScrubProcessCommand(p *Process) []string {
 	if ds.StripAllArguments {
 		return ds.stripArguments(p.Cmdline)
 	}

--- a/pkg/process/procutil/data_scrubber_test.go
+++ b/pkg/process/procutil/data_scrubber_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-package config
+package procutil
 
 import (
 	"flag"
@@ -11,8 +11,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-
-	"github.com/DataDog/datadog-agent/pkg/process/procutil"
 )
 
 func setupDataScrubber(t *testing.T) *DataScrubber {
@@ -58,7 +56,7 @@ type testCase struct {
 }
 
 type testProcess struct {
-	procutil.Process
+	Process
 	parsedCmdline []string
 }
 
@@ -197,9 +195,9 @@ func setupTestProcesses() (fps []testProcess, sensible int) {
 	fps = make([]testProcess, 0, len(cases))
 	for i, c := range cases {
 		fps = append(fps, testProcess{
-			procutil.Process{
+			Process{
 				Pid: int32(i),
-				Stats: &procutil.Stats{
+				Stats: &Stats{
 					CreateTime: time.Now().Unix(),
 				},
 				Cmdline: c.cmdline,
@@ -219,9 +217,9 @@ func setupTestProcessesForBench() []testProcess {
 	fps := make([]testProcess, 0, len(cases))
 	for i := 0; i < nbProcesses; i++ {
 		fps = append(fps, testProcess{
-			procutil.Process{
+			Process{
 				Pid: int32(i),
-				Stats: &procutil.Stats{
+				Stats: &Stats{
 					CreateTime: time.Now().Unix(),
 				},
 				Cmdline: cases[i%len(cases)].cmdline,
@@ -296,7 +294,7 @@ func TestUncompilableWord(t *testing.T) {
 	}
 }
 
-func TestBlacklistedArgs(t *testing.T) {
+func TestDisallowListedArgs(t *testing.T) {
 	cases := setupSensitiveCmdlines()
 	scrubber := setupDataScrubber(t)
 
@@ -306,7 +304,7 @@ func TestBlacklistedArgs(t *testing.T) {
 	}
 }
 
-func TestBlacklistedArgsWhenDisabled(t *testing.T) {
+func TestDisallowListedArgsWhenDisabled(t *testing.T) {
 	cases := []struct {
 		cmdline       []string
 		parsedCmdline []string
@@ -333,7 +331,7 @@ func TestBlacklistedArgsWhenDisabled(t *testing.T) {
 	scrubber.Enabled = false
 
 	for i := range cases {
-		fp := &procutil.Process{Cmdline: cases[i].cmdline}
+		fp := &Process{Cmdline: cases[i].cmdline}
 		cases[i].cmdline = scrubber.ScrubProcessCommand(fp)
 		assert.Equal(t, cases[i].parsedCmdline, cases[i].cmdline)
 	}
@@ -368,13 +366,13 @@ func TestScrubberStrippingAllArgument(t *testing.T) {
 	scrubber.StripAllArguments = true
 
 	for i := range cases {
-		fp := &procutil.Process{Cmdline: cases[i].cmdline}
+		fp := &Process{Cmdline: cases[i].cmdline}
 		cases[i].cmdline = scrubber.ScrubProcessCommand(fp)
 		assert.Equal(t, cases[i].parsedCmdline, cases[i].cmdline)
 	}
 }
 
-func TestNoBlacklistedArgs(t *testing.T) {
+func TestNoDisallowListedArgs(t *testing.T) {
 	cases := setupInsensitiveCmdlines()
 	scrubber := setupDataScrubber(t)
 

--- a/pkg/security/probe/activity_dump_manager.go
+++ b/pkg/security/probe/activity_dump_manager.go
@@ -18,7 +18,7 @@ import (
 	"github.com/cilium/ebpf"
 
 	coreconfig "github.com/DataDog/datadog-agent/pkg/config"
-	pconfig "github.com/DataDog/datadog-agent/pkg/process/config"
+	"github.com/DataDog/datadog-agent/pkg/process/procutil"
 	"github.com/DataDog/datadog-agent/pkg/security/api"
 	"github.com/DataDog/datadog-agent/pkg/security/config"
 	"github.com/DataDog/datadog-agent/pkg/security/ebpf/kernel"
@@ -43,7 +43,7 @@ type ActivityDumpManager struct {
 	statsdClient  statsd.ClientInterface
 	resolvers     *Resolvers
 	kernelVersion *kernel.Version
-	scrubber      *pconfig.DataScrubber
+	scrubber      *procutil.DataScrubber
 	manager       *manager.Manager
 
 	tracedPIDsMap          *ebpf.Map
@@ -169,7 +169,7 @@ func (adm *ActivityDumpManager) resolveTags() {
 
 // NewActivityDumpManager returns a new ActivityDumpManager instance
 func NewActivityDumpManager(p *Probe, config *config.Config, statsdClient statsd.ClientInterface, resolvers *Resolvers,
-	kernelVersion *kernel.Version, scrubber *pconfig.DataScrubber, manager *manager.Manager) (*ActivityDumpManager, error) {
+	kernelVersion *kernel.Version, scrubber *procutil.DataScrubber, manager *manager.Manager) (*ActivityDumpManager, error) {
 	tracedPIDs, err := managerhelper.Map(manager, "traced_pids")
 	if err != nil {
 		return nil, err

--- a/pkg/security/probe/model.go
+++ b/pkg/security/probe/model.go
@@ -20,7 +20,7 @@ import (
 	"github.com/cilium/ebpf/perf"
 	"github.com/mailru/easyjson/jwriter"
 
-	pconfig "github.com/DataDog/datadog-agent/pkg/process/config"
+	"github.com/DataDog/datadog-agent/pkg/process/procutil"
 	"github.com/DataDog/datadog-agent/pkg/security/probe/constantfetch"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
@@ -78,7 +78,7 @@ type Event struct {
 
 	resolvers           *Resolvers
 	pathResolutionError error
-	scrubber            *pconfig.DataScrubber
+	scrubber            *procutil.DataScrubber
 	probe               *Probe
 }
 
@@ -635,7 +635,7 @@ func (ev *Event) ResolveNetworkDeviceIfName(device *model.NetworkDeviceContext) 
 }
 
 // NewEvent returns a new event
-func NewEvent(resolvers *Resolvers, scrubber *pconfig.DataScrubber, probe *Probe) *Event {
+func NewEvent(resolvers *Resolvers, scrubber *procutil.DataScrubber, probe *Probe) *Event {
 	return &Event{
 		Event:     model.Event{},
 		resolvers: resolvers,

--- a/pkg/security/probe/model_test.go
+++ b/pkg/security/probe/model_test.go
@@ -15,7 +15,7 @@ import (
 	"sort"
 	"testing"
 
-	pconfig "github.com/DataDog/datadog-agent/pkg/process/config"
+	"github.com/DataDog/datadog-agent/pkg/process/procutil"
 	"github.com/DataDog/datadog-agent/pkg/security/config"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
@@ -84,7 +84,7 @@ func TestProcessArgsFlags(t *testing.T) {
 	}
 
 	resolver, _ := NewProcessResolver(&manager.Manager{}, &config.Config{}, &statsd.NoOpClient{},
-		&pconfig.DataScrubber{}, nil, NewProcessResolverOpts(nil))
+		&procutil.DataScrubber{}, nil, NewProcessResolverOpts(nil))
 	e.resolvers = &Resolvers{
 		ProcessResolver: resolver,
 	}
@@ -145,7 +145,7 @@ func TestProcessArgsOptions(t *testing.T) {
 	}
 
 	resolver, _ := NewProcessResolver(&manager.Manager{}, &config.Config{}, &statsd.NoOpClient{},
-		&pconfig.DataScrubber{}, nil, NewProcessResolverOpts(nil))
+		&procutil.DataScrubber{}, nil, NewProcessResolverOpts(nil))
 	e.resolvers = &Resolvers{
 		ProcessResolver: resolver,
 	}

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -30,7 +30,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	aconfig "github.com/DataDog/datadog-agent/pkg/config"
-	pconfig "github.com/DataDog/datadog-agent/pkg/process/config"
+	"github.com/DataDog/datadog-agent/pkg/process/procutil"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 	"github.com/DataDog/datadog-agent/pkg/security/api"
 	"github.com/DataDog/datadog-agent/pkg/security/config"
@@ -93,7 +93,7 @@ type Probe struct {
 	resolvers   *Resolvers
 	event       *Event
 	eventStream EventStream
-	scrubber    *pconfig.DataScrubber
+	scrubber    *procutil.DataScrubber
 
 	// ActivityDumps section
 	activityDumpHandler ActivityDumpHandler
@@ -1465,7 +1465,7 @@ func NewProbe(config *config.Config, statsdClient statsd.ClientInterface) (*Prob
 		p.managerOptions.ExcludedFunctions = append(p.managerOptions.ExcludedFunctions, probes.GetAllTCProgramFunctions()...)
 	}
 
-	p.scrubber = pconfig.NewDefaultDataScrubber()
+	p.scrubber = procutil.NewDefaultDataScrubber()
 	p.scrubber.AddCustomSensitiveWords(config.CustomSensitiveWords)
 
 	resolvers, err := NewResolvers(config, p)

--- a/pkg/security/probe/process_resolver.go
+++ b/pkg/security/probe/process_resolver.go
@@ -29,7 +29,7 @@ import (
 	"github.com/hashicorp/golang-lru/v2/simplelru"
 	"go.uber.org/atomic"
 
-	pconfig "github.com/DataDog/datadog-agent/pkg/process/config"
+	"github.com/DataDog/datadog-agent/pkg/process/procutil"
 	"github.com/DataDog/datadog-agent/pkg/security/config"
 	"github.com/DataDog/datadog-agent/pkg/security/ebpf/kernel"
 	"github.com/DataDog/datadog-agent/pkg/security/metrics"
@@ -103,7 +103,7 @@ type ProcessResolver struct {
 	manager      *manager.Manager
 	config       *config.Config
 	statsdClient statsd.ClientInterface
-	scrubber     *pconfig.DataScrubber
+	scrubber     *procutil.DataScrubber
 
 	resolvers        *Resolvers
 	execFileCacheMap *lib.Map
@@ -1290,7 +1290,7 @@ func (p *ProcessResolver) NewProcessVariables(scoper func(ctx *eval.Context) uns
 
 // NewProcessResolver returns a new process resolver
 func NewProcessResolver(manager *manager.Manager, config *config.Config, statsdClient statsd.ClientInterface,
-	scrubber *pconfig.DataScrubber, resolvers *Resolvers, opts ProcessResolverOpts) (*ProcessResolver, error) {
+	scrubber *procutil.DataScrubber, resolvers *Resolvers, opts ProcessResolverOpts) (*ProcessResolver, error) {
 	argsEnvsCache, err := simplelru.NewLRU[uint32, *model.ArgsEnvsCacheEntry](maxParallelArgsEnvs, nil)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
### What does this PR do?

- Move these two fields in preparation for removal of pkg/process/config package.
- Use inclusive naming where possible - will rename the config param in the future.

### Motivation

Deprecation of pkg/process/config package in favor of using common config.

### Describe how to test/QA your changes

Test command args scrubbing and process disallow lists.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
