### PR TITLE
[fake-datadog] add docker compose

### DIFF
--- a/test/e2e/containers/fake_datadog/README.md
+++ b/test/e2e/containers/fake_datadog/README.md
@@ -178,6 +178,7 @@ db.series.aggregate([
 
 This tool can be used as a debug proxy to inspect agent payloads. Here is how to do it for Kubernetes.
 
+##### K8S
 - run the following from within this folder:
 
 ```console
@@ -197,4 +198,43 @@ kubectl apply -f fake-datadog.yaml
     - name: DD_DD_URL
       # if you deployed the service & deployment in a separate namespace, add `.<NAMESPACE>.svc.cluster.local
       value: "http://fake-datadog"
+```
+
+##### Docker
+
+1. Create a `agent-docker-compose-extra.yaml` file to override url and V2 series environment variables
+
+```yaml
+services:
+  agent: # use your agent service name here
+    environment:
+      DD_DD_URL: "http://fake-datadog"
+      DD_USE_V2_API_SERIES: false
+```
+
+- `agent` is the docker service name used for Datadog Agent. Rename it if you are using another service id.
+- `DD_DD_URL` overrides the URL for metric submission
+- `DD_USE_V2_API_SERIES` force using v1 APIs
+
+1. Run `docker compose up` passing datadog agent compose, agent extra compose and fake datadog compose
+
+```bash
+docker compose up -f "${PATH_TO_AGENT_COMPOSE}.yaml" -f "fake-datadog.yaml" -f "agent-docker-compose-extra.yaml"
+```
+
+1. Query `datadog` on `mongo` service, reachable from host at `localhost:27017` and from another container at `mongo:27017`
+
+##### VM
+
+1. Create `fake-datadog` compose
+
+```bash
+docker compose up -f "fake-datadog.yaml"
+```
+
+1. Configure the agent to send requests to `fake-datadog` using `V1` endpoint passing following environment variables
+
+```txt
+DD_DD_URL="http://fake-datadog"
+DD_USE_V2_API_SERIES=false
 ```

--- a/test/e2e/containers/fake_datadog/docker-compose.yaml
+++ b/test/e2e/containers/fake_datadog/docker-compose.yaml
@@ -1,0 +1,13 @@
+version: "3.9"
+services:
+  fake-datadog:
+    image: "datadog/fake-datadog:20220621"
+    ports:
+      - "8080:80"
+      - "27017:27017"
+    container_name: fake-datadog
+  mongo:
+    image: "mongo:5.0"
+    container_name: mongo
+    network_mode: "service:fake-datadog"
+


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Add `docker-compose.yaml` to deploy `fake-datadog` and its friend `mongodb` to run `fake-datadog` on docker.

This will be notably used by e2e test in VM and docker environments 

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Adding support for testing agent e2e without the complexity and dependency on real Datadog backend

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
