### PR TITLE
Prevent check from running after it was unscheduled.

### DIFF
--- a/pkg/collector/internal/middleware/check_wrapper.go
+++ b/pkg/collector/internal/middleware/check_wrapper.go
@@ -20,9 +20,9 @@ import (
 type CheckWrapper struct {
 	inner check.Check
 	// done is true when the check was cancelled and must not run.
-	done  bool
+	done bool
 	// Locked while check is running.
-	runM  sync.Mutex
+	runM sync.Mutex
 }
 
 // NewCheckWrapper returns a wrapped check.

--- a/pkg/collector/internal/middleware/check_wrapper.go
+++ b/pkg/collector/internal/middleware/check_wrapper.go
@@ -15,11 +15,14 @@ import (
 )
 
 // CheckWrapper cleans up the check sender after a check was
-// descheduled, taking care to postpone it until Run returns if it is
-// running.
+// descheduled, taking care that Run is not executing during or after
+// that.
 type CheckWrapper struct {
 	inner check.Check
-	wg    sync.WaitGroup
+	// done is true when the check was cancelled and must not run.
+	done  bool
+	// Locked while check is running.
+	runM  sync.Mutex
 }
 
 // NewCheckWrapper returns a wrapped check.
@@ -31,8 +34,11 @@ func NewCheckWrapper(inner check.Check) *CheckWrapper {
 
 // Run implements Check#Run
 func (c *CheckWrapper) Run() error {
-	c.wg.Add(1)
-	defer c.wg.Done()
+	c.runM.Lock()
+	defer c.runM.Unlock()
+	if c.done {
+		return nil
+	}
 	return c.inner.Run()
 }
 
@@ -43,7 +49,10 @@ func (c *CheckWrapper) Cancel() {
 }
 
 func (c *CheckWrapper) destroySender() {
-	c.wg.Wait()
+	// Done must happen before Wait
+	c.runM.Lock()
+	defer c.runM.Unlock()
+	c.done = true
 	aggregator.DestroySender(c.ID())
 }
 

--- a/pkg/collector/internal/middleware/test_utils.go
+++ b/pkg/collector/internal/middleware/test_utils.go
@@ -20,5 +20,6 @@ func (c *CheckWrapper) Inner() check.Check {
 // Wait blocks until Run() finishes execution in another
 // goroutine. Does not block if Run() is not executing.
 func (c *CheckWrapper) Wait() {
-	c.wg.Wait()
+	c.runM.Lock()
+	defer c.runM.Unlock()
 }


### PR DESCRIPTION

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

If a check runs after it was unscheduled, in particular after it's sender and samplers were removed, would create sender and samplers again, leaking resources. This may happen if the check was cancelled after it was put in the worker channel, but before worker called Run.

This change adjusts check_wrapper to make Cancel fully mutually exclusive with Run, and adds a flag that would prevent Run from executing the check after Cancel has completed.

### Motivation

Fix a memory leak.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Run the agent, make sure checks run normal. Configure several python checks, make sure they execute as expected.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
