### PR TITLE
Enable orchestrator manifest collection by default

### DIFF
--- a/cmd/process-agent/collector_api_test.go
+++ b/cmd/process-agent/collector_api_test.go
@@ -373,7 +373,6 @@ func TestSendPodMessageNotSendManifestPayload(t *testing.T) {
 	ddcfg.Set("orchestrator_explorer.enabled", true)
 	ddcfg.Set("orchestrator_explorer.manifest_collection.enabled", false)
 
-
 	runCollectorTest(t, check, &endpointConfig{}, ddconfig.Mock(t), func(c *Collector, ep *mockEndpoint) {
 
 		testPodMessageMetadata(t, clusterID, c, ep)

--- a/cmd/process-agent/collector_api_test.go
+++ b/cmd/process-agent/collector_api_test.go
@@ -370,6 +370,10 @@ func TestSendPodMessageNotSendManifestPayload(t *testing.T) {
 	defer ddconfig.SetDetectedFeatures(nil)
 
 	ddcfg := ddconfig.Mock(t)
+	ddcfg.Set("orchestrator_explorer.manifest_collection.enabled", false)
+
+
+	ddcfg := ddconfig.Mock(t)
 	ddcfg.Set("orchestrator_explorer.enabled", true)
 
 	runCollectorTest(t, check, &endpointConfig{}, ddconfig.Mock(t), func(c *Collector, ep *mockEndpoint) {

--- a/cmd/process-agent/collector_api_test.go
+++ b/cmd/process-agent/collector_api_test.go
@@ -370,11 +370,9 @@ func TestSendPodMessageNotSendManifestPayload(t *testing.T) {
 	defer ddconfig.SetDetectedFeatures(nil)
 
 	ddcfg := ddconfig.Mock(t)
+	ddcfg.Set("orchestrator_explorer.enabled", true)
 	ddcfg.Set("orchestrator_explorer.manifest_collection.enabled", false)
 
-
-	ddcfg := ddconfig.Mock(t)
-	ddcfg.Set("orchestrator_explorer.enabled", true)
 
 	runCollectorTest(t, check, &endpointConfig{}, ddconfig.Mock(t), func(c *Collector, ep *mockEndpoint) {
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1057,7 +1057,7 @@ func InitConfig(config Config) {
 	config.BindEnv("orchestrator_explorer.orchestrator_dd_url", "DD_ORCHESTRATOR_EXPLORER_ORCHESTRATOR_DD_URL", "DD_ORCHESTRATOR_URL")
 	config.BindEnv("orchestrator_explorer.orchestrator_additional_endpoints", "DD_ORCHESTRATOR_EXPLORER_ORCHESTRATOR_ADDITIONAL_ENDPOINTS", "DD_ORCHESTRATOR_ADDITIONAL_ENDPOINTS")
 	config.BindEnv("orchestrator_explorer.use_legacy_endpoint")
-	config.BindEnvAndSetDefault("orchestrator_explorer.manifest_collection.enabled", false)
+	config.BindEnvAndSetDefault("orchestrator_explorer.manifest_collection.enabled", true)
 	config.BindEnvAndSetDefault("orchestrator_explorer.manifest_collection.buffer_manifest", true)
 	config.BindEnvAndSetDefault("orchestrator_explorer.manifest_collection.buffer_flush_interval", 20*time.Second)
 

--- a/releasenotes-dca/notes/manifest-collection-ga-41ad6d179ed789b5.yaml
+++ b/releasenotes-dca/notes/manifest-collection-ga-41ad6d179ed789b5.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Enable orchestrator manifest collection by default

--- a/releasenotes/notes/manifest-collection-ga-41ad6d179ed789b5.yaml
+++ b/releasenotes/notes/manifest-collection-ga-41ad6d179ed789b5.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Enable orchestrator manifest collection by default


### PR DESCRIPTION
### What does this PR do?

This pr makes orchestrator manifest collection enabled by default which allows users to compare k8s yaml diff on orchestration page

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
