### PR TITLE
[backport][7.42.x] Revert "[agent] Support for running secrets backends with sha256"

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -371,7 +371,6 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("secret_backend_timeout", 30)
 	config.BindEnvAndSetDefault("secret_backend_command_allow_group_exec_perm", false)
 	config.BindEnvAndSetDefault("secret_backend_skip_checks", false)
-	config.BindEnvAndSetDefault("secret_backend_command_sha256", "")
 
 	// Use to output logs in JSON format
 	config.BindEnvAndSetDefault("log_format_json", false)
@@ -1635,8 +1634,6 @@ func ResolveSecrets(config Config, origin string) error {
 		config.GetInt("secret_backend_timeout"),
 		config.GetInt("secret_backend_output_max_size"),
 		config.GetBool("secret_backend_command_allow_group_exec_perm"),
-		config.GetString("secret_backend_command_sha256"),
-		config.ConfigFileUsed(),
 	)
 
 	if config.GetString("secret_backend_command") != "" {

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -711,17 +711,6 @@ api_key:
 #
 # secret_backend_skip_checks: false
 
-## @param secret_backend_command_sha256 - string - optional
-## @env DD_SECRET_BACKEND_COMMAND_SHA256 - string - optional
-## `secret_backend_command_sha256` is the expected SHA256 of the backend command executable.
-## If `secret_backend_command_sha256` is used, the following restrictions are in place:
-## - Value specified in the `secret_backend_command` setting must be an absolute path.
-## - Permissions for the datadog.yaml config file must disallow write access by unprivileged accounts.
-## The agent will refuse to start if the actual SHA256 of 'secret_backend_command' executable is different
-## from the one specified by `secret_backend_command_sha256`.
-#
-# secret_backend_command_sha256: <SHA256>
-
 ## @param snmp_listener - custom object - optional
 ## Creates and schedules a listener to automatically discover your SNMP devices.
 ## Discovered devices can then be monitored with the SNMP integration by using

--- a/pkg/secrets/check_rights_nix.go
+++ b/pkg/secrets/check_rights_nix.go
@@ -10,13 +10,10 @@ package secrets
 
 import (
 	"fmt"
-	"os"
 	"os/user"
-	"strconv"
 	"syscall"
 )
 
-// checkRights validates that a secret backend has supported permissions
 func checkRights(path string, allowGroupExec bool) error {
 	var stat syscall.Stat_t
 	if err := syscall.Stat(path, &stat); err != nil {
@@ -92,53 +89,4 @@ func checkGroupPermission(stat *syscall.Stat_t, usr *user.User, userGroups []str
 	}
 
 	return nil
-}
-
-// checkConfigFilePermissions validates that a config file has supported permissions when using secret_backend_command_sha256 hash
-var checkConfigFilePermissions = func(path string) error {
-	var stat syscall.Stat_t
-	if err := syscall.Stat(path, &stat); err != nil {
-		return fmt.Errorf("unable to check permissions for '%s': can't stat it: %s", path, err)
-	}
-
-	if stat.Mode&syscall.S_IWOTH != 0 {
-		return fmt.Errorf("invalid config file permissions for '%s': cannot have o+w permission", path)
-	}
-
-	usr, err := user.Current()
-	if err != nil {
-		return fmt.Errorf("can't query current user: %s", err)
-	}
-
-	groups, err := usr.GroupIds()
-	if err != nil {
-		return fmt.Errorf("can't query user groups: %s", err)
-	}
-
-	if strconv.FormatInt(int64(stat.Uid), 10) != usr.Uid {
-		return fmt.Errorf("invalid config file permissions for '%s': not owned by %s", path, usr.Uid)
-	}
-
-	for _, g := range groups {
-		if strconv.FormatInt(int64(stat.Gid), 10) == g {
-			return nil
-		}
-	}
-
-	return fmt.Errorf("invalid config file permissions for '%s': not owned by any groups for user %s", path, usr.Uid)
-}
-
-// lockOpenFile opens the file and prevents overwrite and delete by another process
-func lockOpenFile(path string) (*os.File, error) {
-	fd, err := syscall.Open(path, syscall.O_CREAT|syscall.O_RDONLY, 0600)
-	if err != nil {
-		return nil, err
-	}
-
-	if err = syscall.Flock(fd, syscall.LOCK_EX); err != nil {
-		syscall.Close(fd)
-		return nil, err
-	}
-
-	return os.NewFile(uintptr(fd), path), nil
 }

--- a/pkg/secrets/check_rights_nix_test.go
+++ b/pkg/secrets/check_rights_nix_test.go
@@ -144,22 +144,3 @@ func Test_checkGroupPermission(t *testing.T) {
 		})
 	}
 }
