### PR TITLE
[process-agent] Fix kitchen tests for process agent on main

### DIFF
--- a/cmd/process-agent/subcommands/check/check.go
+++ b/cmd/process-agent/subcommands/check/check.go
@@ -206,7 +206,10 @@ func runCheck(cliParams *cliParams, ch checks.Check) error {
 
 	options := &checks.RunOptions{
 		RunStandard: true,
-		RunRealtime: true,
+	}
+
+	if cliParams.checkName == checks.RTName(ch.Name()) {
+		options.RunRealtime = true
 	}
 
 	// We need to run the check twice in order to initialize the stats


### PR DESCRIPTION
### What does this PR do?

- Fixes process agent kitchen tests on `main` (`kitchen_${os}_process_agent_${version}`) broken by https://github.com/DataDog/datadog-agent/pull/15063.
- Addresses an issue where `process-agent check process` would return "Unknown message format" due to passing realtime payloads to the go template for the standard run.

The primary issue here had to do with `RunResult` interface `nil` values and lack of the `nil` check in `Collector`. Unfortunately these kitchen tests only run on main and not on the branch so it went unnoticed. I verified they pass by `inv pipeline.run`.

### Motivation

- Regression

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
