### PR TITLE
[CWS][SEC-4478] add RC to e2e tests

### DIFF
--- a/.gitlab/e2e.yml
+++ b/.gitlab/e2e.yml
@@ -68,6 +68,7 @@ k8s-e2e-tags-7:
   - export DATADOG_AGENT_SITE=datadoghq.com
   - export DATADOG_AGENT_API_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.e2e_tests_api_key --with-decryption --query "Parameter.Value" --out text)
   - export DATADOG_AGENT_APP_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.e2e_tests_app_key --with-decryption --query "Parameter.Value" --out text)
+  - export DATADOG_AGENT_RC_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.e2e_tests_rc_key --with-decryption --query "Parameter.Value" --out text)
 
 k8s-e2e-cws-dev:
   extends: .k8s_e2e_template

--- a/test/e2e/argo-workflows/cws-workflow.yaml
+++ b/test/e2e/argo-workflows/cws-workflow.yaml
@@ -76,6 +76,8 @@ spec:
                   value: "{{inputs.parameters.ci_pipeline_id}}"
                 - name: ci_job_id
                   value: "{{inputs.parameters.ci_job_id}}"
+                - name: remote_configuration_enabled
+                  value: "true"
 
         - - name: wait-datadog-agent
             templateRef:

--- a/test/e2e/argo-workflows/templates/datadog-agent.yaml
+++ b/test/e2e/argo-workflows/templates/datadog-agent.yaml
@@ -110,6 +110,12 @@ spec:
                 env:
                   - name:  DD_USE_V2_API_SERIES
                     value: "false"
+                  - name: REMOTE_CONFIGURATION_ENABLED
+                    value: "true"
+                  - name: REMOTE_CONFIGURATION_KEY
+                    value: $DD_RC_KEY
+                  - name: REMOTE_CONFIGURATION_REFRESH_INTERVAL
+                    value: "5s"
               systemProbe:
                 logLevel: TRACE
                 env:
@@ -117,6 +123,8 @@ spec:
                     value: "module.*"
                   - name: DD_RUNTIME_SECURITY_CONFIG_POLICIES_DIR
                     value: "/tmp/runtime-security.d"
+                  - name: DD_RUNTIME_SECURITY_CONFIG_REMOTE_CONFIGURATION_ENABLED
+                    value: "true"
                 securityContext:
                   capabilities:
                     drop:

--- a/test/e2e/argo-workflows/templates/datadog-agent.yaml
+++ b/test/e2e/argo-workflows/templates/datadog-agent.yaml
@@ -110,17 +110,17 @@ spec:
                 env:
                   - name:  DD_USE_V2_API_SERIES
                     value: "false"
-                  - name: REMOTE_CONFIGURATION_ENABLED
+                  - name: DD_REMOTE_CONFIGURATION_ENABLED
                     value: "true"
-                  - name: REMOTE_CONFIGURATION_KEY
+                  - name: DD_REMOTE_CONFIGURATION_KEY
                     value: $DD_RC_KEY
-                  - name: REMOTE_CONFIGURATION_REFRESH_INTERVAL
+                  - name: DD_REMOTE_CONFIGURATION_REFRESH_INTERVAL
                     value: "5s"
               systemProbe:
                 logLevel: TRACE
                 env:
                   - name:  DD_RUNTIME_SECURITY_CONFIG_LOG_PATTERNS
-                    value: "module.*"
+                    value: "module.APIServer.*"
                   - name: DD_RUNTIME_SECURITY_CONFIG_POLICIES_DIR
                     value: "/tmp/runtime-security.d"
                   - name: DD_RUNTIME_SECURITY_CONFIG_REMOTE_CONFIGURATION_ENABLED

--- a/test/e2e/argo-workflows/templates/datadog-agent.yaml
+++ b/test/e2e/argo-workflows/templates/datadog-agent.yaml
@@ -17,6 +17,7 @@ spec:
           - name: ci_commit_short_sha
           - name: ci_pipeline_id
           - name: ci_job_id
+          - name: remote_configuration_enabled
       script:
         image: alpine/k8s:1.25.4
         envFrom:
