### PR TITLE
[CWS Agent] flags package to organize security agent subcommand flags

### DIFF
--- a/cmd/security-agent/app/app.go
+++ b/cmd/security-agent/app/app.go
@@ -21,8 +21,6 @@ import (
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 
-	ddgostatsd "github.com/DataDog/datadog-go/v5/statsd"
-
 	commonagent "github.com/DataDog/datadog-agent/cmd/agent/common"
 	"github.com/DataDog/datadog-agent/cmd/manager"
 	"github.com/DataDog/datadog-agent/cmd/security-agent/api"
@@ -33,6 +31,7 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/security-agent/app/subcommands/runtime"
 	"github.com/DataDog/datadog-agent/cmd/security-agent/app/subcommands/status"
 	subversion "github.com/DataDog/datadog-agent/cmd/security-agent/app/subcommands/version"
+	"github.com/DataDog/datadog-agent/cmd/security-agent/flags"
 	compconfig "github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/config/resolver"
@@ -50,6 +49,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/startstop"
 	"github.com/DataDog/datadog-agent/pkg/version"
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
+	ddgostatsd "github.com/DataDog/datadog-go/v5/statsd"
 
 	coreconfig "github.com/DataDog/datadog-agent/pkg/config"
 )
@@ -81,7 +81,7 @@ Datadog Security Agent takes care of running compliance and security checks.`,
 			}
 
 			// TODO(paulcacheux): remove this once all subcommands have been converted to use config component
-			_, err := compconfig.MergeConfigurationFiles("datadog", globalParams.ConfPathArray, cmd.Flags().Lookup("cfgpath").Changed)
+			_, err := compconfig.MergeConfigurationFiles("datadog", globalParams.ConfPathArray, cmd.Flags().Lookup(flags.CfgPath).Changed)
 			return err
 		},
 		PersistentPostRun: func(cmd *cobra.Command, args []string) {
@@ -93,8 +93,8 @@ Datadog Security Agent takes care of running compliance and security checks.`,
 		path.Join(commonagent.DefaultConfPath, "datadog.yaml"),
 		path.Join(commonagent.DefaultConfPath, "security-agent.yaml"),
 	}
-	SecurityAgentCmd.PersistentFlags().StringArrayVarP(&globalParams.ConfPathArray, "cfgpath", "c", defaultConfPathArray, "path to a yaml configuration file")
-	SecurityAgentCmd.PersistentFlags().BoolVarP(&flagNoColor, "no-color", "n", false, "disable color output")
+	SecurityAgentCmd.PersistentFlags().StringArrayVarP(&globalParams.ConfPathArray, flags.CfgPath, "c", defaultConfPathArray, "path to a yaml configuration file")
+	SecurityAgentCmd.PersistentFlags().BoolVarP(&flagNoColor, flags.NoColor, "n", false, "disable color output")
 
 	factories := []common.SubcommandFactory{
 		status.Commands,

--- a/cmd/security-agent/app/start.go
+++ b/cmd/security-agent/app/start.go
@@ -8,14 +8,15 @@ package app
 import (
 	"context"
 	"errors"
+	"github.com/spf13/cobra"
 	"os"
 	"os/signal"
 	"syscall"
 
 	"github.com/DataDog/datadog-agent/cmd/security-agent/app/common"
+	"github.com/DataDog/datadog-agent/cmd/security-agent/flags"
 	"github.com/DataDog/datadog-agent/pkg/tagger"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"github.com/spf13/cobra"
 )
 
 type startCliParams struct {
@@ -38,7 +39,7 @@ func StartCommands(globalParams *common.GlobalParams) []*cobra.Command {
 		},
 	}
 
-	startCmd.Flags().StringVarP(&cliParams.pidfilePath, "pidfile", "p", "", "path to the pidfile")
+	startCmd.Flags().StringVarP(&cliParams.pidfilePath, flags.PidFile, "p", "", "path to the pidfile")
 
 	return []*cobra.Command{startCmd}
 }

