### PR TITLE
fix(cluster-agent): apply cluster-name normalization in ksm-core

### DIFF
--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -223,7 +223,7 @@ func start(log log.Component, config config.Component, cliParams *command.Global
 		}
 	}
 
-	clusterName := clustername.GetClusterName(context.TODO(), hname)
+	clusterName := clustername.GetRFC1123CompliantClusterName(context.TODO(), hname)
 	if pkgconfig.Datadog.GetBool("orchestrator_explorer.enabled") {
 		// Generate and persist a cluster ID
 		// this must be a UUID, and ideally be stable for the lifetime of a cluster,

--- a/pkg/clusteragent/externalmetrics/model/utils.go
+++ b/pkg/clusteragent/externalmetrics/model/utils.go
@@ -40,7 +40,7 @@ var templatedTags = map[string]tagGetter{
 		if err != nil {
 			return "", err
 		}
-		return clustername.GetClusterName(ctx, hname), nil
+		return clustername.GetClusterNameTagValue(ctx, hname), nil
 	},
 }
 

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_test.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_test.go
@@ -1107,7 +1107,7 @@ func TestKSMCheck_hostnameAndTags(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			kubeStateMetricsSCheck := newKSMCheck(core.NewCheckBase(kubeStateMetricsCheckName), tt.config)
-			kubeStateMetricsSCheck.clusterName = tt.args.clusterName
+			kubeStateMetricsSCheck.clusterNameRFC1123 = tt.args.clusterName
 			labelJoiner := newLabelJoiner(tt.config.LabelJoins)
 			for _, metricFam := range tt.args.metricsToGet {
 				labelJoiner.insertFamily(metricFam)
@@ -1422,9 +1422,9 @@ func TestKSMCheckInitTags(t *testing.T) {
 			mockConfig := config.Mock(t)
 
 			k := &KSMCheck{
-				instance:    tt.fields.instance,
-				clusterName: tt.fields.clusterName,
-				agentConfig: mockConfig,
+				instance:            tt.fields.instance,
+				clusterNameTagValue: tt.fields.clusterName,
+				agentConfig:         mockConfig,
 			}
 
 			tt.loadFunc(mockConfig)

--- a/pkg/collector/python/datadog_agent.go
+++ b/pkg/collector/python/datadog_agent.go
@@ -66,7 +66,7 @@ func GetHostname(hostname **C.char) {
 //export GetClusterName
 func GetClusterName(clusterName **C.char) {
 	goHostname, _ := hostnameUtil.Get(context.TODO())
-	goClusterName := clustername.GetClusterName(context.TODO(), goHostname)
+	goClusterName := clustername.GetRFC1123CompliantClusterName(context.TODO(), goHostname)
 	// clusterName will be free by rtloader when it's done with it
 	*clusterName = TrackedCString(goClusterName)
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -365,6 +365,7 @@ func InitConfig(config Config) {
 
 	config.BindEnvAndSetDefault("cluster_name", "")
 	config.BindEnvAndSetDefault("disable_cluster_name_tag_key", false)
+	config.BindEnvAndSetDefault("enabled_rfc1123_compliant_cluster_name_tag", false)
 
 	// secrets backend
 	config.BindEnvAndSetDefault("secret_backend_command", "")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -365,7 +365,7 @@ func InitConfig(config Config) {
 
 	config.BindEnvAndSetDefault("cluster_name", "")
 	config.BindEnvAndSetDefault("disable_cluster_name_tag_key", false)
-	config.BindEnvAndSetDefault("enabled_rfc1123_compliant_cluster_name_tag", false)
+	config.BindEnvAndSetDefault("enabled_rfc1123_compliant_cluster_name_tag", true)
 
 	// secrets backend
 	config.BindEnvAndSetDefault("secret_backend_command", "")

--- a/pkg/metadata/host/host_tags.go
+++ b/pkg/metadata/host/host_tags.go
@@ -93,7 +93,7 @@ func GetHostTags(ctx context.Context, cached bool) *Tags {
 	}
 
 	hname, _ := hostname.Get(ctx)
-	clusterName := clustername.GetRFC1123CompliantClusterName(ctx, hname)
+	clusterName := clustername.GetClusterNameTagValue(ctx, hname)
 	if len(clusterName) != 0 {
 		clusterNameTags := []string{"kube_cluster_name:" + clusterName}
 		if !config.Datadog.GetBool("disable_cluster_name_tag_key") {

--- a/pkg/metadata/host/host_tags.go
+++ b/pkg/metadata/host/host_tags.go
@@ -93,7 +93,7 @@ func GetHostTags(ctx context.Context, cached bool) *Tags {
 	}
 
 	hname, _ := hostname.Get(ctx)
-	clusterName := clustername.GetClusterName(ctx, hname)
+	clusterName := clustername.GetRFC1123CompliantClusterName(ctx, hname)
 	if len(clusterName) != 0 {
 		clusterNameTags := []string{"kube_cluster_name:" + clusterName}
 		if !config.Datadog.GetBool("disable_cluster_name_tag_key") {

--- a/pkg/util/kubernetes/clustername/clustername.go
+++ b/pkg/util/kubernetes/clustername/clustername.go
@@ -120,8 +120,11 @@ func getClusterName(ctx context.Context, data *clusterNameData, hostname string)
 				}
 			}
 			if len(clusterName) > 0 {
-				log.Infof("Using cluster name %s from the node label", clusterName)
-				data.clusterName = clusterName
+				if !IsRFC1123CompliantClusterName(clusterName) {
+					log.Infof("Cluster name \"%s\" is not RFC 1123 compliant, it will be converted, ", clusterName)
+				}
+				data.clusterName = MakeClusterNameRFC1123Compliant(clusterName)
+				log.Infof("Using cluster name %s from the node label", data.clusterName)
 			}
 		}
 
@@ -153,6 +156,12 @@ func GetClusterNameTagValue(ctx context.Context, hostname string) string {
 		return GetRFC1123CompliantClusterName(ctx, hostname)
 	}
 	return GetClusterName(ctx, hostname)
+}
+
+// IsRFC1123CompliantClusterName check if the clusterName is RFC1123 compliant
+// return false if not compliant
+func IsRFC1123CompliantClusterName(clusterName string) bool {
+	return !strings.Contains(clusterName, "_")
 }
 
 // GetRFC1123CompliantClusterName returns an RFC-1123 compliant k8s cluster

--- a/pkg/util/kubernetes/clustername/clustername.go
+++ b/pkg/util/kubernetes/clustername/clustername.go
@@ -149,7 +149,7 @@ func GetClusterName(ctx context.Context, hostname string) string {
 // GetClusterNameTagValue  a k8s cluster name if it exists, either directly specified or autodiscovered
 //
 // This function also "normalize" the k8s cluster name if the configuration option
-// `enabled_rfc1123_compliant_cluster_name_tag`` is set to `true`
+// "enabled_rfc1123_compliant_cluster_name_tag" is set to "true"
 // this allow to limit the risk of breaking user that currently rely on previous `kube_cluster_name` tag value.
 func GetClusterNameTagValue(ctx context.Context, hostname string) string {
 	if config.Datadog.GetBool("enabled_rfc1123_compliant_cluster_name_tag") {

--- a/pkg/util/kubernetes/clustername/clustername.go
+++ b/pkg/util/kubernetes/clustername/clustername.go
@@ -121,7 +121,7 @@ func getClusterName(ctx context.Context, data *clusterNameData, hostname string)
 			}
 			if len(clusterName) > 0 {
 				if !IsRFC1123CompliantClusterName(clusterName) {
-					log.Infof("Cluster name \"%s\" is not RFC 1123 compliant, it will be converted, ", clusterName)
+					log.Warnf("Cluster name \"%s\" is not RFC 1123 compliant, it will be converted, ", clusterName)
 				}
 				data.clusterName = MakeClusterNameRFC1123Compliant(clusterName)
 				log.Infof("Using cluster name %s from the node label", data.clusterName)

--- a/pkg/util/kubernetes/clustername/clustername.go
+++ b/pkg/util/kubernetes/clustername/clustername.go
@@ -143,6 +143,18 @@ func GetClusterName(ctx context.Context, hostname string) string {
 	return getClusterName(ctx, defaultClusterNameData, hostname)
 }
 
+// GetClusterNameTagValue  a k8s cluster name if it exists, either directly specified or autodiscovered
+//
+// This function also "normalize" the k8s cluster name if the configuration option
+// `enabled_rfc1123_compliant_cluster_name_tag`` is set to `true`
+// this allow to limit the risk of breaking user that currently rely on previous `kube_cluster_name` tag value.
+func GetClusterNameTagValue(ctx context.Context, hostname string) string {
+	if config.Datadog.GetBool("enabled_rfc1123_compliant_cluster_name_tag") {
+		return GetRFC1123CompliantClusterName(ctx, hostname)
+	}
+	return GetClusterName(ctx, hostname)
+}
+
 // GetRFC1123CompliantClusterName returns an RFC-1123 compliant k8s cluster
 // name if it exists, either directly specified or autodiscovered
 func GetRFC1123CompliantClusterName(ctx context.Context, hostname string) string {

--- a/pkg/util/static_tags.go
+++ b/pkg/util/static_tags.go
@@ -56,7 +56,7 @@ func GetStaticTagsSlice(ctx context.Context) []string {
 		if found {
 			log.Infof("'%s' was set manually via DD_TAGS, not changing it", clusterTagNamePrefix+tag)
 		} else {
-			cluster := clustername.GetClusterName(ctx, "")
+			cluster := clustername.GetClusterNameTagValue(ctx, "")
 			if cluster == "" {
 				log.Infof("Couldn't build the %q.. tag, DD_CLUSTER_NAME can be used to set it", clusterTagNamePrefix)
 			} else {

--- a/releasenotes/notes/fix-cluster-name-tag-normalization-cd0b7cac8a1a761f.yaml
+++ b/releasenotes/notes/fix-cluster-name-tag-normalization-cd0b7cac8a1a761f.yaml
@@ -1,0 +1,18 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Introduce a new option `enabled_rfc1123_compliant_cluster_name_tag`
+    that can be use to enfore `kube_cluster_name` tag value to be
+    RFC1123 Compliant cluster name.
+fixes:
+  - |
+    Fix in `kubernetes_state_core` check the host alias name
+    create to use a normalize (RFC1123 Compliant) cluster name.
+

--- a/releasenotes/notes/fix-cluster-name-tag-normalization-cd0b7cac8a1a761f.yaml
+++ b/releasenotes/notes/fix-cluster-name-tag-normalization-cd0b7cac8a1a761f.yaml
@@ -9,7 +9,7 @@
 enhancements:
   - |
     Introduce a new option `enabled_rfc1123_compliant_cluster_name_tag`
-    that enforce the `kube_cluster_name` tag value to be
+    that enforces the `kube_cluster_name` tag value to be
     an RFC1123 compliant cluster name. It can be disabled by setting this
     new option to `false`.
 fixes:

--- a/releasenotes/notes/fix-cluster-name-tag-normalization-cd0b7cac8a1a761f.yaml
+++ b/releasenotes/notes/fix-cluster-name-tag-normalization-cd0b7cac8a1a761f.yaml
@@ -9,8 +9,9 @@
 enhancements:
   - |
     Introduce a new option `enabled_rfc1123_compliant_cluster_name_tag`
-    that can be use to enforce the `kube_cluster_name` tag value to be
-    an RFC1123 compliant cluster name.
+    that enforce the `kube_cluster_name` tag value to be
+    an RFC1123 compliant cluster name. It can be disable by setting this
+    new option to `false`.
 fixes:
   - |
     Fix the `kubernetes_state_core` check so that the host alias name

--- a/releasenotes/notes/fix-cluster-name-tag-normalization-cd0b7cac8a1a761f.yaml
+++ b/releasenotes/notes/fix-cluster-name-tag-normalization-cd0b7cac8a1a761f.yaml
@@ -10,7 +10,7 @@ enhancements:
   - |
     Introduce a new option `enabled_rfc1123_compliant_cluster_name_tag`
     that enforce the `kube_cluster_name` tag value to be
-    an RFC1123 compliant cluster name. It can be disable by setting this
+    an RFC1123 compliant cluster name. It can be disabled by setting this
     new option to `false`.
 fixes:
   - |

--- a/releasenotes/notes/fix-cluster-name-tag-normalization-cd0b7cac8a1a761f.yaml
+++ b/releasenotes/notes/fix-cluster-name-tag-normalization-cd0b7cac8a1a761f.yaml
@@ -9,10 +9,10 @@
 enhancements:
   - |
     Introduce a new option `enabled_rfc1123_compliant_cluster_name_tag`
-    that can be use to enfore `kube_cluster_name` tag value to be
-    RFC1123 Compliant cluster name.
+    that can be use to enforce the `kube_cluster_name` tag value to be
+    an RFC1123 compliant cluster name.
 fixes:
   - |
-    Fix in `kubernetes_state_core` check the host alias name
-    create to use a normalize (RFC1123 Compliant) cluster name.
+    Fix the `kubernetes_state_core` check so that the host alias name
+    creation uses a normalized (RFC1123 compliant) cluster name.
 


### PR DESCRIPTION
### What does this PR do?

This PR fixing a bug in the `kubernetes_state_core` check in which
the `cluster-name` used to defined the host-alias wasn't normalized
as it should be.


this PR also introduce a new config parameter to also standardise the
cluster name in the `kube_cluster_name` tage
This option is `enabled_rfc1123_compliant_cluster_name_tag` and set by default
to `false` for backward compatibility reason

### Motivation

A wrong host alias could has been attached to the host when the initial
`cluster-name` retrieve from the environment (like EKS) was not compliante
with the RFC1123.

Also, the kube_cluster_name tag was getting the un-normalized cluster name.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

I wasn't able to create an EKS or kind environement with a wrong cluster-name.
In both case, the create tooling refuse that I add an `_` in the cluster name.

What I did is to change the EKS Node labels that contains the cluster-name to set
a wrong cluster-name.


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
