### PR TITLE
Add additional distros/versions to btfhub archive build

### DIFF
--- a/.gitlab/deps_build.yml
+++ b/.gitlab/deps_build.yml
@@ -144,27 +144,36 @@ build_processed_btfhub_archive:
     - git clone https://github.com/aquasecurity/btfhub-archive.git
     - cd btfhub-archive
     # Flatten btfhub-archive directories & separate arm/x64 btfs into separate directories
-    - dirs=("amzn/2" "centos/7" "centos/8" "debian/9" "debian/10" "fedora/29" "fedora/30" "fedora/31" "ol/7")
+    - dirs=("amzn/2" "centos/7" "centos/8" "debian/9" "debian/10" "fedora/28" "fedora/29" "fedora/30" "fedora/31" "ol/7" "ol/8" "rhel/7" "rhel/8")
     - |
-      for dir in ${dirs[@]}; do                                         \
-        platform=${dir%%/*}                                           &&\
-        mkdir -p "btfs-amd64/${platform}" "btfs-arm64/${platform}"    &&\
-        eval "mv ${dir}/x86_64/*.btf.tar.xz btfs-amd64/${platform}/"  &&\
-        eval "mv ${dir}/arm64/*.btf.tar.xz btfs-arm64/${platform}/";    \
+      for dir in ${dirs[@]}; do
+        platform=${dir%%/*}
+        mkdir -p "btfs-amd64/${platform}" "btfs-arm64/${platform}"
+        eval "mv ${dir}/x86_64/*.btf.tar.xz btfs-amd64/${platform}/"
+        eval "mv ${dir}/arm64/*.btf.tar.xz btfs-arm64/${platform}/"
       done
-    # Handle the amazon 2018 (amazon 1) directory separately because it doesn't have an arm64 version
-    - mv amzn/2018/x86_64/* btfs-amd64/amzn/
+    # Handle the these directories separately because they don't have an arm64 version
+    - x64dirs=("amzn/2018" "fedora/24" "fedora/25" "fedora/26" "fedora/27")
+    - |
+      for xdir in ${x64dirs[@]}; do
+        platform=${xdir%%/*}
+        eval "mv ${xdir}/x86_64/*.btf.tar.xz btfs-amd64/${platform}"
+      done
     # Handle ubuntu separately because we want to keep the btfs separated by ubuntu version
-    - mkdir -p btfs-amd64/ubuntu/18.04 btfs-amd64/ubuntu/20.04 btfs-arm64/ubuntu/18.04 btfs-arm64/ubuntu/20.04
-    - mv ubuntu/18.04/x86_64/*.btf.tar.xz btfs-amd64/ubuntu/18.04/
-    - mv ubuntu/20.04/x86_64/*.btf.tar.xz btfs-amd64/ubuntu/20.04/
-    - mv ubuntu/18.04/arm64/*.btf.tar.xz btfs-arm64/ubuntu/18.04/
-    - mv ubuntu/20.04/arm64/*.btf.tar.xz btfs-arm64/ubuntu/20.04/
+    - ubuntu_dirs=("ubuntu/16.04" "ubuntu/18.04" "ubuntu/20.04")
+    - |
+      for udir in ${ubuntu_dirs[@]}; do
+        mkdir -p "btfs-amd64/${udir}" "btfs-arm64/${udir}"
+        eval "mv ${udir}/x86_64/*.btf.tar.xz btfs-amd64/${udir}/"
+        eval "mv ${udir}/arm64/*.btf.tar.xz btfs-arm64/${udir}/"
+      done
     # Clean up platform names to match the names we get at runtime from gopsutil
     - mv btfs-amd64/amzn btfs-amd64/amazon
     - mv btfs-arm64/amzn btfs-arm64/amazon
     - mv btfs-amd64/ol btfs-amd64/oracle
     - mv btfs-arm64/ol btfs-arm64/oracle
+    - mv btfs-amd64/rhel btfs-amd64/redhat
+    - mv btfs-arm64/rhel btfs-arm64/redhat
     # Store results in S3
     - tar -czf btfs-arm64.tar.gz btfs-arm64
     - tar -czf btfs-amd64.tar.gz btfs-amd64
@@ -172,8 +181,3 @@ build_processed_btfhub_archive:
     - $S3_CP_CMD btfs-amd64.tar.gz $S3_PERMANENT_ARTIFACTS_URI/btfs-amd64.tar.gz
     - $S3_CP_CMD btfs-arm64.tar.gz $S3_DD_AGENT_OMNIBUS_BTFS_URI/btfs-arm64.tar.gz --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
     - $S3_CP_CMD btfs-amd64.tar.gz $S3_DD_AGENT_OMNIBUS_BTFS_URI/btfs-amd64.tar.gz --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
-  artifacts:
-    expire_in: 2 weeks
-    paths:
-      - btfhub-archive/btfs-arm64.tar.gz
-      - btfhub-archive/btfs-amd64.tar.gz

--- a/pkg/collector/corechecks/ebpf/probe/tcp_queue_length_test.go
+++ b/pkg/collector/corechecks/ebpf/probe/tcp_queue_length_test.go
@@ -25,8 +25,7 @@ import (
 
 var (
 	missingBTFS = map[string]struct{}{
-		"4.18.0-1018-azure":            {},
-		"4.18.0-147.43.1.el8_1.x86_64": {},
+		"4.18.0-1018-azure": {},
 	}
 )
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Adds the following distros to our BTF packaging, since they are now present in btfhub-archive:
- Ubuntu 16.04
- Oracle 8
- RHEL 7 and 8
- Fedora 24-28

### Motivation

Improved BTF coverage

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