--- a/cmd/security-agent/app/subcommands/check/command.go
+++ b/cmd/security-agent/app/subcommands/check/command.go
@@ -11,6 +11,7 @@ package check
 import (
 	"context"
 	"errors"
+	"github.com/DataDog/datadog-agent/cmd/security-agent/flags"
 	"os"
 	"time"
 
@@ -73,14 +74,14 @@ func Commands(bundleParams core.BundleParams) []*cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&checkArgs.framework, "framework", "", "", "Framework to run the checks from")
-	cmd.Flags().StringVarP(&checkArgs.file, "file", "f", "", "Compliance suite file to read rules from")
-	cmd.Flags().BoolVarP(&checkArgs.verbose, "verbose", "v", false, "Include verbose details")
-	cmd.Flags().BoolVarP(&checkArgs.report, "report", "r", false, "Send report")
-	cmd.Flags().StringVarP(&checkArgs.overrideRegoInput, "override-rego-input", "", "", "Rego input to use when running rego checks")
-	cmd.Flags().StringVarP(&checkArgs.dumpRegoInput, "dump-rego-input", "", "", "Path to file where to dump the Rego input JSON")
-	cmd.Flags().StringVarP(&checkArgs.dumpReports, "dump-reports", "", "", "Path to file where to dump reports")
-	cmd.Flags().BoolVarP(&checkArgs.skipRegoEval, "skip-rego-eval", "", false, "Skip rego evaluation")
+	cmd.Flags().StringVarP(&checkArgs.framework, flags.Framework, "", "", "Framework to run the checks from")
+	cmd.Flags().StringVarP(&checkArgs.file, flags.File, "f", "", "Compliance suite file to read rules from")
+	cmd.Flags().BoolVarP(&checkArgs.verbose, flags.Verbose, "v", false, "Include verbose details")
+	cmd.Flags().BoolVarP(&checkArgs.report, flags.Report, "r", false, "Send report")
+	cmd.Flags().StringVarP(&checkArgs.overrideRegoInput, flags.OverrideRegoInput, "", "", "Rego input to use when running rego checks")
+	cmd.Flags().StringVarP(&checkArgs.dumpRegoInput, flags.DumpRegoInput, "", "", "Path to file where to dump the Rego input JSON")
+	cmd.Flags().StringVarP(&checkArgs.dumpReports, flags.DumpReports, "", "", "Path to file where to dump reports")
+	cmd.Flags().BoolVarP(&checkArgs.skipRegoEval, flags.SkipRegoEval, "", false, "Skip rego evaluation")
 
 	return []*cobra.Command{cmd}
 }

--- a/cmd/security-agent/app/subcommands/compliance/command.go
+++ b/cmd/security-agent/app/subcommands/compliance/command.go
@@ -7,6 +7,7 @@ package compliance
 
 import (
 	"fmt"
+	"github.com/DataDog/datadog-agent/cmd/security-agent/flags"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -66,13 +67,13 @@ func complianceEventCommand(globalParams *common.GlobalParams) *cobra.Command {
 		Hidden: true,
 	}
 
-	eventCmd.Flags().StringVarP(&eventArgs.sourceType, "source-type", "", "compliance", "Log source name")
-	eventCmd.Flags().StringVarP(&eventArgs.sourceName, "source-name", "", "compliance-agent", "Log source name")
-	eventCmd.Flags().StringVarP(&eventArgs.event.AgentRuleID, "rule-id", "", "", "Rule ID")
-	eventCmd.Flags().StringVarP(&eventArgs.event.ResourceID, "resource-id", "", "", "Resource ID")
-	eventCmd.Flags().StringVarP(&eventArgs.event.ResourceType, "resource-type", "", "", "Resource type")
-	eventCmd.Flags().StringSliceVarP(&eventArgs.event.Tags, "tags", "t", []string{"security:compliance"}, "Tags")
-	eventCmd.Flags().StringSliceVarP(&eventArgs.data, "data", "d", []string{}, "Data KV fields")
+	eventCmd.Flags().StringVarP(&eventArgs.sourceType, flags.SourceType, "", "compliance", "Log source name")
+	eventCmd.Flags().StringVarP(&eventArgs.sourceName, flags.SourceName, "", "compliance-agent", "Log source name")
+	eventCmd.Flags().StringVarP(&eventArgs.event.AgentRuleID, flags.RuleID, "", "", "Rule ID")
+	eventCmd.Flags().StringVarP(&eventArgs.event.ResourceID, flags.ResourceID, "", "", "Resource ID")
+	eventCmd.Flags().StringVarP(&eventArgs.event.ResourceType, flags.ResourceType, "", "", "Resource type")
+	eventCmd.Flags().StringSliceVarP(&eventArgs.event.Tags, flags.Tags, "t", []string{"security:compliance"}, "Tags")
+	eventCmd.Flags().StringSliceVarP(&eventArgs.data, flags.Data, "d", []string{}, "Data KV fields")
 
 	return eventCmd
 }

