### PR TITLE
pkg/obfuscate: Fix parsing of sqlserver identifiers enclosed in square brackets

### DIFF
--- a/pkg/obfuscate/sql_tokenizer.go
+++ b/pkg/obfuscate/sql_tokenizer.go
@@ -323,7 +323,12 @@ func (tkn *SQLTokenizer) Scan() (TokenKind, []byte) {
 				}
 			}
 			fallthrough
-		case '=', ',', ';', '(', ')', '+', '*', '&', '|', '^', '[', ']':
+		case '=', ',', ';', '(', ')', '+', '*', '&', '|', '^', ']':
+			return TokenKind(ch), tkn.bytes()
+		case '[':
+			if tkn.cfg.DBMS == DBMSSQLServer {
+				return tkn.scanString(']', DoubleQuotedString)
+			}
 			return TokenKind(ch), tkn.bytes()
 		case '.':
 			if isDigit(tkn.lastChar) {

--- a/releasenotes/notes/apm-fix-parsing-sqlserver-identifiers-square-brackets-a2ee7a4f029694e1.yaml
+++ b/releasenotes/notes/apm-fix-parsing-sqlserver-identifiers-square-brackets-a2ee7a4f029694e1.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    APM: Fix parsing of SQL Server identifiers enclosed in square brackets.

--- a/releasenotes/notes/apm-fix-sql-parsing-of-sqlserver-identifiers-in-square-brackets-8c625935e0bebbf7.yaml
+++ b/releasenotes/notes/apm-fix-sql-parsing-of-sqlserver-identifiers-in-square-brackets-8c625935e0bebbf7.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    APM: Fix parsing of sqlserver identifiers enclosed in square brackets.

--- a/releasenotes/notes/apm-fix-sql-parsing-of-sqlserver-identifiers-in-square-brackets-8c625935e0bebbf7.yaml
+++ b/releasenotes/notes/apm-fix-sql-parsing-of-sqlserver-identifiers-in-square-brackets-8c625935e0bebbf7.yaml
@@ -1,4 +1,0 @@
----
-fixes:
-  - |
-    APM: Fix parsing of sqlserver identifiers enclosed in square brackets.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
This PR fixes the parsing of sqlserver identifiers enclosed in square brackets. Prior to this change, extraction of table names that are wrapped in square brackets would just return `null` instead of the correct list of table names. 

To give a concrete example, here's some test data from a real environment where we see that a dbm sample for the query `SELECT * FROM [ dbm_user ] WHERE [ id ] = @1` has `"tables": null` instead of the expected `"tables": ["dbm_user"]`:

```json
    "db": {
        "instance": "dbmorders_1",
        "metadata": {
          "commands": [
            "SELECT"
          ],
          "comments": null,
          "tables": null
        },
        "procedure_name": null,
        "procedure_signature": null,
        "query_signature": "adfc8701466793b3",
        "statement": "SELECT * FROM [ dbm_user ] WHERE [ id ] = @1"
      },
```
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
We got a support escalation reporting that dbm query metrics and query samples where tables were enclosed in square brackets were missing `tables` metadata. 

### Additional Notes

The change in logic during the tokenization is done only for SQL Server and not other DBMSes because SQL Server uses square brackets as identifier delimiters but other DBMSes like Postgres use square brackets for array literals. The new logic is therefore applicable only to SQL Server.

### Possible Drawbacks / Trade-offs

The obfuscator has good test coverage so all existing test cases are good to have confidence that the changes don't introduce regressions but it's always a possibility. Having the different parsing logic be specific to SQL Server helps make regressions much less likely.

### Describe how to test/QA your changes

DBM will be doing the QA and we'll use our internal integration environment where we have a test application running queries with table names enclosed in square brackets. We also use this environment and look for new obfuscation errors during the agent release.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
