### PR TITLE
[CWS] remove unsafe usage in `ScopedVariables`

### DIFF
--- a/pkg/security/module/module.go
+++ b/pkg/security/module/module.go
@@ -19,7 +19,6 @@ import (
 	"sync"
 	"syscall"
 	"time"
-	"unsafe"
 
 	"github.com/DataDog/datadog-go/v5/statsd"
 	"github.com/hashicorp/go-multierror"
@@ -348,8 +347,8 @@ func (m *Module) getApproverRuleset(policyProviders []rules.PolicyProvider) (*ru
 	opts := m.newRuleOpts()
 	opts.WithStateScopes(map[rules.Scope]rules.VariableProviderFactory{
 		"process": func() rules.VariableProvider {
-			return eval.NewScopedVariables(func(ctx *eval.Context) unsafe.Pointer {
-				return unsafe.Pointer(&ctx.Event.(*model.Event).ProcessContext)
+			return eval.NewScopedVariables(func(ctx *eval.Context) *model.ProcessContext {
+				return ctx.Event.(*model.Event).ProcessContext
 			}, nil)
 		},
 	})
@@ -393,8 +392,8 @@ func (m *Module) LoadPolicies(policyProviders []rules.PolicyProvider, sendLoaded
 	opts.
 		WithStateScopes(map[rules.Scope]rules.VariableProviderFactory{
 			"process": func() rules.VariableProvider {
-				scoper := func(ctx *eval.Context) unsafe.Pointer {
-					return unsafe.Pointer(ctx.Event.(*model.Event).ProcessCacheEntry)
+				scoper := func(ctx *eval.Context) *model.ProcessCacheEntry {
+					return ctx.Event.(*model.Event).ProcessCacheEntry
 				}
 				return m.probe.GetResolvers().ProcessResolver.NewProcessVariables(scoper)
 			},

--- a/pkg/security/probe/process_resolver.go
+++ b/pkg/security/probe/process_resolver.go
@@ -20,7 +20,6 @@ import (
 	"sync"
 	"syscall"
 	"time"
-	"unsafe"
 
 	"github.com/DataDog/datadog-go/v5/statsd"
 	manager "github.com/DataDog/ebpf-manager"
@@ -1283,10 +1282,10 @@ func (p *ProcessResolver) Walk(callback func(entry *model.ProcessCacheEntry)) {
 }
 
 // NewProcessVariables returns a provider for variables attached to a process cache entry
-func (p *ProcessResolver) NewProcessVariables(scoper func(ctx *eval.Context) unsafe.Pointer) rules.VariableProvider {
-	var variables *eval.ScopedVariables
-	variables = eval.NewScopedVariables(scoper, func(key unsafe.Pointer) {
-		(*model.ProcessCacheEntry)(key).SetReleaseCallback(func() {
+func (p *ProcessResolver) NewProcessVariables(scoper func(ctx *eval.Context) *model.ProcessCacheEntry) rules.VariableProvider {
+	var variables *eval.ScopedVariables[*model.ProcessCacheEntry]
+	variables = eval.NewScopedVariables(scoper, func(key *model.ProcessCacheEntry) {
+		key.SetReleaseCallback(func() {
 			variables.ReleaseVariable(key)
 		})
 	})


### PR DESCRIPTION
### What does this PR do?

This PR remove the usage of `unsafe.Pointer` in `ScopedVariables`. This has caused us multiple nasty stack traces in the past (pointer read across strides).

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
