### PR TITLE
[process-agent] Scaffold components for process agent

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -176,6 +176,7 @@
 # BEGIN COMPONENTS
 /comp @DataDog/agent-shared-components
 /comp/core @DataDog/agent-shared-components
+/comp/process @DataDog/processes
 # END COMPONENTS
 
 # pkg

--- a/comp/README.md
+++ b/comp/README.md
@@ -23,3 +23,26 @@ Package flare implements a component to generate flares from the agent.
 ### [comp/core/log](https://pkg.go.dev/github.com/DataDog/dd-agent-comp-experiments/comp/core/log)
 
 Package log implements a component to handle logging internal to the agent.
+
+## [comp/process](https://pkg.go.dev/github.com/DataDog/dd-agent-comp-experiments/comp/process) (Component Bundle)
+
+*Datadog Team*: processes
+
+Package process implements the "process" bundle, providing components for the Process Agent
+
+### [comp/process/containercheck](https://pkg.go.dev/github.com/DataDog/dd-agent-comp-experiments/comp/process/containercheck)
+
+Package containercheck implements a component to handle Container data collection in the Process Agent.
+
+### [comp/process/processcheck](https://pkg.go.dev/github.com/DataDog/dd-agent-comp-experiments/comp/process/processcheck)
+
+Package processcheck implements a component to handle Process data collection in the Process Agent.
+
+### [comp/process/runner](https://pkg.go.dev/github.com/DataDog/dd-agent-comp-experiments/comp/process/runner)
+
+Package runner implements a component to run data collection checks in the Process Agent.
+
+### [comp/process/submitter](https://pkg.go.dev/github.com/DataDog/dd-agent-comp-experiments/comp/process/submitter)
+
+Package submitter implements a component to submit collected data in the Process Agent to
+supported Datadog intakes.

