### PR TITLE
Container image metadata check: add layers history

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	code.cloudfoundry.org/bbs v0.0.0-20200403215808-d7bc971db0db
 	code.cloudfoundry.org/garden v0.0.0-20210208153517-580cadd489d2
 	code.cloudfoundry.org/lager v2.0.0+incompatible
-	github.com/DataDog/agent-payload/v5 v5.0.65
+	github.com/DataDog/agent-payload/v5 v5.0.67
 	github.com/DataDog/datadog-agent/pkg/obfuscate v0.42.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/otlp/model v0.42.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/quantile v0.42.0-rc.3

--- a/go.sum
+++ b/go.sum
@@ -121,8 +121,8 @@ github.com/BurntSushi/toml v1.1.0/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbi
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/CycloneDX/cyclonedx-go v0.7.0 h1:jNxp8hL7UpcvPDFXjY+Y1ibFtsW+e5zyF9QoSmhK/zg=
 github.com/CycloneDX/cyclonedx-go v0.7.0/go.mod h1:W5Z9w8pTTL+t+yG3PCiFRGlr8PUlE0pGWzKSJbsyXkg=
-github.com/DataDog/agent-payload/v5 v5.0.65 h1:8Bmv1zVS/OnCQ4VQjTtSVSWKaZrUPLufjkqp4vLjlZ4=
-github.com/DataDog/agent-payload/v5 v5.0.65/go.mod h1:oQZi1VZp1e3QvlSUX4iphZCpJaFepUxWq0hNXxihKBM=
+github.com/DataDog/agent-payload/v5 v5.0.67 h1:CMBowuUjm5AMC43M1X2npQMHvXVtMByKeZOgTQaY5qI=
+github.com/DataDog/agent-payload/v5 v5.0.67/go.mod h1:oQZi1VZp1e3QvlSUX4iphZCpJaFepUxWq0hNXxihKBM=
 github.com/DataDog/aptly v1.5.0 h1:Oy6JVRC9iDgnmpeVYa4diXwP/exU7wJ/U1kuI4Zacxg=
 github.com/DataDog/aptly v1.5.0/go.mod h1:KVyvkYXGcFugxadGFZ+u5Fc3M6q/EfzFZyeTD9HVbkY=
 github.com/DataDog/cast v1.3.1-0.20190301154711-1ee8c8bd14a3 h1:SobA9WYm4K/MUtWlbKaomWTmnuYp1KhIm8Wlx3vmpsg=

--- a/pkg/collector/corechecks/containerimage/processor.go
+++ b/pkg/collector/corechecks/containerimage/processor.go
@@ -13,8 +13,9 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 
-	"github.com/DataDog/agent-payload/v5/contimage"
 	model "github.com/DataDog/agent-payload/v5/contimage"
