### PR TITLE
Add telemetry for number of contexts per origin

### DIFF
--- a/pkg/aggregator/context_resolver.go
+++ b/pkg/aggregator/context_resolver.go
@@ -111,6 +111,36 @@ func (cr *contextResolver) release() {
 	}
 }
 
+func (c *contextResolver) sendOriginTelemetry(timestamp float64, series metrics.SerieSink, hostname string, constTags []string) {
+	// Within the contextResolver, each set of tags is represented by a unique pointer.
+	perOrigin := map[*tags.Entry]uint64{}
+	for _, cx := range c.contextsByKey {
+		perOrigin[cx.taggerTags]++
+	}
+
+	// We send metrics directly to the sink, instead of using
+	// pkg/telemetry for a few reasons:
+	//
+	// 1. We can send full set of tagger tags for higher level
+	//    aggregations (pod, namespace, etc). pkg/telemetry only
+	//    allows a fixed set of tags.
+	// 2. Avoid the need to manually create and delete tag values
+	//    inside a telemetry Gauge.
+	// 3. Cardinality is automatically limited to origins verified by
+	//    the tagger (although broken applications sending invalid
+	//    origin id would coalesce to no origin, making this less
+	//    useful for troubleshooting).
+	for entry, count := range perOrigin {
+		series.Append(&metrics.Serie{
+			Name:   "datadog.agent.aggregator.dogstatsd_contexts_by_origin",
+			Host:   hostname,
+			Tags:   tagset.NewCompositeTags(constTags, entry.Tags()),
+			MType:  metrics.APIGaugeType,
+			Points: []metrics.Point{{Ts: timestamp, Value: float64(count)}},
+		})
+	}
+}
+
 // timestampContextResolver allows tracking and expiring contexts based on time.
 type timestampContextResolver struct {
 	resolver      *contextResolver
@@ -175,6 +205,10 @@ func (cr *timestampContextResolver) expireContexts(expireTimestamp float64, keep
 	}
 
 	return expiredContextKeys
+}
+
+func (cr *timestampContextResolver) sendOriginTelemetry(timestamp float64, series metrics.SerieSink, hostname string, tags []string) {
+	cr.resolver.sendOriginTelemetry(timestamp, series, hostname, tags)
 }
 
 // countBasedContextResolver allows tracking and expiring contexts based on the number

--- a/pkg/aggregator/demultiplexer_agent.go
+++ b/pkg/aggregator/demultiplexer_agent.go
@@ -169,7 +169,7 @@ func initAgentDemultiplexer(options AgentDemultiplexerOptions, hostname string) 
 		sharedForwarder = forwarder.NewDefaultForwarder(options.SharedForwarderOptions)
 	}
 
-	if config.Datadog.GetBool("telemetry.dogstatsd_origin") && !config.Datadog.GetBool("aggregator_use_tags_store") {
+	if config.Datadog.GetBool("telemetry.enabled") && config.Datadog.GetBool("telemetry.dogstatsd_origin") && !config.Datadog.GetBool("aggregator_use_tags_store") {
 		log.Warn("DogStatsD origin telemetry is not supported when aggregator_use_tags_store is disabled.")
 		config.Datadog.Set("telemetry.dogstatsd_origin", false)
 	}

--- a/pkg/aggregator/demultiplexer_agent.go
+++ b/pkg/aggregator/demultiplexer_agent.go
@@ -169,6 +169,11 @@ func initAgentDemultiplexer(options AgentDemultiplexerOptions, hostname string) 
 		sharedForwarder = forwarder.NewDefaultForwarder(options.SharedForwarderOptions)
 	}
 
+	if config.Datadog.GetBool("telemetry.dogstatsd_origin") && !config.Datadog.GetBool("aggregator_use_tags_store") {
+		log.Warn("DogStatsD origin telemetry is not supported when aggregator_use_tags_store is disabled.")
+		config.Datadog.Set("telemetry.dogstatsd_origin", false)
+	}
+
 	// prepare the serializer
 	// ----------------------
 
