### PR TITLE
[CWS Agent] SecAgent subcmds using log and config components

### DIFF
--- a/cmd/security-agent/app/app.go
+++ b/cmd/security-agent/app/app.go
@@ -33,6 +33,7 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/security-agent/subcommands/status"
 	"github.com/DataDog/datadog-agent/cmd/security-agent/subcommands/version"
 	compconfig "github.com/DataDog/datadog-agent/comp/core/config"
+	complog "github.com/DataDog/datadog-agent/comp/core/log"
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	coreconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/config/resolver"
@@ -259,7 +260,9 @@ func RunAgent(ctx context.Context, pidfilePath string) (err error) {
 		}
 	}
 
-	complianceAgent, err := compliance.StartCompliance(hostnameDetected, stopper, statsdClient)
+	var log complog.Component
+	var config compconfig.Component
+	complianceAgent, err := compliance.StartCompliance(log, config, hostnameDetected, stopper, statsdClient)
 	if err != nil {
 		return err
 	}

--- a/cmd/security-agent/app/app.go
+++ b/cmd/security-agent/app/app.go
@@ -272,7 +272,7 @@ func RunAgent(ctx context.Context, pidfilePath string) (err error) {
 	}
 
 	// start runtime security agent
-	runtimeAgent, err := runtime.StartRuntimeSecurity(hostnameDetected, stopper, statsdClient)
+	runtimeAgent, err := runtime.StartRuntimeSecurity(log, config, hostnameDetected, stopper, statsdClient)
 	if err != nil {
 		return err
 	}

--- a/cmd/security-agent/subcommands/compliance/command.go
+++ b/cmd/security-agent/subcommands/compliance/command.go
@@ -8,21 +8,18 @@ package compliance
 import (
 	"fmt"
 	"github.com/DataDog/datadog-agent/cmd/security-agent/app/common"
-	"github.com/DataDog/datadog-agent/cmd/security-agent/command"
 	"github.com/DataDog/datadog-agent/cmd/security-agent/flags"
 	"strings"
 
 	"github.com/spf13/cobra"
 	"go.uber.org/fx"
 
+	"github.com/DataDog/datadog-agent/cmd/security-agent/command"
 	"github.com/DataDog/datadog-agent/cmd/security-agent/subcommands/check"
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/config"
-	compconfig "github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/log"
-	complog "github.com/DataDog/datadog-agent/comp/core/log"
 	"github.com/DataDog/datadog-agent/pkg/compliance/event"
-	coreconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/DataDog/datadog-agent/pkg/util/startstop"
 )
@@ -80,7 +77,7 @@ func complianceEventCommand(globalParams *command.GlobalParams) *cobra.Command {
 	return eventCmd
 }
 