--- a/comp/process/bundle.go
+++ b/comp/process/bundle.go
@@ -1,0 +1,38 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package process implements the "process" bundle, providing components for the Process Agent
+//
+// The constituent components serve as utilities and are mostly independent of
+// one another.  Other components should depend on any components they need.
+//
+// This bundle does not depend on any other bundles.
+package process
+
+import (
+	"github.com/DataDog/datadog-agent/comp/process/containercheck"
+	"github.com/DataDog/datadog-agent/comp/process/processcheck"
+	"github.com/DataDog/datadog-agent/comp/process/runner"
+	"github.com/DataDog/datadog-agent/comp/process/submitter"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+// team: processes
+
+// Bundle defines the fx options for this bundle.
+var Bundle = fxutil.Bundle(
+	runner.Module,
+	submitter.Module,
+	processcheck.Module,
+	containercheck.Module,
+)
+
+// MockBundle defines the mock fx options for this bundle.
+var MockBundle = fxutil.Bundle(
+	runner.Module,
+	submitter.Module,
+	processcheck.Module,
+	containercheck.Module,
+)

--- a/comp/process/bundle.go
+++ b/comp/process/bundle.go
@@ -28,11 +28,3 @@ var Bundle = fxutil.Bundle(
 	processcheck.Module,
 	containercheck.Module,
 )
-
-// MockBundle defines the mock fx options for this bundle.
-var MockBundle = fxutil.Bundle(
-	runner.Module,
-	submitter.Module,
-	processcheck.Module,
-	containercheck.Module,
-)

--- a/comp/process/bundle_test.go
+++ b/comp/process/bundle_test.go
@@ -6,6 +6,7 @@
 package process
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -37,7 +38,7 @@ func TestBundleOneShot(t *testing.T) {
 		}
 		require.ElementsMatch(t, []string{"process", "container"}, names)
 
-		require.NoError(t, r.Run(nil))
+		require.NoError(t, r.Run(context.TODO()))
 	}
 
 	err := fxutil.OneShot(runCmd,

--- a/comp/process/bundle_test.go
+++ b/comp/process/bundle_test.go
@@ -1,0 +1,65 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package process
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/fx"
+
+	"github.com/DataDog/datadog-agent/comp/process/containercheck"
+	"github.com/DataDog/datadog-agent/comp/process/processcheck"
+	"github.com/DataDog/datadog-agent/comp/process/runner"
+	"github.com/DataDog/datadog-agent/comp/process/submitter"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+func TestBundleDependencies(t *testing.T) {
+	require.NoError(t, fx.ValidateApp(
+		// instantiate all of the process components, since this is not done
+		// automatically.
+		fx.Invoke(func(r runner.Component) {}),
+		fx.Invoke(func(r submitter.Component) {}),
+		fx.Invoke(func(r processcheck.Component) {}),
+		fx.Invoke(func(r containercheck.Component) {}),
+
+		Bundle))
+}
+
+func TestMockBundleDependencies(t *testing.T) {
+	require.NoError(t, fx.ValidateApp(
+		fx.Supply(fx.Annotate(t, fx.As(new(testing.TB)))),
+
+		// instantiate all of the process components, since this is not done
+		// automatically.
+		fx.Invoke(func(runner.Component) {}),
+		fx.Invoke(func(r submitter.Component) {}),
+		fx.Invoke(func(r processcheck.Component) {}),
+		fx.Invoke(func(r containercheck.Component) {}),
+		MockBundle))
+}
+
+func TestBundleOneShot(t *testing.T) {
+	runCmd := func(r runner.Component) {
+		checks := r.GetChecks()
+		require.Len(t, checks, 2)
+
+		names := []string{}
+		for _, c := range checks {
+			require.True(t, c.IsEnabled())
+			names = append(names, c.Name())
+		}
+		require.ElementsMatch(t, []string{"process", "container"}, names)
+
+		require.NoError(t, r.Run(nil))
+	}
+
+	err := fxutil.OneShot(runCmd,
+		Bundle,
+	)
+	require.NoError(t, err)
+}

--- a/comp/process/bundle_test.go
+++ b/comp/process/bundle_test.go
@@ -11,8 +11,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/fx"
 
-	"github.com/DataDog/datadog-agent/comp/process/containercheck"
-	"github.com/DataDog/datadog-agent/comp/process/processcheck"
 	"github.com/DataDog/datadog-agent/comp/process/runner"
 	"github.com/DataDog/datadog-agent/comp/process/submitter"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
@@ -24,23 +22,7 @@ func TestBundleDependencies(t *testing.T) {
 		// automatically.
 		fx.Invoke(func(r runner.Component) {}),
 		fx.Invoke(func(r submitter.Component) {}),
-		fx.Invoke(func(r processcheck.Component) {}),
-		fx.Invoke(func(r containercheck.Component) {}),
-
 		Bundle))
