### PR TITLE
[CWS] Add 4 ebpf tests, one for each rate limiter algo

### DIFF
--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var RuntimeSecurity = newAsset("runtime-security.c", "284489038bc6dfaa1850e06eb8e909c91bcd6a6a1eaf29233b344f8413361b8e")
+var RuntimeSecurity = newAsset("runtime-security.c", "8fc17b02b607a474aa111cd15319ccf7571093c358ca44e3b8a9d413ec8fc7fd")

--- a/pkg/security/ebpf/c/activity_dump.h
+++ b/pkg/security/ebpf/c/activity_dump.h
@@ -364,7 +364,9 @@ enum rate_limiter_algo_ids {
 __attribute__((always_inline)) u8 activity_dump_rate_limiter_reset_period(u64 now, struct activity_dump_rate_limiter_ctx* rate_ctx_p) {
     rate_ctx_p->current_period = now;
     rate_ctx_p->counter = 0;
+#ifndef __BALOUM__ // do not change algo during unit tests
     rate_ctx_p->algo_id = now % RL_ALGO_TOTAL_NUMBER;
+#endif /* __BALOUM__ */
     return 1;
 }
 

--- a/pkg/security/ebpf/c/activity_dump_ratelimiter_test.h
+++ b/pkg/security/ebpf/c/activity_dump_ratelimiter_test.h
@@ -1,0 +1,128 @@
+#ifndef _ACTIVITY_DUMP_RATELIMITER_TEST_H_
+#define _ACTIVITY_DUMP_RATELIMITER_TEST_H_
+
+#include "defs.h"
+#include "activity_dump.h"
+#include "baloum.h"
+#include "utils.h"
+
+#define AD_RL_TEST_RATE 500
+#define NUMBER_OF_PERIOD_PER_TEST 10
+
+SEC("test/ad_ratelimiter_basic")
+int test_ad_ratelimiter_basic()
+{
+    u64 now = bpf_ktime_get_ns();
+
+    struct activity_dump_config config;
+    config.events_rate = AD_RL_TEST_RATE;
+
+    struct activity_dump_rate_limiter_ctx ctx;
+    ctx.counter = 0;
+    ctx.current_period = now;
+    ctx.algo_id = RL_ALGO_BASIC; // force algo basic
+    u32 cookie = 0;
+    bpf_map_update_elem(&activity_dump_rate_limiters, &cookie, &ctx, BPF_ANY);
+
+    for (int period_cpt = 0; period_cpt < NUMBER_OF_PERIOD_PER_TEST; period_cpt++, now += SEC_TO_NS(2)) {
+        assert_not_zero(activity_dump_rate_limiter_allow(&config, cookie, now, 0),
+                        "event not allowed which should be");
+        for (int i = 0; i < AD_RL_TEST_RATE; i++) {
+            assert_not_zero(activity_dump_rate_limiter_allow(&config, cookie, now + i, 1),
+                            "event not allowed which should be");
+        }
+
+        assert_zero(activity_dump_rate_limiter_allow(&config, cookie, now, 0),
+                    "event allowed which should not be");
+        for (int i = 0; i < AD_RL_TEST_RATE; i++) {
+            assert_zero(activity_dump_rate_limiter_allow(&config, cookie, now + i, 1),
+                        "event allowed which should not be");
+        }
+        assert_zero(activity_dump_rate_limiter_allow(&config, cookie, now, 0),
+                    "event allowed which should not be");
+    }
+    return 0;
+}
+
+SEC("test/ad_ratelimiter_basic_half")
+int test_ad_ratelimiter_basic_half()
+{
+    u64 now = bpf_ktime_get_ns();
+
+    struct activity_dump_config config;
+    config.events_rate = AD_RL_TEST_RATE;
+
+    struct activity_dump_rate_limiter_ctx ctx;
+    ctx.counter = 0;
+    ctx.current_period = now;
+    ctx.algo_id = RL_ALGO_BASIC_HALF; // force algo basic half
+    u32 cookie = 0;
+    bpf_map_update_elem(&activity_dump_rate_limiters, &cookie, &ctx, BPF_ANY);
+
+    for (int period_cpt = 0; period_cpt < NUMBER_OF_PERIOD_PER_TEST; period_cpt++, now += SEC_TO_NS(1)) {
+        assert_not_zero(activity_dump_rate_limiter_allow(&config, cookie, now, 0),
+                        "event not allowed which should be");
+        for (int i = 0; i < AD_RL_TEST_RATE / 2; i++) {
+            assert_not_zero(activity_dump_rate_limiter_allow(&config, cookie, now + i, 1),
+                            "event not allowed which should be");
+        }
+
+        assert_zero(activity_dump_rate_limiter_allow(&config, cookie, now, 0),
+                    "event allowed which should not be");
+        for (int i = 0; i < AD_RL_TEST_RATE / 2; i++) {
+            assert_zero(activity_dump_rate_limiter_allow(&config, cookie, now + i, 1),
+                        "event allowed which should not be");
+        }
+        assert_zero(activity_dump_rate_limiter_allow(&config, cookie, now, 0),
+                    "event allowed which should not be");
+    }
+    return 0;
+}
+
+__attribute__((always_inline)) int test_ad_ratelimiter_variable_droprate(int algo)
+{
+    u64 now = bpf_ktime_get_ns();
+
+    struct activity_dump_config config;
+    config.events_rate = AD_RL_TEST_RATE;
+
+    struct activity_dump_rate_limiter_ctx ctx;
+    ctx.counter = 0;
+    ctx.current_period = now;
+    ctx.algo_id = algo; // force algo
+    u32 cookie = 0;
+    bpf_map_update_elem(&activity_dump_rate_limiters, &cookie, &ctx, BPF_ANY);
+
+    for (int period_cpt = 0; period_cpt < NUMBER_OF_PERIOD_PER_TEST; period_cpt++, now += SEC_TO_NS(2)) {
+    assert_not_zero(activity_dump_rate_limiter_allow(&config, cookie, now, 0),
+                    "event not allowed which should be");
+    for (int i = 0; i < AD_RL_TEST_RATE / 4; i++) {
+        assert_not_zero(activity_dump_rate_limiter_allow(&config, cookie, now + i, 1),
+                        "event not allowed which should be");
+    }
+
+    int total_allowed = 0;
+    for (int i = 0; i < AD_RL_TEST_RATE * 10; i++) {
+        if (activity_dump_rate_limiter_allow(&config, cookie, now + i, 1)) {
+            total_allowed++;
+        }
+    }
+    assert_greater_than(total_allowed, AD_RL_TEST_RATE * 3 / 4, "nope");
+    assert_lesser_than(total_allowed, AD_RL_TEST_RATE / 10, "nope");
+    }
+    return 0;
+}
+
+SEC("test/ad_ratelimiter_decreasing_droprate")
+int test_ad_ratelimiter_decreasing_droprate()
+{
+    return test_ad_ratelimiter_variable_droprate(RL_ALGO_DECREASING_DROPRATE);
+}
+
+SEC("test/ad_ratelimiter_increasing_droprate")
+int test_ad_ratelimiter_increasing_droprate()
+{
+    return test_ad_ratelimiter_variable_droprate(RL_ALGO_INCREASING_DROPRATE);
+}
+
+#endif /* _ACTIVITY_DUMP_RATELIMITER_TEST_H_ */

--- a/pkg/security/ebpf/c/baloum.h
+++ b/pkg/security/ebpf/c/baloum.h
@@ -59,6 +59,34 @@ static int (*baloum_sleep)(__u64 ns) = (void *)0xfffb;
         return -1;                                                   \
     }
 
