### PR TITLE
Adding config option to disable delta profiles when profiling the Agent

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -821,6 +821,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("internal_profiling.block_profile_rate", 0)
 	config.BindEnvAndSetDefault("internal_profiling.mutex_profile_fraction", 0)
 	config.BindEnvAndSetDefault("internal_profiling.enable_goroutine_stacktraces", false)
+	config.BindEnvAndSetDefault("internal_profiling.delta_profiles", true)
 
 	config.BindEnvAndSetDefault("internal_profiling.capture_all_allocations", false)
 

--- a/pkg/config/settings/runtime_setting_profiling.go
+++ b/pkg/config/settings/runtime_setting_profiling.go
@@ -85,6 +85,7 @@ func (l ProfilingRuntimeSetting) Set(v interface{}) error {
 			MutexProfileFraction: profiling.GetMutexProfileFraction(),
 			BlockProfileRate:     profiling.GetBlockProfileRate(),
 			WithGoroutineProfile: config.Datadog.GetBool("internal_profiling.enable_goroutine_stacktraces"),
+			WithDeltaProfiles:    config.Datadog.GetBool("internal_profiling.delta_profiles"),
 			Tags:                 []string{fmt.Sprintf("version:%v", v)},
 		}
 		err := profiling.Start(settings)

--- a/pkg/util/profiling/profiling.go
+++ b/pkg/util/profiling/profiling.go
@@ -48,6 +48,7 @@ func Start(settings Settings) error {
 		profiler.WithPeriod(settings.Period),
 		profiler.WithProfileTypes(types...),
 		profiler.CPUDuration(settings.CPUDuration),
+		profiler.WithDeltaProfiles(settings.WithDeltaProfiles),
 		profiler.WithTags(settings.Tags...),
 	}
 

--- a/pkg/util/profiling/profiling_test.go
+++ b/pkg/util/profiling/profiling_test.go
@@ -22,6 +22,7 @@ func TestProfiling(t *testing.T) {
 		MutexProfileFraction: 0,
 		BlockProfileRate:     0,
 		WithGoroutineProfile: false,
+		WithDeltaProfiles:    false,
 		Tags:                 []string{"1.0.0"},
 	}
 	err := Start(settings)

--- a/pkg/util/profiling/settings.go
+++ b/pkg/util/profiling/settings.go
@@ -33,12 +33,14 @@ type Settings struct {
 	BlockProfileRate int
 	// WithGoroutineProfile additionally reports stack traces of all current goroutines
 	WithGoroutineProfile bool
+	// WithDeltaProfiles specifies if delta profiles are enabled
+	WithDeltaProfiles bool
 	// Tags are the additional tags to attach to profiles.
 	Tags []string
 }
 
 func (settings *Settings) String() string {
-	return fmt.Sprintf("[Target:%q][Env:%q][Period:%s][CPU:%s][Mutex:%d][Block:%d][Routines:%v]",
+	return fmt.Sprintf("[Target:%q][Env:%q][Period:%s][CPU:%s][Mutex:%d][Block:%d][Routines:%v][DeltaProfiles:%v]",
 		settings.ProfilingURL,
 		settings.Env,
 		settings.Period,
@@ -46,6 +48,7 @@ func (settings *Settings) String() string {
 		settings.MutexProfileFraction,
 		settings.BlockProfileRate,
 		settings.WithGoroutineProfile,
+		settings.WithDeltaProfiles,
 	)
 }
 


### PR DESCRIPTION
### What does this PR do?

This PR adds a new config option to the internal profiler, `internal_profiling.delta_profiles`. This allows us to enable or disable the delta profiler. By default it is set to `true` as that is the current behaviour of the internal profiler.

### Motivation

When we run some intense benchmarks we want to enable profiling but can't due to the memory usage of the profiler. We are generally not interested in using the [aggregation/compare feature](https://twitter.com/felixge/status/1432396074447159300) when looking into the way our benchmarks are behaving.

### Additional Notes

None.

### Possible Drawbacks / Trade-offs

Not able to use the aggregation/compare feature when delta profiles is disabled.

### Describe how to test/QA your changes

Deploy the two Agents, one running with:

- `DD_INTERNAL_PROFILING_ENABLED` set to `true`
- `DD_INTERNAL_PROFILING_DELTA_PROFILES` set to `false`

Example:
```
docker run -d \
--cgroupns host \
--pid host \
--name dd-agent-delta-profiles-disabled \
-v /var/run/docker.sock:/var/run/docker.sock:ro \
-v /proc/:/host/proc/:ro \
-v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
-e DD_INTERNAL_PROFILING_ENABLED=true \
-e DD_INTERNAL_PROFILING_DELTA_PROFILES=false \
-e DD_API_KEY=<DATADOG_API_KEY> \
gcr.io/datadoghq/agent:7
```
And one:

- `DD_INTERNAL_PROFILING_ENABLED` set to `true`

Example:
```
docker run -d \
--cgroupns host \
--pid host \
--name dd-agent-delta-profiles-enabled \
-v /var/run/docker.sock:/var/run/docker.sock:ro \
-v /proc/:/host/proc/:ro \
-v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
-e DD_INTERNAL_PROFILING_ENABLED=true \
-e DD_API_KEY=<DATADOG_API_KEY> \
gcr.io/datadoghq/agent:7
```

Once running:

- Check that delta profiles still works on `dd-agent-delta-profiles-enabled`
- Check that the memory usage of `dd-agent-delta-profiles-disabled` is less than  `dd-agent-delta-profiles-enabled` (it should be as delta profiles disabled)

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
