### PR TITLE
usm: classification: Shrink classification buffer to 24 bytes

### DIFF
--- a/pkg/ebpf/bytecode/runtime/conntrack.go
+++ b/pkg/ebpf/bytecode/runtime/conntrack.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var Conntrack = newAsset("conntrack.c", "72335fc256c51c132b458278257c91c82cc421b3751b066ceb4f353d21cc531c")
+var Conntrack = newAsset("conntrack.c", "062928aae30a386e5775b572cc76706206296199db998c9e0a9ccd05de3c1e30")

--- a/pkg/ebpf/bytecode/runtime/http.go
+++ b/pkg/ebpf/bytecode/runtime/http.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var Http = newAsset("http.c", "41b3b761a6be86c529ba7ae5465c57e38533cc55c54f10b266477f80b2aac376")
+var Http = newAsset("http.c", "fab897ce4876823d39425fade9bd232dab7db5d4a0203d2065c61def8a3a7713")

--- a/pkg/ebpf/bytecode/runtime/tracer.go
+++ b/pkg/ebpf/bytecode/runtime/tracer.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var Tracer = newAsset("tracer.c", "216cf8f371c638aaad812dd782ddeb83740ba09f13b8d1fcd9b690e22f48edeb")
+var Tracer = newAsset("tracer.c", "bd3239003d3aa7133b2041005565b16b0b0856d0dc449a957a9ec43bb785835a")

--- a/pkg/network/ebpf/c/protocols/protocol-classification-defs.h
+++ b/pkg/network/ebpf/c/protocols/protocol-classification-defs.h
@@ -6,10 +6,9 @@
 #include "amqp-defs.h"
 #include "mongo-defs.h"
 
-// Represents the max buffer size required to classify protocols .
-// We need to round it to be multiplication of 16 since we are reading blocks of 16 bytes in read_into_buffer_skb_all_kernels.
-// ATM, it is HTTP2_MARKER_SIZE + 8 bytes for padding,
-#define CLASSIFICATION_MAX_BUFFER (HTTP2_MARKER_SIZE + 8)
+// Represents the max buffer size required to classify protocols.
+// ATM, it is HTTP2_MARKER_SIZE.
+#define CLASSIFICATION_MAX_BUFFER (HTTP2_MARKER_SIZE)
 
 // Checkout https://datatracker.ietf.org/doc/html/rfc7540 under "HTTP/2 Connection Preface" section
 #define HTTP2_MARKER_SIZE 24


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Shrinks the buffer for classification from 32 bytes to 24 bytes (removing the padding)

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

The padding is not a "must have"
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
