### PR TITLE
CO-RE: TCPQueueLength and OOM Kill tests are missing some BTF

### DIFF
--- a/pkg/collector/corechecks/ebpf/probe/oom_kill_test.go
+++ b/pkg/collector/corechecks/ebpf/probe/oom_kill_test.go
@@ -79,7 +79,7 @@ func TestOOMKillProbe(t *testing.T) {
 	cfg := testConfig()
 
 	fullKV := host.GetStatusInformation().KernelVersion
-	if cfg.EnableCORE && isMissingBTF(fullKV) {
+	if cfg.EnableCORE && isMissingBTF(cfg, fullKV) {
 		t.Skipf("Skipping CO-RE tests for kernel version %v due to missing BTFs", fullKV)
 	}
 

--- a/pkg/collector/corechecks/ebpf/probe/tcp_queue_length_test.go
+++ b/pkg/collector/corechecks/ebpf/probe/tcp_queue_length_test.go
@@ -25,14 +25,20 @@ import (
 
 var (
 	missingBTFS = map[string]struct{}{
-		"4.18.0-1018-azure":            {},
-		"4.18.0-147.43.1.el8_1.x86_64": {},
+		"4.14.275-207.503.amzn2.aarch64": {},
+		"4.18.0-1018-azure":              {},
+		"4.18.0-147.43.1.el8_1.x86_64":   {},
 	}
 )
 
-func isMissingBTF(kv string) bool {
+func isMissingBTF(cfg *ebpf.Config, kv string) bool {
 	_, ok := missingBTFS[kv]
-	return ok
+	if ok {
+		return true
+	}
+
+	btfData, _ = GetBTF(cfg.BTFPath, cfg.BPFDir)
+	return btfData == nil
 }
 
 func TestTCPQueueLengthCompile(t *testing.T) {
@@ -62,7 +68,7 @@ func TestTCPQueueLengthTracer(t *testing.T) {
 	cfg := ebpf.NewConfig()
 
 	fullKV := host.GetStatusInformation().KernelVersion
-	if cfg.EnableCORE && isMissingBTF(fullKV) {
+	if cfg.EnableCORE && isMissingBTF(cfg, fullKV) {
 		t.Skipf("Skipping CO-RE tests for kernel version %v due to missing BTFs", fullKV)
 	}
 


### PR DESCRIPTION
some report from the CI

  [4.14.275-207.503.amzn2.aarch64] started CO-RE
       [4.14.275-207.503.amzn2.aarch64] [pkg/collector/corechecks/ebpf/probe]·✖·✖
       [4.14.275-207.503.amzn2.aarch64] === Failed
       [4.14.275-207.503.amzn2.aarch64] === FAIL: pkg/collector/corechecks/ebpf/probe TestOOMKillProbe (0.17s)
       [4.14.275-207.503.amzn2.aarch64] oom_kill_test.go:88: error loading CO-RE oom-kill probe: could not find BTF data on host. set system_probe_config.allow_runtime_compiled_fallback to true to allow fallback to runtime compilation
       [4.14.275-207.503.amzn2.aarch64]
       [4.14.275-207.503.amzn2.aarch64] === FAIL: pkg/collector/corechecks/ebpf/probe TestTCPQueueLengthTracer (0.17s)
       [4.14.275-207.503.amzn2.aarch64] tcp_queue_length_test.go:71: error loading CO-RE tcp-queue-length probe: could not find BTF data on host. set system_probe_config.allow_runtime_compiled_fallback to true to allow fallback to runtime compilation
       [4.14.275-207.503.amzn2.aarch64]
       [4.14.275-207.503.amzn2.aarch64] DONE 4 tests, 2 failures in 0.367s


       [4.14.262-200.489.amzn2.x86_64] started CO-RE
       [4.14.262-200.489.amzn2.x86_64] [pkg/collector/corechecks/ebpf/probe]·✖·✖
       [4.14.262-200.489.amzn2.x86_64] === Failed
       [4.14.262-200.489.amzn2.x86_64] === FAIL: pkg/collector/corechecks/ebpf/probe TestOOMKillProbe (0.35s)
       [4.14.262-200.489.amzn2.x86_64] oom_kill_test.go:88: error loading CO-RE oom-kill probe: could not find BTF data on host. set system_probe_config.allow_runtime_compiled_fallback to true to allow fallback to runtime compilation
       [4.14.262-200.489.amzn2.x86_64] 
       [4.14.262-200.489.amzn2.x86_64] === FAIL: pkg/collector/corechecks/ebpf/probe TestTCPQueueLengthTracer (0.32s)
       [4.14.262-200.489.amzn2.x86_64] tcp


<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
