### PR TITLE
[Windows] Create service utils

### DIFF
--- a/cmd/agent/windows/controlsvc/controlsvc.go
+++ b/cmd/agent/windows/controlsvc/controlsvc.go
@@ -10,215 +10,21 @@
 package controlsvc
 
 import (
-	"bytes"
-	"encoding/binary"
-	"fmt"
-	"time"
-	"unsafe"
-
-	"golang.org/x/sys/windows"
-	"golang.org/x/sys/windows/svc"
-	"golang.org/x/sys/windows/svc/mgr"
-
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/winutil"
-
-	"github.com/DataDog/datadog-agent/pkg/util/log"
-)
-
-var (
-	modadvapi32 = windows.NewLazyDLL("advapi32.dll")
-
-	procEnumDependentServices = modadvapi32.NewProc("EnumDependentServicesW")
-)
-
-type enumServiceState uint32
-
-//nolint:deadcode,unused
-const (
-	enumServiceActive = enumServiceState(0x1) // START_PENDING, STOP_PENDING, RUNNING
-	// continue_pending, pause_pending, paused
-	enumServiceInactive = enumServiceState(0x02) // STOPPED
-	enumServiceAll      = enumServiceState(0x03) // all of the above
 )
 
 // StartService starts the agent service via the Service Control Manager
 func StartService() error {
-	/*
-	 * default go implementations of mgr.Connect and mgr.OpenService use way too
-	 * open permissions by default.  Use those structures so the other methods
-	 * work properly, but initialize them here using restrictive enough permissions
-	 * that we can actually open/start the service when running as non-root.
-	 */
-	h, err := windows.OpenSCManager(nil, nil, windows.SC_MANAGER_CONNECT)
-	if err != nil {
-		log.Warnf("Failed to connect to scm %v", err)
-		return err
-	}
-	m := &mgr.Mgr{Handle: h}
-	defer m.Disconnect()
-
-	hSvc, err := windows.OpenService(m.Handle, windows.StringToUTF16Ptr(config.ServiceName),
-		windows.SERVICE_START|windows.SERVICE_STOP)
-	if err != nil {
-		log.Warnf("Failed to open service %v", err)
-		return fmt.Errorf("could not access service: %v", err)
-	}
-	scm := &mgr.Service{Name: config.ServiceName, Handle: hSvc}
-	defer scm.Close()
-	err = scm.Start("is", "manual-started")
-	if err != nil {
-		log.Warnf("Failed to start service %v", err)
-		return fmt.Errorf("could not start service: %v", err)
-	}
-	return nil
+	return winutil.StartService(config.ServiceName)
 }
 
