### PR TITLE
[RCM-598] upgrade(remote-config): Use layered gRPC client between trace-agent & core-agent

### DIFF
--- a/cmd/trace-agent/remote_config.go
+++ b/cmd/trace-agent/remote_config.go
@@ -14,8 +14,6 @@ import (
 	"sync"
 	"time"
 
-	"google.golang.org/grpc/metadata"
-
 	"github.com/DataDog/datadog-agent/pkg/config/remote"
 	"github.com/DataDog/datadog-agent/pkg/proto/pbgo"
 	"github.com/DataDog/datadog-agent/pkg/trace/api"
@@ -42,7 +40,7 @@ func putBuffer(buffer *bytes.Buffer) {
 	bufferPool.Put(buffer)
 }
 
-func remoteConfigHandler(r *api.HTTPReceiver, client remote.ConfigUpdater, token string, cfg *config.AgentConfig) http.Handler {
+func remoteConfigHandler(r *api.HTTPReceiver, client remote.ConfigUpdater, cfg *config.AgentConfig) http.Handler {
 	cidProvider := api.NewIDProvider(cfg.ContainerProcRoot)
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		defer timing.Since("datadog.trace_agent.receiver.config_process_ms", time.Now())
@@ -67,10 +65,6 @@ func remoteConfigHandler(r *api.HTTPReceiver, client remote.ConfigUpdater, token
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
-		md := metadata.MD{
-			"authorization": []string{fmt.Sprintf("Bearer %s", token)},
-		}
-		ctx := metadata.NewOutgoingContext(req.Context(), md)
 		if configsRequest.GetClient().GetClientTracer() != nil {
 			normalize(&configsRequest)
 			if configsRequest.Client.ClientTracer.Tags == nil {
@@ -80,7 +74,7 @@ func remoteConfigHandler(r *api.HTTPReceiver, client remote.ConfigUpdater, token
 				configsRequest.Client.ClientTracer.Tags = append(configsRequest.Client.ClientTracer.Tags, tag)
 			}
 		}
-		cfg, err := client.ClientGetConfigs(ctx, &configsRequest)
+		cfg, err := client.ClientGetConfigs(req.Context(), &configsRequest)
 		if err != nil {
 			statusCode = http.StatusInternalServerError
 			http.Error(w, err.Error(), statusCode)

--- a/cmd/trace-agent/remote_config.go
+++ b/cmd/trace-agent/remote_config.go
@@ -16,6 +16,7 @@ import (
 
 	"google.golang.org/grpc/metadata"
 
+	"github.com/DataDog/datadog-agent/pkg/config/remote"
 	"github.com/DataDog/datadog-agent/pkg/proto/pbgo"
 	"github.com/DataDog/datadog-agent/pkg/trace/api"
 	"github.com/DataDog/datadog-agent/pkg/trace/config"
@@ -41,7 +42,7 @@ func putBuffer(buffer *bytes.Buffer) {
 	bufferPool.Put(buffer)
 }
 
-func remoteConfigHandler(r *api.HTTPReceiver, client pbgo.AgentSecureClient, token string, cfg *config.AgentConfig) http.Handler {
+func remoteConfigHandler(r *api.HTTPReceiver, client remote.ConfigUpdater, token string, cfg *config.AgentConfig) http.Handler {
 	cidProvider := api.NewIDProvider(cfg.ContainerProcRoot)
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		defer timing.Since("datadog.trace_agent.receiver.config_process_ms", time.Now())

--- a/cmd/trace-agent/remote_config_test.go
+++ b/cmd/trace-agent/remote_config_test.go
@@ -59,7 +59,7 @@ func TestConfigEndpoint(t *testing.T) {
 			rcv := api.NewHTTPReceiver(config.New(), sampler.NewDynamicConfig(), make(chan *api.Payload, 5000), nil)
 			mux := http.NewServeMux()
 			cfg := &config.AgentConfig{}
-			mux.Handle("/v0.7/config", remoteConfigHandler(rcv, &grpc, "", cfg))
+			mux.Handle("/v0.7/config", remoteConfigHandler(rcv, &grpc, cfg))
 			server := httptest.NewServer(mux)
 			if tc.valid {
 				var request pbgo.ClientGetConfigsRequest
@@ -139,7 +139,7 @@ func TestUpstreamRequest(t *testing.T) {
 			grpc.On("ClientGetConfigs", mock.Anything, &request, mock.Anything).Return(&pbgo.ClientGetConfigsResponse{Targets: []byte("test")}, nil)
 
 			mux := http.NewServeMux()
-			mux.Handle("/v0.7/config", remoteConfigHandler(rcv, &grpc, "", tc.cfg))
+			mux.Handle("/v0.7/config", remoteConfigHandler(rcv, &grpc, tc.cfg))
 			server := httptest.NewServer(mux)
 
 			req, _ := http.NewRequest("POST", server.URL+"/v0.7/config", strings.NewReader(tc.tracerReq))

--- a/cmd/trace-agent/remote_config_test.go
+++ b/cmd/trace-agent/remote_config_test.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"google.golang.org/grpc"
 )
 
 func TestConfigEndpoint(t *testing.T) {
@@ -55,7 +54,7 @@ func TestConfigEndpoint(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			assert := assert.New(t)
-			grpc := mockAgentSecureServer{}
+			grpc := agentGRPCConfigFetcher{}
 			rcv := api.NewHTTPReceiver(config.New(), sampler.NewDynamicConfig(), make(chan *api.Payload, 5000), nil)
 			mux := http.NewServeMux()
 			cfg := &config.AgentConfig{}
@@ -130,7 +129,7 @@ func TestUpstreamRequest(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			assert := assert.New(t)
-			grpc := mockAgentSecureServer{}
+			grpc := agentGRPCConfigFetcher{}
 			rcv := api.NewHTTPReceiver(config.New(), sampler.NewDynamicConfig(), make(chan *api.Payload, 5000), nil)
 
 			var request pbgo.ClientGetConfigsRequest
@@ -156,32 +155,12 @@ func TestUpstreamRequest(t *testing.T) {
 	}
 }
 
-type mockAgentSecureServer struct {
+type agentGRPCConfigFetcher struct {
 	pbgo.AgentSecureClient
 	mock.Mock
 }
 
-func (a *mockAgentSecureServer) TaggerStreamEntities(ctx context.Context, in *pbgo.StreamTagsRequest, opts ...grpc.CallOption) (pbgo.AgentSecure_TaggerStreamEntitiesClient, error) {
-	args := a.Called(ctx, in, opts)
-	return args.Get(0).(pbgo.AgentSecure_TaggerStreamEntitiesClient), args.Error(1)
-}
-
-func (a *mockAgentSecureServer) TaggerFetchEntity(ctx context.Context, in *pbgo.FetchEntityRequest, opts ...grpc.CallOption) (*pbgo.FetchEntityResponse, error) {
-	args := a.Called(ctx, in, opts)
-	return args.Get(0).(*pbgo.FetchEntityResponse), args.Error(1)
-}
-
-func (a *mockAgentSecureServer) DogstatsdCaptureTrigger(ctx context.Context, in *pbgo.CaptureTriggerRequest, opts ...grpc.CallOption) (*pbgo.CaptureTriggerResponse, error) {
-	args := a.Called(ctx, in, opts)
-	return args.Get(0).(*pbgo.CaptureTriggerResponse), args.Error(1)
-}
-
-func (a *mockAgentSecureServer) DogstatsdSetTaggerState(ctx context.Context, in *pbgo.TaggerState, opts ...grpc.CallOption) (*pbgo.TaggerStateResponse, error) {
-	args := a.Called(ctx, in, opts)
-	return args.Get(0).(*pbgo.TaggerStateResponse), args.Error(1)
-}
-
-func (a *mockAgentSecureServer) ClientGetConfigs(ctx context.Context, in *pbgo.ClientGetConfigsRequest, opts ...grpc.CallOption) (*pbgo.ClientGetConfigsResponse, error) {
-	args := a.Called(ctx, in, opts)
+func (a *agentGRPCConfigFetcher) ClientGetConfigs(ctx context.Context, in *pbgo.ClientGetConfigsRequest) (*pbgo.ClientGetConfigsResponse, error) {
+	args := a.Called(ctx, in)
 	return args.Get(0).(*pbgo.ClientGetConfigsResponse), args.Error(1)
 }

--- a/cmd/trace-agent/run.go
+++ b/cmd/trace-agent/run.go
@@ -19,7 +19,6 @@ import (
 	cmdconfig "github.com/DataDog/datadog-agent/cmd/trace-agent/config"
 	"github.com/DataDog/datadog-agent/cmd/trace-agent/internal/flags"
 	"github.com/DataDog/datadog-agent/cmd/trace-agent/internal/osutil"
-	"github.com/DataDog/datadog-agent/pkg/api/security"
 	coreconfig "github.com/DataDog/datadog-agent/pkg/config"
 	rc "github.com/DataDog/datadog-agent/pkg/config/remote"
 	"github.com/DataDog/datadog-agent/pkg/pidfile"
@@ -188,17 +187,14 @@ func Run(ctx context.Context) {
 	}()
 
 	if coreconfig.Datadog.GetBool("remote_configuration.enabled") {
+		// Auth tokens are handled by the rcClient
 		rcClient, err := rc.NewAgentGRPCConfigFetcher()
 		if err != nil {
 			osutil.Exitf("could not instantiate the tracer remote config client: %v", err)
 		}
-		token, err := security.FetchAuthToken()
-		if err != nil {
-			osutil.Exitf("could obtain the auth token for the tracer remote config client: %v", err)
-		}
 		api.AttachEndpoint(api.Endpoint{
 			Pattern: "/v0.7/config",
-			Handler: func(r *api.HTTPReceiver) http.Handler { return remoteConfigHandler(r, rcClient, token, cfg) },
+			Handler: func(r *api.HTTPReceiver) http.Handler { return remoteConfigHandler(r, rcClient, cfg) },
 		})
 	}
 

--- a/pkg/config/remote/client.go
+++ b/pkg/config/remote/client.go
@@ -39,7 +39,7 @@ const (
 // ConfigUpdater defines the interface that an agent client uses to get config updates
 // from the core remote-config service
 type ConfigUpdater interface {
-	ClientGetConfigs(context.Context, *pbgo.ClientGetConfigsRequest, ...grpc.CallOption) (*pbgo.ClientGetConfigsResponse, error)
+	ClientGetConfigs(context.Context, *pbgo.ClientGetConfigsRequest) (*pbgo.ClientGetConfigsResponse, error)
 }
 
 // Client is a remote-configuration client to obtain configurations from the local API
@@ -93,7 +93,7 @@ func NewAgentGRPCConfigFetcher() (*agentGRPCConfigFetcher, error) {
 }
 
 // ClientGetConfigs implements the ConfigUpdater interface for agentGRPCConfigFetcher
-func (g *agentGRPCConfigFetcher) ClientGetConfigs(ctx context.Context, request *pbgo.ClientGetConfigsRequest, opts ...grpc.CallOption) (*pbgo.ClientGetConfigsResponse, error) {
+func (g *agentGRPCConfigFetcher) ClientGetConfigs(ctx context.Context, request *pbgo.ClientGetConfigsRequest) (*pbgo.ClientGetConfigsResponse, error) {
 	// When communicating with the core service via grpc, the auth token is handled
 	// by the core-agent, which runs independently. It's not guaranteed it starts before us,
 	// or that if it restarts that the auth token remains the same. Thus we need to do this every request.
@@ -107,7 +107,7 @@ func (g *agentGRPCConfigFetcher) ClientGetConfigs(ctx context.Context, request *
 
 	ctx = metadata.NewOutgoingContext(ctx, md)
 
-	return g.client.ClientGetConfigs(ctx, request, opts...)
+	return g.client.ClientGetConfigs(ctx, request)
 }
 
 // NewClient creates a new client

--- a/pkg/config/remote/client.go
+++ b/pkg/config/remote/client.go
@@ -33,7 +33,7 @@ const (
 	minBackoffFactor      = 2.0
 	recoveryInterval      = 2
 
-	maxMessageSize = 1024 * 1024 * 500 // 500MB, current backend limit
+	maxMessageSize = 1024 * 1024 * 110 // 110MB, current backend limit
 )
 
 // ConfigUpdater defines the interface that an agent client uses to get config updates

--- a/pkg/config/remote/client.go
+++ b/pkg/config/remote/client.go
@@ -107,7 +107,7 @@ func (g *agentGRPCConfigFetcher) ClientGetConfigs(ctx context.Context, request *
 
 	ctx = metadata.NewOutgoingContext(ctx, md)
 
-	return g.client.ClientGetConfigs(ctx, request, opts)
+	return g.client.ClientGetConfigs(ctx, request, opts...)
 }
 
 // NewClient creates a new client


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
* Use layered gRPC client between trace-agent & core-agent
* Allows RC clients to receive config bundles of up to 110MB, which is what is currently done in the backend

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
[RCM-598], auth safety as well

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs
This may get heavy on the network if too many heavy configs are sent at once

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
Try to create a big DEBUG config (40MB max) and send it to the backend - check you can receive it in a tracer or when simulating a tracer.

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.


[RCM-598]: https://datadoghq.atlassian.net/browse/RCM-598?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