### PR TITLE
Update agent_dev_env.md

### DIFF
--- a/docs/dev/agent_dev_env.md
+++ b/docs/dev/agent_dev_env.md
@@ -2,7 +2,7 @@
 
 ## Linux and MacOS
 
-## Python
+### Python
 
 The Agent embeds a full-fledged CPython interpreter so it requires the
 development files to be available in the dev env. The Agent can embed Python2
@@ -30,7 +30,7 @@ sudo apt-get install python3.8-dev
 
 On Windows, install Python 2.7 and/or 3.8 via the [official installer](https://www.python.org/downloads/).
 
-### Additional Windows Tools
+#### Additional Windows Tools
 You will also need the Visual Studio for [Visual Studio for Python installer](http://aka.ms/vcpython27)
 
 Download the [gcc toolchain](http://win-builds.org/).
@@ -39,9 +39,9 @@ Download the [gcc toolchain](http://win-builds.org/).
 - Add installation folder to the `%PATH%`.
 
 
-### Python Dependencies
+#### Python Dependencies
 
-#### Preface
+##### Preface
 
 To protect and isolate your system-wide python installation, a python virtual
 environment is _highly_ recommended (though optional). It will help keep a
@@ -68,7 +68,7 @@ though).
 PYTHONPATH="./venv/lib/python3.8/site-packages:$PYTHONPATH" ./agent run ...
 ```
 
-### Invoke
+#### Invoke
 
 [Invoke](http://www.pyinvoke.org/) is a task runner written in Python
 that is extensively used in this project to orchestrate builds and test
@@ -93,7 +93,7 @@ are used in the official build. Such values are listed in the `invoke.yaml`
 file at the root of this repo and can be overridden by setting `INVOKE_*` env
 variables (see Invoke docs for more details).
 
-## Golang
+### Golang
 
 You must [install Golang](https://golang.org/doc/install) version `1.18.9` or
 higher. Make sure that `$GOPATH/bin` is in your `$PATH` otherwise `invoke`
@@ -104,18 +104,18 @@ specified in our build images (see e.g. [here](https://github.com/DataDog/datado
 may not be able to build the agent and/or the [rtloader](https://github.com/DataDog/datadog-agent/tree/main/rtloader)
 binary properly.**
 
-## Installing tooling
+### Installing tooling
 
 From the root of `datadog-agent`, run `invoke install-tools` to install go tooling. This uses `go` to install the necessary dependencies.
 
-## System or Embedded?
+### System or Embedded?
 
 When working on the Agent codebase you can choose among two different ways to
 build the binary, informally named _System_ and _Embedded_ builds. For most
 contribution scenarios you should rely on the System build (the default) and use
 the Embedded one only for specific use cases. Let's explore the differences.
 
-### System build
+#### System build
 
 _System_ builds use your operating system's standard system libraries to satisfy
 the Agent's external dependencies. Since, for example, macOS 10.11 may provide a
@@ -128,7 +128,7 @@ sure you have system copies of all the Agent's dependencies, skip the
 _Embedded build_ section below and read on to see how to install them via your
 usual package manager (apt, yum, brew, etc).
 
-### Embedded build
+#### Embedded build
 
 _Embedded_ builds download specifically-versioned dependencies and compile them
 locally from sources. We run Embedded builds to create Datadog's official Agent
@@ -148,7 +148,7 @@ and build dependencies, so you need a recent `ruby` environment with `bundler`
 installed. See [how to build Agent packages with Omnibus][agent-omnibus] for more
 details.
 
-### Systemd
+#### Systemd
 
 The agent is able to collect systemd journal logs using a wrapper on the systemd utility library.
 
@@ -162,7 +162,7 @@ On Redhat/CentOS:
 sudo yum install systemd-devel
 ```
 
-## Docker
+### Docker
 
 If you want to build a Docker image containing the Agent, or if you wan to run
 [system and integration tests][testing] you need to run a recent version of Docker in your
@@ -175,7 +175,7 @@ dev environment.
 [integrations-core]: https://github.com/DataDog/integrations-core
 [datadog_checks_base]: https://github.com/DataDog/integrations-core/tree/master/datadog_checks_base
 
-## Doxygen
+### Doxygen
 
 We use [Doxygen](http://www.doxygen.nl/) to generate the documentation for the `rtloader` part of the Agent.
 
@@ -184,11 +184,11 @@ Alternatively, you can use already-compiled Doxygen binaries from [here](http://
 
 To get the dependency graphs, you may also need to install the `dot` executable from [graphviz](http://www.graphviz.org/) and add it to your `$PATH`.
 
-## Pre-commit hooks
+### Pre-commit hooks
 
 It is optional but recommended to install `pre-commit` to run a number of checks done by the CI locally.
 
-### Installation
+#### Installation
 
 To install it, run:
 
@@ -206,11 +206,11 @@ inv install-shellcheck --destination <path>
 
 (by default, the shellcheck binary is installed in `/usr/local/bin`).
 
-### Skipping `pre-commit`
+#### Skipping `pre-commit`
 
 If you want to skip `pre-commit` for a specific commit you can add `--no-verify` to the `git commit` command.
 
-### Running `pre-commit` manually
+#### Running `pre-commit` manually
 
 If you want to run one of the checks manually, you can run `pre-commit run <check name>`.
 
@@ -221,7 +221,7 @@ pre-commit run flake8 --all-files  # run flake8 on all files
 
 See `pre-commit run --help` for further options.
 
-## Setting up Visual Studio Code Dev Container
+### Setting up Visual Studio Code Dev Container
 
 [Microsoft Visual Studio Code](https://code.visualstudio.com/download) with the [devcontainer plugin](https://code.visualstudio.com/docs/remote/containers) allow to use a container as remote development environment in vscode. It simplify and isolate
 the dependencies needed to develop in this repository.

--- a/docs/dev/agent_dev_env.md
+++ b/docs/dev/agent_dev_env.md
@@ -1,4 +1,6 @@
-# Linux and MacOS Development Environments
+# Development Environments
+
+## Linux and MacOS
 
 ## Python
 
@@ -219,14 +221,6 @@ pre-commit run flake8 --all-files  # run flake8 on all files
 
 See `pre-commit run --help` for further options.
 
-## Setting up your Windows development environment
-
-### Code editor
-
-[Microsoft Visual Studio Code](https://code.visualstudio.com/download) is recommended as it's lightweight and versatile.
-
-Building on Windows would require multiple 3rd-party softwares to be installed. To avoid the complexity, it is recommended to make the code change in VS Code then do the build in Docker image. For complete information, see [Build the Agent packages](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/agent_omnibus.md)
-
 ## Setting up Visual Studio Code Dev Container
 
 [Microsoft Visual Studio Code](https://code.visualstudio.com/download) with the [devcontainer plugin](https://code.visualstudio.com/docs/remote/containers) allow to use a container as remote development environment in vscode. It simplify and isolate
@@ -241,3 +235,10 @@ To configure the vscode editor to use a container as remote development environm
 - A pop-up should show-up to propose to "reopen in container" your workspace.
 - The first start, it might propose you to install the golang plugin dependencies/tooling.
 
+## Windows development environment
+
+### Code editor
+
+[Microsoft Visual Studio Code](https://code.visualstudio.com/download) is recommended as it's lightweight and versatile.
+
+Building on Windows would require multiple 3rd-party softwares to be installed. To avoid the complexity, it is recommended to make the code change in VS Code then do the build in Docker image. For complete information, see [Build the Agent packages](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/agent_omnibus.md)

--- a/docs/dev/agent_dev_env.md
+++ b/docs/dev/agent_dev_env.md
@@ -241,4 +241,4 @@ To configure the vscode editor to use a container as remote development environm
 
 [Microsoft Visual Studio Code](https://code.visualstudio.com/download) is recommended as it's lightweight and versatile.
 
-Building on Windows would require multiple 3rd-party softwares to be installed. To avoid the complexity, it is recommended to make the code change in VS Code then do the build in Docker image. For complete information, see [Build the Agent packages](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/agent_omnibus.md)
+Building on Windows requires multiple 3rd-party software to be installed. To avoid the complexity, Datadog recommends to make the code change in VS Code, and then do the build in Docker image. For complete information, see [Build the Agent packages](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/agent_omnibus.md)


### PR DESCRIPTION
### What does this PR do?

change markdown headers in `agent_dev_env.md` follow markdown linter recommandation: only one H1 in a page.

render: https://github.com/DataDog/datadog-agent/blob/3c2c8695172a573dda7ad1c0d63f0803281fe293/docs/dev/agent_dev_env.md

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
