### PR TITLE
[secrets] Fix getDDAgentUserSID to account for NT AUTHORITY\SYSTEM

### DIFF
--- a/pkg/secrets/check_rights_windows.go
+++ b/pkg/secrets/check_rights_windows.go
@@ -11,7 +11,6 @@ package secrets
 import (
 	"fmt"
 	"os"
-	"strings"
 	"syscall"
 	"unsafe"
 
@@ -190,13 +189,11 @@ var getDDAgentUserSID = func() (*windows.SID, error) {
 		return nil, fmt.Errorf("could not read installedDomain in registry: %s", err)
 	}
 
-	if strings.EqualFold(domain, "NT AUTHORITY") {
-		// Installer writes `NT AUTHORITY` as installedDomain which prevents the username from being resolved correctly
+	if domain != "" {
 		user = domain + `\` + user
-		domain = ""
 	}
 
-	sid, _, _, err := windows.LookupSID(domain, user)
+	sid, _, _, err := windows.LookupSID("", user)
 	return sid, err
 }
 

--- a/pkg/secrets/check_rights_windows.go
+++ b/pkg/secrets/check_rights_windows.go
@@ -11,6 +11,7 @@ package secrets
 import (
 	"fmt"
 	"os"
+	"strings"
 	"syscall"
 	"unsafe"
 
@@ -187,6 +188,12 @@ var getDDAgentUserSID = func() (*windows.SID, error) {
 	domain, _, err := k.GetStringValue("installedDomain")
 	if err != nil {
 		return nil, fmt.Errorf("could not read installedDomain in registry: %s", err)
+	}
+
+	if strings.EqualFold(domain, "NT AUTHORITY") {
+		// Installer writes `NT AUTHORITY` as installedDomain which prevents the username from being resolved correctly
+		user = domain + `\` + user
+		domain = ""
 	}
 
 	sid, _, _, err := windows.LookupSID(domain, user)


### PR DESCRIPTION
### What does this PR do?

- Fixes an issue in the secrets permission check where `NT AUTHORITY\SYSTEM` was used as a user and the Agent service failed to start due to interpreting `NT AUTHORITY` as domain.

### Motivation

- Regression from 7.41.

### Describe how to test/QA your changes

Test agent installation with `DDAGENTUSER_NAME="NT Authority\System"` and make sure the service starts when a secret backend is configured.

```
PS> Start-Process -Wait msiexec -ArgumentList '/qb /l*v log.txt /i datadog-agent-7.42.0-rc.x-1-x86_64.msi PROCESS_ENABLED=true DDAGENTUSER_NAME="NT Authority\System"'
```
### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