-func eventRun(log complog.Component, config compconfig.Component, eventArgs *cliParams) error {
+func eventRun(log log.Component, config config.Component, eventArgs *cliParams) error {
 	stopper := startstop.NewSerialStopper()
 	defer stopper.Stop()
 
@@ -89,7 +86,7 @@ func eventRun(log complog.Component, config compconfig.Component, eventArgs *cli
 		return err
 	}
 
-	runPath := coreconfig.Datadog.GetString("compliance_config.run_path")
+	runPath := config.GetString("compliance_config.run_path")
 	reporter, err := event.NewLogReporter(stopper, eventArgs.sourceName, eventArgs.sourceType, runPath, endpoints, dstContext)
 	if err != nil {
 		return fmt.Errorf("failed to set up compliance log reporter: %w", err)

--- a/cmd/security-agent/subcommands/compliance/compliance.go
+++ b/cmd/security-agent/subcommands/compliance/compliance.go
@@ -18,7 +18,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/compliance/agent"
 	"github.com/DataDog/datadog-agent/pkg/compliance/checks"
 	"github.com/DataDog/datadog-agent/pkg/compliance/event"
-	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/startstop"
 	"github.com/DataDog/datadog-agent/pkg/version"
 	ddgostatsd "github.com/DataDog/datadog-go/v5/statsd"
@@ -60,15 +59,6 @@ func StartCompliance(log log.Component, config config.Component, hostname string
 		checks.MayFail(checks.WithDocker()),
 		checks.MayFail(checks.WithAudit()),
 		checks.WithStatsd(statsdClient),
-	}
-
-	if pkgconfig.IsKubernetes() {
-		nodeLabels, err := agent.WaitGetNodeLabels()
-		if err != nil {
-			log.Error(err)
-		} else {
-			options = append(options, checks.WithNodeLabels(nodeLabels))
-		}
 	}
 
 	agent, err := agent.New(

--- a/cmd/security-agent/subcommands/runtime/activity_dump.go
+++ b/cmd/security-agent/subcommands/runtime/activity_dump.go
@@ -10,20 +10,19 @@ package runtime
 
 import (
 	"fmt"
+	"github.com/spf13/cobra"
+	"go.uber.org/fx"
+
 	"github.com/DataDog/datadog-agent/cmd/security-agent/command"
 	"github.com/DataDog/datadog-agent/cmd/security-agent/flags"
-
 	"github.com/DataDog/datadog-agent/comp/core"
-	compconfig "github.com/DataDog/datadog-agent/comp/core/config"
-	complog "github.com/DataDog/datadog-agent/comp/core/log"
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/log"
 	secagent "github.com/DataDog/datadog-agent/pkg/security/agent"
 	"github.com/DataDog/datadog-agent/pkg/security/api"
-	"github.com/DataDog/datadog-agent/pkg/security/config"
 	secconfig "github.com/DataDog/datadog-agent/pkg/security/config"
 	sprobe "github.com/DataDog/datadog-agent/pkg/security/probe"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
-	"github.com/spf13/cobra"
-	"go.uber.org/fx"
 )
 
 type activityDumpCliParams struct {
@@ -63,8 +62,8 @@ func listCommands(globalParams *command.GlobalParams) []*cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(listActivityDumps,
 				fx.Supply(core.BundleParams{
-					ConfigParams: compconfig.NewSecurityAgentParams(globalParams.ConfigFilePaths),
-					LogParams:    complog.LogForOneShot(command.LoggerName, "info", true)}),
+					ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths),
+					LogParams:    log.LogForOneShot(command.LoggerName, "info", true)}),
 				core.Bundle,
 			)
 		},
@@ -85,8 +84,8 @@ func stopCommands(globalParams *command.GlobalParams) []*cobra.Command {
 			return fxutil.OneShot(stopActivityDump,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams: compconfig.NewSecurityAgentParams(globalParams.ConfigFilePaths),
-					LogParams:    complog.LogForOneShot(command.LoggerName, "info", true)}),
+					ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths),
+					LogParams:    log.LogForOneShot(command.LoggerName, "info", true)}),
 				core.Bundle,
 			)
 		},
@@ -138,8 +137,8 @@ func generateDumpCommands(globalParams *command.GlobalParams) []*cobra.Command {
 			return fxutil.OneShot(generateActivityDump,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams: compconfig.NewSecurityAgentParams(globalParams.ConfigFilePaths),
-					LogParams:    complog.LogForOneShot(command.LoggerName, "info", true)}),
+					ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths),
+					LogParams:    log.LogForOneShot(command.LoggerName, "info", true)}),
 				core.Bundle,
 			)
 		},
