### PR TITLE
[AD/prometheus] Ignore headless services

### DIFF
--- a/pkg/autodiscovery/common/utils/prometheus_apiserver.go
+++ b/pkg/autodiscovery/common/utils/prometheus_apiserver.go
@@ -34,6 +34,13 @@ func ConfigsForService(pc *types.PrometheusCheck, svc *v1.Service) []integration
 		return configs
 	}
 
+	// Ignore headless services because we can't resolve the IP.
+	// Ref: https://kubernetes.io/docs/concepts/services-networking/service/#headless-services
+	if svc.Spec.ClusterIP == "None" {
+		log.Debugf("ignoring Prometheus-annotated headless service: %s", namespacedName)
+		return configs
+	}
+
 	instances, found := buildInstances(pc, svc.GetAnnotations(), namespacedName)
 	if found {
 		serviceID := apiserver.EntityForService(svc)

--- a/pkg/autodiscovery/common/utils/prometheus_apiserver_test.go
+++ b/pkg/autodiscovery/common/utils/prometheus_apiserver_test.go
@@ -201,6 +201,23 @@ func TestConfigsForService(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:    "headless service is ignored",
+			check:   types.DefaultPrometheusCheck,
+			version: 1,
+			svc: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					UID:         k8stypes.UID("foo-uid"),
+					Name:        "svc-foo",
+					Annotations: map[string]string{"prometheus.io/scrape": "true"},
+					Namespace:   "ns",
+				},
+				Spec: corev1.ServiceSpec{
+					ClusterIP: "None",
+				},
+			},
+			want: nil,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/releasenotes/notes/ignore-prometheus-headless-services-6733bb93198c76f4.yaml
+++ b/releasenotes/notes/ignore-prometheus-headless-services-6733bb93198c76f4.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    The Openmetrics check is no longer scheduled for Kubernetes headless services.


### PR DESCRIPTION
### What does this PR do?

Ignores headless services (`clusterIP=None`) in the `prometheus-services` autodiscovery provider.

Currently, when a headless service is annotated with `prometheus.io/scrape=true`, the agent schedules an openmetrics check with an incorrect URL like `None:9090/metrics`.


### Describe how to test/QA your changes

- Deploy the agent in Kubernetes with prometheus scraping enabled (`datadog.prometheusScrape.enabled` when using the Helm chart).
- Create a headless service and check with `agent status` that there isn't an openmetrics check with an incorrect url

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
