### PR TITLE
[Windows] implement mapping of pid to service name

### DIFF
--- a/pkg/network/protocols/http/http_types.go
+++ b/pkg/network/protocols/http/http_types.go
@@ -28,15 +28,15 @@ type ProtocolType C.protocol_t
 
 // Add tests to TestProtocolValue
 const (
-	ProtocolUnknown ProtocolType = C.PROTOCOL_UNKNOWN
-	ProtocolHTTP    ProtocolType = C.PROTOCOL_HTTP
-	ProtocolHTTP2   ProtocolType = C.PROTOCOL_HTTP2
-	ProtocolTLS     ProtocolType = C.PROTOCOL_TLS
-	ProtocolMONGO   ProtocolType = C.PROTOCOL_MONGO
+	ProtocolUnknown  ProtocolType = C.PROTOCOL_UNKNOWN
+	ProtocolHTTP     ProtocolType = C.PROTOCOL_HTTP
+	ProtocolHTTP2    ProtocolType = C.PROTOCOL_HTTP2
+	ProtocolTLS      ProtocolType = C.PROTOCOL_TLS
+	ProtocolMONGO    ProtocolType = C.PROTOCOL_MONGO
 	ProtocolPostgres ProtocolType = C.PROTOCOL_POSTGRES
-	ProtocolAMQP    ProtocolType = C.PROTOCOL_AMQP
-	ProtocolRedis   ProtocolType = C.PROTOCOL_REDIS
-	ProtocolMax     ProtocolType = C.MAX_PROTOCOLS
+	ProtocolAMQP     ProtocolType = C.PROTOCOL_AMQP
+	ProtocolRedis    ProtocolType = C.PROTOCOL_REDIS
+	ProtocolMax      ProtocolType = C.MAX_PROTOCOLS
 )
 
 const (

--- a/pkg/pidfile/pidfile_windows.go
+++ b/pkg/pidfile/pidfile_windows.go
@@ -8,8 +8,6 @@ package pidfile
 import (
 	"path/filepath"
 
-	"golang.org/x/sys/windows"
-
 	"github.com/DataDog/datadog-agent/pkg/util/winutil"
 )
 
@@ -21,17 +19,7 @@ const (
 
 // isProcess checks to see if a given pid is currently valid in the process table
 func isProcess(pid int) bool {
-	h, err := windows.OpenProcess(processQueryLimitedInformation, false, uint32(pid))
-	if err != nil {
-		return false
-	}
-	var c uint32
-	err = windows.GetExitCodeProcess(h, &c)
-	windows.Close(h)
-	if err != nil {
-		return c == stillActive
-	}
-	return true
+	return winutil.IsProcess(pid)
 }
 
 // Path returns a suitable location for the pidfile under Windows

--- a/pkg/pidfile/pidfile_windows.go
+++ b/pkg/pidfile/pidfile_windows.go
@@ -11,12 +11,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/winutil"
 )
 
-const (
-	processQueryLimitedInformation = 0x1000
-
-	stillActive = 259
-)
-
 // isProcess checks to see if a given pid is currently valid in the process table
 func isProcess(pid int) bool {
 	return winutil.IsProcess(pid)

--- a/pkg/trace/remoteconfighandler/mock_remote_client.go
+++ b/pkg/trace/remoteconfighandler/mock_remote_client.go
@@ -4,67 +4,67 @@
 package remoteconfighandler
 
 import (
-        reflect "reflect"
+	reflect "reflect"
 
-        state "github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
-        gomock "github.com/golang/mock/gomock"
+	state "github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
+	gomock "github.com/golang/mock/gomock"
 )
 
 // MockRemoteClient is a mock of RemoteClient interface.
 type MockRemoteClient struct {
-        ctrl     *gomock.Controller
-        recorder *MockRemoteClientMockRecorder
+	ctrl     *gomock.Controller
+	recorder *MockRemoteClientMockRecorder
 }
 
 // MockRemoteClientMockRecorder is the mock recorder for MockRemoteClient.
 type MockRemoteClientMockRecorder struct {
-        mock *MockRemoteClient
+	mock *MockRemoteClient
 }
 
 // NewMockRemoteClient creates a new mock instance.
 func NewMockRemoteClient(ctrl *gomock.Controller) *MockRemoteClient {
-        mock := &MockRemoteClient{ctrl: ctrl}
-        mock.recorder = &MockRemoteClientMockRecorder{mock}
-        return mock
+	mock := &MockRemoteClient{ctrl: ctrl}
+	mock.recorder = &MockRemoteClientMockRecorder{mock}
+	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockRemoteClient) EXPECT() *MockRemoteClientMockRecorder {
-        return m.recorder
+	return m.recorder
 }
 
 // Close mocks base method.
 func (m *MockRemoteClient) Close() {
-        m.ctrl.T.Helper()
-        m.ctrl.Call(m, "Close")
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Close")
 }
 
 // Close indicates an expected call of Close.
 func (mr *MockRemoteClientMockRecorder) Close() *gomock.Call {
-        mr.mock.ctrl.T.Helper()
-        return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockRemoteClient)(nil).Close))
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockRemoteClient)(nil).Close))
 }
 
 // RegisterAPMUpdate mocks base method.
 func (m *MockRemoteClient) RegisterAPMUpdate(arg0 func(map[string]state.APMSamplingConfig)) {
-        m.ctrl.T.Helper()
-        m.ctrl.Call(m, "RegisterAPMUpdate", arg0)
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "RegisterAPMUpdate", arg0)
 }
 
 // RegisterAPMUpdate indicates an expected call of RegisterAPMUpdate.
 func (mr *MockRemoteClientMockRecorder) RegisterAPMUpdate(arg0 interface{}) *gomock.Call {
-        mr.mock.ctrl.T.Helper()
-        return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterAPMUpdate", reflect.TypeOf((*MockRemoteClient)(nil).RegisterAPMUpdate), arg0)
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterAPMUpdate", reflect.TypeOf((*MockRemoteClient)(nil).RegisterAPMUpdate), arg0)
 }
 
 // Start mocks base method.
 func (m *MockRemoteClient) Start() {
-        m.ctrl.T.Helper()
-        m.ctrl.Call(m, "Start")
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Start")
 }
 
 // Start indicates an expected call of Start.
 func (mr *MockRemoteClientMockRecorder) Start() *gomock.Call {
-        mr.mock.ctrl.T.Helper()
-        return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockRemoteClient)(nil).Start))
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockRemoteClient)(nil).Start))
 }

