### PR TITLE
[dca] filter pod annotation during workloadmeta collection

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -716,7 +716,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("cluster_agent.max_leader_connections", 100)
 	config.BindEnvAndSetDefault("cluster_agent.client_reconnect_period_seconds", 1200)
 	config.BindEnvAndSetDefault("cluster_agent.collect_kubernetes_tags", false)
-	config.BindEnvAndSetDefault("cluster_agent.workloadmeta.pod_annotations_exclude", []string{
+	config.BindEnvAndSetDefault("cluster_agent.kubernetes_resources_collection.pod_annotations_exclude", []string{
 		"kubectl.kubernetes.io/last-applied-configuration",
 		"^ad.datadoghq.com\\/([[:alnum:]].*.)?(checks|check_names|init_configs|instances)$",
 	})

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -716,6 +716,10 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("cluster_agent.max_leader_connections", 100)
 	config.BindEnvAndSetDefault("cluster_agent.client_reconnect_period_seconds", 1200)
 	config.BindEnvAndSetDefault("cluster_agent.collect_kubernetes_tags", false)
+	config.BindEnvAndSetDefault("cluster_agent.workloadmeta.pod_annotations_exclude", []string{
+		"kubectl.kubernetes.io/last-applied-configuration",
+		"^ad.datadoghq.com\\/([[:alnum:]].*.)?(checks|check_names|init_configs|instances)$",
+	})
 	config.BindEnvAndSetDefault("metrics_port", "5000")
 
 	// Metadata endpoints

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -717,8 +717,8 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("cluster_agent.client_reconnect_period_seconds", 1200)
 	config.BindEnvAndSetDefault("cluster_agent.collect_kubernetes_tags", false)
 	config.BindEnvAndSetDefault("cluster_agent.kubernetes_resources_collection.pod_annotations_exclude", []string{
-		`^kubectl\.kubernetes\.io/last-applied-configuration$`,
-		`^ad\.datadoghq\.com/([[:alnum:]]+\.)?(checks|check_names|init_configs|instances)$`,
+		`^kubectl\.kubernetes\.io\/last-applied-configuration$`,
+		`^ad\.datadoghq\.com\/([[:alnum:]]+\.)?(checks|check_names|init_configs|instances)$`,
 	})
 	config.BindEnvAndSetDefault("metrics_port", "5000")
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -717,8 +717,8 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("cluster_agent.client_reconnect_period_seconds", 1200)
 	config.BindEnvAndSetDefault("cluster_agent.collect_kubernetes_tags", false)
 	config.BindEnvAndSetDefault("cluster_agent.kubernetes_resources_collection.pod_annotations_exclude", []string{
-		"kubectl.kubernetes.io/last-applied-configuration",
-		"^ad.datadoghq.com\\/([[:alnum:]].*.)?(checks|check_names|init_configs|instances)$",
+		`^kubectl\.kubernetes\.io/last-applied-configuration$`,
+		`^ad\.datadoghq\.com/([[:alnum:]]+\.)?(checks|check_names|init_configs|instances)$`,
 	})
 	config.BindEnvAndSetDefault("metrics_port", "5000")
 

--- a/pkg/workloadmeta/collectors/internal/kubeapiserver/reflector_store.go
+++ b/pkg/workloadmeta/collectors/internal/kubeapiserver/reflector_store.go
@@ -31,7 +31,7 @@ type reflectorStore struct {
 }
 
 func newReflectorStore(wlmetaStore workloadmeta.Store) cache.Store {
-	annotationsExclude := config.Datadog.GetStringSlice("cluster_agent.workloadmeta.pod_annotations_exclude")
+	annotationsExclude := config.Datadog.GetStringSlice("cluster_agent.kubernetes_resources_collection.pod_annotations_exclude")
 	parseOptions, err := newParseOptions(annotationsExclude)
 	if err != nil {
 		_ = log.Errorf("unable to parse all pod_annotations_exclude: %v, err:", err)

--- a/pkg/workloadmeta/collectors/internal/kubeapiserver/reflector_store.go
+++ b/pkg/workloadmeta/collectors/internal/kubeapiserver/reflector_store.go
@@ -9,25 +9,37 @@
 package kubeapiserver
 
 import (
+	"fmt"
+	"regexp"
 	"sync"
 
 	corev1 "k8s.io/api/core/v1"
+	utilserror "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/tools/cache"
 
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 )
 
 type reflectorStore struct {
 	wlmetaStore workloadmeta.Store
 
-	mu   sync.Mutex
-	seen map[string]workloadmeta.EntityID
+	mu      sync.Mutex
+	seen    map[string]workloadmeta.EntityID
+	options *parseOptions
 }
 
 func newReflectorStore(wlmetaStore workloadmeta.Store) cache.Store {
+	annotationsExclude := config.Datadog.GetStringSlice("cluster_agent.workloadmeta.pod_annotations_exclude")
+	parseOptions, err := newParseOptions(annotationsExclude)
+	if err != nil {
+		_ = log.Errorf("unable to parse all pod_annotations_exclude: %v, err:", err)
+	}
 	return &reflectorStore{
 		wlmetaStore: wlmetaStore,
 		seen:        make(map[string]workloadmeta.EntityID),
+		options:     parseOptions,
 	}
 }
 
@@ -38,7 +50,7 @@ func (r *reflectorStore) Add(obj interface{}) error {
 	defer r.mu.Unlock()
 
 	pod := obj.(*corev1.Pod)
-	entity := parsePod(pod)
+	entity := parsePod(pod, r.options)
 
 	r.seen[string(pod.UID)] = entity.EntityID
 
@@ -99,7 +111,7 @@ func (r *reflectorStore) Replace(list []interface{}, _ string) error {
 	for _, obj := range list {
 		pod := obj.(*corev1.Pod)
 		podUID := string(pod.UID)
-		entity := parsePod(pod)
+		entity := parsePod(pod, r.options)
 
 		events = append(events, workloadmeta.CollectorEvent{
 			Type:   workloadmeta.EventTypeSet,
@@ -156,7 +168,26 @@ func (r *reflectorStore) Resync() error {
 	panic("not implemented")
 }
 
-func parsePod(pod *corev1.Pod) *workloadmeta.KubernetesPod {
+type parseOptions struct {
+	annotationsFilter []*regexp.Regexp
+}
+
+func newParseOptions(annotationsExclude []string) (*parseOptions, error) {
+	options := parseOptions{}
+	var errors []error
+	for _, exclude := range annotationsExclude {
+		filter, err := filterToRegex(exclude)
+		if err != nil {
+			errors = append(errors, err)
+			continue
+		}
+		options.annotationsFilter = append(options.annotationsFilter, filter)
+	}
+
+	return &options, utilserror.NewAggregate(errors)
+}
+
+func parsePod(pod *corev1.Pod, options *parseOptions) *workloadmeta.KubernetesPod {
 	owners := make([]workloadmeta.KubernetesPodOwner, 0, len(pod.OwnerReferences))
 	for _, o := range pod.OwnerReferences {
 		owners = append(owners, workloadmeta.KubernetesPodOwner{
@@ -191,7 +222,7 @@ func parsePod(pod *corev1.Pod) *workloadmeta.KubernetesPod {
 		EntityMeta: workloadmeta.EntityMeta{
 			Name:        pod.Name,
 			Namespace:   pod.Namespace,
-			Annotations: pod.Annotations,
+			Annotations: filterMapStringKey(pod.Annotations, options.annotationsFilter),
 			Labels:      pod.Labels,
 		},
 		Phase:                      string(pod.Status.Phase),
@@ -208,4 +239,28 @@ func parsePod(pod *corev1.Pod) *workloadmeta.KubernetesPod {
 		// containers can be quite significant
 		// Containers:                 []workloadmeta.OrchestratorContainer{},
 	}
+}
+
+func filterMapStringKey(mapInput map[string]string, keyFilters []*regexp.Regexp) map[string]string {
+	for key := range mapInput {
+		for _, filter := range keyFilters {
+			if filter.MatchString(key) {
+				delete(mapInput, key)
+				// we can break now since the key is already excluded.
+				break
+			}
+		}
+	}
+
+	return mapInput
+}
+
+// filterToRegex checks a filter's regex
+func filterToRegex(filter string) (*regexp.Regexp, error) {
+	r, err := regexp.Compile(filter)
+	if err != nil {
+		errormsg := fmt.Errorf("invalid regex '%s': %s", filter, err)
+		return nil, errormsg
+	}
+	return r, nil
 }

--- a/pkg/workloadmeta/collectors/internal/kubeapiserver/reflector_store_test.go
+++ b/pkg/workloadmeta/collectors/internal/kubeapiserver/reflector_store_test.go
@@ -28,7 +28,7 @@ func Test_filterMapStringKey(t *testing.T) {
 		"ad.datadoghq.com/tags":             `["bar","foo"]`,
 	}
 
-	defaultExclude := config.Datadog.GetStringSlice("cluster_agent.workloadmeta.pod_annotations_exclude")
+	defaultExclude := config.Datadog.GetStringSlice("cluster_agent.kubernetes_resources_collection.pod_annotations_exclude")
 	extraExclude := append(defaultExclude, "foo")
 
 	tests := []struct {

--- a/pkg/workloadmeta/collectors/internal/kubeapiserver/reflector_store_test.go
+++ b/pkg/workloadmeta/collectors/internal/kubeapiserver/reflector_store_test.go
@@ -1,0 +1,82 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+// +build kubeapiserver
+
+package kubeapiserver
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+)
+
+func Test_filterMapStringKey(t *testing.T) {
+	annotationstest := map[string]string{
+		"foo":                               "bar",
+		"ad.datadoghq.com/foo.checks":       `{"json":"foo"}`,
+		"ad.datadoghq.com/checks":           `{"json":"foo"}`,
+		"ad.datadoghq.com/foo.check_names":  `{"json":"foo"}`,
+		"ad.datadoghq.com/instances":        `{"json":"foo"}`,
+		"ad.datadoghq.com/foo.instances":    `{"json":"foo"}`,
+		"ad.datadoghq.com/init_configs":     `{"json":"foo"}`,
+		"ad.datadoghq.com/foo.init_configs": `{"json":"foo"}`,
+		"ad.datadoghq.com/tags":             `["bar","foo"]`,
+	}
+
+	defaultExclude := config.Datadog.GetStringSlice("cluster_agent.workloadmeta.pod_annotations_exclude")
+	extraExclude := append(defaultExclude, "foo")
+
+	tests := []struct {
+		name          string
+		excludeString []string
+		annotations   map[string]string
+		want          map[string]string
+	}{
+		{
+			name:        "no filter",
+			annotations: copyMap(annotationstest),
+			want:        annotationstest,
+		},
+		{
+			name:          "default filters",
+			excludeString: defaultExclude,
+			annotations:   copyMap(annotationstest),
+			want: map[string]string{
+				"foo":                   "bar",
+				"ad.datadoghq.com/tags": `["bar","foo"]`,
+			},
+		},
+		{
+			name:          "default filters",
+			excludeString: extraExclude,
+			annotations:   copyMap(annotationstest),
+			want: map[string]string{
+				"ad.datadoghq.com/tags": `["bar","foo"]`,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			options, err := newParseOptions(tt.excludeString)
+			if err != nil {
+				t.Errorf("newParseOptions() return an error %v", err)
+			}
+			if got := filterMapStringKey(tt.annotations, options.annotationsFilter); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("filterPodAnnotations() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func copyMap(in map[string]string) map[string]string {
+	out := make(map[string]string, len(in))
+	for key, value := range in {
+		out[key] = value
+	}
+	return out
+}

--- a/releasenotes/notes/cluster-agent-workload-pod-annotations-exclude-30b151c00df6b5fd.yaml
+++ b/releasenotes/notes/cluster-agent-workload-pod-annotations-exclude-30b151c00df6b5fd.yaml
@@ -1,0 +1,6 @@
+---
+enhancements:
+  - |
+    To reduce "cluster-agent" memory consomption when `cluster_agent.collect_kubernetes_tags`
+    option is enabled, we introduce `cluster_agent.workloadmeta.pod_annotations_exclude` option
+    to exclude Pod annotation from the extracted Pod metadata.

--- a/releasenotes/notes/cluster-agent-workload-pod-annotations-exclude-30b151c00df6b5fd.yaml
+++ b/releasenotes/notes/cluster-agent-workload-pod-annotations-exclude-30b151c00df6b5fd.yaml
@@ -2,5 +2,5 @@
 enhancements:
   - |
     To reduce "cluster-agent" memory consomption when `cluster_agent.collect_kubernetes_tags`
-    option is enabled, we introduce `cluster_agent.workloadmeta.pod_annotations_exclude` option
+    option is enabled, we introduce `cluster_agent.kubernetes_resources_collection.pod_annotations_exclude` option
     to exclude Pod annotation from the extracted Pod metadata.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Add an option in cluster-agent to filter Pods annotations during workloadmeta-store
collection.

### Motivation

It allows to reduce the cluster-agent memory usage when `cluster_agent.collect_kubernetes_tags`
is enabled.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

To ease testing it could be good to wait for `cluster-agent workload-list` command it
available in the cluster-agent (it should also be part of 7.43.0 version too).

* check the output of `cluster-agent workload-list` and if the annotations are properly filtered
* set the option `cluster_agent.workloadmeta.pod_annotations_exclude` with other annotation keys.
  and verify that the new values are used. 


<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
