### PR TITLE
[check command] Add `--instance-filter` option

### DIFF
--- a/cmd/agent/common/autodiscovery.go
+++ b/cmd/agent/common/autodiscovery.go
@@ -8,7 +8,6 @@ package common
 import (
 	"context"
 	"fmt"
-	"github.com/DataDog/datadog-agent/pkg/util/jsonquery"
 	"time"
 
 	"go.uber.org/atomic"
@@ -20,6 +19,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/scheduler"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	confad "github.com/DataDog/datadog-agent/pkg/config/autodiscovery"
+	"github.com/DataDog/datadog-agent/pkg/util/jsonquery"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 

--- a/cmd/agent/common/autodiscovery.go
+++ b/cmd/agent/common/autodiscovery.go
@@ -309,7 +309,7 @@ func filterInstances(instances []integration.Data, instanceFilter string) ([]int
 	for _, instance := range instances {
 		exist, err := jsonquery.YAMLCheckExist(instance, instanceFilter)
 		if err != nil {
-			return nil, fmt.Errorf("instance filter errorxx: %v", err)
+			return nil, fmt.Errorf("instance filter error: %v", err)
 		}
 		if exist {
 			newInstances = append(newInstances, instance)

--- a/cmd/agent/common/autodiscovery.go
+++ b/cmd/agent/common/autodiscovery.go
@@ -269,6 +269,7 @@ func waitForConfigsFromAD(ctx context.Context, wildcard bool, checkNames []strin
 	// placing items in configChan
 	go AC.AddScheduler("check-cmd", schedulerFunc(func(configs []integration.Config) {
 		for _, cfg := range configs {
+			// TODO: apply --instance-filter here
 			if match(cfg) && waiting.Load() {
 				configChan <- cfg
 			}

--- a/cmd/agent/subcommands/jmx/command.go
+++ b/cmd/agent/subcommands/jmx/command.go
@@ -45,6 +45,7 @@ type cliParams struct {
 	saveFlare             bool
 	discoveryTimeout      uint
 	discoveryMinInstances uint
+	instanceFilter        string
 }
 
 // Commands returns a slice of subcommands for the 'agent' command.
@@ -63,6 +64,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 	jmxCmd.PersistentFlags().UintVarP(&cliParams.discoveryTimeout, "discovery-timeout", "", 5, "max retry duration until Autodiscovery resolves the check template (in seconds)")
 	jmxCmd.PersistentFlags().UintVarP(&discoveryRetryInterval, "discovery-retry-interval", "", 1, "(unused)")
 	jmxCmd.PersistentFlags().UintVarP(&cliParams.discoveryMinInstances, "discovery-min-instances", "", 1, "minimum number of config instances to be discovered before running the check(s)")
+	jmxCmd.PersistentFlags().StringVarP(&cliParams.instanceFilter, "instance-filter", "", "", "filter instances using jq style syntax, example: --instance-filter '.ip_address == \"127.0.0.51\"'")
 
 	// All subcommands use the same provided components, with a different
 	// oneShot callback, and with some complex derivation of the
@@ -243,7 +245,7 @@ func runJmxCommandConsole(log log.Component, config config.Component, cliParams 
 	if len(cliParams.cliSelectedChecks) == 0 {
 		allConfigs, err = common.WaitForAllConfigsFromAD(waitCtx)
 	} else {
-		allConfigs, err = common.WaitForConfigsFromAD(waitCtx, cliParams.cliSelectedChecks, int(cliParams.discoveryMinInstances), "")
+		allConfigs, err = common.WaitForConfigsFromAD(waitCtx, cliParams.cliSelectedChecks, int(cliParams.discoveryMinInstances), cliParams.instanceFilter)
 	}
 	if err != nil {
 		return err

--- a/cmd/agent/subcommands/jmx/command.go
+++ b/cmd/agent/subcommands/jmx/command.go
@@ -247,10 +247,10 @@ func runJmxCommandConsole(log log.Component, config config.Component, cliParams 
 	} else {
 		allConfigs, err = common.WaitForConfigsFromAD(waitCtx, cliParams.cliSelectedChecks, int(cliParams.discoveryMinInstances), cliParams.instanceFilter)
 	}
+	cancelTimeout()
 	if err != nil {
 		return err
 	}
-	cancelTimeout()
 
 	err = standalone.ExecJMXCommandConsole(cliParams.command, cliParams.cliSelectedChecks, cliParams.jmxLogLevel, allConfigs)
 

--- a/cmd/agent/subcommands/jmx/command.go
+++ b/cmd/agent/subcommands/jmx/command.go
@@ -241,9 +241,12 @@ func runJmxCommandConsole(log log.Component, config config.Component, cliParams 
 		context.Background(), time.Duration(cliParams.discoveryTimeout)*time.Second)
 	var allConfigs []integration.Config
 	if len(cliParams.cliSelectedChecks) == 0 {
-		allConfigs = common.WaitForAllConfigsFromAD(waitCtx)
+		allConfigs, err = common.WaitForAllConfigsFromAD(waitCtx)
 	} else {
-		allConfigs = common.WaitForConfigsFromAD(waitCtx, cliParams.cliSelectedChecks, int(cliParams.discoveryMinInstances))
+		allConfigs, err = common.WaitForConfigsFromAD(waitCtx, cliParams.cliSelectedChecks, int(cliParams.discoveryMinInstances), "")
+	}
+	if err != nil {
+		return err
 	}
 	cancelTimeout()
 

--- a/cmd/cluster-agent/commands/check/check.go
+++ b/cmd/cluster-agent/commands/check/check.go
@@ -43,6 +43,7 @@ var (
 	checkPause                int
 	checkName                 string
 	checkDelay                int
+	instanceFilter            string
 	logLevel                  string
 	formatJSON                bool
 	formatTable               bool
@@ -72,6 +73,7 @@ func setupCmd(cmd *cobra.Command) {
 	cmd.Flags().IntVar(&checkPause, "pause", 0, "pause between multiple runs of the check, in milliseconds")
 	cmd.Flags().StringVarP(&logLevel, "log-level", "l", "", "set the log level (default 'off') (deprecated, use the env var DD_LOG_LEVEL instead)")
 	cmd.Flags().IntVarP(&checkDelay, "delay", "d", 100, "delay between running the check and grabbing the metrics in milliseconds")
+	cmd.Flags().StringVarP(&instanceFilter, "instance-filter", "", "", "filter instances using jq style syntax, example: --instance-filter '.ip_address == \"127.0.0.51\"'")
 	cmd.Flags().BoolVarP(&formatJSON, "json", "", false, "format aggregator and check runner output as json")
 	cmd.Flags().BoolVarP(&formatTable, "table", "", false, "format aggregator and check runner output as an ascii table")
 	cmd.Flags().StringVarP(&breakPoint, "breakpoint", "b", "", "set a breakpoint at a particular line number (Python checks only)")
@@ -164,8 +166,11 @@ func Check(loggerName config.LoggerName, confFilePath *string, flagNoColor *bool
 
 			waitCtx, cancelTimeout := context.WithTimeout(
 				context.Background(), time.Duration(discoveryTimeout)*time.Second)
-			allConfigs := common.WaitForConfigsFromAD(waitCtx, []string{checkName}, int(discoveryMinInstances), "")
+			allConfigs, err := common.WaitForConfigsFromAD(waitCtx, []string{checkName}, int(discoveryMinInstances), instanceFilter)
 			cancelTimeout()
+			if err != nil {
+				return err
+			}
 
 			// make sure the checks in cs are not JMX checks
 			for idx := range allConfigs {

--- a/cmd/cluster-agent/commands/check/check.go
+++ b/cmd/cluster-agent/commands/check/check.go
@@ -164,7 +164,7 @@ func Check(loggerName config.LoggerName, confFilePath *string, flagNoColor *bool
 
 			waitCtx, cancelTimeout := context.WithTimeout(
 				context.Background(), time.Duration(discoveryTimeout)*time.Second)
-			allConfigs := common.WaitForConfigsFromAD(waitCtx, []string{checkName}, int(discoveryMinInstances))
+			allConfigs := common.WaitForConfigsFromAD(waitCtx, []string{checkName}, int(discoveryMinInstances), "")
 			cancelTimeout()
 
 			// make sure the checks in cs are not JMX checks

--- a/pkg/cli/subcommands/check/command.go
+++ b/pkg/cli/subcommands/check/command.go
@@ -56,8 +56,8 @@ type cliParams struct {
 	checkTimes                int
 	checkPause                int
 	checkName                 string
-	instanceFilter            string
 	checkDelay                int
+	instanceFilter            string
 	logLevel                  string
 	formatJSON                bool
 	formatTable               bool

--- a/pkg/cli/subcommands/check/command.go
+++ b/pkg/cli/subcommands/check/command.go
@@ -120,7 +120,7 @@ func MakeCommand(globalParamsGetter func() GlobalParams) *cobra.Command {
 	cmd.Flags().IntVar(&cliParams.checkPause, "pause", 0, "pause between multiple runs of the check, in milliseconds")
 	cmd.Flags().StringVarP(&cliParams.logLevel, "log-level", "l", "", "set the log level (default 'off') (deprecated, use the env var DD_LOG_LEVEL instead)")
 	cmd.Flags().IntVarP(&cliParams.checkDelay, "delay", "d", 100, "delay between running the check and grabbing the metrics in milliseconds")
-	cmd.Flags().StringVarP(&cliParams.instanceFilter, "instance-filter", "", "", "TODO:XXX")
+	cmd.Flags().StringVarP(&cliParams.instanceFilter, "instance-filter", "", "", "filter instances using jq style syntax, example: --instance-filter '.ip_address == \"127.0.0.51\"'")
 	cmd.Flags().BoolVarP(&cliParams.formatJSON, "json", "", false, "format aggregator and check runner output as json")
 	cmd.Flags().BoolVarP(&cliParams.formatTable, "table", "", false, "format aggregator and check runner output as an ascii table")
 	cmd.Flags().StringVarP(&cliParams.breakPoint, "breakpoint", "b", "", "set a breakpoint at a particular line number (Python checks only)")

--- a/pkg/cli/subcommands/check/command_test.go
+++ b/pkg/cli/subcommands/check/command_test.go
@@ -9,9 +9,11 @@ import (
 	"testing"
 
 	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/comp/core"
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
@@ -33,4 +35,22 @@ func TestCommand(t *testing.T) {
 			require.True(t, cliParams.saveFlare)
 			require.Equal(t, true, coreParams.ConfigLoadSecrets())
 		})
+}
+
+func TestYAMLExistQuery(t *testing.T) {
+	exist, err := YAMLExistQuery(integration.Data("{\"ip_address\": \"127.0.0.50\"}"), ".ip_address == \"127.0.0.50\"")
+	assert.NoError(t, err)
+	assert.True(t, exist)
+
+	exist, err = YAMLExistQuery(integration.Data("{\"ip_address\": \"127.0.0.50\"}"), ".ip_address == \"127.0.0.99\"")
+	assert.NoError(t, err)
+	assert.False(t, exist)
+
+	exist, err = YAMLExistQuery(integration.Data("{\"ip_address\": \"127.0.0.50\"}"), ".ip_address")
+	assert.EqualError(t, err, "filter query must return a boolean: yaml: unmarshal errors:\n  line 1: cannot unmarshal !!str `127.0.0.50` into bool")
+	assert.False(t, exist)
+
+	exist, err = YAMLExistQuery(integration.Data("{}"), ".ip_address == \"127.0.0.99\"")
+	assert.NoError(t, err)
+	assert.False(t, exist)
 }

--- a/pkg/cli/subcommands/check/command_test.go
+++ b/pkg/cli/subcommands/check/command_test.go
@@ -9,11 +9,9 @@ import (
 	"testing"
 
 	"github.com/spf13/cobra"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/comp/core"
-	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
@@ -35,22 +33,4 @@ func TestCommand(t *testing.T) {
 			require.True(t, cliParams.saveFlare)
 			require.Equal(t, true, coreParams.ConfigLoadSecrets())
 		})
-}
-
-func TestYAMLExistQuery(t *testing.T) {
-	exist, err := YAMLExistQuery(integration.Data("{\"ip_address\": \"127.0.0.50\"}"), ".ip_address == \"127.0.0.50\"")
-	assert.NoError(t, err)
-	assert.True(t, exist)
-
-	exist, err = YAMLExistQuery(integration.Data("{\"ip_address\": \"127.0.0.50\"}"), ".ip_address == \"127.0.0.99\"")
-	assert.NoError(t, err)
-	assert.False(t, exist)
-
-	exist, err = YAMLExistQuery(integration.Data("{\"ip_address\": \"127.0.0.50\"}"), ".ip_address")
-	assert.EqualError(t, err, "filter query must return a boolean: yaml: unmarshal errors:\n  line 1: cannot unmarshal !!str `127.0.0.50` into bool")
-	assert.False(t, exist)
-
-	exist, err = YAMLExistQuery(integration.Data("{}"), ".ip_address == \"127.0.0.99\"")
-	assert.NoError(t, err)
-	assert.False(t, exist)
 }

--- a/pkg/util/jsonquery/yaml.go
+++ b/pkg/util/jsonquery/yaml.go
@@ -7,6 +7,7 @@ package jsonquery
 
 import (
 	"fmt"
+	"gopkg.in/yaml.v3"
 	"time"
 )
 
@@ -45,4 +46,19 @@ func NormalizeYAMLForGoJQ(v interface{}) interface{} {
 	default:
 		return v
 	}
+}
+
+// YAMLCheckExist check a property/value from a YAML exist (jq style syntax)
+func YAMLCheckExist(yamlData []byte, query string) (bool, error) {
+	var yamlContent interface{}
+	if err := yaml.Unmarshal(yamlData, &yamlContent); err != nil {
+		return false, err
+	}
+	yamlContent = NormalizeYAMLForGoJQ(yamlContent)
+	output, _, err := RunSingleOutput(query, yamlContent)
+	var exist bool
+	if err := yaml.Unmarshal([]byte(output), &exist); err != nil {
+		return false, fmt.Errorf("filter query must return a boolean: %s", err)
+	}
+	return exist, err
 }

--- a/pkg/util/jsonquery/yaml.go
+++ b/pkg/util/jsonquery/yaml.go
@@ -7,8 +7,9 @@ package jsonquery
 
 import (
 	"fmt"
-	"gopkg.in/yaml.v3"
 	"time"
+
+	"gopkg.in/yaml.v3"
 )
 
 // Copy from https://github.com/itchyny/gojq/blob/main/cli/yaml.go

--- a/pkg/util/jsonquery/yaml_test.go
+++ b/pkg/util/jsonquery/yaml_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
 package jsonquery
 
 import (

--- a/pkg/util/jsonquery/yaml_test.go
+++ b/pkg/util/jsonquery/yaml_test.go
@@ -1,0 +1,25 @@
+package jsonquery
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestYAMLExistQuery(t *testing.T) {
+	exist, err := YAMLCheckExist(integration.Data("{\"ip_address\": \"127.0.0.50\"}"), ".ip_address == \"127.0.0.50\"")
+	assert.NoError(t, err)
+	assert.True(t, exist)
+
+	exist, err = YAMLCheckExist(integration.Data("{\"ip_address\": \"127.0.0.50\"}"), ".ip_address == \"127.0.0.99\"")
+	assert.NoError(t, err)
+	assert.False(t, exist)
+
+	exist, err = YAMLCheckExist(integration.Data("{\"ip_address\": \"127.0.0.50\"}"), ".ip_address")
+	assert.EqualError(t, err, "filter query must return a boolean: yaml: unmarshal errors:\n  line 1: cannot unmarshal !!str `127.0.0.50` into bool")
+	assert.False(t, exist)
+
+	exist, err = YAMLCheckExist(integration.Data("{}"), ".ip_address == \"127.0.0.99\"")
+	assert.NoError(t, err)
+	assert.False(t, exist)
+}

--- a/pkg/util/jsonquery/yaml_test.go
+++ b/pkg/util/jsonquery/yaml_test.go
@@ -1,9 +1,11 @@
 package jsonquery
 
 import (
-	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 )
 
 func TestYAMLExistQuery(t *testing.T) {

--- a/releasenotes/notes/add_instance_filter_to_agent_check_command-c166bec4ff8ebf96.yaml
+++ b/releasenotes/notes/add_instance_filter_to_agent_check_command-c166bec4ff8ebf96.yaml
@@ -8,4 +8,4 @@
 ---
 enhancements:
   - |
-    Add ``--instance-filter`` option to agent check command.
+    Add an ``--instance-filter`` option to the Agent check command.

--- a/releasenotes/notes/add_instance_filter_to_agent_check_command-c166bec4ff8ebf96.yaml
+++ b/releasenotes/notes/add_instance_filter_to_agent_check_command-c166bec4ff8ebf96.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Add ``--instance-filter`` option to agent check command.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

[check command] Add `--instance-filter` option

Example, if the `snmp` check instances are like this:
```
instances:
  - ip_address: 127.0.0.50
    community_string
  - ip_address: 127.0.0.51
    community_string
  - ip_address: 127.0.0.52
    community_string
```

1/ You can filter to only run the check command for `127.0.0.51` using:

```
datadog-agent check snmp --instance-filter '.ip_address == "127.0.0.51"'
```

2/ Filter to keep `127.0.0.51` and `127.0.0.52` using:

```
datadog-agent check snmp --instance-filter '.ip_address == "127.0.0.51" or ip_address == "127.0.0.52"'
```

3/ Filter for IP matching specific regex

```
datadog-agent check snmp --instance-filter  'select(.ip_address != null) | .ip_address | test("127\\.0\\.0\\.\\d+")'
```


<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Helps troubleshooting when we only need to target a single instance or few instances.

Often, customer might have dozen or hundreds instances and we are only interested in one instance.

Running all 100s/1000s can also take very long time, so having a way to filter can improve support experience and troubleshoot time.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