+
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 type processor struct {
@@ -24,7 +25,7 @@ type processor struct {
 func newProcessor(sender aggregator.Sender, maxNbItem int, maxRetentionTime time.Duration) *processor {
 	return &processor{
 		queue: queue.NewQueue(maxNbItem, maxRetentionTime, func(images []*model.ContainerImage) {
-			sender.ContainerImage([]contimage.ContainerImagePayload{
+			sender.ContainerImage([]model.ContainerImagePayload{
 				{
 					Version: "v1",
 					Images:  images,
@@ -52,13 +53,27 @@ func (p *processor) processRefresh(allImages []*workloadmeta.ContainerImageMetad
 }
 
 func (p *processor) processImage(img *workloadmeta.ContainerImageMetadata) {
+	var lastCreated *timestamppb.Timestamp = nil
 	layers := make([]*model.ContainerImage_ContainerImageLayer, 0, len(img.Layers))
 	for _, layer := range img.Layers {
+		var created *timestamppb.Timestamp = nil
+		if layer.History.Created != nil {
+			created = timestamppb.New(*layer.History.Created)
+			lastCreated = created
+		}
+
 		layers = append(layers, &model.ContainerImage_ContainerImageLayer{
 			Urls:      layer.URLs,
 			MediaType: layer.MediaType,
 			Digest:    layer.Digest,
 			Size:      layer.SizeBytes,
+			History: &model.ContainerImage_ContainerImageLayer_History{
+				Created:    created,
+				CreatedBy:  layer.History.CreatedBy,
+				Author:     layer.History.Author,
+				Comment:    layer.History.Comment,
+				EmptyLayer: layer.History.EmptyLayer,
+			},
 		})
 	}
 
@@ -76,7 +91,8 @@ func (p *processor) processImage(img *workloadmeta.ContainerImageMetadata) {
 			Version:      img.OSVersion,
 			Architecture: img.Architecture,
 		},
-		Layers: layers,
+		Layers:  layers,
+		BuiltAt: lastCreated,
 	}
 }
 

--- a/pkg/collector/corechecks/containerimage/processor_test.go
+++ b/pkg/collector/corechecks/containerimage/processor_test.go
@@ -14,7 +14,12 @@ import (
 	model "github.com/DataDog/agent-payload/v5/contimage"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	"github.com/DataDog/datadog-agent/pkg/util/pointer"
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
+
+	"github.com/golang/protobuf/ptypes/timestamp"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+
 	"github.com/stretchr/testify/mock"
 )
 
@@ -46,12 +51,18 @@ func TestProcessEvents(t *testing.T) {
 								Digest:    fmt.Sprintf("digest_layer_1_%d", i),
 								SizeBytes: 43,
 								URLs:      []string{"url"},
+								History: v1.History{
+									Created: pointer.Ptr(time.Unix(42, 43)),
+								},
 							},
 							{
 								MediaType: "media",
 								Digest:    fmt.Sprintf("digest_layer_2_%d", i),
 								URLs:      []string{"url"},
 								SizeBytes: 44,
+								History: v1.History{
+									Created: pointer.Ptr(time.Unix(43, 44)),
+								},
 							},
 						},
 					},
@@ -84,13 +95,29 @@ func TestProcessEvents(t *testing.T) {
 							MediaType: "media",
 							Digest:    "digest_layer_1_0",
 							Size:      43,
+							History: &model.ContainerImage_ContainerImageLayer_History{
+								Created: &timestamp.Timestamp{
+									Seconds: 42,
+									Nanos:   43,
+								},
+							},
 						},
 						{
 							Urls:      []string{"url"},
 							MediaType: "media",
 							Digest:    "digest_layer_2_0",
 							Size:      44,
+							History: &model.ContainerImage_ContainerImageLayer_History{
+								Created: &timestamp.Timestamp{
+									Seconds: 43,
+									Nanos:   44,
+								},
+							},
 						},
+					},
+					BuiltAt: &timestamp.Timestamp{
+						Seconds: 43,
+						Nanos:   44,
 					},
 				},
 				{
@@ -111,13 +138,29 @@ func TestProcessEvents(t *testing.T) {
 							MediaType: "media",
 							Digest:    "digest_layer_1_1",
 							Size:      43,
+							History: &model.ContainerImage_ContainerImageLayer_History{
+								Created: &timestamp.Timestamp{
+									Seconds: 42,
+									Nanos:   43,
+								},
+							},
 						},
 						{
 							Urls:      []string{"url"},
 							MediaType: "media",
 							Digest:    "digest_layer_2_1",
 							Size:      44,
+							History: &model.ContainerImage_ContainerImageLayer_History{
+								Created: &timestamp.Timestamp{
+									Seconds: 43,
+									Nanos:   44,
+								},
+							},
 						},
+					},
+					BuiltAt: &timestamp.Timestamp{
+						Seconds: 43,
+						Nanos:   44,
 					},
 				},
 			},
@@ -149,13 +192,29 @@ func TestProcessEvents(t *testing.T) {
 							MediaType: "media",
 							Digest:    "digest_layer_1_2",
 							Size:      43,
+							History: &model.ContainerImage_ContainerImageLayer_History{
+								Created: &timestamp.Timestamp{
+									Seconds: 42,
+									Nanos:   43,
+								},
+							},
 						},
 						{
 							Urls:      []string{"url"},
 							MediaType: "media",
 							Digest:    "digest_layer_2_2",
 							Size:      44,
+							History: &model.ContainerImage_ContainerImageLayer_History{
+								Created: &timestamp.Timestamp{
+									Seconds: 43,
+									Nanos:   44,
+								},
+							},
 						},
+					},
+					BuiltAt: &timestamp.Timestamp{
+						Seconds: 43,
+						Nanos:   44,
 					},
 				},
 			},


### PR DESCRIPTION
### What does this PR do?

Add the layer history information in the `container_image` check.

### Motivation

Processes folks need the images creation time.
In order to compute it, we get the creation time of the last layer of the image.

### Additional Notes

* Requires DataDog/agent-payload#224.

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Validate with processes people that they are properly getting the images creation time.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
