### PR TITLE
usm: classification: Fixed AMQP publish flakiness

### DIFF
--- a/pkg/network/ebpf/c/protocols/amqp-defs.h
+++ b/pkg/network/ebpf/c/protocols/amqp-defs.h
@@ -1,10 +1,16 @@
 #ifndef __AMQP_DEFS_H
 #define __AMQP_DEFS_H
 
+#define AMQP_PREFACE "AMQP"
+
 // RabbitMQ supported classes.
 // Ref: https://www.rabbitmq.com/resources/specs/amqp0-9-1.pdf
 #define AMQP_CONNECTION_CLASS 10
 #define AMQP_BASIC_CLASS 60
+#define AMQP_CHANNEL_CLASS 20
+
+#define AMQP_METHOD_CLOSE_OK 40
+#define AMQP_METHOD_CLOSE 41
 
 // RabbitMQ supported connections.
 #define AMQP_METHOD_CONNECTION_START 10
@@ -18,5 +24,10 @@
 
 #define AMQP_MIN_FRAME_LENGTH 8
 #define AMQP_MIN_PAYLOAD_LENGTH 11
+
+typedef struct {
+    __u16 class_id;
+    __u16 method_id;
+} amqp_header;
 
 #endif

--- a/pkg/network/ebpf/c/protocols/amqp-helpers.h
+++ b/pkg/network/ebpf/c/protocols/amqp-helpers.h
@@ -2,14 +2,13 @@
 #define __AMQP_HELPERS_H
 
 #include "amqp-defs.h"
+#include "bpf_endian.h"
 #include "protocol-classification-common.h"
 
 // The method checks if the given buffer includes the protocol header which must be sent in the start of a new connection.
 // Ref: https://www.rabbitmq.com/resources/specs/amqp0-9-1.pdf
 static __always_inline bool is_amqp_protocol_header(const char* buf, __u32 buf_size) {
     CHECK_PRELIMINARY_BUFFER_CONDITIONS(buf, buf_size, AMQP_MIN_FRAME_LENGTH);
-
-#define AMQP_PREFACE "AMQP"
 
     bool match = !bpf_memcmp(buf, AMQP_PREFACE, sizeof(AMQP_PREFACE)-1);
 
@@ -30,28 +29,47 @@ static __always_inline bool is_amqp(const char* buf, __u32 buf_size) {
        return false;
     }
 
-    uint8_t frame_type = buf[0];
+    __u8 frame_type = buf[0];
     // Check only for method frame type.
     if (frame_type != AMQP_FRAME_METHOD_TYPE) {
         return false;
     }
 
-    // We extract the class id and method id by big indian from the buffer.
+    // We extract the class id and method id by big endian from the buffer.
     // Ref https://www.rabbitmq.com/resources/specs/amqp0-9-1.pdf.
-    __u16 class_id = buf[7] << 8 | buf[8];
-    __u16 method_id = buf[9] << 8 | buf[10];
+    amqp_header *hdr = (amqp_header *)(buf+7);
+    __u16 class_id = bpf_ntohs(hdr->class_id);
+    __u16 method_id = bpf_ntohs(hdr->method_id);
 
-    // ConnectionStart, ConnectionStartOk, BasicPublish, BasicDeliver, BasicConsume are the most likely methods to
-    // consider for the classification.
-    if (class_id == AMQP_CONNECTION_CLASS) {
-        return  method_id == AMQP_METHOD_CONNECTION_START || method_id == AMQP_METHOD_CONNECTION_START_OK;
+    switch (class_id) {
+    case AMQP_CONNECTION_CLASS:
+        switch (method_id) {
+        case AMQP_METHOD_CONNECTION_START:
+        case AMQP_METHOD_CONNECTION_START_OK:
+            return true;
+        default:
+            return false;
+        }
+    case AMQP_BASIC_CLASS:
+        switch (method_id) {
+        case AMQP_METHOD_PUBLISH:
+        case AMQP_METHOD_DELIVER:
+        case AMQP_METHOD_CONSUME:
+            return true;
+        default:
+            return false;
+        }
+    case AMQP_CHANNEL_CLASS:
+        switch (method_id) {
+        case AMQP_METHOD_CLOSE_OK:
+        case AMQP_METHOD_CLOSE:
+            return true;
+        default:
+            return false;
+        }
+    default:
+        return false;
     }
-
-    if (class_id == AMQP_BASIC_CLASS) {
-        return method_id == AMQP_METHOD_PUBLISH || method_id == AMQP_METHOD_DELIVER || method_id == AMQP_METHOD_CONSUME;
-    }
-
-    return false;
 }
 
 #endif

--- a/pkg/network/tracer/tracer_classification_test.go
+++ b/pkg/network/tracer/tracer_classification_test.go
@@ -287,7 +287,11 @@ func testProtocolClassification(t *testing.T, cfg *config.Config, clientHost, ta
 					ServerAddress: ctx.serverAddress,
 				})
 				require.NoError(t, err)
