### PR TITLE
Added data streams config value which enable kafka monitoring and ser…

### DIFF
--- a/Dockerfiles/manifests/all-containers/system-probe-configmap.yaml
+++ b/Dockerfiles/manifests/all-containers/system-probe-configmap.yaml
@@ -31,6 +31,8 @@ data:
       conntrack_init_timeout: 10s
     service_monitoring_config:
       enabled: false
+    data_streams_config:
+      enabled: false
     runtime_security_config:
       enabled: true
       fim_enabled: false

--- a/Dockerfiles/manifests/security-agent/system-probe-configmap.yaml
+++ b/Dockerfiles/manifests/security-agent/system-probe-configmap.yaml
@@ -31,6 +31,8 @@ data:
       conntrack_init_timeout: 10s
     service_monitoring_config:
       enabled: false
+    data_streams_config:
+      enabled: false
     runtime_security_config:
       enabled: true
       fim_enabled: false

--- a/cmd/system-probe/config/config.go
+++ b/cmd/system-probe/config/config.go
@@ -185,6 +185,10 @@ func load(configPath string) (*Config, error) {
 	// this check must come first so we can accurately tell if system_probe was explicitly enabled
 	npmEnabled := cfg.GetBool("network_config.enabled")
 	usmEnabled := cfg.GetBool("service_monitoring_config.enabled")
+	dataStreamsEnabled := cfg.GetBool("data_streams_config.enabled")
+
+	// We enable USM if Data Streams feature is enabled for backend compatability
+	usmEnabled = usmEnabled || dataStreamsEnabled
 
 	if npmEnabled {
 		log.Info("network_config.enabled detected: enabling system-probe with network module running.")

--- a/cmd/system-probe/modules/network_tracer.go
+++ b/cmd/system-probe/modules/network_tracer.go
@@ -42,7 +42,7 @@ const inactivityRestartDuration = 20 * time.Minute
 // NetworkTracer is a factory for NPM's tracer
 var NetworkTracer = module.Factory{
 	Name:             config.NetworkTracerModule,
-	ConfigNamespaces: []string{"network_config", "service_monitoring_config"},
+	ConfigNamespaces: []string{"network_config", "service_monitoring_config", "data_streams_config"},
 	Fn: func(cfg *config.Config) (module.Module, error) {
 		ncfg := networkconfig.New()
 

--- a/pkg/config/system_probe.go
+++ b/pkg/config/system_probe.go
@@ -16,9 +16,10 @@ import (
 )
 
 const (
-	spNS  = "system_probe_config"
-	netNS = "network_config"
-	smNS  = "service_monitoring_config"
+	spNS          = "system_probe_config"
+	netNS         = "network_config"
+	smNS          = "service_monitoring_config"
+	dataStreamsNS = "data_streams_config"
 
 	defaultConnsMessageBatchSize = 600
 
@@ -174,6 +175,9 @@ func InitSystemProbeConfig(cfg Config) {
 
 	// service monitoring
 	cfg.BindEnvAndSetDefault(join(smNS, "enabled"), false, "DD_SYSTEM_PROBE_SERVICE_MONITORING_ENABLED")
+
+	// data streams monitoring
+	cfg.BindEnvAndSetDefault(join(dataStreamsNS, "enabled"), false, "DD_SYSTEM_PROBE_DATA_STREAMS_ENABLED")
 
 	// enable/disable use of root net namespace
 	cfg.BindEnvAndSetDefault(join(netNS, "enable_root_netns"), true)

--- a/pkg/network/config/config.go
+++ b/pkg/network/config/config.go
@@ -16,9 +16,10 @@ import (
 )
 
 const (
-	spNS  = "system_probe_config"
-	netNS = "network_config"
-	smNS  = "service_monitoring_config"
+	spNS          = "system_probe_config"
+	netNS         = "network_config"
+	smNS          = "service_monitoring_config"
+	dataStreamsNS = "data_streams_config"
 
 	defaultUDPTimeoutSeconds       = 30
 	defaultUDPStreamTimeoutSeconds = 120
@@ -36,6 +37,9 @@ type Config struct {
 
 	// ServiceMonitoringEnabled is whether the service monitoring feature is enabled or not
 	ServiceMonitoringEnabled bool
+
+	// DataStreamsEnabled is whether the data streams (kafka) monitoring feature is enabled or not
+	DataStreamsEnabled bool
 
 	// CollectTCPConns specifies whether the tracer should collect traffic statistics for TCP connections
 	CollectTCPConns bool
@@ -206,6 +210,7 @@ func New() *Config {
 
 		NPMEnabled:               cfg.GetBool(join(netNS, "enabled")),
 		ServiceMonitoringEnabled: cfg.GetBool(join(smNS, "enabled")),
+		DataStreamsEnabled:       cfg.GetBool(join(dataStreamsNS, "enabled")),
 
 		CollectTCPConns:  !cfg.GetBool(join(spNS, "disable_tcp")),
 		TCPConnTimeout:   2 * time.Minute,
@@ -312,14 +317,7 @@ func New() *Config {
 		log.Info("network tracer DNS inspection disabled by configuration")
 	}
 
-	if c.ServiceMonitoringEnabled {
-		cfg.Set(join(netNS, "enable_http_monitoring"), true)
-		c.EnableHTTPMonitoring = true
-		if !cfg.IsSet(join(netNS, "enable_https_monitoring")) {
-			cfg.Set(join(netNS, "enable_https_monitoring"), true)
-			c.EnableHTTPSMonitoring = true
-		}
-
+	if c.ServiceMonitoringEnabled || c.DataStreamsEnabled {
 		if !cfg.IsSet(join(spNS, "enable_runtime_compiler")) {
 			cfg.Set(join(spNS, "enable_runtime_compiler"), true)
 			c.EnableRuntimeCompiler = true
@@ -328,6 +326,21 @@ func New() *Config {
 		if !cfg.IsSet(join(spNS, "enable_kernel_header_download")) {
 			cfg.Set(join(spNS, "enable_kernel_header_download"), true)
 			c.EnableKernelHeaderDownload = true
+		}
+
+		if c.ServiceMonitoringEnabled {
+			cfg.Set(join(netNS, "enable_http_monitoring"), true)
+			c.EnableHTTPMonitoring = true
+			if !cfg.IsSet(join(netNS, "enable_https_monitoring")) {
+				cfg.Set(join(netNS, "enable_https_monitoring"), true)
+				c.EnableHTTPSMonitoring = true
+			}
+		}
+
+		if c.DataStreamsEnabled {
+			cfg.Set(join(netNS, "enable_kafka_monitoring"), true)
+			c.EnableKafkaMonitoring = true
+			c.ServiceMonitoringEnabled = true
 		}
 	}
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Added data streams config value which enable Kafka monitoring and service monitoring (without http monitoring)
From the client perspective, it will only use this value without knowing about the service monitoring config value

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