-
-func TestCheckConfigFilePermissionsOtherRights(t *testing.T) {
-	tmpfile, err := os.CreateTemp("", "agent-config-file")
-	require.Nil(t, err)
-	defer os.Remove(tmpfile.Name())
-
-	// file exists
-	require.Error(t, checkConfigFilePermissions("/does not exists"))
-
-	require.NoError(t, os.Chmod(tmpfile.Name(), 0660))
-	require.NoError(t, checkConfigFilePermissions(tmpfile.Name()))
-
-	// other should have no write right
-	require.NoError(t, os.Chmod(tmpfile.Name(), 0664))
-	require.NoError(t, checkConfigFilePermissions(tmpfile.Name()))
-
-	require.NoError(t, os.Chmod(tmpfile.Name(), 0666))
-	require.Error(t, checkConfigFilePermissions(tmpfile.Name()))
-}

--- a/pkg/secrets/check_rights_windows.go
+++ b/pkg/secrets/check_rights_windows.go
@@ -11,7 +11,6 @@ package secrets
 import (
 	"fmt"
 	"os"
-	"syscall"
 	"unsafe"
 
 	"golang.org/x/sys/windows"
@@ -191,97 +190,4 @@ var getDDAgentUserSID = func() (*windows.SID, error) {
 
 	sid, _, _, err := windows.LookupSID(domain, user)
 	return sid, err
-}
-
-// checkConfigFilePermissions validates that a config file has supported permissions when using secret_backend_command_sha256 hash
-var checkConfigFilePermissions = func(filename string) error {
-	if _, err := os.Stat(filename); err != nil {
-		if os.IsNotExist(err) {
-			return fmt.Errorf("config file '%s' does not exist", filename)
-		}
-		return fmt.Errorf("unable to check permissions for config file '%s': %s", filename, err)
-	}
-
-	fileDacl, err := getACL(filename)
-	if err != nil {
-		return fmt.Errorf("could not query ACLs for config file '%s': %s", filename, err)
-	}
-
-	var aclSizeInfo winutil.AclSizeInformation
-	err = winutil.GetAclInformation(fileDacl, &aclSizeInfo, winutil.AclSizeInformationEnum)
-	if err != nil {
-		return fmt.Errorf("could not query ACLs for config file '%s': %s", filename, err)
-	}
-
-	// create the sids that are acceptable to us (local system account and
-	// administrators group)
-	localSystem, err := getLocalSystemSID()
-	if err != nil {
-		return fmt.Errorf("could not query Local System SID: %s", err)
-	}
-	defer windows.FreeSid(localSystem)
-
-	administrators, err := getAdministratorsSID()
-	if err != nil {
-		return fmt.Errorf("could not query Administrator SID: %s", err)
-	}
-	defer windows.FreeSid(administrators)
-
-	secretUser, err := getSecretUserSID()
-	if err != nil {
-		return err
-	}
-
-	for i := uint32(0); i < aclSizeInfo.AceCount; i++ {
-		var pAce *winutil.AccessAllowedAce
-		if err := winutil.GetAce(fileDacl, i, &pAce); err != nil {
-			return fmt.Errorf("could not query a ACE on '%s': %s", filename, err)
-		}
-
-		if pAce.AceType == winutil.ACCESS_DENIED_ACE_TYPE {
-			return fmt.Errorf("invalid permissions for config file '%s': explicit DENY not supported", filename)
-		}
-
-		if pAce.AceType == winutil.ACCESS_ALLOWED_ACE_TYPE {
-			compareSid := (*windows.SID)(unsafe.Pointer(&pAce.SidStart))
-			compareIsLocalSystem := windows.EqualSid(compareSid, localSystem)
-			compareIsAdministrators := windows.EqualSid(compareSid, administrators)
-			compareIsSecretUser := windows.EqualSid(compareSid, secretUser)
-			allowedAccountForWrite := compareIsLocalSystem || compareIsAdministrators || compareIsSecretUser
-			hasOnlyAllowForRead := pAce.AccessMask&^(windows.FILE_GENERIC_READ) == 0
-			if !allowedAccountForWrite && !hasOnlyAllowForRead {
-				return fmt.Errorf("invalid permissions for config file '%s': users/groups other than LOCAL_SYSTEM, Administrators or %s have rights on it", filename, secretUser)
-			}
-		}
-	}
-
-	return nil
-}
-
-// lockOpenFile opens the file and prevents overwrite and delete by another process
-func lockOpenFile(name string) (*os.File, error) {
-	h, err := winOpenFileShareRead(name)
-	if err != nil {
-		return nil, err
-	}
-	return os.NewFile(uintptr(h), name), nil
-}
-
-// winOpenFileShareRead opens the file in FILE_SHARE_READ sharing mode
-func winOpenFileShareRead(path string) (syscall.Handle, error) {
-	const fileFlagNormal = 0x00000080
-	filename, err := syscall.UTF16PtrFromString(path)
-	if err != nil {
-		return syscall.Handle(0), err
-	}
-	handle, err := syscall.CreateFile(
-		filename,
-		syscall.GENERIC_READ,
-		syscall.FILE_SHARE_READ,
-		nil,
-		syscall.OPEN_EXISTING,
-		fileFlagNormal,
-		0)
-
-	return handle, err
 }

--- a/pkg/secrets/fetch_secret.go
+++ b/pkg/secrets/fetch_secret.go
@@ -11,33 +11,21 @@ package secrets
 import (
 	"bytes"
 	"context"
-	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"hash"
-	"io"
-	"os"
 	"os/exec"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
-
-	"github.com/dustin/go-humanize"
 
 	"github.com/DataDog/datadog-agent/pkg/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util/common"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-const (
-	// PayloadVersion defines the current payload version sent to a secret backend
-	PayloadVersion = "1.0"
-
-	// maxHashFileLimit is the limit for the size of hashing of the binary
-	maxHashFileLimit = 1024 * 1024 * 1024 // 1Gi
-)
+// PayloadVersion defines the current payload version sent to a secret backend
+const PayloadVersion = "1.0"
 
 var (
 	tlmSecretBackendElapsed = telemetry.NewGauge("secret_backend", "elapsed_ms", []string{"command", "exit_code"}, "Elapsed time of secret backend invocation")
@@ -66,33 +54,7 @@ func execCommand(inputPayload string) ([]byte, error) {
 	}
 	defer done()
 
-	if secretBackendCommandSHA256 != "" {
-		if !filepath.IsAbs(secretBackendCommand) {
-			return nil, fmt.Errorf("error while running '%s': absolute path required with SHA256", secretBackendCommand)
-		}
-
-		if err := checkConfigFilePermissions(configFileUsed); err != nil {
-			return nil, err
-		}
-
-		f, err := lockOpenFile(secretBackendCommand)
-		if err != nil {
-			return nil, err
-		}
-		defer f.Close() //nolint:errcheck
-
-		sha256, err := fileHashSHA256(f)
-		if err != nil {
-			return nil, err
-		}
-
-		if !strings.EqualFold(sha256, secretBackendCommandSHA256) {
-			return nil, fmt.Errorf("error while running '%s': SHA256 mismatch, actual '%s' expected '%s'", secretBackendCommand, sha256, secretBackendCommandSHA256)
-		}
-
-	}
-
-	if err = checkRights(cmd.Path, secretBackendCommandAllowGroupExec); err != nil {
+	if err := checkRights(cmd.Path, secretBackendCommandAllowGroupExec); err != nil {
 		return nil, err
 	}
 
@@ -199,53 +161,4 @@ func fetchSecret(secretsHandle []string, origin string) (map[string]string, erro
 		res[sec] = v.Value
 	}
 	return res, nil
-}
-
-func fileHashSHA256(f *os.File) (string, error) {
-	stat, err := f.Stat()
-	if err != nil {
-		return "", err
-	}
-
-	if !stat.Mode().IsRegular() ||
-		(stat.Mode()&(os.ModeSymlink|os.ModeSocket|os.ModeCharDevice|os.ModeDevice|os.ModeNamedPipe) != 0) {
-		return "", fmt.Errorf("expecting regular file, got 0x%x", stat.Mode())
-	}
-
-	h := sha256.New()
-
-	fileSize := stat.Size()
-	if fileSize == 0 {
-		return formatHash(h), nil
-	}
-
-	if fileSize > maxHashFileLimit {
-		return "", fmt.Errorf("file size exceeds the limit of %s", humanize.Bytes(maxHashFileLimit))
-	}
-
-	r := io.LimitReader(f, maxHashFileLimit)
-
-	var bufSize int64 = 102400
-	if fileSize < bufSize {
-		bufSize = fileSize
-	}
-
-	buffer := make([]byte, bufSize)
-
-	for {
-		read, err := r.Read(buffer)
-		if err != nil {
-			if err != io.EOF {
-				return "", err
-			}
-			break
-		}
-		h.Write(buffer[:read])
-	}
-
-	return formatHash(h), nil
-}
-
-func formatHash(h hash.Hash) string {
-	return fmt.Sprintf("%x", h.Sum(nil))
 }

--- a/pkg/secrets/fetch_secret_test.go
+++ b/pkg/secrets/fetch_secret_test.go
@@ -13,7 +13,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"runtime"
 	"testing"
 
@@ -89,8 +88,7 @@ func TestExecCommandError(t *testing.T) {
 	defer func() {
 		secretBackendCommand = ""
 		secretBackendArguments = []string{}
-		secretBackendTimeout = defaultSecretBackendTimeout
-		SecretBackendOutputMaxSize = defaultSecretBackendOutputMaxSize
+		secretBackendTimeout = 0
 	}()
 
 	inputPayload := "{\"version\": \"" + PayloadVersion + "\" , \"secrets\": [\"sec1\", \"sec2\"]}"
@@ -146,63 +144,6 @@ func TestExecCommandError(t *testing.T) {
 	_, err = execCommand(inputPayload)
 	require.NotNil(t, err)
 	assert.Equal(t, "error while running './test/response_too_long/response_too_long"+binExtension+"': command output was too long: exceeded 20 bytes", err.Error())
-}
-
-func TestExecCommandWithHash(t *testing.T) {
-	prevCheckConfigFilePermissions := checkConfigFilePermissions
-	checkConfigFilePermissions = func(string) error { return nil }
-	defer func() {
-		secretBackendCommand = ""
-		secretBackendArguments = []string{}
-		secretBackendTimeout = defaultSecretBackendTimeout
-		secretBackendCommandSHA256 = ""
-		SecretBackendOutputMaxSize = defaultSecretBackendOutputMaxSize
-		checkConfigFilePermissions = prevCheckConfigFilePermissions
-	}()
-
-	inputPayload := `{"version": ""` + PayloadVersion + `" , "secrets": ["sec1", "sec2"]}`
-
-	// test simple with hash (no error)
-	secretBackendCommand, _ = filepath.Abs("./test/simple/simple" + binExtension)
-	setCorrectRight(secretBackendCommand)
-	f, err := os.Open(secretBackendCommand)
-	require.NoError(t, err)
-	hash, err := fileHashSHA256(f)
-	_ = f.Close()
-	require.NoError(t, err)
-	secretBackendCommandSHA256 = hash
-	resp, err := execCommand(inputPayload)
-	require.NoError(t, err)
-	require.Equal(t, []byte(`{"handle1":{"value":"simple_password"}}`), resp)
-}
-
-func TestExecCommandErrorNotAbsPath(t *testing.T) {
-	secretBackendCommand = "test/simple/simple.go"
-	secretBackendCommandSHA256 = "foo"
-	defer func() {
-		secretBackendCommand = ""
-		secretBackendCommandSHA256 = ""
-	}()
-	resp, err := execCommand("")
-	assert.Nil(t, resp)
-	assert.EqualError(t, err, `error while running 'test/simple/simple.go': absolute path required with SHA256`)
-}
-
-func TestExecCommandErrorHashMismatch(t *testing.T) {
-	var err error
-	secretBackendCommand, err = filepath.Abs("./test/simple/simple.go")
-	require.NoError(t, err)
-	secretBackendCommandSHA256 = "foo"
-	prevCheckConfigFilePermissions := checkConfigFilePermissions
-	checkConfigFilePermissions = func(string) error { return nil }
-	defer func() {
-		secretBackendCommand = ""
-		secretBackendCommandSHA256 = ""
-		checkConfigFilePermissions = prevCheckConfigFilePermissions
-	}()
-	resp, err := execCommand("")
-	assert.Nil(t, resp)
-	assert.EqualError(t, err, `error while running '`+secretBackendCommand+`': SHA256 mismatch, actual '0e47e4f4749aa31a8d0c92607b75c251efdf9602fec15f060a18ad4aabbf0d1f' expected 'foo'`)
 }
 
 func TestFetchSecretExecError(t *testing.T) {
@@ -304,13 +245,4 @@ func TestFetchSecret(t *testing.T) {
 		"handle2": "p2",
 	}, secretCache)
 	assert.Equal(t, map[string]common.StringSet{"handle1": common.NewStringSet("test"), "handle2": common.NewStringSet("test")}, secretOrigin)
-}
-
-func TestCheckHash(t *testing.T) {
-	f, err := os.Open("test/simple/simple.go")
-	assert.NoError(t, err)
-	defer f.Close() //nolint:errcheck
-	hash, err := fileHashSHA256(f)
-	assert.NoError(t, err)
-	assert.Equal(t, "0e47e4f4749aa31a8d0c92607b75c251efdf9602fec15f060a18ad4aabbf0d1f", hash)
 }

--- a/pkg/secrets/info.go
+++ b/pkg/secrets/info.go
@@ -14,25 +14,18 @@ import (
 
 // SecretInfo export troubleshooting information about the decrypted secrets
 type SecretInfo struct {
-	ExecutablePath       string
-	ExecutablePathSHA256 string
-	Rights               string
-	RightDetails         string
-	UnixOwner            string
-	UnixGroup            string
-	SecretsHandles       map[string][]string
+	ExecutablePath string
+	Rights         string
+	RightDetails   string
+	UnixOwner      string
+	UnixGroup      string
+	SecretsHandles map[string][]string
 }
 
 // Print output a SecretInfo to a io.Writer
 func (si *SecretInfo) Print(w io.Writer) {
 	fmt.Fprintf(w, "=== Checking executable rights ===\n")
 	fmt.Fprintf(w, "Executable path: %s\n", si.ExecutablePath)
-
-	sha256 := si.ExecutablePathSHA256
-	if si.ExecutablePathSHA256 == "" {
-		sha256 = "Not configured"
-	}
-	fmt.Fprintf(w, "Executable path SHA256: %s\n", sha256)
 
 	fmt.Fprintf(w, "Check Rights: %s\n", si.Rights)
 

--- a/pkg/secrets/no_secrets.go
+++ b/pkg/secrets/no_secrets.go
@@ -18,8 +18,7 @@ import (
 var SecretBackendOutputMaxSize = 1024 * 1024
 
 // Init placeholder when compiled without the 'secrets' build tag
-func Init(command string, arguments []string, timeout int, maxSize int, groupExecPerm bool, sha256 string, configFile string) {
-}
+func Init(command string, arguments []string, timeout int, maxSize int, groupExecPerm bool) {}
 
 // Decrypt encrypted secrets are not available on windows
 func Decrypt(data []byte, origin string) ([]byte, error) {
@@ -28,5 +27,5 @@ func Decrypt(data []byte, origin string) ([]byte, error) {
 
 // GetDebugInfo exposes debug informations about secrets to be included in a flare
 func GetDebugInfo() (*SecretInfo, error) {
-	return nil, fmt.Errorf("secret feature is not available in this version of the agent")
+	return nil, fmt.Errorf("Secret feature is not available in this version of the agent")
 }

--- a/pkg/secrets/secrets.go
+++ b/pkg/secrets/secrets.go
@@ -18,11 +18,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-const (
-	defaultSecretBackendTimeout       = 5
-	defaultSecretBackendOutputMaxSize = 1024 * 1024
-)
-
 var (
 	secretCache map[string]string
 	// list of handles and where they were found
@@ -30,13 +25,11 @@ var (
 
 	secretBackendCommand               string
 	secretBackendArguments             []string
-	secretBackendTimeout               = defaultSecretBackendTimeout
+	secretBackendTimeout               = 5
 	secretBackendCommandAllowGroupExec bool
-	secretBackendCommandSHA256         string
-	configFileUsed                     string
 
 	// SecretBackendOutputMaxSize defines max size of the JSON output from a secrets reader backend
-	SecretBackendOutputMaxSize = defaultSecretBackendOutputMaxSize
+	SecretBackendOutputMaxSize = 1024 * 1024
 )
 
 func init() {
@@ -47,14 +40,12 @@ func init() {
 // Init initializes the command and other options of the secrets package. Since
 // this package is used by the 'config' package to decrypt itself we can't
 // directly use it.
-func Init(command string, arguments []string, timeout int, maxSize int, groupExecPerm bool, sha256 string, configFile string) {
+func Init(command string, arguments []string, timeout int, maxSize int, groupExecPerm bool) {
 	secretBackendCommand = command
 	secretBackendArguments = arguments
 	secretBackendTimeout = timeout
 	SecretBackendOutputMaxSize = maxSize
 	secretBackendCommandAllowGroupExec = groupExecPerm
-	secretBackendCommandSHA256 = sha256
-	configFileUsed = configFile
 	if secretBackendCommandAllowGroupExec {
 		log.Warnf("Agent configuration relax permissions constraint on the secret backend cmd, Group can read and exec")
 	}
@@ -212,10 +203,7 @@ func GetDebugInfo() (*SecretInfo, error) {
 	if secretBackendCommand == "" {
 		return nil, fmt.Errorf("No secret_backend_command set: secrets feature is not enabled")
 	}
-	info := &SecretInfo{
-		ExecutablePath:       secretBackendCommand,
-		ExecutablePathSHA256: secretBackendCommandSHA256,
-	}
+	info := &SecretInfo{ExecutablePath: secretBackendCommand}
 	info.populateRights()
 
 	info.SecretsHandles = map[string][]string{}


### PR DESCRIPTION
### What does this PR do?

Backport of https://github.com/DataDog/datadog-agent/pull/14940 to 7.42.x.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

See details in https://github.com/DataDog/datadog-agent/pull/14940.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