@@ -193,7 +198,7 @@ func initAgentDemultiplexer(options AgentDemultiplexerOptions, hostname string) 
 	for i := 0; i < statsdPipelinesCount; i++ {
 		// the sampler
 		tagsStore := tags.NewStore(config.Datadog.GetBool("aggregator_use_tags_store"), fmt.Sprintf("timesampler #%d", i))
-		statsdSampler := NewTimeSampler(TimeSamplerID(i), bucketSize, tagsStore)
+		statsdSampler := NewTimeSampler(TimeSamplerID(i), bucketSize, tagsStore, agg.hostname)
 
 		// its worker (process loop + flush/serialization mechanism)
 

--- a/pkg/aggregator/demultiplexer_serverless.go
+++ b/pkg/aggregator/demultiplexer_serverless.go
@@ -43,7 +43,7 @@ func InitAndStartServerlessDemultiplexer(domainResolvers map[string]resolver.Dom
 	metricSamplePool := metrics.NewMetricSamplePool(MetricSamplePoolBatchSize)
 	tagsStore := tags.NewStore(config.Datadog.GetBool("aggregator_use_tags_store"), "timesampler")
 
-	statsdSampler := NewTimeSampler(TimeSamplerID(0), bucketSize, tagsStore)
+	statsdSampler := NewTimeSampler(TimeSamplerID(0), bucketSize, tagsStore, "")
 	flushAndSerializeInParallel := NewFlushAndSerializeInParallel(config.Datadog)
 	statsdWorker := newTimeSamplerWorker(statsdSampler, DefaultFlushInterval, bufferSize, metricSamplePool, flushAndSerializeInParallel, tagsStore)
 

--- a/pkg/aggregator/time_sampler.go
+++ b/pkg/aggregator/time_sampler.go
@@ -235,7 +235,7 @@ func (s *TimeSampler) flush(timestamp float64, series metrics.SerieSink, sketche
 		tlmDogstatsdContextsByMtype.Set(float64(count), mtype)
 	}
 
-	if config.Datadog.GetBool("telemetry.dogstatsd_origin") {
+	if config.Datadog.GetBool("telemetry.enabled") && config.Datadog.GetBool("telemetry.dogstatsd_origin") {
 		s.sendOriginTelemetry(timestamp, series)
 	}
 }

--- a/pkg/aggregator/time_sampler_test.go
+++ b/pkg/aggregator/time_sampler_test.go
@@ -33,7 +33,7 @@ func generateSerieContextKey(serie *metrics.Serie) ckey.ContextKey {
 }
 
 func testTimeSampler() *TimeSampler {
-	sampler := NewTimeSampler(TimeSamplerID(0), 10, tags.NewStore(false, "test"))
+	sampler := NewTimeSampler(TimeSamplerID(0), 10, tags.NewStore(false, "test"), "host")
 	return sampler
 }
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Report number of contexts at the end of flush for each container
sending dogstatsd metrics.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Improve visibility into how different applications use agent memory.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

This PR relies on origin detection to provide a set of identifying
tags for each origin, and reports number of distinct contexts for each
tag set. While this may not fully identify individual origins when
running with low tagger cardinality, it accurately reflects the way
agent would aggregate metrics from different origins together if their
tags end up the same.

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Run the agent on Docker/K8s with 
```
DD_TELEMETRY_ENABLED=true
DD_TELEMETRY_DOGSTATSD_ORIGIN=true
DD_DOGSTATSD_SOCKET=/tmp/dsd.sock
DD_DOGSTATSD_ORIGIN_DETECTION=true
DD_DOGSTATSD_TAG_CARDINALITY=high
DD_LOG_LEVEL=debug
DD_LOG_PAYLOADS=true
```

Send metrics from several containers.

```
docker run --rm -v /tmp:/tmp python:slim python3 -c \
'from socket import *; s=socket(AF_UNIX, SOCK_DGRAM); s.connect("/tmp/dsd.sock"); s.send(b"foo.baz:1|g\n");s.send(b"foo.bar:1|c\n")'
```

 Check that a metric `datadog.agent.aggregator.dogstatsd_contexts_by_origin` is present, has the same container tags as the metrics sent, and correctly displays number of metrics sent by each container.

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
