### PR TITLE
pkg/trace/traceutil: Add fast-path for NormalizeTags to reduce cpu usage

### DIFF
--- a/pkg/trace/traceutil/normalize.go
+++ b/pkg/trace/traceutil/normalize.go
@@ -293,8 +293,9 @@ func isNormalizedASCIITag(tag string) bool {
 		b := tag[i]
 		// TODO: Attempt to optimize this check using SIMD/vectorization.
 		if isValidASCIITagChar(b) {
-			// okay!
-		} else if b == '_' {
+			continue
+		} 
+		if b == '_' {
 			// an underscore is only okay if followed by a valid non-underscore character
 			i++
 			if i == len(tag) || !isValidASCIITagChar(tag[i]) {

--- a/pkg/trace/traceutil/normalize.go
+++ b/pkg/trace/traceutil/normalize.go
@@ -97,6 +97,11 @@ const maxTagLength = 200
 
 // NormalizeTag applies some normalization to ensure the tags match the backend requirements.
 func NormalizeTag(v string) string {
+	// Fast path: Check if the tag is valid and only contains ASCII characters,
+	// if yes return it as-is right away. For most use-cases this reduces CPU usage.
+	if isNormalizedASCIITag(v) {
+		return v
+	}
 	// the algorithm works by creating a set of cuts marking start and end offsets in v
 	// that have to be replaced with underscore (_)
 	if len(v) == 0 {
@@ -272,4 +277,40 @@ func normMetricNameParse(name string) (string, bool) {
 	}
 
 	return string(res), true
+}
+
+func isNormalizedASCIITag(tag string) bool {
+	if len(tag) == 0 {
+		return true
+	}
+	if len(tag) > maxTagLength {
+		return false
+	}
+	if !isValidASCIIStartChar(tag[0]) {
+		return false
+	}
+	for i := 1; i < len(tag); i++ {
+		b := tag[i]
+		// TODO: Attempt to optimize this check using SIMD/vectorization.
+		if isValidASCIITagChar(b) {
+			// okay!
+		} else if b == '_' {
+			// an underscore is only okay if followed by a valid non-underscore character
+			i++
+			if i == len(tag) || !isValidASCIITagChar(tag[i]) {
+				return false
+			}
+		} else {
+			return false
+		}
+	}
+	return true
+}
+
+func isValidASCIIStartChar(c byte) bool {
+	return ('a' <= c && c <= 'z') || c == ':'
+}
+
+func isValidASCIITagChar(c byte) bool {
+	return isValidASCIIStartChar(c) || ('0' <= c && c <= '9') || c == '.' || c == '/' || c == '-'
 }

--- a/pkg/trace/traceutil/normalize.go
+++ b/pkg/trace/traceutil/normalize.go
@@ -294,7 +294,7 @@ func isNormalizedASCIITag(tag string) bool {
 		// TODO: Attempt to optimize this check using SIMD/vectorization.
 		if isValidASCIITagChar(b) {
 			continue
-		} 
+		}
 		if b == '_' {
 			// an underscore is only okay if followed by a valid non-underscore character
 			i++

--- a/releasenotes/notes/PortNormalizedTagImprovements-374203de9f436f90.yaml
+++ b/releasenotes/notes/PortNormalizedTagImprovements-374203de9f436f90.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    APM: Ported a faster implementation of NormalizeTag with a fast-path for already normalized ASCII tags. Should marginally improve CPU usage of the trace-agent.


### PR DESCRIPTION
### What does this PR do?
This PR ports a fast-path improvement for Tag Normalization thanks in large part to @felixge 

### Motivation
We've seen a large portion of tags are already ascii and normalized, by introducing a fast path here we can reduce the amount of CPU spent on normalizing tags.

### Additional Notes
According to the already included benchmark `BenchmarkNormalizeTag` when a tag is already normalized this fast path provides a significant improvement over the current implementation (61ns / op -> 7ns / op)

### Describe how to test/QA your changes
I believe the numerous unit tests here are sufficient to ensure backwards compatibility. 

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