--- a/pkg/util/winutil/process.go
+++ b/pkg/util/winutil/process.go
@@ -363,3 +363,40 @@ func GetImagePathForProcess(h windows.Handle) (string, error) {
 	}
 	return "", lastErr
 }
+
+const (
+	processQueryLimitedInformation = 0x1000
+
+	stillActive = 259
+)
+
+// IsProcess checks to see if a given pid is currently valid in the process table
+func IsProcess(pid int) bool {
+	h, err := windows.OpenProcess(processQueryLimitedInformation, false, uint32(pid))
+	if err != nil {
+		return false
+	}
+	var c uint32
+	err = windows.GetExitCodeProcess(h, &c)
+	windows.Close(h)
+	if err != nil {
+		return c == stillActive
+	}
+	return true
+}
+
+func getProcessStartTimeAsNs(pid uint64) (uint64, error) {
+	h, err := windows.OpenProcess(processQueryLimitedInformation, false, uint32(pid))
+	if err != nil {
+		return 0, fmt.Errorf("Error opening process %v", err)
+	}
+	var creation windows.Filetime
+	var exit windows.Filetime
+	var krn windows.Filetime
+	var user windows.Filetime
+	err = windows.GetProcessTimes(h, &creation, &exit, &krn, &user)
+	if err != nil {
+		return 0, err
+	}
+	return uint64(creation.Nanoseconds()), nil
+}

--- a/pkg/util/winutil/process.go
+++ b/pkg/util/winutil/process.go
@@ -365,9 +365,9 @@ func GetImagePathForProcess(h windows.Handle) (string, error) {
 }
 
 const (
-	processQueryLimitedInformation = 0x1000
+	processQueryLimitedInformation = windows.PROCESS_QUERY_LIMITED_INFORMATION
 
-	stillActive = 259
+	stillActive = windows.STATUS_PENDING
 )
 
 // IsProcess checks to see if a given pid is currently valid in the process table
