### PR TITLE
[CWS] eval.Opts holds MacroStore and VariableStore

### DIFF
--- a/cmd/security-agent/app/subcommands/runtime/command.go
+++ b/cmd/security-agent/app/subcommands/runtime/command.go
@@ -468,7 +468,7 @@ func checkPoliciesInner(dir string) error {
 		WithLogger(seclog.DefaultLogger)
 
 	model := &model.Model{}
-	ruleSet := rules.NewRuleSet(model, model.NewEvent, &opts, &evalOpts, &eval.MacroStore{})
+	ruleSet := rules.NewRuleSet(model, model.NewEvent, &opts, &evalOpts)
 
 	agentVersionFilter, err := newAgentVersionFilter()
 	if err != nil {
@@ -601,7 +601,7 @@ func evalRule(log complog.Component, config compconfig.Component, evalArgs *eval
 		WithLogger(seclog.DefaultLogger)
 
 	model := &model.Model{}
-	ruleSet := rules.NewRuleSet(model, model.NewEvent, &opts, &evalOpts, &eval.MacroStore{})
+	ruleSet := rules.NewRuleSet(model, model.NewEvent, &opts, &evalOpts)
 
 	agentVersionFilter, err := newAgentVersionFilter()
 	if err != nil {

--- a/pkg/security/module/module.go
+++ b/pkg/security/module/module.go
@@ -355,7 +355,7 @@ func (m *Module) getApproverRuleset(policyProviders []rules.PolicyProvider) (*ru
 
 	// approver ruleset
 	model := &model.Model{}
-	approverRuleSet := rules.NewRuleSet(model, model.NewEvent, &opts, &evalOpts, &eval.MacroStore{})
+	approverRuleSet := rules.NewRuleSet(model, model.NewEvent, &opts, &evalOpts)
 
 	// load policies
 	loadApproversErrs := approverRuleSet.LoadPolicies(m.policyLoader, m.policyOpts)
@@ -404,7 +404,7 @@ func (m *Module) LoadPolicies(policyProviders []rules.PolicyProvider, sendLoaded
 	evalOpts.WithVariables(model.SECLVariables)
 
 	// standard ruleset
-	ruleSet := m.probe.NewRuleSet(&opts, &evalOpts, &eval.MacroStore{})
+	ruleSet := m.probe.NewRuleSet(&opts, &evalOpts)
 
 	loadErrs := ruleSet.LoadPolicies(m.policyLoader, m.policyOpts)
 	if loadApproversErrs.ErrorOrNil() == nil && loadErrs.ErrorOrNil() != nil {

--- a/pkg/security/probe/approvers_test.go
+++ b/pkg/security/probe/approvers_test.go
@@ -31,7 +31,7 @@ func TestApproverAncestors1(t *testing.T) {
 		WithLogger(seclog.DefaultLogger)
 
 	m := &model.Model{}
-	rs := rules.NewRuleSet(m, m.NewEvent, &opts, &evalOpts, &eval.MacroStore{})
+	rs := rules.NewRuleSet(m, m.NewEvent, &opts, &evalOpts)
 	addRuleExpr(t, rs, `open.file.path == "/etc/passwd" && process.ancestors.file.name == "vipw"`, `open.file.path == "/etc/shadow" && process.ancestors.file.name == "vipw"`)
 
 	capabilities, exists := allCapabilities["open"]
@@ -63,7 +63,7 @@ func TestApproverAncestors2(t *testing.T) {
 		WithLogger(seclog.DefaultLogger)
 
 	m := &model.Model{}
-	rs := rules.NewRuleSet(m, m.NewEvent, &opts, &evalOpts, &eval.MacroStore{})
+	rs := rules.NewRuleSet(m, m.NewEvent, &opts, &evalOpts)
 	addRuleExpr(t, rs, `(open.file.path == "/etc/shadow" || open.file.path == "/etc/gshadow") && process.ancestors.file.path not in ["/usr/bin/dpkg"]`)
 	capabilities, exists := allCapabilities["open"]
 	if !exists {
@@ -92,7 +92,7 @@ func TestApproverAncestors3(t *testing.T) {
 		WithLogger(seclog.DefaultLogger)
 
 	m := &model.Model{}
-	rs := rules.NewRuleSet(m, m.NewEvent, &opts, &evalOpts, &eval.MacroStore{})
+	rs := rules.NewRuleSet(m, m.NewEvent, &opts, &evalOpts)
 	addRuleExpr(t, rs, `open.file.path =~ "/var/run/secrets/eks.amazonaws.com/serviceaccount/*/token" && process.file.path not in ["/bin/kubectl"]`)
 	capabilities, exists := allCapabilities["open"]
 	if !exists {

--- a/pkg/security/probe/discarders_test.go
+++ b/pkg/security/probe/discarders_test.go
@@ -55,49 +55,49 @@ func TestIsParentDiscarder(t *testing.T) {
 		WithEventTypeEnabled(enabled).
 		WithLogger(seclog.DefaultLogger)
 
-	rs := rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts, &eval.MacroStore{})
+	rs := rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts)
 	addRuleExpr(t, rs, `unlink.file.path =~ "/var/log/*" && unlink.file.path != "/var/log/datadog/system-probe.log"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/var/log/datadog/system-probe.log", 1); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts, &eval.MacroStore{})
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts)
 	addRuleExpr(t, rs, `unlink.file.path =~ "/var/log/*" && unlink.file.path != "/var/log/datadog/system-probe.log"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/var/lib/datadog/system-probe.sock", 1); !is {
 		t.Error("should be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts, &eval.MacroStore{})
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts)
 	addRuleExpr(t, rs, `unlink.file.path == "/var/log/datadog/system-probe.log"`, `unlink.file.name == "datadog"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/var/log/datadog/datadog-agent.log", 1); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts, &eval.MacroStore{})
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts)
 	addRuleExpr(t, rs, `unlink.file.path =~ "/var/log/*" && unlink.file.name =~ ".*"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/var/lib/.runc/1234", 1); is {
 		t.Error("shouldn't be able to find a parent discarder, due to partial evaluation: true && unlink.file.name =~ '.*'")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts, &eval.MacroStore{})
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts)
 	addRuleExpr(t, rs, `unlink.file.path == "/etc/conf.d/httpd.conf" || unlink.file.name == "conf.d"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/etc/conf.d/nginx.conf", 1); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts, &eval.MacroStore{})
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts)
 	addRuleExpr(t, rs, `unlink.file.path == "/etc/conf.d/httpd.conf" || unlink.file.name == "sys.d"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/etc/sys.d/nginx.conf", 1); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts, &eval.MacroStore{})
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts)
 	addRuleExpr(t, rs, `unlink.file.name == "conf.d"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/etc/conf.d/nginx.conf", 1); is {
@@ -105,77 +105,77 @@ func TestIsParentDiscarder(t *testing.T) {
 	}
 
 	// field that doesn't exists shouldn't return any discarders
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts, &eval.MacroStore{})
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts)
 	addRuleExpr(t, rs, `rename.file.path == "/etc/conf.d/abc"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileRenameEventType, "rename.file.path", "/etc/conf.d/nginx.conf", 1); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts, &eval.MacroStore{})
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts)
 	addRuleExpr(t, rs, `rename.file.path == "/etc/conf.d/abc"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileRenameEventType, "rename.file.path", "/etc/nginx/nginx.conf", 1); !is {
 		t.Error("should be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts, &eval.MacroStore{})
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts)
 	addRuleExpr(t, rs, `unlink.file.path =~ "/etc/conf.d/*"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/etc/sys.d/nginx.conf", 1); !is {
 		t.Error("should be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts, &eval.MacroStore{})
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts)
 	addRuleExpr(t, rs, `unlink.file.path =~ "*/conf.*"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/etc/conf.d/abc", 1); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts, &eval.MacroStore{})
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts)
 	addRuleExpr(t, rs, `unlink.file.path =~ "/etc/conf.d/ab*"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/etc/conf.d/abc", 1); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts, &eval.MacroStore{})
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts)
 	addRuleExpr(t, rs, `unlink.file.path =~ "*/conf.d/ab*"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/etc/conf.d/abc", 1); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts, &eval.MacroStore{})
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts)
 	addRuleExpr(t, rs, `unlink.file.path =~ "*/conf.d"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/etc/conf.d/abc", 1); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts, &eval.MacroStore{})
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts)
 	addRuleExpr(t, rs, `unlink.file.path =~ "/etc/*"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/etc/cron.d/log", 1); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts, &eval.MacroStore{})
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts)
 	addRuleExpr(t, rs, `open.file.path == "/tmp/passwd"`, `open.file.path == "/tmp/secret"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileOpenEventType, "open.file.path", "/tmp/runc", 1); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts, &eval.MacroStore{})
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts)
 	addRuleExpr(t, rs, `open.file.path =~ "/run/secrets/kubernetes.io/serviceaccount/*/token"`, `open.file.path == "/etc/secret"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileOpenEventType, "open.file.path", "/tmp/token", 1); !is {
 		t.Error("should be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts, &eval.MacroStore{})
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts)
 	addRuleExpr(t, rs, `open.file.path =~ "*/token"`, `open.file.path == "/etc/secret"`)
 
 	is, err := id.isParentPathDiscarder(rs, model.FileOpenEventType, "open.file.path", "/tmp/token", 1)
@@ -186,35 +186,35 @@ func TestIsParentDiscarder(t *testing.T) {
 		t.Error("shouldn't be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts, &eval.MacroStore{})
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts)
 	addRuleExpr(t, rs, `open.file.path =~ "/tmp/dir/no-approver-*"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileOpenEventType, "open.file.path", "/tmp/dir/a/test", 1); !is {
 		t.Error("should be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts, &eval.MacroStore{})
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts)
 	addRuleExpr(t, rs, `open.file.path =~ "/"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileOpenEventType, "open.file.path", "/tmp", 1); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts, &eval.MacroStore{})
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts)
 	addRuleExpr(t, rs, `open.file.path =~ "*/conf.d/aaa"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileOpenEventType, "open.file.path", "/tmp/dir/bbb", 1); !is {
 		t.Error("should be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts, &eval.MacroStore{})
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts)
 	addRuleExpr(t, rs, `open.file.path =~ "/etc/**"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileOpenEventType, "open.file.path", "/etc/conf.d/dir/aaa", 1); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts, &eval.MacroStore{})
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts)
 	addRuleExpr(t, rs, `open.file.path == "/proc/${process.pid}/maps"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileOpenEventType, "open.file.path", "/proc/1/maps", 1); is {
@@ -222,14 +222,14 @@ func TestIsParentDiscarder(t *testing.T) {
 	}
 
 	// test basename conflict, a basename based rule matches the parent discarder
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts, &eval.MacroStore{})
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts)
 	addRuleExpr(t, rs, `open.file.path =~ "/var/log/datadog/**" && open.file.name == "token"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileOpenEventType, "open.file.path", "/tmp/test1/test2", 1); !is {
 		t.Error("should be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts, &eval.MacroStore{})
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts)
 	addRuleExpr(t, rs, `open.file.path =~ "/var/log/datadog/**" && open.file.name == "test1"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileOpenEventType, "open.file.path", "/tmp/test1/test2", 1); is {
@@ -252,105 +252,105 @@ func TestIsGrandParentDiscarder(t *testing.T) {
 		WithEventTypeEnabled(enabled).
 		WithLogger(seclog.DefaultLogger)
 
-	rs := rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts, &eval.MacroStore{})
+	rs := rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts)
 	addRuleExpr(t, rs, `unlink.file.path == "/var/lib/datadog/system-probe.cache"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/var/run/datadog/system-probe.pid", 2); !is {
 		t.Error("should be a grand parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts, &eval.MacroStore{})
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts)
 	addRuleExpr(t, rs, `unlink.file.path =~ "/tmp/test"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/var/lib", 2); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts, &eval.MacroStore{})
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts)
 	addRuleExpr(t, rs, `unlink.file.path == "/var/run/datadog/system-probe.pid"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/var/run/pids/system-probe.pid", 2); is {
 		t.Error("shouldn't be a grand parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts, &eval.MacroStore{})
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts)
 	addRuleExpr(t, rs, `unlink.file.path =~ "/var/lib/datadog/system-probe.cache"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/var/run/datadog/system-probe.pid", 2); !is {
 		t.Error("should be a grand parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts, &eval.MacroStore{})
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts)
 	addRuleExpr(t, rs, `unlink.file.path =~ "/var/run/datadog/system-probe.pid"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/var/run/pids/system-probe.pid", 2); is {
 		t.Error("shouldn't be a grand parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts, &eval.MacroStore{})
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts)
 	addRuleExpr(t, rs, `unlink.file.path =~ "*/run/datadog/system-probe.pid"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/var/run/datadog/system-probe.pid", 2); is {
 		t.Error("shouldn't be a grand parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts, &eval.MacroStore{})
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts)
 	addRuleExpr(t, rs, `unlink.file.path =~ "*/run/datadog/system-probe.pid"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/var/lib/datadog/system-probe.pid", 2); !is {
 		t.Error("should be a grand parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts, &eval.MacroStore{})
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts)
 	addRuleExpr(t, rs, `unlink.file.path =~ "/var/*/datadog/system-probe.pid"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/var/run/datadog/system-probe.pid", 2); is {
 		t.Error("shouldn't be a grand parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts, &eval.MacroStore{})
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts)
 	addRuleExpr(t, rs, `unlink.file.path =~ "/var/lib/datadog/system-probe.pid"`, `unlink.file.name =~ "run"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/var/run/datadog/system-probe.pid", 2); is {
 		t.Error("shouldn't be a grand parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts, &eval.MacroStore{})
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts)
 	addRuleExpr(t, rs, `unlink.file.path =~ "/var/*"`, `unlink.file.name =~ "run"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/var/run/datadog/system-probe.pid", 2); is {
 		t.Error("shouldn't be a grand parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts, &eval.MacroStore{})
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts)
 	addRuleExpr(t, rs, `open.file.path =~ "/tmp/dir/*"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileOpenEventType, "open.file.path", "/tmp/dir/a/test", 2); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts, &eval.MacroStore{})
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts)
 	addRuleExpr(t, rs, `unlink.file.name == "dir"`) // + variants
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/tmp/dir/a/test", 2); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts, &eval.MacroStore{})
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts)
 	addRuleExpr(t, rs, `unlink.file.path == "/tmp/dir/a"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/tmp", 2); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts, &eval.MacroStore{})
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts)
 	addRuleExpr(t, rs, `unlink.file.path == "/tmp"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/tmp/dir/a", 2); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts, &eval.MacroStore{})
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts)
 	addRuleExpr(t, rs, `unlink.file.path == "/tmp"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/tmp", 2); is {
@@ -386,7 +386,7 @@ func TestIsDiscarderOverride(t *testing.T) {
 
 	var listener testEventListener
 
-	rs := rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts, &eval.MacroStore{})
+	rs := rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts)
 	rs.AddListener(&listener)
 	addRuleExpr(t, rs, `unlink.file.path == "/var/log/httpd" && process.file.path == "/bin/touch"`)
 
@@ -427,7 +427,7 @@ func BenchmarkParentDiscarder(b *testing.B) {
 		WithEventTypeEnabled(enabled).
 		WithLogger(seclog.DefaultLogger)
 
-	rs := rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts, &eval.MacroStore{})
+	rs := rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts, &evalOpts)
 	addRuleExpr(b, rs, `unlink.file.path =~ "/var/log/*" && unlink.file.path != "/var/log/datadog/system-probe.log"`)
 
 	b.ResetTimer()

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -1123,13 +1123,13 @@ func (p *Probe) GetDebugStats() map[string]interface{} {
 }
 
 // NewRuleSet returns a new rule set
-func (p *Probe) NewRuleSet(opts *rules.Opts, evalOpts *eval.Opts, macroStore *eval.MacroStore) *rules.RuleSet {
+func (p *Probe) NewRuleSet(opts *rules.Opts, evalOpts *eval.Opts) *rules.RuleSet {
 	eventCtor := func() eval.Event {
 		return NewEvent(p.resolvers, p.scrubber, p)
 	}
 	opts.WithLogger(seclog.DefaultLogger)
 
-	return rules.NewRuleSet(&Model{probe: p}, eventCtor, opts, evalOpts, macroStore)
+	return rules.NewRuleSet(&Model{probe: p}, eventCtor, opts, evalOpts)
 }
 
 // QueuedNetworkDeviceError is used to indicate that the new network device was queued until its namespace handle is

--- a/pkg/security/secl/compiler/eval/eval.go
+++ b/pkg/security/secl/compiler/eval/eval.go
@@ -64,14 +64,8 @@ type ident struct {
 	Ident *string
 }
 
-// ReplacementContext represents the group of Options and Macro Store used during SECL evaluation
-type ReplacementContext struct {
-	*Opts
-	*MacroStore
-}
-
-func identToEvaluator(obj *ident, state *State) (interface{}, lexer.Position, error) {
-	if accessor, ok := state.replCtx.Opts.Constants[*obj.Ident]; ok {
+func identToEvaluator(obj *ident, opts *Opts, state *State) (interface{}, lexer.Position, error) {
+	if accessor, ok := opts.Constants[*obj.Ident]; ok {
 		return accessor, obj.Pos, nil
 	}
 
@@ -87,11 +81,11 @@ func identToEvaluator(obj *ident, state *State) (interface{}, lexer.Position, er
 	}
 
 	// transform extracted field to support legacy SECL fields
-	if state.replCtx.Opts.LegacyFields != nil {
-		if newField, ok := state.replCtx.Opts.LegacyFields[field]; ok {
+	if opts.LegacyFields != nil {
+		if newField, ok := opts.LegacyFields[field]; ok {
 			field = newField
 		}
-		if newField, ok := state.replCtx.Opts.LegacyFields[field]; ok {
+		if newField, ok := opts.LegacyFields[field]; ok {
 			itField = newField
 		}
 	}
@@ -158,7 +152,7 @@ func identToEvaluator(obj *ident, state *State) (interface{}, lexer.Position, er
 	return accessor, obj.Pos, nil
 }
 
-func arrayToEvaluator(array *ast.Array, state *State) (interface{}, lexer.Position, error) {
+func arrayToEvaluator(array *ast.Array, opts *Opts, state *State) (interface{}, lexer.Position, error) {
 	if len(array.Numbers) != 0 {
 		var evaluator IntArrayEvaluator
 		evaluator.AppendValues(array.Numbers...)
@@ -175,13 +169,13 @@ func arrayToEvaluator(array *ast.Array, state *State) (interface{}, lexer.Positi
 		}
 
 		// could be an iterator
-		return identToEvaluator(&ident{Pos: array.Pos, Ident: array.Ident}, state)
+		return identToEvaluator(&ident{Pos: array.Pos, Ident: array.Ident}, opts, state)
 	} else if array.Variable != nil {
 		varName, ok := isVariableName(*array.Variable)
 		if !ok {
 			return nil, array.Pos, NewError(array.Pos, "invalid variable name '%s'", *array.Variable)
 		}
-		return evaluatorFromVariable(varName, array.Pos, state.replCtx)
+		return evaluatorFromVariable(varName, array.Pos, opts)
 	} else if array.CIDR != nil {
 		var values CIDRValues
 		if err := values.AppendCIDR(*array.CIDR); err != nil {
@@ -224,26 +218,25 @@ func isVariableName(str string) (string, bool) {
 	return "", false
 }
 
-func evaluatorFromVariable(varname string, pos lexer.Position, replCtx ReplacementContext) (interface{}, lexer.Position, error) {
-	value, exists := replCtx.Opts.Variables[varname]
-	if !exists {
+func evaluatorFromVariable(varname string, pos lexer.Position, opts *Opts) (interface{}, lexer.Position, error) {
+	variable := opts.VariableStore.Get(varname)
+	if variable == nil {
 		return nil, pos, NewError(pos, "variable '%s' doesn't exist", varname)
 	}
 
-	return value.GetEvaluator(), pos, nil
+	return variable.GetEvaluator(), pos, nil
 }
 
-func stringEvaluatorFromVariable(str string, pos lexer.Position, replCtx ReplacementContext) (interface{}, lexer.Position, error) {
+func stringEvaluatorFromVariable(str string, pos lexer.Position, opts *Opts) (interface{}, lexer.Position, error) {
 	var evaluators []*StringEvaluator
 
 	doLoc := func(sub string) error {
 		if varname, ok := isVariableName(sub); ok {
-			value, exists := replCtx.Opts.Variables[varname]
-			if !exists {
-				return NewError(pos, "variable '%s' doesn't exist", varname)
+			evaluator, pos, err := evaluatorFromVariable(varname, pos, opts)
+			if err != nil {
+				return err
 			}
 
-			evaluator := value.GetEvaluator()
 			switch evaluator := evaluator.(type) {
 			case *StringArrayEvaluator:
 				evaluators = append(evaluators, &StringEvaluator{
@@ -386,7 +379,7 @@ func StringArrayMatchesWrapper(a *StringArrayEvaluator, b *StringValuesEvaluator
 	return evaluator, nil
 }
 
-func nodeToEvaluator(obj interface{}, state *State) (interface{}, lexer.Position, error) {
+func nodeToEvaluator(obj interface{}, opts *Opts, state *State) (interface{}, lexer.Position, error) {
 	var err error
 	var boolEvaluator *BoolEvaluator
 	var pos lexer.Position
@@ -394,9 +387,9 @@ func nodeToEvaluator(obj interface{}, state *State) (interface{}, lexer.Position
 
 	switch obj := obj.(type) {
 	case *ast.BooleanExpression:
-		return nodeToEvaluator(obj.Expression, state)
+		return nodeToEvaluator(obj.Expression, opts, state)
 	case *ast.Expression:
-		cmp, pos, err = nodeToEvaluator(obj.Comparison, state)
+		cmp, pos, err = nodeToEvaluator(obj.Comparison, opts, state)
 		if err != nil {
 			return nil, pos, err
 		}
@@ -407,7 +400,7 @@ func nodeToEvaluator(obj interface{}, state *State) (interface{}, lexer.Position
 				return nil, obj.Pos, NewTypeError(obj.Pos, reflect.Bool)
 			}
 
-			next, pos, err = nodeToEvaluator(obj.Next, state)
+			next, pos, err = nodeToEvaluator(obj.Next, opts, state)
 			if err != nil {
 				return nil, pos, err
 			}
@@ -435,7 +428,7 @@ func nodeToEvaluator(obj interface{}, state *State) (interface{}, lexer.Position
 		}
 		return cmp, obj.Pos, nil
 	case *ast.BitOperation:
-		unary, pos, err = nodeToEvaluator(obj.Unary, state)
+		unary, pos, err = nodeToEvaluator(obj.Unary, opts, state)
 		if err != nil {
 			return nil, pos, err
 		}
@@ -446,7 +439,7 @@ func nodeToEvaluator(obj interface{}, state *State) (interface{}, lexer.Position
 				return nil, obj.Pos, NewTypeError(obj.Pos, reflect.Int)
 			}
 
-			next, pos, err = nodeToEvaluator(obj.Next, state)
+			next, pos, err = nodeToEvaluator(obj.Next, opts, state)
 			if err != nil {
 				return nil, pos, err
 			}
@@ -481,13 +474,13 @@ func nodeToEvaluator(obj interface{}, state *State) (interface{}, lexer.Position
 		return unary, obj.Pos, nil
 
 	case *ast.Comparison:
-		unary, pos, err = nodeToEvaluator(obj.BitOperation, state)
+		unary, pos, err = nodeToEvaluator(obj.BitOperation, opts, state)
 		if err != nil {
 			return nil, pos, err
 		}
 
 		if obj.ArrayComparison != nil {
-			next, pos, err = nodeToEvaluator(obj.ArrayComparison, state)
+			next, pos, err = nodeToEvaluator(obj.ArrayComparison, opts, state)
 			if err != nil {
 				return nil, pos, err
 			}
@@ -710,7 +703,7 @@ func nodeToEvaluator(obj interface{}, state *State) (interface{}, lexer.Position
 				return nil, pos, NewTypeError(pos, reflect.Array)
 			}
 		} else if obj.ScalarComparison != nil {
-			next, pos, err = nodeToEvaluator(obj.ScalarComparison, state)
+			next, pos, err = nodeToEvaluator(obj.ScalarComparison, opts, state)
 			if err != nil {
 				return nil, pos, err
 			}
@@ -1052,14 +1045,14 @@ func nodeToEvaluator(obj interface{}, state *State) (interface{}, lexer.Position
 		}
 
 	case *ast.ArrayComparison:
-		return nodeToEvaluator(obj.Array, state)
+		return nodeToEvaluator(obj.Array, opts, state)
 
 	case *ast.ScalarComparison:
-		return nodeToEvaluator(obj.Next, state)
+		return nodeToEvaluator(obj.Next, opts, state)
 
 	case *ast.Unary:
 		if obj.Op != nil {
-			unary, pos, err = nodeToEvaluator(obj.Unary, state)
+			unary, pos, err = nodeToEvaluator(obj.Unary, opts, state)
 			if err != nil {
 				return nil, pos, err
 			}
@@ -1090,11 +1083,11 @@ func nodeToEvaluator(obj interface{}, state *State) (interface{}, lexer.Position
 			return nil, pos, NewOpUnknownError(obj.Pos, *obj.Op)
 		}
 
-		return nodeToEvaluator(obj.Primary, state)
+		return nodeToEvaluator(obj.Primary, opts, state)
 	case *ast.Primary:
 		switch {
 		case obj.Ident != nil:
-			return identToEvaluator(&ident{Pos: obj.Pos, Ident: obj.Ident}, state)
+			return identToEvaluator(&ident{Pos: obj.Pos, Ident: obj.Ident}, opts, state)
 		case obj.Number != nil:
 			return &IntEvaluator{
 				Value: *obj.Number,
@@ -1105,7 +1098,7 @@ func nodeToEvaluator(obj interface{}, state *State) (interface{}, lexer.Position
 				return nil, obj.Pos, NewError(obj.Pos, "internal variable error '%s'", varname)
 			}
 
-			return evaluatorFromVariable(varname, obj.Pos, state.replCtx)
+			return evaluatorFromVariable(varname, obj.Pos, opts)
 		case obj.Duration != nil:
 			return &IntEvaluator{
 				Value:      *obj.Duration,
@@ -1116,7 +1109,7 @@ func nodeToEvaluator(obj interface{}, state *State) (interface{}, lexer.Position
 
 			// contains variables
 			if len(variableRegex.FindAllIndex([]byte(str), -1)) > 0 {
-				return stringEvaluatorFromVariable(str, obj.Pos, state.replCtx)
+				return stringEvaluatorFromVariable(str, obj.Pos, opts)
 			}
 
 			return &StringEvaluator{
@@ -1158,12 +1151,12 @@ func nodeToEvaluator(obj interface{}, state *State) (interface{}, lexer.Position
 			}
 			return evaluator, obj.Pos, nil
 		case obj.SubExpression != nil:
-			return nodeToEvaluator(obj.SubExpression, state)
+			return nodeToEvaluator(obj.SubExpression, opts, state)
 		default:
 			return nil, obj.Pos, NewError(obj.Pos, "unknown primary '%s'", reflect.TypeOf(obj))
 		}
 	case *ast.Array:
-		return arrayToEvaluator(obj, state)
+		return arrayToEvaluator(obj, opts, state)
 	}
 
 	return nil, lexer.Position{}, NewError(lexer.Position{}, "unknown entity '%s'", reflect.TypeOf(obj))

--- a/pkg/security/secl/compiler/eval/macro.go
+++ b/pkg/security/secl/compiler/eval/macro.go
@@ -16,8 +16,8 @@ type MacroID = string
 
 // Macro - Macro object identified by an `ID` containing a SECL `Expression`
 type Macro struct {
-	ID    MacroID
-	Store *MacroStore
+	ID   MacroID
+	Opts *Opts
 
 	evaluator *MacroEvaluator
 	ast       *ast.Macro
@@ -31,17 +31,17 @@ type MacroEvaluator struct {
 }
 
 // NewMacro parses an expression and returns a new macro
-func NewMacro(id, expression string, model Model, parsingContext *ast.ParsingContext, replCtx ReplacementContext) (*Macro, error) {
+func NewMacro(id, expression string, model Model, parsingContext *ast.ParsingContext, opts *Opts) (*Macro, error) {
 	macro := &Macro{
-		ID:    id,
-		Store: replCtx.MacroStore,
+		ID:   id,
+		Opts: opts,
 	}
 
 	if err := macro.Parse(parsingContext, expression); err != nil {
 		return nil, fmt.Errorf("syntax error: %w", err)
 	}
 
-	if err := macro.GenEvaluator(expression, model, replCtx); err != nil {
+	if err := macro.GenEvaluator(expression, model); err != nil {
 		return nil, fmt.Errorf("compilation error: %w", err)
 	}
 
@@ -49,7 +49,7 @@ func NewMacro(id, expression string, model Model, parsingContext *ast.ParsingCon
 }
 
 // NewStringValuesMacro returns a new macro from an array of strings
-func NewStringValuesMacro(id string, values []string, macroStore *MacroStore) (*Macro, error) {
+func NewStringValuesMacro(id string, values []string, opts *Opts) (*Macro, error) {
 	var evaluator StringValuesEvaluator
 	for _, value := range values {
 		fieldValue := FieldValue{
@@ -66,7 +66,7 @@ func NewStringValuesMacro(id string, values []string, macroStore *MacroStore) (*
 
 	return &Macro{
 		ID:        id,
-		Store:     macroStore,
+		Opts:      opts,
 		evaluator: &MacroEvaluator{Value: &evaluator},
 	}, nil
 }
@@ -91,23 +91,23 @@ func (m *Macro) Parse(parsingContext *ast.ParsingContext, expression string) err
 	return nil
 }
 
-func macroToEvaluator(macro *ast.Macro, model Model, replCtx ReplacementContext, field Field) (*MacroEvaluator, error) {
+func macroToEvaluator(macro *ast.Macro, model Model, opts *Opts, field Field) (*MacroEvaluator, error) {
 	macros := make(map[MacroID]*MacroEvaluator)
-	for id, macro := range replCtx.Macros {
-		macros[id] = macro.evaluator
+	for _, macro := range opts.MacroStore.List() {
+		macros[macro.ID] = macro.evaluator
 	}
-	state := NewState(model, field, macros, replCtx)
+	state := NewState(model, field, macros)
 
 	var eval interface{}
 	var err error
 
 	switch {
 	case macro.Expression != nil:
-		eval, _, err = nodeToEvaluator(macro.Expression, state)
+		eval, _, err = nodeToEvaluator(macro.Expression, opts, state)
 	case macro.Array != nil:
-		eval, _, err = nodeToEvaluator(macro.Array, state)
+		eval, _, err = nodeToEvaluator(macro.Array, opts, state)
 	case macro.Primary != nil:
-		eval, _, err = nodeToEvaluator(macro.Primary, state)
+		eval, _, err = nodeToEvaluator(macro.Primary, opts, state)
 	}
 
 	if err != nil {
@@ -127,10 +127,8 @@ func macroToEvaluator(macro *ast.Macro, model Model, replCtx ReplacementContext,
 }
 
 // GenEvaluator - Compiles and generates the evalutor
-func (m *Macro) GenEvaluator(expression string, model Model, replCtx ReplacementContext) error {
-	m.Store = replCtx.MacroStore
-
-	evaluator, err := macroToEvaluator(m.ast, model, replCtx, "")
+func (m *Macro) GenEvaluator(expression string, model Model) error {
+	evaluator, err := macroToEvaluator(m.ast, model, m.Opts, "")
 	if err != nil {
 		if err, ok := err.(*ErrAstToEval); ok {
 			return fmt.Errorf("macro syntax error: %w", &ErrRuleParse{pos: err.Pos, expr: expression})
@@ -146,7 +144,7 @@ func (m *Macro) GenEvaluator(expression string, model Model, replCtx Replacement
 func (m *Macro) GetEventTypes() []EventType {
 	eventTypes := m.evaluator.EventTypes
 
-	for _, macro := range m.Store.Macros {
+	for _, macro := range m.Opts.MacroStore.List() {
 		eventTypes = append(eventTypes, macro.evaluator.EventTypes...)
 	}
 
@@ -157,7 +155,7 @@ func (m *Macro) GetEventTypes() []EventType {
 func (m *Macro) GetFields() []Field {
 	fields := m.evaluator.GetFields()
 
-	for _, macro := range m.Store.Macros {
+	for _, macro := range m.Opts.MacroStore.List() {
 		fields = append(fields, macro.evaluator.GetFields()...)
 	}
 

--- a/pkg/security/secl/compiler/eval/oo_dns_name_test.go
+++ b/pkg/security/secl/compiler/eval/oo_dns_name_test.go
@@ -26,7 +26,7 @@ func TestLowerCaseEquals(t *testing.T) {
 		}
 
 		var ctx Context
-		state := NewState(&testModel{}, "", nil, nilReplCtx())
+		state := NewState(&testModel{}, "", nil)
 
 		e, err := DNSNameCmp.StringEquals(a, b, state)
 		assert.Empty(t, err)
@@ -51,7 +51,7 @@ func TestLowerCaseEquals(t *testing.T) {
 		}
 
 		var ctx Context
-		state := NewState(&testModel{}, "", nil, nilReplCtx())
+		state := NewState(&testModel{}, "", nil)
 
 		e, err := DNSNameCmp.StringEquals(a, b, state)
 		assert.Empty(t, err)
@@ -76,7 +76,7 @@ func TestLowerCaseEquals(t *testing.T) {
 		}
 
 		var ctx Context
-		state := NewState(&testModel{}, "", nil, nilReplCtx())
+		state := NewState(&testModel{}, "", nil)
 
 		e, err := DNSNameCmp.StringEquals(a, b, state)
 		assert.Empty(t, err)
@@ -101,7 +101,7 @@ func TestLowerCaseEquals(t *testing.T) {
 		}
 
 		var ctx Context
-		state := NewState(&testModel{}, "", nil, nilReplCtx())
+		state := NewState(&testModel{}, "", nil)
 
 		e, err := DNSNameCmp.StringEquals(a, b, state)
 		assert.Empty(t, err)
@@ -131,7 +131,7 @@ func TestLowerCaseContains(t *testing.T) {
 		}
 
 		var ctx Context
-		state := NewState(&testModel{}, "", nil, nilReplCtx())
+		state := NewState(&testModel{}, "", nil)
 
 		e, err := DNSNameCmp.StringValuesContains(a, b, state)
 		assert.Empty(t, err)
@@ -155,7 +155,7 @@ func TestLowerCaseContains(t *testing.T) {
 		}
 
 		var ctx Context
-		state := NewState(&testModel{}, "", nil, nilReplCtx())
+		state := NewState(&testModel{}, "", nil)
 
 		e, err := DNSNameCmp.StringValuesContains(a, b, state)
 		assert.Empty(t, err)
@@ -179,7 +179,7 @@ func TestLowerCaseContains(t *testing.T) {
 		}
 
 		var ctx Context
-		state := NewState(&testModel{}, "", nil, nilReplCtx())
+		state := NewState(&testModel{}, "", nil)
 
 		e, err := DNSNameCmp.StringValuesContains(a, b, state)
 		assert.Empty(t, err)
@@ -203,7 +203,7 @@ func TestLowerCaseContains(t *testing.T) {
 		}
 
 		var ctx Context
-		state := NewState(&testModel{}, "", nil, nilReplCtx())
+		state := NewState(&testModel{}, "", nil)
 
 		e, err := DNSNameCmp.StringValuesContains(a, b, state)
 		assert.Empty(t, err)
@@ -248,7 +248,7 @@ func TestLowerCaseContains(t *testing.T) {
 		}
 
 		var ctx Context
-		state := NewState(&testModel{}, "", nil, nilReplCtx())
+		state := NewState(&testModel{}, "", nil)
 
 		e, err := DNSNameCmp.StringValuesContains(a, b, state)
 		assert.Empty(t, err)
@@ -270,7 +270,7 @@ func TestLowerCaseArrayContains(t *testing.T) {
 		}
 
 		var ctx Context
-		state := NewState(&testModel{}, "", nil, nilReplCtx())
+		state := NewState(&testModel{}, "", nil)
 
 		e, err := DNSNameCmp.StringArrayContains(a, b, state)
 		assert.Empty(t, err)
@@ -290,7 +290,7 @@ func TestLowerCaseArrayContains(t *testing.T) {
 		}
 
 		var ctx Context
-		state := NewState(&testModel{}, "", nil, nilReplCtx())
+		state := NewState(&testModel{}, "", nil)
 
 		e, err := DNSNameCmp.StringArrayContains(a, b, state)
 		assert.Empty(t, err)
@@ -312,17 +312,10 @@ func TestLowerCaseArrayContains(t *testing.T) {
 		}
 
 		var ctx Context
-		state := NewState(&testModel{}, "", nil, nilReplCtx())
+		state := NewState(&testModel{}, "", nil)
 
 		e, err := DNSNameCmp.StringArrayContains(a, b, state)
 		assert.Empty(t, err)
 		assert.True(t, e.Eval(&ctx).(bool))
 	})
-}
-
-func nilReplCtx() ReplacementContext {
-	return ReplacementContext{
-		Opts:       nil,
-		MacroStore: nil,
-	}
 }

--- a/pkg/security/secl/compiler/eval/oo_glob_cmp_test.go
+++ b/pkg/security/secl/compiler/eval/oo_glob_cmp_test.go
@@ -26,7 +26,7 @@ func TestOPOverrideGlobEquals(t *testing.T) {
 		}
 
 		var ctx Context
-		state := NewState(&testModel{}, "", nil, nilReplCtx())
+		state := NewState(&testModel{}, "", nil)
 
 		e, err := GlobCmp.StringEquals(a, b, state)
 		assert.Empty(t, err)
@@ -51,7 +51,7 @@ func TestOPOverrideGlobEquals(t *testing.T) {
 		}
 
 		var ctx Context
-		state := NewState(&testModel{}, "", nil, nilReplCtx())
+		state := NewState(&testModel{}, "", nil)
 
 		e, err := GlobCmp.StringEquals(a, b, state)
 		assert.Empty(t, err)
@@ -82,7 +82,7 @@ func TestOPOverrideGlobContains(t *testing.T) {
 		}
 
 		var ctx Context
-		state := NewState(&testModel{}, "", nil, nilReplCtx())
+		state := NewState(&testModel{}, "", nil)
 
 		e, err := GlobCmp.StringValuesContains(a, b, state)
 		assert.Empty(t, err)
@@ -106,7 +106,7 @@ func TestOPOverrideGlobContains(t *testing.T) {
 		}
 
 		var ctx Context
-		state := NewState(&testModel{}, "", nil, nilReplCtx())
+		state := NewState(&testModel{}, "", nil)
 
 		e, err := GlobCmp.StringValuesContains(a, b, state)
 		assert.Empty(t, err)
@@ -128,7 +128,7 @@ func TestOPOverrideGlobArrayMatches(t *testing.T) {
 		b := &StringValuesEvaluator{
 			Values: values,
 		}
-		state := NewState(&testModel{}, "", nil, nilReplCtx())
+		state := NewState(&testModel{}, "", nil)
 
 		e, err := GlobCmp.StringArrayMatches(a, b, state)
 		assert.Empty(t, err)
@@ -147,7 +147,7 @@ func TestOPOverrideGlobArrayMatches(t *testing.T) {
 		b := &StringValuesEvaluator{
 			Values: values,
 		}
-		state := NewState(&testModel{}, "", nil, nilReplCtx())
+		state := NewState(&testModel{}, "", nil)
 
 		e, err := GlobCmp.StringArrayMatches(a, b, state)
 		assert.Empty(t, err)
@@ -165,7 +165,7 @@ func TestOPOverrideGlobArrayContains(t *testing.T) {
 		b := &StringArrayEvaluator{
 			Values: []string{"/2/abc/3"},
 		}
-		state := NewState(&testModel{}, "", nil, nilReplCtx())
+		state := NewState(&testModel{}, "", nil)
 
 		e, err := GlobCmp.StringArrayContains(a, b, state)
 		assert.Empty(t, err)
@@ -182,7 +182,7 @@ func TestOPOverrideGlobArrayContains(t *testing.T) {
 			Field:  "dont_forget_me_or_it_wont_compile_a",
 			Values: []string{"/2/abc/3"},
 		}
-		state := NewState(&testModel{}, "", nil, nilReplCtx())
+		state := NewState(&testModel{}, "", nil)
 
 		e, err := GlobCmp.StringArrayContains(a, b, state)
 		assert.Empty(t, err)

--- a/pkg/security/secl/compiler/eval/opts.go
+++ b/pkg/security/secl/compiler/eval/opts.go
@@ -10,14 +10,8 @@ type MacroStore struct {
 	Macros map[MacroID]*Macro
 }
 
-// WithMacros set macros fields
-func (s *MacroStore) WithMacros(macros map[MacroID]*Macro) *MacroStore {
-	s.Macros = macros
-	return s
-}
-
 // AddMacro add a macro
-func (s *MacroStore) AddMacro(macro *Macro) *MacroStore {
+func (s *MacroStore) Add(macro *Macro) *MacroStore {
 	if s.Macros == nil {
 		s.Macros = make(map[string]*Macro)
 	}
@@ -25,11 +19,55 @@ func (s *MacroStore) AddMacro(macro *Macro) *MacroStore {
 	return s
 }
 
+func (s *MacroStore) List() []*Macro {
+	var macros []*Macro
+
+	if s == nil || s.Macros == nil {
+		return macros
+	}
+
+	for _, macro := range s.Macros {
+		macros = append(macros, macro)
+	}
+	return macros
+}
+
+// Get returns the marcro
+func (s *MacroStore) Get(id string) *Macro {
+	if s == nil || s.Macros == nil {
+		return nil
+	}
+	return s.Macros[id]
+}
+
+// VariableStore represents a store of SECL variables
+type VariableStore struct {
+	Variables map[string]VariableValue
+}
+
+// AddVariable add a variable
+func (s *VariableStore) Add(name string, variable VariableValue) *VariableStore {
+	if s.Variables == nil {
+		s.Variables = make(map[string]VariableValue)
+	}
+	s.Variables[name] = variable
+	return s
+}
+
+// Get returns the variable
+func (s *VariableStore) Get(name string) VariableValue {
+	if s == nil || s.Variables == nil {
+		return nil
+	}
+	return s.Variables[name]
+}
+
 // Opts are the options to be passed to the evaluator
 type Opts struct {
-	LegacyFields map[Field]Field
-	Constants    map[string]interface{}
-	Variables    map[string]VariableValue
+	LegacyFields  map[Field]Field
+	Constants     map[string]interface{}
+	VariableStore *VariableStore
+	MacroStore    *MacroStore
 }
 
 // WithConstants set constants
@@ -40,17 +78,48 @@ func (o *Opts) WithConstants(constants map[string]interface{}) *Opts {
 
 // WithVariables set variables
 func (o *Opts) WithVariables(variables map[string]VariableValue) *Opts {
-	optsVariables := make(map[string]VariableValue, len(variables))
-	for name, value := range variables {
-		optsVariables[name] = value
+	if o.VariableStore == nil {
+		o.VariableStore = &VariableStore{}
 	}
 
-	o.Variables = optsVariables
+	for n, v := range variables {
+		o.VariableStore.Add(n, v)
+	}
+	return o
+}
+
+// WithVariableStore set the variable store
+func (o *Opts) WithVariableStore(store *VariableStore) *Opts {
+	o.VariableStore = store
 	return o
 }
 
 // WithLegacyFields set legacy fields
 func (o *Opts) WithLegacyFields(fields map[Field]Field) *Opts {
 	o.LegacyFields = fields
+	return o
+}
+
+// WithMacroStore set the macro store
+func (o *Opts) WithMacroStore(store *MacroStore) *Opts {
+	o.MacroStore = store
+	return o
+}
+
+// AddMacro add a macro
+func (o *Opts) AddMacro(macro *Macro) *Opts {
+	if o.MacroStore == nil {
+		o.MacroStore = &MacroStore{}
+	}
+	o.MacroStore.Add(macro)
+	return o
+}
+
+// AddVariable add a variable
+func (o *Opts) AddVariable(name string, variable VariableValue) *Opts {
+	if o.VariableStore == nil {
+		o.VariableStore = &VariableStore{}
+	}
+	o.VariableStore.Add(name, variable)
 	return o
 }

--- a/pkg/security/secl/compiler/eval/state.go
+++ b/pkg/security/secl/compiler/eval/state.go
@@ -28,7 +28,6 @@ type State struct {
 	macros        map[MacroID]*MacroEvaluator
 	registersInfo map[RegisterID]*registerInfo
 	regexpCache   StateRegexpCache
-	replCtx       ReplacementContext
 }
 
 // UpdateFields updates the fields used in the rule
@@ -60,7 +59,7 @@ func (s *State) UpdateFieldValues(field Field, value FieldValue) error {
 }
 
 // NewState returns a new State
-func NewState(model Model, field Field, macros map[MacroID]*MacroEvaluator, replCtx ReplacementContext) *State {
+func NewState(model Model, field Field, macros map[MacroID]*MacroEvaluator) *State {
 	if macros == nil {
 		macros = make(map[MacroID]*MacroEvaluator)
 	}
@@ -71,6 +70,5 @@ func NewState(model Model, field Field, macros map[MacroID]*MacroEvaluator, repl
 		events:        make(map[EventType]bool),
 		fieldValues:   make(map[Field][]FieldValue),
 		registersInfo: make(map[RegisterID]*registerInfo),
-		replCtx:       replCtx,
 	}
 }

--- a/pkg/security/secl/rules/policy_test.go
+++ b/pkg/security/secl/rules/policy_test.go
@@ -31,14 +31,16 @@ func savePolicy(filename string, testPolicy *PolicyDef) error {
 
 func TestMacroMerge(t *testing.T) {
 	var evalOpts eval.Opts
-	evalOpts.WithConstants(testConstants)
+	evalOpts.
+		WithConstants(testConstants).
+		WithMacroStore(&eval.MacroStore{})
 
 	var opts Opts
 	opts.
 		WithSupportedDiscarders(testSupportedDiscarders).
 		WithEventTypeEnabled(map[eval.EventType]bool{"*": true})
 
-	rs := NewRuleSet(&testModel{}, func() eval.Event { return &testEvent{} }, &opts, &evalOpts, &eval.MacroStore{})
+	rs := NewRuleSet(&testModel{}, func() eval.Event { return &testEvent{} }, &opts, &evalOpts)
 	testPolicy := &PolicyDef{
 		Rules: []*RuleDefinition{{
 			ID:         "test_rule",
@@ -87,9 +89,9 @@ func TestMacroMerge(t *testing.T) {
 		t.Error(err)
 	}
 
-	macro := rs.macroStore.Macros["test_macro"]
+	macro := rs.evalOpts.MacroStore.Get("test_macro")
 	if macro == nil {
-		t.Fatalf("failed to find test_macro in ruleset: %+v", rs.macroStore.Macros)
+		t.Fatalf("failed to find test_macro in ruleset: %+v", rs.evalOpts.MacroStore.List())
 	}
 
 	testPolicy2.Macros[0].Combine = ""
@@ -105,13 +107,15 @@ func TestMacroMerge(t *testing.T) {
 
 func TestRuleMerge(t *testing.T) {
 	var evalOpts eval.Opts
-	evalOpts.WithConstants(testConstants)
+	evalOpts.
+		WithConstants(testConstants).
+		WithMacroStore(&eval.MacroStore{})
 
 	var opts Opts
 	opts.
 		WithSupportedDiscarders(testSupportedDiscarders).
 		WithEventTypeEnabled(map[eval.EventType]bool{"*": true})
-	rs := NewRuleSet(&testModel{}, func() eval.Event { return &testEvent{} }, &opts, &evalOpts, &eval.MacroStore{})
+	rs := NewRuleSet(&testModel{}, func() eval.Event { return &testEvent{} }, &opts, &evalOpts)
 
 	testPolicy := &PolicyDef{
 		Rules: []*RuleDefinition{{
@@ -213,7 +217,8 @@ func TestActionSetVariable(t *testing.T) {
 	var evalOpts eval.Opts
 	evalOpts.
 		WithConstants(testConstants).
-		WithVariables(make(map[string]eval.VariableValue))
+		WithVariables(make(map[string]eval.VariableValue)).
+		WithMacroStore(&eval.MacroStore{})
 
 	var opts Opts
 	opts.
@@ -221,7 +226,7 @@ func TestActionSetVariable(t *testing.T) {
 		WithEventTypeEnabled(enabled).
 		WithStateScopes(stateScopes)
 
-	rs := NewRuleSet(&testModel{}, func() eval.Event { return &testEvent{} }, &opts, &evalOpts, &eval.MacroStore{})
+	rs := NewRuleSet(&testModel{}, func() eval.Event { return &testEvent{} }, &opts, &evalOpts)
 
 	testPolicy := &PolicyDef{
 		Rules: []*RuleDefinition{{
@@ -364,14 +369,15 @@ func TestActionSetVariableConflict(t *testing.T) {
 	var evalOpts eval.Opts
 	evalOpts.
 		WithConstants(testConstants).
-		WithVariables(make(map[string]eval.VariableValue))
+		WithVariables(make(map[string]eval.VariableValue)).
+		WithMacroStore(&eval.MacroStore{})
 
 	var opts Opts
 	opts.
 		WithSupportedDiscarders(testSupportedDiscarders).
 		WithEventTypeEnabled(enabled)
 
-	rs := NewRuleSet(&testModel{}, func() eval.Event { return &testEvent{} }, &opts, &evalOpts, &eval.MacroStore{})
+	rs := NewRuleSet(&testModel{}, func() eval.Event { return &testEvent{} }, &opts, &evalOpts)
 
 	testPolicy := &PolicyDef{
 		Rules: []*RuleDefinition{{
@@ -418,14 +424,15 @@ func loadPolicy(t *testing.T, testPolicy *PolicyDef, policyOpts PolicyLoaderOpts
 	var evalOpts eval.Opts
 	evalOpts.
 		WithConstants(testConstants).
-		WithVariables(make(map[string]eval.VariableValue))
+		WithVariables(make(map[string]eval.VariableValue)).
+		WithMacroStore(&eval.MacroStore{})
 
 	var opts Opts
 	opts.
 		WithSupportedDiscarders(testSupportedDiscarders).
 		WithEventTypeEnabled(enabled)
 
-	rs := NewRuleSet(&testModel{}, func() eval.Event { return &testEvent{} }, &opts, &evalOpts, &eval.MacroStore{})
+	rs := NewRuleSet(&testModel{}, func() eval.Event { return &testEvent{} }, &opts, &evalOpts)
 
 	tmpDir := t.TempDir()
 

--- a/pkg/security/secl/rules/rule_filters.go
+++ b/pkg/security/secl/rules/rule_filters.go
@@ -121,10 +121,7 @@ func (r *SECLRuleFilter) IsRuleAccepted(rule *RuleDefinition) (bool, error) {
 	evalOpts.
 		WithConstants(model.SECLConstants)
 
-	evaluator, err := eval.NewRuleEvaluator(astRule, r.model, eval.ReplacementContext{
-		Opts:       evalOpts,
-		MacroStore: &eval.MacroStore{},
-	})
+	evaluator, err := eval.NewRuleEvaluator(astRule, r.model, evalOpts)
 	if err != nil {
 		return false, err
 	}
@@ -144,7 +141,7 @@ func (r *SECLRuleFilter) IsMacroAccepted(macro *MacroDefinition) (bool, error) {
 		return false, err
 	}
 
-	evaluator, err := eval.NewRuleEvaluator(astRule, r.model, eval.ReplacementContext{})
+	evaluator, err := eval.NewRuleEvaluator(astRule, r.model, &eval.Opts{})
 	if err != nil {
 		return false, err
 	}

--- a/pkg/security/secl/rules/ruleset_test.go
+++ b/pkg/security/secl/rules/ruleset_test.go
@@ -87,14 +87,7 @@ func newRuleSet() *RuleSet {
 		WithSupportedDiscarders(testSupportedDiscarders).
 		WithEventTypeEnabled(enabled)
 
-	return NewRuleSet(&testModel{}, func() eval.Event { return &testEvent{} }, &opts, &evalOpts, &eval.MacroStore{})
-}
-
-func emptyReplCtx() eval.ReplacementContext {
-	return eval.ReplacementContext{
-		Opts:       &eval.Opts{},
-		MacroStore: &eval.MacroStore{},
-	}
+	return NewRuleSet(&testModel{}, func() eval.Event { return &testEvent{} }, &opts, &evalOpts)
 }
 
 func TestRuleBuckets(t *testing.T) {
@@ -572,12 +565,11 @@ func TestRuleSetApprovers14(t *testing.T) {
 }
 
 func TestGetRuleEventType(t *testing.T) {
+	rule := eval.NewRule("aaa", `open.filename == "test"`, &eval.Opts{})
+
 	pc := ast.NewParsingContext()
-	rule := &eval.Rule{
-		ID:         "aaa",
-		Expression: `open.filename == "test"`,
-	}
-	if err := rule.GenEvaluator(&testModel{}, pc, emptyReplCtx()); err != nil {
+
+	if err := rule.GenEvaluator(&testModel{}, pc); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This PR refactor the macro store usage. It removes the need to pass an empty MacroStore when using the SECL package.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
