### PR TITLE
pkg/obfuscate: ensure correct format for http.url

### DIFF
--- a/pkg/obfuscate/http.go
+++ b/pkg/obfuscate/http.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 )
 
-// obfuscateUserInfo ensures there is no userinfo field in a given URL.
+// obfuscateUserInfo returns a URL string that obfuscates any userinfo by setting url.User to nil.
 func obfuscateUserInfo(val string) string {
 	u, err := url.Parse(val)
 	if err != nil {

--- a/pkg/obfuscate/http.go
+++ b/pkg/obfuscate/http.go
@@ -10,12 +10,22 @@ import (
 	"strings"
 )
 
+// obfuscateUserInfo ensures there is no userinfo field in a given URL.
+func obfuscateUserInfo(val string) string {
+	u, err := url.Parse(val)
+	if err != nil {
+		return val
+	}
+	u.User = nil
+	return u.String()
+}
+
 // ObfuscateURLString obfuscates the given URL. It must be a valid URL and at least one
 // HTTP obfuscation option must be enabled at Obfuscator instantiation time.
 func (o *Obfuscator) ObfuscateURLString(val string) string {
 	if !o.opts.HTTP.RemoveQueryString && !o.opts.HTTP.RemovePathDigits {
 		// nothing to do
-		return val
+		return obfuscateUserInfo(val)
 	}
 	u, err := url.Parse(val)
 	if err != nil {
@@ -23,6 +33,7 @@ func (o *Obfuscator) ObfuscateURLString(val string) string {
 		// rather than expose sensitive information when this option is on.
 		return "?"
 	}
+	u.User = nil
 	if o.opts.HTTP.RemoveQueryString && u.RawQuery != "" {
 		u.ForceQuery = true // add the '?'
 		u.RawQuery = ""

--- a/pkg/obfuscate/http.go
+++ b/pkg/obfuscate/http.go
@@ -20,8 +20,7 @@ func obfuscateUserInfo(val string) string {
 	return u.String()
 }
 
-// ObfuscateURLString obfuscates the given URL. It must be a valid URL and at least one
-// HTTP obfuscation option must be enabled at Obfuscator instantiation time.
+// ObfuscateURLString obfuscates the given URL. It must be a valid URL.
 func (o *Obfuscator) ObfuscateURLString(val string) string {
 	if !o.opts.HTTP.RemoveQueryString && !o.opts.HTTP.RemovePathDigits {
 		// nothing to do

--- a/pkg/obfuscate/http_test.go
+++ b/pkg/obfuscate/http_test.go
@@ -23,6 +23,11 @@ func TestObfuscateHTTP(t *testing.T) {
 		out: testURL,
 	}, nil))
 
+	t.Run("disabledUserinfo", testHTTPObfuscation(&inOutTest{
+		in:  "http://user:password@foo.com/1/2/3?q=james",
+		out: "http://foo.com/1/2/3?q=james",
+	}, nil))
+
 	t.Run("query", func(t *testing.T) {
 		conf := &Config{HTTP: HTTPConfig{
 			RemoveQueryString: true,
@@ -51,6 +56,10 @@ func TestObfuscateHTTP(t *testing.T) {
 			{
 				in:  "http://foo.com/id/123/pa%3Fge/1?blabla",
 				out: "http://foo.com/id/123/pa%3Fge/1?",
+			},
+			{
+				in:  "http://user:password@foo.com/1/2/3?q=james",
+				out: "http://foo.com/1/2/3?",
 			},
 		} {
 			t.Run(strconv.Itoa(ti), testHTTPObfuscation(&tt, conf))
@@ -98,6 +107,10 @@ func TestObfuscateHTTP(t *testing.T) {
 				in:  "http://foo.com/1%3F3/nam%3Fe/abcd9",
 				out: "http://foo.com/?/nam%3Fe/?",
 			},
+			{
+				in:  "http://user:password@foo.com/1/2/3?q=james",
+				out: "http://foo.com/?/?/??q=james",
+			},
 		} {
 			t.Run(strconv.Itoa(ti), testHTTPObfuscation(&tt, conf))
 		}
@@ -136,6 +149,10 @@ func TestObfuscateHTTP(t *testing.T) {
 			{
 				in:  "http://foo.com/id/123/pa%3Fge/1?blabla",
 				out: "http://foo.com/id/?/pa%3Fge/??",
+			},
+			{
+				in:  "http://user:password@foo.com/1/2/3?q=james",
+				out: "http://foo.com/?/?/??",
 			},
 		} {
 			t.Run(strconv.Itoa(ti), testHTTPObfuscation(&tt, conf))


### PR DESCRIPTION
### What does this PR do?

This PR ensures that any http.url tags do not contain a userinfo field. This new behavior will be enabled by default, even if other http obfuscation is not enabled. There is no option to disable this obfuscation.

### Describe how to test/QA your changes

Send a trace to the trace agent with the `http.url` tag set to a url string with a userinfo field, such as `http://abc:def@example.com/whatever`, and ensure that the userinfo part (`abc:def`) does not appear in the `http.url` tag in the UI.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
