### PR TITLE
[BUGFIX] Handle signals only after child process is started

### DIFF
--- a/cmd/serverless-init/initcontainer/initcontainer.go
+++ b/cmd/serverless-init/initcontainer/initcontainer.go
@@ -55,11 +55,11 @@ func execute(cloudService cloudservice.CloudService, config *serverlessLog.Confi
 		LineBuffer: bytes.Buffer{},
 		IsError:    true,
 	}
-	handleSignals(cloudService, cmd.Process, config, metricAgent, traceAgent)
 	err := cmd.Start()
 	if err != nil {
 		return err
 	}
+	handleSignals(cloudService, cmd.Process, config, metricAgent, traceAgent)
 	err = cmd.Wait()
 	flush(config.FlushTimeout, metricAgent, traceAgent)
 	return err


### PR DESCRIPTION
Addresses https://github.com/DataDog/datadog-agent/issues/13940

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
Moves the `handleSignals` call until after the call to `cmd.Start` - otherwise, the `cmd.Process` pointer passed to the `handleSignals` function is nil. This means that the [call to `syscall.Kill` never happens](https://github.com/DataDog/datadog-agent/blob/main/cmd/serverless-init/initcontainer/initcontainer.go#L90), and the child process does not receive signals (critically: including `SIGTERM`) from the serverless process wrapper.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
In environments like Google Cloud Run,[ containers are given the `SIGTERM` signal 10 seconds before `SIGKILL`](https://cloud.google.com/run/docs/container-contract#instance-shutdown), allowing them to gracefully terminate or finish any in-flight requests before the container is brought down. When running serverless-init around a web server, the `SIGTERM` is handled and suppressed silently, orphaning the web process. 10 seconds later, the container is brought down and the processes are killed at a unpredictable moment.
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
Note that in the [godocs for exec](https://pkg.go.dev/os/exec#Cmd.Start), it is called out for `*Cmd` that:

>If Start returns successfully, the c.Process field will be set.
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
