### PR TITLE
Replacing TODOs in exposed comments with more meaningful comments

### DIFF
--- a/pkg/collector/corechecks/embed/jmx/check.go
+++ b/pkg/collector/corechecks/embed/jmx/check.go
@@ -18,7 +18,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-// JMXCheck TODO <agent-core> : IML-199
+// JMXCheck represents a JMXFetch check
 type JMXCheck struct {
 	id             check.ID
 	name           string
@@ -45,7 +45,7 @@ func newJMXCheck(config integration.Config, source string) *JMXCheck {
 	return check
 }
 
-// Run TODO <agent-core> : IML-199
+// Run schedules this JMXCheck to run
 func (c *JMXCheck) Run() error {
 	err := state.scheduleCheck(c)
 	if err != nil {
@@ -62,68 +62,69 @@ func (c *JMXCheck) Run() error {
 	return nil
 }
 
-// Stop TODO <agent-core> : IML-199
+// Stop forces the JMXCheck to stop and will unschedule it
 func (c *JMXCheck) Stop() {
 	close(c.stop)
 	state.unscheduleCheck(c)
 }
 
-// Cancel TODO <agent-core> : IML-199
+// Cancel is a noop
 func (c *JMXCheck) Cancel() {}
 
-// String TODO <agent-core> : IML-199
+// String provides a printable version of the JMXCheck
 func (c *JMXCheck) String() string {
 	return c.name
 }
 
-// Version TODO <agent-core> : IML-199
+// Version returns the version of the JMXCheck
+// (note, returns an empty string)
 func (c *JMXCheck) Version() string {
 	return ""
 }
 
-// ConfigSource TODO <agent-core> : IML-199
+// ConfigSource returns the source of the configuration of the JMXCheck
 func (c *JMXCheck) ConfigSource() string {
 	return c.source
 }
 
-// InitConfig TODO <agent-core> : IML-199
+// InitConfig returns the init_config in YAML or JSON of the JMXCheck
 func (c *JMXCheck) InitConfig() string {
 	return c.initConfig
 }
 
-// InstanceConfig TODO <agent-core> : IML-199
+// InstanceConfig returns the metric config in YAML or JSON of the JMXCheck
 func (c *JMXCheck) InstanceConfig() string {
 	return c.instanceConfig
 }
 
-// Configure TODO <agent-core> : IML-199
+// Configure configures this JMXCheck, setting InitConfig and InstanceConfig
 func (c *JMXCheck) Configure(integrationConfigDigest uint64, config integration.Data, initConfig integration.Data, source string) error {
 	c.initConfig = string(config)
 	c.instanceConfig = string(initConfig)
 	return nil
 }
 
-// Interval TODO <agent-core> : IML-199
+// Interval returns the scheduling time for the check (0 for JMXCheck)
 func (c *JMXCheck) Interval() time.Duration {
 	return 0
 }
 
-// ID TODO <agent-core> : IML-199
+// ID provides a unique identifier for this JMXCheck instance
 func (c *JMXCheck) ID() check.ID {
 	return c.id
 }
 
-// IsTelemetryEnabled TODO <agent-core> : IML-199
+// IsTelemetryEnabled returns if telemetry is enabled for this JMXCheck
 func (c *JMXCheck) IsTelemetryEnabled() bool {
 	return c.telemetry
 }
 
-// GetWarnings TODO <agent-core> : IML-199
+// GetWarnings returns the last warning registered by this JMXCheck (currently an empty slice)
 func (c *JMXCheck) GetWarnings() []error {
 	return []error{}
 }
 
-// GetSenderStats TODO <agent-core> : IML-199
+// GetSenderStats returns the stats from the last run of this JMXCheck
 func (c *JMXCheck) GetSenderStats() (check.SenderStats, error) {
 	return check.NewSenderStats(), nil
 }

--- a/pkg/jmxfetch/jmxfetch.go
+++ b/pkg/jmxfetch/jmxfetch.go
@@ -108,7 +108,7 @@ type checkInitCfg struct {
 	JavaOptions    string   `yaml:"java_options,omitempty"`
 }
 
-// Monitor TODO <agent-core> : IML-199
+// Monitor monitors this JMXFetch instance, waiting for JMX to stop. Gracefully handles restarting the JMXFetch process.
 func (j *JMXFetch) Monitor() {
 	limiter := newRestartLimiter(config.Datadog.GetInt("jmx_max_restarts"), float64(config.Datadog.GetInt("jmx_restart_interval")))
 	ticker := time.NewTicker(500 * time.Millisecond)

--- a/pkg/serializer/internal/stream/compressor.go
+++ b/pkg/serializer/internal/stream/compressor.go
@@ -76,7 +76,7 @@ type Compressor struct {
 	separator           []byte
 }
 
-// NewCompressor TODO <agent-core> : IML-199
+// NewCompressor returns a new instance of a Compressor
 func NewCompressor(input, output *bytes.Buffer, maxPayloadSize, maxUncompressedSize int, header, footer []byte, separator []byte) (*Compressor, error) {
 	c := &Compressor{
 		header:              header,
@@ -170,7 +170,7 @@ func (c *Compressor) AddItem(data []byte) error {
 	return nil
 }
 
-// Close TODO <agent-core> : IML-199
+// Close closes the Compressor, flushing any remaining uncompressed data
 func (c *Compressor) Close() ([]byte, error) {
 	// Flush remaining uncompressed data
 	if c.input.Len() > 0 {

--- a/pkg/serializer/internal/stream/json_payload_builder.go
+++ b/pkg/serializer/internal/stream/json_payload_builder.go
@@ -70,7 +70,7 @@ type JSONPayloadBuilder struct {
 	mu                            sync.Mutex
 }
 
-// NewJSONPayloadBuilder TODO <agent-core> : IML-199
+// NewJSONPayloadBuilder returns a new JSONPayloadBuilder
 func NewJSONPayloadBuilder(shareAndLockBuffers bool) *JSONPayloadBuilder {
 	if shareAndLockBuffers {
 		return &JSONPayloadBuilder{


### PR DESCRIPTION

### What does this PR do?

Adding more meaningful comments to Agent Metrics Logs components which just had ` TODO <agent-core> : IML-199`.

### Motivation

Removes the `TODO` with a more useful comment.

### Possible Drawbacks / Trade-offs

None.

### Describe how to test/QA your changes

Nothing to QA.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
