### PR TITLE
document trace API v04, including response

### DIFF
--- a/pkg/trace/api/version.go
+++ b/pkg/trace/api/version.go
@@ -20,16 +20,51 @@ const (
 	v03 Version = "v0.3"
 
 	// v04
-	// Traces: msgpack/JSON (Content-Type) slice of traces + returns service sampling ratios
+	//
+	// Request: Trace chunks.
+	// 	Content-Type: application/msgpack
+	// 	Payload: An array of arrays of Span (pkg/trace/pb/span.proto)
+	//
+	// Response: Service sampling rates.
+	// 	Content-Type: application/json
+	// 	Payload: Object mapping span pattern to sample rate.
+	//
+	// The response payload is an object whose keys are of the form
+	// "service:my-service,env:my-env", where "my-service" is the name of the
+	// affected service, and "my-env" is the name of the relevant deployment
+	// environment. The value at each key is the sample rate to apply to traces
+	// beginning with a span that matches the key.
+	//
+	//  {
+	//    "service:foosvc,env:prod": 0.223443,
+	//    "service:barsvc,env:staging": 0.011249
+	//  }
+	//
+	// There is a special key, "service:,env:", that denotes the sample rate for
+	// traces that do not match any other key.
+	//
+	//  {
+	//    "service:foosvc,env:prod": 0.223443,
+	//    "service:barsvc,env:staging": 0.011249,
+	//    "service:,env:": 0.5
+	//  }
+	//
+	// Neither the "service:,env:" key nor any other need be present in the
+	// response.
+	//
+	//  {}
+	//
 	v04 Version = "v0.4"
 
 	// v05
 	//
-	// Content-Type: application/msgpack
-	// Payload: Traces with strings de-duplicated into a dictionary.
-	// Response: Service sampling rates.
+	// Request: Trace chunks with a shared dictionary of strings.
+	// 	Content-Type: application/msgpack
+	// 	Payload: Traces with strings de-duplicated into a dictionary (see below).
 	//
-	// The payload is an array containing exactly 2 elements:
+	// Response: Service sampling rates (see description in v04).
+	//
+	// The request payload is an array containing exactly 2 elements:
 	//
 	// 	1. An array of all unique strings present in the payload (a dictionary referred to by index).
 	// 	2. An array of traces, where each trace is an array of spans. A span is encoded as an array having
@@ -76,9 +111,11 @@ const (
 
 	// V07 API
 	//
-	// Content-Type: application/msgpack
-	// Payload: TracerPayload (pkg/trace/pb/tracer_payload.proto)
-	// Response: Service sampling rates.
+	// Request: Tracer Payload.
+	// 	Content-Type: application/msgpack
+	// 	Payload: TracerPayload (pkg/trace/pb/tracer_payload.proto)
+	//
+	// Response: Service sampling rates (see description in v04).
 	//
 	V07 Version = "v0.7"
 )


### PR DESCRIPTION
### What does this PR do?
It adds documenting comments to `pkg/trace/api/version.go`.

### Motivation
I was talking to Andrew about the differences between the API versions, and thought `v04` could use some more documentation.

### Describe how to test/QA your changes
N/A

### Reviewer's Checklist
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