@@ -179,7 +178,7 @@ func generateDumpCommands(globalParams *command.GlobalParams) []*cobra.Command {
 		&cliParams.localStorageFormats,
 		flags.Format,
 		[]string{},
-		fmt.Sprintf("local storage output formats. Available options are %v.", config.AllStorageFormats()),
+		fmt.Sprintf("local storage output formats. Available options are %v.", secconfig.AllStorageFormats()),
 	)
 	activityDumpGenerateDumpCmd.Flags().BoolVar(
 		&cliParams.remoteStorageCompression,
@@ -191,7 +190,7 @@ func generateDumpCommands(globalParams *command.GlobalParams) []*cobra.Command {
 		&cliParams.remoteStorageFormats,
 		flags.RemoteFormat,
 		[]string{},
-		fmt.Sprintf("remote storage output formats. Available options are %v.", config.AllStorageFormats()),
+		fmt.Sprintf("remote storage output formats. Available options are %v.", secconfig.AllStorageFormats()),
 	)
 
 	return []*cobra.Command{activityDumpGenerateDumpCmd}
@@ -209,8 +208,8 @@ func generateEncodingCommands(globalParams *command.GlobalParams) []*cobra.Comma
 			return fxutil.OneShot(generateEncodingFromActivityDump,
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams: compconfig.NewSecurityAgentParams(globalParams.ConfigFilePaths),
-					LogParams:    complog.LogForOneShot(command.LoggerName, "info", true)}),
+					ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths),
+					LogParams:    log.LogForOneShot(command.LoggerName, "info", true)}),
 				core.Bundle,
 			)
 		},
@@ -239,7 +238,7 @@ func generateEncodingCommands(globalParams *command.GlobalParams) []*cobra.Comma
 		&cliParams.localStorageFormats,
 		flags.Format,
 		[]string{},
-		fmt.Sprintf("local storage output formats. Available options are %v.", config.AllStorageFormats()),
+		fmt.Sprintf("local storage output formats. Available options are %v.", secconfig.AllStorageFormats()),
 	)
 	activityDumpGenerateEncodingCmd.Flags().BoolVar(
 		&cliParams.remoteStorageCompression,
@@ -251,7 +250,7 @@ func generateEncodingCommands(globalParams *command.GlobalParams) []*cobra.Comma
 		&cliParams.remoteStorageFormats,
 		flags.RemoteFormat,
 		[]string{},
-		fmt.Sprintf("remote storage output formats. Available options are %v.", config.AllStorageFormats()),
+		fmt.Sprintf("remote storage output formats. Available options are %v.", secconfig.AllStorageFormats()),
 	)
 	activityDumpGenerateEncodingCmd.Flags().BoolVar(
 		&cliParams.remoteRequest,
@@ -263,7 +262,7 @@ func generateEncodingCommands(globalParams *command.GlobalParams) []*cobra.Comma
 	return []*cobra.Command{activityDumpGenerateEncodingCmd}
 }
 
