### PR TITLE
[usm] Fix `ProcessMonitor` termination

### DIFF
--- a/pkg/process/monitor/process_monitor.go
+++ b/pkg/process/monitor/process_monitor.go
@@ -60,7 +60,6 @@ type ProcessMonitor struct {
 	procEventCallbacks map[ProcessEventType][]*ProcessCallback
 	runningPids        map[uint32]interface{}
 	callbackRunner     chan func()
-	callbackRunnerDone chan struct{}
 }
 
 type ProcessEventType int
@@ -204,26 +203,19 @@ func (pm *ProcessMonitor) Initialize() error {
 
 	pm.events = make(chan netlink.ProcEvent, processMonitorMaxEvents)
 	pm.done = make(chan struct{})
-	pm.errors = make(chan error)
+	pm.errors = make(chan error, 10)
 
 	if err := netlink.ProcEventMonitor(pm.events, pm.done, pm.errors); err != nil {
 		return fmt.Errorf("couldn't initialize process monitor: %s", err)
 	}
 
-	pm.callbackRunnerDone = make(chan struct{}, runtime.NumCPU())
 	pm.callbackRunner = make(chan func(), runtime.NumCPU())
 	for i := 0; i < runtime.NumCPU(); i++ {
 		pm.wg.Add(1)
 		go func() {
 			defer pm.wg.Done()
-			for {
-				select {
-				case <-pm.callbackRunnerDone:
-					return
-				case call, ok := <-pm.callbackRunner:
-					if !ok {
-						continue
-					}
+			for call := range pm.callbackRunner {
+				if call != nil {
 					call()
 				}
 			}
@@ -237,12 +229,12 @@ func (pm *ProcessMonitor) Initialize() error {
 		defer func() {
 			log.Info("netlink process monitor ended")
 			pm.wg.Done()
+			close(pm.callbackRunner)
 		}()
 		for {
 			select {
 			case <-pm.done:
 				return
-
 			case event, ok := <-pm.events:
 				if !ok {
 					return
@@ -270,7 +262,7 @@ func (pm *ProcessMonitor) Initialize() error {
 				if !ok {
 					return
 				}
-				log.Errorf("process montior error: %s", err)
+				log.Errorf("process monitor error: %s", err)
 				pm.Stop()
 				return
 			}
@@ -346,15 +338,14 @@ func (pm *ProcessMonitor) Subscribe(callback *ProcessCallback) (UnSubscribe func
 
 func (pm *ProcessMonitor) Stop() {
 	pm.m.Lock()
-	defer pm.m.Unlock()
 	pm.refcount--
-	if pm.refcount > 0 {
+	if pm.refcount != 0 {
+		pm.m.Unlock()
 		return
 	}
+	pm.isInitialized = false
+	pm.m.Unlock()
 
-	close(pm.callbackRunnerDone)
 	close(pm.done)
 	pm.wg.Wait()
-
-	pm.isInitialized = false
 }

--- a/pkg/process/monitor/process_monitor.go
+++ b/pkg/process/monitor/process_monitor.go
@@ -338,14 +338,19 @@ func (pm *ProcessMonitor) Subscribe(callback *ProcessCallback) (UnSubscribe func
 
 func (pm *ProcessMonitor) Stop() {
 	pm.m.Lock()
-	pm.refcount--
-	if pm.refcount != 0 {
+	if pm.refcount == 0 {
 		pm.m.Unlock()
 		return
 	}
+
+	pm.refcount--
+	if pm.refcount > 0 {
+		pm.m.Unlock()
+		return
+	}
+
 	pm.isInitialized = false
 	pm.m.Unlock()
-
 	close(pm.done)
 	pm.wg.Wait()
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Fix `ProcessMonitor` termination, which was triggering a dead-lock in some cases.


### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

Here are the relevant parts of the go-routine dump depicting the dead-lock:
```
goroutine 275 [semacquire, 9 minutes]:
sync.runtime_SemacquireMutex(0xc001e42080?, 0x60?, 0xc0020e3dfa?)
	/home/vagrant/.gimme/versions/go1.18.5.linux.amd64/src/runtime/sema.go:71 +0x25
sync.(*Mutex).lockSlow(0xc00096c780)
	/home/vagrant/.gimme/versions/go1.18.5.linux.amd64/src/sync/mutex.go:162 +0x271
sync.(*Mutex).Lock(0xc00096c780)
	/home/vagrant/.gimme/versions/go1.18.5.linux.amd64/src/sync/mutex.go:81 +0x51
github.com/DataDog/datadog-agent/pkg/process/monitor.(*ProcessMonitor).Initialize.func2()
	/git/datadog-agent/pkg/process/monitor/process_monitor.go:250 +0x39e
created by github.com/DataDog/datadog-agent/pkg/process/monitor.(*ProcessMonitor).Initialize
	/git/datadog-agent/pkg/process/monitor/process_monitor.go:236 +0x554
	
goroutine 1 [semacquire, 9 minutes]:
sync.runtime_Semacquire(0xc00096c788?)
	/home/vagrant/.gimme/versions/go1.18.5.linux.amd64/src/runtime/sema.go:56 +0x25
sync.(*WaitGroup).Wait(0xc00096c788)
	/home/vagrant/.gimme/versions/go1.18.5.linux.amd64/src/sync/waitgroup.go:136 +0xbc
github.com/DataDog/datadog-agent/pkg/process/monitor.(*ProcessMonitor).Stop(0xc00096c780)
	/git/datadog-agent/pkg/process/monitor/process_monitor.go:357 +0x127
github.com/DataDog/datadog-agent/pkg/network/protocols/http.(*Monitor).Stop(0xc002147440)
	/git/datadog-agent/pkg/network/protocols/http/monitor.go:134 +0x32
github.com/DataDog/datadog-agent/pkg/network/tracer.(*Tracer).Stop(0xc001cceb60)
	/git/datadog-agent/pkg/network/tracer/tracer.go:359 +0x87
github.com/DataDog/datadog-agent/cmd/system-probe/modules.(*networkTracer).Close(0xc00084a060)
	/git/datadog-agent/cmd/system-probe/modules/network_tracer.go:225 +0x3d
github.com/DataDog/datadog-agent/cmd/system-probe/api/module.Close()
	/git/datadog-agent/cmd/system-probe/api/module/loader.go:154 +0x16d
github.com/DataDog/datadog-agent/cmd/system-probe/app.StopSystemProbe()
	/git/datadog-agent/cmd/system-probe/app/run.go:223 +0x19
github.com/DataDog/datadog-agent/cmd/system-probe/app.run.func1()
	/git/datadog-agent/cmd/system-probe/app/run.go:69 +0x27
github.com/DataDog/datadog-agent/cmd/system-probe/app.run(0x8cad900, {0x93e6a20, 0x0, 0x0})
	/git/datadog-agent/cmd/system-probe/app/run.go:127 +0x5dd
github.com/spf13/cobra.(*Command).execute(0x8cad900, {0x93e6a20, 0x0, 0x0})
	/home/vagrant/go/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:916 +0xcad
github.com/spf13/cobra.(*Command).ExecuteC(0x8cad060)
	/home/vagrant/go/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:1044 +0x8c6
github.com/spf13/cobra.(*Command).Execute(0x8cad060)
	/home/vagrant/go/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:968 +0x2f
main.main()
	/git/datadog-agent/cmd/system-probe/main.go:20 +0x2a
```

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
