### PR TITLE
[CWS] rework event json marshalling

### DIFF
--- a/cmd/security-agent/app/subcommands/runtime/command.go
+++ b/cmd/security-agent/app/subcommands/runtime/command.go
@@ -638,7 +638,7 @@ func evalRule(log complog.Component, config compconfig.Component, evalArgs *eval
 	}
 
 	report := EvalReport{
-		// Event: event,
+		Event: event,
 	}
 
 	approvers, err := ruleSet.GetApprovers(sprobe.GetCapababilities())

--- a/pkg/security/events/custom.go
+++ b/pkg/security/events/custom.go
@@ -6,9 +6,8 @@
 package events
 
 import (
-	"encoding/json"
-
 	"github.com/mailru/easyjson"
+	"github.com/mailru/easyjson/jwriter"
 
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
@@ -86,16 +85,6 @@ func (ce *CustomEvent) GetEventType() model.EventType {
 	return ce.eventType
 }
 
-// MarshalJSON is the JSON marshaller function of the custom event
-func (ce *CustomEvent) MarshalJSON() ([]byte, error) {
-	return easyjson.Marshal(ce.marshaler)
-}
-
-// String returns the string representation of a custom event
-func (ce *CustomEvent) String() string {
-	d, err := json.Marshal(ce)
-	if err != nil {
-		return err.Error()
-	}
-	return string(d)
+func (ce *CustomEvent) MarshalEasyJSON(w *jwriter.Writer) {
+	ce.marshaler.MarshalEasyJSON(w)
 }

--- a/pkg/security/module/server.go
+++ b/pkg/security/module/server.go
@@ -479,20 +479,19 @@ func (a *APIServer) SendEvent(rule *rules.Rule, event Event, extTagsCb func() []
 }
 
 func marshalEvent(event Event, probe *sprobe.Probe) ([]byte, error) {
-	var s easyjson.Marshaler
 	if ev, ok := event.(*model.Event); ok {
-		s = sprobe.NewEventSerializer(ev, probe)
-	} else if m, ok := event.(easyjson.Marshaler); ok {
-		s = m
-	} else {
-		return json.Marshal(event)
+		return sprobe.MarshalEvent(ev, probe)
 	}
 
-	w := &jwriter.Writer{
-		Flags: jwriter.NilSliceAsEmpty | jwriter.NilMapAsEmpty,
+	if m, ok := event.(easyjson.Marshaler); ok {
+		w := &jwriter.Writer{
+			Flags: jwriter.NilSliceAsEmpty | jwriter.NilMapAsEmpty,
+		}
+		m.MarshalEasyJSON(w)
+		return w.BuildBytes()
 	}
-	s.MarshalEasyJSON(w)
-	return w.BuildBytes()
+
+	return json.Marshal(event)
 }
 
 // expireEvent updates the count of expired messages for the appropriate rule

--- a/pkg/security/probe/activity_dump.go
+++ b/pkg/security/probe/activity_dump.go
@@ -1173,7 +1173,7 @@ func (ad *ActivityDump) snapshotProcess(pan *ProcessActivityNode) error {
 }
 
 func (ad *ActivityDump) insertSnapshotedSocket(pan *ProcessActivityNode, p *process.Process, family uint16, ip net.IP, port uint16) {
-	evt := NewEvent(ad.adm.fieldHandlers, ad.adm.EventMarshaler)
+	evt := NewEvent(ad.adm.fieldHandlers)
 	evt.Type = uint32(model.BindEventType)
 
 	evt.Bind.SyscallEvent.Retval = 0
@@ -1315,7 +1315,7 @@ func (pan *ProcessActivityNode) snapshotFiles(p *process.Process, ad *ActivityDu
 			continue
 		}
 
-		evt := NewEvent(ad.adm.fieldHandlers, ad.adm.EventMarshaler)
+		evt := NewEvent(ad.adm.fieldHandlers)
 		evt.Type = uint32(model.FileOpenEventType)
 
 		resolvedPath, err = filepath.EvalSymlinks(f)

--- a/pkg/security/probe/activity_dump_manager.go
+++ b/pkg/security/probe/activity_dump_manager.go
@@ -38,13 +38,12 @@ func areCGroupADsEnabled(c *config.Config) bool {
 // ActivityDumpManager is used to manage ActivityDumps
 type ActivityDumpManager struct {
 	sync.RWMutex
-	config         *config.Config
-	statsdClient   statsd.ClientInterface
-	fieldHandlers  *FieldHandlers
-	EventMarshaler *EventMarshaler
-	resolvers      *Resolvers
-	kernelVersion  *kernel.Version
-	manager        *manager.Manager
+	config        *config.Config
+	statsdClient  statsd.ClientInterface
+	fieldHandlers *FieldHandlers
+	resolvers     *Resolvers
+	kernelVersion *kernel.Version
+	manager       *manager.Manager
 
 	tracedPIDsMap          *ebpf.Map
 	tracedCommsMap         *ebpf.Map
@@ -204,7 +203,6 @@ func NewActivityDumpManager(p *Probe, config *config.Config, statsdClient statsd
 		config:                 config,
 		statsdClient:           statsdClient,
 		fieldHandlers:          p.fieldHandlers,
-		EventMarshaler:         p.eventMarshaler,
 		resolvers:              resolvers,
 		kernelVersion:          kernelVersion,
 		manager:                manager,

--- a/pkg/security/probe/model.go
+++ b/pkg/security/probe/model.go
@@ -11,8 +11,6 @@ package probe
 import (
 	"fmt"
 
-	"github.com/mailru/easyjson/jwriter"
-
 	"github.com/DataDog/datadog-agent/pkg/security/probe/constantfetch"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
@@ -47,23 +45,8 @@ func NewModel(probe *Probe) *model.Model {
 }
 
 // NewEvent returns a new event
-func NewEvent(fh *FieldHandlers, marshaler *EventMarshaler) *model.Event {
+func NewEvent(fh *FieldHandlers) *model.Event {
 	return &model.Event{
 		FieldHandlers: fh,
-		JSONMarshaler: marshaler.MarshalJSONEvent,
 	}
-}
-
-type EventMarshaler struct {
-	probe *Probe
-}
-
-// MarshalJSONEvent returns the JSON encoding of the event
-func (em *EventMarshaler) MarshalJSONEvent(ev *model.Event) ([]byte, error) {
-	s := NewEventSerializer(ev, em.probe)
-	w := &jwriter.Writer{
-		Flags: jwriter.NilSliceAsEmpty | jwriter.NilMapAsEmpty,
-	}
-	s.MarshalEasyJSON(w)
-	return w.BuildBytes()
 }

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -87,13 +87,12 @@ type Probe struct {
 	cancelFnc      context.CancelFunc
 	wg             sync.WaitGroup
 	// Events section
-	handlers       [model.MaxAllEventType][]EventHandler
-	monitor        *Monitor
-	resolvers      *Resolvers
-	event          *model.Event
-	fieldHandlers  *FieldHandlers
-	eventMarshaler *EventMarshaler
-	scrubber       *procutil.DataScrubber
+	handlers      [model.MaxAllEventType][]EventHandler
+	monitor       *Monitor
+	resolvers     *Resolvers
+	event         *model.Event
+	fieldHandlers *FieldHandlers
+	scrubber      *procutil.DataScrubber
 
 	// Ring
 	eventStream EventStream
@@ -372,7 +371,6 @@ func (p *Probe) GetMonitor() *Monitor {
 func (p *Probe) zeroEvent() *model.Event {
 	*p.event = eventZero
 	p.event.FieldHandlers = p.fieldHandlers
-	p.event.JSONMarshaler = p.eventMarshaler.MarshalJSONEvent
 	return p.event
 }
 
@@ -1114,7 +1112,6 @@ func (p *Probe) NewRuleSet(opts *rules.Opts, evalOpts *eval.Opts) *rules.RuleSet
 	eventCtor := func() eval.Event {
 		return &model.Event{
 			FieldHandlers: p.fieldHandlers,
-			JSONMarshaler: p.eventMarshaler.MarshalJSONEvent,
 		}
 	}
 
@@ -1381,7 +1378,6 @@ func NewProbe(config *config.Config, statsdClient statsd.ClientInterface) (*Prob
 	p.resolvers = resolvers
 
 	p.fieldHandlers = &FieldHandlers{probe: p, resolvers: resolvers}
-	p.eventMarshaler = &EventMarshaler{probe: p}
 
 	// be sure to zero the probe event before everything else
 	p.zeroEvent()

--- a/pkg/security/probe/serializers.go
+++ b/pkg/security/probe/serializers.go
@@ -18,6 +18,7 @@ import (
 
 	"golang.org/x/sys/unix"
 
+	"github.com/DataDog/datadog-agent/pkg/security/events"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
@@ -991,6 +992,14 @@ func MarshalEvent(event *model.Event, probe *Probe) ([]byte, error) {
 		Flags: jwriter.NilSliceAsEmpty | jwriter.NilMapAsEmpty,
 	}
 	s.MarshalEasyJSON(w)
+	return w.BuildBytes()
+}
+
+func MarshalCustomEvent(event *events.CustomEvent) ([]byte, error) {
+	w := &jwriter.Writer{
+		Flags: jwriter.NilSliceAsEmpty | jwriter.NilMapAsEmpty,
+	}
+	event.MarshalEasyJSON(w)
 	return w.BuildBytes()
 }
 

--- a/pkg/security/probe/serializers.go
+++ b/pkg/security/probe/serializers.go
@@ -21,6 +21,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
+	jwriter "github.com/mailru/easyjson/jwriter"
 )
 
 // FileSerializer serializes a file to JSON
@@ -982,6 +983,15 @@ func serializeSyscallRetval(retval int64) string {
 	default:
 		return "Success"
 	}
+}
+
+func MarshalEvent(event *model.Event, probe *Probe) ([]byte, error) {
+	s := NewEventSerializer(event, probe)
+	w := &jwriter.Writer{
+		Flags: jwriter.NilSliceAsEmpty | jwriter.NilMapAsEmpty,
+	}
+	s.MarshalEasyJSON(w)
+	return w.BuildBytes()
 }
 
 // NewEventSerializer creates a new event serializer based on the event type

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -218,9 +218,6 @@ type Event struct {
 
 	// field resolution
 	FieldHandlers FieldHandlers `field:"-" json:"-"`
-
-	// Serializer
-	JSONMarshaler func(ev *Event) ([]byte, error) `field:"-" json:"-"`
 }
 
 func initMember(member reflect.Value, deja map[string]bool) {
@@ -284,22 +281,6 @@ func (e *Event) GetTags() []string {
 		tags = append(tags, e.ContainerContext.Tags...)
 	}
 	return tags
-}
-
-func (ev *Event) String() string {
-	d, err := ev.MarshalJSON()
-	if err != nil {
-		return err.Error()
-	}
-	return string(d)
-}
-
-// MarshalJSON returns the JSON encoding of the event
-func (ev *Event) MarshalJSON() ([]byte, error) {
-	if ev.JSONMarshaler != nil {
-		return ev.JSONMarshaler(ev)
-	}
-	return nil, errors.New("no json marshaller defined for this event")
 }
 
 // Retain the event

--- a/pkg/security/tests/bind_test.go
+++ b/pkg/security/tests/bind_test.go
@@ -66,9 +66,7 @@ func TestBindEvent(t *testing.T) {
 			assert.Equal(t, string("0.0.0.0/32"), event.Bind.Addr.IPNet.String(), "wrong address")
 			assert.Equal(t, int64(0), event.Bind.Retval, "wrong retval")
 
-			if !validateBindSchema(t, event) {
-				t.Error(event.String())
-			}
+			test.validateBindSchema(t, event)
 		})
 	})
 
@@ -90,9 +88,7 @@ func TestBindEvent(t *testing.T) {
 			assert.Equal(t, string("0.0.0.0/32"), event.Bind.Addr.IPNet.String(), "wrong address")
 			assert.Equal(t, int64(0), event.Bind.Retval, "wrong retval")
 
-			if !validateBindSchema(t, event) {
-				t.Error(event.String())
-			}
+			test.validateBindSchema(t, event)
 		})
 	})
 
@@ -114,9 +110,7 @@ func TestBindEvent(t *testing.T) {
 			assert.Equal(t, string("::/128"), event.Bind.Addr.IPNet.String(), "wrong address")
 			assert.Equal(t, int64(0), event.Bind.Retval, "wrong retval")
 
-			if !validateBindSchema(t, event) {
-				t.Error(event.String())
-			}
+			test.validateBindSchema(t, event)
 		})
 	})
 
@@ -139,9 +133,7 @@ func TestBindEvent(t *testing.T) {
 				event.Bind.Addr.IPNet, "wrong address")
 			assert.Equal(t, int64(0), event.Bind.Retval, "wrong retval")
 
-			if !validateBindSchema(t, event) {
-				t.Error(event.String())
-			}
+			test.validateBindSchema(t, event)
 		})
 	})
 }

