### PR TITLE
[tasks/licenses] Don't call `open` on dirs

### DIFF
--- a/tasks/licenses.py
+++ b/tasks/licenses.py
@@ -196,7 +196,7 @@ def find_copyright_for(package, overrides, ctx):
 
     for filename in COPYRIGHT_LOCATIONS:
         filename = os.path.join(pkgdir, filename)
-        if os.path.exists(filename) and not os.path.isdir(filename):
+        if os.path.isfile(filename):
             for line in open(filename, encoding="utf-8"):
                 mo = COPYRIGHT_RE.search(line)
                 if not mo:

--- a/tasks/licenses.py
+++ b/tasks/licenses.py
@@ -196,7 +196,7 @@ def find_copyright_for(package, overrides, ctx):
 
     for filename in COPYRIGHT_LOCATIONS:
         filename = os.path.join(pkgdir, filename)
-        if os.path.exists(filename):
+        if os.path.exists(filename) and not os.path.isdir(filename):
             for line in open(filename, encoding="utf-8"):
                 mo = COPYRIGHT_RE.search(line)
                 if not mo:


### PR DESCRIPTION

### What does this PR do?

Fixes a bug in the `licenses` Python script. It triggers when we find a directory that has a name included in the expected names for copyright files (COPYRIGHT_LOCATIONS).

Example:
```
IsADirectoryError: [Errno 21] Is a directory: 'vendor/github.com/google/licenseclassifier/v2/assets/license'
```

The dependency shown in the error is needed in this PR: https://github.com/DataDog/datadog-agent/pull/15139 That's how I realized that there was a bug.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