@@ -120,7 +121,7 @@ spec:
                   - name:  DD_USE_V2_API_SERIES
                     value: "false"
                   - name: DD_REMOTE_CONFIGURATION_ENABLED
-                    value: "true"
+                    value: "{{inputs.parameters.remote_configuration_enabled}}"
                   - name: DD_REMOTE_CONFIGURATION_KEY
                     value: $DD_RC_KEY
                   - name: DD_REMOTE_CONFIGURATION_REFRESH_INTERVAL
@@ -133,7 +134,7 @@ spec:
                   - name: DD_RUNTIME_SECURITY_CONFIG_POLICIES_DIR
                     value: "/tmp/runtime-security.d"
                   - name: DD_RUNTIME_SECURITY_CONFIG_REMOTE_CONFIGURATION_ENABLED
-                    value: "true"
+                    value: "{{inputs.parameters.remote_configuration_enabled}}"
                 securityContext:
                   capabilities:
                     drop:

--- a/test/e2e/argo-workflows/templates/datadog-agent.yaml
+++ b/test/e2e/argo-workflows/templates/datadog-agent.yaml
@@ -26,6 +26,15 @@ spec:
         source: |
           set -euo pipefail
 
+          # for CWS tests we need to have a test policy before the container start
+          mkdir -p /tmp/runtime-security.d
+          cat > /tmp/runtime-security.d/test.policy <<EOF
+          rules:
+            - id: TEST
+              expression: open.file.path == "/tmp/test123"
+          EOF
+          kubectl create configmap cws-test-policy --from-file=/tmp/runtime-security.d/test.policy
+
           cat > /tmp/values.yaml <<EOF
           datadog:
             kubeStateMetricsEnabled: false
@@ -129,6 +138,14 @@ spec:
                   capabilities:
                     drop:
                       - all
+            volumes:
+              - configMap:
+                  name: cws-test-policy
+                name: cws-test-policy
+            volumeMounts:
+              - name: cws-test-policy
+                mountPath: /tmp/runtime-security.d/test.policy
+                subPath: test.policy
             useConfigMap: true
             customAgentConfig:
               additional_endpoints:

--- a/test/e2e/cws-tests/tests/lib/config.py
+++ b/test/e2e/cws-tests/tests/lib/config.py
@@ -3,29 +3,42 @@ import tempfile
 import yaml
 
 
-def gen_system_probe_config(npm_enabled=False, log_level="INFO", log_patterns=None):
+def gen_system_probe_config(npm_enabled=False, rc_enabled=False, log_level="INFO", log_patterns=None):
     fp = tempfile.NamedTemporaryFile(prefix="e2e-system-probe-", mode="w", delete=False)
 
     if not log_patterns:
         log_patterns = []
+
     data = {
         "system_probe_config": {"log_level": log_level},
         "network_config": {"enabled": npm_enabled},
-        "runtime_security_config": {"log_patterns": log_patterns, "network": {"enabled": True}},
+        "runtime_security_config": {
+            "log_patterns": log_patterns,
+            "network": {"enabled": True},
+            "remote_configuration": {"enabled": rc_enabled, "refresh_interval": "5s"},
+        },
     }
+
     yaml.dump(data, fp)
     fp.close()
 
     return fp.name
 
 
-def gen_datadog_agent_config(hostname="myhost", log_level="INFO", tags=None):
+def gen_datadog_agent_config(hostname="myhost", log_level="INFO", tags=None, rc_enabled=False, rc_key=None):
     fp = tempfile.NamedTemporaryFile(prefix="e2e-datadog-agent-", mode="w", delete=False)
 
     if not tags:
         tags = []
 
-    data = {"log_level": log_level, "hostname": hostname, "tags": tags, "security_agent.remote_workloadmeta": True}
+    data = {
+        "log_level": log_level,
+        "hostname": hostname,
+        "tags": tags,
+        "security_agent.remote_workloadmeta": True,
+        "remote_configuration": {"enabled": rc_enabled, "refresh_interval": "5s", "key": rc_key},
+    }
+
     yaml.dump(data, fp)
     fp.close()
 

