### PR TITLE
usm: postgres classification: Reduced 5 seconds per test, 1m30s in total

### DIFF
--- a/pkg/network/protocols/postgres/server.go
+++ b/pkg/network/protocols/postgres/server.go
@@ -23,5 +23,5 @@ func RunPostgresServer(t *testing.T, serverAddr string, serverPort string) {
 
 	dir, _ := testutil.CurDir()
 
-	protocolsUtils.RunDockerServer(t, "postgres", dir+"/testdata/docker-compose.yml", env, regexp.MustCompile(".*database system is ready to accept connections"))
+	protocolsUtils.RunDockerServer(t, "postgres", dir+"/testdata/docker-compose.yml", env, regexp.MustCompile(".*\\[1].*database system is ready to accept connections"))
 }

--- a/pkg/network/protocols/postgres/utils.go
+++ b/pkg/network/protocols/postgres/utils.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"database/sql"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/uptrace/bun"
@@ -17,7 +16,7 @@ import (
 	"github.com/uptrace/bun/driver/pgdriver"
 )
 
-// Define a table schema, so that Bun can generates queries for it.
+// DummyTable defines a table schema, so that `bun` module can generate queries for it.
 type DummyTable struct {
 	bun.BaseModel `bun:"table:dummy,alias:d"`
 
@@ -25,14 +24,13 @@ type DummyTable struct {
 	Foo string
 }
 
-var dummyModel *DummyTable = &DummyTable{ID: 1, Foo: "bar"}
+var dummyModel = &DummyTable{ID: 1, Foo: "bar"}
 
 // GetPGHandle returns a handle on the test Postgres DB. This does not initiate
 // a connection
 func GetPGHandle(t *testing.T, serverAddr string) *sql.DB {
 	t.Helper()
 
-	time.Sleep(5 * time.Second)
 	pg := sql.OpenDB(pgdriver.NewConnector(
 		pgdriver.WithNetwork("tcp"),
 		pgdriver.WithAddr(serverAddr),
@@ -46,7 +44,7 @@ func GetPGHandle(t *testing.T, serverAddr string) *sql.DB {
 }
 
 // ConnectAndGetDB initiates a connection to the database, get a handle on the
-// test db, and register cleanup handlers for the test. Finally it saves the db
+// test db, and register cleanup handlers for the test. Finally, it saves the db
 // handle and task context in the provided extras map.
 func ConnectAndGetDB(t *testing.T, serverAddr string, extras map[string]interface{}) {
 	t.Helper()
@@ -132,9 +130,9 @@ func RunUpdateQuery(t *testing.T, extras map[string]interface{}) {
 	t.Helper()
 	db, ctx := getCtx(extras)
 
-	new := *dummyModel
-	new.Foo = "baz"
+	newModel := *dummyModel
+	newModel.Foo = "baz"
 
-	_, err := db.NewUpdate().Model(&new).WherePK().Exec(ctx)
+	_, err := db.NewUpdate().Model(&newModel).WherePK().Exec(ctx)
 	require.NoError(t, err)
 }


### PR DESCRIPTION

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Improved the regex for which we are using to detect if the server is up and running, by that we can spare the 'wait 5 seconds' in GetPGHandle

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Reducing test time

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