--- a/pkg/security/tests/bpf_test.go
+++ b/pkg/security/tests/bpf_test.go
@@ -48,9 +48,7 @@ func TestBPFEventLoad(t *testing.T) {
 			assert.Equal(t, "bpf", event.GetType(), "wrong event type")
 			assert.Equal(t, uint32(model.BpfProgTypeKprobe), event.BPF.Program.Type, "wrong program type")
 
-			if !validateBPFSchema(t, event) {
-				t.Error(event.String())
-			}
+			test.validateBPFSchema(t, event)
 		})
 	})
 }
@@ -85,9 +83,7 @@ func TestBPFEventMap(t *testing.T) {
 			assert.Equal(t, "bpf", event.GetType(), "wrong event type")
 			assert.Equal(t, uint32(model.BpfMapTypeHash), event.BPF.Map.Type, "wrong map type")
 
-			if !validateBPFSchema(t, event) {
-				t.Error(event.String())
-			}
+			test.validateBPFSchema(t, event)
 		})
 	})
 }

--- a/pkg/security/tests/chmod_test.go
+++ b/pkg/security/tests/chmod_test.go
@@ -63,9 +63,7 @@ func TestChmod(t *testing.T) {
 			assertNearTime(t, event.Chmod.File.CTime)
 			assert.Equal(t, event.Async, false)
 
-			if !validateChmodSchema(t, event) {
-				t.Error(event.String())
-			}
+			test.validateChmodSchema(t, event)
 		})
 	})
 
@@ -86,9 +84,7 @@ func TestChmod(t *testing.T) {
 			assertNearTime(t, event.Chmod.File.CTime)
 			assert.Equal(t, event.Async, false)
 
-			if !validateChmodSchema(t, event) {
-				t.Error(event.String())
-			}
+			test.validateChmodSchema(t, event)
 		})
 	})
 
@@ -107,9 +103,7 @@ func TestChmod(t *testing.T) {
 			assertNearTime(t, event.Chmod.File.CTime)
 			assert.Equal(t, event.Async, false)
 
-			if !validateChmodSchema(t, event) {
-				t.Error(event.String())
-			}
+			test.validateChmodSchema(t, event)
 		})
 	}))
 }

--- a/pkg/security/tests/chown32_test.go
+++ b/pkg/security/tests/chown32_test.go
@@ -76,9 +76,7 @@ func TestChown32(t *testing.T) {
 			assertNearTime(t, event.Chown.File.CTime)
 			assert.Equal(t, event.Async, false)
 
-			if !validateChownSchema(t, event) {
-				t.Error(event.String())
-			}
+			test.validateChownSchema(t, event)
 		})
 	})
 
@@ -103,9 +101,7 @@ func TestChown32(t *testing.T) {
 			assertNearTime(t, event.Chown.File.CTime)
 			assert.Equal(t, event.Async, false)
 
-			if !validateChownSchema(t, event) {
-				t.Error(event.String())
-			}
+			test.validateChownSchema(t, event)
 		})
 	})
 
@@ -130,9 +126,7 @@ func TestChown32(t *testing.T) {
 			assertNearTime(t, event.Chown.File.CTime)
 			assert.Equal(t, event.Async, false)
 
-			if !validateChownSchema(t, event) {
-				t.Error(event.String())
-			}
+			test.validateChownSchema(t, event)
 		})
 	})
 
@@ -162,9 +156,7 @@ func TestChown32(t *testing.T) {
 			assertNearTime(t, event.Chown.File.CTime)
 			assert.Equal(t, event.Async, false)
 
-			if !validateChownSchema(t, event) {
-				t.Error(event.String())
-			}
+			test.validateChownSchema(t, event)
 		})
 	})
 
@@ -194,9 +186,7 @@ func TestChown32(t *testing.T) {
 			assertNearTime(t, event.Chown.File.CTime)
 			assert.Equal(t, event.Async, false)
 
-			if !validateChownSchema(t, event) {
-				t.Error(event.String())
-			}
+			test.validateChownSchema(t, event)
 		})
 	})
 
@@ -222,9 +212,7 @@ func TestChown32(t *testing.T) {
 			assertNearTime(t, event.Chown.File.CTime)
 			assert.Equal(t, event.Async, false)
 
-			if !validateChownSchema(t, event) {
-				t.Error(event.String())
-			}
+			test.validateChownSchema(t, event)
 		})
 	})
 
@@ -249,9 +237,7 @@ func TestChown32(t *testing.T) {
 			assertNearTime(t, event.Chown.File.CTime)
 			assert.Equal(t, event.Async, false)
 
-			if !validateChownSchema(t, event) {
-				t.Error(event.String())
-			}
+			test.validateChownSchema(t, event)
 		})
 	})
 }

--- a/pkg/security/tests/chown_test.go
+++ b/pkg/security/tests/chown_test.go
@@ -90,9 +90,7 @@ func TestChown(t *testing.T) {
 			assertNearTime(t, event.Chown.File.CTime)
 			assert.Equal(t, event.Async, false)
 
-			if !validateChownSchema(t, event) {
-				t.Error(event.String())
-			}
+			test.validateChownSchema(t, event)
 		})
 	})
 