+#define assert_greater_than(v1, v2, msg)                             \
+    if (v1 > v2)                                                     \
+    {                                                                \
+        bpf_printk("assert line %d : v1 == v2 : %s", __LINE__, msg); \
+        return -1;                                                   \
+    }
+
+#define assert_lesser_than(v1, v2, msg)                              \
+    if (v1 < v2)                                                     \
+    {                                                                \
+        bpf_printk("assert line %d : v1 == v2 : %s", __LINE__, msg); \
+        return -1;                                                   \
+    }
+
+#define assert_greater_or_equal_than(v1, v2, msg)                       \
+    if (v1 >= v2)                                                       \
+    {                                                                   \
+        bpf_printk("assert line %d : v1 == v2 : %s", __LINE__, msg);    \
+        return -1;                                                      \
+    }
+
+#define assert_lesser_or_equal_than(v1, v2, msg)                        \
+    if (v1 <= v2)                                                       \
+    {                                                                   \
+        bpf_printk("assert line %d : v1 == v2 : %s", __LINE__, msg);    \
+        return -1;                                                      \
+    }
+
 #define assert_not_null(v1, msg)                                       \
     if (v1 == NULL)                                                    \
     {                                                                  \

--- a/pkg/security/ebpf/c/discarders.h
+++ b/pkg/security/ebpf/c/discarders.h
@@ -1,13 +1,12 @@
 #ifndef _DISCARDERS_H
 #define _DISCARDERS_H
 
+#include "utils.h"
+
 #define REVISION_ARRAY_SIZE 4096
 
 #define INODE_DISCARDER_TYPE 0
 #define PID_DISCARDER_TYPE   1
-
-#define NS_TO_SEC(x) x / 1000000000
-#define SEC_TO_NS(x) x * 1000000000
 
 struct discarder_stats_t {
     u64 discarders_added;

--- a/pkg/security/ebpf/c/tests.h
+++ b/pkg/security/ebpf/c/tests.h
@@ -2,5 +2,6 @@
 #define _TESTS_H
 
 #include "discarders_test.h"
+#include "activity_dump_ratelimiter_test.h"
 
 #endif

--- a/pkg/security/ebpf/c/utils.h
+++ b/pkg/security/ebpf/c/utils.h
@@ -1,0 +1,7 @@
+#ifndef _UTILS_H_
+#define _UTILS_H_
+
+#define NS_TO_SEC(x) (x) / 1000000000
+#define SEC_TO_NS(x) (x) * 1000000000
+
+#endif /* _UTILS_H_ */

--- a/pkg/security/ebpf/tests/activity_dump_ratelimiter_test.go
+++ b/pkg/security/ebpf/tests/activity_dump_ratelimiter_test.go
@@ -1,0 +1,47 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux && ebpf_bindata
+// +build linux,ebpf_bindata
+
+package tests
+
+import (
+	"testing"
+
+	"github.com/safchain/baloum/pkg/baloum"
+)
+
+func TestActivityDumpRateLimiterBasic(t *testing.T) {
+	var ctx baloum.StdContext
+	code, err := newVM(t).RunProgram(&ctx, "test/ad_ratelimiter_basic")
+	if err != nil || code != 0 {
+		t.Errorf("unexpected error: %v, %d", err, code)
+	}
+}
+
+func TestActivityDumpRateLimiterBasicHalf(t *testing.T) {
+	var ctx baloum.StdContext
+	code, err := newVM(t).RunProgram(&ctx, "test/ad_ratelimiter_basic_half")
+	if err != nil || code != 0 {
+		t.Errorf("unexpected error: %v, %d", err, code)
+	}
+}
+
+func TestActivityDumpRateLimiterDecreasingDroprate(t *testing.T) {
+	var ctx baloum.StdContext
+	code, err := newVM(t).RunProgram(&ctx, "test/ad_ratelimiter_decreasing_droprate")
+	if err != nil || code != 0 {
+		t.Errorf("unexpected error: %v, %d", err, code)
+	}
+}
+
+func TestActivityDumpRateLimiterIncreasingDroprate(t *testing.T) {
+	var ctx baloum.StdContext
+	code, err := newVM(t).RunProgram(&ctx, "test/ad_ratelimiter_increasing_droprate")
+	if err != nil || code != 0 {
+		t.Errorf("unexpected error: %v, %d", err, code)
+	}
+}


### PR DESCRIPTION
### What does this PR do?

This PR adds an ebpf unit test for each 4 kernel rate limiters.


<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
