### PR TITLE
[CWS][SEC-5001] Add container.created_at attribute

### DIFF
--- a/docs/cloud-workload-security/agent_expressions.md
+++ b/docs/cloud-workload-security/agent_expressions.md
@@ -169,6 +169,7 @@ The *file.rights* attribute can now be used in addition to *file.mode*. *file.mo
 | Property | Definition |
 | -------- | ------------- |
 | [`async`](#async-doc) | True if the syscall was asynchronous |
+| [`container.created_at`](#container-created_at-doc) | Timestamp of the creation of the container |
 | [`container.id`](#container-id-doc) | ID of the container |
 | [`container.tags`](#container-tags-doc) | Tags of the container |
 | [`network.destination.ip`](#common-ipportcontext-ip-doc) | IP address |
@@ -2257,6 +2258,13 @@ Definition: New UID of the chown-ed file's owner
 Type: string
 
 Definition: New user of the chown-ed file's owner
+
+
+
+### `container.created_at` {#container-created_at-doc}
+Type: int
+
+Definition: Timestamp of the creation of the container
 
 
 

--- a/docs/cloud-workload-security/backend.md
+++ b/docs/cloud-workload-security/backend.md
@@ -104,6 +104,11 @@ CWS logs have the following JSON schema:
                 "id": {
                     "type": "string",
                     "description": "Container ID"
+                },
+                "created_at": {
+                    "type": "string",
+                    "format": "date-time",
+                    "description": "Creation time of the container"
                 }
             },
             "additionalProperties": false,
@@ -1376,6 +1381,11 @@ CWS logs have the following JSON schema:
         "id": {
             "type": "string",
             "description": "Container ID"
+        },
+        "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Creation time of the container"
         }
     },
     "additionalProperties": false,
@@ -1388,6 +1398,7 @@ CWS logs have the following JSON schema:
 | Field | Description |
 | ----- | ----------- |
 | `id` | Container ID |
+| `created_at` | Creation time of the container |
 
 
 ## `DDContext`

--- a/docs/cloud-workload-security/backend.schema.json
+++ b/docs/cloud-workload-security/backend.schema.json
@@ -88,6 +88,11 @@
         "id": {
           "type": "string",
           "description": "Container ID"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Creation time of the container"
         }
       },
       "additionalProperties": false,

--- a/docs/cloud-workload-security/secl.json
+++ b/docs/cloud-workload-security/secl.json
@@ -13,6 +13,11 @@
           "property_doc_link": "async-doc"
         },
         {
+          "name": "container.created_at",
+          "definition": "Timestamp of the creation of the container",
+          "property_doc_link": "container-created_at-doc"
+        },
+        {
           "name": "container.id",
           "definition": "ID of the container",
           "property_doc_link": "container-id-doc"
@@ -7941,6 +7946,18 @@
       "definition": "New user of the chown-ed file's owner",
       "prefixes": [
         "chown"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "container.created_at",
+      "link": "container-created_at-doc",
+      "type": "int",
+      "definition": "Timestamp of the creation of the container",
+      "prefixes": [
+        "container"
       ],
       "constants": "",
       "constants_link": "",

--- a/pkg/security/activitydump/manager_test.go
+++ b/pkg/security/activitydump/manager_test.go
@@ -220,11 +220,11 @@ func TestActivityDumpManager_getOverweightDumps(t *testing.T) {
 			"one_dump/one_overweight_dump",
 			fields{
 				activeDumps: []*ActivityDump{
-					{Mutex: &sync.Mutex{}, DumpMetadata: DumpMetadata{Name: "1"}, nodeStats: ActivityDumpNodeStats{processNodes: 2}},
+					{Mutex: &sync.Mutex{}, DumpMetadata: DumpMetadata{Name: "1"}, nodeStats: ActivityDumpNodeStats{processNodes: 3}},
 				},
 			},
 			[]*ActivityDump{
-				{DumpMetadata: DumpMetadata{Name: "1"}, nodeStats: ActivityDumpNodeStats{processNodes: 2}},
+				{DumpMetadata: DumpMetadata{Name: "1"}, nodeStats: ActivityDumpNodeStats{processNodes: 3}},
 			},
 			[]*ActivityDump{},
 		},
@@ -264,19 +264,19 @@ func TestActivityDumpManager_getOverweightDumps(t *testing.T) {
 			"5_dumps/5_overweight_dumps",
 			fields{
 				activeDumps: []*ActivityDump{
-					{Mutex: &sync.Mutex{}, DumpMetadata: DumpMetadata{Name: "1"}, nodeStats: ActivityDumpNodeStats{processNodes: 2}},
+					{Mutex: &sync.Mutex{}, DumpMetadata: DumpMetadata{Name: "1"}, nodeStats: ActivityDumpNodeStats{processNodes: 3}},
 					{Mutex: &sync.Mutex{}, DumpMetadata: DumpMetadata{Name: "2"}, nodeStats: ActivityDumpNodeStats{processNodes: 3}},
-					{Mutex: &sync.Mutex{}, DumpMetadata: DumpMetadata{Name: "3"}, nodeStats: ActivityDumpNodeStats{processNodes: 2}},
+					{Mutex: &sync.Mutex{}, DumpMetadata: DumpMetadata{Name: "3"}, nodeStats: ActivityDumpNodeStats{processNodes: 3}},
 					{Mutex: &sync.Mutex{}, DumpMetadata: DumpMetadata{Name: "4"}, nodeStats: ActivityDumpNodeStats{processNodes: 3}},
-					{Mutex: &sync.Mutex{}, DumpMetadata: DumpMetadata{Name: "5"}, nodeStats: ActivityDumpNodeStats{processNodes: 2}},
+					{Mutex: &sync.Mutex{}, DumpMetadata: DumpMetadata{Name: "5"}, nodeStats: ActivityDumpNodeStats{processNodes: 3}},
 				},
 			},
 			[]*ActivityDump{
-				{DumpMetadata: DumpMetadata{Name: "1"}, nodeStats: ActivityDumpNodeStats{processNodes: 2}},
+				{DumpMetadata: DumpMetadata{Name: "1"}, nodeStats: ActivityDumpNodeStats{processNodes: 3}},
 				{DumpMetadata: DumpMetadata{Name: "2"}, nodeStats: ActivityDumpNodeStats{processNodes: 3}},
-				{DumpMetadata: DumpMetadata{Name: "3"}, nodeStats: ActivityDumpNodeStats{processNodes: 2}},
+				{DumpMetadata: DumpMetadata{Name: "3"}, nodeStats: ActivityDumpNodeStats{processNodes: 3}},
 				{DumpMetadata: DumpMetadata{Name: "4"}, nodeStats: ActivityDumpNodeStats{processNodes: 3}},
-				{DumpMetadata: DumpMetadata{Name: "5"}, nodeStats: ActivityDumpNodeStats{processNodes: 2}},
+				{DumpMetadata: DumpMetadata{Name: "5"}, nodeStats: ActivityDumpNodeStats{processNodes: 3}},
 			},
 			[]*ActivityDump{},
 		},
@@ -287,13 +287,13 @@ func TestActivityDumpManager_getOverweightDumps(t *testing.T) {
 					{Mutex: &sync.Mutex{}, DumpMetadata: DumpMetadata{Name: "1"}},
 					{Mutex: &sync.Mutex{}, DumpMetadata: DumpMetadata{Name: "2"}, nodeStats: ActivityDumpNodeStats{processNodes: 3}},
 					{Mutex: &sync.Mutex{}, DumpMetadata: DumpMetadata{Name: "3"}},
-					{Mutex: &sync.Mutex{}, DumpMetadata: DumpMetadata{Name: "4"}, nodeStats: ActivityDumpNodeStats{processNodes: 2}},
+					{Mutex: &sync.Mutex{}, DumpMetadata: DumpMetadata{Name: "4"}, nodeStats: ActivityDumpNodeStats{processNodes: 3}},
 					{Mutex: &sync.Mutex{}, DumpMetadata: DumpMetadata{Name: "5"}},
 				},
 			},
 			[]*ActivityDump{
 				{DumpMetadata: DumpMetadata{Name: "2"}, nodeStats: ActivityDumpNodeStats{processNodes: 3}},
-				{DumpMetadata: DumpMetadata{Name: "4"}, nodeStats: ActivityDumpNodeStats{processNodes: 2}},
+				{DumpMetadata: DumpMetadata{Name: "4"}, nodeStats: ActivityDumpNodeStats{processNodes: 3}},
 			},
 			[]*ActivityDump{
 				{DumpMetadata: DumpMetadata{Name: "1"}},
@@ -306,7 +306,7 @@ func TestActivityDumpManager_getOverweightDumps(t *testing.T) {
 			fields{
 				activeDumps: []*ActivityDump{
 					{Mutex: &sync.Mutex{}, DumpMetadata: DumpMetadata{Name: "1"}, nodeStats: ActivityDumpNodeStats{processNodes: 3}},
-					{Mutex: &sync.Mutex{}, DumpMetadata: DumpMetadata{Name: "2"}, nodeStats: ActivityDumpNodeStats{processNodes: 2}},
+					{Mutex: &sync.Mutex{}, DumpMetadata: DumpMetadata{Name: "2"}, nodeStats: ActivityDumpNodeStats{processNodes: 3}},
 					{Mutex: &sync.Mutex{}, DumpMetadata: DumpMetadata{Name: "3"}},
 					{Mutex: &sync.Mutex{}, DumpMetadata: DumpMetadata{Name: "4"}},
 					{Mutex: &sync.Mutex{}, DumpMetadata: DumpMetadata{Name: "5"}},
@@ -314,7 +314,7 @@ func TestActivityDumpManager_getOverweightDumps(t *testing.T) {
 			},
 			[]*ActivityDump{
 				{DumpMetadata: DumpMetadata{Name: "1"}, nodeStats: ActivityDumpNodeStats{processNodes: 3}},
-				{DumpMetadata: DumpMetadata{Name: "2"}, nodeStats: ActivityDumpNodeStats{processNodes: 2}},
+				{DumpMetadata: DumpMetadata{Name: "2"}, nodeStats: ActivityDumpNodeStats{processNodes: 3}},
 			},
 			[]*ActivityDump{
 				{DumpMetadata: DumpMetadata{Name: "3", End: time.Now().Add(time.Minute)}},
@@ -330,12 +330,12 @@ func TestActivityDumpManager_getOverweightDumps(t *testing.T) {
 					{Mutex: &sync.Mutex{}, DumpMetadata: DumpMetadata{Name: "2"}},
 					{Mutex: &sync.Mutex{}, DumpMetadata: DumpMetadata{Name: "3"}},
 					{Mutex: &sync.Mutex{}, DumpMetadata: DumpMetadata{Name: "4"}, nodeStats: ActivityDumpNodeStats{processNodes: 3}},
-					{Mutex: &sync.Mutex{}, DumpMetadata: DumpMetadata{Name: "5"}, nodeStats: ActivityDumpNodeStats{processNodes: 2}},
+					{Mutex: &sync.Mutex{}, DumpMetadata: DumpMetadata{Name: "5"}, nodeStats: ActivityDumpNodeStats{processNodes: 3}},
 				},
 			},
 			[]*ActivityDump{
 				{DumpMetadata: DumpMetadata{Name: "4"}, nodeStats: ActivityDumpNodeStats{processNodes: 3}},
-				{DumpMetadata: DumpMetadata{Name: "5"}, nodeStats: ActivityDumpNodeStats{processNodes: 2}},
+				{DumpMetadata: DumpMetadata{Name: "5"}, nodeStats: ActivityDumpNodeStats{processNodes: 3}},
 			},
 			[]*ActivityDump{
 				{DumpMetadata: DumpMetadata{Name: "1"}},

--- a/pkg/security/probe/field_handlers.go
+++ b/pkg/security/probe/field_handlers.go
@@ -124,6 +124,18 @@ func (fh *FieldHandlers) ResolveContainerID(ev *model.Event, e *model.ContainerC
 	return e.ID
 }
 
+// ResolveContainerCreatedAt resolves the container creation time of the event
+func (fh *FieldHandlers) ResolveContainerCreatedAt(ev *model.Event, e *model.ContainerContext) int {
+	if e.CreatedAt == 0 {
+		if entry, _ := fh.ResolveProcessCacheEntry(ev); entry != nil && entry.ContainerID != "" {
+			if cgroup, _ := fh.resolvers.CGroupResolver.GetWorkload(entry.ContainerID); cgroup != nil {
+				e.CreatedAt = cgroup.GetCreationTime()
+			}
+		}
+	}
+	return int(e.CreatedAt)
+}
+
 // ResolveContainerTags resolves the container tags of the event
 func (fh *FieldHandlers) ResolveContainerTags(ev *model.Event, e *model.ContainerContext) []string {
 	if len(e.Tags) == 0 && e.ID != "" {

--- a/pkg/security/probe/field_handlers.go
+++ b/pkg/security/probe/field_handlers.go
@@ -129,7 +129,7 @@ func (fh *FieldHandlers) ResolveContainerCreatedAt(ev *model.Event, e *model.Con
 	if e.CreatedAt == 0 {
 		if entry, _ := fh.ResolveProcessCacheEntry(ev); entry != nil && entry.ContainerID != "" {
 			if cgroup, _ := fh.resolvers.CGroupResolver.GetWorkload(entry.ContainerID); cgroup != nil {
-				e.CreatedAt = cgroup.GetCreationTime()
+				e.CreatedAt = cgroup.CreationTime
 			}
 		}
 	}

--- a/pkg/security/resolvers/cgroup/model/model.go
+++ b/pkg/security/resolvers/cgroup/model/model.go
@@ -34,6 +34,7 @@ type CacheEntry struct {
 	Deleted          *atomic.Bool
 	ID               string
 	Tags             []string
+	CreationTime     uint64
 	WorkloadSelector WorkloadSelector
 	PIDs             *simplelru.LRU[uint32, int8]
 }
@@ -97,4 +98,9 @@ func (cgce *CacheEntry) SetTags(tags []string) {
 // NeedsTagsResolution returns true if this workload is missing its tags
 func (cgce *CacheEntry) NeedsTagsResolution() bool {
 	return len(cgce.ID) != 0 && !cgce.WorkloadSelector.IsEmpty()
+}
+
+// GetCreationTime returns the root pid of a cgroup
+func (cgce *CacheEntry) GetCreationTime() uint64 {
+	return cgce.CreationTime
 }

--- a/pkg/security/resolvers/cgroup/model/model.go
+++ b/pkg/security/resolvers/cgroup/model/model.go
@@ -99,8 +99,3 @@ func (cgce *CacheEntry) SetTags(tags []string) {
 func (cgce *CacheEntry) NeedsTagsResolution() bool {
 	return len(cgce.ID) != 0 && !cgce.WorkloadSelector.IsEmpty()
 }
-
-// GetCreationTime returns the root pid of a cgroup
-func (cgce *CacheEntry) GetCreationTime() uint64 {
-	return cgce.CreationTime
-}

--- a/pkg/security/resolvers/cgroup/resolver.go
+++ b/pkg/security/resolvers/cgroup/resolver.go
@@ -130,6 +130,7 @@ func (cr *Resolver) AddPID(process *model.ProcessCacheEntry) {
 		seclog.Errorf("couldn't create new cgroup_resolver cache entry: %v", err)
 		return
 	}
+	newCGroup.CreationTime = uint64(process.ProcessContext.ExecTime.UnixNano())
 
 	// add the new CGroup to the cache
 	cr.workloads.Add(process.ContainerID, newCGroup)

--- a/pkg/security/resolvers/process/resolver.go
+++ b/pkg/security/resolvers/process/resolver.go
@@ -367,6 +367,7 @@ func (p *Resolver) enrichEventFromProc(entry *model.ProcessCacheEntry, proc *pro
 	entry.FileEvent.SetBasenameStr(path.Base(pathnameStr))
 
 	entry.Process.ContainerID = string(containerID)
+
 	// resolve container path with the MountResolver
 	entry.FileEvent.Filesystem, err = p.mountResolver.ResolveFilesystem(entry.Process.FileEvent.MountID, entry.Process.Pid, string(containerID))
 	if err != nil {

--- a/pkg/security/secl/model/accessors.go
+++ b/pkg/security/secl/model/accessors.go
@@ -604,6 +604,15 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field:  field,
 			Weight: eval.FunctionWeight,
 		}, nil
+	case "container.created_at":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ev := ctx.Event.(*Event)
+				return int(ev.FieldHandlers.ResolveContainerCreatedAt(ev, &ev.ContainerContext))
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+		}, nil
 	case "container.id":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
@@ -14813,6 +14822,7 @@ func (ev *Event) GetFields() []eval.Field {
 		"chown.file.uid",
 		"chown.file.user",
 		"chown.retval",
+		"container.created_at",
 		"container.id",
 		"container.tags",
 		"dns.id",
@@ -16029,6 +16039,8 @@ func (ev *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return ev.FieldHandlers.ResolveFileFieldsUser(ev, &ev.Chown.File.FileFields), nil
 	case "chown.retval":
 		return int(ev.Chown.SyscallEvent.Retval), nil
+	case "container.created_at":
+		return int(ev.FieldHandlers.ResolveContainerCreatedAt(ev, &ev.ContainerContext)), nil
 	case "container.id":
 		return ev.FieldHandlers.ResolveContainerID(ev, &ev.ContainerContext), nil
 	case "container.tags":
@@ -20400,6 +20412,8 @@ func (ev *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "chown", nil
 	case "chown.retval":
 		return "chown", nil
+	case "container.created_at":
+		return "*", nil
 	case "container.id":
 		return "*", nil
 	case "container.tags":
@@ -22700,6 +22714,8 @@ func (ev *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "chown.file.user":
 		return reflect.String, nil
 	case "chown.retval":
+		return reflect.Int, nil
+	case "container.created_at":
 		return reflect.Int, nil
 	case "container.id":
 		return reflect.String, nil
@@ -25286,6 +25302,13 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			return &eval.ErrValueTypeMismatch{Field: "Chown.SyscallEvent.Retval"}
 		}
 		ev.Chown.SyscallEvent.Retval = int64(rv)
+		return nil
+	case "container.created_at":
+		rv, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "ContainerContext.CreatedAt"}
+		}
+		ev.ContainerContext.CreatedAt = uint64(rv)
 		return nil
 	case "container.id":
 		rv, ok := value.(string)

--- a/pkg/security/secl/model/field_handlers.go
+++ b/pkg/security/secl/model/field_handlers.go
@@ -17,6 +17,7 @@ func (ev *Event) ResolveFieldsForAD() {
 func (ev *Event) resolveFields(forADs bool) {
 	// resolve context fields that are not related to any event type
 	_ = ev.FieldHandlers.ResolveAsync(ev)
+	_ = ev.FieldHandlers.ResolveContainerCreatedAt(ev, &ev.ContainerContext)
 	_ = ev.FieldHandlers.ResolveContainerID(ev, &ev.ContainerContext)
 	if !forADs {
 		_ = ev.FieldHandlers.ResolveContainerTags(ev, &ev.ContainerContext)
@@ -698,6 +699,7 @@ type FieldHandlers interface {
 	ResolveAsync(ev *Event) bool
 	ResolveChownGID(ev *Event, e *ChownEvent) string
 	ResolveChownUID(ev *Event, e *ChownEvent) string
+	ResolveContainerCreatedAt(ev *Event, e *ContainerContext) int
 	ResolveContainerID(ev *Event, e *ContainerContext) string
 	ResolveContainerTags(ev *Event, e *ContainerContext) []string
 	ResolveFileBasename(ev *Event, e *FileEvent) string
@@ -739,6 +741,9 @@ type DefaultFieldHandlers struct{}
 func (dfh *DefaultFieldHandlers) ResolveAsync(ev *Event) bool                     { return ev.Async }
 func (dfh *DefaultFieldHandlers) ResolveChownGID(ev *Event, e *ChownEvent) string { return e.Group }
 func (dfh *DefaultFieldHandlers) ResolveChownUID(ev *Event, e *ChownEvent) string { return e.User }
+func (dfh *DefaultFieldHandlers) ResolveContainerCreatedAt(ev *Event, e *ContainerContext) int {
+	return int(e.CreatedAt)
+}
 func (dfh *DefaultFieldHandlers) ResolveContainerID(ev *Event, e *ContainerContext) string {
 	return e.ID
 }

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -145,8 +145,9 @@ type ChownEvent struct {
 
 // ContainerContext holds the container context of an event
 type ContainerContext struct {
-	ID   string   `field:"id,handler:ResolveContainerID"`                              // SECLDoc[id] Definition:`ID of the container`
-	Tags []string `field:"tags,handler:ResolveContainerTags,opts:skip_ad,weight:9999"` // SECLDoc[tags] Definition:`Tags of the container`
+	ID        string   `field:"id,handler:ResolveContainerID"`                              // SECLDoc[id] Definition:`ID of the container`
+	CreatedAt uint64   `field:"created_at,handler:ResolveContainerCreatedAt"`               // SECLDoc[created_at] Definition:`Timestamp of the creation of the container``
+	Tags      []string `field:"tags,handler:ResolveContainerTags,opts:skip_ad,weight:9999"` // SECLDoc[tags] Definition:`Tags of the container`
 }
 
 // Event represents an event sent from the kernel

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -448,8 +448,7 @@ type Process struct {
 
 	FileEvent FileEvent `field:"file,check:IsNotKworker"`
 
-	ContainerID   string   `field:"container.id"` // SECLDoc[container.id] Definition:`Container ID`
-	ContainerTags []string `field:"-"`
+	ContainerID string `field:"container.id"` // SECLDoc[container.id] Definition:`Container ID`
 
 	SpanID  uint64 `field:"-"`
 	TraceID uint64 `field:"-"`

--- a/pkg/security/serializers/serializers.go
+++ b/pkg/security/serializers/serializers.go
@@ -667,7 +667,7 @@ func newProcessSerializer(ps *model.Process, e *model.Event, resolvers *resolver
 				ID: ps.ContainerID,
 			}
 			if cgroup, _ := resolvers.CGroupResolver.GetWorkload(ps.ContainerID); cgroup != nil {
-				psSerializer.Container.CreatedAt = getTimeIfNotZero(time.Unix(0, int64(cgroup.GetCreationTime())))
+				psSerializer.Container.CreatedAt = getTimeIfNotZero(time.Unix(0, int64(cgroup.CreationTime)))
 			}
 		}
 		return psSerializer
@@ -1044,7 +1044,7 @@ func NewEventSerializer(event *model.Event, resolvers *resolvers.Resolvers) *Eve
 	if id := event.FieldHandlers.ResolveContainerID(event, &event.ContainerContext); id != "" {
 		var creationTime time.Time
 		if cgroup, _ := resolvers.CGroupResolver.GetWorkload(id); cgroup != nil {
-			creationTime = time.Unix(0, int64(cgroup.GetCreationTime()))
+			creationTime = time.Unix(0, int64(cgroup.CreationTime))
 		}
 		s.ContainerContextSerializer = &ContainerContextSerializer{
 			ID:        id,

--- a/pkg/security/serializers/serializers_easyjson.go
+++ b/pkg/security/serializers/serializers_easyjson.go
@@ -4194,6 +4194,18 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecuritySerializers30(
 		switch key {
 		case "id":
 			out.ID = string(in.String())
+		case "created_at":
+			if in.IsNull() {
+				in.Skip()
+				out.CreatedAt = nil
+			} else {
+				if out.CreatedAt == nil {
+					out.CreatedAt = new(utils.EasyjsonTime)
+				}
+				if data := in.Raw(); in.Ok() {
+					in.AddError((*out.CreatedAt).UnmarshalJSON(data))
+				}
+			}
 		default:
 			in.SkipRecursive()
 		}
@@ -4213,6 +4225,16 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecuritySerializers30(
 		first = false
 		out.RawString(prefix[1:])
 		out.String(string(in.ID))
+	}
+	if in.CreatedAt != nil {
+		const prefix string = ",\"created_at\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		(*in.CreatedAt).MarshalEasyJSON(out)
 	}
 	out.RawByte('}')
 }

--- a/pkg/security/tests/container_test.go
+++ b/pkg/security/tests/container_test.go
@@ -1,0 +1,88 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build functionaltests
+// +build functionaltests
+
+package tests
+
+import (
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestContainerCreatedAt(t *testing.T) {
+	ruleDefs := []*rules.RuleDefinition{
+		{
+			ID:         "test_container_created_at",
+			Expression: `container.id != "" && container.created_at < 3s && open.file.path == "{{.Root}}/test-open"`,
+		},
+		{
+			ID:         "test_container_created_at_delay",
+			Expression: `container.id != "" && container.created_at > 3s && open.file.path == "{{.Root}}/test-open-delay"`,
+		},
+	}
+	test, err := newTestModule(t, nil, ruleDefs, testOpts{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer test.Close()
+
+	testFile, _, err := test.Path("test-open")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testFileDelay, _, err := test.Path("test-open-delay")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dockerWrapper, err := newDockerCmdWrapper(test.Root(), test.Root(), "ubuntu")
+	if err != nil {
+		t.Skip("Skipping created time in containers tests: Docker not available")
+		return
+	}
+	defer dockerWrapper.stop()
+
+	dockerWrapper.Run(t, "container-tags", func(t *testing.T, kind wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
+		test.WaitSignal(t, func() error {
+			cmd := cmdFunc("touch", []string{testFile}, nil)
+			return cmd.Run()
+		}, func(event *model.Event, rule *rules.Rule) {
+			assertTriggeredRule(t, rule, "test_container_created_at")
+			assertFieldEqual(t, event, "open.file.path", testFile)
+			assertFieldNotEmpty(t, event, "container.id", "container id shouldn't be empty")
+
+			test.validateOpenSchema(t, event)
+		})
+	})
+
+	dockerWrapper.Run(t, "container-tags-delay", func(t *testing.T, kind wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
+		test.WaitSignal(t, func() error {
+			cmd := cmdFunc("touch", []string{testFileDelay}, nil) // shouldn't trigger an event
+			if err := cmd.Run(); err != nil {
+				return err
+			}
+			time.Sleep(3 * time.Second)
+			cmd = cmdFunc("touch", []string{testFileDelay}, nil)
+			return cmd.Run()
+		}, func(event *model.Event, rule *rules.Rule) {
+			assertTriggeredRule(t, rule, "test_container_created_at_delay")
+			assertFieldEqual(t, event, "open.file.path", testFileDelay)
+			assertFieldNotEmpty(t, event, "container.id", "container id shouldn't be empty")
+			createdAtNano, _ := event.GetFieldValue("container.created_at")
+			createdAt := time.Unix(0, int64(createdAtNano.(int)))
+			assert.True(t, time.Now().Sub(createdAt) > 3*time.Second)
+
+			test.validateOpenSchema(t, event)
+		})
+	})
+}

--- a/releasenotes/notes/runtime-security-container-creation-time-41c50c708921080d.yaml
+++ b/releasenotes/notes/runtime-security-container-creation-time-41c50c708921080d.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Allow writing SECL rules against container creation time through the new `container.created_at`
+    field, similar to the existing `process.container_at` field.
+    The container creation time is also reported in the sent events.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Allow writing SECL rules against container creation time through the new `container.created_at`
field, similar to the existing `process.container_at` field.

Example:  `container.created_at > 3s && exec.file.path == "/path/to/a/file"`

The container creation time is also reported in the sent events.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
