### PR TITLE
[serverless] feat: add _dd.origin tags for azure and gcp

### DIFF
--- a/cmd/serverless-init/cloudservice/cloudrun.go
+++ b/cmd/serverless-init/cloudservice/cloudrun.go
@@ -37,6 +37,7 @@ func (c *CloudRun) GetTags() map[string]string {
 	}
 
 	tags["origin"] = c.GetOrigin()
+	tags["_dd.origin"] = c.GetOrigin()
 
 	return tags
 }

--- a/cmd/serverless-init/cloudservice/cloudrun_test.go
+++ b/cmd/serverless-init/cloudservice/cloudrun_test.go
@@ -39,6 +39,7 @@ func TestGetCloudRunTags(t *testing.T) {
 		"region":       "test_region",
 		"origin":       "cloudrun",
 		"project_id":   "test_project",
+		"_dd.origin":   "cloudrun",
 	}, tags)
 }
 
@@ -74,5 +75,6 @@ func TestGetCloudRunTagsWithEnvironmentVariables(t *testing.T) {
 		"project_id":    "test_project",
 		"service_name":  "test_service",
 		"revision_name": "test_revision",
+		"_dd.origin":    "cloudrun",
 	}, tags)
 }

--- a/cmd/serverless-init/cloudservice/containerapp.go
+++ b/cmd/serverless-init/cloudservice/containerapp.go
@@ -30,10 +30,11 @@ func (c *ContainerApp) GetTags() map[string]string {
 	revision := os.Getenv(ContainerAppRevision)
 
 	return map[string]string{
-		"app_name": appName,
-		"region":   region,
-		"revision": revision,
-		"origin":   c.GetOrigin(),
+		"app_name":   appName,
+		"region":     region,
+		"revision":   revision,
+		"origin":     c.GetOrigin(),
+		"_dd.origin": c.GetOrigin(),
 	}
 }
 

--- a/cmd/serverless-init/cloudservice/containerapp_test.go
+++ b/cmd/serverless-init/cloudservice/containerapp_test.go
@@ -21,9 +21,10 @@ func TestGetContainerAppTags(t *testing.T) {
 	tags := service.GetTags()
 
 	assert.Equal(t, map[string]string{
-		"app_name": "test_app_name",
-		"origin":   "containerapp",
-		"region":   "eastus",
-		"revision": "test_revision",
+		"app_name":   "test_app_name",
+		"origin":     "containerapp",
+		"region":     "eastus",
+		"revision":   "test_revision",
+		"_dd.origin": "containerapp",
 	}, tags)
 }

--- a/releasenotes/notes/add_dd_origin-9ce5fa87b7b222a8.yaml
+++ b/releasenotes/notes/add_dd_origin-9ce5fa87b7b222a8.yaml
@@ -1,3 +1,0 @@
-features:
-  - |
-    Added _dd.origin tag for Azure and GCP during serverless initialization

--- a/releasenotes/notes/add_dd_origin-9ce5fa87b7b222a8.yaml
+++ b/releasenotes/notes/add_dd_origin-9ce5fa87b7b222a8.yaml
@@ -1,0 +1,3 @@
+features:
+  - |
+    Added _dd.origin tag for Azure and GCP during serverless initialization


### PR DESCRIPTION
# What does this PR do?
add _dd.origin tags for azure and gcp

# Possible Drawbacks / Trade-offs
same tag values are already exported with `origin` tag
