### PR TITLE
[CWS][SEC-6349] Check tracefs default mount dir before checking for the debugfs one

### DIFF
--- a/pkg/ebpf/debuglog_dumper.go
+++ b/pkg/ebpf/debuglog_dumper.go
@@ -11,14 +11,13 @@ package ebpf
 import (
 	"bufio"
 	"context"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
-)
 
-const (
-	debugLogPath = "/sys/kernel/debug/tracing/trace_pipe"
+	utilkernel "github.com/DataDog/datadog-agent/pkg/util/kernel"
 )
 
 // DumpDebugLog is a utility to write the debug log of the running application to a given writer.
@@ -34,7 +33,11 @@ func DumpDebugLog(ctx context.Context, writer io.Writer) error {
 		maxFilenameSize = len(filename)
 	}
 
-	f, err := os.Open(debugLogPath)
+	tracefsPath := utilkernel.GetTraceFSMountPath()
+	if tracefsPath == "" {
+		return errors.New("tracefs not available")
+	}
+	f, err := os.Open(filepath.Join(tracefsPath, "trace_pipe"))
 	if err != nil {
 		return err
 	}

--- a/pkg/flare/archive_linux.go
+++ b/pkg/flare/archive_linux.go
@@ -10,6 +10,7 @@ package flare
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"path/filepath"
@@ -18,6 +19,7 @@ import (
 
 	flarehelpers "github.com/DataDog/datadog-agent/comp/core/flare/helpers"
 	"github.com/DataDog/datadog-agent/pkg/config"
+	utilkernel "github.com/DataDog/datadog-agent/pkg/util/kernel"
 )
 
 func addSystemProbePlatformSpecificEntries(fb flarehelpers.FlareBuilder) {
@@ -32,7 +34,11 @@ func getLinuxKernelSymbols(fb flarehelpers.FlareBuilder) error {
 }
 
 func getLinuxKprobeEvents(fb flarehelpers.FlareBuilder) error {
-	return fb.CopyFile("/sys/kernel/debug/tracing/kprobe_events")
+	traceFSPath := utilkernel.GetTraceFSMountPath()
+	if traceFSPath == "" {
+		return errors.New("tracefs not available")
+	}
+	return fb.CopyFile(filepath.Join(traceFSPath, "kprobe_events"))
 }
 
 func getLinuxPid1MountInfo(fb flarehelpers.FlareBuilder) error {
@@ -98,9 +104,17 @@ func getLinuxDmesg(fb flarehelpers.FlareBuilder) error {
 }
 
 func getLinuxTracingAvailableEvents(fb flarehelpers.FlareBuilder) error {
-	return fb.CopyFile("/sys/kernel/debug/tracing/available_events")
+	traceFSPath := utilkernel.GetTraceFSMountPath()
+	if traceFSPath == "" {
+		return errors.New("tracefs not available")
+	}
+	return fb.CopyFile(filepath.Join(traceFSPath, "available_events"))
 }
 
 func getLinuxTracingAvailableFilterFunctions(fb flarehelpers.FlareBuilder) error {
-	return fb.CopyFile("/sys/kernel/debug/tracing/available_filter_functions")
+	traceFSPath := utilkernel.GetTraceFSMountPath()
+	if traceFSPath == "" {
+		return errors.New("tracefs not available")
+	}
+	return fb.CopyFile(filepath.Join(traceFSPath, "available_filter_functions"))
 }

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -108,7 +108,7 @@ func NewTracer(config *config.Config) (*Tracer, error) {
 // (and NewTracer above)
 func newTracer(config *config.Config) (*Tracer, error) {
 	// make sure debugfs is mounted
-	if mounted, err := kernel.IsDebugFSMounted(); !mounted {
+	if mounted, err := kernel.IsDebugFSOrTraceFSMounted(); !mounted {
 		return nil, fmt.Errorf("system-probe unsupported: %s", err)
 	}
 

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -146,7 +146,7 @@ func (p *Probe) UseRingBuffers() bool {
 
 func (p *Probe) sanityChecks() error {
 	// make sure debugfs is mounted
-	if mounted, err := utilkernel.IsDebugFSMounted(); !mounted {
+	if mounted, err := utilkernel.IsDebugFSOrTraceFSMounted(); !mounted {
 		return err
 	}
 

--- a/pkg/util/kernel/fs.go
+++ b/pkg/util/kernel/fs.go
@@ -17,6 +17,7 @@ import (
 	"github.com/moby/sys/mountinfo"
 
 	"github.com/DataDog/datadog-agent/pkg/process/util"
+	"github.com/DataDog/datadog-agent/pkg/security/seclog"
 	"github.com/DataDog/datadog-agent/pkg/util/fargate"
 )
 
@@ -63,9 +64,9 @@ func GetMountPoint(path string) (*mountinfo.Info, error) {
 	return nil, fmt.Errorf("no matching mountpoint found")
 }
 
-// IsDebugFSMounted would test the existence of file /sys/kernel/debug/tracing/kprobe_events to determine if debugfs is mounted or not
+// isDebugFSMounted would test the existence of file /sys/kernel/debug/tracing/kprobe_events to determine if debugfs (or debugfs AND tracefs) is/are mounted or not
 // returns a boolean and a possible error message
-func IsDebugFSMounted() (bool, error) {
+func isDebugFSMounted() (bool, error) {
 	_, err := os.Stat("/sys/kernel/debug/tracing/kprobe_events")
 	if err != nil {
 		if os.IsPermission(err) {
@@ -97,4 +98,76 @@ func IsDebugFSMounted() (bool, error) {
 	}
 
 	return true, nil
+}
+
+// isTraceFSMounted would test the existence of file /sys/kernel/tracing/kprobe_events to determine if tracefs is mounted (and debugfs is not)
+// returns a boolean and a possible error message
+func isTraceFSMounted() bool {
+	_, err := os.Stat("/sys/kernel/tracing/kprobe_events")
+	if err != nil {
+		if os.IsPermission(err) {
+			seclog.Errorf("eBPF not supported, does not have permission to access tracefs")
+			return false
+		} else if os.IsNotExist(err) {
+			seclog.Errorf("tracefs is not mounted and is needed for eBPF-based checks, run \"sudo mount -t tracefs none /sys/kernel/tracing\" to mount tracefs")
+			return false
+		} else {
+			seclog.Errorf("an error occurred while accessing tracefs: %s", err)
+			return false
+		}
+	}
+
+	mi, err := GetMountPoint("/sys/kernel/tracing/kprobe_events")
+	if err != nil {
+		seclog.Errorf("unable to detect tracefs mount point: %s", err)
+		return false
+	}
+
+	if mi.FSType != "tracefs" {
+		seclog.Errorf("kprobe_events mount point(%s): wrong fs type(%s)", mi.Mountpoint, mi.FSType)
+		return false
+	}
+
+	// on fargate, kprobe_events is mounted as ro
+	if !fargate.IsFargateInstance() {
+		options := strings.Split(mi.Options, ",")
+		for _, option := range options {
+			if option == "ro" {
+				seclog.Errorf("kprobe_events mount point(%s) is in read-only mode", mi.Mountpoint)
+				return false
+			}
+		}
+	}
+
+	return true
+}
+
+// Cf https://www.kernel.org/doc/Documentation/trace/ftrace.txt :
+//     [...] When tracefs is configured into the kernel (which selecting any ftrace
+//     option will do) the directory /sys/kernel/tracing will be created.
+//     [...] Before 4.1, all ftrace tracing control files were within the debugfs
+//     file system, which is typically located at /sys/kernel/debug/tracing.
+//     For backward compatibility, when mounting the debugfs file system,
+//     the tracefs file system will be automatically mounted at:
+//      /sys/kernel/debug/tracing
+//     All files located in the tracefs file system will be located in that
+//     debugfs file system directory as well.
+
+// IsDebugFSOrTraceFSMounted would test the existence of file /sys/kernel/tracing/kprobe_events to determine if tracefs is mounted or not
+// returns a boolean and a possible error message
+func IsDebugFSOrTraceFSMounted() (bool, error) {
+	isMounted := isTraceFSMounted()
+	if isMounted {
+		return true, nil
+	}
+	return isDebugFSMounted()
+}
+
+func GetTraceFSMountPath() string {
+	if isTraceFSMounted() {
+		return "/sys/kernel/tracing"
+	} else if isMounted, _ := isDebugFSMounted(); isMounted {
+		return "/sys/kernel/debug/tracing"
+	}
+	return ""
 }


### PR DESCRIPTION
### What does this PR do?

This PR add a check for distributions whithout debugfs mounted at init, where we should rely instead on default tracefs mount dir (aka `/sys/kernel/tracing`)

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