-// RestartService restarts the agent service by calling StopService and StartService.
+// RestartService restarts the agent service by calling StopService and StartService
 func RestartService() error {
-	var err error
-	if err = StopService(); err == nil {
-		err = StartService()
-	}
-	return err
+	return winutil.RestartService(config.ServiceName)
 }
 
 // StopService stops the agent service via the Service Control Manager
 func StopService() error {
-	return stopService(config.ServiceName, true)
-}
-
-// stopService stops the named service.
-//
-// If withDeps is true, then dependents of this service are stopped as well.
-func stopService(serviceName string, withDeps bool) error {
-	/*
-	 * default go impolementations of mgr.Connect and mgr.OpenService use way too
-	 * open permissions by default.  Use those structures so the other methods
-	 * work properly, but initialize them here using restrictive enough permissions
-	 * that we can actually open/start the service when running as non-root.
-	 */
-	h, err := windows.OpenSCManager(nil, nil, windows.SC_MANAGER_CONNECT)
-	if err != nil {
-		log.Warnf("Failed to connect to scm %v", err)
-		return err
-	}
-	m := &mgr.Mgr{Handle: h}
-	defer m.Disconnect()
-
-	hSvc, err := windows.OpenService(m.Handle, windows.StringToUTF16Ptr(serviceName),
-		windows.SERVICE_START|windows.SERVICE_STOP|windows.SERVICE_QUERY_STATUS|windows.SERVICE_ENUMERATE_DEPENDENTS)
-	if err != nil {
-		log.Warnf("Failed to open service %v", err)
-		return fmt.Errorf("could not access service: %v", err)
-	}
-	s := &mgr.Service{Name: serviceName, Handle: hSvc}
-	defer s.Close()
-	if withDeps {
-		deps, err := enumDependentServices(s.Handle, enumServiceActive)
-		if err != nil {
-			log.Warnf("Failed to enumerate dependencies; skipping %v", err)
-		} else {
-			for _, dep := range deps {
-				log.Debugf("Stopping service %s", dep.serviceName)
-				// recurse to this service, but only once
-				err = stopService(dep.serviceName, false)
-				if err != nil {
-					log.Warnf("Failed to stop service %v: %v", dep.serviceName, err)
-					return fmt.Errorf("could not stop service %v: %v", dep.serviceName, err)
-				}
-			}
-		}
-	}
-	status, err := s.Control(svc.Stop)
-	if err != nil {
-		return fmt.Errorf("could not send control=%d: %v", svc.Stop, err)
-	}
-	timeout := time.Now().Add(10 * time.Second)
-	for status.State != svc.Stopped {
-		if timeout.Before(time.Now()) {
-			return fmt.Errorf("timeout waiting for service to go to state=%d", svc.Stopped)
-		}
-		time.Sleep(300 * time.Millisecond)
-		status, err = s.Query()
-		if err != nil {
-			return fmt.Errorf("could not retrieve service status: %v", err)
-		}
-	}
-	return nil
-}
-
-// ServiceStatus reports information pertaining to enumerated services
-// only exported so binary.Read works
-type ServiceStatus struct {
-	DwServiceType             uint32
-	DwCurrentState            uint32
-	DwControlsAccepted        uint32
-	DwWin32ExitCode           uint32
-	DwServiceSpecificExitCode uint32
-	DwCheckPoint              uint32
-	DwWaitHint                uint32
-}
-
-// EnumServiceStatus complete enumerated service information
-// only exported so binary.Read works
-type EnumServiceStatus struct {
-	serviceName string
-	displayName string
-	status      ServiceStatus
-}
-
-type internalEnumServiceStatus struct {
-	ServiceName uint64 // offset from beginning of buffer
-	DisplayName uint64 // offset from beginning of buffer.
-	Status      ServiceStatus
-	Padding     uint32 // structure is qword aligned.
-
-}
-
-func enumDependentServices(h windows.Handle, state enumServiceState) (services []EnumServiceStatus, err error) {
-	services = make([]EnumServiceStatus, 0)
-	var bufsz uint32
-	var count uint32
-	_, _, err = procEnumDependentServices.Call(uintptr(h),
-		uintptr(state),
-		uintptr(0),
-		uintptr(0), // current buffer size is zero
-		uintptr(unsafe.Pointer(&bufsz)),
-		uintptr(unsafe.Pointer(&count)))
-
-	if err != error(windows.ERROR_MORE_DATA) {
-		log.Warnf("Error getting buffer %v", err)
-		return
-	}
-	servicearray := make([]uint8, bufsz)
-	ret, _, err := procEnumDependentServices.Call(uintptr(h),
-		uintptr(state),
-		uintptr(unsafe.Pointer(&servicearray[0])),
-		uintptr(bufsz),
-		uintptr(unsafe.Pointer(&bufsz)),
-		uintptr(unsafe.Pointer(&count)))
-	if ret == 0 {
-		log.Warnf("Error getting deps %d %v", int(ret), err)
-		return
-	}
-	// now get to parse out the C structure into go.
-	var ess internalEnumServiceStatus
-	baseptr := uintptr(unsafe.Pointer(&servicearray[0]))
-	buf := bytes.NewReader(servicearray)
-	for i := uint32(0); i < count; i++ {
-
-		err = binary.Read(buf, binary.LittleEndian, &ess)
-		if err != nil {
-			break
-		}
-
-		ess.ServiceName = ess.ServiceName - uint64(baseptr)
-		ess.DisplayName = ess.DisplayName - uint64(baseptr)
-		ss := EnumServiceStatus{serviceName: winutil.ConvertWindowsString(servicearray[ess.ServiceName:]),
-			displayName: winutil.ConvertWindowsString(servicearray[ess.DisplayName:]),
-			status:      ess.Status}
-		services = append(services, ss)
-	}
-	return
+	return winutil.StopService(config.ServiceName)
 }

