### PR TITLE
[CWS] fix event missing field resolver

### DIFF
--- a/cmd/security-agent/app/subcommands/runtime/command.go
+++ b/cmd/security-agent/app/subcommands/runtime/command.go
@@ -554,7 +554,7 @@ func eventDataFromJSON(file string) (eval.Event, error) {
 	}
 
 	m := &model.Model{}
-	event := m.NewEventWithType(kind)
+	event := m.NewDefaultEventWithType(kind)
 	event.Init()
 
 	for k, v := range eventData.Values {
@@ -602,8 +602,8 @@ func evalRule(log complog.Component, config compconfig.Component, evalArgs *eval
 		WithReservedRuleIDs(events.AllCustomRuleIDs()).
 		WithLogger(seclog.DefaultLogger)
 
-	model := &model.Model{}
-	ruleSet := rules.NewRuleSet(model, model.NewEvent, &opts, &evalOpts)
+	m := &model.Model{}
+	ruleSet := rules.NewRuleSet(m, model.NewDefaultEvent, &opts, &evalOpts)
 
 	agentVersionFilter, err := newAgentVersionFilter()
 	if err != nil {

--- a/cmd/security-agent/app/subcommands/runtime/command.go
+++ b/cmd/security-agent/app/subcommands/runtime/command.go
@@ -638,7 +638,7 @@ func evalRule(log complog.Component, config compconfig.Component, evalArgs *eval
 	}
 
 	report := EvalReport{
-		Event: event,
+		// Event: event,
 	}
 
 	approvers, err := ruleSet.GetApprovers(sprobe.GetCapababilities())

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -38,10 +38,11 @@ func (m *Model) NewEvent() eval.Event {
 	return &Event{}
 }
 
-// NewEventWithType returns a new Event for the given type
-func (m *Model) NewEventWithType(kind EventType) eval.Event {
+// NewDefaultEventWithType returns a new Event for the given type
+func (m *Model) NewDefaultEventWithType(kind EventType) eval.Event {
 	return &Event{
-		Type: uint32(kind),
+		Type:          uint32(kind),
+		FieldHandlers: &DefaultFieldHandlers{},
 	}
 }
 

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -8,7 +8,6 @@
 package model
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
@@ -300,7 +299,7 @@ func (ev *Event) MarshalJSON() ([]byte, error) {
 	if ev.JSONMarshaler != nil {
 		return ev.JSONMarshaler(ev)
 	}
-	return json.Marshal(ev)
+	return nil, errors.New("no json marshaller defined for this event")
 }
 
 // Retain the event


### PR DESCRIPTION
### What does this PR do?

This PR fixes the issue where event decoded from JSON (used in security monitoring CI tests) was missing the field resolver.
This PR also temporarily removes the event from the output so that we can take some time to fix the JSON cycle issue.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
