### PR TITLE
Add `SBOM` core check

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -220,6 +220,7 @@
 /pkg/collector/corechecks/embed/apm*.go            @Datadog/agent-platform @DataDog/agent-apm
 /pkg/collector/corechecks/embed/process_agent*.go  @Datadog/agent-platform @DataDog/processes
 /pkg/collector/corechecks/net/          @DataDog/agent-platform
+/pkg/collector/corechecks/sbom/         @DataDog/container-integrations
 /pkg/collector/corechecks/snmp/         @DataDog/network-device-monitoring
 /pkg/collector/corechecks/system/                 @DataDog/agent-platform
 /pkg/collector/corechecks/system/**/*_windows*.go @DataDog/agent-platform @DataDog/windows-agent

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -26,6 +26,7 @@ core,code.cloudfoundry.org/lager,Apache-2.0,"Copyright (c) 2016-Present CloudFou
 core,code.cloudfoundry.org/tlsconfig,Apache-2.0,"Copyright (c) 2016-Present CloudFoundry.org Foundation, Inc. All Rights Reserved."
 core,contrib.go.opencensus.io/exporter/prometheus,Apache-2.0,"Copyright 2020, OpenCensus Authors"
 core,github.com/AlekSi/pointer,MIT,Copyright (c) 2015 Alexey Palazhchenko
+core,github.com/CycloneDX/cyclonedx-go,Apache-2.0,Copyright & License | Copyright (c) OWASP Foundation | Copyright (c) OWASP Foundation. All Rights Reserved | Copyright OWASP Foundation
 core,github.com/DataDog/agent-payload/v5/contimage,BSD-3-Clause,"Copyright (c) 2017, Datadog, Inc"
 core,github.com/DataDog/agent-payload/v5/contlcycle,BSD-3-Clause,"Copyright (c) 2017, Datadog, Inc"
 core,github.com/DataDog/agent-payload/v5/cyclonedx_v1_4,BSD-3-Clause,"Copyright (c) 2017, Datadog, Inc"