--- a/cmd/security-agent/app/subcommands/flare/command.go
+++ b/cmd/security-agent/app/subcommands/flare/command.go
@@ -8,6 +8,7 @@ package flare
 import (
 	"bytes"
 	"fmt"
+	"github.com/DataDog/datadog-agent/cmd/security-agent/flags"
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
@@ -56,8 +57,8 @@ func Commands(globalParams *common.GlobalParams) []*cobra.Command {
 		},
 	}
 
-	flareCmd.Flags().StringVarP(&cliParams.customerEmail, "email", "e", "", "Your email")
-	flareCmd.Flags().BoolVarP(&cliParams.autoconfirm, "send", "s", false, "Automatically send flare (don't prompt for confirmation)")
+	flareCmd.Flags().StringVarP(&cliParams.customerEmail, flags.Email, "e", "", "Your email")
+	flareCmd.Flags().BoolVarP(&cliParams.autoconfirm, flags.Send, "s", false, "Automatically send flare (don't prompt for confirmation)")
 	flareCmd.SetArgs([]string{"caseID"})
 
 	return []*cobra.Command{flareCmd}

--- a/cmd/security-agent/app/subcommands/runtime/activity_dump.go
+++ b/cmd/security-agent/app/subcommands/runtime/activity_dump.go
@@ -10,6 +10,7 @@ package runtime
 
 import (
 	"fmt"
+	"github.com/DataDog/datadog-agent/cmd/security-agent/flags"
 
 	"github.com/DataDog/datadog-agent/cmd/security-agent/app/common"
 	"github.com/DataDog/datadog-agent/comp/core"
@@ -93,19 +94,19 @@ func stopCommands(globalParams *common.GlobalParams) []*cobra.Command {
 
 	activityDumpStopCmd.Flags().StringVar(
 		&cliParams.name,
-		"name",
+		flags.Name,
 		"",
 		"an activity dump name can be used to filter the activity dump.",
 	)
 	activityDumpStopCmd.Flags().StringVar(
 		&cliParams.containerID,
-		"containerID",
+		flags.ContainerID,
 		"",
 		"an containerID can be used to filter the activity dump.",
 	)
 	activityDumpStopCmd.Flags().StringVar(
 		&cliParams.comm,
-		"comm",
+		flags.Comm,
 		"",
 		"a process command can be used to filter the activity dump from a specific process.",
 	)
@@ -146,49 +147,49 @@ func generateDumpCommands(globalParams *common.GlobalParams) []*cobra.Command {
 
 	activityDumpGenerateDumpCmd.Flags().StringVar(
 		&cliParams.comm,
-		"comm",
+		flags.Comm,
 		"",
 		"a process command can be used to filter the activity dump from a specific process.",
 	)
 	activityDumpGenerateDumpCmd.Flags().IntVar(
 		&cliParams.timeout,
-		"timeout",
+		flags.Timeout,
 		60,
 		"timeout for the activity dump in minutes",
 	)
 	activityDumpGenerateDumpCmd.Flags().BoolVar(
 		&cliParams.differentiateArgs,
-		"differentiate-args",
+		flags.DifferentiateArgs,
 		true,
 		"add the arguments in the process node merge algorithm",
 	)
 	activityDumpGenerateDumpCmd.Flags().StringVar(
 		&cliParams.localStorageDirectory,
-		"output",
+		flags.Output,
 		"/tmp/activity_dumps/",
 		"local storage output directory",
 	)
 	activityDumpGenerateDumpCmd.Flags().BoolVar(
 		&cliParams.localStorageCompression,
-		"compression",
+		flags.Compression,
 		false,
 		"defines if the local storage output should be compressed before persisting the data to disk",
 	)
 	activityDumpGenerateDumpCmd.Flags().StringArrayVar(
 		&cliParams.localStorageFormats,
-		"format",
+		flags.Format,
 		[]string{},
 		fmt.Sprintf("local storage output formats. Available options are %v.", config.AllStorageFormats()),
 	)
 	activityDumpGenerateDumpCmd.Flags().BoolVar(
 		&cliParams.remoteStorageCompression,
-		"remote-compression",
+		flags.RemoteCompression,
 		true,
 		"defines if the remote storage output should be compressed before sending the data",
 	)
 	activityDumpGenerateDumpCmd.Flags().StringArrayVar(
 		&cliParams.remoteStorageFormats,
-		"remote-format",
+		flags.RemoteFormat,
 		[]string{},
 		fmt.Sprintf("remote storage output formats. Available options are %v.", config.AllStorageFormats()),
 	)
@@ -217,44 +218,44 @@ func generateEncodingCommands(globalParams *common.GlobalParams) []*cobra.Comman
 
 	activityDumpGenerateEncodingCmd.Flags().StringVar(
 		&cliParams.file,
-		"input",
+		flags.Input,
 		"",
 		"path to the activity dump file",
 	)
-	_ = activityDumpGenerateEncodingCmd.MarkFlagRequired("input")
+	_ = activityDumpGenerateEncodingCmd.MarkFlagRequired(flags.Input)
 	activityDumpGenerateEncodingCmd.Flags().StringVar(
 		&cliParams.localStorageDirectory,
-		"output",
+		flags.Output,
 		"/tmp/activity_dumps/",
 		"local storage output directory",
 	)
 	activityDumpGenerateEncodingCmd.Flags().BoolVar(
 		&cliParams.localStorageCompression,
-		"compression",
+		flags.Compression,
 		false,
 		"defines if the local storage output should be compressed before persisting the data to disk",
 	)
 	activityDumpGenerateEncodingCmd.Flags().StringArrayVar(
 		&cliParams.localStorageFormats,
-		"format",
+		flags.Format,
 		[]string{},
 		fmt.Sprintf("local storage output formats. Available options are %v.", config.AllStorageFormats()),
 	)
 	activityDumpGenerateEncodingCmd.Flags().BoolVar(
 		&cliParams.remoteStorageCompression,
-		"remote-compression",
+		flags.RemoteCompression,
 		true,
 		"defines if the remote storage output should be compressed before sending the data",
 	)
 	activityDumpGenerateEncodingCmd.Flags().StringArrayVar(
 		&cliParams.remoteStorageFormats,
-		"remote-format",
+		flags.RemoteFormat,
 		[]string{},
 		fmt.Sprintf("remote storage output formats. Available options are %v.", config.AllStorageFormats()),
 	)
 	activityDumpGenerateEncodingCmd.Flags().BoolVar(
 		&cliParams.remoteRequest,
-		"remote",
+		flags.Remote,
 		false,
 		"when set, the transcoding will be done by system-probe instead of the current security-agent instance",
 	)

--- a/cmd/security-agent/app/subcommands/runtime/command.go
+++ b/cmd/security-agent/app/subcommands/runtime/command.go
@@ -13,6 +13,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/DataDog/datadog-agent/cmd/security-agent/flags"
 	"io"
 	"os"
 	"path"
@@ -103,7 +104,7 @@ func checkPoliciesCommands(globalParams *common.GlobalParams) []*cobra.Command {
 		Deprecated: "please use `security-agent runtime policy check` instead",
 	}
 
-	checkPoliciesCmd.Flags().StringVar(&cliParams.dir, "policies-dir", coreconfig.DefaultRuntimePoliciesDir, "Path to policies directory")
+	checkPoliciesCmd.Flags().StringVar(&cliParams.dir, flags.PoliciesDir, coreconfig.DefaultRuntimePoliciesDir, "Path to policies directory")
 
 	return []*cobra.Command{checkPoliciesCmd}
 }
@@ -167,12 +168,12 @@ func evalCommands(globalParams *common.GlobalParams) []*cobra.Command {
 		},
 	}
 
-	evalCmd.Flags().StringVar(&evalArgs.dir, "policies-dir", coreconfig.DefaultRuntimePoliciesDir, "Path to policies directory")
-	evalCmd.Flags().StringVar(&evalArgs.ruleID, "rule-id", "", "Rule ID to evaluate")
-	_ = evalCmd.MarkFlagRequired("rule-id")
-	evalCmd.Flags().StringVar(&evalArgs.eventFile, "event-file", "", "File of the event data")
-	_ = evalCmd.MarkFlagRequired("event-file")
-	evalCmd.Flags().BoolVar(&evalArgs.debug, "debug", false, "Display an event dump if the evaluation fail")
+	evalCmd.Flags().StringVar(&evalArgs.dir, flags.PoliciesDir, coreconfig.DefaultRuntimePoliciesDir, "Path to policies directory")
+	evalCmd.Flags().StringVar(&evalArgs.ruleID, flags.RuleID, "", "Rule ID to evaluate")
+	_ = evalCmd.MarkFlagRequired(flags.RuleID)
+	evalCmd.Flags().StringVar(&evalArgs.eventFile, flags.EventFile, "", "File of the event data")
+	_ = evalCmd.MarkFlagRequired(flags.EventFile)
+	evalCmd.Flags().BoolVar(&evalArgs.debug, flags.Debug, false, "Display an event dump if the evaluation fail")
 
 	return []*cobra.Command{evalCmd}
 }
