### PR TITLE
[CWS] rename json fields to make them less misleading

### DIFF
--- a/docs/cloud-workload-security/backend.md
+++ b/docs/cloud-workload-security/backend.md
@@ -543,10 +543,10 @@ CWS logs have the following JSON schema:
         },
         "MountEvent": {
             "properties": {
-                "mountpoint": {
+                "mp": {
                     "$ref": "#/$defs/File"
                 },
-                "source": {
+                "root": {
                     "$ref": "#/$defs/File"
                 },
                 "mount_id": {
@@ -567,16 +567,16 @@ CWS logs have the following JSON schema:
                 "fs_type": {
                     "type": "string"
                 },
-                "mountpoint_path": {
+                "mountpoint.path": {
                     "type": "string"
                 },
-                "mountsource_path": {
+                "source.path": {
                     "type": "string"
                 },
-                "mountpoint_path_error": {
+                "mountpoint.path_error": {
                     "type": "string"
                 },
-                "mountsource_path_error": {
+                "source.path_error": {
                     "type": "string"
                 }
             },
@@ -2021,10 +2021,10 @@ CWS logs have the following JSON schema:
 {{< code-block lang="json" collapsible="true" >}}
 {
     "properties": {
-        "mountpoint": {
+        "mp": {
             "$ref": "#/$defs/File"
         },
-        "source": {
+        "root": {
             "$ref": "#/$defs/File"
         },
         "mount_id": {
@@ -2045,16 +2045,16 @@ CWS logs have the following JSON schema:
         "fs_type": {
             "type": "string"
         },
-        "mountpoint_path": {
+        "mountpoint.path": {
             "type": "string"
         },
-        "mountsource_path": {
+        "source.path": {
             "type": "string"
         },
-        "mountpoint_path_error": {
+        "mountpoint.path_error": {
             "type": "string"
         },
-        "mountsource_path_error": {
+        "source.path_error": {
             "type": "string"
         }
     },

--- a/docs/cloud-workload-security/backend.schema.json
+++ b/docs/cloud-workload-security/backend.schema.json
@@ -527,10 +527,10 @@
     },
     "MountEvent": {
       "properties": {
-        "mountpoint": {
+        "mp": {
           "$ref": "#/$defs/File"
         },
-        "source": {
+        "root": {
           "$ref": "#/$defs/File"
         },
         "mount_id": {
@@ -551,16 +551,16 @@
         "fs_type": {
           "type": "string"
         },
-        "mountpoint_path": {
+        "mountpoint.path": {
           "type": "string"
         },
-        "mountsource_path": {
+        "source.path": {
           "type": "string"
         },
-        "mountpoint_path_error": {
+        "mountpoint.path_error": {
           "type": "string"
         },
-        "mountsource_path_error": {
+        "source.path_error": {
           "type": "string"
         }
       },

--- a/pkg/security/probe/serializers.go
+++ b/pkg/security/probe/serializers.go
@@ -499,18 +499,18 @@ type ExitEventSerializer struct {
 // MountEventSerializer serializes a mount event to JSON
 // easyjson:json
 type MountEventSerializer struct {
-	MountPoint                     *FileSerializer `json:"mountpoint,omitempty"`             // Mount point file information
-	Root                           *FileSerializer `json:"source,omitempty"`                 // Root file information
-	MountID                        uint32          `json:"mount_id"`                         // Mount ID of the new mount
-	GroupID                        uint32          `json:"group_id"`                         // ID of the peer group
-	ParentMountID                  uint32          `json:"parent_mount_id"`                  // Mount ID of the parent mount
-	BindSrcMountID                 uint32          `json:"bind_src_mount_id"`                // Mount ID of the source of a bind mount
-	Device                         uint32          `json:"device"`                           // Device associated with the file
-	FSType                         string          `json:"fs_type,omitempty"`                // Filesystem type
-	MountPointPath                 string          `json:"mountpoint_path,omitempty"`        // Mount point path
-	MountSourcePath                string          `json:"mountsource_path,omitempty"`       // Mount source path
-	MountPointPathResolutionError  string          `json:"mountpoint_path_error,omitempty"`  // Mount point path error
-	MountSourcePathResolutionError string          `json:"mountsource_path_error,omitempty"` // Mount source path error
+	MountPoint                     *FileSerializer `json:"mp,omitempty"`                    // Mount point file information
+	Root                           *FileSerializer `json:"root,omitempty"`                  // Root file information
+	MountID                        uint32          `json:"mount_id"`                        // Mount ID of the new mount
+	GroupID                        uint32          `json:"group_id"`                        // ID of the peer group
+	ParentMountID                  uint32          `json:"parent_mount_id"`                 // Mount ID of the parent mount
+	BindSrcMountID                 uint32          `json:"bind_src_mount_id"`               // Mount ID of the source of a bind mount
+	Device                         uint32          `json:"device"`                          // Device associated with the file
+	FSType                         string          `json:"fs_type,omitempty"`               // Filesystem type
+	MountPointPath                 string          `json:"mountpoint.path,omitempty"`       // Mount point path
+	MountSourcePath                string          `json:"source.path,omitempty"`           // Mount source path
+	MountPointPathResolutionError  string          `json:"mountpoint.path_error,omitempty"` // Mount point path error
+	MountSourcePathResolutionError string          `json:"source.path_error,omitempty"`     // Mount source path error
 }
 
 // EventSerializer serializes an event to JSON

--- a/pkg/security/probe/serializers_easyjson.go
+++ b/pkg/security/probe/serializers_easyjson.go
@@ -1975,7 +1975,7 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe15(in *jl
 			continue
 		}
 		switch key {
-		case "mountpoint":
+		case "mp":
 			if in.IsNull() {
 				in.Skip()
 				out.MountPoint = nil
@@ -1985,7 +1985,7 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe15(in *jl
 				}
 				(*out.MountPoint).UnmarshalEasyJSON(in)
 			}
-		case "source":
+		case "root":
 			if in.IsNull() {
 				in.Skip()
 				out.Root = nil
@@ -2007,13 +2007,13 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe15(in *jl
 			out.Device = uint32(in.Uint32())
 		case "fs_type":
 			out.FSType = string(in.String())
-		case "mountpoint_path":
+		case "mountpoint.path":
 			out.MountPointPath = string(in.String())
-		case "mountsource_path":
+		case "source.path":
 			out.MountSourcePath = string(in.String())
-		case "mountpoint_path_error":
+		case "mountpoint.path_error":
 			out.MountPointPathResolutionError = string(in.String())
-		case "mountsource_path_error":
+		case "source.path_error":
 			out.MountSourcePathResolutionError = string(in.String())
 		default:
 			in.SkipRecursive()
@@ -2030,13 +2030,13 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe15(out *j
 	first := true
 	_ = first
 	if in.MountPoint != nil {
-		const prefix string = ",\"mountpoint\":"
+		const prefix string = ",\"mp\":"
 		first = false
 		out.RawString(prefix[1:])
 		(*in.MountPoint).MarshalEasyJSON(out)
 	}
 	if in.Root != nil {
-		const prefix string = ",\"source\":"
+		const prefix string = ",\"root\":"
 		if first {
 			first = false
 			out.RawString(prefix[1:])
@@ -2081,22 +2081,22 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe15(out *j
 		out.String(string(in.FSType))
 	}
 	if in.MountPointPath != "" {
-		const prefix string = ",\"mountpoint_path\":"
+		const prefix string = ",\"mountpoint.path\":"
 		out.RawString(prefix)
 		out.String(string(in.MountPointPath))
 	}
 	if in.MountSourcePath != "" {
-		const prefix string = ",\"mountsource_path\":"
+		const prefix string = ",\"source.path\":"
 		out.RawString(prefix)
 		out.String(string(in.MountSourcePath))
 	}
 	if in.MountPointPathResolutionError != "" {
-		const prefix string = ",\"mountpoint_path_error\":"
+		const prefix string = ",\"mountpoint.path_error\":"
 		out.RawString(prefix)
 		out.String(string(in.MountPointPathResolutionError))
 	}
 	if in.MountSourcePathResolutionError != "" {
-		const prefix string = ",\"mountsource_path_error\":"
+		const prefix string = ",\"source.path_error\":"
 		out.RawString(prefix)
 		out.String(string(in.MountSourcePathResolutionError))
 	}

--- a/pkg/security/tests/schemas/mount.schema.json
+++ b/pkg/security/tests/schemas/mount.schema.json
@@ -16,13 +16,13 @@
                 "mount": {
                     "type": "object",
                     "required": [
-                        "mountpoint",
+                        "mp",
                         "mount_id",
                         "parent_mount_id",
                         "fs_type"
                     ],
                     "properties": {
-                        "mountpoint": {
+                        "mp": {
                             "properties": {
                                 "path": {
                                     "type": "string"
@@ -41,7 +41,7 @@
                         "fs_type": {
                             "type": "string"
                         },
-                        "source": {
+                        "root": {
                             "properties": {
                                 "path": {
                                     "type": "string"


### PR DESCRIPTION
Rename the mount event json fields to make them match the name of the agent rules attributes.

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
