### PR TITLE
Adding return statment in GUI when an error is encountered

### DIFF
--- a/cmd/agent/gui/agent.go
+++ b/cmd/agent/gui/agent.go
@@ -132,6 +132,7 @@ func makeFlare(w http.ResponseWriter, r *http.Request) {
 	payload, e := parseBody(r)
 	if e != nil {
 		w.Write([]byte(e.Error()))
+		return
 	} else if payload.Email == "" || payload.CaseID == "" {
 		w.Write([]byte("Error creating flare: missing information"))
 		return
@@ -191,6 +192,7 @@ func getConfigSetting(w http.ResponseWriter, r *http.Request) {
 	}[setting]; !ok {
 		w.WriteHeader(http.StatusForbidden)
 		fmt.Fprintf(w, `"error": "requested setting is not whitelisted"`)
+		return
 	}
 	if err := json.NewEncoder(w).Encode(map[string]interface{}{
 		setting: config.Datadog.Get(setting),
@@ -218,6 +220,7 @@ func setConfigFile(w http.ResponseWriter, r *http.Request) {
 	payload, e := parseBody(r)
 	if e != nil {
 		w.Write([]byte(e.Error()))
+		return
 	}
 	data := []byte(payload.Config)
 

--- a/cmd/agent/gui/agent_test.go
+++ b/cmd/agent/gui/agent_test.go
@@ -1,0 +1,104 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
+package gui
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_makeFlare(t *testing.T) {
+	tests := []struct {
+		name         string
+		payload      string
+		expectedBody string
+	}{
+		{
+			name:         "Bad payload",
+			payload:      "a\n",
+			expectedBody: "invalid character 'a' looking for beginning of value",
+		},
+		{
+			name:         "Missing email",
+			payload:      "{\"caseID\": \"102123123\"}",
+			expectedBody: "Error creating flare: missing information",
+		},
+		{
+			name:         "Missing caseID",
+			payload:      "{\"email\": \"test@example.com\"}",
+			expectedBody: "Error creating flare: missing information",
+		},
+		{
+			name:         "Invalid caseID",
+			payload:      "{\"email\": \"test@example.com\", \"caseID\": \"102123123a\"}",
+			expectedBody: "Invalid CaseID (must be a number)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := http.NewRequest("POST", "/flare", strings.NewReader(tt.payload))
+			require.NoError(t, err)
+
+			rr := httptest.NewRecorder()
+
+			router := mux.NewRouter()
+			agentHandler(router)
+			router.ServeHTTP(rr, req)
+
+			resp := rr.Result()
+			defer resp.Body.Close()
+			body, _ := io.ReadAll(resp.Body)
+			assert.Equal(t, string(body), tt.expectedBody)
+		})
+	}
+}
+
+func Test_getConfigSetting(t *testing.T) {
+	tests := []struct {
+		name          string
+		configSetting string
+		expectedBody  string
+	}{
+		{
+			name:          "Allowed setting",
+			configSetting: "apm_config.receiver_port",
+			expectedBody:  "{\"apm_config.receiver_port\":8126}\n",
+		},
+		{
+			name:          "Not allowed setting",
+			configSetting: "api_key",
+			expectedBody:  "\"error\": \"requested setting is not whitelisted\"",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := fmt.Sprintf("/getConfig/%s", tt.configSetting)
+			req, err := http.NewRequest("GET", path, nil)
+			require.NoError(t, err)
+
+			rr := httptest.NewRecorder()
+
+			router := mux.NewRouter()
+			agentHandler(router)
+			router.ServeHTTP(rr, req)
+
+			resp := rr.Result()
+			defer resp.Body.Close()
+			body, _ := io.ReadAll(resp.Body)
+			assert.Equal(t, string(body), tt.expectedBody)
+		})
+	}
+}


### PR DESCRIPTION
### What does this PR do?

This is a small fix to make sure that only allowed settings items can be retrieved using the Agent GUI server. Also fixes the creation of flares with invalid configs.

### Motivation

Stop potential miss-use of the Agent GUI server. Previously you could get things like the `api_key` through `/agent/getConfig` endpoint. Example, previously:

```
$ curl -kis -H "Authorization: Bearer replace_me_with_cookie_authtoken" http://127.0.0.1:5002/agent/getConfig/api_key
HTTP/1.1 403 Forbidden
Content-Type: application/json
Date: Wed, 28 Sep 2022 16:07:52 GMT
Content-Length: 94

"error": "requested setting is not whitelisted"{"api_key":"953xxxxxxxxxxxxx"}
```

But now:

```
$ curl -kis -H "Authorization: Bearer replace_me_with_cookie_authtoken" http://127.0.0.1:5002/agent/getConfig/api_key
HTTP/1.1 403 Forbidden
Content-Type: application/json
Date: Wed, 28 Sep 2022 16:07:52 GMT
Content-Length: 94

"error": "requested setting is not whitelisted"
```

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Run the GUI and try:

```
curl -kis -H "Authorization: Bearer replace_me_with_cookie_authtoken" http://127.0.0.1:5002/agent/getConfig/api_key
```

The response back should just be `"error": "requested setting is not whitelisted"`.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
