### PR TITLE
Fix serializer tests flakiness

### DIFF
--- a/pkg/serializer/serializer_test.go
+++ b/pkg/serializer/serializer_test.go
@@ -15,8 +15,8 @@ import (
 	"strconv"
 	"strings"
 	"testing"
-	"time"
 
+	"github.com/benbjohnson/clock"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -371,16 +371,18 @@ func TestSendProcessesMetadata(t *testing.T) {
 }
 
 func TestSendContainerLifecycleEvents(t *testing.T) {
+	clock := clock.NewMock()
 	f := &forwarder.MockedForwarder{}
 	payload := []byte("\x0a\x02v1\x12\x08hostname\x18\x01")
 	payloads, _ := mkPayloads(payload, false)
 	extraHeaders := protobufExtraHeaders.Clone()
 	extraHeaders.Set(headers.EVPOriginHeader, "agent")
 	extraHeaders.Set(headers.EVPOriginVersionHeader, version.AgentVersion)
-	extraHeaders.Set(headers.TimestampHeader, strconv.Itoa(int(time.Now().Unix())))
+	extraHeaders.Set(headers.TimestampHeader, strconv.Itoa(int(clock.Now().Unix())))
 	f.On("SubmitContainerLifecycleEvents", payloads, extraHeaders).Return(nil).Times(1)
 
 	s := NewSerializer(nil, nil, f, nil, nil)
+	s.clock = clock
 
 	msg := []ContainerLifecycleMessage{
 		{
@@ -401,16 +403,18 @@ func TestSendContainerLifecycleEvents(t *testing.T) {
 }
 
 func TestSendContainerImage(t *testing.T) {
+	clock := clock.NewMock()
 	f := &forwarder.MockedForwarder{}
 	payload := []byte("\x0a\x02v1\x12\x08hostname")
 	payloads, _ := mkPayloads(payload, false)
 	extraHeaders := protobufExtraHeaders.Clone()
 	extraHeaders.Set(headers.EVPOriginHeader, "agent")
 	extraHeaders.Set(headers.EVPOriginVersionHeader, version.AgentVersion)
-	extraHeaders.Set(headers.TimestampHeader, strconv.Itoa(int(time.Now().Unix())))
+	extraHeaders.Set(headers.TimestampHeader, strconv.Itoa(int(clock.Now().Unix())))
 	f.On("SubmitContainerImages", payloads, extraHeaders).Return(nil).Times(1)
 
 	s := NewSerializer(nil, nil, nil, f, nil)
+	s.clock = clock
 
 	msg := []ContainerImageMessage{
 		{
@@ -434,16 +438,18 @@ func makePtr(val string) *string {
 }
 
 func TestSendSBOM(t *testing.T) {
+	clock := clock.NewMock()
 	f := &forwarder.MockedForwarder{}
 	payload := []byte("\x08\x01\x12\x08hostname\x1a\x05agent")
 	payloads, _ := mkPayloads(payload, false)
 	extraHeaders := protobufExtraHeaders.Clone()
 	extraHeaders.Set(headers.EVPOriginHeader, "agent")
 	extraHeaders.Set(headers.EVPOriginVersionHeader, version.AgentVersion)
-	extraHeaders.Set(headers.TimestampHeader, strconv.Itoa(int(time.Now().Unix())))
+	extraHeaders.Set(headers.TimestampHeader, strconv.Itoa(int(clock.Now().Unix())))
 	f.On("SubmitSBOM", payloads, extraHeaders).Return(nil).Times(1)
 
 	s := NewSerializer(nil, nil, nil, nil, f)
+	s.clock = clock
 
 	msg := []SBOMMessage{
 		{


### PR DESCRIPTION
### What does this PR do?

Use a mockable time library to compute the timestamp to put in the `X-DD-Agent-Timestamp` HTTP header.

### Motivation

Fix `TestSendContainerLifecycleEvents` flakiness.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Validate that `TestSendContainerLifecycleEvents` is no more flaky.

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