-func generateActivityDump(log complog.Component, config compconfig.Component, activityDumpArgs *activityDumpCliParams) error {
+func generateActivityDump(log log.Component, config config.Component, activityDumpArgs *activityDumpCliParams) error {
 	client, err := secagent.NewRuntimeSecurityClient()
 	if err != nil {
 		return fmt.Errorf("unable to create a runtime security client instance: %w", err)
@@ -292,7 +291,7 @@ func generateActivityDump(log complog.Component, config compconfig.Component, ac
 	return nil
 }
 
-func generateEncodingFromActivityDump(log complog.Component, config compconfig.Component, activityDumpArgs *activityDumpCliParams) error {
+func generateEncodingFromActivityDump(log log.Component, config config.Component, activityDumpArgs *activityDumpCliParams) error {
 	var output *api.TranscodingRequestMessage
 
 	if activityDumpArgs.remoteRequest {
@@ -365,7 +364,7 @@ func generateEncodingFromActivityDump(log complog.Component, config compconfig.C
 	return nil
 }
 
-func listActivityDumps(log complog.Component, config compconfig.Component) error {
+func listActivityDumps(log log.Component, config config.Component) error {
 	client, err := secagent.NewRuntimeSecurityClient()
 	if err != nil {
 		return fmt.Errorf("unable to create a runtime security client instance: %w", err)
@@ -394,13 +393,13 @@ func listActivityDumps(log complog.Component, config compconfig.Component) error
 
 func parseStorageRequest(activityDumpArgs *activityDumpCliParams) (*api.StorageRequestParams, error) {
 	// parse local storage formats
-	_, err := config.ParseStorageFormats(activityDumpArgs.localStorageFormats)
+	_, err := secconfig.ParseStorageFormats(activityDumpArgs.localStorageFormats)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't parse local storage formats %v: %v", activityDumpArgs.localStorageFormats, err)
 	}
 
 	// parse remote storage formats
-	_, err = config.ParseStorageFormats(activityDumpArgs.remoteStorageFormats)
+	_, err = secconfig.ParseStorageFormats(activityDumpArgs.remoteStorageFormats)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't parse remote storage formats %v: %v", activityDumpArgs.remoteStorageFormats, err)
 	}
@@ -413,7 +412,7 @@ func parseStorageRequest(activityDumpArgs *activityDumpCliParams) (*api.StorageR
 	}, nil
 }
 
-func stopActivityDump(log complog.Component, config compconfig.Component, activityDumpArgs *activityDumpCliParams) error {
+func stopActivityDump(log log.Component, config config.Component, activityDumpArgs *activityDumpCliParams) error {
 	client, err := secagent.NewRuntimeSecurityClient()
 	if err != nil {
 		return fmt.Errorf("unable to create a runtime security client instance: %w", err)

--- a/cmd/security-agent/subcommands/runtime/command_test.go
+++ b/cmd/security-agent/subcommands/runtime/command_test.go
@@ -1,0 +1,45 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+// +build linux
+
+package runtime
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/cmd/security-agent/command"
+	"github.com/DataDog/datadog-agent/comp/core"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+func TestDownloadCommand(t *testing.T) {
+	tests := []struct {
+		name     string
+		cliInput []string
+		check    func(cliParams *downloadPolicyCliParams, params core.BundleParams)
+	}{
+		{
+			name:     "runtime download",
+			cliInput: []string{"download"},
+			check: func(cliParams *downloadPolicyCliParams, params core.BundleParams) {
+				// Verify logger defaults
+				require.Equal(t, command.LoggerName, params.LoggerName(), "logger name not matching")
+				require.Equal(t, "off", params.LogLevelFn(nil), "log level not matching")
+			},
+		},
+	}
+
+	for _, test := range tests {
+		fxutil.TestOneShotSubcommand(t,
+			downloadPolicyCommands(&command.GlobalParams{}),
+			test.cliInput,
+			downloadPolicy,
+			test.check,
+		)
+	}
+}

--- a/cmd/security-agent/subcommands/runtime/command_unsupported.go
+++ b/cmd/security-agent/subcommands/runtime/command_unsupported.go
@@ -6,11 +6,6 @@
 //go:build !linux
 // +build !linux
 
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2016-present Datadog, Inc.
-
 package runtime
 
 import (
@@ -19,9 +14,9 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/DataDog/datadog-agent/cmd/security-agent/command"
-	coreconfig "github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/log"
 	secagent "github.com/DataDog/datadog-agent/pkg/security/agent"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/startstop"
 	ddgostatsd "github.com/DataDog/datadog-go/v5/statsd"
 )
@@ -30,8 +25,8 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 	return nil
 }
 
-func StartRuntimeSecurity(hostname string, stopper startstop.Stopper, statsdClient *ddgostatsd.Client) (*secagent.RuntimeSecurityAgent, error) {
-	enabled := coreconfig.Datadog.GetBool("runtime_security_config.enabled")
+func StartRuntimeSecurity(log log.Component, config config.Component, hostname string, stopper startstop.Stopper, statsdClient *ddgostatsd.Client) (*secagent.RuntimeSecurityAgent, error) {
+	enabled := config.GetBool("runtime_security_config.enabled")
 	if !enabled {
 		log.Info("Datadog runtime security agent disabled by config")
 		return nil, nil


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

SecAgent subcommands use config and log components. Also changing import aliases to be more clear.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
