### PR TITLE
[CWS] cleanup last uses of `jsonschema_description`

### DIFF
--- a/docs/cloud-workload-security/README.md
+++ b/docs/cloud-workload-security/README.md
@@ -75,7 +75,7 @@ The Cloud Workload Security (CWS) part of the Agent sends events to the backend.
 
 ### Editing files
 
-To change the documentation of one of the fields in the schema, edit the correct field in `pkg/security/probe/serializers.go`. The documentation of a field is added through the `jsonschema_description` tag of the field.
+To change the documentation of one of the fields in the schema, edit the correct field in `pkg/security/probe/serializers.go`. The documentation of a field is added through the commont of the field.
 
 For example:
 

--- a/pkg/security/probe/serializers.go
+++ b/pkg/security/probe/serializers.go
@@ -207,9 +207,9 @@ type ProcessSerializer struct {
 	// Indicator of environments variable truncation
 	EnvsTruncated bool `json:"envs_truncated,omitempty"`
 	// Indicates whether the process is considered a thread (that is, a child process that hasn't executed another program)
-	IsThread bool `json:"is_thread,omitempty" jsonschema_description:""`
+	IsThread bool `json:"is_thread,omitempty"`
 	// Indicates whether the process is a kworker
-	IsKworker bool `json:"is_kworker,omitempty" jsonschema_description:""`
+	IsKworker bool `json:"is_kworker,omitempty"`
 }
 
 // ContainerContextSerializer serializes a container context to JSON
@@ -490,8 +490,10 @@ type BindEventSerializer struct {
 // ExitEventSerializer serializes an exit event to JSON
 // easyjson:json
 type ExitEventSerializer struct {
-	Cause string `json:"cause" jsonschema_description:"Cause of the process termination (one of EXITED, SIGNALED, COREDUMPED)"`
-	Code  uint32 `json:"code" jsonschema_description:"Exit code of the process or number of the signal that caused the process to terminate"`
+	// Cause of the process termination (one of EXITED, SIGNALED, COREDUMPED)
+	Cause string `json:"cause"`
+	// Exit code of the process or number of the signal that caused the process to terminate
+	Code uint32 `json:"code"`
 }
 
 // MountEventSerializer serializes a mount event to JSON


### PR DESCRIPTION
### What does this PR do?

No-op cleanup of last uses of `jsonschema_description`. Comments are now used everywhere

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