@@ -119,9 +117,7 @@ func TestChown(t *testing.T) {
 			assertNearTime(t, event.Chown.File.CTime)
 			assert.Equal(t, event.Async, false)
 
-			if !validateChownSchema(t, event) {
-				t.Error(event.String())
-			}
+			test.validateChownSchema(t, event)
 		})
 	})
 
@@ -158,9 +154,7 @@ func TestChown(t *testing.T) {
 			assertNearTime(t, event.Chown.File.CTime)
 			assert.Equal(t, event.Async, false)
 
-			if !validateChownSchema(t, event) {
-				t.Error(event.String())
-			}
+			test.validateChownSchema(t, event)
 		})
 	}))
 
@@ -184,9 +178,7 @@ func TestChown(t *testing.T) {
 			assertNearTime(t, event.Chown.File.CTime)
 			assert.Equal(t, event.Async, false)
 
-			if !validateChownSchema(t, event) {
-				t.Error(event.String())
-			}
+			test.validateChownSchema(t, event)
 		})
 	}))
 
@@ -206,9 +198,7 @@ func TestChown(t *testing.T) {
 			assert.Equal(t, int64(-1), event.Chown.GID, "wrong group")
 			assert.Equal(t, event.Async, false)
 
-			if !validateChownSchema(t, event) {
-				t.Error(event.String())
-			}
+			test.validateChownSchema(t, event)
 		})
 	}))
 
@@ -228,9 +218,7 @@ func TestChown(t *testing.T) {
 			assert.Equal(t, int64(204), event.Chown.GID, "wrong group")
 			assert.Equal(t, event.Async, false)
 
-			if !validateChownSchema(t, event) {
-				t.Error(event.String())
-			}
+			test.validateChownSchema(t, event)
 		})
 	}))
 

--- a/pkg/security/tests/dns_test.go
+++ b/pkg/security/tests/dns_test.go
@@ -69,9 +69,7 @@ func TestDNS(t *testing.T) {
 			assertTriggeredRule(t, rule, "test_rule_dns")
 			assert.Equal(t, "google.com", event.DNS.Name, "wrong domain name")
 
-			if !validateDNSSchema(t, event) {
-				t.Error(event.String())
-			}
+			test.validateDNSSchema(t, event)
 		})
 	})
 
@@ -86,9 +84,7 @@ func TestDNS(t *testing.T) {
 			assertTriggeredRule(t, rule, "test_rule_dns")
 			assert.Equal(t, "GOOGLE.COM", event.DNS.Name, "wrong domain name")
 
-			if !validateDNSSchema(t, event) {
-				t.Error(event.String())
-			}
+			test.validateDNSSchema(t, event)
 		})
 	})
 
@@ -102,9 +98,7 @@ func TestDNS(t *testing.T) {
 			assert.Equal(t, "dns", event.GetType(), "wrong event type")
 			assert.Equal(t, longDomain, event.DNS.Name, "wrong domain name")
 
-			if !validateDNSSchema(t, event) {
-				t.Error(event.String())
-			}
+			test.validateDNSSchema(t, event)
 		})
 	})
 }

--- a/pkg/security/tests/fields_test.go
+++ b/pkg/security/tests/fields_test.go
@@ -54,7 +54,7 @@ func TestFieldsResolver(t *testing.T) {
 			cmd := exec.Command(lsExecutable, "test-fields")
 			_ = cmd.Run()
 			return nil
-		}, validateExecEvent(t, noWrapperType, func(event *model.Event, rule *rules.Rule) {
+		}, test.validateExecEvent(t, noWrapperType, func(event *model.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_fields_exec")
 
 			event.ResolveFields(false)

--- a/pkg/security/tests/kernel_module_test.go
+++ b/pkg/security/tests/kernel_module_test.go
@@ -172,9 +172,7 @@ func TestLoadModule(t *testing.T) {
 			event.ResolveFields(false)
 			assert.Equal(t, "", event.LoadModule.File.PathnameStr, "shouldn't get a path")
 
-			if !validateLoadModuleNoFileSchema(t, event) {
-				t.Error(event.String())
-			}
+			test.validateLoadModuleNoFileSchema(t, event)
 		})
 	})
 
@@ -195,9 +193,7 @@ func TestLoadModule(t *testing.T) {
 		}, func(event *model.Event, r *rules.Rule) {
 			assert.Equal(t, "test_load_module", r.ID, "invalid rule triggered")
 
-			if !validateLoadModuleSchema(t, event) {
-				t.Error(event.String())
-			}
+			test.validateLoadModuleSchema(t, event)
 		})
 	})
 
@@ -288,9 +284,7 @@ func TestUnloadModule(t *testing.T) {
 		}, func(event *model.Event, r *rules.Rule) {
 			assert.Equal(t, "test_unload_module", r.ID, "invalid rule triggered")
 
-			if !validateUnloadModuleSchema(t, event) {
-				t.Error(event.String())
-			}
+			test.validateUnloadModuleSchema(t, event)
 		})
 	})
 }

--- a/pkg/security/tests/link_test.go
+++ b/pkg/security/tests/link_test.go
@@ -65,9 +65,7 @@ func TestLink(t *testing.T) {
 			assertNearTime(t, event.Link.Target.CTime)
 			assert.Equal(t, event.Async, false)
 
-			if !validateLinkSchema(t, event) {
-				t.Error(event.String())
-			}
+			test.validateLinkSchema(t, event)
 		})
 
 		if err = os.Remove(testNewFile); err != nil {
@@ -93,9 +91,7 @@ func TestLink(t *testing.T) {
 			assertNearTime(t, event.Link.Target.CTime)
 			assert.Equal(t, event.Async, false)
 
-			if !validateLinkSchema(t, event) {
-				t.Error(event.String())
-			}
+			test.validateLinkSchema(t, event)
 		})
 
 		if err = os.Remove(testNewFile); err != nil {

--- a/pkg/security/tests/mmap_test.go
+++ b/pkg/security/tests/mmap_test.go
@@ -56,9 +56,7 @@ func TestMMapEvent(t *testing.T) {
 			}
 			assertFieldEqual(t, event, "process.file.path", executable)
 
-			if !validateMMapSchema(t, event) {
-				t.Error(event.String())
-			}
+			test.validateMMapSchema(t, event)
 		})
 	})
 }

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -998,6 +998,14 @@ func (tm *testModule) marshalEvent(ev *model.Event) (string, error) {
 	return string(b), err
 }
 
