### PR TITLE
[CWS] rework/cleanup `FieldHandlers`

### DIFF
--- a/pkg/security/probe/field_handlers.go
+++ b/pkg/security/probe/field_handlers.go
@@ -19,7 +19,6 @@ import (
 )
 
 type FieldHandlers struct {
-	probe     *Probe
 	resolvers *Resolvers
 }
 

--- a/pkg/security/probe/model_test.go
+++ b/pkg/security/probe/model_test.go
@@ -74,7 +74,7 @@ func TestProcessArgsFlags(t *testing.T) {
 	})
 
 	resolver, _ := NewProcessResolver(&manager.Manager{}, &config.Config{}, &statsd.NoOpClient{},
-		&procutil.DataScrubber{}, nil, NewProcessResolverOpts(nil))
+		&procutil.DataScrubber{}, NewProcessResolverOpts(nil))
 
 	e := model.Event{
 		Exec: model.ExecEvent{
@@ -135,7 +135,7 @@ func TestProcessArgsOptions(t *testing.T) {
 	})
 
 	resolver, _ := NewProcessResolver(&manager.Manager{}, &config.Config{}, &statsd.NoOpClient{},
-		&procutil.DataScrubber{}, nil, NewProcessResolverOpts(nil))
+		&procutil.DataScrubber{}, NewProcessResolverOpts(nil))
 
 	e := model.Event{
 		Exec: model.ExecEvent{

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -1393,7 +1393,7 @@ func NewProbe(config *config.Config, statsdClient statsd.ClientInterface) (*Prob
 	}
 	p.resolvers = resolvers
 
-	p.fieldHandlers = &FieldHandlers{probe: p, resolvers: resolvers}
+	p.fieldHandlers = &FieldHandlers{resolvers: resolvers}
 
 	// be sure to zero the probe event before everything else
 	p.zeroEvent()

--- a/pkg/security/probe/process_resolver.go
+++ b/pkg/security/probe/process_resolver.go
@@ -1289,7 +1289,7 @@ func (p *ProcessResolver) NewProcessVariables(scoper func(ctx *eval.Context) uns
 
 // NewProcessResolver returns a new process resolver
 func NewProcessResolver(manager *manager.Manager, config *config.Config, statsdClient statsd.ClientInterface,
-	scrubber *procutil.DataScrubber, resolvers *Resolvers, opts ProcessResolverOpts) (*ProcessResolver, error) {
+	scrubber *procutil.DataScrubber, opts ProcessResolverOpts) (*ProcessResolver, error) {
 	argsEnvsCache, err := simplelru.NewLRU[uint32, *model.ArgsEnvsCacheEntry](maxParallelArgsEnvs, nil)
 	if err != nil {
 		return nil, err
@@ -1300,7 +1300,6 @@ func NewProcessResolver(manager *manager.Manager, config *config.Config, statsdC
 		config:         config,
 		statsdClient:   statsdClient,
 		scrubber:       scrubber,
-		resolvers:      resolvers,
 		entryCache:     make(map[uint32]*model.ProcessCacheEntry),
 		opts:           opts,
 		argsEnvsCache:  argsEnvsCache,

--- a/pkg/security/probe/process_resolver_test.go
+++ b/pkg/security/probe/process_resolver_test.go
@@ -34,7 +34,7 @@ func testCacheSize(t *testing.T, resolver *ProcessResolver) {
 }
 
 func TestFork1st(t *testing.T) {
-	resolver, err := NewProcessResolver(nil, nil, &statsd.NoOpClient{}, nil, nil, NewProcessResolverOpts(nil))
+	resolver, err := NewProcessResolver(nil, nil, &statsd.NoOpClient{}, nil, NewProcessResolverOpts(nil))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -73,7 +73,7 @@ func TestFork1st(t *testing.T) {
 }
 
 func TestFork2nd(t *testing.T) {
-	resolver, err := NewProcessResolver(nil, nil, &statsd.NoOpClient{}, nil, nil, NewProcessResolverOpts(nil))
+	resolver, err := NewProcessResolver(nil, nil, &statsd.NoOpClient{}, nil, NewProcessResolverOpts(nil))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -114,7 +114,7 @@ func TestFork2nd(t *testing.T) {
 }
 
 func TestForkExec(t *testing.T) {
-	resolver, err := NewProcessResolver(nil, nil, &statsd.NoOpClient{}, nil, nil, NewProcessResolverOpts(nil))
+	resolver, err := NewProcessResolver(nil, nil, &statsd.NoOpClient{}, nil, NewProcessResolverOpts(nil))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -169,7 +169,7 @@ func TestForkExec(t *testing.T) {
 }
 
 func TestOrphanExec(t *testing.T) {
-	resolver, err := NewProcessResolver(nil, nil, &statsd.NoOpClient{}, nil, nil, NewProcessResolverOpts(nil))
+	resolver, err := NewProcessResolver(nil, nil, &statsd.NoOpClient{}, nil, NewProcessResolverOpts(nil))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -224,7 +224,7 @@ func TestOrphanExec(t *testing.T) {
 }
 
 func TestForkExecExec(t *testing.T) {
-	resolver, err := NewProcessResolver(nil, nil, &statsd.NoOpClient{}, nil, nil, NewProcessResolverOpts(nil))
+	resolver, err := NewProcessResolver(nil, nil, &statsd.NoOpClient{}, nil, NewProcessResolverOpts(nil))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -293,7 +293,7 @@ func TestForkExecExec(t *testing.T) {
 }
 
 func TestForkReuse(t *testing.T) {
-	resolver, err := NewProcessResolver(nil, nil, &statsd.NoOpClient{}, nil, nil, NewProcessResolverOpts(nil))
+	resolver, err := NewProcessResolver(nil, nil, &statsd.NoOpClient{}, nil, NewProcessResolverOpts(nil))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -387,7 +387,7 @@ func TestForkReuse(t *testing.T) {
 }
 
 func TestForkForkExec(t *testing.T) {
-	resolver, err := NewProcessResolver(nil, nil, &statsd.NoOpClient{}, nil, nil, NewProcessResolverOpts(nil))
+	resolver, err := NewProcessResolver(nil, nil, &statsd.NoOpClient{}, nil, NewProcessResolverOpts(nil))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/probe/resolvers.go
+++ b/pkg/security/probe/resolvers.go
@@ -23,11 +23,12 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	manager "github.com/DataDog/ebpf-manager"
 )
 
 // Resolvers holds the list of the event attribute resolvers
 type Resolvers struct {
-	probe             *Probe
+	manager           *manager.Manager
 	MountResolver     *resolvers.MountResolver
 	ContainerResolver *resolvers.ContainerResolver
 	TimeResolver      *resolvers.TimeResolver
@@ -81,7 +82,7 @@ func NewResolvers(config *config.Config, probe *Probe) (*Resolvers, error) {
 	}
 
 	resolvers := &Resolvers{
-		probe:             probe,
+		manager:           probe.Manager,
 		MountResolver:     mountResolver,
 		ContainerResolver: &resolvers.ContainerResolver{},
 		TimeResolver:      timeResolver,
@@ -201,7 +202,7 @@ func (r *Resolvers) Start(ctx context.Context) error {
 		return err
 	}
 
-	if err := r.DentryResolver.Start(r.probe.Manager); err != nil {
+	if err := r.DentryResolver.Start(r.manager); err != nil {
 		return err
 	}
 
@@ -217,7 +218,7 @@ func (r *Resolvers) Snapshot() error {
 	r.ProcessResolver.SetState(snapshotted)
 	r.NamespaceResolver.SetState(snapshotted)
 
-	selinuxStatusMap, err := managerhelper.Map(r.probe.Manager, "selinux_enforce_status")
+	selinuxStatusMap, err := managerhelper.Map(r.manager, "selinux_enforce_status")
 	if err != nil {
 		return fmt.Errorf("unable to snapshot SELinux: %w", err)
 	}

--- a/pkg/security/probe/resolvers.go
+++ b/pkg/security/probe/resolvers.go
@@ -74,6 +74,12 @@ func NewResolvers(config *config.Config, probe *Probe) (*Resolvers, error) {
 
 	tcResolver := resolvers.NewTCResolver(config)
 
+	processResolver, err := NewProcessResolver(probe.Manager, probe.Config, probe.StatsdClient,
+		probe.scrubber, NewProcessResolverOpts(probe.Config.EnvsWithValue))
+	if err != nil {
+		return nil, err
+	}
+
 	resolvers := &Resolvers{
 		probe:             probe,
 		MountResolver:     mountResolver,
@@ -85,14 +91,10 @@ func NewResolvers(config *config.Config, probe *Probe) (*Resolvers, error) {
 		NamespaceResolver: namespaceResolver,
 		CgroupsResolver:   cgroupsResolver,
 		TCResolver:        tcResolver,
+		ProcessResolver:   processResolver,
 	}
 
-	processResolver, err := NewProcessResolver(probe.Manager, probe.Config, probe.StatsdClient,
-		probe.scrubber, resolvers, NewProcessResolverOpts(probe.Config.EnvsWithValue))
-	if err != nil {
-		return nil, err
-	}
-	resolvers.ProcessResolver = processResolver
+	resolvers.ProcessResolver.resolvers = resolvers
 
 	return resolvers, nil
 }


### PR DESCRIPTION
### What does this PR do?

Small cleanup so that `FieldHandlers` do not have access to `*Probe`, and the resolvers only need `*Manager`

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
