### PR TITLE
Auto instrumentation: add RC provider

### DIFF
--- a/pkg/clusteragent/admission/common/const.go
+++ b/pkg/clusteragent/admission/common/const.go
@@ -20,4 +20,10 @@ const (
 
 	// LibConfigV1AnnotKeyFormat is the format of the library config annotation
 	LibConfigV1AnnotKeyFormat = "admission.datadoghq.com/%s-lib.config.v1"
+
+	// RcIDAnnotKey is the format of the RC ID annotation
+	RcIDAnnotKeyFormat = "admission.datadoghq.com/%s-lib.rc.id"
+
+	// RcRevisionAnnotKey is the format of the RC revision annotation
+	RcRevisionAnnotKeyFormat = "admission.datadoghq.com/%s-lib.rc.rev"
 )

--- a/pkg/clusteragent/admission/common/lib_config.go
+++ b/pkg/clusteragent/admission/common/lib_config.go
@@ -17,16 +17,43 @@ import (
 
 // LibConfig holds the APM library configuration
 type LibConfig struct {
-	Version         int    `yaml:"version,omitempty" json:"version,omitempty"` // config schema version, not config version
-	ServiceLanguage string `yaml:"service_language,omitempty" json:"service_language,omitempty"`
+	Language string `yaml:"library_language" json:"library_language"`
+	Version  string `yaml:"library_version" json:"library_version"`
 
-	Tracing             *bool    `yaml:"tracing_enabled,omitempty" json:"tracing_enabled,omitempty"`
-	LogInjection        *bool    `yaml:"log_injection_enabled,omitempty" json:"log_injection_enabled,omitempty"`
-	HealthMetrics       *bool    `yaml:"health_metrics_enabled,omitempty" json:"health_metrics_enabled,omitempty"`
-	RuntimeMetrics      *bool    `yaml:"runtime_metrics_enabled,omitempty" json:"runtime_metrics_enabled,omitempty"`
-	TracingSamplingRate *float64 `yaml:"tracing_sampling_rate,omitempty" json:"tracing_sampling_rate,omitempty"`
-	TracingRateLimit    *int     `yaml:"tracing_rate_limit,omitempty" json:"tracing_rate_limit,omitempty"`
-	TracingTags         []string `yaml:"tracing_tags,omitempty" json:"tracing_tags,omitempty"`
+	ServiceName *string `yaml:"service_name,omitempty" json:"service_name,omitempty"`
+	Env         *string `yaml:"env,omitempty" json:"env,omitempty"`
+
+	Tracing        *bool `yaml:"tracing_enabled,omitempty" json:"tracing_enabled,omitempty"`
+	LogInjection   *bool `yaml:"log_injection_enabled,omitempty" json:"log_injection_enabled,omitempty"`
+	HealthMetrics  *bool `yaml:"health_metrics_enabled,omitempty" json:"health_metrics_enabled,omitempty"`
+	RuntimeMetrics *bool `yaml:"runtime_metrics_enabled,omitempty" json:"runtime_metrics_enabled,omitempty"`
+
+	TracingSamplingRate *float64 `yaml:"tracing_sampling_rate" json:"tracing_sampling_rate,omitempty"`
+	TracingRateLimit    *int     `yaml:"tracing_rate_limit" json:"tracing_rate_limit,omitempty"`
+	TracingTags         []string `yaml:"tracing_tags" json:"tracing_tags,omitempty"`
+
+	// TODO: Implement the conversion of the following parameters in the ToEnvs() method
+	TracingServiceMapping          []TracingServiceMapEntry `yaml:"tracing_service_mapping" json:"tracing_service_mapping,omitempty"`
+	TracingAgentTimeout            *int                     `yaml:"tracing_agent_timeout" json:"tracing_agent_timeout,omitempty"`
+	TracingHeaderTags              []TracingHeaderTagEntry  `yaml:"tracing_header_tags" json:"tracing_header_tags,omitempty"`
+	TracingPartialFlushMinSpans    *int                     `yaml:"tracing_partial_flush_min_spans" json:"tracing_partial_flush_min_spans,omitempty"`
+	TracingDebug                   *bool                    `yaml:"tracing_debug" json:"tracing_debug,omitempty"`
+	TracingLogLevel                *string                  `yaml:"tracing_log_level" json:"tracing_log_level,omitempty"`
+	TracingMethods                 []string                 `yaml:"tracing_methods" json:"tracing_methods,omitempty"`
+	TracingPropagationStyleInject  []string                 `yaml:"tracing_propagation_style_inject" json:"tracing_propagation_style_inject,omitempty"`
+	TracingPropagationStyleExtract []string                 `yaml:"tracing_propagation_style_extract" json:"tracing_propagation_style_extract,omitempty"`
+}
+
+// TracingServiceMapEntry holds service mapping config
+type TracingServiceMapEntry struct {
+	FromKey string `yaml:"from_key" json:"from_key"`
+	ToName  string `yaml:"to_name" json:"to_name"`
+}
+
+// TracingHeaderTagEntry holds header tags config
+type TracingHeaderTagEntry struct {
+	Header  string `yaml:"header" json:"header"`
+	TagName string `yaml:"tag_name" json:"tag_name"`
 }
 
 // ToEnvs converts the config fields into environment variables

--- a/pkg/clusteragent/admission/patch/file_provider.go
+++ b/pkg/clusteragent/admission/patch/file_provider.go
@@ -1,0 +1,104 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+// +build kubeapiserver
+
+package patch
+
+import (
+	"encoding/json"
+	"os"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// filePatchProvider this is a stub and will be used for e2e testing only
+type filePatchProvider struct {
+	file                  string
+	pollInterval          time.Duration
+	isLeader              func() bool
+	subscribers           map[TargetObjKind]chan PatchRequest
+	lastSuccessfulRefresh time.Time
+	clusterName           string
+}
+
+var _ patchProvider = &filePatchProvider{}
+
+func newfileProvider(isLeaderFunc func() bool, clusterName string) *filePatchProvider {
+	return &filePatchProvider{
+		file:         "/etc/datadog-agent/auto-instru.json",
+		pollInterval: 15 * time.Second,
+		isLeader:     isLeaderFunc,
+		subscribers:  make(map[TargetObjKind]chan PatchRequest),
+		clusterName:  clusterName,
+	}
+}
+
+func (fpp *filePatchProvider) subscribe(kind TargetObjKind) chan PatchRequest {
+	ch := make(chan PatchRequest, 10)
+	fpp.subscribers[kind] = ch
+	return ch
+}
+
+func (fpp *filePatchProvider) start(stopCh <-chan struct{}) {
+	ticker := time.NewTicker(fpp.pollInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			if err := fpp.refresh(); err != nil {
+				log.Errorf(err.Error())
+			}
+		case <-stopCh:
+			log.Info("Shutting down patch provider")
+			return
+		}
+	}
+}
+
+func (fpp *filePatchProvider) refresh() error {
+	if !fpp.isLeader() {
+		log.Debug("Not leader, skipping")
+		return nil
+	}
+	requests, err := fpp.poll()
+	if err != nil {
+		return err
+	}
+	log.Debugf("Got %d new patch requests", len(requests))
+	for _, req := range requests {
+		if err := req.Validate(fpp.clusterName); err != nil {
+			log.Errorf("Skipping invalid patch request: %s", err)
+			continue
+		}
+		if ch, found := fpp.subscribers[req.K8sTarget.Kind]; found {
+			log.Infof("Publishing patch requests for target %s", req.K8sTarget)
+			ch <- req
+		}
+	}
+	fpp.lastSuccessfulRefresh = time.Now()
+	return nil
+}
+
+func (fpp *filePatchProvider) poll() ([]PatchRequest, error) {
+	info, err := os.Stat(fpp.file)
+	if err != nil {
+		return nil, err
+	}
+	modTime := info.ModTime()
+	if fpp.lastSuccessfulRefresh.After(modTime) {
+		log.Debugf("File %q hasn't changed since the last Successful refresh at %v", fpp.file, fpp.lastSuccessfulRefresh)
+		return []PatchRequest{}, nil
+	}
+	content, err := os.ReadFile(fpp.file)
+	if err != nil {
+		return nil, err
+	}
+	var requests []PatchRequest
+	err = json.Unmarshal(content, &requests)
+	return requests, err
+}

--- a/pkg/clusteragent/admission/patch/patcher.go
+++ b/pkg/clusteragent/admission/patch/patcher.go
@@ -17,6 +17,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
 	jsonpatch "github.com/evanphx/json-patch"
+	corev1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
@@ -50,6 +51,7 @@ func (p *patcher) start(stopCh <-chan struct{}) {
 	}
 }
 
