### PR TITLE
Tweak system-probe kitchen tests

### DIFF
--- a/test/kitchen/test/integration/system-probe-test/rspec/system-probe-test_spec.rb
+++ b/test/kitchen/test/integration/system-probe-test/rspec/system-probe-test_spec.rb
@@ -20,6 +20,25 @@ co_re_tests = Array.[](
   "pkg/collector/corechecks/ebpf/probe"
 )
 
+TIMEOUTS = {
+  "pkg/network/protocols" => "5m"
+}
+DEFAULT_TIMEOUT = "10m"
+def get_timeout(package)
+  match = ""
+  timeout = DEFAULT_TIMEOUT
+
+  # determine longest match
+  TIMEOUTS.each do |k, v|
+    if package.include?(k) && k.size > match.size
+      match = k
+      timeout = v
+    end
+  end
+
+  timeout
+end
+
 print KernelOut.format(`cat /etc/os-release`)
 print KernelOut.format(`uname -a`)
 
@@ -46,7 +65,7 @@ shared_examples "passes" do |bundle, env, filter, filter_inclusive|
     print KernelOut.format(`find "/tmp/pkgjson/#{bundle}" -maxdepth 1 -type f -path "*.json" -exec cat >"/tmp/testjson/#{bundle}.json" {} +`)
   end
 
-  Dir.glob('/tmp/system-probe-tests/**/testsuite').each do |f|
+  Dir.glob('/tmp/system-probe-tests/**/testsuite').sort.each do |f|
     pkg = f.delete_prefix('/tmp/system-probe-tests/').delete_suffix('/testsuite')
     next unless (filter_inclusive and filter.include? pkg) or (!filter_inclusive and !filter.include? pkg)
 
@@ -65,7 +84,7 @@ shared_examples "passes" do |bundle, env, filter, filter_inclusive|
           "--junitfile", xmlpath,
           "--jsonfile", "/tmp/pkgjson/#{bundle}/#{pkg.gsub("/","-")}.json",
           "--raw-command", "--",
-          "/go/bin/test2json", "-t", "-p", pkg, f, "-test.v", "-test.count=1"
+          "/go/bin/test2json", "-t", "-p", pkg, f, "-test.v", "-test.count=1", "-test.timeout=#{get_timeout(pkg)}"
         ]
 
         final_env = base_env.merge(env)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

* Make test package ordering deterministic across different distros;
* Allow timeouts to be specified;

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
