### PR TITLE
[CWS Agent] SecAgent command pkg to replace common pkg, moving status and version subcommands

### DIFF
--- a/cmd/security-agent/app/app.go
+++ b/cmd/security-agent/app/app.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/DataDog/datadog-agent/cmd/security-agent/command"
 	"net/http"
 	"os"
 	"path"
@@ -24,7 +25,6 @@ import (
 	commonagent "github.com/DataDog/datadog-agent/cmd/agent/common"
 	"github.com/DataDog/datadog-agent/cmd/manager"
 	"github.com/DataDog/datadog-agent/cmd/security-agent/api"
-	"github.com/DataDog/datadog-agent/cmd/security-agent/app/common"
 	"github.com/DataDog/datadog-agent/cmd/security-agent/app/subcommands/compliance"
 	subconfig "github.com/DataDog/datadog-agent/cmd/security-agent/app/subcommands/config"
 	"github.com/DataDog/datadog-agent/cmd/security-agent/app/subcommands/flare"
@@ -56,7 +56,7 @@ import (
 
 const (
 	// loggerName is the name of the security agent logger
-	loggerName coreconfig.LoggerName = common.LoggerName
+	loggerName coreconfig.LoggerName = command.LoggerName
 )
 
 var (
@@ -66,7 +66,7 @@ var (
 )
 
 func CreateSecurityAgentCmd() *cobra.Command {
-	globalParams := common.GlobalParams{}
+	globalParams := command.GlobalParams{}
 	var flagNoColor bool
 
 	SecurityAgentCmd := &cobra.Command{
@@ -81,7 +81,7 @@ Datadog Security Agent takes care of running compliance and security checks.`,
 			}
 
 			// TODO(paulcacheux): remove this once all subcommands have been converted to use config component
-			_, err := compconfig.MergeConfigurationFiles("datadog", globalParams.ConfPathArray, cmd.Flags().Lookup(flags.CfgPath).Changed)
+			_, err := compconfig.MergeConfigurationFiles("datadog", globalParams.ConfigFilePaths, cmd.Flags().Lookup(flags.CfgPath).Changed)
 			return err
 		},
 		PersistentPostRun: func(cmd *cobra.Command, args []string) {
@@ -89,14 +89,14 @@ Datadog Security Agent takes care of running compliance and security checks.`,
 		},
 	}
 
-	defaultConfPathArray := []string{
+	defaultConfigFilePaths := []string{
 		path.Join(commonagent.DefaultConfPath, "datadog.yaml"),
 		path.Join(commonagent.DefaultConfPath, "security-agent.yaml"),
 	}
-	SecurityAgentCmd.PersistentFlags().StringArrayVarP(&globalParams.ConfPathArray, flags.CfgPath, "c", defaultConfPathArray, "path to a yaml configuration file")
+	SecurityAgentCmd.PersistentFlags().StringArrayVarP(&globalParams.ConfigFilePaths, flags.CfgPath, "c", defaultConfigFilePaths, "path to a yaml configuration file")
 	SecurityAgentCmd.PersistentFlags().BoolVarP(&flagNoColor, flags.NoColor, "n", false, "disable color output")
 
-	factories := []common.SubcommandFactory{
+	factories := []command.SubcommandFactory{
 		status.Commands,
 		flare.Commands,
 		subconfig.Commands,

--- a/cmd/security-agent/app/app.go
+++ b/cmd/security-agent/app/app.go
@@ -29,9 +29,9 @@ import (
 	subconfig "github.com/DataDog/datadog-agent/cmd/security-agent/app/subcommands/config"
 	"github.com/DataDog/datadog-agent/cmd/security-agent/app/subcommands/flare"
 	"github.com/DataDog/datadog-agent/cmd/security-agent/app/subcommands/runtime"
-	"github.com/DataDog/datadog-agent/cmd/security-agent/app/subcommands/status"
-	subversion "github.com/DataDog/datadog-agent/cmd/security-agent/app/subcommands/version"
 	"github.com/DataDog/datadog-agent/cmd/security-agent/flags"
+	"github.com/DataDog/datadog-agent/cmd/security-agent/subcommands/status"
+	"github.com/DataDog/datadog-agent/cmd/security-agent/subcommands/version"
 	compconfig "github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/config/resolver"
@@ -47,7 +47,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/profiling"
 	"github.com/DataDog/datadog-agent/pkg/util/startstop"
-	"github.com/DataDog/datadog-agent/pkg/version"
+	pkgversion "github.com/DataDog/datadog-agent/pkg/version"
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 	ddgostatsd "github.com/DataDog/datadog-go/v5/statsd"
 
@@ -102,7 +102,7 @@ Datadog Security Agent takes care of running compliance and security checks.`,
 		subconfig.Commands,
 		compliance.Commands,
 		runtime.Commands,
-		subversion.Commands,
+		version.Commands,
 		StartCommands,
 	}
 
@@ -218,7 +218,7 @@ func RunAgent(ctx context.Context, pidfilePath string) (err error) {
 	opts.UseOrchestratorForwarder = false
 	opts.UseContainerLifecycleForwarder = false
 	demux := aggregator.InitAndStartAgentDemultiplexer(opts, hostnameDetected)
-	demux.AddAgentStartupTelemetry(fmt.Sprintf("%s - Datadog Security Agent", version.AgentVersion))
+	demux.AddAgentStartupTelemetry(fmt.Sprintf("%s - Datadog Security Agent", pkgversion.AgentVersion))
 
 	stopper = startstop.NewSerialStopper()
 
@@ -332,7 +332,7 @@ func StopAgent(cancel context.CancelFunc) {
 func setupInternalProfiling() error {
 	cfg := coreconfig.Datadog
 	if cfg.GetBool(secAgentKey("internal_profiling.enabled")) {
-		v, _ := version.Agent()
+		v, _ := pkgversion.Agent()
 
 		cfgSite := cfg.GetString(secAgentKey("internal_profiling.site"))
 		cfgURL := cfg.GetString(secAgentKey("security_agent.internal_profiling.profile_dd_url"))

--- a/cmd/security-agent/app/start.go
+++ b/cmd/security-agent/app/start.go
@@ -8,24 +8,24 @@ package app
 import (
 	"context"
 	"errors"
+	"github.com/DataDog/datadog-agent/cmd/security-agent/command"
 	"github.com/spf13/cobra"
 	"os"
 	"os/signal"
 	"syscall"
 
-	"github.com/DataDog/datadog-agent/cmd/security-agent/app/common"
 	"github.com/DataDog/datadog-agent/cmd/security-agent/flags"
 	"github.com/DataDog/datadog-agent/pkg/tagger"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 type startCliParams struct {
-	*common.GlobalParams
+	*command.GlobalParams
 
 	pidfilePath string
 }
 
-func StartCommands(globalParams *common.GlobalParams) []*cobra.Command {
+func StartCommands(globalParams *command.GlobalParams) []*cobra.Command {
 	cliParams := startCliParams{
 		GlobalParams: globalParams,
 	}

--- a/cmd/security-agent/app/subcommands/check/command.go
+++ b/cmd/security-agent/app/subcommands/check/command.go
@@ -11,6 +11,7 @@ package check
 import (
 	"context"
 	"errors"
+	"github.com/DataDog/datadog-agent/cmd/security-agent/command"
 	"github.com/DataDog/datadog-agent/cmd/security-agent/flags"
 	"os"
 	"time"
@@ -18,7 +19,6 @@ import (
 	"github.com/spf13/cobra"
 	"go.uber.org/fx"
 
-	"github.com/DataDog/datadog-agent/cmd/security-agent/app/common"
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/log"
@@ -45,10 +45,10 @@ type checkCliParams struct {
 	skipRegoEval      bool
 }
 
-func SecAgentCommands(globalParams *common.GlobalParams) []*cobra.Command {
+func SecAgentCommands(globalParams *command.GlobalParams) []*cobra.Command {
 	bp := core.BundleParams{
-		ConfigParams: config.NewSecurityAgentParams(globalParams.ConfPathArray),
-		LogParams:    log.LogForOneShot(common.LoggerName, "info", true)}
+		ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths),
+		LogParams:    log.LogForOneShot(command.LoggerName, "info", true)}
 	return Commands(bp)
 }
 

--- a/cmd/security-agent/app/subcommands/compliance/command.go
+++ b/cmd/security-agent/app/subcommands/compliance/command.go
@@ -7,13 +7,14 @@ package compliance
 
 import (
 	"fmt"
+	"github.com/DataDog/datadog-agent/cmd/security-agent/app/common"
+	"github.com/DataDog/datadog-agent/cmd/security-agent/command"
 	"github.com/DataDog/datadog-agent/cmd/security-agent/flags"
 	"strings"
 
 	"github.com/spf13/cobra"
 	"go.uber.org/fx"
 
-	"github.com/DataDog/datadog-agent/cmd/security-agent/app/common"
 	"github.com/DataDog/datadog-agent/cmd/security-agent/app/subcommands/check"
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/config"
@@ -26,7 +27,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/startstop"
 )
 
-func Commands(globalParams *common.GlobalParams) []*cobra.Command {
+func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 	complianceCmd := &cobra.Command{
 		Use:   "compliance",
 		Short: "Compliance Agent utility commands",
@@ -39,7 +40,7 @@ func Commands(globalParams *common.GlobalParams) []*cobra.Command {
 }
 
 type eventCliParams struct {
-	*common.GlobalParams
+	*command.GlobalParams
 
 	sourceName string
 	sourceType string
@@ -47,7 +48,7 @@ type eventCliParams struct {
 	data       []string
 }
 
-func complianceEventCommand(globalParams *common.GlobalParams) *cobra.Command {
+func complianceEventCommand(globalParams *command.GlobalParams) *cobra.Command {
 	eventArgs := &eventCliParams{
 		GlobalParams: globalParams,
 	}
@@ -59,8 +60,8 @@ func complianceEventCommand(globalParams *common.GlobalParams) *cobra.Command {
 			return fxutil.OneShot(eventRun,
 				fx.Supply(eventArgs),
 				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewSecurityAgentParams(globalParams.ConfPathArray),
-					LogParams:    log.LogForOneShot(common.LoggerName, "info", true)}),
+					ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths),
+					LogParams:    log.LogForOneShot(command.LoggerName, "info", true)}),
 				core.Bundle,
 			)
 		},

--- a/cmd/security-agent/app/subcommands/compliance/compliance.go
+++ b/cmd/security-agent/app/subcommands/compliance/compliance.go
@@ -7,12 +7,12 @@ package compliance
 
 import (
 	"fmt"
+	"github.com/DataDog/datadog-agent/cmd/security-agent/app/common"
 	"os"
 	"time"
 
 	ddgostatsd "github.com/DataDog/datadog-go/v5/statsd"
 
-	"github.com/DataDog/datadog-agent/cmd/security-agent/app/common"
 	"github.com/DataDog/datadog-agent/pkg/collector/runner"
 	"github.com/DataDog/datadog-agent/pkg/collector/scheduler"
 	"github.com/DataDog/datadog-agent/pkg/compliance/agent"

--- a/cmd/security-agent/app/subcommands/config/config.go
+++ b/cmd/security-agent/app/subcommands/config/config.go
@@ -10,10 +10,10 @@ package config
 
 import (
 	"fmt"
+	"github.com/DataDog/datadog-agent/cmd/security-agent/command"
 
 	"github.com/spf13/cobra"
 
-	"github.com/DataDog/datadog-agent/cmd/security-agent/app/common"
 	cmdconfig "github.com/DataDog/datadog-agent/cmd/security-agent/commands/config"
 	"github.com/DataDog/datadog-agent/pkg/api/util"
 	"github.com/DataDog/datadog-agent/pkg/config"
@@ -21,13 +21,13 @@ import (
 	settingshttp "github.com/DataDog/datadog-agent/pkg/config/settings/http"
 )
 
-func Commands(globalParams *common.GlobalParams) []*cobra.Command {
+func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 	cmd := cmdconfig.Config(getSettingsClient)
 	return []*cobra.Command{cmd}
 }
 
 func setupConfig(cmd *cobra.Command) error {
-	err := config.SetupLogger(common.LoggerName, config.GetEnvDefault("DD_LOG_LEVEL", "off"), "", "", false, true, false)
+	err := config.SetupLogger(command.LoggerName, config.GetEnvDefault("DD_LOG_LEVEL", "off"), "", "", false, true, false)
 	if err != nil {
 		fmt.Printf("Cannot setup logger, exiting: %v\n", err)
 		return err

--- a/cmd/security-agent/app/subcommands/config/config_unsupported.go
+++ b/cmd/security-agent/app/subcommands/config/config_unsupported.go
@@ -10,10 +10,8 @@ package config
 
 import (
 	"github.com/spf13/cobra"
-
-	"github.com/DataDog/datadog-agent/cmd/security-agent/app/common"
 )
 
-func Commands(globalParams *common.GlobalParams) []*cobra.Command {
+func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 	return nil
 }

--- a/cmd/security-agent/app/subcommands/flare/command.go
+++ b/cmd/security-agent/app/subcommands/flare/command.go
@@ -8,13 +8,13 @@ package flare
 import (
 	"bytes"
 	"fmt"
-	"github.com/DataDog/datadog-agent/cmd/security-agent/flags"
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 	"go.uber.org/fx"
 
-	"github.com/DataDog/datadog-agent/cmd/security-agent/app/common"
+	"github.com/DataDog/datadog-agent/cmd/security-agent/command"
+	"github.com/DataDog/datadog-agent/cmd/security-agent/flags"
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/log"
@@ -25,14 +25,14 @@ import (
 )
 
 type flareCliParams struct {
-	*common.GlobalParams
+	*command.GlobalParams
 
 	customerEmail string
 	autoconfirm   bool
 	caseID        string
 }
 
-func Commands(globalParams *common.GlobalParams) []*cobra.Command {
+func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 	cliParams := &flareCliParams{
 		GlobalParams: globalParams,
 	}
@@ -50,8 +50,8 @@ func Commands(globalParams *common.GlobalParams) []*cobra.Command {
 			return fxutil.OneShot(requestFlare,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewParams("", config.WithSecurityAgentConfigFilePaths(globalParams.ConfPathArray), config.WithConfigLoadSecurityAgent(true)),
-					LogParams:    log.LogForOneShot(common.LoggerName, "off", true)}),
+					ConfigParams: config.NewParams("", config.WithSecurityAgentConfigFilePaths(globalParams.ConfigFilePaths), config.WithConfigLoadSecurityAgent(true)),
+					LogParams:    log.LogForOneShot(command.LoggerName, "off", true)}),
 				core.Bundle,
 			)
 		},

--- a/cmd/security-agent/app/subcommands/runtime/activity_dump.go
+++ b/cmd/security-agent/app/subcommands/runtime/activity_dump.go
@@ -10,9 +10,9 @@ package runtime
 
 import (
 	"fmt"
+	"github.com/DataDog/datadog-agent/cmd/security-agent/command"
 	"github.com/DataDog/datadog-agent/cmd/security-agent/flags"
 
-	"github.com/DataDog/datadog-agent/cmd/security-agent/app/common"
 	"github.com/DataDog/datadog-agent/comp/core"
 	compconfig "github.com/DataDog/datadog-agent/comp/core/config"
 	complog "github.com/DataDog/datadog-agent/comp/core/log"
@@ -27,7 +27,7 @@ import (
 )
 
 type activityDumpCliParams struct {
-	*common.GlobalParams
+	*command.GlobalParams
 
 	name                     string
 	containerID              string
@@ -43,7 +43,7 @@ type activityDumpCliParams struct {
 	remoteRequest            bool
 }
 
-func activityDumpCommands(globalParams *common.GlobalParams) []*cobra.Command {
+func activityDumpCommands(globalParams *command.GlobalParams) []*cobra.Command {
 	activityDumpCmd := &cobra.Command{
 		Use:   "activity-dump",
 		Short: "activity dump command",
@@ -56,15 +56,15 @@ func activityDumpCommands(globalParams *common.GlobalParams) []*cobra.Command {
 	return []*cobra.Command{activityDumpCmd}
 }
 
-func listCommands(globalParams *common.GlobalParams) []*cobra.Command {
+func listCommands(globalParams *command.GlobalParams) []*cobra.Command {
 	activityDumpListCmd := &cobra.Command{
 		Use:   "list",
 		Short: "get the list of running activity dumps",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(listActivityDumps,
 				fx.Supply(core.BundleParams{
-					ConfigParams: compconfig.NewSecurityAgentParams(globalParams.ConfPathArray),
-					LogParams:    complog.LogForOneShot(common.LoggerName, "info", true)}),
+					ConfigParams: compconfig.NewSecurityAgentParams(globalParams.ConfigFilePaths),
+					LogParams:    complog.LogForOneShot(command.LoggerName, "info", true)}),
 				core.Bundle,
 			)
 		},
@@ -73,7 +73,7 @@ func listCommands(globalParams *common.GlobalParams) []*cobra.Command {
 	return []*cobra.Command{activityDumpListCmd}
 }
 
-func stopCommands(globalParams *common.GlobalParams) []*cobra.Command {
+func stopCommands(globalParams *command.GlobalParams) []*cobra.Command {
 	cliParams := &activityDumpCliParams{
 		GlobalParams: globalParams,
 	}
@@ -85,8 +85,8 @@ func stopCommands(globalParams *common.GlobalParams) []*cobra.Command {
 			return fxutil.OneShot(stopActivityDump,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams: compconfig.NewSecurityAgentParams(globalParams.ConfPathArray),
-					LogParams:    complog.LogForOneShot(common.LoggerName, "info", true)}),
+					ConfigParams: compconfig.NewSecurityAgentParams(globalParams.ConfigFilePaths),
+					LogParams:    complog.LogForOneShot(command.LoggerName, "info", true)}),
 				core.Bundle,
 			)
 		},
@@ -114,7 +114,7 @@ func stopCommands(globalParams *common.GlobalParams) []*cobra.Command {
 	return []*cobra.Command{activityDumpStopCmd}
 }
 
-func generateCommands(globalParams *common.GlobalParams) []*cobra.Command {
+func generateCommands(globalParams *command.GlobalParams) []*cobra.Command {
 	activityDumpGenerateCmd := &cobra.Command{
 		Use:   "generate",
 		Short: "generate command for activity dumps",
@@ -126,7 +126,7 @@ func generateCommands(globalParams *common.GlobalParams) []*cobra.Command {
 	return []*cobra.Command{activityDumpGenerateCmd}
 }
 
-func generateDumpCommands(globalParams *common.GlobalParams) []*cobra.Command {
+func generateDumpCommands(globalParams *command.GlobalParams) []*cobra.Command {
 	cliParams := &activityDumpCliParams{
 		GlobalParams: globalParams,
 	}
@@ -138,8 +138,8 @@ func generateDumpCommands(globalParams *common.GlobalParams) []*cobra.Command {
 			return fxutil.OneShot(generateActivityDump,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams: compconfig.NewSecurityAgentParams(globalParams.ConfPathArray),
-					LogParams:    complog.LogForOneShot(common.LoggerName, "info", true)}),
+					ConfigParams: compconfig.NewSecurityAgentParams(globalParams.ConfigFilePaths),
+					LogParams:    complog.LogForOneShot(command.LoggerName, "info", true)}),
 				core.Bundle,
 			)
 		},
@@ -197,7 +197,7 @@ func generateDumpCommands(globalParams *common.GlobalParams) []*cobra.Command {
 	return []*cobra.Command{activityDumpGenerateDumpCmd}
 }
 
-func generateEncodingCommands(globalParams *common.GlobalParams) []*cobra.Command {
+func generateEncodingCommands(globalParams *command.GlobalParams) []*cobra.Command {
 	cliParams := &activityDumpCliParams{
 		GlobalParams: globalParams,
 	}
@@ -209,8 +209,8 @@ func generateEncodingCommands(globalParams *common.GlobalParams) []*cobra.Comman
 			return fxutil.OneShot(generateEncodingFromActivityDump,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams: compconfig.NewSecurityAgentParams(globalParams.ConfPathArray),
-					LogParams:    complog.LogForOneShot(common.LoggerName, "info", true)}),
+					ConfigParams: compconfig.NewSecurityAgentParams(globalParams.ConfigFilePaths),
+					LogParams:    complog.LogForOneShot(command.LoggerName, "info", true)}),
 				core.Bundle,
 			)
 		},

--- a/cmd/security-agent/app/subcommands/runtime/command_unsupported.go
+++ b/cmd/security-agent/app/subcommands/runtime/command_unsupported.go
@@ -18,16 +18,15 @@ import (
 
 	"github.com/spf13/cobra"
 
-	ddgostatsd "github.com/DataDog/datadog-go/v5/statsd"
-
-	"github.com/DataDog/datadog-agent/cmd/security-agent/app/common"
+	"github.com/DataDog/datadog-agent/cmd/security-agent/command"
 	coreconfig "github.com/DataDog/datadog-agent/pkg/config"
 	secagent "github.com/DataDog/datadog-agent/pkg/security/agent"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/startstop"
+	ddgostatsd "github.com/DataDog/datadog-go/v5/statsd"
 )
 
-func Commands(globalParams *common.GlobalParams) []*cobra.Command {
+func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 	return nil
 }
 

--- a/cmd/security-agent/command/command.go
+++ b/cmd/security-agent/command/command.go
@@ -3,15 +3,16 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build windows || !kubeapiserver
-
-package check
+package command
 
 import (
-	"github.com/DataDog/datadog-agent/cmd/security-agent/command"
 	"github.com/spf13/cobra"
 )
 
-func SecAgentCommands(globalParams *command.GlobalParams) []*cobra.Command {
-	return nil
+type GlobalParams struct {
+	ConfigFilePaths []string
 }
+
+type SubcommandFactory func(globalParams *GlobalParams) []*cobra.Command
+
+const LoggerName = "SECURITY"

--- a/cmd/security-agent/subcommands/status/command.go
+++ b/cmd/security-agent/subcommands/status/command.go
@@ -9,13 +9,12 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/DataDog/datadog-agent/cmd/security-agent/flags"
-	"os"
-
 	"github.com/spf13/cobra"
 	"go.uber.org/fx"
+	"os"
 
-	"github.com/DataDog/datadog-agent/cmd/security-agent/app/common"
+	"github.com/DataDog/datadog-agent/cmd/security-agent/command"
+	"github.com/DataDog/datadog-agent/cmd/security-agent/flags"
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/log"
@@ -24,16 +23,16 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
-type statusCliParams struct {
-	*common.GlobalParams
+type cliParams struct {
+	*command.GlobalParams
 
 	json            bool
 	prettyPrintJSON bool
 	file            string
 }
 
-func Commands(globalParams *common.GlobalParams) []*cobra.Command {
-	cliParams := &statusCliParams{
+func Commands(globalParams *command.GlobalParams) []*cobra.Command {
+	cliParams := &cliParams{
 		GlobalParams: globalParams,
 	}
 
@@ -45,8 +44,8 @@ func Commands(globalParams *common.GlobalParams) []*cobra.Command {
 			return fxutil.OneShot(runStatus,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewParams("", config.WithSecurityAgentConfigFilePaths(globalParams.ConfPathArray), config.WithConfigLoadSecurityAgent(true)),
-					LogParams:    log.LogForOneShot(common.LoggerName, "off", true)}),
+					ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths),
+					LogParams:    log.LogForOneShot(command.LoggerName, "off", true)}),
 				core.Bundle,
 			)
 		},
@@ -59,7 +58,7 @@ func Commands(globalParams *common.GlobalParams) []*cobra.Command {
 	return []*cobra.Command{statusCmd}
 }
 
-func runStatus(log log.Component, config config.Component, params *statusCliParams) error {
+func runStatus(log log.Component, config config.Component, params *cliParams) error {
 	fmt.Printf("Getting the status from the agent.\n")
 	var e error
 	var s string

--- a/cmd/security-agent/subcommands/status/command_test.go
+++ b/cmd/security-agent/subcommands/status/command_test.go
@@ -1,0 +1,43 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package status
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/cmd/security-agent/command"
+	"github.com/DataDog/datadog-agent/comp/core"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+func TestCommand(t *testing.T) {
+	tests := []struct {
+		name     string
+		cliInput []string
+		check    func(cliParams *cliParams, params core.BundleParams)
+	}{
+		{
+			name:     "status",
+			cliInput: []string{"status"},
+			check: func(cliParams *cliParams, params core.BundleParams) {
+				// Verify logger defaults
+				require.Equal(t, command.LoggerName, params.LoggerName(), "logger name not matching")
+				require.Equal(t, "off", params.LogLevelFn(nil), "log level not matching")
+			},
+		},
+	}
+
+	for _, test := range tests {
+		fxutil.TestOneShotSubcommand(t,
+			Commands(&command.GlobalParams{}),
+			test.cliInput,
+			runStatus,
+			test.check,
+		)
+	}
+}

--- a/cmd/security-agent/subcommands/version/command.go
+++ b/cmd/security-agent/subcommands/version/command.go
@@ -7,22 +7,20 @@ package version
 
 import (
 	"fmt"
-
-	"github.com/DataDog/datadog-agent/cmd/security-agent/app/common"
-	"github.com/DataDog/datadog-agent/comp/core"
-	"github.com/DataDog/datadog-agent/comp/core/config"
-	compconfig "github.com/DataDog/datadog-agent/comp/core/config"
-	"github.com/DataDog/datadog-agent/comp/core/log"
-	complog "github.com/DataDog/datadog-agent/comp/core/log"
-	"github.com/DataDog/datadog-agent/pkg/serializer"
-	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
-	"github.com/DataDog/datadog-agent/pkg/version"
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 	"go.uber.org/fx"
+
+	"github.com/DataDog/datadog-agent/cmd/security-agent/command"
+	"github.com/DataDog/datadog-agent/comp/core"
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/log"
+	"github.com/DataDog/datadog-agent/pkg/serializer"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+	pkgversion "github.com/DataDog/datadog-agent/pkg/version"
 )
 
-func Commands(globalParams *common.GlobalParams) []*cobra.Command {
+func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 	versionCmd := &cobra.Command{
 		Use:   "version",
 		Short: "Print the version info",
@@ -30,8 +28,8 @@ func Commands(globalParams *common.GlobalParams) []*cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(displayVersion,
 				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewParams("", config.WithSecurityAgentConfigFilePaths(globalParams.ConfPathArray), config.WithConfigLoadSecurityAgent(true)),
-					LogParams:    log.LogForOneShot(common.LoggerName, "off", true)}),
+					ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths),
+					LogParams:    log.LogForOneShot(command.LoggerName, "off", true)}),
 				core.Bundle,
 			)
 		},
@@ -40,8 +38,8 @@ func Commands(globalParams *common.GlobalParams) []*cobra.Command {
 	return []*cobra.Command{versionCmd}
 }
 
-func displayVersion(log complog.Component, config compconfig.Component) {
-	av, _ := version.Agent()
+func displayVersion(log log.Component, config config.Component) {
+	av, _ := pkgversion.Agent()
 	meta := ""
 	if av.Meta != "" {
 		meta = fmt.Sprintf("- Meta: %s ", color.YellowString(av.Meta))
@@ -50,7 +48,7 @@ func displayVersion(log complog.Component, config compconfig.Component) {
 	fmt.Fprintf(color.Output, "Security agent %s %s- Commit: '%s' - Serialization version: %s\n",
 		color.BlueString(av.GetNumberAndPre()),
 		meta,
-		color.GreenString(version.Commit),
+		color.GreenString(pkgversion.Commit),
 		color.MagentaString(serializer.AgentPayloadVersion),
 	)
 }

--- a/cmd/security-agent/subcommands/version/command_test.go
+++ b/cmd/security-agent/subcommands/version/command_test.go
@@ -1,0 +1,43 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package version
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/cmd/security-agent/command"
+	"github.com/DataDog/datadog-agent/comp/core"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+func TestCommand(t *testing.T) {
+	tests := []struct {
+		name     string
+		cliInput []string
+		check    func(params core.BundleParams)
+	}{
+		{
+			name:     "version",
+			cliInput: []string{"version"},
+			check: func(params core.BundleParams) {
+				// Verify logger defaults
+				require.Equal(t, command.LoggerName, params.LoggerName(), "logger name not matching")
+				require.Equal(t, "off", params.LogLevelFn(nil), "log level not matching")
+			},
+		},
+	}
+
+	for _, test := range tests {
+		fxutil.TestOneShotSubcommand(t,
+			Commands(&command.GlobalParams{}),
+			test.cliInput,
+			displayVersion,
+			test.check,
+		)
+	}
+}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

1. Move SecAgent `common` package to `command` package to be consistent with rest of the Agent: https://github.com/DataDog/datadog-agent/blob/main/docs/components/defining-apps.md
2. Moving the version and status subcommands into the new directory structure.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