+// patchDeployment applies a patch request to a k8s target deployment
 func (p *patcher) patchDeployment(req PatchRequest) error {
 	if !p.isLeader() {
 		log.Debug("Not leader, skipping")
@@ -63,33 +65,29 @@ func (p *patcher) patchDeployment(req PatchRequest) error {
 	if err != nil {
 		return fmt.Errorf("failed to encode object: %v", err)
 	}
-	versionAnnotKey := fmt.Sprintf(common.LibVersionAnnotKeyFormat, req.LibID.Language)
-	configAnnotKey := fmt.Sprintf(common.LibConfigV1AnnotKeyFormat, req.LibID.Language)
+	rcIDAnnotKey := fmt.Sprintf(common.RcIDAnnotKeyFormat, req.LibConfig.Language)
+	rcRevAnnotKey := fmt.Sprintf(common.RcRevisionAnnotKeyFormat, req.LibConfig.Language)
+	revision := fmt.Sprint(req.Revision)
+	if deploy.Annotations == nil {
+		deploy.Annotations = make(map[string]string)
+	}
+	if deploy.Annotations[rcIDAnnotKey] == req.ID && deploy.Annotations[rcRevAnnotKey] == revision {
+		log.Infof("Remote Config ID %q with revision %q has already been applied to object %s, skipping", req.ID, revision, req.K8sTarget)
+		return nil
+	}
+	log.Infof("Applying Remote Config ID %q with revision %q to object %s", req.ID, revision, req.K8sTarget)
 	switch req.Action {
-	case ApplyConfig:
-		if deploy.Spec.Template.Labels == nil {
-			deploy.Spec.Template.Labels = make(map[string]string)
+	case EnableConfig:
+		if err := enableConfig(deploy, req); err != nil {
+			return err
 		}
-		deploy.Spec.Template.Labels[common.EnabledLabelKey] = "true"
-		if deploy.Spec.Template.Annotations == nil {
-			deploy.Spec.Template.Annotations = make(map[string]string)
-		}
-		deploy.Spec.Template.Annotations[versionAnnotKey] = req.LibID.Version
-		conf, err := json.Marshal(req.LibConfig)
-		if err != nil {
-			return fmt.Errorf("failed to encode library config: %v", err)
-		}
-		deploy.Spec.Template.Annotations[configAnnotKey] = string(conf)
-	case DisableInjection:
-		if deploy.Spec.Template.Labels == nil {
-			deploy.Spec.Template.Labels = make(map[string]string)
-		}
-		deploy.Spec.Template.Labels[common.EnabledLabelKey] = "false"
-		delete(deploy.Spec.Template.Annotations, versionAnnotKey)
-		delete(deploy.Spec.Template.Annotations, configAnnotKey)
+	case DisableConfig:
+		disableConfig(deploy, req)
 	default:
 		return fmt.Errorf("unknown action %q", req.Action)
 	}
+	deploy.Annotations[rcIDAnnotKey] = req.ID
+	deploy.Annotations[rcRevAnnotKey] = revision
 	newObj, err := json.Marshal(deploy)
 	if err != nil {
 		return fmt.Errorf("failed to encode object: %v", err)
@@ -101,4 +99,37 @@ func (p *patcher) patchDeployment(req PatchRequest) error {
 	log.Infof("Patching %s with patch %s", req.K8sTarget, string(patch))
 	_, err = p.k8sClient.AppsV1().Deployments(req.K8sTarget.Namespace).Patch(context.TODO(), req.K8sTarget.Name, types.StrategicMergePatchType, patch, metav1.PatchOptions{})
 	return err
+}
+
+func enableConfig(deploy *corev1.Deployment, req PatchRequest) error {
+	if deploy.Spec.Template.Labels == nil {
+		deploy.Spec.Template.Labels = make(map[string]string)
+	}
+	deploy.Spec.Template.Labels[common.EnabledLabelKey] = "true"
+	if deploy.Spec.Template.Annotations == nil {
+		deploy.Spec.Template.Annotations = make(map[string]string)
+	}
+	versionAnnotKey := fmt.Sprintf(common.LibVersionAnnotKeyFormat, req.LibConfig.Language)
+	deploy.Spec.Template.Annotations[versionAnnotKey] = req.LibConfig.Version
+	conf, err := json.Marshal(req.LibConfig)
+	if err != nil {
+		return fmt.Errorf("failed to encode library config: %v", err)
+	}
+	configAnnotKey := fmt.Sprintf(common.LibConfigV1AnnotKeyFormat, req.LibConfig.Language)
+	deploy.Spec.Template.Annotations[configAnnotKey] = string(conf)
+	return nil
+}
+
+func disableConfig(deploy *corev1.Deployment, req PatchRequest) {
+	if deploy.Spec.Template.Labels == nil {
+		deploy.Spec.Template.Labels = make(map[string]string)
+	}
+	if val, found := deploy.Spec.Template.Labels[common.EnabledLabelKey]; found {
+		log.Debugf("Found pod label %q=%q in target %s. Setting it to false", common.EnabledLabelKey, val, req.K8sTarget)
+	}
+	deploy.Spec.Template.Labels[common.EnabledLabelKey] = "false"
+	versionAnnotKey := fmt.Sprintf(common.LibVersionAnnotKeyFormat, req.LibConfig.Language)
+	delete(deploy.Spec.Template.Annotations, versionAnnotKey)
+	configAnnotKey := fmt.Sprintf(common.LibConfigV1AnnotKeyFormat, req.LibConfig.Language)
+	delete(deploy.Spec.Template.Annotations, configAnnotKey)
 }

--- a/pkg/clusteragent/admission/patch/provider.go
+++ b/pkg/clusteragent/admission/patch/provider.go
@@ -9,12 +9,10 @@
 package patch
 
 import (
-	"os"
-	"time"
+	"errors"
 
-	"github.com/DataDog/datadog-agent/pkg/util/log"
-
-	"gopkg.in/yaml.v3"
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/config/remote"
 )
 
 type patchProvider interface {
@@ -22,94 +20,13 @@ type patchProvider interface {
 	subscribe(kind TargetObjKind) chan PatchRequest
 }
 
-// filePatchProvider this is a stub and will be replaced by a RC patch provider
-type filePatchProvider struct {
-	file                  string
-	pollInterval          time.Duration
-	isLeader              func() bool
-	subscribers           map[TargetObjKind]chan PatchRequest
-	lastSuccessfulRefresh time.Time
-	clusterName           string
-}
-
-var _ patchProvider = &filePatchProvider{}
-
-func newPatchProvider(isLeaderFunc func() bool, clusterName string) patchProvider {
-	// Only the file-based implementation is available at the moment.
-	return newfileProvider(isLeaderFunc, clusterName)
-}
-
-func newfileProvider(isLeaderFunc func() bool, clusterName string) *filePatchProvider {
-	return &filePatchProvider{
-		file:         "/etc/datadog-agent/auto-instru.yaml",
-		pollInterval: 15 * time.Second,
-		isLeader:     isLeaderFunc,
-		subscribers:  make(map[TargetObjKind]chan PatchRequest),
-		clusterName:  clusterName,
+func newPatchProvider(rcClient *remote.Client, isLeaderFunc func() bool, clusterName string) (patchProvider, error) {
+	if config.Datadog.GetBool("remote_configuration.enabled") {
+		return newRemoteConfigProvider(rcClient, isLeaderFunc, clusterName)
 	}
-}
-
-func (fpp *filePatchProvider) subscribe(kind TargetObjKind) chan PatchRequest {
-	ch := make(chan PatchRequest, 10)
-	fpp.subscribers[kind] = ch
-	return ch
-}
-
-func (fpp *filePatchProvider) start(stopCh <-chan struct{}) {
-	ticker := time.NewTicker(fpp.pollInterval)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-ticker.C:
-			if err := fpp.refresh(); err != nil {
-				log.Errorf(err.Error())
-			}
-		case <-stopCh:
-			log.Info("Shutting down patch provider")
-			return
-		}
+	if config.Datadog.GetBool("admission_controller.auto_instrumentation.patcher.fallback_to_file_provider") {
+		// Use the file config provider for e2e testing only (it replaces RC as a source of configs)
+		return newfileProvider(isLeaderFunc, clusterName), nil
 	}
-}
-
-func (fpp *filePatchProvider) refresh() error {
-	if !fpp.isLeader() {
-		log.Debug("Not leader, skipping")
-		return nil
-	}
-	requests, err := fpp.poll()
-	if err != nil {
-		return err
-	}
-	log.Debugf("Got %d new patch requests", len(requests))
-	for _, req := range requests {
-		if err := req.Validate(fpp.clusterName); err != nil {
-			log.Errorf("Skipping invalid patch request: %s", err)
-			continue
-		}
-		if ch, found := fpp.subscribers[req.K8sTarget.Kind]; found {
-			log.Infof("Publishing patch requests for target %s", req.K8sTarget)
-			ch <- req
-		}
-	}
-	fpp.lastSuccessfulRefresh = time.Now()
-	return nil
-}
-
-func (fpp *filePatchProvider) poll() ([]PatchRequest, error) {
-	info, err := os.Stat(fpp.file)
-	if err != nil {
-		return nil, err
-	}
-	modTime := info.ModTime()
-	if fpp.lastSuccessfulRefresh.After(modTime) {
-		log.Debugf("File %q hasn't changed since the last Successful refresh at %v", fpp.file, fpp.lastSuccessfulRefresh)
-		return []PatchRequest{}, nil
-	}
-	content, err := os.ReadFile(fpp.file)
-	if err != nil {
-		return nil, err
-	}
-	var requests []PatchRequest
-	err = yaml.Unmarshal(content, &requests)
-	return requests, err
+	return nil, errors.New("remote config is disabled")
 }

--- a/pkg/clusteragent/admission/patch/rc_provider.go
+++ b/pkg/clusteragent/admission/patch/rc_provider.go
@@ -1,0 +1,78 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+// +build kubeapiserver
+
+package patch
+
+import (
+	"encoding/json"
+	"errors"
+
+	"github.com/DataDog/datadog-agent/pkg/config/remote"
+	"github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// remoteConfigProvider consumes tracing configs from RC and delivers them to the patcher
+type remoteConfigProvider struct {
+	client      *remote.Client
+	isLeader    func() bool
+	subscribers map[TargetObjKind]chan PatchRequest
+	clusterName string
+}
+
+var _ patchProvider = &remoteConfigProvider{}
+
+func newRemoteConfigProvider(client *remote.Client, isLeaderFunc func() bool, clusterName string) (*remoteConfigProvider, error) {
+	if client == nil {
+		return nil, errors.New("remote config client not initialized")
+	}
+	return &remoteConfigProvider{
+		client:      client,
+		isLeader:    isLeaderFunc,
+		subscribers: make(map[TargetObjKind]chan PatchRequest),
+		clusterName: clusterName,
+	}, nil
+}
+
+func (rcp *remoteConfigProvider) start(stopCh <-chan struct{}) {
+	log.Info("Starting RC patch provider")
+	rcp.client.RegisterAPMTracing(rcp.process)
+	rcp.client.Start()
+	<-stopCh
+	log.Info("Shutting down RC patch provider")
+	rcp.client.Close()
+}
+
+func (rcp *remoteConfigProvider) subscribe(kind TargetObjKind) chan PatchRequest {
+	ch := make(chan PatchRequest, 10)
+	rcp.subscribers[kind] = ch
+	return ch
+}
+
+// process is the event handler called by the RC client on config updates
+func (rcp *remoteConfigProvider) process(update map[string]state.APMTracingConfig) {
+	log.Infof("Got %d updates from RC", len(update))
+	for path, config := range update {
+		log.Debugf("Parsing config %s with metadata %+v from path %s", config.Config, config.Metadata, path)
+		var req PatchRequest
+		err := json.Unmarshal(config.Config, &req)
+		if err != nil {
+			log.Errorf("Error while parsing config: %v", err)
+			continue
+		}
+		log.Debugf("Patch request parsed %+v", req)
+		if err := req.Validate(rcp.clusterName); err != nil {
+			log.Errorf("Skipping invalid patch request: %s", err)
+			continue
+		}
+		if ch, found := rcp.subscribers[req.K8sTarget.Kind]; found {
+			log.Debugf("Publishing patch request for target %s", req.K8sTarget)
+			ch <- req
+		}
+	}
+}

--- a/pkg/clusteragent/admission/patch/start.go
+++ b/pkg/clusteragent/admission/patch/start.go
@@ -9,6 +9,7 @@
 package patch
 
 import (
+	"github.com/DataDog/datadog-agent/pkg/config/remote"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
 	"k8s.io/client-go/kubernetes"
@@ -17,15 +18,21 @@ import (
 // ControllerContext holds necessary context for the patch controller
 type ControllerContext struct {
 	IsLeaderFunc func() bool
-	Client       kubernetes.Interface
+	K8sClient    kubernetes.Interface
+	RcClient     *remote.Client
+	ClusterName  string
 	StopCh       chan struct{}
 }
 
 // StartControllers starts the patch controllers
-func StartControllers(ctx ControllerContext, clusterName string) {
+func StartControllers(ctx ControllerContext) error {
 	log.Info("Starting patch controllers")
-	provider := newPatchProvider(ctx.IsLeaderFunc, clusterName)
-	patcher := newPatcher(ctx.Client, ctx.IsLeaderFunc, provider)
+	provider, err := newPatchProvider(ctx.RcClient, ctx.IsLeaderFunc, ctx.ClusterName)
+	if err != nil {
+		return err
+	}
+	patcher := newPatcher(ctx.K8sClient, ctx.IsLeaderFunc, provider)
 	go provider.start(ctx.StopCh)
 	go patcher.start(ctx.StopCh)
+	return nil
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1019,6 +1019,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("admission_controller.auto_instrumentation.endpoint", "/injectlib")
 	config.BindEnvAndSetDefault("admission_controller.auto_instrumentation.container_registry", "gcr.io/datadoghq")
 	config.BindEnvAndSetDefault("admission_controller.auto_instrumentation.patcher.enabled", false)
+	config.BindEnvAndSetDefault("admission_controller.auto_instrumentation.patcher.fallback_to_file_provider", false) // to be enabled only in e2e tests
 
 	// Telemetry
 	// Enable telemetry metrics on the internals of the Agent.

--- a/pkg/config/remote/client.go
+++ b/pkg/config/remote/client.go
@@ -63,9 +63,10 @@ type Client struct {
 	state *state.Repository
 
 	// Listeners
-	apmListeners       []func(update map[string]state.APMSamplingConfig)
-	cwsListeners       []func(update map[string]state.ConfigCWSDD)
-	cwsCustomListeners []func(update map[string]state.ConfigCWSCustom)
+	apmListeners        []func(update map[string]state.APMSamplingConfig)
+	cwsListeners        []func(update map[string]state.ConfigCWSDD)
+	cwsCustomListeners  []func(update map[string]state.ConfigCWSCustom)
+	apmTracingListeners []func(update map[string]state.APMTracingConfig)
 }
 
 // agentGRPCConfigFetcher defines how to retrieve config updates over a
@@ -154,20 +155,21 @@ func newClient(agentName string, updater ConfigUpdater, doTufVerification bool, 
 	ctx, close := context.WithCancel(context.Background())
 
 	return &Client{
-		ID:                 generateID(),
-		startupSync:        sync.Once{},
-		ctx:                ctx,
-		close:              close,
-		agentName:          agentName,
-		agentVersion:       agentVersion,
-		products:           data.ProductListToString(products),
-		state:              repository,
-		pollInterval:       pollInterval,
-		backoffPolicy:      backoffPolicy,
-		apmListeners:       make([]func(update map[string]state.APMSamplingConfig), 0),
-		cwsListeners:       make([]func(update map[string]state.ConfigCWSDD), 0),
-		cwsCustomListeners: make([]func(update map[string]state.ConfigCWSCustom), 0),
-		updater:            updater,
+		ID:                  generateID(),
+		startupSync:         sync.Once{},
+		ctx:                 ctx,
+		close:               close,
+		agentName:           agentName,
+		agentVersion:        agentVersion,
+		products:            data.ProductListToString(products),
+		state:               repository,
+		pollInterval:        pollInterval,
+		backoffPolicy:       backoffPolicy,
+		apmListeners:        make([]func(update map[string]state.APMSamplingConfig), 0),
+		cwsListeners:        make([]func(update map[string]state.ConfigCWSDD), 0),
+		cwsCustomListeners:  make([]func(update map[string]state.ConfigCWSCustom), 0),
+		apmTracingListeners: make([]func(update map[string]state.APMTracingConfig), 0),
+		updater:             updater,
 	}, nil
 }
 
@@ -258,6 +260,11 @@ func (c *Client) update() error {
 			listener(c.state.CWSCustomConfigs())
 		}
 	}
+	if containsProduct(changedProducts, state.ProductAPMTracing) {
+		for _, listener := range c.apmTracingListeners {
+			listener(c.state.APMTracingConfigs())
+		}
+	}
 
 	return nil
 }
@@ -297,6 +304,15 @@ func (c *Client) RegisterCWSCustomUpdate(fn func(update map[string]state.ConfigC
 	defer c.m.Unlock()
 	c.cwsCustomListeners = append(c.cwsCustomListeners, fn)
 	fn(c.state.CWSCustomConfigs())
+}
+
+// RegisterAPMTracing registers a callback function to be called after a successful client update that will
+// contain the current state of the APMTracing product.
+func (c *Client) RegisterAPMTracing(fn func(update map[string]state.APMTracingConfig)) {
+	c.m.Lock()
+	defer c.m.Unlock()
+	c.apmTracingListeners = append(c.apmTracingListeners, fn)
+	fn(c.state.APMTracingConfigs())
 }
 
 func (c *Client) applyUpdate(pbUpdate *pbgo.ClientGetConfigsResponse) ([]string, error) {

--- a/pkg/config/remote/data/product.go
+++ b/pkg/config/remote/data/product.go
@@ -15,6 +15,8 @@ const (
 	ProductCWSDD Product = "CWS_DD"
 	// ProductCWSCustom is the cloud workload security product
 	ProductCWSCustom Product = "CWS_CUSTOM"
+	// ProductAPMTracing is the apm tracing product
+	ProductAPMTracing Product = "APM_TRACING"
 	// ProductTesting1 is a testing product
 	ProductTesting1 Product = "TESTING1"
 )


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

- The admission controller's patcher now consumes tracing configs from RC
- Align the tracing config's data model w/ the backend

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Related to https://github.com/DataDog/datadog-agent/pull/14500

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

The file config provider will not be exposed/documented for customer use. It will help us mocking RC in the e2e tests of the agent.

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

This has been tested e2e by manually posting RC configs to the backend. More testing scenarios and automated e2e tests will be added as we iterate on this.

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
