### PR TITLE
[process-agent] Fix the ProcessCheck receiver for consistency

### DIFF
--- a/pkg/process/checks/process.go
+++ b/pkg/process/checks/process.go
@@ -109,28 +109,28 @@ func (p *ProcessCheck) Init(_ *SysProbeConfig, info *HostInfo) error {
 	return nil
 }
 
-func (c *ProcessCheck) initConnRates() {
-	c.lastConnRates = atomic.NewPointer[ProcessConnRates](nil)
-	c.connRatesReceiver = subscriptions.NewReceiver[ProcessConnRates]()
+func (p *ProcessCheck) initConnRates() {
+	p.lastConnRates = atomic.NewPointer[ProcessConnRates](nil)
+	p.connRatesReceiver = subscriptions.NewReceiver[ProcessConnRates]()
 
-	go c.updateConnRates()
+	go p.updateConnRates()
 }
 
-func (c *ProcessCheck) updateConnRates() {
+func (p *ProcessCheck) updateConnRates() {
 	for {
-		connRates, ok := <-c.connRatesReceiver.Ch
+		connRates, ok := <-p.connRatesReceiver.Ch
 		if !ok {
 			return
 		}
-		c.lastConnRates.Store(&connRates)
+		p.lastConnRates.Store(&connRates)
 	}
 }
 
-func (c *ProcessCheck) getLastConnRates() ProcessConnRates {
-	if c.lastConnRates == nil {
+func (p *ProcessCheck) getLastConnRates() ProcessConnRates {
+	if p.lastConnRates == nil {
 		return nil
 	}
-	if result := c.lastConnRates.Load(); result != nil {
+	if result := p.lastConnRates.Load(); result != nil {
 		return *result
 	}
 	return nil


### PR DESCRIPTION
### What does this PR do?

Renames the ProcessCheck pointer receiver from `c` to `p` to match the rest of the package.

### Motivation

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
