### PR TITLE
[process-agent] Support dynamically enabling profiling for process agent from CLI

### DIFF
--- a/cmd/agent/subcommands/run/settings.go
+++ b/cmd/agent/subcommands/run/settings.go
@@ -34,5 +34,5 @@ func initRuntimeSettings() error {
 	if err := commonsettings.RegisterRuntimeSetting(commonsettings.ProfilingGoroutines("internal_profiling_goroutines")); err != nil {
 		return err
 	}
-	return commonsettings.RegisterRuntimeSetting(commonsettings.ProfilingRuntimeSetting("internal_profiling"))
+	return commonsettings.RegisterRuntimeSetting(commonsettings.ProfilingRuntimeSetting{SettingName: "internal_profiling", Service: "datadog-agent"})
 }

--- a/cmd/cluster-agent/app/config.go
+++ b/cmd/cluster-agent/app/config.go
@@ -77,5 +77,5 @@ func initRuntimeSettings() error {
 		return err
 	}
 
-	return commonsettings.RegisterRuntimeSetting(commonsettings.ProfilingRuntimeSetting("internal_profiling"))
+	return commonsettings.RegisterRuntimeSetting(commonsettings.ProfilingRuntimeSetting{SettingName: "internal_profiling", Service: "datadog-cluster-agent"})
 }

