### PR TITLE
Reorganize the specs for some kitchen test

### DIFF
--- a/test/kitchen/test/integration/common/rspec/spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec/spec_helper.rb
@@ -559,6 +559,13 @@ shared_examples_for "a running Agent with APM" do
   end
 end
 
+shared_examples_for "a running Agent with process enabled" do
+  it 'has the process agent running' do
+    expect(is_process_running?("process-agent.exe")).to be_truthy
+    expect(is_service_running?("datadog-process-agent")).to be_truthy
+  end
+end
+
 shared_examples_for "a running Agent with APM manually disabled" do
   it 'is not bound to the port that receives traces when apm_enabled is set to false' do
     conf_path = ""
@@ -868,10 +875,6 @@ shared_examples_for 'an Agent with process enabled' do
     expect(confYaml["process_config"]).to have_key("process_collection")
     expect(confYaml["process_config"]["process_collection"]).to have_key("enabled")
     expect(confYaml["process_config"]["process_collection"]["enabled"]).to be_truthy
-  end
-  it 'has the process agent running' do
-    expect(is_process_running?("process-agent.exe")).to be_truthy
-    expect(is_service_running?("datadog-process-agent")).to be_truthy
   end
 end
 

--- a/test/kitchen/test/integration/common/rspec/spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec/spec_helper.rb
@@ -550,9 +550,11 @@ shared_examples_for "a running Agent with no errors" do
 end
 
 shared_examples_for "a running Agent with APM" do
-  it 'has the apm agent running' do
-    expect(is_process_running?("trace-agent.exe")).to be_truthy
-    expect(is_service_running?("datadog-trace-agent")).to be_truthy
+  if os == :windows
+    it 'has the apm agent running' do
+      expect(is_process_running?("trace-agent.exe")).to be_truthy
+      expect(is_service_running?("datadog-trace-agent")).to be_truthy
+    end
   end
   it 'is bound to the port that receives traces by default' do
     expect(is_port_bound(8126)).to be_truthy

--- a/test/kitchen/test/integration/common/rspec/spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec/spec_helper.rb
@@ -550,6 +550,10 @@ shared_examples_for "a running Agent with no errors" do
 end
 
 shared_examples_for "a running Agent with APM" do
+  it 'has the apm agent running' do
+    expect(is_process_running?("trace-agent.exe")).to be_truthy
+    expect(is_service_running?("datadog-trace-agent")).to be_truthy
+  end
   it 'is bound to the port that receives traces by default' do
     expect(is_port_bound(8126)).to be_truthy
   end
@@ -845,11 +849,6 @@ shared_examples_for 'an Agent with APM enabled' do
     expect(confYaml).to have_key("apm_config")
     expect(confYaml["apm_config"]).to have_key("enabled")
     expect(confYaml["apm_config"]["enabled"]).to be_truthy
-    expect(is_port_bound(8126)).to be_truthy
-  end
-  it 'has the apm agent running' do
-    expect(is_process_running?("trace-agent.exe")).to be_truthy
-    expect(is_service_running?("datadog-trace-agent")).to be_truthy
   end
 end
 

--- a/test/kitchen/test/integration/win-all-subservices/rspec/win-all-subservices_spec.rb
+++ b/test/kitchen/test/integration/win-all-subservices/rspec/win-all-subservices_spec.rb
@@ -9,5 +9,6 @@ describe 'win-all-subservices' do
   it_behaves_like 'an Agent with process enabled'
   it_behaves_like 'a running Agent with no errors'
   it_behaves_like 'a running Agent with APM'
+  it_behaves_like 'a running Agent with process enabled'
 end
   

--- a/test/kitchen/test/integration/win-all-subservices/rspec/win-all-subservices_spec.rb
+++ b/test/kitchen/test/integration/win-all-subservices/rspec/win-all-subservices_spec.rb
@@ -4,9 +4,10 @@ require_relative 'spec_helper'
 
 describe 'win-all-subservices' do
   it_behaves_like 'an installed Agent'
-  it_behaves_like 'a running Agent with no errors'
   it_behaves_like 'an Agent with APM enabled'
   it_behaves_like 'an Agent with logs enabled'
   it_behaves_like 'an Agent with process enabled'
+  it_behaves_like 'a running Agent with no errors'
+  it_behaves_like 'a running Agent with APM'
 end
   

--- a/test/kitchen/test/integration/win-user/rspec/win-user_spec.rb
+++ b/test/kitchen/test/integration/win-user/rspec/win-user_spec.rb
@@ -148,9 +148,10 @@ shared_examples_for 'an Agent with valid permissions' do
 end
 describe 'dd-agent-win-user' do
 #  it_behaves_like 'an installed Agent'
-  it_behaves_like 'a running Agent with no errors'
   it_behaves_like 'an Agent with APM enabled'
   it_behaves_like 'an Agent with process enabled'
   it_behaves_like 'an Agent with valid permissions'
+  it_behaves_like 'a running Agent with no errors'
+  it_behaves_like 'a running Agent with APM'
 end
   

--- a/test/kitchen/test/integration/win-user/rspec/win-user_spec.rb
+++ b/test/kitchen/test/integration/win-user/rspec/win-user_spec.rb
@@ -153,5 +153,6 @@ describe 'dd-agent-win-user' do
   it_behaves_like 'an Agent with valid permissions'
   it_behaves_like 'a running Agent with no errors'
   it_behaves_like 'a running Agent with APM'
+  it_behaves_like 'a running Agent with process enabled'
 end
   


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
This PR refactors the rspecs for the kitchen specs for APM & process to clarify what they do, and reorders some expectations to first test the configuration, then test the agent processes.
This allows for more granular testing and better error reporting when something fails.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Better kitchen tests.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
