### PR TITLE
Fix shutdown deadlock in docker socket tailer

### DIFF
--- a/pkg/logs/internal/launchers/container/tailerfactory/tailers/socket.go
+++ b/pkg/logs/internal/launchers/container/tailerfactory/tailers/socket.go
@@ -157,7 +157,9 @@ func (t *DockerSocketTailer) run(
 					}
 				}()
 				stopTailer(inner)
-				close(erroredContainerID)
+				if erroredContainerID != nil {
+					close(erroredContainerID)
+				}
 			}
 			return
 

--- a/pkg/logs/internal/launchers/container/tailerfactory/tailers/socket.go
+++ b/pkg/logs/internal/launchers/container/tailerfactory/tailers/socket.go
@@ -149,7 +149,15 @@ func (t *DockerSocketTailer) run(
 		case <-t.ctx.Done():
 			// the launcher has requested that the tailer stop
 			if inner != nil {
+				// Ensure any pending errors are cleared when we try to stop the tailer. Since erroredContainerID
+				// is unbuffered, any pending writes to this channel could cause a deadlock as the tailers stop
+				// condition is managed in the same goroutine in dockerTailerPkg.
+				go func() {
+					for range erroredContainerID {
+					}
+				}()
 				stopTailer(inner)
+				close(erroredContainerID)
 			}
 			return
 

--- a/pkg/logs/internal/launchers/container/tailerfactory/tailers/socket_test.go
+++ b/pkg/logs/internal/launchers/container/tailerfactory/tailers/socket_test.go
@@ -108,15 +108,15 @@ func TestDockerSocketTailer_run_canStopWithError(t *testing.T) {
 			tailerStopped.Inc()
 		})
 
-	// wait until the inner tailer has started a third time due to two errors
+	// wait until the inner tailer has started
 	for tailerStarted.Load() < 1 {
 		time.Sleep(1 * time.Millisecond)
 	}
 
-	// stop the tailer
+	// stop the tailer - this should not block.
 	dst.Stop()
 
-	// check that the tailer was started and subsequently stopped twice
+	// check that the tailer was started and subsequently stopped
 	require.Equal(t, int32(1), tailerStarted.Load())
 	require.Equal(t, int32(1), tailerStopped.Load())
 }

--- a/pkg/logs/internal/launchers/container/tailerfactory/tailers/socket_test.go
+++ b/pkg/logs/internal/launchers/container/tailerfactory/tailers/socket_test.go
@@ -84,6 +84,43 @@ func TestDockerSocketTailer_run_erroredContainer(t *testing.T) {
 	require.Equal(t, int32(3), tailerStopped.Load())
 }
 
+func TestDockerSocketTailer_run_canStopWithError(t *testing.T) {
+	dst := &DockerSocketTailer{}
+	dst.ctx, dst.cancel = context.WithCancel(context.Background())
+	dst.stopped = make(chan struct{})
+
+	tailerStarted := atomic.NewInt32(0)
+	tailerStopped := atomic.NewInt32(0)
+
+	// emulate dst.Start(), but with fake tryStartTailer and stopTailer
+	erroredContainerID := make(chan string)
+	go dst.run(
+		func() (*dockerTailerPkg.Tailer, chan string, error) {
+			tailerStarted.Inc()
+			return &dockerTailerPkg.Tailer{}, erroredContainerID, nil
+		},
+		func(*dockerTailerPkg.Tailer) {
+			// Simulate an error occuring at the same time as as the tailer is trying to stop.
+			// This can happen in the real socket tailer implementation as these errors are handled by
+			// the same goroutine that manages the tailer shutdown. This test ensures any pending errors
+			// do not prevent the tailer from being stopped.
+			erroredContainerID <- "abcd"
+			tailerStopped.Inc()
+		})
+
+	// wait until the inner tailer has started a third time due to two errors
+	for tailerStarted.Load() < 1 {
+		time.Sleep(1 * time.Millisecond)
+	}
+
+	// stop the tailer
+	dst.Stop()
+
+	// check that the tailer was started and subsequently stopped twice
+	require.Equal(t, int32(1), tailerStarted.Load())
+	require.Equal(t, int32(1), tailerStopped.Load())
+}
+
 func TestDockerSocketTailer_run_error_starting(t *testing.T) {
 	backoffInitialDuration = 1 * time.Millisecond
 	defer func() { backoffInitialDuration = 1 * time.Second }()

--- a/pkg/logs/internal/launchers/container/tailerfactory/tailers/socket_test.go
+++ b/pkg/logs/internal/launchers/container/tailerfactory/tailers/socket_test.go
@@ -100,7 +100,7 @@ func TestDockerSocketTailer_run_canStopWithError(t *testing.T) {
 			return &dockerTailerPkg.Tailer{}, erroredContainerID, nil
 		},
 		func(*dockerTailerPkg.Tailer) {
-			// Simulate an error occuring at the same time as as the tailer is trying to stop.
+			// Simulate an error occurring at the same time as as the tailer is trying to stop.
 			// This can happen in the real socket tailer implementation as these errors are handled by
 			// the same goroutine that manages the tailer shutdown. This test ensures any pending errors
 			// do not prevent the tailer from being stopped.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

When tailing docker containers via the docker socket, it is possible for a docker socket error to occur while we are attempting to stop a tailer. In these circumstances `erroredContainerID` (an unbuffered channel) [is written to in same goroutine](https://github.com/DataDog/datadog-agent/blob/main/pkg/logs/internal/tailers/docker/tailer.go#L182) that needs to stop in order to satisfy the `stop` condition when shutting down the tailer. `erroredContainerID` [is also read by the same goroutine that waits for the stop condition to be satisfied](https://github.com/DataDog/datadog-agent/blob/main/pkg/logs/internal/launchers/container/tailerfactory/tailers/socket.go#L156). 

As a result - this causes a deadlock. Unfortunately, this deadlock propagates up to the `MetaScheduler` preventing all future configs from being scheduled or unscheduled. 

The fix here is to drain the error channel when a shutdown is triggered. We don't care about these errors since the tailer is being destroyed anyway. 

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Fixes a deadlock.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

This only affects docker tailing in socket mode and `cca_in_ad: true` so there is a reasonable fallback for users who encounter this (by settings `cca_in_ad: false`). 

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->


### Describe how to test/QA your changes

Start and kill logging docker containers with `container_collect_all` enabled in rapid succession for several minutes. Ensure logs continue to flow. 

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
