### PR TITLE
Add __TARGET_ARCH_ to runtime compilation flags

### DIFF
--- a/pkg/ebpf/bytecode/runtime/runtime_compilation_helpers.go
+++ b/pkg/ebpf/bytecode/runtime/runtime_compilation_helpers.go
@@ -117,10 +117,10 @@ func compileToObjectFile(in io.Reader, outputDir, filename, inHash string, addit
 }
 
 func computeFlagsAndHash(additionalFlags []string) ([]string, string) {
-	flags := make([]string, len(defaultFlags)+len(additionalFlags)+1)
-	flags[0] = fmt.Sprintf("-D__TARGET_ARCH_%s", kernel.Arch())
-	copy(flags[1:], defaultFlags)
-	copy(flags[len(defaultFlags)+1:], additionalFlags)
+	flags := make([]string, 0, len(defaultFlags)+len(additionalFlags)+1)
+	flags = append(flags, fmt.Sprintf("-D__TARGET_ARCH_%s", kernel.Arch()))
+	flags = append(flags, defaultFlags...)
+	flags = append(flags, additionalFlags...)
 
 	hasher := sha256.New()
 	for _, f := range flags {

--- a/pkg/ebpf/bytecode/runtime/runtime_compilation_helpers.go
+++ b/pkg/ebpf/bytecode/runtime/runtime_compilation_helpers.go
@@ -117,9 +117,10 @@ func compileToObjectFile(in io.Reader, outputDir, filename, inHash string, addit
 }
 
 func computeFlagsAndHash(additionalFlags []string) ([]string, string) {
-	flags := make([]string, len(defaultFlags)+len(additionalFlags))
-	copy(flags, defaultFlags)
-	copy(flags[len(defaultFlags):], additionalFlags)
+	flags := make([]string, len(defaultFlags)+len(additionalFlags)+1)
+	flags[0] = fmt.Sprintf("-D__TARGET_ARCH_%s", kernel.Arch())
+	copy(flags[1:], defaultFlags)
+	copy(flags[len(defaultFlags)+1:], additionalFlags)
 
 	hasher := sha256.New()
 	for _, f := range flags {

--- a/pkg/util/kernel/arch.go
+++ b/pkg/util/kernel/arch.go
@@ -26,6 +26,6 @@ func Arch() string {
 	case "s390x":
 		return "s390"
 	default:
-		return ""
+		return runtime.GOARCH
 	}
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Add __TARGET_ARCH_ to runtime compilation flags

### Motivation

Consistency with CO-RE flags

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
