### PR TITLE
[process-agent] Remove check intervals from pkg/process/config

### DIFF
--- a/cmd/process-agent/collector_api_test.go
+++ b/cmd/process-agent/collector_api_test.go
@@ -546,7 +546,6 @@ func runCollectorTestWithAPIKeys(t *testing.T, check checks.Check, cfg *config.A
 	setProcessEventsEndpointsForTest(mockConfig, eventsEps...)
 
 	cfg.HostName = testHostName
-	cfg.CheckIntervals[check.Name()] = 500 * time.Millisecond
 
 	exit := make(chan struct{})
 

--- a/cmd/process-agent/collector_test.go
+++ b/cmd/process-agent/collector_test.go
@@ -343,7 +343,7 @@ func TestIgnoreResponseBody(t *testing.T) {
 		{checkName: checks.Container.Name(), ignore: false},
 		{checkName: checks.RTContainer.Name(), ignore: false},
 		{checkName: checks.Pod.Name(), ignore: true},
-		{checkName: config.PodCheckManifestName, ignore: true},
+		{checkName: checks.PodCheckManifestName, ignore: true},
 		{checkName: checks.Connections.Name(), ignore: false},
 		{checkName: checks.ProcessEvents.Name(), ignore: true},
 	} {

--- a/pkg/process/checks/checks.go
+++ b/pkg/process/checks/checks.go
@@ -11,6 +11,19 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/process/config"
 )
 
+// Name for check performed by process-agent or system-probe
+const (
+	ProcessCheckName       = "process"
+	RTProcessCheckName     = "rtprocess"
+	ContainerCheckName     = "container"
+	RTContainerCheckName   = "rtcontainer"
+	ConnectionsCheckName   = "connections"
+	PodCheckName           = "pod"
+	PodCheckManifestName   = "pod_manifest"
+	DiscoveryCheckName     = "process_discovery"
+	ProcessEventsCheckName = "process_events"
+)
+
 // Check is an interface for Agent checks that collect data. Each check returns
 // a specific MessageBody type that will be published to the intake endpoint or
 // processed in another way (e.g. printed for debugging).

--- a/pkg/process/checks/container.go
+++ b/pkg/process/checks/container.go
@@ -57,7 +57,7 @@ func (c *ContainerCheck) Init(cfg *config.AgentConfig, info *model.SystemInfo) e
 }
 
 // Name returns the name of the ProcessCheck.
-func (c *ContainerCheck) Name() string { return config.ContainerCheckName }
+func (c *ContainerCheck) Name() string { return ContainerCheckName }
 
 // RealTime indicates if this check only runs in real-time mode.
 func (c *ContainerCheck) RealTime() bool { return false }

--- a/pkg/process/checks/container_rt.go
+++ b/pkg/process/checks/container_rt.go
@@ -40,7 +40,7 @@ func (r *RTContainerCheck) Init(_ *config.AgentConfig, sysInfo *model.SystemInfo
 }
 
 // Name returns the name of the RTContainerCheck.
-func (r *RTContainerCheck) Name() string { return config.RTContainerCheckName }
+func (r *RTContainerCheck) Name() string { return RTContainerCheckName }
 
 // RealTime indicates if this check only runs in real-time mode.
 func (r *RTContainerCheck) RealTime() bool { return true }

--- a/pkg/process/checks/format.go
+++ b/pkg/process/checks/format.go
@@ -18,8 +18,6 @@ import (
 
 	model "github.com/DataDog/agent-payload/v5/process"
 
-	"github.com/DataDog/datadog-agent/pkg/process/config"
-
 	"github.com/dustin/go-humanize"
 )
 
