### PR TITLE
usm: remove the scenario of nil subprograms

### DIFF
--- a/pkg/network/protocols/http/ebpf_gotls.go
+++ b/pkg/network/protocols/http/ebpf_gotls.go
@@ -186,10 +186,6 @@ func newGoTLSProgram(c *config.Config) *GoTLSProgram {
 }
 
 func (p *GoTLSProgram) ConfigureManager(m *errtelemetry.Manager) {
-	if p == nil {
-		return
-	}
-
 	p.manager = m
 	p.manager.Maps = append(p.manager.Maps, []*manager.Map{
 		{Name: offsetsDataMap},
@@ -199,7 +195,7 @@ func (p *GoTLSProgram) ConfigureManager(m *errtelemetry.Manager) {
 	// Hooks will be added in runtime for each binary
 }
 
-func (p *GoTLSProgram) ConfigureOptions(options *manager.Options) {}
+func (p *GoTLSProgram) ConfigureOptions(_ *manager.Options) {}
 
 func (p *GoTLSProgram) GetAllUndefinedProbes() (probeList []manager.ProbeIdentificationPair) {
 	for _, probeInfo := range functionToProbes {
@@ -216,9 +212,6 @@ func (p *GoTLSProgram) GetAllUndefinedProbes() (probeList []manager.ProbeIdentif
 }
 
 func (p *GoTLSProgram) Start() {
-	if p == nil {
-		return
-	}
 
 	var err error
 	p.offsetsDataMap, _, err = p.manager.GetMap(offsetsDataMap)
@@ -258,9 +251,6 @@ failed:
 }
 
 func (p *GoTLSProgram) Stop() {
-	if p == nil {
-		return
-	}
 	p.procMonitor.cleanupExec()
 	p.procMonitor.cleanupExit()
 }

--- a/pkg/network/protocols/http/ebpf_gotls.go
+++ b/pkg/network/protocols/http/ebpf_gotls.go
@@ -197,7 +197,8 @@ func (p *GoTLSProgram) ConfigureManager(m *errtelemetry.Manager) {
 
 func (p *GoTLSProgram) ConfigureOptions(_ *manager.Options) {}
 
-func (p *GoTLSProgram) GetAllUndefinedProbes() (probeList []manager.ProbeIdentificationPair) {
+func (*GoTLSProgram) GetAllUndefinedProbes() []manager.ProbeIdentificationPair {
+	probeList := make([]manager.ProbeIdentificationPair, 0)
 	for _, probeInfo := range functionToProbes {
 		if probeInfo.functionInfo != nil {
 			probeList = append(probeList, probeInfo.functionInfo.getIdentificationPair())
@@ -208,11 +209,10 @@ func (p *GoTLSProgram) GetAllUndefinedProbes() (probeList []manager.ProbeIdentif
 		}
 	}
 
-	return
+	return probeList
 }
 
 func (p *GoTLSProgram) Start() {
-
 	var err error
 	p.offsetsDataMap, _, err = p.manager.GetMap(offsetsDataMap)
 	if err != nil {
@@ -247,7 +247,6 @@ failed:
 	if p.procMonitor.cleanupExit != nil {
 		p.procMonitor.cleanupExit()
 	}
-	return
 }
 
 func (p *GoTLSProgram) Stop() {

--- a/pkg/network/protocols/http/ebpf_main.go
+++ b/pkg/network/protocols/http/ebpf_main.go
@@ -10,11 +10,12 @@ package http
 
 import (
 	"fmt"
+	"math"
+	"os"
+
 	"github.com/cilium/ebpf"
 	"github.com/iovisor/gobpf/pkg/cpupossible"
 	"golang.org/x/sys/unix"
-	"math"
-	"os"
 
 	manager "github.com/DataDog/ebpf-manager"
 

--- a/pkg/network/protocols/http/ebpf_ssl.go
+++ b/pkg/network/protocols/http/ebpf_ssl.go
@@ -258,9 +258,6 @@ func newSSLProgram(c *config.Config, sockFDMap *ebpf.Map) *sslProgram {
 }
 
 func (o *sslProgram) ConfigureManager(m *errtelemetry.Manager) {
-	if o == nil {
-		return
-	}
 
 	o.manager = m
 
@@ -294,9 +291,6 @@ func (o *sslProgram) ConfigureManager(m *errtelemetry.Manager) {
 }
 
 func (o *sslProgram) ConfigureOptions(options *manager.Options) {
-	if o == nil {
-		return
-	}
 
 	options.MapSpecEditors[sslSockByCtxMap] = manager.MapSpecEditor{
 		Type:       ebpf.Hash,
@@ -328,10 +322,6 @@ func (o *sslProgram) ConfigureOptions(options *manager.Options) {
 }
 
 func (o *sslProgram) Start() {
-	if o == nil {
-		return
-	}
-
 	// Setup shared library watcher and configure the appropriate callbacks
 	o.watcher = newSOWatcher(o.cfg.ProcRoot, o.perfHandler,
 		soRule{
@@ -355,10 +345,6 @@ func (o *sslProgram) Start() {
 }
 
 func (o *sslProgram) Stop() {
-	if o == nil {
-		return
-	}
-
 	o.perfHandler.Stop()
 }
 

--- a/pkg/network/protocols/http/ebpf_ssl.go
+++ b/pkg/network/protocols/http/ebpf_ssl.go
@@ -427,7 +427,7 @@ func getUID(libPath string) string {
 	return libPath
 }
 
-func (o *sslProgram) GetAllUndefinedProbes() []manager.ProbeIdentificationPair {
+func (*sslProgram) GetAllUndefinedProbes() []manager.ProbeIdentificationPair {
 	var probeList []manager.ProbeIdentificationPair
 
 	for _, sslProbeList := range [][]manager.ProbesSelector{openSSLProbes, cryptoProbes, gnuTLSProbes} {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Removes the need for nil subprograms.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

We have to get all hooks from all subprograms even if they are not enabled, so the ebpf-manager can disable them.
It caused us to add for each function:
```go
if currentObj == nil {
        return
}
```
which only complicates the code.

The fix will remove all `nil` subprograms after getting their undefined programs.
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
