### PR TITLE
Fix new flare behavior

### DIFF
--- a/comp/core/flare/helpers/builder.go
+++ b/comp/core/flare/helpers/builder.go
@@ -21,6 +21,10 @@ import (
 	"github.com/mholt/archiver/v3"
 )
 
+const (
+	filePerm = 0644
+)
+
 func newBuilder(root string, hostname string) (*builder, error) {
 	fb := &builder{
 		tmpDir:     root,
@@ -58,7 +62,7 @@ func newBuilder(root string, hostname string) (*builder, error) {
 		return nil, err
 	}
 
-	f, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY, os.ModePerm)
+	f, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY, filePerm)
 	if err != nil {
 		return nil, fmt.Errorf("Could not create flare_creation.log file: %s", err)
 	}
@@ -162,7 +166,7 @@ func (fb *builder) AddFile(destFile string, content []byte) error {
 		return err
 	}
 
-	if err := os.WriteFile(f, content, os.ModePerm); err != nil {
+	if err := os.WriteFile(f, content, filePerm); err != nil {
 		return fb.logError("error writing data to '%s': %s", destFile, err)
 	}
 	return nil
@@ -189,7 +193,7 @@ func (fb *builder) copyFileTo(shouldScrub bool, srcFile string, destFile string)
 		}
 	}
 
-	err = os.WriteFile(path, content, os.ModePerm)
+	err = os.WriteFile(path, content, filePerm)
 	if err != nil {
 		return fb.logError("error writing file '%s': %s", destFile, err)
 	}