@@ -70,17 +68,17 @@ var (
 // HumanFormat takes the messages produced by a check run and outputs them in a human-readable format
 func HumanFormat(check string, msgs []model.MessageBody, w io.Writer) error {
 	switch check {
-	case config.ProcessCheckName:
+	case ProcessCheckName:
 		return humanFormatProcess(msgs, w)
-	case config.RTProcessCheckName:
+	case RTProcessCheckName:
 		return humanFormatRealTimeProcess(msgs, w)
-	case config.ContainerCheckName:
+	case ContainerCheckName:
 		return humanFormatContainer(msgs, w)
-	case config.RTContainerCheckName:
+	case RTContainerCheckName:
 		return humanFormatRealTimeContainer(msgs, w)
-	case config.DiscoveryCheckName:
+	case DiscoveryCheckName:
 		return humanFormatProcessDiscovery(msgs, w)
-	case config.ProcessEventsCheckName:
+	case ProcessEventsCheckName:
 		return HumanFormatProcessEvents(msgs, w, true)
 	}
 	return ErrNoHumanFormat

--- a/pkg/process/checks/interval.go
+++ b/pkg/process/checks/interval.go
@@ -23,16 +23,16 @@ const (
 
 	discoveryMinInterval = 10 * time.Minute
 
-	configIntervals = configPrefix + ".intervals"
+	configIntervals = configPrefix + "intervals."
 
 	// The interval, in seconds, at which we will run each check. If you want consistent
 	// behavior between real-time you may set the Container/ProcessRT intervals to 10.
 	// Defaults to 10s for normal checks and 2s for others.
-	configProcessInterval     = configIntervals + ".process"
-	configRTProcessInterval   = configIntervals + ".process_realtime"
-	configContainerInterval   = configIntervals + ".container"
-	configRTContainerInterval = configIntervals + ".container_realtime"
-	configConnectionsInterval = configIntervals + ".connections"
+	configProcessInterval     = configIntervals + "process"
+	configRTProcessInterval   = configIntervals + "process_realtime"
+	configContainerInterval   = configIntervals + "container"
+	configRTContainerInterval = configIntervals + "container_realtime"
+	configConnectionsInterval = configIntervals + "connections"
 )
 
 var (
@@ -63,7 +63,6 @@ func GetDefaultInterval(checkName string) time.Duration {
 
 // GetInterval returns the configured check interval value
 func GetInterval(checkName string) time.Duration {
-
 	switch checkName {
 	case DiscoveryCheckName:
 		// We don't need to check if the key exists since we already bound it to a default in InitConfig.
@@ -71,7 +70,7 @@ func GetInterval(checkName string) time.Duration {
 		discoveryInterval := config.Datadog.GetDuration("process_config.process_discovery.interval")
 		if discoveryInterval < discoveryMinInterval {
 			discoveryInterval = discoveryMinInterval
-			_ = log.Warnf("Invalid interval for process discovery (<= %s) using default value of %[1]s", discoveryMinInterval.String())
+			_ = log.Warnf("Invalid interval for process discovery (< %s) using minimum value of %[1]s", discoveryMinInterval.String())
 		}
 		return discoveryInterval
 
@@ -88,7 +87,6 @@ func GetInterval(checkName string) time.Duration {
 		defaultInterval := defaultIntervals[checkName]
 		configKey, ok := configKeys[checkName]
 		if !ok || !config.Datadog.IsSet(configKey) {
-			_ = log.Errorf("missing check interval for '%s', you must set a default", checkName)
 			return defaultInterval
 		}
 

--- a/pkg/process/checks/interval.go
+++ b/pkg/process/checks/interval.go
@@ -1,0 +1,101 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package checks
+
+import (
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+const (
+	ProcessCheckDefaultInterval          = 10 * time.Second
+	RTProcessCheckDefaultInterval        = 2 * time.Second
+	ContainerCheckDefaultInterval        = 10 * time.Second
+	RTContainerCheckDefaultInterval      = 2 * time.Second
+	ConnectionsCheckDefaultInterval      = 30 * time.Second
+	PodCheckDefaultInterval              = 10 * time.Second
+	ProcessDiscoveryCheckDefaultInterval = 4 * time.Hour
+
+	discoveryMinInterval = 10 * time.Minute
+
+	configIntervals = configPrefix + ".intervals"
+
+	// The interval, in seconds, at which we will run each check. If you want consistent
+	// behavior between real-time you may set the Container/ProcessRT intervals to 10.
+	// Defaults to 10s for normal checks and 2s for others.
+	configProcessInterval     = configIntervals + ".process"
+	configRTProcessInterval   = configIntervals + ".process_realtime"
+	configContainerInterval   = configIntervals + ".container"
+	configRTContainerInterval = configIntervals + ".container_realtime"
+	configConnectionsInterval = configIntervals + ".connections"
+)
+
+var (
+	defaultIntervals = map[string]time.Duration{
+		ProcessCheckName:       ProcessCheckDefaultInterval,
+		RTProcessCheckName:     RTProcessCheckDefaultInterval,
+		ContainerCheckName:     ContainerCheckDefaultInterval,
+		RTContainerCheckName:   RTContainerCheckDefaultInterval,
+		ConnectionsCheckName:   ConnectionsCheckDefaultInterval,
+		PodCheckName:           PodCheckDefaultInterval,
+		DiscoveryCheckName:     ProcessDiscoveryCheckDefaultInterval,
+		ProcessEventsCheckName: config.DefaultProcessEventsCheckInterval,
+	}
+
+	configKeys = map[string]string{
+		ProcessCheckName:     configProcessInterval,
+		RTProcessCheckName:   configRTProcessInterval,
+		ContainerCheckName:   configContainerInterval,
+		RTContainerCheckName: configRTContainerInterval,
+		ConnectionsCheckName: configConnectionsInterval,
+	}
+)
+
+// GetDefaultInterval returns the default check interval value
+func GetDefaultInterval(checkName string) time.Duration {
+	return defaultIntervals[checkName]
+}
+
+// GetInterval returns the configured check interval value
+func GetInterval(checkName string) time.Duration {
+
+	switch checkName {
+	case DiscoveryCheckName:
+		// We don't need to check if the key exists since we already bound it to a default in InitConfig.
+		// We use a minimum of 10 minutes for this value.
+		discoveryInterval := config.Datadog.GetDuration("process_config.process_discovery.interval")
+		if discoveryInterval < discoveryMinInterval {
+			discoveryInterval = discoveryMinInterval
+			_ = log.Warnf("Invalid interval for process discovery (<= %s) using default value of %[1]s", discoveryMinInterval.String())
+		}
+		return discoveryInterval
+
+	case ProcessEventsCheckName:
+		eventsInterval := config.Datadog.GetDuration("process_config.event_collection.interval")
+		if eventsInterval < config.DefaultProcessEventsMinCheckInterval {
+			eventsInterval = config.DefaultProcessEventsCheckInterval
+			_ = log.Warnf("Invalid interval for process_events check (< %s) using default value of %s",
+				config.DefaultProcessEventsMinCheckInterval.String(), config.DefaultProcessEventsCheckInterval.String())
+		}
+		return eventsInterval
+
+	default:
+		defaultInterval := defaultIntervals[checkName]
+		configKey, ok := configKeys[checkName]
+		if !ok || !config.Datadog.IsSet(configKey) {
+			_ = log.Errorf("missing check interval for '%s', you must set a default", checkName)
+			return defaultInterval
+		}
+
+		if seconds := config.Datadog.GetInt(configKey); seconds != 0 {
+			log.Infof("Overriding %s check interval to %ds", configKey, seconds)
+			return time.Duration(seconds) * time.Second
+		}
+		return defaultInterval
+	}
+}

--- a/pkg/process/checks/interval_test.go
+++ b/pkg/process/checks/interval_test.go
@@ -1,0 +1,42 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package checks
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+)
+
+// TestProcessDiscoveryInterval tests to make sure that the process discovery interval validation works properly
+func TestProcessDiscoveryInterval(t *testing.T) {
+	for _, tc := range []struct {
+		name             string
+		interval         time.Duration
+		expectedInterval time.Duration
+	}{
+		{
+			name:             "allowed interval",
+			interval:         8 * time.Hour,
+			expectedInterval: 8 * time.Hour,
+		},
+		{
+			name:             "below minimum",
+			interval:         0,
+			expectedInterval: discoveryMinInterval,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := config.Mock(t)
+			cfg.Set("process_config.process_discovery.interval", tc.interval)
+
+			assert.Equal(t, tc.expectedInterval, GetInterval(DiscoveryCheckName))
+		})
+	}
+}

--- a/pkg/process/checks/net.go
+++ b/pkg/process/checks/net.go
@@ -91,7 +91,7 @@ func (c *ConnectionsCheck) Init(cfg *config.AgentConfig, _ *model.SystemInfo) er
 }
 
 // Name returns the name of the ConnectionsCheck.
-func (c *ConnectionsCheck) Name() string { return config.ConnectionsCheckName }
+func (c *ConnectionsCheck) Name() string { return ConnectionsCheckName }
 
 // RealTime indicates if this check only runs in real-time mode.
 func (c *ConnectionsCheck) RealTime() bool { return false }

--- a/pkg/process/checks/pod.go
+++ b/pkg/process/checks/pod.go
@@ -47,7 +47,7 @@ func (c *PodCheck) Init(_ *config.AgentConfig, info *model.SystemInfo) error {
 }
 
 // Name returns the name of the ProcessCheck.
-func (c *PodCheck) Name() string { return config.PodCheckName }
+func (c *PodCheck) Name() string { return PodCheckName }
 
 // RealTime indicates if this check only runs in real-time mode.
 func (c *PodCheck) RealTime() bool { return false }

--- a/pkg/process/checks/process.go
+++ b/pkg/process/checks/process.go
@@ -104,10 +104,10 @@ func (p *ProcessCheck) Init(_ *config.AgentConfig, info *model.SystemInfo) error
 }
 
 // Name returns the name of the ProcessCheck.
-func (p *ProcessCheck) Name() string { return config.ProcessCheckName }
+func (p *ProcessCheck) Name() string { return ProcessCheckName }
 
 // RealTimeName returns the name of the RTProcessCheck
-func (p *ProcessCheck) RealTimeName() string { return config.RTProcessCheckName }
+func (p *ProcessCheck) RealTimeName() string { return RTProcessCheckName }
 
 // RealTime indicates if this check only runs in real-time mode.
 func (p *ProcessCheck) RealTime() bool { return false }
@@ -329,7 +329,7 @@ func fmtProcesses(
 	connsByPID map[int32][]*model.Connection,
 ) map[string][]*model.Process {
 	procsByCtr := make(map[string][]*model.Process)
-	connCheckIntervalS := int(cfg.CheckIntervals[config.ConnectionsCheckName] / time.Second)
+	connCheckIntervalS := int(GetInterval(ConnectionsCheckName) / time.Second)
 
 	for _, fp := range procs {
 		if skipProcess(disallowList, fp, lastProcs) {

--- a/pkg/process/checks/process_discovery_check.go
+++ b/pkg/process/checks/process_discovery_check.go
@@ -40,7 +40,7 @@ func (d *ProcessDiscoveryCheck) Init(_ *config.AgentConfig, info *model.SystemIn
 }
 
 // Name returns the name of the ProcessDiscoveryCheck.
-func (d *ProcessDiscoveryCheck) Name() string { return config.DiscoveryCheckName }
+func (d *ProcessDiscoveryCheck) Name() string { return DiscoveryCheckName }
 
 // RealTime returns a value that says whether this check should be run in real time.
 func (d *ProcessDiscoveryCheck) RealTime() bool { return false }

--- a/pkg/process/checks/process_events_fallback.go
+++ b/pkg/process/checks/process_events_fallback.go
@@ -29,7 +29,7 @@ func (e *ProcessEventsCheck) Init(_ *config.AgentConfig, info *model.SystemInfo)
 }
 
 // Name returns the name of the ProcessEventsCheck.
-func (e *ProcessEventsCheck) Name() string { return config.ProcessEventsCheckName }
+func (e *ProcessEventsCheck) Name() string { return ProcessEventsCheckName }
 
 // RealTime returns a value that says whether this check should be run in real time.
 func (e *ProcessEventsCheck) RealTime() bool { return false }

--- a/pkg/process/checks/process_events_linux.go
+++ b/pkg/process/checks/process_events_linux.go
@@ -80,7 +80,7 @@ func (e *ProcessEventsCheck) start() {
 }
 
 // Name returns the name of the ProcessEventsCheck.
-func (e *ProcessEventsCheck) Name() string { return config.ProcessEventsCheckName }
+func (e *ProcessEventsCheck) Name() string { return ProcessEventsCheckName }
 
 // RealTime returns a value that says whether this check should be run in real time.
 func (e *ProcessEventsCheck) RealTime() bool { return false }

--- a/pkg/process/checks/process_rt.go
+++ b/pkg/process/checks/process_rt.go
@@ -103,7 +103,7 @@ func fmtProcessStats(
 	lastRun time.Time,
 	connsByPID map[int32][]*model.Connection,
 ) [][]*model.ProcessStat {
-	connCheckIntervalS := int(cfg.CheckIntervals[config.ConnectionsCheckName] / time.Second)
+	connCheckIntervalS := int(GetInterval(ConnectionsCheckName) / time.Second)
 
 	chunked := make([][]*model.ProcessStat, 0)
 	chunk := make([]*model.ProcessStat, 0, maxBatchSize)

--- a/pkg/process/config/config.go
+++ b/pkg/process/config/config.go
@@ -29,27 +29,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-// Name for check performed by process-agent or system-probe
-const (
-	ProcessCheckName       = "process"
-	RTProcessCheckName     = "rtprocess"
-	ContainerCheckName     = "container"
-	RTContainerCheckName   = "rtcontainer"
-	ConnectionsCheckName   = "connections"
-	PodCheckName           = "pod"
-	PodCheckManifestName   = "pod_manifest"
-	DiscoveryCheckName     = "process_discovery"
-	ProcessEventsCheckName = "process_events"
-
-	ProcessCheckDefaultInterval          = 10 * time.Second
-	RTProcessCheckDefaultInterval        = 2 * time.Second
-	ContainerCheckDefaultInterval        = 10 * time.Second
-	RTContainerCheckDefaultInterval      = 2 * time.Second
-	ConnectionsCheckDefaultInterval      = 30 * time.Second
-	PodCheckDefaultInterval              = 10 * time.Second
-	ProcessDiscoveryCheckDefaultInterval = 4 * time.Hour
-)
-
 type cmdFunc = func(name string, arg ...string) *exec.Cmd
 
 // AgentConfig is the global config for the process-agent. This information
@@ -66,19 +45,6 @@ type AgentConfig struct {
 
 	// System probe collection configuration
 	SystemProbeAddress string
-
-	// Check config
-	CheckIntervals map[string]time.Duration
-}
-
-// CheckInterval returns the interval for the given check name, defaulting to 10s if not found.
-func (a AgentConfig) CheckInterval(checkName string) time.Duration {
-	d, ok := a.CheckIntervals[checkName]
-	if !ok {
-		log.Errorf("missing check interval for '%s', you must set a default", checkName)
-		d = 10 * time.Second
-	}
-	return d
 }
 
 // NewDefaultAgentConfig returns an AgentConfig with defaults initialized
@@ -91,18 +57,6 @@ func NewDefaultAgentConfig() *AgentConfig {
 
 		// System probe collection configuration
 		SystemProbeAddress: defaultSystemProbeAddress,
-
-		// Check config
-		CheckIntervals: map[string]time.Duration{
-			ProcessCheckName:       ProcessCheckDefaultInterval,
-			RTProcessCheckName:     RTProcessCheckDefaultInterval,
-			ContainerCheckName:     ContainerCheckDefaultInterval,
-			RTContainerCheckName:   RTContainerCheckDefaultInterval,
-			ConnectionsCheckName:   ConnectionsCheckDefaultInterval,
-			PodCheckName:           PodCheckDefaultInterval,
-			DiscoveryCheckName:     ProcessDiscoveryCheckDefaultInterval,
-			ProcessEventsCheckName: config.DefaultProcessEventsCheckInterval,
-		},
 	}
 
 	// Set default values for proc/sys paths if unset.

--- a/pkg/process/config/config_test.go
+++ b/pkg/process/config/config_test.go
@@ -162,36 +162,30 @@ func TestAgentConfigYamlAndSystemProbeConfig(t *testing.T) {
 
 	assert := assert.New(t)
 
-	agentConfig := loadAgentConfigForTest(t, "./testdata/TestDDAgentConfigYamlAndSystemProbeConfig.yaml", "")
+	_ = loadAgentConfigForTest(t, "./testdata/TestDDAgentConfigYamlAndSystemProbeConfig.yaml", "")
 
 	assert.Equal("apikey_20", config.Datadog.GetString("api_key"))
 	assert.Equal("http://my-process-app.datadoghq.com", config.Datadog.GetString("process_config.process_dd_url"))
 	assert.Equal(10, config.Datadog.GetInt("process_config.queue_size"))
-	assert.Equal(8*time.Second, agentConfig.CheckIntervals[ContainerCheckName])
-	assert.Equal(30*time.Second, agentConfig.CheckIntervals[ProcessCheckName])
 	assert.Equal(5065, config.Datadog.GetInt("process_config.expvar_port"))
 
 	newConfig()
-	agentConfig = loadAgentConfigForTest(t, "./testdata/TestDDAgentConfigYamlAndSystemProbeConfig.yaml", "./testdata/TestDDAgentConfigYamlAndSystemProbeConfig-Net.yaml")
+	agentConfig := loadAgentConfigForTest(t, "./testdata/TestDDAgentConfigYamlAndSystemProbeConfig.yaml", "./testdata/TestDDAgentConfigYamlAndSystemProbeConfig-Net.yaml")
 
 	assert.Equal("apikey_20", config.Datadog.GetString("api_key"))
 	assert.Equal("http://my-process-app.datadoghq.com", config.Datadog.GetString("process_config.process_dd_url"))
 	assert.Equal("server-01", agentConfig.HostName)
 	assert.Equal(10, config.Datadog.GetInt("process_config.queue_size"))
-	assert.Equal(8*time.Second, agentConfig.CheckIntervals[ContainerCheckName])
-	assert.Equal(30*time.Second, agentConfig.CheckIntervals[ProcessCheckName])
 	if runtime.GOOS != "windows" {
 		assert.Equal("/var/my-location/system-probe.log", agentConfig.SystemProbeAddress)
 	}
 
 	newConfig()
-	agentConfig = loadAgentConfigForTest(t, "./testdata/TestDDAgentConfigYamlAndSystemProbeConfig.yaml", "./testdata/TestDDAgentConfigYamlAndSystemProbeConfig-Net-2.yaml")
+	_ = loadAgentConfigForTest(t, "./testdata/TestDDAgentConfigYamlAndSystemProbeConfig.yaml", "./testdata/TestDDAgentConfigYamlAndSystemProbeConfig-Net-2.yaml")
 
 	assert.Equal("apikey_20", config.Datadog.GetString("api_key"))
 	assert.Equal("http://my-process-app.datadoghq.com", config.Datadog.GetString("process_config.process_dd_url"))
 	assert.Equal(10, config.Datadog.GetInt("process_config.queue_size"))
-	assert.Equal(8*time.Second, agentConfig.CheckIntervals[ContainerCheckName])
-	assert.Equal(30*time.Second, agentConfig.CheckIntervals[ProcessCheckName])
 
 	newConfig()
 	agentConfig = loadAgentConfigForTest(t, "./testdata/TestDDAgentConfigYamlAndSystemProbeConfig.yaml", "./testdata/TestDDAgentConfigYamlAndSystemProbeConfig-Net-Windows.yaml")
@@ -293,36 +287,6 @@ func TestGetHostnameShellCmd(t *testing.T) {
 	case "agent-empty_hostname":
 		assert.EqualValues(t, []string{"hostname"}, args)
 		fmt.Fprintf(os.Stdout, "")
-	}
-}
-
-// TestProcessDiscoveryInterval tests to make sure that the process discovery interval validation works properly
-func TestProcessDiscoveryInterval(t *testing.T) {
-	for _, tc := range []struct {
-		name             string
-		interval         time.Duration
-		expectedInterval time.Duration
-	}{
-		{
-			name:             "allowed interval",
-			interval:         8 * time.Hour,
-			expectedInterval: 8 * time.Hour,
-		},
-		{
-			name:             "below minimum",
-			interval:         0,
-			expectedInterval: discoveryMinInterval,
-		},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			cfg := config.Mock(t)
-			cfg.Set("process_config.process_discovery.interval", tc.interval)
-
-			agentCfg := NewDefaultAgentConfig()
-			assert.NoError(t, agentCfg.LoadAgentConfig(""))
-
-			assert.Equal(t, tc.expectedInterval, agentCfg.CheckIntervals[DiscoveryCheckName])
-		})
 	}
 }
 

--- a/pkg/process/config/config_test.go
+++ b/pkg/process/config/config_test.go
@@ -32,6 +32,14 @@ import (
 
 var originalConfig = config.Datadog
 
+const (
+	ns = "process_config"
+)
+
+func key(pieces ...string) string {
+	return strings.Join(pieces, ".")
+}
+
 func restoreGlobalConfig() {
 	config.Datadog = originalConfig
 }

--- a/pkg/process/config/yaml_config.go
+++ b/pkg/process/config/yaml_config.go
@@ -7,18 +7,9 @@ package config
 
 import (
 	"path/filepath"
-	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 )
-
-const (
-	ns = "process_config"
-)
-
-func key(pieces ...string) string {
-	return strings.Join(pieces, ".")
-}
 
 // LoadAgentConfig loads process-agent specific configurations based on the global Config object
 func (a *AgentConfig) LoadAgentConfig(path string) error {

--- a/pkg/process/config/yaml_config.go
+++ b/pkg/process/config/yaml_config.go
@@ -8,15 +8,12 @@ package config
 import (
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 const (
-	ns                   = "process_config"
-	discoveryMinInterval = 10 * time.Minute
+	ns = "process_config"
 )
 
 func key(pieces ...string) string {
@@ -36,58 +33,5 @@ func (a *AgentConfig) LoadAgentConfig(path string) error {
 		a.HostName = config.Datadog.GetString("hostname")
 	}
 
-	// The interval, in seconds, at which we will run each check. If you want consistent
-	// behavior between real-time you may set the Container/ProcessRT intervals to 10.
-	// Defaults to 10s for normal checks and 2s for others.
-	a.setCheckInterval(ns, "container", ContainerCheckName)
-	a.setCheckInterval(ns, "container_realtime", RTContainerCheckName)
-	a.setCheckInterval(ns, "process", ProcessCheckName)
-	a.setCheckInterval(ns, "process_realtime", RTProcessCheckName)
-	a.setCheckInterval(ns, "connections", ConnectionsCheckName)
-
-	// We don't need to check if the key exists since we already bound it to a default in InitConfig.
-	// We use a minimum of 10 minutes for this value.
-	discoveryInterval := config.Datadog.GetDuration("process_config.process_discovery.interval")
-	if discoveryInterval < discoveryMinInterval {
-		discoveryInterval = discoveryMinInterval
-		_ = log.Warnf("Invalid interval for process discovery (<= %s) using default value of %[1]s", discoveryMinInterval.String())
-	}
-	a.CheckIntervals[DiscoveryCheckName] = discoveryInterval
-
-	eventsInterval := config.Datadog.GetDuration("process_config.event_collection.interval")
-	if eventsInterval < config.DefaultProcessEventsMinCheckInterval {
-		eventsInterval = config.DefaultProcessEventsCheckInterval
-		_ = log.Warnf("Invalid interval for process_events check (< %s) using default value of %s",
-			config.DefaultProcessEventsMinCheckInterval.String(), config.DefaultProcessEventsCheckInterval.String())
-	}
-	a.CheckIntervals[ProcessEventsCheckName] = eventsInterval
-
-	if a.CheckIntervals[ProcessCheckName] < a.CheckIntervals[RTProcessCheckName] || a.CheckIntervals[ProcessCheckName]%a.CheckIntervals[RTProcessCheckName] != 0 {
-		// Process check interval must be greater or equal to RTProcess check interval and the intervals must be divisible
-		// in order to be run on the same goroutine
-		log.Warnf(
-			"Invalid process check interval overrides [%s,%s], resetting to defaults [%s,%s]",
-			a.CheckIntervals[ProcessCheckName],
-			a.CheckIntervals[RTProcessCheckName],
-			ProcessCheckDefaultInterval,
-			RTProcessCheckDefaultInterval,
-		)
-		a.CheckIntervals[ProcessCheckName] = ProcessCheckDefaultInterval
-		a.CheckIntervals[RTProcessCheckName] = RTProcessCheckDefaultInterval
-	}
-
 	return nil
-}
-
-func (a *AgentConfig) setCheckInterval(ns, check, checkKey string) {
-	k := key(ns, "intervals", check)
-
-	if !config.Datadog.IsSet(k) {
-		return
-	}
-
-	if interval := config.Datadog.GetInt(k); interval != 0 {
-		log.Infof("Overriding %s check interval to %ds", checkKey, interval)
-		a.CheckIntervals[checkKey] = time.Duration(interval) * time.Second
-	}
 }


### PR DESCRIPTION
### What does this PR do?

- Remove check interval management from pkg/process/config package
- Never store intervals, just use config settings
- Generalize check for process and process RT check intervals
- Move consts for check names and default interval values to pkg/process/checks

### Motivation

Prep for removal of pkg/process/config

### Describe how to test/QA your changes

Verify check interval configuration and overrides.

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
