### PR TITLE
Trace-Agent: Prevent OOMs from big dictionary allocations in v5

### DIFF
--- a/cmd/trace-agent/test/testsuite/traces_test.go
+++ b/cmd/trace-agent/test/testsuite/traces_test.go
@@ -9,11 +9,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/DataDog/datadog-agent/cmd/trace-agent/test"
 	"github.com/DataDog/datadog-agent/pkg/trace/config"
 	"github.com/DataDog/datadog-agent/pkg/trace/pb"
 	"github.com/DataDog/datadog-agent/pkg/trace/testutil"
-	"github.com/stretchr/testify/assert"
 )
 
 // create a new config to access default config values

--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -311,6 +311,11 @@ func (r *HTTPReceiver) handleWithVersion(v Version, f func(Version, http.Respons
 			return
 		}
 
+		if req.Header.Get("Sec-Fetch-Site") == "cross-site" {
+			http.Error(w, "cross-site request rejected", http.StatusForbidden)
+			return
+		}
+
 		// TODO(x): replace with http.MaxBytesReader?
 		req.Body = apiutil.NewLimitedReader(req.Body, r.conf.MaxRequestBytes)
 

--- a/pkg/trace/pb/decoder_v05.go
+++ b/pkg/trace/pb/decoder_v05.go
@@ -42,6 +42,9 @@ func (t *Traces) UnmarshalMsgDictionary(bts []byte) error {
 	if sz, bts, err = msgp.ReadArrayHeaderBytes(bts); err != nil {
 		return err
 	}
+	if sz > 25*1e6 { // Dictionary can't be larger than 25 MB
+		return errors.New("too long payload")
+	}
 	dict := make([]string, sz)
 	for i := range dict {
 		var str string
@@ -151,6 +154,9 @@ func (z *Span) UnmarshalMsgDictionary(bts []byte, dict []string) ([]byte, error)
 	sz, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if err != nil {
 		return bts, err
+	}
+	if sz > 25*1e6 { // Dictionary can't be larger than 25 MB
+		return bts, errors.New("too long payload")
 	}
 	if z.Meta == nil && sz > 0 {
 		z.Meta = make(map[string]string, sz)

--- a/pkg/trace/pb/decoder_v05_test.go
+++ b/pkg/trace/pb/decoder_v05_test.go
@@ -80,6 +80,20 @@ func TestUnmarshalMsgDictionary(t *testing.T) {
 	})
 }
 
+func TestUnmarshalMsgDictionaryLimitsSize(t *testing.T) {
+	ps := [][]byte{
+		[]byte("\x9e\xdd\xff\xff\xff\xff"),
+		[]byte("\x96\x97\xa40000\xa6000000\xa6000000\xa6000000\xa6000000\xa6000000\xa6000000\x96\x94\x9c\x00\x00\x0000\xd100000\xdf0000"),
+	}
+	for _, p := range ps {
+		t.Run("", func(t *testing.T) {
+			var traces Traces
+			err := traces.UnmarshalMsgDictionary(p)
+			assert.EqualError(t, err, "too long payload")
+		})
+	}
+}
+
 var benchOut Traces
 
 func BenchmarkUnmarshalMsgDictionary(b *testing.B) {


### PR DESCRIPTION
### What does this PR do?
Limit allocation sizes for v5 endpoint.
Don't allow requests coming from the browser.

### Describe how to test/QA your changes
Covered by unit tests

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