--- a/cmd/agent/subcommands/run/command.go
+++ b/cmd/agent/subcommands/run/command.go
@@ -81,6 +81,7 @@ import (
 	_ "github.com/DataDog/datadog-agent/pkg/collector/corechecks/embed"
 	_ "github.com/DataDog/datadog-agent/pkg/collector/corechecks/net"
 	_ "github.com/DataDog/datadog-agent/pkg/collector/corechecks/nvidia/jetson"
+	_ "github.com/DataDog/datadog-agent/pkg/collector/corechecks/sbom"
 	_ "github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp"
 	_ "github.com/DataDog/datadog-agent/pkg/collector/corechecks/system/cpu"
 	_ "github.com/DataDog/datadog-agent/pkg/collector/corechecks/system/disk"
@@ -376,6 +377,7 @@ func startAgent(cliParams *cliParams, flare flare.Component) error {
 	opts.EnableNoAggregationPipeline = pkgconfig.Datadog.GetBool("dogstatsd_no_aggregation_pipeline")
 	opts.UseContainerLifecycleForwarder = pkgconfig.Datadog.GetBool("container_lifecycle.enabled")
 	opts.UseContainerImageForwarder = pkgconfig.Datadog.GetBool("container_image.enabled")
+	opts.UseSBOMForwarder = pkgconfig.Datadog.GetBool("sbom.enabled")
 	demux = aggregator.InitAndStartAgentDemultiplexer(opts, hostnameDetected)
 
 	// Setup stats telemetry handler

--- a/go.mod
+++ b/go.mod
@@ -291,7 +291,7 @@ require (
 	github.com/gogo/googleapis v1.4.0 // indirect
 	github.com/golang/glog v1.0.0 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
-	github.com/google/gofuzz v1.2.0 // indirect
+	github.com/google/gofuzz v1.2.0
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.2.0 // indirect
 	github.com/googleapis/gax-go/v2 v2.7.0 // indirect
@@ -427,6 +427,7 @@ require (
 )
 
 require (
+	github.com/CycloneDX/cyclonedx-go v0.6.0
 	github.com/DataDog/go-libddwaf v0.0.0-20221118110754-0372d7c76b8a
 	github.com/go-redis/redis/v9 v9.0.0-rc.2
 	github.com/safchain/baloum v0.0.0-20221229104256-b1fc8f70a86b

--- a/go.sum
+++ b/go.sum
@@ -119,6 +119,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/toml v1.1.0 h1:ksErzDEI1khOiGPgpwuI7x2ebx/uXQNw7xJpn9Eq1+I=
 github.com/BurntSushi/toml v1.1.0/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/CycloneDX/cyclonedx-go v0.6.0 h1:SizWGbZzFTC/O/1yh072XQBMxfvsoWqd//oKCIyzFyE=
+github.com/CycloneDX/cyclonedx-go v0.6.0/go.mod h1:nQCiF4Tvrg5Ieu8qPhYMvzPGMu5I7fANZkrSsJjl5mg=
 github.com/DataDog/agent-payload/v5 v5.0.61 h1:3HC4B1NpHgAedZHmM9/oCJvFo6pu/ugDAjrISK5AJsk=
 github.com/DataDog/agent-payload/v5 v5.0.61/go.mod h1:oQZi1VZp1e3QvlSUX4iphZCpJaFepUxWq0hNXxihKBM=
 github.com/DataDog/aptly v1.5.0 h1:Oy6JVRC9iDgnmpeVYa4diXwP/exU7wJ/U1kuI4Zacxg=
@@ -313,6 +315,8 @@ github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dR
 github.com/bmizerany/pat v0.0.0-20170815010413-6226ea591a40 h1:y4B3+GPxKlrigF1ha5FFErxK+sr6sWxQovRMzwMhejo=
 github.com/bmizerany/pat v0.0.0-20170815010413-6226ea591a40/go.mod h1:8rLXio+WjiTceGBHIoTvn60HIbs7Hm7bcHjyrSqYB9c=
 github.com/bradfitz/gomemcache v0.0.0-20220106215444-fb4bf637b56d/go.mod h1:H0wQNHz2YrLsuXOZozoeDmnHXkNCRmMW0gwFWDfEZDA=
+github.com/bradleyjkemp/cupaloy/v2 v2.7.0 h1:AT0vOjO68RcLyenLCHOGZzSNiuto7ziqzq6Q1/3xzMQ=
+github.com/bradleyjkemp/cupaloy/v2 v2.7.0/go.mod h1:bm7JXdkRd4BHJk9HpwqAI8BoAY1lps46Enkdqw6aRX0=
 github.com/buger/jsonparser v0.0.0-20180808090653-f4dd9f5a6b44/go.mod h1:bbYlZJ7hK1yFx9hf58LP0zeX7UjIGs20ufpu3evjr+s=
 github.com/bytecodealliance/wasmtime-go v1.0.0 h1:9u9gqaUiaJeN5IoD1L7egD8atOnTGyJcNp8BhkL9cUU=
 github.com/cavaliergopher/grab/v3 v3.0.1 h1:4z7TkBfmPjmLAAmkkAZNX/6QJ1nNFdv3SdIHXju0Fr4=

--- a/pkg/collector/corechecks/sbom/check.go
+++ b/pkg/collector/corechecks/sbom/check.go
@@ -1,0 +1,166 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
+package sbom
+
+import (
+	"errors"
+	"time"
+
+	yaml "gopkg.in/yaml.v2"
+
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
+	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
+	ddConfig "github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
+)
+
+const (
+	checkName = "sbom"
+)
+
+func init() {
+	core.RegisterCheck(checkName, CheckFactory)
+}
+
+// Config holds the container_image check configuration
+type Config struct {
+	chunkSize                int `yaml:"chunk_size"`
+	newSBOMMaxLatencySeconds int `yaml:"new_images_max_latency_seconds"`
+	periodicRefreshSeconds   int `yaml:"periodic_refresh_seconds"`
+}
+
+type configValueRange struct {
+	min      int
+	max      int
+	default_ int
+}
+
+var /* const */ (
+	chunkSizeValueRange = &configValueRange{
+		min:      1,
+		max:      100,
+		default_: 1,
+	}
+
+	newSBOMMaxLatencySecondsValueRange = &configValueRange{
+		min:      1,   // 1 s
+		max:      300, // 5 min
+		default_: 30,  // 30 s
+	}
+
+	periodicRefreshSecondsValueRange = &configValueRange{
+		min:      60,     // 1 min
+		max:      604800, // 1 week
+		default_: 3600,   // 1h
+	}
+)
+
+func validateValue(val *int, range_ *configValueRange) {
+	if *val == 0 {
+		*val = range_.default_
+	} else if *val < range_.min {
+		*val = range_.min
+	} else if *val > range_.max {
+		*val = range_.max
+	}
+}
+
+func (c *Config) Parse(data []byte) error {
+	if err := yaml.Unmarshal(data, c); err != nil {
+		return err
+	}
+
+	validateValue(&c.chunkSize, chunkSizeValueRange)
+	validateValue(&c.newSBOMMaxLatencySeconds, newSBOMMaxLatencySecondsValueRange)
+	validateValue(&c.periodicRefreshSeconds, periodicRefreshSecondsValueRange)
+
+	return nil
+}
+
+// Check reports SBOM
+type Check struct {
+	core.CheckBase
+	workloadmetaStore workloadmeta.Store
+	instance          *Config
+	processor         *processor
+	stopCh            chan struct{}
+}
+
+// CheckFactory registers the sbom check
+func CheckFactory() check.Check {
+	return &Check{
+		CheckBase:         core.NewCheckBase(checkName),
+		workloadmetaStore: workloadmeta.GetGlobalStore(),
+		instance:          &Config{},
+		stopCh:            make(chan struct{}),
+	}
+}
+
+// Configure parses the check configuration and initializes the sbom check
+func (c *Check) Configure(integrationConfigDigest uint64, config, initConfig integration.Data, source string) error {
+	if !ddConfig.Datadog.GetBool("sbom.enabled") {
+		return errors.New("collection of SBOM is disabled")
+	}
+
+	if err := c.CommonConfigure(integrationConfigDigest, initConfig, config, source); err != nil {
+		return err
+	}
+
+	if err := c.instance.Parse(config); err != nil {
+		return err
+	}
+
+	sender, err := c.GetSender()
+	if err != nil {
+		return err
+	}
+
+	c.processor = newProcessor(sender, c.instance.chunkSize, time.Duration(c.instance.newSBOMMaxLatencySeconds)*time.Second)
+
+	return nil
+}
+
+// Run starts the sbom check
+func (c *Check) Run() error {
+	log.Infof("Starting long-running check %q", c.ID())
+	defer log.Infof("Shutting down long-running check %q", c.ID())
+
+	imgEventsCh := c.workloadmetaStore.Subscribe(
+		checkName,
+		workloadmeta.NormalPriority,
+		workloadmeta.NewFilter(
+			[]workloadmeta.Kind{workloadmeta.KindContainerImageMetadata},
+			workloadmeta.SourceAll,
+			workloadmeta.EventTypeSet, // We don’t care about SBOM removal because we just have to wait for them to expire on BE side once we stopped refreshing them periodically.
+		),
+	)
+
+	imgRefreshTicker := time.NewTicker(time.Duration(c.instance.periodicRefreshSeconds) * time.Second)
+
+	for {
+		select {
+		case eventBundle := <-imgEventsCh:
+			c.processor.processEvents(eventBundle)
+		case <-imgRefreshTicker.C:
+			c.processor.processRefresh(c.workloadmetaStore.ListImages())
+		case <-c.stopCh:
+			c.processor.stop()
+			return nil
+		}
+	}
+}
+
+// Stop stops the sbom check
+func (c *Check) Stop() {
+	close(c.stopCh)
+}
+
+// Interval returns 0. It makes sbom a long-running check
+func (c *Check) Interval() time.Duration {
+	return 0
+}

--- a/pkg/collector/corechecks/sbom/convert.go
+++ b/pkg/collector/corechecks/sbom/convert.go
@@ -1,0 +1,1022 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
+package sbom
+
+import (
+	"time"
+	"unsafe"
+
+	"github.com/DataDog/datadog-agent/pkg/util/pointer"
+
+	"github.com/CycloneDX/cyclonedx-go"
+	"github.com/DataDog/agent-payload/v5/cyclonedx_v1_4"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func stringPtr(in string) *string {
+	if in == "" {
+		return nil
+	} else {
+		return &in
+	}
+}
+
+func strSliceDeref(in *[]string) []string {
+	if in == nil {
+		return nil
+	} else {
+		return *in
+	}
+}
+
+type inArrayElement interface {
+	cyclonedx.Advisory |
+		cyclonedx.AffectedVersions |
+		cyclonedx.Affects |
+		cyclonedx.Commit |
+		cyclonedx.Component |
+		cyclonedx.Composition |
+		cyclonedx.Copyright |
+		cyclonedx.DataClassification |
+		cyclonedx.Dependency |
+		cyclonedx.ExternalReference |
+		cyclonedx.Hash |
+		cyclonedx.Issue |
+		cyclonedx.LicenseChoice |
+		cyclonedx.Note |
+		cyclonedx.OrganizationalContact |
+		cyclonedx.OrganizationalEntity |
+		cyclonedx.Patch |
+		cyclonedx.Property |
+		cyclonedx.Service |
+		cyclonedx.Tool |
+		cyclonedx.Vulnerability |
+		cyclonedx.VulnerabilityRating |
+		cyclonedx.VulnerabilityReference
+}
+
+type outArrayElement interface {
+	cyclonedx_v1_4.Advisory |
+		cyclonedx_v1_4.Commit |
+		cyclonedx_v1_4.Component |
+		cyclonedx_v1_4.Composition |
+		cyclonedx_v1_4.DataClassification |
+		cyclonedx_v1_4.Dependency |
+		cyclonedx_v1_4.EvidenceCopyright |
+		cyclonedx_v1_4.ExternalReference |
+		cyclonedx_v1_4.Hash |
+		cyclonedx_v1_4.Issue |
+		cyclonedx_v1_4.LicenseChoice |
+		cyclonedx_v1_4.Note |
+		cyclonedx_v1_4.OrganizationalContact |
+		cyclonedx_v1_4.OrganizationalEntity |
+		cyclonedx_v1_4.Patch |
+		cyclonedx_v1_4.Property |
+		cyclonedx_v1_4.Service |
+		cyclonedx_v1_4.Tool |
+		cyclonedx_v1_4.Vulnerability |
+		cyclonedx_v1_4.VulnerabilityAffectedVersions |
+		cyclonedx_v1_4.VulnerabilityAffects |
+		cyclonedx_v1_4.VulnerabilityRating |
+		cyclonedx_v1_4.VulnerabilityReference
+}
+
+func convertArray[In inArrayElement, Out outArrayElement](in *[]In, convert func(*In) *Out) (out []*Out) {
+	if in == nil {
+		return nil
+	}
+
+	out = make([]*Out, 0, len(*in))
+	for _, e := range *in {
+		out = append(out, convert(&e))
+	}
+	return out
+}
+
+func convertAdvisory(in *cyclonedx.Advisory) *cyclonedx_v1_4.Advisory {
+	if in == nil {
+		return nil
+	}
+
+	return &cyclonedx_v1_4.Advisory{
+		Title: stringPtr(in.Title),
+		Url:   in.URL,
+	}
+}
+
+func convertAttachedText(in *cyclonedx.AttachedText) *cyclonedx_v1_4.AttachedText {
+	if in == nil {
+		return nil
+	}
+
+	return &cyclonedx_v1_4.AttachedText{
+		ContentType: stringPtr(in.ContentType),
+		Encoding:    stringPtr(in.Encoding),
+		Value:       in.Content,
+	}
+}
+
+func convertBOM(in *cyclonedx.BOM) *cyclonedx_v1_4.Bom {
+	if in == nil {
+		return nil
+	}
+
+	return &cyclonedx_v1_4.Bom{
+		SpecVersion:        in.SpecVersion,
+		Version:            pointer.Int32Ptr(int32(in.Version)),
+		SerialNumber:       stringPtr(in.SerialNumber),
+		Metadata:           convertMetadata(in.Metadata),
+		Components:         convertArray(in.Components, convertComponent),
+		Services:           convertArray(in.Services, convertService),
+		ExternalReferences: convertArray(in.ExternalReferences, convertExternalReference),
+		Dependencies:       convertArray(in.Dependencies, convertDependency),
+		Compositions:       convertArray(in.Compositions, convertComposition),
+		Vulnerabilities:    convertArray(in.Vulnerabilities, convertVulnerability),
+	}
+}
+
+func convertCommit(in *cyclonedx.Commit) *cyclonedx_v1_4.Commit {
+	if in == nil {
+		return nil
+	}
+
+	return &cyclonedx_v1_4.Commit{
+		Uid:       stringPtr(in.UID),
+		Url:       stringPtr(in.URL),
+		Author:    convertIdentifiableAction(in.Author),
+		Committer: convertIdentifiableAction(in.Committer),
+		Message:   stringPtr(in.Message),
+	}
+}
+
+func convertComponent(in *cyclonedx.Component) *cyclonedx_v1_4.Component {
+	if in == nil {
+		return nil
+	}
+
+	var evidence []*cyclonedx_v1_4.Evidence
+	if in.Evidence != nil {
+		evidence = []*cyclonedx_v1_4.Evidence{convertEvidence(in.Evidence)}
+	}
+
+	return &cyclonedx_v1_4.Component{
+		Type:               convertComponentType(in.Type),
+		MimeType:           stringPtr(in.MIMEType),
+		BomRef:             stringPtr(in.BOMRef),
+		Supplier:           convertOrganizationalEntity(in.Supplier),
+		Author:             stringPtr(in.Author),
+		Publisher:          stringPtr(in.Publisher),
+		Group:              stringPtr(in.Group),
+		Name:               in.Name,
+		Version:            in.Version,
+		Description:        stringPtr(in.Description),
+		Scope:              convertScope(in.Scope),
+		Hashes:             convertArray(in.Hashes, convertHash),
+		Licenses:           convertArray(castLicenses(in.Licenses), convertLicenseChoice),
+		Copyright:          stringPtr(in.Copyright),
+		Cpe:                stringPtr(in.CPE),
+		Purl:               stringPtr(in.PackageURL),
+		Swid:               convertSwid(in.SWID),
+		Modified:           in.Modified,
+		Pedigree:           convertPedigree(in.Pedigree),
+		ExternalReferences: convertArray(in.ExternalReferences, convertExternalReference),
+		Components:         convertArray(in.Components, convertComponent),
+		Properties:         convertArray(in.Properties, convertProperty),
+		Evidence:           evidence,
+		ReleaseNotes:       convertReleaseNotes(in.ReleaseNotes),
+	}
+}
+
+func convertComponentType(in cyclonedx.ComponentType) cyclonedx_v1_4.Classification {
+	switch in {
+	case cyclonedx.ComponentTypeApplication:
+		return cyclonedx_v1_4.Classification_CLASSIFICATION_APPLICATION
+	case cyclonedx.ComponentTypeContainer:
+		return cyclonedx_v1_4.Classification_CLASSIFICATION_CONTAINER
+	case cyclonedx.ComponentTypeDevice:
+		return cyclonedx_v1_4.Classification_CLASSIFICATION_DEVICE
+	case cyclonedx.ComponentTypeFile:
+		return cyclonedx_v1_4.Classification_CLASSIFICATION_FILE
+	case cyclonedx.ComponentTypeFirmware:
+		return cyclonedx_v1_4.Classification_CLASSIFICATION_FIRMWARE
+	case cyclonedx.ComponentTypeFramework:
+		return cyclonedx_v1_4.Classification_CLASSIFICATION_FRAMEWORK
+	case cyclonedx.ComponentTypeLibrary:
+		return cyclonedx_v1_4.Classification_CLASSIFICATION_LIBRARY
+	case cyclonedx.ComponentTypeOS:
+		return cyclonedx_v1_4.Classification_CLASSIFICATION_OPERATING_SYSTEM
+	default:
+		return cyclonedx_v1_4.Classification_CLASSIFICATION_NULL
+	}
+}
+
+func convertComposition(in *cyclonedx.Composition) (out *cyclonedx_v1_4.Composition) {
+	if in == nil {
+		return nil
+	}
+
+	out = &cyclonedx_v1_4.Composition{
+		Aggregate: convertCompositionAggregate(in.Aggregate),
+	}
+
+	if in.Assemblies != nil {
+		out.Assemblies = *(*[]string)(unsafe.Pointer(in.Assemblies))
+	}
+
+	if in.Dependencies != nil {
+		out.Dependencies = *(*[]string)(unsafe.Pointer(in.Dependencies))
+	}
+
+	return out
+}
+
+func convertCompositionAggregate(in cyclonedx.CompositionAggregate) cyclonedx_v1_4.Aggregate {
+	switch in {
+	case cyclonedx.CompositionAggregateComplete:
+		return cyclonedx_v1_4.Aggregate_AGGREGATE_COMPLETE
+	case cyclonedx.CompositionAggregateIncomplete:
+		return cyclonedx_v1_4.Aggregate_AGGREGATE_INCOMPLETE
+	case cyclonedx.CompositionAggregateIncompleteFirstPartyOnly:
+		return cyclonedx_v1_4.Aggregate_AGGREGATE_INCOMPLETE_FIRST_PARTY_ONLY
+	case cyclonedx.CompositionAggregateIncompleteThirdPartyOnly:
+		return cyclonedx_v1_4.Aggregate_AGGREGATE_INCOMPLETE_THIRD_PARTY_ONLY
+	case cyclonedx.CompositionAggregateUnknown:
+		return cyclonedx_v1_4.Aggregate_AGGREGATE_UNKNOWN
+	case cyclonedx.CompositionAggregateNotSpecified:
+		return cyclonedx_v1_4.Aggregate_AGGREGATE_NOT_SPECIFIED
+	default:
+		return cyclonedx_v1_4.Aggregate_AGGREGATE_NOT_SPECIFIED
+	}
+}
+
+func convertCopyright(in *cyclonedx.Copyright) *cyclonedx_v1_4.EvidenceCopyright {
+	if in == nil {
+		return nil
+	}
+
+	return &cyclonedx_v1_4.EvidenceCopyright{
+		Text: in.Text,
+	}
+}
+
+func convertDataClassification(in *cyclonedx.DataClassification) *cyclonedx_v1_4.DataClassification {
+	if in == nil {
+		return nil
+	}
+
+	return &cyclonedx_v1_4.DataClassification{
+		Flow:  convertDataFlow(in.Flow),
+		Value: in.Classification,
+	}
+}
+
+func convertDataFlow(in cyclonedx.DataFlow) cyclonedx_v1_4.DataFlow {
+	switch in {
+	case cyclonedx.DataFlowBidirectional:
+		return cyclonedx_v1_4.DataFlow_DATA_FLOW_BI_DIRECTIONAL
+	case cyclonedx.DataFlowInbound:
+		return cyclonedx_v1_4.DataFlow_DATA_FLOW_INBOUND
+	case cyclonedx.DataFlowOutbound:
+		return cyclonedx_v1_4.DataFlow_DATA_FLOW_OUTBOUND
+	case cyclonedx.DataFlowUnknown:
+		return cyclonedx_v1_4.DataFlow_DATA_FLOW_UNKNOWN
+	default:
+		return cyclonedx_v1_4.DataFlow_DATA_FLOW_NULL
+	}
+}
+
+func convertDependency(in *cyclonedx.Dependency) *cyclonedx_v1_4.Dependency {
+	if in == nil {
+		return nil
+	}
+
+	return &cyclonedx_v1_4.Dependency{
+		Ref:          in.Ref,
+		Dependencies: convertArray(in.Dependencies, convertDependency),
+	}
+}
+
+func convertDiff(in *cyclonedx.Diff) *cyclonedx_v1_4.Diff {
+	if in == nil {
+		return nil
+	}
+
+	return &cyclonedx_v1_4.Diff{
+		Text: convertAttachedText(in.Text),
+		Url:  stringPtr(in.URL),
+	}
+}
+
+func convertEvidence(in *cyclonedx.Evidence) *cyclonedx_v1_4.Evidence {
+	if in == nil {
+		return nil
+	}
+
+	return &cyclonedx_v1_4.Evidence{
+		Licenses:  convertArray(castLicenses(in.Licenses), convertLicenseChoice),
+		Copyright: convertArray(in.Copyright, convertCopyright),
+	}
+}
+
+func convertExternalReference(in *cyclonedx.ExternalReference) *cyclonedx_v1_4.ExternalReference {
+	if in == nil {
+		return nil
+	}
+
+	return &cyclonedx_v1_4.ExternalReference{
+		Type:    convertExternalReferenceType(in.Type),
+		Url:     in.URL,
+		Comment: stringPtr(in.Comment),
+		Hashes:  convertArray(in.Hashes, convertHash),
+	}
+}
+
+func convertExternalReferenceType(in cyclonedx.ExternalReferenceType) cyclonedx_v1_4.ExternalReferenceType {
+	switch in {
+	case cyclonedx.ERTypeAdvisories:
+		return cyclonedx_v1_4.ExternalReferenceType_EXTERNAL_REFERENCE_TYPE_ADVISORIES
+	case cyclonedx.ERTypeBOM:
+		return cyclonedx_v1_4.ExternalReferenceType_EXTERNAL_REFERENCE_TYPE_BOM
+	case cyclonedx.ERTypeBuildMeta:
+		return cyclonedx_v1_4.ExternalReferenceType_EXTERNAL_REFERENCE_TYPE_BUILD_META
+	case cyclonedx.ERTypeBuildSystem:
+		return cyclonedx_v1_4.ExternalReferenceType_EXTERNAL_REFERENCE_TYPE_BUILD_SYSTEM
+	case cyclonedx.ERTypeChat:
+		return cyclonedx_v1_4.ExternalReferenceType_EXTERNAL_REFERENCE_TYPE_CHAT
+	case cyclonedx.ERTypeDistribution:
+		return cyclonedx_v1_4.ExternalReferenceType_EXTERNAL_REFERENCE_TYPE_DISTRIBUTION
+	case cyclonedx.ERTypeDocumentation:
+		return cyclonedx_v1_4.ExternalReferenceType_EXTERNAL_REFERENCE_TYPE_DOCUMENTATION
+	case cyclonedx.ERTypeLicense:
+		return cyclonedx_v1_4.ExternalReferenceType_EXTERNAL_REFERENCE_TYPE_LICENSE
+	case cyclonedx.ERTypeMailingList:
+		return cyclonedx_v1_4.ExternalReferenceType_EXTERNAL_REFERENCE_TYPE_MAILING_LIST
+	case cyclonedx.ERTypeOther:
+		return cyclonedx_v1_4.ExternalReferenceType_EXTERNAL_REFERENCE_TYPE_OTHER
+	case cyclonedx.ERTypeIssueTracker:
+		return cyclonedx_v1_4.ExternalReferenceType_EXTERNAL_REFERENCE_TYPE_ISSUE_TRACKER
+	case cyclonedx.ERTypeReleaseNotes:
+		return cyclonedx_v1_4.ExternalReferenceType_EXTERNAL_REFERENCE_TYPE_OTHER // ??
+	case cyclonedx.ERTypeSocial:
+		return cyclonedx_v1_4.ExternalReferenceType_EXTERNAL_REFERENCE_TYPE_SOCIAL
+	case cyclonedx.ERTypeSupport:
+		return cyclonedx_v1_4.ExternalReferenceType_EXTERNAL_REFERENCE_TYPE_SUPPORT
+	case cyclonedx.ERTypeVCS:
+		return cyclonedx_v1_4.ExternalReferenceType_EXTERNAL_REFERENCE_TYPE_VCS
+	case cyclonedx.ERTypeWebsite:
+		return cyclonedx_v1_4.ExternalReferenceType_EXTERNAL_REFERENCE_TYPE_WEBSITE
+	default:
+		return cyclonedx_v1_4.ExternalReferenceType_EXTERNAL_REFERENCE_TYPE_OTHER
+	}
+}
+
+func convertHash(in *cyclonedx.Hash) *cyclonedx_v1_4.Hash {
+	if in == nil {
+		return nil
+	}
+
+	return &cyclonedx_v1_4.Hash{
+		Alg:   convertHashAlgo(in.Algorithm),
+		Value: in.Value,
+	}
+}
+
+func convertHashAlgo(in cyclonedx.HashAlgorithm) cyclonedx_v1_4.HashAlg {
+	switch in {
+	case cyclonedx.HashAlgoMD5:
+		return cyclonedx_v1_4.HashAlg_HASH_ALG_MD_5
+	case cyclonedx.HashAlgoSHA1:
+		return cyclonedx_v1_4.HashAlg_HASH_ALG_SHA_1
+	case cyclonedx.HashAlgoSHA256:
+		return cyclonedx_v1_4.HashAlg_HASH_ALG_SHA_256
+	case cyclonedx.HashAlgoSHA384:
+		return cyclonedx_v1_4.HashAlg_HASH_ALG_SHA_384
+	case cyclonedx.HashAlgoSHA512:
+		return cyclonedx_v1_4.HashAlg_HASH_ALG_SHA_512
+	case cyclonedx.HashAlgoSHA3_256:
+		return cyclonedx_v1_4.HashAlg_HASH_ALG_SHA_3_256
+	case cyclonedx.HashAlgoSHA3_512:
+		return cyclonedx_v1_4.HashAlg_HASH_ALG_SHA_3_512
+	case cyclonedx.HashAlgoBlake2b_256:
+		return cyclonedx_v1_4.HashAlg_HASH_ALG_BLAKE_2_B_256
+	case cyclonedx.HashAlgoBlake2b_384:
+		return cyclonedx_v1_4.HashAlg_HASH_ALG_BLAKE_2_B_384
+	case cyclonedx.HashAlgoBlake2b_512:
+		return cyclonedx_v1_4.HashAlg_HASH_ALG_BLAKE_2_B_512
+	case cyclonedx.HashAlgoBlake3:
+		return cyclonedx_v1_4.HashAlg_HASH_ALG_BLAKE_3
+	default:
+		return cyclonedx_v1_4.HashAlg_HASH_ALG_NULL
+	}
+}
+
+func convertIdentifiableAction(in *cyclonedx.IdentifiableAction) *cyclonedx_v1_4.IdentifiableAction {
+	if in == nil {
+		return nil
+	}
+
+	return &cyclonedx_v1_4.IdentifiableAction{
+		Timestamp: convertTimestamp(in.Timestamp),
+		Name:      stringPtr(in.Name),
+		Email:     stringPtr(in.Email),
+	}
+}
+
+func convertImpactAnalysisJustification(in cyclonedx.ImpactAnalysisJustification) *cyclonedx_v1_4.ImpactAnalysisJustification {
+	if in == "" {
+		return nil
+	}
+
+	ptr := func(v cyclonedx_v1_4.ImpactAnalysisJustification) *cyclonedx_v1_4.ImpactAnalysisJustification {
+		return &v
+	}
+
+	switch in {
+	case cyclonedx.IAJCodeNotPresent:
+		return ptr(cyclonedx_v1_4.ImpactAnalysisJustification_IMPACT_ANALYSIS_JUSTIFICATION_CODE_NOT_PRESENT)
+	case cyclonedx.IAJCodeNotReachable:
+		return ptr(cyclonedx_v1_4.ImpactAnalysisJustification_IMPACT_ANALYSIS_JUSTIFICATION_CODE_NOT_REACHABLE)
+	case cyclonedx.IAJRequiresConfiguration:
+		return ptr(cyclonedx_v1_4.ImpactAnalysisJustification_IMPACT_ANALYSIS_JUSTIFICATION_REQUIRES_CONFIGURATION)
+	case cyclonedx.IAJRequiresDependency:
+		return ptr(cyclonedx_v1_4.ImpactAnalysisJustification_IMPACT_ANALYSIS_JUSTIFICATION_REQUIRES_DEPENDENCY)
+	case cyclonedx.IAJRequiresEnvironment:
+		return ptr(cyclonedx_v1_4.ImpactAnalysisJustification_IMPACT_ANALYSIS_JUSTIFICATION_REQUIRES_ENVIRONMENT)
+	case cyclonedx.IAJProtectedByCompiler:
+		return ptr(cyclonedx_v1_4.ImpactAnalysisJustification_IMPACT_ANALYSIS_JUSTIFICATION_PROTECTED_BY_COMPILER)
+	case cyclonedx.IAJProtectedAtRuntime:
+		return ptr(cyclonedx_v1_4.ImpactAnalysisJustification_IMPACT_ANALYSIS_JUSTIFICATION_PROTECTED_AT_RUNTIME)
+	case cyclonedx.IAJProtectedAtPerimeter:
+		return ptr(cyclonedx_v1_4.ImpactAnalysisJustification_IMPACT_ANALYSIS_JUSTIFICATION_PROTECTED_AT_PERIMETER)
+	case cyclonedx.IAJProtectedByMitigatingControl:
+		return ptr(cyclonedx_v1_4.ImpactAnalysisJustification_IMPACT_ANALYSIS_JUSTIFICATION_PROTECTED_BY_MITIGATING_CONTROL)
+	default:
+		return ptr(cyclonedx_v1_4.ImpactAnalysisJustification_IMPACT_ANALYSIS_JUSTIFICATION_NULL)
+	}
+}
+
+func convertImpactAnalysisResponse(in cyclonedx.ImpactAnalysisResponse) cyclonedx_v1_4.VulnerabilityResponse {
+	switch in {
+	case cyclonedx.IARCanNotFix:
+		return cyclonedx_v1_4.VulnerabilityResponse_VULNERABILITY_RESPONSE_CAN_NOT_FIX
+	case cyclonedx.IARWillNotFix:
+		return cyclonedx_v1_4.VulnerabilityResponse_VULNERABILITY_RESPONSE_WILL_NOT_FIX
+	case cyclonedx.IARUpdate:
+		return cyclonedx_v1_4.VulnerabilityResponse_VULNERABILITY_RESPONSE_UPDATE
+	case cyclonedx.IARRollback:
+		return cyclonedx_v1_4.VulnerabilityResponse_VULNERABILITY_RESPONSE_ROLLBACK
+	case cyclonedx.IARWorkaroundAvailable:
+		return cyclonedx_v1_4.VulnerabilityResponse_VULNERABILITY_RESPONSE_WORKAROUND_AVAILABLE
+	default:
+		return cyclonedx_v1_4.VulnerabilityResponse_VULNERABILITY_RESPONSE_NULL
+	}
+}
+
+func convertImpactAnalysisState(in cyclonedx.ImpactAnalysisState) *cyclonedx_v1_4.ImpactAnalysisState {
+	if in == "" {
+		return nil
+	}
+
+	ptr := func(v cyclonedx_v1_4.ImpactAnalysisState) *cyclonedx_v1_4.ImpactAnalysisState {
+		return &v
+	}
+
+	switch in {
+	case cyclonedx.IASResolved:
+		return ptr(cyclonedx_v1_4.ImpactAnalysisState_IMPACT_ANALYSIS_STATE_RESOLVED)
+	case cyclonedx.IASResolvedWithPedigree:
+		return ptr(cyclonedx_v1_4.ImpactAnalysisState_IMPACT_ANALYSIS_STATE_RESOLVED_WITH_PEDIGREE)
+	case cyclonedx.IASExploitable:
+		return ptr(cyclonedx_v1_4.ImpactAnalysisState_IMPACT_ANALYSIS_STATE_EXPLOITABLE)
+	case cyclonedx.IASInTriage:
+		return ptr(cyclonedx_v1_4.ImpactAnalysisState_IMPACT_ANALYSIS_STATE_IN_TRIAGE)
+	case cyclonedx.IASFalsePositive:
+		return ptr(cyclonedx_v1_4.ImpactAnalysisState_IMPACT_ANALYSIS_STATE_FALSE_POSITIVE)
+	case cyclonedx.IASNotAffected:
+		return ptr(cyclonedx_v1_4.ImpactAnalysisState_IMPACT_ANALYSIS_STATE_NOT_AFFECTED)
+	default:
+		return ptr(cyclonedx_v1_4.ImpactAnalysisState_IMPACT_ANALYSIS_STATE_NULL)
+	}
+}
+
+func convertIssue(in *cyclonedx.Issue) *cyclonedx_v1_4.Issue {
+	if in == nil {
+		return nil
+	}
+
+	return &cyclonedx_v1_4.Issue{
+		Type:        convertIssueType(in.Type),
+		Id:          stringPtr(in.ID),
+		Name:        stringPtr(in.Name),
+		Description: stringPtr(in.Description),
+		Source:      convertSource(in.Source),
+		References:  strSliceDeref(in.References),
+	}
+}
+
+func convertIssueType(in cyclonedx.IssueType) cyclonedx_v1_4.IssueClassification {
+	switch in {
+	case cyclonedx.IssueTypeDefect:
+		return cyclonedx_v1_4.IssueClassification_ISSUE_CLASSIFICATION_DEFECT
+	case cyclonedx.IssueTypeEnhancement:
+		return cyclonedx_v1_4.IssueClassification_ISSUE_CLASSIFICATION_ENHANCEMENT
+	case cyclonedx.IssueTypeSecurity:
+		return cyclonedx_v1_4.IssueClassification_ISSUE_CLASSIFICATION_SECURITY
+	default:
+		return cyclonedx_v1_4.IssueClassification_ISSUE_CLASSIFICATION_NULL
+	}
+}
+
+func castLicenses(in *cyclonedx.Licenses) *[]cyclonedx.LicenseChoice {
+	if in == nil {
+		return nil
+	}
+
+	var l []cyclonedx.LicenseChoice = *in
+	return &l
+}
+
+func convertLicense(in *cyclonedx.License) (out *cyclonedx_v1_4.License) {
+	if in == nil {
+		return nil
+	}
+
+	out = &cyclonedx_v1_4.License{
+		Text: convertAttachedText(in.Text),
+		Url:  stringPtr(in.URL),
+	}
+
+	if in.ID != "" {
+		out.License = &cyclonedx_v1_4.License_Id{
+			Id: in.ID,
+		}
+	}
+
+	if in.Name != "" {
+		out.License = &cyclonedx_v1_4.License_Name{
+			Name: in.Name,
+		}
+	}
+
+	return out
+}
+
+func convertLicenseChoice(in *cyclonedx.LicenseChoice) *cyclonedx_v1_4.LicenseChoice {
+	if in == nil {
+		return nil
+	}
+
+	if in.License != nil {
+		return &cyclonedx_v1_4.LicenseChoice{
+			Choice: &cyclonedx_v1_4.LicenseChoice_License{
+				License: convertLicense(in.License),
+			},
+		}
+	}
+
+	if in.Expression != "" {
+		return &cyclonedx_v1_4.LicenseChoice{
+			Choice: &cyclonedx_v1_4.LicenseChoice_Expression{
+				Expression: in.Expression,
+			},
+		}
+	}
+
+	return nil
+}
+
+func convertMetadata(in *cyclonedx.Metadata) *cyclonedx_v1_4.Metadata {
+	if in == nil {
+		return nil
+	}
+
+	var licenses *cyclonedx_v1_4.LicenseChoice = nil
+	if in.Licenses != nil && len(*in.Licenses) > 0 {
+		licenses = convertLicenseChoice(&(*in.Licenses)[0])
+	}
+
+	return &cyclonedx_v1_4.Metadata{
+		Timestamp:   convertTimestamp(in.Timestamp),
+		Tools:       convertArray(in.Tools, convertTool),
+		Authors:     convertArray(in.Authors, convertOrganizationalContact),
+		Component:   convertComponent(in.Component),
+		Manufacture: convertOrganizationalEntity(in.Manufacture),
+		Supplier:    convertOrganizationalEntity(in.Supplier),
+		Licenses:    licenses,
+		Properties:  convertArray(in.Properties, convertProperty),
+	}
+}
+
+func convertNote(in *cyclonedx.Note) *cyclonedx_v1_4.Note {
+	if in == nil {
+		return nil
+	}
+
+	return &cyclonedx_v1_4.Note{
+		Locale: stringPtr(in.Locale),
+		Text:   convertAttachedText(&in.Text),
+	}
+}
+
+func convertOrganizationalContact(in *cyclonedx.OrganizationalContact) *cyclonedx_v1_4.OrganizationalContact {
+	if in == nil {
+		return nil
+	}
+
+	return &cyclonedx_v1_4.OrganizationalContact{
+		Name:  stringPtr(in.Name),
+		Email: stringPtr(in.Email),
+		Phone: stringPtr(in.Phone),
+	}
+}
+
+func convertOrganizationalEntity(in *cyclonedx.OrganizationalEntity) *cyclonedx_v1_4.OrganizationalEntity {
+	if in == nil {
+		return nil
+	}
+
+	return &cyclonedx_v1_4.OrganizationalEntity{
+		Name:    stringPtr(in.Name),
+		Url:     strSliceDeref(in.URL),
+		Contact: convertArray(in.Contact, convertOrganizationalContact),
+	}
+}
+
+func convertPatch(in *cyclonedx.Patch) *cyclonedx_v1_4.Patch {
+	if in == nil {
+		return nil
+	}
+
+	return &cyclonedx_v1_4.Patch{
+		Type:     convertPatchType(in.Type),
+		Diff:     convertDiff(in.Diff),
+		Resolves: convertArray(in.Resolves, convertIssue),
+	}
+}
+
+func convertPatchType(in cyclonedx.PatchType) cyclonedx_v1_4.PatchClassification {
+	switch in {
+	case cyclonedx.PatchTypeBackport:
+		return cyclonedx_v1_4.PatchClassification_PATCH_CLASSIFICATION_BACKPORT
+	case cyclonedx.PatchTypeCherryPick:
+		return cyclonedx_v1_4.PatchClassification_PATCH_CLASSIFICATION_CHERRY_PICK
+	case cyclonedx.PatchTypeMonkey:
+		return cyclonedx_v1_4.PatchClassification_PATCH_CLASSIFICATION_MONKEY
+	case cyclonedx.PatchTypeUnofficial:
+		return cyclonedx_v1_4.PatchClassification_PATCH_CLASSIFICATION_UNOFFICIAL
+	default:
+		return cyclonedx_v1_4.PatchClassification_PATCH_CLASSIFICATION_NULL
+	}
+}
+
+func convertPedigree(in *cyclonedx.Pedigree) *cyclonedx_v1_4.Pedigree {
+	if in == nil {
+		return nil
+	}
+
+	return &cyclonedx_v1_4.Pedigree{
+		Ancestors:   convertArray(in.Ancestors, convertComponent),
+		Descendants: convertArray(in.Descendants, convertComponent),
+		Variants:    convertArray(in.Variants, convertComponent),
+		Commits:     convertArray(in.Commits, convertCommit),
+		Patches:     convertArray(in.Patches, convertPatch),
+		Notes:       stringPtr(in.Notes),
+	}
+}
+
+func convertProperty(in *cyclonedx.Property) *cyclonedx_v1_4.Property {
+	if in == nil {
+		return nil
+	}
+
+	return &cyclonedx_v1_4.Property{
+		Name:  in.Name,
+		Value: stringPtr(in.Value),
+	}
+}
+
+func convertReleaseNotes(in *cyclonedx.ReleaseNotes) *cyclonedx_v1_4.ReleaseNotes {
+	if in == nil {
+		return nil
+	}
+
+	return &cyclonedx_v1_4.ReleaseNotes{
+		Type:          in.Type,
+		Title:         stringPtr(in.Title),
+		FeaturedImage: stringPtr(in.FeaturedImage),
+		SocialImage:   stringPtr(in.SocialImage),
+		Description:   stringPtr(in.Description),
+		Timestamp:     convertTimestamp(in.Timestamp),
+		Aliases:       strSliceDeref(in.Aliases),
+		Tags:          strSliceDeref(in.Tags),
+		Resolves:      convertArray(in.Resolves, convertIssue),
+		Notes:         convertArray(in.Notes, convertNote),
+		Properties:    convertArray(in.Properties, convertProperty),
+	}
+}
+
+func convertScope(in cyclonedx.Scope) *cyclonedx_v1_4.Scope {
+	if in == "" {
+		return nil
+	}
+
+	ptr := func(v cyclonedx_v1_4.Scope) *cyclonedx_v1_4.Scope {
+		return &v
+	}
+
+	switch in {
+	case cyclonedx.ScopeExcluded:
+		return ptr(cyclonedx_v1_4.Scope_SCOPE_EXCLUDED)
+	case cyclonedx.ScopeOptional:
+		return ptr(cyclonedx_v1_4.Scope_SCOPE_OPTIONAL)
+	case cyclonedx.ScopeRequired:
+		return ptr(cyclonedx_v1_4.Scope_SCOPE_REQUIRED)
+	default:
+		return ptr(cyclonedx_v1_4.Scope_SCOPE_UNSPECIFIED)
+	}
+}
+
+func convertScoringMethod(in cyclonedx.ScoringMethod) *cyclonedx_v1_4.ScoreMethod {
+	if in == "" {
+		return nil
+	}
+
+	ptr := func(v cyclonedx_v1_4.ScoreMethod) *cyclonedx_v1_4.ScoreMethod {
+		return &v
+	}
+
+	switch in {
+	case cyclonedx.ScoringMethodOther:
+		return ptr(cyclonedx_v1_4.ScoreMethod_SCORE_METHOD_OTHER)
+	case cyclonedx.ScoringMethodCVSSv2:
+		return ptr(cyclonedx_v1_4.ScoreMethod_SCORE_METHOD_CVSSV2)
+	case cyclonedx.ScoringMethodCVSSv3:
+		return ptr(cyclonedx_v1_4.ScoreMethod_SCORE_METHOD_CVSSV3)
+	case cyclonedx.ScoringMethodCVSSv31:
+		return ptr(cyclonedx_v1_4.ScoreMethod_SCORE_METHOD_CVSSV31)
+	case cyclonedx.ScoringMethodOWASP:
+		return ptr(cyclonedx_v1_4.ScoreMethod_SCORE_METHOD_OWASP)
+	default:
+		return ptr(cyclonedx_v1_4.ScoreMethod_SCORE_METHOD_NULL)
+	}
+}
+
+func convertService(in *cyclonedx.Service) *cyclonedx_v1_4.Service {
+	if in == nil {
+		return nil
+	}
+
+	return &cyclonedx_v1_4.Service{
+		BomRef:             stringPtr(in.BOMRef),
+		Provider:           convertOrganizationalEntity(in.Provider),
+		Group:              stringPtr(in.Group),
+		Name:               in.Name,
+		Version:            stringPtr(in.Version),
+		Description:        stringPtr(in.Description),
+		Endpoints:          strSliceDeref(in.Endpoints),
+		Authenticated:      in.Authenticated,
+		XTrustBoundary:     in.CrossesTrustBoundary,
+		Data:               convertArray(in.Data, convertDataClassification),
+		Licenses:           convertArray(castLicenses(in.Licenses), convertLicenseChoice),
+		ExternalReferences: convertArray(in.ExternalReferences, convertExternalReference),
+		Services:           convertArray(in.Services, convertService),
+		Properties:         convertArray(in.Properties, convertProperty),
+		ReleaseNotes:       convertReleaseNotes(in.ReleaseNotes),
+	}
+}
+
+func convertSeverity(in cyclonedx.Severity) *cyclonedx_v1_4.Severity {
+	if in == "" {
+		return nil
+	}
+
+	ptr := func(v cyclonedx_v1_4.Severity) *cyclonedx_v1_4.Severity {
+		return &v
+	}
+
+	switch in {
+	case cyclonedx.SeverityUnknown:
+		return ptr(cyclonedx_v1_4.Severity_SEVERITY_UNKNOWN)
+	case cyclonedx.SeverityNone:
+		return ptr(cyclonedx_v1_4.Severity_SEVERITY_NONE)
+	case cyclonedx.SeverityInfo:
+		return ptr(cyclonedx_v1_4.Severity_SEVERITY_INFO)
+	case cyclonedx.SeverityLow:
+		return ptr(cyclonedx_v1_4.Severity_SEVERITY_LOW)
+	case cyclonedx.SeverityMedium:
+		return ptr(cyclonedx_v1_4.Severity_SEVERITY_MEDIUM)
+	case cyclonedx.SeverityHigh:
+		return ptr(cyclonedx_v1_4.Severity_SEVERITY_HIGH)
+	case cyclonedx.SeverityCritical:
+		return ptr(cyclonedx_v1_4.Severity_SEVERITY_CRITICAL)
+	default:
+		return ptr(cyclonedx_v1_4.Severity_SEVERITY_UNKNOWN)
+	}
+}
+
+func convertSource(in *cyclonedx.Source) *cyclonedx_v1_4.Source {
+	if in == nil {
+		return nil
+	}
+
+	return &cyclonedx_v1_4.Source{
+		Name: stringPtr(in.Name),
+		Url:  stringPtr(in.URL),
+	}
+}
+
+func convertSwid(in *cyclonedx.SWID) *cyclonedx_v1_4.Swid {
+	if in == nil {
+		return nil
+	}
+
+	var tagVersion *int32 = nil
+	if in.TagVersion != nil {
+		tagVersion = pointer.Int32Ptr(int32(*in.TagVersion))
+	}
+
+	return &cyclonedx_v1_4.Swid{
+		TagId:      in.TagID,
+		Name:       in.Name,
+		Version:    stringPtr(in.Version),
+		TagVersion: tagVersion,
+		Patch:      in.Patch,
+		Text:       convertAttachedText(in.Text),
+		Url:        stringPtr(in.URL),
+	}
+}
+
+func convertTimestamp(in string) *timestamppb.Timestamp {
+	ts, err := time.Parse("CHECK FORMAT", in)
+	if err != nil {
+		return nil
+	} else {
+		return timestamppb.New(ts)
+	}
+}
+
+func convertTool(in *cyclonedx.Tool) *cyclonedx_v1_4.Tool {
+	if in == nil {
+		return nil
+	}
+
+	return &cyclonedx_v1_4.Tool{
+		Vendor:             stringPtr(in.Vendor),
+		Name:               stringPtr(in.Name),
+		Version:            stringPtr(in.Version),
+		Hashes:             convertArray(in.Hashes, convertHash),
+		ExternalReferences: convertArray(in.ExternalReferences, convertExternalReference),
+	}
+}
+
+func convertVulnerability(in *cyclonedx.Vulnerability) *cyclonedx_v1_4.Vulnerability {
+	if in == nil {
+		return nil
+	}
+
+	var cwes []int32
+	if in.CWEs != nil {
+		cwes = make([]int32, len(*in.CWEs))
+		for i := range *in.CWEs {
+			cwes[i] = int32((*in.CWEs)[i])
+		}
+	}
+
+	return &cyclonedx_v1_4.Vulnerability{
+		BomRef:         stringPtr(in.BOMRef),
+		Id:             stringPtr(in.ID),
+		Source:         convertSource(in.Source),
+		References:     convertArray(in.References, convertVulnerabilityReference),
+		Ratings:        convertArray(in.Ratings, convertVulnerabilityRating),
+		Cwes:           cwes,
+		Description:    stringPtr(in.Description),
+		Detail:         stringPtr(in.Detail),
+		Recommendation: stringPtr(in.Recommendation),
+		Advisories:     convertArray(in.Advisories, convertAdvisory),
+		Created:        convertTimestamp(in.Created),
+		Published:      convertTimestamp(in.Published),
+		Updated:        convertTimestamp(in.Updated),
+		Credits:        convertVulnerabilityCredits(in.Credits),
+		Tools:          convertArray(in.Tools, convertTool),
+		Analysis:       convertVulnerabilityAnalysis(in.Analysis),
+		Affects:        convertArray(in.Affects, convertVulnerabilityAffects),
+		Properties:     convertArray(in.Properties, convertProperty),
+	}
+}
+
+func convertVulnerabilityAffectedStatus(in cyclonedx.VulnerabilityStatus) *cyclonedx_v1_4.VulnerabilityAffectedStatus {
+	if in == "" {
+		return nil
+	}
+
+	ptr := func(v cyclonedx_v1_4.VulnerabilityAffectedStatus) *cyclonedx_v1_4.VulnerabilityAffectedStatus {
+		return &v
+	}
+
+	switch in {
+	case cyclonedx.VulnerabilityStatusUnknown:
+		return ptr(cyclonedx_v1_4.VulnerabilityAffectedStatus_VULNERABILITY_AFFECTED_STATUS_UNKNOWN)
+	case cyclonedx.VulnerabilityStatusAffected:
+		return ptr(cyclonedx_v1_4.VulnerabilityAffectedStatus_VULNERABILITY_AFFECTED_STATUS_AFFECTED)
+	case cyclonedx.VulnerabilityStatusNotAffected:
+		return ptr(cyclonedx_v1_4.VulnerabilityAffectedStatus_VULNERABILITY_AFFECTED_STATUS_NOT_AFFECTED)
+	default:
+		return ptr(cyclonedx_v1_4.VulnerabilityAffectedStatus_VULNERABILITY_AFFECTED_STATUS_UNKNOWN)
+	}
+}
+
+func convertVulnerabilityAffectedVersions(in *cyclonedx.AffectedVersions) (out *cyclonedx_v1_4.VulnerabilityAffectedVersions) {
+	if in == nil {
+		return nil
+	}
+
+	out = &cyclonedx_v1_4.VulnerabilityAffectedVersions{
+		Status: convertVulnerabilityAffectedStatus(in.Status),
+	}
+
+	if in.Version != "" {
+		out.Choice = &cyclonedx_v1_4.VulnerabilityAffectedVersions_Version{
+			Version: in.Version,
+		}
+	}
+
+	if in.Range != "" {
+		out.Choice = &cyclonedx_v1_4.VulnerabilityAffectedVersions_Range{
+			Range: in.Range,
+		}
+	}
+
+	return out
+}
+
+func convertVulnerabilityAffects(in *cyclonedx.Affects) *cyclonedx_v1_4.VulnerabilityAffects {
+	if in == nil {
+		return nil
+	}
+
+	return &cyclonedx_v1_4.VulnerabilityAffects{
+		Ref:      in.Ref,
+		Versions: convertArray(in.Range, convertVulnerabilityAffectedVersions),
+	}
+}
+
+func convertVulnerabilityAnalysis(in *cyclonedx.VulnerabilityAnalysis) *cyclonedx_v1_4.VulnerabilityAnalysis {
+	if in == nil {
+		return nil
+	}
+
+	var response []cyclonedx_v1_4.VulnerabilityResponse
+	if in.Response != nil {
+		response = make([]cyclonedx_v1_4.VulnerabilityResponse, 0, len(*in.Response))
+		for _, e := range *in.Response {
+			response = append(response, convertImpactAnalysisResponse(e))
+		}
+	}
+
+	return &cyclonedx_v1_4.VulnerabilityAnalysis{
+		State:         convertImpactAnalysisState(in.State),
+		Justification: convertImpactAnalysisJustification(in.Justification),
+		Response:      response,
+		Detail:        stringPtr(in.Detail),
+	}
+}
+
+func convertVulnerabilityCredits(in *cyclonedx.Credits) *cyclonedx_v1_4.VulnerabilityCredits {
+	if in == nil {
+		return nil
+	}
+
+	return &cyclonedx_v1_4.VulnerabilityCredits{
+		Organizations: convertArray(in.Organizations, convertOrganizationalEntity),
+		Individuals:   convertArray(in.Individuals, convertOrganizationalContact),
+	}
+}
+
+func convertVulnerabilityRating(in *cyclonedx.VulnerabilityRating) *cyclonedx_v1_4.VulnerabilityRating {
+	if in == nil {
+		return nil
+	}
+
+	return &cyclonedx_v1_4.VulnerabilityRating{
+		Source:        convertSource(in.Source),
+		Score:         in.Score,
+		Severity:      convertSeverity(in.Severity),
+		Method:        convertScoringMethod(in.Method),
+		Vector:        stringPtr(in.Vector),
+		Justification: stringPtr(in.Justification),
+	}
+}
+
+func convertVulnerabilityReference(in *cyclonedx.VulnerabilityReference) *cyclonedx_v1_4.VulnerabilityReference {
+	if in == nil {
+		return nil
+	}
+
+	return &cyclonedx_v1_4.VulnerabilityReference{
+		Id:     stringPtr(in.ID),
+		Source: convertSource(in.Source),
+	}
+}

--- a/pkg/collector/corechecks/sbom/convert_test.go
+++ b/pkg/collector/corechecks/sbom/convert_test.go
@@ -1,0 +1,28 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
+package sbom
+
+import (
+	"testing"
+
+	"github.com/CycloneDX/cyclonedx-go"
+	fuzz "github.com/google/gofuzz"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/proto"
+)
+
+func FuzzConvertBOM(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data []byte) {
+		f := fuzz.NewFromGoFuzz(data).NilChance(0.8).NumElements(0, 2)
+
+		var bom cyclonedx.BOM
+		f.Fuzz(&bom)
+
+		pb := convertBOM(&bom)
+		_, err := proto.Marshal(pb)
+		assert.Nil(t, err)
+	})
+}

--- a/pkg/collector/corechecks/sbom/processor.go
+++ b/pkg/collector/corechecks/sbom/processor.go
@@ -1,0 +1,77 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
+package sbom
+
+import (
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
+
+	"github.com/DataDog/agent-payload/v5/sbom"
+	model "github.com/DataDog/agent-payload/v5/sbom"
+)
+
+var /* const */ (
+	sourceAgent = "agent"
+)
+
+type processor struct {
+	queue chan *model.SBOMEntity
+}
+
+func newProcessor(sender aggregator.Sender, maxNbItem int, maxRetentionTime time.Duration) *processor {
+	return &processor{
+		queue: newQueue(maxNbItem, maxRetentionTime, func(entities []*model.SBOMEntity) {
+			sender.SBOM([]sbom.SBOMPayload{
+				{
+					Version:  1,
+					Source:   &sourceAgent,
+					Entities: entities,
+				},
+			})
+		}),
+	}
+}
+
+func (p *processor) processEvents(evBundle workloadmeta.EventBundle) {
+	close(evBundle.Ch)
+
+	log.Tracef("Processing %d events", len(evBundle.Events))
+
+	for _, event := range evBundle.Events {
+		p.processSBOM(event.Entity.(*workloadmeta.ContainerImageMetadata))
+	}
+}
+
+func (p *processor) processRefresh(allImages []*workloadmeta.ContainerImageMetadata) {
+	// So far, the check is refreshing all the images every 5 minutes all together.
+	for _, img := range allImages {
+		p.processSBOM(img)
+	}
+}
+
+func (p *processor) processSBOM(img *workloadmeta.ContainerImageMetadata) {
+	if img.CycloneDXBOM == nil {
+		return
+	}
+
+	p.queue <- &model.SBOMEntity{
+		Type:        model.SBOMSourceType_CONTAINER_IMAGE_LAYERS,
+		Id:          img.ID,
+		GeneratedAt: nil,
+		Tags:        img.RepoTags,
+		InUse:       true, // TODO: compute this field
+		Sbom: &sbom.SBOMEntity_Cyclonedx{
+			Cyclonedx: convertBOM(img.CycloneDXBOM),
+		},
+	}
+}
+
+func (p *processor) stop() {
+	close(p.queue)
+}

--- a/pkg/collector/corechecks/sbom/processor_test.go
+++ b/pkg/collector/corechecks/sbom/processor_test.go
@@ -1,0 +1,149 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
+package sbom
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/CycloneDX/cyclonedx-go"
+	"github.com/DataDog/agent-payload/v5/cyclonedx_v1_4"
+	model "github.com/DataDog/agent-payload/v5/sbom"
+	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
+	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	"github.com/DataDog/datadog-agent/pkg/util/pointer"
+	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestProcessEvents(t *testing.T) {
+	sender := mocksender.NewMockSender(check.ID(""))
+	sender.On("SBOM", mock.Anything, mock.Anything).Return()
+	p := newProcessor(sender, 2, 50*time.Millisecond)
+
+	for i := 0; i < 3; i++ {
+		p.processEvents(workloadmeta.EventBundle{
+			Events: []workloadmeta.Event{
+				{
+					Type: workloadmeta.EventTypeSet,
+					Entity: &workloadmeta.ContainerImageMetadata{
+						EntityID: workloadmeta.EntityID{
+							Kind: workloadmeta.KindContainerImageMetadata,
+							ID:   strconv.Itoa(i),
+						},
+						CycloneDXBOM: &cyclonedx.BOM{
+							SpecVersion: "1.4",
+							Version:     42,
+							Components: &[]cyclonedx.Component{
+								{
+									Name: strconv.Itoa(100 * i),
+								},
+								{
+									Name: strconv.Itoa(100*i + 1),
+								},
+								{
+									Name: strconv.Itoa(100*i + 2),
+								},
+							},
+						},
+					},
+				},
+			},
+			Ch: make(chan struct{}),
+		})
+	}
+
+	sender.AssertNumberOfCalls(t, "SBOM", 1)
+	sender.AssertSBOM(t, []model.SBOMPayload{
+		{
+			Version: 1,
+			Source:  &sourceAgent,
+			Entities: []*model.SBOMEntity{
+				{
+					Type:  model.SBOMSourceType_CONTAINER_IMAGE_LAYERS,
+					Id:    "0",
+					InUse: true,
+					Sbom: &model.SBOMEntity_Cyclonedx{
+						Cyclonedx: &cyclonedx_v1_4.Bom{
+							SpecVersion: "1.4",
+							Version:     pointer.Int32Ptr(42),
+							Components: []*cyclonedx_v1_4.Component{
+								{
+									Name: "0",
+								},
+								{
+									Name: "1",
+								},
+								{
+									Name: "2",
+								},
+							},
+						},
+					},
+				},
+				{
+					Type:  model.SBOMSourceType_CONTAINER_IMAGE_LAYERS,
+					Id:    "1",
+					InUse: true,
+					Sbom: &model.SBOMEntity_Cyclonedx{
+						Cyclonedx: &cyclonedx_v1_4.Bom{
+							SpecVersion: "1.4",
+							Version:     pointer.Int32Ptr(42),
+							Components: []*cyclonedx_v1_4.Component{
+								{
+									Name: "100",
+								},
+								{
+									Name: "101",
+								},
+								{
+									Name: "102",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	time.Sleep(100 * time.Millisecond)
+
+	sender.AssertNumberOfCalls(t, "SBOM", 2)
+	sender.AssertSBOM(t, []model.SBOMPayload{
+		{
+			Version: 1,
+			Source:  &sourceAgent,
+			Entities: []*model.SBOMEntity{
+				{
+					Type:  model.SBOMSourceType_CONTAINER_IMAGE_LAYERS,
+					Id:    "2",
+					InUse: true,
+					Sbom: &model.SBOMEntity_Cyclonedx{
+						Cyclonedx: &cyclonedx_v1_4.Bom{
+							SpecVersion: "1.4",
+							Version:     pointer.Int32Ptr(42),
+							Components: []*cyclonedx_v1_4.Component{
+								{
+									Name: "200",
+								},
+								{
+									Name: "201",
+								},
+								{
+									Name: "202",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	p.stop()
+}

--- a/pkg/collector/corechecks/sbom/queue.go
+++ b/pkg/collector/corechecks/sbom/queue.go
@@ -1,0 +1,71 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
+package sbom
+
+import (
+	"time"
+
+	model "github.com/DataDog/agent-payload/v5/sbom"
+)
+
+type queue struct {
+	maxNbItem        int
+	maxRetentionTime time.Duration
+	flushCB          func([]*model.SBOMEntity)
+	enqueueCh        chan *model.SBOMEntity
+	data             []*model.SBOMEntity
+	timer            *time.Timer
+}
+
+// newQueue returns a chan to enqueue newly discovered container images
+func newQueue(maxNbItem int, maxRetentionTime time.Duration, flushCB func([]*model.SBOMEntity)) chan *model.SBOMEntity {
+	q := queue{
+		maxNbItem:        maxNbItem,
+		maxRetentionTime: maxRetentionTime,
+		flushCB:          flushCB,
+		enqueueCh:        make(chan *model.SBOMEntity),
+		data:             make([]*model.SBOMEntity, 0, maxNbItem),
+		timer:            time.NewTimer(maxRetentionTime),
+	}
+
+	if !q.timer.Stop() {
+		<-q.timer.C
+	}
+
+	go func() {
+		for {
+			select {
+			case <-q.timer.C:
+				q.flush()
+			case sbom, more := <-q.enqueueCh:
+				if !more {
+					return
+				}
+				q.enqueue(sbom)
+			}
+		}
+	}()
+
+	return q.enqueueCh
+}
+
+func (q *queue) enqueue(elem *model.SBOMEntity) {
+	if len(q.data) == 0 {
+		q.timer.Reset(q.maxRetentionTime)
+	}
+
+	q.data = append(q.data, elem)
+
+	if len(q.data) == q.maxNbItem {
+		q.flush()
+	}
+}
+
+func (q *queue) flush() {
+	q.timer.Stop()
+	q.flushCB(q.data)
+	q.data = make([]*model.SBOMEntity, 0, q.maxNbItem)
+}

--- a/pkg/collector/corechecks/sbom/queue_test.go
+++ b/pkg/collector/corechecks/sbom/queue_test.go
@@ -1,0 +1,71 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
+package sbom
+
+import (
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	model "github.com/DataDog/agent-payload/v5/sbom"
+	"github.com/stretchr/testify/assert"
+)
+
+func newMockFlush() (callback func([]*model.SBOMEntity), getAccumulator func() [][]*model.SBOMEntity) {
+	accumulator := [][]*model.SBOMEntity{}
+	var mutex sync.RWMutex
+
+	callback = func(sbom []*model.SBOMEntity) {
+		mutex.Lock()
+		defer mutex.Unlock()
+		accumulator = append(accumulator, sbom)
+	}
+
+	getAccumulator = func() [][]*model.SBOMEntity {
+		mutex.RLock()
+		defer mutex.RUnlock()
+		return accumulator
+	}
+
+	return
+}
+
+func TestQueue(t *testing.T) {
+	callback, accumulator := newMockFlush()
+	queue := newQueue(3, 50*time.Millisecond, callback)
+
+	for i := 0; i <= 10; i++ {
+		queue <- &model.SBOMEntity{
+			Id: strconv.Itoa(i),
+		}
+	}
+
+	assert.Equal(
+		t,
+		accumulator(),
+		[][]*model.SBOMEntity{
+			{{Id: "0"}, {Id: "1"}, {Id: "2"}},
+			{{Id: "3"}, {Id: "4"}, {Id: "5"}},
+			{{Id: "6"}, {Id: "7"}, {Id: "8"}},
+		},
+	)
+
+	time.Sleep(100 * time.Millisecond)
+
+	assert.Equal(
+		t,
+		accumulator(),
+		[][]*model.SBOMEntity{
+			{{Id: "0"}, {Id: "1"}, {Id: "2"}},
+			{{Id: "3"}, {Id: "4"}, {Id: "5"}},
+			{{Id: "6"}, {Id: "7"}, {Id: "8"}},
+			{{Id: "9"}, {Id: "10"}},
+		},
+	)
+
+	close(queue)
+}

--- a/pkg/util/pointer/pointer.go
+++ b/pkg/util/pointer/pointer.go
@@ -10,6 +10,11 @@ func Int64Ptr(v int64) *int64 {
 	return &v
 }
 
+// Int32Ptr returns a pointer from a value. It will allocate a new heap object for it.
+func Int32Ptr(v int32) *int32 {
+	return &v
+}
+
 // UInt16Ptr returns a pointer from a value. It will allocate a new heap object for it.
 func UInt16Ptr(v uint16) *uint16 {
 	return &v

--- a/pkg/workloadmeta/types.go
+++ b/pkg/workloadmeta/types.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/CycloneDX/cyclonedx-go"
 	"github.com/mohae/deepcopy"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 
@@ -636,6 +637,7 @@ type ContainerImageMetadata struct {
 	Architecture string
 	Variant      string
 	Layers       []ContainerImageLayer
+	CycloneDXBOM *cyclonedx.BOM
 }
 
 // ContainerImageLayer represents a layer of a container image

--- a/releasenotes/notes/sbom-01e923031b7d118b.yaml
+++ b/releasenotes/notes/sbom-01e923031b7d118b.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Add a new ``sbom`` core check to collect the software bill of materials of containers.


### PR DESCRIPTION
### What does this PR do?

Implement a `SBOM` long-running core check to collect the container SBOM (software bill of materials) and send them to a dedicated EVP track.

* The scheduling of the check is controlled by the `sbom.enabled` parameter which defaults to `false`.
* The intake URL at which the data are sent can be overridden by the `sbom.dd_url` parameter.
* In order to dual-ship data to several datacenters, additional URLs can be configured in the `sbom.additional_endpoints` parameter.

The SBOM sent by the `sbom` check implemented in this PR are coming from the workloadmeta store <!--(see #)--> which is itself fed by several collectors <!--(see # for the `containerd` image collector)-->.

The SBOM are sent on two conditions:
* When a new image event is detected. Being event-based allow new images to show up in the app quickly.
* On a regular basis, every `x` minutes. Because the back-end keeps the received SBOM for a given period of time. And SBOM not refreshed are automatically deleted after a TTL expiration. A consequence of this mechanism is that no deletion event needs to be sent.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

Depends on #14962 and DataDog/agent-payload#212.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

The EVP track is not ready yet.
The check is gated by a feature flag `sbom.enabled` defaulting to `false`.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
