### PR TITLE
Removed sending API key as params in forwarder

### DIFF
--- a/pkg/forwarder/forwarder.go
+++ b/pkg/forwarder/forwarder.go
@@ -419,11 +419,11 @@ func (f *DefaultForwarder) State() uint32 {
 	return f.internalState.Load()
 }
 
-func (f *DefaultForwarder) createHTTPTransactions(endpoint transaction.Endpoint, payloads transaction.BytesPayloads, apiKeyInQueryString bool, extra http.Header) []*transaction.HTTPTransaction {
-	return f.createAdvancedHTTPTransactions(endpoint, payloads, apiKeyInQueryString, extra, transaction.TransactionPriorityNormal, true)
+func (f *DefaultForwarder) createHTTPTransactions(endpoint transaction.Endpoint, payloads transaction.BytesPayloads, extra http.Header) []*transaction.HTTPTransaction {
+	return f.createAdvancedHTTPTransactions(endpoint, payloads, extra, transaction.TransactionPriorityNormal, true)
 }
 
-func (f *DefaultForwarder) createAdvancedHTTPTransactions(endpoint transaction.Endpoint, payloads transaction.BytesPayloads, apiKeyInQueryString bool, extra http.Header, priority transaction.Priority, storableOnDisk bool) []*transaction.HTTPTransaction {
+func (f *DefaultForwarder) createAdvancedHTTPTransactions(endpoint transaction.Endpoint, payloads transaction.BytesPayloads, extra http.Header, priority transaction.Priority, storableOnDisk bool) []*transaction.HTTPTransaction {
 	transactions := make([]*transaction.HTTPTransaction, 0, len(payloads)*len(f.domainForwarders))
 	allowArbitraryTags := config.Datadog.GetBool("allow_arbitrary_tags")
 
@@ -433,9 +433,6 @@ func (f *DefaultForwarder) createAdvancedHTTPTransactions(endpoint transaction.E
 				t := transaction.NewHTTPTransaction()
 				t.Domain, _ = dr.Resolve(endpoint)
 				t.Endpoint = endpoint
-				if apiKeyInQueryString {
-					t.Endpoint.Route = fmt.Sprintf("%s?api_key=%s", endpoint.Route, apiKey)
-				}
 				t.Payload = payload
 				t.Priority = priority
 				t.StorableOnDisk = storableOnDisk
@@ -513,53 +510,53 @@ func (f *DefaultForwarder) sendHTTPTransactions(transactions []*transaction.HTTP
 
 // SubmitSketchSeries will send payloads to Datadog backend - PROTOTYPE FOR PERCENTILE
 func (f *DefaultForwarder) SubmitSketchSeries(payload transaction.BytesPayloads, extra http.Header) error {
-	transactions := f.createHTTPTransactions(endpoints.SketchSeriesEndpoint, payload, false, extra)
+	transactions := f.createHTTPTransactions(endpoints.SketchSeriesEndpoint, payload, extra)
 	return f.sendHTTPTransactions(transactions)
 }
 
 // SubmitHostMetadata will send a host_metadata tag type payload to Datadog backend.
 func (f *DefaultForwarder) SubmitHostMetadata(payload transaction.BytesPayloads, extra http.Header) error {
 	return f.submitV1IntakeWithTransactionsFactory(payload, extra,
-		func(endpoint transaction.Endpoint, payloads transaction.BytesPayloads, apiKeyInQueryString bool, extra http.Header) []*transaction.HTTPTransaction {
+		func(endpoint transaction.Endpoint, payloads transaction.BytesPayloads, extra http.Header) []*transaction.HTTPTransaction {
 			// Host metadata contains the API KEY and should not be stored on disk.
 			storableOnDisk := false
-			return f.createAdvancedHTTPTransactions(endpoint, payloads, apiKeyInQueryString, extra, transaction.TransactionPriorityHigh, storableOnDisk)
+			return f.createAdvancedHTTPTransactions(endpoint, payloads, extra, transaction.TransactionPriorityHigh, storableOnDisk)
 		})
 }
 
 // SubmitAgentChecksMetadata will send a agentchecks_metadata tag type payload to Datadog backend.
 func (f *DefaultForwarder) SubmitAgentChecksMetadata(payload transaction.BytesPayloads, extra http.Header) error {
 	return f.submitV1IntakeWithTransactionsFactory(payload, extra,
-		func(endpoint transaction.Endpoint, payloads transaction.BytesPayloads, apiKeyInQueryString bool, extra http.Header) []*transaction.HTTPTransaction {
+		func(endpoint transaction.Endpoint, payloads transaction.BytesPayloads, extra http.Header) []*transaction.HTTPTransaction {
 			// Agentchecks metadata contains the API KEY and should not be stored on disk.
 			storableOnDisk := false
-			return f.createAdvancedHTTPTransactions(endpoint, payloads, apiKeyInQueryString, extra, transaction.TransactionPriorityNormal, storableOnDisk)
+			return f.createAdvancedHTTPTransactions(endpoint, payloads, extra, transaction.TransactionPriorityNormal, storableOnDisk)
 		})
 }
 
 // SubmitMetadata will send a metadata type payload to Datadog backend.
 func (f *DefaultForwarder) SubmitMetadata(payload transaction.BytesPayloads, extra http.Header) error {
-	transactions := f.createHTTPTransactions(endpoints.V1MetadataEndpoint, payload, false, extra)
+	transactions := f.createHTTPTransactions(endpoints.V1MetadataEndpoint, payload, extra)
 	return f.sendHTTPTransactions(transactions)
 }
 
 // SubmitV1Series will send timeserie to v1 endpoint (this will be remove once
 // the backend handles v2 endpoints).
 func (f *DefaultForwarder) SubmitV1Series(payloads transaction.BytesPayloads, extra http.Header) error {
-	transactions := f.createHTTPTransactions(endpoints.V1SeriesEndpoint, payloads, true, extra)
+	transactions := f.createHTTPTransactions(endpoints.V1SeriesEndpoint, payloads, extra)
 	return f.sendHTTPTransactions(transactions)
 }
 
 // SubmitSeries will send timeseries to the v2 endpoint
 func (f *DefaultForwarder) SubmitSeries(payloads transaction.BytesPayloads, extra http.Header) error {
-	transactions := f.createHTTPTransactions(endpoints.SeriesEndpoint, payloads, false, extra)
+	transactions := f.createHTTPTransactions(endpoints.SeriesEndpoint, payloads, extra)
 	return f.sendHTTPTransactions(transactions)
 }
 
 // SubmitV1CheckRuns will send service checks to v1 endpoint (this will be removed once
 // the backend handles v2 endpoints).
 func (f *DefaultForwarder) SubmitV1CheckRuns(payload transaction.BytesPayloads, extra http.Header) error {
-	transactions := f.createHTTPTransactions(endpoints.V1CheckRunsEndpoint, payload, true, extra)
+	transactions := f.createHTTPTransactions(endpoints.V1CheckRunsEndpoint, payload, extra)
 	return f.sendHTTPTransactions(transactions)
 }
 
@@ -571,8 +568,8 @@ func (f *DefaultForwarder) SubmitV1Intake(payload transaction.BytesPayloads, ext
 func (f *DefaultForwarder) submitV1IntakeWithTransactionsFactory(
 	payload transaction.BytesPayloads,
 	extra http.Header,
-	createHTTPTransactions func(endpoint transaction.Endpoint, payload transaction.BytesPayloads, apiKeyInQueryString bool, extra http.Header) []*transaction.HTTPTransaction) error {
-	transactions := createHTTPTransactions(endpoints.V1IntakeEndpoint, payload, true, extra)
+	createHTTPTransactions func(endpoint transaction.Endpoint, payload transaction.BytesPayloads, extra http.Header) []*transaction.HTTPTransaction) error {
+	transactions := createHTTPTransactions(endpoints.V1IntakeEndpoint, payload, extra)
 
 	// the intake endpoint requires the Content-Type header to be set
 	for _, t := range transactions {
@@ -636,12 +633,12 @@ func (f *DefaultForwarder) SubmitOrchestratorManifests(payload transaction.Bytes
 
 // SubmitContainerLifecycleEvents sends container lifecycle events
 func (f *DefaultForwarder) SubmitContainerLifecycleEvents(payload transaction.BytesPayloads, extra http.Header) error {
-	transactions := f.createHTTPTransactions(endpoints.ContainerLifecycleEndpoint, payload, false, extra)
+	transactions := f.createHTTPTransactions(endpoints.ContainerLifecycleEndpoint, payload, extra)
 	return f.sendHTTPTransactions(transactions)
 }
 
 func (f *DefaultForwarder) submitProcessLikePayload(ep transaction.Endpoint, payload transaction.BytesPayloads, extra http.Header, retryable bool) (chan Response, error) {
-	transactions := f.createHTTPTransactions(ep, payload, false, extra)
+	transactions := f.createHTTPTransactions(ep, payload, extra)
 	results := make(chan Response, len(transactions))
 	internalResults := make(chan Response, len(transactions))
 	expectedResponses := len(transactions)

--- a/pkg/forwarder/forwarder_test.go
+++ b/pkg/forwarder/forwarder_test.go
@@ -10,7 +10,6 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -141,7 +140,7 @@ func TestCreateHTTPTransactions(t *testing.T) {
 	headers := make(http.Header)
 	headers.Set("HTTP-MAGIC", "foo")
 
-	transactions := forwarder.createHTTPTransactions(endpoint, payloads, false, headers)
+	transactions := forwarder.createHTTPTransactions(endpoint, payloads, headers)
 	require.Len(t, transactions, 4)
 	assert.Equal(t, testVersionDomain, transactions[0].Domain)
 	assert.Equal(t, testVersionDomain, transactions[1].Domain)
@@ -161,13 +160,6 @@ func TestCreateHTTPTransactions(t *testing.T) {
 	assert.Equal(t, p1, transactions[1].Payload.GetContent())
 	assert.Equal(t, p2, transactions[2].Payload.GetContent())
 	assert.Equal(t, p2, transactions[3].Payload.GetContent())
-
-	transactions = forwarder.createHTTPTransactions(endpoint, payloads, true, headers)
-	require.Len(t, transactions, 4)
-	assert.Contains(t, transactions[0].Endpoint.Route, "api_key=api-key-1")
-	assert.Contains(t, transactions[1].Endpoint.Route, "api_key=api-key-2")
-	assert.Contains(t, transactions[2].Endpoint.Route, "api_key=api-key-1")
-	assert.Contains(t, transactions[3].Endpoint.Route, "api_key=api-key-2")
 }
 
 func TestCreateHTTPTransactionsWithMultipleDomains(t *testing.T) {
@@ -178,7 +170,7 @@ func TestCreateHTTPTransactionsWithMultipleDomains(t *testing.T) {
 	headers := make(http.Header)
 	headers.Set("HTTP-MAGIC", "foo")
 
-	transactions := forwarder.createHTTPTransactions(endpoint, payloads, true, headers)
+	transactions := forwarder.createHTTPTransactions(endpoint, payloads, headers)
 	require.Len(t, transactions, 3, "should contain 3 transactions, contains %d", len(transactions))
 
 	var txNormal, txBar []*transaction.HTTPTransaction
@@ -194,14 +186,15 @@ func TestCreateHTTPTransactionsWithMultipleDomains(t *testing.T) {
 	assert.Equal(t, len(txNormal), 2, "Two transactions should target the normal domain")
 	assert.Equal(t, len(txBar), 1, "One transactions should target the normal domain")
 
-	if strings.HasSuffix(txNormal[0].Endpoint.Route, "api-key-1") {
-		assert.Equal(t, txNormal[0].Endpoint.Route, "/api/foo?api_key=api-key-1")
-		assert.Equal(t, txNormal[1].Endpoint.Route, "/api/foo?api_key=api-key-2")
+	if txNormal[0].Headers.Get("DD-Api-Key") == "api-key-1" {
+		assert.Equal(t, txNormal[0].Headers.Get("DD-Api-Key"), "api-key-1")
+		assert.Equal(t, txNormal[1].Headers.Get("DD-Api-Key"), "api-key-2")
 	} else {
-		assert.Equal(t, txNormal[0].Endpoint.Route, "/api/foo?api_key=api-key-2")
-		assert.Equal(t, txNormal[1].Endpoint.Route, "/api/foo?api_key=api-key-1")
+		assert.Equal(t, txNormal[0].Headers.Get("DD-Api-Key"), "api-key-2")
+		assert.Equal(t, txNormal[1].Headers.Get("DD-Api-Key"), "api-key-1")
 	}
-	assert.Equal(t, txBar[0].Endpoint.Route, "/api/foo?api_key=api-key-3")
+
+	assert.Equal(t, txBar[0].Headers.Get("DD-Api-Key"), "api-key-3")
 }
 
 func TestCreateHTTPTransactionsWithDifferentResolvers(t *testing.T) {
@@ -216,7 +209,7 @@ func TestCreateHTTPTransactionsWithDifferentResolvers(t *testing.T) {
 	headers := make(http.Header)
 	headers.Set("HTTP-MAGIC", "foo")
 
-	transactions := forwarder.createHTTPTransactions(endpoint, payloads, true, headers)
+	transactions := forwarder.createHTTPTransactions(endpoint, payloads, headers)
 	require.Len(t, transactions, 4, "should contain 4 transactions, contains %d", len(transactions))
 
 	var txNormal, txBar, txVector []*transaction.HTTPTransaction
@@ -235,15 +228,15 @@ func TestCreateHTTPTransactionsWithDifferentResolvers(t *testing.T) {
 	assert.Equal(t, len(txNormal), 2, "Two transactions should target the normal domain")
 	assert.Equal(t, len(txBar), 1, "One transactions should target the normal domain")
 
-	if strings.HasSuffix(txNormal[0].Endpoint.Route, "api-key-1") {
-		assert.Equal(t, txNormal[0].Endpoint.Route, "/api/foo?api_key=api-key-1")
-		assert.Equal(t, txNormal[1].Endpoint.Route, "/api/foo?api_key=api-key-2")
+	if txNormal[0].Headers.Get("DD-Api-Key") == "api-key-1" {
+		assert.Equal(t, txNormal[0].Headers.Get("DD-Api-Key"), "api-key-1")
+		assert.Equal(t, txNormal[1].Headers.Get("DD-Api-Key"), "api-key-2")
 	} else {
-		assert.Equal(t, txNormal[0].Endpoint.Route, "/api/foo?api_key=api-key-2")
-		assert.Equal(t, txNormal[1].Endpoint.Route, "/api/foo?api_key=api-key-1")
+		assert.Equal(t, txNormal[0].Headers.Get("DD-Api-Key"), "api-key-2")
+		assert.Equal(t, txNormal[1].Headers.Get("DD-Api-Key"), "api-key-1")
 	}
-	assert.Equal(t, txBar[0].Endpoint.Route, "/api/foo?api_key=api-key-3")
-	assert.Equal(t, txVector[0].Endpoint.Route, "/api/foo?api_key=api-key-4")
+	assert.Equal(t, txBar[0].Headers.Get("DD-Api-Key"), "api-key-3")
+	assert.Equal(t, txVector[0].Headers.Get("DD-Api-Key"), "api-key-4")
 }
 
 func TestCreateHTTPTransactionsWithOverrides(t *testing.T) {
@@ -259,17 +252,17 @@ func TestCreateHTTPTransactionsWithOverrides(t *testing.T) {
 	headers := make(http.Header)
 	headers.Set("HTTP-MAGIC", "foo")
 
-	transactions := forwarder.createHTTPTransactions(endpoint, payloads, true, headers)
+	transactions := forwarder.createHTTPTransactions(endpoint, payloads, headers)
 	require.Len(t, transactions, 1, "should contain 1 transaction, contains %d", len(transactions))
 
-	assert.Equal(t, transactions[0].Endpoint.Route, "/api/foo?api_key=api-key-1")
+	assert.Equal(t, transactions[0].Endpoint.Route, "/api/foo")
 	assert.Equal(t, transactions[0].Domain, testVersionDomain)
 
 	endpoint.Name = "diverted"
-	transactions = forwarder.createHTTPTransactions(endpoint, payloads, true, headers)
+	transactions = forwarder.createHTTPTransactions(endpoint, payloads, headers)
 	require.Len(t, transactions, 1, "should contain 1 transaction, contains %d", len(transactions))
 
-	assert.Equal(t, transactions[0].Endpoint.Route, "/api/foo?api_key=api-key-1")
+	assert.Equal(t, transactions[0].Endpoint.Route, "/api/foo")
 	assert.Equal(t, transactions[0].Domain, "vector.tld")
 }
 
@@ -283,7 +276,7 @@ func TestArbitraryTagsHTTPHeader(t *testing.T) {
 	payload := []byte("A payload")
 	headers := make(http.Header)
 
-	transactions := forwarder.createHTTPTransactions(endpoint, transaction.NewBytesPayloadsWithoutMetaData([]*[]byte{&payload}), false, headers)
+	transactions := forwarder.createHTTPTransactions(endpoint, transaction.NewBytesPayloadsWithoutMetaData([]*[]byte{&payload}), headers)
 	require.True(t, len(transactions) > 0)
 	assert.Equal(t, "true", transactions[0].Headers.Get(arbitraryTagHTTPHeaderKey))
 }
@@ -294,7 +287,7 @@ func TestSendHTTPTransactions(t *testing.T) {
 	p1 := []byte("A payload")
 	payloads := transaction.NewBytesPayloadsWithoutMetaData([]*[]byte{&p1})
 	headers := make(http.Header)
-	tr := forwarder.createHTTPTransactions(endpoint, payloads, false, headers)
+	tr := forwarder.createHTTPTransactions(endpoint, payloads, headers)
 
 	// fw is stopped, we should get an error
 	err := forwarder.sendHTTPTransactions(tr)
@@ -424,7 +417,7 @@ func TestTransactionEventHandlers(t *testing.T) {
 	headers := http.Header{}
 	headers.Set("key", "value")
 
-	transactions := f.createHTTPTransactions(endpoints.SeriesEndpoint, payload, false, headers)
+	transactions := f.createHTTPTransactions(endpoints.SeriesEndpoint, payload, headers)
 	require.Len(t, transactions, 1)
 
 	attempts := atomic.NewInt64(0)
@@ -482,7 +475,7 @@ func TestTransactionEventHandlersOnRetry(t *testing.T) {
 	headers := http.Header{}
 	headers.Set("key", "value")
 
-	transactions := f.createHTTPTransactions(endpoints.SeriesEndpoint, payload, false, headers)
+	transactions := f.createHTTPTransactions(endpoints.SeriesEndpoint, payload, headers)
 	require.Len(t, transactions, 1)
 
 	attempts := atomic.NewInt64(0)
@@ -536,7 +529,7 @@ func TestTransactionEventHandlersNotRetryable(t *testing.T) {
 	headers := http.Header{}
 	headers.Set("key", "value")
 
-	transactions := f.createHTTPTransactions(endpoints.SeriesEndpoint, payload, false, headers)
+	transactions := f.createHTTPTransactions(endpoints.SeriesEndpoint, payload, headers)
 	require.Len(t, transactions, 1)
 
 	attempts := atomic.NewInt64(0)
@@ -595,7 +588,7 @@ func TestProcessLikePayloadResponseTimeout(t *testing.T) {
 	headers := http.Header{}
 	headers.Set("key", "value")
 
-	transactions := f.createHTTPTransactions(endpoints.SeriesEndpoint, payload, false, headers)
+	transactions := f.createHTTPTransactions(endpoints.SeriesEndpoint, payload, headers)
 	require.Len(t, transactions, 1)
 
 	responses, err := f.submitProcessLikePayload(endpoints.SeriesEndpoint, payload, headers, true)

--- a/pkg/forwarder/sync_forwarder.go
+++ b/pkg/forwarder/sync_forwarder.go
@@ -64,19 +64,19 @@ func (f *SyncForwarder) sendHTTPTransactions(transactions []*transaction.HTTPTra
 // SubmitV1Series will send timeserie to v1 endpoint (this will be remove once
 // the backend handles v2 endpoints).
 func (f *SyncForwarder) SubmitV1Series(payload transaction.BytesPayloads, extra http.Header) error {
-	transactions := f.defaultForwarder.createHTTPTransactions(endpoints.V1SeriesEndpoint, payload, true, extra)
+	transactions := f.defaultForwarder.createHTTPTransactions(endpoints.V1SeriesEndpoint, payload, extra)
 	return f.sendHTTPTransactions(transactions)
 }
 
 // SubmitSeries will send timeseries to the v2 endpoint
 func (f *SyncForwarder) SubmitSeries(payload transaction.BytesPayloads, extra http.Header) error {
-	transactions := f.defaultForwarder.createHTTPTransactions(endpoints.SeriesEndpoint, payload, true, extra)
+	transactions := f.defaultForwarder.createHTTPTransactions(endpoints.SeriesEndpoint, payload, extra)
 	return f.sendHTTPTransactions(transactions)
 }
 
 // SubmitV1Intake will send payloads to the universal `/intake/` endpoint used by Agent v.5
 func (f *SyncForwarder) SubmitV1Intake(payload transaction.BytesPayloads, extra http.Header) error {
-	transactions := f.defaultForwarder.createHTTPTransactions(endpoints.V1IntakeEndpoint, payload, true, extra)
+	transactions := f.defaultForwarder.createHTTPTransactions(endpoints.V1IntakeEndpoint, payload, extra)
 	// the intake endpoint requires the Content-Type header to be set
 	for _, t := range transactions {
 		t.Headers.Set("Content-Type", "application/json")
@@ -87,13 +87,13 @@ func (f *SyncForwarder) SubmitV1Intake(payload transaction.BytesPayloads, extra 
 // SubmitV1CheckRuns will send service checks to v1 endpoint (this will be removed once
 // the backend handles v2 endpoints).
 func (f *SyncForwarder) SubmitV1CheckRuns(payload transaction.BytesPayloads, extra http.Header) error {
-	transactions := f.defaultForwarder.createHTTPTransactions(endpoints.V1CheckRunsEndpoint, payload, true, extra)
+	transactions := f.defaultForwarder.createHTTPTransactions(endpoints.V1CheckRunsEndpoint, payload, extra)
 	return f.sendHTTPTransactions(transactions)
 }
 
 // SubmitSketchSeries will send payloads to Datadog backend - PROTOTYPE FOR PERCENTILE
 func (f *SyncForwarder) SubmitSketchSeries(payload transaction.BytesPayloads, extra http.Header) error {
-	transactions := f.defaultForwarder.createHTTPTransactions(endpoints.SketchSeriesEndpoint, payload, true, extra)
+	transactions := f.defaultForwarder.createHTTPTransactions(endpoints.SketchSeriesEndpoint, payload, extra)
 	return f.sendHTTPTransactions(transactions)
 }
 

--- a/pkg/forwarder/transaction/transaction.go
+++ b/pkg/forwarder/transaction/transaction.go
@@ -300,7 +300,7 @@ func (t *HTTPTransaction) internalProcess(ctx context.Context, client *http.Clie
 	transactionEndpointName := t.GetEndpointName()
 	logURL := scrubber.ScrubLine(url) // sanitized url that can be logged
 
-	req, err := http.NewRequest("POST", url, reader)
+	req, err := http.NewRequestWithContext(ctx, "POST", url, reader)
 	if err != nil {
 		log.Errorf("Could not create request for transaction to invalid URL %q (dropping transaction): %s", logURL, err)
 		transactionsErrors.Add(1)
@@ -308,7 +308,6 @@ func (t *HTTPTransaction) internalProcess(ctx context.Context, client *http.Clie
 		transactionsSentRequestErrors.Add(1)
 		return 0, nil, nil
 	}
-	req = req.WithContext(ctx)
 	req.Header = t.Headers
 	resp, err := client.Do(req)
 

--- a/releasenotes/notes/remove-sending-API-keys-as-params-1cec05cf38b99b71.yaml
+++ b/releasenotes/notes/remove-sending-API-keys-as-params-1cec05cf38b99b71.yaml
@@ -1,0 +1,8 @@
+---
+security:
+  - |
+    Some HTTP requests sent by the Datadog Agent to Datadog endpoints were including the Datadog API key in the query parameters (in the URL).
+    This meant that the keys could potentially have been logged in various locations, for example, in a forward or a reverse proxy server logs the Agent connected to.
+    We have updated all requests to not send the API key as a query parameter.
+    Anyone who uses a proxy to connect the Agent to Datadog endpoints should make sure their proxy forwards all Datadog headers (patricularly ``DD-Api-Key``).
+    Failure to not send all Datadog headers could cause payloads to be rejected by our endpoints.


### PR DESCRIPTION
### What does this PR do?

This PR stops the Agent from sending the DD API key as a query parameter when making requests to our endpoints.

### Motivation

This was done to stop potential leaks of the DD API key when the Agent is used with a forward or reverse proxy.

### Additional Notes

Anyone using a proxy needs to make sure that all Datadog headers are correctly forwarded to our endpoints. Failure to do so could cause payloads to be rejected.

### Possible Drawbacks / Trade-offs

Badly configured proxies might see payloads being rejected.

### Describe how to test/QA your changes

AML
- Deploy the Agent and check:
  - Metadata appears correctly
  - Host metrics all appear as expected
  - Custom metrics sent via DogStatsD still appear in DD
  - Check custom checks have been submitted correctly
- Deploy the Agent with `use_v2_api.series` set to `false`
  - Metadata appears correctly
  - Host metrics all appear as expected
  - Custom metrics sent via DogStatsD still appear in DD
  - Check custom checks have been submitted correctly

ASC
- Setup a proxy and verify that Agent requests are accepted by the backend (via Agent logs and in the app)

Serverless
- Deploy the Agent and check:
  - Metadata appears correctly
  - Host metrics all appear as expected
  - Custom metrics sent via DogStatsD still appear in DD
  - Check custom checks have been submitted correctly

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