@@ -376,13 +376,13 @@ func IsProcess(pid int) bool {
 	if err != nil {
 		return false
 	}
-	var c uint32
-	err = windows.GetExitCodeProcess(h, &c)
+	var c windows.NTStatus
+	err = windows.GetExitCodeProcess(h, (*uint32)(&c))
 	windows.Close(h)
-	if err != nil {
+	if err == nil {
 		return c == stillActive
 	}
-	return true
+	return false
 }
 
 func getProcessStartTimeAsNs(pid uint64) (uint64, error) {

--- a/pkg/util/winutil/scmmonitor.go
+++ b/pkg/util/winutil/scmmonitor.go
@@ -1,0 +1,187 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+//go:build windows
+// +build windows
+
+package winutil
+
+import (
+	"fmt"
+	"sync"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+	"golang.org/x/sys/windows/svc/mgr"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+type ServiceInfo struct {
+	ServiceName string
+	DisplayName string
+}
+
+// Service is the return value from a query by pid.
+type Service struct {
+	essp      *windows.ENUM_SERVICE_STATUS_PROCESS
+	startTime uint64
+}
+
+// SCMMonitor is an object that allows the caller to monitor Windows services.
+// The object will maintain a table of active services indexed by PID
+type SCMMonitor struct {
+	mux              sync.Mutex
+	pidToService     map[uint64]*Service
+	nonServicePid    map[uint64]uint64 // start time of this pid
+	lastMapTime      uint64            // ns since jan1 1970
+	serviceRefreshes uint64
+}
+
+// GetServiceMonitor returns a service monitor object
+func GetServiceMonitor() *SCMMonitor {
+	return &SCMMonitor{
+		pidToService:  make(map[uint64]*Service),
+		nonServicePid: make(map[uint64]uint64),
+	}
+}
+
+// GetRefreshCount returns the number of times we've actually queried
+// the SCM database.  used for logging stats.
+func (scm *SCMMonitor) GetRefreshCount() uint64 {
+	return scm.serviceRefreshes
+}
+func (scm *SCMMonitor) refreshCache() error {
+
+	// EnumServiceStatusEx requires only SC_MANAGER_ENUM_SERVICE.  Switch to
+	// new library to use least privilege
+	h, err := windows.OpenSCManager(nil, nil, windows.SC_MANAGER_ENUMERATE_SERVICE)
+	if err != nil {
+		log.Warnf("Failed to connect to scm %v", err)
+		return fmt.Errorf("Failed to open SCM %v", err)
+	}
+	m := &mgr.Mgr{Handle: h}
+	defer m.Disconnect()
+
+	var bytesNeeded, servicesReturned uint32
+	var buf []byte
+	for {
+		var p *byte
+		if len(buf) > 0 {
+			p = &buf[0]
+		}
+		err = windows.EnumServicesStatusEx(m.Handle, windows.SC_ENUM_PROCESS_INFO,
+			windows.SERVICE_WIN32, windows.SERVICE_STATE_ALL,
+			p, uint32(len(buf)), &bytesNeeded, &servicesReturned, nil, nil)
+		if err == nil {
+			break
+		}
+		if err != windows.ERROR_MORE_DATA {
+			return fmt.Errorf("Failed to enum services %v", err)
+		}
+		if bytesNeeded <= uint32(len(buf)) {
+			return err
+		}
+		buf = make([]byte, bytesNeeded)
+	}
+	if servicesReturned == 0 {
+		return nil
+	}
+
+	//var services []windows.ENUM_SERVICE_STATUS_PROCESS
+	services := (*[1<<29 - 1]windows.ENUM_SERVICE_STATUS_PROCESS)(unsafe.Pointer(&buf[0]))[:servicesReturned]
+	//hdr.Data = unsafe.Pointer(&buf[0])
+	//hdr.Len = int(servicesReturned)
+	//hdr.Cap = int(servicesReturned)
+
+	newmap := make(map[uint64]*Service)
+	for idx, svc := range services {
+		newmap[uint64(svc.ServiceStatusProcess.ProcessId)] = &Service{essp: &services[idx]}
+	}
+	var current windows.Filetime
+	windows.GetSystemTimeAsFileTime(&current)
+	scm.lastMapTime = uint64(current.Nanoseconds())
+	scm.pidToService = newmap
+	scm.serviceRefreshes++
+	return nil
+}
+
+func (s *Service) toServiceInfo() *ServiceInfo {
+	var si ServiceInfo
+	si.DisplayName = windows.UTF16PtrToString(s.essp.DisplayName)
+	si.ServiceName = windows.UTF16PtrToString(s.essp.ServiceName)
+	return &si
+
+}
+
+func (scm *SCMMonitor) getServiceFromCache(pid, pidstart uint64) (*ServiceInfo, error) {
+	var err error
+	if val, ok := scm.pidToService[pid]; ok {
+		// it was in there.  see if it's the right one
+		if val.startTime == 0 {
+			// we don't prepopulate the cache with pid start times
+			val.startTime, err = getProcessStartTimeAsNs(pid)
+			if err != nil {
+				return nil, err
+			}
+		}
+		if val.startTime == pidstart {
+			// it's the same one.
+			return val.toServiceInfo(), nil
+		}
+	}
+	return nil, nil
+}
+
+// GetServiceInfo gets the service name and display name if the process identified
+// by the pid is in the SCM.  A process which is not an SCM controlled service will
+// return nil with no error
+func (scm *SCMMonitor) GetServiceInfo(pid uint64) (*ServiceInfo, error) {
+	// get the process start time of the pid being checked
+	pidstart, err := getProcessStartTimeAsNs(pid)
+	if err != nil {
+		return nil, err
+	}
+	scm.mux.Lock()
+	defer scm.mux.Unlock()
+	// check to see if the pid is in the cache of known, not service pids
+	if val, ok := scm.nonServicePid[pid]; ok {
+		// it's a known non service pid.  Make sure it's not recycled.
+		if val == pidstart {
+			// it's the same process.  We know this isn't a service
+			return nil, nil
+		} else {
+			// it was in there but the times didn't match, which means
+			// it's a different process.  Clean it out.
+			delete(scm.nonServicePid, pid)
+		}
+	}
+	// if we get here it either wasn't in the map, or it was but the
+	// start time didn't match
+
+	if pidstart <= scm.lastMapTime {
+		// so it's been around longer than our last check of the service
+		// table.  so if it's in there it's probably good.
+		si, err := scm.getServiceFromCache(pid, pidstart)
+		if (si == nil && err != nil) || (si != nil && err == nil) {
+			return si, err
+		}
+
+	}
+
+	// if we get here, either it wasn't in either map, or the process
+	// is newer than the service map.  In either case, refresh the service
+	// map, to see if the pid is in there.
+	if err = scm.refreshCache(); err != nil {
+		return nil, err
+	}
+	// now check the service map
+	si, err := scm.getServiceFromCache(pid, pidstart)
+	if (si == nil && err != nil) || (si != nil && err == nil) {
+		return si, err
+	}
+	// otherwise put this pid as a known, non service
+	scm.nonServicePid[pid] = pidstart
+	return nil, nil
+}

--- a/pkg/util/winutil/scmmonitor.go
+++ b/pkg/util/winutil/scmmonitor.go
@@ -93,13 +93,7 @@ func (scm *SCMMonitor) refreshCache() error {
 		return nil
 	}
 
-	//var services []windows.ENUM_SERVICE_STATUS_PROCESS
-	//services := (*[1<<29 - 1]windows.ENUM_SERVICE_STATUS_PROCESS)(unsafe.Pointer(&buf[0]))[:servicesReturned]
 	services := unsafe.Slice((*windows.ENUM_SERVICE_STATUS_PROCESS)(unsafe.Pointer(&buf[0])), servicesReturned)
-
-	//hdr.Data = unsafe.Pointer(&buf[0])
-	//hdr.Len = int(servicesReturned)
-	//hdr.Cap = int(servicesReturned)
 
 	newmap := make(map[uint64]*Service)
 	for idx, svc := range services {
@@ -178,8 +172,11 @@ func (scm *SCMMonitor) GetServiceInfo(pid uint64) (*ServiceInfo, error) {
 		// so it's been around longer than our last check of the service
 		// table.  so if it's in there it's probably good.
 		si, err := scm.getServiceFromCache(pid, pidstart)
-		if (si == nil && err != nil) || (si != nil && err == nil) {
-			return si, err
+		if err != nil {
+			return nil, err
+		}
+		if si != nil {
+			return si, nil
 		}
 		// else
 		scm.nonServicePid[pid] = pidstart
@@ -194,8 +191,11 @@ func (scm *SCMMonitor) GetServiceInfo(pid uint64) (*ServiceInfo, error) {
 	}
 	// now check the service map
 	si, err := scm.getServiceFromCache(pid, pidstart)
-	if (si == nil && err != nil) || (si != nil && err == nil) {
-		return si, err
+	if err != nil {
+		return nil, err
+	}
+	if si != nil {
+		return si, nil
 	}
 	// otherwise put this pid as a known, non service
 	scm.nonServicePid[pid] = pidstart

--- a/pkg/util/winutil/scmmonitor.go
+++ b/pkg/util/winutil/scmmonitor.go
@@ -184,7 +184,7 @@ func (scm *SCMMonitor) GetServiceInfo(pid uint64) (*ServiceInfo, error) {
 
 	}
 
-	// if we get here, either it wasn't in either map, or the process
+	// if we get here, the process
 	// is newer than the service map.
 	if err = scm.refreshCache(); err != nil {
 		return nil, err

--- a/pkg/util/winutil/scmmonitor_test.go
+++ b/pkg/util/winutil/scmmonitor_test.go
@@ -1,0 +1,73 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+//go:build windows
+// +build windows
+
+package winutil
+
+import (
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/sys/windows"
+)
+
+type saveOutput struct {
+	savedOutput []byte
+}
+
+func (so *saveOutput) Write(p []byte) (n int, err error) {
+	so.savedOutput = append(so.savedOutput, p...)
+	return os.Stdout.Write(p)
+}
+
+func TestServices(t *testing.T) {
+	var output saveOutput
+	cmd := exec.Command("tasklist", "/svc", "/fo", "csv")
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = &output
+	cmd.Stderr = os.Stderr
+	_ = cmd.Run()
+
+	scm := GetServiceMonitor()
+
+	for _, line := range strings.Split(strings.TrimRight(string(output.savedOutput), "\r\n"), "\r\n")[1:] {
+
+		entries := strings.Split(line, ",")
+		for i, s := range entries {
+			entries[i] = strings.Replace(s, "\"", "", -1)
+		}
+		pid, _ := strconv.ParseInt(entries[1], 10, 64)
+		if pid == 0 {
+			continue
+		}
+		if pid == int64(windows.GetCurrentProcessId()) {
+			continue
+		}
+		if pid == int64(cmd.Process.Pid) {
+			continue
+		}
+		si, err := scm.GetServiceInfo(uint64(pid))
+		assert.Nil(t, err, "Error on pid %v", pid)
+
+		if entries[2] != "N/A" {
+			assert.NotNil(t, si)
+			for _, name := range entries[2:] {
+				assert.Contains(t, si.ServiceName, name)
+			}
+		} else {
+			// the "N/A" processes are not services, so should not get
+			// an entry back
+			assert.Nil(t, si)
+		}
+	}
+	count := scm.GetRefreshCount()
+	assert.EqualValues(t, 1, count)
+
+}


### PR DESCRIPTION
Checks the pid against the table of SCM controlled processes. If it's SCM controlled, returns the service information.

Because we must enumerate the entire SCM (there doesn't seem to be an api for that), the SCMManager object maintains a cache of objects, and refreshes only when it sees a PID it hasn't seen before.

On a machine with high process churn, this could still result in a lot of accesses.  However, if process agent queries only when doing the process check (i.e. every 30s), then it should only iterate the list once per 30s.

### What does this PR do?


### Motivation


### Additional Notes

During the course of this PR, found that we'd previously been accessing the API incorrectly
to check if a given pid was still valid (used in the pidfile).

Added `team/agent-shared-components` for QA validation that this doesn't have unintended consequences
(the tests pass, and logically the new code is more correct).

### Possible Drawbacks / Trade-offs


### Describe how to test/QA your changes

This PR doesn't actually use the new functionality; it's provided as an underlying library to be used later.
However, as noted above, a previously existing problem with the PID checking was found; therefore should
be checked for regressions with pidfile generation and validation.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