--- a/test/e2e/cws-tests/tests/lib/docker.py
+++ b/test/e2e/cws-tests/tests/lib/docker.py
@@ -110,7 +110,7 @@ class DockerHelper(LogGetter):
         temppolicy.write(policies)
         temppolicy.close()
         temppolicy_path = temppolicy.name
-        self.cp_file(temppolicy_path, "/etc/datadog-agent/runtime-security.d/default.policy")
+        self.cp_file(temppolicy_path, "/etc/datadog-agent/runtime-security.d/test.policy")
         os.remove(temppolicy_path)
 
     def cp_file(self, src, dst):

--- a/test/e2e/cws-tests/tests/lib/docker.py
+++ b/test/e2e/cws-tests/tests/lib/docker.py
@@ -110,7 +110,7 @@ class DockerHelper(LogGetter):
         temppolicy.write(policies)
         temppolicy.close()
         temppolicy_path = temppolicy.name
-        self.cp_file(temppolicy_path, "/etc/datadog-agent/runtime-security.d/test.policy")
+        self.cp_file(temppolicy_path, "/etc/datadog-agent/runtime-security.d/default.policy")
         os.remove(temppolicy_path)
 
     def cp_file(self, src, dst):

--- a/test/e2e/cws-tests/tests/lib/kubernetes.py
+++ b/test/e2e/cws-tests/tests/lib/kubernetes.py
@@ -79,7 +79,7 @@ class KubernetesHelper(LogGetter):
         temppolicy.close()
         temppolicy_path = temppolicy.name
         self.exec_command("security-agent", command=["mkdir", "-p", "/tmp/runtime-security.d"])
-        self.cp_to_agent("security-agent", temppolicy_path, "/tmp/runtime-security.d/default.policy")
+        self.cp_to_agent("security-agent", temppolicy_path, "/tmp/runtime-security.d/custom.policy")
         os.remove(temppolicy_path)
 
     def cp_to_agent(self, agent_name, src_file, dst_file):

--- a/test/e2e/cws-tests/tests/lib/kubernetes.py
+++ b/test/e2e/cws-tests/tests/lib/kubernetes.py
@@ -79,7 +79,7 @@ class KubernetesHelper(LogGetter):
         temppolicy.close()
         temppolicy_path = temppolicy.name
         self.exec_command("security-agent", command=["mkdir", "-p", "/tmp/runtime-security.d"])
-        self.cp_to_agent("security-agent", temppolicy_path, "/tmp/runtime-security.d/default.policy")
+        self.cp_to_agent("security-agent", temppolicy_path, "/tmp/runtime-security.d/test.policy")
         os.remove(temppolicy_path)
 
     def cp_to_agent(self, agent_name, src_file, dst_file):

--- a/test/e2e/cws-tests/tests/lib/kubernetes.py
+++ b/test/e2e/cws-tests/tests/lib/kubernetes.py
@@ -79,7 +79,7 @@ class KubernetesHelper(LogGetter):
         temppolicy.close()
         temppolicy_path = temppolicy.name
         self.exec_command("security-agent", command=["mkdir", "-p", "/tmp/runtime-security.d"])
-        self.cp_to_agent("security-agent", temppolicy_path, "/tmp/runtime-security.d/test.policy")
+        self.cp_to_agent("security-agent", temppolicy_path, "/tmp/runtime-security.d/default.policy")
         os.remove(temppolicy_path)
 
     def cp_to_agent(self, agent_name, src_file, dst_file):

--- a/test/e2e/cws-tests/tests/test_e2e_cws_docker.py
+++ b/test/e2e/cws-tests/tests/test_e2e_cws_docker.py
@@ -91,10 +91,10 @@ class TestE2EDocker(unittest.TestCase):
             wait_agent_log("system-probe", self.docker_helper, SYS_PROBE_START_LOG)
 
         if rc_enabled:
-            with Step(msg="check remote-config ruleset_loaded", emoji=":delivery_truck:"):
+            with Step(msg="check `remote-config` ruleset_loaded", emoji=":delivery_truck:"):
                 event = self.app.wait_app_log("rule_id:ruleset_loaded @policies.source:remote-config")
                 attributes = event["data"][-1]["attributes"]["attributes"]
