### PR TITLE
[workloadmeta/kubelet] Parse image ID if name is a SHA256

### DIFF
--- a/pkg/workloadmeta/collectors/internal/kubelet/kubelet.go
+++ b/pkg/workloadmeta/collectors/internal/kubelet/kubelet.go
@@ -176,7 +176,16 @@ func (c *collector) parsePodContainers(
 
 		image, err := workloadmeta.NewContainerImage(container.Image)
 		if err != nil {
-			log.Debugf("cannot split image name %q: %s", container.Image, err)
+			if err == containers.ErrImageIsSha256 {
+				// try the resolved image ID if the image name in the container
+				// status is a SHA256. this seems to happen sometimes when
+				// pinning the image to a SHA256
+				image, err = workloadmeta.NewContainerImage(container.ImageID)
+			}
+
+			if err != nil {
+				log.Debugf("cannot split image name %q nor %q: %s", container.Image, container.ImageID, err)
+			}
 		}
 
 		image.ID = container.ImageID


### PR DESCRIPTION
### What does this PR do?

We now try to parse the resolved image ID if the image in the pod's
container status is a SHA256. This seems to happen when pinning the
SHA256 in the container spec. This fixes an issue where `image:` filters
in DD_CONTAINER_INCLUDE/DD_CONTAINER_EXCLUDE would not be respected.

### Describe how to test/QA your changes

Create a pod with an image name such as `redis@sha256:8184cfe57f205ab34c62bd0e9552dffeb885d2a7f82ce4295c0df344cb6f0007` (and check that the pod status has just the SHA256 in the `image` field, in my testing that wasn't always the case and I can't figure out why. GKE seems to work consistently). `agent workload-list --verbose` should not have the SHA256 as the image name, either for the `node_orchestrator` source, nor the merged result.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
