### PR TITLE
[process-agent] Remove check singletons

### DIFF
--- a/cmd/process-agent/collector.go
+++ b/cmd/process-agent/collector.go
@@ -82,9 +82,9 @@ func NewCollector(syscfg *sysconfig.Config, hostInfo *checks.HostInfo, enabledCh
 	if syscfg != nil && syscfg.Enabled {
 		// If the sysprobe module is enabled, the process check can call out to the sysprobe for privileged stats
 		_, processModuleEnabled := syscfg.EnabledModules[sysconfig.ProcessModule]
+		cfg.ProcessModuleEnabled = processModuleEnabled
 		cfg.MaxConnsPerMessage = syscfg.MaxConnsPerMessage
 		cfg.SystemProbeAddress = syscfg.SocketAddress
-		cfg.ProcessModuleEnabled = processModuleEnabled
 	}
 
 	for _, c := range enabledChecks {

--- a/cmd/process-agent/collector.go
+++ b/cmd/process-agent/collector.go
@@ -80,8 +80,11 @@ func NewCollector(syscfg *sysconfig.Config, hostInfo *checks.HostInfo, enabledCh
 
 	cfg := &checks.SysProbeConfig{}
 	if syscfg != nil && syscfg.Enabled {
+		// If the sysprobe module is enabled, the process check can call out to the sysprobe for privileged stats
+		_, processModuleEnabled := syscfg.EnabledModules[sysconfig.ProcessModule]
 		cfg.MaxConnsPerMessage = syscfg.MaxConnsPerMessage
 		cfg.SystemProbeAddress = syscfg.SocketAddress
+		cfg.ProcessModuleEnabled = processModuleEnabled
 	}
 
 	for _, c := range enabledChecks {
@@ -232,7 +235,7 @@ func (l *Collector) run(exit chan struct{}) error {
 
 		// Append `process_rt` if process check is enabled, and rt is enabled, so the customer doesn't get confused if
 		// process_rt doesn't show up in the enabled checks
-		if check.Name() == checks.Process.Name() && !ddconfig.Datadog.GetBool("process_config.disable_realtime_checks") {
+		if check.Name() == checks.ProcessCheckName && !ddconfig.Datadog.GetBool("process_config.disable_realtime_checks") {
 			checkNames = append(checkNames, checks.RTProcessCheckName)
 		}
 	}
@@ -455,7 +458,7 @@ func readResponseStatuses(checkName string, responses <-chan forwarder.Response)
 
 func ignoreResponseBody(checkName string) bool {
 	switch checkName {
-	case checks.Pod.Name(), checks.PodCheckManifestName, checks.ProcessEvents.Name():
+	case checks.PodCheckName, checks.PodCheckManifestName, checks.ProcessEventsCheckName:
 		return true
 	default:
 		return false

--- a/cmd/process-agent/collector_api_test.go
+++ b/cmd/process-agent/collector_api_test.go
@@ -75,7 +75,7 @@ func TestSendConnectionsMessage(t *testing.T) {
 	}
 
 	check := &testCheck{
-		name: checks.Connections.Name(),
+		name: checks.ConnectionsCheckName,
 		data: [][]process.MessageBody{{m}},
 	}
 
@@ -114,7 +114,7 @@ func TestSendContainerMessage(t *testing.T) {
 	}
 
 	check := &testCheck{
-		name: checks.Container.Name(),
+		name: checks.ContainerCheckName,
 		data: [][]process.MessageBody{{m}},
 	}
 
@@ -151,7 +151,7 @@ func TestSendProcMessage(t *testing.T) {
 	}
 
 	check := &testCheck{
-		name: checks.Process.Name(),
+		name: checks.ProcessCheckName,
 		data: [][]process.MessageBody{{m}},
 	}
 
@@ -191,7 +191,7 @@ func TestSendProcessDiscoveryMessage(t *testing.T) {
 	}
 
 	check := &testCheck{
-		name: checks.ProcessDiscovery.Name(),
+		name: checks.DiscoveryCheckName,
 		data: [][]process.MessageBody{{m}},
 	}
 
@@ -240,7 +240,7 @@ func TestSendProcessEventMessage(t *testing.T) {
 	}
 
 	check := &testCheck{
-		name: checks.ProcessEvents.Name(),
+		name: checks.ProcessEventsCheckName,
 		data: [][]process.MessageBody{{m}},
 	}
 
@@ -284,7 +284,7 @@ func TestSendProcMessageWithRetry(t *testing.T) {
 	}
 
 	check := &testCheck{
-		name: checks.Process.Name(),
+		name: checks.ProcessCheckName,
 		data: [][]process.MessageBody{{m}},
 	}
 
@@ -401,7 +401,7 @@ func getPodCheckMessage(t *testing.T) (string, checks.Check) {
 	pd = append(pd, m, mm)
 
 	check := &testCheck{
-		name: checks.Pod.Name(),
+		name: checks.PodCheckName,
 		data: [][]process.MessageBody{pd},
 	}
 	return clusterID, check
@@ -521,7 +521,7 @@ func TestMultipleAPIKeys(t *testing.T) {
 	}
 
 	check := &testCheck{
-		name: checks.Connections.Name(),
+		name: checks.ConnectionsCheckName,
 		data: [][]process.MessageBody{{m}},
 	}
 

--- a/cmd/process-agent/config_test.go
+++ b/cmd/process-agent/config_test.go
@@ -26,6 +26,24 @@ func mkurl(rawurl string) *url.URL {
 	return urlResult
 }
 
+func getCheckNames(checks []checks.Check) []string {
+	names := make([]string, len(checks))
+	for idx, ch := range checks {
+		names[idx] = ch.Name()
+	}
+	return names
+}
+
+func assertContainsCheck(t *testing.T, checks []checks.Check, name string) {
+	t.Helper()
+	assert.Contains(t, getCheckNames(checks), name)
+}
+
+func assertNotContainsCheck(t *testing.T, checks []checks.Check, name string) {
+	t.Helper()
+	assert.NotContains(t, getCheckNames(checks), name)
+}
+
 func TestProcessDiscovery(t *testing.T) {
 	scfg := &sysconfig.Config{}
 	cfg := config.Mock(t)
@@ -34,14 +52,14 @@ func TestProcessDiscovery(t *testing.T) {
 	t.Run("enabled", func(t *testing.T) {
 		cfg.Set("process_config.process_discovery.enabled", true)
 		enabledChecks := getChecks(scfg, false)
-		assert.Contains(t, enabledChecks, checks.ProcessDiscovery)
+		assertContainsCheck(t, enabledChecks, checks.DiscoveryCheckName)
 	})
 
 	// Make sure the process_discovery check can be disabled
 	t.Run("disabled", func(t *testing.T) {
 		cfg.Set("process_config.process_discovery.enabled", false)
 		enabledChecks := getChecks(scfg, true)
-		assert.NotContains(t, enabledChecks, checks.ProcessDiscovery)
+		assertNotContainsCheck(t, enabledChecks, checks.DiscoveryCheckName)
 	})
 
 	// Make sure the process and process_discovery checks are mutually exclusive
@@ -49,7 +67,7 @@ func TestProcessDiscovery(t *testing.T) {
 		cfg.Set("process_config.process_discovery.enabled", true)
 		cfg.Set("process_config.process_collection.enabled", true)
 		enabledChecks := getChecks(scfg, true)
-		assert.NotContains(t, enabledChecks, checks.ProcessDiscovery)
+		assertNotContainsCheck(t, enabledChecks, checks.DiscoveryCheckName)
 	})
 }
 
@@ -64,9 +82,9 @@ func TestContainerCheck(t *testing.T) {
 		cfg.Set("process_config.disable_realtime_checks", false)
 
 		enabledChecks := getChecks(scfg, true)
-		assert.Contains(t, enabledChecks, checks.Container)
-		assert.Contains(t, enabledChecks, checks.RTContainer)
-		assert.NotContains(t, enabledChecks, checks.Process)
+		assertContainsCheck(t, enabledChecks, checks.ContainerCheckName)
+		assertContainsCheck(t, enabledChecks, checks.RTContainerCheckName)
+		assertNotContainsCheck(t, enabledChecks, checks.ProcessCheckName)
 	})
 
 	// Make sure that disabling RT disables the rt container check
@@ -76,8 +94,8 @@ func TestContainerCheck(t *testing.T) {
 		cfg.Set("process_config.disable_realtime_checks", true)
 
 		enabledChecks := getChecks(scfg, true)
-		assert.Contains(t, enabledChecks, checks.Container)
-		assert.NotContains(t, enabledChecks, checks.RTContainer)
+		assertContainsCheck(t, enabledChecks, checks.ContainerCheckName)
+		assertNotContainsCheck(t, enabledChecks, checks.RTContainerCheckName)
 	})
 
 	// Make sure the container check cannot be enabled if we cannot access containers
@@ -86,8 +104,8 @@ func TestContainerCheck(t *testing.T) {
 		cfg.Set("process_config.container_collection.enabled", true)
 
 		enabledChecks := getChecks(scfg, false)
-		assert.NotContains(t, enabledChecks, checks.Container)
-		assert.NotContains(t, enabledChecks, checks.RTContainer)
+		assertNotContainsCheck(t, enabledChecks, checks.ContainerCheckName)
+		assertNotContainsCheck(t, enabledChecks, checks.RTContainerCheckName)
 	})
 
 	// Make sure the container and process check are mutually exclusive
@@ -96,9 +114,9 @@ func TestContainerCheck(t *testing.T) {
 		cfg.Set("process_config.container_collection.enabled", true)
 
 		enabledChecks := getChecks(scfg, true)
-		assert.Contains(t, enabledChecks, checks.Process)
-		assert.NotContains(t, enabledChecks, checks.Container)
-		assert.NotContains(t, enabledChecks, checks.RTContainer)
+		assertContainsCheck(t, enabledChecks, checks.ProcessCheckName)
+		assertNotContainsCheck(t, enabledChecks, checks.ContainerCheckName)
+		assertNotContainsCheck(t, enabledChecks, checks.RTContainerCheckName)
 	})
 }
 
@@ -111,38 +129,14 @@ func TestProcessCheck(t *testing.T) {
 	t.Run("disabled", func(t *testing.T) {
 		cfg.Set("process_config.process_collection.enabled", false)
 		enabledChecks := getChecks(scfg, true)
-		assert.NotContains(t, enabledChecks, checks.Process)
+		assertNotContainsCheck(t, enabledChecks, checks.ProcessCheckName)
 	})
 
 	// Make sure the process check can be enabled
 	t.Run("enabled", func(t *testing.T) {
 		cfg.Set("process_config.process_collection.enabled", true)
 		enabledChecks := getChecks(scfg, true)
-		assert.Contains(t, enabledChecks, checks.Process)
-	})
-}
-
-func TestSysprobeProcessModule(t *testing.T) {
-	cfg := config.Mock(t)
-	cfg.Set("process_config.process_collection.enabled", true)
-	cfg.Set("system_probe_config.enabled", true)
-
-	t.Run("enabled", func(t *testing.T) {
-		cfg.Set("system_probe_config.process_config.enabled", true)
-		scfg, err := sysconfig.New("")
-		assert.NoError(t, err)
-
-		_ = getChecks(scfg, true)
-		assert.True(t, checks.Process.SysprobeProcessModuleEnabled)
-	})
-
-	t.Run("disabled", func(t *testing.T) {
-		cfg.Set("system_probe_config.process_config.enabled", false)
-		scfg, err := sysconfig.New("")
-		assert.NoError(t, err)
-
-		_ = getChecks(scfg, false)
-		assert.False(t, checks.Process.SysprobeProcessModuleEnabled)
+		assertContainsCheck(t, enabledChecks, checks.ProcessCheckName)
 	})
 }
 
@@ -156,7 +150,7 @@ func TestConnectionsCheck(t *testing.T) {
 		assert.NoError(t, err)
 
 		enabledChecks := getChecks(scfg, true)
-		assert.Contains(t, enabledChecks, checks.Connections)
+		assertContainsCheck(t, enabledChecks, checks.ConnectionsCheckName)
 	})
 
 	t.Run("disabled", func(t *testing.T) {
@@ -165,7 +159,7 @@ func TestConnectionsCheck(t *testing.T) {
 		assert.NoError(t, err)
 
 		enabledChecks := getChecks(scfg, true)
-		assert.NotContains(t, enabledChecks, checks.Connections)
+		assertNotContainsCheck(t, enabledChecks, checks.ConnectionsCheckName)
 	})
 }
 
@@ -183,7 +177,7 @@ func TestPodCheck(t *testing.T) {
 		cfg.Set("cluster_name", "test")
 
 		enabledChecks := getChecks(&sysconfig.Config{}, true)
-		assert.Contains(t, enabledChecks, checks.Pod)
+		assertContainsCheck(t, enabledChecks, checks.PodCheckName)
 	})
 
 	t.Run("disabled", func(t *testing.T) {
@@ -194,7 +188,7 @@ func TestPodCheck(t *testing.T) {
 		cfg.Set("orchestrator_explorer.enabled", false)
 
 		enabledChecks := getChecks(&sysconfig.Config{}, true)
-		assert.NotContains(t, enabledChecks, checks.Pod)
+		assertNotContainsCheck(t, enabledChecks, checks.PodCheckName)
 	})
 }
 
@@ -204,19 +198,19 @@ func TestProcessEventsCheck(t *testing.T) {
 
 	t.Run("default", func(t *testing.T) {
 		enabledChecks := getChecks(scfg, false)
-		assert.NotContains(t, enabledChecks, checks.ProcessEvents)
+		assertNotContainsCheck(t, enabledChecks, checks.ProcessEventsCheckName)
 	})
 
 	t.Run("enabled", func(t *testing.T) {
 		cfg.Set("process_config.event_collection.enabled", true)
 		enabledChecks := getChecks(scfg, false)
-		assert.Contains(t, enabledChecks, checks.ProcessEvents)
+		assertContainsCheck(t, enabledChecks, checks.ProcessEventsCheckName)
 	})
 
 	t.Run("disabled", func(t *testing.T) {
 		cfg.Set("process_config.event_collection.enabled", false)
 		enabledChecks := getChecks(scfg, false)
-		assert.NotContains(t, enabledChecks, checks.ProcessEvents)
+		assertNotContainsCheck(t, enabledChecks, checks.ProcessEventsCheckName)
 	})
 }
 

--- a/cmd/process-agent/info.go
+++ b/cmd/process-agent/info.go
@@ -23,7 +23,6 @@ import (
 	model "github.com/DataDog/agent-payload/v5/process"
 
 	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
-	"github.com/DataDog/datadog-agent/pkg/process/checks"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 	"github.com/DataDog/datadog-agent/pkg/version"
 )
@@ -105,10 +104,6 @@ const (
 `
 )
 
-func publishSystemProbeProcessModuleEnabled() interface{} {
-	return checks.Process.SysprobeProcessModuleEnabled
-}
-
 func publishUptime() interface{} {
 	return int(time.Since(infoStart) / time.Second)
 }
@@ -149,6 +144,12 @@ func updateLastCollectTime(t time.Time) {
 func publishInt(i *atomic.Int64) expvar.Func {
 	return func() any {
 		return i.Load()
+	}
+}
+
+func publishBool(v bool) expvar.Func {
+	return func() any {
+		return v
 	}
 }
 
@@ -307,7 +308,7 @@ type StatusInfo struct {
 	SystemProbeProcessModuleEnabled bool                   `json:"system_probe_process_module_enabled"`
 }
 
-func initInfo(hostname string) error {
+func initInfo(hostname string, processModuleEnabled bool) error {
 	var err error
 
 	funcMap := template.FuncMap{
@@ -342,7 +343,7 @@ func initInfo(hostname string) error {
 		expvar.Publish("enabled_checks", expvar.Func(publishEnabledChecks))
 		expvar.Publish("endpoints", expvar.Func(publishEndpoints))
 		expvar.Publish("drop_check_payloads", expvar.Func(publishDropCheckPayloads))
-		expvar.Publish("system_probe_process_module_enabled", expvar.Func(publishSystemProbeProcessModuleEnabled))
+		expvar.Publish("system_probe_process_module_enabled", expvar.Func(publishBool(processModuleEnabled)))
 
 		infoTmpl, err = template.New("info").Funcs(funcMap).Parse(infoTmplSrc)
 		if err != nil {

--- a/cmd/process-agent/info_test.go
+++ b/cmd/process-agent/info_test.go
@@ -122,7 +122,7 @@ func TestInfo(t *testing.T) {
 	assert.NotNil(server)
 	defer server.Close()
 
-	err := initInfo("ubuntu-1404.vagrantup.com")
+	err := initInfo("ubuntu-1404.vagrantup.com", true)
 	assert.NoError(err)
 	var buf bytes.Buffer
 	err = Info(&buf, server.URL+expVarPath)
@@ -151,7 +151,7 @@ func TestNotRunning(t *testing.T) {
 	assert.NotNil(server)
 	defer server.Close()
 
-	err := initInfo("host")
+	err := initInfo("host", false)
 	assert.NoError(err)
 	var buf bytes.Buffer
 	// we are going to use a different port so we got
@@ -179,7 +179,7 @@ func TestError(t *testing.T) {
 	assert.NotNil(server)
 	defer server.Close()
 
-	err := initInfo("host")
+	err := initInfo("host", false)
 	assert.NoError(err)
 	var buf bytes.Buffer
 	// same port but a 404 response

--- a/cmd/process-agent/main_common.go
+++ b/cmd/process-agent/main_common.go
@@ -96,6 +96,9 @@ func runAgent(globalParams *command.GlobalParams, exit chan struct{}) {
 		cleanupAndExit(1)
 	}
 
+	// If the sysprobe module is enabled, the process check can call out to the sysprobe for privileged stats
+	_, processModuleEnabled := syscfg.EnabledModules[sysconfig.ProcessModule]
+
 	initRuntimeSettings()
 
 	mainCtx, mainCancel := context.WithCancel(context.Background())
@@ -221,7 +224,7 @@ func runAgent(globalParams *command.GlobalParams, exit chan struct{}) {
 		return
 	}
 
-	err = initInfo(hostInfo.HostName)
+	err = initInfo(hostInfo.HostName, processModuleEnabled)
 	if err != nil {
 		log.Criticalf("Error initializing info: %s", err)
 		cleanupAndExit(1)

--- a/cmd/process-agent/submitter.go
+++ b/cmd/process-agent/submitter.go
@@ -358,7 +358,7 @@ func (s *checkSubmitter) consumePayloads(results *api.WeightedQueue, fwd forward
 			// Pod check manifest data
 			case checks.PodCheckManifestName:
 				responses, err = fwd.SubmitOrchestratorManifests(forwarderPayload, payload.headers)
-			case checks.ProcessDiscovery.Name():
+			case checks.DiscoveryCheckName:
 				// A Process Discovery check does not change the RT mode
 				responses, err = fwd.SubmitProcessDiscoveryChecks(forwarderPayload, payload.headers)
 			case checks.ProcessEventsCheckName:
@@ -464,10 +464,10 @@ func (s *checkSubmitter) messagesToCheckResult(start time.Time, name string, mes
 		}
 
 		switch name {
-		case checks.ProcessEvents.Name():
+		case checks.ProcessEventsCheckName:
 			extraHeaders.Set(headers.EVPOriginHeader, "process-agent")
 			extraHeaders.Set(headers.EVPOriginVersionHeader, version.AgentVersion)
-		case checks.Connections.Name(), checks.Process.Name():
+		case checks.ConnectionsCheckName, checks.ProcessCheckName:
 			requestID := s.getRequestID(start, messageIndex)
 			log.Debugf("the request id of the current message: %s", requestID)
 			extraHeaders.Set(headers.RequestIDHeader, requestID)

--- a/pkg/process/checks/checks.go
+++ b/pkg/process/checks/checks.go
@@ -27,6 +27,8 @@ type SysProbeConfig struct {
 	MaxConnsPerMessage int
 	// System probe collection configuration
 	SystemProbeAddress string
+	// System probe process module on/off configuration
+	ProcessModuleEnabled bool
 }
 
 // Check is an interface for Agent checks that collect data. Each check returns
@@ -92,14 +94,16 @@ func (p CombinedRunResult) RealtimePayloads() []model.MessageBody {
 // All is a list of all runnable checks. Putting a check in here does not guarantee it will be run,
 // it just guarantees that the collector will be able to find the check.
 // If you want to add a check you MUST register it here.
-var All = []Check{
-	Process,
-	Container,
-	RTContainer,
-	Connections,
-	Pod,
-	ProcessDiscovery,
-	ProcessEvents,
+func All() []Check {
+	return []Check{
+		NewProcessCheck(),
+		NewContainerCheck(),
+		NewRTContainerCheck(),
+		NewConnectionsCheck(),
+		NewPodCheck(),
+		NewProcessDiscoveryCheck(),
+		NewProcessEventsCheck(),
+	}
 }
 
 // RTName returns the name of the corresponding realtime check

--- a/pkg/process/checks/container.go
+++ b/pkg/process/checks/container.go
@@ -22,8 +22,10 @@ const (
 	cacheValidityNoRT = 2 * time.Second
 )
 
-// Container is a singleton ContainerCheck.
-var Container = &ContainerCheck{}
+// NewContainerCheck returns an instance of the ContainerCheck.
+func NewContainerCheck() Check {
+	return &ContainerCheck{}
+}
 
 // ContainerCheck is a check that returns container metadata and stats.
 type ContainerCheck struct {

--- a/pkg/process/checks/container_rt.go
+++ b/pkg/process/checks/container_rt.go
@@ -19,8 +19,10 @@ const (
 	cacheValidityRT = 500 * time.Millisecond
 )
 
-// RTContainer is a singleton RTContainerCheck.
-var RTContainer = &RTContainerCheck{}
+// NewRTContainerCheck returns an instance of the RTContainerCheck.
+func NewRTContainerCheck() Check {
+	return &RTContainerCheck{}
+}
 
 // RTContainerCheck collects numeric statistics about live ctrList.
 type RTContainerCheck struct {

--- a/pkg/process/checks/net.go
+++ b/pkg/process/checks/net.go
@@ -26,9 +26,6 @@ import (
 )
 
 var (
-	// Connections is a singleton ConnectionsCheck.
-	Connections = &ConnectionsCheck{}
-
 	// LocalResolver is a singleton LocalResolver
 	LocalResolver = &resolver.LocalResolver{}
 
@@ -38,6 +35,11 @@ var (
 	// ProcessAgentClientID process-agent unique ID
 	ProcessAgentClientID = "process-agent-unique-id"
 )
+
+// NewConnectionsCheck returns an instance of the ConnectionsCheck.
+func NewConnectionsCheck() Check {
+	return &ConnectionsCheck{}
+}
 
 // ConnectionsCheck collects statistics about live TCP and UDP connections.
 type ConnectionsCheck struct {

--- a/pkg/process/checks/pod.go
+++ b/pkg/process/checks/pod.go
@@ -22,9 +22,11 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet"
 )
 
-// Pod is a singleton PodCheck.
-var Pod = &PodCheck{
-	config: oconfig.NewDefaultOrchestratorConfig(),
+// NewPodCheck returns an instance of the Pod check
+func NewPodCheck() Check {
+	return &PodCheck{
+		config: oconfig.NewDefaultOrchestratorConfig(),
+	}
 }
 
 // PodCheck is a check that returns container metadata and stats.

--- a/pkg/process/checks/pod_null.go
+++ b/pkg/process/checks/pod_null.go
@@ -12,8 +12,10 @@ import (
 	"fmt"
 )
 
-// Pod is a singleton PodCheck.
-var Pod = &PodCheck{}
+// NewPodCheck returns an instance of the Pod check
+func NewPodCheck() Check {
+	return &PodCheck{}
+}
 
 // PodCheck is a check that returns container metadata and stats.
 type PodCheck struct {

--- a/pkg/process/checks/process.go
+++ b/pkg/process/checks/process.go
@@ -35,12 +35,12 @@ const (
 	configDisallowList         = configPrefix + "blacklist_patterns"
 )
 
-// Process is a singleton ProcessCheck.
-var Process = &ProcessCheck{
-	scrubber: procutil.NewDefaultDataScrubber(),
+// NewProcessCehck returns an instance of the ProcessCheck.
+func NewProcessCheck() Check {
+	return &ProcessCheck{
+		scrubber: procutil.NewDefaultDataScrubber(),
+	}
 }
-
-var _ Check = (*ProcessCheck)(nil)
 
 var errEmptyCPUTime = errors.New("empty CPU time information returned")
 
@@ -85,9 +85,10 @@ type ProcessCheck struct {
 }
 
 // Init initializes the singleton ProcessCheck.
-func (p *ProcessCheck) Init(_ *SysProbeConfig, info *HostInfo) error {
+func (p *ProcessCheck) Init(syscfg *SysProbeConfig, info *HostInfo) error {
 	p.hostInfo = info
-	p.probe = newProcessProbe(procutil.WithPermission(Process.SysprobeProcessModuleEnabled))
+	p.SysprobeProcessModuleEnabled = syscfg.ProcessModuleEnabled
+	p.probe = newProcessProbe(procutil.WithPermission(syscfg.ProcessModuleEnabled))
 	p.containerProvider = util.GetSharedContainerProvider()
 
 	p.notInitializedLogLimit = util.NewLogLimit(1, time.Minute*10)

--- a/pkg/process/checks/process_discovery_check.go
+++ b/pkg/process/checks/process_discovery_check.go
@@ -14,8 +14,10 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/process/procutil"
 )
 
-// ProcessDiscovery is a ProcessDiscoveryCheck singleton. ProcessDiscovery should not be instantiated elsewhere.
-var ProcessDiscovery = &ProcessDiscoveryCheck{}
+// NewProcessDiscoveryCheck returns an instance of the ProcessDiscoveryCheck.
+func NewProcessDiscoveryCheck() Check {
+	return &ProcessDiscoveryCheck{}
+}
 
 // ProcessDiscoveryCheck is a check that gathers basic process metadata.
 // It uses its own ProcessDiscovery payload.
@@ -29,10 +31,10 @@ type ProcessDiscoveryCheck struct {
 }
 
 // Init initializes the ProcessDiscoveryCheck. It is a runtime error to call Run without first having called Init.
-func (d *ProcessDiscoveryCheck) Init(_ *SysProbeConfig, info *HostInfo) error {
+func (d *ProcessDiscoveryCheck) Init(syscfg *SysProbeConfig, info *HostInfo) error {
 	d.info = info
 	d.initCalled = true
-	d.probe = newProcessProbe(procutil.WithPermission(Process.SysprobeProcessModuleEnabled))
+	d.probe = newProcessProbe(procutil.WithPermission(syscfg.ProcessModuleEnabled))
 
 	d.maxBatchSize = getMaxBatchSize()
 	return nil

--- a/pkg/process/checks/process_discovery_check_test.go
+++ b/pkg/process/checks/process_discovery_check_test.go
@@ -27,8 +27,9 @@ func TestProcessDiscoveryCheck(t *testing.T) {
 	maxBatchSize := 10
 	getMaxBatchSize = func() int { return maxBatchSize }
 
-	ProcessDiscovery.Init(
-		nil,
+	check := &ProcessDiscoveryCheck{}
+	check.Init(
+		&SysProbeConfig{},
 		&HostInfo{
 			SystemInfo: &model.SystemInfo{
 				Cpus:        []*model.CPUInfo{{Number: 0}},
@@ -38,7 +39,7 @@ func TestProcessDiscoveryCheck(t *testing.T) {
 	)
 
 	// Test check runs without error
-	result, err := ProcessDiscovery.Run(testGroupId(0), nil)
+	result, err := check.Run(testGroupId(0), nil)
 	assert.NoError(t, err)
 
 	// Test that result has the proper number of chunks, and that those chunks are of the correct type

--- a/pkg/process/checks/process_events_fallback.go
+++ b/pkg/process/checks/process_events_fallback.go
@@ -12,8 +12,10 @@ import (
 	"errors"
 )
 
-// ProcessEvents is a ProcessEventsCheck singleton
-var ProcessEvents = &ProcessEventsCheck{}
+// NewProcessEventsCheck returns an instance of the ProcessEventsCheck.
+func NewProcessEventsCheck() Check {
+	return &ProcessEventsCheck{}
+}
 
 // ProcessEventsCheck collects process lifecycle events such as exec and exit signals
 type ProcessEventsCheck struct {

--- a/pkg/process/checks/process_events_linux.go
+++ b/pkg/process/checks/process_events_linux.go
@@ -23,8 +23,10 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-// ProcessEvents is a ProcessEventsCheck singleton
-var ProcessEvents = &ProcessEventsCheck{}
+// NewProcessEventsCheck returns an instance of the ProcessEventsCheck.
+func NewProcessEventsCheck() Check {
+	return &ProcessEventsCheck{}
+}
 
 // ProcessEventsCheck collects process lifecycle events such as exec and exit signals
 type ProcessEventsCheck struct {

--- a/pkg/process/checks/process_windows_test.go
+++ b/pkg/process/checks/process_windows_test.go
@@ -23,14 +23,14 @@ func TestPerfCountersConfigSetting(t *testing.T) {
 	t.Run("use toolhelp API", func(t *testing.T) {
 		cfg := config.Mock(t)
 		cfg.Set("process_config.windows.use_perf_counters", false)
-		probe := newProcessProbe(procutil.WithPermission(Process.SysprobeProcessModuleEnabled))
+		probe := newProcessProbe(procutil.WithPermission(false))
 		assert.IsType(t, procutil.NewWindowsToolhelpProbe(), probe)
 	})
 
 	t.Run("use PDH api", func(t *testing.T) {
 		cfg := config.Mock(t)
 		cfg.Set("process_config.windows.use_perf_counters", true)
-		probe := newProcessProbe(procutil.WithPermission(Process.SysprobeProcessModuleEnabled))
+		probe := newProcessProbe(procutil.WithPermission(false))
 		assert.IsType(t, procutil.NewProcessProbe(), probe)
 	})
 }


### PR DESCRIPTION
### What does this PR do?

- Remove check singletons from `pkg/process/checks`
- Remove code from the check subcommand that was made unnecessary in https://github.com/DataDog/datadog-agent/pull/14474 (connections is not using PID <> create time data)

### Motivation

- Preparation for fitting checks into components

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

- Test basic check functionality.
- Verify `info` is showing correct status for process module.
- Verify running checks via `process-agent check <check>`.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
