### PR TITLE
[CWS] mount fallback to pid 1 by default

### DIFF
--- a/pkg/security/probe/resolvers/mount_resolver.go
+++ b/pkg/security/probe/resolvers/mount_resolver.go
@@ -130,11 +130,9 @@ func (mr *MountResolver) SyncCache(pid uint32) error {
 	mr.lock.Lock()
 	defer mr.lock.Unlock()
 
-	if err := mr.syncCache(0, pid); err != nil {
-		return err
-	}
+	err := mr.syncCache(pid)
 
-	// store the minimal mount ID found to use it a reference
+	// store the minimal mount ID found to use it as a reference
 	if pid == 1 {
 		for mountID := range mr.mounts {
 			if mr.minMountID == 0 || mr.minMountID > mountID {
@@ -143,24 +141,13 @@ func (mr *MountResolver) SyncCache(pid uint32) error {
 		}
 	}
 
-	return nil
+	return err
 }
 
 // syncCache update cache with the first working pid
-func (mr *MountResolver) syncCache(mountID uint32, pids ...uint32) error {
+func (mr *MountResolver) syncCache(pids ...uint32) error {
 	var err error
 	var mnts []*mountinfo.Info
-
-	now := time.Now()
-	if mountID != 0 {
-		if ts, ok := mr.fallbackLimiter.Get(mountID); ok {
-			if now.After(ts) {
-				mr.fallbackLimiter.Remove(mountID)
-			} else {
-				return ErrMountNotFound
-			}
-		}
-	}
 
 	for _, pid := range pids {
 		mnts, err = kernel.ParseMountInfoFile(int32(pid))
@@ -179,11 +166,6 @@ func (mr *MountResolver) syncCache(mountID uint32, pids ...uint32) error {
 		}
 
 		return nil
-	}
-
-	if mountID != 0 {
-		// add to fallback limiter to avoid storm of file access
-		mr.fallbackLimiter.Add(mountID, now.Add(fallbackLimiterPeriod))
 	}
 
 	return err
@@ -418,13 +400,29 @@ func (mr *MountResolver) ResolveMountPath(mountID, pid uint32, containerID strin
 	return mr.resolveMountPath(mountID, pid, containerID)
 }
 
+func (mr *MountResolver) isSyncCacheAllowed(mountID uint32) bool {
+	now := time.Now()
+	if ts, ok := mr.fallbackLimiter.Get(mountID); ok {
+		if now.After(ts) {
+			mr.fallbackLimiter.Remove(mountID)
+		} else {
+			return false
+		}
+	}
+	return true
+}
+
+func (mr *MountResolver) syncCacheMiss(mountID uint32) {
+	mr.procMissStats.Inc()
+
+	// add to fallback limiter to avoid storm of file access
+	mr.fallbackLimiter.Add(mountID, time.Now().Add(fallbackLimiterPeriod))
+}
+
 func (mr *MountResolver) resolveMountPath(mountID, pid uint32, containerID string) (string, error) {
 	if _, err := mr.IsMountIDValid(mountID); err != nil {
 		return "", err
 	}
-
-	// force pid1 resolution here to keep the LRU doing his job and not evicting important entries
-	pid1, _ := mr.cgroupsResolver.GetPID1(containerID)
 
 	path, err := mr.getMountPath(mountID)
 	if err == nil {
@@ -441,10 +439,22 @@ func (mr *MountResolver) resolveMountPath(mountID, pid uint32, containerID strin
 		return "", ErrMountNotFound
 	}
 
-	if err := mr.syncCache(mountID, pid, pid1); err != nil {
-		mr.procMissStats.Inc()
+	// force pid1 resolution here to keep the LRU doing his job and not evicting important entries
+	pid1, _ := mr.cgroupsResolver.GetPID1(containerID)
+	if pid1 == 0 {
+		// use the pid1 of the host
+		pid1 = 1
+	}
+
+	if !mr.isSyncCacheAllowed(mountID) {
+		return "", ErrMountNotFound
+	}
+
+	if err := mr.syncCache(pid, pid1); err != nil {
+		mr.syncCacheMiss(mountID)
 		return "", err
 	}
+
 	path, err = mr.getMountPath(mountID)
 	if err == nil {
 		mr.procHitsStats.Inc()
@@ -468,9 +478,6 @@ func (mr *MountResolver) resolveMount(mountID, pid uint32, containerID string) (
 		return nil, err
 	}
 
-	// force pid1 resolution here to keep the LRU doing his job and not evicting important entries
-	pid1, _ := mr.cgroupsResolver.GetPID1(containerID)
-
 	mount, exists := mr.mounts[mountID]
 	if exists {
 		mr.cacheHitsStats.Inc()
@@ -486,10 +493,18 @@ func (mr *MountResolver) resolveMount(mountID, pid uint32, containerID string) (
 		return nil, ErrMountNotFound
 	}
 
+	// force pid1 resolution here to keep the LRU doing his job and not evicting important entries
+	pid1, _ := mr.cgroupsResolver.GetPID1(containerID)
+	if pid1 == 0 {
+		// use the pid1 of the host
+		pid1 = 1
+	}
+
 	if err := mr.syncCache(mountID, pid, pid1); err != nil {
-		mr.procMissStats.Inc()
+		mr.syncCacheMiss(mountID)
 		return nil, err
 	}
+
 	mount, exists = mr.mounts[mountID]
 	if exists {
 		mr.procMissStats.Inc()


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Refactor the proc fallback and uses pid1 as default pid.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
