### PR TITLE
[CWS] remove now useless runtime files sync check

### DIFF
--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -18,7 +18,6 @@ from .system_probe import (
     CURRENT_ARCH,
     build_cws_object_files,
     check_for_ninja,
-    generate_runtime_files,
     ninja_define_ebpf_compiler,
     ninja_define_exe_compiler,
 )
@@ -656,7 +655,6 @@ def go_generate_check(ctx):
         [cws_go_generate],
         [generate_cws_documentation],
         [gen_mocks],
-        [generate_runtime_files],
     ]
     failing_tasks = []
 

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -264,7 +264,6 @@ def ninja_runtime_compilation_files(nw):
             rule="headerincl",
         )
         rc_outputs.extend([c_file, hash_file])
-    nw.build(rule="phony", inputs=rc_outputs, outputs=["runtime-compilation"])
 
 
 def ninja_cgo_type_files(nw, windows):
@@ -1105,11 +1104,6 @@ def clean_object_files(
         strip_object_files=strip_object_files,
         kernel_release=kernel_release,
     )
-
-
-# deprecated: this function is only kept to prevent breaking security-agent.go-generate-check
-def generate_runtime_files(ctx):
-    run_ninja(ctx, explain=True, target="runtime-compilation")
 
 
 @task


### PR DESCRIPTION
### What does this PR do?

With https://github.com/DataDog/datadog-agent/pull/14764 merged, we don't need this anymore

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