+func (tm *testModule) debugEvent(ev *model.Event) string {
+	b, err := tm.marshalEvent(ev)
+	if err != nil {
+		return err.Error()
+	}
+	return string(b)
+}
+
 // GetStatusMetrics returns a string representation of the perf buffer monitor metrics
 func GetStatusMetrics(probe *sprobe.Probe) string {
 	if probe == nil {

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -498,7 +498,7 @@ func validateProcessContextLineage(tb testing.TB, event *model.Event, probe *spr
 }
 
 //nolint:deadcode,unused
-func validateProcessContextSECL(tb testing.TB, event *model.Event) bool {
+func validateProcessContextSECL(tb testing.TB, event *model.Event, probe *sprobe.Probe) {
 	// Process file name values cannot be blank
 	nameFields := []string{
 		"process.file.name",
@@ -520,7 +520,16 @@ func validateProcessContextSECL(tb testing.TB, event *model.Event) bool {
 		pathFieldValid, _ = checkProcessContextFieldsForBlankValues(tb, event, pathFields)
 	}
 
-	return nameFieldValid && pathFieldValid
+	valid := nameFieldValid && pathFieldValid
+
+	if !valid {
+		eventJSON, err := sprobe.MarshalEvent(event, probe)
+		if err != nil {
+			tb.Errorf("failed to marshal event: %v", err)
+			return
+		}
+		tb.Error(eventJSON)
+	}
 }
 
 func checkProcessContextFieldsForBlankValues(tb testing.TB, event *model.Event, fieldNamesToCheck []string) (bool, bool) {
@@ -570,10 +579,7 @@ func validateProcessContext(tb testing.TB, event *model.Event, probe *sprobe.Pro
 	}
 
 	validateProcessContextLineage(tb, event, probe)
-
-	if !validateProcessContextSECL(tb, event) {
-		tb.Error(event)
-	}
+	validateProcessContextSECL(tb, event, probe)
 }
 
 //nolint:deadcode,unused

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -993,11 +993,13 @@ func (tm *testModule) GetEventDiscarder(tb testing.TB, action func() error, cb o
 	}
 }
 
+//nolint:deadcode,unused
 func (tm *testModule) marshalEvent(ev *model.Event) (string, error) {
 	b, err := sprobe.MarshalEvent(ev, tm.probe)
 	return string(b), err
 }
 
+//nolint:deadcode,unused
 func (tm *testModule) debugEvent(ev *model.Event) string {
 	b, err := tm.marshalEvent(ev)
 	if err != nil {

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -433,16 +433,25 @@ func assertFieldStringArrayIndexedOneOf(tb *testing.T, e *model.Event, field str
 }
 
 //nolint:deadcode,unused
-func validateProcessContextLineage(tb testing.TB, event *model.Event) bool {
+func validateProcessContextLineage(tb testing.TB, event *model.Event, probe *sprobe.Probe) {
+	eventJSON, err := sprobe.MarshalEvent(event, probe)
+	if err != nil {
+		tb.Errorf("failed to marshal event: %v", err)
+		return
+	}
+
 	var data interface{}
-	if err := json.Unmarshal([]byte(event.String()), &data); err != nil {
+	if err := json.Unmarshal(eventJSON, &data); err != nil {
 		tb.Error(err)
+		tb.Error(eventJSON)
+		return
 	}
 
 	json, err := jsonpath.JsonPathLookup(data, "$.process.ancestors")
 	if err != nil {
 		tb.Errorf("should have a process context with ancestors, got %+v (%s)", json, spew.Sdump(data))
-		return false
+		tb.Error(eventJSON)
+		return
 	}
 
 	var prevPID, prevPPID float64
@@ -451,19 +460,22 @@ func validateProcessContextLineage(tb testing.TB, event *model.Event) bool {
 		pce, ok := entry.(map[string]interface{})
 		if !ok {
 			tb.Errorf("invalid process cache entry, %+v", entry)
-			return false
+			tb.Error(eventJSON)
+			return
 		}
 
 		pid, ok := pce["pid"].(float64)
 		if !ok || pid == 0 {
 			tb.Errorf("invalid pid, %+v", pce)
-			return false
+			tb.Error(eventJSON)
+			return
 		}
 
 		// check lineage, exec should have the exact same pid, fork pid/ppid relationship
 		if prevPID != 0 && pid != prevPID && pid != prevPPID {
 			tb.Errorf("invalid process tree, parent/child broken (%f -> %f/%f), %+v", pid, prevPID, prevPPID, json)
-			return false
+			tb.Error(eventJSON)
+			return
 		}
 		prevPID = pid
 
@@ -471,7 +483,8 @@ func validateProcessContextLineage(tb testing.TB, event *model.Event) bool {
 			ppid, ok := pce["ppid"].(float64)
 			if !ok {
 				tb.Errorf("invalid pid, %+v", pce)
-				return false
+				tb.Error(eventJSON)
+				return
 			}
 
 			prevPPID = ppid
@@ -480,9 +493,8 @@ func validateProcessContextLineage(tb testing.TB, event *model.Event) bool {
 
 	if prevPID != 1 {
 		tb.Errorf("invalid process tree, last ancestor should be pid 1, %+v", json)
+		tb.Error(eventJSON)
 	}
-
-	return true
 }
 
 //nolint:deadcode,unused
@@ -552,30 +564,28 @@ func checkProcessContextFieldsForBlankValues(tb testing.TB, event *model.Event, 
 }
 
 //nolint:deadcode,unused
-func validateProcessContext(tb testing.TB, event *model.Event) {
+func validateProcessContext(tb testing.TB, event *model.Event, probe *sprobe.Probe) {
 	if event.ProcessContext.IsKworker {
 		return
 	}
 
-	if !validateProcessContextLineage(tb, event) {
-		tb.Error(event.String())
-	}
+	validateProcessContextLineage(tb, event, probe)
 
 	if !validateProcessContextSECL(tb, event) {
-		tb.Error(event.String())
+		tb.Error(event)
 	}
 }
 
 //nolint:deadcode,unused
-func validateEvent(tb testing.TB, validate func(event *model.Event, rule *rules.Rule)) func(event *model.Event, rule *rules.Rule) {
+func validateEvent(tb testing.TB, validate func(event *model.Event, rule *rules.Rule), probe *sprobe.Probe) func(event *model.Event, rule *rules.Rule) {
 	return func(event *model.Event, rule *rules.Rule) {
-		validateProcessContext(tb, event)
+		validateProcessContext(tb, event, probe)
 		validate(event, rule)
 	}
 }
 
 //nolint:deadcode,unused
-func validateExecEvent(tb *testing.T, kind wrapperType, validate func(event *model.Event, rule *rules.Rule)) func(event *model.Event, rule *rules.Rule) {
+func (tm *testModule) validateExecEvent(tb *testing.T, kind wrapperType, validate func(event *model.Event, rule *rules.Rule)) func(event *model.Event, rule *rules.Rule) {
 	return func(event *model.Event, rule *rules.Rule) {
 		validate(event, rule)
 
@@ -584,9 +594,7 @@ func validateExecEvent(tb *testing.T, kind wrapperType, validate func(event *mod
 			assertFieldNotEmpty(tb, event, "process.container.id", "process container id not found")
 		}
 
-		if !validateExecSchema(tb, event) {
-			tb.Error(event.String())
-		}
+		tm.validateExecSchema(tb, event)
 	}
 }
 
@@ -985,6 +993,11 @@ func (tm *testModule) GetEventDiscarder(tb testing.TB, action func() error, cb o
 	}
 }
 
+func (tm *testModule) marshalEvent(ev *model.Event) (string, error) {
+	b, err := sprobe.MarshalEvent(ev, tm.probe)
+	return string(b), err
+}
+
 // GetStatusMetrics returns a string representation of the perf buffer monitor metrics
 func GetStatusMetrics(probe *sprobe.Probe) string {
 	if probe == nil {
@@ -1054,7 +1067,7 @@ func (err ErrSkipTest) Error() string {
 func (tm *testModule) WaitSignal(tb testing.TB, action func() error, cb onRuleHandler) {
 	tb.Helper()
 
-	if err := tm.GetSignal(tb, action, validateEvent(tb, cb)); err != nil {
+	if err := tm.GetSignal(tb, action, validateEvent(tb, cb, tm.probe)); err != nil {
 		if _, ok := err.(ErrSkipTest); ok {
 			tb.Skip(err)
 		} else {

--- a/pkg/security/tests/mount_test.go
+++ b/pkg/security/tests/mount_test.go
@@ -438,9 +438,8 @@ func TestMountEvent(t *testing.T) {
 			assertFieldEqual(t, event, "mount.mountpoint.path", tmpfsMountPointPath)
 			assertFieldEqual(t, event, "mount.fs_type", "tmpfs")
 			assertFieldEqual(t, event, "process.file.path", executable)
-			if !validateMountSchema(t, event) {
-				t.Error(event.String())
-			}
+
+			test.validateMountSchema(t, event)
 		})
 	})
 
@@ -462,9 +461,8 @@ func TestMountEvent(t *testing.T) {
 			assertFieldEqual(t, event, "mount.source.path", bindMountSourcePath)
 			assertFieldEqual(t, event, "mount.fs_type", testDrive.FSType())
 			assertFieldEqual(t, event, "process.file.path", executable)
-			if !validateMountSchema(t, event) {
-				t.Error(event.String())
-			}
+
+			test.validateMountSchema(t, event)
 		})
 	})
 
@@ -490,9 +488,8 @@ func TestMountEvent(t *testing.T) {
 			assertFieldEqual(t, event, "mount.source.path", "/")
 			assertFieldNotEqual(t, event, "mount.fs_type", "overlay")
 			assertFieldNotEmpty(t, event, "container.id", "container id shouldn't be empty")
-			if !validateMountSchema(t, event) {
-				t.Error(event.String())
-			}
+
+			test.validateMountSchema(t, event)
 		})
 	})
 

--- a/pkg/security/tests/mount_test.go
+++ b/pkg/security/tests/mount_test.go
@@ -512,7 +512,7 @@ func TestMountEvent(t *testing.T) {
 			}
 			return nil
 		}, func(event *model.Event, rule *rules.Rule) {
-			t.Errorf("shouldn't get an event: event %s matched rule %s", event, rule.Expression)
+			t.Errorf("shouldn't get an event: event %s matched rule %s", test.debugEvent(event), rule.Expression)
 		})
 		if err == nil {
 			t.Error("shouldn't get an event")

--- a/pkg/security/tests/mprotect_test.go
+++ b/pkg/security/tests/mprotect_test.go
@@ -58,9 +58,7 @@ func TestMProtectEvent(t *testing.T) {
 			}
 			assertFieldEqual(t, event, "process.file.path", executable)
 
-			if !validateMProtectSchema(t, event) {
-				t.Error(event.String())
-			}
+			test.validateMProtectSchema(t, event)
 		})
 	})
 }

--- a/pkg/security/tests/network_test.go
+++ b/pkg/security/tests/network_test.go
@@ -64,9 +64,7 @@ func TestNetworkCIDR(t *testing.T) {
 			assert.Equal(t, "dns", event.GetType(), "wrong event type")
 			assert.Equal(t, "google.com", event.DNS.Name, "wrong domain name")
 
-			if !validateDNSSchema(t, event) {
-				t.Error(event.String())
-			}
+			test.validateDNSSchema(t, event)
 		})
 	})
 }

--- a/pkg/security/tests/open_test.go
+++ b/pkg/security/tests/open_test.go
@@ -62,9 +62,7 @@ func TestOpen(t *testing.T) {
 			assert.Equal(t, getInode(t, testFile), event.Open.File.Inode, "wrong inode")
 			assert.Equal(t, event.Async, false)
 
-			if !validateOpenSchema(t, event) {
-				t.Error(event.String())
-			}
+			test.validateOpenSchema(t, event)
 		})
 	}))
 