--- a/cmd/process-agent/main_common.go
+++ b/cmd/process-agent/main_common.go
@@ -299,6 +299,7 @@ func initRuntimeSettings() {
 	// NOTE: Any settings you want to register should simply be added here
 	processRuntimeSettings := []settings.RuntimeSetting{
 		settings.LogLevelRuntimeSetting{},
+		settings.ProfilingRuntimeSetting{SettingName: "internal_profiling", Service: "process-agent"},
 	}
 
 	// Before we begin listening, register runtime settings

--- a/cmd/process-agent/main_common.go
+++ b/cmd/process-agent/main_common.go
@@ -299,6 +299,9 @@ func initRuntimeSettings() {
 	// NOTE: Any settings you want to register should simply be added here
 	processRuntimeSettings := []settings.RuntimeSetting{
 		settings.LogLevelRuntimeSetting{},
+		settings.RuntimeMutexProfileFraction("runtime_mutex_profile_fraction"),
+		settings.RuntimeBlockProfileRate("runtime_block_profile_rate"),
+		settings.ProfilingGoroutines("internal_profiling_goroutines"),
 		settings.ProfilingRuntimeSetting{SettingName: "internal_profiling", Service: "process-agent"},
 	}
 

--- a/pkg/config/settings/runtime_setting_profiling.go
+++ b/pkg/config/settings/runtime_setting_profiling.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
-	"github.com/DataDog/datadog-agent/pkg/util/flavor"
 	"github.com/DataDog/datadog-agent/pkg/util/profiling"
 	"github.com/DataDog/datadog-agent/pkg/version"
 )
@@ -75,7 +74,7 @@ func (l ProfilingRuntimeSetting) Set(v interface{}) error {
 		// Note that we must derive a new profiling.Settings on every
 		// invocation, as many of these settings may have changed at runtime.
 		v, _ := version.Agent()
-		service := l.GetService()
+		service := l.Service
 
 		settings := profiling.Settings{
 			ProfilingURL:         site,
@@ -98,12 +97,4 @@ func (l ProfilingRuntimeSetting) Set(v interface{}) error {
 	}
 
 	return nil
-}
-
-func (l ProfilingRuntimeSetting) GetService() string {
-	service := l.Service
-	if flavor.GetFlavor() == flavor.ClusterAgent {
-		service = "datadog-cluster-agent"
-	}
-	return service
 }

--- a/pkg/config/settings/runtime_setting_profiling.go
+++ b/pkg/config/settings/runtime_setting_profiling.go
@@ -16,7 +16,10 @@ import (
 )
 
 // ProfilingRuntimeSetting wraps operations to change log level at runtime
-type ProfilingRuntimeSetting string
+type ProfilingRuntimeSetting struct {
+	SettingName string
+	Service     string
+}
 
 // Description returns the runtime setting's description
 func (l ProfilingRuntimeSetting) Description() string {
@@ -30,7 +33,7 @@ func (l ProfilingRuntimeSetting) Hidden() bool {
 
 // Name returns the name of the runtime setting
 func (l ProfilingRuntimeSetting) Name() string {
-	return string(l)
+	return l.SettingName
 }
 
 // Get returns the current value of the runtime setting
@@ -72,10 +75,7 @@ func (l ProfilingRuntimeSetting) Set(v interface{}) error {
 		// Note that we must derive a new profiling.Settings on every
 		// invocation, as many of these settings may have changed at runtime.
 		v, _ := version.Agent()
-		service := "datadog-agent"
-		if flavor.GetFlavor() == flavor.ClusterAgent {
-			service = "datadog-cluster-agent"
-		}
+		service := l.GetService()
 
 		settings := profiling.Settings{
 			ProfilingURL:         site,
@@ -98,4 +98,12 @@ func (l ProfilingRuntimeSetting) Set(v interface{}) error {
 	}
 
 	return nil
+}
+
+func (l ProfilingRuntimeSetting) GetService() string {
+	service := l.Service
+	if flavor.GetFlavor() == flavor.ClusterAgent {
+		service = "datadog-cluster-agent"
+	}
+	return service
 }

--- a/pkg/config/settings/runtime_settings_test.go
+++ b/pkg/config/settings/runtime_settings_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
-	"github.com/DataDog/datadog-agent/pkg/util/flavor"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -110,7 +109,7 @@ func TestProfiling(t *testing.T) {
 
 	ll := ProfilingRuntimeSetting{SettingName: "internal_profiling", Service: "datadog-agent"}
 	assert.Equal(t, "internal_profiling", ll.Name())
-	assert.Equal(t, "datadog-agent", ll.GetService())
+	assert.Equal(t, "datadog-agent", ll.Service)
 
 	err := ll.Set("false")
 	assert.Nil(t, err)
@@ -123,11 +122,10 @@ func TestProfiling(t *testing.T) {
 	assert.NotNil(t, err)
 
 	ll = ProfilingRuntimeSetting{SettingName: "internal_profiling", Service: "process-agent"}
-	assert.Equal(t, "process-agent", ll.GetService())
+	assert.Equal(t, "process-agent", ll.Service)
 
-	ll = ProfilingRuntimeSetting{SettingName: "internal_profiling", Service: "datadog-agent"}
-	flavor.SetFlavor(flavor.ClusterAgent)
-	assert.Equal(t, "datadog-cluster-agent", ll.GetService())
+	ll = ProfilingRuntimeSetting{SettingName: "internal_profiling", Service: "datadog-cluster-agent"}
+	assert.Equal(t, "datadog-cluster-agent", ll.Service)
 }
 
 func TestGetInt(t *testing.T) {

--- a/pkg/config/settings/runtime_settings_test.go
+++ b/pkg/config/settings/runtime_settings_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/flavor"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -107,8 +108,9 @@ func TestProfiling(t *testing.T) {
 	cleanRuntimeSetting()
 	setupConf()
 
-	ll := ProfilingRuntimeSetting("internal_profiling")
+	ll := ProfilingRuntimeSetting{SettingName: "internal_profiling", Service: "datadog-agent"}
 	assert.Equal(t, "internal_profiling", ll.Name())
+	assert.Equal(t, "datadog-agent", ll.GetService())
 
 	err := ll.Set("false")
 	assert.Nil(t, err)
@@ -119,6 +121,13 @@ func TestProfiling(t *testing.T) {
 
 	err = ll.Set("on")
 	assert.NotNil(t, err)
+
+	ll = ProfilingRuntimeSetting{SettingName: "internal_profiling", Service: "process-agent"}
+	assert.Equal(t, "process-agent", ll.GetService())
+
+	ll = ProfilingRuntimeSetting{SettingName: "internal_profiling", Service: "datadog-agent"}
+	flavor.SetFlavor(flavor.ClusterAgent)
+	assert.Equal(t, "datadog-cluster-agent", ll.GetService())
 }
 
 func TestGetInt(t *testing.T) {

--- a/releasenotes/notes/process-agent-dynamic-profiling-0aece4cec9ca7526.yaml
+++ b/releasenotes/notes/process-agent-dynamic-profiling-0aece4cec9ca7526.yaml
@@ -1,0 +1,3 @@
+---
+enhancements:
+  - Allow profiling for the process agent to be dynamically enabled from the CLI with `process-agent config set internal_profiling`.

--- a/releasenotes/notes/process-agent-dynamic-profiling-0aece4cec9ca7526.yaml
+++ b/releasenotes/notes/process-agent-dynamic-profiling-0aece4cec9ca7526.yaml
@@ -1,3 +1,3 @@
 ---
 enhancements:
-  - Allow profiling for the process agent to be dynamically enabled from the CLI with `process-agent config set internal_profiling`.
+  - Allows profiling for the process agent to be dynamically enabled from the CLI with `process-agent config set internal_profiling`. Optionally, once profiling is enabled, block, mutex and goroutine profiling can also be enabled with `process-agent config set runtime_block_profile_rate`, `process-agent config set runtime_mutex_profile_fraction` and `process-agent config set internal_profiling_goroutines`.

--- a/releasenotes/notes/process-agent-dynamic-profiling-0aece4cec9ca7526.yaml
+++ b/releasenotes/notes/process-agent-dynamic-profiling-0aece4cec9ca7526.yaml
@@ -1,3 +1,3 @@
 ---
 enhancements:
-  - Allows profiling for the process agent to be dynamically enabled from the CLI with `process-agent config set internal_profiling`. Optionally, once profiling is enabled, block, mutex and goroutine profiling can also be enabled with `process-agent config set runtime_block_profile_rate`, `process-agent config set runtime_mutex_profile_fraction` and `process-agent config set internal_profiling_goroutines`.
+  - Allows profiling for the Process Agent to be dynamically enabled from the CLI with `process-agent config set internal_profiling`. Optionally, once profiling is enabled, block, mutex, and goroutine profiling can also be enabled with `process-agent config set runtime_block_profile_rate`, `process-agent config set runtime_mutex_profile_fraction`, and `process-agent config set internal_profiling_goroutines`.


### PR DESCRIPTION
### What does this PR do?

Adds support for dynamically enabling profiling for the process agent from the CLI.

This PR also refactors the `ProfilingRuntimeSetting` struct to allow clients to pass in a service name used when tagging emitted profiles, in order to avoid the need for clients who want to use a different service name to create a new agent flavor, as not all clients may be using a dedicated agent flavor.

### Motivation

When investigating memory usage of the process agent during QA, we sometimes need to enable profiling to get additional information about CPU time spent and memory allocations. Adding a CLI command to allow profiling to be dynamically enabled without needing the process agent to be restarted will help speed up this process.

### Describe how to test/QA your changes

#### Process Agent
Enable process agent profiling from the CLI with `process-agent config set internal_profiling true` and validate that profiling is now correctly enabled, and that profiles are tagged with `service:process-agent`. Disable profiling with `process-agent config set internal_profiling false` and validate that profiling is now disabled i.e. profiles are no longer reported to Datadog. Validate that `process-agent config get internal_profiling` correctly reflects whether or not internal profiling is enabled.

Test with the optional profiling settings as well, and validate that mutex, block and goroutine profiling settings are reflected in `process-agent config get`, and that profiling data shows up once they are enabled:
- `process-agent config set internal_profiling_goroutines <true/false>`
- `process-agent config set runtime_block_profile_rate 10000`
- `process-agent config set runtime_mutex_profile_fraction 100`

Note that you will need to disable and re-enable profiling with `process-agent config set internal_profiling false` and `process-agent config set internal_profiling true` for the optional profiling settings to take effect.

#### Core Agent
Enable profiling from the CLI with `datadog-agent config set internal_profiling true` and validate that profiling is still correctly enabled, and that profiles are still tagged with `service:datadog-agent`

#### Cluster Agent
Enable profiling for the cluster agent (functionality added in #11568) and validate that profiling is still correctly enabled, and that profiles are still tagged with `service:datadog-cluster-agent`

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
