### PR TITLE
[process-agent] Refactor conn rates with util/subscriptions

### DIFF
--- a/pkg/process/checks/process.go
+++ b/pkg/process/checks/process.go
@@ -14,6 +14,7 @@ import (
 
 	model "github.com/DataDog/agent-payload/v5/process"
 	"github.com/DataDog/gopsutil/cpu"
+	"go.uber.org/atomic"
 
 	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/process/net"
@@ -22,6 +23,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 	"github.com/DataDog/datadog-agent/pkg/util/cloudproviders"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/util/subscriptions"
 )
 
 const (
@@ -77,6 +79,9 @@ type ProcessCheck struct {
 
 	maxBatchSize  int
 	maxBatchBytes int
+
+	lastConnRates     *atomic.Pointer[ProcessConnRates]
+	connRatesReceiver subscriptions.Receiver[ProcessConnRates]
 }
 
 // Init initializes the singleton ProcessCheck.
@@ -99,6 +104,31 @@ func (p *ProcessCheck) Init(_ *SysProbeConfig, info *HostInfo) error {
 	initScrubber(p.scrubber)
 
 	p.disallowList = initDisallowList()
+
+	p.lastConnRates = atomic.NewPointer[ProcessConnRates](nil)
+	p.connRatesReceiver = subscriptions.NewReceiver[ProcessConnRates]()
+
+	if p.connRatesReceiver.Ch != nil {
+		go func() {
+			for {
+				connRates, ok := <-p.connRatesReceiver.Ch
+				if !ok {
+					return
+				}
+				p.lastConnRates.Store(&connRates)
+			}
+		}()
+	}
+	return nil
+}
+
+func (c *ProcessCheck) getLastConnRates() ProcessConnRates {
+	if c.lastConnRates == nil {
+		return nil
+	}
+	if result := c.lastConnRates.Load(); result != nil {
+		return *result
+	}
 	return nil
 }
 
@@ -190,8 +220,8 @@ func (p *ProcessCheck) run(groupID int32, collectRealTime bool) (*RunResult, err
 		return &RunResult{}, nil
 	}
 
-	connsByPID := Connections.getLastConnectionsByPID()
-	procsByCtr := fmtProcesses(p.scrubber, p.disallowList, procs, p.lastProcs, pidToCid, cpuTimes[0], p.lastCPUTime, p.lastRun, connsByPID)
+	connsRates := p.getLastConnRates()
+	procsByCtr := fmtProcesses(p.scrubber, p.disallowList, procs, p.lastProcs, pidToCid, cpuTimes[0], p.lastCPUTime, p.lastRun, connsRates)
 	messages, totalProcs, totalContainers := createProcCtrMessages(p.hostInfo, procsByCtr, containers, p.maxBatchSize, p.maxBatchBytes, groupID, p.networkID)
 
 	// Store the last state for comparison on the next run.
@@ -208,7 +238,7 @@ func (p *ProcessCheck) run(groupID int32, collectRealTime bool) (*RunResult, err
 
 		if p.realtimeLastProcs != nil {
 			// TODO: deduplicate chunking with RT collection
-			chunkedStats := fmtProcessStats(p.maxBatchSize, stats, p.realtimeLastProcs, pidToCid, cpuTimes[0], p.realtimeLastCPUTime, p.realtimeLastRun, connsByPID)
+			chunkedStats := fmtProcessStats(p.maxBatchSize, stats, p.realtimeLastProcs, pidToCid, cpuTimes[0], p.realtimeLastCPUTime, p.realtimeLastRun, connsRates)
 			groupSize := len(chunkedStats)
 			chunkedCtrStats := convertAndChunkContainers(containers, groupSize)
 
@@ -323,10 +353,9 @@ func fmtProcesses(
 	ctrByProc map[int]string,
 	syst2, syst1 cpu.TimesStat,
 	lastRun time.Time,
-	connsByPID map[int32][]*model.Connection,
+	connRates ProcessConnRates,
 ) map[string][]*model.Process {
 	procsByCtr := make(map[string][]*model.Process)
-	connCheckIntervalS := int(GetInterval(ConnectionsCheckName) / time.Second)
 
 	for _, fp := range procs {
 		if skipProcess(disallowList, fp, lastProcs) {
@@ -350,7 +379,10 @@ func fmtProcesses(
 			VoluntaryCtxSwitches:   uint64(fp.Stats.CtxSwitches.Voluntary),
 			InvoluntaryCtxSwitches: uint64(fp.Stats.CtxSwitches.Involuntary),
 			ContainerId:            ctrByProc[int(fp.Pid)],
-			Networks:               formatNetworks(connsByPID[fp.Pid], connCheckIntervalS),
+		}
+
+		if connRates != nil {
+			proc.Networks = connRates[fp.Pid]
 		}
 		_, ok := procsByCtr[proc.ContainerId]
 		if !ok {

--- a/pkg/process/checks/process_common_test.go
+++ b/pkg/process/checks/process_common_test.go
@@ -74,7 +74,6 @@ func makeProcessModel(t *testing.T, process *procutil.Process) *model.Process {
 		},
 		CreateTime: process.Stats.CreateTime,
 		IoStat:     &model.IOStat{},
-		Networks:   &model.ProcessNetworks{},
 	}
 }
 
@@ -95,8 +94,7 @@ func makeProcessStatModels(t *testing.T, processes ...*procutil.Process) []*mode
 				SystemPct: float32(cpu.SystemPct),
 				TotalPct:  float32(cpu.UserPct + cpu.SystemPct),
 			},
-			IoStat:   &model.IOStat{},
-			Networks: &model.ProcessNetworks{},
+			IoStat: &model.IOStat{},
 		})
 	}
 

--- a/pkg/process/checks/process_nix_test.go
+++ b/pkg/process/checks/process_nix_test.go
@@ -120,9 +120,8 @@ func TestBasicProcessMessages(t *testing.T) {
 			for _, s := range tc.disallowList {
 				disallowList = append(disallowList, regexp.MustCompile(s))
 			}
-			networks := make(map[int32][]*model.Connection)
 
-			procs := fmtProcesses(procutil.NewDefaultDataScrubber(), disallowList, tc.processes, tc.processes, tc.pidToCid, syst2, syst1, lastRun, networks)
+			procs := fmtProcesses(procutil.NewDefaultDataScrubber(), disallowList, tc.processes, tc.processes, tc.pidToCid, syst2, syst1, lastRun, nil)
 			messages, totalProcs, totalContainers := createProcCtrMessages(hostInfo, procs, tc.containers, tc.maxSize, maxBatchBytes, int32(i), "nid")
 
 			assert.Equal(t, tc.expectedChunks, len(messages))
@@ -225,7 +224,6 @@ func TestContainerProcessChunking(t *testing.T) {
 		},
 	} {
 		t.Run(tc.testName, func(t *testing.T) {
-			networks := make(map[int32][]*model.Connection)
 			procs, ctrs, pidToCid := generateCtrProcs(tc.ctrProcs)
 			procsByPid := procsToHash(procs)
 
@@ -234,7 +232,7 @@ func TestContainerProcessChunking(t *testing.T) {
 			sysInfo := &model.SystemInfo{}
 			hostInfo := &HostInfo{SystemInfo: sysInfo}
 
-			processes := fmtProcesses(procutil.NewDefaultDataScrubber(), nil, procsByPid, procsByPid, pidToCid, syst2, syst1, lastRun, networks)
+			processes := fmtProcesses(procutil.NewDefaultDataScrubber(), nil, procsByPid, procsByPid, pidToCid, syst2, syst1, lastRun, nil)
 			messages, totalProcs, totalContainers := createProcCtrMessages(hostInfo, processes, ctrs, tc.maxSize, maxBatchBytes, int32(i), "nid")
 
 			assert.Equal(t, tc.expectedProcCount, totalProcs)


### PR DESCRIPTION
### What does this PR do?

- This refactors connection rates info in the process check payloads to be filled by pub/sub using `util/subcriptions`.
- Note that this currently results in disconnecting this functionality (backend currently ignores this field so this is safe).
- The subscriptions group will be initialized once the checks are wrapped into components (see https://github.com/DataDog/datadog-agent/pull/14972).

### Motivation

- Avoid passing data between check singletons directly.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Validate functionality in the process check with the connections check enabled.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