--- a/pkg/security/tests/process_test.go
+++ b/pkg/security/tests/process_test.go
@@ -248,7 +248,7 @@ func TestProcessContext(t *testing.T) {
 			// we need to ignore the error because "--password" is not a valid option for ls
 			_ = cmd.Run()
 			return nil
-		}, validateExecEvent(t, kind, func(event *model.Event, rule *rules.Rule) {
+		}, test.validateExecEvent(t, kind, func(event *model.Event, rule *rules.Rule) {
 			argv0, err := event.GetFieldValue("exec.argv0")
 			if err != nil {
 				t.Errorf("not able to get argv0")
@@ -294,7 +294,10 @@ func TestProcessContext(t *testing.T) {
 			}
 
 			// trigger serialization to test scrubber
-			str := event.String()
+			str, err := test.marshalEvent(event)
+			if err != nil {
+				t.Error(err)
+			}
 
 			if !strings.Contains(str, "password") || !strings.Contains(str, "custom") {
 				t.Error("args not serialized")
@@ -314,7 +317,7 @@ func TestProcessContext(t *testing.T) {
 			cmd := cmdFunc("ls", args, envs)
 			_ = cmd.Run()
 			return nil
-		}, validateExecEvent(t, kind, func(event *model.Event, rule *rules.Rule) {
+		}, test.validateExecEvent(t, kind, func(event *model.Event, rule *rules.Rule) {
 			assert.Equal(t, "test_rule_envp", rule.ID, "wrong rule triggered")
 		}))
 	})
@@ -325,7 +328,7 @@ func TestProcessContext(t *testing.T) {
 		test.WaitSignal(t, func() error {
 			cmd := exec.Command(lsExecutable, "-ll")
 			return cmd.Run()
-		}, validateExecEvent(t, noWrapperType, func(event *model.Event, rule *rules.Rule) {
+		}, test.validateExecEvent(t, noWrapperType, func(event *model.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_rule_argv")
 		}))
 	})
@@ -336,7 +339,7 @@ func TestProcessContext(t *testing.T) {
 		test.WaitSignal(t, func() error {
 			cmd := exec.Command(lsExecutable, "-ls", "--escape")
 			return cmd.Run()
-		}, validateExecEvent(t, noWrapperType, func(event *model.Event, rule *rules.Rule) {
+		}, test.validateExecEvent(t, noWrapperType, func(event *model.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_rule_args_flags")
 		}))
 	})
@@ -347,7 +350,7 @@ func TestProcessContext(t *testing.T) {
 		test.WaitSignal(t, func() error {
 			cmd := exec.Command(lsExecutable, "--block-size", "123")
 			return cmd.Run()
-		}, validateExecEvent(t, noWrapperType, func(event *model.Event, rule *rules.Rule) {
+		}, test.validateExecEvent(t, noWrapperType, func(event *model.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_rule_args_options")
 		}))
 	})
@@ -368,7 +371,7 @@ func TestProcessContext(t *testing.T) {
 			// we need to ignore the error because the string of "a" generates a "File name too long" error
 			_ = cmd.Run()
 			return nil
-		}, validateExecEvent(t, kind, func(event *model.Event, rule *rules.Rule) {
+		}, test.validateExecEvent(t, kind, func(event *model.Event, rule *rules.Rule) {
 			args, err := event.GetFieldValue("exec.args")
 			if err != nil {
 				t.Errorf("not able to get args")
@@ -505,7 +508,7 @@ func TestProcessContext(t *testing.T) {
 			}
 			cmd := cmdFunc(bin, args, envs)
 			return cmd.Run()
-		}, validateExecEvent(t, kind, func(event *model.Event, rule *rules.Rule) {
+		}, test.validateExecEvent(t, kind, func(event *model.Event, rule *rules.Rule) {
 			execEnvp, err := event.GetFieldValue("exec.envp")
 			if err != nil {
 				t.Errorf("not able to get exec.envp")
@@ -696,7 +699,10 @@ func TestProcessContext(t *testing.T) {
 				t.Errorf("expected inode %d, got %d => %+v", entry.FileEvent.Inode, inode, event)
 			}
 
-			str := event.String()
+			str, err := test.marshalEvent(event)
+			if err != nil {
+				t.Error(err)
+			}
 
 			if !strings.Contains(str, "pts") {
 				t.Error("tty not serialized")
@@ -830,11 +836,15 @@ func TestProcessContext(t *testing.T) {
 			cmd := cmdFunc(shell, args, envs)
 			_ = cmd.Run()
 			return nil
-		}, validateExecEvent(t, kind, func(event *model.Event, rule *rules.Rule) {
+		}, test.validateExecEvent(t, kind, func(event *model.Event, rule *rules.Rule) {
 			assert.Equal(t, "test_rule_args_envs_dedup", rule.ID, "wrong rule triggered")
 
 			var data interface{}
-			serialized := event.String()
+			serialized, err := test.marshalEvent(event)
+			if err != nil {
+				t.Error(err)
+			}
+
 			if err := json.Unmarshal([]byte(serialized), &data); err != nil {
 				t.Error(err)
 			}
@@ -864,7 +874,7 @@ func TestProcessContext(t *testing.T) {
 			cmd := exec.Command(lsExecutable, "glob")
 			_ = cmd.Run()
 			return nil
-		}, validateExecEvent(t, noWrapperType, func(event *model.Event, rule *rules.Rule) {
+		}, test.validateExecEvent(t, noWrapperType, func(event *model.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_rule_ancestors_glob")
 		}))
 	})
@@ -878,7 +888,7 @@ func TestProcessContext(t *testing.T) {
 			_, _ = cmd.CombinedOutput()
 
 			return nil
-		}, validateExecEvent(t, kind, func(event *model.Event, rule *rules.Rule) {
+		}, test.validateExecEvent(t, kind, func(event *model.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_self_exec")
 		}))
 	})
@@ -899,7 +909,7 @@ func TestProcessContext(t *testing.T) {
 				return fmt.Errorf("%s: %w", out, err)
 			}
 			return nil
-		}, validateExecEvent(t, kind, func(event *model.Event, rule *rules.Rule) {
+		}, test.validateExecEvent(t, kind, func(event *model.Event, rule *rules.Rule) {
 			assert.Equal(t, "test_rule_container", rule.ID, "wrong rule triggered")
 
 			if kind == dockerWrapperType {
@@ -964,7 +974,7 @@ func TestProcessEnvsWithValue(t *testing.T) {
 			cmd.Env = envp
 			_ = cmd.Run()
 			return nil
-		}, validateExecEvent(t, noWrapperType, func(event *model.Event, rule *rules.Rule) {
+		}, test.validateExecEvent(t, noWrapperType, func(event *model.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_ldpreload_from_tmp_with_envs")
 			assertFieldEqual(t, event, "exec.file.path", lsExec)
 			assertFieldStringArrayIndexedOneOf(t, event, "exec.envs", 0, []string{"LD_PRELOAD=/tmp/dyn.so"})
@@ -995,7 +1005,7 @@ func TestProcessExecCTime(t *testing.T) {
 
 		cmd := exec.Command(testFile, "/tmp/test")
 		return cmd.Run()
-	}, validateExecEvent(t, noWrapperType, func(event *model.Event, rule *rules.Rule) {
+	}, test.validateExecEvent(t, noWrapperType, func(event *model.Event, rule *rules.Rule) {
 		assert.Equal(t, "test_exec_ctime", rule.ID, "wrong rule triggered")
 	}))
 }
@@ -1157,7 +1167,7 @@ func TestProcessExec(t *testing.T) {
 		test.WaitSignal(t, func() error {
 			cmd := exec.Command("sh", "-c", executable+" /dev/null")
 			return cmd.Run()
-		}, validateExecEvent(t, noWrapperType, func(event *model.Event, rule *rules.Rule) {
+		}, test.validateExecEvent(t, noWrapperType, func(event *model.Event, rule *rules.Rule) {
 			assertFieldEqual(t, event, "exec.file.path", executable)
 			assertFieldIsOneOf(t, event, "process.parent.file.name", []string{"sh", "bash", "dash"}, "wrong process parent file name")
 			assertFieldStringArrayIndexedOneOf(t, event, "process.ancestors.file.name", 0, []string{"sh", "bash", "dash"})
@@ -1169,7 +1179,7 @@ func TestProcessExec(t *testing.T) {
 			args := []string{"exec-in-pthread", executable, "/dev/null"}
 			cmd := exec.Command(syscallTester, args...)
 			return cmd.Run()
-		}, validateExecEvent(t, noWrapperType, func(event *model.Event, rule *rules.Rule) {
+		}, test.validateExecEvent(t, noWrapperType, func(event *model.Event, rule *rules.Rule) {
 			assertFieldEqual(t, event, "exec.file.path", executable)
 			assertFieldEqual(t, event, "process.parent.file.name", "syscall_tester", "wrong process parent file name")
 		}))
@@ -1215,7 +1225,7 @@ func TestProcessMetadata(t *testing.T) {
 		test.WaitSignal(t, func() error {
 			cmd := exec.Command(testFile)
 			return cmd.Run()
-		}, validateExecEvent(t, noWrapperType, func(event *model.Event, rule *rules.Rule) {
+		}, test.validateExecEvent(t, noWrapperType, func(event *model.Event, rule *rules.Rule) {
 			assert.Equal(t, "exec", event.GetType(), "wrong event type")
 			assertRights(t, event.Exec.FileEvent.Mode, fileMode)
 			assertNearTime(t, event.Exec.FileEvent.MTime)
@@ -1235,7 +1245,7 @@ func TestProcessMetadata(t *testing.T) {
 			}
 			_, err := syscall.ForkExec(testFile, []string{}, attr)
 			return err
-		}, validateExecEvent(t, noWrapperType, func(event *model.Event, rule *rules.Rule) {
+		}, test.validateExecEvent(t, noWrapperType, func(event *model.Event, rule *rules.Rule) {
 			assert.Equal(t, "exec", event.GetType(), "wrong event type")
 			assert.Equal(t, 1001, int(event.Exec.Credentials.UID), "wrong uid")
 			assert.Equal(t, 1001, int(event.Exec.Credentials.EUID), "wrong euid")
@@ -1277,13 +1287,11 @@ func TestProcessExecExit(t *testing.T) {
 				return false
 			}
 
-			validate := validateExecEvent(t, noWrapperType, func(event *model.Event, rule *rules.Rule) {
-				if !validateProcessContextLineage(t, event) {
-					t.Error(event.String())
-				}
+			validate := test.validateExecEvent(t, noWrapperType, func(event *model.Event, rule *rules.Rule) {
+				validateProcessContextLineage(t, event, test.probe)
 
 				if !validateProcessContextSECL(t, event) {
-					t.Error(event.String())
+					t.Error(event)
 				}
 
 				assertFieldEqual(t, event, "exec.file.name", "touch")
@@ -1604,9 +1612,7 @@ func TestProcessExit(t *testing.T) {
 			cmd.Env = envp
 			return cmd.Run()
 		}, func(event *model.Event, rule *rules.Rule) {
-			if !validateExitSchema(t, event) {
-				t.Error(event.String())
-			}
+			test.validateExitSchema(t, event)
 			assertTriggeredRule(t, rule, "test_exit_ok")
 			assertFieldEqual(t, event, "exit.file.path", sleepExec)
 			assert.Equal(t, uint32(model.ExitExited), event.Exit.Cause, "wrong exit cause")
@@ -1625,9 +1631,7 @@ func TestProcessExit(t *testing.T) {
 			_ = cmd.Run()
 			return nil
 		}, func(event *model.Event, rule *rules.Rule) {
-			if !validateExitSchema(t, event) {
-				t.Error(event.String())
-			}
+			test.validateExitSchema(t, event)
 			assertTriggeredRule(t, rule, "test_exit_error")
 			assertFieldEqual(t, event, "exit.file.path", sleepExec)
 			assert.Equal(t, uint32(model.ExitExited), event.Exit.Cause, "wrong exit cause")
@@ -1646,9 +1650,7 @@ func TestProcessExit(t *testing.T) {
 			_ = cmd.Run()
 			return nil
 		}, func(event *model.Event, rule *rules.Rule) {
-			if !validateExitSchema(t, event) {
-				t.Error(event.String())
-			}
+			test.validateExitSchema(t, event)
 			assertTriggeredRule(t, rule, "test_exit_coredump")
 			assertFieldEqual(t, event, "exit.file.path", sleepExec)
 			assert.Equal(t, uint32(model.ExitCoreDumped), event.Exit.Cause, "wrong exit cause")
@@ -1667,9 +1669,7 @@ func TestProcessExit(t *testing.T) {
 			_ = cmd.Run()
 			return nil
 		}, func(event *model.Event, rule *rules.Rule) {
-			if !validateExitSchema(t, event) {
-				t.Error(event.String())
-			}
+			test.validateExitSchema(t, event)
 			assertTriggeredRule(t, rule, "test_exit_signal")
 			assertFieldEqual(t, event, "exit.file.path", sleepExec)
 			assert.Equal(t, uint32(model.ExitSignaled), event.Exit.Cause, "wrong exit cause")
@@ -1687,9 +1687,7 @@ func TestProcessExit(t *testing.T) {
 			cmd.Env = envp
 			return cmd.Run()
 		}, func(event *model.Event, rule *rules.Rule) {
-			if !validateExitSchema(t, event) {
-				t.Error(event.String())
-			}
+			test.validateExitSchema(t, event)
 			assertTriggeredRule(t, rule, "test_exit_time_1")
 			assertFieldEqual(t, event, "exit.file.path", sleepExec)
 			assert.Equal(t, uint32(model.ExitExited), event.Exit.Cause, "wrong exit cause")
@@ -1707,9 +1705,7 @@ func TestProcessExit(t *testing.T) {
 			cmd.Env = envp
 			return cmd.Run()
 		}, func(event *model.Event, rule *rules.Rule) {
-			if !validateExitSchema(t, event) {
-				t.Error(event.String())
-			}
+			test.validateExitSchema(t, event)
 			assertTriggeredRule(t, rule, "test_exit_time_2")
 			assertFieldEqual(t, event, "exit.file.path", sleepExec)
 			assert.Equal(t, uint32(model.ExitExited), event.Exit.Cause, "wrong exit cause")
@@ -1964,7 +1960,7 @@ chmod 755 pyscript.py
 				t.Logf("%s: %+v\n", constantfetch.OffsetNameLinuxBinprmStructFile, offsets[constantfetch.OffsetNameLinuxBinprmStructFile])
 
 				return nil
-			}, validateExecEvent(t, noWrapperType, func(event *model.Event, rule *rules.Rule) {
+			}, testModule.validateExecEvent(t, noWrapperType, func(event *model.Event, rule *rules.Rule) {
 				assertTriggeredRule(t, rule, test.rule.ID)
 				test.check(event)
 			}))

--- a/pkg/security/tests/process_test.go
+++ b/pkg/security/tests/process_test.go
@@ -1289,10 +1289,7 @@ func TestProcessExecExit(t *testing.T) {
 
 			validate := test.validateExecEvent(t, noWrapperType, func(event *model.Event, rule *rules.Rule) {
 				validateProcessContextLineage(t, event, test.probe)
-
-				if !validateProcessContextSECL(t, event) {
-					t.Error(event)
-				}
+				validateProcessContextSECL(t, event, test.probe)
 
 				assertFieldEqual(t, event, "exec.file.name", "touch")
 				assertFieldContains(t, event, "exec.args", "01010101")

--- a/pkg/security/tests/process_test.go
+++ b/pkg/security/tests/process_test.go
@@ -188,7 +188,7 @@ func TestProcessContext(t *testing.T) {
 
 			return nil
 		}, func(event *model.Event, rule *rules.Rule) {
-			t.Errorf("shouldn't get an event: got event: %s", event)
+			t.Errorf("shouldn't get an event: got event: %s", test.debugEvent(event))
 		})
 		if err == nil {
 			t.Fatal("shouldn't get an event")
@@ -2152,7 +2152,7 @@ func TestProcessFilelessExecution(t *testing.T) {
 					cmd := exec.Command(testFile)
 					return cmd.Run()
 				}, func(event *model.Event, rule *rules.Rule) {
-					t.Errorf("shouldn't get an event: got event: %s", event)
+					t.Errorf("shouldn't get an event: got event: %s", testModule.debugEvent(event))
 				})
 				if err == nil {
 					t.Fatal("shouldn't get an event")

--- a/pkg/security/tests/ptrace_test.go
+++ b/pkg/security/tests/ptrace_test.go
@@ -54,9 +54,7 @@ func TestPTraceEvent(t *testing.T) {
 			assert.Equal(t, uint64(42), event.PTrace.Address, "wrong address")
 			assert.Equal(t, event.Async, false)
 
-			if !validatePTraceSchema(t, event) {
-				t.Error(event.String())
-			}
+			test.validatePTraceSchema(t, event)
 		})
 	})
 }

--- a/pkg/security/tests/rename_test.go
+++ b/pkg/security/tests/rename_test.go
@@ -74,9 +74,7 @@ func TestRename(t *testing.T) {
 			assertNearTime(t, event.Rename.New.CTime)
 			assert.Equal(t, event.Async, false)
 
-			if !validateRenameSchema(t, event) {
-				t.Error(event.String())
-			}
+			test.validateRenameSchema(t, event)
 		})
 	}))
 
@@ -105,9 +103,7 @@ func TestRename(t *testing.T) {
 			assertNearTime(t, event.Rename.New.CTime)
 			assert.Equal(t, event.Async, false)
 
-			if !validateRenameSchema(t, event) {
-				t.Error(event.String())
-			}
+			test.validateRenameSchema(t, event)
 		})
 	})
 
@@ -137,9 +133,7 @@ func TestRename(t *testing.T) {
 			assertNearTime(t, event.Rename.New.CTime)
 			assert.Equal(t, event.Async, false)
 
-			if !validateRenameSchema(t, event) {
-				t.Error(event.String())
-			}
+			test.validateRenameSchema(t, event)
 		})
 	})
 
@@ -241,9 +235,7 @@ func TestRenameInvalidate(t *testing.T) {
 			assert.Equal(t, "rename", event.GetType(), "wrong event type")
 			assertFieldEqual(t, event, "rename.file.destination.path", testNewFile)
 
-			if !validateRenameSchema(t, event) {
-				t.Error(event.String())
-			}
+			test.validateRenameSchema(t, event)
 		})
 
 		// swap
@@ -340,9 +332,7 @@ func TestRenameReuseInode(t *testing.T) {
 		assertFieldEqual(t, event, "open.file.inode", int(testNewFileInode))
 		assertFieldEqual(t, event, "open.file.path", testReuseInodeFile)
 
-		if !validateOpenSchema(t, event) {
-			t.Error(event.String())
-		}
+		test.validateOpenSchema(t, event)
 	})
 }
 
@@ -384,9 +374,7 @@ func TestRenameFolder(t *testing.T) {
 			assert.Equal(t, "open", event.GetType(), "wrong event type")
 			assertFieldEqual(t, event, "open.file.path", filename)
 
-			if !validateOpenSchema(t, event) {
-				t.Error(event.String())
-			}
+			test.validateOpenSchema(t, event)
 
 			// swap
 			if err := os.Rename(testOldFolder, testNewFolder); err != nil {

--- a/pkg/security/tests/schemas.go
+++ b/pkg/security/tests/schemas.go
@@ -17,6 +17,7 @@ import (
 	"github.com/xeipuuv/gojsonschema"
 
 	"github.com/DataDog/datadog-agent/pkg/security/events"
+	"github.com/DataDog/datadog-agent/pkg/security/probe"
 	"github.com/DataDog/datadog-agent/pkg/security/probe/resolvers"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 )
@@ -53,7 +54,7 @@ func (v ValidInodeFormatChecker) IsFormat(input interface{}) bool {
 }
 
 //nolint:deadcode,unused
-func validateSchema(t *testing.T, json string, path string) bool {
+func validateStringSchema(t *testing.T, json string, path string) bool {
 	t.Helper()
 
 	fs := http.FS(schemaAssetFS)
@@ -72,6 +73,7 @@ func validateSchema(t *testing.T, json string, path string) bool {
 		for _, desc := range result.Errors() {
 			t.Errorf("%s", desc)
 		}
+		t.Error(json)
 		return false
 	}
 
@@ -79,151 +81,159 @@ func validateSchema(t *testing.T, json string, path string) bool {
 }
 
 //nolint:deadcode,unused
-func validateEventSchema(t *testing.T, event *model.Event, path string) bool {
+func (tm *testModule) validateEventSchema(t *testing.T, event *model.Event, path string) bool {
 	t.Helper()
-	return validateSchema(t, event.String(), path)
+
+	eventJSON, err := tm.marshalEvent(event)
+	if err != nil {
+		t.Error(err)
+		return false
+	}
+
+	return validateStringSchema(t, eventJSON, path)
 }
 
 //nolint:deadcode,unused
-func validateStringSchema(t *testing.T, event string, path string) bool {
+func (tm *testModule) validateExecSchema(t *testing.T, event *model.Event) bool {
 	t.Helper()
-	return validateSchema(t, event, path)
+	return tm.validateEventSchema(t, event, "file:///schemas/exec.schema.json")
 }
 
 //nolint:deadcode,unused
-func validateExecSchema(t *testing.T, event *model.Event) bool {
+func (tm *testModule) validateExitSchema(t *testing.T, event *model.Event) bool {
 	t.Helper()
-	return validateEventSchema(t, event, "file:///schemas/exec.schema.json")
+	return tm.validateEventSchema(t, event, "file:///schemas/exit.schema.json")
 }
 
 //nolint:deadcode,unused
-func validateExitSchema(t *testing.T, event *model.Event) bool {
+func (tm *testModule) validateOpenSchema(t *testing.T, event *model.Event) bool {
 	t.Helper()
-	return validateEventSchema(t, event, "file:///schemas/exit.schema.json")
+	return tm.validateEventSchema(t, event, "file:///schemas/open.schema.json")
 }
 
 //nolint:deadcode,unused
-func validateOpenSchema(t *testing.T, event *model.Event) bool {
+func (tm *testModule) validateRenameSchema(t *testing.T, event *model.Event) bool {
 	t.Helper()
-	return validateEventSchema(t, event, "file:///schemas/open.schema.json")
+	return tm.validateEventSchema(t, event, "file:///schemas/rename.schema.json")
 }
 
 //nolint:deadcode,unused
-func validateRenameSchema(t *testing.T, event *model.Event) bool {
+func (tm *testModule) validateChmodSchema(t *testing.T, event *model.Event) bool {
 	t.Helper()
-	return validateEventSchema(t, event, "file:///schemas/rename.schema.json")
+	return tm.validateEventSchema(t, event, "file:///schemas/chmod.schema.json")
 }
 
 //nolint:deadcode,unused
-func validateChmodSchema(t *testing.T, event *model.Event) bool {
+func (tm *testModule) validateChownSchema(t *testing.T, event *model.Event) bool {
 	t.Helper()
-	return validateEventSchema(t, event, "file:///schemas/chmod.schema.json")
+	return tm.validateEventSchema(t, event, "file:///schemas/chown.schema.json")
 }
 
 //nolint:deadcode,unused
-func validateChownSchema(t *testing.T, event *model.Event) bool {
+func (tm *testModule) validateSELinuxSchema(t *testing.T, event *model.Event) bool {
 	t.Helper()
-	return validateEventSchema(t, event, "file:///schemas/chown.schema.json")
+	return tm.validateEventSchema(t, event, "file:///schemas/selinux.schema.json")
 }
 
 //nolint:deadcode,unused
-func validateSELinuxSchema(t *testing.T, event *model.Event) bool {
+func (tm *testModule) validateLinkSchema(t *testing.T, event *model.Event) bool {
 	t.Helper()
-	return validateEventSchema(t, event, "file:///schemas/selinux.schema.json")
+	return tm.validateEventSchema(t, event, "file:///schemas/link.schema.json")
 }
 
 //nolint:deadcode,unused
-func validateLinkSchema(t *testing.T, event *model.Event) bool {
+func (tm *testModule) validateSpanSchema(t *testing.T, event *model.Event) bool {
 	t.Helper()
-	return validateEventSchema(t, event, "file:///schemas/link.schema.json")
+	return tm.validateEventSchema(t, event, "file:///schemas/span.schema.json")
 }
 
 //nolint:deadcode,unused
-func validateSpanSchema(t *testing.T, event *model.Event) bool {
+func (tm *testModule) validateBPFSchema(t *testing.T, event *model.Event) bool {
 	t.Helper()
-	return validateEventSchema(t, event, "file:///schemas/span.schema.json")
+	return tm.validateEventSchema(t, event, "file:///schemas/bpf.schema.json")
 }
 
 //nolint:deadcode,unused
-func validateBPFSchema(t *testing.T, event *model.Event) bool {
+func (tm *testModule) validateMMapSchema(t *testing.T, event *model.Event) bool {
 	t.Helper()
-	return validateEventSchema(t, event, "file:///schemas/bpf.schema.json")
+	return tm.validateEventSchema(t, event, "file:///schemas/mmap.schema.json")
 }
 
 //nolint:deadcode,unused
-func validateMMapSchema(t *testing.T, event *model.Event) bool {
+func (tm *testModule) validateMProtectSchema(t *testing.T, event *model.Event) bool {
 	t.Helper()
-	return validateEventSchema(t, event, "file:///schemas/mmap.schema.json")
+	return tm.validateEventSchema(t, event, "file:///schemas/mprotect.schema.json")
 }
 
 //nolint:deadcode,unused
-func validateMProtectSchema(t *testing.T, event *model.Event) bool {
+func (tm *testModule) validatePTraceSchema(t *testing.T, event *model.Event) bool {
 	t.Helper()
-	return validateEventSchema(t, event, "file:///schemas/mprotect.schema.json")
+	return tm.validateEventSchema(t, event, "file:///schemas/ptrace.schema.json")
 }
 
 //nolint:deadcode,unused
-func validatePTraceSchema(t *testing.T, event *model.Event) bool {
+func (tm *testModule) validateLoadModuleSchema(t *testing.T, event *model.Event) bool {
 	t.Helper()
-	return validateEventSchema(t, event, "file:///schemas/ptrace.schema.json")
+	return tm.validateEventSchema(t, event, "file:///schemas/load_module.schema.json")
 }
 
 //nolint:deadcode,unused
-func validateLoadModuleSchema(t *testing.T, event *model.Event) bool {
+func (tm *testModule) validateLoadModuleNoFileSchema(t *testing.T, event *model.Event) bool {
 	t.Helper()
-	return validateEventSchema(t, event, "file:///schemas/load_module.schema.json")
+	return tm.validateEventSchema(t, event, "file:///schemas/load_module_no_file.schema.json")
 }
 
 //nolint:deadcode,unused
-func validateLoadModuleNoFileSchema(t *testing.T, event *model.Event) bool {
+func (tm *testModule) validateUnloadModuleSchema(t *testing.T, event *model.Event) bool {
 	t.Helper()
-	return validateEventSchema(t, event, "file:///schemas/load_module_no_file.schema.json")
+	return tm.validateEventSchema(t, event, "file:///schemas/unload_module.schema.json")
 }
 
 //nolint:deadcode,unused
-func validateUnloadModuleSchema(t *testing.T, event *model.Event) bool {
+func (tm *testModule) validateSignalSchema(t *testing.T, event *model.Event) bool {
 	t.Helper()
-	return validateEventSchema(t, event, "file:///schemas/unload_module.schema.json")
+	return tm.validateEventSchema(t, event, "file:///schemas/signal.schema.json")
 }
 
 //nolint:deadcode,unused
-func validateSignalSchema(t *testing.T, event *model.Event) bool {
+func (tm *testModule) validateSpliceSchema(t *testing.T, event *model.Event) bool {
 	t.Helper()
-	return validateEventSchema(t, event, "file:///schemas/signal.schema.json")
+	return tm.validateEventSchema(t, event, "file:///schemas/splice.schema.json")
 }
 
 //nolint:deadcode,unused
-func validateSpliceSchema(t *testing.T, event *model.Event) bool {
+func (tm *testModule) validateDNSSchema(t *testing.T, event *model.Event) bool {
 	t.Helper()
-	return validateEventSchema(t, event, "file:///schemas/splice.schema.json")
+	return tm.validateEventSchema(t, event, "file:///schemas/dns.schema.json")
 }
 
 //nolint:deadcode,unused
-func validateDNSSchema(t *testing.T, event *model.Event) bool {
+func (tm *testModule) validateBindSchema(t *testing.T, event *model.Event) bool {
 	t.Helper()
-	return validateEventSchema(t, event, "file:///schemas/dns.schema.json")
+	return tm.validateEventSchema(t, event, "file:///schemas/bind.schema.json")
 }
 
 //nolint:deadcode,unused
-func validateBindSchema(t *testing.T, event *model.Event) bool {
+func (tm *testModule) validateMountSchema(t *testing.T, event *model.Event) bool {
 	t.Helper()
-	return validateEventSchema(t, event, "file:///schemas/bind.schema.json")
+	return tm.validateEventSchema(t, event, "file:///schemas/mount.schema.json")
 }
 
 //nolint:deadcode,unused
-func validateMountSchema(t *testing.T, event *model.Event) bool {
+func validateRuleSetLoadedSchema(t *testing.T, event *events.CustomEvent) bool {
 	t.Helper()
-	return validateEventSchema(t, event, "file:///schemas/mount.schema.json")
+
+	eventJSON, err := probe.MarshalCustomEvent(event)
+	if err != nil {
+		t.Error(err)
+		return false
+	}
+
+	return validateStringSchema(t, string(eventJSON), "file:///schemas/ruleset_loaded.schema.json")
 }
 
 //nolint:deadcode,unused
 func validateActivityDumpProtoSchema(t *testing.T, ad string) bool {
 	t.Helper()
 	return validateStringSchema(t, ad, "file:///schemas/activity_dump_proto.schema.json")
-}
-
-//nolint:deadcode,unused
-func validateRuleSetLoadedSchema(t *testing.T, event *events.CustomEvent) bool {
-	t.Helper()
-	return validateStringSchema(t, event.String(), "file:///schemas/ruleset_loaded.schema.json")
 }

--- a/pkg/security/tests/selinux_test.go
+++ b/pkg/security/tests/selinux_test.go
@@ -76,9 +76,7 @@ func TestSELinux(t *testing.T) {
 			assert.Equal(t, "selinux", event.GetType(), "wrong event type")
 			assertFieldEqual(t, event, "selinux.enforce.status", "permissive", "wrong enforce value")
 
-			if !validateSELinuxSchema(t, event) {
-				t.Error(event.String())
-			}
+			test.validateSELinuxSchema(t, event)
 		})
 	})
 
@@ -92,9 +90,7 @@ func TestSELinux(t *testing.T) {
 			assertTriggeredRule(t, rule, "test_selinux_enforce")
 			assert.Equal(t, "selinux", event.GetType(), "wrong event type")
 
-			if !validateSELinuxSchema(t, event) {
-				t.Error(event.String())
-			}
+			test.validateSELinuxSchema(t, event)
 		})
 	})
 
@@ -110,9 +106,7 @@ func TestSELinux(t *testing.T) {
 			assertFieldEqual(t, event, "selinux.bool.name", TestBoolName, "wrong bool name")
 			assertFieldEqual(t, event, "selinux.bool.state", "on", "wrong bool value")
 
-			if !validateSELinuxSchema(t, event) {
-				t.Error(event.String())
-			}
+			test.validateSELinuxSchema(t, event)
 		})
 	})
 
@@ -128,9 +122,7 @@ func TestSELinux(t *testing.T) {
 			assertFieldEqual(t, event, "selinux.bool.name", TestBoolName, "wrong bool name")
 			assertFieldEqual(t, event, "selinux.bool.state", "off", "wrong bool value")
 
-			if !validateSELinuxSchema(t, event) {
-				t.Error(event.String())
-			}
+			test.validateSELinuxSchema(t, event)
 		})
 	})
 
@@ -187,9 +179,7 @@ func TestSELinuxCommitBools(t *testing.T) {
 			assert.Equal(t, "selinux", event.GetType(), "wrong event type")
 			assertFieldEqual(t, event, "selinux.bool_commit.state", true, "wrong bool value")
 
-			if !validateSELinuxSchema(t, event) {
-				t.Error(event.String())
-			}
+			test.validateSELinuxSchema(t, event)
 		})
 	})
 }

--- a/pkg/security/tests/selinux_test.go
+++ b/pkg/security/tests/selinux_test.go
@@ -133,7 +133,7 @@ func TestSELinux(t *testing.T) {
 			}
 			return nil
 		}, func(event *model.Event, rule *rules.Rule) {
-			t.Errorf("expected error and got an event: %s", event)
+			t.Errorf("expected error and got an event: %s", test.debugEvent(event))
 		})
 		if err == nil {
 			t.Fatal("expected error")

--- a/pkg/security/tests/signal_test.go
+++ b/pkg/security/tests/signal_test.go
@@ -60,9 +60,7 @@ func TestSignalEvent(t *testing.T) {
 			assert.Equal(t, int64(0), event.Signal.Retval, "wrong retval")
 			assert.Equal(t, event.Async, false)
 
-			if !validateSignalSchema(t, event) {
-				t.Error(event.String())
-			}
+			test.validateSignalSchema(t, event)
 		})
 	})
 
@@ -83,9 +81,7 @@ func TestSignalEvent(t *testing.T) {
 			assert.Equal(t, -int64(unix.EPERM), event.Signal.Retval, "wrong retval")
 			assert.Equal(t, event.Async, false)
 
-			if !validateSignalSchema(t, event) {
-				t.Error(event.String())
-			}
+			test.validateSignalSchema(t, event)
 		})
 	})
 }

--- a/pkg/security/tests/span_test.go
+++ b/pkg/security/tests/span_test.go
@@ -67,9 +67,7 @@ func TestSpan(t *testing.T) {
 		}, func(event *model.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_span_rule_open")
 
-			if !validateSpanSchema(t, event) {
-				t.Error(event.String())
-			}
+			test.validateSpanSchema(t, event)
 
 			assert.Equal(t, uint64(204), event.SpanContext.SpanID)
 			assert.Equal(t, uint64(104), event.SpanContext.TraceID)
@@ -101,9 +99,7 @@ func TestSpan(t *testing.T) {
 		}, func(event *model.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_span_rule_exec")
 
-			if !validateSpanSchema(t, event) {
-				t.Error(event.String())
-			}
+			test.validateSpanSchema(t, event)
 
 			assert.Equal(t, uint64(204), event.SpanContext.SpanID)
 			assert.Equal(t, uint64(104), event.SpanContext.TraceID)

--- a/pkg/security/tests/splice_test.go
+++ b/pkg/security/tests/splice_test.go
@@ -45,9 +45,7 @@ func TestSpliceEvent(t *testing.T) {
 			assert.Equal(t, uint32(0), event.Splice.PipeExitFlag, "wrong pipe exit flag")
 			assert.Equal(t, event.Async, false)
 
-			if !validateSpliceSchema(t, event) {
-				t.Error(event.String())
-			}
+			test.validateSpliceSchema(t, event)
 		})
 	})
 }


### PR DESCRIPTION
### What does this PR do?

This PR reverses the way we serialize (JSON) the event by letting the control on the serialization on the caller (who most likely has access to the `*Probe`), instead of letting the event itself decide (and sometime decide wrong for the `policy eval` case).

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