-                start_date = attributes["date"]
+                prev_load_date = attributes["date"]
                 self.app.check_for_ignored_policies(self, attributes)
 
         with Step(msg="download policies", emoji=":file_folder:"):
@@ -114,13 +114,13 @@ class TestE2EDocker(unittest.TestCase):
         with Step(msg="reload policies", emoji=":file_folder:"):
             self.docker_helper.reload_policies()
 
-        with Step(msg="check ruleset_loaded", emoji=":delivery_truck:"):
+        with Step(msg="check `downloaded` ruleset_loaded", emoji=":delivery_truck:"):
             for _i in range(60):  # retry 60 times
                 event = self.app.wait_app_log("rule_id:ruleset_loaded  @policies.source:file")
                 attributes = event["data"][-1]["attributes"]["attributes"]
-                restart_date = attributes["date"]
+                load_date = attributes["date"]
                 # search for restart log until the timestamp differs
-                if restart_date != start_date:
+                if load_date != prev_load_date:
                     break
                 time.sleep(1)
             else:

--- a/test/e2e/cws-tests/tests/test_e2e_cws_docker.py
+++ b/test/e2e/cws-tests/tests/test_e2e_cws_docker.py
@@ -66,7 +66,7 @@ class TestE2EDocker(unittest.TestCase):
 
         with Step(msg="check agent start", emoji=":man_running:"):
             image = os.getenv("DD_AGENT_IMAGE")
