### PR TITLE
[NDM] Do not send empty tags for snmp.interface.status

### DIFF
--- a/pkg/collector/corechecks/snmp/internal/report/report_device_metadata.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_device_metadata.go
@@ -53,7 +53,13 @@ func (ms *MetricSender) ReportNetworkDeviceMetadata(config *checkconfig.CheckCon
 	// Telemetry
 	for _, interfaceStatus := range interfaces {
 		status := string(computeInterfaceStatus(interfaceStatus.AdminStatus, interfaceStatus.OperStatus))
-		interfaceTags := []string{"status:" + status, "interface:" + interfaceStatus.Name, "interface_alias:" + interfaceStatus.Alias, "interface_index:" + strconv.Itoa(int(interfaceStatus.Index))}
+		interfaceTags := []string{"status:" + status, "interface_index:" + strconv.Itoa(int(interfaceStatus.Index))}
+		if interfaceStatus.Name != "" {
+			interfaceTags = append(interfaceTags, "interface:"+interfaceStatus.Name)
+		}
+		if interfaceStatus.Alias != "" {
+			interfaceTags = append(interfaceTags, "interface_alias:"+interfaceStatus.Alias)
+		}
 		interfaceTags = append(interfaceTags, tags...)
 		ms.sender.Gauge(interfaceStatusMetric, 1, "", interfaceTags)
 	}

--- a/pkg/collector/corechecks/snmp/internal/report/report_device_metadata_test.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_device_metadata_test.go
@@ -332,8 +332,7 @@ func Test_metricSender_reportNetworkDeviceMetadata_withInterfaces(t *testing.T) 
                 "interface:22"
             ],
             "index": 2,
-            "name": "22",
-			"alias": ""
+            "name": "22"
         }
     ],
     "collect_timestamp":1415792726

--- a/pkg/collector/corechecks/snmp/internal/report/report_device_metadata_test.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_device_metadata_test.go
@@ -239,7 +239,7 @@ func Test_metricSender_reportNetworkDeviceMetadata_withInterfaces(t *testing.T) 
 			},
 			"1.3.6.1.2.1.31.1.1.1.18": {
 				"1": valuestore.ResultValue{Value: "ifAlias1"},
-				"2": valuestore.ResultValue{Value: "ifAlias2"},
+				"2": valuestore.ResultValue{Value: ""},
 			},
 		},
 	}
@@ -292,7 +292,7 @@ func Test_metricSender_reportNetworkDeviceMetadata_withInterfaces(t *testing.T) 
 	ms.ReportNetworkDeviceMetadata(config, storeWithIfName, []string{"tag1", "tag2"}, collectTime, metadata.DeviceStatusReachable)
 
 	ifTags1 := []string{"tag1", "tag2", "status:down", "interface:21", "interface_alias:ifAlias1", "interface_index:1"}
-	ifTags2 := []string{"tag1", "tag2", "status:down", "interface:22", "interface_alias:ifAlias2", "interface_index:2"}
+	ifTags2 := []string{"tag1", "tag2", "status:down", "interface:22", "interface_index:2"}
 
 	sender.AssertMetric(t, "Gauge", interfaceStatusMetric, 1., "", ifTags1)
 	sender.AssertMetric(t, "Gauge", interfaceStatusMetric, 1., "", ifTags2)
@@ -333,7 +333,7 @@ func Test_metricSender_reportNetworkDeviceMetadata_withInterfaces(t *testing.T) 
             ],
             "index": 2,
             "name": "22",
-			"alias": "ifAlias2"
+			"alias": ""
         }
     ],
     "collect_timestamp":1415792726


### PR DESCRIPTION
Sometimes the interface name and or alias can be empty. In such case it's best to defer to Datadog "N/A" rather than showing an empty tag.