--- a/pkg/util/winutil/service.go
+++ b/pkg/util/winutil/service.go
@@ -1,0 +1,37 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build windows
+// +build windows
+
+package winutil
+
+import (
+	"golang.org/x/sys/windows"
+	"golang.org/x/sys/windows/svc/mgr"
+)
+
+type ServiceManager struct {
+	manager *mgr.Mgr
+	service *mgr.Service
+}
+
+func (sm *ServiceManager) Connect(desiredAccess uint32) error {
+	h, err := windows.OpenSCManager(nil, nil, desiredAccess)
+	if err != nil {
+		return err
+	}
+	sm.manager = &mgr.Mgr{Handle: h}
+	return nil
+}
+
+func (sm *ServiceManager) OpenService(serviceName string, desiredAccess uint32) error {
+	h, err := windows.OpenService(sm.manager.Handle, windows.StringToUTF16Ptr(serviceName), desiredAccess)
+	if err != nil {
+		return err
+	}
+	sm.service = &mgr.Service{Name: serviceName, Handle: h}
+	return err
+}

--- a/pkg/util/winutil/service.go
+++ b/pkg/util/winutil/service.go
@@ -199,7 +199,7 @@ func enumDependentServices(h windows.Handle, state enumServiceState) (services [
 		}
 	}
 
