### PR TITLE
pkg/clusteragent/admission/patch: poll rc on leadership switch

### DIFF
--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -298,11 +298,12 @@ func start(log log.Component, config config.Component, cliParams *command.Global
 	if pkgconfig.Datadog.GetBool("admission_controller.enabled") {
 		if pkgconfig.Datadog.GetBool("admission_controller.auto_instrumentation.patcher.enabled") {
 			patchCtx := admissionpatch.ControllerContext{
-				IsLeaderFunc: le.IsLeader,
-				K8sClient:    apiCl.Cl,
-				RcClient:     rcClient,
-				ClusterName:  clusterName,
-				StopCh:       stopCh,
+				IsLeaderFunc:        le.IsLeader,
+				LeaderSubscribeFunc: le.Subscribe,
+				K8sClient:           apiCl.Cl,
+				RcClient:            rcClient,
+				ClusterName:         clusterName,
+				StopCh:              stopCh,
 			}
 			if err := admissionpatch.StartControllers(patchCtx); err != nil {
 				log.Errorf("Cannot start auto instrumentation patcher: %v", err)

--- a/pkg/clusteragent/admission/patch/provider.go
+++ b/pkg/clusteragent/admission/patch/provider.go
@@ -20,9 +20,9 @@ type patchProvider interface {
 	subscribe(kind TargetObjKind) chan PatchRequest
 }
 
-func newPatchProvider(rcClient *remote.Client, clusterName string) (patchProvider, error) {
+func newPatchProvider(rcClient *remote.Client, isLeaderNotif <-chan struct{}, clusterName string) (patchProvider, error) {
 	if config.Datadog.GetBool("remote_configuration.enabled") {
-		return newRemoteConfigProvider(rcClient, clusterName)
+		return newRemoteConfigProvider(rcClient, isLeaderNotif, clusterName)
 	}
 	if config.Datadog.GetBool("admission_controller.auto_instrumentation.patcher.fallback_to_file_provider") {
 		// Use the file config provider for e2e testing only (it replaces RC as a source of configs)

--- a/pkg/clusteragent/admission/patch/rc_provider_test.go
+++ b/pkg/clusteragent/admission/patch/rc_provider_test.go
@@ -39,7 +39,7 @@ func TestProcess(t *testing.T) {
 `
 		return []byte(fmt.Sprintf(base, cluster, kind))
 	}
-	rcp, err := newRemoteConfigProvider(&remote.Client{}, "dev")
+	rcp, err := newRemoteConfigProvider(&remote.Client{}, make(chan struct{}), "dev")
 	require.NoError(t, err)
 	notifs := rcp.subscribe(KindDeployment)
 	in := map[string]state.APMTracingConfig{

--- a/pkg/clusteragent/admission/patch/start.go
+++ b/pkg/clusteragent/admission/patch/start.go
@@ -17,17 +17,18 @@ import (
 
 // ControllerContext holds necessary context for the patch controller
 type ControllerContext struct {
-	IsLeaderFunc func() bool
-	K8sClient    kubernetes.Interface
-	RcClient     *remote.Client
-	ClusterName  string
-	StopCh       chan struct{}
+	IsLeaderFunc        func() bool
+	LeaderSubscribeFunc func() <-chan struct{}
+	K8sClient           kubernetes.Interface
+	RcClient            *remote.Client
+	ClusterName         string
+	StopCh              chan struct{}
 }
 
 // StartControllers starts the patch controllers
 func StartControllers(ctx ControllerContext) error {
 	log.Info("Starting patch controllers")
-	provider, err := newPatchProvider(ctx.RcClient, ctx.ClusterName)
+	provider, err := newPatchProvider(ctx.RcClient, ctx.LeaderSubscribeFunc(), ctx.ClusterName)
 	if err != nil {
 		return err
 	}

--- a/pkg/config/remote/client.go
+++ b/pkg/config/remote/client.go
@@ -315,6 +315,13 @@ func (c *Client) RegisterAPMTracing(fn func(update map[string]state.APMTracingCo
 	fn(c.state.APMTracingConfigs())
 }
 
+// APMTracingConfigs returns the current set of valid APM Tracing configs
+func (c *Client) APMTracingConfigs() map[string]state.APMTracingConfig {
+	c.m.Lock()
+	defer c.m.Unlock()
+	return c.state.APMTracingConfigs()
+}
+
 func (c *Client) applyUpdate(pbUpdate *pbgo.ClientGetConfigsResponse) ([]string, error) {
 	fileMap := make(map[string][]byte, len(pbUpdate.TargetFiles))
 	for _, f := range pbUpdate.TargetFiles {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

- The rc provider in the cluster agent lists and processes the configs when it becomes leader
- Minor logging improvements 

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

- Avoids an edge case where the cluster agent replicas can miss rc updates during leader election transitions

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

Relies on https://github.com/DataDog/datadog-agent/pull/15054

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

- kill the leader, apply a RC config, ensures the followers detects and applies the new config once it becomes leader

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
