### PR TITLE
[CWS][SEC-6692] introduce SECLDoc and add secl field examples to documentation

### DIFF
--- a/docs/cloud-workload-security/agent_expressions.md
+++ b/docs/cloud-workload-security/agent_expressions.md
@@ -162,219 +162,219 @@ Examples:
 
 The *file.rights* attribute can now be used in addition to *file.mode*. *file.mode* can hold values set by the kernel, while the *file.rights* only holds the values set by the user. These rights may be more familiar because they are in the `chmod` commands.
 
-## Event types
+## Event attributes
 
 ### Common to all event types
 
-| Property | Type | Definition | Constants |
-| -------- | ---- | ---------- | --------- |
-| `async` | bool | True if the syscall was asynchronous |  |
-| `container.id` | string | ID of the container |  |
-| `container.tags` | string | Tags of the container |  |
-| `network.destination.ip` | IP/CIDR | IP address |  |
-| `network.destination.port` | int | Port number |  |
-| `network.device.ifindex` | int | interface ifindex |  |
-| `network.device.ifname` | string | interface ifname |  |
-| `network.l3_protocol` | int | l3 protocol of the network packet | L3 protocols |
-| `network.l4_protocol` | int | l4 protocol of the network packet | L4 protocols |
-| `network.size` | int | size in bytes of the network packet |  |
-| `network.source.ip` | IP/CIDR | IP address |  |
-| `network.source.port` | int | Port number |  |
-| `process.ancestors.args` | string | Arguments of the process (as a string) |  |
-| `process.ancestors.args_flags` | string | Arguments of the process (as an array) |  |
-| `process.ancestors.args_options` | string | Arguments of the process (as an array) |  |
-| `process.ancestors.args_truncated` | bool | Indicator of arguments truncation |  |
-| `process.ancestors.argv` | string | Arguments of the process (as an array) |  |
-| `process.ancestors.argv0` | string | First argument of the process |  |
-| `process.ancestors.cap_effective` | int | Effective capability set of the process | Kernel Capability constants |
-| `process.ancestors.cap_permitted` | int | Permitted capability set of the process | Kernel Capability constants |
-| `process.ancestors.comm` | string | Comm attribute of the process |  |
-| `process.ancestors.container.id` | string | Container ID |  |
-| `process.ancestors.cookie` | int | Cookie of the process |  |
-| `process.ancestors.created_at` | int | Timestamp of the creation of the process |  |
-| `process.ancestors.egid` | int | Effective GID of the process |  |
-| `process.ancestors.egroup` | string | Effective group of the process |  |
-| `process.ancestors.envp` | string | Environment variables of the process |  |
-| `process.ancestors.envs` | string | Environment variable names of the process |  |
-| `process.ancestors.envs_truncated` | bool | Indicator of environment variables truncation |  |
-| `process.ancestors.euid` | int | Effective UID of the process |  |
-| `process.ancestors.euser` | string | Effective user of the process |  |
-| `process.ancestors.file.change_time` | int | Change time of the file |  |
-| `process.ancestors.file.filesystem` | string | File's filesystem |  |
-| `process.ancestors.file.gid` | int | GID of the file's owner |  |
-| `process.ancestors.file.group` | string | Group of the file's owner |  |
-| `process.ancestors.file.in_upper_layer` | bool | Indicator of the file layer, for example, in an OverlayFS |  |
-| `process.ancestors.file.inode` | int | Inode of the file |  |
-| `process.ancestors.file.mode` | int | Mode/rights of the file | Chmod mode constants |
-| `process.ancestors.file.modification_time` | int | Modification time of the file |  |
-| `process.ancestors.file.mount_id` | int | Mount ID of the file |  |
-| `process.ancestors.file.name` | string | File's basename |  |
-| `process.ancestors.file.name.length` | int | Length of 'process.ancestors.file.name' string |  |
-| `process.ancestors.file.path` | string | File's path |  |
-| `process.ancestors.file.path.length` | int | Length of 'process.ancestors.file.path' string |  |
-| `process.ancestors.file.rights` | int | Mode/rights of the file | Chmod mode constants |
-| `process.ancestors.file.uid` | int | UID of the file's owner |  |
-| `process.ancestors.file.user` | string | User of the file's owner |  |
-| `process.ancestors.fsgid` | int | FileSystem-gid of the process |  |
-| `process.ancestors.fsgroup` | string | FileSystem-group of the process |  |
-| `process.ancestors.fsuid` | int | FileSystem-uid of the process |  |
-| `process.ancestors.fsuser` | string | FileSystem-user of the process |  |
-| `process.ancestors.gid` | int | GID of the process |  |
-| `process.ancestors.group` | string | Group of the process |  |
-| `process.ancestors.interpreter.file.change_time` | int | Change time of the file |  |
-| `process.ancestors.interpreter.file.filesystem` | string | File's filesystem |  |
-| `process.ancestors.interpreter.file.gid` | int | GID of the file's owner |  |
-| `process.ancestors.interpreter.file.group` | string | Group of the file's owner |  |
-| `process.ancestors.interpreter.file.in_upper_layer` | bool | Indicator of the file layer, for example, in an OverlayFS |  |
-| `process.ancestors.interpreter.file.inode` | int | Inode of the file |  |
-| `process.ancestors.interpreter.file.mode` | int | Mode/rights of the file | Chmod mode constants |
-| `process.ancestors.interpreter.file.modification_time` | int | Modification time of the file |  |
-| `process.ancestors.interpreter.file.mount_id` | int | Mount ID of the file |  |
-| `process.ancestors.interpreter.file.name` | string | File's basename |  |
-| `process.ancestors.interpreter.file.name.length` | int | Length of 'process.ancestors.interpreter.file.name' string |  |
-| `process.ancestors.interpreter.file.path` | string | File's path |  |
-| `process.ancestors.interpreter.file.path.length` | int | Length of 'process.ancestors.interpreter.file.path' string |  |
-| `process.ancestors.interpreter.file.rights` | int | Mode/rights of the file | Chmod mode constants |
-| `process.ancestors.interpreter.file.uid` | int | UID of the file's owner |  |
-| `process.ancestors.interpreter.file.user` | string | User of the file's owner |  |
-| `process.ancestors.is_kworker` | bool | Indicates whether the process is a kworker |  |
-| `process.ancestors.is_thread` | bool | Indicates whether the process is considered a thread (that is, a child process that hasn't executed another program) |  |
-| `process.ancestors.pid` | int | Process ID of the process (also called thread group ID) |  |
-| `process.ancestors.ppid` | int | Parent process ID |  |
-| `process.ancestors.tid` | int | Thread ID of the thread |  |
-| `process.ancestors.tty_name` | string | Name of the TTY associated with the process |  |
-| `process.ancestors.uid` | int | UID of the process |  |
-| `process.ancestors.user` | string | User of the process |  |
-| `process.args` | string | Arguments of the process (as a string) |  |
-| `process.args_flags` | string | Arguments of the process (as an array) |  |
-| `process.args_options` | string | Arguments of the process (as an array) |  |
-| `process.args_truncated` | bool | Indicator of arguments truncation |  |
-| `process.argv` | string | Arguments of the process (as an array) |  |
-| `process.argv0` | string | First argument of the process |  |
-| `process.cap_effective` | int | Effective capability set of the process | Kernel Capability constants |
-| `process.cap_permitted` | int | Permitted capability set of the process | Kernel Capability constants |
-| `process.comm` | string | Comm attribute of the process |  |
-| `process.container.id` | string | Container ID |  |
-| `process.cookie` | int | Cookie of the process |  |
-| `process.created_at` | int | Timestamp of the creation of the process |  |
-| `process.egid` | int | Effective GID of the process |  |
-| `process.egroup` | string | Effective group of the process |  |
-| `process.envp` | string | Environment variables of the process |  |
-| `process.envs` | string | Environment variable names of the process |  |
-| `process.envs_truncated` | bool | Indicator of environment variables truncation |  |
-| `process.euid` | int | Effective UID of the process |  |
-| `process.euser` | string | Effective user of the process |  |
-| `process.file.change_time` | int | Change time of the file |  |
-| `process.file.filesystem` | string | File's filesystem |  |
-| `process.file.gid` | int | GID of the file's owner |  |
-| `process.file.group` | string | Group of the file's owner |  |
-| `process.file.in_upper_layer` | bool | Indicator of the file layer, for example, in an OverlayFS |  |
-| `process.file.inode` | int | Inode of the file |  |
-| `process.file.mode` | int | Mode/rights of the file | Chmod mode constants |
-| `process.file.modification_time` | int | Modification time of the file |  |
-| `process.file.mount_id` | int | Mount ID of the file |  |
-| `process.file.name` | string | File's basename |  |
-| `process.file.name.length` | int | Length of 'process.file.name' string |  |
-| `process.file.path` | string | File's path |  |
-| `process.file.path.length` | int | Length of 'process.file.path' string |  |
-| `process.file.rights` | int | Mode/rights of the file | Chmod mode constants |
-| `process.file.uid` | int | UID of the file's owner |  |
-| `process.file.user` | string | User of the file's owner |  |
-| `process.fsgid` | int | FileSystem-gid of the process |  |
-| `process.fsgroup` | string | FileSystem-group of the process |  |
-| `process.fsuid` | int | FileSystem-uid of the process |  |
-| `process.fsuser` | string | FileSystem-user of the process |  |
-| `process.gid` | int | GID of the process |  |
-| `process.group` | string | Group of the process |  |
-| `process.interpreter.file.change_time` | int | Change time of the file |  |
-| `process.interpreter.file.filesystem` | string | File's filesystem |  |
-| `process.interpreter.file.gid` | int | GID of the file's owner |  |
-| `process.interpreter.file.group` | string | Group of the file's owner |  |
-| `process.interpreter.file.in_upper_layer` | bool | Indicator of the file layer, for example, in an OverlayFS |  |
-| `process.interpreter.file.inode` | int | Inode of the file |  |
-| `process.interpreter.file.mode` | int | Mode/rights of the file | Chmod mode constants |
-| `process.interpreter.file.modification_time` | int | Modification time of the file |  |
-| `process.interpreter.file.mount_id` | int | Mount ID of the file |  |
-| `process.interpreter.file.name` | string | File's basename |  |
-| `process.interpreter.file.name.length` | int | Length of 'process.interpreter.file.name' string |  |
-| `process.interpreter.file.path` | string | File's path |  |
-| `process.interpreter.file.path.length` | int | Length of 'process.interpreter.file.path' string |  |
-| `process.interpreter.file.rights` | int | Mode/rights of the file | Chmod mode constants |
-| `process.interpreter.file.uid` | int | UID of the file's owner |  |
-| `process.interpreter.file.user` | string | User of the file's owner |  |
-| `process.is_kworker` | bool | Indicates whether the process is a kworker |  |
-| `process.is_thread` | bool | Indicates whether the process is considered a thread (that is, a child process that hasn't executed another program) |  |
-| `process.parent.args` | string | Arguments of the process (as a string) |  |
-| `process.parent.args_flags` | string | Arguments of the process (as an array) |  |
-| `process.parent.args_options` | string | Arguments of the process (as an array) |  |
-| `process.parent.args_truncated` | bool | Indicator of arguments truncation |  |
-| `process.parent.argv` | string | Arguments of the process (as an array) |  |
-| `process.parent.argv0` | string | First argument of the process |  |
-| `process.parent.cap_effective` | int | Effective capability set of the process | Kernel Capability constants |
-| `process.parent.cap_permitted` | int | Permitted capability set of the process | Kernel Capability constants |
-| `process.parent.comm` | string | Comm attribute of the process |  |
-| `process.parent.container.id` | string | Container ID |  |
-| `process.parent.cookie` | int | Cookie of the process |  |
-| `process.parent.created_at` | int | Timestamp of the creation of the process |  |
-| `process.parent.egid` | int | Effective GID of the process |  |
-| `process.parent.egroup` | string | Effective group of the process |  |
-| `process.parent.envp` | string | Environment variables of the process |  |
-| `process.parent.envs` | string | Environment variable names of the process |  |
-| `process.parent.envs_truncated` | bool | Indicator of environment variables truncation |  |
-| `process.parent.euid` | int | Effective UID of the process |  |
-| `process.parent.euser` | string | Effective user of the process |  |
-| `process.parent.file.change_time` | int | Change time of the file |  |
-| `process.parent.file.filesystem` | string | File's filesystem |  |
-| `process.parent.file.gid` | int | GID of the file's owner |  |
-| `process.parent.file.group` | string | Group of the file's owner |  |
-| `process.parent.file.in_upper_layer` | bool | Indicator of the file layer, for example, in an OverlayFS |  |
-| `process.parent.file.inode` | int | Inode of the file |  |
-| `process.parent.file.mode` | int | Mode/rights of the file | Chmod mode constants |
-| `process.parent.file.modification_time` | int | Modification time of the file |  |
-| `process.parent.file.mount_id` | int | Mount ID of the file |  |
-| `process.parent.file.name` | string | File's basename |  |
-| `process.parent.file.name.length` | int | Length of 'process.parent.file.name' string |  |
-| `process.parent.file.path` | string | File's path |  |
-| `process.parent.file.path.length` | int | Length of 'process.parent.file.path' string |  |
-| `process.parent.file.rights` | int | Mode/rights of the file | Chmod mode constants |
-| `process.parent.file.uid` | int | UID of the file's owner |  |
-| `process.parent.file.user` | string | User of the file's owner |  |
-| `process.parent.fsgid` | int | FileSystem-gid of the process |  |
-| `process.parent.fsgroup` | string | FileSystem-group of the process |  |
-| `process.parent.fsuid` | int | FileSystem-uid of the process |  |
-| `process.parent.fsuser` | string | FileSystem-user of the process |  |
-| `process.parent.gid` | int | GID of the process |  |
-| `process.parent.group` | string | Group of the process |  |
-| `process.parent.interpreter.file.change_time` | int | Change time of the file |  |
-| `process.parent.interpreter.file.filesystem` | string | File's filesystem |  |
-| `process.parent.interpreter.file.gid` | int | GID of the file's owner |  |
-| `process.parent.interpreter.file.group` | string | Group of the file's owner |  |
-| `process.parent.interpreter.file.in_upper_layer` | bool | Indicator of the file layer, for example, in an OverlayFS |  |
-| `process.parent.interpreter.file.inode` | int | Inode of the file |  |
-| `process.parent.interpreter.file.mode` | int | Mode/rights of the file | Chmod mode constants |
-| `process.parent.interpreter.file.modification_time` | int | Modification time of the file |  |
-| `process.parent.interpreter.file.mount_id` | int | Mount ID of the file |  |
-| `process.parent.interpreter.file.name` | string | File's basename |  |
-| `process.parent.interpreter.file.name.length` | int | Length of 'process.parent.interpreter.file.name' string |  |
-| `process.parent.interpreter.file.path` | string | File's path |  |
-| `process.parent.interpreter.file.path.length` | int | Length of 'process.parent.interpreter.file.path' string |  |
-| `process.parent.interpreter.file.rights` | int | Mode/rights of the file | Chmod mode constants |
-| `process.parent.interpreter.file.uid` | int | UID of the file's owner |  |
-| `process.parent.interpreter.file.user` | string | User of the file's owner |  |
-| `process.parent.is_kworker` | bool | Indicates whether the process is a kworker |  |
-| `process.parent.is_thread` | bool | Indicates whether the process is considered a thread (that is, a child process that hasn't executed another program) |  |
-| `process.parent.pid` | int | Process ID of the process (also called thread group ID) |  |
-| `process.parent.ppid` | int | Parent process ID |  |
-| `process.parent.tid` | int | Thread ID of the thread |  |
-| `process.parent.tty_name` | string | Name of the TTY associated with the process |  |
-| `process.parent.uid` | int | UID of the process |  |
-| `process.parent.user` | string | User of the process |  |
-| `process.pid` | int | Process ID of the process (also called thread group ID) |  |
-| `process.ppid` | int | Parent process ID |  |
-| `process.tid` | int | Thread ID of the thread |  |
-| `process.tty_name` | string | Name of the TTY associated with the process |  |
-| `process.uid` | int | UID of the process |  |
-| `process.user` | string | User of the process |  |
+| Property | Definition |
+| -------- | ------------- |
+| [`async`](#async-doc) | True if the syscall was asynchronous |
+| [`container.id`](#container-id-doc) | ID of the container |
+| [`container.tags`](#container-tags-doc) | Tags of the container |
+| [`network.destination.ip`](#common-ipportcontext-ip-doc) | IP address |
+| [`network.destination.port`](#common-ipportcontext-port-doc) | Port number |
+| [`network.device.ifindex`](#network-device-ifindex-doc) | interface ifindex |
+| [`network.device.ifname`](#network-device-ifname-doc) | interface ifname |
+| [`network.l3_protocol`](#network-l3_protocol-doc) | l3 protocol of the network packet |
+| [`network.l4_protocol`](#network-l4_protocol-doc) | l4 protocol of the network packet |
+| [`network.size`](#network-size-doc) | size in bytes of the network packet |
+| [`network.source.ip`](#common-ipportcontext-ip-doc) | IP address |
+| [`network.source.port`](#common-ipportcontext-port-doc) | Port number |
+| [`process.ancestors.args`](#common-process-args-doc) | Arguments of the process (as a string, excluding argv0) |
+| [`process.ancestors.args_flags`](#common-process-args_flags-doc) | Flags in the process arguments |
+| [`process.ancestors.args_options`](#common-process-args_options-doc) | Argument of the process as options |
+| [`process.ancestors.args_truncated`](#common-process-args_truncated-doc) | Indicator of arguments truncation |
+| [`process.ancestors.argv`](#common-process-argv-doc) | Arguments of the process (as an array, excluding argv0) |
+| [`process.ancestors.argv0`](#common-process-argv0-doc) | First argument of the process |
+| [`process.ancestors.cap_effective`](#common-credentials-cap_effective-doc) | Effective capability set of the process |
+| [`process.ancestors.cap_permitted`](#common-credentials-cap_permitted-doc) | Permitted capability set of the process |
+| [`process.ancestors.comm`](#common-process-comm-doc) | Comm attribute of the process |
+| [`process.ancestors.container.id`](#common-process-container-id-doc) | Container ID |
+| [`process.ancestors.cookie`](#common-process-cookie-doc) | Cookie of the process |
+| [`process.ancestors.created_at`](#common-process-created_at-doc) | Timestamp of the creation of the process |
+| [`process.ancestors.egid`](#common-credentials-egid-doc) | Effective GID of the process |
+| [`process.ancestors.egroup`](#common-credentials-egroup-doc) | Effective group of the process |
+| [`process.ancestors.envp`](#common-process-envp-doc) | Environment variables of the process |
+| [`process.ancestors.envs`](#common-process-envs-doc) | Environment variable names of the process |
+| [`process.ancestors.envs_truncated`](#common-process-envs_truncated-doc) | Indicator of environment variables truncation |
+| [`process.ancestors.euid`](#common-credentials-euid-doc) | Effective UID of the process |
+| [`process.ancestors.euser`](#common-credentials-euser-doc) | Effective user of the process |
+| [`process.ancestors.file.change_time`](#common-filefields-change_time-doc) | Change time of the file |
+| [`process.ancestors.file.filesystem`](#common-fileevent-filesystem-doc) | File's filesystem |
+| [`process.ancestors.file.gid`](#common-filefields-gid-doc) | GID of the file's owner |
+| [`process.ancestors.file.group`](#common-filefields-group-doc) | Group of the file's owner |
+| [`process.ancestors.file.in_upper_layer`](#common-filefields-in_upper_layer-doc) | Indicator of the file layer, for example, in an OverlayFS |
+| [`process.ancestors.file.inode`](#common-filefields-inode-doc) | Inode of the file |
+| [`process.ancestors.file.mode`](#common-filefields-mode-doc) | Mode of the file |
+| [`process.ancestors.file.modification_time`](#common-filefields-modification_time-doc) | Modification time of the file |
+| [`process.ancestors.file.mount_id`](#common-filefields-mount_id-doc) | Mount ID of the file |
+| [`process.ancestors.file.name`](#common-fileevent-name-doc) | File's basename |
+| [`process.ancestors.file.name.length`](#common-string-length-doc) | Length of the corresponding string |
+| [`process.ancestors.file.path`](#common-fileevent-path-doc) | File's path |
+| [`process.ancestors.file.path.length`](#common-string-length-doc) | Length of the corresponding string |
+| [`process.ancestors.file.rights`](#common-filefields-rights-doc) | Rights of the file |
+| [`process.ancestors.file.uid`](#common-filefields-uid-doc) | UID of the file's owner |
+| [`process.ancestors.file.user`](#common-filefields-user-doc) | User of the file's owner |
+| [`process.ancestors.fsgid`](#common-credentials-fsgid-doc) | FileSystem-gid of the process |
+| [`process.ancestors.fsgroup`](#common-credentials-fsgroup-doc) | FileSystem-group of the process |
+| [`process.ancestors.fsuid`](#common-credentials-fsuid-doc) | FileSystem-uid of the process |
+| [`process.ancestors.fsuser`](#common-credentials-fsuser-doc) | FileSystem-user of the process |
+| [`process.ancestors.gid`](#common-credentials-gid-doc) | GID of the process |
+| [`process.ancestors.group`](#common-credentials-group-doc) | Group of the process |
+| [`process.ancestors.interpreter.file.change_time`](#common-filefields-change_time-doc) | Change time of the file |
+| [`process.ancestors.interpreter.file.filesystem`](#common-fileevent-filesystem-doc) | File's filesystem |
+| [`process.ancestors.interpreter.file.gid`](#common-filefields-gid-doc) | GID of the file's owner |
+| [`process.ancestors.interpreter.file.group`](#common-filefields-group-doc) | Group of the file's owner |
+| [`process.ancestors.interpreter.file.in_upper_layer`](#common-filefields-in_upper_layer-doc) | Indicator of the file layer, for example, in an OverlayFS |
+| [`process.ancestors.interpreter.file.inode`](#common-filefields-inode-doc) | Inode of the file |
+| [`process.ancestors.interpreter.file.mode`](#common-filefields-mode-doc) | Mode of the file |
+| [`process.ancestors.interpreter.file.modification_time`](#common-filefields-modification_time-doc) | Modification time of the file |
+| [`process.ancestors.interpreter.file.mount_id`](#common-filefields-mount_id-doc) | Mount ID of the file |
+| [`process.ancestors.interpreter.file.name`](#common-fileevent-name-doc) | File's basename |
+| [`process.ancestors.interpreter.file.name.length`](#common-string-length-doc) | Length of the corresponding string |
+| [`process.ancestors.interpreter.file.path`](#common-fileevent-path-doc) | File's path |
+| [`process.ancestors.interpreter.file.path.length`](#common-string-length-doc) | Length of the corresponding string |
+| [`process.ancestors.interpreter.file.rights`](#common-filefields-rights-doc) | Rights of the file |
+| [`process.ancestors.interpreter.file.uid`](#common-filefields-uid-doc) | UID of the file's owner |
+| [`process.ancestors.interpreter.file.user`](#common-filefields-user-doc) | User of the file's owner |
+| [`process.ancestors.is_kworker`](#common-pidcontext-is_kworker-doc) | Indicates whether the process is a kworker |
+| [`process.ancestors.is_thread`](#common-process-is_thread-doc) | Indicates whether the process is considered a thread (that is, a child process that hasn't executed another program) |
+| [`process.ancestors.pid`](#common-pidcontext-pid-doc) | Process ID of the process (also called thread group ID) |
+| [`process.ancestors.ppid`](#common-process-ppid-doc) | Parent process ID |
+| [`process.ancestors.tid`](#common-pidcontext-tid-doc) | Thread ID of the thread |
+| [`process.ancestors.tty_name`](#common-process-tty_name-doc) | Name of the TTY associated with the process |
+| [`process.ancestors.uid`](#common-credentials-uid-doc) | UID of the process |
+| [`process.ancestors.user`](#common-credentials-user-doc) | User of the process |
+| [`process.args`](#common-process-args-doc) | Arguments of the process (as a string, excluding argv0) |
+| [`process.args_flags`](#common-process-args_flags-doc) | Flags in the process arguments |
+| [`process.args_options`](#common-process-args_options-doc) | Argument of the process as options |
+| [`process.args_truncated`](#common-process-args_truncated-doc) | Indicator of arguments truncation |
+| [`process.argv`](#common-process-argv-doc) | Arguments of the process (as an array, excluding argv0) |
+| [`process.argv0`](#common-process-argv0-doc) | First argument of the process |
+| [`process.cap_effective`](#common-credentials-cap_effective-doc) | Effective capability set of the process |
+| [`process.cap_permitted`](#common-credentials-cap_permitted-doc) | Permitted capability set of the process |
+| [`process.comm`](#common-process-comm-doc) | Comm attribute of the process |
+| [`process.container.id`](#common-process-container-id-doc) | Container ID |
+| [`process.cookie`](#common-process-cookie-doc) | Cookie of the process |
+| [`process.created_at`](#common-process-created_at-doc) | Timestamp of the creation of the process |
+| [`process.egid`](#common-credentials-egid-doc) | Effective GID of the process |
+| [`process.egroup`](#common-credentials-egroup-doc) | Effective group of the process |
+| [`process.envp`](#common-process-envp-doc) | Environment variables of the process |
+| [`process.envs`](#common-process-envs-doc) | Environment variable names of the process |
+| [`process.envs_truncated`](#common-process-envs_truncated-doc) | Indicator of environment variables truncation |
+| [`process.euid`](#common-credentials-euid-doc) | Effective UID of the process |
+| [`process.euser`](#common-credentials-euser-doc) | Effective user of the process |
+| [`process.file.change_time`](#common-filefields-change_time-doc) | Change time of the file |
+| [`process.file.filesystem`](#common-fileevent-filesystem-doc) | File's filesystem |
+| [`process.file.gid`](#common-filefields-gid-doc) | GID of the file's owner |
+| [`process.file.group`](#common-filefields-group-doc) | Group of the file's owner |
+| [`process.file.in_upper_layer`](#common-filefields-in_upper_layer-doc) | Indicator of the file layer, for example, in an OverlayFS |
+| [`process.file.inode`](#common-filefields-inode-doc) | Inode of the file |
+| [`process.file.mode`](#common-filefields-mode-doc) | Mode of the file |
+| [`process.file.modification_time`](#common-filefields-modification_time-doc) | Modification time of the file |
+| [`process.file.mount_id`](#common-filefields-mount_id-doc) | Mount ID of the file |
+| [`process.file.name`](#common-fileevent-name-doc) | File's basename |
+| [`process.file.name.length`](#common-string-length-doc) | Length of the corresponding string |
+| [`process.file.path`](#common-fileevent-path-doc) | File's path |
+| [`process.file.path.length`](#common-string-length-doc) | Length of the corresponding string |
+| [`process.file.rights`](#common-filefields-rights-doc) | Rights of the file |
+| [`process.file.uid`](#common-filefields-uid-doc) | UID of the file's owner |
+| [`process.file.user`](#common-filefields-user-doc) | User of the file's owner |
+| [`process.fsgid`](#common-credentials-fsgid-doc) | FileSystem-gid of the process |
+| [`process.fsgroup`](#common-credentials-fsgroup-doc) | FileSystem-group of the process |
+| [`process.fsuid`](#common-credentials-fsuid-doc) | FileSystem-uid of the process |
+| [`process.fsuser`](#common-credentials-fsuser-doc) | FileSystem-user of the process |
+| [`process.gid`](#common-credentials-gid-doc) | GID of the process |
+| [`process.group`](#common-credentials-group-doc) | Group of the process |
+| [`process.interpreter.file.change_time`](#common-filefields-change_time-doc) | Change time of the file |
+| [`process.interpreter.file.filesystem`](#common-fileevent-filesystem-doc) | File's filesystem |
+| [`process.interpreter.file.gid`](#common-filefields-gid-doc) | GID of the file's owner |
+| [`process.interpreter.file.group`](#common-filefields-group-doc) | Group of the file's owner |
+| [`process.interpreter.file.in_upper_layer`](#common-filefields-in_upper_layer-doc) | Indicator of the file layer, for example, in an OverlayFS |
+| [`process.interpreter.file.inode`](#common-filefields-inode-doc) | Inode of the file |
+| [`process.interpreter.file.mode`](#common-filefields-mode-doc) | Mode of the file |
+| [`process.interpreter.file.modification_time`](#common-filefields-modification_time-doc) | Modification time of the file |
+| [`process.interpreter.file.mount_id`](#common-filefields-mount_id-doc) | Mount ID of the file |
+| [`process.interpreter.file.name`](#common-fileevent-name-doc) | File's basename |
+| [`process.interpreter.file.name.length`](#common-string-length-doc) | Length of the corresponding string |
+| [`process.interpreter.file.path`](#common-fileevent-path-doc) | File's path |
+| [`process.interpreter.file.path.length`](#common-string-length-doc) | Length of the corresponding string |
+| [`process.interpreter.file.rights`](#common-filefields-rights-doc) | Rights of the file |
+| [`process.interpreter.file.uid`](#common-filefields-uid-doc) | UID of the file's owner |
+| [`process.interpreter.file.user`](#common-filefields-user-doc) | User of the file's owner |
+| [`process.is_kworker`](#common-pidcontext-is_kworker-doc) | Indicates whether the process is a kworker |
+| [`process.is_thread`](#common-process-is_thread-doc) | Indicates whether the process is considered a thread (that is, a child process that hasn't executed another program) |
+| [`process.parent.args`](#common-process-args-doc) | Arguments of the process (as a string, excluding argv0) |
+| [`process.parent.args_flags`](#common-process-args_flags-doc) | Flags in the process arguments |
+| [`process.parent.args_options`](#common-process-args_options-doc) | Argument of the process as options |
+| [`process.parent.args_truncated`](#common-process-args_truncated-doc) | Indicator of arguments truncation |
+| [`process.parent.argv`](#common-process-argv-doc) | Arguments of the process (as an array, excluding argv0) |
+| [`process.parent.argv0`](#common-process-argv0-doc) | First argument of the process |
+| [`process.parent.cap_effective`](#common-credentials-cap_effective-doc) | Effective capability set of the process |
+| [`process.parent.cap_permitted`](#common-credentials-cap_permitted-doc) | Permitted capability set of the process |
+| [`process.parent.comm`](#common-process-comm-doc) | Comm attribute of the process |
+| [`process.parent.container.id`](#common-process-container-id-doc) | Container ID |
+| [`process.parent.cookie`](#common-process-cookie-doc) | Cookie of the process |
+| [`process.parent.created_at`](#common-process-created_at-doc) | Timestamp of the creation of the process |
+| [`process.parent.egid`](#common-credentials-egid-doc) | Effective GID of the process |
+| [`process.parent.egroup`](#common-credentials-egroup-doc) | Effective group of the process |
+| [`process.parent.envp`](#common-process-envp-doc) | Environment variables of the process |
+| [`process.parent.envs`](#common-process-envs-doc) | Environment variable names of the process |
+| [`process.parent.envs_truncated`](#common-process-envs_truncated-doc) | Indicator of environment variables truncation |
+| [`process.parent.euid`](#common-credentials-euid-doc) | Effective UID of the process |
+| [`process.parent.euser`](#common-credentials-euser-doc) | Effective user of the process |
+| [`process.parent.file.change_time`](#common-filefields-change_time-doc) | Change time of the file |
+| [`process.parent.file.filesystem`](#common-fileevent-filesystem-doc) | File's filesystem |
+| [`process.parent.file.gid`](#common-filefields-gid-doc) | GID of the file's owner |
+| [`process.parent.file.group`](#common-filefields-group-doc) | Group of the file's owner |
+| [`process.parent.file.in_upper_layer`](#common-filefields-in_upper_layer-doc) | Indicator of the file layer, for example, in an OverlayFS |
+| [`process.parent.file.inode`](#common-filefields-inode-doc) | Inode of the file |
+| [`process.parent.file.mode`](#common-filefields-mode-doc) | Mode of the file |
+| [`process.parent.file.modification_time`](#common-filefields-modification_time-doc) | Modification time of the file |
+| [`process.parent.file.mount_id`](#common-filefields-mount_id-doc) | Mount ID of the file |
+| [`process.parent.file.name`](#common-fileevent-name-doc) | File's basename |
+| [`process.parent.file.name.length`](#common-string-length-doc) | Length of the corresponding string |
+| [`process.parent.file.path`](#common-fileevent-path-doc) | File's path |
+| [`process.parent.file.path.length`](#common-string-length-doc) | Length of the corresponding string |
+| [`process.parent.file.rights`](#common-filefields-rights-doc) | Rights of the file |
+| [`process.parent.file.uid`](#common-filefields-uid-doc) | UID of the file's owner |
+| [`process.parent.file.user`](#common-filefields-user-doc) | User of the file's owner |
+| [`process.parent.fsgid`](#common-credentials-fsgid-doc) | FileSystem-gid of the process |
+| [`process.parent.fsgroup`](#common-credentials-fsgroup-doc) | FileSystem-group of the process |
+| [`process.parent.fsuid`](#common-credentials-fsuid-doc) | FileSystem-uid of the process |
+| [`process.parent.fsuser`](#common-credentials-fsuser-doc) | FileSystem-user of the process |
+| [`process.parent.gid`](#common-credentials-gid-doc) | GID of the process |
+| [`process.parent.group`](#common-credentials-group-doc) | Group of the process |
+| [`process.parent.interpreter.file.change_time`](#common-filefields-change_time-doc) | Change time of the file |
+| [`process.parent.interpreter.file.filesystem`](#common-fileevent-filesystem-doc) | File's filesystem |
+| [`process.parent.interpreter.file.gid`](#common-filefields-gid-doc) | GID of the file's owner |
+| [`process.parent.interpreter.file.group`](#common-filefields-group-doc) | Group of the file's owner |
+| [`process.parent.interpreter.file.in_upper_layer`](#common-filefields-in_upper_layer-doc) | Indicator of the file layer, for example, in an OverlayFS |
+| [`process.parent.interpreter.file.inode`](#common-filefields-inode-doc) | Inode of the file |
+| [`process.parent.interpreter.file.mode`](#common-filefields-mode-doc) | Mode of the file |
+| [`process.parent.interpreter.file.modification_time`](#common-filefields-modification_time-doc) | Modification time of the file |
+| [`process.parent.interpreter.file.mount_id`](#common-filefields-mount_id-doc) | Mount ID of the file |
+| [`process.parent.interpreter.file.name`](#common-fileevent-name-doc) | File's basename |
+| [`process.parent.interpreter.file.name.length`](#common-string-length-doc) | Length of the corresponding string |
+| [`process.parent.interpreter.file.path`](#common-fileevent-path-doc) | File's path |
+| [`process.parent.interpreter.file.path.length`](#common-string-length-doc) | Length of the corresponding string |
+| [`process.parent.interpreter.file.rights`](#common-filefields-rights-doc) | Rights of the file |
+| [`process.parent.interpreter.file.uid`](#common-filefields-uid-doc) | UID of the file's owner |
+| [`process.parent.interpreter.file.user`](#common-filefields-user-doc) | User of the file's owner |
+| [`process.parent.is_kworker`](#common-pidcontext-is_kworker-doc) | Indicates whether the process is a kworker |
+| [`process.parent.is_thread`](#common-process-is_thread-doc) | Indicates whether the process is considered a thread (that is, a child process that hasn't executed another program) |
+| [`process.parent.pid`](#common-pidcontext-pid-doc) | Process ID of the process (also called thread group ID) |
+| [`process.parent.ppid`](#common-process-ppid-doc) | Parent process ID |
+| [`process.parent.tid`](#common-pidcontext-tid-doc) | Thread ID of the thread |
+| [`process.parent.tty_name`](#common-process-tty_name-doc) | Name of the TTY associated with the process |
+| [`process.parent.uid`](#common-credentials-uid-doc) | UID of the process |
+| [`process.parent.user`](#common-credentials-user-doc) | User of the process |
+| [`process.pid`](#common-pidcontext-pid-doc) | Process ID of the process (also called thread group ID) |
+| [`process.ppid`](#common-process-ppid-doc) | Parent process ID |
+| [`process.tid`](#common-pidcontext-tid-doc) | Thread ID of the thread |
+| [`process.tty_name`](#common-process-tty_name-doc) | Name of the TTY associated with the process |
+| [`process.uid`](#common-credentials-uid-doc) | UID of the process |
+| [`process.user`](#common-credentials-user-doc) | User of the process |
 
 ### Event `bind`
 
@@ -382,369 +382,369 @@ _This event type is experimental and may change in the future._
 
 A bind was executed
 
-| Property | Type | Definition | Constants |
-| -------- | ---- | ---------- | --------- |
-| `bind.addr.family` | int | Address family |  |
-| `bind.addr.ip` | IP/CIDR | IP address |  |
-| `bind.addr.port` | int | Port number |  |
-| `bind.retval` | int | Return value of the syscall | Error Constants |
+| Property | Definition |
+| -------- | ------------- |
+| [`bind.addr.family`](#bind-addr-family-doc) | Address family |
+| [`bind.addr.ip`](#common-ipportcontext-ip-doc) | IP address |
+| [`bind.addr.port`](#common-ipportcontext-port-doc) | Port number |
+| [`bind.retval`](#common-syscallevent-retval-doc) | Return value of the syscall |
 
 ### Event `bpf`
 
 A BPF command was executed
 
-| Property | Type | Definition | Constants |
-| -------- | ---- | ---------- | --------- |
-| `bpf.cmd` | int | BPF command name | BPF commands |
-| `bpf.map.name` | string | Name of the eBPF map (added in 7.35) |  |
-| `bpf.map.type` | int | Type of the eBPF map | BPF map types |
-| `bpf.prog.attach_type` | int | Attach type of the eBPF program | BPF attach types |
-| `bpf.prog.helpers` | int | eBPF helpers used by the eBPF program (added in 7.35) | BPF helper functions |
-| `bpf.prog.name` | string | Name of the eBPF program (added in 7.35) |  |
-| `bpf.prog.tag` | string | Hash (sha1) of the eBPF program (added in 7.35) |  |
-| `bpf.prog.type` | int | Type of the eBPF program | BPF program types |
-| `bpf.retval` | int | Return value of the syscall | Error Constants |
+| Property | Definition |
+| -------- | ------------- |
+| [`bpf.cmd`](#bpf-cmd-doc) | BPF command name |
+| [`bpf.map.name`](#bpf-map-name-doc) | Name of the eBPF map (added in 7.35) |
+| [`bpf.map.type`](#bpf-map-type-doc) | Type of the eBPF map |
+| [`bpf.prog.attach_type`](#bpf-prog-attach_type-doc) | Attach type of the eBPF program |
+| [`bpf.prog.helpers`](#bpf-prog-helpers-doc) | eBPF helpers used by the eBPF program (added in 7.35) |
+| [`bpf.prog.name`](#bpf-prog-name-doc) | Name of the eBPF program (added in 7.35) |
+| [`bpf.prog.tag`](#bpf-prog-tag-doc) | Hash (sha1) of the eBPF program (added in 7.35) |
+| [`bpf.prog.type`](#bpf-prog-type-doc) | Type of the eBPF program |
+| [`bpf.retval`](#common-syscallevent-retval-doc) | Return value of the syscall |
 
 ### Event `capset`
 
 A process changed its capacity set
 
-| Property | Type | Definition | Constants |
-| -------- | ---- | ---------- | --------- |
-| `capset.cap_effective` | int | Effective capability set of the process | Kernel Capability constants |
-| `capset.cap_permitted` | int | Permitted capability set of the process | Kernel Capability constants |
+| Property | Definition |
+| -------- | ------------- |
+| [`capset.cap_effective`](#capset-cap_effective-doc) | Effective capability set of the process |
+| [`capset.cap_permitted`](#capset-cap_permitted-doc) | Permitted capability set of the process |
 
 ### Event `chmod`
 
 A file’s permissions were changed
 
-| Property | Type | Definition | Constants |
-| -------- | ---- | ---------- | --------- |
-| `chmod.file.change_time` | int | Change time of the file |  |
-| `chmod.file.destination.mode` | int | New mode/rights of the chmod-ed file | Chmod mode constants |
-| `chmod.file.destination.rights` | int | New mode/rights of the chmod-ed file | Chmod mode constants |
-| `chmod.file.filesystem` | string | File's filesystem |  |
-| `chmod.file.gid` | int | GID of the file's owner |  |
-| `chmod.file.group` | string | Group of the file's owner |  |
-| `chmod.file.in_upper_layer` | bool | Indicator of the file layer, for example, in an OverlayFS |  |
-| `chmod.file.inode` | int | Inode of the file |  |
-| `chmod.file.mode` | int | Mode/rights of the file | Chmod mode constants |
-| `chmod.file.modification_time` | int | Modification time of the file |  |
-| `chmod.file.mount_id` | int | Mount ID of the file |  |
-| `chmod.file.name` | string | File's basename |  |
-| `chmod.file.name.length` | int | Length of 'chmod.file.name' string |  |
-| `chmod.file.path` | string | File's path |  |
-| `chmod.file.path.length` | int | Length of 'chmod.file.path' string |  |
-| `chmod.file.rights` | int | Mode/rights of the file | Chmod mode constants |
-| `chmod.file.uid` | int | UID of the file's owner |  |
-| `chmod.file.user` | string | User of the file's owner |  |
-| `chmod.retval` | int | Return value of the syscall | Error Constants |
+| Property | Definition |
+| -------- | ------------- |
+| [`chmod.file.change_time`](#common-filefields-change_time-doc) | Change time of the file |
+| [`chmod.file.destination.mode`](#chmod-file-destination-mode-doc) | New mode of the chmod-ed file |
+| [`chmod.file.destination.rights`](#chmod-file-destination-rights-doc) | New rights of the chmod-ed file |
+| [`chmod.file.filesystem`](#common-fileevent-filesystem-doc) | File's filesystem |
+| [`chmod.file.gid`](#common-filefields-gid-doc) | GID of the file's owner |
+| [`chmod.file.group`](#common-filefields-group-doc) | Group of the file's owner |
+| [`chmod.file.in_upper_layer`](#common-filefields-in_upper_layer-doc) | Indicator of the file layer, for example, in an OverlayFS |
+| [`chmod.file.inode`](#common-filefields-inode-doc) | Inode of the file |
+| [`chmod.file.mode`](#common-filefields-mode-doc) | Mode of the file |
+| [`chmod.file.modification_time`](#common-filefields-modification_time-doc) | Modification time of the file |
+| [`chmod.file.mount_id`](#common-filefields-mount_id-doc) | Mount ID of the file |
+| [`chmod.file.name`](#common-fileevent-name-doc) | File's basename |
+| [`chmod.file.name.length`](#common-string-length-doc) | Length of the corresponding string |
+| [`chmod.file.path`](#common-fileevent-path-doc) | File's path |
+| [`chmod.file.path.length`](#common-string-length-doc) | Length of the corresponding string |
+| [`chmod.file.rights`](#common-filefields-rights-doc) | Rights of the file |
+| [`chmod.file.uid`](#common-filefields-uid-doc) | UID of the file's owner |
+| [`chmod.file.user`](#common-filefields-user-doc) | User of the file's owner |
+| [`chmod.retval`](#common-syscallevent-retval-doc) | Return value of the syscall |
 
 ### Event `chown`
 
 A file’s owner was changed
 
-| Property | Type | Definition | Constants |
-| -------- | ---- | ---------- | --------- |
-| `chown.file.change_time` | int | Change time of the file |  |
-| `chown.file.destination.gid` | int | New GID of the chown-ed file's owner |  |
-| `chown.file.destination.group` | string | New group of the chown-ed file's owner |  |
-| `chown.file.destination.uid` | int | New UID of the chown-ed file's owner |  |
-| `chown.file.destination.user` | string | New user of the chown-ed file's owner |  |
-| `chown.file.filesystem` | string | File's filesystem |  |
-| `chown.file.gid` | int | GID of the file's owner |  |
-| `chown.file.group` | string | Group of the file's owner |  |
-| `chown.file.in_upper_layer` | bool | Indicator of the file layer, for example, in an OverlayFS |  |
-| `chown.file.inode` | int | Inode of the file |  |
-| `chown.file.mode` | int | Mode/rights of the file | Chmod mode constants |
-| `chown.file.modification_time` | int | Modification time of the file |  |
-| `chown.file.mount_id` | int | Mount ID of the file |  |
-| `chown.file.name` | string | File's basename |  |
-| `chown.file.name.length` | int | Length of 'chown.file.name' string |  |
-| `chown.file.path` | string | File's path |  |
-| `chown.file.path.length` | int | Length of 'chown.file.path' string |  |
-| `chown.file.rights` | int | Mode/rights of the file | Chmod mode constants |
-| `chown.file.uid` | int | UID of the file's owner |  |
-| `chown.file.user` | string | User of the file's owner |  |
-| `chown.retval` | int | Return value of the syscall | Error Constants |
+| Property | Definition |
+| -------- | ------------- |
+| [`chown.file.change_time`](#common-filefields-change_time-doc) | Change time of the file |
+| [`chown.file.destination.gid`](#chown-file-destination-gid-doc) | New GID of the chown-ed file's owner |
+| [`chown.file.destination.group`](#chown-file-destination-group-doc) | New group of the chown-ed file's owner |
+| [`chown.file.destination.uid`](#chown-file-destination-uid-doc) | New UID of the chown-ed file's owner |
+| [`chown.file.destination.user`](#chown-file-destination-user-doc) | New user of the chown-ed file's owner |
+| [`chown.file.filesystem`](#common-fileevent-filesystem-doc) | File's filesystem |
+| [`chown.file.gid`](#common-filefields-gid-doc) | GID of the file's owner |
+| [`chown.file.group`](#common-filefields-group-doc) | Group of the file's owner |
+| [`chown.file.in_upper_layer`](#common-filefields-in_upper_layer-doc) | Indicator of the file layer, for example, in an OverlayFS |
+| [`chown.file.inode`](#common-filefields-inode-doc) | Inode of the file |
+| [`chown.file.mode`](#common-filefields-mode-doc) | Mode of the file |
+| [`chown.file.modification_time`](#common-filefields-modification_time-doc) | Modification time of the file |
+| [`chown.file.mount_id`](#common-filefields-mount_id-doc) | Mount ID of the file |
+| [`chown.file.name`](#common-fileevent-name-doc) | File's basename |
+| [`chown.file.name.length`](#common-string-length-doc) | Length of the corresponding string |
+| [`chown.file.path`](#common-fileevent-path-doc) | File's path |
+| [`chown.file.path.length`](#common-string-length-doc) | Length of the corresponding string |
+| [`chown.file.rights`](#common-filefields-rights-doc) | Rights of the file |
+| [`chown.file.uid`](#common-filefields-uid-doc) | UID of the file's owner |
+| [`chown.file.user`](#common-filefields-user-doc) | User of the file's owner |
+| [`chown.retval`](#common-syscallevent-retval-doc) | Return value of the syscall |
 
 ### Event `dns`
 
 A DNS request was sent
 
-| Property | Type | Definition | Constants |
-| -------- | ---- | ---------- | --------- |
-| `dns.id` | int | [Experimental] the DNS request ID |  |
-| `dns.question.class` | int | the class looked up by the DNS question | DNS qclasses |
-| `dns.question.count` | int | the total count of questions in the DNS request |  |
-| `dns.question.length` | int | the total DNS request size in bytes |  |
-| `dns.question.name` | string | the queried domain name |  |
-| `dns.question.name.length` | int | the queried domain name |  |
-| `dns.question.type` | int | a two octet code which specifies the DNS question type | DNS qtypes |
+| Property | Definition |
+| -------- | ------------- |
+| [`dns.id`](#dns-id-doc) | [Experimental] the DNS request ID |
+| [`dns.question.class`](#dns-question-class-doc) | the class looked up by the DNS question |
+| [`dns.question.count`](#dns-question-count-doc) | the total count of questions in the DNS request |
+| [`dns.question.length`](#dns-question-length-doc) | the total DNS request size in bytes |
+| [`dns.question.name`](#dns-question-name-doc) | the queried domain name |
+| [`dns.question.name.length`](#common-string-length-doc) | Length of the corresponding string |
+| [`dns.question.type`](#dns-question-type-doc) | a two octet code which specifies the DNS question type |
 
 ### Event `exec`
 
 A process was executed or forked
 
-| Property | Type | Definition | Constants |
-| -------- | ---- | ---------- | --------- |
-| `exec.args` | string | Arguments of the process (as a string) |  |
-| `exec.args_flags` | string | Arguments of the process (as an array) |  |
-| `exec.args_options` | string | Arguments of the process (as an array) |  |
-| `exec.args_truncated` | bool | Indicator of arguments truncation |  |
-| `exec.argv` | string | Arguments of the process (as an array) |  |
-| `exec.argv0` | string | First argument of the process |  |
-| `exec.cap_effective` | int | Effective capability set of the process | Kernel Capability constants |
-| `exec.cap_permitted` | int | Permitted capability set of the process | Kernel Capability constants |
-| `exec.comm` | string | Comm attribute of the process |  |
-| `exec.container.id` | string | Container ID |  |
-| `exec.cookie` | int | Cookie of the process |  |
-| `exec.created_at` | int | Timestamp of the creation of the process |  |
-| `exec.egid` | int | Effective GID of the process |  |
-| `exec.egroup` | string | Effective group of the process |  |
-| `exec.envp` | string | Environment variables of the process |  |
-| `exec.envs` | string | Environment variable names of the process |  |
-| `exec.envs_truncated` | bool | Indicator of environment variables truncation |  |
-| `exec.euid` | int | Effective UID of the process |  |
-| `exec.euser` | string | Effective user of the process |  |
-| `exec.file.change_time` | int | Change time of the file |  |
-| `exec.file.filesystem` | string | File's filesystem |  |
-| `exec.file.gid` | int | GID of the file's owner |  |
-| `exec.file.group` | string | Group of the file's owner |  |
-| `exec.file.in_upper_layer` | bool | Indicator of the file layer, for example, in an OverlayFS |  |
-| `exec.file.inode` | int | Inode of the file |  |
-| `exec.file.mode` | int | Mode/rights of the file | Chmod mode constants |
-| `exec.file.modification_time` | int | Modification time of the file |  |
-| `exec.file.mount_id` | int | Mount ID of the file |  |
-| `exec.file.name` | string | File's basename |  |
-| `exec.file.name.length` | int | Length of 'exec.file.name' string |  |
-| `exec.file.path` | string | File's path |  |
-| `exec.file.path.length` | int | Length of 'exec.file.path' string |  |
-| `exec.file.rights` | int | Mode/rights of the file | Chmod mode constants |
-| `exec.file.uid` | int | UID of the file's owner |  |
-| `exec.file.user` | string | User of the file's owner |  |
-| `exec.fsgid` | int | FileSystem-gid of the process |  |
-| `exec.fsgroup` | string | FileSystem-group of the process |  |
-| `exec.fsuid` | int | FileSystem-uid of the process |  |
-| `exec.fsuser` | string | FileSystem-user of the process |  |
-| `exec.gid` | int | GID of the process |  |
-| `exec.group` | string | Group of the process |  |
-| `exec.interpreter.file.change_time` | int | Change time of the file |  |
-| `exec.interpreter.file.filesystem` | string | File's filesystem |  |
-| `exec.interpreter.file.gid` | int | GID of the file's owner |  |
-| `exec.interpreter.file.group` | string | Group of the file's owner |  |
-| `exec.interpreter.file.in_upper_layer` | bool | Indicator of the file layer, for example, in an OverlayFS |  |
-| `exec.interpreter.file.inode` | int | Inode of the file |  |
-| `exec.interpreter.file.mode` | int | Mode/rights of the file | Chmod mode constants |
-| `exec.interpreter.file.modification_time` | int | Modification time of the file |  |
-| `exec.interpreter.file.mount_id` | int | Mount ID of the file |  |
-| `exec.interpreter.file.name` | string | File's basename |  |
-| `exec.interpreter.file.name.length` | int | Length of 'exec.interpreter.file.name' string |  |
-| `exec.interpreter.file.path` | string | File's path |  |
-| `exec.interpreter.file.path.length` | int | Length of 'exec.interpreter.file.path' string |  |
-| `exec.interpreter.file.rights` | int | Mode/rights of the file | Chmod mode constants |
-| `exec.interpreter.file.uid` | int | UID of the file's owner |  |
-| `exec.interpreter.file.user` | string | User of the file's owner |  |
-| `exec.is_kworker` | bool | Indicates whether the process is a kworker |  |
-| `exec.is_thread` | bool | Indicates whether the process is considered a thread (that is, a child process that hasn't executed another program) |  |
-| `exec.pid` | int | Process ID of the process (also called thread group ID) |  |
-| `exec.ppid` | int | Parent process ID |  |
-| `exec.tid` | int | Thread ID of the thread |  |
-| `exec.tty_name` | string | Name of the TTY associated with the process |  |
-| `exec.uid` | int | UID of the process |  |
-| `exec.user` | string | User of the process |  |
+| Property | Definition |
+| -------- | ------------- |
+| [`exec.args`](#common-process-args-doc) | Arguments of the process (as a string, excluding argv0) |
+| [`exec.args_flags`](#common-process-args_flags-doc) | Flags in the process arguments |
+| [`exec.args_options`](#common-process-args_options-doc) | Argument of the process as options |
+| [`exec.args_truncated`](#common-process-args_truncated-doc) | Indicator of arguments truncation |
+| [`exec.argv`](#common-process-argv-doc) | Arguments of the process (as an array, excluding argv0) |
+| [`exec.argv0`](#common-process-argv0-doc) | First argument of the process |
+| [`exec.cap_effective`](#common-credentials-cap_effective-doc) | Effective capability set of the process |
+| [`exec.cap_permitted`](#common-credentials-cap_permitted-doc) | Permitted capability set of the process |
+| [`exec.comm`](#common-process-comm-doc) | Comm attribute of the process |
+| [`exec.container.id`](#common-process-container-id-doc) | Container ID |
+| [`exec.cookie`](#common-process-cookie-doc) | Cookie of the process |
+| [`exec.created_at`](#common-process-created_at-doc) | Timestamp of the creation of the process |
+| [`exec.egid`](#common-credentials-egid-doc) | Effective GID of the process |
+| [`exec.egroup`](#common-credentials-egroup-doc) | Effective group of the process |
+| [`exec.envp`](#common-process-envp-doc) | Environment variables of the process |
+| [`exec.envs`](#common-process-envs-doc) | Environment variable names of the process |
+| [`exec.envs_truncated`](#common-process-envs_truncated-doc) | Indicator of environment variables truncation |
+| [`exec.euid`](#common-credentials-euid-doc) | Effective UID of the process |
+| [`exec.euser`](#common-credentials-euser-doc) | Effective user of the process |
+| [`exec.file.change_time`](#common-filefields-change_time-doc) | Change time of the file |
+| [`exec.file.filesystem`](#common-fileevent-filesystem-doc) | File's filesystem |
+| [`exec.file.gid`](#common-filefields-gid-doc) | GID of the file's owner |
+| [`exec.file.group`](#common-filefields-group-doc) | Group of the file's owner |
+| [`exec.file.in_upper_layer`](#common-filefields-in_upper_layer-doc) | Indicator of the file layer, for example, in an OverlayFS |
+| [`exec.file.inode`](#common-filefields-inode-doc) | Inode of the file |
+| [`exec.file.mode`](#common-filefields-mode-doc) | Mode of the file |
+| [`exec.file.modification_time`](#common-filefields-modification_time-doc) | Modification time of the file |
+| [`exec.file.mount_id`](#common-filefields-mount_id-doc) | Mount ID of the file |
+| [`exec.file.name`](#common-fileevent-name-doc) | File's basename |
+| [`exec.file.name.length`](#common-string-length-doc) | Length of the corresponding string |
+| [`exec.file.path`](#common-fileevent-path-doc) | File's path |
+| [`exec.file.path.length`](#common-string-length-doc) | Length of the corresponding string |
+| [`exec.file.rights`](#common-filefields-rights-doc) | Rights of the file |
+| [`exec.file.uid`](#common-filefields-uid-doc) | UID of the file's owner |
+| [`exec.file.user`](#common-filefields-user-doc) | User of the file's owner |
+| [`exec.fsgid`](#common-credentials-fsgid-doc) | FileSystem-gid of the process |
+| [`exec.fsgroup`](#common-credentials-fsgroup-doc) | FileSystem-group of the process |
+| [`exec.fsuid`](#common-credentials-fsuid-doc) | FileSystem-uid of the process |
+| [`exec.fsuser`](#common-credentials-fsuser-doc) | FileSystem-user of the process |
+| [`exec.gid`](#common-credentials-gid-doc) | GID of the process |
+| [`exec.group`](#common-credentials-group-doc) | Group of the process |
+| [`exec.interpreter.file.change_time`](#common-filefields-change_time-doc) | Change time of the file |
+| [`exec.interpreter.file.filesystem`](#common-fileevent-filesystem-doc) | File's filesystem |
+| [`exec.interpreter.file.gid`](#common-filefields-gid-doc) | GID of the file's owner |
+| [`exec.interpreter.file.group`](#common-filefields-group-doc) | Group of the file's owner |
+| [`exec.interpreter.file.in_upper_layer`](#common-filefields-in_upper_layer-doc) | Indicator of the file layer, for example, in an OverlayFS |
+| [`exec.interpreter.file.inode`](#common-filefields-inode-doc) | Inode of the file |
+| [`exec.interpreter.file.mode`](#common-filefields-mode-doc) | Mode of the file |
+| [`exec.interpreter.file.modification_time`](#common-filefields-modification_time-doc) | Modification time of the file |
+| [`exec.interpreter.file.mount_id`](#common-filefields-mount_id-doc) | Mount ID of the file |
+| [`exec.interpreter.file.name`](#common-fileevent-name-doc) | File's basename |
+| [`exec.interpreter.file.name.length`](#common-string-length-doc) | Length of the corresponding string |
+| [`exec.interpreter.file.path`](#common-fileevent-path-doc) | File's path |
+| [`exec.interpreter.file.path.length`](#common-string-length-doc) | Length of the corresponding string |
+| [`exec.interpreter.file.rights`](#common-filefields-rights-doc) | Rights of the file |
+| [`exec.interpreter.file.uid`](#common-filefields-uid-doc) | UID of the file's owner |
+| [`exec.interpreter.file.user`](#common-filefields-user-doc) | User of the file's owner |
+| [`exec.is_kworker`](#common-pidcontext-is_kworker-doc) | Indicates whether the process is a kworker |
+| [`exec.is_thread`](#common-process-is_thread-doc) | Indicates whether the process is considered a thread (that is, a child process that hasn't executed another program) |
+| [`exec.pid`](#common-pidcontext-pid-doc) | Process ID of the process (also called thread group ID) |
+| [`exec.ppid`](#common-process-ppid-doc) | Parent process ID |
+| [`exec.tid`](#common-pidcontext-tid-doc) | Thread ID of the thread |
+| [`exec.tty_name`](#common-process-tty_name-doc) | Name of the TTY associated with the process |
+| [`exec.uid`](#common-credentials-uid-doc) | UID of the process |
+| [`exec.user`](#common-credentials-user-doc) | User of the process |
 
 ### Event `exit`
 
 A process was terminated
 
-| Property | Type | Definition | Constants |
-| -------- | ---- | ---------- | --------- |
-| `exit.args` | string | Arguments of the process (as a string) |  |
-| `exit.args_flags` | string | Arguments of the process (as an array) |  |
-| `exit.args_options` | string | Arguments of the process (as an array) |  |
-| `exit.args_truncated` | bool | Indicator of arguments truncation |  |
-| `exit.argv` | string | Arguments of the process (as an array) |  |
-| `exit.argv0` | string | First argument of the process |  |
-| `exit.cap_effective` | int | Effective capability set of the process | Kernel Capability constants |
-| `exit.cap_permitted` | int | Permitted capability set of the process | Kernel Capability constants |
-| `exit.cause` | int | Cause of the process termination (one of EXITED, SIGNALED, COREDUMPED) |  |
-| `exit.code` | int | Exit code of the process or number of the signal that caused the process to terminate |  |
-| `exit.comm` | string | Comm attribute of the process |  |
-| `exit.container.id` | string | Container ID |  |
-| `exit.cookie` | int | Cookie of the process |  |
-| `exit.created_at` | int | Timestamp of the creation of the process |  |
-| `exit.egid` | int | Effective GID of the process |  |
-| `exit.egroup` | string | Effective group of the process |  |
-| `exit.envp` | string | Environment variables of the process |  |
-| `exit.envs` | string | Environment variable names of the process |  |
-| `exit.envs_truncated` | bool | Indicator of environment variables truncation |  |
-| `exit.euid` | int | Effective UID of the process |  |
-| `exit.euser` | string | Effective user of the process |  |
-| `exit.file.change_time` | int | Change time of the file |  |
-| `exit.file.filesystem` | string | File's filesystem |  |
-| `exit.file.gid` | int | GID of the file's owner |  |
-| `exit.file.group` | string | Group of the file's owner |  |
-| `exit.file.in_upper_layer` | bool | Indicator of the file layer, for example, in an OverlayFS |  |
-| `exit.file.inode` | int | Inode of the file |  |
-| `exit.file.mode` | int | Mode/rights of the file | Chmod mode constants |
-| `exit.file.modification_time` | int | Modification time of the file |  |
-| `exit.file.mount_id` | int | Mount ID of the file |  |
-| `exit.file.name` | string | File's basename |  |
-| `exit.file.name.length` | int | Length of 'exit.file.name' string |  |
-| `exit.file.path` | string | File's path |  |
-| `exit.file.path.length` | int | Length of 'exit.file.path' string |  |
-| `exit.file.rights` | int | Mode/rights of the file | Chmod mode constants |
-| `exit.file.uid` | int | UID of the file's owner |  |
-| `exit.file.user` | string | User of the file's owner |  |
-| `exit.fsgid` | int | FileSystem-gid of the process |  |
-| `exit.fsgroup` | string | FileSystem-group of the process |  |
-| `exit.fsuid` | int | FileSystem-uid of the process |  |
-| `exit.fsuser` | string | FileSystem-user of the process |  |
-| `exit.gid` | int | GID of the process |  |
-| `exit.group` | string | Group of the process |  |
-| `exit.interpreter.file.change_time` | int | Change time of the file |  |
-| `exit.interpreter.file.filesystem` | string | File's filesystem |  |
-| `exit.interpreter.file.gid` | int | GID of the file's owner |  |
-| `exit.interpreter.file.group` | string | Group of the file's owner |  |
-| `exit.interpreter.file.in_upper_layer` | bool | Indicator of the file layer, for example, in an OverlayFS |  |
-| `exit.interpreter.file.inode` | int | Inode of the file |  |
-| `exit.interpreter.file.mode` | int | Mode/rights of the file | Chmod mode constants |
-| `exit.interpreter.file.modification_time` | int | Modification time of the file |  |
-| `exit.interpreter.file.mount_id` | int | Mount ID of the file |  |
-| `exit.interpreter.file.name` | string | File's basename |  |
-| `exit.interpreter.file.name.length` | int | Length of 'exit.interpreter.file.name' string |  |
-| `exit.interpreter.file.path` | string | File's path |  |
-| `exit.interpreter.file.path.length` | int | Length of 'exit.interpreter.file.path' string |  |
-| `exit.interpreter.file.rights` | int | Mode/rights of the file | Chmod mode constants |
-| `exit.interpreter.file.uid` | int | UID of the file's owner |  |
-| `exit.interpreter.file.user` | string | User of the file's owner |  |
-| `exit.is_kworker` | bool | Indicates whether the process is a kworker |  |
-| `exit.is_thread` | bool | Indicates whether the process is considered a thread (that is, a child process that hasn't executed another program) |  |
-| `exit.pid` | int | Process ID of the process (also called thread group ID) |  |
-| `exit.ppid` | int | Parent process ID |  |
-| `exit.tid` | int | Thread ID of the thread |  |
-| `exit.tty_name` | string | Name of the TTY associated with the process |  |
-| `exit.uid` | int | UID of the process |  |
-| `exit.user` | string | User of the process |  |
+| Property | Definition |
+| -------- | ------------- |
+| [`exit.args`](#common-process-args-doc) | Arguments of the process (as a string, excluding argv0) |
+| [`exit.args_flags`](#common-process-args_flags-doc) | Flags in the process arguments |
+| [`exit.args_options`](#common-process-args_options-doc) | Argument of the process as options |
+| [`exit.args_truncated`](#common-process-args_truncated-doc) | Indicator of arguments truncation |
+| [`exit.argv`](#common-process-argv-doc) | Arguments of the process (as an array, excluding argv0) |
+| [`exit.argv0`](#common-process-argv0-doc) | First argument of the process |
+| [`exit.cap_effective`](#common-credentials-cap_effective-doc) | Effective capability set of the process |
+| [`exit.cap_permitted`](#common-credentials-cap_permitted-doc) | Permitted capability set of the process |
+| [`exit.cause`](#exit-cause-doc) | Cause of the process termination (one of EXITED, SIGNALED, COREDUMPED) |
+| [`exit.code`](#exit-code-doc) | Exit code of the process or number of the signal that caused the process to terminate |
+| [`exit.comm`](#common-process-comm-doc) | Comm attribute of the process |
+| [`exit.container.id`](#common-process-container-id-doc) | Container ID |
+| [`exit.cookie`](#common-process-cookie-doc) | Cookie of the process |
+| [`exit.created_at`](#common-process-created_at-doc) | Timestamp of the creation of the process |
+| [`exit.egid`](#common-credentials-egid-doc) | Effective GID of the process |
+| [`exit.egroup`](#common-credentials-egroup-doc) | Effective group of the process |
+| [`exit.envp`](#common-process-envp-doc) | Environment variables of the process |
+| [`exit.envs`](#common-process-envs-doc) | Environment variable names of the process |
+| [`exit.envs_truncated`](#common-process-envs_truncated-doc) | Indicator of environment variables truncation |
+| [`exit.euid`](#common-credentials-euid-doc) | Effective UID of the process |
+| [`exit.euser`](#common-credentials-euser-doc) | Effective user of the process |
+| [`exit.file.change_time`](#common-filefields-change_time-doc) | Change time of the file |
+| [`exit.file.filesystem`](#common-fileevent-filesystem-doc) | File's filesystem |
+| [`exit.file.gid`](#common-filefields-gid-doc) | GID of the file's owner |
+| [`exit.file.group`](#common-filefields-group-doc) | Group of the file's owner |
+| [`exit.file.in_upper_layer`](#common-filefields-in_upper_layer-doc) | Indicator of the file layer, for example, in an OverlayFS |
+| [`exit.file.inode`](#common-filefields-inode-doc) | Inode of the file |
+| [`exit.file.mode`](#common-filefields-mode-doc) | Mode of the file |
+| [`exit.file.modification_time`](#common-filefields-modification_time-doc) | Modification time of the file |
+| [`exit.file.mount_id`](#common-filefields-mount_id-doc) | Mount ID of the file |
+| [`exit.file.name`](#common-fileevent-name-doc) | File's basename |
+| [`exit.file.name.length`](#common-string-length-doc) | Length of the corresponding string |
+| [`exit.file.path`](#common-fileevent-path-doc) | File's path |
+| [`exit.file.path.length`](#common-string-length-doc) | Length of the corresponding string |
+| [`exit.file.rights`](#common-filefields-rights-doc) | Rights of the file |
+| [`exit.file.uid`](#common-filefields-uid-doc) | UID of the file's owner |
+| [`exit.file.user`](#common-filefields-user-doc) | User of the file's owner |
+| [`exit.fsgid`](#common-credentials-fsgid-doc) | FileSystem-gid of the process |
+| [`exit.fsgroup`](#common-credentials-fsgroup-doc) | FileSystem-group of the process |
+| [`exit.fsuid`](#common-credentials-fsuid-doc) | FileSystem-uid of the process |
+| [`exit.fsuser`](#common-credentials-fsuser-doc) | FileSystem-user of the process |
+| [`exit.gid`](#common-credentials-gid-doc) | GID of the process |
+| [`exit.group`](#common-credentials-group-doc) | Group of the process |
+| [`exit.interpreter.file.change_time`](#common-filefields-change_time-doc) | Change time of the file |
+| [`exit.interpreter.file.filesystem`](#common-fileevent-filesystem-doc) | File's filesystem |
+| [`exit.interpreter.file.gid`](#common-filefields-gid-doc) | GID of the file's owner |
+| [`exit.interpreter.file.group`](#common-filefields-group-doc) | Group of the file's owner |
+| [`exit.interpreter.file.in_upper_layer`](#common-filefields-in_upper_layer-doc) | Indicator of the file layer, for example, in an OverlayFS |
+| [`exit.interpreter.file.inode`](#common-filefields-inode-doc) | Inode of the file |
+| [`exit.interpreter.file.mode`](#common-filefields-mode-doc) | Mode of the file |
+| [`exit.interpreter.file.modification_time`](#common-filefields-modification_time-doc) | Modification time of the file |
+| [`exit.interpreter.file.mount_id`](#common-filefields-mount_id-doc) | Mount ID of the file |
+| [`exit.interpreter.file.name`](#common-fileevent-name-doc) | File's basename |
+| [`exit.interpreter.file.name.length`](#common-string-length-doc) | Length of the corresponding string |
+| [`exit.interpreter.file.path`](#common-fileevent-path-doc) | File's path |
+| [`exit.interpreter.file.path.length`](#common-string-length-doc) | Length of the corresponding string |
+| [`exit.interpreter.file.rights`](#common-filefields-rights-doc) | Rights of the file |
+| [`exit.interpreter.file.uid`](#common-filefields-uid-doc) | UID of the file's owner |
+| [`exit.interpreter.file.user`](#common-filefields-user-doc) | User of the file's owner |
+| [`exit.is_kworker`](#common-pidcontext-is_kworker-doc) | Indicates whether the process is a kworker |
+| [`exit.is_thread`](#common-process-is_thread-doc) | Indicates whether the process is considered a thread (that is, a child process that hasn't executed another program) |
+| [`exit.pid`](#common-pidcontext-pid-doc) | Process ID of the process (also called thread group ID) |
+| [`exit.ppid`](#common-process-ppid-doc) | Parent process ID |
+| [`exit.tid`](#common-pidcontext-tid-doc) | Thread ID of the thread |
+| [`exit.tty_name`](#common-process-tty_name-doc) | Name of the TTY associated with the process |
+| [`exit.uid`](#common-credentials-uid-doc) | UID of the process |
+| [`exit.user`](#common-credentials-user-doc) | User of the process |
 
 ### Event `link`
 
 Create a new name/alias for a file
 
-| Property | Type | Definition | Constants |
-| -------- | ---- | ---------- | --------- |
-| `link.file.change_time` | int | Change time of the file |  |
-| `link.file.destination.change_time` | int | Change time of the file |  |
-| `link.file.destination.filesystem` | string | File's filesystem |  |
-| `link.file.destination.gid` | int | GID of the file's owner |  |
-| `link.file.destination.group` | string | Group of the file's owner |  |
-| `link.file.destination.in_upper_layer` | bool | Indicator of the file layer, for example, in an OverlayFS |  |
-| `link.file.destination.inode` | int | Inode of the file |  |
-| `link.file.destination.mode` | int | Mode/rights of the file | Chmod mode constants |
-| `link.file.destination.modification_time` | int | Modification time of the file |  |
-| `link.file.destination.mount_id` | int | Mount ID of the file |  |
-| `link.file.destination.name` | string | File's basename |  |
-| `link.file.destination.name.length` | int | Length of 'link.file.destination.name' string |  |
-| `link.file.destination.path` | string | File's path |  |
-| `link.file.destination.path.length` | int | Length of 'link.file.destination.path' string |  |
-| `link.file.destination.rights` | int | Mode/rights of the file | Chmod mode constants |
-| `link.file.destination.uid` | int | UID of the file's owner |  |
-| `link.file.destination.user` | string | User of the file's owner |  |
-| `link.file.filesystem` | string | File's filesystem |  |
-| `link.file.gid` | int | GID of the file's owner |  |
-| `link.file.group` | string | Group of the file's owner |  |
-| `link.file.in_upper_layer` | bool | Indicator of the file layer, for example, in an OverlayFS |  |
-| `link.file.inode` | int | Inode of the file |  |
-| `link.file.mode` | int | Mode/rights of the file | Chmod mode constants |
-| `link.file.modification_time` | int | Modification time of the file |  |
-| `link.file.mount_id` | int | Mount ID of the file |  |
-| `link.file.name` | string | File's basename |  |
-| `link.file.name.length` | int | Length of 'link.file.name' string |  |
-| `link.file.path` | string | File's path |  |
-| `link.file.path.length` | int | Length of 'link.file.path' string |  |
-| `link.file.rights` | int | Mode/rights of the file | Chmod mode constants |
-| `link.file.uid` | int | UID of the file's owner |  |
-| `link.file.user` | string | User of the file's owner |  |
-| `link.retval` | int | Return value of the syscall | Error Constants |
+| Property | Definition |
+| -------- | ------------- |
+| [`link.file.change_time`](#common-filefields-change_time-doc) | Change time of the file |
+| [`link.file.destination.change_time`](#common-filefields-change_time-doc) | Change time of the file |
+| [`link.file.destination.filesystem`](#common-fileevent-filesystem-doc) | File's filesystem |
+| [`link.file.destination.gid`](#common-filefields-gid-doc) | GID of the file's owner |
+| [`link.file.destination.group`](#common-filefields-group-doc) | Group of the file's owner |
+| [`link.file.destination.in_upper_layer`](#common-filefields-in_upper_layer-doc) | Indicator of the file layer, for example, in an OverlayFS |
+| [`link.file.destination.inode`](#common-filefields-inode-doc) | Inode of the file |
+| [`link.file.destination.mode`](#common-filefields-mode-doc) | Mode of the file |
+| [`link.file.destination.modification_time`](#common-filefields-modification_time-doc) | Modification time of the file |
+| [`link.file.destination.mount_id`](#common-filefields-mount_id-doc) | Mount ID of the file |
+| [`link.file.destination.name`](#common-fileevent-name-doc) | File's basename |
+| [`link.file.destination.name.length`](#common-string-length-doc) | Length of the corresponding string |
+| [`link.file.destination.path`](#common-fileevent-path-doc) | File's path |
+| [`link.file.destination.path.length`](#common-string-length-doc) | Length of the corresponding string |
+| [`link.file.destination.rights`](#common-filefields-rights-doc) | Rights of the file |
+| [`link.file.destination.uid`](#common-filefields-uid-doc) | UID of the file's owner |
+| [`link.file.destination.user`](#common-filefields-user-doc) | User of the file's owner |
+| [`link.file.filesystem`](#common-fileevent-filesystem-doc) | File's filesystem |
+| [`link.file.gid`](#common-filefields-gid-doc) | GID of the file's owner |
+| [`link.file.group`](#common-filefields-group-doc) | Group of the file's owner |
+| [`link.file.in_upper_layer`](#common-filefields-in_upper_layer-doc) | Indicator of the file layer, for example, in an OverlayFS |
+| [`link.file.inode`](#common-filefields-inode-doc) | Inode of the file |
+| [`link.file.mode`](#common-filefields-mode-doc) | Mode of the file |
+| [`link.file.modification_time`](#common-filefields-modification_time-doc) | Modification time of the file |
+| [`link.file.mount_id`](#common-filefields-mount_id-doc) | Mount ID of the file |
+| [`link.file.name`](#common-fileevent-name-doc) | File's basename |
+| [`link.file.name.length`](#common-string-length-doc) | Length of the corresponding string |
+| [`link.file.path`](#common-fileevent-path-doc) | File's path |
+| [`link.file.path.length`](#common-string-length-doc) | Length of the corresponding string |
+| [`link.file.rights`](#common-filefields-rights-doc) | Rights of the file |
+| [`link.file.uid`](#common-filefields-uid-doc) | UID of the file's owner |
+| [`link.file.user`](#common-filefields-user-doc) | User of the file's owner |
+| [`link.retval`](#common-syscallevent-retval-doc) | Return value of the syscall |
 
 ### Event `load_module`
 
 A new kernel module was loaded
 
-| Property | Type | Definition | Constants |
-| -------- | ---- | ---------- | --------- |
-| `load_module.file.change_time` | int | Change time of the file |  |
-| `load_module.file.filesystem` | string | File's filesystem |  |
-| `load_module.file.gid` | int | GID of the file's owner |  |
-| `load_module.file.group` | string | Group of the file's owner |  |
-| `load_module.file.in_upper_layer` | bool | Indicator of the file layer, for example, in an OverlayFS |  |
-| `load_module.file.inode` | int | Inode of the file |  |
-| `load_module.file.mode` | int | Mode/rights of the file | Chmod mode constants |
-| `load_module.file.modification_time` | int | Modification time of the file |  |
-| `load_module.file.mount_id` | int | Mount ID of the file |  |
-| `load_module.file.name` | string | File's basename |  |
-| `load_module.file.name.length` | int | Length of 'load_module.file.name' string |  |
-| `load_module.file.path` | string | File's path |  |
-| `load_module.file.path.length` | int | Length of 'load_module.file.path' string |  |
-| `load_module.file.rights` | int | Mode/rights of the file | Chmod mode constants |
-| `load_module.file.uid` | int | UID of the file's owner |  |
-| `load_module.file.user` | string | User of the file's owner |  |
-| `load_module.loaded_from_memory` | bool | Indicates if the kernel module was loaded from memory |  |
-| `load_module.name` | string | Name of the new kernel module |  |
-| `load_module.retval` | int | Return value of the syscall | Error Constants |
+| Property | Definition |
+| -------- | ------------- |
+| [`load_module.file.change_time`](#common-filefields-change_time-doc) | Change time of the file |
+| [`load_module.file.filesystem`](#common-fileevent-filesystem-doc) | File's filesystem |
+| [`load_module.file.gid`](#common-filefields-gid-doc) | GID of the file's owner |
+| [`load_module.file.group`](#common-filefields-group-doc) | Group of the file's owner |
+| [`load_module.file.in_upper_layer`](#common-filefields-in_upper_layer-doc) | Indicator of the file layer, for example, in an OverlayFS |
+| [`load_module.file.inode`](#common-filefields-inode-doc) | Inode of the file |
+| [`load_module.file.mode`](#common-filefields-mode-doc) | Mode of the file |
+| [`load_module.file.modification_time`](#common-filefields-modification_time-doc) | Modification time of the file |
+| [`load_module.file.mount_id`](#common-filefields-mount_id-doc) | Mount ID of the file |
+| [`load_module.file.name`](#common-fileevent-name-doc) | File's basename |
+| [`load_module.file.name.length`](#common-string-length-doc) | Length of the corresponding string |
+| [`load_module.file.path`](#common-fileevent-path-doc) | File's path |
+| [`load_module.file.path.length`](#common-string-length-doc) | Length of the corresponding string |
+| [`load_module.file.rights`](#common-filefields-rights-doc) | Rights of the file |
+| [`load_module.file.uid`](#common-filefields-uid-doc) | UID of the file's owner |
+| [`load_module.file.user`](#common-filefields-user-doc) | User of the file's owner |
+| [`load_module.loaded_from_memory`](#load_module-loaded_from_memory-doc) | Indicates if the kernel module was loaded from memory |
+| [`load_module.name`](#load_module-name-doc) | Name of the new kernel module |
+| [`load_module.retval`](#common-syscallevent-retval-doc) | Return value of the syscall |
 
 ### Event `mkdir`
 
 A directory was created
 
-| Property | Type | Definition | Constants |
-| -------- | ---- | ---------- | --------- |
-| `mkdir.file.change_time` | int | Change time of the file |  |
-| `mkdir.file.destination.mode` | int | Mode/rights of the new directory | Chmod mode constants |
-| `mkdir.file.destination.rights` | int | Mode/rights of the new directory | Chmod mode constants |
-| `mkdir.file.filesystem` | string | File's filesystem |  |
-| `mkdir.file.gid` | int | GID of the file's owner |  |
-| `mkdir.file.group` | string | Group of the file's owner |  |
-| `mkdir.file.in_upper_layer` | bool | Indicator of the file layer, for example, in an OverlayFS |  |
-| `mkdir.file.inode` | int | Inode of the file |  |
-| `mkdir.file.mode` | int | Mode/rights of the file | Chmod mode constants |
-| `mkdir.file.modification_time` | int | Modification time of the file |  |
-| `mkdir.file.mount_id` | int | Mount ID of the file |  |
-| `mkdir.file.name` | string | File's basename |  |
-| `mkdir.file.name.length` | int | Length of 'mkdir.file.name' string |  |
-| `mkdir.file.path` | string | File's path |  |
-| `mkdir.file.path.length` | int | Length of 'mkdir.file.path' string |  |
-| `mkdir.file.rights` | int | Mode/rights of the file | Chmod mode constants |
-| `mkdir.file.uid` | int | UID of the file's owner |  |
-| `mkdir.file.user` | string | User of the file's owner |  |
-| `mkdir.retval` | int | Return value of the syscall | Error Constants |
+| Property | Definition |
+| -------- | ------------- |
+| [`mkdir.file.change_time`](#common-filefields-change_time-doc) | Change time of the file |
+| [`mkdir.file.destination.mode`](#mkdir-file-destination-mode-doc) | Mode of the new directory |
+| [`mkdir.file.destination.rights`](#mkdir-file-destination-rights-doc) | Rights of the new directory |
+| [`mkdir.file.filesystem`](#common-fileevent-filesystem-doc) | File's filesystem |
+| [`mkdir.file.gid`](#common-filefields-gid-doc) | GID of the file's owner |
+| [`mkdir.file.group`](#common-filefields-group-doc) | Group of the file's owner |
+| [`mkdir.file.in_upper_layer`](#common-filefields-in_upper_layer-doc) | Indicator of the file layer, for example, in an OverlayFS |
+| [`mkdir.file.inode`](#common-filefields-inode-doc) | Inode of the file |
+| [`mkdir.file.mode`](#common-filefields-mode-doc) | Mode of the file |
+| [`mkdir.file.modification_time`](#common-filefields-modification_time-doc) | Modification time of the file |
+| [`mkdir.file.mount_id`](#common-filefields-mount_id-doc) | Mount ID of the file |
+| [`mkdir.file.name`](#common-fileevent-name-doc) | File's basename |
+| [`mkdir.file.name.length`](#common-string-length-doc) | Length of the corresponding string |
+| [`mkdir.file.path`](#common-fileevent-path-doc) | File's path |
+| [`mkdir.file.path.length`](#common-string-length-doc) | Length of the corresponding string |
+| [`mkdir.file.rights`](#common-filefields-rights-doc) | Rights of the file |
+| [`mkdir.file.uid`](#common-filefields-uid-doc) | UID of the file's owner |
+| [`mkdir.file.user`](#common-filefields-user-doc) | User of the file's owner |
+| [`mkdir.retval`](#common-syscallevent-retval-doc) | Return value of the syscall |
 
 ### Event `mmap`
 
 A mmap command was executed
 
-| Property | Type | Definition | Constants |
-| -------- | ---- | ---------- | --------- |
-| `mmap.file.change_time` | int | Change time of the file |  |
-| `mmap.file.filesystem` | string | File's filesystem |  |
-| `mmap.file.gid` | int | GID of the file's owner |  |
-| `mmap.file.group` | string | Group of the file's owner |  |
-| `mmap.file.in_upper_layer` | bool | Indicator of the file layer, for example, in an OverlayFS |  |
-| `mmap.file.inode` | int | Inode of the file |  |
-| `mmap.file.mode` | int | Mode/rights of the file | Chmod mode constants |
-| `mmap.file.modification_time` | int | Modification time of the file |  |
-| `mmap.file.mount_id` | int | Mount ID of the file |  |
-| `mmap.file.name` | string | File's basename |  |
-| `mmap.file.name.length` | int | Length of 'mmap.file.name' string |  |
-| `mmap.file.path` | string | File's path |  |
-| `mmap.file.path.length` | int | Length of 'mmap.file.path' string |  |
-| `mmap.file.rights` | int | Mode/rights of the file | Chmod mode constants |
-| `mmap.file.uid` | int | UID of the file's owner |  |
-| `mmap.file.user` | string | User of the file's owner |  |
-| `mmap.flags` | int | memory segment flags | MMap flags |
-| `mmap.protection` | int | memory segment protection | Protection constants |
-| `mmap.retval` | int | Return value of the syscall | Error Constants |
+| Property | Definition |
+| -------- | ------------- |
+| [`mmap.file.change_time`](#common-filefields-change_time-doc) | Change time of the file |
+| [`mmap.file.filesystem`](#common-fileevent-filesystem-doc) | File's filesystem |
+| [`mmap.file.gid`](#common-filefields-gid-doc) | GID of the file's owner |
+| [`mmap.file.group`](#common-filefields-group-doc) | Group of the file's owner |
+| [`mmap.file.in_upper_layer`](#common-filefields-in_upper_layer-doc) | Indicator of the file layer, for example, in an OverlayFS |
+| [`mmap.file.inode`](#common-filefields-inode-doc) | Inode of the file |
+| [`mmap.file.mode`](#common-filefields-mode-doc) | Mode of the file |
+| [`mmap.file.modification_time`](#common-filefields-modification_time-doc) | Modification time of the file |
+| [`mmap.file.mount_id`](#common-filefields-mount_id-doc) | Mount ID of the file |
+| [`mmap.file.name`](#common-fileevent-name-doc) | File's basename |
+| [`mmap.file.name.length`](#common-string-length-doc) | Length of the corresponding string |
+| [`mmap.file.path`](#common-fileevent-path-doc) | File's path |
+| [`mmap.file.path.length`](#common-string-length-doc) | Length of the corresponding string |
+| [`mmap.file.rights`](#common-filefields-rights-doc) | Rights of the file |
+| [`mmap.file.uid`](#common-filefields-uid-doc) | UID of the file's owner |
+| [`mmap.file.user`](#common-filefields-user-doc) | User of the file's owner |
+| [`mmap.flags`](#mmap-flags-doc) | memory segment flags |
+| [`mmap.protection`](#mmap-protection-doc) | memory segment protection |
+| [`mmap.retval`](#common-syscallevent-retval-doc) | Return value of the syscall |
 
 ### Event `mount`
 
@@ -752,702 +752,1833 @@ _This event type is experimental and may change in the future._
 
 A filesystem was mounted
 
-| Property | Type | Definition | Constants |
-| -------- | ---- | ---------- | --------- |
-| `mount.fs_type` | string | Type of the mounted file system |  |
-| `mount.mountpoint.path` | string | Path of the mount point |  |
-| `mount.retval` | int | Return value of the syscall | Error Constants |
-| `mount.source.path` | string | Source path of a bind mount |  |
+| Property | Definition |
+| -------- | ------------- |
+| [`mount.fs_type`](#mount-fs_type-doc) | Type of the mounted file system |
+| [`mount.mountpoint.path`](#mount-mountpoint-path-doc) | Path of the mount point |
+| [`mount.retval`](#common-syscallevent-retval-doc) | Return value of the syscall |
+| [`mount.source.path`](#mount-source-path-doc) | Source path of a bind mount |
 
 ### Event `mprotect`
 
 A mprotect command was executed
 
-| Property | Type | Definition | Constants |
-| -------- | ---- | ---------- | --------- |
-| `mprotect.req_protection` | int | new memory segment protection | Virtual Memory flags |
-| `mprotect.retval` | int | Return value of the syscall | Error Constants |
-| `mprotect.vm_protection` | int | initial memory segment protection | Virtual Memory flags |
+| Property | Definition |
+| -------- | ------------- |
+| [`mprotect.req_protection`](#mprotect-req_protection-doc) | new memory segment protection |
+| [`mprotect.retval`](#common-syscallevent-retval-doc) | Return value of the syscall |
+| [`mprotect.vm_protection`](#mprotect-vm_protection-doc) | initial memory segment protection |
 
 ### Event `open`
 
 A file was opened
 
-| Property | Type | Definition | Constants |
-| -------- | ---- | ---------- | --------- |
-| `open.file.change_time` | int | Change time of the file |  |
-| `open.file.destination.mode` | int | Mode of the created file | Chmod mode constants |
-| `open.file.filesystem` | string | File's filesystem |  |
-| `open.file.gid` | int | GID of the file's owner |  |
-| `open.file.group` | string | Group of the file's owner |  |
-| `open.file.in_upper_layer` | bool | Indicator of the file layer, for example, in an OverlayFS |  |
-| `open.file.inode` | int | Inode of the file |  |
-| `open.file.mode` | int | Mode/rights of the file | Chmod mode constants |
-| `open.file.modification_time` | int | Modification time of the file |  |
-| `open.file.mount_id` | int | Mount ID of the file |  |
-| `open.file.name` | string | File's basename |  |
-| `open.file.name.length` | int | Length of 'open.file.name' string |  |
-| `open.file.path` | string | File's path |  |
-| `open.file.path.length` | int | Length of 'open.file.path' string |  |
-| `open.file.rights` | int | Mode/rights of the file | Chmod mode constants |
-| `open.file.uid` | int | UID of the file's owner |  |
-| `open.file.user` | string | User of the file's owner |  |
-| `open.flags` | int | Flags used when opening the file | Open flags |
-| `open.retval` | int | Return value of the syscall | Error Constants |
+| Property | Definition |
+| -------- | ------------- |
+| [`open.file.change_time`](#common-filefields-change_time-doc) | Change time of the file |
+| [`open.file.destination.mode`](#open-file-destination-mode-doc) | Mode of the created file |
+| [`open.file.filesystem`](#common-fileevent-filesystem-doc) | File's filesystem |
+| [`open.file.gid`](#common-filefields-gid-doc) | GID of the file's owner |
+| [`open.file.group`](#common-filefields-group-doc) | Group of the file's owner |
+| [`open.file.in_upper_layer`](#common-filefields-in_upper_layer-doc) | Indicator of the file layer, for example, in an OverlayFS |
+| [`open.file.inode`](#common-filefields-inode-doc) | Inode of the file |
+| [`open.file.mode`](#common-filefields-mode-doc) | Mode of the file |
+| [`open.file.modification_time`](#common-filefields-modification_time-doc) | Modification time of the file |
+| [`open.file.mount_id`](#common-filefields-mount_id-doc) | Mount ID of the file |
+| [`open.file.name`](#common-fileevent-name-doc) | File's basename |
+| [`open.file.name.length`](#common-string-length-doc) | Length of the corresponding string |
+| [`open.file.path`](#common-fileevent-path-doc) | File's path |
+| [`open.file.path.length`](#common-string-length-doc) | Length of the corresponding string |
+| [`open.file.rights`](#common-filefields-rights-doc) | Rights of the file |
+| [`open.file.uid`](#common-filefields-uid-doc) | UID of the file's owner |
+| [`open.file.user`](#common-filefields-user-doc) | User of the file's owner |
+| [`open.flags`](#open-flags-doc) | Flags used when opening the file |
+| [`open.retval`](#common-syscallevent-retval-doc) | Return value of the syscall |
 
 ### Event `ptrace`
 
 A ptrace command was executed
 
-| Property | Type | Definition | Constants |
-| -------- | ---- | ---------- | --------- |
-| `ptrace.request` | int | ptrace request | Ptrace constants |
-| `ptrace.retval` | int | Return value of the syscall | Error Constants |
-| `ptrace.tracee.ancestors.args` | string | Arguments of the process (as a string) |  |
-| `ptrace.tracee.ancestors.args_flags` | string | Arguments of the process (as an array) |  |
-| `ptrace.tracee.ancestors.args_options` | string | Arguments of the process (as an array) |  |
-| `ptrace.tracee.ancestors.args_truncated` | bool | Indicator of arguments truncation |  |
-| `ptrace.tracee.ancestors.argv` | string | Arguments of the process (as an array) |  |
-| `ptrace.tracee.ancestors.argv0` | string | First argument of the process |  |
-| `ptrace.tracee.ancestors.cap_effective` | int | Effective capability set of the process | Kernel Capability constants |
-| `ptrace.tracee.ancestors.cap_permitted` | int | Permitted capability set of the process | Kernel Capability constants |
-| `ptrace.tracee.ancestors.comm` | string | Comm attribute of the process |  |
-| `ptrace.tracee.ancestors.container.id` | string | Container ID |  |
-| `ptrace.tracee.ancestors.cookie` | int | Cookie of the process |  |
-| `ptrace.tracee.ancestors.created_at` | int | Timestamp of the creation of the process |  |
-| `ptrace.tracee.ancestors.egid` | int | Effective GID of the process |  |
-| `ptrace.tracee.ancestors.egroup` | string | Effective group of the process |  |
-| `ptrace.tracee.ancestors.envp` | string | Environment variables of the process |  |
-| `ptrace.tracee.ancestors.envs` | string | Environment variable names of the process |  |
-| `ptrace.tracee.ancestors.envs_truncated` | bool | Indicator of environment variables truncation |  |
-| `ptrace.tracee.ancestors.euid` | int | Effective UID of the process |  |
-| `ptrace.tracee.ancestors.euser` | string | Effective user of the process |  |
-| `ptrace.tracee.ancestors.file.change_time` | int | Change time of the file |  |
-| `ptrace.tracee.ancestors.file.filesystem` | string | File's filesystem |  |
-| `ptrace.tracee.ancestors.file.gid` | int | GID of the file's owner |  |
-| `ptrace.tracee.ancestors.file.group` | string | Group of the file's owner |  |
-| `ptrace.tracee.ancestors.file.in_upper_layer` | bool | Indicator of the file layer, for example, in an OverlayFS |  |
-| `ptrace.tracee.ancestors.file.inode` | int | Inode of the file |  |
-| `ptrace.tracee.ancestors.file.mode` | int | Mode/rights of the file | Chmod mode constants |
-| `ptrace.tracee.ancestors.file.modification_time` | int | Modification time of the file |  |
-| `ptrace.tracee.ancestors.file.mount_id` | int | Mount ID of the file |  |
-| `ptrace.tracee.ancestors.file.name` | string | File's basename |  |
-| `ptrace.tracee.ancestors.file.name.length` | int | Length of 'ptrace.tracee.ancestors.file.name' string |  |
-| `ptrace.tracee.ancestors.file.path` | string | File's path |  |
-| `ptrace.tracee.ancestors.file.path.length` | int | Length of 'ptrace.tracee.ancestors.file.path' string |  |
-| `ptrace.tracee.ancestors.file.rights` | int | Mode/rights of the file | Chmod mode constants |
-| `ptrace.tracee.ancestors.file.uid` | int | UID of the file's owner |  |
-| `ptrace.tracee.ancestors.file.user` | string | User of the file's owner |  |
-| `ptrace.tracee.ancestors.fsgid` | int | FileSystem-gid of the process |  |
-| `ptrace.tracee.ancestors.fsgroup` | string | FileSystem-group of the process |  |
-| `ptrace.tracee.ancestors.fsuid` | int | FileSystem-uid of the process |  |
-| `ptrace.tracee.ancestors.fsuser` | string | FileSystem-user of the process |  |
-| `ptrace.tracee.ancestors.gid` | int | GID of the process |  |
-| `ptrace.tracee.ancestors.group` | string | Group of the process |  |
-| `ptrace.tracee.ancestors.interpreter.file.change_time` | int | Change time of the file |  |
-| `ptrace.tracee.ancestors.interpreter.file.filesystem` | string | File's filesystem |  |
-| `ptrace.tracee.ancestors.interpreter.file.gid` | int | GID of the file's owner |  |
-| `ptrace.tracee.ancestors.interpreter.file.group` | string | Group of the file's owner |  |
-| `ptrace.tracee.ancestors.interpreter.file.in_upper_layer` | bool | Indicator of the file layer, for example, in an OverlayFS |  |
-| `ptrace.tracee.ancestors.interpreter.file.inode` | int | Inode of the file |  |
-| `ptrace.tracee.ancestors.interpreter.file.mode` | int | Mode/rights of the file | Chmod mode constants |
-| `ptrace.tracee.ancestors.interpreter.file.modification_time` | int | Modification time of the file |  |
-| `ptrace.tracee.ancestors.interpreter.file.mount_id` | int | Mount ID of the file |  |
-| `ptrace.tracee.ancestors.interpreter.file.name` | string | File's basename |  |
-| `ptrace.tracee.ancestors.interpreter.file.name.length` | int | Length of 'ptrace.tracee.ancestors.interpreter.file.name' string |  |
-| `ptrace.tracee.ancestors.interpreter.file.path` | string | File's path |  |
-| `ptrace.tracee.ancestors.interpreter.file.path.length` | int | Length of 'ptrace.tracee.ancestors.interpreter.file.path' string |  |
-| `ptrace.tracee.ancestors.interpreter.file.rights` | int | Mode/rights of the file | Chmod mode constants |
-| `ptrace.tracee.ancestors.interpreter.file.uid` | int | UID of the file's owner |  |
-| `ptrace.tracee.ancestors.interpreter.file.user` | string | User of the file's owner |  |
-| `ptrace.tracee.ancestors.is_kworker` | bool | Indicates whether the process is a kworker |  |
-| `ptrace.tracee.ancestors.is_thread` | bool | Indicates whether the process is considered a thread (that is, a child process that hasn't executed another program) |  |
-| `ptrace.tracee.ancestors.pid` | int | Process ID of the process (also called thread group ID) |  |
-| `ptrace.tracee.ancestors.ppid` | int | Parent process ID |  |
-| `ptrace.tracee.ancestors.tid` | int | Thread ID of the thread |  |
-| `ptrace.tracee.ancestors.tty_name` | string | Name of the TTY associated with the process |  |
-| `ptrace.tracee.ancestors.uid` | int | UID of the process |  |
-| `ptrace.tracee.ancestors.user` | string | User of the process |  |
-| `ptrace.tracee.args` | string | Arguments of the process (as a string) |  |
-| `ptrace.tracee.args_flags` | string | Arguments of the process (as an array) |  |
-| `ptrace.tracee.args_options` | string | Arguments of the process (as an array) |  |
-| `ptrace.tracee.args_truncated` | bool | Indicator of arguments truncation |  |
-| `ptrace.tracee.argv` | string | Arguments of the process (as an array) |  |
-| `ptrace.tracee.argv0` | string | First argument of the process |  |
-| `ptrace.tracee.cap_effective` | int | Effective capability set of the process | Kernel Capability constants |
-| `ptrace.tracee.cap_permitted` | int | Permitted capability set of the process | Kernel Capability constants |
-| `ptrace.tracee.comm` | string | Comm attribute of the process |  |
-| `ptrace.tracee.container.id` | string | Container ID |  |
-| `ptrace.tracee.cookie` | int | Cookie of the process |  |
-| `ptrace.tracee.created_at` | int | Timestamp of the creation of the process |  |
-| `ptrace.tracee.egid` | int | Effective GID of the process |  |
-| `ptrace.tracee.egroup` | string | Effective group of the process |  |
-| `ptrace.tracee.envp` | string | Environment variables of the process |  |
-| `ptrace.tracee.envs` | string | Environment variable names of the process |  |
-| `ptrace.tracee.envs_truncated` | bool | Indicator of environment variables truncation |  |
-| `ptrace.tracee.euid` | int | Effective UID of the process |  |
-| `ptrace.tracee.euser` | string | Effective user of the process |  |
-| `ptrace.tracee.file.change_time` | int | Change time of the file |  |
-| `ptrace.tracee.file.filesystem` | string | File's filesystem |  |
-| `ptrace.tracee.file.gid` | int | GID of the file's owner |  |
-| `ptrace.tracee.file.group` | string | Group of the file's owner |  |
-| `ptrace.tracee.file.in_upper_layer` | bool | Indicator of the file layer, for example, in an OverlayFS |  |
-| `ptrace.tracee.file.inode` | int | Inode of the file |  |
-| `ptrace.tracee.file.mode` | int | Mode/rights of the file | Chmod mode constants |
-| `ptrace.tracee.file.modification_time` | int | Modification time of the file |  |
-| `ptrace.tracee.file.mount_id` | int | Mount ID of the file |  |
-| `ptrace.tracee.file.name` | string | File's basename |  |
-| `ptrace.tracee.file.name.length` | int | Length of 'ptrace.tracee.file.name' string |  |
-| `ptrace.tracee.file.path` | string | File's path |  |
-| `ptrace.tracee.file.path.length` | int | Length of 'ptrace.tracee.file.path' string |  |
-| `ptrace.tracee.file.rights` | int | Mode/rights of the file | Chmod mode constants |
-| `ptrace.tracee.file.uid` | int | UID of the file's owner |  |
-| `ptrace.tracee.file.user` | string | User of the file's owner |  |
-| `ptrace.tracee.fsgid` | int | FileSystem-gid of the process |  |
-| `ptrace.tracee.fsgroup` | string | FileSystem-group of the process |  |
-| `ptrace.tracee.fsuid` | int | FileSystem-uid of the process |  |
-| `ptrace.tracee.fsuser` | string | FileSystem-user of the process |  |
-| `ptrace.tracee.gid` | int | GID of the process |  |
-| `ptrace.tracee.group` | string | Group of the process |  |
-| `ptrace.tracee.interpreter.file.change_time` | int | Change time of the file |  |
-| `ptrace.tracee.interpreter.file.filesystem` | string | File's filesystem |  |
-| `ptrace.tracee.interpreter.file.gid` | int | GID of the file's owner |  |
-| `ptrace.tracee.interpreter.file.group` | string | Group of the file's owner |  |
-| `ptrace.tracee.interpreter.file.in_upper_layer` | bool | Indicator of the file layer, for example, in an OverlayFS |  |
-| `ptrace.tracee.interpreter.file.inode` | int | Inode of the file |  |
-| `ptrace.tracee.interpreter.file.mode` | int | Mode/rights of the file | Chmod mode constants |
-| `ptrace.tracee.interpreter.file.modification_time` | int | Modification time of the file |  |
-| `ptrace.tracee.interpreter.file.mount_id` | int | Mount ID of the file |  |
-| `ptrace.tracee.interpreter.file.name` | string | File's basename |  |
-| `ptrace.tracee.interpreter.file.name.length` | int | Length of 'ptrace.tracee.interpreter.file.name' string |  |
-| `ptrace.tracee.interpreter.file.path` | string | File's path |  |
-| `ptrace.tracee.interpreter.file.path.length` | int | Length of 'ptrace.tracee.interpreter.file.path' string |  |
-| `ptrace.tracee.interpreter.file.rights` | int | Mode/rights of the file | Chmod mode constants |
-| `ptrace.tracee.interpreter.file.uid` | int | UID of the file's owner |  |
-| `ptrace.tracee.interpreter.file.user` | string | User of the file's owner |  |
-| `ptrace.tracee.is_kworker` | bool | Indicates whether the process is a kworker |  |
-| `ptrace.tracee.is_thread` | bool | Indicates whether the process is considered a thread (that is, a child process that hasn't executed another program) |  |
-| `ptrace.tracee.parent.args` | string | Arguments of the process (as a string) |  |
-| `ptrace.tracee.parent.args_flags` | string | Arguments of the process (as an array) |  |
-| `ptrace.tracee.parent.args_options` | string | Arguments of the process (as an array) |  |
-| `ptrace.tracee.parent.args_truncated` | bool | Indicator of arguments truncation |  |
-| `ptrace.tracee.parent.argv` | string | Arguments of the process (as an array) |  |
-| `ptrace.tracee.parent.argv0` | string | First argument of the process |  |
-| `ptrace.tracee.parent.cap_effective` | int | Effective capability set of the process | Kernel Capability constants |
-| `ptrace.tracee.parent.cap_permitted` | int | Permitted capability set of the process | Kernel Capability constants |
-| `ptrace.tracee.parent.comm` | string | Comm attribute of the process |  |
-| `ptrace.tracee.parent.container.id` | string | Container ID |  |
-| `ptrace.tracee.parent.cookie` | int | Cookie of the process |  |
-| `ptrace.tracee.parent.created_at` | int | Timestamp of the creation of the process |  |
-| `ptrace.tracee.parent.egid` | int | Effective GID of the process |  |
-| `ptrace.tracee.parent.egroup` | string | Effective group of the process |  |
-| `ptrace.tracee.parent.envp` | string | Environment variables of the process |  |
-| `ptrace.tracee.parent.envs` | string | Environment variable names of the process |  |
-| `ptrace.tracee.parent.envs_truncated` | bool | Indicator of environment variables truncation |  |
-| `ptrace.tracee.parent.euid` | int | Effective UID of the process |  |
-| `ptrace.tracee.parent.euser` | string | Effective user of the process |  |
-| `ptrace.tracee.parent.file.change_time` | int | Change time of the file |  |
-| `ptrace.tracee.parent.file.filesystem` | string | File's filesystem |  |
-| `ptrace.tracee.parent.file.gid` | int | GID of the file's owner |  |
-| `ptrace.tracee.parent.file.group` | string | Group of the file's owner |  |
-| `ptrace.tracee.parent.file.in_upper_layer` | bool | Indicator of the file layer, for example, in an OverlayFS |  |
-| `ptrace.tracee.parent.file.inode` | int | Inode of the file |  |
-| `ptrace.tracee.parent.file.mode` | int | Mode/rights of the file | Chmod mode constants |
-| `ptrace.tracee.parent.file.modification_time` | int | Modification time of the file |  |
-| `ptrace.tracee.parent.file.mount_id` | int | Mount ID of the file |  |
-| `ptrace.tracee.parent.file.name` | string | File's basename |  |
-| `ptrace.tracee.parent.file.name.length` | int | Length of 'ptrace.tracee.parent.file.name' string |  |
-| `ptrace.tracee.parent.file.path` | string | File's path |  |
-| `ptrace.tracee.parent.file.path.length` | int | Length of 'ptrace.tracee.parent.file.path' string |  |
-| `ptrace.tracee.parent.file.rights` | int | Mode/rights of the file | Chmod mode constants |
-| `ptrace.tracee.parent.file.uid` | int | UID of the file's owner |  |
-| `ptrace.tracee.parent.file.user` | string | User of the file's owner |  |
-| `ptrace.tracee.parent.fsgid` | int | FileSystem-gid of the process |  |
-| `ptrace.tracee.parent.fsgroup` | string | FileSystem-group of the process |  |
-| `ptrace.tracee.parent.fsuid` | int | FileSystem-uid of the process |  |
-| `ptrace.tracee.parent.fsuser` | string | FileSystem-user of the process |  |
-| `ptrace.tracee.parent.gid` | int | GID of the process |  |
-| `ptrace.tracee.parent.group` | string | Group of the process |  |
-| `ptrace.tracee.parent.interpreter.file.change_time` | int | Change time of the file |  |
-| `ptrace.tracee.parent.interpreter.file.filesystem` | string | File's filesystem |  |
-| `ptrace.tracee.parent.interpreter.file.gid` | int | GID of the file's owner |  |
-| `ptrace.tracee.parent.interpreter.file.group` | string | Group of the file's owner |  |
-| `ptrace.tracee.parent.interpreter.file.in_upper_layer` | bool | Indicator of the file layer, for example, in an OverlayFS |  |
-| `ptrace.tracee.parent.interpreter.file.inode` | int | Inode of the file |  |
-| `ptrace.tracee.parent.interpreter.file.mode` | int | Mode/rights of the file | Chmod mode constants |
-| `ptrace.tracee.parent.interpreter.file.modification_time` | int | Modification time of the file |  |
-| `ptrace.tracee.parent.interpreter.file.mount_id` | int | Mount ID of the file |  |
-| `ptrace.tracee.parent.interpreter.file.name` | string | File's basename |  |
-| `ptrace.tracee.parent.interpreter.file.name.length` | int | Length of 'ptrace.tracee.parent.interpreter.file.name' string |  |
-| `ptrace.tracee.parent.interpreter.file.path` | string | File's path |  |
-| `ptrace.tracee.parent.interpreter.file.path.length` | int | Length of 'ptrace.tracee.parent.interpreter.file.path' string |  |
-| `ptrace.tracee.parent.interpreter.file.rights` | int | Mode/rights of the file | Chmod mode constants |
-| `ptrace.tracee.parent.interpreter.file.uid` | int | UID of the file's owner |  |
-| `ptrace.tracee.parent.interpreter.file.user` | string | User of the file's owner |  |
-| `ptrace.tracee.parent.is_kworker` | bool | Indicates whether the process is a kworker |  |
-| `ptrace.tracee.parent.is_thread` | bool | Indicates whether the process is considered a thread (that is, a child process that hasn't executed another program) |  |
-| `ptrace.tracee.parent.pid` | int | Process ID of the process (also called thread group ID) |  |
-| `ptrace.tracee.parent.ppid` | int | Parent process ID |  |
-| `ptrace.tracee.parent.tid` | int | Thread ID of the thread |  |
-| `ptrace.tracee.parent.tty_name` | string | Name of the TTY associated with the process |  |
-| `ptrace.tracee.parent.uid` | int | UID of the process |  |
-| `ptrace.tracee.parent.user` | string | User of the process |  |
-| `ptrace.tracee.pid` | int | Process ID of the process (also called thread group ID) |  |
-| `ptrace.tracee.ppid` | int | Parent process ID |  |
-| `ptrace.tracee.tid` | int | Thread ID of the thread |  |
-| `ptrace.tracee.tty_name` | string | Name of the TTY associated with the process |  |
-| `ptrace.tracee.uid` | int | UID of the process |  |
-| `ptrace.tracee.user` | string | User of the process |  |
+| Property | Definition |
+| -------- | ------------- |
+| [`ptrace.request`](#ptrace-request-doc) | ptrace request |
+| [`ptrace.retval`](#common-syscallevent-retval-doc) | Return value of the syscall |
+| [`ptrace.tracee.ancestors.args`](#common-process-args-doc) | Arguments of the process (as a string, excluding argv0) |
+| [`ptrace.tracee.ancestors.args_flags`](#common-process-args_flags-doc) | Flags in the process arguments |
+| [`ptrace.tracee.ancestors.args_options`](#common-process-args_options-doc) | Argument of the process as options |
+| [`ptrace.tracee.ancestors.args_truncated`](#common-process-args_truncated-doc) | Indicator of arguments truncation |
+| [`ptrace.tracee.ancestors.argv`](#common-process-argv-doc) | Arguments of the process (as an array, excluding argv0) |
+| [`ptrace.tracee.ancestors.argv0`](#common-process-argv0-doc) | First argument of the process |
+| [`ptrace.tracee.ancestors.cap_effective`](#common-credentials-cap_effective-doc) | Effective capability set of the process |
+| [`ptrace.tracee.ancestors.cap_permitted`](#common-credentials-cap_permitted-doc) | Permitted capability set of the process |
+| [`ptrace.tracee.ancestors.comm`](#common-process-comm-doc) | Comm attribute of the process |
+| [`ptrace.tracee.ancestors.container.id`](#common-process-container-id-doc) | Container ID |
+| [`ptrace.tracee.ancestors.cookie`](#common-process-cookie-doc) | Cookie of the process |
+| [`ptrace.tracee.ancestors.created_at`](#common-process-created_at-doc) | Timestamp of the creation of the process |
+| [`ptrace.tracee.ancestors.egid`](#common-credentials-egid-doc) | Effective GID of the process |
+| [`ptrace.tracee.ancestors.egroup`](#common-credentials-egroup-doc) | Effective group of the process |
+| [`ptrace.tracee.ancestors.envp`](#common-process-envp-doc) | Environment variables of the process |
+| [`ptrace.tracee.ancestors.envs`](#common-process-envs-doc) | Environment variable names of the process |
+| [`ptrace.tracee.ancestors.envs_truncated`](#common-process-envs_truncated-doc) | Indicator of environment variables truncation |
+| [`ptrace.tracee.ancestors.euid`](#common-credentials-euid-doc) | Effective UID of the process |
+| [`ptrace.tracee.ancestors.euser`](#common-credentials-euser-doc) | Effective user of the process |
+| [`ptrace.tracee.ancestors.file.change_time`](#common-filefields-change_time-doc) | Change time of the file |
+| [`ptrace.tracee.ancestors.file.filesystem`](#common-fileevent-filesystem-doc) | File's filesystem |
+| [`ptrace.tracee.ancestors.file.gid`](#common-filefields-gid-doc) | GID of the file's owner |
+| [`ptrace.tracee.ancestors.file.group`](#common-filefields-group-doc) | Group of the file's owner |
+| [`ptrace.tracee.ancestors.file.in_upper_layer`](#common-filefields-in_upper_layer-doc) | Indicator of the file layer, for example, in an OverlayFS |
+| [`ptrace.tracee.ancestors.file.inode`](#common-filefields-inode-doc) | Inode of the file |
+| [`ptrace.tracee.ancestors.file.mode`](#common-filefields-mode-doc) | Mode of the file |
+| [`ptrace.tracee.ancestors.file.modification_time`](#common-filefields-modification_time-doc) | Modification time of the file |
+| [`ptrace.tracee.ancestors.file.mount_id`](#common-filefields-mount_id-doc) | Mount ID of the file |
+| [`ptrace.tracee.ancestors.file.name`](#common-fileevent-name-doc) | File's basename |
+| [`ptrace.tracee.ancestors.file.name.length`](#common-string-length-doc) | Length of the corresponding string |
+| [`ptrace.tracee.ancestors.file.path`](#common-fileevent-path-doc) | File's path |
+| [`ptrace.tracee.ancestors.file.path.length`](#common-string-length-doc) | Length of the corresponding string |
+| [`ptrace.tracee.ancestors.file.rights`](#common-filefields-rights-doc) | Rights of the file |
+| [`ptrace.tracee.ancestors.file.uid`](#common-filefields-uid-doc) | UID of the file's owner |
+| [`ptrace.tracee.ancestors.file.user`](#common-filefields-user-doc) | User of the file's owner |
+| [`ptrace.tracee.ancestors.fsgid`](#common-credentials-fsgid-doc) | FileSystem-gid of the process |
+| [`ptrace.tracee.ancestors.fsgroup`](#common-credentials-fsgroup-doc) | FileSystem-group of the process |
+| [`ptrace.tracee.ancestors.fsuid`](#common-credentials-fsuid-doc) | FileSystem-uid of the process |
+| [`ptrace.tracee.ancestors.fsuser`](#common-credentials-fsuser-doc) | FileSystem-user of the process |
+| [`ptrace.tracee.ancestors.gid`](#common-credentials-gid-doc) | GID of the process |
+| [`ptrace.tracee.ancestors.group`](#common-credentials-group-doc) | Group of the process |
+| [`ptrace.tracee.ancestors.interpreter.file.change_time`](#common-filefields-change_time-doc) | Change time of the file |
+| [`ptrace.tracee.ancestors.interpreter.file.filesystem`](#common-fileevent-filesystem-doc) | File's filesystem |
+| [`ptrace.tracee.ancestors.interpreter.file.gid`](#common-filefields-gid-doc) | GID of the file's owner |
+| [`ptrace.tracee.ancestors.interpreter.file.group`](#common-filefields-group-doc) | Group of the file's owner |
+| [`ptrace.tracee.ancestors.interpreter.file.in_upper_layer`](#common-filefields-in_upper_layer-doc) | Indicator of the file layer, for example, in an OverlayFS |
+| [`ptrace.tracee.ancestors.interpreter.file.inode`](#common-filefields-inode-doc) | Inode of the file |
+| [`ptrace.tracee.ancestors.interpreter.file.mode`](#common-filefields-mode-doc) | Mode of the file |
+| [`ptrace.tracee.ancestors.interpreter.file.modification_time`](#common-filefields-modification_time-doc) | Modification time of the file |
+| [`ptrace.tracee.ancestors.interpreter.file.mount_id`](#common-filefields-mount_id-doc) | Mount ID of the file |
+| [`ptrace.tracee.ancestors.interpreter.file.name`](#common-fileevent-name-doc) | File's basename |
+| [`ptrace.tracee.ancestors.interpreter.file.name.length`](#common-string-length-doc) | Length of the corresponding string |
+| [`ptrace.tracee.ancestors.interpreter.file.path`](#common-fileevent-path-doc) | File's path |
+| [`ptrace.tracee.ancestors.interpreter.file.path.length`](#common-string-length-doc) | Length of the corresponding string |
+| [`ptrace.tracee.ancestors.interpreter.file.rights`](#common-filefields-rights-doc) | Rights of the file |
+| [`ptrace.tracee.ancestors.interpreter.file.uid`](#common-filefields-uid-doc) | UID of the file's owner |
+| [`ptrace.tracee.ancestors.interpreter.file.user`](#common-filefields-user-doc) | User of the file's owner |
+| [`ptrace.tracee.ancestors.is_kworker`](#common-pidcontext-is_kworker-doc) | Indicates whether the process is a kworker |
+| [`ptrace.tracee.ancestors.is_thread`](#common-process-is_thread-doc) | Indicates whether the process is considered a thread (that is, a child process that hasn't executed another program) |
+| [`ptrace.tracee.ancestors.pid`](#common-pidcontext-pid-doc) | Process ID of the process (also called thread group ID) |
+| [`ptrace.tracee.ancestors.ppid`](#common-process-ppid-doc) | Parent process ID |
+| [`ptrace.tracee.ancestors.tid`](#common-pidcontext-tid-doc) | Thread ID of the thread |
+| [`ptrace.tracee.ancestors.tty_name`](#common-process-tty_name-doc) | Name of the TTY associated with the process |
+| [`ptrace.tracee.ancestors.uid`](#common-credentials-uid-doc) | UID of the process |
+| [`ptrace.tracee.ancestors.user`](#common-credentials-user-doc) | User of the process |
+| [`ptrace.tracee.args`](#common-process-args-doc) | Arguments of the process (as a string, excluding argv0) |
+| [`ptrace.tracee.args_flags`](#common-process-args_flags-doc) | Flags in the process arguments |
+| [`ptrace.tracee.args_options`](#common-process-args_options-doc) | Argument of the process as options |
+| [`ptrace.tracee.args_truncated`](#common-process-args_truncated-doc) | Indicator of arguments truncation |
+| [`ptrace.tracee.argv`](#common-process-argv-doc) | Arguments of the process (as an array, excluding argv0) |
+| [`ptrace.tracee.argv0`](#common-process-argv0-doc) | First argument of the process |
+| [`ptrace.tracee.cap_effective`](#common-credentials-cap_effective-doc) | Effective capability set of the process |
+| [`ptrace.tracee.cap_permitted`](#common-credentials-cap_permitted-doc) | Permitted capability set of the process |
+| [`ptrace.tracee.comm`](#common-process-comm-doc) | Comm attribute of the process |
+| [`ptrace.tracee.container.id`](#common-process-container-id-doc) | Container ID |
+| [`ptrace.tracee.cookie`](#common-process-cookie-doc) | Cookie of the process |
+| [`ptrace.tracee.created_at`](#common-process-created_at-doc) | Timestamp of the creation of the process |
+| [`ptrace.tracee.egid`](#common-credentials-egid-doc) | Effective GID of the process |
+| [`ptrace.tracee.egroup`](#common-credentials-egroup-doc) | Effective group of the process |
+| [`ptrace.tracee.envp`](#common-process-envp-doc) | Environment variables of the process |
+| [`ptrace.tracee.envs`](#common-process-envs-doc) | Environment variable names of the process |
+| [`ptrace.tracee.envs_truncated`](#common-process-envs_truncated-doc) | Indicator of environment variables truncation |
+| [`ptrace.tracee.euid`](#common-credentials-euid-doc) | Effective UID of the process |
+| [`ptrace.tracee.euser`](#common-credentials-euser-doc) | Effective user of the process |
+| [`ptrace.tracee.file.change_time`](#common-filefields-change_time-doc) | Change time of the file |
+| [`ptrace.tracee.file.filesystem`](#common-fileevent-filesystem-doc) | File's filesystem |
+| [`ptrace.tracee.file.gid`](#common-filefields-gid-doc) | GID of the file's owner |
+| [`ptrace.tracee.file.group`](#common-filefields-group-doc) | Group of the file's owner |
+| [`ptrace.tracee.file.in_upper_layer`](#common-filefields-in_upper_layer-doc) | Indicator of the file layer, for example, in an OverlayFS |
+| [`ptrace.tracee.file.inode`](#common-filefields-inode-doc) | Inode of the file |
+| [`ptrace.tracee.file.mode`](#common-filefields-mode-doc) | Mode of the file |
+| [`ptrace.tracee.file.modification_time`](#common-filefields-modification_time-doc) | Modification time of the file |
+| [`ptrace.tracee.file.mount_id`](#common-filefields-mount_id-doc) | Mount ID of the file |
+| [`ptrace.tracee.file.name`](#common-fileevent-name-doc) | File's basename |
+| [`ptrace.tracee.file.name.length`](#common-string-length-doc) | Length of the corresponding string |
+| [`ptrace.tracee.file.path`](#common-fileevent-path-doc) | File's path |
+| [`ptrace.tracee.file.path.length`](#common-string-length-doc) | Length of the corresponding string |
+| [`ptrace.tracee.file.rights`](#common-filefields-rights-doc) | Rights of the file |
+| [`ptrace.tracee.file.uid`](#common-filefields-uid-doc) | UID of the file's owner |
+| [`ptrace.tracee.file.user`](#common-filefields-user-doc) | User of the file's owner |
+| [`ptrace.tracee.fsgid`](#common-credentials-fsgid-doc) | FileSystem-gid of the process |
+| [`ptrace.tracee.fsgroup`](#common-credentials-fsgroup-doc) | FileSystem-group of the process |
+| [`ptrace.tracee.fsuid`](#common-credentials-fsuid-doc) | FileSystem-uid of the process |
+| [`ptrace.tracee.fsuser`](#common-credentials-fsuser-doc) | FileSystem-user of the process |
+| [`ptrace.tracee.gid`](#common-credentials-gid-doc) | GID of the process |
+| [`ptrace.tracee.group`](#common-credentials-group-doc) | Group of the process |
+| [`ptrace.tracee.interpreter.file.change_time`](#common-filefields-change_time-doc) | Change time of the file |
+| [`ptrace.tracee.interpreter.file.filesystem`](#common-fileevent-filesystem-doc) | File's filesystem |
+| [`ptrace.tracee.interpreter.file.gid`](#common-filefields-gid-doc) | GID of the file's owner |
+| [`ptrace.tracee.interpreter.file.group`](#common-filefields-group-doc) | Group of the file's owner |
+| [`ptrace.tracee.interpreter.file.in_upper_layer`](#common-filefields-in_upper_layer-doc) | Indicator of the file layer, for example, in an OverlayFS |
+| [`ptrace.tracee.interpreter.file.inode`](#common-filefields-inode-doc) | Inode of the file |
+| [`ptrace.tracee.interpreter.file.mode`](#common-filefields-mode-doc) | Mode of the file |
+| [`ptrace.tracee.interpreter.file.modification_time`](#common-filefields-modification_time-doc) | Modification time of the file |
+| [`ptrace.tracee.interpreter.file.mount_id`](#common-filefields-mount_id-doc) | Mount ID of the file |
+| [`ptrace.tracee.interpreter.file.name`](#common-fileevent-name-doc) | File's basename |
+| [`ptrace.tracee.interpreter.file.name.length`](#common-string-length-doc) | Length of the corresponding string |
+| [`ptrace.tracee.interpreter.file.path`](#common-fileevent-path-doc) | File's path |
+| [`ptrace.tracee.interpreter.file.path.length`](#common-string-length-doc) | Length of the corresponding string |
+| [`ptrace.tracee.interpreter.file.rights`](#common-filefields-rights-doc) | Rights of the file |
+| [`ptrace.tracee.interpreter.file.uid`](#common-filefields-uid-doc) | UID of the file's owner |
+| [`ptrace.tracee.interpreter.file.user`](#common-filefields-user-doc) | User of the file's owner |
+| [`ptrace.tracee.is_kworker`](#common-pidcontext-is_kworker-doc) | Indicates whether the process is a kworker |
+| [`ptrace.tracee.is_thread`](#common-process-is_thread-doc) | Indicates whether the process is considered a thread (that is, a child process that hasn't executed another program) |
+| [`ptrace.tracee.parent.args`](#common-process-args-doc) | Arguments of the process (as a string, excluding argv0) |
+| [`ptrace.tracee.parent.args_flags`](#common-process-args_flags-doc) | Flags in the process arguments |
+| [`ptrace.tracee.parent.args_options`](#common-process-args_options-doc) | Argument of the process as options |
+| [`ptrace.tracee.parent.args_truncated`](#common-process-args_truncated-doc) | Indicator of arguments truncation |
+| [`ptrace.tracee.parent.argv`](#common-process-argv-doc) | Arguments of the process (as an array, excluding argv0) |
+| [`ptrace.tracee.parent.argv0`](#common-process-argv0-doc) | First argument of the process |
+| [`ptrace.tracee.parent.cap_effective`](#common-credentials-cap_effective-doc) | Effective capability set of the process |
+| [`ptrace.tracee.parent.cap_permitted`](#common-credentials-cap_permitted-doc) | Permitted capability set of the process |
+| [`ptrace.tracee.parent.comm`](#common-process-comm-doc) | Comm attribute of the process |
+| [`ptrace.tracee.parent.container.id`](#common-process-container-id-doc) | Container ID |
+| [`ptrace.tracee.parent.cookie`](#common-process-cookie-doc) | Cookie of the process |
+| [`ptrace.tracee.parent.created_at`](#common-process-created_at-doc) | Timestamp of the creation of the process |
+| [`ptrace.tracee.parent.egid`](#common-credentials-egid-doc) | Effective GID of the process |
+| [`ptrace.tracee.parent.egroup`](#common-credentials-egroup-doc) | Effective group of the process |
+| [`ptrace.tracee.parent.envp`](#common-process-envp-doc) | Environment variables of the process |
+| [`ptrace.tracee.parent.envs`](#common-process-envs-doc) | Environment variable names of the process |
+| [`ptrace.tracee.parent.envs_truncated`](#common-process-envs_truncated-doc) | Indicator of environment variables truncation |
+| [`ptrace.tracee.parent.euid`](#common-credentials-euid-doc) | Effective UID of the process |
+| [`ptrace.tracee.parent.euser`](#common-credentials-euser-doc) | Effective user of the process |
+| [`ptrace.tracee.parent.file.change_time`](#common-filefields-change_time-doc) | Change time of the file |
+| [`ptrace.tracee.parent.file.filesystem`](#common-fileevent-filesystem-doc) | File's filesystem |
+| [`ptrace.tracee.parent.file.gid`](#common-filefields-gid-doc) | GID of the file's owner |
+| [`ptrace.tracee.parent.file.group`](#common-filefields-group-doc) | Group of the file's owner |
+| [`ptrace.tracee.parent.file.in_upper_layer`](#common-filefields-in_upper_layer-doc) | Indicator of the file layer, for example, in an OverlayFS |
+| [`ptrace.tracee.parent.file.inode`](#common-filefields-inode-doc) | Inode of the file |
+| [`ptrace.tracee.parent.file.mode`](#common-filefields-mode-doc) | Mode of the file |
+| [`ptrace.tracee.parent.file.modification_time`](#common-filefields-modification_time-doc) | Modification time of the file |
+| [`ptrace.tracee.parent.file.mount_id`](#common-filefields-mount_id-doc) | Mount ID of the file |
+| [`ptrace.tracee.parent.file.name`](#common-fileevent-name-doc) | File's basename |
+| [`ptrace.tracee.parent.file.name.length`](#common-string-length-doc) | Length of the corresponding string |
+| [`ptrace.tracee.parent.file.path`](#common-fileevent-path-doc) | File's path |
+| [`ptrace.tracee.parent.file.path.length`](#common-string-length-doc) | Length of the corresponding string |
+| [`ptrace.tracee.parent.file.rights`](#common-filefields-rights-doc) | Rights of the file |
+| [`ptrace.tracee.parent.file.uid`](#common-filefields-uid-doc) | UID of the file's owner |
+| [`ptrace.tracee.parent.file.user`](#common-filefields-user-doc) | User of the file's owner |
+| [`ptrace.tracee.parent.fsgid`](#common-credentials-fsgid-doc) | FileSystem-gid of the process |
+| [`ptrace.tracee.parent.fsgroup`](#common-credentials-fsgroup-doc) | FileSystem-group of the process |
+| [`ptrace.tracee.parent.fsuid`](#common-credentials-fsuid-doc) | FileSystem-uid of the process |
+| [`ptrace.tracee.parent.fsuser`](#common-credentials-fsuser-doc) | FileSystem-user of the process |
+| [`ptrace.tracee.parent.gid`](#common-credentials-gid-doc) | GID of the process |
+| [`ptrace.tracee.parent.group`](#common-credentials-group-doc) | Group of the process |
+| [`ptrace.tracee.parent.interpreter.file.change_time`](#common-filefields-change_time-doc) | Change time of the file |
+| [`ptrace.tracee.parent.interpreter.file.filesystem`](#common-fileevent-filesystem-doc) | File's filesystem |
+| [`ptrace.tracee.parent.interpreter.file.gid`](#common-filefields-gid-doc) | GID of the file's owner |
+| [`ptrace.tracee.parent.interpreter.file.group`](#common-filefields-group-doc) | Group of the file's owner |
+| [`ptrace.tracee.parent.interpreter.file.in_upper_layer`](#common-filefields-in_upper_layer-doc) | Indicator of the file layer, for example, in an OverlayFS |
+| [`ptrace.tracee.parent.interpreter.file.inode`](#common-filefields-inode-doc) | Inode of the file |
+| [`ptrace.tracee.parent.interpreter.file.mode`](#common-filefields-mode-doc) | Mode of the file |
+| [`ptrace.tracee.parent.interpreter.file.modification_time`](#common-filefields-modification_time-doc) | Modification time of the file |
+| [`ptrace.tracee.parent.interpreter.file.mount_id`](#common-filefields-mount_id-doc) | Mount ID of the file |
+| [`ptrace.tracee.parent.interpreter.file.name`](#common-fileevent-name-doc) | File's basename |
+| [`ptrace.tracee.parent.interpreter.file.name.length`](#common-string-length-doc) | Length of the corresponding string |
+| [`ptrace.tracee.parent.interpreter.file.path`](#common-fileevent-path-doc) | File's path |
+| [`ptrace.tracee.parent.interpreter.file.path.length`](#common-string-length-doc) | Length of the corresponding string |
+| [`ptrace.tracee.parent.interpreter.file.rights`](#common-filefields-rights-doc) | Rights of the file |
+| [`ptrace.tracee.parent.interpreter.file.uid`](#common-filefields-uid-doc) | UID of the file's owner |
+| [`ptrace.tracee.parent.interpreter.file.user`](#common-filefields-user-doc) | User of the file's owner |
+| [`ptrace.tracee.parent.is_kworker`](#common-pidcontext-is_kworker-doc) | Indicates whether the process is a kworker |
+| [`ptrace.tracee.parent.is_thread`](#common-process-is_thread-doc) | Indicates whether the process is considered a thread (that is, a child process that hasn't executed another program) |
+| [`ptrace.tracee.parent.pid`](#common-pidcontext-pid-doc) | Process ID of the process (also called thread group ID) |
+| [`ptrace.tracee.parent.ppid`](#common-process-ppid-doc) | Parent process ID |
+| [`ptrace.tracee.parent.tid`](#common-pidcontext-tid-doc) | Thread ID of the thread |
+| [`ptrace.tracee.parent.tty_name`](#common-process-tty_name-doc) | Name of the TTY associated with the process |
+| [`ptrace.tracee.parent.uid`](#common-credentials-uid-doc) | UID of the process |
+| [`ptrace.tracee.parent.user`](#common-credentials-user-doc) | User of the process |
+| [`ptrace.tracee.pid`](#common-pidcontext-pid-doc) | Process ID of the process (also called thread group ID) |
+| [`ptrace.tracee.ppid`](#common-process-ppid-doc) | Parent process ID |
+| [`ptrace.tracee.tid`](#common-pidcontext-tid-doc) | Thread ID of the thread |
+| [`ptrace.tracee.tty_name`](#common-process-tty_name-doc) | Name of the TTY associated with the process |
+| [`ptrace.tracee.uid`](#common-credentials-uid-doc) | UID of the process |
+| [`ptrace.tracee.user`](#common-credentials-user-doc) | User of the process |
 
 ### Event `removexattr`
 
 Remove extended attributes
 
-| Property | Type | Definition | Constants |
-| -------- | ---- | ---------- | --------- |
-| `removexattr.file.change_time` | int | Change time of the file |  |
-| `removexattr.file.destination.name` | string | Name of the extended attribute |  |
-| `removexattr.file.destination.namespace` | string | Namespace of the extended attribute |  |
-| `removexattr.file.filesystem` | string | File's filesystem |  |
-| `removexattr.file.gid` | int | GID of the file's owner |  |
-| `removexattr.file.group` | string | Group of the file's owner |  |
-| `removexattr.file.in_upper_layer` | bool | Indicator of the file layer, for example, in an OverlayFS |  |
-| `removexattr.file.inode` | int | Inode of the file |  |
-| `removexattr.file.mode` | int | Mode/rights of the file | Chmod mode constants |
-| `removexattr.file.modification_time` | int | Modification time of the file |  |
-| `removexattr.file.mount_id` | int | Mount ID of the file |  |
-| `removexattr.file.name` | string | File's basename |  |
-| `removexattr.file.name.length` | int | Length of 'removexattr.file.name' string |  |
-| `removexattr.file.path` | string | File's path |  |
-| `removexattr.file.path.length` | int | Length of 'removexattr.file.path' string |  |
-| `removexattr.file.rights` | int | Mode/rights of the file | Chmod mode constants |
-| `removexattr.file.uid` | int | UID of the file's owner |  |
-| `removexattr.file.user` | string | User of the file's owner |  |
-| `removexattr.retval` | int | Return value of the syscall | Error Constants |
+| Property | Definition |
+| -------- | ------------- |
+| [`removexattr.file.change_time`](#common-filefields-change_time-doc) | Change time of the file |
+| [`removexattr.file.destination.name`](#common-setxattrevent-file-destination-name-doc) | Name of the extended attribute |
+| [`removexattr.file.destination.namespace`](#common-setxattrevent-file-destination-namespace-doc) | Namespace of the extended attribute |
+| [`removexattr.file.filesystem`](#common-fileevent-filesystem-doc) | File's filesystem |
+| [`removexattr.file.gid`](#common-filefields-gid-doc) | GID of the file's owner |
+| [`removexattr.file.group`](#common-filefields-group-doc) | Group of the file's owner |
+| [`removexattr.file.in_upper_layer`](#common-filefields-in_upper_layer-doc) | Indicator of the file layer, for example, in an OverlayFS |
+| [`removexattr.file.inode`](#common-filefields-inode-doc) | Inode of the file |
+| [`removexattr.file.mode`](#common-filefields-mode-doc) | Mode of the file |
+| [`removexattr.file.modification_time`](#common-filefields-modification_time-doc) | Modification time of the file |
+| [`removexattr.file.mount_id`](#common-filefields-mount_id-doc) | Mount ID of the file |
+| [`removexattr.file.name`](#common-fileevent-name-doc) | File's basename |
+| [`removexattr.file.name.length`](#common-string-length-doc) | Length of the corresponding string |
+| [`removexattr.file.path`](#common-fileevent-path-doc) | File's path |
+| [`removexattr.file.path.length`](#common-string-length-doc) | Length of the corresponding string |
+| [`removexattr.file.rights`](#common-filefields-rights-doc) | Rights of the file |
+| [`removexattr.file.uid`](#common-filefields-uid-doc) | UID of the file's owner |
+| [`removexattr.file.user`](#common-filefields-user-doc) | User of the file's owner |
+| [`removexattr.retval`](#common-syscallevent-retval-doc) | Return value of the syscall |
 
 ### Event `rename`
 
 A file/directory was renamed
 
-| Property | Type | Definition | Constants |
-| -------- | ---- | ---------- | --------- |
-| `rename.file.change_time` | int | Change time of the file |  |
-| `rename.file.destination.change_time` | int | Change time of the file |  |
-| `rename.file.destination.filesystem` | string | File's filesystem |  |
-| `rename.file.destination.gid` | int | GID of the file's owner |  |
-| `rename.file.destination.group` | string | Group of the file's owner |  |
-| `rename.file.destination.in_upper_layer` | bool | Indicator of the file layer, for example, in an OverlayFS |  |
-| `rename.file.destination.inode` | int | Inode of the file |  |
-| `rename.file.destination.mode` | int | Mode/rights of the file | Chmod mode constants |
-| `rename.file.destination.modification_time` | int | Modification time of the file |  |
-| `rename.file.destination.mount_id` | int | Mount ID of the file |  |
-| `rename.file.destination.name` | string | File's basename |  |
-| `rename.file.destination.name.length` | int | Length of 'rename.file.destination.name' string |  |
-| `rename.file.destination.path` | string | File's path |  |
-| `rename.file.destination.path.length` | int | Length of 'rename.file.destination.path' string |  |
-| `rename.file.destination.rights` | int | Mode/rights of the file | Chmod mode constants |
-| `rename.file.destination.uid` | int | UID of the file's owner |  |
-| `rename.file.destination.user` | string | User of the file's owner |  |
-| `rename.file.filesystem` | string | File's filesystem |  |
-| `rename.file.gid` | int | GID of the file's owner |  |
-| `rename.file.group` | string | Group of the file's owner |  |
-| `rename.file.in_upper_layer` | bool | Indicator of the file layer, for example, in an OverlayFS |  |
-| `rename.file.inode` | int | Inode of the file |  |
-| `rename.file.mode` | int | Mode/rights of the file | Chmod mode constants |
-| `rename.file.modification_time` | int | Modification time of the file |  |
-| `rename.file.mount_id` | int | Mount ID of the file |  |
-| `rename.file.name` | string | File's basename |  |
-| `rename.file.name.length` | int | Length of 'rename.file.name' string |  |
-| `rename.file.path` | string | File's path |  |
-| `rename.file.path.length` | int | Length of 'rename.file.path' string |  |
-| `rename.file.rights` | int | Mode/rights of the file | Chmod mode constants |
-| `rename.file.uid` | int | UID of the file's owner |  |
-| `rename.file.user` | string | User of the file's owner |  |
-| `rename.retval` | int | Return value of the syscall | Error Constants |
+| Property | Definition |
+| -------- | ------------- |
+| [`rename.file.change_time`](#common-filefields-change_time-doc) | Change time of the file |
+| [`rename.file.destination.change_time`](#common-filefields-change_time-doc) | Change time of the file |
+| [`rename.file.destination.filesystem`](#common-fileevent-filesystem-doc) | File's filesystem |
+| [`rename.file.destination.gid`](#common-filefields-gid-doc) | GID of the file's owner |
+| [`rename.file.destination.group`](#common-filefields-group-doc) | Group of the file's owner |
+| [`rename.file.destination.in_upper_layer`](#common-filefields-in_upper_layer-doc) | Indicator of the file layer, for example, in an OverlayFS |
+| [`rename.file.destination.inode`](#common-filefields-inode-doc) | Inode of the file |
+| [`rename.file.destination.mode`](#common-filefields-mode-doc) | Mode of the file |
+| [`rename.file.destination.modification_time`](#common-filefields-modification_time-doc) | Modification time of the file |
+| [`rename.file.destination.mount_id`](#common-filefields-mount_id-doc) | Mount ID of the file |
+| [`rename.file.destination.name`](#common-fileevent-name-doc) | File's basename |
+| [`rename.file.destination.name.length`](#common-string-length-doc) | Length of the corresponding string |
+| [`rename.file.destination.path`](#common-fileevent-path-doc) | File's path |
+| [`rename.file.destination.path.length`](#common-string-length-doc) | Length of the corresponding string |
+| [`rename.file.destination.rights`](#common-filefields-rights-doc) | Rights of the file |
+| [`rename.file.destination.uid`](#common-filefields-uid-doc) | UID of the file's owner |
+| [`rename.file.destination.user`](#common-filefields-user-doc) | User of the file's owner |
+| [`rename.file.filesystem`](#common-fileevent-filesystem-doc) | File's filesystem |
+| [`rename.file.gid`](#common-filefields-gid-doc) | GID of the file's owner |
+| [`rename.file.group`](#common-filefields-group-doc) | Group of the file's owner |
+| [`rename.file.in_upper_layer`](#common-filefields-in_upper_layer-doc) | Indicator of the file layer, for example, in an OverlayFS |
+| [`rename.file.inode`](#common-filefields-inode-doc) | Inode of the file |
+| [`rename.file.mode`](#common-filefields-mode-doc) | Mode of the file |
+| [`rename.file.modification_time`](#common-filefields-modification_time-doc) | Modification time of the file |
+| [`rename.file.mount_id`](#common-filefields-mount_id-doc) | Mount ID of the file |
+| [`rename.file.name`](#common-fileevent-name-doc) | File's basename |
+| [`rename.file.name.length`](#common-string-length-doc) | Length of the corresponding string |
+| [`rename.file.path`](#common-fileevent-path-doc) | File's path |
+| [`rename.file.path.length`](#common-string-length-doc) | Length of the corresponding string |
+| [`rename.file.rights`](#common-filefields-rights-doc) | Rights of the file |
+| [`rename.file.uid`](#common-filefields-uid-doc) | UID of the file's owner |
+| [`rename.file.user`](#common-filefields-user-doc) | User of the file's owner |
+| [`rename.retval`](#common-syscallevent-retval-doc) | Return value of the syscall |
 
 ### Event `rmdir`
 
 A directory was removed
 
-| Property | Type | Definition | Constants |
-| -------- | ---- | ---------- | --------- |
-| `rmdir.file.change_time` | int | Change time of the file |  |
-| `rmdir.file.filesystem` | string | File's filesystem |  |
-| `rmdir.file.gid` | int | GID of the file's owner |  |
-| `rmdir.file.group` | string | Group of the file's owner |  |
-| `rmdir.file.in_upper_layer` | bool | Indicator of the file layer, for example, in an OverlayFS |  |
-| `rmdir.file.inode` | int | Inode of the file |  |
-| `rmdir.file.mode` | int | Mode/rights of the file | Chmod mode constants |
-| `rmdir.file.modification_time` | int | Modification time of the file |  |
-| `rmdir.file.mount_id` | int | Mount ID of the file |  |
-| `rmdir.file.name` | string | File's basename |  |
-| `rmdir.file.name.length` | int | Length of 'rmdir.file.name' string |  |
-| `rmdir.file.path` | string | File's path |  |
-| `rmdir.file.path.length` | int | Length of 'rmdir.file.path' string |  |
-| `rmdir.file.rights` | int | Mode/rights of the file | Chmod mode constants |
-| `rmdir.file.uid` | int | UID of the file's owner |  |
-| `rmdir.file.user` | string | User of the file's owner |  |
-| `rmdir.retval` | int | Return value of the syscall | Error Constants |
+| Property | Definition |
+| -------- | ------------- |
+| [`rmdir.file.change_time`](#common-filefields-change_time-doc) | Change time of the file |
+| [`rmdir.file.filesystem`](#common-fileevent-filesystem-doc) | File's filesystem |
+| [`rmdir.file.gid`](#common-filefields-gid-doc) | GID of the file's owner |
+| [`rmdir.file.group`](#common-filefields-group-doc) | Group of the file's owner |
+| [`rmdir.file.in_upper_layer`](#common-filefields-in_upper_layer-doc) | Indicator of the file layer, for example, in an OverlayFS |
+| [`rmdir.file.inode`](#common-filefields-inode-doc) | Inode of the file |
+| [`rmdir.file.mode`](#common-filefields-mode-doc) | Mode of the file |
+| [`rmdir.file.modification_time`](#common-filefields-modification_time-doc) | Modification time of the file |
+| [`rmdir.file.mount_id`](#common-filefields-mount_id-doc) | Mount ID of the file |
+| [`rmdir.file.name`](#common-fileevent-name-doc) | File's basename |
+| [`rmdir.file.name.length`](#common-string-length-doc) | Length of the corresponding string |
+| [`rmdir.file.path`](#common-fileevent-path-doc) | File's path |
+| [`rmdir.file.path.length`](#common-string-length-doc) | Length of the corresponding string |
+| [`rmdir.file.rights`](#common-filefields-rights-doc) | Rights of the file |
+| [`rmdir.file.uid`](#common-filefields-uid-doc) | UID of the file's owner |
+| [`rmdir.file.user`](#common-filefields-user-doc) | User of the file's owner |
+| [`rmdir.retval`](#common-syscallevent-retval-doc) | Return value of the syscall |
 
 ### Event `selinux`
 
 An SELinux operation was run
 
-| Property | Type | Definition | Constants |
-| -------- | ---- | ---------- | --------- |
-| `selinux.bool.name` | string | SELinux boolean name |  |
-| `selinux.bool.state` | string | SELinux boolean new value |  |
-| `selinux.bool_commit.state` | bool | Indicator of a SELinux boolean commit operation |  |
-| `selinux.enforce.status` | string | SELinux enforcement status (one of "enforcing", "permissive", "disabled"") |  |
+| Property | Definition |
+| -------- | ------------- |
+| [`selinux.bool.name`](#selinux-bool-name-doc) | SELinux boolean name |
+| [`selinux.bool.state`](#selinux-bool-state-doc) | SELinux boolean new value |
+| [`selinux.bool_commit.state`](#selinux-bool_commit-state-doc) | Indicator of a SELinux boolean commit operation |
+| [`selinux.enforce.status`](#selinux-enforce-status-doc) | SELinux enforcement status (one of "enforcing", "permissive", "disabled") |
 
 ### Event `setgid`
 
 A process changed its effective gid
 
-| Property | Type | Definition | Constants |
-| -------- | ---- | ---------- | --------- |
-| `setgid.egid` | int | New effective GID of the process |  |
-| `setgid.egroup` | string | New effective group of the process |  |
-| `setgid.fsgid` | int | New FileSystem GID of the process |  |
-| `setgid.fsgroup` | string | New FileSystem group of the process |  |
-| `setgid.gid` | int | New GID of the process |  |
-| `setgid.group` | string | New group of the process |  |
+| Property | Definition |
+| -------- | ------------- |
+| [`setgid.egid`](#setgid-egid-doc) | New effective GID of the process |
+| [`setgid.egroup`](#setgid-egroup-doc) | New effective group of the process |
+| [`setgid.fsgid`](#setgid-fsgid-doc) | New FileSystem GID of the process |
+| [`setgid.fsgroup`](#setgid-fsgroup-doc) | New FileSystem group of the process |
+| [`setgid.gid`](#setgid-gid-doc) | New GID of the process |
+| [`setgid.group`](#setgid-group-doc) | New group of the process |
 
 ### Event `setuid`
 
 A process changed its effective uid
 
-| Property | Type | Definition | Constants |
-| -------- | ---- | ---------- | --------- |
-| `setuid.euid` | int | New effective UID of the process |  |
-| `setuid.euser` | string | New effective user of the process |  |
-| `setuid.fsuid` | int | New FileSystem UID of the process |  |
-| `setuid.fsuser` | string | New FileSystem user of the process |  |
-| `setuid.uid` | int | New UID of the process |  |
-| `setuid.user` | string | New user of the process |  |
+| Property | Definition |
+| -------- | ------------- |
+| [`setuid.euid`](#setuid-euid-doc) | New effective UID of the process |
+| [`setuid.euser`](#setuid-euser-doc) | New effective user of the process |
+| [`setuid.fsuid`](#setuid-fsuid-doc) | New FileSystem UID of the process |
+| [`setuid.fsuser`](#setuid-fsuser-doc) | New FileSystem user of the process |
+| [`setuid.uid`](#setuid-uid-doc) | New UID of the process |
+| [`setuid.user`](#setuid-user-doc) | New user of the process |
 
 ### Event `setxattr`
 
 Set exteneded attributes
 
-| Property | Type | Definition | Constants |
-| -------- | ---- | ---------- | --------- |
-| `setxattr.file.change_time` | int | Change time of the file |  |
-| `setxattr.file.destination.name` | string | Name of the extended attribute |  |
-| `setxattr.file.destination.namespace` | string | Namespace of the extended attribute |  |
-| `setxattr.file.filesystem` | string | File's filesystem |  |
-| `setxattr.file.gid` | int | GID of the file's owner |  |
-| `setxattr.file.group` | string | Group of the file's owner |  |
-| `setxattr.file.in_upper_layer` | bool | Indicator of the file layer, for example, in an OverlayFS |  |
-| `setxattr.file.inode` | int | Inode of the file |  |
-| `setxattr.file.mode` | int | Mode/rights of the file | Chmod mode constants |
-| `setxattr.file.modification_time` | int | Modification time of the file |  |
-| `setxattr.file.mount_id` | int | Mount ID of the file |  |
-| `setxattr.file.name` | string | File's basename |  |
-| `setxattr.file.name.length` | int | Length of 'setxattr.file.name' string |  |
-| `setxattr.file.path` | string | File's path |  |
-| `setxattr.file.path.length` | int | Length of 'setxattr.file.path' string |  |
-| `setxattr.file.rights` | int | Mode/rights of the file | Chmod mode constants |
-| `setxattr.file.uid` | int | UID of the file's owner |  |
-| `setxattr.file.user` | string | User of the file's owner |  |
-| `setxattr.retval` | int | Return value of the syscall | Error Constants |
+| Property | Definition |
+| -------- | ------------- |
+| [`setxattr.file.change_time`](#common-filefields-change_time-doc) | Change time of the file |
+| [`setxattr.file.destination.name`](#common-setxattrevent-file-destination-name-doc) | Name of the extended attribute |
+| [`setxattr.file.destination.namespace`](#common-setxattrevent-file-destination-namespace-doc) | Namespace of the extended attribute |
+| [`setxattr.file.filesystem`](#common-fileevent-filesystem-doc) | File's filesystem |
+| [`setxattr.file.gid`](#common-filefields-gid-doc) | GID of the file's owner |
+| [`setxattr.file.group`](#common-filefields-group-doc) | Group of the file's owner |
+| [`setxattr.file.in_upper_layer`](#common-filefields-in_upper_layer-doc) | Indicator of the file layer, for example, in an OverlayFS |
+| [`setxattr.file.inode`](#common-filefields-inode-doc) | Inode of the file |
+| [`setxattr.file.mode`](#common-filefields-mode-doc) | Mode of the file |
+| [`setxattr.file.modification_time`](#common-filefields-modification_time-doc) | Modification time of the file |
+| [`setxattr.file.mount_id`](#common-filefields-mount_id-doc) | Mount ID of the file |
+| [`setxattr.file.name`](#common-fileevent-name-doc) | File's basename |
+| [`setxattr.file.name.length`](#common-string-length-doc) | Length of the corresponding string |
+| [`setxattr.file.path`](#common-fileevent-path-doc) | File's path |
+| [`setxattr.file.path.length`](#common-string-length-doc) | Length of the corresponding string |
+| [`setxattr.file.rights`](#common-filefields-rights-doc) | Rights of the file |
+| [`setxattr.file.uid`](#common-filefields-uid-doc) | UID of the file's owner |
+| [`setxattr.file.user`](#common-filefields-user-doc) | User of the file's owner |
+| [`setxattr.retval`](#common-syscallevent-retval-doc) | Return value of the syscall |
 
 ### Event `signal`
 
 A signal was sent
 
-| Property | Type | Definition | Constants |
-| -------- | ---- | ---------- | --------- |
-| `signal.pid` | int | Target PID |  |
-| `signal.retval` | int | Return value of the syscall | Error Constants |
-| `signal.target.ancestors.args` | string | Arguments of the process (as a string) |  |
-| `signal.target.ancestors.args_flags` | string | Arguments of the process (as an array) |  |
-| `signal.target.ancestors.args_options` | string | Arguments of the process (as an array) |  |
-| `signal.target.ancestors.args_truncated` | bool | Indicator of arguments truncation |  |
-| `signal.target.ancestors.argv` | string | Arguments of the process (as an array) |  |
-| `signal.target.ancestors.argv0` | string | First argument of the process |  |
-| `signal.target.ancestors.cap_effective` | int | Effective capability set of the process | Kernel Capability constants |
-| `signal.target.ancestors.cap_permitted` | int | Permitted capability set of the process | Kernel Capability constants |
-| `signal.target.ancestors.comm` | string | Comm attribute of the process |  |
-| `signal.target.ancestors.container.id` | string | Container ID |  |
-| `signal.target.ancestors.cookie` | int | Cookie of the process |  |
-| `signal.target.ancestors.created_at` | int | Timestamp of the creation of the process |  |
-| `signal.target.ancestors.egid` | int | Effective GID of the process |  |
-| `signal.target.ancestors.egroup` | string | Effective group of the process |  |
-| `signal.target.ancestors.envp` | string | Environment variables of the process |  |
-| `signal.target.ancestors.envs` | string | Environment variable names of the process |  |
-| `signal.target.ancestors.envs_truncated` | bool | Indicator of environment variables truncation |  |
-| `signal.target.ancestors.euid` | int | Effective UID of the process |  |
-| `signal.target.ancestors.euser` | string | Effective user of the process |  |
-| `signal.target.ancestors.file.change_time` | int | Change time of the file |  |
-| `signal.target.ancestors.file.filesystem` | string | File's filesystem |  |
-| `signal.target.ancestors.file.gid` | int | GID of the file's owner |  |
-| `signal.target.ancestors.file.group` | string | Group of the file's owner |  |
-| `signal.target.ancestors.file.in_upper_layer` | bool | Indicator of the file layer, for example, in an OverlayFS |  |
-| `signal.target.ancestors.file.inode` | int | Inode of the file |  |
-| `signal.target.ancestors.file.mode` | int | Mode/rights of the file | Chmod mode constants |
-| `signal.target.ancestors.file.modification_time` | int | Modification time of the file |  |
-| `signal.target.ancestors.file.mount_id` | int | Mount ID of the file |  |
-| `signal.target.ancestors.file.name` | string | File's basename |  |
-| `signal.target.ancestors.file.name.length` | int | Length of 'signal.target.ancestors.file.name' string |  |
-| `signal.target.ancestors.file.path` | string | File's path |  |
-| `signal.target.ancestors.file.path.length` | int | Length of 'signal.target.ancestors.file.path' string |  |
-| `signal.target.ancestors.file.rights` | int | Mode/rights of the file | Chmod mode constants |
-| `signal.target.ancestors.file.uid` | int | UID of the file's owner |  |
-| `signal.target.ancestors.file.user` | string | User of the file's owner |  |
-| `signal.target.ancestors.fsgid` | int | FileSystem-gid of the process |  |
-| `signal.target.ancestors.fsgroup` | string | FileSystem-group of the process |  |
-| `signal.target.ancestors.fsuid` | int | FileSystem-uid of the process |  |
-| `signal.target.ancestors.fsuser` | string | FileSystem-user of the process |  |
-| `signal.target.ancestors.gid` | int | GID of the process |  |
-| `signal.target.ancestors.group` | string | Group of the process |  |
-| `signal.target.ancestors.interpreter.file.change_time` | int | Change time of the file |  |
-| `signal.target.ancestors.interpreter.file.filesystem` | string | File's filesystem |  |
-| `signal.target.ancestors.interpreter.file.gid` | int | GID of the file's owner |  |
-| `signal.target.ancestors.interpreter.file.group` | string | Group of the file's owner |  |
-| `signal.target.ancestors.interpreter.file.in_upper_layer` | bool | Indicator of the file layer, for example, in an OverlayFS |  |
-| `signal.target.ancestors.interpreter.file.inode` | int | Inode of the file |  |
-| `signal.target.ancestors.interpreter.file.mode` | int | Mode/rights of the file | Chmod mode constants |
-| `signal.target.ancestors.interpreter.file.modification_time` | int | Modification time of the file |  |
-| `signal.target.ancestors.interpreter.file.mount_id` | int | Mount ID of the file |  |
-| `signal.target.ancestors.interpreter.file.name` | string | File's basename |  |
-| `signal.target.ancestors.interpreter.file.name.length` | int | Length of 'signal.target.ancestors.interpreter.file.name' string |  |
-| `signal.target.ancestors.interpreter.file.path` | string | File's path |  |
-| `signal.target.ancestors.interpreter.file.path.length` | int | Length of 'signal.target.ancestors.interpreter.file.path' string |  |
-| `signal.target.ancestors.interpreter.file.rights` | int | Mode/rights of the file | Chmod mode constants |
-| `signal.target.ancestors.interpreter.file.uid` | int | UID of the file's owner |  |
-| `signal.target.ancestors.interpreter.file.user` | string | User of the file's owner |  |
-| `signal.target.ancestors.is_kworker` | bool | Indicates whether the process is a kworker |  |
-| `signal.target.ancestors.is_thread` | bool | Indicates whether the process is considered a thread (that is, a child process that hasn't executed another program) |  |
-| `signal.target.ancestors.pid` | int | Process ID of the process (also called thread group ID) |  |
-| `signal.target.ancestors.ppid` | int | Parent process ID |  |
-| `signal.target.ancestors.tid` | int | Thread ID of the thread |  |
-| `signal.target.ancestors.tty_name` | string | Name of the TTY associated with the process |  |
-| `signal.target.ancestors.uid` | int | UID of the process |  |
-| `signal.target.ancestors.user` | string | User of the process |  |
-| `signal.target.args` | string | Arguments of the process (as a string) |  |
-| `signal.target.args_flags` | string | Arguments of the process (as an array) |  |
-| `signal.target.args_options` | string | Arguments of the process (as an array) |  |
-| `signal.target.args_truncated` | bool | Indicator of arguments truncation |  |
-| `signal.target.argv` | string | Arguments of the process (as an array) |  |
-| `signal.target.argv0` | string | First argument of the process |  |
-| `signal.target.cap_effective` | int | Effective capability set of the process | Kernel Capability constants |
-| `signal.target.cap_permitted` | int | Permitted capability set of the process | Kernel Capability constants |
-| `signal.target.comm` | string | Comm attribute of the process |  |
-| `signal.target.container.id` | string | Container ID |  |
-| `signal.target.cookie` | int | Cookie of the process |  |
-| `signal.target.created_at` | int | Timestamp of the creation of the process |  |
-| `signal.target.egid` | int | Effective GID of the process |  |
-| `signal.target.egroup` | string | Effective group of the process |  |
-| `signal.target.envp` | string | Environment variables of the process |  |
-| `signal.target.envs` | string | Environment variable names of the process |  |
-| `signal.target.envs_truncated` | bool | Indicator of environment variables truncation |  |
-| `signal.target.euid` | int | Effective UID of the process |  |
-| `signal.target.euser` | string | Effective user of the process |  |
-| `signal.target.file.change_time` | int | Change time of the file |  |
-| `signal.target.file.filesystem` | string | File's filesystem |  |
-| `signal.target.file.gid` | int | GID of the file's owner |  |
-| `signal.target.file.group` | string | Group of the file's owner |  |
-| `signal.target.file.in_upper_layer` | bool | Indicator of the file layer, for example, in an OverlayFS |  |
-| `signal.target.file.inode` | int | Inode of the file |  |
-| `signal.target.file.mode` | int | Mode/rights of the file | Chmod mode constants |
-| `signal.target.file.modification_time` | int | Modification time of the file |  |
-| `signal.target.file.mount_id` | int | Mount ID of the file |  |
-| `signal.target.file.name` | string | File's basename |  |
-| `signal.target.file.name.length` | int | Length of 'signal.target.file.name' string |  |
-| `signal.target.file.path` | string | File's path |  |
-| `signal.target.file.path.length` | int | Length of 'signal.target.file.path' string |  |
-| `signal.target.file.rights` | int | Mode/rights of the file | Chmod mode constants |
-| `signal.target.file.uid` | int | UID of the file's owner |  |
-| `signal.target.file.user` | string | User of the file's owner |  |
-| `signal.target.fsgid` | int | FileSystem-gid of the process |  |
-| `signal.target.fsgroup` | string | FileSystem-group of the process |  |
-| `signal.target.fsuid` | int | FileSystem-uid of the process |  |
-| `signal.target.fsuser` | string | FileSystem-user of the process |  |
-| `signal.target.gid` | int | GID of the process |  |
-| `signal.target.group` | string | Group of the process |  |
-| `signal.target.interpreter.file.change_time` | int | Change time of the file |  |
-| `signal.target.interpreter.file.filesystem` | string | File's filesystem |  |
-| `signal.target.interpreter.file.gid` | int | GID of the file's owner |  |
-| `signal.target.interpreter.file.group` | string | Group of the file's owner |  |
-| `signal.target.interpreter.file.in_upper_layer` | bool | Indicator of the file layer, for example, in an OverlayFS |  |
-| `signal.target.interpreter.file.inode` | int | Inode of the file |  |
-| `signal.target.interpreter.file.mode` | int | Mode/rights of the file | Chmod mode constants |
-| `signal.target.interpreter.file.modification_time` | int | Modification time of the file |  |
-| `signal.target.interpreter.file.mount_id` | int | Mount ID of the file |  |
-| `signal.target.interpreter.file.name` | string | File's basename |  |
-| `signal.target.interpreter.file.name.length` | int | Length of 'signal.target.interpreter.file.name' string |  |
-| `signal.target.interpreter.file.path` | string | File's path |  |
-| `signal.target.interpreter.file.path.length` | int | Length of 'signal.target.interpreter.file.path' string |  |
-| `signal.target.interpreter.file.rights` | int | Mode/rights of the file | Chmod mode constants |
-| `signal.target.interpreter.file.uid` | int | UID of the file's owner |  |
-| `signal.target.interpreter.file.user` | string | User of the file's owner |  |
-| `signal.target.is_kworker` | bool | Indicates whether the process is a kworker |  |
-| `signal.target.is_thread` | bool | Indicates whether the process is considered a thread (that is, a child process that hasn't executed another program) |  |
-| `signal.target.parent.args` | string | Arguments of the process (as a string) |  |
-| `signal.target.parent.args_flags` | string | Arguments of the process (as an array) |  |
-| `signal.target.parent.args_options` | string | Arguments of the process (as an array) |  |
-| `signal.target.parent.args_truncated` | bool | Indicator of arguments truncation |  |
-| `signal.target.parent.argv` | string | Arguments of the process (as an array) |  |
-| `signal.target.parent.argv0` | string | First argument of the process |  |
-| `signal.target.parent.cap_effective` | int | Effective capability set of the process | Kernel Capability constants |
-| `signal.target.parent.cap_permitted` | int | Permitted capability set of the process | Kernel Capability constants |
-| `signal.target.parent.comm` | string | Comm attribute of the process |  |
-| `signal.target.parent.container.id` | string | Container ID |  |
-| `signal.target.parent.cookie` | int | Cookie of the process |  |
-| `signal.target.parent.created_at` | int | Timestamp of the creation of the process |  |
-| `signal.target.parent.egid` | int | Effective GID of the process |  |
-| `signal.target.parent.egroup` | string | Effective group of the process |  |
-| `signal.target.parent.envp` | string | Environment variables of the process |  |
-| `signal.target.parent.envs` | string | Environment variable names of the process |  |
-| `signal.target.parent.envs_truncated` | bool | Indicator of environment variables truncation |  |
-| `signal.target.parent.euid` | int | Effective UID of the process |  |
-| `signal.target.parent.euser` | string | Effective user of the process |  |
-| `signal.target.parent.file.change_time` | int | Change time of the file |  |
-| `signal.target.parent.file.filesystem` | string | File's filesystem |  |
-| `signal.target.parent.file.gid` | int | GID of the file's owner |  |
-| `signal.target.parent.file.group` | string | Group of the file's owner |  |
-| `signal.target.parent.file.in_upper_layer` | bool | Indicator of the file layer, for example, in an OverlayFS |  |
-| `signal.target.parent.file.inode` | int | Inode of the file |  |
-| `signal.target.parent.file.mode` | int | Mode/rights of the file | Chmod mode constants |
-| `signal.target.parent.file.modification_time` | int | Modification time of the file |  |
-| `signal.target.parent.file.mount_id` | int | Mount ID of the file |  |
-| `signal.target.parent.file.name` | string | File's basename |  |
-| `signal.target.parent.file.name.length` | int | Length of 'signal.target.parent.file.name' string |  |
-| `signal.target.parent.file.path` | string | File's path |  |
-| `signal.target.parent.file.path.length` | int | Length of 'signal.target.parent.file.path' string |  |
-| `signal.target.parent.file.rights` | int | Mode/rights of the file | Chmod mode constants |
-| `signal.target.parent.file.uid` | int | UID of the file's owner |  |
-| `signal.target.parent.file.user` | string | User of the file's owner |  |
-| `signal.target.parent.fsgid` | int | FileSystem-gid of the process |  |
-| `signal.target.parent.fsgroup` | string | FileSystem-group of the process |  |
-| `signal.target.parent.fsuid` | int | FileSystem-uid of the process |  |
-| `signal.target.parent.fsuser` | string | FileSystem-user of the process |  |
-| `signal.target.parent.gid` | int | GID of the process |  |
-| `signal.target.parent.group` | string | Group of the process |  |
-| `signal.target.parent.interpreter.file.change_time` | int | Change time of the file |  |
-| `signal.target.parent.interpreter.file.filesystem` | string | File's filesystem |  |
-| `signal.target.parent.interpreter.file.gid` | int | GID of the file's owner |  |
-| `signal.target.parent.interpreter.file.group` | string | Group of the file's owner |  |
-| `signal.target.parent.interpreter.file.in_upper_layer` | bool | Indicator of the file layer, for example, in an OverlayFS |  |
-| `signal.target.parent.interpreter.file.inode` | int | Inode of the file |  |
-| `signal.target.parent.interpreter.file.mode` | int | Mode/rights of the file | Chmod mode constants |
-| `signal.target.parent.interpreter.file.modification_time` | int | Modification time of the file |  |
-| `signal.target.parent.interpreter.file.mount_id` | int | Mount ID of the file |  |
-| `signal.target.parent.interpreter.file.name` | string | File's basename |  |
-| `signal.target.parent.interpreter.file.name.length` | int | Length of 'signal.target.parent.interpreter.file.name' string |  |
-| `signal.target.parent.interpreter.file.path` | string | File's path |  |
-| `signal.target.parent.interpreter.file.path.length` | int | Length of 'signal.target.parent.interpreter.file.path' string |  |
-| `signal.target.parent.interpreter.file.rights` | int | Mode/rights of the file | Chmod mode constants |
-| `signal.target.parent.interpreter.file.uid` | int | UID of the file's owner |  |
-| `signal.target.parent.interpreter.file.user` | string | User of the file's owner |  |
-| `signal.target.parent.is_kworker` | bool | Indicates whether the process is a kworker |  |
-| `signal.target.parent.is_thread` | bool | Indicates whether the process is considered a thread (that is, a child process that hasn't executed another program) |  |
-| `signal.target.parent.pid` | int | Process ID of the process (also called thread group ID) |  |
-| `signal.target.parent.ppid` | int | Parent process ID |  |
-| `signal.target.parent.tid` | int | Thread ID of the thread |  |
-| `signal.target.parent.tty_name` | string | Name of the TTY associated with the process |  |
-| `signal.target.parent.uid` | int | UID of the process |  |
-| `signal.target.parent.user` | string | User of the process |  |
-| `signal.target.pid` | int | Process ID of the process (also called thread group ID) |  |
-| `signal.target.ppid` | int | Parent process ID |  |
-| `signal.target.tid` | int | Thread ID of the thread |  |
-| `signal.target.tty_name` | string | Name of the TTY associated with the process |  |
-| `signal.target.uid` | int | UID of the process |  |
-| `signal.target.user` | string | User of the process |  |
-| `signal.type` | int | Signal type (ex: SIGHUP, SIGINT, SIGQUIT, etc) | Signal constants |
+| Property | Definition |
+| -------- | ------------- |
+| [`signal.pid`](#signal-pid-doc) | Target PID |
+| [`signal.retval`](#common-syscallevent-retval-doc) | Return value of the syscall |
+| [`signal.target.ancestors.args`](#common-process-args-doc) | Arguments of the process (as a string, excluding argv0) |
+| [`signal.target.ancestors.args_flags`](#common-process-args_flags-doc) | Flags in the process arguments |
+| [`signal.target.ancestors.args_options`](#common-process-args_options-doc) | Argument of the process as options |
+| [`signal.target.ancestors.args_truncated`](#common-process-args_truncated-doc) | Indicator of arguments truncation |
+| [`signal.target.ancestors.argv`](#common-process-argv-doc) | Arguments of the process (as an array, excluding argv0) |
+| [`signal.target.ancestors.argv0`](#common-process-argv0-doc) | First argument of the process |
+| [`signal.target.ancestors.cap_effective`](#common-credentials-cap_effective-doc) | Effective capability set of the process |
+| [`signal.target.ancestors.cap_permitted`](#common-credentials-cap_permitted-doc) | Permitted capability set of the process |
+| [`signal.target.ancestors.comm`](#common-process-comm-doc) | Comm attribute of the process |
+| [`signal.target.ancestors.container.id`](#common-process-container-id-doc) | Container ID |
+| [`signal.target.ancestors.cookie`](#common-process-cookie-doc) | Cookie of the process |
+| [`signal.target.ancestors.created_at`](#common-process-created_at-doc) | Timestamp of the creation of the process |
+| [`signal.target.ancestors.egid`](#common-credentials-egid-doc) | Effective GID of the process |
+| [`signal.target.ancestors.egroup`](#common-credentials-egroup-doc) | Effective group of the process |
+| [`signal.target.ancestors.envp`](#common-process-envp-doc) | Environment variables of the process |
+| [`signal.target.ancestors.envs`](#common-process-envs-doc) | Environment variable names of the process |
+| [`signal.target.ancestors.envs_truncated`](#common-process-envs_truncated-doc) | Indicator of environment variables truncation |
+| [`signal.target.ancestors.euid`](#common-credentials-euid-doc) | Effective UID of the process |
+| [`signal.target.ancestors.euser`](#common-credentials-euser-doc) | Effective user of the process |
+| [`signal.target.ancestors.file.change_time`](#common-filefields-change_time-doc) | Change time of the file |
+| [`signal.target.ancestors.file.filesystem`](#common-fileevent-filesystem-doc) | File's filesystem |
+| [`signal.target.ancestors.file.gid`](#common-filefields-gid-doc) | GID of the file's owner |
+| [`signal.target.ancestors.file.group`](#common-filefields-group-doc) | Group of the file's owner |
+| [`signal.target.ancestors.file.in_upper_layer`](#common-filefields-in_upper_layer-doc) | Indicator of the file layer, for example, in an OverlayFS |
+| [`signal.target.ancestors.file.inode`](#common-filefields-inode-doc) | Inode of the file |
+| [`signal.target.ancestors.file.mode`](#common-filefields-mode-doc) | Mode of the file |
+| [`signal.target.ancestors.file.modification_time`](#common-filefields-modification_time-doc) | Modification time of the file |
+| [`signal.target.ancestors.file.mount_id`](#common-filefields-mount_id-doc) | Mount ID of the file |
+| [`signal.target.ancestors.file.name`](#common-fileevent-name-doc) | File's basename |
+| [`signal.target.ancestors.file.name.length`](#common-string-length-doc) | Length of the corresponding string |
+| [`signal.target.ancestors.file.path`](#common-fileevent-path-doc) | File's path |
+| [`signal.target.ancestors.file.path.length`](#common-string-length-doc) | Length of the corresponding string |
+| [`signal.target.ancestors.file.rights`](#common-filefields-rights-doc) | Rights of the file |
+| [`signal.target.ancestors.file.uid`](#common-filefields-uid-doc) | UID of the file's owner |
+| [`signal.target.ancestors.file.user`](#common-filefields-user-doc) | User of the file's owner |
+| [`signal.target.ancestors.fsgid`](#common-credentials-fsgid-doc) | FileSystem-gid of the process |
+| [`signal.target.ancestors.fsgroup`](#common-credentials-fsgroup-doc) | FileSystem-group of the process |
+| [`signal.target.ancestors.fsuid`](#common-credentials-fsuid-doc) | FileSystem-uid of the process |
+| [`signal.target.ancestors.fsuser`](#common-credentials-fsuser-doc) | FileSystem-user of the process |
+| [`signal.target.ancestors.gid`](#common-credentials-gid-doc) | GID of the process |
+| [`signal.target.ancestors.group`](#common-credentials-group-doc) | Group of the process |
+| [`signal.target.ancestors.interpreter.file.change_time`](#common-filefields-change_time-doc) | Change time of the file |
+| [`signal.target.ancestors.interpreter.file.filesystem`](#common-fileevent-filesystem-doc) | File's filesystem |
+| [`signal.target.ancestors.interpreter.file.gid`](#common-filefields-gid-doc) | GID of the file's owner |
+| [`signal.target.ancestors.interpreter.file.group`](#common-filefields-group-doc) | Group of the file's owner |
+| [`signal.target.ancestors.interpreter.file.in_upper_layer`](#common-filefields-in_upper_layer-doc) | Indicator of the file layer, for example, in an OverlayFS |
+| [`signal.target.ancestors.interpreter.file.inode`](#common-filefields-inode-doc) | Inode of the file |
+| [`signal.target.ancestors.interpreter.file.mode`](#common-filefields-mode-doc) | Mode of the file |
+| [`signal.target.ancestors.interpreter.file.modification_time`](#common-filefields-modification_time-doc) | Modification time of the file |
+| [`signal.target.ancestors.interpreter.file.mount_id`](#common-filefields-mount_id-doc) | Mount ID of the file |
+| [`signal.target.ancestors.interpreter.file.name`](#common-fileevent-name-doc) | File's basename |
+| [`signal.target.ancestors.interpreter.file.name.length`](#common-string-length-doc) | Length of the corresponding string |
+| [`signal.target.ancestors.interpreter.file.path`](#common-fileevent-path-doc) | File's path |
+| [`signal.target.ancestors.interpreter.file.path.length`](#common-string-length-doc) | Length of the corresponding string |
+| [`signal.target.ancestors.interpreter.file.rights`](#common-filefields-rights-doc) | Rights of the file |
+| [`signal.target.ancestors.interpreter.file.uid`](#common-filefields-uid-doc) | UID of the file's owner |
+| [`signal.target.ancestors.interpreter.file.user`](#common-filefields-user-doc) | User of the file's owner |
+| [`signal.target.ancestors.is_kworker`](#common-pidcontext-is_kworker-doc) | Indicates whether the process is a kworker |
+| [`signal.target.ancestors.is_thread`](#common-process-is_thread-doc) | Indicates whether the process is considered a thread (that is, a child process that hasn't executed another program) |
+| [`signal.target.ancestors.pid`](#common-pidcontext-pid-doc) | Process ID of the process (also called thread group ID) |
+| [`signal.target.ancestors.ppid`](#common-process-ppid-doc) | Parent process ID |
+| [`signal.target.ancestors.tid`](#common-pidcontext-tid-doc) | Thread ID of the thread |
+| [`signal.target.ancestors.tty_name`](#common-process-tty_name-doc) | Name of the TTY associated with the process |
+| [`signal.target.ancestors.uid`](#common-credentials-uid-doc) | UID of the process |
+| [`signal.target.ancestors.user`](#common-credentials-user-doc) | User of the process |
+| [`signal.target.args`](#common-process-args-doc) | Arguments of the process (as a string, excluding argv0) |
+| [`signal.target.args_flags`](#common-process-args_flags-doc) | Flags in the process arguments |
+| [`signal.target.args_options`](#common-process-args_options-doc) | Argument of the process as options |
+| [`signal.target.args_truncated`](#common-process-args_truncated-doc) | Indicator of arguments truncation |
+| [`signal.target.argv`](#common-process-argv-doc) | Arguments of the process (as an array, excluding argv0) |
+| [`signal.target.argv0`](#common-process-argv0-doc) | First argument of the process |
+| [`signal.target.cap_effective`](#common-credentials-cap_effective-doc) | Effective capability set of the process |
+| [`signal.target.cap_permitted`](#common-credentials-cap_permitted-doc) | Permitted capability set of the process |
+| [`signal.target.comm`](#common-process-comm-doc) | Comm attribute of the process |
+| [`signal.target.container.id`](#common-process-container-id-doc) | Container ID |
+| [`signal.target.cookie`](#common-process-cookie-doc) | Cookie of the process |
+| [`signal.target.created_at`](#common-process-created_at-doc) | Timestamp of the creation of the process |
+| [`signal.target.egid`](#common-credentials-egid-doc) | Effective GID of the process |
+| [`signal.target.egroup`](#common-credentials-egroup-doc) | Effective group of the process |
+| [`signal.target.envp`](#common-process-envp-doc) | Environment variables of the process |
+| [`signal.target.envs`](#common-process-envs-doc) | Environment variable names of the process |
+| [`signal.target.envs_truncated`](#common-process-envs_truncated-doc) | Indicator of environment variables truncation |
+| [`signal.target.euid`](#common-credentials-euid-doc) | Effective UID of the process |
+| [`signal.target.euser`](#common-credentials-euser-doc) | Effective user of the process |
+| [`signal.target.file.change_time`](#common-filefields-change_time-doc) | Change time of the file |
+| [`signal.target.file.filesystem`](#common-fileevent-filesystem-doc) | File's filesystem |
+| [`signal.target.file.gid`](#common-filefields-gid-doc) | GID of the file's owner |
+| [`signal.target.file.group`](#common-filefields-group-doc) | Group of the file's owner |
+| [`signal.target.file.in_upper_layer`](#common-filefields-in_upper_layer-doc) | Indicator of the file layer, for example, in an OverlayFS |
+| [`signal.target.file.inode`](#common-filefields-inode-doc) | Inode of the file |
+| [`signal.target.file.mode`](#common-filefields-mode-doc) | Mode of the file |
+| [`signal.target.file.modification_time`](#common-filefields-modification_time-doc) | Modification time of the file |
+| [`signal.target.file.mount_id`](#common-filefields-mount_id-doc) | Mount ID of the file |
+| [`signal.target.file.name`](#common-fileevent-name-doc) | File's basename |
+| [`signal.target.file.name.length`](#common-string-length-doc) | Length of the corresponding string |
+| [`signal.target.file.path`](#common-fileevent-path-doc) | File's path |
+| [`signal.target.file.path.length`](#common-string-length-doc) | Length of the corresponding string |
+| [`signal.target.file.rights`](#common-filefields-rights-doc) | Rights of the file |
+| [`signal.target.file.uid`](#common-filefields-uid-doc) | UID of the file's owner |
+| [`signal.target.file.user`](#common-filefields-user-doc) | User of the file's owner |
+| [`signal.target.fsgid`](#common-credentials-fsgid-doc) | FileSystem-gid of the process |
+| [`signal.target.fsgroup`](#common-credentials-fsgroup-doc) | FileSystem-group of the process |
+| [`signal.target.fsuid`](#common-credentials-fsuid-doc) | FileSystem-uid of the process |
+| [`signal.target.fsuser`](#common-credentials-fsuser-doc) | FileSystem-user of the process |
+| [`signal.target.gid`](#common-credentials-gid-doc) | GID of the process |
+| [`signal.target.group`](#common-credentials-group-doc) | Group of the process |
+| [`signal.target.interpreter.file.change_time`](#common-filefields-change_time-doc) | Change time of the file |
+| [`signal.target.interpreter.file.filesystem`](#common-fileevent-filesystem-doc) | File's filesystem |
+| [`signal.target.interpreter.file.gid`](#common-filefields-gid-doc) | GID of the file's owner |
+| [`signal.target.interpreter.file.group`](#common-filefields-group-doc) | Group of the file's owner |
+| [`signal.target.interpreter.file.in_upper_layer`](#common-filefields-in_upper_layer-doc) | Indicator of the file layer, for example, in an OverlayFS |
+| [`signal.target.interpreter.file.inode`](#common-filefields-inode-doc) | Inode of the file |
+| [`signal.target.interpreter.file.mode`](#common-filefields-mode-doc) | Mode of the file |
+| [`signal.target.interpreter.file.modification_time`](#common-filefields-modification_time-doc) | Modification time of the file |
+| [`signal.target.interpreter.file.mount_id`](#common-filefields-mount_id-doc) | Mount ID of the file |
+| [`signal.target.interpreter.file.name`](#common-fileevent-name-doc) | File's basename |
+| [`signal.target.interpreter.file.name.length`](#common-string-length-doc) | Length of the corresponding string |
+| [`signal.target.interpreter.file.path`](#common-fileevent-path-doc) | File's path |
+| [`signal.target.interpreter.file.path.length`](#common-string-length-doc) | Length of the corresponding string |
+| [`signal.target.interpreter.file.rights`](#common-filefields-rights-doc) | Rights of the file |
+| [`signal.target.interpreter.file.uid`](#common-filefields-uid-doc) | UID of the file's owner |
+| [`signal.target.interpreter.file.user`](#common-filefields-user-doc) | User of the file's owner |
+| [`signal.target.is_kworker`](#common-pidcontext-is_kworker-doc) | Indicates whether the process is a kworker |
+| [`signal.target.is_thread`](#common-process-is_thread-doc) | Indicates whether the process is considered a thread (that is, a child process that hasn't executed another program) |
+| [`signal.target.parent.args`](#common-process-args-doc) | Arguments of the process (as a string, excluding argv0) |
+| [`signal.target.parent.args_flags`](#common-process-args_flags-doc) | Flags in the process arguments |
+| [`signal.target.parent.args_options`](#common-process-args_options-doc) | Argument of the process as options |
+| [`signal.target.parent.args_truncated`](#common-process-args_truncated-doc) | Indicator of arguments truncation |
+| [`signal.target.parent.argv`](#common-process-argv-doc) | Arguments of the process (as an array, excluding argv0) |
+| [`signal.target.parent.argv0`](#common-process-argv0-doc) | First argument of the process |
+| [`signal.target.parent.cap_effective`](#common-credentials-cap_effective-doc) | Effective capability set of the process |
+| [`signal.target.parent.cap_permitted`](#common-credentials-cap_permitted-doc) | Permitted capability set of the process |
+| [`signal.target.parent.comm`](#common-process-comm-doc) | Comm attribute of the process |
+| [`signal.target.parent.container.id`](#common-process-container-id-doc) | Container ID |
+| [`signal.target.parent.cookie`](#common-process-cookie-doc) | Cookie of the process |
+| [`signal.target.parent.created_at`](#common-process-created_at-doc) | Timestamp of the creation of the process |
+| [`signal.target.parent.egid`](#common-credentials-egid-doc) | Effective GID of the process |
+| [`signal.target.parent.egroup`](#common-credentials-egroup-doc) | Effective group of the process |
+| [`signal.target.parent.envp`](#common-process-envp-doc) | Environment variables of the process |
+| [`signal.target.parent.envs`](#common-process-envs-doc) | Environment variable names of the process |
+| [`signal.target.parent.envs_truncated`](#common-process-envs_truncated-doc) | Indicator of environment variables truncation |
+| [`signal.target.parent.euid`](#common-credentials-euid-doc) | Effective UID of the process |
+| [`signal.target.parent.euser`](#common-credentials-euser-doc) | Effective user of the process |
+| [`signal.target.parent.file.change_time`](#common-filefields-change_time-doc) | Change time of the file |
+| [`signal.target.parent.file.filesystem`](#common-fileevent-filesystem-doc) | File's filesystem |
+| [`signal.target.parent.file.gid`](#common-filefields-gid-doc) | GID of the file's owner |
+| [`signal.target.parent.file.group`](#common-filefields-group-doc) | Group of the file's owner |
+| [`signal.target.parent.file.in_upper_layer`](#common-filefields-in_upper_layer-doc) | Indicator of the file layer, for example, in an OverlayFS |
+| [`signal.target.parent.file.inode`](#common-filefields-inode-doc) | Inode of the file |
+| [`signal.target.parent.file.mode`](#common-filefields-mode-doc) | Mode of the file |
+| [`signal.target.parent.file.modification_time`](#common-filefields-modification_time-doc) | Modification time of the file |
+| [`signal.target.parent.file.mount_id`](#common-filefields-mount_id-doc) | Mount ID of the file |
+| [`signal.target.parent.file.name`](#common-fileevent-name-doc) | File's basename |
+| [`signal.target.parent.file.name.length`](#common-string-length-doc) | Length of the corresponding string |
+| [`signal.target.parent.file.path`](#common-fileevent-path-doc) | File's path |
+| [`signal.target.parent.file.path.length`](#common-string-length-doc) | Length of the corresponding string |
+| [`signal.target.parent.file.rights`](#common-filefields-rights-doc) | Rights of the file |
+| [`signal.target.parent.file.uid`](#common-filefields-uid-doc) | UID of the file's owner |
+| [`signal.target.parent.file.user`](#common-filefields-user-doc) | User of the file's owner |
+| [`signal.target.parent.fsgid`](#common-credentials-fsgid-doc) | FileSystem-gid of the process |
+| [`signal.target.parent.fsgroup`](#common-credentials-fsgroup-doc) | FileSystem-group of the process |
+| [`signal.target.parent.fsuid`](#common-credentials-fsuid-doc) | FileSystem-uid of the process |
+| [`signal.target.parent.fsuser`](#common-credentials-fsuser-doc) | FileSystem-user of the process |
+| [`signal.target.parent.gid`](#common-credentials-gid-doc) | GID of the process |
+| [`signal.target.parent.group`](#common-credentials-group-doc) | Group of the process |
+| [`signal.target.parent.interpreter.file.change_time`](#common-filefields-change_time-doc) | Change time of the file |
+| [`signal.target.parent.interpreter.file.filesystem`](#common-fileevent-filesystem-doc) | File's filesystem |
+| [`signal.target.parent.interpreter.file.gid`](#common-filefields-gid-doc) | GID of the file's owner |
+| [`signal.target.parent.interpreter.file.group`](#common-filefields-group-doc) | Group of the file's owner |
+| [`signal.target.parent.interpreter.file.in_upper_layer`](#common-filefields-in_upper_layer-doc) | Indicator of the file layer, for example, in an OverlayFS |
+| [`signal.target.parent.interpreter.file.inode`](#common-filefields-inode-doc) | Inode of the file |
+| [`signal.target.parent.interpreter.file.mode`](#common-filefields-mode-doc) | Mode of the file |
+| [`signal.target.parent.interpreter.file.modification_time`](#common-filefields-modification_time-doc) | Modification time of the file |
+| [`signal.target.parent.interpreter.file.mount_id`](#common-filefields-mount_id-doc) | Mount ID of the file |
+| [`signal.target.parent.interpreter.file.name`](#common-fileevent-name-doc) | File's basename |
+| [`signal.target.parent.interpreter.file.name.length`](#common-string-length-doc) | Length of the corresponding string |
+| [`signal.target.parent.interpreter.file.path`](#common-fileevent-path-doc) | File's path |
+| [`signal.target.parent.interpreter.file.path.length`](#common-string-length-doc) | Length of the corresponding string |
+| [`signal.target.parent.interpreter.file.rights`](#common-filefields-rights-doc) | Rights of the file |
+| [`signal.target.parent.interpreter.file.uid`](#common-filefields-uid-doc) | UID of the file's owner |
+| [`signal.target.parent.interpreter.file.user`](#common-filefields-user-doc) | User of the file's owner |
+| [`signal.target.parent.is_kworker`](#common-pidcontext-is_kworker-doc) | Indicates whether the process is a kworker |
+| [`signal.target.parent.is_thread`](#common-process-is_thread-doc) | Indicates whether the process is considered a thread (that is, a child process that hasn't executed another program) |
+| [`signal.target.parent.pid`](#common-pidcontext-pid-doc) | Process ID of the process (also called thread group ID) |
+| [`signal.target.parent.ppid`](#common-process-ppid-doc) | Parent process ID |
+| [`signal.target.parent.tid`](#common-pidcontext-tid-doc) | Thread ID of the thread |
+| [`signal.target.parent.tty_name`](#common-process-tty_name-doc) | Name of the TTY associated with the process |
+| [`signal.target.parent.uid`](#common-credentials-uid-doc) | UID of the process |
+| [`signal.target.parent.user`](#common-credentials-user-doc) | User of the process |
+| [`signal.target.pid`](#common-pidcontext-pid-doc) | Process ID of the process (also called thread group ID) |
+| [`signal.target.ppid`](#common-process-ppid-doc) | Parent process ID |
+| [`signal.target.tid`](#common-pidcontext-tid-doc) | Thread ID of the thread |
+| [`signal.target.tty_name`](#common-process-tty_name-doc) | Name of the TTY associated with the process |
+| [`signal.target.uid`](#common-credentials-uid-doc) | UID of the process |
+| [`signal.target.user`](#common-credentials-user-doc) | User of the process |
+| [`signal.type`](#signal-type-doc) | Signal type (ex: SIGHUP, SIGINT, SIGQUIT, etc) |
 
 ### Event `splice`
 
 A splice command was executed
 
-| Property | Type | Definition | Constants |
-| -------- | ---- | ---------- | --------- |
-| `splice.file.change_time` | int | Change time of the file |  |
-| `splice.file.filesystem` | string | File's filesystem |  |
-| `splice.file.gid` | int | GID of the file's owner |  |
-| `splice.file.group` | string | Group of the file's owner |  |
-| `splice.file.in_upper_layer` | bool | Indicator of the file layer, for example, in an OverlayFS |  |
-| `splice.file.inode` | int | Inode of the file |  |
-| `splice.file.mode` | int | Mode/rights of the file | Chmod mode constants |
-| `splice.file.modification_time` | int | Modification time of the file |  |
-| `splice.file.mount_id` | int | Mount ID of the file |  |
-| `splice.file.name` | string | File's basename |  |
-| `splice.file.name.length` | int | Length of 'splice.file.name' string |  |
-| `splice.file.path` | string | File's path |  |
-| `splice.file.path.length` | int | Length of 'splice.file.path' string |  |
-| `splice.file.rights` | int | Mode/rights of the file | Chmod mode constants |
-| `splice.file.uid` | int | UID of the file's owner |  |
-| `splice.file.user` | string | User of the file's owner |  |
-| `splice.pipe_entry_flag` | int | Entry flag of the "fd_out" pipe passed to the splice syscall | Pipe buffer flags |
-| `splice.pipe_exit_flag` | int | Exit flag of the "fd_out" pipe passed to the splice syscall | Pipe buffer flags |
-| `splice.retval` | int | Return value of the syscall | Error Constants |
+| Property | Definition |
+| -------- | ------------- |
+| [`splice.file.change_time`](#common-filefields-change_time-doc) | Change time of the file |
+| [`splice.file.filesystem`](#common-fileevent-filesystem-doc) | File's filesystem |
+| [`splice.file.gid`](#common-filefields-gid-doc) | GID of the file's owner |
+| [`splice.file.group`](#common-filefields-group-doc) | Group of the file's owner |
+| [`splice.file.in_upper_layer`](#common-filefields-in_upper_layer-doc) | Indicator of the file layer, for example, in an OverlayFS |
+| [`splice.file.inode`](#common-filefields-inode-doc) | Inode of the file |
+| [`splice.file.mode`](#common-filefields-mode-doc) | Mode of the file |
+| [`splice.file.modification_time`](#common-filefields-modification_time-doc) | Modification time of the file |
+| [`splice.file.mount_id`](#common-filefields-mount_id-doc) | Mount ID of the file |
+| [`splice.file.name`](#common-fileevent-name-doc) | File's basename |
+| [`splice.file.name.length`](#common-string-length-doc) | Length of the corresponding string |
+| [`splice.file.path`](#common-fileevent-path-doc) | File's path |
+| [`splice.file.path.length`](#common-string-length-doc) | Length of the corresponding string |
+| [`splice.file.rights`](#common-filefields-rights-doc) | Rights of the file |
+| [`splice.file.uid`](#common-filefields-uid-doc) | UID of the file's owner |
+| [`splice.file.user`](#common-filefields-user-doc) | User of the file's owner |
+| [`splice.pipe_entry_flag`](#splice-pipe_entry_flag-doc) | Entry flag of the "fd_out" pipe passed to the splice syscall |
+| [`splice.pipe_exit_flag`](#splice-pipe_exit_flag-doc) | Exit flag of the "fd_out" pipe passed to the splice syscall |
+| [`splice.retval`](#common-syscallevent-retval-doc) | Return value of the syscall |
 
 ### Event `unlink`
 
 A file was deleted
 
-| Property | Type | Definition | Constants |
-| -------- | ---- | ---------- | --------- |
-| `unlink.file.change_time` | int | Change time of the file |  |
-| `unlink.file.filesystem` | string | File's filesystem |  |
-| `unlink.file.gid` | int | GID of the file's owner |  |
-| `unlink.file.group` | string | Group of the file's owner |  |
-| `unlink.file.in_upper_layer` | bool | Indicator of the file layer, for example, in an OverlayFS |  |
-| `unlink.file.inode` | int | Inode of the file |  |
-| `unlink.file.mode` | int | Mode/rights of the file | Chmod mode constants |
-| `unlink.file.modification_time` | int | Modification time of the file |  |
-| `unlink.file.mount_id` | int | Mount ID of the file |  |
-| `unlink.file.name` | string | File's basename |  |
-| `unlink.file.name.length` | int | Length of 'unlink.file.name' string |  |
-| `unlink.file.path` | string | File's path |  |
-| `unlink.file.path.length` | int | Length of 'unlink.file.path' string |  |
-| `unlink.file.rights` | int | Mode/rights of the file | Chmod mode constants |
-| `unlink.file.uid` | int | UID of the file's owner |  |
-| `unlink.file.user` | string | User of the file's owner |  |
-| `unlink.flags` | int |  | Unlink flags |
-| `unlink.retval` | int | Return value of the syscall | Error Constants |
+| Property | Definition |
+| -------- | ------------- |
+| [`unlink.file.change_time`](#common-filefields-change_time-doc) | Change time of the file |
+| [`unlink.file.filesystem`](#common-fileevent-filesystem-doc) | File's filesystem |
+| [`unlink.file.gid`](#common-filefields-gid-doc) | GID of the file's owner |
+| [`unlink.file.group`](#common-filefields-group-doc) | Group of the file's owner |
+| [`unlink.file.in_upper_layer`](#common-filefields-in_upper_layer-doc) | Indicator of the file layer, for example, in an OverlayFS |
+| [`unlink.file.inode`](#common-filefields-inode-doc) | Inode of the file |
+| [`unlink.file.mode`](#common-filefields-mode-doc) | Mode of the file |
+| [`unlink.file.modification_time`](#common-filefields-modification_time-doc) | Modification time of the file |
+| [`unlink.file.mount_id`](#common-filefields-mount_id-doc) | Mount ID of the file |
+| [`unlink.file.name`](#common-fileevent-name-doc) | File's basename |
+| [`unlink.file.name.length`](#common-string-length-doc) | Length of the corresponding string |
+| [`unlink.file.path`](#common-fileevent-path-doc) | File's path |
+| [`unlink.file.path.length`](#common-string-length-doc) | Length of the corresponding string |
+| [`unlink.file.rights`](#common-filefields-rights-doc) | Rights of the file |
+| [`unlink.file.uid`](#common-filefields-uid-doc) | UID of the file's owner |
+| [`unlink.file.user`](#common-filefields-user-doc) | User of the file's owner |
+| [`unlink.flags`](#unlink-flags-doc) | Flags of the unlink syscall |
+| [`unlink.retval`](#common-syscallevent-retval-doc) | Return value of the syscall |
 
 ### Event `unload_module`
 
 A kernel module was deleted
 
-| Property | Type | Definition | Constants |
-| -------- | ---- | ---------- | --------- |
-| `unload_module.name` | string | Name of the kernel module that was deleted |  |
-| `unload_module.retval` | int | Return value of the syscall | Error Constants |
+| Property | Definition |
+| -------- | ------------- |
+| [`unload_module.name`](#unload_module-name-doc) | Name of the kernel module that was deleted |
+| [`unload_module.retval`](#common-syscallevent-retval-doc) | Return value of the syscall |
 
 ### Event `utimes`
 
 Change file access/modification times
 
-| Property | Type | Definition | Constants |
-| -------- | ---- | ---------- | --------- |
-| `utimes.file.change_time` | int | Change time of the file |  |
-| `utimes.file.filesystem` | string | File's filesystem |  |
-| `utimes.file.gid` | int | GID of the file's owner |  |
-| `utimes.file.group` | string | Group of the file's owner |  |
-| `utimes.file.in_upper_layer` | bool | Indicator of the file layer, for example, in an OverlayFS |  |
-| `utimes.file.inode` | int | Inode of the file |  |
-| `utimes.file.mode` | int | Mode/rights of the file | Chmod mode constants |
-| `utimes.file.modification_time` | int | Modification time of the file |  |
-| `utimes.file.mount_id` | int | Mount ID of the file |  |
-| `utimes.file.name` | string | File's basename |  |
-| `utimes.file.name.length` | int | Length of 'utimes.file.name' string |  |
-| `utimes.file.path` | string | File's path |  |
-| `utimes.file.path.length` | int | Length of 'utimes.file.path' string |  |
-| `utimes.file.rights` | int | Mode/rights of the file | Chmod mode constants |
-| `utimes.file.uid` | int | UID of the file's owner |  |
-| `utimes.file.user` | string | User of the file's owner |  |
-| `utimes.retval` | int | Return value of the syscall | Error Constants |
+| Property | Definition |
+| -------- | ------------- |
+| [`utimes.file.change_time`](#common-filefields-change_time-doc) | Change time of the file |
+| [`utimes.file.filesystem`](#common-fileevent-filesystem-doc) | File's filesystem |
+| [`utimes.file.gid`](#common-filefields-gid-doc) | GID of the file's owner |
+| [`utimes.file.group`](#common-filefields-group-doc) | Group of the file's owner |
+| [`utimes.file.in_upper_layer`](#common-filefields-in_upper_layer-doc) | Indicator of the file layer, for example, in an OverlayFS |
+| [`utimes.file.inode`](#common-filefields-inode-doc) | Inode of the file |
+| [`utimes.file.mode`](#common-filefields-mode-doc) | Mode of the file |
+| [`utimes.file.modification_time`](#common-filefields-modification_time-doc) | Modification time of the file |
+| [`utimes.file.mount_id`](#common-filefields-mount_id-doc) | Mount ID of the file |
+| [`utimes.file.name`](#common-fileevent-name-doc) | File's basename |
+| [`utimes.file.name.length`](#common-string-length-doc) | Length of the corresponding string |
+| [`utimes.file.path`](#common-fileevent-path-doc) | File's path |
+| [`utimes.file.path.length`](#common-string-length-doc) | Length of the corresponding string |
+| [`utimes.file.rights`](#common-filefields-rights-doc) | Rights of the file |
+| [`utimes.file.uid`](#common-filefields-uid-doc) | UID of the file's owner |
+| [`utimes.file.user`](#common-filefields-user-doc) | User of the file's owner |
+| [`utimes.retval`](#common-syscallevent-retval-doc) | Return value of the syscall |
+
+
+## Attributes documentation
+
+
+### `*.args` {#common-process-args-doc}
+Type: string
+
+Definition: Arguments of the process (as a string, excluding argv0)
+
+`*.args` has 11 possible prefixes:
+`exec` `exit` `process` `process.ancestors` `process.parent` `ptrace.tracee` `ptrace.tracee.ancestors` `ptrace.tracee.parent` `signal.target` `signal.target.ancestors` `signal.target.parent`
+
+
+
+Example:
+
+{{< code-block lang="javascript" >}}
+exec.args == "-sV -p 22,53,110,143,4564 198.116.0-255.1-127"
+{{< /code-block >}}
+
+Matches any process with these exact arguments.
+
+Example:
+
+{{< code-block lang="javascript" >}}
+exec.args =~ "* -F * http*"
+{{< /code-block >}}
+
+Matches any process that has the "-F" argument anywhere before an argument starting with "http".
+
+### `*.args_flags` {#common-process-args_flags-doc}
+Type: string
+
+Definition: Flags in the process arguments
+
+`*.args_flags` has 11 possible prefixes:
+`exec` `exit` `process` `process.ancestors` `process.parent` `ptrace.tracee` `ptrace.tracee.ancestors` `ptrace.tracee.parent` `signal.target` `signal.target.ancestors` `signal.target.parent`
+
+
+
+Example:
+
+{{< code-block lang="javascript" >}}
+exec.args_flags in ["s"] && exec.args_flags in ["V"]
+{{< /code-block >}}
+
+Matches any process with both "-s" and "-V" flags in its arguments. Also matches "-sV".
+
+### `*.args_options` {#common-process-args_options-doc}
+Type: string
+
+Definition: Argument of the process as options
+
+`*.args_options` has 11 possible prefixes:
+`exec` `exit` `process` `process.ancestors` `process.parent` `ptrace.tracee` `ptrace.tracee.ancestors` `ptrace.tracee.parent` `signal.target` `signal.target.ancestors` `signal.target.parent`
+
+
+
+Example:
+
+{{< code-block lang="javascript" >}}
+exec.args_options in ["p=0-1024"]
+{{< /code-block >}}
+
+Matches any process that has either "-p 0-1024" or "--p=0-1024" in its arguments.
+
+### `*.args_truncated` {#common-process-args_truncated-doc}
+Type: bool
+
+Definition: Indicator of arguments truncation
+
+`*.args_truncated` has 11 possible prefixes:
+`exec` `exit` `process` `process.ancestors` `process.parent` `ptrace.tracee` `ptrace.tracee.ancestors` `ptrace.tracee.parent` `signal.target` `signal.target.ancestors` `signal.target.parent`
+
+
+### `*.argv` {#common-process-argv-doc}
+Type: string
+
+Definition: Arguments of the process (as an array, excluding argv0)
+
+`*.argv` has 11 possible prefixes:
+`exec` `exit` `process` `process.ancestors` `process.parent` `ptrace.tracee` `ptrace.tracee.ancestors` `ptrace.tracee.parent` `signal.target` `signal.target.ancestors` `signal.target.parent`
+
+
+
+Example:
+
+{{< code-block lang="javascript" >}}
+exec.argv in ["127.0.0.1"]
+{{< /code-block >}}
+
+Matches any process that has this IP address as one of its arguments.
+
+### `*.argv0` {#common-process-argv0-doc}
+Type: string
+
+Definition: First argument of the process
+
+`*.argv0` has 11 possible prefixes:
+`exec` `exit` `process` `process.ancestors` `process.parent` `ptrace.tracee` `ptrace.tracee.ancestors` `ptrace.tracee.parent` `signal.target` `signal.target.ancestors` `signal.target.parent`
+
+
+### `*.cap_effective` {#common-credentials-cap_effective-doc}
+Type: int
+
+Definition: Effective capability set of the process
+
+`*.cap_effective` has 11 possible prefixes:
+`exec` `exit` `process` `process.ancestors` `process.parent` `ptrace.tracee` `ptrace.tracee.ancestors` `ptrace.tracee.parent` `signal.target` `signal.target.ancestors` `signal.target.parent`
+
+Constants: [Kernel Capability constants](#kernel-capability-constants)
+
+
+
+### `*.cap_permitted` {#common-credentials-cap_permitted-doc}
+Type: int
+
+Definition: Permitted capability set of the process
+
+`*.cap_permitted` has 11 possible prefixes:
+`exec` `exit` `process` `process.ancestors` `process.parent` `ptrace.tracee` `ptrace.tracee.ancestors` `ptrace.tracee.parent` `signal.target` `signal.target.ancestors` `signal.target.parent`
+
+Constants: [Kernel Capability constants](#kernel-capability-constants)
+
+
+
+### `*.change_time` {#common-filefields-change_time-doc}
+Type: int
+
+Definition: Change time of the file
+
+`*.change_time` has 38 possible prefixes:
+`chmod.file` `chown.file` `exec.file` `exec.interpreter.file` `exit.file` `exit.interpreter.file` `link.file` `link.file.destination` `load_module.file` `mkdir.file` `mmap.file` `open.file` `process.ancestors.file` `process.ancestors.interpreter.file` `process.file` `process.interpreter.file` `process.parent.file` `process.parent.interpreter.file` `ptrace.tracee.ancestors.file` `ptrace.tracee.ancestors.interpreter.file` `ptrace.tracee.file` `ptrace.tracee.interpreter.file` `ptrace.tracee.parent.file` `ptrace.tracee.parent.interpreter.file` `removexattr.file` `rename.file` `rename.file.destination` `rmdir.file` `setxattr.file` `signal.target.ancestors.file` `signal.target.ancestors.interpreter.file` `signal.target.file` `signal.target.interpreter.file` `signal.target.parent.file` `signal.target.parent.interpreter.file` `splice.file` `unlink.file` `utimes.file`
+
+
+### `*.comm` {#common-process-comm-doc}
+Type: string
+
+Definition: Comm attribute of the process
+
+`*.comm` has 11 possible prefixes:
+`exec` `exit` `process` `process.ancestors` `process.parent` `ptrace.tracee` `ptrace.tracee.ancestors` `ptrace.tracee.parent` `signal.target` `signal.target.ancestors` `signal.target.parent`
+
+
+### `*.container.id` {#common-process-container-id-doc}
+Type: string
+
+Definition: Container ID
+
+`*.container.id` has 11 possible prefixes:
+`exec` `exit` `process` `process.ancestors` `process.parent` `ptrace.tracee` `ptrace.tracee.ancestors` `ptrace.tracee.parent` `signal.target` `signal.target.ancestors` `signal.target.parent`
+
+
+### `*.cookie` {#common-process-cookie-doc}
+Type: int
+
+Definition: Cookie of the process
+
+`*.cookie` has 11 possible prefixes:
+`exec` `exit` `process` `process.ancestors` `process.parent` `ptrace.tracee` `ptrace.tracee.ancestors` `ptrace.tracee.parent` `signal.target` `signal.target.ancestors` `signal.target.parent`
+
+
+### `*.created_at` {#common-process-created_at-doc}
+Type: int
+
+Definition: Timestamp of the creation of the process
+
+`*.created_at` has 11 possible prefixes:
+`exec` `exit` `process` `process.ancestors` `process.parent` `ptrace.tracee` `ptrace.tracee.ancestors` `ptrace.tracee.parent` `signal.target` `signal.target.ancestors` `signal.target.parent`
+
+
+### `*.egid` {#common-credentials-egid-doc}
+Type: int
+
+Definition: Effective GID of the process
+
+`*.egid` has 11 possible prefixes:
+`exec` `exit` `process` `process.ancestors` `process.parent` `ptrace.tracee` `ptrace.tracee.ancestors` `ptrace.tracee.parent` `signal.target` `signal.target.ancestors` `signal.target.parent`
+
+
+### `*.egroup` {#common-credentials-egroup-doc}
+Type: string
+
+Definition: Effective group of the process
+
+`*.egroup` has 11 possible prefixes:
+`exec` `exit` `process` `process.ancestors` `process.parent` `ptrace.tracee` `ptrace.tracee.ancestors` `ptrace.tracee.parent` `signal.target` `signal.target.ancestors` `signal.target.parent`
+
+
+### `*.envp` {#common-process-envp-doc}
+Type: string
+
+Definition: Environment variables of the process
+
+`*.envp` has 11 possible prefixes:
+`exec` `exit` `process` `process.ancestors` `process.parent` `ptrace.tracee` `ptrace.tracee.ancestors` `ptrace.tracee.parent` `signal.target` `signal.target.ancestors` `signal.target.parent`
+
+
+### `*.envs` {#common-process-envs-doc}
+Type: string
+
+Definition: Environment variable names of the process
+
+`*.envs` has 11 possible prefixes:
+`exec` `exit` `process` `process.ancestors` `process.parent` `ptrace.tracee` `ptrace.tracee.ancestors` `ptrace.tracee.parent` `signal.target` `signal.target.ancestors` `signal.target.parent`
+
+
+### `*.envs_truncated` {#common-process-envs_truncated-doc}
+Type: bool
+
+Definition: Indicator of environment variables truncation
+
+`*.envs_truncated` has 11 possible prefixes:
+`exec` `exit` `process` `process.ancestors` `process.parent` `ptrace.tracee` `ptrace.tracee.ancestors` `ptrace.tracee.parent` `signal.target` `signal.target.ancestors` `signal.target.parent`
+
+
+### `*.euid` {#common-credentials-euid-doc}
+Type: int
+
+Definition: Effective UID of the process
+
+`*.euid` has 11 possible prefixes:
+`exec` `exit` `process` `process.ancestors` `process.parent` `ptrace.tracee` `ptrace.tracee.ancestors` `ptrace.tracee.parent` `signal.target` `signal.target.ancestors` `signal.target.parent`
+
+
+### `*.euser` {#common-credentials-euser-doc}
+Type: string
+
+Definition: Effective user of the process
+
+`*.euser` has 11 possible prefixes:
+`exec` `exit` `process` `process.ancestors` `process.parent` `ptrace.tracee` `ptrace.tracee.ancestors` `ptrace.tracee.parent` `signal.target` `signal.target.ancestors` `signal.target.parent`
+
+
+### `*.file.destination.name` {#common-setxattrevent-file-destination-name-doc}
+Type: string
+
+Definition: Name of the extended attribute
+
+`*.file.destination.name` has 2 possible prefixes:
+`removexattr` `setxattr`
+
+
+### `*.file.destination.namespace` {#common-setxattrevent-file-destination-namespace-doc}
+Type: string
+
+Definition: Namespace of the extended attribute
+
+`*.file.destination.namespace` has 2 possible prefixes:
+`removexattr` `setxattr`
+
+
+### `*.filesystem` {#common-fileevent-filesystem-doc}
+Type: string
+
+Definition: File's filesystem
+
+`*.filesystem` has 38 possible prefixes:
+`chmod.file` `chown.file` `exec.file` `exec.interpreter.file` `exit.file` `exit.interpreter.file` `link.file` `link.file.destination` `load_module.file` `mkdir.file` `mmap.file` `open.file` `process.ancestors.file` `process.ancestors.interpreter.file` `process.file` `process.interpreter.file` `process.parent.file` `process.parent.interpreter.file` `ptrace.tracee.ancestors.file` `ptrace.tracee.ancestors.interpreter.file` `ptrace.tracee.file` `ptrace.tracee.interpreter.file` `ptrace.tracee.parent.file` `ptrace.tracee.parent.interpreter.file` `removexattr.file` `rename.file` `rename.file.destination` `rmdir.file` `setxattr.file` `signal.target.ancestors.file` `signal.target.ancestors.interpreter.file` `signal.target.file` `signal.target.interpreter.file` `signal.target.parent.file` `signal.target.parent.interpreter.file` `splice.file` `unlink.file` `utimes.file`
+
+
+### `*.fsgid` {#common-credentials-fsgid-doc}
+Type: int
+
+Definition: FileSystem-gid of the process
+
+`*.fsgid` has 11 possible prefixes:
+`exec` `exit` `process` `process.ancestors` `process.parent` `ptrace.tracee` `ptrace.tracee.ancestors` `ptrace.tracee.parent` `signal.target` `signal.target.ancestors` `signal.target.parent`
+
+
+### `*.fsgroup` {#common-credentials-fsgroup-doc}
+Type: string
+
+Definition: FileSystem-group of the process
+
+`*.fsgroup` has 11 possible prefixes:
+`exec` `exit` `process` `process.ancestors` `process.parent` `ptrace.tracee` `ptrace.tracee.ancestors` `ptrace.tracee.parent` `signal.target` `signal.target.ancestors` `signal.target.parent`
+
+
+### `*.fsuid` {#common-credentials-fsuid-doc}
+Type: int
+
+Definition: FileSystem-uid of the process
+
+`*.fsuid` has 11 possible prefixes:
+`exec` `exit` `process` `process.ancestors` `process.parent` `ptrace.tracee` `ptrace.tracee.ancestors` `ptrace.tracee.parent` `signal.target` `signal.target.ancestors` `signal.target.parent`
+
+
+### `*.fsuser` {#common-credentials-fsuser-doc}
+Type: string
+
+Definition: FileSystem-user of the process
+
+`*.fsuser` has 11 possible prefixes:
+`exec` `exit` `process` `process.ancestors` `process.parent` `ptrace.tracee` `ptrace.tracee.ancestors` `ptrace.tracee.parent` `signal.target` `signal.target.ancestors` `signal.target.parent`
+
+
+### `*.gid` {#common-credentials-gid-doc}
+Type: int
+
+Definition: GID of the process
+
+`*.gid` has 11 possible prefixes:
+`exec` `exit` `process` `process.ancestors` `process.parent` `ptrace.tracee` `ptrace.tracee.ancestors` `ptrace.tracee.parent` `signal.target` `signal.target.ancestors` `signal.target.parent`
+
+
+### `*.gid` {#common-filefields-gid-doc}
+Type: int
+
+Definition: GID of the file's owner
+
+`*.gid` has 38 possible prefixes:
+`chmod.file` `chown.file` `exec.file` `exec.interpreter.file` `exit.file` `exit.interpreter.file` `link.file` `link.file.destination` `load_module.file` `mkdir.file` `mmap.file` `open.file` `process.ancestors.file` `process.ancestors.interpreter.file` `process.file` `process.interpreter.file` `process.parent.file` `process.parent.interpreter.file` `ptrace.tracee.ancestors.file` `ptrace.tracee.ancestors.interpreter.file` `ptrace.tracee.file` `ptrace.tracee.interpreter.file` `ptrace.tracee.parent.file` `ptrace.tracee.parent.interpreter.file` `removexattr.file` `rename.file` `rename.file.destination` `rmdir.file` `setxattr.file` `signal.target.ancestors.file` `signal.target.ancestors.interpreter.file` `signal.target.file` `signal.target.interpreter.file` `signal.target.parent.file` `signal.target.parent.interpreter.file` `splice.file` `unlink.file` `utimes.file`
+
+
+### `*.group` {#common-credentials-group-doc}
+Type: string
+
+Definition: Group of the process
+
+`*.group` has 11 possible prefixes:
+`exec` `exit` `process` `process.ancestors` `process.parent` `ptrace.tracee` `ptrace.tracee.ancestors` `ptrace.tracee.parent` `signal.target` `signal.target.ancestors` `signal.target.parent`
+
+
+### `*.group` {#common-filefields-group-doc}
+Type: string
+
+Definition: Group of the file's owner
+
+`*.group` has 38 possible prefixes:
+`chmod.file` `chown.file` `exec.file` `exec.interpreter.file` `exit.file` `exit.interpreter.file` `link.file` `link.file.destination` `load_module.file` `mkdir.file` `mmap.file` `open.file` `process.ancestors.file` `process.ancestors.interpreter.file` `process.file` `process.interpreter.file` `process.parent.file` `process.parent.interpreter.file` `ptrace.tracee.ancestors.file` `ptrace.tracee.ancestors.interpreter.file` `ptrace.tracee.file` `ptrace.tracee.interpreter.file` `ptrace.tracee.parent.file` `ptrace.tracee.parent.interpreter.file` `removexattr.file` `rename.file` `rename.file.destination` `rmdir.file` `setxattr.file` `signal.target.ancestors.file` `signal.target.ancestors.interpreter.file` `signal.target.file` `signal.target.interpreter.file` `signal.target.parent.file` `signal.target.parent.interpreter.file` `splice.file` `unlink.file` `utimes.file`
+
+
+### `*.in_upper_layer` {#common-filefields-in_upper_layer-doc}
+Type: bool
+
+Definition: Indicator of the file layer, for example, in an OverlayFS
+
+`*.in_upper_layer` has 38 possible prefixes:
+`chmod.file` `chown.file` `exec.file` `exec.interpreter.file` `exit.file` `exit.interpreter.file` `link.file` `link.file.destination` `load_module.file` `mkdir.file` `mmap.file` `open.file` `process.ancestors.file` `process.ancestors.interpreter.file` `process.file` `process.interpreter.file` `process.parent.file` `process.parent.interpreter.file` `ptrace.tracee.ancestors.file` `ptrace.tracee.ancestors.interpreter.file` `ptrace.tracee.file` `ptrace.tracee.interpreter.file` `ptrace.tracee.parent.file` `ptrace.tracee.parent.interpreter.file` `removexattr.file` `rename.file` `rename.file.destination` `rmdir.file` `setxattr.file` `signal.target.ancestors.file` `signal.target.ancestors.interpreter.file` `signal.target.file` `signal.target.interpreter.file` `signal.target.parent.file` `signal.target.parent.interpreter.file` `splice.file` `unlink.file` `utimes.file`
+
+
+### `*.inode` {#common-filefields-inode-doc}
+Type: int
+
+Definition: Inode of the file
+
+`*.inode` has 38 possible prefixes:
+`chmod.file` `chown.file` `exec.file` `exec.interpreter.file` `exit.file` `exit.interpreter.file` `link.file` `link.file.destination` `load_module.file` `mkdir.file` `mmap.file` `open.file` `process.ancestors.file` `process.ancestors.interpreter.file` `process.file` `process.interpreter.file` `process.parent.file` `process.parent.interpreter.file` `ptrace.tracee.ancestors.file` `ptrace.tracee.ancestors.interpreter.file` `ptrace.tracee.file` `ptrace.tracee.interpreter.file` `ptrace.tracee.parent.file` `ptrace.tracee.parent.interpreter.file` `removexattr.file` `rename.file` `rename.file.destination` `rmdir.file` `setxattr.file` `signal.target.ancestors.file` `signal.target.ancestors.interpreter.file` `signal.target.file` `signal.target.interpreter.file` `signal.target.parent.file` `signal.target.parent.interpreter.file` `splice.file` `unlink.file` `utimes.file`
+
+
+### `*.ip` {#common-ipportcontext-ip-doc}
+Type: IP/CIDR
+
+Definition: IP address
+
+`*.ip` has 3 possible prefixes:
+`bind.addr` `network.destination` `network.source`
+
+
+### `*.is_kworker` {#common-pidcontext-is_kworker-doc}
+Type: bool
+
+Definition: Indicates whether the process is a kworker
+
+`*.is_kworker` has 11 possible prefixes:
+`exec` `exit` `process` `process.ancestors` `process.parent` `ptrace.tracee` `ptrace.tracee.ancestors` `ptrace.tracee.parent` `signal.target` `signal.target.ancestors` `signal.target.parent`
+
+
+### `*.is_thread` {#common-process-is_thread-doc}
+Type: bool
+
+Definition: Indicates whether the process is considered a thread (that is, a child process that hasn't executed another program)
+
+`*.is_thread` has 11 possible prefixes:
+`exec` `exit` `process` `process.ancestors` `process.parent` `ptrace.tracee` `ptrace.tracee.ancestors` `ptrace.tracee.parent` `signal.target` `signal.target.ancestors` `signal.target.parent`
+
+
+### `*.length` {#common-string-length-doc}
+Type: int
+
+Definition: Length of the corresponding string
+
+`*.length` has 77 possible prefixes:
+`chmod.file.name` `chmod.file.path` `chown.file.name` `chown.file.path` `dns.question.name` `exec.file.name` `exec.file.path` `exec.interpreter.file.name` `exec.interpreter.file.path` `exit.file.name` `exit.file.path` `exit.interpreter.file.name` `exit.interpreter.file.path` `link.file.destination.name` `link.file.destination.path` `link.file.name` `link.file.path` `load_module.file.name` `load_module.file.path` `mkdir.file.name` `mkdir.file.path` `mmap.file.name` `mmap.file.path` `open.file.name` `open.file.path` `process.ancestors.file.name` `process.ancestors.file.path` `process.ancestors.interpreter.file.name` `process.ancestors.interpreter.file.path` `process.file.name` `process.file.path` `process.interpreter.file.name` `process.interpreter.file.path` `process.parent.file.name` `process.parent.file.path` `process.parent.interpreter.file.name` `process.parent.interpreter.file.path` `ptrace.tracee.ancestors.file.name` `ptrace.tracee.ancestors.file.path` `ptrace.tracee.ancestors.interpreter.file.name` `ptrace.tracee.ancestors.interpreter.file.path` `ptrace.tracee.file.name` `ptrace.tracee.file.path` `ptrace.tracee.interpreter.file.name` `ptrace.tracee.interpreter.file.path` `ptrace.tracee.parent.file.name` `ptrace.tracee.parent.file.path` `ptrace.tracee.parent.interpreter.file.name` `ptrace.tracee.parent.interpreter.file.path` `removexattr.file.name` `removexattr.file.path` `rename.file.destination.name` `rename.file.destination.path` `rename.file.name` `rename.file.path` `rmdir.file.name` `rmdir.file.path` `setxattr.file.name` `setxattr.file.path` `signal.target.ancestors.file.name` `signal.target.ancestors.file.path` `signal.target.ancestors.interpreter.file.name` `signal.target.ancestors.interpreter.file.path` `signal.target.file.name` `signal.target.file.path` `signal.target.interpreter.file.name` `signal.target.interpreter.file.path` `signal.target.parent.file.name` `signal.target.parent.file.path` `signal.target.parent.interpreter.file.name` `signal.target.parent.interpreter.file.path` `splice.file.name` `splice.file.path` `unlink.file.name` `unlink.file.path` `utimes.file.name` `utimes.file.path`
+
+
+### `*.mode` {#common-filefields-mode-doc}
+Type: int
+
+Definition: Mode of the file
+
+`*.mode` has 38 possible prefixes:
+`chmod.file` `chown.file` `exec.file` `exec.interpreter.file` `exit.file` `exit.interpreter.file` `link.file` `link.file.destination` `load_module.file` `mkdir.file` `mmap.file` `open.file` `process.ancestors.file` `process.ancestors.interpreter.file` `process.file` `process.interpreter.file` `process.parent.file` `process.parent.interpreter.file` `ptrace.tracee.ancestors.file` `ptrace.tracee.ancestors.interpreter.file` `ptrace.tracee.file` `ptrace.tracee.interpreter.file` `ptrace.tracee.parent.file` `ptrace.tracee.parent.interpreter.file` `removexattr.file` `rename.file` `rename.file.destination` `rmdir.file` `setxattr.file` `signal.target.ancestors.file` `signal.target.ancestors.interpreter.file` `signal.target.file` `signal.target.interpreter.file` `signal.target.parent.file` `signal.target.parent.interpreter.file` `splice.file` `unlink.file` `utimes.file`
+
+
+### `*.modification_time` {#common-filefields-modification_time-doc}
+Type: int
+
+Definition: Modification time of the file
+
+`*.modification_time` has 38 possible prefixes:
+`chmod.file` `chown.file` `exec.file` `exec.interpreter.file` `exit.file` `exit.interpreter.file` `link.file` `link.file.destination` `load_module.file` `mkdir.file` `mmap.file` `open.file` `process.ancestors.file` `process.ancestors.interpreter.file` `process.file` `process.interpreter.file` `process.parent.file` `process.parent.interpreter.file` `ptrace.tracee.ancestors.file` `ptrace.tracee.ancestors.interpreter.file` `ptrace.tracee.file` `ptrace.tracee.interpreter.file` `ptrace.tracee.parent.file` `ptrace.tracee.parent.interpreter.file` `removexattr.file` `rename.file` `rename.file.destination` `rmdir.file` `setxattr.file` `signal.target.ancestors.file` `signal.target.ancestors.interpreter.file` `signal.target.file` `signal.target.interpreter.file` `signal.target.parent.file` `signal.target.parent.interpreter.file` `splice.file` `unlink.file` `utimes.file`
+
+
+### `*.mount_id` {#common-filefields-mount_id-doc}
+Type: int
+
+Definition: Mount ID of the file
+
+`*.mount_id` has 38 possible prefixes:
+`chmod.file` `chown.file` `exec.file` `exec.interpreter.file` `exit.file` `exit.interpreter.file` `link.file` `link.file.destination` `load_module.file` `mkdir.file` `mmap.file` `open.file` `process.ancestors.file` `process.ancestors.interpreter.file` `process.file` `process.interpreter.file` `process.parent.file` `process.parent.interpreter.file` `ptrace.tracee.ancestors.file` `ptrace.tracee.ancestors.interpreter.file` `ptrace.tracee.file` `ptrace.tracee.interpreter.file` `ptrace.tracee.parent.file` `ptrace.tracee.parent.interpreter.file` `removexattr.file` `rename.file` `rename.file.destination` `rmdir.file` `setxattr.file` `signal.target.ancestors.file` `signal.target.ancestors.interpreter.file` `signal.target.file` `signal.target.interpreter.file` `signal.target.parent.file` `signal.target.parent.interpreter.file` `splice.file` `unlink.file` `utimes.file`
+
+
+### `*.name` {#common-fileevent-name-doc}
+Type: string
+
+Definition: File's basename
+
+`*.name` has 38 possible prefixes:
+`chmod.file` `chown.file` `exec.file` `exec.interpreter.file` `exit.file` `exit.interpreter.file` `link.file` `link.file.destination` `load_module.file` `mkdir.file` `mmap.file` `open.file` `process.ancestors.file` `process.ancestors.interpreter.file` `process.file` `process.interpreter.file` `process.parent.file` `process.parent.interpreter.file` `ptrace.tracee.ancestors.file` `ptrace.tracee.ancestors.interpreter.file` `ptrace.tracee.file` `ptrace.tracee.interpreter.file` `ptrace.tracee.parent.file` `ptrace.tracee.parent.interpreter.file` `removexattr.file` `rename.file` `rename.file.destination` `rmdir.file` `setxattr.file` `signal.target.ancestors.file` `signal.target.ancestors.interpreter.file` `signal.target.file` `signal.target.interpreter.file` `signal.target.parent.file` `signal.target.parent.interpreter.file` `splice.file` `unlink.file` `utimes.file`
+
+
+
+Example:
+
+{{< code-block lang="javascript" >}}
+exec.file.name == "apt"
+{{< /code-block >}}
+
+Matches the execution of any file named apt.
+
+### `*.path` {#common-fileevent-path-doc}
+Type: string
+
+Definition: File's path
+
+`*.path` has 38 possible prefixes:
+`chmod.file` `chown.file` `exec.file` `exec.interpreter.file` `exit.file` `exit.interpreter.file` `link.file` `link.file.destination` `load_module.file` `mkdir.file` `mmap.file` `open.file` `process.ancestors.file` `process.ancestors.interpreter.file` `process.file` `process.interpreter.file` `process.parent.file` `process.parent.interpreter.file` `ptrace.tracee.ancestors.file` `ptrace.tracee.ancestors.interpreter.file` `ptrace.tracee.file` `ptrace.tracee.interpreter.file` `ptrace.tracee.parent.file` `ptrace.tracee.parent.interpreter.file` `removexattr.file` `rename.file` `rename.file.destination` `rmdir.file` `setxattr.file` `signal.target.ancestors.file` `signal.target.ancestors.interpreter.file` `signal.target.file` `signal.target.interpreter.file` `signal.target.parent.file` `signal.target.parent.interpreter.file` `splice.file` `unlink.file` `utimes.file`
+
+
+
+Example:
+
+{{< code-block lang="javascript" >}}
+exec.file.path == "/usr/bin/apt"
+{{< /code-block >}}
+
+Matches the execution of the file located at /usr/bin/apt
+
+Example:
+
+{{< code-block lang="javascript" >}}
+open.file.path == "/etc/passwd"
+{{< /code-block >}}
+
+Matches any process opening the /etc/passwd file.
+
+### `*.pid` {#common-pidcontext-pid-doc}
+Type: int
+
+Definition: Process ID of the process (also called thread group ID)
+
+`*.pid` has 11 possible prefixes:
+`exec` `exit` `process` `process.ancestors` `process.parent` `ptrace.tracee` `ptrace.tracee.ancestors` `ptrace.tracee.parent` `signal.target` `signal.target.ancestors` `signal.target.parent`
+
+
+### `*.port` {#common-ipportcontext-port-doc}
+Type: int
+
+Definition: Port number
+
+`*.port` has 3 possible prefixes:
+`bind.addr` `network.destination` `network.source`
+
+
+### `*.ppid` {#common-process-ppid-doc}
+Type: int
+
+Definition: Parent process ID
+
+`*.ppid` has 11 possible prefixes:
+`exec` `exit` `process` `process.ancestors` `process.parent` `ptrace.tracee` `ptrace.tracee.ancestors` `ptrace.tracee.parent` `signal.target` `signal.target.ancestors` `signal.target.parent`
+
+
+### `*.retval` {#common-syscallevent-retval-doc}
+Type: int
+
+Definition: Return value of the syscall
+
+`*.retval` has 21 possible prefixes:
+`bind` `bpf` `chmod` `chown` `link` `load_module` `mkdir` `mmap` `mount` `mprotect` `open` `ptrace` `removexattr` `rename` `rmdir` `setxattr` `signal` `splice` `unlink` `unload_module` `utimes`
+
+Constants: [Error constants](#error-constants)
+
+
+
+### `*.rights` {#common-filefields-rights-doc}
+Type: int
+
+Definition: Rights of the file
+
+`*.rights` has 38 possible prefixes:
+`chmod.file` `chown.file` `exec.file` `exec.interpreter.file` `exit.file` `exit.interpreter.file` `link.file` `link.file.destination` `load_module.file` `mkdir.file` `mmap.file` `open.file` `process.ancestors.file` `process.ancestors.interpreter.file` `process.file` `process.interpreter.file` `process.parent.file` `process.parent.interpreter.file` `ptrace.tracee.ancestors.file` `ptrace.tracee.ancestors.interpreter.file` `ptrace.tracee.file` `ptrace.tracee.interpreter.file` `ptrace.tracee.parent.file` `ptrace.tracee.parent.interpreter.file` `removexattr.file` `rename.file` `rename.file.destination` `rmdir.file` `setxattr.file` `signal.target.ancestors.file` `signal.target.ancestors.interpreter.file` `signal.target.file` `signal.target.interpreter.file` `signal.target.parent.file` `signal.target.parent.interpreter.file` `splice.file` `unlink.file` `utimes.file`
+
+Constants: [Chmod mode constants](#chmod-mode-constants)
+
+
+
+### `*.tid` {#common-pidcontext-tid-doc}
+Type: int
+
+Definition: Thread ID of the thread
+
+`*.tid` has 11 possible prefixes:
+`exec` `exit` `process` `process.ancestors` `process.parent` `ptrace.tracee` `ptrace.tracee.ancestors` `ptrace.tracee.parent` `signal.target` `signal.target.ancestors` `signal.target.parent`
+
+
+### `*.tty_name` {#common-process-tty_name-doc}
+Type: string
+
+Definition: Name of the TTY associated with the process
+
+`*.tty_name` has 11 possible prefixes:
+`exec` `exit` `process` `process.ancestors` `process.parent` `ptrace.tracee` `ptrace.tracee.ancestors` `ptrace.tracee.parent` `signal.target` `signal.target.ancestors` `signal.target.parent`
+
+
+### `*.uid` {#common-credentials-uid-doc}
+Type: int
+
+Definition: UID of the process
+
+`*.uid` has 11 possible prefixes:
+`exec` `exit` `process` `process.ancestors` `process.parent` `ptrace.tracee` `ptrace.tracee.ancestors` `ptrace.tracee.parent` `signal.target` `signal.target.ancestors` `signal.target.parent`
+
+
+### `*.uid` {#common-filefields-uid-doc}
+Type: int
+
+Definition: UID of the file's owner
+
+`*.uid` has 38 possible prefixes:
+`chmod.file` `chown.file` `exec.file` `exec.interpreter.file` `exit.file` `exit.interpreter.file` `link.file` `link.file.destination` `load_module.file` `mkdir.file` `mmap.file` `open.file` `process.ancestors.file` `process.ancestors.interpreter.file` `process.file` `process.interpreter.file` `process.parent.file` `process.parent.interpreter.file` `ptrace.tracee.ancestors.file` `ptrace.tracee.ancestors.interpreter.file` `ptrace.tracee.file` `ptrace.tracee.interpreter.file` `ptrace.tracee.parent.file` `ptrace.tracee.parent.interpreter.file` `removexattr.file` `rename.file` `rename.file.destination` `rmdir.file` `setxattr.file` `signal.target.ancestors.file` `signal.target.ancestors.interpreter.file` `signal.target.file` `signal.target.interpreter.file` `signal.target.parent.file` `signal.target.parent.interpreter.file` `splice.file` `unlink.file` `utimes.file`
+
+
+### `*.user` {#common-credentials-user-doc}
+Type: string
+
+Definition: User of the process
+
+`*.user` has 11 possible prefixes:
+`exec` `exit` `process` `process.ancestors` `process.parent` `ptrace.tracee` `ptrace.tracee.ancestors` `ptrace.tracee.parent` `signal.target` `signal.target.ancestors` `signal.target.parent`
+
+
+
+Example:
+
+{{< code-block lang="javascript" >}}
+process.user == "root"
+{{< /code-block >}}
+
+Constrain an event to be triggered by a process running as the root user.
+
+### `*.user` {#common-filefields-user-doc}
+Type: string
+
+Definition: User of the file's owner
+
+`*.user` has 38 possible prefixes:
+`chmod.file` `chown.file` `exec.file` `exec.interpreter.file` `exit.file` `exit.interpreter.file` `link.file` `link.file.destination` `load_module.file` `mkdir.file` `mmap.file` `open.file` `process.ancestors.file` `process.ancestors.interpreter.file` `process.file` `process.interpreter.file` `process.parent.file` `process.parent.interpreter.file` `ptrace.tracee.ancestors.file` `ptrace.tracee.ancestors.interpreter.file` `ptrace.tracee.file` `ptrace.tracee.interpreter.file` `ptrace.tracee.parent.file` `ptrace.tracee.parent.interpreter.file` `removexattr.file` `rename.file` `rename.file.destination` `rmdir.file` `setxattr.file` `signal.target.ancestors.file` `signal.target.ancestors.interpreter.file` `signal.target.file` `signal.target.interpreter.file` `signal.target.parent.file` `signal.target.parent.interpreter.file` `splice.file` `unlink.file` `utimes.file`
+
+
+### `async` {#async-doc}
+Type: bool
+
+Definition: True if the syscall was asynchronous
+
+
+
+### `bind.addr.family` {#bind-addr-family-doc}
+Type: int
+
+Definition: Address family
+
+
+
+### `bpf.cmd` {#bpf-cmd-doc}
+Type: int
+
+Definition: BPF command name
+
+
+Constants: [BPF commands](#bpf-commands)
+
+
+
+### `bpf.map.name` {#bpf-map-name-doc}
+Type: string
+
+Definition: Name of the eBPF map (added in 7.35)
+
+
+
+### `bpf.map.type` {#bpf-map-type-doc}
+Type: int
+
+Definition: Type of the eBPF map
+
+
+Constants: [BPF map types](#bpf-map-types)
+
+
+
+### `bpf.prog.attach_type` {#bpf-prog-attach_type-doc}
+Type: int
+
+Definition: Attach type of the eBPF program
+
+
+Constants: [BPF attach types](#bpf-attach-types)
+
+
+
+### `bpf.prog.helpers` {#bpf-prog-helpers-doc}
+Type: int
+
+Definition: eBPF helpers used by the eBPF program (added in 7.35)
+
+
+Constants: [BPF helper functions](#bpf-helper-functions)
+
+
+
+### `bpf.prog.name` {#bpf-prog-name-doc}
+Type: string
+
+Definition: Name of the eBPF program (added in 7.35)
+
+
+
+### `bpf.prog.tag` {#bpf-prog-tag-doc}
+Type: string
+
+Definition: Hash (sha1) of the eBPF program (added in 7.35)
+
+
+
+### `bpf.prog.type` {#bpf-prog-type-doc}
+Type: int
+
+Definition: Type of the eBPF program
+
+
+Constants: [BPF program types](#bpf-program-types)
+
+
+
+### `capset.cap_effective` {#capset-cap_effective-doc}
+Type: int
+
+Definition: Effective capability set of the process
+
+
+Constants: [Kernel Capability constants](#kernel-capability-constants)
+
+
+
+### `capset.cap_permitted` {#capset-cap_permitted-doc}
+Type: int
+
+Definition: Permitted capability set of the process
+
+
+Constants: [Kernel Capability constants](#kernel-capability-constants)
+
+
+
+### `chmod.file.destination.mode` {#chmod-file-destination-mode-doc}
+Type: int
+
+Definition: New mode of the chmod-ed file
+
+
+Constants: [Chmod mode constants](#chmod-mode-constants)
+
+
+
+### `chmod.file.destination.rights` {#chmod-file-destination-rights-doc}
+Type: int
+
+Definition: New rights of the chmod-ed file
+
+
+Constants: [Chmod mode constants](#chmod-mode-constants)
+
+
+
+### `chown.file.destination.gid` {#chown-file-destination-gid-doc}
+Type: int
+
+Definition: New GID of the chown-ed file's owner
+
+
+
+### `chown.file.destination.group` {#chown-file-destination-group-doc}
+Type: string
+
+Definition: New group of the chown-ed file's owner
+
+
+
+### `chown.file.destination.uid` {#chown-file-destination-uid-doc}
+Type: int
+
+Definition: New UID of the chown-ed file's owner
+
+
+
+### `chown.file.destination.user` {#chown-file-destination-user-doc}
+Type: string
+
+Definition: New user of the chown-ed file's owner
+
+
+
+### `container.id` {#container-id-doc}
+Type: string
+
+Definition: ID of the container
+
+
+
+### `container.tags` {#container-tags-doc}
+Type: string
+
+Definition: Tags of the container
+
+
+
+### `dns.id` {#dns-id-doc}
+Type: int
+
+Definition: [Experimental] the DNS request ID
+
+
+
+### `dns.question.class` {#dns-question-class-doc}
+Type: int
+
+Definition: the class looked up by the DNS question
+
+
+Constants: [DNS qclasses](#dns-qclasses)
+
+
+
+### `dns.question.count` {#dns-question-count-doc}
+Type: int
+
+Definition: the total count of questions in the DNS request
+
+
+
+### `dns.question.length` {#dns-question-length-doc}
+Type: int
+
+Definition: the total DNS request size in bytes
+
+
+
+### `dns.question.name` {#dns-question-name-doc}
+Type: string
+
+Definition: the queried domain name
+
+
+
+### `dns.question.type` {#dns-question-type-doc}
+Type: int
+
+Definition: a two octet code which specifies the DNS question type
+
+
+Constants: [DNS qtypes](#dns-qtypes)
+
+
+
+### `exit.cause` {#exit-cause-doc}
+Type: int
+
+Definition: Cause of the process termination (one of EXITED, SIGNALED, COREDUMPED)
+
+
+
+### `exit.code` {#exit-code-doc}
+Type: int
+
+Definition: Exit code of the process or number of the signal that caused the process to terminate
+
+
+
+### `load_module.loaded_from_memory` {#load_module-loaded_from_memory-doc}
+Type: bool
+
+Definition: Indicates if the kernel module was loaded from memory
+
+
+
+### `load_module.name` {#load_module-name-doc}
+Type: string
+
+Definition: Name of the new kernel module
+
+
+
+### `mkdir.file.destination.mode` {#mkdir-file-destination-mode-doc}
+Type: int
+
+Definition: Mode of the new directory
+
+
+Constants: [Chmod mode constants](#chmod-mode-constants)
+
+
+
+### `mkdir.file.destination.rights` {#mkdir-file-destination-rights-doc}
+Type: int
+
+Definition: Rights of the new directory
+
+
+Constants: [Chmod mode constants](#chmod-mode-constants)
+
+
+
+### `mmap.flags` {#mmap-flags-doc}
+Type: int
+
+Definition: memory segment flags
+
+
+Constants: [MMap flags](#mmap-flags)
+
+
+
+### `mmap.protection` {#mmap-protection-doc}
+Type: int
+
+Definition: memory segment protection
+
+
+Constants: [Protection constants](#protection-constants)
+
+
+
+### `mount.fs_type` {#mount-fs_type-doc}
+Type: string
+
+Definition: Type of the mounted file system
+
+
+
+### `mount.mountpoint.path` {#mount-mountpoint-path-doc}
+Type: string
+
+Definition: Path of the mount point
+
+
+
+### `mount.source.path` {#mount-source-path-doc}
+Type: string
+
+Definition: Source path of a bind mount
+
+
+
+### `mprotect.req_protection` {#mprotect-req_protection-doc}
+Type: int
+
+Definition: new memory segment protection
+
+
+Constants: [Virtual Memory flags](#virtual-memory-flags)
+
+
+
+### `mprotect.vm_protection` {#mprotect-vm_protection-doc}
+Type: int
+
+Definition: initial memory segment protection
+
+
+Constants: [Virtual Memory flags](#virtual-memory-flags)
+
+
+
+### `network.device.ifindex` {#network-device-ifindex-doc}
+Type: int
+
+Definition: interface ifindex
+
+
+
+### `network.device.ifname` {#network-device-ifname-doc}
+Type: string
+
+Definition: interface ifname
+
+
+
+### `network.l3_protocol` {#network-l3_protocol-doc}
+Type: int
+
+Definition: l3 protocol of the network packet
+
+
+Constants: [L3 protocols](#l3-protocols)
+
+
+
+### `network.l4_protocol` {#network-l4_protocol-doc}
+Type: int
+
+Definition: l4 protocol of the network packet
+
+
+Constants: [L4 protocols](#l4-protocols)
+
+
+
+### `network.size` {#network-size-doc}
+Type: int
+
+Definition: size in bytes of the network packet
+
+
+
+### `open.file.destination.mode` {#open-file-destination-mode-doc}
+Type: int
+
+Definition: Mode of the created file
+
+
+Constants: [Chmod mode constants](#chmod-mode-constants)
+
+
+
+### `open.flags` {#open-flags-doc}
+Type: int
+
+Definition: Flags used when opening the file
+
+
+Constants: [Open flags](#open-flags)
+
+
+
+### `ptrace.request` {#ptrace-request-doc}
+Type: int
+
+Definition: ptrace request
+
+
+Constants: [Ptrace constants](#ptrace-constants)
+
+
+
+### `selinux.bool.name` {#selinux-bool-name-doc}
+Type: string
+
+Definition: SELinux boolean name
+
+
+
+### `selinux.bool.state` {#selinux-bool-state-doc}
+Type: string
+
+Definition: SELinux boolean new value
+
+
+
+### `selinux.bool_commit.state` {#selinux-bool_commit-state-doc}
+Type: bool
+
+Definition: Indicator of a SELinux boolean commit operation
+
+
+
+### `selinux.enforce.status` {#selinux-enforce-status-doc}
+Type: string
+
+Definition: SELinux enforcement status (one of "enforcing", "permissive", "disabled")
+
+
+
+### `setgid.egid` {#setgid-egid-doc}
+Type: int
+
+Definition: New effective GID of the process
+
+
+
+### `setgid.egroup` {#setgid-egroup-doc}
+Type: string
+
+Definition: New effective group of the process
+
+
+
+### `setgid.fsgid` {#setgid-fsgid-doc}
+Type: int
+
+Definition: New FileSystem GID of the process
+
+
+
+### `setgid.fsgroup` {#setgid-fsgroup-doc}
+Type: string
+
+Definition: New FileSystem group of the process
+
+
+
+### `setgid.gid` {#setgid-gid-doc}
+Type: int
+
+Definition: New GID of the process
+
+
+
+### `setgid.group` {#setgid-group-doc}
+Type: string
+
+Definition: New group of the process
+
+
+
+### `setuid.euid` {#setuid-euid-doc}
+Type: int
+
+Definition: New effective UID of the process
+
+
+
+### `setuid.euser` {#setuid-euser-doc}
+Type: string
+
+Definition: New effective user of the process
+
+
+
+### `setuid.fsuid` {#setuid-fsuid-doc}
+Type: int
+
+Definition: New FileSystem UID of the process
+
+
+
+### `setuid.fsuser` {#setuid-fsuser-doc}
+Type: string
+
+Definition: New FileSystem user of the process
+
+
+
+### `setuid.uid` {#setuid-uid-doc}
+Type: int
+
+Definition: New UID of the process
+
+
+
+### `setuid.user` {#setuid-user-doc}
+Type: string
+
+Definition: New user of the process
+
+
+
+### `signal.pid` {#signal-pid-doc}
+Type: int
+
+Definition: Target PID
+
+
+
+### `signal.type` {#signal-type-doc}
+Type: int
+
+Definition: Signal type (ex: SIGHUP, SIGINT, SIGQUIT, etc)
+
+
+Constants: [Signal constants](#signal-constants)
+
+
+
+### `splice.pipe_entry_flag` {#splice-pipe_entry_flag-doc}
+Type: int
+
+Definition: Entry flag of the "fd_out" pipe passed to the splice syscall
+
+
+Constants: [Pipe buffer flags](#pipe-buffer-flags)
+
+
+
+### `splice.pipe_exit_flag` {#splice-pipe_exit_flag-doc}
+Type: int
+
+Definition: Exit flag of the "fd_out" pipe passed to the splice syscall
+
+
+Constants: [Pipe buffer flags](#pipe-buffer-flags)
+
+
+
+### `unlink.flags` {#unlink-flags-doc}
+Type: int
+
+Definition: Flags of the unlink syscall
+
+
+Constants: [Unlink flags](#unlink-flags)
+
+
+
+### `unload_module.name` {#unload_module-name-doc}
+Type: string
+
+Definition: Name of the kernel module that was deleted
+
 
 
 ## Constants
 
 Constants are used to improve the readability of your rules. Some constants are common to all architectures, others are specific to some architectures.
 
-### `BPF attach types`
-
+### `BPF attach types` {#bpf-attach-types}
 BPF attach types are the supported eBPF program attach types.
 
 | Name | Architectures |
@@ -1492,8 +2623,7 @@ BPF attach types are the supported eBPF program attach types.
 | `BPF_XDP` | all |
 | `BPF_SK_SKB_VERDICT` | all |
 
-### `BPF commands`
-
+### `BPF commands` {#bpf-commands}
 BPF commands are used to specify a command to a bpf syscall.
 
 | Name | Architectures |
@@ -1536,8 +2666,7 @@ BPF commands are used to specify a command to a bpf syscall.
 | `BPF_LINK_DETACH` | all |
 | `BPF_PROG_BIND_MAP` | all |
 
-### `BPF helper functions`
-
+### `BPF helper functions` {#bpf-helper-functions}
 BPF helper functions are the supported BPF helper functions.
 
 | Name | Architectures |
@@ -1709,8 +2838,7 @@ BPF helper functions are the supported BPF helper functions.
 | `BPF_FOR_EACH_MAP_ELEM` | all |
 | `BPF_SNPRINTF` | all |
 
-### `BPF map types`
-
+### `BPF map types` {#bpf-map-types}
 BPF map types are the supported eBPF map types.
 
 | Name | Architectures |
@@ -1746,8 +2874,7 @@ BPF map types are the supported eBPF map types.
 | `BPF_MAP_TYPE_INODE_STORAGE` | all |
 | `BPF_MAP_TYPE_TASK_STORAGE` | all |
 
-### `BPF program types`
-
+### `BPF program types` {#bpf-program-types}
 BPF program types are the supported eBPF program types.
 
 | Name | Architectures |
@@ -1784,8 +2911,7 @@ BPF program types are the supported eBPF program types.
 | `BPF_PROG_TYPE_LSM` | all |
 | `BPF_PROG_TYPE_SK_LOOKUP` | all |
 
-### `Chmod mode constants`
-
+### `Chmod mode constants` {#chmod-mode-constants}
 Chmod mode constants are the supported modes for the chmod syscall.
 
 | Name | Architectures |
@@ -1814,8 +2940,7 @@ Chmod mode constants are the supported modes for the chmod syscall.
 | `S_IXOTH` | all |
 | `S_IXUSR` | all |
 
-### `DNS qclasses`
-
+### `DNS qclasses` {#dns-qclasses}
 DNS qclasses are the supported DNS query classes.
 
 | Name | Architectures |
@@ -1827,8 +2952,7 @@ DNS qclasses are the supported DNS query classes.
 | `CLASS_NONE` | all |
 | `CLASS_ANY` | all |
 
-### `DNS qtypes`
-
+### `DNS qtypes` {#dns-qtypes}
 DNS qtypes are the supported DNS query types.
 
 | Name | Architectures |
@@ -1918,9 +3042,8 @@ DNS qtypes are the supported DNS query types.
 | `DLV` | all |
 | `Reserved` | all |
 
-### `Error Constants`
-
-Error Constants are the supported error constants.
+### `Error constants` {#error-constants}
+Error constants are the supported error constants.
 
 | Name | Architectures |
 | ---- |---------------|
@@ -2058,8 +3181,7 @@ Error Constants are the supported error constants.
 | `EXDEV` | all |
 | `EXFULL` | all |
 
-### `Kernel Capability constants`
-
+### `Kernel Capability constants` {#kernel-capability-constants}
 Kernel Capability constants are the supported Linux Kernel Capability.
 
 | Name | Architectures |
@@ -2107,8 +3229,7 @@ Kernel Capability constants are the supported Linux Kernel Capability.
 | `CAP_SYS_TTY_CONFIG` | all |
 | `CAP_WAKE_ALARM` | all |
 
-### `L3 protocols`
-
+### `L3 protocols` {#l3-protocols}
 L3 protocols are the supported Layer 3 protocols.
 
 | Name | Architectures |
@@ -2204,8 +3325,7 @@ L3 protocols are the supported Layer 3 protocols.
 | `ETH_P_XDSA` | all |
 | `ETH_P_MAP` | all |
 
-### `L4 protocols`
-
+### `L4 protocols` {#l4-protocols}
 L4 protocols are the supported Layer 4 protocols.
 
 | Name | Architectures |
@@ -2238,8 +3358,7 @@ L4 protocols are the supported Layer 4 protocols.
 | `IP_PROTO_MPLS` | all |
 | `IP_PROTO_RAW` | all |
 
-### `MMap flags`
-
+### `MMap flags` {#mmap-flags}
 MMap flags are the supported flags for the mmap syscall.
 
 | Name | Architectures |
@@ -2277,8 +3396,7 @@ MMap flags are the supported flags for the mmap syscall.
 | `MAP_HUGE_16GB` | all |
 | `MAP_32BIT` | amd64 |
 
-### `Network Address Family constants`
-
+### `Network Address Family constants` {#network-address-family-constants}
 Network Address Family constants are the supported network address families.
 
 | Name | Architectures |
@@ -2333,8 +3451,7 @@ Network Address Family constants are the supported network address families.
 | `AF_XDP` | all |
 | `AF_MAX` | all |
 
-### `Open flags`
-
+### `Open flags` {#open-flags}
 Open flags are the supported flags for the open syscall.
 
 | Name | Architectures |
@@ -2361,8 +3478,7 @@ Open flags are the supported flags for the open syscall.
 | `O_NONBLOCK` | all |
 | `O_RSYNC` | all |
 
-### `Pipe buffer flags`
-
+### `Pipe buffer flags` {#pipe-buffer-flags}
 Pipe buffer flags are the supported flags for a pipe buffer.
 
 | Name | Architectures |
@@ -2375,8 +3491,7 @@ Pipe buffer flags are the supported flags for a pipe buffer.
 | `PIPE_BUF_FLAG_WHOLE` | all |
 | `PIPE_BUF_FLAG_LOSS` | all |
 
-### `Protection constants`
-
+### `Protection constants` {#protection-constants}
 Protection constants are the supported protections for the mmap syscall.
 
 | Name | Architectures |
@@ -2388,8 +3503,7 @@ Protection constants are the supported protections for the mmap syscall.
 | `PROT_GROWSDOWN` | all |
 | `PROT_GROWSUP` | all |
 
-### `Ptrace constants`
-
+### `Ptrace constants` {#ptrace-constants}
 Ptrace constants are the supported ptrace commands for the ptrace syscall.
 
 | Name | Architectures |
@@ -2448,8 +3562,7 @@ Ptrace constants are the supported ptrace commands for the ptrace syscall.
 | `PTRACE_PEEKMTETAGS` | arm64 |
 | `PTRACE_POKEMTETAGS` | arm64 |
 
-### `SecL constants`
-
+### `SecL constants` {#secl-constants}
 SecL constants are the supported generic SecL constants.
 
 | Name | Architectures |
@@ -2457,8 +3570,7 @@ SecL constants are the supported generic SecL constants.
 | `true` | all |
 | `false` | all |
 
-### `Signal constants`
-
+### `Signal constants` {#signal-constants}
 Signal constants are the supported signals for the kill syscall.
 
 | Name | Architectures |
@@ -2497,16 +3609,14 @@ Signal constants are the supported signals for the kill syscall.
 | `SIGPWR` | all |
 | `SIGSYS` | all |
 
-### `Unlink flags`
-
+### `Unlink flags` {#unlink-flags}
 Unlink flags are the supported flags for the unlink syscall.
 
 | Name | Architectures |
 | ---- |---------------|
 | `AT_REMOVEDIR` | all |
 
-### `Virtual Memory flags`
-
+### `Virtual Memory flags` {#virtual-memory-flags}
 Virtual Memory flags define the protection of a virtual memory segment.
 
 | Name | Architectures |

--- a/docs/cloud-workload-security/scripts/secl-doc-gen.py
+++ b/docs/cloud-workload-security/scripts/secl-doc-gen.py
@@ -9,10 +9,8 @@ import common
 @dataclass
 class EventTypeProperty:
     name: str
-    datatype: str
     definition: str
-    constants: str
-
+    doc_link: str
 
 @dataclass
 class EventType:
@@ -25,6 +23,22 @@ class EventType:
 
 
 @dataclass
+class Example:
+    expression: str
+    description: str
+
+@dataclass
+class PropertyDocumentation:
+    name: str
+    link: str
+    datatype: str
+    definition: str
+    prefixes: List[str]
+    constants: str
+    constants_link: str
+    examples: List[Example]
+
+@dataclass
 class Constant:
     name: str
     architecture: str
@@ -33,8 +47,10 @@ class Constant:
 @dataclass
 class Constants:
     name: str
+    link: str
     definition: str
     all: List[Constant]
+
 
 
 def build_event_types(top_node):
@@ -44,19 +60,24 @@ def build_event_types(top_node):
             et["name"], et["type"], et["definition"], et["from_agent_version"], et["experimental"], []
         )
         for p in et["properties"]:
-            try:
-                prop = EventTypeProperty(p["name"], p["type"], p["definition"], p["constants"])
-            except KeyError:
-                prop = EventTypeProperty(p["name"], p["type"], p["definition"], "none")
+            prop = EventTypeProperty(p["name"], p["definition"], p["property_doc_link"])
             event_type.properties.append(prop)
         output.append(event_type)
     return output
 
+def build_properties_doc(top_node):
+    output = []
+    for property in top_node["properties_doc"]:
+        property_doc = PropertyDocumentation(property["name"], property["link"], property["type"], property["definition"], property["prefixes"], property["constants"], property["constants_link"], [])
+        for exp in property["examples"]:
+            property_doc.examples.append(Example(exp["expression"], exp["description"]))
+        output.append(property_doc)
+    return output
 
 def build_constants(top_node):
     output = []
     for cs in top_node["constants"]:
-        constants = Constants(cs["name"], cs["description"], [])
+        constants = Constants(cs["name"], cs["link"], cs["description"], [])
         for c in cs["all"]:
             constants.all.append(Constant(c["name"], c["architecture"]))
         output.append(constants)
@@ -75,8 +96,9 @@ if __name__ == "__main__":
     secl_json_file.close()
 
     event_types = build_event_types(json_top_node)
+    properties_doc_list = build_properties_doc(json_top_node)
     constants_list = build_constants(json_top_node)
 
     output_file = open(args.output, "w")
-    print(common.fill_template(args.template, event_types=event_types, constants_list=constants_list), file=output_file)
+    print(common.fill_template(args.template, event_types=event_types, constants_list=constants_list, properties_doc_list=properties_doc_list), file=output_file)
     output_file.close()

--- a/docs/cloud-workload-security/scripts/templates/agent_expressions.md
+++ b/docs/cloud-workload-security/scripts/templates/agent_expressions.md
@@ -146,7 +146,7 @@ Examples:
 
 The *file.rights* attribute can now be used in addition to *file.mode*. *file.mode* can hold values set by the kernel, while the *file.rights* only holds the values set by the user. These rights may be more familiar because they are in the `chmod` commands.
 
-## Event types
+## Event attributes
 
 {% for event_type in event_types %}
 {% if event_type.name == "*" %}
@@ -161,12 +161,54 @@ _This event type is experimental and may change in the future._
 {{ event_type.definition }}
 {% endif %}
 
-| Property | Type | Definition | Constants |
-| -------- | ---- | ---------- | --------- |
+| Property | Definition |
+| -------- | ------------- |
 {% for property in event_type.properties %}
-| `{{ property.name }}` | {{ property.datatype }} | {{ property.definition }} | {{ property.constants }} |
+| [`{{ property.name }}`](#{{ property.doc_link }}) | {{ property.definition }} |
 {% endfor %}
 
+{% endfor %}
+
+## Attributes documentation
+
+{% for property_doc in properties_doc_list %}
+
+### `{{ property_doc.name }}` {% raw %}{#{% endraw %}{{ property_doc.link }}{% raw %}}{% endraw %}
+
+Type: {{ property_doc.datatype }}
+
+{% if property_doc.definition != "" %}
+Definition: {{ property_doc.definition }}
+{% endif %}
+
+{% if property_doc.prefixes|length > 1 %}
+`{{ property_doc.name }}` has {{ property_doc.prefixes|length }} possible prefixes:
+{% for prefix in property_doc.prefixes %}`{{ prefix }}`{% if not loop.last %} {% endif %}{% endfor %}
+
+{% endif %}
+{% if property_doc.constants != "" %}
+
+Constants: [{{ property_doc.constants }}](#{{ property_doc.constants_link }})
+
+{% endif %}
+
+{% if property_doc.examples|length > 0 %}
+
+{% for example in property_doc.examples %}
+
+Example:
+
+{% raw %}{{< code-block lang="javascript" >}}{% endraw %}
+
+{{ example.expression }}
+{% raw %}{{< /code-block >}}{% endraw %}
+
+{% if example.description != "" %}
+
+{{ example.description }}
+{% endif %}
+{% endfor %}
+{% endif %}
 {% endfor %}
 
 ## Constants
@@ -174,7 +216,7 @@ _This event type is experimental and may change in the future._
 Constants are used to improve the readability of your rules. Some constants are common to all architectures, others are specific to some architectures.
 
 {% for constants in constants_list %}
-### `{{ constants.name }}`
+### `{{ constants.name }}` {% raw %}{#{% endraw %}{{ constants.link }}{% raw %}}{% endraw %}
 
 {{ constants.definition }}
 

--- a/docs/cloud-workload-security/secl.json
+++ b/docs/cloud-workload-security/secl.json
@@ -9,1245 +9,1038 @@
       "properties": [
         {
           "name": "async",
-          "type": "bool",
           "definition": "True if the syscall was asynchronous",
-          "constants": ""
+          "property_doc_link": "async-doc"
         },
         {
           "name": "container.id",
-          "type": "string",
           "definition": "ID of the container",
-          "constants": ""
+          "property_doc_link": "container-id-doc"
         },
         {
           "name": "container.tags",
-          "type": "string",
           "definition": "Tags of the container",
-          "constants": ""
+          "property_doc_link": "container-tags-doc"
         },
         {
           "name": "network.destination.ip",
-          "type": "IP/CIDR",
           "definition": "IP address",
-          "constants": ""
+          "property_doc_link": "common-ipportcontext-ip-doc"
         },
         {
           "name": "network.destination.port",
-          "type": "int",
           "definition": "Port number",
-          "constants": ""
+          "property_doc_link": "common-ipportcontext-port-doc"
         },
         {
           "name": "network.device.ifindex",
-          "type": "int",
           "definition": "interface ifindex",
-          "constants": ""
+          "property_doc_link": "network-device-ifindex-doc"
         },
         {
           "name": "network.device.ifname",
-          "type": "string",
           "definition": "interface ifname",
-          "constants": ""
+          "property_doc_link": "network-device-ifname-doc"
         },
         {
           "name": "network.l3_protocol",
-          "type": "int",
           "definition": "l3 protocol of the network packet",
-          "constants": "L3 protocols"
+          "property_doc_link": "network-l3_protocol-doc"
         },
         {
           "name": "network.l4_protocol",
-          "type": "int",
           "definition": "l4 protocol of the network packet",
-          "constants": "L4 protocols"
+          "property_doc_link": "network-l4_protocol-doc"
         },
         {
           "name": "network.size",
-          "type": "int",
           "definition": "size in bytes of the network packet",
-          "constants": ""
+          "property_doc_link": "network-size-doc"
         },
         {
           "name": "network.source.ip",
-          "type": "IP/CIDR",
           "definition": "IP address",
-          "constants": ""
+          "property_doc_link": "common-ipportcontext-ip-doc"
         },
         {
           "name": "network.source.port",
-          "type": "int",
           "definition": "Port number",
-          "constants": ""
+          "property_doc_link": "common-ipportcontext-port-doc"
         },
         {
           "name": "process.ancestors.args",
-          "type": "string",
-          "definition": "Arguments of the process (as a string)",
-          "constants": ""
+          "definition": "Arguments of the process (as a string, excluding argv0)",
+          "property_doc_link": "common-process-args-doc"
         },
         {
           "name": "process.ancestors.args_flags",
-          "type": "string",
-          "definition": "Arguments of the process (as an array)",
-          "constants": ""
+          "definition": "Flags in the process arguments",
+          "property_doc_link": "common-process-args_flags-doc"
         },
         {
           "name": "process.ancestors.args_options",
-          "type": "string",
-          "definition": "Arguments of the process (as an array)",
-          "constants": ""
+          "definition": "Argument of the process as options",
+          "property_doc_link": "common-process-args_options-doc"
         },
         {
           "name": "process.ancestors.args_truncated",
-          "type": "bool",
           "definition": "Indicator of arguments truncation",
-          "constants": ""
+          "property_doc_link": "common-process-args_truncated-doc"
         },
         {
           "name": "process.ancestors.argv",
-          "type": "string",
-          "definition": "Arguments of the process (as an array)",
-          "constants": ""
+          "definition": "Arguments of the process (as an array, excluding argv0)",
+          "property_doc_link": "common-process-argv-doc"
         },
         {
           "name": "process.ancestors.argv0",
-          "type": "string",
           "definition": "First argument of the process",
-          "constants": ""
+          "property_doc_link": "common-process-argv0-doc"
         },
         {
           "name": "process.ancestors.cap_effective",
-          "type": "int",
           "definition": "Effective capability set of the process",
-          "constants": "Kernel Capability constants"
+          "property_doc_link": "common-credentials-cap_effective-doc"
         },
         {
           "name": "process.ancestors.cap_permitted",
-          "type": "int",
           "definition": "Permitted capability set of the process",
-          "constants": "Kernel Capability constants"
+          "property_doc_link": "common-credentials-cap_permitted-doc"
         },
         {
           "name": "process.ancestors.comm",
-          "type": "string",
           "definition": "Comm attribute of the process",
-          "constants": ""
+          "property_doc_link": "common-process-comm-doc"
         },
         {
           "name": "process.ancestors.container.id",
-          "type": "string",
           "definition": "Container ID",
-          "constants": ""
+          "property_doc_link": "common-process-container-id-doc"
         },
         {
           "name": "process.ancestors.cookie",
-          "type": "int",
           "definition": "Cookie of the process",
-          "constants": ""
+          "property_doc_link": "common-process-cookie-doc"
         },
         {
           "name": "process.ancestors.created_at",
-          "type": "int",
           "definition": "Timestamp of the creation of the process",
-          "constants": ""
+          "property_doc_link": "common-process-created_at-doc"
         },
         {
           "name": "process.ancestors.egid",
-          "type": "int",
           "definition": "Effective GID of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-egid-doc"
         },
         {
           "name": "process.ancestors.egroup",
-          "type": "string",
           "definition": "Effective group of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-egroup-doc"
         },
         {
           "name": "process.ancestors.envp",
-          "type": "string",
           "definition": "Environment variables of the process",
-          "constants": ""
+          "property_doc_link": "common-process-envp-doc"
         },
         {
           "name": "process.ancestors.envs",
-          "type": "string",
           "definition": "Environment variable names of the process",
-          "constants": ""
+          "property_doc_link": "common-process-envs-doc"
         },
         {
           "name": "process.ancestors.envs_truncated",
-          "type": "bool",
           "definition": "Indicator of environment variables truncation",
-          "constants": ""
+          "property_doc_link": "common-process-envs_truncated-doc"
         },
         {
           "name": "process.ancestors.euid",
-          "type": "int",
           "definition": "Effective UID of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-euid-doc"
         },
         {
           "name": "process.ancestors.euser",
-          "type": "string",
           "definition": "Effective user of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-euser-doc"
         },
         {
           "name": "process.ancestors.file.change_time",
-          "type": "int",
           "definition": "Change time of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-change_time-doc"
         },
         {
           "name": "process.ancestors.file.filesystem",
-          "type": "string",
           "definition": "File's filesystem",
-          "constants": ""
+          "property_doc_link": "common-fileevent-filesystem-doc"
         },
         {
           "name": "process.ancestors.file.gid",
-          "type": "int",
           "definition": "GID of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-gid-doc"
         },
         {
           "name": "process.ancestors.file.group",
-          "type": "string",
           "definition": "Group of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-group-doc"
         },
         {
           "name": "process.ancestors.file.in_upper_layer",
-          "type": "bool",
           "definition": "Indicator of the file layer, for example, in an OverlayFS",
-          "constants": ""
+          "property_doc_link": "common-filefields-in_upper_layer-doc"
         },
         {
           "name": "process.ancestors.file.inode",
-          "type": "int",
           "definition": "Inode of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-inode-doc"
         },
         {
           "name": "process.ancestors.file.mode",
-          "type": "int",
-          "definition": "Mode/rights of the file",
-          "constants": "Chmod mode constants"
+          "definition": "Mode of the file",
+          "property_doc_link": "common-filefields-mode-doc"
         },
         {
           "name": "process.ancestors.file.modification_time",
-          "type": "int",
           "definition": "Modification time of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
           "name": "process.ancestors.file.mount_id",
-          "type": "int",
           "definition": "Mount ID of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-mount_id-doc"
         },
         {
           "name": "process.ancestors.file.name",
-          "type": "string",
           "definition": "File's basename",
-          "constants": ""
+          "property_doc_link": "common-fileevent-name-doc"
         },
         {
           "name": "process.ancestors.file.name.length",
-          "type": "int",
-          "definition": "Length of 'process.ancestors.file.name' string",
-          "constants": ""
+          "definition": "Length of the corresponding string",
+          "property_doc_link": "common-string-length-doc"
         },
         {
           "name": "process.ancestors.file.path",
-          "type": "string",
           "definition": "File's path",
-          "constants": ""
+          "property_doc_link": "common-fileevent-path-doc"
         },
         {
           "name": "process.ancestors.file.path.length",
-          "type": "int",
-          "definition": "Length of 'process.ancestors.file.path' string",
-          "constants": ""
+          "definition": "Length of the corresponding string",
+          "property_doc_link": "common-string-length-doc"
         },
         {
           "name": "process.ancestors.file.rights",
-          "type": "int",
-          "definition": "Mode/rights of the file",
-          "constants": "Chmod mode constants"
+          "definition": "Rights of the file",
+          "property_doc_link": "common-filefields-rights-doc"
         },
         {
           "name": "process.ancestors.file.uid",
-          "type": "int",
           "definition": "UID of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-uid-doc"
         },
         {
           "name": "process.ancestors.file.user",
-          "type": "string",
           "definition": "User of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-user-doc"
         },
         {
           "name": "process.ancestors.fsgid",
-          "type": "int",
           "definition": "FileSystem-gid of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-fsgid-doc"
         },
         {
           "name": "process.ancestors.fsgroup",
-          "type": "string",
           "definition": "FileSystem-group of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-fsgroup-doc"
         },
         {
           "name": "process.ancestors.fsuid",
-          "type": "int",
           "definition": "FileSystem-uid of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-fsuid-doc"
         },
         {
           "name": "process.ancestors.fsuser",
-          "type": "string",
           "definition": "FileSystem-user of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-fsuser-doc"
         },
         {
           "name": "process.ancestors.gid",
-          "type": "int",
           "definition": "GID of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-gid-doc"
         },
         {
           "name": "process.ancestors.group",
-          "type": "string",
           "definition": "Group of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-group-doc"
         },
         {
           "name": "process.ancestors.interpreter.file.change_time",
-          "type": "int",
           "definition": "Change time of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-change_time-doc"
         },
         {
           "name": "process.ancestors.interpreter.file.filesystem",
-          "type": "string",
           "definition": "File's filesystem",
-          "constants": ""
+          "property_doc_link": "common-fileevent-filesystem-doc"
         },
         {
           "name": "process.ancestors.interpreter.file.gid",
-          "type": "int",
           "definition": "GID of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-gid-doc"
         },
         {
           "name": "process.ancestors.interpreter.file.group",
-          "type": "string",
           "definition": "Group of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-group-doc"
         },
         {
           "name": "process.ancestors.interpreter.file.in_upper_layer",
-          "type": "bool",
           "definition": "Indicator of the file layer, for example, in an OverlayFS",
-          "constants": ""
+          "property_doc_link": "common-filefields-in_upper_layer-doc"
         },
         {
           "name": "process.ancestors.interpreter.file.inode",
-          "type": "int",
           "definition": "Inode of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-inode-doc"
         },
         {
           "name": "process.ancestors.interpreter.file.mode",
-          "type": "int",
-          "definition": "Mode/rights of the file",
-          "constants": "Chmod mode constants"
+          "definition": "Mode of the file",
+          "property_doc_link": "common-filefields-mode-doc"
         },
         {
           "name": "process.ancestors.interpreter.file.modification_time",
-          "type": "int",
           "definition": "Modification time of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
           "name": "process.ancestors.interpreter.file.mount_id",
-          "type": "int",
           "definition": "Mount ID of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-mount_id-doc"
         },
         {
           "name": "process.ancestors.interpreter.file.name",
-          "type": "string",
           "definition": "File's basename",
-          "constants": ""
+          "property_doc_link": "common-fileevent-name-doc"
         },
         {
           "name": "process.ancestors.interpreter.file.name.length",
-          "type": "int",
-          "definition": "Length of 'process.ancestors.interpreter.file.name' string",
-          "constants": ""
+          "definition": "Length of the corresponding string",
+          "property_doc_link": "common-string-length-doc"
         },
         {
           "name": "process.ancestors.interpreter.file.path",
-          "type": "string",
           "definition": "File's path",
-          "constants": ""
+          "property_doc_link": "common-fileevent-path-doc"
         },
         {
           "name": "process.ancestors.interpreter.file.path.length",
-          "type": "int",
-          "definition": "Length of 'process.ancestors.interpreter.file.path' string",
-          "constants": ""
+          "definition": "Length of the corresponding string",
+          "property_doc_link": "common-string-length-doc"
         },
         {
           "name": "process.ancestors.interpreter.file.rights",
-          "type": "int",
-          "definition": "Mode/rights of the file",
-          "constants": "Chmod mode constants"
+          "definition": "Rights of the file",
+          "property_doc_link": "common-filefields-rights-doc"
         },
         {
           "name": "process.ancestors.interpreter.file.uid",
-          "type": "int",
           "definition": "UID of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-uid-doc"
         },
         {
           "name": "process.ancestors.interpreter.file.user",
-          "type": "string",
           "definition": "User of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-user-doc"
         },
         {
           "name": "process.ancestors.is_kworker",
-          "type": "bool",
           "definition": "Indicates whether the process is a kworker",
-          "constants": ""
+          "property_doc_link": "common-pidcontext-is_kworker-doc"
         },
         {
           "name": "process.ancestors.is_thread",
-          "type": "bool",
           "definition": "Indicates whether the process is considered a thread (that is, a child process that hasn't executed another program)",
-          "constants": ""
+          "property_doc_link": "common-process-is_thread-doc"
         },
         {
           "name": "process.ancestors.pid",
-          "type": "int",
           "definition": "Process ID of the process (also called thread group ID)",
-          "constants": ""
+          "property_doc_link": "common-pidcontext-pid-doc"
         },
         {
           "name": "process.ancestors.ppid",
-          "type": "int",
           "definition": "Parent process ID",
-          "constants": ""
+          "property_doc_link": "common-process-ppid-doc"
         },
         {
           "name": "process.ancestors.tid",
-          "type": "int",
           "definition": "Thread ID of the thread",
-          "constants": ""
+          "property_doc_link": "common-pidcontext-tid-doc"
         },
         {
           "name": "process.ancestors.tty_name",
-          "type": "string",
           "definition": "Name of the TTY associated with the process",
-          "constants": ""
+          "property_doc_link": "common-process-tty_name-doc"
         },
         {
           "name": "process.ancestors.uid",
-          "type": "int",
           "definition": "UID of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-uid-doc"
         },
         {
           "name": "process.ancestors.user",
-          "type": "string",
           "definition": "User of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-user-doc"
         },
         {
           "name": "process.args",
-          "type": "string",
-          "definition": "Arguments of the process (as a string)",
-          "constants": ""
+          "definition": "Arguments of the process (as a string, excluding argv0)",
+          "property_doc_link": "common-process-args-doc"
         },
         {
           "name": "process.args_flags",
-          "type": "string",
-          "definition": "Arguments of the process (as an array)",
-          "constants": ""
+          "definition": "Flags in the process arguments",
+          "property_doc_link": "common-process-args_flags-doc"
         },
         {
           "name": "process.args_options",
-          "type": "string",
-          "definition": "Arguments of the process (as an array)",
-          "constants": ""
+          "definition": "Argument of the process as options",
+          "property_doc_link": "common-process-args_options-doc"
         },
         {
           "name": "process.args_truncated",
-          "type": "bool",
           "definition": "Indicator of arguments truncation",
-          "constants": ""
+          "property_doc_link": "common-process-args_truncated-doc"
         },
         {
           "name": "process.argv",
-          "type": "string",
-          "definition": "Arguments of the process (as an array)",
-          "constants": ""
+          "definition": "Arguments of the process (as an array, excluding argv0)",
+          "property_doc_link": "common-process-argv-doc"
         },
         {
           "name": "process.argv0",
-          "type": "string",
           "definition": "First argument of the process",
-          "constants": ""
+          "property_doc_link": "common-process-argv0-doc"
         },
         {
           "name": "process.cap_effective",
-          "type": "int",
           "definition": "Effective capability set of the process",
-          "constants": "Kernel Capability constants"
+          "property_doc_link": "common-credentials-cap_effective-doc"
         },
         {
           "name": "process.cap_permitted",
-          "type": "int",
           "definition": "Permitted capability set of the process",
-          "constants": "Kernel Capability constants"
+          "property_doc_link": "common-credentials-cap_permitted-doc"
         },
         {
           "name": "process.comm",
-          "type": "string",
           "definition": "Comm attribute of the process",
-          "constants": ""
+          "property_doc_link": "common-process-comm-doc"
         },
         {
           "name": "process.container.id",
-          "type": "string",
           "definition": "Container ID",
-          "constants": ""
+          "property_doc_link": "common-process-container-id-doc"
         },
         {
           "name": "process.cookie",
-          "type": "int",
           "definition": "Cookie of the process",
-          "constants": ""
+          "property_doc_link": "common-process-cookie-doc"
         },
         {
           "name": "process.created_at",
-          "type": "int",
           "definition": "Timestamp of the creation of the process",
-          "constants": ""
+          "property_doc_link": "common-process-created_at-doc"
         },
         {
           "name": "process.egid",
-          "type": "int",
           "definition": "Effective GID of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-egid-doc"
         },
         {
           "name": "process.egroup",
-          "type": "string",
           "definition": "Effective group of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-egroup-doc"
         },
         {
           "name": "process.envp",
-          "type": "string",
           "definition": "Environment variables of the process",
-          "constants": ""
+          "property_doc_link": "common-process-envp-doc"
         },
         {
           "name": "process.envs",
-          "type": "string",
           "definition": "Environment variable names of the process",
-          "constants": ""
+          "property_doc_link": "common-process-envs-doc"
         },
         {
           "name": "process.envs_truncated",
-          "type": "bool",
           "definition": "Indicator of environment variables truncation",
-          "constants": ""
+          "property_doc_link": "common-process-envs_truncated-doc"
         },
         {
           "name": "process.euid",
-          "type": "int",
           "definition": "Effective UID of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-euid-doc"
         },
         {
           "name": "process.euser",
-          "type": "string",
           "definition": "Effective user of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-euser-doc"
         },
         {
           "name": "process.file.change_time",
-          "type": "int",
           "definition": "Change time of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-change_time-doc"
         },
         {
           "name": "process.file.filesystem",
-          "type": "string",
           "definition": "File's filesystem",
-          "constants": ""
+          "property_doc_link": "common-fileevent-filesystem-doc"
         },
         {
           "name": "process.file.gid",
-          "type": "int",
           "definition": "GID of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-gid-doc"
         },
         {
           "name": "process.file.group",
-          "type": "string",
           "definition": "Group of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-group-doc"
         },
         {
           "name": "process.file.in_upper_layer",
-          "type": "bool",
           "definition": "Indicator of the file layer, for example, in an OverlayFS",
-          "constants": ""
+          "property_doc_link": "common-filefields-in_upper_layer-doc"
         },
         {
           "name": "process.file.inode",
-          "type": "int",
           "definition": "Inode of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-inode-doc"
         },
         {
           "name": "process.file.mode",
-          "type": "int",
-          "definition": "Mode/rights of the file",
-          "constants": "Chmod mode constants"
+          "definition": "Mode of the file",
+          "property_doc_link": "common-filefields-mode-doc"
         },
         {
           "name": "process.file.modification_time",
-          "type": "int",
           "definition": "Modification time of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
           "name": "process.file.mount_id",
-          "type": "int",
           "definition": "Mount ID of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-mount_id-doc"
         },
         {
           "name": "process.file.name",
-          "type": "string",
           "definition": "File's basename",
-          "constants": ""
+          "property_doc_link": "common-fileevent-name-doc"
         },
         {
           "name": "process.file.name.length",
-          "type": "int",
-          "definition": "Length of 'process.file.name' string",
-          "constants": ""
+          "definition": "Length of the corresponding string",
+          "property_doc_link": "common-string-length-doc"
         },
         {
           "name": "process.file.path",
-          "type": "string",
           "definition": "File's path",
-          "constants": ""
+          "property_doc_link": "common-fileevent-path-doc"
         },
         {
           "name": "process.file.path.length",
-          "type": "int",
-          "definition": "Length of 'process.file.path' string",
-          "constants": ""
+          "definition": "Length of the corresponding string",
+          "property_doc_link": "common-string-length-doc"
         },
         {
           "name": "process.file.rights",
-          "type": "int",
-          "definition": "Mode/rights of the file",
-          "constants": "Chmod mode constants"
+          "definition": "Rights of the file",
+          "property_doc_link": "common-filefields-rights-doc"
         },
         {
           "name": "process.file.uid",
-          "type": "int",
           "definition": "UID of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-uid-doc"
         },
         {
           "name": "process.file.user",
-          "type": "string",
           "definition": "User of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-user-doc"
         },
         {
           "name": "process.fsgid",
-          "type": "int",
           "definition": "FileSystem-gid of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-fsgid-doc"
         },
         {
           "name": "process.fsgroup",
-          "type": "string",
           "definition": "FileSystem-group of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-fsgroup-doc"
         },
         {
           "name": "process.fsuid",
-          "type": "int",
           "definition": "FileSystem-uid of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-fsuid-doc"
         },
         {
           "name": "process.fsuser",
-          "type": "string",
           "definition": "FileSystem-user of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-fsuser-doc"
         },
         {
           "name": "process.gid",
-          "type": "int",
           "definition": "GID of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-gid-doc"
         },
         {
           "name": "process.group",
-          "type": "string",
           "definition": "Group of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-group-doc"
         },
         {
           "name": "process.interpreter.file.change_time",
-          "type": "int",
           "definition": "Change time of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-change_time-doc"
         },
         {
           "name": "process.interpreter.file.filesystem",
-          "type": "string",
           "definition": "File's filesystem",
-          "constants": ""
+          "property_doc_link": "common-fileevent-filesystem-doc"
         },
         {
           "name": "process.interpreter.file.gid",
-          "type": "int",
           "definition": "GID of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-gid-doc"
         },
         {
           "name": "process.interpreter.file.group",
-          "type": "string",
           "definition": "Group of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-group-doc"
         },
         {
           "name": "process.interpreter.file.in_upper_layer",
-          "type": "bool",
           "definition": "Indicator of the file layer, for example, in an OverlayFS",
-          "constants": ""
+          "property_doc_link": "common-filefields-in_upper_layer-doc"
         },
         {
           "name": "process.interpreter.file.inode",
-          "type": "int",
           "definition": "Inode of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-inode-doc"
         },
         {
           "name": "process.interpreter.file.mode",
-          "type": "int",
-          "definition": "Mode/rights of the file",
-          "constants": "Chmod mode constants"
+          "definition": "Mode of the file",
+          "property_doc_link": "common-filefields-mode-doc"
         },
         {
           "name": "process.interpreter.file.modification_time",
-          "type": "int",
           "definition": "Modification time of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
           "name": "process.interpreter.file.mount_id",
-          "type": "int",
           "definition": "Mount ID of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-mount_id-doc"
         },
         {
           "name": "process.interpreter.file.name",
-          "type": "string",
           "definition": "File's basename",
-          "constants": ""
+          "property_doc_link": "common-fileevent-name-doc"
         },
         {
           "name": "process.interpreter.file.name.length",
-          "type": "int",
-          "definition": "Length of 'process.interpreter.file.name' string",
-          "constants": ""
+          "definition": "Length of the corresponding string",
+          "property_doc_link": "common-string-length-doc"
         },
         {
           "name": "process.interpreter.file.path",
-          "type": "string",
           "definition": "File's path",
-          "constants": ""
+          "property_doc_link": "common-fileevent-path-doc"
         },
         {
           "name": "process.interpreter.file.path.length",
-          "type": "int",
-          "definition": "Length of 'process.interpreter.file.path' string",
-          "constants": ""
+          "definition": "Length of the corresponding string",
+          "property_doc_link": "common-string-length-doc"
         },
         {
           "name": "process.interpreter.file.rights",
-          "type": "int",
-          "definition": "Mode/rights of the file",
-          "constants": "Chmod mode constants"
+          "definition": "Rights of the file",
+          "property_doc_link": "common-filefields-rights-doc"
         },
         {
           "name": "process.interpreter.file.uid",
-          "type": "int",
           "definition": "UID of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-uid-doc"
         },
         {
           "name": "process.interpreter.file.user",
-          "type": "string",
           "definition": "User of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-user-doc"
         },
         {
           "name": "process.is_kworker",
-          "type": "bool",
           "definition": "Indicates whether the process is a kworker",
-          "constants": ""
+          "property_doc_link": "common-pidcontext-is_kworker-doc"
         },
         {
           "name": "process.is_thread",
-          "type": "bool",
           "definition": "Indicates whether the process is considered a thread (that is, a child process that hasn't executed another program)",
-          "constants": ""
+          "property_doc_link": "common-process-is_thread-doc"
         },
         {
           "name": "process.parent.args",
-          "type": "string",
-          "definition": "Arguments of the process (as a string)",
-          "constants": ""
+          "definition": "Arguments of the process (as a string, excluding argv0)",
+          "property_doc_link": "common-process-args-doc"
         },
         {
           "name": "process.parent.args_flags",
-          "type": "string",
-          "definition": "Arguments of the process (as an array)",
-          "constants": ""
+          "definition": "Flags in the process arguments",
+          "property_doc_link": "common-process-args_flags-doc"
         },
         {
           "name": "process.parent.args_options",
-          "type": "string",
-          "definition": "Arguments of the process (as an array)",
-          "constants": ""
+          "definition": "Argument of the process as options",
+          "property_doc_link": "common-process-args_options-doc"
         },
         {
           "name": "process.parent.args_truncated",
-          "type": "bool",
           "definition": "Indicator of arguments truncation",
-          "constants": ""
+          "property_doc_link": "common-process-args_truncated-doc"
         },
         {
           "name": "process.parent.argv",
-          "type": "string",
-          "definition": "Arguments of the process (as an array)",
-          "constants": ""
+          "definition": "Arguments of the process (as an array, excluding argv0)",
+          "property_doc_link": "common-process-argv-doc"
         },
         {
           "name": "process.parent.argv0",
-          "type": "string",
           "definition": "First argument of the process",
-          "constants": ""
+          "property_doc_link": "common-process-argv0-doc"
         },
         {
           "name": "process.parent.cap_effective",
-          "type": "int",
           "definition": "Effective capability set of the process",
-          "constants": "Kernel Capability constants"
+          "property_doc_link": "common-credentials-cap_effective-doc"
         },
         {
           "name": "process.parent.cap_permitted",
-          "type": "int",
           "definition": "Permitted capability set of the process",
-          "constants": "Kernel Capability constants"
+          "property_doc_link": "common-credentials-cap_permitted-doc"
         },
         {
           "name": "process.parent.comm",
-          "type": "string",
           "definition": "Comm attribute of the process",
-          "constants": ""
+          "property_doc_link": "common-process-comm-doc"
         },
         {
           "name": "process.parent.container.id",
-          "type": "string",
           "definition": "Container ID",
-          "constants": ""
+          "property_doc_link": "common-process-container-id-doc"
         },
         {
           "name": "process.parent.cookie",
-          "type": "int",
           "definition": "Cookie of the process",
-          "constants": ""
+          "property_doc_link": "common-process-cookie-doc"
         },
         {
           "name": "process.parent.created_at",
-          "type": "int",
           "definition": "Timestamp of the creation of the process",
-          "constants": ""
+          "property_doc_link": "common-process-created_at-doc"
         },
         {
           "name": "process.parent.egid",
-          "type": "int",
           "definition": "Effective GID of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-egid-doc"
         },
         {
           "name": "process.parent.egroup",
-          "type": "string",
           "definition": "Effective group of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-egroup-doc"
         },
         {
           "name": "process.parent.envp",
-          "type": "string",
           "definition": "Environment variables of the process",
-          "constants": ""
+          "property_doc_link": "common-process-envp-doc"
         },
         {
           "name": "process.parent.envs",
-          "type": "string",
           "definition": "Environment variable names of the process",
-          "constants": ""
+          "property_doc_link": "common-process-envs-doc"
         },
         {
           "name": "process.parent.envs_truncated",
-          "type": "bool",
           "definition": "Indicator of environment variables truncation",
-          "constants": ""
+          "property_doc_link": "common-process-envs_truncated-doc"
         },
         {
           "name": "process.parent.euid",
-          "type": "int",
           "definition": "Effective UID of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-euid-doc"
         },
         {
           "name": "process.parent.euser",
-          "type": "string",
           "definition": "Effective user of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-euser-doc"
         },
         {
           "name": "process.parent.file.change_time",
-          "type": "int",
           "definition": "Change time of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-change_time-doc"
         },
         {
           "name": "process.parent.file.filesystem",
-          "type": "string",
           "definition": "File's filesystem",
-          "constants": ""
+          "property_doc_link": "common-fileevent-filesystem-doc"
         },
         {
           "name": "process.parent.file.gid",
-          "type": "int",
           "definition": "GID of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-gid-doc"
         },
         {
           "name": "process.parent.file.group",
-          "type": "string",
           "definition": "Group of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-group-doc"
         },
         {
           "name": "process.parent.file.in_upper_layer",
-          "type": "bool",
           "definition": "Indicator of the file layer, for example, in an OverlayFS",
-          "constants": ""
+          "property_doc_link": "common-filefields-in_upper_layer-doc"
         },
         {
           "name": "process.parent.file.inode",
-          "type": "int",
           "definition": "Inode of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-inode-doc"
         },
         {
           "name": "process.parent.file.mode",
-          "type": "int",
-          "definition": "Mode/rights of the file",
-          "constants": "Chmod mode constants"
+          "definition": "Mode of the file",
+          "property_doc_link": "common-filefields-mode-doc"
         },
         {
           "name": "process.parent.file.modification_time",
-          "type": "int",
           "definition": "Modification time of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
           "name": "process.parent.file.mount_id",
-          "type": "int",
           "definition": "Mount ID of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-mount_id-doc"
         },
         {
           "name": "process.parent.file.name",
-          "type": "string",
           "definition": "File's basename",
-          "constants": ""
+          "property_doc_link": "common-fileevent-name-doc"
         },
         {
           "name": "process.parent.file.name.length",
-          "type": "int",
-          "definition": "Length of 'process.parent.file.name' string",
-          "constants": ""
+          "definition": "Length of the corresponding string",
+          "property_doc_link": "common-string-length-doc"
         },
         {
           "name": "process.parent.file.path",
-          "type": "string",
           "definition": "File's path",
-          "constants": ""
+          "property_doc_link": "common-fileevent-path-doc"
         },
         {
           "name": "process.parent.file.path.length",
-          "type": "int",
-          "definition": "Length of 'process.parent.file.path' string",
-          "constants": ""
+          "definition": "Length of the corresponding string",
+          "property_doc_link": "common-string-length-doc"
         },
         {
           "name": "process.parent.file.rights",
-          "type": "int",
-          "definition": "Mode/rights of the file",
-          "constants": "Chmod mode constants"
+          "definition": "Rights of the file",
+          "property_doc_link": "common-filefields-rights-doc"
         },
         {
           "name": "process.parent.file.uid",
-          "type": "int",
           "definition": "UID of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-uid-doc"
         },
         {
           "name": "process.parent.file.user",
-          "type": "string",
           "definition": "User of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-user-doc"
         },
         {
           "name": "process.parent.fsgid",
-          "type": "int",
           "definition": "FileSystem-gid of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-fsgid-doc"
         },
         {
           "name": "process.parent.fsgroup",
-          "type": "string",
           "definition": "FileSystem-group of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-fsgroup-doc"
         },
         {
           "name": "process.parent.fsuid",
-          "type": "int",
           "definition": "FileSystem-uid of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-fsuid-doc"
         },
         {
           "name": "process.parent.fsuser",
-          "type": "string",
           "definition": "FileSystem-user of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-fsuser-doc"
         },
         {
           "name": "process.parent.gid",
-          "type": "int",
           "definition": "GID of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-gid-doc"
         },
         {
           "name": "process.parent.group",
-          "type": "string",
           "definition": "Group of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-group-doc"
         },
         {
           "name": "process.parent.interpreter.file.change_time",
-          "type": "int",
           "definition": "Change time of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-change_time-doc"
         },
         {
           "name": "process.parent.interpreter.file.filesystem",
-          "type": "string",
           "definition": "File's filesystem",
-          "constants": ""
+          "property_doc_link": "common-fileevent-filesystem-doc"
         },
         {
           "name": "process.parent.interpreter.file.gid",
-          "type": "int",
           "definition": "GID of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-gid-doc"
         },
         {
           "name": "process.parent.interpreter.file.group",
-          "type": "string",
           "definition": "Group of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-group-doc"
         },
         {
           "name": "process.parent.interpreter.file.in_upper_layer",
-          "type": "bool",
           "definition": "Indicator of the file layer, for example, in an OverlayFS",
-          "constants": ""
+          "property_doc_link": "common-filefields-in_upper_layer-doc"
         },
         {
           "name": "process.parent.interpreter.file.inode",
-          "type": "int",
           "definition": "Inode of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-inode-doc"
         },
         {
           "name": "process.parent.interpreter.file.mode",
-          "type": "int",
-          "definition": "Mode/rights of the file",
-          "constants": "Chmod mode constants"
+          "definition": "Mode of the file",
+          "property_doc_link": "common-filefields-mode-doc"
         },
         {
           "name": "process.parent.interpreter.file.modification_time",
-          "type": "int",
           "definition": "Modification time of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
           "name": "process.parent.interpreter.file.mount_id",
-          "type": "int",
           "definition": "Mount ID of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-mount_id-doc"
         },
         {
           "name": "process.parent.interpreter.file.name",
-          "type": "string",
           "definition": "File's basename",
-          "constants": ""
+          "property_doc_link": "common-fileevent-name-doc"
         },
         {
           "name": "process.parent.interpreter.file.name.length",
-          "type": "int",
-          "definition": "Length of 'process.parent.interpreter.file.name' string",
-          "constants": ""
+          "definition": "Length of the corresponding string",
+          "property_doc_link": "common-string-length-doc"
         },
         {
           "name": "process.parent.interpreter.file.path",
-          "type": "string",
           "definition": "File's path",
-          "constants": ""
+          "property_doc_link": "common-fileevent-path-doc"
         },
         {
           "name": "process.parent.interpreter.file.path.length",
-          "type": "int",
-          "definition": "Length of 'process.parent.interpreter.file.path' string",
-          "constants": ""
+          "definition": "Length of the corresponding string",
+          "property_doc_link": "common-string-length-doc"
         },
         {
           "name": "process.parent.interpreter.file.rights",
-          "type": "int",
-          "definition": "Mode/rights of the file",
-          "constants": "Chmod mode constants"
+          "definition": "Rights of the file",
+          "property_doc_link": "common-filefields-rights-doc"
         },
         {
           "name": "process.parent.interpreter.file.uid",
-          "type": "int",
           "definition": "UID of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-uid-doc"
         },
         {
           "name": "process.parent.interpreter.file.user",
-          "type": "string",
           "definition": "User of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-user-doc"
         },
         {
           "name": "process.parent.is_kworker",
-          "type": "bool",
           "definition": "Indicates whether the process is a kworker",
-          "constants": ""
+          "property_doc_link": "common-pidcontext-is_kworker-doc"
         },
         {
           "name": "process.parent.is_thread",
-          "type": "bool",
           "definition": "Indicates whether the process is considered a thread (that is, a child process that hasn't executed another program)",
-          "constants": ""
+          "property_doc_link": "common-process-is_thread-doc"
         },
         {
           "name": "process.parent.pid",
-          "type": "int",
           "definition": "Process ID of the process (also called thread group ID)",
-          "constants": ""
+          "property_doc_link": "common-pidcontext-pid-doc"
         },
         {
           "name": "process.parent.ppid",
-          "type": "int",
           "definition": "Parent process ID",
-          "constants": ""
+          "property_doc_link": "common-process-ppid-doc"
         },
         {
           "name": "process.parent.tid",
-          "type": "int",
           "definition": "Thread ID of the thread",
-          "constants": ""
+          "property_doc_link": "common-pidcontext-tid-doc"
         },
         {
           "name": "process.parent.tty_name",
-          "type": "string",
           "definition": "Name of the TTY associated with the process",
-          "constants": ""
+          "property_doc_link": "common-process-tty_name-doc"
         },
         {
           "name": "process.parent.uid",
-          "type": "int",
           "definition": "UID of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-uid-doc"
         },
         {
           "name": "process.parent.user",
-          "type": "string",
           "definition": "User of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-user-doc"
         },
         {
           "name": "process.pid",
-          "type": "int",
           "definition": "Process ID of the process (also called thread group ID)",
-          "constants": ""
+          "property_doc_link": "common-pidcontext-pid-doc"
         },
         {
           "name": "process.ppid",
-          "type": "int",
           "definition": "Parent process ID",
-          "constants": ""
+          "property_doc_link": "common-process-ppid-doc"
         },
         {
           "name": "process.tid",
-          "type": "int",
           "definition": "Thread ID of the thread",
-          "constants": ""
+          "property_doc_link": "common-pidcontext-tid-doc"
         },
         {
           "name": "process.tty_name",
-          "type": "string",
           "definition": "Name of the TTY associated with the process",
-          "constants": ""
+          "property_doc_link": "common-process-tty_name-doc"
         },
         {
           "name": "process.uid",
-          "type": "int",
           "definition": "UID of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-uid-doc"
         },
         {
           "name": "process.user",
-          "type": "string",
           "definition": "User of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-user-doc"
         }
       ]
     },
@@ -1260,27 +1053,23 @@
       "properties": [
         {
           "name": "bind.addr.family",
-          "type": "int",
           "definition": "Address family",
-          "constants": ""
+          "property_doc_link": "bind-addr-family-doc"
         },
         {
           "name": "bind.addr.ip",
-          "type": "IP/CIDR",
           "definition": "IP address",
-          "constants": ""
+          "property_doc_link": "common-ipportcontext-ip-doc"
         },
         {
           "name": "bind.addr.port",
-          "type": "int",
           "definition": "Port number",
-          "constants": ""
+          "property_doc_link": "common-ipportcontext-port-doc"
         },
         {
           "name": "bind.retval",
-          "type": "int",
           "definition": "Return value of the syscall",
-          "constants": "Error Constants"
+          "property_doc_link": "common-syscallevent-retval-doc"
         }
       ]
     },
@@ -1293,57 +1082,48 @@
       "properties": [
         {
           "name": "bpf.cmd",
-          "type": "int",
           "definition": "BPF command name",
-          "constants": "BPF commands"
+          "property_doc_link": "bpf-cmd-doc"
         },
         {
           "name": "bpf.map.name",
-          "type": "string",
           "definition": "Name of the eBPF map (added in 7.35)",
-          "constants": ""
+          "property_doc_link": "bpf-map-name-doc"
         },
         {
           "name": "bpf.map.type",
-          "type": "int",
           "definition": "Type of the eBPF map",
-          "constants": "BPF map types"
+          "property_doc_link": "bpf-map-type-doc"
         },
         {
           "name": "bpf.prog.attach_type",
-          "type": "int",
           "definition": "Attach type of the eBPF program",
-          "constants": "BPF attach types"
+          "property_doc_link": "bpf-prog-attach_type-doc"
         },
         {
           "name": "bpf.prog.helpers",
-          "type": "int",
           "definition": "eBPF helpers used by the eBPF program (added in 7.35)",
-          "constants": "BPF helper functions"
+          "property_doc_link": "bpf-prog-helpers-doc"
         },
         {
           "name": "bpf.prog.name",
-          "type": "string",
           "definition": "Name of the eBPF program (added in 7.35)",
-          "constants": ""
+          "property_doc_link": "bpf-prog-name-doc"
         },
         {
           "name": "bpf.prog.tag",
-          "type": "string",
           "definition": "Hash (sha1) of the eBPF program (added in 7.35)",
-          "constants": ""
+          "property_doc_link": "bpf-prog-tag-doc"
         },
         {
           "name": "bpf.prog.type",
-          "type": "int",
           "definition": "Type of the eBPF program",
-          "constants": "BPF program types"
+          "property_doc_link": "bpf-prog-type-doc"
         },
         {
           "name": "bpf.retval",
-          "type": "int",
           "definition": "Return value of the syscall",
-          "constants": "Error Constants"
+          "property_doc_link": "common-syscallevent-retval-doc"
         }
       ]
     },
@@ -1356,15 +1136,13 @@
       "properties": [
         {
           "name": "capset.cap_effective",
-          "type": "int",
           "definition": "Effective capability set of the process",
-          "constants": "Kernel Capability constants"
+          "property_doc_link": "capset-cap_effective-doc"
         },
         {
           "name": "capset.cap_permitted",
-          "type": "int",
           "definition": "Permitted capability set of the process",
-          "constants": "Kernel Capability constants"
+          "property_doc_link": "capset-cap_permitted-doc"
         }
       ]
     },
@@ -1377,117 +1155,98 @@
       "properties": [
         {
           "name": "chmod.file.change_time",
-          "type": "int",
           "definition": "Change time of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-change_time-doc"
         },
         {
           "name": "chmod.file.destination.mode",
-          "type": "int",
-          "definition": "New mode/rights of the chmod-ed file",
-          "constants": "Chmod mode constants"
+          "definition": "New mode of the chmod-ed file",
+          "property_doc_link": "chmod-file-destination-mode-doc"
         },
         {
           "name": "chmod.file.destination.rights",
-          "type": "int",
-          "definition": "New mode/rights of the chmod-ed file",
-          "constants": "Chmod mode constants"
+          "definition": "New rights of the chmod-ed file",
+          "property_doc_link": "chmod-file-destination-rights-doc"
         },
         {
           "name": "chmod.file.filesystem",
-          "type": "string",
           "definition": "File's filesystem",
-          "constants": ""
+          "property_doc_link": "common-fileevent-filesystem-doc"
         },
         {
           "name": "chmod.file.gid",
-          "type": "int",
           "definition": "GID of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-gid-doc"
         },
         {
           "name": "chmod.file.group",
-          "type": "string",
           "definition": "Group of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-group-doc"
         },
         {
           "name": "chmod.file.in_upper_layer",
-          "type": "bool",
           "definition": "Indicator of the file layer, for example, in an OverlayFS",
-          "constants": ""
+          "property_doc_link": "common-filefields-in_upper_layer-doc"
         },
         {
           "name": "chmod.file.inode",
-          "type": "int",
           "definition": "Inode of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-inode-doc"
         },
         {
           "name": "chmod.file.mode",
-          "type": "int",
-          "definition": "Mode/rights of the file",
-          "constants": "Chmod mode constants"
+          "definition": "Mode of the file",
+          "property_doc_link": "common-filefields-mode-doc"
         },
         {
           "name": "chmod.file.modification_time",
-          "type": "int",
           "definition": "Modification time of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
           "name": "chmod.file.mount_id",
-          "type": "int",
           "definition": "Mount ID of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-mount_id-doc"
         },
         {
           "name": "chmod.file.name",
-          "type": "string",
           "definition": "File's basename",
-          "constants": ""
+          "property_doc_link": "common-fileevent-name-doc"
         },
         {
           "name": "chmod.file.name.length",
-          "type": "int",
-          "definition": "Length of 'chmod.file.name' string",
-          "constants": ""
+          "definition": "Length of the corresponding string",
+          "property_doc_link": "common-string-length-doc"
         },
         {
           "name": "chmod.file.path",
-          "type": "string",
           "definition": "File's path",
-          "constants": ""
+          "property_doc_link": "common-fileevent-path-doc"
         },
         {
           "name": "chmod.file.path.length",
-          "type": "int",
-          "definition": "Length of 'chmod.file.path' string",
-          "constants": ""
+          "definition": "Length of the corresponding string",
+          "property_doc_link": "common-string-length-doc"
         },
         {
           "name": "chmod.file.rights",
-          "type": "int",
-          "definition": "Mode/rights of the file",
-          "constants": "Chmod mode constants"
+          "definition": "Rights of the file",
+          "property_doc_link": "common-filefields-rights-doc"
         },
         {
           "name": "chmod.file.uid",
-          "type": "int",
           "definition": "UID of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-uid-doc"
         },
         {
           "name": "chmod.file.user",
-          "type": "string",
           "definition": "User of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-user-doc"
         },
         {
           "name": "chmod.retval",
-          "type": "int",
           "definition": "Return value of the syscall",
-          "constants": "Error Constants"
+          "property_doc_link": "common-syscallevent-retval-doc"
         }
       ]
     },
@@ -1500,129 +1259,108 @@
       "properties": [
         {
           "name": "chown.file.change_time",
-          "type": "int",
           "definition": "Change time of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-change_time-doc"
         },
         {
           "name": "chown.file.destination.gid",
-          "type": "int",
           "definition": "New GID of the chown-ed file's owner",
-          "constants": ""
+          "property_doc_link": "chown-file-destination-gid-doc"
         },
         {
           "name": "chown.file.destination.group",
-          "type": "string",
           "definition": "New group of the chown-ed file's owner",
-          "constants": ""
+          "property_doc_link": "chown-file-destination-group-doc"
         },
         {
           "name": "chown.file.destination.uid",
-          "type": "int",
           "definition": "New UID of the chown-ed file's owner",
-          "constants": ""
+          "property_doc_link": "chown-file-destination-uid-doc"
         },
         {
           "name": "chown.file.destination.user",
-          "type": "string",
           "definition": "New user of the chown-ed file's owner",
-          "constants": ""
+          "property_doc_link": "chown-file-destination-user-doc"
         },
         {
           "name": "chown.file.filesystem",
-          "type": "string",
           "definition": "File's filesystem",
-          "constants": ""
+          "property_doc_link": "common-fileevent-filesystem-doc"
         },
         {
           "name": "chown.file.gid",
-          "type": "int",
           "definition": "GID of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-gid-doc"
         },
         {
           "name": "chown.file.group",
-          "type": "string",
           "definition": "Group of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-group-doc"
         },
         {
           "name": "chown.file.in_upper_layer",
-          "type": "bool",
           "definition": "Indicator of the file layer, for example, in an OverlayFS",
-          "constants": ""
+          "property_doc_link": "common-filefields-in_upper_layer-doc"
         },
         {
           "name": "chown.file.inode",
-          "type": "int",
           "definition": "Inode of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-inode-doc"
         },
         {
           "name": "chown.file.mode",
-          "type": "int",
-          "definition": "Mode/rights of the file",
-          "constants": "Chmod mode constants"
+          "definition": "Mode of the file",
+          "property_doc_link": "common-filefields-mode-doc"
         },
         {
           "name": "chown.file.modification_time",
-          "type": "int",
           "definition": "Modification time of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
           "name": "chown.file.mount_id",
-          "type": "int",
           "definition": "Mount ID of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-mount_id-doc"
         },
         {
           "name": "chown.file.name",
-          "type": "string",
           "definition": "File's basename",
-          "constants": ""
+          "property_doc_link": "common-fileevent-name-doc"
         },
         {
           "name": "chown.file.name.length",
-          "type": "int",
-          "definition": "Length of 'chown.file.name' string",
-          "constants": ""
+          "definition": "Length of the corresponding string",
+          "property_doc_link": "common-string-length-doc"
         },
         {
           "name": "chown.file.path",
-          "type": "string",
           "definition": "File's path",
-          "constants": ""
+          "property_doc_link": "common-fileevent-path-doc"
         },
         {
           "name": "chown.file.path.length",
-          "type": "int",
-          "definition": "Length of 'chown.file.path' string",
-          "constants": ""
+          "definition": "Length of the corresponding string",
+          "property_doc_link": "common-string-length-doc"
         },
         {
           "name": "chown.file.rights",
-          "type": "int",
-          "definition": "Mode/rights of the file",
-          "constants": "Chmod mode constants"
+          "definition": "Rights of the file",
+          "property_doc_link": "common-filefields-rights-doc"
         },
         {
           "name": "chown.file.uid",
-          "type": "int",
           "definition": "UID of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-uid-doc"
         },
         {
           "name": "chown.file.user",
-          "type": "string",
           "definition": "User of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-user-doc"
         },
         {
           "name": "chown.retval",
-          "type": "int",
           "definition": "Return value of the syscall",
-          "constants": "Error Constants"
+          "property_doc_link": "common-syscallevent-retval-doc"
         }
       ]
     },
@@ -1635,45 +1373,38 @@
       "properties": [
         {
           "name": "dns.id",
-          "type": "int",
           "definition": "[Experimental] the DNS request ID",
-          "constants": ""
+          "property_doc_link": "dns-id-doc"
         },
         {
           "name": "dns.question.class",
-          "type": "int",
           "definition": "the class looked up by the DNS question",
-          "constants": "DNS qclasses"
+          "property_doc_link": "dns-question-class-doc"
         },
         {
           "name": "dns.question.count",
-          "type": "int",
           "definition": "the total count of questions in the DNS request",
-          "constants": ""
+          "property_doc_link": "dns-question-count-doc"
         },
         {
           "name": "dns.question.length",
-          "type": "int",
           "definition": "the total DNS request size in bytes",
-          "constants": ""
+          "property_doc_link": "dns-question-length-doc"
         },
         {
           "name": "dns.question.name",
-          "type": "string",
           "definition": "the queried domain name",
-          "constants": ""
+          "property_doc_link": "dns-question-name-doc"
         },
         {
           "name": "dns.question.name.length",
-          "type": "int",
-          "definition": "the queried domain name",
-          "constants": ""
+          "definition": "Length of the corresponding string",
+          "property_doc_link": "common-string-length-doc"
         },
         {
           "name": "dns.question.type",
-          "type": "int",
           "definition": "a two octet code which specifies the DNS question type",
-          "constants": "DNS qtypes"
+          "property_doc_link": "dns-question-type-doc"
         }
       ]
     },
@@ -1686,393 +1417,328 @@
       "properties": [
         {
           "name": "exec.args",
-          "type": "string",
-          "definition": "Arguments of the process (as a string)",
-          "constants": ""
+          "definition": "Arguments of the process (as a string, excluding argv0)",
+          "property_doc_link": "common-process-args-doc"
         },
         {
           "name": "exec.args_flags",
-          "type": "string",
-          "definition": "Arguments of the process (as an array)",
-          "constants": ""
+          "definition": "Flags in the process arguments",
+          "property_doc_link": "common-process-args_flags-doc"
         },
         {
           "name": "exec.args_options",
-          "type": "string",
-          "definition": "Arguments of the process (as an array)",
-          "constants": ""
+          "definition": "Argument of the process as options",
+          "property_doc_link": "common-process-args_options-doc"
         },
         {
           "name": "exec.args_truncated",
-          "type": "bool",
           "definition": "Indicator of arguments truncation",
-          "constants": ""
+          "property_doc_link": "common-process-args_truncated-doc"
         },
         {
           "name": "exec.argv",
-          "type": "string",
-          "definition": "Arguments of the process (as an array)",
-          "constants": ""
+          "definition": "Arguments of the process (as an array, excluding argv0)",
+          "property_doc_link": "common-process-argv-doc"
         },
         {
           "name": "exec.argv0",
-          "type": "string",
           "definition": "First argument of the process",
-          "constants": ""
+          "property_doc_link": "common-process-argv0-doc"
         },
         {
           "name": "exec.cap_effective",
-          "type": "int",
           "definition": "Effective capability set of the process",
-          "constants": "Kernel Capability constants"
+          "property_doc_link": "common-credentials-cap_effective-doc"
         },
         {
           "name": "exec.cap_permitted",
-          "type": "int",
           "definition": "Permitted capability set of the process",
-          "constants": "Kernel Capability constants"
+          "property_doc_link": "common-credentials-cap_permitted-doc"
         },
         {
           "name": "exec.comm",
-          "type": "string",
           "definition": "Comm attribute of the process",
-          "constants": ""
+          "property_doc_link": "common-process-comm-doc"
         },
         {
           "name": "exec.container.id",
-          "type": "string",
           "definition": "Container ID",
-          "constants": ""
+          "property_doc_link": "common-process-container-id-doc"
         },
         {
           "name": "exec.cookie",
-          "type": "int",
           "definition": "Cookie of the process",
-          "constants": ""
+          "property_doc_link": "common-process-cookie-doc"
         },
         {
           "name": "exec.created_at",
-          "type": "int",
           "definition": "Timestamp of the creation of the process",
-          "constants": ""
+          "property_doc_link": "common-process-created_at-doc"
         },
         {
           "name": "exec.egid",
-          "type": "int",
           "definition": "Effective GID of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-egid-doc"
         },
         {
           "name": "exec.egroup",
-          "type": "string",
           "definition": "Effective group of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-egroup-doc"
         },
         {
           "name": "exec.envp",
-          "type": "string",
           "definition": "Environment variables of the process",
-          "constants": ""
+          "property_doc_link": "common-process-envp-doc"
         },
         {
           "name": "exec.envs",
-          "type": "string",
           "definition": "Environment variable names of the process",
-          "constants": ""
+          "property_doc_link": "common-process-envs-doc"
         },
         {
           "name": "exec.envs_truncated",
-          "type": "bool",
           "definition": "Indicator of environment variables truncation",
-          "constants": ""
+          "property_doc_link": "common-process-envs_truncated-doc"
         },
         {
           "name": "exec.euid",
-          "type": "int",
           "definition": "Effective UID of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-euid-doc"
         },
         {
           "name": "exec.euser",
-          "type": "string",
           "definition": "Effective user of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-euser-doc"
         },
         {
           "name": "exec.file.change_time",
-          "type": "int",
           "definition": "Change time of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-change_time-doc"
         },
         {
           "name": "exec.file.filesystem",
-          "type": "string",
           "definition": "File's filesystem",
-          "constants": ""
+          "property_doc_link": "common-fileevent-filesystem-doc"
         },
         {
           "name": "exec.file.gid",
-          "type": "int",
           "definition": "GID of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-gid-doc"
         },
         {
           "name": "exec.file.group",
-          "type": "string",
           "definition": "Group of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-group-doc"
         },
         {
           "name": "exec.file.in_upper_layer",
-          "type": "bool",
           "definition": "Indicator of the file layer, for example, in an OverlayFS",
-          "constants": ""
+          "property_doc_link": "common-filefields-in_upper_layer-doc"
         },
         {
           "name": "exec.file.inode",
-          "type": "int",
           "definition": "Inode of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-inode-doc"
         },
         {
           "name": "exec.file.mode",
-          "type": "int",
-          "definition": "Mode/rights of the file",
-          "constants": "Chmod mode constants"
+          "definition": "Mode of the file",
+          "property_doc_link": "common-filefields-mode-doc"
         },
         {
           "name": "exec.file.modification_time",
-          "type": "int",
           "definition": "Modification time of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
           "name": "exec.file.mount_id",
-          "type": "int",
           "definition": "Mount ID of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-mount_id-doc"
         },
         {
           "name": "exec.file.name",
-          "type": "string",
           "definition": "File's basename",
-          "constants": ""
+          "property_doc_link": "common-fileevent-name-doc"
         },
         {
           "name": "exec.file.name.length",
-          "type": "int",
-          "definition": "Length of 'exec.file.name' string",
-          "constants": ""
+          "definition": "Length of the corresponding string",
+          "property_doc_link": "common-string-length-doc"
         },
         {
           "name": "exec.file.path",
-          "type": "string",
           "definition": "File's path",
-          "constants": ""
+          "property_doc_link": "common-fileevent-path-doc"
         },
         {
           "name": "exec.file.path.length",
-          "type": "int",
-          "definition": "Length of 'exec.file.path' string",
-          "constants": ""
+          "definition": "Length of the corresponding string",
+          "property_doc_link": "common-string-length-doc"
         },
         {
           "name": "exec.file.rights",
-          "type": "int",
-          "definition": "Mode/rights of the file",
-          "constants": "Chmod mode constants"
+          "definition": "Rights of the file",
+          "property_doc_link": "common-filefields-rights-doc"
         },
         {
           "name": "exec.file.uid",
-          "type": "int",
           "definition": "UID of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-uid-doc"
         },
         {
           "name": "exec.file.user",
-          "type": "string",
           "definition": "User of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-user-doc"
         },
         {
           "name": "exec.fsgid",
-          "type": "int",
           "definition": "FileSystem-gid of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-fsgid-doc"
         },
         {
           "name": "exec.fsgroup",
-          "type": "string",
           "definition": "FileSystem-group of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-fsgroup-doc"
         },
         {
           "name": "exec.fsuid",
-          "type": "int",
           "definition": "FileSystem-uid of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-fsuid-doc"
         },
         {
           "name": "exec.fsuser",
-          "type": "string",
           "definition": "FileSystem-user of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-fsuser-doc"
         },
         {
           "name": "exec.gid",
-          "type": "int",
           "definition": "GID of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-gid-doc"
         },
         {
           "name": "exec.group",
-          "type": "string",
           "definition": "Group of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-group-doc"
         },
         {
           "name": "exec.interpreter.file.change_time",
-          "type": "int",
           "definition": "Change time of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-change_time-doc"
         },
         {
           "name": "exec.interpreter.file.filesystem",
-          "type": "string",
           "definition": "File's filesystem",
-          "constants": ""
+          "property_doc_link": "common-fileevent-filesystem-doc"
         },
         {
           "name": "exec.interpreter.file.gid",
-          "type": "int",
           "definition": "GID of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-gid-doc"
         },
         {
           "name": "exec.interpreter.file.group",
-          "type": "string",
           "definition": "Group of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-group-doc"
         },
         {
           "name": "exec.interpreter.file.in_upper_layer",
-          "type": "bool",
           "definition": "Indicator of the file layer, for example, in an OverlayFS",
-          "constants": ""
+          "property_doc_link": "common-filefields-in_upper_layer-doc"
         },
         {
           "name": "exec.interpreter.file.inode",
-          "type": "int",
           "definition": "Inode of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-inode-doc"
         },
         {
           "name": "exec.interpreter.file.mode",
-          "type": "int",
-          "definition": "Mode/rights of the file",
-          "constants": "Chmod mode constants"
+          "definition": "Mode of the file",
+          "property_doc_link": "common-filefields-mode-doc"
         },
         {
           "name": "exec.interpreter.file.modification_time",
-          "type": "int",
           "definition": "Modification time of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
           "name": "exec.interpreter.file.mount_id",
-          "type": "int",
           "definition": "Mount ID of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-mount_id-doc"
         },
         {
           "name": "exec.interpreter.file.name",
-          "type": "string",
           "definition": "File's basename",
-          "constants": ""
+          "property_doc_link": "common-fileevent-name-doc"
         },
         {
           "name": "exec.interpreter.file.name.length",
-          "type": "int",
-          "definition": "Length of 'exec.interpreter.file.name' string",
-          "constants": ""
+          "definition": "Length of the corresponding string",
+          "property_doc_link": "common-string-length-doc"
         },
         {
           "name": "exec.interpreter.file.path",
-          "type": "string",
           "definition": "File's path",
-          "constants": ""
+          "property_doc_link": "common-fileevent-path-doc"
         },
         {
           "name": "exec.interpreter.file.path.length",
-          "type": "int",
-          "definition": "Length of 'exec.interpreter.file.path' string",
-          "constants": ""
+          "definition": "Length of the corresponding string",
+          "property_doc_link": "common-string-length-doc"
         },
         {
           "name": "exec.interpreter.file.rights",
-          "type": "int",
-          "definition": "Mode/rights of the file",
-          "constants": "Chmod mode constants"
+          "definition": "Rights of the file",
+          "property_doc_link": "common-filefields-rights-doc"
         },
         {
           "name": "exec.interpreter.file.uid",
-          "type": "int",
           "definition": "UID of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-uid-doc"
         },
         {
           "name": "exec.interpreter.file.user",
-          "type": "string",
           "definition": "User of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-user-doc"
         },
         {
           "name": "exec.is_kworker",
-          "type": "bool",
           "definition": "Indicates whether the process is a kworker",
-          "constants": ""
+          "property_doc_link": "common-pidcontext-is_kworker-doc"
         },
         {
           "name": "exec.is_thread",
-          "type": "bool",
           "definition": "Indicates whether the process is considered a thread (that is, a child process that hasn't executed another program)",
-          "constants": ""
+          "property_doc_link": "common-process-is_thread-doc"
         },
         {
           "name": "exec.pid",
-          "type": "int",
           "definition": "Process ID of the process (also called thread group ID)",
-          "constants": ""
+          "property_doc_link": "common-pidcontext-pid-doc"
         },
         {
           "name": "exec.ppid",
-          "type": "int",
           "definition": "Parent process ID",
-          "constants": ""
+          "property_doc_link": "common-process-ppid-doc"
         },
         {
           "name": "exec.tid",
-          "type": "int",
           "definition": "Thread ID of the thread",
-          "constants": ""
+          "property_doc_link": "common-pidcontext-tid-doc"
         },
         {
           "name": "exec.tty_name",
-          "type": "string",
           "definition": "Name of the TTY associated with the process",
-          "constants": ""
+          "property_doc_link": "common-process-tty_name-doc"
         },
         {
           "name": "exec.uid",
-          "type": "int",
           "definition": "UID of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-uid-doc"
         },
         {
           "name": "exec.user",
-          "type": "string",
           "definition": "User of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-user-doc"
         }
       ]
     },
@@ -2085,405 +1751,338 @@
       "properties": [
         {
           "name": "exit.args",
-          "type": "string",
-          "definition": "Arguments of the process (as a string)",
-          "constants": ""
+          "definition": "Arguments of the process (as a string, excluding argv0)",
+          "property_doc_link": "common-process-args-doc"
         },
         {
           "name": "exit.args_flags",
-          "type": "string",
-          "definition": "Arguments of the process (as an array)",
-          "constants": ""
+          "definition": "Flags in the process arguments",
+          "property_doc_link": "common-process-args_flags-doc"
         },
         {
           "name": "exit.args_options",
-          "type": "string",
-          "definition": "Arguments of the process (as an array)",
-          "constants": ""
+          "definition": "Argument of the process as options",
+          "property_doc_link": "common-process-args_options-doc"
         },
         {
           "name": "exit.args_truncated",
-          "type": "bool",
           "definition": "Indicator of arguments truncation",
-          "constants": ""
+          "property_doc_link": "common-process-args_truncated-doc"
         },
         {
           "name": "exit.argv",
-          "type": "string",
-          "definition": "Arguments of the process (as an array)",
-          "constants": ""
+          "definition": "Arguments of the process (as an array, excluding argv0)",
+          "property_doc_link": "common-process-argv-doc"
         },
         {
           "name": "exit.argv0",
-          "type": "string",
           "definition": "First argument of the process",
-          "constants": ""
+          "property_doc_link": "common-process-argv0-doc"
         },
         {
           "name": "exit.cap_effective",
-          "type": "int",
           "definition": "Effective capability set of the process",
-          "constants": "Kernel Capability constants"
+          "property_doc_link": "common-credentials-cap_effective-doc"
         },
         {
           "name": "exit.cap_permitted",
-          "type": "int",
           "definition": "Permitted capability set of the process",
-          "constants": "Kernel Capability constants"
+          "property_doc_link": "common-credentials-cap_permitted-doc"
         },
         {
           "name": "exit.cause",
-          "type": "int",
           "definition": "Cause of the process termination (one of EXITED, SIGNALED, COREDUMPED)",
-          "constants": ""
+          "property_doc_link": "exit-cause-doc"
         },
         {
           "name": "exit.code",
-          "type": "int",
           "definition": "Exit code of the process or number of the signal that caused the process to terminate",
-          "constants": ""
+          "property_doc_link": "exit-code-doc"
         },
         {
           "name": "exit.comm",
-          "type": "string",
           "definition": "Comm attribute of the process",
-          "constants": ""
+          "property_doc_link": "common-process-comm-doc"
         },
         {
           "name": "exit.container.id",
-          "type": "string",
           "definition": "Container ID",
-          "constants": ""
+          "property_doc_link": "common-process-container-id-doc"
         },
         {
           "name": "exit.cookie",
-          "type": "int",
           "definition": "Cookie of the process",
-          "constants": ""
+          "property_doc_link": "common-process-cookie-doc"
         },
         {
           "name": "exit.created_at",
-          "type": "int",
           "definition": "Timestamp of the creation of the process",
-          "constants": ""
+          "property_doc_link": "common-process-created_at-doc"
         },
         {
           "name": "exit.egid",
-          "type": "int",
           "definition": "Effective GID of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-egid-doc"
         },
         {
           "name": "exit.egroup",
-          "type": "string",
           "definition": "Effective group of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-egroup-doc"
         },
         {
           "name": "exit.envp",
-          "type": "string",
           "definition": "Environment variables of the process",
-          "constants": ""
+          "property_doc_link": "common-process-envp-doc"
         },
         {
           "name": "exit.envs",
-          "type": "string",
           "definition": "Environment variable names of the process",
-          "constants": ""
+          "property_doc_link": "common-process-envs-doc"
         },
         {
           "name": "exit.envs_truncated",
-          "type": "bool",
           "definition": "Indicator of environment variables truncation",
-          "constants": ""
+          "property_doc_link": "common-process-envs_truncated-doc"
         },
         {
           "name": "exit.euid",
-          "type": "int",
           "definition": "Effective UID of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-euid-doc"
         },
         {
           "name": "exit.euser",
-          "type": "string",
           "definition": "Effective user of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-euser-doc"
         },
         {
           "name": "exit.file.change_time",
-          "type": "int",
           "definition": "Change time of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-change_time-doc"
         },
         {
           "name": "exit.file.filesystem",
-          "type": "string",
           "definition": "File's filesystem",
-          "constants": ""
+          "property_doc_link": "common-fileevent-filesystem-doc"
         },
         {
           "name": "exit.file.gid",
-          "type": "int",
           "definition": "GID of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-gid-doc"
         },
         {
           "name": "exit.file.group",
-          "type": "string",
           "definition": "Group of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-group-doc"
         },
         {
           "name": "exit.file.in_upper_layer",
-          "type": "bool",
           "definition": "Indicator of the file layer, for example, in an OverlayFS",
-          "constants": ""
+          "property_doc_link": "common-filefields-in_upper_layer-doc"
         },
         {
           "name": "exit.file.inode",
-          "type": "int",
           "definition": "Inode of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-inode-doc"
         },
         {
           "name": "exit.file.mode",
-          "type": "int",
-          "definition": "Mode/rights of the file",
-          "constants": "Chmod mode constants"
+          "definition": "Mode of the file",
+          "property_doc_link": "common-filefields-mode-doc"
         },
         {
           "name": "exit.file.modification_time",
-          "type": "int",
           "definition": "Modification time of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
           "name": "exit.file.mount_id",
-          "type": "int",
           "definition": "Mount ID of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-mount_id-doc"
         },
         {
           "name": "exit.file.name",
-          "type": "string",
           "definition": "File's basename",
-          "constants": ""
+          "property_doc_link": "common-fileevent-name-doc"
         },
         {
           "name": "exit.file.name.length",
-          "type": "int",
-          "definition": "Length of 'exit.file.name' string",
-          "constants": ""
+          "definition": "Length of the corresponding string",
+          "property_doc_link": "common-string-length-doc"
         },
         {
           "name": "exit.file.path",
-          "type": "string",
           "definition": "File's path",
-          "constants": ""
+          "property_doc_link": "common-fileevent-path-doc"
         },
         {
           "name": "exit.file.path.length",
-          "type": "int",
-          "definition": "Length of 'exit.file.path' string",
-          "constants": ""
+          "definition": "Length of the corresponding string",
+          "property_doc_link": "common-string-length-doc"
         },
         {
           "name": "exit.file.rights",
-          "type": "int",
-          "definition": "Mode/rights of the file",
-          "constants": "Chmod mode constants"
+          "definition": "Rights of the file",
+          "property_doc_link": "common-filefields-rights-doc"
         },
         {
           "name": "exit.file.uid",
-          "type": "int",
           "definition": "UID of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-uid-doc"
         },
         {
           "name": "exit.file.user",
-          "type": "string",
           "definition": "User of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-user-doc"
         },
         {
           "name": "exit.fsgid",
-          "type": "int",
           "definition": "FileSystem-gid of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-fsgid-doc"
         },
         {
           "name": "exit.fsgroup",
-          "type": "string",
           "definition": "FileSystem-group of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-fsgroup-doc"
         },
         {
           "name": "exit.fsuid",
-          "type": "int",
           "definition": "FileSystem-uid of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-fsuid-doc"
         },
         {
           "name": "exit.fsuser",
-          "type": "string",
           "definition": "FileSystem-user of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-fsuser-doc"
         },
         {
           "name": "exit.gid",
-          "type": "int",
           "definition": "GID of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-gid-doc"
         },
         {
           "name": "exit.group",
-          "type": "string",
           "definition": "Group of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-group-doc"
         },
         {
           "name": "exit.interpreter.file.change_time",
-          "type": "int",
           "definition": "Change time of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-change_time-doc"
         },
         {
           "name": "exit.interpreter.file.filesystem",
-          "type": "string",
           "definition": "File's filesystem",
-          "constants": ""
+          "property_doc_link": "common-fileevent-filesystem-doc"
         },
         {
           "name": "exit.interpreter.file.gid",
-          "type": "int",
           "definition": "GID of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-gid-doc"
         },
         {
           "name": "exit.interpreter.file.group",
-          "type": "string",
           "definition": "Group of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-group-doc"
         },
         {
           "name": "exit.interpreter.file.in_upper_layer",
-          "type": "bool",
           "definition": "Indicator of the file layer, for example, in an OverlayFS",
-          "constants": ""
+          "property_doc_link": "common-filefields-in_upper_layer-doc"
         },
         {
           "name": "exit.interpreter.file.inode",
-          "type": "int",
           "definition": "Inode of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-inode-doc"
         },
         {
           "name": "exit.interpreter.file.mode",
-          "type": "int",
-          "definition": "Mode/rights of the file",
-          "constants": "Chmod mode constants"
+          "definition": "Mode of the file",
+          "property_doc_link": "common-filefields-mode-doc"
         },
         {
           "name": "exit.interpreter.file.modification_time",
-          "type": "int",
           "definition": "Modification time of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
           "name": "exit.interpreter.file.mount_id",
-          "type": "int",
           "definition": "Mount ID of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-mount_id-doc"
         },
         {
           "name": "exit.interpreter.file.name",
-          "type": "string",
           "definition": "File's basename",
-          "constants": ""
+          "property_doc_link": "common-fileevent-name-doc"
         },
         {
           "name": "exit.interpreter.file.name.length",
-          "type": "int",
-          "definition": "Length of 'exit.interpreter.file.name' string",
-          "constants": ""
+          "definition": "Length of the corresponding string",
+          "property_doc_link": "common-string-length-doc"
         },
         {
           "name": "exit.interpreter.file.path",
-          "type": "string",
           "definition": "File's path",
-          "constants": ""
+          "property_doc_link": "common-fileevent-path-doc"
         },
         {
           "name": "exit.interpreter.file.path.length",
-          "type": "int",
-          "definition": "Length of 'exit.interpreter.file.path' string",
-          "constants": ""
+          "definition": "Length of the corresponding string",
+          "property_doc_link": "common-string-length-doc"
         },
         {
           "name": "exit.interpreter.file.rights",
-          "type": "int",
-          "definition": "Mode/rights of the file",
-          "constants": "Chmod mode constants"
+          "definition": "Rights of the file",
+          "property_doc_link": "common-filefields-rights-doc"
         },
         {
           "name": "exit.interpreter.file.uid",
-          "type": "int",
           "definition": "UID of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-uid-doc"
         },
         {
           "name": "exit.interpreter.file.user",
-          "type": "string",
           "definition": "User of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-user-doc"
         },
         {
           "name": "exit.is_kworker",
-          "type": "bool",
           "definition": "Indicates whether the process is a kworker",
-          "constants": ""
+          "property_doc_link": "common-pidcontext-is_kworker-doc"
         },
         {
           "name": "exit.is_thread",
-          "type": "bool",
           "definition": "Indicates whether the process is considered a thread (that is, a child process that hasn't executed another program)",
-          "constants": ""
+          "property_doc_link": "common-process-is_thread-doc"
         },
         {
           "name": "exit.pid",
-          "type": "int",
           "definition": "Process ID of the process (also called thread group ID)",
-          "constants": ""
+          "property_doc_link": "common-pidcontext-pid-doc"
         },
         {
           "name": "exit.ppid",
-          "type": "int",
           "definition": "Parent process ID",
-          "constants": ""
+          "property_doc_link": "common-process-ppid-doc"
         },
         {
           "name": "exit.tid",
-          "type": "int",
           "definition": "Thread ID of the thread",
-          "constants": ""
+          "property_doc_link": "common-pidcontext-tid-doc"
         },
         {
           "name": "exit.tty_name",
-          "type": "string",
           "definition": "Name of the TTY associated with the process",
-          "constants": ""
+          "property_doc_link": "common-process-tty_name-doc"
         },
         {
           "name": "exit.uid",
-          "type": "int",
           "definition": "UID of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-uid-doc"
         },
         {
           "name": "exit.user",
-          "type": "string",
           "definition": "User of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-user-doc"
         }
       ]
     },
@@ -2496,201 +2095,168 @@
       "properties": [
         {
           "name": "link.file.change_time",
-          "type": "int",
           "definition": "Change time of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-change_time-doc"
         },
         {
           "name": "link.file.destination.change_time",
-          "type": "int",
           "definition": "Change time of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-change_time-doc"
         },
         {
           "name": "link.file.destination.filesystem",
-          "type": "string",
           "definition": "File's filesystem",
-          "constants": ""
+          "property_doc_link": "common-fileevent-filesystem-doc"
         },
         {
           "name": "link.file.destination.gid",
-          "type": "int",
           "definition": "GID of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-gid-doc"
         },
         {
           "name": "link.file.destination.group",
-          "type": "string",
           "definition": "Group of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-group-doc"
         },
         {
           "name": "link.file.destination.in_upper_layer",
-          "type": "bool",
           "definition": "Indicator of the file layer, for example, in an OverlayFS",
-          "constants": ""
+          "property_doc_link": "common-filefields-in_upper_layer-doc"
         },
         {
           "name": "link.file.destination.inode",
-          "type": "int",
           "definition": "Inode of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-inode-doc"
         },
         {
           "name": "link.file.destination.mode",
-          "type": "int",
-          "definition": "Mode/rights of the file",
-          "constants": "Chmod mode constants"
+          "definition": "Mode of the file",
+          "property_doc_link": "common-filefields-mode-doc"
         },
         {
           "name": "link.file.destination.modification_time",
-          "type": "int",
           "definition": "Modification time of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
           "name": "link.file.destination.mount_id",
-          "type": "int",
           "definition": "Mount ID of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-mount_id-doc"
         },
         {
           "name": "link.file.destination.name",
-          "type": "string",
           "definition": "File's basename",
-          "constants": ""
+          "property_doc_link": "common-fileevent-name-doc"
         },
         {
           "name": "link.file.destination.name.length",
-          "type": "int",
-          "definition": "Length of 'link.file.destination.name' string",
-          "constants": ""
+          "definition": "Length of the corresponding string",
+          "property_doc_link": "common-string-length-doc"
         },
         {
           "name": "link.file.destination.path",
-          "type": "string",
           "definition": "File's path",
-          "constants": ""
+          "property_doc_link": "common-fileevent-path-doc"
         },
         {
           "name": "link.file.destination.path.length",
-          "type": "int",
-          "definition": "Length of 'link.file.destination.path' string",
-          "constants": ""
+          "definition": "Length of the corresponding string",
+          "property_doc_link": "common-string-length-doc"
         },
         {
           "name": "link.file.destination.rights",
-          "type": "int",
-          "definition": "Mode/rights of the file",
-          "constants": "Chmod mode constants"
+          "definition": "Rights of the file",
+          "property_doc_link": "common-filefields-rights-doc"
         },
         {
           "name": "link.file.destination.uid",
-          "type": "int",
           "definition": "UID of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-uid-doc"
         },
         {
           "name": "link.file.destination.user",
-          "type": "string",
           "definition": "User of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-user-doc"
         },
         {
           "name": "link.file.filesystem",
-          "type": "string",
           "definition": "File's filesystem",
-          "constants": ""
+          "property_doc_link": "common-fileevent-filesystem-doc"
         },
         {
           "name": "link.file.gid",
-          "type": "int",
           "definition": "GID of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-gid-doc"
         },
         {
           "name": "link.file.group",
-          "type": "string",
           "definition": "Group of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-group-doc"
         },
         {
           "name": "link.file.in_upper_layer",
-          "type": "bool",
           "definition": "Indicator of the file layer, for example, in an OverlayFS",
-          "constants": ""
+          "property_doc_link": "common-filefields-in_upper_layer-doc"
         },
         {
           "name": "link.file.inode",
-          "type": "int",
           "definition": "Inode of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-inode-doc"
         },
         {
           "name": "link.file.mode",
-          "type": "int",
-          "definition": "Mode/rights of the file",
-          "constants": "Chmod mode constants"
+          "definition": "Mode of the file",
+          "property_doc_link": "common-filefields-mode-doc"
         },
         {
           "name": "link.file.modification_time",
-          "type": "int",
           "definition": "Modification time of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
           "name": "link.file.mount_id",
-          "type": "int",
           "definition": "Mount ID of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-mount_id-doc"
         },
         {
           "name": "link.file.name",
-          "type": "string",
           "definition": "File's basename",
-          "constants": ""
+          "property_doc_link": "common-fileevent-name-doc"
         },
         {
           "name": "link.file.name.length",
-          "type": "int",
-          "definition": "Length of 'link.file.name' string",
-          "constants": ""
+          "definition": "Length of the corresponding string",
+          "property_doc_link": "common-string-length-doc"
         },
         {
           "name": "link.file.path",
-          "type": "string",
           "definition": "File's path",
-          "constants": ""
+          "property_doc_link": "common-fileevent-path-doc"
         },
         {
           "name": "link.file.path.length",
-          "type": "int",
-          "definition": "Length of 'link.file.path' string",
-          "constants": ""
+          "definition": "Length of the corresponding string",
+          "property_doc_link": "common-string-length-doc"
         },
         {
           "name": "link.file.rights",
-          "type": "int",
-          "definition": "Mode/rights of the file",
-          "constants": "Chmod mode constants"
+          "definition": "Rights of the file",
+          "property_doc_link": "common-filefields-rights-doc"
         },
         {
           "name": "link.file.uid",
-          "type": "int",
           "definition": "UID of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-uid-doc"
         },
         {
           "name": "link.file.user",
-          "type": "string",
           "definition": "User of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-user-doc"
         },
         {
           "name": "link.retval",
-          "type": "int",
           "definition": "Return value of the syscall",
-          "constants": "Error Constants"
+          "property_doc_link": "common-syscallevent-retval-doc"
         }
       ]
     },
@@ -2703,117 +2269,98 @@
       "properties": [
         {
           "name": "load_module.file.change_time",
-          "type": "int",
           "definition": "Change time of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-change_time-doc"
         },
         {
           "name": "load_module.file.filesystem",
-          "type": "string",
           "definition": "File's filesystem",
-          "constants": ""
+          "property_doc_link": "common-fileevent-filesystem-doc"
         },
         {
           "name": "load_module.file.gid",
-          "type": "int",
           "definition": "GID of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-gid-doc"
         },
         {
           "name": "load_module.file.group",
-          "type": "string",
           "definition": "Group of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-group-doc"
         },
         {
           "name": "load_module.file.in_upper_layer",
-          "type": "bool",
           "definition": "Indicator of the file layer, for example, in an OverlayFS",
-          "constants": ""
+          "property_doc_link": "common-filefields-in_upper_layer-doc"
         },
         {
           "name": "load_module.file.inode",
-          "type": "int",
           "definition": "Inode of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-inode-doc"
         },
         {
           "name": "load_module.file.mode",
-          "type": "int",
-          "definition": "Mode/rights of the file",
-          "constants": "Chmod mode constants"
+          "definition": "Mode of the file",
+          "property_doc_link": "common-filefields-mode-doc"
         },
         {
           "name": "load_module.file.modification_time",
-          "type": "int",
           "definition": "Modification time of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
           "name": "load_module.file.mount_id",
-          "type": "int",
           "definition": "Mount ID of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-mount_id-doc"
         },
         {
           "name": "load_module.file.name",
-          "type": "string",
           "definition": "File's basename",
-          "constants": ""
+          "property_doc_link": "common-fileevent-name-doc"
         },
         {
           "name": "load_module.file.name.length",
-          "type": "int",
-          "definition": "Length of 'load_module.file.name' string",
-          "constants": ""
+          "definition": "Length of the corresponding string",
+          "property_doc_link": "common-string-length-doc"
         },
         {
           "name": "load_module.file.path",
-          "type": "string",
           "definition": "File's path",
-          "constants": ""
+          "property_doc_link": "common-fileevent-path-doc"
         },
         {
           "name": "load_module.file.path.length",
-          "type": "int",
-          "definition": "Length of 'load_module.file.path' string",
-          "constants": ""
+          "definition": "Length of the corresponding string",
+          "property_doc_link": "common-string-length-doc"
         },
         {
           "name": "load_module.file.rights",
-          "type": "int",
-          "definition": "Mode/rights of the file",
-          "constants": "Chmod mode constants"
+          "definition": "Rights of the file",
+          "property_doc_link": "common-filefields-rights-doc"
         },
         {
           "name": "load_module.file.uid",
-          "type": "int",
           "definition": "UID of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-uid-doc"
         },
         {
           "name": "load_module.file.user",
-          "type": "string",
           "definition": "User of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-user-doc"
         },
         {
           "name": "load_module.loaded_from_memory",
-          "type": "bool",
           "definition": "Indicates if the kernel module was loaded from memory",
-          "constants": ""
+          "property_doc_link": "load_module-loaded_from_memory-doc"
         },
         {
           "name": "load_module.name",
-          "type": "string",
           "definition": "Name of the new kernel module",
-          "constants": ""
+          "property_doc_link": "load_module-name-doc"
         },
         {
           "name": "load_module.retval",
-          "type": "int",
           "definition": "Return value of the syscall",
-          "constants": "Error Constants"
+          "property_doc_link": "common-syscallevent-retval-doc"
         }
       ]
     },
@@ -2826,117 +2373,98 @@
       "properties": [
         {
           "name": "mkdir.file.change_time",
-          "type": "int",
           "definition": "Change time of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-change_time-doc"
         },
         {
           "name": "mkdir.file.destination.mode",
-          "type": "int",
-          "definition": "Mode/rights of the new directory",
-          "constants": "Chmod mode constants"
+          "definition": "Mode of the new directory",
+          "property_doc_link": "mkdir-file-destination-mode-doc"
         },
         {
           "name": "mkdir.file.destination.rights",
-          "type": "int",
-          "definition": "Mode/rights of the new directory",
-          "constants": "Chmod mode constants"
+          "definition": "Rights of the new directory",
+          "property_doc_link": "mkdir-file-destination-rights-doc"
         },
         {
           "name": "mkdir.file.filesystem",
-          "type": "string",
           "definition": "File's filesystem",
-          "constants": ""
+          "property_doc_link": "common-fileevent-filesystem-doc"
         },
         {
           "name": "mkdir.file.gid",
-          "type": "int",
           "definition": "GID of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-gid-doc"
         },
         {
           "name": "mkdir.file.group",
-          "type": "string",
           "definition": "Group of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-group-doc"
         },
         {
           "name": "mkdir.file.in_upper_layer",
-          "type": "bool",
           "definition": "Indicator of the file layer, for example, in an OverlayFS",
-          "constants": ""
+          "property_doc_link": "common-filefields-in_upper_layer-doc"
         },
         {
           "name": "mkdir.file.inode",
-          "type": "int",
           "definition": "Inode of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-inode-doc"
         },
         {
           "name": "mkdir.file.mode",
-          "type": "int",
-          "definition": "Mode/rights of the file",
-          "constants": "Chmod mode constants"
+          "definition": "Mode of the file",
+          "property_doc_link": "common-filefields-mode-doc"
         },
         {
           "name": "mkdir.file.modification_time",
-          "type": "int",
           "definition": "Modification time of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
           "name": "mkdir.file.mount_id",
-          "type": "int",
           "definition": "Mount ID of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-mount_id-doc"
         },
         {
           "name": "mkdir.file.name",
-          "type": "string",
           "definition": "File's basename",
-          "constants": ""
+          "property_doc_link": "common-fileevent-name-doc"
         },
         {
           "name": "mkdir.file.name.length",
-          "type": "int",
-          "definition": "Length of 'mkdir.file.name' string",
-          "constants": ""
+          "definition": "Length of the corresponding string",
+          "property_doc_link": "common-string-length-doc"
         },
         {
           "name": "mkdir.file.path",
-          "type": "string",
           "definition": "File's path",
-          "constants": ""
+          "property_doc_link": "common-fileevent-path-doc"
         },
         {
           "name": "mkdir.file.path.length",
-          "type": "int",
-          "definition": "Length of 'mkdir.file.path' string",
-          "constants": ""
+          "definition": "Length of the corresponding string",
+          "property_doc_link": "common-string-length-doc"
         },
         {
           "name": "mkdir.file.rights",
-          "type": "int",
-          "definition": "Mode/rights of the file",
-          "constants": "Chmod mode constants"
+          "definition": "Rights of the file",
+          "property_doc_link": "common-filefields-rights-doc"
         },
         {
           "name": "mkdir.file.uid",
-          "type": "int",
           "definition": "UID of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-uid-doc"
         },
         {
           "name": "mkdir.file.user",
-          "type": "string",
           "definition": "User of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-user-doc"
         },
         {
           "name": "mkdir.retval",
-          "type": "int",
           "definition": "Return value of the syscall",
-          "constants": "Error Constants"
+          "property_doc_link": "common-syscallevent-retval-doc"
         }
       ]
     },
@@ -2949,117 +2477,98 @@
       "properties": [
         {
           "name": "mmap.file.change_time",
-          "type": "int",
           "definition": "Change time of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-change_time-doc"
         },
         {
           "name": "mmap.file.filesystem",
-          "type": "string",
           "definition": "File's filesystem",
-          "constants": ""
+          "property_doc_link": "common-fileevent-filesystem-doc"
         },
         {
           "name": "mmap.file.gid",
-          "type": "int",
           "definition": "GID of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-gid-doc"
         },
         {
           "name": "mmap.file.group",
-          "type": "string",
           "definition": "Group of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-group-doc"
         },
         {
           "name": "mmap.file.in_upper_layer",
-          "type": "bool",
           "definition": "Indicator of the file layer, for example, in an OverlayFS",
-          "constants": ""
+          "property_doc_link": "common-filefields-in_upper_layer-doc"
         },
         {
           "name": "mmap.file.inode",
-          "type": "int",
           "definition": "Inode of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-inode-doc"
         },
         {
           "name": "mmap.file.mode",
-          "type": "int",
-          "definition": "Mode/rights of the file",
-          "constants": "Chmod mode constants"
+          "definition": "Mode of the file",
+          "property_doc_link": "common-filefields-mode-doc"
         },
         {
           "name": "mmap.file.modification_time",
-          "type": "int",
           "definition": "Modification time of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
           "name": "mmap.file.mount_id",
-          "type": "int",
           "definition": "Mount ID of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-mount_id-doc"
         },
         {
           "name": "mmap.file.name",
-          "type": "string",
           "definition": "File's basename",
-          "constants": ""
+          "property_doc_link": "common-fileevent-name-doc"
         },
         {
           "name": "mmap.file.name.length",
-          "type": "int",
-          "definition": "Length of 'mmap.file.name' string",
-          "constants": ""
+          "definition": "Length of the corresponding string",
+          "property_doc_link": "common-string-length-doc"
         },
         {
           "name": "mmap.file.path",
-          "type": "string",
           "definition": "File's path",
-          "constants": ""
+          "property_doc_link": "common-fileevent-path-doc"
         },
         {
           "name": "mmap.file.path.length",
-          "type": "int",
-          "definition": "Length of 'mmap.file.path' string",
-          "constants": ""
+          "definition": "Length of the corresponding string",
+          "property_doc_link": "common-string-length-doc"
         },
         {
           "name": "mmap.file.rights",
-          "type": "int",
-          "definition": "Mode/rights of the file",
-          "constants": "Chmod mode constants"
+          "definition": "Rights of the file",
+          "property_doc_link": "common-filefields-rights-doc"
         },
         {
           "name": "mmap.file.uid",
-          "type": "int",
           "definition": "UID of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-uid-doc"
         },
         {
           "name": "mmap.file.user",
-          "type": "string",
           "definition": "User of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-user-doc"
         },
         {
           "name": "mmap.flags",
-          "type": "int",
           "definition": "memory segment flags",
-          "constants": "MMap flags"
+          "property_doc_link": "mmap-flags-doc"
         },
         {
           "name": "mmap.protection",
-          "type": "int",
           "definition": "memory segment protection",
-          "constants": "Protection constants"
+          "property_doc_link": "mmap-protection-doc"
         },
         {
           "name": "mmap.retval",
-          "type": "int",
           "definition": "Return value of the syscall",
-          "constants": "Error Constants"
+          "property_doc_link": "common-syscallevent-retval-doc"
         }
       ]
     },
@@ -3072,27 +2581,23 @@
       "properties": [
         {
           "name": "mount.fs_type",
-          "type": "string",
           "definition": "Type of the mounted file system",
-          "constants": ""
+          "property_doc_link": "mount-fs_type-doc"
         },
         {
           "name": "mount.mountpoint.path",
-          "type": "string",
           "definition": "Path of the mount point",
-          "constants": ""
+          "property_doc_link": "mount-mountpoint-path-doc"
         },
         {
           "name": "mount.retval",
-          "type": "int",
           "definition": "Return value of the syscall",
-          "constants": "Error Constants"
+          "property_doc_link": "common-syscallevent-retval-doc"
         },
         {
           "name": "mount.source.path",
-          "type": "string",
           "definition": "Source path of a bind mount",
-          "constants": ""
+          "property_doc_link": "mount-source-path-doc"
         }
       ]
     },
@@ -3105,21 +2610,18 @@
       "properties": [
         {
           "name": "mprotect.req_protection",
-          "type": "int",
           "definition": "new memory segment protection",
-          "constants": "Virtual Memory flags"
+          "property_doc_link": "mprotect-req_protection-doc"
         },
         {
           "name": "mprotect.retval",
-          "type": "int",
           "definition": "Return value of the syscall",
-          "constants": "Error Constants"
+          "property_doc_link": "common-syscallevent-retval-doc"
         },
         {
           "name": "mprotect.vm_protection",
-          "type": "int",
           "definition": "initial memory segment protection",
-          "constants": "Virtual Memory flags"
+          "property_doc_link": "mprotect-vm_protection-doc"
         }
       ]
     },
@@ -3132,117 +2634,98 @@
       "properties": [
         {
           "name": "open.file.change_time",
-          "type": "int",
           "definition": "Change time of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-change_time-doc"
         },
         {
           "name": "open.file.destination.mode",
-          "type": "int",
           "definition": "Mode of the created file",
-          "constants": "Chmod mode constants"
+          "property_doc_link": "open-file-destination-mode-doc"
         },
         {
           "name": "open.file.filesystem",
-          "type": "string",
           "definition": "File's filesystem",
-          "constants": ""
+          "property_doc_link": "common-fileevent-filesystem-doc"
         },
         {
           "name": "open.file.gid",
-          "type": "int",
           "definition": "GID of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-gid-doc"
         },
         {
           "name": "open.file.group",
-          "type": "string",
           "definition": "Group of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-group-doc"
         },
         {
           "name": "open.file.in_upper_layer",
-          "type": "bool",
           "definition": "Indicator of the file layer, for example, in an OverlayFS",
-          "constants": ""
+          "property_doc_link": "common-filefields-in_upper_layer-doc"
         },
         {
           "name": "open.file.inode",
-          "type": "int",
           "definition": "Inode of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-inode-doc"
         },
         {
           "name": "open.file.mode",
-          "type": "int",
-          "definition": "Mode/rights of the file",
-          "constants": "Chmod mode constants"
+          "definition": "Mode of the file",
+          "property_doc_link": "common-filefields-mode-doc"
         },
         {
           "name": "open.file.modification_time",
-          "type": "int",
           "definition": "Modification time of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
           "name": "open.file.mount_id",
-          "type": "int",
           "definition": "Mount ID of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-mount_id-doc"
         },
         {
           "name": "open.file.name",
-          "type": "string",
           "definition": "File's basename",
-          "constants": ""
+          "property_doc_link": "common-fileevent-name-doc"
         },
         {
           "name": "open.file.name.length",
-          "type": "int",
-          "definition": "Length of 'open.file.name' string",
-          "constants": ""
+          "definition": "Length of the corresponding string",
+          "property_doc_link": "common-string-length-doc"
         },
         {
           "name": "open.file.path",
-          "type": "string",
           "definition": "File's path",
-          "constants": ""
+          "property_doc_link": "common-fileevent-path-doc"
         },
         {
           "name": "open.file.path.length",
-          "type": "int",
-          "definition": "Length of 'open.file.path' string",
-          "constants": ""
+          "definition": "Length of the corresponding string",
+          "property_doc_link": "common-string-length-doc"
         },
         {
           "name": "open.file.rights",
-          "type": "int",
-          "definition": "Mode/rights of the file",
-          "constants": "Chmod mode constants"
+          "definition": "Rights of the file",
+          "property_doc_link": "common-filefields-rights-doc"
         },
         {
           "name": "open.file.uid",
-          "type": "int",
           "definition": "UID of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-uid-doc"
         },
         {
           "name": "open.file.user",
-          "type": "string",
           "definition": "User of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-user-doc"
         },
         {
           "name": "open.flags",
-          "type": "int",
           "definition": "Flags used when opening the file",
-          "constants": "Open flags"
+          "property_doc_link": "open-flags-doc"
         },
         {
           "name": "open.retval",
-          "type": "int",
           "definition": "Return value of the syscall",
-          "constants": "Error Constants"
+          "property_doc_link": "common-syscallevent-retval-doc"
         }
       ]
     },
@@ -3255,1185 +2738,988 @@
       "properties": [
         {
           "name": "ptrace.request",
-          "type": "int",
           "definition": "ptrace request",
-          "constants": "Ptrace constants"
+          "property_doc_link": "ptrace-request-doc"
         },
         {
           "name": "ptrace.retval",
-          "type": "int",
           "definition": "Return value of the syscall",
-          "constants": "Error Constants"
+          "property_doc_link": "common-syscallevent-retval-doc"
         },
         {
           "name": "ptrace.tracee.ancestors.args",
-          "type": "string",
-          "definition": "Arguments of the process (as a string)",
-          "constants": ""
+          "definition": "Arguments of the process (as a string, excluding argv0)",
+          "property_doc_link": "common-process-args-doc"
         },
         {
           "name": "ptrace.tracee.ancestors.args_flags",
-          "type": "string",
-          "definition": "Arguments of the process (as an array)",
-          "constants": ""
+          "definition": "Flags in the process arguments",
+          "property_doc_link": "common-process-args_flags-doc"
         },
         {
           "name": "ptrace.tracee.ancestors.args_options",
-          "type": "string",
-          "definition": "Arguments of the process (as an array)",
-          "constants": ""
+          "definition": "Argument of the process as options",
+          "property_doc_link": "common-process-args_options-doc"
         },
         {
           "name": "ptrace.tracee.ancestors.args_truncated",
-          "type": "bool",
           "definition": "Indicator of arguments truncation",
-          "constants": ""
+          "property_doc_link": "common-process-args_truncated-doc"
         },
         {
           "name": "ptrace.tracee.ancestors.argv",
-          "type": "string",
-          "definition": "Arguments of the process (as an array)",
-          "constants": ""
+          "definition": "Arguments of the process (as an array, excluding argv0)",
+          "property_doc_link": "common-process-argv-doc"
         },
         {
           "name": "ptrace.tracee.ancestors.argv0",
-          "type": "string",
           "definition": "First argument of the process",
-          "constants": ""
+          "property_doc_link": "common-process-argv0-doc"
         },
         {
           "name": "ptrace.tracee.ancestors.cap_effective",
-          "type": "int",
           "definition": "Effective capability set of the process",
-          "constants": "Kernel Capability constants"
+          "property_doc_link": "common-credentials-cap_effective-doc"
         },
         {
           "name": "ptrace.tracee.ancestors.cap_permitted",
-          "type": "int",
           "definition": "Permitted capability set of the process",
-          "constants": "Kernel Capability constants"
+          "property_doc_link": "common-credentials-cap_permitted-doc"
         },
         {
           "name": "ptrace.tracee.ancestors.comm",
-          "type": "string",
           "definition": "Comm attribute of the process",
-          "constants": ""
+          "property_doc_link": "common-process-comm-doc"
         },
         {
           "name": "ptrace.tracee.ancestors.container.id",
-          "type": "string",
           "definition": "Container ID",
-          "constants": ""
+          "property_doc_link": "common-process-container-id-doc"
         },
         {
           "name": "ptrace.tracee.ancestors.cookie",
-          "type": "int",
           "definition": "Cookie of the process",
-          "constants": ""
+          "property_doc_link": "common-process-cookie-doc"
         },
         {
           "name": "ptrace.tracee.ancestors.created_at",
-          "type": "int",
           "definition": "Timestamp of the creation of the process",
-          "constants": ""
+          "property_doc_link": "common-process-created_at-doc"
         },
         {
           "name": "ptrace.tracee.ancestors.egid",
-          "type": "int",
           "definition": "Effective GID of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-egid-doc"
         },
         {
           "name": "ptrace.tracee.ancestors.egroup",
-          "type": "string",
           "definition": "Effective group of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-egroup-doc"
         },
         {
           "name": "ptrace.tracee.ancestors.envp",
-          "type": "string",
           "definition": "Environment variables of the process",
-          "constants": ""
+          "property_doc_link": "common-process-envp-doc"
         },
         {
           "name": "ptrace.tracee.ancestors.envs",
-          "type": "string",
           "definition": "Environment variable names of the process",
-          "constants": ""
+          "property_doc_link": "common-process-envs-doc"
         },
         {
           "name": "ptrace.tracee.ancestors.envs_truncated",
-          "type": "bool",
           "definition": "Indicator of environment variables truncation",
-          "constants": ""
+          "property_doc_link": "common-process-envs_truncated-doc"
         },
         {
           "name": "ptrace.tracee.ancestors.euid",
-          "type": "int",
           "definition": "Effective UID of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-euid-doc"
         },
         {
           "name": "ptrace.tracee.ancestors.euser",
-          "type": "string",
           "definition": "Effective user of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-euser-doc"
         },
         {
           "name": "ptrace.tracee.ancestors.file.change_time",
-          "type": "int",
           "definition": "Change time of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-change_time-doc"
         },
         {
           "name": "ptrace.tracee.ancestors.file.filesystem",
-          "type": "string",
           "definition": "File's filesystem",
-          "constants": ""
+          "property_doc_link": "common-fileevent-filesystem-doc"
         },
         {
           "name": "ptrace.tracee.ancestors.file.gid",
-          "type": "int",
           "definition": "GID of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-gid-doc"
         },
         {
           "name": "ptrace.tracee.ancestors.file.group",
-          "type": "string",
           "definition": "Group of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-group-doc"
         },
         {
           "name": "ptrace.tracee.ancestors.file.in_upper_layer",
-          "type": "bool",
           "definition": "Indicator of the file layer, for example, in an OverlayFS",
-          "constants": ""
+          "property_doc_link": "common-filefields-in_upper_layer-doc"
         },
         {
           "name": "ptrace.tracee.ancestors.file.inode",
-          "type": "int",
           "definition": "Inode of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-inode-doc"
         },
         {
           "name": "ptrace.tracee.ancestors.file.mode",
-          "type": "int",
-          "definition": "Mode/rights of the file",
-          "constants": "Chmod mode constants"
+          "definition": "Mode of the file",
+          "property_doc_link": "common-filefields-mode-doc"
         },
         {
           "name": "ptrace.tracee.ancestors.file.modification_time",
-          "type": "int",
           "definition": "Modification time of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
           "name": "ptrace.tracee.ancestors.file.mount_id",
-          "type": "int",
           "definition": "Mount ID of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-mount_id-doc"
         },
         {
           "name": "ptrace.tracee.ancestors.file.name",
-          "type": "string",
           "definition": "File's basename",
-          "constants": ""
+          "property_doc_link": "common-fileevent-name-doc"
         },
         {
           "name": "ptrace.tracee.ancestors.file.name.length",
-          "type": "int",
-          "definition": "Length of 'ptrace.tracee.ancestors.file.name' string",
-          "constants": ""
+          "definition": "Length of the corresponding string",
+          "property_doc_link": "common-string-length-doc"
         },
         {
           "name": "ptrace.tracee.ancestors.file.path",
-          "type": "string",
           "definition": "File's path",
-          "constants": ""
+          "property_doc_link": "common-fileevent-path-doc"
         },
         {
           "name": "ptrace.tracee.ancestors.file.path.length",
-          "type": "int",
-          "definition": "Length of 'ptrace.tracee.ancestors.file.path' string",
-          "constants": ""
+          "definition": "Length of the corresponding string",
+          "property_doc_link": "common-string-length-doc"
         },
         {
           "name": "ptrace.tracee.ancestors.file.rights",
-          "type": "int",
-          "definition": "Mode/rights of the file",
-          "constants": "Chmod mode constants"
+          "definition": "Rights of the file",
+          "property_doc_link": "common-filefields-rights-doc"
         },
         {
           "name": "ptrace.tracee.ancestors.file.uid",
-          "type": "int",
           "definition": "UID of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-uid-doc"
         },
         {
           "name": "ptrace.tracee.ancestors.file.user",
-          "type": "string",
           "definition": "User of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-user-doc"
         },
         {
           "name": "ptrace.tracee.ancestors.fsgid",
-          "type": "int",
           "definition": "FileSystem-gid of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-fsgid-doc"
         },
         {
           "name": "ptrace.tracee.ancestors.fsgroup",
-          "type": "string",
           "definition": "FileSystem-group of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-fsgroup-doc"
         },
         {
           "name": "ptrace.tracee.ancestors.fsuid",
-          "type": "int",
           "definition": "FileSystem-uid of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-fsuid-doc"
         },
         {
           "name": "ptrace.tracee.ancestors.fsuser",
-          "type": "string",
           "definition": "FileSystem-user of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-fsuser-doc"
         },
         {
           "name": "ptrace.tracee.ancestors.gid",
-          "type": "int",
           "definition": "GID of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-gid-doc"
         },
         {
           "name": "ptrace.tracee.ancestors.group",
-          "type": "string",
           "definition": "Group of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-group-doc"
         },
         {
           "name": "ptrace.tracee.ancestors.interpreter.file.change_time",
-          "type": "int",
           "definition": "Change time of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-change_time-doc"
         },
         {
           "name": "ptrace.tracee.ancestors.interpreter.file.filesystem",
-          "type": "string",
           "definition": "File's filesystem",
-          "constants": ""
+          "property_doc_link": "common-fileevent-filesystem-doc"
         },
         {
           "name": "ptrace.tracee.ancestors.interpreter.file.gid",
-          "type": "int",
           "definition": "GID of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-gid-doc"
         },
         {
           "name": "ptrace.tracee.ancestors.interpreter.file.group",
-          "type": "string",
           "definition": "Group of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-group-doc"
         },
         {
           "name": "ptrace.tracee.ancestors.interpreter.file.in_upper_layer",
-          "type": "bool",
           "definition": "Indicator of the file layer, for example, in an OverlayFS",
-          "constants": ""
+          "property_doc_link": "common-filefields-in_upper_layer-doc"
         },
         {
           "name": "ptrace.tracee.ancestors.interpreter.file.inode",
-          "type": "int",
           "definition": "Inode of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-inode-doc"
         },
         {
           "name": "ptrace.tracee.ancestors.interpreter.file.mode",
-          "type": "int",
-          "definition": "Mode/rights of the file",
-          "constants": "Chmod mode constants"
+          "definition": "Mode of the file",
+          "property_doc_link": "common-filefields-mode-doc"
         },
         {
           "name": "ptrace.tracee.ancestors.interpreter.file.modification_time",
-          "type": "int",
           "definition": "Modification time of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
           "name": "ptrace.tracee.ancestors.interpreter.file.mount_id",
-          "type": "int",
           "definition": "Mount ID of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-mount_id-doc"
         },
         {
           "name": "ptrace.tracee.ancestors.interpreter.file.name",
-          "type": "string",
           "definition": "File's basename",
-          "constants": ""
+          "property_doc_link": "common-fileevent-name-doc"
         },
         {
           "name": "ptrace.tracee.ancestors.interpreter.file.name.length",
-          "type": "int",
-          "definition": "Length of 'ptrace.tracee.ancestors.interpreter.file.name' string",
-          "constants": ""
+          "definition": "Length of the corresponding string",
+          "property_doc_link": "common-string-length-doc"
         },
         {
           "name": "ptrace.tracee.ancestors.interpreter.file.path",
-          "type": "string",
           "definition": "File's path",
-          "constants": ""
+          "property_doc_link": "common-fileevent-path-doc"
         },
         {
           "name": "ptrace.tracee.ancestors.interpreter.file.path.length",
-          "type": "int",
-          "definition": "Length of 'ptrace.tracee.ancestors.interpreter.file.path' string",
-          "constants": ""
+          "definition": "Length of the corresponding string",
+          "property_doc_link": "common-string-length-doc"
         },
         {
           "name": "ptrace.tracee.ancestors.interpreter.file.rights",
-          "type": "int",
-          "definition": "Mode/rights of the file",
-          "constants": "Chmod mode constants"
+          "definition": "Rights of the file",
+          "property_doc_link": "common-filefields-rights-doc"
         },
         {
           "name": "ptrace.tracee.ancestors.interpreter.file.uid",
-          "type": "int",
           "definition": "UID of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-uid-doc"
         },
         {
           "name": "ptrace.tracee.ancestors.interpreter.file.user",
-          "type": "string",
           "definition": "User of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-user-doc"
         },
         {
           "name": "ptrace.tracee.ancestors.is_kworker",
-          "type": "bool",
           "definition": "Indicates whether the process is a kworker",
-          "constants": ""
+          "property_doc_link": "common-pidcontext-is_kworker-doc"
         },
         {
           "name": "ptrace.tracee.ancestors.is_thread",
-          "type": "bool",
           "definition": "Indicates whether the process is considered a thread (that is, a child process that hasn't executed another program)",
-          "constants": ""
+          "property_doc_link": "common-process-is_thread-doc"
         },
         {
           "name": "ptrace.tracee.ancestors.pid",
-          "type": "int",
           "definition": "Process ID of the process (also called thread group ID)",
-          "constants": ""
+          "property_doc_link": "common-pidcontext-pid-doc"
         },
         {
           "name": "ptrace.tracee.ancestors.ppid",
-          "type": "int",
           "definition": "Parent process ID",
-          "constants": ""
+          "property_doc_link": "common-process-ppid-doc"
         },
         {
           "name": "ptrace.tracee.ancestors.tid",
-          "type": "int",
           "definition": "Thread ID of the thread",
-          "constants": ""
+          "property_doc_link": "common-pidcontext-tid-doc"
         },
         {
           "name": "ptrace.tracee.ancestors.tty_name",
-          "type": "string",
           "definition": "Name of the TTY associated with the process",
-          "constants": ""
+          "property_doc_link": "common-process-tty_name-doc"
         },
         {
           "name": "ptrace.tracee.ancestors.uid",
-          "type": "int",
           "definition": "UID of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-uid-doc"
         },
         {
           "name": "ptrace.tracee.ancestors.user",
-          "type": "string",
           "definition": "User of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-user-doc"
         },
         {
           "name": "ptrace.tracee.args",
-          "type": "string",
-          "definition": "Arguments of the process (as a string)",
-          "constants": ""
+          "definition": "Arguments of the process (as a string, excluding argv0)",
+          "property_doc_link": "common-process-args-doc"
         },
         {
           "name": "ptrace.tracee.args_flags",
-          "type": "string",
-          "definition": "Arguments of the process (as an array)",
-          "constants": ""
+          "definition": "Flags in the process arguments",
+          "property_doc_link": "common-process-args_flags-doc"
         },
         {
           "name": "ptrace.tracee.args_options",
-          "type": "string",
-          "definition": "Arguments of the process (as an array)",
-          "constants": ""
+          "definition": "Argument of the process as options",
+          "property_doc_link": "common-process-args_options-doc"
         },
         {
           "name": "ptrace.tracee.args_truncated",
-          "type": "bool",
           "definition": "Indicator of arguments truncation",
-          "constants": ""
+          "property_doc_link": "common-process-args_truncated-doc"
         },
         {
           "name": "ptrace.tracee.argv",
-          "type": "string",
-          "definition": "Arguments of the process (as an array)",
-          "constants": ""
+          "definition": "Arguments of the process (as an array, excluding argv0)",
+          "property_doc_link": "common-process-argv-doc"
         },
         {
           "name": "ptrace.tracee.argv0",
-          "type": "string",
           "definition": "First argument of the process",
-          "constants": ""
+          "property_doc_link": "common-process-argv0-doc"
         },
         {
           "name": "ptrace.tracee.cap_effective",
-          "type": "int",
           "definition": "Effective capability set of the process",
-          "constants": "Kernel Capability constants"
+          "property_doc_link": "common-credentials-cap_effective-doc"
         },
         {
           "name": "ptrace.tracee.cap_permitted",
-          "type": "int",
           "definition": "Permitted capability set of the process",
-          "constants": "Kernel Capability constants"
+          "property_doc_link": "common-credentials-cap_permitted-doc"
         },
         {
           "name": "ptrace.tracee.comm",
-          "type": "string",
           "definition": "Comm attribute of the process",
-          "constants": ""
+          "property_doc_link": "common-process-comm-doc"
         },
         {
           "name": "ptrace.tracee.container.id",
-          "type": "string",
           "definition": "Container ID",
-          "constants": ""
+          "property_doc_link": "common-process-container-id-doc"
         },
         {
           "name": "ptrace.tracee.cookie",
-          "type": "int",
           "definition": "Cookie of the process",
-          "constants": ""
+          "property_doc_link": "common-process-cookie-doc"
         },
         {
           "name": "ptrace.tracee.created_at",
-          "type": "int",
           "definition": "Timestamp of the creation of the process",
-          "constants": ""
+          "property_doc_link": "common-process-created_at-doc"
         },
         {
           "name": "ptrace.tracee.egid",
-          "type": "int",
           "definition": "Effective GID of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-egid-doc"
         },
         {
           "name": "ptrace.tracee.egroup",
-          "type": "string",
           "definition": "Effective group of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-egroup-doc"
         },
         {
           "name": "ptrace.tracee.envp",
-          "type": "string",
           "definition": "Environment variables of the process",
-          "constants": ""
+          "property_doc_link": "common-process-envp-doc"
         },
         {
           "name": "ptrace.tracee.envs",
-          "type": "string",
           "definition": "Environment variable names of the process",
-          "constants": ""
+          "property_doc_link": "common-process-envs-doc"
         },
         {
           "name": "ptrace.tracee.envs_truncated",
-          "type": "bool",
           "definition": "Indicator of environment variables truncation",
-          "constants": ""
+          "property_doc_link": "common-process-envs_truncated-doc"
         },
         {
           "name": "ptrace.tracee.euid",
-          "type": "int",
           "definition": "Effective UID of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-euid-doc"
         },
         {
           "name": "ptrace.tracee.euser",
-          "type": "string",
           "definition": "Effective user of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-euser-doc"
         },
         {
           "name": "ptrace.tracee.file.change_time",
-          "type": "int",
           "definition": "Change time of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-change_time-doc"
         },
         {
           "name": "ptrace.tracee.file.filesystem",
-          "type": "string",
           "definition": "File's filesystem",
-          "constants": ""
+          "property_doc_link": "common-fileevent-filesystem-doc"
         },
         {
           "name": "ptrace.tracee.file.gid",
-          "type": "int",
           "definition": "GID of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-gid-doc"
         },
         {
           "name": "ptrace.tracee.file.group",
-          "type": "string",
           "definition": "Group of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-group-doc"
         },
         {
           "name": "ptrace.tracee.file.in_upper_layer",
-          "type": "bool",
           "definition": "Indicator of the file layer, for example, in an OverlayFS",
-          "constants": ""
+          "property_doc_link": "common-filefields-in_upper_layer-doc"
         },
         {
           "name": "ptrace.tracee.file.inode",
-          "type": "int",
           "definition": "Inode of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-inode-doc"
         },
         {
           "name": "ptrace.tracee.file.mode",
-          "type": "int",
-          "definition": "Mode/rights of the file",
-          "constants": "Chmod mode constants"
+          "definition": "Mode of the file",
+          "property_doc_link": "common-filefields-mode-doc"
         },
         {
           "name": "ptrace.tracee.file.modification_time",
-          "type": "int",
           "definition": "Modification time of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
           "name": "ptrace.tracee.file.mount_id",
-          "type": "int",
           "definition": "Mount ID of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-mount_id-doc"
         },
         {
           "name": "ptrace.tracee.file.name",
-          "type": "string",
           "definition": "File's basename",
-          "constants": ""
+          "property_doc_link": "common-fileevent-name-doc"
         },
         {
           "name": "ptrace.tracee.file.name.length",
-          "type": "int",
-          "definition": "Length of 'ptrace.tracee.file.name' string",
-          "constants": ""
+          "definition": "Length of the corresponding string",
+          "property_doc_link": "common-string-length-doc"
         },
         {
           "name": "ptrace.tracee.file.path",
-          "type": "string",
           "definition": "File's path",
-          "constants": ""
+          "property_doc_link": "common-fileevent-path-doc"
         },
         {
           "name": "ptrace.tracee.file.path.length",
-          "type": "int",
-          "definition": "Length of 'ptrace.tracee.file.path' string",
-          "constants": ""
+          "definition": "Length of the corresponding string",
+          "property_doc_link": "common-string-length-doc"
         },
         {
           "name": "ptrace.tracee.file.rights",
-          "type": "int",
-          "definition": "Mode/rights of the file",
-          "constants": "Chmod mode constants"
+          "definition": "Rights of the file",
+          "property_doc_link": "common-filefields-rights-doc"
         },
         {
           "name": "ptrace.tracee.file.uid",
-          "type": "int",
           "definition": "UID of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-uid-doc"
         },
         {
           "name": "ptrace.tracee.file.user",
-          "type": "string",
           "definition": "User of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-user-doc"
         },
         {
           "name": "ptrace.tracee.fsgid",
-          "type": "int",
           "definition": "FileSystem-gid of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-fsgid-doc"
         },
         {
           "name": "ptrace.tracee.fsgroup",
-          "type": "string",
           "definition": "FileSystem-group of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-fsgroup-doc"
         },
         {
           "name": "ptrace.tracee.fsuid",
-          "type": "int",
           "definition": "FileSystem-uid of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-fsuid-doc"
         },
         {
           "name": "ptrace.tracee.fsuser",
-          "type": "string",
           "definition": "FileSystem-user of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-fsuser-doc"
         },
         {
           "name": "ptrace.tracee.gid",
-          "type": "int",
           "definition": "GID of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-gid-doc"
         },
         {
           "name": "ptrace.tracee.group",
-          "type": "string",
           "definition": "Group of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-group-doc"
         },
         {
           "name": "ptrace.tracee.interpreter.file.change_time",
-          "type": "int",
           "definition": "Change time of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-change_time-doc"
         },
         {
           "name": "ptrace.tracee.interpreter.file.filesystem",
-          "type": "string",
           "definition": "File's filesystem",
-          "constants": ""
+          "property_doc_link": "common-fileevent-filesystem-doc"
         },
         {
           "name": "ptrace.tracee.interpreter.file.gid",
-          "type": "int",
           "definition": "GID of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-gid-doc"
         },
         {
           "name": "ptrace.tracee.interpreter.file.group",
-          "type": "string",
           "definition": "Group of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-group-doc"
         },
         {
           "name": "ptrace.tracee.interpreter.file.in_upper_layer",
-          "type": "bool",
           "definition": "Indicator of the file layer, for example, in an OverlayFS",
-          "constants": ""
+          "property_doc_link": "common-filefields-in_upper_layer-doc"
         },
         {
           "name": "ptrace.tracee.interpreter.file.inode",
-          "type": "int",
           "definition": "Inode of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-inode-doc"
         },
         {
           "name": "ptrace.tracee.interpreter.file.mode",
-          "type": "int",
-          "definition": "Mode/rights of the file",
-          "constants": "Chmod mode constants"
+          "definition": "Mode of the file",
+          "property_doc_link": "common-filefields-mode-doc"
         },
         {
           "name": "ptrace.tracee.interpreter.file.modification_time",
-          "type": "int",
           "definition": "Modification time of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
           "name": "ptrace.tracee.interpreter.file.mount_id",
-          "type": "int",
           "definition": "Mount ID of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-mount_id-doc"
         },
         {
           "name": "ptrace.tracee.interpreter.file.name",
-          "type": "string",
           "definition": "File's basename",
-          "constants": ""
+          "property_doc_link": "common-fileevent-name-doc"
         },
         {
           "name": "ptrace.tracee.interpreter.file.name.length",
-          "type": "int",
-          "definition": "Length of 'ptrace.tracee.interpreter.file.name' string",
-          "constants": ""
+          "definition": "Length of the corresponding string",
+          "property_doc_link": "common-string-length-doc"
         },
         {
           "name": "ptrace.tracee.interpreter.file.path",
-          "type": "string",
           "definition": "File's path",
-          "constants": ""
+          "property_doc_link": "common-fileevent-path-doc"
         },
         {
           "name": "ptrace.tracee.interpreter.file.path.length",
-          "type": "int",
-          "definition": "Length of 'ptrace.tracee.interpreter.file.path' string",
-          "constants": ""
+          "definition": "Length of the corresponding string",
+          "property_doc_link": "common-string-length-doc"
         },
         {
           "name": "ptrace.tracee.interpreter.file.rights",
-          "type": "int",
-          "definition": "Mode/rights of the file",
-          "constants": "Chmod mode constants"
+          "definition": "Rights of the file",
+          "property_doc_link": "common-filefields-rights-doc"
         },
         {
           "name": "ptrace.tracee.interpreter.file.uid",
-          "type": "int",
           "definition": "UID of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-uid-doc"
         },
         {
           "name": "ptrace.tracee.interpreter.file.user",
-          "type": "string",
           "definition": "User of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-user-doc"
         },
         {
           "name": "ptrace.tracee.is_kworker",
-          "type": "bool",
           "definition": "Indicates whether the process is a kworker",
-          "constants": ""
+          "property_doc_link": "common-pidcontext-is_kworker-doc"
         },
         {
           "name": "ptrace.tracee.is_thread",
-          "type": "bool",
           "definition": "Indicates whether the process is considered a thread (that is, a child process that hasn't executed another program)",
-          "constants": ""
+          "property_doc_link": "common-process-is_thread-doc"
         },
         {
           "name": "ptrace.tracee.parent.args",
-          "type": "string",
-          "definition": "Arguments of the process (as a string)",
-          "constants": ""
+          "definition": "Arguments of the process (as a string, excluding argv0)",
+          "property_doc_link": "common-process-args-doc"
         },
         {
           "name": "ptrace.tracee.parent.args_flags",
-          "type": "string",
-          "definition": "Arguments of the process (as an array)",
-          "constants": ""
+          "definition": "Flags in the process arguments",
+          "property_doc_link": "common-process-args_flags-doc"
         },
         {
           "name": "ptrace.tracee.parent.args_options",
-          "type": "string",
-          "definition": "Arguments of the process (as an array)",
-          "constants": ""
+          "definition": "Argument of the process as options",
+          "property_doc_link": "common-process-args_options-doc"
         },
         {
           "name": "ptrace.tracee.parent.args_truncated",
-          "type": "bool",
           "definition": "Indicator of arguments truncation",
-          "constants": ""
+          "property_doc_link": "common-process-args_truncated-doc"
         },
         {
           "name": "ptrace.tracee.parent.argv",
-          "type": "string",
-          "definition": "Arguments of the process (as an array)",
-          "constants": ""
+          "definition": "Arguments of the process (as an array, excluding argv0)",
+          "property_doc_link": "common-process-argv-doc"
         },
         {
           "name": "ptrace.tracee.parent.argv0",
-          "type": "string",
           "definition": "First argument of the process",
-          "constants": ""
+          "property_doc_link": "common-process-argv0-doc"
         },
         {
           "name": "ptrace.tracee.parent.cap_effective",
-          "type": "int",
           "definition": "Effective capability set of the process",
-          "constants": "Kernel Capability constants"
+          "property_doc_link": "common-credentials-cap_effective-doc"
         },
         {
           "name": "ptrace.tracee.parent.cap_permitted",
-          "type": "int",
           "definition": "Permitted capability set of the process",
-          "constants": "Kernel Capability constants"
+          "property_doc_link": "common-credentials-cap_permitted-doc"
         },
         {
           "name": "ptrace.tracee.parent.comm",
-          "type": "string",
           "definition": "Comm attribute of the process",
-          "constants": ""
+          "property_doc_link": "common-process-comm-doc"
         },
         {
           "name": "ptrace.tracee.parent.container.id",
-          "type": "string",
           "definition": "Container ID",
-          "constants": ""
+          "property_doc_link": "common-process-container-id-doc"
         },
         {
           "name": "ptrace.tracee.parent.cookie",
-          "type": "int",
           "definition": "Cookie of the process",
-          "constants": ""
+          "property_doc_link": "common-process-cookie-doc"
         },
         {
           "name": "ptrace.tracee.parent.created_at",
-          "type": "int",
           "definition": "Timestamp of the creation of the process",
-          "constants": ""
+          "property_doc_link": "common-process-created_at-doc"
         },
         {
           "name": "ptrace.tracee.parent.egid",
-          "type": "int",
           "definition": "Effective GID of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-egid-doc"
         },
         {
           "name": "ptrace.tracee.parent.egroup",
-          "type": "string",
           "definition": "Effective group of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-egroup-doc"
         },
         {
           "name": "ptrace.tracee.parent.envp",
-          "type": "string",
           "definition": "Environment variables of the process",
-          "constants": ""
+          "property_doc_link": "common-process-envp-doc"
         },
         {
           "name": "ptrace.tracee.parent.envs",
-          "type": "string",
           "definition": "Environment variable names of the process",
-          "constants": ""
+          "property_doc_link": "common-process-envs-doc"
         },
         {
           "name": "ptrace.tracee.parent.envs_truncated",
-          "type": "bool",
           "definition": "Indicator of environment variables truncation",
-          "constants": ""
+          "property_doc_link": "common-process-envs_truncated-doc"
         },
         {
           "name": "ptrace.tracee.parent.euid",
-          "type": "int",
           "definition": "Effective UID of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-euid-doc"
         },
         {
           "name": "ptrace.tracee.parent.euser",
-          "type": "string",
           "definition": "Effective user of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-euser-doc"
         },
         {
           "name": "ptrace.tracee.parent.file.change_time",
-          "type": "int",
           "definition": "Change time of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-change_time-doc"
         },
         {
           "name": "ptrace.tracee.parent.file.filesystem",
-          "type": "string",
           "definition": "File's filesystem",
-          "constants": ""
+          "property_doc_link": "common-fileevent-filesystem-doc"
         },
         {
           "name": "ptrace.tracee.parent.file.gid",
-          "type": "int",
           "definition": "GID of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-gid-doc"
         },
         {
           "name": "ptrace.tracee.parent.file.group",
-          "type": "string",
           "definition": "Group of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-group-doc"
         },
         {
           "name": "ptrace.tracee.parent.file.in_upper_layer",
-          "type": "bool",
           "definition": "Indicator of the file layer, for example, in an OverlayFS",
-          "constants": ""
+          "property_doc_link": "common-filefields-in_upper_layer-doc"
         },
         {
           "name": "ptrace.tracee.parent.file.inode",
-          "type": "int",
           "definition": "Inode of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-inode-doc"
         },
         {
           "name": "ptrace.tracee.parent.file.mode",
-          "type": "int",
-          "definition": "Mode/rights of the file",
-          "constants": "Chmod mode constants"
+          "definition": "Mode of the file",
+          "property_doc_link": "common-filefields-mode-doc"
         },
         {
           "name": "ptrace.tracee.parent.file.modification_time",
-          "type": "int",
           "definition": "Modification time of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
           "name": "ptrace.tracee.parent.file.mount_id",
-          "type": "int",
           "definition": "Mount ID of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-mount_id-doc"
         },
         {
           "name": "ptrace.tracee.parent.file.name",
-          "type": "string",
           "definition": "File's basename",
-          "constants": ""
+          "property_doc_link": "common-fileevent-name-doc"
         },
         {
           "name": "ptrace.tracee.parent.file.name.length",
-          "type": "int",
-          "definition": "Length of 'ptrace.tracee.parent.file.name' string",
-          "constants": ""
+          "definition": "Length of the corresponding string",
+          "property_doc_link": "common-string-length-doc"
         },
         {
           "name": "ptrace.tracee.parent.file.path",
-          "type": "string",
           "definition": "File's path",
-          "constants": ""
+          "property_doc_link": "common-fileevent-path-doc"
         },
         {
           "name": "ptrace.tracee.parent.file.path.length",
-          "type": "int",
-          "definition": "Length of 'ptrace.tracee.parent.file.path' string",
-          "constants": ""
+          "definition": "Length of the corresponding string",
+          "property_doc_link": "common-string-length-doc"
         },
         {
           "name": "ptrace.tracee.parent.file.rights",
-          "type": "int",
-          "definition": "Mode/rights of the file",
-          "constants": "Chmod mode constants"
+          "definition": "Rights of the file",
+          "property_doc_link": "common-filefields-rights-doc"
         },
         {
           "name": "ptrace.tracee.parent.file.uid",
-          "type": "int",
           "definition": "UID of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-uid-doc"
         },
         {
           "name": "ptrace.tracee.parent.file.user",
-          "type": "string",
           "definition": "User of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-user-doc"
         },
         {
           "name": "ptrace.tracee.parent.fsgid",
-          "type": "int",
           "definition": "FileSystem-gid of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-fsgid-doc"
         },
         {
           "name": "ptrace.tracee.parent.fsgroup",
-          "type": "string",
           "definition": "FileSystem-group of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-fsgroup-doc"
         },
         {
           "name": "ptrace.tracee.parent.fsuid",
-          "type": "int",
           "definition": "FileSystem-uid of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-fsuid-doc"
         },
         {
           "name": "ptrace.tracee.parent.fsuser",
-          "type": "string",
           "definition": "FileSystem-user of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-fsuser-doc"
         },
         {
           "name": "ptrace.tracee.parent.gid",
-          "type": "int",
           "definition": "GID of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-gid-doc"
         },
         {
           "name": "ptrace.tracee.parent.group",
-          "type": "string",
           "definition": "Group of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-group-doc"
         },
         {
           "name": "ptrace.tracee.parent.interpreter.file.change_time",
-          "type": "int",
           "definition": "Change time of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-change_time-doc"
         },
         {
           "name": "ptrace.tracee.parent.interpreter.file.filesystem",
-          "type": "string",
           "definition": "File's filesystem",
-          "constants": ""
+          "property_doc_link": "common-fileevent-filesystem-doc"
         },
         {
           "name": "ptrace.tracee.parent.interpreter.file.gid",
-          "type": "int",
           "definition": "GID of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-gid-doc"
         },
         {
           "name": "ptrace.tracee.parent.interpreter.file.group",
-          "type": "string",
           "definition": "Group of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-group-doc"
         },
         {
           "name": "ptrace.tracee.parent.interpreter.file.in_upper_layer",
-          "type": "bool",
           "definition": "Indicator of the file layer, for example, in an OverlayFS",
-          "constants": ""
+          "property_doc_link": "common-filefields-in_upper_layer-doc"
         },
         {
           "name": "ptrace.tracee.parent.interpreter.file.inode",
-          "type": "int",
           "definition": "Inode of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-inode-doc"
         },
         {
           "name": "ptrace.tracee.parent.interpreter.file.mode",
-          "type": "int",
-          "definition": "Mode/rights of the file",
-          "constants": "Chmod mode constants"
+          "definition": "Mode of the file",
+          "property_doc_link": "common-filefields-mode-doc"
         },
         {
           "name": "ptrace.tracee.parent.interpreter.file.modification_time",
-          "type": "int",
           "definition": "Modification time of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
           "name": "ptrace.tracee.parent.interpreter.file.mount_id",
-          "type": "int",
           "definition": "Mount ID of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-mount_id-doc"
         },
         {
           "name": "ptrace.tracee.parent.interpreter.file.name",
-          "type": "string",
           "definition": "File's basename",
-          "constants": ""
+          "property_doc_link": "common-fileevent-name-doc"
         },
         {
           "name": "ptrace.tracee.parent.interpreter.file.name.length",
-          "type": "int",
-          "definition": "Length of 'ptrace.tracee.parent.interpreter.file.name' string",
-          "constants": ""
+          "definition": "Length of the corresponding string",
+          "property_doc_link": "common-string-length-doc"
         },
         {
           "name": "ptrace.tracee.parent.interpreter.file.path",
-          "type": "string",
           "definition": "File's path",
-          "constants": ""
+          "property_doc_link": "common-fileevent-path-doc"
         },
         {
           "name": "ptrace.tracee.parent.interpreter.file.path.length",
-          "type": "int",
-          "definition": "Length of 'ptrace.tracee.parent.interpreter.file.path' string",
-          "constants": ""
+          "definition": "Length of the corresponding string",
+          "property_doc_link": "common-string-length-doc"
         },
         {
           "name": "ptrace.tracee.parent.interpreter.file.rights",
-          "type": "int",
-          "definition": "Mode/rights of the file",
-          "constants": "Chmod mode constants"
+          "definition": "Rights of the file",
+          "property_doc_link": "common-filefields-rights-doc"
         },
         {
           "name": "ptrace.tracee.parent.interpreter.file.uid",
-          "type": "int",
           "definition": "UID of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-uid-doc"
         },
         {
           "name": "ptrace.tracee.parent.interpreter.file.user",
-          "type": "string",
           "definition": "User of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-user-doc"
         },
         {
           "name": "ptrace.tracee.parent.is_kworker",
-          "type": "bool",
           "definition": "Indicates whether the process is a kworker",
-          "constants": ""
+          "property_doc_link": "common-pidcontext-is_kworker-doc"
         },
         {
           "name": "ptrace.tracee.parent.is_thread",
-          "type": "bool",
           "definition": "Indicates whether the process is considered a thread (that is, a child process that hasn't executed another program)",
-          "constants": ""
+          "property_doc_link": "common-process-is_thread-doc"
         },
         {
           "name": "ptrace.tracee.parent.pid",
-          "type": "int",
           "definition": "Process ID of the process (also called thread group ID)",
-          "constants": ""
+          "property_doc_link": "common-pidcontext-pid-doc"
         },
         {
           "name": "ptrace.tracee.parent.ppid",
-          "type": "int",
           "definition": "Parent process ID",
-          "constants": ""
+          "property_doc_link": "common-process-ppid-doc"
         },
         {
           "name": "ptrace.tracee.parent.tid",
-          "type": "int",
           "definition": "Thread ID of the thread",
-          "constants": ""
+          "property_doc_link": "common-pidcontext-tid-doc"
         },
         {
           "name": "ptrace.tracee.parent.tty_name",
-          "type": "string",
           "definition": "Name of the TTY associated with the process",
-          "constants": ""
+          "property_doc_link": "common-process-tty_name-doc"
         },
         {
           "name": "ptrace.tracee.parent.uid",
-          "type": "int",
           "definition": "UID of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-uid-doc"
         },
         {
           "name": "ptrace.tracee.parent.user",
-          "type": "string",
           "definition": "User of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-user-doc"
         },
         {
           "name": "ptrace.tracee.pid",
-          "type": "int",
           "definition": "Process ID of the process (also called thread group ID)",
-          "constants": ""
+          "property_doc_link": "common-pidcontext-pid-doc"
         },
         {
           "name": "ptrace.tracee.ppid",
-          "type": "int",
           "definition": "Parent process ID",
-          "constants": ""
+          "property_doc_link": "common-process-ppid-doc"
         },
         {
           "name": "ptrace.tracee.tid",
-          "type": "int",
           "definition": "Thread ID of the thread",
-          "constants": ""
+          "property_doc_link": "common-pidcontext-tid-doc"
         },
         {
           "name": "ptrace.tracee.tty_name",
-          "type": "string",
           "definition": "Name of the TTY associated with the process",
-          "constants": ""
+          "property_doc_link": "common-process-tty_name-doc"
         },
         {
           "name": "ptrace.tracee.uid",
-          "type": "int",
           "definition": "UID of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-uid-doc"
         },
         {
           "name": "ptrace.tracee.user",
-          "type": "string",
           "definition": "User of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-user-doc"
         }
       ]
     },
@@ -4446,117 +3732,98 @@
       "properties": [
         {
           "name": "removexattr.file.change_time",
-          "type": "int",
           "definition": "Change time of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-change_time-doc"
         },
         {
           "name": "removexattr.file.destination.name",
-          "type": "string",
           "definition": "Name of the extended attribute",
-          "constants": ""
+          "property_doc_link": "common-setxattrevent-file-destination-name-doc"
         },
         {
           "name": "removexattr.file.destination.namespace",
-          "type": "string",
           "definition": "Namespace of the extended attribute",
-          "constants": ""
+          "property_doc_link": "common-setxattrevent-file-destination-namespace-doc"
         },
         {
           "name": "removexattr.file.filesystem",
-          "type": "string",
           "definition": "File's filesystem",
-          "constants": ""
+          "property_doc_link": "common-fileevent-filesystem-doc"
         },
         {
           "name": "removexattr.file.gid",
-          "type": "int",
           "definition": "GID of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-gid-doc"
         },
         {
           "name": "removexattr.file.group",
-          "type": "string",
           "definition": "Group of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-group-doc"
         },
         {
           "name": "removexattr.file.in_upper_layer",
-          "type": "bool",
           "definition": "Indicator of the file layer, for example, in an OverlayFS",
-          "constants": ""
+          "property_doc_link": "common-filefields-in_upper_layer-doc"
         },
         {
           "name": "removexattr.file.inode",
-          "type": "int",
           "definition": "Inode of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-inode-doc"
         },
         {
           "name": "removexattr.file.mode",
-          "type": "int",
-          "definition": "Mode/rights of the file",
-          "constants": "Chmod mode constants"
+          "definition": "Mode of the file",
+          "property_doc_link": "common-filefields-mode-doc"
         },
         {
           "name": "removexattr.file.modification_time",
-          "type": "int",
           "definition": "Modification time of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
           "name": "removexattr.file.mount_id",
-          "type": "int",
           "definition": "Mount ID of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-mount_id-doc"
         },
         {
           "name": "removexattr.file.name",
-          "type": "string",
           "definition": "File's basename",
-          "constants": ""
+          "property_doc_link": "common-fileevent-name-doc"
         },
         {
           "name": "removexattr.file.name.length",
-          "type": "int",
-          "definition": "Length of 'removexattr.file.name' string",
-          "constants": ""
+          "definition": "Length of the corresponding string",
+          "property_doc_link": "common-string-length-doc"
         },
         {
           "name": "removexattr.file.path",
-          "type": "string",
           "definition": "File's path",
-          "constants": ""
+          "property_doc_link": "common-fileevent-path-doc"
         },
         {
           "name": "removexattr.file.path.length",
-          "type": "int",
-          "definition": "Length of 'removexattr.file.path' string",
-          "constants": ""
+          "definition": "Length of the corresponding string",
+          "property_doc_link": "common-string-length-doc"
         },
         {
           "name": "removexattr.file.rights",
-          "type": "int",
-          "definition": "Mode/rights of the file",
-          "constants": "Chmod mode constants"
+          "definition": "Rights of the file",
+          "property_doc_link": "common-filefields-rights-doc"
         },
         {
           "name": "removexattr.file.uid",
-          "type": "int",
           "definition": "UID of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-uid-doc"
         },
         {
           "name": "removexattr.file.user",
-          "type": "string",
           "definition": "User of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-user-doc"
         },
         {
           "name": "removexattr.retval",
-          "type": "int",
           "definition": "Return value of the syscall",
-          "constants": "Error Constants"
+          "property_doc_link": "common-syscallevent-retval-doc"
         }
       ]
     },
@@ -4569,201 +3836,168 @@
       "properties": [
         {
           "name": "rename.file.change_time",
-          "type": "int",
           "definition": "Change time of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-change_time-doc"
         },
         {
           "name": "rename.file.destination.change_time",
-          "type": "int",
           "definition": "Change time of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-change_time-doc"
         },
         {
           "name": "rename.file.destination.filesystem",
-          "type": "string",
           "definition": "File's filesystem",
-          "constants": ""
+          "property_doc_link": "common-fileevent-filesystem-doc"
         },
         {
           "name": "rename.file.destination.gid",
-          "type": "int",
           "definition": "GID of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-gid-doc"
         },
         {
           "name": "rename.file.destination.group",
-          "type": "string",
           "definition": "Group of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-group-doc"
         },
         {
           "name": "rename.file.destination.in_upper_layer",
-          "type": "bool",
           "definition": "Indicator of the file layer, for example, in an OverlayFS",
-          "constants": ""
+          "property_doc_link": "common-filefields-in_upper_layer-doc"
         },
         {
           "name": "rename.file.destination.inode",
-          "type": "int",
           "definition": "Inode of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-inode-doc"
         },
         {
           "name": "rename.file.destination.mode",
-          "type": "int",
-          "definition": "Mode/rights of the file",
-          "constants": "Chmod mode constants"
+          "definition": "Mode of the file",
+          "property_doc_link": "common-filefields-mode-doc"
         },
         {
           "name": "rename.file.destination.modification_time",
-          "type": "int",
           "definition": "Modification time of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
           "name": "rename.file.destination.mount_id",
-          "type": "int",
           "definition": "Mount ID of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-mount_id-doc"
         },
         {
           "name": "rename.file.destination.name",
-          "type": "string",
           "definition": "File's basename",
-          "constants": ""
+          "property_doc_link": "common-fileevent-name-doc"
         },
         {
           "name": "rename.file.destination.name.length",
-          "type": "int",
-          "definition": "Length of 'rename.file.destination.name' string",
-          "constants": ""
+          "definition": "Length of the corresponding string",
+          "property_doc_link": "common-string-length-doc"
         },
         {
           "name": "rename.file.destination.path",
-          "type": "string",
           "definition": "File's path",
-          "constants": ""
+          "property_doc_link": "common-fileevent-path-doc"
         },
         {
           "name": "rename.file.destination.path.length",
-          "type": "int",
-          "definition": "Length of 'rename.file.destination.path' string",
-          "constants": ""
+          "definition": "Length of the corresponding string",
+          "property_doc_link": "common-string-length-doc"
         },
         {
           "name": "rename.file.destination.rights",
-          "type": "int",
-          "definition": "Mode/rights of the file",
-          "constants": "Chmod mode constants"
+          "definition": "Rights of the file",
+          "property_doc_link": "common-filefields-rights-doc"
         },
         {
           "name": "rename.file.destination.uid",
-          "type": "int",
           "definition": "UID of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-uid-doc"
         },
         {
           "name": "rename.file.destination.user",
-          "type": "string",
           "definition": "User of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-user-doc"
         },
         {
           "name": "rename.file.filesystem",
-          "type": "string",
           "definition": "File's filesystem",
-          "constants": ""
+          "property_doc_link": "common-fileevent-filesystem-doc"
         },
         {
           "name": "rename.file.gid",
-          "type": "int",
           "definition": "GID of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-gid-doc"
         },
         {
           "name": "rename.file.group",
-          "type": "string",
           "definition": "Group of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-group-doc"
         },
         {
           "name": "rename.file.in_upper_layer",
-          "type": "bool",
           "definition": "Indicator of the file layer, for example, in an OverlayFS",
-          "constants": ""
+          "property_doc_link": "common-filefields-in_upper_layer-doc"
         },
         {
           "name": "rename.file.inode",
-          "type": "int",
           "definition": "Inode of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-inode-doc"
         },
         {
           "name": "rename.file.mode",
-          "type": "int",
-          "definition": "Mode/rights of the file",
-          "constants": "Chmod mode constants"
+          "definition": "Mode of the file",
+          "property_doc_link": "common-filefields-mode-doc"
         },
         {
           "name": "rename.file.modification_time",
-          "type": "int",
           "definition": "Modification time of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
           "name": "rename.file.mount_id",
-          "type": "int",
           "definition": "Mount ID of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-mount_id-doc"
         },
         {
           "name": "rename.file.name",
-          "type": "string",
           "definition": "File's basename",
-          "constants": ""
+          "property_doc_link": "common-fileevent-name-doc"
         },
         {
           "name": "rename.file.name.length",
-          "type": "int",
-          "definition": "Length of 'rename.file.name' string",
-          "constants": ""
+          "definition": "Length of the corresponding string",
+          "property_doc_link": "common-string-length-doc"
         },
         {
           "name": "rename.file.path",
-          "type": "string",
           "definition": "File's path",
-          "constants": ""
+          "property_doc_link": "common-fileevent-path-doc"
         },
         {
           "name": "rename.file.path.length",
-          "type": "int",
-          "definition": "Length of 'rename.file.path' string",
-          "constants": ""
+          "definition": "Length of the corresponding string",
+          "property_doc_link": "common-string-length-doc"
         },
         {
           "name": "rename.file.rights",
-          "type": "int",
-          "definition": "Mode/rights of the file",
-          "constants": "Chmod mode constants"
+          "definition": "Rights of the file",
+          "property_doc_link": "common-filefields-rights-doc"
         },
         {
           "name": "rename.file.uid",
-          "type": "int",
           "definition": "UID of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-uid-doc"
         },
         {
           "name": "rename.file.user",
-          "type": "string",
           "definition": "User of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-user-doc"
         },
         {
           "name": "rename.retval",
-          "type": "int",
           "definition": "Return value of the syscall",
-          "constants": "Error Constants"
+          "property_doc_link": "common-syscallevent-retval-doc"
         }
       ]
     },
@@ -4776,105 +4010,88 @@
       "properties": [
         {
           "name": "rmdir.file.change_time",
-          "type": "int",
           "definition": "Change time of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-change_time-doc"
         },
         {
           "name": "rmdir.file.filesystem",
-          "type": "string",
           "definition": "File's filesystem",
-          "constants": ""
+          "property_doc_link": "common-fileevent-filesystem-doc"
         },
         {
           "name": "rmdir.file.gid",
-          "type": "int",
           "definition": "GID of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-gid-doc"
         },
         {
           "name": "rmdir.file.group",
-          "type": "string",
           "definition": "Group of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-group-doc"
         },
         {
           "name": "rmdir.file.in_upper_layer",
-          "type": "bool",
           "definition": "Indicator of the file layer, for example, in an OverlayFS",
-          "constants": ""
+          "property_doc_link": "common-filefields-in_upper_layer-doc"
         },
         {
           "name": "rmdir.file.inode",
-          "type": "int",
           "definition": "Inode of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-inode-doc"
         },
         {
           "name": "rmdir.file.mode",
-          "type": "int",
-          "definition": "Mode/rights of the file",
-          "constants": "Chmod mode constants"
+          "definition": "Mode of the file",
+          "property_doc_link": "common-filefields-mode-doc"
         },
         {
           "name": "rmdir.file.modification_time",
-          "type": "int",
           "definition": "Modification time of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
           "name": "rmdir.file.mount_id",
-          "type": "int",
           "definition": "Mount ID of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-mount_id-doc"
         },
         {
           "name": "rmdir.file.name",
-          "type": "string",
           "definition": "File's basename",
-          "constants": ""
+          "property_doc_link": "common-fileevent-name-doc"
         },
         {
           "name": "rmdir.file.name.length",
-          "type": "int",
-          "definition": "Length of 'rmdir.file.name' string",
-          "constants": ""
+          "definition": "Length of the corresponding string",
+          "property_doc_link": "common-string-length-doc"
         },
         {
           "name": "rmdir.file.path",
-          "type": "string",
           "definition": "File's path",
-          "constants": ""
+          "property_doc_link": "common-fileevent-path-doc"
         },
         {
           "name": "rmdir.file.path.length",
-          "type": "int",
-          "definition": "Length of 'rmdir.file.path' string",
-          "constants": ""
+          "definition": "Length of the corresponding string",
+          "property_doc_link": "common-string-length-doc"
         },
         {
           "name": "rmdir.file.rights",
-          "type": "int",
-          "definition": "Mode/rights of the file",
-          "constants": "Chmod mode constants"
+          "definition": "Rights of the file",
+          "property_doc_link": "common-filefields-rights-doc"
         },
         {
           "name": "rmdir.file.uid",
-          "type": "int",
           "definition": "UID of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-uid-doc"
         },
         {
           "name": "rmdir.file.user",
-          "type": "string",
           "definition": "User of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-user-doc"
         },
         {
           "name": "rmdir.retval",
-          "type": "int",
           "definition": "Return value of the syscall",
-          "constants": "Error Constants"
+          "property_doc_link": "common-syscallevent-retval-doc"
         }
       ]
     },
@@ -4887,27 +4104,23 @@
       "properties": [
         {
           "name": "selinux.bool.name",
-          "type": "string",
           "definition": "SELinux boolean name",
-          "constants": ""
+          "property_doc_link": "selinux-bool-name-doc"
         },
         {
           "name": "selinux.bool.state",
-          "type": "string",
           "definition": "SELinux boolean new value",
-          "constants": ""
+          "property_doc_link": "selinux-bool-state-doc"
         },
         {
           "name": "selinux.bool_commit.state",
-          "type": "bool",
           "definition": "Indicator of a SELinux boolean commit operation",
-          "constants": ""
+          "property_doc_link": "selinux-bool_commit-state-doc"
         },
         {
           "name": "selinux.enforce.status",
-          "type": "string",
-          "definition": "SELinux enforcement status (one of \"enforcing\", \"permissive\", \"disabled\"\")",
-          "constants": ""
+          "definition": "SELinux enforcement status (one of \"enforcing\", \"permissive\", \"disabled\")",
+          "property_doc_link": "selinux-enforce-status-doc"
         }
       ]
     },
@@ -4920,39 +4133,33 @@
       "properties": [
         {
           "name": "setgid.egid",
-          "type": "int",
           "definition": "New effective GID of the process",
-          "constants": ""
+          "property_doc_link": "setgid-egid-doc"
         },
         {
           "name": "setgid.egroup",
-          "type": "string",
           "definition": "New effective group of the process",
-          "constants": ""
+          "property_doc_link": "setgid-egroup-doc"
         },
         {
           "name": "setgid.fsgid",
-          "type": "int",
           "definition": "New FileSystem GID of the process",
-          "constants": ""
+          "property_doc_link": "setgid-fsgid-doc"
         },
         {
           "name": "setgid.fsgroup",
-          "type": "string",
           "definition": "New FileSystem group of the process",
-          "constants": ""
+          "property_doc_link": "setgid-fsgroup-doc"
         },
         {
           "name": "setgid.gid",
-          "type": "int",
           "definition": "New GID of the process",
-          "constants": ""
+          "property_doc_link": "setgid-gid-doc"
         },
         {
           "name": "setgid.group",
-          "type": "string",
           "definition": "New group of the process",
-          "constants": ""
+          "property_doc_link": "setgid-group-doc"
         }
       ]
     },
@@ -4965,39 +4172,33 @@
       "properties": [
         {
           "name": "setuid.euid",
-          "type": "int",
           "definition": "New effective UID of the process",
-          "constants": ""
+          "property_doc_link": "setuid-euid-doc"
         },
         {
           "name": "setuid.euser",
-          "type": "string",
           "definition": "New effective user of the process",
-          "constants": ""
+          "property_doc_link": "setuid-euser-doc"
         },
         {
           "name": "setuid.fsuid",
-          "type": "int",
           "definition": "New FileSystem UID of the process",
-          "constants": ""
+          "property_doc_link": "setuid-fsuid-doc"
         },
         {
           "name": "setuid.fsuser",
-          "type": "string",
           "definition": "New FileSystem user of the process",
-          "constants": ""
+          "property_doc_link": "setuid-fsuser-doc"
         },
         {
           "name": "setuid.uid",
-          "type": "int",
           "definition": "New UID of the process",
-          "constants": ""
+          "property_doc_link": "setuid-uid-doc"
         },
         {
           "name": "setuid.user",
-          "type": "string",
           "definition": "New user of the process",
-          "constants": ""
+          "property_doc_link": "setuid-user-doc"
         }
       ]
     },
@@ -5010,117 +4211,98 @@
       "properties": [
         {
           "name": "setxattr.file.change_time",
-          "type": "int",
           "definition": "Change time of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-change_time-doc"
         },
         {
           "name": "setxattr.file.destination.name",
-          "type": "string",
           "definition": "Name of the extended attribute",
-          "constants": ""
+          "property_doc_link": "common-setxattrevent-file-destination-name-doc"
         },
         {
           "name": "setxattr.file.destination.namespace",
-          "type": "string",
           "definition": "Namespace of the extended attribute",
-          "constants": ""
+          "property_doc_link": "common-setxattrevent-file-destination-namespace-doc"
         },
         {
           "name": "setxattr.file.filesystem",
-          "type": "string",
           "definition": "File's filesystem",
-          "constants": ""
+          "property_doc_link": "common-fileevent-filesystem-doc"
         },
         {
           "name": "setxattr.file.gid",
-          "type": "int",
           "definition": "GID of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-gid-doc"
         },
         {
           "name": "setxattr.file.group",
-          "type": "string",
           "definition": "Group of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-group-doc"
         },
         {
           "name": "setxattr.file.in_upper_layer",
-          "type": "bool",
           "definition": "Indicator of the file layer, for example, in an OverlayFS",
-          "constants": ""
+          "property_doc_link": "common-filefields-in_upper_layer-doc"
         },
         {
           "name": "setxattr.file.inode",
-          "type": "int",
           "definition": "Inode of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-inode-doc"
         },
         {
           "name": "setxattr.file.mode",
-          "type": "int",
-          "definition": "Mode/rights of the file",
-          "constants": "Chmod mode constants"
+          "definition": "Mode of the file",
+          "property_doc_link": "common-filefields-mode-doc"
         },
         {
           "name": "setxattr.file.modification_time",
-          "type": "int",
           "definition": "Modification time of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
           "name": "setxattr.file.mount_id",
-          "type": "int",
           "definition": "Mount ID of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-mount_id-doc"
         },
         {
           "name": "setxattr.file.name",
-          "type": "string",
           "definition": "File's basename",
-          "constants": ""
+          "property_doc_link": "common-fileevent-name-doc"
         },
         {
           "name": "setxattr.file.name.length",
-          "type": "int",
-          "definition": "Length of 'setxattr.file.name' string",
-          "constants": ""
+          "definition": "Length of the corresponding string",
+          "property_doc_link": "common-string-length-doc"
         },
         {
           "name": "setxattr.file.path",
-          "type": "string",
           "definition": "File's path",
-          "constants": ""
+          "property_doc_link": "common-fileevent-path-doc"
         },
         {
           "name": "setxattr.file.path.length",
-          "type": "int",
-          "definition": "Length of 'setxattr.file.path' string",
-          "constants": ""
+          "definition": "Length of the corresponding string",
+          "property_doc_link": "common-string-length-doc"
         },
         {
           "name": "setxattr.file.rights",
-          "type": "int",
-          "definition": "Mode/rights of the file",
-          "constants": "Chmod mode constants"
+          "definition": "Rights of the file",
+          "property_doc_link": "common-filefields-rights-doc"
         },
         {
           "name": "setxattr.file.uid",
-          "type": "int",
           "definition": "UID of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-uid-doc"
         },
         {
           "name": "setxattr.file.user",
-          "type": "string",
           "definition": "User of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-user-doc"
         },
         {
           "name": "setxattr.retval",
-          "type": "int",
           "definition": "Return value of the syscall",
-          "constants": "Error Constants"
+          "property_doc_link": "common-syscallevent-retval-doc"
         }
       ]
     },
@@ -5133,1191 +4315,993 @@
       "properties": [
         {
           "name": "signal.pid",
-          "type": "int",
           "definition": "Target PID",
-          "constants": ""
+          "property_doc_link": "signal-pid-doc"
         },
         {
           "name": "signal.retval",
-          "type": "int",
           "definition": "Return value of the syscall",
-          "constants": "Error Constants"
+          "property_doc_link": "common-syscallevent-retval-doc"
         },
         {
           "name": "signal.target.ancestors.args",
-          "type": "string",
-          "definition": "Arguments of the process (as a string)",
-          "constants": ""
+          "definition": "Arguments of the process (as a string, excluding argv0)",
+          "property_doc_link": "common-process-args-doc"
         },
         {
           "name": "signal.target.ancestors.args_flags",
-          "type": "string",
-          "definition": "Arguments of the process (as an array)",
-          "constants": ""
+          "definition": "Flags in the process arguments",
+          "property_doc_link": "common-process-args_flags-doc"
         },
         {
           "name": "signal.target.ancestors.args_options",
-          "type": "string",
-          "definition": "Arguments of the process (as an array)",
-          "constants": ""
+          "definition": "Argument of the process as options",
+          "property_doc_link": "common-process-args_options-doc"
         },
         {
           "name": "signal.target.ancestors.args_truncated",
-          "type": "bool",
           "definition": "Indicator of arguments truncation",
-          "constants": ""
+          "property_doc_link": "common-process-args_truncated-doc"
         },
         {
           "name": "signal.target.ancestors.argv",
-          "type": "string",
-          "definition": "Arguments of the process (as an array)",
-          "constants": ""
+          "definition": "Arguments of the process (as an array, excluding argv0)",
+          "property_doc_link": "common-process-argv-doc"
         },
         {
           "name": "signal.target.ancestors.argv0",
-          "type": "string",
           "definition": "First argument of the process",
-          "constants": ""
+          "property_doc_link": "common-process-argv0-doc"
         },
         {
           "name": "signal.target.ancestors.cap_effective",
-          "type": "int",
           "definition": "Effective capability set of the process",
-          "constants": "Kernel Capability constants"
+          "property_doc_link": "common-credentials-cap_effective-doc"
         },
         {
           "name": "signal.target.ancestors.cap_permitted",
-          "type": "int",
           "definition": "Permitted capability set of the process",
-          "constants": "Kernel Capability constants"
+          "property_doc_link": "common-credentials-cap_permitted-doc"
         },
         {
           "name": "signal.target.ancestors.comm",
-          "type": "string",
           "definition": "Comm attribute of the process",
-          "constants": ""
+          "property_doc_link": "common-process-comm-doc"
         },
         {
           "name": "signal.target.ancestors.container.id",
-          "type": "string",
           "definition": "Container ID",
-          "constants": ""
+          "property_doc_link": "common-process-container-id-doc"
         },
         {
           "name": "signal.target.ancestors.cookie",
-          "type": "int",
           "definition": "Cookie of the process",
-          "constants": ""
+          "property_doc_link": "common-process-cookie-doc"
         },
         {
           "name": "signal.target.ancestors.created_at",
-          "type": "int",
           "definition": "Timestamp of the creation of the process",
-          "constants": ""
+          "property_doc_link": "common-process-created_at-doc"
         },
         {
           "name": "signal.target.ancestors.egid",
-          "type": "int",
           "definition": "Effective GID of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-egid-doc"
         },
         {
           "name": "signal.target.ancestors.egroup",
-          "type": "string",
           "definition": "Effective group of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-egroup-doc"
         },
         {
           "name": "signal.target.ancestors.envp",
-          "type": "string",
           "definition": "Environment variables of the process",
-          "constants": ""
+          "property_doc_link": "common-process-envp-doc"
         },
         {
           "name": "signal.target.ancestors.envs",
-          "type": "string",
           "definition": "Environment variable names of the process",
-          "constants": ""
+          "property_doc_link": "common-process-envs-doc"
         },
         {
           "name": "signal.target.ancestors.envs_truncated",
-          "type": "bool",
           "definition": "Indicator of environment variables truncation",
-          "constants": ""
+          "property_doc_link": "common-process-envs_truncated-doc"
         },
         {
           "name": "signal.target.ancestors.euid",
-          "type": "int",
           "definition": "Effective UID of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-euid-doc"
         },
         {
           "name": "signal.target.ancestors.euser",
-          "type": "string",
           "definition": "Effective user of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-euser-doc"
         },
         {
           "name": "signal.target.ancestors.file.change_time",
-          "type": "int",
           "definition": "Change time of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-change_time-doc"
         },
         {
           "name": "signal.target.ancestors.file.filesystem",
-          "type": "string",
           "definition": "File's filesystem",
-          "constants": ""
+          "property_doc_link": "common-fileevent-filesystem-doc"
         },
         {
           "name": "signal.target.ancestors.file.gid",
-          "type": "int",
           "definition": "GID of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-gid-doc"
         },
         {
           "name": "signal.target.ancestors.file.group",
-          "type": "string",
           "definition": "Group of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-group-doc"
         },
         {
           "name": "signal.target.ancestors.file.in_upper_layer",
-          "type": "bool",
           "definition": "Indicator of the file layer, for example, in an OverlayFS",
-          "constants": ""
+          "property_doc_link": "common-filefields-in_upper_layer-doc"
         },
         {
           "name": "signal.target.ancestors.file.inode",
-          "type": "int",
           "definition": "Inode of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-inode-doc"
         },
         {
           "name": "signal.target.ancestors.file.mode",
-          "type": "int",
-          "definition": "Mode/rights of the file",
-          "constants": "Chmod mode constants"
+          "definition": "Mode of the file",
+          "property_doc_link": "common-filefields-mode-doc"
         },
         {
           "name": "signal.target.ancestors.file.modification_time",
-          "type": "int",
           "definition": "Modification time of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
           "name": "signal.target.ancestors.file.mount_id",
-          "type": "int",
           "definition": "Mount ID of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-mount_id-doc"
         },
         {
           "name": "signal.target.ancestors.file.name",
-          "type": "string",
           "definition": "File's basename",
-          "constants": ""
+          "property_doc_link": "common-fileevent-name-doc"
         },
         {
           "name": "signal.target.ancestors.file.name.length",
-          "type": "int",
-          "definition": "Length of 'signal.target.ancestors.file.name' string",
-          "constants": ""
+          "definition": "Length of the corresponding string",
+          "property_doc_link": "common-string-length-doc"
         },
         {
           "name": "signal.target.ancestors.file.path",
-          "type": "string",
           "definition": "File's path",
-          "constants": ""
+          "property_doc_link": "common-fileevent-path-doc"
         },
         {
           "name": "signal.target.ancestors.file.path.length",
-          "type": "int",
-          "definition": "Length of 'signal.target.ancestors.file.path' string",
-          "constants": ""
+          "definition": "Length of the corresponding string",
+          "property_doc_link": "common-string-length-doc"
         },
         {
           "name": "signal.target.ancestors.file.rights",
-          "type": "int",
-          "definition": "Mode/rights of the file",
-          "constants": "Chmod mode constants"
+          "definition": "Rights of the file",
+          "property_doc_link": "common-filefields-rights-doc"
         },
         {
           "name": "signal.target.ancestors.file.uid",
-          "type": "int",
           "definition": "UID of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-uid-doc"
         },
         {
           "name": "signal.target.ancestors.file.user",
-          "type": "string",
           "definition": "User of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-user-doc"
         },
         {
           "name": "signal.target.ancestors.fsgid",
-          "type": "int",
           "definition": "FileSystem-gid of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-fsgid-doc"
         },
         {
           "name": "signal.target.ancestors.fsgroup",
-          "type": "string",
           "definition": "FileSystem-group of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-fsgroup-doc"
         },
         {
           "name": "signal.target.ancestors.fsuid",
-          "type": "int",
           "definition": "FileSystem-uid of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-fsuid-doc"
         },
         {
           "name": "signal.target.ancestors.fsuser",
-          "type": "string",
           "definition": "FileSystem-user of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-fsuser-doc"
         },
         {
           "name": "signal.target.ancestors.gid",
-          "type": "int",
           "definition": "GID of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-gid-doc"
         },
         {
           "name": "signal.target.ancestors.group",
-          "type": "string",
           "definition": "Group of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-group-doc"
         },
         {
           "name": "signal.target.ancestors.interpreter.file.change_time",
-          "type": "int",
           "definition": "Change time of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-change_time-doc"
         },
         {
           "name": "signal.target.ancestors.interpreter.file.filesystem",
-          "type": "string",
           "definition": "File's filesystem",
-          "constants": ""
+          "property_doc_link": "common-fileevent-filesystem-doc"
         },
         {
           "name": "signal.target.ancestors.interpreter.file.gid",
-          "type": "int",
           "definition": "GID of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-gid-doc"
         },
         {
           "name": "signal.target.ancestors.interpreter.file.group",
-          "type": "string",
           "definition": "Group of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-group-doc"
         },
         {
           "name": "signal.target.ancestors.interpreter.file.in_upper_layer",
-          "type": "bool",
           "definition": "Indicator of the file layer, for example, in an OverlayFS",
-          "constants": ""
+          "property_doc_link": "common-filefields-in_upper_layer-doc"
         },
         {
           "name": "signal.target.ancestors.interpreter.file.inode",
-          "type": "int",
           "definition": "Inode of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-inode-doc"
         },
         {
           "name": "signal.target.ancestors.interpreter.file.mode",
-          "type": "int",
-          "definition": "Mode/rights of the file",
-          "constants": "Chmod mode constants"
+          "definition": "Mode of the file",
+          "property_doc_link": "common-filefields-mode-doc"
         },
         {
           "name": "signal.target.ancestors.interpreter.file.modification_time",
-          "type": "int",
           "definition": "Modification time of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
           "name": "signal.target.ancestors.interpreter.file.mount_id",
-          "type": "int",
           "definition": "Mount ID of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-mount_id-doc"
         },
         {
           "name": "signal.target.ancestors.interpreter.file.name",
-          "type": "string",
           "definition": "File's basename",
-          "constants": ""
+          "property_doc_link": "common-fileevent-name-doc"
         },
         {
           "name": "signal.target.ancestors.interpreter.file.name.length",
-          "type": "int",
-          "definition": "Length of 'signal.target.ancestors.interpreter.file.name' string",
-          "constants": ""
+          "definition": "Length of the corresponding string",
+          "property_doc_link": "common-string-length-doc"
         },
         {
           "name": "signal.target.ancestors.interpreter.file.path",
-          "type": "string",
           "definition": "File's path",
-          "constants": ""
+          "property_doc_link": "common-fileevent-path-doc"
         },
         {
           "name": "signal.target.ancestors.interpreter.file.path.length",
-          "type": "int",
-          "definition": "Length of 'signal.target.ancestors.interpreter.file.path' string",
-          "constants": ""
+          "definition": "Length of the corresponding string",
+          "property_doc_link": "common-string-length-doc"
         },
         {
           "name": "signal.target.ancestors.interpreter.file.rights",
-          "type": "int",
-          "definition": "Mode/rights of the file",
-          "constants": "Chmod mode constants"
+          "definition": "Rights of the file",
+          "property_doc_link": "common-filefields-rights-doc"
         },
         {
           "name": "signal.target.ancestors.interpreter.file.uid",
-          "type": "int",
           "definition": "UID of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-uid-doc"
         },
         {
           "name": "signal.target.ancestors.interpreter.file.user",
-          "type": "string",
           "definition": "User of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-user-doc"
         },
         {
           "name": "signal.target.ancestors.is_kworker",
-          "type": "bool",
           "definition": "Indicates whether the process is a kworker",
-          "constants": ""
+          "property_doc_link": "common-pidcontext-is_kworker-doc"
         },
         {
           "name": "signal.target.ancestors.is_thread",
-          "type": "bool",
           "definition": "Indicates whether the process is considered a thread (that is, a child process that hasn't executed another program)",
-          "constants": ""
+          "property_doc_link": "common-process-is_thread-doc"
         },
         {
           "name": "signal.target.ancestors.pid",
-          "type": "int",
           "definition": "Process ID of the process (also called thread group ID)",
-          "constants": ""
+          "property_doc_link": "common-pidcontext-pid-doc"
         },
         {
           "name": "signal.target.ancestors.ppid",
-          "type": "int",
           "definition": "Parent process ID",
-          "constants": ""
+          "property_doc_link": "common-process-ppid-doc"
         },
         {
           "name": "signal.target.ancestors.tid",
-          "type": "int",
           "definition": "Thread ID of the thread",
-          "constants": ""
+          "property_doc_link": "common-pidcontext-tid-doc"
         },
         {
           "name": "signal.target.ancestors.tty_name",
-          "type": "string",
           "definition": "Name of the TTY associated with the process",
-          "constants": ""
+          "property_doc_link": "common-process-tty_name-doc"
         },
         {
           "name": "signal.target.ancestors.uid",
-          "type": "int",
           "definition": "UID of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-uid-doc"
         },
         {
           "name": "signal.target.ancestors.user",
-          "type": "string",
           "definition": "User of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-user-doc"
         },
         {
           "name": "signal.target.args",
-          "type": "string",
-          "definition": "Arguments of the process (as a string)",
-          "constants": ""
+          "definition": "Arguments of the process (as a string, excluding argv0)",
+          "property_doc_link": "common-process-args-doc"
         },
         {
           "name": "signal.target.args_flags",
-          "type": "string",
-          "definition": "Arguments of the process (as an array)",
-          "constants": ""
+          "definition": "Flags in the process arguments",
+          "property_doc_link": "common-process-args_flags-doc"
         },
         {
           "name": "signal.target.args_options",
-          "type": "string",
-          "definition": "Arguments of the process (as an array)",
-          "constants": ""
+          "definition": "Argument of the process as options",
+          "property_doc_link": "common-process-args_options-doc"
         },
         {
           "name": "signal.target.args_truncated",
-          "type": "bool",
           "definition": "Indicator of arguments truncation",
-          "constants": ""
+          "property_doc_link": "common-process-args_truncated-doc"
         },
         {
           "name": "signal.target.argv",
-          "type": "string",
-          "definition": "Arguments of the process (as an array)",
-          "constants": ""
+          "definition": "Arguments of the process (as an array, excluding argv0)",
+          "property_doc_link": "common-process-argv-doc"
         },
         {
           "name": "signal.target.argv0",
-          "type": "string",
           "definition": "First argument of the process",
-          "constants": ""
+          "property_doc_link": "common-process-argv0-doc"
         },
         {
           "name": "signal.target.cap_effective",
-          "type": "int",
           "definition": "Effective capability set of the process",
-          "constants": "Kernel Capability constants"
+          "property_doc_link": "common-credentials-cap_effective-doc"
         },
         {
           "name": "signal.target.cap_permitted",
-          "type": "int",
           "definition": "Permitted capability set of the process",
-          "constants": "Kernel Capability constants"
+          "property_doc_link": "common-credentials-cap_permitted-doc"
         },
         {
           "name": "signal.target.comm",
-          "type": "string",
           "definition": "Comm attribute of the process",
-          "constants": ""
+          "property_doc_link": "common-process-comm-doc"
         },
         {
           "name": "signal.target.container.id",
-          "type": "string",
           "definition": "Container ID",
-          "constants": ""
+          "property_doc_link": "common-process-container-id-doc"
         },
         {
           "name": "signal.target.cookie",
-          "type": "int",
           "definition": "Cookie of the process",
-          "constants": ""
+          "property_doc_link": "common-process-cookie-doc"
         },
         {
           "name": "signal.target.created_at",
-          "type": "int",
           "definition": "Timestamp of the creation of the process",
-          "constants": ""
+          "property_doc_link": "common-process-created_at-doc"
         },
         {
           "name": "signal.target.egid",
-          "type": "int",
           "definition": "Effective GID of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-egid-doc"
         },
         {
           "name": "signal.target.egroup",
-          "type": "string",
           "definition": "Effective group of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-egroup-doc"
         },
         {
           "name": "signal.target.envp",
-          "type": "string",
           "definition": "Environment variables of the process",
-          "constants": ""
+          "property_doc_link": "common-process-envp-doc"
         },
         {
           "name": "signal.target.envs",
-          "type": "string",
           "definition": "Environment variable names of the process",
-          "constants": ""
+          "property_doc_link": "common-process-envs-doc"
         },
         {
           "name": "signal.target.envs_truncated",
-          "type": "bool",
           "definition": "Indicator of environment variables truncation",
-          "constants": ""
+          "property_doc_link": "common-process-envs_truncated-doc"
         },
         {
           "name": "signal.target.euid",
-          "type": "int",
           "definition": "Effective UID of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-euid-doc"
         },
         {
           "name": "signal.target.euser",
-          "type": "string",
           "definition": "Effective user of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-euser-doc"
         },
         {
           "name": "signal.target.file.change_time",
-          "type": "int",
           "definition": "Change time of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-change_time-doc"
         },
         {
           "name": "signal.target.file.filesystem",
-          "type": "string",
           "definition": "File's filesystem",
-          "constants": ""
+          "property_doc_link": "common-fileevent-filesystem-doc"
         },
         {
           "name": "signal.target.file.gid",
-          "type": "int",
           "definition": "GID of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-gid-doc"
         },
         {
           "name": "signal.target.file.group",
-          "type": "string",
           "definition": "Group of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-group-doc"
         },
         {
           "name": "signal.target.file.in_upper_layer",
-          "type": "bool",
           "definition": "Indicator of the file layer, for example, in an OverlayFS",
-          "constants": ""
+          "property_doc_link": "common-filefields-in_upper_layer-doc"
         },
         {
           "name": "signal.target.file.inode",
-          "type": "int",
           "definition": "Inode of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-inode-doc"
         },
         {
           "name": "signal.target.file.mode",
-          "type": "int",
-          "definition": "Mode/rights of the file",
-          "constants": "Chmod mode constants"
+          "definition": "Mode of the file",
+          "property_doc_link": "common-filefields-mode-doc"
         },
         {
           "name": "signal.target.file.modification_time",
-          "type": "int",
           "definition": "Modification time of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
           "name": "signal.target.file.mount_id",
-          "type": "int",
           "definition": "Mount ID of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-mount_id-doc"
         },
         {
           "name": "signal.target.file.name",
-          "type": "string",
           "definition": "File's basename",
-          "constants": ""
+          "property_doc_link": "common-fileevent-name-doc"
         },
         {
           "name": "signal.target.file.name.length",
-          "type": "int",
-          "definition": "Length of 'signal.target.file.name' string",
-          "constants": ""
+          "definition": "Length of the corresponding string",
+          "property_doc_link": "common-string-length-doc"
         },
         {
           "name": "signal.target.file.path",
-          "type": "string",
           "definition": "File's path",
-          "constants": ""
+          "property_doc_link": "common-fileevent-path-doc"
         },
         {
           "name": "signal.target.file.path.length",
-          "type": "int",
-          "definition": "Length of 'signal.target.file.path' string",
-          "constants": ""
+          "definition": "Length of the corresponding string",
+          "property_doc_link": "common-string-length-doc"
         },
         {
           "name": "signal.target.file.rights",
-          "type": "int",
-          "definition": "Mode/rights of the file",
-          "constants": "Chmod mode constants"
+          "definition": "Rights of the file",
+          "property_doc_link": "common-filefields-rights-doc"
         },
         {
           "name": "signal.target.file.uid",
-          "type": "int",
           "definition": "UID of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-uid-doc"
         },
         {
           "name": "signal.target.file.user",
-          "type": "string",
           "definition": "User of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-user-doc"
         },
         {
           "name": "signal.target.fsgid",
-          "type": "int",
           "definition": "FileSystem-gid of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-fsgid-doc"
         },
         {
           "name": "signal.target.fsgroup",
-          "type": "string",
           "definition": "FileSystem-group of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-fsgroup-doc"
         },
         {
           "name": "signal.target.fsuid",
-          "type": "int",
           "definition": "FileSystem-uid of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-fsuid-doc"
         },
         {
           "name": "signal.target.fsuser",
-          "type": "string",
           "definition": "FileSystem-user of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-fsuser-doc"
         },
         {
           "name": "signal.target.gid",
-          "type": "int",
           "definition": "GID of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-gid-doc"
         },
         {
           "name": "signal.target.group",
-          "type": "string",
           "definition": "Group of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-group-doc"
         },
         {
           "name": "signal.target.interpreter.file.change_time",
-          "type": "int",
           "definition": "Change time of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-change_time-doc"
         },
         {
           "name": "signal.target.interpreter.file.filesystem",
-          "type": "string",
           "definition": "File's filesystem",
-          "constants": ""
+          "property_doc_link": "common-fileevent-filesystem-doc"
         },
         {
           "name": "signal.target.interpreter.file.gid",
-          "type": "int",
           "definition": "GID of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-gid-doc"
         },
         {
           "name": "signal.target.interpreter.file.group",
-          "type": "string",
           "definition": "Group of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-group-doc"
         },
         {
           "name": "signal.target.interpreter.file.in_upper_layer",
-          "type": "bool",
           "definition": "Indicator of the file layer, for example, in an OverlayFS",
-          "constants": ""
+          "property_doc_link": "common-filefields-in_upper_layer-doc"
         },
         {
           "name": "signal.target.interpreter.file.inode",
-          "type": "int",
           "definition": "Inode of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-inode-doc"
         },
         {
           "name": "signal.target.interpreter.file.mode",
-          "type": "int",
-          "definition": "Mode/rights of the file",
-          "constants": "Chmod mode constants"
+          "definition": "Mode of the file",
+          "property_doc_link": "common-filefields-mode-doc"
         },
         {
           "name": "signal.target.interpreter.file.modification_time",
-          "type": "int",
           "definition": "Modification time of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
           "name": "signal.target.interpreter.file.mount_id",
-          "type": "int",
           "definition": "Mount ID of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-mount_id-doc"
         },
         {
           "name": "signal.target.interpreter.file.name",
-          "type": "string",
           "definition": "File's basename",
-          "constants": ""
+          "property_doc_link": "common-fileevent-name-doc"
         },
         {
           "name": "signal.target.interpreter.file.name.length",
-          "type": "int",
-          "definition": "Length of 'signal.target.interpreter.file.name' string",
-          "constants": ""
+          "definition": "Length of the corresponding string",
+          "property_doc_link": "common-string-length-doc"
         },
         {
           "name": "signal.target.interpreter.file.path",
-          "type": "string",
           "definition": "File's path",
-          "constants": ""
+          "property_doc_link": "common-fileevent-path-doc"
         },
         {
           "name": "signal.target.interpreter.file.path.length",
-          "type": "int",
-          "definition": "Length of 'signal.target.interpreter.file.path' string",
-          "constants": ""
+          "definition": "Length of the corresponding string",
+          "property_doc_link": "common-string-length-doc"
         },
         {
           "name": "signal.target.interpreter.file.rights",
-          "type": "int",
-          "definition": "Mode/rights of the file",
-          "constants": "Chmod mode constants"
+          "definition": "Rights of the file",
+          "property_doc_link": "common-filefields-rights-doc"
         },
         {
           "name": "signal.target.interpreter.file.uid",
-          "type": "int",
           "definition": "UID of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-uid-doc"
         },
         {
           "name": "signal.target.interpreter.file.user",
-          "type": "string",
           "definition": "User of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-user-doc"
         },
         {
           "name": "signal.target.is_kworker",
-          "type": "bool",
           "definition": "Indicates whether the process is a kworker",
-          "constants": ""
+          "property_doc_link": "common-pidcontext-is_kworker-doc"
         },
         {
           "name": "signal.target.is_thread",
-          "type": "bool",
           "definition": "Indicates whether the process is considered a thread (that is, a child process that hasn't executed another program)",
-          "constants": ""
+          "property_doc_link": "common-process-is_thread-doc"
         },
         {
           "name": "signal.target.parent.args",
-          "type": "string",
-          "definition": "Arguments of the process (as a string)",
-          "constants": ""
+          "definition": "Arguments of the process (as a string, excluding argv0)",
+          "property_doc_link": "common-process-args-doc"
         },
         {
           "name": "signal.target.parent.args_flags",
-          "type": "string",
-          "definition": "Arguments of the process (as an array)",
-          "constants": ""
+          "definition": "Flags in the process arguments",
+          "property_doc_link": "common-process-args_flags-doc"
         },
         {
           "name": "signal.target.parent.args_options",
-          "type": "string",
-          "definition": "Arguments of the process (as an array)",
-          "constants": ""
+          "definition": "Argument of the process as options",
+          "property_doc_link": "common-process-args_options-doc"
         },
         {
           "name": "signal.target.parent.args_truncated",
-          "type": "bool",
           "definition": "Indicator of arguments truncation",
-          "constants": ""
+          "property_doc_link": "common-process-args_truncated-doc"
         },
         {
           "name": "signal.target.parent.argv",
-          "type": "string",
-          "definition": "Arguments of the process (as an array)",
-          "constants": ""
+          "definition": "Arguments of the process (as an array, excluding argv0)",
+          "property_doc_link": "common-process-argv-doc"
         },
         {
           "name": "signal.target.parent.argv0",
-          "type": "string",
           "definition": "First argument of the process",
-          "constants": ""
+          "property_doc_link": "common-process-argv0-doc"
         },
         {
           "name": "signal.target.parent.cap_effective",
-          "type": "int",
           "definition": "Effective capability set of the process",
-          "constants": "Kernel Capability constants"
+          "property_doc_link": "common-credentials-cap_effective-doc"
         },
         {
           "name": "signal.target.parent.cap_permitted",
-          "type": "int",
           "definition": "Permitted capability set of the process",
-          "constants": "Kernel Capability constants"
+          "property_doc_link": "common-credentials-cap_permitted-doc"
         },
         {
           "name": "signal.target.parent.comm",
-          "type": "string",
           "definition": "Comm attribute of the process",
-          "constants": ""
+          "property_doc_link": "common-process-comm-doc"
         },
         {
           "name": "signal.target.parent.container.id",
-          "type": "string",
           "definition": "Container ID",
-          "constants": ""
+          "property_doc_link": "common-process-container-id-doc"
         },
         {
           "name": "signal.target.parent.cookie",
-          "type": "int",
           "definition": "Cookie of the process",
-          "constants": ""
+          "property_doc_link": "common-process-cookie-doc"
         },
         {
           "name": "signal.target.parent.created_at",
-          "type": "int",
           "definition": "Timestamp of the creation of the process",
-          "constants": ""
+          "property_doc_link": "common-process-created_at-doc"
         },
         {
           "name": "signal.target.parent.egid",
-          "type": "int",
           "definition": "Effective GID of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-egid-doc"
         },
         {
           "name": "signal.target.parent.egroup",
-          "type": "string",
           "definition": "Effective group of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-egroup-doc"
         },
         {
           "name": "signal.target.parent.envp",
-          "type": "string",
           "definition": "Environment variables of the process",
-          "constants": ""
+          "property_doc_link": "common-process-envp-doc"
         },
         {
           "name": "signal.target.parent.envs",
-          "type": "string",
           "definition": "Environment variable names of the process",
-          "constants": ""
+          "property_doc_link": "common-process-envs-doc"
         },
         {
           "name": "signal.target.parent.envs_truncated",
-          "type": "bool",
           "definition": "Indicator of environment variables truncation",
-          "constants": ""
+          "property_doc_link": "common-process-envs_truncated-doc"
         },
         {
           "name": "signal.target.parent.euid",
-          "type": "int",
           "definition": "Effective UID of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-euid-doc"
         },
         {
           "name": "signal.target.parent.euser",
-          "type": "string",
           "definition": "Effective user of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-euser-doc"
         },
         {
           "name": "signal.target.parent.file.change_time",
-          "type": "int",
           "definition": "Change time of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-change_time-doc"
         },
         {
           "name": "signal.target.parent.file.filesystem",
-          "type": "string",
           "definition": "File's filesystem",
-          "constants": ""
+          "property_doc_link": "common-fileevent-filesystem-doc"
         },
         {
           "name": "signal.target.parent.file.gid",
-          "type": "int",
           "definition": "GID of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-gid-doc"
         },
         {
           "name": "signal.target.parent.file.group",
-          "type": "string",
           "definition": "Group of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-group-doc"
         },
         {
           "name": "signal.target.parent.file.in_upper_layer",
-          "type": "bool",
           "definition": "Indicator of the file layer, for example, in an OverlayFS",
-          "constants": ""
+          "property_doc_link": "common-filefields-in_upper_layer-doc"
         },
         {
           "name": "signal.target.parent.file.inode",
-          "type": "int",
           "definition": "Inode of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-inode-doc"
         },
         {
           "name": "signal.target.parent.file.mode",
-          "type": "int",
-          "definition": "Mode/rights of the file",
-          "constants": "Chmod mode constants"
+          "definition": "Mode of the file",
+          "property_doc_link": "common-filefields-mode-doc"
         },
         {
           "name": "signal.target.parent.file.modification_time",
-          "type": "int",
           "definition": "Modification time of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
           "name": "signal.target.parent.file.mount_id",
-          "type": "int",
           "definition": "Mount ID of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-mount_id-doc"
         },
         {
           "name": "signal.target.parent.file.name",
-          "type": "string",
           "definition": "File's basename",
-          "constants": ""
+          "property_doc_link": "common-fileevent-name-doc"
         },
         {
           "name": "signal.target.parent.file.name.length",
-          "type": "int",
-          "definition": "Length of 'signal.target.parent.file.name' string",
-          "constants": ""
+          "definition": "Length of the corresponding string",
+          "property_doc_link": "common-string-length-doc"
         },
         {
           "name": "signal.target.parent.file.path",
-          "type": "string",
           "definition": "File's path",
-          "constants": ""
+          "property_doc_link": "common-fileevent-path-doc"
         },
         {
           "name": "signal.target.parent.file.path.length",
-          "type": "int",
-          "definition": "Length of 'signal.target.parent.file.path' string",
-          "constants": ""
+          "definition": "Length of the corresponding string",
+          "property_doc_link": "common-string-length-doc"
         },
         {
           "name": "signal.target.parent.file.rights",
-          "type": "int",
-          "definition": "Mode/rights of the file",
-          "constants": "Chmod mode constants"
+          "definition": "Rights of the file",
+          "property_doc_link": "common-filefields-rights-doc"
         },
         {
           "name": "signal.target.parent.file.uid",
-          "type": "int",
           "definition": "UID of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-uid-doc"
         },
         {
           "name": "signal.target.parent.file.user",
-          "type": "string",
           "definition": "User of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-user-doc"
         },
         {
           "name": "signal.target.parent.fsgid",
-          "type": "int",
           "definition": "FileSystem-gid of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-fsgid-doc"
         },
         {
           "name": "signal.target.parent.fsgroup",
-          "type": "string",
           "definition": "FileSystem-group of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-fsgroup-doc"
         },
         {
           "name": "signal.target.parent.fsuid",
-          "type": "int",
           "definition": "FileSystem-uid of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-fsuid-doc"
         },
         {
           "name": "signal.target.parent.fsuser",
-          "type": "string",
           "definition": "FileSystem-user of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-fsuser-doc"
         },
         {
           "name": "signal.target.parent.gid",
-          "type": "int",
           "definition": "GID of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-gid-doc"
         },
         {
           "name": "signal.target.parent.group",
-          "type": "string",
           "definition": "Group of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-group-doc"
         },
         {
           "name": "signal.target.parent.interpreter.file.change_time",
-          "type": "int",
           "definition": "Change time of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-change_time-doc"
         },
         {
           "name": "signal.target.parent.interpreter.file.filesystem",
-          "type": "string",
           "definition": "File's filesystem",
-          "constants": ""
+          "property_doc_link": "common-fileevent-filesystem-doc"
         },
         {
           "name": "signal.target.parent.interpreter.file.gid",
-          "type": "int",
           "definition": "GID of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-gid-doc"
         },
         {
           "name": "signal.target.parent.interpreter.file.group",
-          "type": "string",
           "definition": "Group of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-group-doc"
         },
         {
           "name": "signal.target.parent.interpreter.file.in_upper_layer",
-          "type": "bool",
           "definition": "Indicator of the file layer, for example, in an OverlayFS",
-          "constants": ""
+          "property_doc_link": "common-filefields-in_upper_layer-doc"
         },
         {
           "name": "signal.target.parent.interpreter.file.inode",
-          "type": "int",
           "definition": "Inode of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-inode-doc"
         },
         {
           "name": "signal.target.parent.interpreter.file.mode",
-          "type": "int",
-          "definition": "Mode/rights of the file",
-          "constants": "Chmod mode constants"
+          "definition": "Mode of the file",
+          "property_doc_link": "common-filefields-mode-doc"
         },
         {
           "name": "signal.target.parent.interpreter.file.modification_time",
-          "type": "int",
           "definition": "Modification time of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
           "name": "signal.target.parent.interpreter.file.mount_id",
-          "type": "int",
           "definition": "Mount ID of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-mount_id-doc"
         },
         {
           "name": "signal.target.parent.interpreter.file.name",
-          "type": "string",
           "definition": "File's basename",
-          "constants": ""
+          "property_doc_link": "common-fileevent-name-doc"
         },
         {
           "name": "signal.target.parent.interpreter.file.name.length",
-          "type": "int",
-          "definition": "Length of 'signal.target.parent.interpreter.file.name' string",
-          "constants": ""
+          "definition": "Length of the corresponding string",
+          "property_doc_link": "common-string-length-doc"
         },
         {
           "name": "signal.target.parent.interpreter.file.path",
-          "type": "string",
           "definition": "File's path",
-          "constants": ""
+          "property_doc_link": "common-fileevent-path-doc"
         },
         {
           "name": "signal.target.parent.interpreter.file.path.length",
-          "type": "int",
-          "definition": "Length of 'signal.target.parent.interpreter.file.path' string",
-          "constants": ""
+          "definition": "Length of the corresponding string",
+          "property_doc_link": "common-string-length-doc"
         },
         {
           "name": "signal.target.parent.interpreter.file.rights",
-          "type": "int",
-          "definition": "Mode/rights of the file",
-          "constants": "Chmod mode constants"
+          "definition": "Rights of the file",
+          "property_doc_link": "common-filefields-rights-doc"
         },
         {
           "name": "signal.target.parent.interpreter.file.uid",
-          "type": "int",
           "definition": "UID of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-uid-doc"
         },
         {
           "name": "signal.target.parent.interpreter.file.user",
-          "type": "string",
           "definition": "User of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-user-doc"
         },
         {
           "name": "signal.target.parent.is_kworker",
-          "type": "bool",
           "definition": "Indicates whether the process is a kworker",
-          "constants": ""
+          "property_doc_link": "common-pidcontext-is_kworker-doc"
         },
         {
           "name": "signal.target.parent.is_thread",
-          "type": "bool",
           "definition": "Indicates whether the process is considered a thread (that is, a child process that hasn't executed another program)",
-          "constants": ""
+          "property_doc_link": "common-process-is_thread-doc"
         },
         {
           "name": "signal.target.parent.pid",
-          "type": "int",
           "definition": "Process ID of the process (also called thread group ID)",
-          "constants": ""
+          "property_doc_link": "common-pidcontext-pid-doc"
         },
         {
           "name": "signal.target.parent.ppid",
-          "type": "int",
           "definition": "Parent process ID",
-          "constants": ""
+          "property_doc_link": "common-process-ppid-doc"
         },
         {
           "name": "signal.target.parent.tid",
-          "type": "int",
           "definition": "Thread ID of the thread",
-          "constants": ""
+          "property_doc_link": "common-pidcontext-tid-doc"
         },
         {
           "name": "signal.target.parent.tty_name",
-          "type": "string",
           "definition": "Name of the TTY associated with the process",
-          "constants": ""
+          "property_doc_link": "common-process-tty_name-doc"
         },
         {
           "name": "signal.target.parent.uid",
-          "type": "int",
           "definition": "UID of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-uid-doc"
         },
         {
           "name": "signal.target.parent.user",
-          "type": "string",
           "definition": "User of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-user-doc"
         },
         {
           "name": "signal.target.pid",
-          "type": "int",
           "definition": "Process ID of the process (also called thread group ID)",
-          "constants": ""
+          "property_doc_link": "common-pidcontext-pid-doc"
         },
         {
           "name": "signal.target.ppid",
-          "type": "int",
           "definition": "Parent process ID",
-          "constants": ""
+          "property_doc_link": "common-process-ppid-doc"
         },
         {
           "name": "signal.target.tid",
-          "type": "int",
           "definition": "Thread ID of the thread",
-          "constants": ""
+          "property_doc_link": "common-pidcontext-tid-doc"
         },
         {
           "name": "signal.target.tty_name",
-          "type": "string",
           "definition": "Name of the TTY associated with the process",
-          "constants": ""
+          "property_doc_link": "common-process-tty_name-doc"
         },
         {
           "name": "signal.target.uid",
-          "type": "int",
           "definition": "UID of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-uid-doc"
         },
         {
           "name": "signal.target.user",
-          "type": "string",
           "definition": "User of the process",
-          "constants": ""
+          "property_doc_link": "common-credentials-user-doc"
         },
         {
           "name": "signal.type",
-          "type": "int",
           "definition": "Signal type (ex: SIGHUP, SIGINT, SIGQUIT, etc)",
-          "constants": "Signal constants"
+          "property_doc_link": "signal-type-doc"
         }
       ]
     },
@@ -6330,117 +5314,98 @@
       "properties": [
         {
           "name": "splice.file.change_time",
-          "type": "int",
           "definition": "Change time of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-change_time-doc"
         },
         {
           "name": "splice.file.filesystem",
-          "type": "string",
           "definition": "File's filesystem",
-          "constants": ""
+          "property_doc_link": "common-fileevent-filesystem-doc"
         },
         {
           "name": "splice.file.gid",
-          "type": "int",
           "definition": "GID of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-gid-doc"
         },
         {
           "name": "splice.file.group",
-          "type": "string",
           "definition": "Group of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-group-doc"
         },
         {
           "name": "splice.file.in_upper_layer",
-          "type": "bool",
           "definition": "Indicator of the file layer, for example, in an OverlayFS",
-          "constants": ""
+          "property_doc_link": "common-filefields-in_upper_layer-doc"
         },
         {
           "name": "splice.file.inode",
-          "type": "int",
           "definition": "Inode of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-inode-doc"
         },
         {
           "name": "splice.file.mode",
-          "type": "int",
-          "definition": "Mode/rights of the file",
-          "constants": "Chmod mode constants"
+          "definition": "Mode of the file",
+          "property_doc_link": "common-filefields-mode-doc"
         },
         {
           "name": "splice.file.modification_time",
-          "type": "int",
           "definition": "Modification time of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
           "name": "splice.file.mount_id",
-          "type": "int",
           "definition": "Mount ID of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-mount_id-doc"
         },
         {
           "name": "splice.file.name",
-          "type": "string",
           "definition": "File's basename",
-          "constants": ""
+          "property_doc_link": "common-fileevent-name-doc"
         },
         {
           "name": "splice.file.name.length",
-          "type": "int",
-          "definition": "Length of 'splice.file.name' string",
-          "constants": ""
+          "definition": "Length of the corresponding string",
+          "property_doc_link": "common-string-length-doc"
         },
         {
           "name": "splice.file.path",
-          "type": "string",
           "definition": "File's path",
-          "constants": ""
+          "property_doc_link": "common-fileevent-path-doc"
         },
         {
           "name": "splice.file.path.length",
-          "type": "int",
-          "definition": "Length of 'splice.file.path' string",
-          "constants": ""
+          "definition": "Length of the corresponding string",
+          "property_doc_link": "common-string-length-doc"
         },
         {
           "name": "splice.file.rights",
-          "type": "int",
-          "definition": "Mode/rights of the file",
-          "constants": "Chmod mode constants"
+          "definition": "Rights of the file",
+          "property_doc_link": "common-filefields-rights-doc"
         },
         {
           "name": "splice.file.uid",
-          "type": "int",
           "definition": "UID of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-uid-doc"
         },
         {
           "name": "splice.file.user",
-          "type": "string",
           "definition": "User of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-user-doc"
         },
         {
           "name": "splice.pipe_entry_flag",
-          "type": "int",
           "definition": "Entry flag of the \"fd_out\" pipe passed to the splice syscall",
-          "constants": "Pipe buffer flags"
+          "property_doc_link": "splice-pipe_entry_flag-doc"
         },
         {
           "name": "splice.pipe_exit_flag",
-          "type": "int",
           "definition": "Exit flag of the \"fd_out\" pipe passed to the splice syscall",
-          "constants": "Pipe buffer flags"
+          "property_doc_link": "splice-pipe_exit_flag-doc"
         },
         {
           "name": "splice.retval",
-          "type": "int",
           "definition": "Return value of the syscall",
-          "constants": "Error Constants"
+          "property_doc_link": "common-syscallevent-retval-doc"
         }
       ]
     },
@@ -6453,111 +5418,93 @@
       "properties": [
         {
           "name": "unlink.file.change_time",
-          "type": "int",
           "definition": "Change time of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-change_time-doc"
         },
         {
           "name": "unlink.file.filesystem",
-          "type": "string",
           "definition": "File's filesystem",
-          "constants": ""
+          "property_doc_link": "common-fileevent-filesystem-doc"
         },
         {
           "name": "unlink.file.gid",
-          "type": "int",
           "definition": "GID of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-gid-doc"
         },
         {
           "name": "unlink.file.group",
-          "type": "string",
           "definition": "Group of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-group-doc"
         },
         {
           "name": "unlink.file.in_upper_layer",
-          "type": "bool",
           "definition": "Indicator of the file layer, for example, in an OverlayFS",
-          "constants": ""
+          "property_doc_link": "common-filefields-in_upper_layer-doc"
         },
         {
           "name": "unlink.file.inode",
-          "type": "int",
           "definition": "Inode of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-inode-doc"
         },
         {
           "name": "unlink.file.mode",
-          "type": "int",
-          "definition": "Mode/rights of the file",
-          "constants": "Chmod mode constants"
+          "definition": "Mode of the file",
+          "property_doc_link": "common-filefields-mode-doc"
         },
         {
           "name": "unlink.file.modification_time",
-          "type": "int",
           "definition": "Modification time of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
           "name": "unlink.file.mount_id",
-          "type": "int",
           "definition": "Mount ID of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-mount_id-doc"
         },
         {
           "name": "unlink.file.name",
-          "type": "string",
           "definition": "File's basename",
-          "constants": ""
+          "property_doc_link": "common-fileevent-name-doc"
         },
         {
           "name": "unlink.file.name.length",
-          "type": "int",
-          "definition": "Length of 'unlink.file.name' string",
-          "constants": ""
+          "definition": "Length of the corresponding string",
+          "property_doc_link": "common-string-length-doc"
         },
         {
           "name": "unlink.file.path",
-          "type": "string",
           "definition": "File's path",
-          "constants": ""
+          "property_doc_link": "common-fileevent-path-doc"
         },
         {
           "name": "unlink.file.path.length",
-          "type": "int",
-          "definition": "Length of 'unlink.file.path' string",
-          "constants": ""
+          "definition": "Length of the corresponding string",
+          "property_doc_link": "common-string-length-doc"
         },
         {
           "name": "unlink.file.rights",
-          "type": "int",
-          "definition": "Mode/rights of the file",
-          "constants": "Chmod mode constants"
+          "definition": "Rights of the file",
+          "property_doc_link": "common-filefields-rights-doc"
         },
         {
           "name": "unlink.file.uid",
-          "type": "int",
           "definition": "UID of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-uid-doc"
         },
         {
           "name": "unlink.file.user",
-          "type": "string",
           "definition": "User of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-user-doc"
         },
         {
           "name": "unlink.flags",
-          "type": "int",
-          "definition": "",
-          "constants": "Unlink flags"
+          "definition": "Flags of the unlink syscall",
+          "property_doc_link": "unlink-flags-doc"
         },
         {
           "name": "unlink.retval",
-          "type": "int",
           "definition": "Return value of the syscall",
-          "constants": "Error Constants"
+          "property_doc_link": "common-syscallevent-retval-doc"
         }
       ]
     },
@@ -6570,15 +5517,13 @@
       "properties": [
         {
           "name": "unload_module.name",
-          "type": "string",
           "definition": "Name of the kernel module that was deleted",
-          "constants": ""
+          "property_doc_link": "unload_module-name-doc"
         },
         {
           "name": "unload_module.retval",
-          "type": "int",
           "definition": "Return value of the syscall",
-          "constants": "Error Constants"
+          "property_doc_link": "common-syscallevent-retval-doc"
         }
       ]
     },
@@ -6591,112 +5536,2555 @@
       "properties": [
         {
           "name": "utimes.file.change_time",
-          "type": "int",
           "definition": "Change time of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-change_time-doc"
         },
         {
           "name": "utimes.file.filesystem",
-          "type": "string",
           "definition": "File's filesystem",
-          "constants": ""
+          "property_doc_link": "common-fileevent-filesystem-doc"
         },
         {
           "name": "utimes.file.gid",
-          "type": "int",
           "definition": "GID of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-gid-doc"
         },
         {
           "name": "utimes.file.group",
-          "type": "string",
           "definition": "Group of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-group-doc"
         },
         {
           "name": "utimes.file.in_upper_layer",
-          "type": "bool",
           "definition": "Indicator of the file layer, for example, in an OverlayFS",
-          "constants": ""
+          "property_doc_link": "common-filefields-in_upper_layer-doc"
         },
         {
           "name": "utimes.file.inode",
-          "type": "int",
           "definition": "Inode of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-inode-doc"
         },
         {
           "name": "utimes.file.mode",
-          "type": "int",
-          "definition": "Mode/rights of the file",
-          "constants": "Chmod mode constants"
+          "definition": "Mode of the file",
+          "property_doc_link": "common-filefields-mode-doc"
         },
         {
           "name": "utimes.file.modification_time",
-          "type": "int",
           "definition": "Modification time of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
           "name": "utimes.file.mount_id",
-          "type": "int",
           "definition": "Mount ID of the file",
-          "constants": ""
+          "property_doc_link": "common-filefields-mount_id-doc"
         },
         {
           "name": "utimes.file.name",
-          "type": "string",
           "definition": "File's basename",
-          "constants": ""
+          "property_doc_link": "common-fileevent-name-doc"
         },
         {
           "name": "utimes.file.name.length",
-          "type": "int",
-          "definition": "Length of 'utimes.file.name' string",
-          "constants": ""
+          "definition": "Length of the corresponding string",
+          "property_doc_link": "common-string-length-doc"
         },
         {
           "name": "utimes.file.path",
-          "type": "string",
           "definition": "File's path",
-          "constants": ""
+          "property_doc_link": "common-fileevent-path-doc"
         },
         {
           "name": "utimes.file.path.length",
-          "type": "int",
-          "definition": "Length of 'utimes.file.path' string",
-          "constants": ""
+          "definition": "Length of the corresponding string",
+          "property_doc_link": "common-string-length-doc"
         },
         {
           "name": "utimes.file.rights",
-          "type": "int",
-          "definition": "Mode/rights of the file",
-          "constants": "Chmod mode constants"
+          "definition": "Rights of the file",
+          "property_doc_link": "common-filefields-rights-doc"
         },
         {
           "name": "utimes.file.uid",
-          "type": "int",
           "definition": "UID of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-uid-doc"
         },
         {
           "name": "utimes.file.user",
-          "type": "string",
           "definition": "User of the file's owner",
-          "constants": ""
+          "property_doc_link": "common-filefields-user-doc"
         },
         {
           "name": "utimes.retval",
-          "type": "int",
           "definition": "Return value of the syscall",
-          "constants": "Error Constants"
+          "property_doc_link": "common-syscallevent-retval-doc"
         }
       ]
+    }
+  ],
+  "properties_doc": [
+    {
+      "name": "*.args",
+      "link": "common-process-args-doc",
+      "type": "string",
+      "definition": "Arguments of the process (as a string, excluding argv0)",
+      "prefixes": [
+        "exec",
+        "exit",
+        "process",
+        "process.ancestors",
+        "process.parent",
+        "ptrace.tracee",
+        "ptrace.tracee.ancestors",
+        "ptrace.tracee.parent",
+        "signal.target",
+        "signal.target.ancestors",
+        "signal.target.parent"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": [
+        {
+          "expression": "exec.args == \"-sV -p 22,53,110,143,4564 198.116.0-255.1-127\"",
+          "description": "Matches any process with these exact arguments."
+        },
+        {
+          "expression": "exec.args =~ \"* -F * http*\"",
+          "description": "Matches any process that has the \"-F\" argument anywhere before an argument starting with \"http\"."
+        }
+      ]
+    },
+    {
+      "name": "*.args_flags",
+      "link": "common-process-args_flags-doc",
+      "type": "string",
+      "definition": "Flags in the process arguments",
+      "prefixes": [
+        "exec",
+        "exit",
+        "process",
+        "process.ancestors",
+        "process.parent",
+        "ptrace.tracee",
+        "ptrace.tracee.ancestors",
+        "ptrace.tracee.parent",
+        "signal.target",
+        "signal.target.ancestors",
+        "signal.target.parent"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": [
+        {
+          "expression": "exec.args_flags in [\"s\"] \u0026\u0026 exec.args_flags in [\"V\"]",
+          "description": "Matches any process with both \"-s\" and \"-V\" flags in its arguments. Also matches \"-sV\"."
+        }
+      ]
+    },
+    {
+      "name": "*.args_options",
+      "link": "common-process-args_options-doc",
+      "type": "string",
+      "definition": "Argument of the process as options",
+      "prefixes": [
+        "exec",
+        "exit",
+        "process",
+        "process.ancestors",
+        "process.parent",
+        "ptrace.tracee",
+        "ptrace.tracee.ancestors",
+        "ptrace.tracee.parent",
+        "signal.target",
+        "signal.target.ancestors",
+        "signal.target.parent"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": [
+        {
+          "expression": "exec.args_options in [\"p=0-1024\"]",
+          "description": "Matches any process that has either \"-p 0-1024\" or \"--p=0-1024\" in its arguments."
+        }
+      ]
+    },
+    {
+      "name": "*.args_truncated",
+      "link": "common-process-args_truncated-doc",
+      "type": "bool",
+      "definition": "Indicator of arguments truncation",
+      "prefixes": [
+        "exec",
+        "exit",
+        "process",
+        "process.ancestors",
+        "process.parent",
+        "ptrace.tracee",
+        "ptrace.tracee.ancestors",
+        "ptrace.tracee.parent",
+        "signal.target",
+        "signal.target.ancestors",
+        "signal.target.parent"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "*.argv",
+      "link": "common-process-argv-doc",
+      "type": "string",
+      "definition": "Arguments of the process (as an array, excluding argv0)",
+      "prefixes": [
+        "exec",
+        "exit",
+        "process",
+        "process.ancestors",
+        "process.parent",
+        "ptrace.tracee",
+        "ptrace.tracee.ancestors",
+        "ptrace.tracee.parent",
+        "signal.target",
+        "signal.target.ancestors",
+        "signal.target.parent"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": [
+        {
+          "expression": "exec.argv in [\"127.0.0.1\"]",
+          "description": "Matches any process that has this IP address as one of its arguments."
+        }
+      ]
+    },
+    {
+      "name": "*.argv0",
+      "link": "common-process-argv0-doc",
+      "type": "string",
+      "definition": "First argument of the process",
+      "prefixes": [
+        "exec",
+        "exit",
+        "process",
+        "process.ancestors",
+        "process.parent",
+        "ptrace.tracee",
+        "ptrace.tracee.ancestors",
+        "ptrace.tracee.parent",
+        "signal.target",
+        "signal.target.ancestors",
+        "signal.target.parent"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "*.cap_effective",
+      "link": "common-credentials-cap_effective-doc",
+      "type": "int",
+      "definition": "Effective capability set of the process",
+      "prefixes": [
+        "exec",
+        "exit",
+        "process",
+        "process.ancestors",
+        "process.parent",
+        "ptrace.tracee",
+        "ptrace.tracee.ancestors",
+        "ptrace.tracee.parent",
+        "signal.target",
+        "signal.target.ancestors",
+        "signal.target.parent"
+      ],
+      "constants": "Kernel Capability constants",
+      "constants_link": "kernel-capability-constants",
+      "examples": []
+    },
+    {
+      "name": "*.cap_permitted",
+      "link": "common-credentials-cap_permitted-doc",
+      "type": "int",
+      "definition": "Permitted capability set of the process",
+      "prefixes": [
+        "exec",
+        "exit",
+        "process",
+        "process.ancestors",
+        "process.parent",
+        "ptrace.tracee",
+        "ptrace.tracee.ancestors",
+        "ptrace.tracee.parent",
+        "signal.target",
+        "signal.target.ancestors",
+        "signal.target.parent"
+      ],
+      "constants": "Kernel Capability constants",
+      "constants_link": "kernel-capability-constants",
+      "examples": []
+    },
+    {
+      "name": "*.change_time",
+      "link": "common-filefields-change_time-doc",
+      "type": "int",
+      "definition": "Change time of the file",
+      "prefixes": [
+        "chmod.file",
+        "chown.file",
+        "exec.file",
+        "exec.interpreter.file",
+        "exit.file",
+        "exit.interpreter.file",
+        "link.file",
+        "link.file.destination",
+        "load_module.file",
+        "mkdir.file",
+        "mmap.file",
+        "open.file",
+        "process.ancestors.file",
+        "process.ancestors.interpreter.file",
+        "process.file",
+        "process.interpreter.file",
+        "process.parent.file",
+        "process.parent.interpreter.file",
+        "ptrace.tracee.ancestors.file",
+        "ptrace.tracee.ancestors.interpreter.file",
+        "ptrace.tracee.file",
+        "ptrace.tracee.interpreter.file",
+        "ptrace.tracee.parent.file",
+        "ptrace.tracee.parent.interpreter.file",
+        "removexattr.file",
+        "rename.file",
+        "rename.file.destination",
+        "rmdir.file",
+        "setxattr.file",
+        "signal.target.ancestors.file",
+        "signal.target.ancestors.interpreter.file",
+        "signal.target.file",
+        "signal.target.interpreter.file",
+        "signal.target.parent.file",
+        "signal.target.parent.interpreter.file",
+        "splice.file",
+        "unlink.file",
+        "utimes.file"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "*.comm",
+      "link": "common-process-comm-doc",
+      "type": "string",
+      "definition": "Comm attribute of the process",
+      "prefixes": [
+        "exec",
+        "exit",
+        "process",
+        "process.ancestors",
+        "process.parent",
+        "ptrace.tracee",
+        "ptrace.tracee.ancestors",
+        "ptrace.tracee.parent",
+        "signal.target",
+        "signal.target.ancestors",
+        "signal.target.parent"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "*.container.id",
+      "link": "common-process-container-id-doc",
+      "type": "string",
+      "definition": "Container ID",
+      "prefixes": [
+        "exec",
+        "exit",
+        "process",
+        "process.ancestors",
+        "process.parent",
+        "ptrace.tracee",
+        "ptrace.tracee.ancestors",
+        "ptrace.tracee.parent",
+        "signal.target",
+        "signal.target.ancestors",
+        "signal.target.parent"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "*.cookie",
+      "link": "common-process-cookie-doc",
+      "type": "int",
+      "definition": "Cookie of the process",
+      "prefixes": [
+        "exec",
+        "exit",
+        "process",
+        "process.ancestors",
+        "process.parent",
+        "ptrace.tracee",
+        "ptrace.tracee.ancestors",
+        "ptrace.tracee.parent",
+        "signal.target",
+        "signal.target.ancestors",
+        "signal.target.parent"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "*.created_at",
+      "link": "common-process-created_at-doc",
+      "type": "int",
+      "definition": "Timestamp of the creation of the process",
+      "prefixes": [
+        "exec",
+        "exit",
+        "process",
+        "process.ancestors",
+        "process.parent",
+        "ptrace.tracee",
+        "ptrace.tracee.ancestors",
+        "ptrace.tracee.parent",
+        "signal.target",
+        "signal.target.ancestors",
+        "signal.target.parent"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "*.egid",
+      "link": "common-credentials-egid-doc",
+      "type": "int",
+      "definition": "Effective GID of the process",
+      "prefixes": [
+        "exec",
+        "exit",
+        "process",
+        "process.ancestors",
+        "process.parent",
+        "ptrace.tracee",
+        "ptrace.tracee.ancestors",
+        "ptrace.tracee.parent",
+        "signal.target",
+        "signal.target.ancestors",
+        "signal.target.parent"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "*.egroup",
+      "link": "common-credentials-egroup-doc",
+      "type": "string",
+      "definition": "Effective group of the process",
+      "prefixes": [
+        "exec",
+        "exit",
+        "process",
+        "process.ancestors",
+        "process.parent",
+        "ptrace.tracee",
+        "ptrace.tracee.ancestors",
+        "ptrace.tracee.parent",
+        "signal.target",
+        "signal.target.ancestors",
+        "signal.target.parent"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "*.envp",
+      "link": "common-process-envp-doc",
+      "type": "string",
+      "definition": "Environment variables of the process",
+      "prefixes": [
+        "exec",
+        "exit",
+        "process",
+        "process.ancestors",
+        "process.parent",
+        "ptrace.tracee",
+        "ptrace.tracee.ancestors",
+        "ptrace.tracee.parent",
+        "signal.target",
+        "signal.target.ancestors",
+        "signal.target.parent"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "*.envs",
+      "link": "common-process-envs-doc",
+      "type": "string",
+      "definition": "Environment variable names of the process",
+      "prefixes": [
+        "exec",
+        "exit",
+        "process",
+        "process.ancestors",
+        "process.parent",
+        "ptrace.tracee",
+        "ptrace.tracee.ancestors",
+        "ptrace.tracee.parent",
+        "signal.target",
+        "signal.target.ancestors",
+        "signal.target.parent"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "*.envs_truncated",
+      "link": "common-process-envs_truncated-doc",
+      "type": "bool",
+      "definition": "Indicator of environment variables truncation",
+      "prefixes": [
+        "exec",
+        "exit",
+        "process",
+        "process.ancestors",
+        "process.parent",
+        "ptrace.tracee",
+        "ptrace.tracee.ancestors",
+        "ptrace.tracee.parent",
+        "signal.target",
+        "signal.target.ancestors",
+        "signal.target.parent"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "*.euid",
+      "link": "common-credentials-euid-doc",
+      "type": "int",
+      "definition": "Effective UID of the process",
+      "prefixes": [
+        "exec",
+        "exit",
+        "process",
+        "process.ancestors",
+        "process.parent",
+        "ptrace.tracee",
+        "ptrace.tracee.ancestors",
+        "ptrace.tracee.parent",
+        "signal.target",
+        "signal.target.ancestors",
+        "signal.target.parent"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "*.euser",
+      "link": "common-credentials-euser-doc",
+      "type": "string",
+      "definition": "Effective user of the process",
+      "prefixes": [
+        "exec",
+        "exit",
+        "process",
+        "process.ancestors",
+        "process.parent",
+        "ptrace.tracee",
+        "ptrace.tracee.ancestors",
+        "ptrace.tracee.parent",
+        "signal.target",
+        "signal.target.ancestors",
+        "signal.target.parent"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "*.file.destination.name",
+      "link": "common-setxattrevent-file-destination-name-doc",
+      "type": "string",
+      "definition": "Name of the extended attribute",
+      "prefixes": [
+        "removexattr",
+        "setxattr"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "*.file.destination.namespace",
+      "link": "common-setxattrevent-file-destination-namespace-doc",
+      "type": "string",
+      "definition": "Namespace of the extended attribute",
+      "prefixes": [
+        "removexattr",
+        "setxattr"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "*.filesystem",
+      "link": "common-fileevent-filesystem-doc",
+      "type": "string",
+      "definition": "File's filesystem",
+      "prefixes": [
+        "chmod.file",
+        "chown.file",
+        "exec.file",
+        "exec.interpreter.file",
+        "exit.file",
+        "exit.interpreter.file",
+        "link.file",
+        "link.file.destination",
+        "load_module.file",
+        "mkdir.file",
+        "mmap.file",
+        "open.file",
+        "process.ancestors.file",
+        "process.ancestors.interpreter.file",
+        "process.file",
+        "process.interpreter.file",
+        "process.parent.file",
+        "process.parent.interpreter.file",
+        "ptrace.tracee.ancestors.file",
+        "ptrace.tracee.ancestors.interpreter.file",
+        "ptrace.tracee.file",
+        "ptrace.tracee.interpreter.file",
+        "ptrace.tracee.parent.file",
+        "ptrace.tracee.parent.interpreter.file",
+        "removexattr.file",
+        "rename.file",
+        "rename.file.destination",
+        "rmdir.file",
+        "setxattr.file",
+        "signal.target.ancestors.file",
+        "signal.target.ancestors.interpreter.file",
+        "signal.target.file",
+        "signal.target.interpreter.file",
+        "signal.target.parent.file",
+        "signal.target.parent.interpreter.file",
+        "splice.file",
+        "unlink.file",
+        "utimes.file"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "*.fsgid",
+      "link": "common-credentials-fsgid-doc",
+      "type": "int",
+      "definition": "FileSystem-gid of the process",
+      "prefixes": [
+        "exec",
+        "exit",
+        "process",
+        "process.ancestors",
+        "process.parent",
+        "ptrace.tracee",
+        "ptrace.tracee.ancestors",
+        "ptrace.tracee.parent",
+        "signal.target",
+        "signal.target.ancestors",
+        "signal.target.parent"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "*.fsgroup",
+      "link": "common-credentials-fsgroup-doc",
+      "type": "string",
+      "definition": "FileSystem-group of the process",
+      "prefixes": [
+        "exec",
+        "exit",
+        "process",
+        "process.ancestors",
+        "process.parent",
+        "ptrace.tracee",
+        "ptrace.tracee.ancestors",
+        "ptrace.tracee.parent",
+        "signal.target",
+        "signal.target.ancestors",
+        "signal.target.parent"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "*.fsuid",
+      "link": "common-credentials-fsuid-doc",
+      "type": "int",
+      "definition": "FileSystem-uid of the process",
+      "prefixes": [
+        "exec",
+        "exit",
+        "process",
+        "process.ancestors",
+        "process.parent",
+        "ptrace.tracee",
+        "ptrace.tracee.ancestors",
+        "ptrace.tracee.parent",
+        "signal.target",
+        "signal.target.ancestors",
+        "signal.target.parent"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "*.fsuser",
+      "link": "common-credentials-fsuser-doc",
+      "type": "string",
+      "definition": "FileSystem-user of the process",
+      "prefixes": [
+        "exec",
+        "exit",
+        "process",
+        "process.ancestors",
+        "process.parent",
+        "ptrace.tracee",
+        "ptrace.tracee.ancestors",
+        "ptrace.tracee.parent",
+        "signal.target",
+        "signal.target.ancestors",
+        "signal.target.parent"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "*.gid",
+      "link": "common-credentials-gid-doc",
+      "type": "int",
+      "definition": "GID of the process",
+      "prefixes": [
+        "exec",
+        "exit",
+        "process",
+        "process.ancestors",
+        "process.parent",
+        "ptrace.tracee",
+        "ptrace.tracee.ancestors",
+        "ptrace.tracee.parent",
+        "signal.target",
+        "signal.target.ancestors",
+        "signal.target.parent"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "*.gid",
+      "link": "common-filefields-gid-doc",
+      "type": "int",
+      "definition": "GID of the file's owner",
+      "prefixes": [
+        "chmod.file",
+        "chown.file",
+        "exec.file",
+        "exec.interpreter.file",
+        "exit.file",
+        "exit.interpreter.file",
+        "link.file",
+        "link.file.destination",
+        "load_module.file",
+        "mkdir.file",
+        "mmap.file",
+        "open.file",
+        "process.ancestors.file",
+        "process.ancestors.interpreter.file",
+        "process.file",
+        "process.interpreter.file",
+        "process.parent.file",
+        "process.parent.interpreter.file",
+        "ptrace.tracee.ancestors.file",
+        "ptrace.tracee.ancestors.interpreter.file",
+        "ptrace.tracee.file",
+        "ptrace.tracee.interpreter.file",
+        "ptrace.tracee.parent.file",
+        "ptrace.tracee.parent.interpreter.file",
+        "removexattr.file",
+        "rename.file",
+        "rename.file.destination",
+        "rmdir.file",
+        "setxattr.file",
+        "signal.target.ancestors.file",
+        "signal.target.ancestors.interpreter.file",
+        "signal.target.file",
+        "signal.target.interpreter.file",
+        "signal.target.parent.file",
+        "signal.target.parent.interpreter.file",
+        "splice.file",
+        "unlink.file",
+        "utimes.file"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "*.group",
+      "link": "common-credentials-group-doc",
+      "type": "string",
+      "definition": "Group of the process",
+      "prefixes": [
+        "exec",
+        "exit",
+        "process",
+        "process.ancestors",
+        "process.parent",
+        "ptrace.tracee",
+        "ptrace.tracee.ancestors",
+        "ptrace.tracee.parent",
+        "signal.target",
+        "signal.target.ancestors",
+        "signal.target.parent"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "*.group",
+      "link": "common-filefields-group-doc",
+      "type": "string",
+      "definition": "Group of the file's owner",
+      "prefixes": [
+        "chmod.file",
+        "chown.file",
+        "exec.file",
+        "exec.interpreter.file",
+        "exit.file",
+        "exit.interpreter.file",
+        "link.file",
+        "link.file.destination",
+        "load_module.file",
+        "mkdir.file",
+        "mmap.file",
+        "open.file",
+        "process.ancestors.file",
+        "process.ancestors.interpreter.file",
+        "process.file",
+        "process.interpreter.file",
+        "process.parent.file",
+        "process.parent.interpreter.file",
+        "ptrace.tracee.ancestors.file",
+        "ptrace.tracee.ancestors.interpreter.file",
+        "ptrace.tracee.file",
+        "ptrace.tracee.interpreter.file",
+        "ptrace.tracee.parent.file",
+        "ptrace.tracee.parent.interpreter.file",
+        "removexattr.file",
+        "rename.file",
+        "rename.file.destination",
+        "rmdir.file",
+        "setxattr.file",
+        "signal.target.ancestors.file",
+        "signal.target.ancestors.interpreter.file",
+        "signal.target.file",
+        "signal.target.interpreter.file",
+        "signal.target.parent.file",
+        "signal.target.parent.interpreter.file",
+        "splice.file",
+        "unlink.file",
+        "utimes.file"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "*.in_upper_layer",
+      "link": "common-filefields-in_upper_layer-doc",
+      "type": "bool",
+      "definition": "Indicator of the file layer, for example, in an OverlayFS",
+      "prefixes": [
+        "chmod.file",
+        "chown.file",
+        "exec.file",
+        "exec.interpreter.file",
+        "exit.file",
+        "exit.interpreter.file",
+        "link.file",
+        "link.file.destination",
+        "load_module.file",
+        "mkdir.file",
+        "mmap.file",
+        "open.file",
+        "process.ancestors.file",
+        "process.ancestors.interpreter.file",
+        "process.file",
+        "process.interpreter.file",
+        "process.parent.file",
+        "process.parent.interpreter.file",
+        "ptrace.tracee.ancestors.file",
+        "ptrace.tracee.ancestors.interpreter.file",
+        "ptrace.tracee.file",
+        "ptrace.tracee.interpreter.file",
+        "ptrace.tracee.parent.file",
+        "ptrace.tracee.parent.interpreter.file",
+        "removexattr.file",
+        "rename.file",
+        "rename.file.destination",
+        "rmdir.file",
+        "setxattr.file",
+        "signal.target.ancestors.file",
+        "signal.target.ancestors.interpreter.file",
+        "signal.target.file",
+        "signal.target.interpreter.file",
+        "signal.target.parent.file",
+        "signal.target.parent.interpreter.file",
+        "splice.file",
+        "unlink.file",
+        "utimes.file"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "*.inode",
+      "link": "common-filefields-inode-doc",
+      "type": "int",
+      "definition": "Inode of the file",
+      "prefixes": [
+        "chmod.file",
+        "chown.file",
+        "exec.file",
+        "exec.interpreter.file",
+        "exit.file",
+        "exit.interpreter.file",
+        "link.file",
+        "link.file.destination",
+        "load_module.file",
+        "mkdir.file",
+        "mmap.file",
+        "open.file",
+        "process.ancestors.file",
+        "process.ancestors.interpreter.file",
+        "process.file",
+        "process.interpreter.file",
+        "process.parent.file",
+        "process.parent.interpreter.file",
+        "ptrace.tracee.ancestors.file",
+        "ptrace.tracee.ancestors.interpreter.file",
+        "ptrace.tracee.file",
+        "ptrace.tracee.interpreter.file",
+        "ptrace.tracee.parent.file",
+        "ptrace.tracee.parent.interpreter.file",
+        "removexattr.file",
+        "rename.file",
+        "rename.file.destination",
+        "rmdir.file",
+        "setxattr.file",
+        "signal.target.ancestors.file",
+        "signal.target.ancestors.interpreter.file",
+        "signal.target.file",
+        "signal.target.interpreter.file",
+        "signal.target.parent.file",
+        "signal.target.parent.interpreter.file",
+        "splice.file",
+        "unlink.file",
+        "utimes.file"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "*.ip",
+      "link": "common-ipportcontext-ip-doc",
+      "type": "IP/CIDR",
+      "definition": "IP address",
+      "prefixes": [
+        "bind.addr",
+        "network.destination",
+        "network.source"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "*.is_kworker",
+      "link": "common-pidcontext-is_kworker-doc",
+      "type": "bool",
+      "definition": "Indicates whether the process is a kworker",
+      "prefixes": [
+        "exec",
+        "exit",
+        "process",
+        "process.ancestors",
+        "process.parent",
+        "ptrace.tracee",
+        "ptrace.tracee.ancestors",
+        "ptrace.tracee.parent",
+        "signal.target",
+        "signal.target.ancestors",
+        "signal.target.parent"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "*.is_thread",
+      "link": "common-process-is_thread-doc",
+      "type": "bool",
+      "definition": "Indicates whether the process is considered a thread (that is, a child process that hasn't executed another program)",
+      "prefixes": [
+        "exec",
+        "exit",
+        "process",
+        "process.ancestors",
+        "process.parent",
+        "ptrace.tracee",
+        "ptrace.tracee.ancestors",
+        "ptrace.tracee.parent",
+        "signal.target",
+        "signal.target.ancestors",
+        "signal.target.parent"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "*.length",
+      "link": "common-string-length-doc",
+      "type": "int",
+      "definition": "Length of the corresponding string",
+      "prefixes": [
+        "chmod.file.name",
+        "chmod.file.path",
+        "chown.file.name",
+        "chown.file.path",
+        "dns.question.name",
+        "exec.file.name",
+        "exec.file.path",
+        "exec.interpreter.file.name",
+        "exec.interpreter.file.path",
+        "exit.file.name",
+        "exit.file.path",
+        "exit.interpreter.file.name",
+        "exit.interpreter.file.path",
+        "link.file.destination.name",
+        "link.file.destination.path",
+        "link.file.name",
+        "link.file.path",
+        "load_module.file.name",
+        "load_module.file.path",
+        "mkdir.file.name",
+        "mkdir.file.path",
+        "mmap.file.name",
+        "mmap.file.path",
+        "open.file.name",
+        "open.file.path",
+        "process.ancestors.file.name",
+        "process.ancestors.file.path",
+        "process.ancestors.interpreter.file.name",
+        "process.ancestors.interpreter.file.path",
+        "process.file.name",
+        "process.file.path",
+        "process.interpreter.file.name",
+        "process.interpreter.file.path",
+        "process.parent.file.name",
+        "process.parent.file.path",
+        "process.parent.interpreter.file.name",
+        "process.parent.interpreter.file.path",
+        "ptrace.tracee.ancestors.file.name",
+        "ptrace.tracee.ancestors.file.path",
+        "ptrace.tracee.ancestors.interpreter.file.name",
+        "ptrace.tracee.ancestors.interpreter.file.path",
+        "ptrace.tracee.file.name",
+        "ptrace.tracee.file.path",
+        "ptrace.tracee.interpreter.file.name",
+        "ptrace.tracee.interpreter.file.path",
+        "ptrace.tracee.parent.file.name",
+        "ptrace.tracee.parent.file.path",
+        "ptrace.tracee.parent.interpreter.file.name",
+        "ptrace.tracee.parent.interpreter.file.path",
+        "removexattr.file.name",
+        "removexattr.file.path",
+        "rename.file.destination.name",
+        "rename.file.destination.path",
+        "rename.file.name",
+        "rename.file.path",
+        "rmdir.file.name",
+        "rmdir.file.path",
+        "setxattr.file.name",
+        "setxattr.file.path",
+        "signal.target.ancestors.file.name",
+        "signal.target.ancestors.file.path",
+        "signal.target.ancestors.interpreter.file.name",
+        "signal.target.ancestors.interpreter.file.path",
+        "signal.target.file.name",
+        "signal.target.file.path",
+        "signal.target.interpreter.file.name",
+        "signal.target.interpreter.file.path",
+        "signal.target.parent.file.name",
+        "signal.target.parent.file.path",
+        "signal.target.parent.interpreter.file.name",
+        "signal.target.parent.interpreter.file.path",
+        "splice.file.name",
+        "splice.file.path",
+        "unlink.file.name",
+        "unlink.file.path",
+        "utimes.file.name",
+        "utimes.file.path"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "*.mode",
+      "link": "common-filefields-mode-doc",
+      "type": "int",
+      "definition": "Mode of the file",
+      "prefixes": [
+        "chmod.file",
+        "chown.file",
+        "exec.file",
+        "exec.interpreter.file",
+        "exit.file",
+        "exit.interpreter.file",
+        "link.file",
+        "link.file.destination",
+        "load_module.file",
+        "mkdir.file",
+        "mmap.file",
+        "open.file",
+        "process.ancestors.file",
+        "process.ancestors.interpreter.file",
+        "process.file",
+        "process.interpreter.file",
+        "process.parent.file",
+        "process.parent.interpreter.file",
+        "ptrace.tracee.ancestors.file",
+        "ptrace.tracee.ancestors.interpreter.file",
+        "ptrace.tracee.file",
+        "ptrace.tracee.interpreter.file",
+        "ptrace.tracee.parent.file",
+        "ptrace.tracee.parent.interpreter.file",
+        "removexattr.file",
+        "rename.file",
+        "rename.file.destination",
+        "rmdir.file",
+        "setxattr.file",
+        "signal.target.ancestors.file",
+        "signal.target.ancestors.interpreter.file",
+        "signal.target.file",
+        "signal.target.interpreter.file",
+        "signal.target.parent.file",
+        "signal.target.parent.interpreter.file",
+        "splice.file",
+        "unlink.file",
+        "utimes.file"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "*.modification_time",
+      "link": "common-filefields-modification_time-doc",
+      "type": "int",
+      "definition": "Modification time of the file",
+      "prefixes": [
+        "chmod.file",
+        "chown.file",
+        "exec.file",
+        "exec.interpreter.file",
+        "exit.file",
+        "exit.interpreter.file",
+        "link.file",
+        "link.file.destination",
+        "load_module.file",
+        "mkdir.file",
+        "mmap.file",
+        "open.file",
+        "process.ancestors.file",
+        "process.ancestors.interpreter.file",
+        "process.file",
+        "process.interpreter.file",
+        "process.parent.file",
+        "process.parent.interpreter.file",
+        "ptrace.tracee.ancestors.file",
+        "ptrace.tracee.ancestors.interpreter.file",
+        "ptrace.tracee.file",
+        "ptrace.tracee.interpreter.file",
+        "ptrace.tracee.parent.file",
+        "ptrace.tracee.parent.interpreter.file",
+        "removexattr.file",
+        "rename.file",
+        "rename.file.destination",
+        "rmdir.file",
+        "setxattr.file",
+        "signal.target.ancestors.file",
+        "signal.target.ancestors.interpreter.file",
+        "signal.target.file",
+        "signal.target.interpreter.file",
+        "signal.target.parent.file",
+        "signal.target.parent.interpreter.file",
+        "splice.file",
+        "unlink.file",
+        "utimes.file"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "*.mount_id",
+      "link": "common-filefields-mount_id-doc",
+      "type": "int",
+      "definition": "Mount ID of the file",
+      "prefixes": [
+        "chmod.file",
+        "chown.file",
+        "exec.file",
+        "exec.interpreter.file",
+        "exit.file",
+        "exit.interpreter.file",
+        "link.file",
+        "link.file.destination",
+        "load_module.file",
+        "mkdir.file",
+        "mmap.file",
+        "open.file",
+        "process.ancestors.file",
+        "process.ancestors.interpreter.file",
+        "process.file",
+        "process.interpreter.file",
+        "process.parent.file",
+        "process.parent.interpreter.file",
+        "ptrace.tracee.ancestors.file",
+        "ptrace.tracee.ancestors.interpreter.file",
+        "ptrace.tracee.file",
+        "ptrace.tracee.interpreter.file",
+        "ptrace.tracee.parent.file",
+        "ptrace.tracee.parent.interpreter.file",
+        "removexattr.file",
+        "rename.file",
+        "rename.file.destination",
+        "rmdir.file",
+        "setxattr.file",
+        "signal.target.ancestors.file",
+        "signal.target.ancestors.interpreter.file",
+        "signal.target.file",
+        "signal.target.interpreter.file",
+        "signal.target.parent.file",
+        "signal.target.parent.interpreter.file",
+        "splice.file",
+        "unlink.file",
+        "utimes.file"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "*.name",
+      "link": "common-fileevent-name-doc",
+      "type": "string",
+      "definition": "File's basename",
+      "prefixes": [
+        "chmod.file",
+        "chown.file",
+        "exec.file",
+        "exec.interpreter.file",
+        "exit.file",
+        "exit.interpreter.file",
+        "link.file",
+        "link.file.destination",
+        "load_module.file",
+        "mkdir.file",
+        "mmap.file",
+        "open.file",
+        "process.ancestors.file",
+        "process.ancestors.interpreter.file",
+        "process.file",
+        "process.interpreter.file",
+        "process.parent.file",
+        "process.parent.interpreter.file",
+        "ptrace.tracee.ancestors.file",
+        "ptrace.tracee.ancestors.interpreter.file",
+        "ptrace.tracee.file",
+        "ptrace.tracee.interpreter.file",
+        "ptrace.tracee.parent.file",
+        "ptrace.tracee.parent.interpreter.file",
+        "removexattr.file",
+        "rename.file",
+        "rename.file.destination",
+        "rmdir.file",
+        "setxattr.file",
+        "signal.target.ancestors.file",
+        "signal.target.ancestors.interpreter.file",
+        "signal.target.file",
+        "signal.target.interpreter.file",
+        "signal.target.parent.file",
+        "signal.target.parent.interpreter.file",
+        "splice.file",
+        "unlink.file",
+        "utimes.file"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": [
+        {
+          "expression": "exec.file.name == \"apt\"",
+          "description": "Matches the execution of any file named apt."
+        }
+      ]
+    },
+    {
+      "name": "*.path",
+      "link": "common-fileevent-path-doc",
+      "type": "string",
+      "definition": "File's path",
+      "prefixes": [
+        "chmod.file",
+        "chown.file",
+        "exec.file",
+        "exec.interpreter.file",
+        "exit.file",
+        "exit.interpreter.file",
+        "link.file",
+        "link.file.destination",
+        "load_module.file",
+        "mkdir.file",
+        "mmap.file",
+        "open.file",
+        "process.ancestors.file",
+        "process.ancestors.interpreter.file",
+        "process.file",
+        "process.interpreter.file",
+        "process.parent.file",
+        "process.parent.interpreter.file",
+        "ptrace.tracee.ancestors.file",
+        "ptrace.tracee.ancestors.interpreter.file",
+        "ptrace.tracee.file",
+        "ptrace.tracee.interpreter.file",
+        "ptrace.tracee.parent.file",
+        "ptrace.tracee.parent.interpreter.file",
+        "removexattr.file",
+        "rename.file",
+        "rename.file.destination",
+        "rmdir.file",
+        "setxattr.file",
+        "signal.target.ancestors.file",
+        "signal.target.ancestors.interpreter.file",
+        "signal.target.file",
+        "signal.target.interpreter.file",
+        "signal.target.parent.file",
+        "signal.target.parent.interpreter.file",
+        "splice.file",
+        "unlink.file",
+        "utimes.file"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": [
+        {
+          "expression": "exec.file.path == \"/usr/bin/apt\"",
+          "description": "Matches the execution of the file located at /usr/bin/apt"
+        },
+        {
+          "expression": "open.file.path == \"/etc/passwd\"",
+          "description": "Matches any process opening the /etc/passwd file."
+        }
+      ]
+    },
+    {
+      "name": "*.pid",
+      "link": "common-pidcontext-pid-doc",
+      "type": "int",
+      "definition": "Process ID of the process (also called thread group ID)",
+      "prefixes": [
+        "exec",
+        "exit",
+        "process",
+        "process.ancestors",
+        "process.parent",
+        "ptrace.tracee",
+        "ptrace.tracee.ancestors",
+        "ptrace.tracee.parent",
+        "signal.target",
+        "signal.target.ancestors",
+        "signal.target.parent"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "*.port",
+      "link": "common-ipportcontext-port-doc",
+      "type": "int",
+      "definition": "Port number",
+      "prefixes": [
+        "bind.addr",
+        "network.destination",
+        "network.source"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "*.ppid",
+      "link": "common-process-ppid-doc",
+      "type": "int",
+      "definition": "Parent process ID",
+      "prefixes": [
+        "exec",
+        "exit",
+        "process",
+        "process.ancestors",
+        "process.parent",
+        "ptrace.tracee",
+        "ptrace.tracee.ancestors",
+        "ptrace.tracee.parent",
+        "signal.target",
+        "signal.target.ancestors",
+        "signal.target.parent"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "*.retval",
+      "link": "common-syscallevent-retval-doc",
+      "type": "int",
+      "definition": "Return value of the syscall",
+      "prefixes": [
+        "bind",
+        "bpf",
+        "chmod",
+        "chown",
+        "link",
+        "load_module",
+        "mkdir",
+        "mmap",
+        "mount",
+        "mprotect",
+        "open",
+        "ptrace",
+        "removexattr",
+        "rename",
+        "rmdir",
+        "setxattr",
+        "signal",
+        "splice",
+        "unlink",
+        "unload_module",
+        "utimes"
+      ],
+      "constants": "Error constants",
+      "constants_link": "error-constants",
+      "examples": []
+    },
+    {
+      "name": "*.rights",
+      "link": "common-filefields-rights-doc",
+      "type": "int",
+      "definition": "Rights of the file",
+      "prefixes": [
+        "chmod.file",
+        "chown.file",
+        "exec.file",
+        "exec.interpreter.file",
+        "exit.file",
+        "exit.interpreter.file",
+        "link.file",
+        "link.file.destination",
+        "load_module.file",
+        "mkdir.file",
+        "mmap.file",
+        "open.file",
+        "process.ancestors.file",
+        "process.ancestors.interpreter.file",
+        "process.file",
+        "process.interpreter.file",
+        "process.parent.file",
+        "process.parent.interpreter.file",
+        "ptrace.tracee.ancestors.file",
+        "ptrace.tracee.ancestors.interpreter.file",
+        "ptrace.tracee.file",
+        "ptrace.tracee.interpreter.file",
+        "ptrace.tracee.parent.file",
+        "ptrace.tracee.parent.interpreter.file",
+        "removexattr.file",
+        "rename.file",
+        "rename.file.destination",
+        "rmdir.file",
+        "setxattr.file",
+        "signal.target.ancestors.file",
+        "signal.target.ancestors.interpreter.file",
+        "signal.target.file",
+        "signal.target.interpreter.file",
+        "signal.target.parent.file",
+        "signal.target.parent.interpreter.file",
+        "splice.file",
+        "unlink.file",
+        "utimes.file"
+      ],
+      "constants": "Chmod mode constants",
+      "constants_link": "chmod-mode-constants",
+      "examples": []
+    },
+    {
+      "name": "*.tid",
+      "link": "common-pidcontext-tid-doc",
+      "type": "int",
+      "definition": "Thread ID of the thread",
+      "prefixes": [
+        "exec",
+        "exit",
+        "process",
+        "process.ancestors",
+        "process.parent",
+        "ptrace.tracee",
+        "ptrace.tracee.ancestors",
+        "ptrace.tracee.parent",
+        "signal.target",
+        "signal.target.ancestors",
+        "signal.target.parent"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "*.tty_name",
+      "link": "common-process-tty_name-doc",
+      "type": "string",
+      "definition": "Name of the TTY associated with the process",
+      "prefixes": [
+        "exec",
+        "exit",
+        "process",
+        "process.ancestors",
+        "process.parent",
+        "ptrace.tracee",
+        "ptrace.tracee.ancestors",
+        "ptrace.tracee.parent",
+        "signal.target",
+        "signal.target.ancestors",
+        "signal.target.parent"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "*.uid",
+      "link": "common-credentials-uid-doc",
+      "type": "int",
+      "definition": "UID of the process",
+      "prefixes": [
+        "exec",
+        "exit",
+        "process",
+        "process.ancestors",
+        "process.parent",
+        "ptrace.tracee",
+        "ptrace.tracee.ancestors",
+        "ptrace.tracee.parent",
+        "signal.target",
+        "signal.target.ancestors",
+        "signal.target.parent"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "*.uid",
+      "link": "common-filefields-uid-doc",
+      "type": "int",
+      "definition": "UID of the file's owner",
+      "prefixes": [
+        "chmod.file",
+        "chown.file",
+        "exec.file",
+        "exec.interpreter.file",
+        "exit.file",
+        "exit.interpreter.file",
+        "link.file",
+        "link.file.destination",
+        "load_module.file",
+        "mkdir.file",
+        "mmap.file",
+        "open.file",
+        "process.ancestors.file",
+        "process.ancestors.interpreter.file",
+        "process.file",
+        "process.interpreter.file",
+        "process.parent.file",
+        "process.parent.interpreter.file",
+        "ptrace.tracee.ancestors.file",
+        "ptrace.tracee.ancestors.interpreter.file",
+        "ptrace.tracee.file",
+        "ptrace.tracee.interpreter.file",
+        "ptrace.tracee.parent.file",
+        "ptrace.tracee.parent.interpreter.file",
+        "removexattr.file",
+        "rename.file",
+        "rename.file.destination",
+        "rmdir.file",
+        "setxattr.file",
+        "signal.target.ancestors.file",
+        "signal.target.ancestors.interpreter.file",
+        "signal.target.file",
+        "signal.target.interpreter.file",
+        "signal.target.parent.file",
+        "signal.target.parent.interpreter.file",
+        "splice.file",
+        "unlink.file",
+        "utimes.file"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "*.user",
+      "link": "common-credentials-user-doc",
+      "type": "string",
+      "definition": "User of the process",
+      "prefixes": [
+        "exec",
+        "exit",
+        "process",
+        "process.ancestors",
+        "process.parent",
+        "ptrace.tracee",
+        "ptrace.tracee.ancestors",
+        "ptrace.tracee.parent",
+        "signal.target",
+        "signal.target.ancestors",
+        "signal.target.parent"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": [
+        {
+          "expression": "process.user == \"root\"",
+          "description": "Constrain an event to be triggered by a process running as the root user."
+        }
+      ]
+    },
+    {
+      "name": "*.user",
+      "link": "common-filefields-user-doc",
+      "type": "string",
+      "definition": "User of the file's owner",
+      "prefixes": [
+        "chmod.file",
+        "chown.file",
+        "exec.file",
+        "exec.interpreter.file",
+        "exit.file",
+        "exit.interpreter.file",
+        "link.file",
+        "link.file.destination",
+        "load_module.file",
+        "mkdir.file",
+        "mmap.file",
+        "open.file",
+        "process.ancestors.file",
+        "process.ancestors.interpreter.file",
+        "process.file",
+        "process.interpreter.file",
+        "process.parent.file",
+        "process.parent.interpreter.file",
+        "ptrace.tracee.ancestors.file",
+        "ptrace.tracee.ancestors.interpreter.file",
+        "ptrace.tracee.file",
+        "ptrace.tracee.interpreter.file",
+        "ptrace.tracee.parent.file",
+        "ptrace.tracee.parent.interpreter.file",
+        "removexattr.file",
+        "rename.file",
+        "rename.file.destination",
+        "rmdir.file",
+        "setxattr.file",
+        "signal.target.ancestors.file",
+        "signal.target.ancestors.interpreter.file",
+        "signal.target.file",
+        "signal.target.interpreter.file",
+        "signal.target.parent.file",
+        "signal.target.parent.interpreter.file",
+        "splice.file",
+        "unlink.file",
+        "utimes.file"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "async",
+      "link": "async-doc",
+      "type": "bool",
+      "definition": "True if the syscall was asynchronous",
+      "prefixes": [
+        ""
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "bind.addr.family",
+      "link": "bind-addr-family-doc",
+      "type": "int",
+      "definition": "Address family",
+      "prefixes": [
+        "bind"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "bpf.cmd",
+      "link": "bpf-cmd-doc",
+      "type": "int",
+      "definition": "BPF command name",
+      "prefixes": [
+        "bpf"
+      ],
+      "constants": "BPF commands",
+      "constants_link": "bpf-commands",
+      "examples": []
+    },
+    {
+      "name": "bpf.map.name",
+      "link": "bpf-map-name-doc",
+      "type": "string",
+      "definition": "Name of the eBPF map (added in 7.35)",
+      "prefixes": [
+        "bpf.map"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "bpf.map.type",
+      "link": "bpf-map-type-doc",
+      "type": "int",
+      "definition": "Type of the eBPF map",
+      "prefixes": [
+        "bpf.map"
+      ],
+      "constants": "BPF map types",
+      "constants_link": "bpf-map-types",
+      "examples": []
+    },
+    {
+      "name": "bpf.prog.attach_type",
+      "link": "bpf-prog-attach_type-doc",
+      "type": "int",
+      "definition": "Attach type of the eBPF program",
+      "prefixes": [
+        "bpf.prog"
+      ],
+      "constants": "BPF attach types",
+      "constants_link": "bpf-attach-types",
+      "examples": []
+    },
+    {
+      "name": "bpf.prog.helpers",
+      "link": "bpf-prog-helpers-doc",
+      "type": "int",
+      "definition": "eBPF helpers used by the eBPF program (added in 7.35)",
+      "prefixes": [
+        "bpf.prog"
+      ],
+      "constants": "BPF helper functions",
+      "constants_link": "bpf-helper-functions",
+      "examples": []
+    },
+    {
+      "name": "bpf.prog.name",
+      "link": "bpf-prog-name-doc",
+      "type": "string",
+      "definition": "Name of the eBPF program (added in 7.35)",
+      "prefixes": [
+        "bpf.prog"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "bpf.prog.tag",
+      "link": "bpf-prog-tag-doc",
+      "type": "string",
+      "definition": "Hash (sha1) of the eBPF program (added in 7.35)",
+      "prefixes": [
+        "bpf.prog"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "bpf.prog.type",
+      "link": "bpf-prog-type-doc",
+      "type": "int",
+      "definition": "Type of the eBPF program",
+      "prefixes": [
+        "bpf.prog"
+      ],
+      "constants": "BPF program types",
+      "constants_link": "bpf-program-types",
+      "examples": []
+    },
+    {
+      "name": "capset.cap_effective",
+      "link": "capset-cap_effective-doc",
+      "type": "int",
+      "definition": "Effective capability set of the process",
+      "prefixes": [
+        "capset"
+      ],
+      "constants": "Kernel Capability constants",
+      "constants_link": "kernel-capability-constants",
+      "examples": []
+    },
+    {
+      "name": "capset.cap_permitted",
+      "link": "capset-cap_permitted-doc",
+      "type": "int",
+      "definition": "Permitted capability set of the process",
+      "prefixes": [
+        "capset"
+      ],
+      "constants": "Kernel Capability constants",
+      "constants_link": "kernel-capability-constants",
+      "examples": []
+    },
+    {
+      "name": "chmod.file.destination.mode",
+      "link": "chmod-file-destination-mode-doc",
+      "type": "int",
+      "definition": "New mode of the chmod-ed file",
+      "prefixes": [
+        "chmod"
+      ],
+      "constants": "Chmod mode constants",
+      "constants_link": "chmod-mode-constants",
+      "examples": []
+    },
+    {
+      "name": "chmod.file.destination.rights",
+      "link": "chmod-file-destination-rights-doc",
+      "type": "int",
+      "definition": "New rights of the chmod-ed file",
+      "prefixes": [
+        "chmod"
+      ],
+      "constants": "Chmod mode constants",
+      "constants_link": "chmod-mode-constants",
+      "examples": []
+    },
+    {
+      "name": "chown.file.destination.gid",
+      "link": "chown-file-destination-gid-doc",
+      "type": "int",
+      "definition": "New GID of the chown-ed file's owner",
+      "prefixes": [
+        "chown"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "chown.file.destination.group",
+      "link": "chown-file-destination-group-doc",
+      "type": "string",
+      "definition": "New group of the chown-ed file's owner",
+      "prefixes": [
+        "chown"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "chown.file.destination.uid",
+      "link": "chown-file-destination-uid-doc",
+      "type": "int",
+      "definition": "New UID of the chown-ed file's owner",
+      "prefixes": [
+        "chown"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "chown.file.destination.user",
+      "link": "chown-file-destination-user-doc",
+      "type": "string",
+      "definition": "New user of the chown-ed file's owner",
+      "prefixes": [
+        "chown"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "container.id",
+      "link": "container-id-doc",
+      "type": "string",
+      "definition": "ID of the container",
+      "prefixes": [
+        "container"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "container.tags",
+      "link": "container-tags-doc",
+      "type": "string",
+      "definition": "Tags of the container",
+      "prefixes": [
+        "container"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "dns.id",
+      "link": "dns-id-doc",
+      "type": "int",
+      "definition": "[Experimental] the DNS request ID",
+      "prefixes": [
+        "dns"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "dns.question.class",
+      "link": "dns-question-class-doc",
+      "type": "int",
+      "definition": "the class looked up by the DNS question",
+      "prefixes": [
+        "dns"
+      ],
+      "constants": "DNS qclasses",
+      "constants_link": "dns-qclasses",
+      "examples": []
+    },
+    {
+      "name": "dns.question.count",
+      "link": "dns-question-count-doc",
+      "type": "int",
+      "definition": "the total count of questions in the DNS request",
+      "prefixes": [
+        "dns"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "dns.question.length",
+      "link": "dns-question-length-doc",
+      "type": "int",
+      "definition": "the total DNS request size in bytes",
+      "prefixes": [
+        "dns"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "dns.question.name",
+      "link": "dns-question-name-doc",
+      "type": "string",
+      "definition": "the queried domain name",
+      "prefixes": [
+        "dns"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "dns.question.type",
+      "link": "dns-question-type-doc",
+      "type": "int",
+      "definition": "a two octet code which specifies the DNS question type",
+      "prefixes": [
+        "dns"
+      ],
+      "constants": "DNS qtypes",
+      "constants_link": "dns-qtypes",
+      "examples": []
+    },
+    {
+      "name": "exit.cause",
+      "link": "exit-cause-doc",
+      "type": "int",
+      "definition": "Cause of the process termination (one of EXITED, SIGNALED, COREDUMPED)",
+      "prefixes": [
+        "exit"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "exit.code",
+      "link": "exit-code-doc",
+      "type": "int",
+      "definition": "Exit code of the process or number of the signal that caused the process to terminate",
+      "prefixes": [
+        "exit"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "load_module.loaded_from_memory",
+      "link": "load_module-loaded_from_memory-doc",
+      "type": "bool",
+      "definition": "Indicates if the kernel module was loaded from memory",
+      "prefixes": [
+        "load_module"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "load_module.name",
+      "link": "load_module-name-doc",
+      "type": "string",
+      "definition": "Name of the new kernel module",
+      "prefixes": [
+        "load_module"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "mkdir.file.destination.mode",
+      "link": "mkdir-file-destination-mode-doc",
+      "type": "int",
+      "definition": "Mode of the new directory",
+      "prefixes": [
+        "mkdir"
+      ],
+      "constants": "Chmod mode constants",
+      "constants_link": "chmod-mode-constants",
+      "examples": []
+    },
+    {
+      "name": "mkdir.file.destination.rights",
+      "link": "mkdir-file-destination-rights-doc",
+      "type": "int",
+      "definition": "Rights of the new directory",
+      "prefixes": [
+        "mkdir"
+      ],
+      "constants": "Chmod mode constants",
+      "constants_link": "chmod-mode-constants",
+      "examples": []
+    },
+    {
+      "name": "mmap.flags",
+      "link": "mmap-flags-doc",
+      "type": "int",
+      "definition": "memory segment flags",
+      "prefixes": [
+        "mmap"
+      ],
+      "constants": "MMap flags",
+      "constants_link": "mmap-flags",
+      "examples": []
+    },
+    {
+      "name": "mmap.protection",
+      "link": "mmap-protection-doc",
+      "type": "int",
+      "definition": "memory segment protection",
+      "prefixes": [
+        "mmap"
+      ],
+      "constants": "Protection constants",
+      "constants_link": "protection-constants",
+      "examples": []
+    },
+    {
+      "name": "mount.fs_type",
+      "link": "mount-fs_type-doc",
+      "type": "string",
+      "definition": "Type of the mounted file system",
+      "prefixes": [
+        "mount"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "mount.mountpoint.path",
+      "link": "mount-mountpoint-path-doc",
+      "type": "string",
+      "definition": "Path of the mount point",
+      "prefixes": [
+        "mount"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "mount.source.path",
+      "link": "mount-source-path-doc",
+      "type": "string",
+      "definition": "Source path of a bind mount",
+      "prefixes": [
+        "mount"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "mprotect.req_protection",
+      "link": "mprotect-req_protection-doc",
+      "type": "int",
+      "definition": "new memory segment protection",
+      "prefixes": [
+        "mprotect"
+      ],
+      "constants": "Virtual Memory flags",
+      "constants_link": "virtual-memory-flags",
+      "examples": []
+    },
+    {
+      "name": "mprotect.vm_protection",
+      "link": "mprotect-vm_protection-doc",
+      "type": "int",
+      "definition": "initial memory segment protection",
+      "prefixes": [
+        "mprotect"
+      ],
+      "constants": "Virtual Memory flags",
+      "constants_link": "virtual-memory-flags",
+      "examples": []
+    },
+    {
+      "name": "network.device.ifindex",
+      "link": "network-device-ifindex-doc",
+      "type": "int",
+      "definition": "interface ifindex",
+      "prefixes": [
+        "network.device"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "network.device.ifname",
+      "link": "network-device-ifname-doc",
+      "type": "string",
+      "definition": "interface ifname",
+      "prefixes": [
+        "network.device"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "network.l3_protocol",
+      "link": "network-l3_protocol-doc",
+      "type": "int",
+      "definition": "l3 protocol of the network packet",
+      "prefixes": [
+        "network"
+      ],
+      "constants": "L3 protocols",
+      "constants_link": "l3-protocols",
+      "examples": []
+    },
+    {
+      "name": "network.l4_protocol",
+      "link": "network-l4_protocol-doc",
+      "type": "int",
+      "definition": "l4 protocol of the network packet",
+      "prefixes": [
+        "network"
+      ],
+      "constants": "L4 protocols",
+      "constants_link": "l4-protocols",
+      "examples": []
+    },
+    {
+      "name": "network.size",
+      "link": "network-size-doc",
+      "type": "int",
+      "definition": "size in bytes of the network packet",
+      "prefixes": [
+        "network"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "open.file.destination.mode",
+      "link": "open-file-destination-mode-doc",
+      "type": "int",
+      "definition": "Mode of the created file",
+      "prefixes": [
+        "open"
+      ],
+      "constants": "Chmod mode constants",
+      "constants_link": "chmod-mode-constants",
+      "examples": []
+    },
+    {
+      "name": "open.flags",
+      "link": "open-flags-doc",
+      "type": "int",
+      "definition": "Flags used when opening the file",
+      "prefixes": [
+        "open"
+      ],
+      "constants": "Open flags",
+      "constants_link": "open-flags",
+      "examples": []
+    },
+    {
+      "name": "ptrace.request",
+      "link": "ptrace-request-doc",
+      "type": "int",
+      "definition": "ptrace request",
+      "prefixes": [
+        "ptrace"
+      ],
+      "constants": "Ptrace constants",
+      "constants_link": "ptrace-constants",
+      "examples": []
+    },
+    {
+      "name": "selinux.bool.name",
+      "link": "selinux-bool-name-doc",
+      "type": "string",
+      "definition": "SELinux boolean name",
+      "prefixes": [
+        "selinux"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "selinux.bool.state",
+      "link": "selinux-bool-state-doc",
+      "type": "string",
+      "definition": "SELinux boolean new value",
+      "prefixes": [
+        "selinux"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "selinux.bool_commit.state",
+      "link": "selinux-bool_commit-state-doc",
+      "type": "bool",
+      "definition": "Indicator of a SELinux boolean commit operation",
+      "prefixes": [
+        "selinux"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "selinux.enforce.status",
+      "link": "selinux-enforce-status-doc",
+      "type": "string",
+      "definition": "SELinux enforcement status (one of \"enforcing\", \"permissive\", \"disabled\")",
+      "prefixes": [
+        "selinux"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "setgid.egid",
+      "link": "setgid-egid-doc",
+      "type": "int",
+      "definition": "New effective GID of the process",
+      "prefixes": [
+        "setgid"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "setgid.egroup",
+      "link": "setgid-egroup-doc",
+      "type": "string",
+      "definition": "New effective group of the process",
+      "prefixes": [
+        "setgid"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "setgid.fsgid",
+      "link": "setgid-fsgid-doc",
+      "type": "int",
+      "definition": "New FileSystem GID of the process",
+      "prefixes": [
+        "setgid"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "setgid.fsgroup",
+      "link": "setgid-fsgroup-doc",
+      "type": "string",
+      "definition": "New FileSystem group of the process",
+      "prefixes": [
+        "setgid"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "setgid.gid",
+      "link": "setgid-gid-doc",
+      "type": "int",
+      "definition": "New GID of the process",
+      "prefixes": [
+        "setgid"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "setgid.group",
+      "link": "setgid-group-doc",
+      "type": "string",
+      "definition": "New group of the process",
+      "prefixes": [
+        "setgid"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "setuid.euid",
+      "link": "setuid-euid-doc",
+      "type": "int",
+      "definition": "New effective UID of the process",
+      "prefixes": [
+        "setuid"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "setuid.euser",
+      "link": "setuid-euser-doc",
+      "type": "string",
+      "definition": "New effective user of the process",
+      "prefixes": [
+        "setuid"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "setuid.fsuid",
+      "link": "setuid-fsuid-doc",
+      "type": "int",
+      "definition": "New FileSystem UID of the process",
+      "prefixes": [
+        "setuid"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "setuid.fsuser",
+      "link": "setuid-fsuser-doc",
+      "type": "string",
+      "definition": "New FileSystem user of the process",
+      "prefixes": [
+        "setuid"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "setuid.uid",
+      "link": "setuid-uid-doc",
+      "type": "int",
+      "definition": "New UID of the process",
+      "prefixes": [
+        "setuid"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "setuid.user",
+      "link": "setuid-user-doc",
+      "type": "string",
+      "definition": "New user of the process",
+      "prefixes": [
+        "setuid"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "signal.pid",
+      "link": "signal-pid-doc",
+      "type": "int",
+      "definition": "Target PID",
+      "prefixes": [
+        "signal"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "signal.type",
+      "link": "signal-type-doc",
+      "type": "int",
+      "definition": "Signal type (ex: SIGHUP, SIGINT, SIGQUIT, etc)",
+      "prefixes": [
+        "signal"
+      ],
+      "constants": "Signal constants",
+      "constants_link": "signal-constants",
+      "examples": []
+    },
+    {
+      "name": "splice.pipe_entry_flag",
+      "link": "splice-pipe_entry_flag-doc",
+      "type": "int",
+      "definition": "Entry flag of the \"fd_out\" pipe passed to the splice syscall",
+      "prefixes": [
+        "splice"
+      ],
+      "constants": "Pipe buffer flags",
+      "constants_link": "pipe-buffer-flags",
+      "examples": []
+    },
+    {
+      "name": "splice.pipe_exit_flag",
+      "link": "splice-pipe_exit_flag-doc",
+      "type": "int",
+      "definition": "Exit flag of the \"fd_out\" pipe passed to the splice syscall",
+      "prefixes": [
+        "splice"
+      ],
+      "constants": "Pipe buffer flags",
+      "constants_link": "pipe-buffer-flags",
+      "examples": []
+    },
+    {
+      "name": "unlink.flags",
+      "link": "unlink-flags-doc",
+      "type": "int",
+      "definition": "Flags of the unlink syscall",
+      "prefixes": [
+        "unlink"
+      ],
+      "constants": "Unlink flags",
+      "constants_link": "unlink-flags",
+      "examples": []
+    },
+    {
+      "name": "unload_module.name",
+      "link": "unload_module-name-doc",
+      "type": "string",
+      "definition": "Name of the kernel module that was deleted",
+      "prefixes": [
+        "unload_module"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
     }
   ],
   "constants": [
     {
       "name": "BPF attach types",
+      "link": "bpf-attach-types",
       "description": "BPF attach types are the supported eBPF program attach types.",
       "all": [
         {
@@ -6859,6 +8247,7 @@
     },
     {
       "name": "BPF commands",
+      "link": "bpf-commands",
       "description": "BPF commands are used to specify a command to a bpf syscall.",
       "all": [
         {
@@ -7013,6 +8402,7 @@
     },
     {
       "name": "BPF helper functions",
+      "link": "bpf-helper-functions",
       "description": "BPF helper functions are the supported BPF helper functions.",
       "all": [
         {
@@ -7683,6 +9073,7 @@
     },
     {
       "name": "BPF map types",
+      "link": "bpf-map-types",
       "description": "BPF map types are the supported eBPF map types.",
       "all": [
         {
@@ -7809,6 +9200,7 @@
     },
     {
       "name": "BPF program types",
+      "link": "bpf-program-types",
       "description": "BPF program types are the supported eBPF program types.",
       "all": [
         {
@@ -7939,6 +9331,7 @@
     },
     {
       "name": "Chmod mode constants",
+      "link": "chmod-mode-constants",
       "description": "Chmod mode constants are the supported modes for the chmod syscall.",
       "all": [
         {
@@ -8037,6 +9430,7 @@
     },
     {
       "name": "DNS qclasses",
+      "link": "dns-qclasses",
       "description": "DNS qclasses are the supported DNS query classes.",
       "all": [
         {
@@ -8067,6 +9461,7 @@
     },
     {
       "name": "DNS qtypes",
+      "link": "dns-qtypes",
       "description": "DNS qtypes are the supported DNS query types.",
       "all": [
         {
@@ -8408,8 +9803,9 @@
       ]
     },
     {
-      "name": "Error Constants",
-      "description": "Error Constants are the supported error constants.",
+      "name": "Error constants",
+      "link": "error-constants",
+      "description": "Error constants are the supported error constants.",
       "all": [
         {
           "name": "E2BIG",
@@ -8947,6 +10343,7 @@
     },
     {
       "name": "Kernel Capability constants",
+      "link": "kernel-capability-constants",
       "description": "Kernel Capability constants are the supported Linux Kernel Capability.",
       "all": [
         {
@@ -9121,6 +10518,7 @@
     },
     {
       "name": "L3 protocols",
+      "link": "l3-protocols",
       "description": "L3 protocols are the supported Layer 3 protocols.",
       "all": [
         {
@@ -9487,6 +10885,7 @@
     },
     {
       "name": "L4 protocols",
+      "link": "l4-protocols",
       "description": "L4 protocols are the supported Layer 4 protocols.",
       "all": [
         {
@@ -9601,6 +11000,7 @@
     },
     {
       "name": "MMap flags",
+      "link": "mmap-flags",
       "description": "MMap flags are the supported flags for the mmap syscall.",
       "all": [
         {
@@ -9735,6 +11135,7 @@
     },
     {
       "name": "Network Address Family constants",
+      "link": "network-address-family-constants",
       "description": "Network Address Family constants are the supported network address families.",
       "all": [
         {
@@ -9937,6 +11338,7 @@
     },
     {
       "name": "Open flags",
+      "link": "open-flags",
       "description": "Open flags are the supported flags for the open syscall.",
       "all": [
         {
@@ -10027,6 +11429,7 @@
     },
     {
       "name": "Pipe buffer flags",
+      "link": "pipe-buffer-flags",
       "description": "Pipe buffer flags are the supported flags for a pipe buffer.",
       "all": [
         {
@@ -10061,6 +11464,7 @@
     },
     {
       "name": "Protection constants",
+      "link": "protection-constants",
       "description": "Protection constants are the supported protections for the mmap syscall.",
       "all": [
         {
@@ -10091,6 +11495,7 @@
     },
     {
       "name": "Ptrace constants",
+      "link": "ptrace-constants",
       "description": "Ptrace constants are the supported ptrace commands for the ptrace syscall.",
       "all": [
         {
@@ -10309,6 +11714,7 @@
     },
     {
       "name": "SecL constants",
+      "link": "secl-constants",
       "description": "SecL constants are the supported generic SecL constants.",
       "all": [
         {
@@ -10323,6 +11729,7 @@
     },
     {
       "name": "Signal constants",
+      "link": "signal-constants",
       "description": "Signal constants are the supported signals for the kill syscall.",
       "all": [
         {
@@ -10461,6 +11868,7 @@
     },
     {
       "name": "Unlink flags",
+      "link": "unlink-flags",
       "description": "Unlink flags are the supported flags for the unlink syscall.",
       "all": [
         {
@@ -10471,6 +11879,7 @@
     },
     {
       "name": "Virtual Memory flags",
+      "link": "virtual-memory-flags",
       "description": "Virtual Memory flags define the protection of a virtual memory segment.",
       "all": [
         {

--- a/pkg/security/secl/compiler/generators/accessors/common/types.go
+++ b/pkg/security/secl/compiler/generators/accessors/common/types.go
@@ -51,8 +51,9 @@ type StructField struct {
 	Weight              int64
 	CommentText         string
 	OpOverrides         string
-	Constants           string
 	Check               string
+	Alias               string
+	AliasPrefix         string
 }
 
 // GetEvaluatorType returns the evaluator type name

--- a/pkg/security/secl/model/consts_linux.go
+++ b/pkg/security/secl/model/consts_linux.go
@@ -13,7 +13,7 @@ import (
 
 var (
 	// errorConstants are the supported error constants
-	// generate_constants:Error Constants,Error Constants are the supported error constants.
+	// generate_constants:Error constants,Error constants are the supported error constants.
 	errorConstants = map[string]int{
 		"E2BIG":           -int(syscall.E2BIG),
 		"EACCES":          -int(syscall.EACCES),

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -130,23 +130,23 @@ func (m *Model) ValidateField(field eval.Field, fieldValue eval.FieldValue) erro
 type ChmodEvent struct {
 	SyscallEvent
 	File FileEvent `field:"file"`
-	Mode uint32    `field:"file.destination.mode; file.destination.rights" constants:"Chmod mode constants"` // New mode/rights of the chmod-ed file
+	Mode uint32    `field:"file.destination.mode; file.destination.rights"` // SECLDoc[file.destination.mode] Definition:`New mode of the chmod-ed file` Constants:`Chmod mode constants` SECLDoc[file.destination.rights] Definition:`New rights of the chmod-ed file` Constants:`Chmod mode constants`
 }
 
 // ChownEvent represents a chown event
 type ChownEvent struct {
 	SyscallEvent
 	File  FileEvent `field:"file"`
-	UID   int64     `field:"file.destination.uid"`                           // New UID of the chown-ed file's owner
-	User  string    `field:"file.destination.user,handler:ResolveChownUID"`  // New user of the chown-ed file's owner
-	GID   int64     `field:"file.destination.gid"`                           // New GID of the chown-ed file's owner
-	Group string    `field:"file.destination.group,handler:ResolveChownGID"` // New group of the chown-ed file's owner
+	UID   int64     `field:"file.destination.uid"`                           // SECLDoc[file.destination.uid] Definition:`New UID of the chown-ed file's owner`
+	User  string    `field:"file.destination.user,handler:ResolveChownUID"`  // SECLDoc[file.destination.user] Definition:`New user of the chown-ed file's owner`
+	GID   int64     `field:"file.destination.gid"`                           // SECLDoc[file.destination.gid] Definition:`New GID of the chown-ed file's owner`
+	Group string    `field:"file.destination.group,handler:ResolveChownGID"` // SECLDoc[file.destination.group] Definition:`New group of the chown-ed file's owner`
 }
 
 // ContainerContext holds the container context of an event
 type ContainerContext struct {
-	ID   string   `field:"id,handler:ResolveContainerID"`                              // ID of the container
-	Tags []string `field:"tags,handler:ResolveContainerTags,opts:skip_ad,weight:9999"` // Tags of the container
+	ID   string   `field:"id,handler:ResolveContainerID"`                              // SECLDoc[id] Definition:`ID of the container`
+	Tags []string `field:"tags,handler:ResolveContainerTags,opts:skip_ad,weight:9999"` // SECLDoc[tags] Definition:`Tags of the container`
 }
 
 // Event represents an event sent from the kernel
@@ -154,7 +154,7 @@ type ContainerContext struct {
 type Event struct {
 	ID                   string    `field:"-" json:"-"`
 	Type                 uint32    `field:"-"`
-	Async                bool      `field:"async" event:"*"` // True if the syscall was asynchronous
+	Async                bool      `field:"async" event:"*"` // SECLDoc[async] Definition:`True if the syscall was asynchronous`
 	SavedByActivityDumps bool      `field:"-"`               // True if the event should have been discarded if the AD were disabled
 	IsActivityDumpSample bool      `field:"-"`               // True if the event was sampled for the activity dumps
 	TimestampRaw         uint64    `field:"-" json:"-"`
@@ -332,49 +332,49 @@ func (ev *Event) GetProcessServiceTag() string {
 
 // SetuidEvent represents a setuid event
 type SetuidEvent struct {
-	UID    uint32 `field:"uid"`                                // New UID of the process
-	User   string `field:"user,handler:ResolveSetuidUser"`     // New user of the process
-	EUID   uint32 `field:"euid"`                               // New effective UID of the process
-	EUser  string `field:"euser,handler:ResolveSetuidEUser"`   // New effective user of the process
-	FSUID  uint32 `field:"fsuid"`                              // New FileSystem UID of the process
-	FSUser string `field:"fsuser,handler:ResolveSetuidFSUser"` // New FileSystem user of the process
+	UID    uint32 `field:"uid"`                                // SECLDoc[uid] Definition:`New UID of the process`
+	User   string `field:"user,handler:ResolveSetuidUser"`     // SECLDoc[user] Definition:`New user of the process`
+	EUID   uint32 `field:"euid"`                               // SECLDoc[euid] Definition:`New effective UID of the process`
+	EUser  string `field:"euser,handler:ResolveSetuidEUser"`   // SECLDoc[euser] Definition:`New effective user of the process`
+	FSUID  uint32 `field:"fsuid"`                              // SECLDoc[fsuid] Definition:`New FileSystem UID of the process`
+	FSUser string `field:"fsuser,handler:ResolveSetuidFSUser"` // SECLDoc[fsuser] Definition:`New FileSystem user of the process`
 }
 
 // SetgidEvent represents a setgid event
 type SetgidEvent struct {
-	GID     uint32 `field:"gid"`                                  // New GID of the process
-	Group   string `field:"group,handler:ResolveSetgidGroup"`     // New group of the process
-	EGID    uint32 `field:"egid"`                                 // New effective GID of the process
-	EGroup  string `field:"egroup,handler:ResolveSetgidEGroup"`   // New effective group of the process
-	FSGID   uint32 `field:"fsgid"`                                // New FileSystem GID of the process
-	FSGroup string `field:"fsgroup,handler:ResolveSetgidFSGroup"` // New FileSystem group of the process
+	GID     uint32 `field:"gid"`                                  // SECLDoc[gid] Definition:`New GID of the process`
+	Group   string `field:"group,handler:ResolveSetgidGroup"`     // SECLDoc[group] Definition:`New group of the process`
+	EGID    uint32 `field:"egid"`                                 // SECLDoc[egid] Definition:`New effective GID of the process`
+	EGroup  string `field:"egroup,handler:ResolveSetgidEGroup"`   // SECLDoc[egroup] Definition:`New effective group of the process`
+	FSGID   uint32 `field:"fsgid"`                                // SECLDoc[fsgid] Definition:`New FileSystem GID of the process`
+	FSGroup string `field:"fsgroup,handler:ResolveSetgidFSGroup"` // SECLDoc[fsgroup] Definition:`New FileSystem group of the process`
 }
 
 // CapsetEvent represents a capset event
 type CapsetEvent struct {
-	CapEffective uint64 `field:"cap_effective" constants:"Kernel Capability constants"` // Effective capability set of the process
-	CapPermitted uint64 `field:"cap_permitted" constants:"Kernel Capability constants"` // Permitted capability set of the process
+	CapEffective uint64 `field:"cap_effective"` // SECLDoc[cap_effective] Definition:`Effective capability set of the process` Constants:`Kernel Capability constants`
+	CapPermitted uint64 `field:"cap_permitted"` // SECLDoc[cap_permitted] Definition:`Permitted capability set of the process` Constants:`Kernel Capability constants`
 }
 
 // Credentials represents the kernel credentials of a process
 type Credentials struct {
-	UID   uint32 `field:"uid"`   // UID of the process
-	GID   uint32 `field:"gid"`   // GID of the process
-	User  string `field:"user"`  // User of the process
-	Group string `field:"group"` // Group of the process
+	UID   uint32 `field:"uid"`   // SECLDoc[uid] Definition:`UID of the process`
+	GID   uint32 `field:"gid"`   // SECLDoc[gid] Definition:`GID of the process`
+	User  string `field:"user"`  // SECLDoc[user] Definition:`User of the process` Example:`process.user == "root"` Description:`Constrain an event to be triggered by a process running as the root user.`
+	Group string `field:"group"` // SECLDoc[group] Definition:`Group of the process`
 
-	EUID   uint32 `field:"euid"`   // Effective UID of the process
-	EGID   uint32 `field:"egid"`   // Effective GID of the process
-	EUser  string `field:"euser"`  // Effective user of the process
-	EGroup string `field:"egroup"` // Effective group of the process
+	EUID   uint32 `field:"euid"`   // SECLDoc[euid] Definition:`Effective UID of the process`
+	EGID   uint32 `field:"egid"`   // SECLDoc[egid] Definition:`Effective GID of the process`
+	EUser  string `field:"euser"`  // SECLDoc[euser] Definition:`Effective user of the process`
+	EGroup string `field:"egroup"` // SECLDoc[egroup] Definition:`Effective group of the process`
 
-	FSUID   uint32 `field:"fsuid"`   // FileSystem-uid of the process
-	FSGID   uint32 `field:"fsgid"`   // FileSystem-gid of the process
-	FSUser  string `field:"fsuser"`  // FileSystem-user of the process
-	FSGroup string `field:"fsgroup"` // FileSystem-group of the process
+	FSUID   uint32 `field:"fsuid"`   // SECLDoc[fsuid] Definition:`FileSystem-uid of the process`
+	FSGID   uint32 `field:"fsgid"`   // SECLDoc[fsgid] Definition:`FileSystem-gid of the process`
+	FSUser  string `field:"fsuser"`  // SECLDoc[fsuser] Definition:`FileSystem-user of the process`
+	FSGroup string `field:"fsgroup"` // SECLDoc[fsgroup] Definition:`FileSystem-group of the process`
 
-	CapEffective uint64 `field:"cap_effective" constants:"Kernel Capability constants"` // Effective capability set of the process
-	CapPermitted uint64 `field:"cap_permitted" constants:"Kernel Capability constants"` // Permitted capability set of the process
+	CapEffective uint64 `field:"cap_effective"` // SECLDoc[cap_effective] Definition:`Effective capability set of the process` Constants:`Kernel Capability constants`
+	CapPermitted uint64 `field:"cap_permitted"` // SECLDoc[cap_permitted] Definition:`Permitted capability set of the process` Constants:`Kernel Capability constants`
 }
 
 // GetPathResolutionError returns the path resolution error as a string if there is one
@@ -403,14 +403,14 @@ type Process struct {
 
 	FileEvent FileEvent `field:"file,check:IsNotKworker"`
 
-	ContainerID   string   `field:"container.id"` // Container ID
+	ContainerID   string   `field:"container.id"` // SECLDoc[container.id] Definition:`Container ID`
 	ContainerTags []string `field:"-"`
 
 	SpanID  uint64 `field:"-"`
 	TraceID uint64 `field:"-"`
 
-	TTYName     string      `field:"tty_name"`                         // Name of the TTY associated with the process
-	Comm        string      `field:"comm"`                             // Comm attribute of the process
+	TTYName     string      `field:"tty_name"`                         // SECLDoc[tty_name] Definition:`Name of the TTY associated with the process`
+	Comm        string      `field:"comm"`                             // SECLDoc[comm] Definition:`Comm attribute of the process`
 	LinuxBinprm LinuxBinprm `field:"interpreter,check:HasInterpreter"` // Script interpreter as identified by the shebang
 
 	// pid_cache_t
@@ -418,10 +418,10 @@ type Process struct {
 	ExitTime time.Time `field:"-" json:"-"`
 	ExecTime time.Time `field:"-" json:"-"`
 
-	CreatedAt uint64 `field:"created_at,handler:ResolveProcessCreatedAt"` // Timestamp of the creation of the process
+	CreatedAt uint64 `field:"created_at,handler:ResolveProcessCreatedAt"` // SECLDoc[created_at] Definition:`Timestamp of the creation of the process`
 
-	Cookie uint32 `field:"cookie"` // Cookie of the process
-	PPid   uint32 `field:"ppid"`   // Parent process ID
+	Cookie uint32 `field:"cookie"` // SECLDoc[cookie] Definition:`Cookie of the process`
+	PPid   uint32 `field:"ppid"`   // SECLDoc[ppid] Definition:`Parent process ID`
 
 	// credentials_t section of pid_cache_t
 	Credentials ``
@@ -433,13 +433,13 @@ type Process struct {
 	EnvsEntry *EnvsEntry `field:"-" json:"-"`
 
 	// defined to generate accessors, ArgsTruncated and EnvsTruncated are used during by unmarshaller
-	Argv0         string   `field:"argv0,handler:ResolveProcessArgv0,weight:100"`                                                                                                                                               // First argument of the process
-	Args          string   `field:"args,handler:ResolveProcessArgs,weight:100"`                                                                                                                                                 // Arguments of the process (as a string)
-	Argv          []string `field:"argv,handler:ResolveProcessArgv,weight:100; args_flags,handler:ResolveProcessArgsFlags,opts:cacheless_resolution; args_options,handler:ResolveProcessArgsOptions,opts:cacheless_resolution"` // Arguments of the process (as an array)
-	ArgsTruncated bool     `field:"args_truncated,handler:ResolveProcessArgsTruncated"`                                                                                                                                         // Indicator of arguments truncation
-	Envs          []string `field:"envs,handler:ResolveProcessEnvs:100"`                                                                                                                                                        // Environment variable names of the process
-	Envp          []string `field:"envp,handler:ResolveProcessEnvp:100"`                                                                                                                                                        // Environment variables of the process
-	EnvsTruncated bool     `field:"envs_truncated,handler:ResolveProcessEnvsTruncated"`                                                                                                                                         // Indicator of environment variables truncation
+	Argv0         string   `field:"argv0,handler:ResolveProcessArgv0,weight:100"`                                                                                                                                               // SECLDoc[argv0] Definition:`First argument of the process`
+	Args          string   `field:"args,handler:ResolveProcessArgs,weight:100"`                                                                                                                                                 // SECLDoc[args] Definition:`Arguments of the process (as a string, excluding argv0)` Example:`exec.args == "-sV -p 22,53,110,143,4564 198.116.0-255.1-127"` Description:`Matches any process with these exact arguments.` Example:`exec.args =~ "* -F * http*"` Description:`Matches any process that has the "-F" argument anywhere before an argument starting with "http".`
+	Argv          []string `field:"argv,handler:ResolveProcessArgv,weight:100; args_flags,handler:ResolveProcessArgsFlags,opts:cacheless_resolution; args_options,handler:ResolveProcessArgsOptions,opts:cacheless_resolution"` // SECLDoc[argv] Definition:`Arguments of the process (as an array, excluding argv0)` Example:`exec.argv in ["127.0.0.1"]` Description:`Matches any process that has this IP address as one of its arguments.` SECLDoc[args_flags] Definition:`Flags in the process arguments` Example:`exec.args_flags in ["s"] && exec.args_flags in ["V"]` Description:`Matches any process with both "-s" and "-V" flags in its arguments. Also matches "-sV".` SECLDoc[args_options] Definition:`Argument of the process as options` Example:`exec.args_options in ["p=0-1024"]` Description:`Matches any process that has either "-p 0-1024" or "--p=0-1024" in its arguments.`
+	ArgsTruncated bool     `field:"args_truncated,handler:ResolveProcessArgsTruncated"`                                                                                                                                         // SECLDoc[args_truncated] Definition:`Indicator of arguments truncation`
+	Envs          []string `field:"envs,handler:ResolveProcessEnvs:100"`                                                                                                                                                        // SECLDoc[envs] Definition:`Environment variable names of the process`
+	Envp          []string `field:"envp,handler:ResolveProcessEnvp:100"`                                                                                                                                                        // SECLDoc[envp] Definition:`Environment variables of the process`
+	EnvsTruncated bool     `field:"envs_truncated,handler:ResolveProcessEnvsTruncated"`                                                                                                                                         // SECLDoc[envs_truncated] Definition:`Indicator of environment variables truncation`
 
 	// symlink to the process binary
 	SymlinkPathnameStr [MaxSymlinks]string `field:"-" json:"-"`
@@ -451,7 +451,7 @@ type Process struct {
 	ScrubbedArgsTruncated bool           `field:"-" json:"-"`
 	Variables             eval.Variables `field:"-" json:"-"`
 
-	IsThread bool `field:"is_thread"` // Indicates whether the process is considered a thread (that is, a child process that hasn't executed another program)
+	IsThread bool `field:"is_thread"` // SECLDoc[is_thread] Definition:`Indicates whether the process is considered a thread (that is, a child process that hasn't executed another program)`
 }
 
 // SpanContext describes a span context
@@ -468,23 +468,23 @@ type ExecEvent struct {
 // ExitEvent represents a process exit event
 type ExitEvent struct {
 	*Process
-	Cause uint32 `field:"cause"` // Cause of the process termination (one of EXITED, SIGNALED, COREDUMPED)
-	Code  uint32 `field:"code"`  // Exit code of the process or number of the signal that caused the process to terminate
+	Cause uint32 `field:"cause"` // SECLDoc[cause] Definition:`Cause of the process termination (one of EXITED, SIGNALED, COREDUMPED)`
+	Code  uint32 `field:"code"`  // SECLDoc[code] Definition:`Exit code of the process or number of the signal that caused the process to terminate`
 }
 
 // FileFields holds the information required to identify a file
 type FileFields struct {
-	UID   uint32 `field:"uid"`                                                                                          // UID of the file's owner
-	User  string `field:"user,handler:ResolveFileFieldsUser"`                                                           // User of the file's owner
-	GID   uint32 `field:"gid"`                                                                                          // GID of the file's owner
-	Group string `field:"group,handler:ResolveFileFieldsGroup"`                                                         // Group of the file's owner
-	Mode  uint16 `field:"mode;rights,handler:ResolveRights,opts:cacheless_resolution" constants:"Chmod mode constants"` // Mode/rights of the file
-	CTime uint64 `field:"change_time"`                                                                                  // Change time of the file
-	MTime uint64 `field:"modification_time"`                                                                            // Modification time of the file
+	UID   uint32 `field:"uid"`                                                         // SECLDoc[uid] Definition:`UID of the file's owner`
+	User  string `field:"user,handler:ResolveFileFieldsUser"`                          // SECLDoc[user] Definition:`User of the file's owner`
+	GID   uint32 `field:"gid"`                                                         // SECLDoc[gid] Definition:`GID of the file's owner`
+	Group string `field:"group,handler:ResolveFileFieldsGroup"`                        // SECLDoc[group] Definition:`Group of the file's owner`
+	Mode  uint16 `field:"mode;rights,handler:ResolveRights,opts:cacheless_resolution"` // SECLDoc[mode] Definition:`Mode of the file` SECLDoc[rights] Definition:`Rights of the file` Constants:`Chmod mode constants`
+	CTime uint64 `field:"change_time"`                                                 // SECLDoc[change_time] Definition:`Change time of the file`
+	MTime uint64 `field:"modification_time"`                                           // SECLDoc[modification_time] Definition:`Modification time of the file`
 
-	MountID      uint32 `field:"mount_id"`                                             // Mount ID of the file
-	Inode        uint64 `field:"inode"`                                                // Inode of the file
-	InUpperLayer bool   `field:"in_upper_layer,handler:ResolveFileFieldsInUpperLayer"` // Indicator of the file layer, for example, in an OverlayFS
+	MountID      uint32 `field:"mount_id"`                                             // SECLDoc[mount_id] Definition:`Mount ID of the file`
+	Inode        uint64 `field:"inode"`                                                // SECLDoc[inode] Definition:`Inode of the file`
+	InUpperLayer bool   `field:"in_upper_layer,handler:ResolveFileFieldsInUpperLayer"` // SECLDoc[in_upper_layer] Definition:`Indicator of the file layer, for example, in an OverlayFS`
 
 	NLink  uint32 `field:"-" json:"-"`
 	PathID uint32 `field:"-" json:"-"`
@@ -516,9 +516,9 @@ func (f *FileFields) GetInUpperLayer() bool {
 type FileEvent struct {
 	FileFields ``
 
-	PathnameStr string `field:"path,handler:ResolveFilePath,opts:length" op_override:"ProcessSymlinkPathname"`     // File's path
-	BasenameStr string `field:"name,handler:ResolveFileBasename,opts:length" op_override:"ProcessSymlinkBasename"` // File's basename
-	Filesystem  string `field:"filesystem,handler:ResolveFileFilesystem"`                                          // File's filesystem
+	PathnameStr string `field:"path,handler:ResolveFilePath,opts:length" op_override:"ProcessSymlinkPathname"`     // SECLDoc[path] Definition:`File's path` Example:`exec.file.path == "/usr/bin/apt"` Description:`Matches the execution of the file located at /usr/bin/apt` Example:`open.file.path == "/etc/passwd"` Description:`Matches any process opening the /etc/passwd file.`
+	BasenameStr string `field:"name,handler:ResolveFileBasename,opts:length" op_override:"ProcessSymlinkBasename"` // SECLDoc[name] Definition:`File's basename` Example:`exec.file.name == "apt"` Description:`Matches the execution of any file named apt.`
+	Filesystem  string `field:"filesystem,handler:ResolveFileFilesystem"`                                          // SECLDoc[filesystem] Definition:`File's filesystem`
 
 	PathResolutionError error `field:"-" json:"-"`
 
@@ -569,7 +569,7 @@ type LinkEvent struct {
 type MkdirEvent struct {
 	SyscallEvent
 	File FileEvent `field:"file"`
-	Mode uint32    `field:"file.destination.mode; file.destination.rights" constants:"Chmod mode constants"` // Mode/rights of the new directory
+	Mode uint32    `field:"file.destination.mode; file.destination.rights"` // SECLDoc[file.destination.mode] Definition:`Mode of the new directory` Constants:`Chmod mode constants` SECLDoc[file.destination.rights] Definition:`Rights of the new directory` Constants:`Chmod mode constants`
 }
 
 // ArgsEnvsEvent defines a args/envs event
@@ -587,7 +587,7 @@ type Mount struct {
 	RootMountID    uint32 `field:"-"`
 	RootInode      uint64 `field:"-"`
 	BindSrcMountID uint32 `field:"-"`
-	FSType         string `field:"fs_type"` // Type of the mounted file system
+	FSType         string `field:"fs_type"` // SECLDoc[fs_type] Definition:`Type of the mounted file system`
 	MountPointStr  string `field:"-"`
 	RootStr        string `field:"-"`
 	Path           string `field:"-"`
@@ -599,8 +599,8 @@ type Mount struct {
 type MountEvent struct {
 	SyscallEvent
 	Mount
-	MountPointPath                 string `field:"mountpoint.path,handler:ResolveMountPointPath"` // Path of the mount point
-	MountSourcePath                string `field:"source.path,handler:ResolveMountSourcePath"`    // Source path of a bind mount
+	MountPointPath                 string `field:"mountpoint.path,handler:ResolveMountPointPath"` // SECLDoc[mountpoint.path] Definition:`Path of the mount point`
+	MountSourcePath                string `field:"source.path,handler:ResolveMountSourcePath"`    // SECLDoc[source.path] Definition:`Source path of a bind mount`
 	MountPointPathResolutionError  error  `field:"-"`
 	MountSourcePathResolutionError error  `field:"-"`
 }
@@ -624,8 +624,8 @@ func (m *Mount) IsOverlayFS() bool {
 type OpenEvent struct {
 	SyscallEvent
 	File  FileEvent `field:"file"`
-	Flags uint32    `field:"flags" constants:"Open flags"`                           // Flags used when opening the file
-	Mode  uint32    `field:"file.destination.mode" constants:"Chmod mode constants"` // Mode of the created file
+	Flags uint32    `field:"flags"`                 // SECLDoc[flags] Definition:`Flags used when opening the file` Constants:`Open flags`
+	Mode  uint32    `field:"file.destination.mode"` // SECLDoc[file.destination.mode] Definition:`Mode of the created file` Constants:`Chmod mode constants`
 }
 
 // SELinuxEventKind represents the event kind for SELinux events
@@ -644,10 +644,10 @@ const (
 type SELinuxEvent struct {
 	File            FileEvent        `field:"-" json:"-"`
 	EventKind       SELinuxEventKind `field:"-" json:"-"`
-	BoolName        string           `field:"bool.name,handler:ResolveSELinuxBoolName"` // SELinux boolean name
-	BoolChangeValue string           `field:"bool.state"`                               // SELinux boolean new value
-	BoolCommitValue bool             `field:"bool_commit.state"`                        // Indicator of a SELinux boolean commit operation
-	EnforceStatus   string           `field:"enforce.status"`                           // SELinux enforcement status (one of "enforcing", "permissive", "disabled"")
+	BoolName        string           `field:"bool.name,handler:ResolveSELinuxBoolName"` // SECLDoc[bool.name] Definition:`SELinux boolean name`
+	BoolChangeValue string           `field:"bool.state"`                               // SECLDoc[bool.state] Definition:`SELinux boolean new value`
+	BoolCommitValue bool             `field:"bool_commit.state"`                        // SECLDoc[bool_commit.state] Definition:`Indicator of a SELinux boolean commit operation`
+	EnforceStatus   string           `field:"enforce.status"`                           // SECLDoc[enforce.status] Definition:`SELinux enforcement status (one of "enforcing", "permissive", "disabled")`
 }
 
 var zeroProcessContext ProcessContext
@@ -744,10 +744,10 @@ type ProcessContext struct {
 
 // PIDContext holds the process context of an kernel event
 type PIDContext struct {
-	Pid       uint32 `field:"pid"` // Process ID of the process (also called thread group ID)
-	Tid       uint32 `field:"tid"` // Thread ID of the thread
+	Pid       uint32 `field:"pid"` // SECLDoc[pid] Definition:`Process ID of the process (also called thread group ID)`
+	Tid       uint32 `field:"tid"` // SECLDoc[tid] Definition:`Thread ID of the thread`
 	NetNS     uint32 `field:"-"`
-	IsKworker bool   `field:"is_kworker"` // Indicates whether the process is a kworker
+	IsKworker bool   `field:"is_kworker"` // SECLDoc[is_kworker] Definition:`Indicates whether the process is a kworker`
 	Inode     uint64 `field:"-"`          // used to track exec and event loss
 }
 
@@ -768,22 +768,22 @@ type RmdirEvent struct {
 type SetXAttrEvent struct {
 	SyscallEvent
 	File      FileEvent `field:"file"`
-	Namespace string    `field:"file.destination.namespace,handler:ResolveXAttrNamespace"` // Namespace of the extended attribute
-	Name      string    `field:"file.destination.name,handler:ResolveXAttrName"`           // Name of the extended attribute
+	Namespace string    `field:"file.destination.namespace,handler:ResolveXAttrNamespace"` // SECLDoc[file.destination.namespace] Definition:`Namespace of the extended attribute`
+	Name      string    `field:"file.destination.name,handler:ResolveXAttrName"`           // SECLDoc[file.destination.name] Definition:`Name of the extended attribute`
 
 	NameRaw [200]byte `field:"-" json:"-"`
 }
 
 // SyscallEvent contains common fields for all the event
 type SyscallEvent struct {
-	Retval int64 `field:"retval" constants:"Error Constants"` // Return value of the syscall
+	Retval int64 `field:"retval"` // SECLDoc[retval] Definition:`Return value of the syscall` Constants:`Error constants`
 }
 
 // UnlinkEvent represents an unlink event
 type UnlinkEvent struct {
 	SyscallEvent
 	File  FileEvent `field:"file"`
-	Flags uint32    `field:"flags" constants:"Unlink flags"`
+	Flags uint32    `field:"flags"` // SECLDoc[flags] Definition:`Flags of the unlink syscall` Constants:`Unlink flags`
 }
 
 // UmountEvent represents an umount event
@@ -804,33 +804,33 @@ type UtimesEvent struct {
 type BPFEvent struct {
 	SyscallEvent
 
-	Map     BPFMap     `field:"map"`                          // eBPF map involved in the BPF command
-	Program BPFProgram `field:"prog"`                         // eBPF program involved in the BPF command
-	Cmd     uint32     `field:"cmd" constants:"BPF commands"` // BPF command name
+	Map     BPFMap     `field:"map"`  // eBPF map involved in the BPF command
+	Program BPFProgram `field:"prog"` // eBPF program involved in the BPF command
+	Cmd     uint32     `field:"cmd"`  // SECLDoc[cmd] Definition:`BPF command name` Constants:`BPF commands`
 }
 
 // BPFMap represents a BPF map
 type BPFMap struct {
-	ID   uint32 `field:"-" json:"-"`                     // ID of the eBPF map
-	Type uint32 `field:"type" constants:"BPF map types"` // Type of the eBPF map
-	Name string `field:"name"`                           // Name of the eBPF map (added in 7.35)
+	ID   uint32 `field:"-" json:"-"` // ID of the eBPF map
+	Type uint32 `field:"type"`       // SECLDoc[type] Definition:`Type of the eBPF map` Constants:`BPF map types`
+	Name string `field:"name"`       // SECLDoc[name] Definition:`Name of the eBPF map (added in 7.35)`
 }
 
 // BPFProgram represents a BPF program
 type BPFProgram struct {
-	ID         uint32   `field:"-" json:"-"`                               // ID of the eBPF program
-	Type       uint32   `field:"type" constants:"BPF program types"`       // Type of the eBPF program
-	AttachType uint32   `field:"attach_type" constants:"BPF attach types"` // Attach type of the eBPF program
-	Helpers    []uint32 `field:"helpers" constants:"BPF helper functions"` // eBPF helpers used by the eBPF program (added in 7.35)
-	Name       string   `field:"name"`                                     // Name of the eBPF program (added in 7.35)
-	Tag        string   `field:"tag"`                                      // Hash (sha1) of the eBPF program (added in 7.35)
+	ID         uint32   `field:"-" json:"-"`  // ID of the eBPF program
+	Type       uint32   `field:"type"`        // SECLDoc[type] Definition:`Type of the eBPF program` Constants:`BPF program types`
+	AttachType uint32   `field:"attach_type"` // SECLDoc[attach_type] Definition:`Attach type of the eBPF program` Constants:`BPF attach types`
+	Helpers    []uint32 `field:"helpers"`     // SECLDoc[helpers] Definition:`eBPF helpers used by the eBPF program (added in 7.35)` Constants:`BPF helper functions`
+	Name       string   `field:"name"`        // SECLDoc[name] Definition:`Name of the eBPF program (added in 7.35)`
+	Tag        string   `field:"tag"`         // SECLDoc[tag] Definition:`Hash (sha1) of the eBPF program (added in 7.35)`
 }
 
 // PTraceEvent represents a ptrace event
 type PTraceEvent struct {
 	SyscallEvent
 
-	Request uint32          `field:"request" constants:"Ptrace constants"` //  ptrace request
+	Request uint32          `field:"request"` // SECLDoc[request] Definition:`ptrace request` Constants:`Ptrace constants`
 	PID     uint32          `field:"-" json:"-"`
 	Address uint64          `field:"-" json:"-"`
 	Tracee  *ProcessContext `field:"tracee"` // process context of the tracee
@@ -844,8 +844,8 @@ type MMapEvent struct {
 	Addr       uint64    `field:"-" json:"-"`
 	Offset     uint64    `field:"-" json:"-"`
 	Len        uint32    `field:"-" json:"-"`
-	Protection int       `field:"protection" constants:"Protection constants"` // memory segment protection
-	Flags      int       `field:"flags" constants:"MMap flags"`                // memory segment flags
+	Protection int       `field:"protection"` // SECLDoc[protection] Definition:`memory segment protection` Constants:`Protection constants`
+	Flags      int       `field:"flags"`      // SECLDoc[flags] Definition:`memory segment flags` Constants:`MMap flags`
 }
 
 // MProtectEvent represents a mprotect event
@@ -854,8 +854,8 @@ type MProtectEvent struct {
 
 	VMStart       uint64 `field:"-" json:"-"`
 	VMEnd         uint64 `field:"-" json:"-"`
-	VMProtection  int    `field:"vm_protection" constants:"Virtual Memory flags"`  // initial memory segment protection
-	ReqProtection int    `field:"req_protection" constants:"Virtual Memory flags"` // new memory segment protection
+	VMProtection  int    `field:"vm_protection"`  // SECLDoc[vm_protection] Definition:`initial memory segment protection` Constants:`Virtual Memory flags`
+	ReqProtection int    `field:"req_protection"` // SECLDoc[req_protection] Definition:`new memory segment protection` Constants:`Virtual Memory flags`
 }
 
 // LoadModuleEvent represents a load_module event
@@ -863,33 +863,33 @@ type LoadModuleEvent struct {
 	SyscallEvent
 
 	File             FileEvent `field:"file"`               // Path to the kernel module file
-	LoadedFromMemory bool      `field:"loaded_from_memory"` // Indicates if the kernel module was loaded from memory
-	Name             string    `field:"name"`               // Name of the new kernel module
+	LoadedFromMemory bool      `field:"loaded_from_memory"` // SECLDoc[loaded_from_memory] Definition:`Indicates if the kernel module was loaded from memory`
+	Name             string    `field:"name"`               // SECLDoc[name] Definition:`Name of the new kernel module`
 }
 
 // UnloadModuleEvent represents an unload_module event
 type UnloadModuleEvent struct {
 	SyscallEvent
 
-	Name string `field:"name"` // Name of the kernel module that was deleted
+	Name string `field:"name"` // SECLDoc[name] Definition:`Name of the kernel module that was deleted`
 }
 
 // SignalEvent represents a signal event
 type SignalEvent struct {
 	SyscallEvent
 
-	Type   uint32          `field:"type" constants:"Signal constants"` // Signal type (ex: SIGHUP, SIGINT, SIGQUIT, etc)
-	PID    uint32          `field:"pid"`                               // Target PID
-	Target *ProcessContext `field:"target"`                            // Target process context
+	Type   uint32          `field:"type"`   // SECLDoc[type] Definition:`Signal type (ex: SIGHUP, SIGINT, SIGQUIT, etc)` Constants:`Signal constants`
+	PID    uint32          `field:"pid"`    // SECLDoc[pid] Definition:`Target PID`
+	Target *ProcessContext `field:"target"` // Target process context
 }
 
 // SpliceEvent represents a splice event
 type SpliceEvent struct {
 	SyscallEvent
 
-	File          FileEvent `field:"file"`                                          // File modified by the splice syscall
-	PipeEntryFlag uint32    `field:"pipe_entry_flag" constants:"Pipe buffer flags"` // Entry flag of the "fd_out" pipe passed to the splice syscall
-	PipeExitFlag  uint32    `field:"pipe_exit_flag" constants:"Pipe buffer flags"`  // Exit flag of the "fd_out" pipe passed to the splice syscall
+	File          FileEvent `field:"file"`            // File modified by the splice syscall
+	PipeEntryFlag uint32    `field:"pipe_entry_flag"` // SECLDoc[pipe_entry_flag] Definition:`Entry flag of the "fd_out" pipe passed to the splice syscall` Constants:`Pipe buffer flags`
+	PipeExitFlag  uint32    `field:"pipe_exit_flag"`  // SECLDoc[pipe_exit_flag] Definition:`Exit flag of the "fd_out" pipe passed to the splice syscall` Constants:`Pipe buffer flags`
 }
 
 // CgroupTracingEvent is used to signal that a new cgroup should be traced by the activity dump manager
@@ -919,35 +919,35 @@ func (adlc *ActivityDumpLoadConfig) SetTimeout(duration time.Duration) {
 // NetworkDeviceContext represents the network device context of a network event
 type NetworkDeviceContext struct {
 	NetNS   uint32 `field:"-" json:"-"`
-	IfIndex uint32 `field:"ifindex"`                                   // interface ifindex
-	IfName  string `field:"ifname,handler:ResolveNetworkDeviceIfName"` // interface ifname
+	IfIndex uint32 `field:"ifindex"`                                   // SECLDoc[ifindex] Definition:`interface ifindex`
+	IfName  string `field:"ifname,handler:ResolveNetworkDeviceIfName"` // SECLDoc[ifname] Definition:`interface ifname`
 }
 
 // IPPortContext is used to hold an IP and Port
 type IPPortContext struct {
-	IPNet net.IPNet `field:"ip"`   // IP address
-	Port  uint16    `field:"port"` // Port number
+	IPNet net.IPNet `field:"ip"`   // SECLDoc[ip] Definition:`IP address`
+	Port  uint16    `field:"port"` // SECLDoc[port] Definition:`Port number`
 }
 
 // NetworkContext represents the network context of the event
 type NetworkContext struct {
 	Device NetworkDeviceContext `field:"device"` // network device on which the network packet was captured
 
-	L3Protocol  uint16        `field:"l3_protocol" constants:"L3 protocols"` // l3 protocol of the network packet
-	L4Protocol  uint16        `field:"l4_protocol" constants:"L4 protocols"` // l4 protocol of the network packet
-	Source      IPPortContext `field:"source"`                               // source of the network packet
-	Destination IPPortContext `field:"destination"`                          // destination of the network packet
-	Size        uint32        `field:"size"`                                 // size in bytes of the network packet
+	L3Protocol  uint16        `field:"l3_protocol"` // SECLDoc[l3_protocol] Definition:`l3 protocol of the network packet` Constants:`L3 protocols`
+	L4Protocol  uint16        `field:"l4_protocol"` // SECLDoc[l4_protocol] Definition:`l4 protocol of the network packet` Constants:`L4 protocols`
+	Source      IPPortContext `field:"source"`      // source of the network packet
+	Destination IPPortContext `field:"destination"` // destination of the network packet
+	Size        uint32        `field:"size"`        // SECLDoc[size] Definition:`size in bytes of the network packet`
 }
 
 // DNSEvent represents a DNS event
 type DNSEvent struct {
-	ID    uint16 `field:"id" json:"-"`                                             // [Experimental] the DNS request ID
-	Name  string `field:"question.name,opts:length" op_override:"eval.DNSNameCmp"` // the queried domain name
-	Type  uint16 `field:"question.type" constants:"DNS qtypes"`                    // a two octet code which specifies the DNS question type
-	Class uint16 `field:"question.class" constants:"DNS qclasses"`                 // the class looked up by the DNS question
-	Size  uint16 `field:"question.length"`                                         // the total DNS request size in bytes
-	Count uint16 `field:"question.count"`                                          // the total count of questions in the DNS request
+	ID    uint16 `field:"id" json:"-"`                                             // SECLDoc[id] Definition:`[Experimental] the DNS request ID`
+	Name  string `field:"question.name,opts:length" op_override:"eval.DNSNameCmp"` // SECLDoc[question.name] Definition:`the queried domain name`
+	Type  uint16 `field:"question.type"`                                           // SECLDoc[question.type] Definition:`a two octet code which specifies the DNS question type` Constants:`DNS qtypes`
+	Class uint16 `field:"question.class"`                                          // SECLDoc[question.class] Definition:`the class looked up by the DNS question` Constants:`DNS qclasses`
+	Size  uint16 `field:"question.length"`                                         // SECLDoc[question.length] Definition:`the total DNS request size in bytes`
+	Count uint16 `field:"question.count"`                                          // SECLDoc[question.count] Definition:`the total count of questions in the DNS request`
 }
 
 // BindEvent represents a bind event
@@ -955,7 +955,7 @@ type BindEvent struct {
 	SyscallEvent
 
 	Addr       IPPortContext `field:"addr"`        // Bound address
-	AddrFamily uint16        `field:"addr.family"` // Address family
+	AddrFamily uint16        `field:"addr.family"` // SECLDoc[addr.family] Definition:`Address family`
 }
 
 // NetDevice represents a network device


### PR DESCRIPTION
This PR adds the ability to provide examples for agent rule fields in code comments.

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
