### PR TITLE
Append to sslkeylogfile instead of truncating existing content

### DIFF
--- a/pkg/util/http/transport.go
+++ b/pkg/util/http/transport.go
@@ -90,7 +90,7 @@ func CreateHTTPTransport() *http.Transport {
 		sslKeyLogFile := config.Datadog.GetString("sslkeylogfile")
 		if sslKeyLogFile != "" {
 			var err error
-			keyLogWriter, err = os.OpenFile(sslKeyLogFile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+			keyLogWriter, err = os.OpenFile(sslKeyLogFile, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0600)
 			if err != nil {
 				log.Warnf("Failed to open %s for writing NSS keys: %v", sslKeyLogFile, err)
 			}


### PR DESCRIPTION
### What does this PR do?
If the config option `sslkeylogfile` is set, then the Agent will instruct the underlying go HTTP libraries to persist certain TLS secrets in a well-known format that tools like Wireshark can utilize to decrypt TLS encrypted traffic.

### Motivation
This code is utilized by both the process-agent and the core-agent, leading to a race between them.
Without this change, its unpredictable if the key log file will contain TLS secrets relevant to the process-agent or the core agent.



### Additional Notes

### Possible Drawbacks / Trade-offs

A trade-off here is that any deployments that have this option on will now result in a continuously-growing keylog file which could eventually get quite large
As this option is not intended to be on for extended periods of time (its for debugging only), this does not seem like a deal breaker to me.

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
1. With both the core agent and process agent enabled (eg, a docker build), set `DD_SSLKEYLOGFILE` to a valid path.
2. Start a packet capture with `tcpdump` (or another tool) _before_ starting the agent in order to ensure the TLS handshake is captured.
3. Start the agent
4. Let it run for at least a minute or two to generate some traffic
5. Load the packet capture and keylogfile into wireshark (or inject it into the packet capture directly eg `editcap --inject-secrets tls,./keylogfile.keys out.pcap injected.pcapng`, I find this to be less error-prone)
6. Ensure that you can see traffic generated by both the process agent and the core agent and they are both decrypted. A good way to check this is to look for POST requests to both host `7-xx-0-app.agent.datadoghq.com` and host `process.datadoghq.com`.


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
