### PR TITLE
Bump wheel dependency

### DIFF
--- a/omnibus/config/software/datadog-agent-integrations-py2.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py2.rb
@@ -142,7 +142,7 @@ build do
     #
     command "#{pip} download --dest #{build_deps_dir} hatchling==0.25.1", :env => pre_build_env
     command "#{pip} download --dest #{build_deps_dir} setuptools==40.9.0", :env => pre_build_env # Version from ./setuptools2.rb
-    command "#{pip} install wheel==0.34.1", :env => pre_build_env
+    command "#{pip} install wheel==0.37.1", :env => pre_build_env # Pin to the last version that supports Python 2
     command "#{pip} install setuptools-scm==5.0.2", :env => pre_build_env # Pin to the last version that supports Python 2
     command "#{pip} install pip-tools==5.4.0", :env => pre_build_env
     uninstall_buildtime_deps = ['rtloader', 'click', 'first', 'pip-tools']

--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -146,7 +146,7 @@ build do
     #
     command "#{pip} download --dest #{build_deps_dir} hatchling==0.25.1", :env => pre_build_env
     command "#{pip} download --dest #{build_deps_dir} setuptools==40.9.0", :env => pre_build_env # Version from ./setuptools3.rb
-    command "#{pip} install wheel==0.34.1", :env => pre_build_env
+    command "#{pip} install wheel==0.38.4", :env => pre_build_env
     command "#{pip} install pip-tools==6.4.0", :env => pre_build_env
     uninstall_buildtime_deps = ['rtloader', 'click', 'first', 'pip-tools']
     nix_build_env = {

--- a/releasenotes/notes/bump-wheel-218fcf0e14839ed5.yaml
+++ b/releasenotes/notes/bump-wheel-218fcf0e14839ed5.yaml
@@ -1,0 +1,4 @@
+---
+security:
+  - Upgrade the wheel package to ``0.37.1`` for Python 2.
+  - Upgrade the wheel package to ``0.38.4`` for Python 3.


### PR DESCRIPTION
### What does this PR do?

Bump the wheel package to 0.38.4 for Python 3.

### Motivation

https://github.com/DataDog/image-vuln-scans/issues/787

### Additional Notes

- Will be backported to 7.42.x
- They dropped py27 support with `0.38.0`: https://wheel.readthedocs.io/en/stable/news.html. I upgraded the wheel package to the latest version that supports py2 and updated our docs.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