-}
-
-func TestMockBundleDependencies(t *testing.T) {
-	require.NoError(t, fx.ValidateApp(
-		fx.Supply(fx.Annotate(t, fx.As(new(testing.TB)))),
-
-		// instantiate all of the process components, since this is not done
-		// automatically.
-		fx.Invoke(func(runner.Component) {}),
-		fx.Invoke(func(r submitter.Component) {}),
-		fx.Invoke(func(r processcheck.Component) {}),
-		fx.Invoke(func(r containercheck.Component) {}),
-		MockBundle))
 }
 
 func TestBundleOneShot(t *testing.T) {

--- a/comp/process/containercheck/check.go
+++ b/comp/process/containercheck/check.go
@@ -1,0 +1,47 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package containercheck
+
+import (
+	"go.uber.org/fx"
+
+	"github.com/DataDog/datadog-agent/comp/process/runner"
+	"github.com/DataDog/datadog-agent/comp/process/submitter"
+)
+
+// provides wraps the check implementation
+type provides struct {
+	fx.Out
+
+	Component
+
+	Check runner.Check `group:"check"`
+}
+
+type check struct {
+}
+
+func (c *check) IsEnabled() bool {
+	return true
+}
+
+func (c *check) Run() (*submitter.Payload, error) {
+	return &submitter.Payload{}, nil
+}
+
+func (c *check) Name() string {
+	return "container"
+}
+
+type dependencies struct {
+	fx.In
+}
+
+func newCheck(deps dependencies) provides {
+	return provides{
+		Check: &check{},
+	}
+}

--- a/comp/process/containercheck/check.go
+++ b/comp/process/containercheck/check.go
@@ -8,16 +8,8 @@ package containercheck
 import (
 	"go.uber.org/fx"
 
-	"github.com/DataDog/datadog-agent/comp/process/runner"
-	"github.com/DataDog/datadog-agent/comp/process/submitter"
+	"github.com/DataDog/datadog-agent/comp/process/types"
 )
-
-// provides wraps the check implementation
-type provides struct {
-	fx.Out
-
-	Check runner.Check `group:"check"`
-}
 
 type check struct {
 }
@@ -26,8 +18,8 @@ func (c *check) IsEnabled() bool {
 	return true
 }
 
-func (c *check) Run() (*submitter.Payload, error) {
-	return &submitter.Payload{}, nil
+func (c *check) Run() (*types.Payload, error) {
+	return &types.Payload{}, nil
 }
 
 func (c *check) Name() string {
@@ -38,8 +30,8 @@ type dependencies struct {
 	fx.In
 }
 
-func newCheck(deps dependencies) provides {
-	return provides{
+func newCheck(deps dependencies) types.ProvidesCheck {
+	return types.ProvidesCheck{
 		Check: &check{},
 	}
 }

--- a/comp/process/containercheck/check.go
+++ b/comp/process/containercheck/check.go
@@ -16,8 +16,6 @@ import (
 type provides struct {
 	fx.Out
 
-	Component
-
 	Check runner.Check `group:"check"`
 }
 

--- a/comp/process/containercheck/component.go
+++ b/comp/process/containercheck/component.go
@@ -14,6 +14,10 @@ import (
 
 // team: processes
 
+// Component is the component type.
+type Component interface {
+}
+
 // Module defines the fx options for this component.
 var Module = fxutil.Component(
 	fx.Provide(newCheck),

--- a/comp/process/containercheck/component.go
+++ b/comp/process/containercheck/component.go
@@ -14,10 +14,6 @@ import (
 
 // team: processes
 
-// Component is the component type.
-type Component interface {
-}
-
 // Module defines the fx options for this component.
 var Module = fxutil.Component(
 	fx.Provide(newCheck),

--- a/comp/process/containercheck/component.go
+++ b/comp/process/containercheck/component.go
@@ -1,0 +1,24 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package containercheck implements a component to handle Container data collection in the Process Agent.
+package containercheck
+
+import (
+	"go.uber.org/fx"
+
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+// team: processes
+
+// Component is the component type.
+type Component interface {
+}
+
+// Module defines the fx options for this component.
+var Module = fxutil.Component(
+	fx.Provide(newCheck),
+)

--- a/comp/process/processcheck/check.go
+++ b/comp/process/processcheck/check.go
@@ -16,8 +16,6 @@ import (
 type provides struct {
 	fx.Out
 
-	Component
-
 	Check runner.Check `group:"check"`
 }
 

--- a/comp/process/processcheck/check.go
+++ b/comp/process/processcheck/check.go
@@ -1,0 +1,47 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package processcheck
+
+import (
+	"go.uber.org/fx"
+
+	"github.com/DataDog/datadog-agent/comp/process/runner"
+	"github.com/DataDog/datadog-agent/comp/process/submitter"
+)
+
+// provides wraps the check implementation
+type provides struct {
+	fx.Out
+
+	Component
+
+	Check runner.Check `group:"check"`
+}
+
+type check struct {
+}
+
+func (c *check) IsEnabled() bool {
+	return true
+}
+
+func (c *check) Run() (*submitter.Payload, error) {
+	return &submitter.Payload{}, nil
+}
+
+func (c *check) Name() string {
+	return "process"
+}
+
+type dependencies struct {
+	fx.In
+}
+
+func newCheck(deps dependencies) provides {
+	return provides{
+		Check: &check{},
+	}
+}

--- a/comp/process/processcheck/check.go
+++ b/comp/process/processcheck/check.go
@@ -8,16 +8,8 @@ package processcheck
 import (
 	"go.uber.org/fx"
 
-	"github.com/DataDog/datadog-agent/comp/process/runner"
-	"github.com/DataDog/datadog-agent/comp/process/submitter"
+	"github.com/DataDog/datadog-agent/comp/process/types"
 )
-
-// provides wraps the check implementation
-type provides struct {
-	fx.Out
-
-	Check runner.Check `group:"check"`
-}
 
 type check struct {
 }
@@ -26,8 +18,8 @@ func (c *check) IsEnabled() bool {
 	return true
 }
 
-func (c *check) Run() (*submitter.Payload, error) {
-	return &submitter.Payload{}, nil
+func (c *check) Run() (*types.Payload, error) {
+	return &types.Payload{}, nil
 }
 
 func (c *check) Name() string {
@@ -38,8 +30,8 @@ type dependencies struct {
 	fx.In
 }
 
-func newCheck(deps dependencies) provides {
-	return provides{
+func newCheck(deps dependencies) types.ProvidesCheck {
+	return types.ProvidesCheck{
 		Check: &check{},
 	}
 }

--- a/comp/process/processcheck/component.go
+++ b/comp/process/processcheck/component.go
@@ -1,0 +1,24 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package processcheck implements a component to handle Process data collection in the Process Agent.
+package processcheck
+
+import (
+	"go.uber.org/fx"
+
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+// team: processes
+
+// Component is the component type.
+type Component interface {
+}
+
+// Module defines the fx options for this component.
+var Module = fxutil.Component(
+	fx.Provide(newCheck),
+)

--- a/comp/process/processcheck/component.go
+++ b/comp/process/processcheck/component.go
@@ -14,6 +14,10 @@ import (
 
 // team: processes
 
+// Component is the component type.
+type Component interface {
+}
+
 // Module defines the fx options for this component.
 var Module = fxutil.Component(
 	fx.Provide(newCheck),

--- a/comp/process/processcheck/component.go
+++ b/comp/process/processcheck/component.go
@@ -14,10 +14,6 @@ import (
 
 // team: processes
 
-// Component is the component type.
-type Component interface {
-}
-
 // Module defines the fx options for this component.
 var Module = fxutil.Component(
 	fx.Provide(newCheck),

--- a/comp/process/runner/check.go
+++ b/comp/process/runner/check.go
@@ -1,0 +1,17 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package runner
+
+import (
+	"github.com/DataDog/datadog-agent/comp/process/submitter"
+)
+
+// Check defines an interface implemented by checks
+type Check interface {
+	IsEnabled() bool
+	Name() string
+	Run() (*submitter.Payload, error)
+}

--- a/comp/process/runner/component.go
+++ b/comp/process/runner/component.go
@@ -1,0 +1,36 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package runner implements a component to run data collection checks in the Process Agent.
+package runner
+
+import (
+	"go.uber.org/fx"
+
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+// team: processes
+
+// Component is the component type.
+type Component interface {
+	GetChecks() []Check
+	Run(exit <-chan struct{}) error
+}
+
+// Mock implements mock-specific methods.
+type Mock interface {
+	Component
+}
+
+// Module defines the fx options for this component.
+var Module = fxutil.Component(
+	fx.Provide(newRunner),
+)
+
+// MockModule defines the fx options for the mock component.
+var MockModule = fxutil.Component(
+	fx.Provide(newMock),
+)

--- a/comp/process/runner/component.go
+++ b/comp/process/runner/component.go
@@ -9,6 +9,7 @@ package runner
 import (
 	"go.uber.org/fx"
 
+	"github.com/DataDog/datadog-agent/comp/process/types"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
@@ -16,7 +17,7 @@ import (
 
 // Component is the component type.
 type Component interface {
-	GetChecks() []Check
+	GetChecks() []types.Check
 	Run(exit <-chan struct{}) error
 }
 

--- a/comp/process/runner/component.go
+++ b/comp/process/runner/component.go
@@ -7,6 +7,8 @@
 package runner
 
 import (
+	"context"
+
 	"go.uber.org/fx"
 
 	"github.com/DataDog/datadog-agent/comp/process/types"
@@ -18,7 +20,7 @@ import (
 // Component is the component type.
 type Component interface {
 	GetChecks() []types.Check
-	Run(exit <-chan struct{}) error
+	Run(ctx context.Context) error
 }
 
 // Mock implements mock-specific methods.

--- a/comp/process/runner/runner.go
+++ b/comp/process/runner/runner.go
@@ -1,0 +1,60 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package runner
+
+import (
+	"testing"
+	"time"
+
+	"go.uber.org/fx"
+
+	"github.com/DataDog/datadog-agent/comp/process/submitter"
+)
+
+// runner implements the Component.
+type runner struct {
+	checks    []Check
+	submitter submitter.Component
+}
+
+type dependencies struct {
+	fx.In
+
+	Checks    []Check `group:"check"`
+	Submitter submitter.Component
+}
+
+func newRunner(deps dependencies) (Component, error) {
+	return &runner{
+		checks:    deps.Checks,
+		submitter: deps.Submitter,
+	}, nil
+}
+
+func (r *runner) Run(exit <-chan struct{}) error {
+
+	for _, c := range r.checks {
+		if !c.IsEnabled() {
+			continue
+		}
+
+		payload, err := c.Run()
+		if err != nil {
+			return err
+		}
+		r.submitter.Submit(time.Now(), c.Name(), payload)
+	}
+	return nil
+}
+
+func (r *runner) GetChecks() []Check {
+	return r.checks
+}
+
+func newMock(deps dependencies, t testing.TB) Component {
+	// TODO
+	return nil
+}

--- a/comp/process/runner/runner.go
+++ b/comp/process/runner/runner.go
@@ -12,18 +12,19 @@ import (
 	"go.uber.org/fx"
 
 	"github.com/DataDog/datadog-agent/comp/process/submitter"
+	"github.com/DataDog/datadog-agent/comp/process/types"
 )
 
 // runner implements the Component.
 type runner struct {
-	checks    []Check
+	checks    []types.Check
 	submitter submitter.Component
 }
 
 type dependencies struct {
 	fx.In
 
-	Checks    []Check `group:"check"`
+	Checks    []types.Check `group:"check"`
 	Submitter submitter.Component
 }
 
@@ -50,7 +51,7 @@ func (r *runner) Run(exit <-chan struct{}) error {
 	return nil
 }
 
-func (r *runner) GetChecks() []Check {
+func (r *runner) GetChecks() []types.Check {
 	return r.checks
 }
 

--- a/comp/process/runner/runner.go
+++ b/comp/process/runner/runner.go
@@ -6,6 +6,7 @@
 package runner
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -35,7 +36,7 @@ func newRunner(deps dependencies) (Component, error) {
 	}, nil
 }
 
-func (r *runner) Run(exit <-chan struct{}) error {
+func (r *runner) Run(ctx context.Context) error {
 
 	for _, c := range r.checks {
 		if !c.IsEnabled() {

--- a/comp/process/submitter/component.go
+++ b/comp/process/submitter/component.go
@@ -1,0 +1,44 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package submitter implements a component to submit collected data in the Process Agent to
+// supported Datadog intakes.
+package submitter
+
+import (
+	"time"
+
+	"go.uber.org/fx"
+
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+// team: processes
+
+// Payload defines payload to be submitted
+type Payload struct {
+}
+
+// Component is the component type.
+type Component interface {
+	Submit(start time.Time, checkName string, payload *Payload)
+	Start() error
+	Stop()
+}
+
+// Mock implements mock-specific methods.
+type Mock interface {
+	Component
+}
+
+// Module defines the fx options for this component.
+var Module = fxutil.Component(
+	fx.Provide(newSubmitter),
+)
+
+// MockModule defines the fx options for the mock component.
+var MockModule = fxutil.Component(
+	fx.Provide(newMock),
+)

--- a/comp/process/submitter/component.go
+++ b/comp/process/submitter/component.go
@@ -12,18 +12,15 @@ import (
 
 	"go.uber.org/fx"
 
+	"github.com/DataDog/datadog-agent/comp/process/types"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
 // team: processes
 
-// Payload defines payload to be submitted
-type Payload struct {
-}
-
 // Component is the component type.
 type Component interface {
-	Submit(start time.Time, checkName string, payload *Payload)
+	Submit(start time.Time, checkName string, payload *types.Payload)
 	Start() error
 	Stop()
 }

--- a/comp/process/submitter/submitter.go
+++ b/comp/process/submitter/submitter.go
@@ -10,6 +10,8 @@ import (
 	"time"
 
 	"go.uber.org/fx"
+
+	"github.com/DataDog/datadog-agent/comp/process/types"
 )
 
 // submitter implements the Component.
@@ -24,7 +26,7 @@ func newSubmitter(deps dependencies) (Component, error) {
 	return &submitter{}, nil
 }
 
-func (s *submitter) Submit(start time.Time, checkName string, payload *Payload) {
+func (s *submitter) Submit(start time.Time, checkName string, payload *types.Payload) {
 
 }
 

--- a/comp/process/submitter/submitter.go
+++ b/comp/process/submitter/submitter.go
@@ -1,0 +1,42 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package submitter
+
+import (
+	"testing"
+	"time"
+
+	"go.uber.org/fx"
+)
+
+// submitter implements the Component.
+type submitter struct {
+}
+
+type dependencies struct {
+	fx.In
+}
+
+func newSubmitter(deps dependencies) (Component, error) {
+	return &submitter{}, nil
+}
+
+func (s *submitter) Submit(start time.Time, checkName string, payload *Payload) {
+
+}
+
+func (s *submitter) Start() error {
+	return nil
+}
+
+func (s *submitter) Stop() {
+
+}
+
+func newMock(deps dependencies, t testing.TB) Component {
+	// TODO
+	return nil
+}

--- a/comp/process/types/check.go
+++ b/comp/process/types/check.go
@@ -3,15 +3,26 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-package runner
+package types
 
 import (
-	"github.com/DataDog/datadog-agent/comp/process/submitter"
+	"go.uber.org/fx"
 )
+
+// Payload defines payload from the check
+type Payload struct {
+}
 
 // Check defines an interface implemented by checks
 type Check interface {
 	IsEnabled() bool
 	Name() string
-	Run() (*submitter.Payload, error)
+	Run() (*Payload, error)
+}
+
+// ProvidesCheck wraps a check implementation for consumption in components
+type ProvidesCheck struct {
+	fx.Out
+
+	Check Check `group:"check"`
 }


### PR DESCRIPTION
### What does this PR do?

- Scaffolds component structure for the process-agent.
- Introduces `runner`, `submitter` and a group of components implementing the `Check` interface.
- Basic tests to ensure DI works correctly.

### Motivation

Refactoring of the Process Agent using components.

### Describe how to test/QA your changes

This code is not used yet.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