-            hostname = f"host_{test_id}"
+            hostname = f"host-{test_id}"
             self.datadog_agent_config = gen_datadog_agent_config(
                 hostname=hostname,
                 log_level="DEBUG",

--- a/test/e2e/cws-tests/tests/test_e2e_cws_docker.py
+++ b/test/e2e/cws-tests/tests/test_e2e_cws_docker.py
@@ -90,12 +90,6 @@ class TestE2EDocker(unittest.TestCase):
             wait_agent_log("security-agent", self.docker_helper, SECURITY_START_LOG)
             wait_agent_log("system-probe", self.docker_helper, SYS_PROBE_START_LOG)
 
-        with Step(msg="check file ruleset_loaded", emoji=":delivery_truck:"):
-            event = self.app.wait_app_log("rule_id:ruleset_loaded @policies.source:file")
-            attributes = event["data"][-1]["attributes"]["attributes"]
-            start_date = attributes["date"]
-            self.app.check_for_ignored_policies(self, attributes)
-
         if rc_enabled:
             with Step(msg="check remote-config ruleset_loaded", emoji=":delivery_truck:"):
                 event = self.app.wait_app_log("rule_id:ruleset_loaded @policies.source:remote-config")
@@ -122,7 +116,7 @@ class TestE2EDocker(unittest.TestCase):
 
         with Step(msg="check ruleset_loaded", emoji=":delivery_truck:"):
             for _i in range(60):  # retry 60 times
-                event = self.app.wait_app_log("rule_id:ruleset_loaded")
+                event = self.app.wait_app_log("rule_id:ruleset_loaded  @policies.source:file")
                 attributes = event["data"][-1]["attributes"]["attributes"]
                 restart_date = attributes["date"]
                 # search for restart log until the timestamp differs

--- a/test/e2e/cws-tests/tests/test_e2e_cws_kubernetes.py
+++ b/test/e2e/cws-tests/tests/test_e2e_cws_kubernetes.py
@@ -76,7 +76,7 @@ class TestE2EKubernetes(unittest.TestCase):
         with Step(msg="check system-probe start", emoji=":customs:"):
             wait_agent_log("system-probe", self.kubernetes_helper, SYS_PROBE_START_LOG)
 
-        with Step(msg="check file ruleset_loaded", emoji=":delivery_truck:"):
+        with Step(msg="create ", emoji=":delivery_truck:"):
             event = self.app.wait_app_log("rule_id:ruleset_loaded @policies.source:file")
             attributes = event["data"][-1]["attributes"]["attributes"]
             start_date = attributes["date"]
@@ -84,12 +84,6 @@ class TestE2EKubernetes(unittest.TestCase):
 
         with Step(msg="check remote-config ruleset_loaded", emoji=":delivery_truck:"):
             event = self.app.wait_app_log("rule_id:ruleset_loaded @policies.source:remote-config")
-            attributes = event["data"][-1]["attributes"]["attributes"]
-            start_date = attributes["date"]
-            self.app.check_for_ignored_policies(self, attributes)
-
-        with Step(msg="check ruleset_loaded", emoji=":delivery_truck:"):
-            event = self.app.wait_app_log("rule_id:ruleset_loaded")
             attributes = event["data"][-1]["attributes"]["attributes"]
             start_date = attributes["date"]
             self.app.check_for_ignored_policies(self, attributes)
@@ -116,7 +110,7 @@ class TestE2EKubernetes(unittest.TestCase):
 
         with Step(msg="check ruleset_loaded", emoji=":delivery_truck:"):
             for _i in range(60):  # retry 60 times
-                event = self.app.wait_app_log("rule_id:ruleset_loaded")
+                event = self.app.wait_app_log("rule_id:ruleset_loaded  @policies.source:file")
                 attributes = event["data"][-1]["attributes"]["attributes"]
                 restart_date = attributes["date"]
                 # search for restart log until the timestamp differs

--- a/test/e2e/cws-tests/tests/test_e2e_cws_kubernetes.py
+++ b/test/e2e/cws-tests/tests/test_e2e_cws_kubernetes.py
@@ -76,6 +76,18 @@ class TestE2EKubernetes(unittest.TestCase):
         with Step(msg="check system-probe start", emoji=":customs:"):
             wait_agent_log("system-probe", self.kubernetes_helper, SYS_PROBE_START_LOG)
 
+        with Step(msg="check file ruleset_loaded", emoji=":delivery_truck:"):
+            event = self.app.wait_app_log("rule_id:ruleset_loaded @policies.source:file")
+            attributes = event["data"][-1]["attributes"]["attributes"]
+            start_date = attributes["date"]
+            self.app.check_for_ignored_policies(self, attributes)
+
+        with Step(msg="check remote-config ruleset_loaded", emoji=":delivery_truck:"):
+            event = self.app.wait_app_log("rule_id:ruleset_loaded @policies.source:remote-config")
+            attributes = event["data"][-1]["attributes"]["attributes"]
+            start_date = attributes["date"]
+            self.app.check_for_ignored_policies(self, attributes)
+
         with Step(msg="check ruleset_loaded", emoji=":delivery_truck:"):
             event = self.app.wait_app_log("rule_id:ruleset_loaded")
             attributes = event["data"][-1]["attributes"]["attributes"]

--- a/test/e2e/cws-tests/tests/test_e2e_cws_kubernetes.py
+++ b/test/e2e/cws-tests/tests/test_e2e_cws_kubernetes.py
@@ -77,12 +77,13 @@ class TestE2EKubernetes(unittest.TestCase):
             wait_agent_log("system-probe", self.kubernetes_helper, SYS_PROBE_START_LOG)
 
         with Step(msg="copy default policies", emoji=":delivery_truck:"):
+            self.kubernetes_helper.exec_command("security-agent", command=["mkdir", "-p", "/tmp/runtime-security.d"])
             command = [
                 "cp",
                 "/etc/datadog-agent/runtime-security.d/default.policy",
                 "/tmp/runtime-security.d/default.policy",
             ]
-            self.kubernetes_helper.exec_command("system-probe", command=command)
+            self.kubernetes_helper.exec_command("security-agent", command=command)
 
         with Step(msg="reload policies", emoji=":rocket:"):
             self.kubernetes_helper.reload_policies()

--- a/test/e2e/scripts/run-instance/22-argo-submit.sh
+++ b/test/e2e/scripts/run-instance/22-argo-submit.sh
@@ -29,12 +29,16 @@ argo_submit_cws_cspm() {
 
     oldstate=$(shopt -po xtrace ||:); set +x  # Do not log credentials
 
-    if [[ -z ${DATADOG_AGENT_API_KEY:+x} ]] || [[ -z ${DATADOG_AGENT_APP_KEY:+x} ]]; then
-        echo "DATADOG_AGENT_API_KEY and DATADOG_AGENT_APP_KEY environment variables need to be set" >&2
+    if [[ -z ${DATADOG_AGENT_API_KEY:+x} ]] || [[ -z ${DATADOG_AGENT_APP_KEY:+x} ]] || [[ -z ${DATADOG_AGENT_RC_KEY:+x} ]]; then
+        echo "DATADOG_AGENT_API_KEY, DATADOG_AGENT_APP_KEY and DATADOG_AGENT_RC_KEY environment variables need to be set" >&2
         exit 2
     fi
 
-    kubectl create secret generic dd-keys --from-literal=DD_API_KEY="${DATADOG_AGENT_API_KEY}" --from-literal=DD_APP_KEY="${DATADOG_AGENT_APP_KEY}" --from-literal=DD_DDDEV_API_KEY="${DD_API_KEY}"
+    kubectl create secret generic dd-keys \
+        --from-literal=DD_API_KEY="${DATADOG_AGENT_API_KEY}" \
+        --from-literal=DD_APP_KEY="${DATADOG_AGENT_APP_KEY}" \
+        --from-literal=DD_RC_KEY="${DATADOG_AGENT_RC_KEY}" \
+        --from-literal=DD_DDDEV_API_KEY="${DD_API_KEY}"
 
     eval "$oldstate"
 
@@ -58,7 +62,11 @@ case "$ARGO_WORKFLOW" in
         argo_submit_cws_cspm cspm-workflow.yaml
         ;;
     *)
-        kubectl create secret generic dd-keys --from-literal=DD_API_KEY=123er --from-literal=DD_APP_KEY=123er1 --from-literal=DD_DDDEV_API_KEY="${DD_API_KEY}"
+        kubectl create secret generic dd-keys  \
+            --from-literal=DD_API_KEY=123er \
+            --from-literal=DD_APP_KEY=123er1 \
+            --from-literal=DD_RC_KEY=123er2 \
+            --from-literal=DD_DDDEV_API_KEY="${DD_API_KEY}"
 
         ./argo template create ../../argo-workflows/templates/*.yaml
         ./argo submit "../../argo-workflows/${ARGO_WORKFLOW}-workflow.yaml" --wait \

--- a/test/e2e/scripts/setup-instance/03-ssh.sh
+++ b/test/e2e/scripts/setup-instance/03-ssh.sh
@@ -16,7 +16,7 @@ test "${COMMIT_ID}" || {
     COMMIT_ID=$(git rev-parse --verify HEAD)
 }
 
-SSH_OPTS=("-o" "ServerAliveInterval=20" "-o" "ConnectTimeout=6" "-o" "StrictHostKeyChecking=no" "-o" "UserKnownHostsFile=/dev/null" "-i" "${PWD}/id_rsa" "-o" "SendEnv=CI_* DD_API_KEY DOCKER_REGISTRY_* DATADOG_AGENT_IMAGE=${DATADOG_AGENT_IMAGE:-datadog/agent-dev:master} DATADOG_CLUSTER_AGENT_IMAGE=${DATADOG_CLUSTER_AGENT_IMAGE:-datadog/cluster-agent-dev:master} ARGO_WORKFLOW DATADOG_AGENT_SITE DATADOG_AGENT_API_KEY DATADOG_AGENT_APP_KEY")
+SSH_OPTS=("-o" "ServerAliveInterval=20" "-o" "ConnectTimeout=6" "-o" "StrictHostKeyChecking=no" "-o" "UserKnownHostsFile=/dev/null" "-i" "${PWD}/id_rsa" "-o" "SendEnv=CI_* DD_API_KEY DOCKER_REGISTRY_* DATADOG_AGENT_IMAGE=${DATADOG_AGENT_IMAGE:-datadog/agent-dev:master} DATADOG_CLUSTER_AGENT_IMAGE=${DATADOG_CLUSTER_AGENT_IMAGE:-datadog/cluster-agent-dev:master} ARGO_WORKFLOW DATADOG_AGENT_SITE DATADOG_AGENT_API_KEY DATADOG_AGENT_APP_KEY DATADOG_AGENT_RC_KEY")
 
 function _ssh() {
     ssh "${SSH_OPTS[@]}" -lcore "${MACHINE}" "$@"


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Enable RC in CWS e2e tests and add a check to validate the ruleset_loaded event with remote-config as source.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