-	servicearray := make([]uint8, bufsz) // TODO convert to uint16 and bufsz/2 to allow windows.UTF16toString call
+	servicearray := make([]uint8, bufsz)
 	ret, _, err := procEnumDependentServices.Call(uintptr(h),
 		uintptr(state),
 		uintptr(unsafe.Pointer(&servicearray[0])),

--- a/pkg/util/winutil/service.go
+++ b/pkg/util/winutil/service.go
@@ -108,6 +108,10 @@ func ControlService(serviceName string, command svc.Cmd, to svc.State, desiredAc
 	return nil
 }
 
+func doStopService(serviceName string) error {
+	return ControlService(serviceName, svc.Stop, svc.Stopped, windows.SERVICE_STOP|windows.SERVICE_QUERY_STATUS, defaultServiceCommandTimeout)
+}
+
 func StopService(serviceName string) error {
 
 	deps, err := ListDependentServices(serviceName, windows.SERVICE_ACTIVE)
@@ -116,13 +120,12 @@ func StopService(serviceName string) error {
 	}
 
 	for _, dep := range deps {
-		err = StopService(dep.serviceName)
+		err = doStopService(dep.serviceName)
 		if err != nil {
-			return fmt.Errorf("could not stop service")
+			return fmt.Errorf("could not stop service %s: %v", dep.serviceName, err)
 		}
 	}
-
-	return ControlService(serviceName, svc.Stop, svc.Stopped, windows.SERVICE_STOP|windows.SERVICE_QUERY_STATUS, defaultServiceCommandTimeout)
+	return doStopService(serviceName)
 }
 
 func RestartService(serviceName string) error {

--- a/pkg/util/winutil/service.go
+++ b/pkg/util/winutil/service.go
@@ -9,29 +9,217 @@
 package winutil
 
 import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"time"
+	"unsafe"
+
 	"golang.org/x/sys/windows"
+	"golang.org/x/sys/windows/svc"
 	"golang.org/x/sys/windows/svc/mgr"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-type ServiceManager struct {
-	manager *mgr.Mgr
-	service *mgr.Service
+const (
+	defaultServiceCommandTimeout = 10
+)
+
+var (
+	modadvapi32               = windows.NewLazyDLL("advapi32.dll")
+	procEnumDependentServices = modadvapi32.NewProc("EnumDependentServicesW")
+)
+
+type enumServiceState uint32
+
+func OpenSCManager(desiredAccess uint32) (*mgr.Mgr, error) {
+	h, err := windows.OpenSCManager(nil, nil, desiredAccess)
+	if err != nil {
+		return nil, err
+	}
+	return &mgr.Mgr{Handle: h}, err
 }
 
-func (sm *ServiceManager) Connect(desiredAccess uint32) error {
-	h, err := windows.OpenSCManager(nil, nil, desiredAccess)
+func OpenService(manager *mgr.Mgr, serviceName string, desiredAccess uint32) (*mgr.Service, error) {
+	h, err := windows.OpenService(manager.Handle, windows.StringToUTF16Ptr(serviceName), desiredAccess)
+	if err != nil {
+		return nil, err
+	}
+	return &mgr.Service{Name: serviceName, Handle: h}, err
+}
+
+func StartService(serviceName string) error {
+
+	m, err := OpenSCManager(windows.SC_MANAGER_CONNECT)
 	if err != nil {
 		return err
 	}
-	sm.manager = &mgr.Mgr{Handle: h}
+	defer m.Disconnect()
+
+	s, err := OpenService(m, serviceName, windows.SERVICE_START)
+	if err != nil {
+		return fmt.Errorf("could not open service: %v", err)
+	}
+	defer s.Close()
+
+	err = s.Start()
+	if err != nil {
+		return fmt.Errorf("could not start service: %v", err)
+	}
 	return nil
 }
 
-func (sm *ServiceManager) OpenService(serviceName string, desiredAccess uint32) error {
-	h, err := windows.OpenService(sm.manager.Handle, windows.StringToUTF16Ptr(serviceName), desiredAccess)
+func ControlService(serviceName string, command svc.Cmd, to svc.State, desiredAccess uint32, timeout int64) error {
+
+	m, err := OpenSCManager(windows.SC_MANAGER_CONNECT)
 	if err != nil {
 		return err
 	}
-	sm.service = &mgr.Service{Name: serviceName, Handle: h}
+	defer m.Disconnect()
+
+	s, err := OpenService(m, serviceName, desiredAccess)
+	if err != nil {
+		return fmt.Errorf("could not open service: %v", err)
+	}
+	defer s.Close()
+
+	status, err := s.Control(command)
+	if err != nil {
+		return fmt.Errorf("could not send control=%d: %v", svc.Stop, err)
+	}
+
+	timesup := time.Now().Add(time.Duration(timeout) * time.Second)
+	for status.State != to {
+		if time.Now().After(timesup) {
+			return fmt.Errorf("timeout waiting for service to go to state=%d", to)
+		}
+		time.Sleep(300 * time.Millisecond)
+		status, err = s.Query()
+		if err != nil {
+			return fmt.Errorf("could not retrieve service status: %v", err)
+		}
+	}
+	return nil
+}
+
+func StopService(serviceName string) error {
+
+	deps, err := ListDependentServices(serviceName, windows.SERVICE_ACTIVE)
+	if err != nil {
+		return fmt.Errorf("could not list dependent services")
+	}
+
+	for _, dep := range deps {
+		err = StopService(dep.serviceName)
+		if err != nil {
+			return fmt.Errorf("could not stop service")
+		}
+	}
+
+	return ControlService(serviceName, svc.Stop, svc.Stopped, windows.SERVICE_STOP|windows.SERVICE_QUERY_STATUS, defaultServiceCommandTimeout)
+}
+
+func RestartService(serviceName string) error {
+	var err error
+	if err = StopService(serviceName); err == nil {
+		err = StartService(serviceName)
+	}
 	return err
+}
+
+// when Go has their version, replace ours with the upstream
+func ListDependentServices(serviceName string, state enumServiceState) ([]EnumServiceStatus, error) {
+	m, err := OpenSCManager(windows.SC_MANAGER_CONNECT)
+	if err != nil {
+		return nil, err
+	}
+	defer m.Disconnect()
+
+	s, err := OpenService(m, serviceName, windows.SERVICE_ENUMERATE_DEPENDENTS)
+	if err != nil {
+		return nil, fmt.Errorf("could not open service: %v", err)
+	}
+	defer s.Close()
+
+	deps, err := enumDependentServices(s.Handle, state)
+	if err != nil {
+		return nil, fmt.Errorf("could not enumerate dependent services: %v", err)
+	}
+	return deps, nil
+}
+
+// ServiceStatus reports information pertaining to enumerated services
+// only exported so binary.Read works
+type ServiceStatus struct {
+	DwServiceType             uint32
+	DwCurrentState            uint32
+	DwControlsAccepted        uint32
+	DwWin32ExitCode           uint32
+	DwServiceSpecificExitCode uint32
+	DwCheckPoint              uint32
+	DwWaitHint                uint32
+}
+
+// EnumServiceStatus complete enumerated service information
+// only exported so binary.Read works
+type EnumServiceStatus struct {
+	serviceName string
+	displayName string
+	status      ServiceStatus
+}
+
+type internalEnumServiceStatus struct {
+	ServiceName uint64 // offset from beginning of buffer
+	DisplayName uint64 // offset from beginning of buffer.
+	Status      ServiceStatus
+	Padding     uint32 // structure is qword aligned.
+
+}
+
+func enumDependentServices(h windows.Handle, state enumServiceState) (services []EnumServiceStatus, err error) {
+	services = make([]EnumServiceStatus, 0)
+	var bufsz uint32
+	var count uint32
+	_, _, err = procEnumDependentServices.Call(uintptr(h),
+		uintptr(state),
+		uintptr(0),
+		uintptr(0), // current buffer size is zero
+		uintptr(unsafe.Pointer(&bufsz)),
+		uintptr(unsafe.Pointer(&count)))
+
+	if err != error(windows.ERROR_MORE_DATA) {
+		log.Warnf("Error getting buffer %v", err)
+		return
+	}
+	servicearray := make([]uint8, bufsz) // TODO convert to uint16 and bufsz/2 to allow windows.UTF16toString call
+	ret, _, err := procEnumDependentServices.Call(uintptr(h),
+		uintptr(state),
+		uintptr(unsafe.Pointer(&servicearray[0])),
+		uintptr(bufsz),
+		uintptr(unsafe.Pointer(&bufsz)),
+		uintptr(unsafe.Pointer(&count)))
+	if ret == 0 {
+		log.Warnf("Error getting deps %d %v", int(ret), err)
+		return
+	}
+	// now get to parse out the C structure into go.
+	var ess internalEnumServiceStatus
+	baseptr := uintptr(unsafe.Pointer(&servicearray[0]))
+	buf := bytes.NewReader(servicearray)
+	for i := uint32(0); i < count; i++ {
+
+		err = binary.Read(buf, binary.LittleEndian, &ess)
+		if err != nil {
+			break
+		}
+
+		ess.ServiceName = ess.ServiceName - uint64(baseptr)
+		ess.DisplayName = ess.DisplayName - uint64(baseptr)
+		ss := EnumServiceStatus{serviceName: ConvertWindowsString(servicearray[ess.ServiceName:]),
+			displayName: ConvertWindowsString(servicearray[ess.DisplayName:]),
+			status:      ess.Status}
+		services = append(services, ss)
+	}
+	return
 }

--- a/pkg/util/winutil/service.go
+++ b/pkg/util/winutil/service.go
@@ -52,7 +52,7 @@ func OpenService(manager *mgr.Mgr, serviceName string, desiredAccess uint32) (*m
 // Start serviceName via SCM
 // Does not block until service is started
 // https://learn.microsoft.com/en-us/windows/win32/api/winsvc/nf-winsvc-startservicea#remarks
-func StartService(serviceName string) error {
+func StartService(serviceName string, serviceArgs ...string) error {
 
 	manager, err := OpenSCManager(windows.SC_MANAGER_CONNECT)
 	if err != nil {
@@ -62,13 +62,13 @@ func StartService(serviceName string) error {
 
 	service, err := OpenService(manager, serviceName, windows.SERVICE_START)
 	if err != nil {
-		return fmt.Errorf("could not open service: %v", err)
+		return fmt.Errorf("could not open service %s: %v", serviceName, err)
 	}
 	defer service.Close()
 
-	err = service.Start()
+	err = service.Start(serviceArgs...)
 	if err != nil {
-		return fmt.Errorf("could not start service: %v", err)
+		return fmt.Errorf("could not start service %s: %v", serviceName, err)
 	}
 	return nil
 }

--- a/pkg/util/winutil/service_test.go
+++ b/pkg/util/winutil/service_test.go
@@ -65,11 +65,13 @@ func TestOpenSCManager(t *testing.T) {
 func TestOpenService(t *testing.T) {
 
 	// open the SC manager with CONNECT and CREATE_SERVICE
-	m, _ := OpenSCManager(windows.SC_MANAGER_CONNECT | windows.SC_MANAGER_CREATE_SERVICE)
+	m, err := OpenSCManager(windows.SC_MANAGER_CONNECT | windows.SC_MANAGER_CREATE_SERVICE)
+	assert.Nilf(t, err, "Unexpected error: %v", err)
+	assert.NotNil(t, m, "Expected OpenSCManager to return a valid manager handle")
 	defer m.Disconnect()
 
 	// test that OpenService returns an error with non-existent service
-	_, err := OpenService(m, "nottestingservice", windows.SERVICE_START)
+	_, err = OpenService(m, "nottestingservice", windows.SERVICE_START)
 	assert.NotNil(t, err, "Expected OpenService to return an error with invalid service name")
 
 	c := mgr.Config{
@@ -96,7 +98,9 @@ func TestListDependentServices(t *testing.T) {
 	assert.NotNil(t, err, "Expected ListDependentServices to return an error with invalid service name")
 
 	// open the SC manager so we can create some test services
-	m, _ := OpenSCManager(windows.SC_MANAGER_CONNECT | windows.SC_MANAGER_CREATE_SERVICE)
+	m, err := OpenSCManager(windows.SC_MANAGER_CONNECT | windows.SC_MANAGER_CREATE_SERVICE)
+	assert.Nilf(t, err, "Unexpected error: %v", err)
+	assert.NotNil(t, m, "Expected OpenSCManager to return a valid manager handle")
 	defer m.Disconnect()
 
 	// install the base service, it will have no dependents, but several dependents

--- a/pkg/util/winutil/service_test.go
+++ b/pkg/util/winutil/service_test.go
@@ -1,3 +1,11 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build windows
+// +build windows
+
 package winutil
 
 import (
@@ -140,6 +148,13 @@ func TestListDependentServices(t *testing.T) {
 	deps, err = ListDependentServices(baseServiceName, windows.SERVICE_STATE_ALL)
 	assert.Nilf(t, err, "Unexpected error: %v", err)
 	assert.Equal(t, 2, len(deps), "Expected ListDependentServices to return a list of dependent services")
+
+	// ensure that we get the deps back in reverse startup order
+	// so that when this is used to stop services, we stop the outermost ones
+	// first
+	// https://learn.microsoft.com/en-us/windows/win32/api/winsvc/nf-winsvc-enumdependentservicesa#parameters
+	assert.EqualValues(t, secondLevelServiceName, deps[0].serviceName)
+	assert.EqualValues(t, firstLevelServiceName, deps[1].serviceName)
 
 	// the deps
 	t.Logf("%s has the following dependents", baseServiceName)

--- a/pkg/util/winutil/service_test.go
+++ b/pkg/util/winutil/service_test.go
@@ -1,0 +1,140 @@
+package winutil
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/sys/windows"
+	"golang.org/x/sys/windows/svc/mgr"
+)
+
+// copied from go\pkg\mod\golang.org\x\sys@v0.4.0\windows\svc\mgr\mgr_test.go
+func install(t *testing.T, m *mgr.Mgr, name, exepath string, c mgr.Config) {
+	// Sometimes it takes a while for the service to get
+	// removed after previous test run.
+	for i := 0; ; i++ {
+		s, err := m.OpenService(name)
+		if err != nil {
+			break
+		}
+		s.Close()
+
+		if i > 10 {
+			t.Fatalf("service %s already exists", name)
+		}
+		time.Sleep(300 * time.Millisecond)
+	}
+
+	s, err := m.CreateService(name, exepath, c)
+	if err != nil {
+		t.Fatalf("CreateService(%s) failed: %v", name, err)
+	}
+	defer s.Close()
+}
+
+// copied from go\pkg\mod\golang.org\x\sys@v0.4.0\windows\svc\mgr\mgr_test.go
+func remove(t *testing.T, s *mgr.Service) {
+	err := s.Delete()
+	if err != nil {
+		t.Fatalf("Delete failed: %s", err)
+	}
+}
+
+func TestOpenSCManager(t *testing.T) {
+
+	// test that OpenSCManager returns an error if the desired access is not valid
+	_, err := OpenSCManager(777)
+	assert.NotNil(t, err, "Expected OpenSCManager to return an error with invalid desired access")
+
+	// test that OpenSCManager returns a valid manager handle with valid desired access
+	m, err := OpenSCManager(windows.SC_MANAGER_CONNECT)
+	assert.Nilf(t, err, "Unexpected error: %v", err)
+	assert.NotNil(t, m, "Expected OpenSCManager to return a valid manager handle")
+	defer m.Disconnect()
+}
+
+func TestOpenService(t *testing.T) {
+
+	// open the SC manager with CONNECT and CREATE_SERVICE
+	m, _ := OpenSCManager(windows.SC_MANAGER_CONNECT | windows.SC_MANAGER_CREATE_SERVICE)
+	defer m.Disconnect()
+
+	// test that OpenService returns an error with non-existent service
+	_, err := OpenService(m, "nottestingservice", windows.SERVICE_START)
+	assert.NotNil(t, err, "Expected OpenService to return an error with invalid service name")
+
+	c := mgr.Config{
+		StartType:    mgr.StartDisabled,
+		DisplayName:  "Test Service",
+		Description:  "This is a test service",
+		Dependencies: []string{"LanmanServer", "W32Time"},
+	}
+	install(t, m, "testingservice", "", c)
+
+	// test that OpenService returns a valid service handle with a valid service name
+	s, err := OpenService(m, "testingservice", windows.SERVICE_START|windows.DELETE)
+	assert.Nil(t, err, "Unexpected error: %v", err)
+	assert.NotNil(t, s, "Expected OpenService to return a valid service handle")
+	remove(t, s)
+	s.Close()
+}
+
+func TestListDependentServices(t *testing.T) {
+
+	nTestServices := 3
+
+	// test that ListDependentServices returns an error if the service name is not valid
+	_, err := ListDependentServices("notaservice", windows.SERVICE_ACTIVE)
+	assert.NotNil(t, err, "Expected ListDependentServices to return an error with invalid service name")
+
+	// open the SC manager so we can create some test services
+	m, _ := OpenSCManager(windows.SC_MANAGER_CONNECT | windows.SC_MANAGER_CREATE_SERVICE)
+	defer m.Disconnect()
+
+	// install the test services
+	for i := 0; i < nTestServices; i++ {
+
+		// general config for all test services
+		c := mgr.Config{
+			StartType:   mgr.StartDisabled,
+			DisplayName: "Test Service",
+			Description: "This is a test service",
+		}
+
+		// all services will depend on the first
+		if i != 0 {
+			c.Dependencies = append(c.Dependencies, "service1")
+		}
+
+		// install the service
+		serviceName := fmt.Sprintf("service%d", i+1)
+		install(t, m, serviceName, "", c)
+	}
+
+	// test that ListDependentServices returns an empty list for service with no dependencies
+	deps, err := ListDependentServices("service2", windows.SERVICE_STATE_ALL)
+	assert.Nilf(t, err, "Unexpected error: %v", err)
+	assert.Zero(t, len(deps), "")
+
+	// test that ListDependentServices returns a list of dependent services for service with dependencies
+	deps, err = ListDependentServices("service1", windows.SERVICE_STATE_ALL)
+	assert.Nilf(t, err, "Unexpected error: %v", err)
+	assert.Equal(t, 2, len(deps), "Expected ListDependentServices to return a list of dependent services")
+
+	// the deps
+	for _, dep := range deps {
+		t.Logf("Dependent: %s", dep.serviceName)
+	}
+
+	// clean up test services
+	for i := 0; i < nTestServices; i++ {
+		serviceName := fmt.Sprintf("service%d", i+1)
+		s, err := OpenService(m, serviceName, windows.SERVICE_START|windows.DELETE)
+		assert.Nil(t, err, "Unexpected error: %v", err)
+		assert.NotNil(t, s, "Expected OpenService to return a valid service handle")
+		remove(t, s)
+		s.Close()
+	}
+}


### PR DESCRIPTION
### What does this PR do?
This PR creates a file that exposes utilities to interact with Windows services via the Service Control Manager (SCM). It wraps `OpenSCManager` and `OpenService` to allow the caller to specify the `desiredAccess` rights (as opposed to the Go package that uses `ALL_ACCESS`). This will allow agent code to use least-privilege accesses when working with Windows services. 

### Motivation
The motivation is to enable least-privileges SCM interactions from one place in the agent repo.

### Additional Notes
- The `ListDependentServices` function will list first, second, third, ... level dependencies
- It doesn't seem like Go is planning to make this change upstream:
  - https://github.com/golang/go/issues/48777
- Some of the test code helper functions are copy/pasted from: `go\pkg\mod\golang.org\x\sys@v0.4.0\windows\svc\mgr\mgr_test.go`. Assuming this is fine, because in the above issue the answerer suggested copying code directly from the package
- There is an open issue to add `enumDependentServices` to the Go package, when that is merged, we should update our code to use that function
  - https://github.com/golang/go/issues/56766 

### Possible Drawbacks / Trade-offs
- None I was able to identify at this time.

### Describe how to test/QA your changes
- There is some coverage in the unit tests:
  - https://github.com/DataDog/datadog-agent/pkg/util/winutil/service_test.go
- The current kitchen tests install and run the agent, so those should be sufficient
- To manually test this, installing the agent should also be sufficient

### Reviewer's Checklist
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