-				defer client.Terminate()
+				ctx.extras["client"] = client
+			},
+			teardown: func(t *testing.T, ctx testContext) {
+				client := ctx.extras["client"].(*amqp.Client)
+				client.Terminate()
 			},
 			shouldSkip: composeSkips(skipIfNotLinux, skipIfUsingNAT),
 			validation: validateProtocolConnection,
@@ -312,9 +316,11 @@ func testProtocolClassification(t *testing.T, cfg *config.Config, clientHost, ta
 			},
 			postTracerSetup: func(t *testing.T, ctx testContext) {
 				client := ctx.extras["client"].(*amqp.Client)
-				defer client.Terminate()
-
 				require.NoError(t, client.DeclareQueue("test", client.PublishChannel))
+			},
+			teardown: func(t *testing.T, ctx testContext) {
+				client := ctx.extras["client"].(*amqp.Client)
+				client.Terminate()
 			},
 			shouldSkip: composeSkips(skipIfNotLinux, skipIfUsingNAT),
 			validation: validateProtocolConnection,
@@ -340,9 +346,11 @@ func testProtocolClassification(t *testing.T, cfg *config.Config, clientHost, ta
 			},
 			postTracerSetup: func(t *testing.T, ctx testContext) {
 				client := ctx.extras["client"].(*amqp.Client)
-				defer client.Terminate()
-
 				require.NoError(t, client.Publish("test", "my msg"))
+			},
+			teardown: func(t *testing.T, ctx testContext) {
+				client := ctx.extras["client"].(*amqp.Client)
+				client.Terminate()
 			},
 			shouldSkip: composeSkips(skipIfNotLinux, skipIfUsingNAT),
 			validation: validateProtocolConnection,
@@ -370,11 +378,13 @@ func testProtocolClassification(t *testing.T, cfg *config.Config, clientHost, ta
 			},
 			postTracerSetup: func(t *testing.T, ctx testContext) {
 				client := ctx.extras["client"].(*amqp.Client)
-				defer client.Terminate()
-
 				res, err := client.Consume("test", 1)
 				require.NoError(t, err)
 				require.Equal(t, []string{"my msg"}, res)
+			},
+			teardown: func(t *testing.T, ctx testContext) {
+				client := ctx.extras["client"].(*amqp.Client)
+				client.Terminate()
 			},
 			shouldSkip: composeSkips(skipIfNotLinux, skipIfUsingNAT),
 			validation: validateProtocolConnection,

--- a/pkg/network/tracer/tracer_classification_test.go
+++ b/pkg/network/tracer/tracer_classification_test.go
@@ -54,6 +54,7 @@ type testContext struct {
 }
 
 func setupTracer(t *testing.T, cfg *config.Config) *Tracer {
+	cfg.BPFDebug = true
 	tr, err := NewTracer(cfg)
 	if err != nil {
 		t.Fatal(err)
@@ -277,6 +278,7 @@ func testProtocolClassification(t *testing.T, cfg *config.Config, clientHost, ta
 				serverPort:       "5672",
 				clientDialer:     defaultDialer,
 				expectedProtocol: network.ProtocolAMQP,
+				extras:           make(map[string]interface{}),
 			},
 			preTracerSetup: func(t *testing.T, ctx testContext) {
 				host, port, _ := net.SplitHostPort(ctx.serverAddress)

--- a/pkg/network/tracer/tracer_classification_test.go
+++ b/pkg/network/tracer/tracer_classification_test.go
@@ -54,7 +54,6 @@ type testContext struct {
 }
 
 func setupTracer(t *testing.T, cfg *config.Config) *Tracer {
-	cfg.BPFDebug = true
 	tr, err := NewTracer(cfg)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Improves classification by AMQP.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Publish has no response, so added classification by close-reply and close-ok messages.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