--- a/comp/core/flare/helpers/helpers.go
+++ b/comp/core/flare/helpers/helpers.go
@@ -50,9 +50,6 @@ type FlareBuilder interface {
 
 	// CopyFile copies the content of 'srcFile' to the root of the flare.
 	//
-	// 'destFile' is a path relative to the flare root (ex: "some/path/to/a/file"). Any necessary directory will
-	// automatically be created.
-	//
 	// The data is automatically scrubbed of any sensitive informations before being copied.
 	//
 	// Example: CopyFile("/etc/datadog/datadog.yaml") will create a copy of "/etc/datadog/datadog.yaml", named
@@ -75,7 +72,7 @@ type FlareBuilder interface {
 	// The path for each file in 'srcDir' is passed to the 'shouldInclude' callback. If 'shouldInclude' returns true, the
 	// file is copies to the flare. If not, the file is ignored.
 	//
-	// 'destFile' is a path relative to the flare root (ex: "some/path/to/a/dir").
+	// 'destDir' is a path relative to the flare root (ex: "some/path/to/a/dir").
 	//
 	// The data of each copied file is automatically scrubbed of any sensitive informations before being copied.
 	//
@@ -88,7 +85,7 @@ type FlareBuilder interface {
 	// The path for each file in 'srcDir' is passed to the 'shouldInclude' callback. If 'shouldInclude' returns true, the
 	// file is copies to the flare. If not, the file is ignored.
 	//
-	// 'destFile' is a path relative to the flare root (ex: "some/path/to/a/dir").
+	// 'destDir' is a path relative to the flare root (ex: "some/path/to/a/dir").
 	//
 	// The data of each copied file is NOT scrubbed of any sensitive informations before being copied. Only files
 	// already scrubbed should be added in this way (ex: agent logs that are scrubbed at creation).

--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -320,7 +320,7 @@ func getProcessAgentFullConfig() ([]byte, error) {
 
 func getConfigFiles(fb flarehelpers.FlareBuilder, confSearchPaths SearchPaths) {
 	for prefix, filePath := range confSearchPaths {
-		fb.CopyDirTo(filePath, prefix, func(path string) bool {
+		fb.CopyDirTo(filePath, filepath.Join("etc", "confd", prefix), func(path string) bool {
 			// ignore .example file
 			if filepath.Ext(path) == ".example" {
 				return false

--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -207,7 +207,7 @@ func createArchive(fb flarehelpers.FlareBuilder, confSearchPaths SearchPaths, lo
 }
 
 func getVersionHistory(fb flarehelpers.FlareBuilder) {
-	fb.CopyFileTo(config.Datadog.GetString("run_path"), "version-history.json")
+	fb.CopyFile(filepath.Join(config.Datadog.GetString("run_path"), "version-history.json"))
 }
 
 func getPerformanceProfile(fb flarehelpers.FlareBuilder, pdata ProfileData) {
@@ -217,7 +217,7 @@ func getPerformanceProfile(fb flarehelpers.FlareBuilder, pdata ProfileData) {
 }
 
 func getRegistryJSON(fb flarehelpers.FlareBuilder) {
-	fb.CopyFile(filepath.Join(config.Datadog.GetString("logs_config.run_path")))
+	fb.CopyFile(filepath.Join(config.Datadog.GetString("logs_config.run_path"), "registry.json"))
 }
 
 func getMetadataV5() ([]byte, error) {

--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -340,7 +340,7 @@ func getConfigFiles(fb flarehelpers.FlareBuilder, confSearchPaths SearchPaths) {
 		confDir := filepath.Dir(mainConfpath)
 
 		// zip up the config file that was actually used, if one exists
-		fb.CopyFileTo(mainConfpath, filepath.Join("etc", "datadog-agent.yaml"))
+		fb.CopyFileTo(mainConfpath, filepath.Join("etc", "datadog.yaml"))
 
 		// figure out system-probe file path based on main config path, and use best effort to include
 		// system-probe.yaml to the flare

--- a/pkg/flare/archive_test.go
+++ b/pkg/flare/archive_test.go
@@ -62,9 +62,20 @@ func TestIncludeConfigFiles(t *testing.T) {
 	mock := flarehelpers.NewFlareBuilderMock(t)
 	getConfigFiles(mock.Fb, SearchPaths{"": "./test/confd"})
 
-	mock.AssertFileExists("test.yaml")
-	mock.AssertFileExists("test.Yml")
-	mock.AssertNoFileExists("not_included.conf")
+	mock.AssertFileExists("etc/confd/test.yaml")
+	mock.AssertFileExists("etc/confd/test.Yml")
+	mock.AssertNoFileExists("etc/confd/not_included.conf")
+}
+
+func TestIncludeConfigFilesWithPrefix(t *testing.T) {
+	common.SetupConfig("./test")
+
+	mock := flarehelpers.NewFlareBuilderMock(t)
+	getConfigFiles(mock.Fb, SearchPaths{"prefix": "./test/confd"})
+
+	mock.AssertFileExists("etc/confd/prefix/test.yaml")
+	mock.AssertFileExists("etc/confd/prefix/test.Yml")
+	mock.AssertNoFileExists("etc/confd/prefix/not_included.conf")
 }
 
 func createTestFile(t *testing.T, filename string) string {

--- a/pkg/flare/archive_test.go
+++ b/pkg/flare/archive_test.go
@@ -52,7 +52,7 @@ func TestIncludeSystemProbeConfig(t *testing.T) {
 	mock := flarehelpers.NewFlareBuilderMock(t)
 	getConfigFiles(mock.Fb, SearchPaths{"": "./test/confd"})
 
-	mock.AssertFileExists("etc", "datadog-agent.yaml")
+	mock.AssertFileExists("etc", "datadog.yaml")
 	mock.AssertFileExists("etc", "system-probe.yaml")
 }
 

--- a/pkg/flare/archive_test.go
+++ b/pkg/flare/archive_test.go
@@ -88,7 +88,7 @@ func TestRegistryJSON(t *testing.T) {
 	srcDir := createTestFile(t, "registry.json")
 
 	confMock := config.Mock(t)
-	confMock.Set("logs_config.run_path", srcDir)
+	confMock.Set("logs_config.run_path", filepath.Dir(srcDir))
 
 	mock := flarehelpers.NewFlareBuilderMock(t)
 	getRegistryJSON(mock.Fb)
@@ -186,7 +186,7 @@ func TestVersionHistory(t *testing.T) {
 	srcDir := createTestFile(t, "version-history.json")
 
 	confMock := config.Mock(t)
-	confMock.Set("run_path", srcDir)
+	confMock.Set("run_path", filepath.Dir(srcDir))
 
 	mock := flarehelpers.NewFlareBuilderMock(t)
 	getVersionHistory(mock.Fb)


### PR DESCRIPTION
### What does this PR do?

- Durring the migration to component the hardcoded directory 'etc/confd' for check configuration was removed.
- Fix shipping of 'version-history.json' in flares. When migrating to component the logic to include `/opt/datadog-agent/run/version-history.json` was broken and the file was no longer added to the flares.
- Fix name for `etc/datdog.yaml`
- Force file permission to 644 

### QA

The new flare behavior hasn't been release yet so those fix will be QA has part of the PR which introduce the main change.