### PR TITLE
pkg/clusteragent/admission: add additional libconfig env vars

### DIFF
--- a/pkg/clusteragent/admission/common/lib_config_test.go
+++ b/pkg/clusteragent/admission/common/lib_config_test.go
@@ -27,17 +27,15 @@ func TestLibConfig_ToEnvs(t *testing.T) {
 		TracingRateLimit    *int
 		TracingTags         []string
 
-		/*
-			TracingServiceMapping          []TracingServiceMapEntry
-			TracingAgentTimeout            *int
-			TracingHeaderTags              []TracingHeaderTagEntry
-			TracingPartialFlushMinSpans    *int
-			TracingDebug                   *bool
-			TracingLogLevel                *string
-			TracingMethods                 []string
-			TracingPropagationStyleInject  []string
-			TracingPropagationStyleExtract []string
-		*/
+		TracingServiceMapping          []TracingServiceMapEntry
+		TracingAgentTimeout            *int
+		TracingHeaderTags              []TracingHeaderTagEntry
+		TracingPartialFlushMinSpans    *int
+		TracingDebug                   *bool
+		TracingLogLevel                *string
+		TracingMethods                 []string
+		TracingPropagationStyleInject  []string
+		TracingPropagationStyleExtract []string
 	}
 	tests := []struct {
 		name   string
@@ -56,6 +54,31 @@ func TestLibConfig_ToEnvs(t *testing.T) {
 				TracingSamplingRate: ptr(0.5),
 				TracingRateLimit:    ptr(50),
 				TracingTags:         []string{"k1:v1", "k2:v2"},
+				TracingServiceMapping: []TracingServiceMapEntry{{
+					FromKey: "svc1",
+					ToName:  "svc2",
+				}, {
+					FromKey: "svc3",
+					ToName:  "svc4",
+				},
+				},
+				TracingAgentTimeout: ptr(2),
+				TracingHeaderTags: []TracingHeaderTagEntry{
+					{
+						Header:  "X-Test-Header",
+						TagName: "x.test.header",
+					},
+					{
+						Header:  "X-Test-Other-Header",
+						TagName: "x.test.other.header",
+					},
+				},
+				TracingPartialFlushMinSpans:    ptr(100),
+				TracingDebug:                   ptr(true),
+				TracingLogLevel:                ptr("DEBUG"),
+				TracingMethods:                 []string{"modA.method", "modB.method"},
+				TracingPropagationStyleInject:  []string{"Datadog", "B3", "W3C"},
+				TracingPropagationStyleExtract: []string{"W3C", "B3", "Datadog"},
 			},
 			want: []corev1.EnvVar{
 				{
@@ -93,6 +116,42 @@ func TestLibConfig_ToEnvs(t *testing.T) {
 				{
 					Name:  "DD_TAGS",
 					Value: "k1:v1,k2:v2",
+				},
+				{
+					Name:  "DD_TRACE_SERVICE_MAPPING",
+					Value: "svc1:svc2, svc3:svc4",
+				},
+				{
+					Name:  "DD_TRACE_AGENT_TIMEOUT",
+					Value: "2",
+				},
+				{
+					Name:  "DD_TRACE_HEADER_TAGS",
+					Value: "X-Test-Header:x.test.header, X-Test-Other-Header:x.test.other.header",
+				},
+				{
+					Name:  "DD_TRACE_PARTIAL_FLUSH_MIN_SPANS",
+					Value: "100",
+				},
+				{
+					Name:  "DD_TRACE_DEBUG",
+					Value: "true",
+				},
+				{
+					Name:  "DD_TRACE_LOG_LEVEL",
+					Value: "DEBUG",
+				},
+				{
+					Name:  "DD_TRACE_METHODS",
+					Value: "modA.method;modB.method",
+				},
+				{
+					Name:  "DD_PROPAGATION_STYLE_INJECT",
+					Value: "Datadog,B3,W3C",
+				},
+				{
+					Name:  "DD_PROPAGATION_STYLE_EXTRACT",
+					Value: "W3C,B3,Datadog",
 				},
 			},
 		},
@@ -132,17 +191,15 @@ func TestLibConfig_ToEnvs(t *testing.T) {
 				TracingRateLimit:    tt.fields.TracingRateLimit,
 				TracingTags:         tt.fields.TracingTags,
 
-				/*
-					TracingServiceMapping:          tt.fields.TracingServiceMapping,
-					TracingAgentTimeout:            tt.fields.TracingAgentTimeout,
-					TracingHeaderTags:              tt.fields.TracingHeaderTags,
-					TracingPartialFlushMinSpans:    tt.fields.TracingPartialFlushMinSpans,
-					TracingDebug:                   tt.fields.TracingDebug,
-					TracingLogLevel:                tt.fields.TracingLogLevel,
-					TracingMethods:                 tt.fields.TracingMethods,
-					TracingPropagationStyleInject:  tt.fields.TracingPropagationStyleInject,
-					TracingPropagationStyleExtract: tt.fields.TracingPropagationStyleExtract,
-				*/
+				TracingServiceMapping:          tt.fields.TracingServiceMapping,
+				TracingAgentTimeout:            tt.fields.TracingAgentTimeout,
+				TracingHeaderTags:              tt.fields.TracingHeaderTags,
+				TracingPartialFlushMinSpans:    tt.fields.TracingPartialFlushMinSpans,
+				TracingDebug:                   tt.fields.TracingDebug,
+				TracingLogLevel:                tt.fields.TracingLogLevel,
+				TracingMethods:                 tt.fields.TracingMethods,
+				TracingPropagationStyleInject:  tt.fields.TracingPropagationStyleInject,
+				TracingPropagationStyleExtract: tt.fields.TracingPropagationStyleExtract,
 			}
 			require.EqualValues(t, tt.want, lc.ToEnvs())
 		})


### PR DESCRIPTION
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Add logic for the remaining environment variables. 


### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