@@ -196,7 +197,7 @@ func commonCheckPoliciesCommands(globalParams *common.GlobalParams) []*cobra.Com
 		},
 	}
 
-	commonCheckPoliciesCmd.Flags().StringVar(&cliParams.dir, "policies-dir", coreconfig.DefaultRuntimePoliciesDir, "Path to policies directory")
+	commonCheckPoliciesCmd.Flags().StringVar(&cliParams.dir, flags.PoliciesDir, coreconfig.DefaultRuntimePoliciesDir, "Path to policies directory")
 
 	return []*cobra.Command{commonCheckPoliciesCmd}
 }
@@ -260,8 +261,8 @@ func downloadPolicyCommands(globalParams *common.GlobalParams) []*cobra.Command 
 		},
 	}
 
-	downloadPolicyCmd.Flags().BoolVar(&downloadPolicyArgs.check, "check", false, "Check policies after downloading")
-	downloadPolicyCmd.Flags().StringVar(&downloadPolicyArgs.outputPath, "output-path", "", "Output path for downloaded policies")
+	downloadPolicyCmd.Flags().BoolVar(&downloadPolicyArgs.check, flags.Check, false, "Check policies after downloading")
+	downloadPolicyCmd.Flags().StringVar(&downloadPolicyArgs.outputPath, flags.OutputPath, "", "Output path for downloaded policies")
 
 	return []*cobra.Command{downloadPolicyCmd}
 }
@@ -290,7 +291,7 @@ func processCacheCommands(globalParams *common.GlobalParams) []*cobra.Command {
 			)
 		},
 	}
-	processCacheDumpCmd.Flags().BoolVar(&cliParams.withArgs, "with-args", false, "add process arguments to the dump")
+	processCacheDumpCmd.Flags().BoolVar(&cliParams.withArgs, flags.WithArgs, false, "add process arguments to the dump")
 
 	processCacheCmd := &cobra.Command{
 		Use:   "process-cache",
@@ -325,7 +326,7 @@ func networkNamespaceCommands(globalParams *common.GlobalParams) []*cobra.Comman
 			)
 		},
 	}
-	dumpNetworkNamespaceCmd.Flags().BoolVar(&cliParams.snapshotInterfaces, "snapshot-interfaces", true, "snapshot the interfaces of each network namespace during the dump")
+	dumpNetworkNamespaceCmd.Flags().BoolVar(&cliParams.snapshotInterfaces, flags.SnapshotInterfaces, true, "snapshot the interfaces of each network namespace during the dump")
 
 	networkNamespaceCmd := &cobra.Command{
 		Use:   "network-namespace",

--- a/cmd/security-agent/app/subcommands/status/command.go
+++ b/cmd/security-agent/app/subcommands/status/command.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"github.com/DataDog/datadog-agent/cmd/security-agent/flags"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -51,9 +52,9 @@ func Commands(globalParams *common.GlobalParams) []*cobra.Command {
 		},
 	}
 
-	statusCmd.Flags().BoolVarP(&cliParams.json, "json", "j", false, "print out raw json")
-	statusCmd.Flags().BoolVarP(&cliParams.prettyPrintJSON, "pretty-json", "p", false, "pretty print JSON")
-	statusCmd.Flags().StringVarP(&cliParams.file, "file", "o", "", "Output the status command to a file")
+	statusCmd.Flags().BoolVarP(&cliParams.json, flags.JSON, "j", false, "print out raw json")
+	statusCmd.Flags().BoolVarP(&cliParams.prettyPrintJSON, flags.PrettyJSON, "p", false, "pretty print JSON")
+	statusCmd.Flags().StringVarP(&cliParams.file, flags.File, "o", "", "Output the status command to a file")
 
 	return []*cobra.Command{statusCmd}
 }

--- a/cmd/security-agent/flags/flags_common.go
+++ b/cmd/security-agent/flags/flags_common.go
@@ -1,0 +1,64 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package flags
+
+const (
+	// Start Subcommand
+	// CfgPath defines the cfgpath flag
+	CfgPath = "cfgpath"
+	NoColor = "no-color"
+	PidFile = "pidfile"
+
+	// Status Subcommand
+	JSON       = "json"
+	PrettyJSON = "pretty-json"
+	File       = "file" // Also for check subcommand
+
+	// Flare Subcommand
+	Email = "email"
+	Send  = "send"
+
+	// Runtime Subcommand
+	PoliciesDir        = "policies-dir"
+	EventFile          = "event-file"
+	Debug              = "debug"
+	Check              = "check"
+	OutputPath         = "output-path"
+	WithArgs           = "with-args"
+	SnapshotInterfaces = "snapshot-interfaces"
+	RuleID             = "rule-id" // Also for compliance subcommand
+
+	// Runtime Activity Dump Subcommand
+	Name              = "name"
+	ContainerID       = "containerID"
+	Comm              = "comm"
+	Timeout           = "timeout"
+	DifferentiateArgs = "differentiate-args"
+	Output            = "output" // TODO: unify with OutputPath
+	Compression       = "compression"
+	Format            = "format"
+	RemoteCompression = "remote-compression"
+	RemoteFormat      = "remote-format"
+	Input             = "input"
+	Remote            = "remote"
+
+	// Compliance Subcommand
+	SourceType   = "source-type"
+	SourceName   = "source-name"
+	ResourceID   = "resource-id"
+	ResourceType = "resource-type"
+	Tags         = "tags"
+	Data         = "data"
+
+	// Check Subcommand
+	Framework         = "framework"
+	Verbose           = "verbose"
+	Report            = "report"
+	OverrideRegoInput = "override-rego-input"
+	DumpRegoInput     = "dump-rego-input"
+	DumpReports       = "dump-reports" // TODO: Unify with OutputPath
+	SkipRegoEval      = "skip-rego-eval"
+)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Adding a flags package to store the flag name constants to facilitate UX consistency across the different subcommands. For example, we have flags "dump-reports", "output", and "output-path" that all mean the same thing, but because it was hard to see at a glance what all the existing flags were, we ended up with 3 flags that mean the same thing.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
