### PR TITLE
[serializer] Use google's protobuf lib for marshaling SBOMs and Images

### DIFF
--- a/pkg/serializer/serializer.go
+++ b/pkg/serializer/serializer.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/benbjohnson/clock"
 	"github.com/gogo/protobuf/proto"
+	googleproto "google.golang.org/protobuf/proto"
 )
 
 const (
@@ -545,7 +546,7 @@ func (s *Serializer) SendSBOM(msgs []SBOMMessage, hostname string) error {
 
 	for i := range msgs {
 		msgs[i].Host = hostname
-		encoded, err := proto.Marshal(&msgs[i])
+		encoded, err := googleproto.Marshal(&msgs[i])
 		if err != nil {
 			return log.Errorf("Unable to encode message: %+v", err)
 		}

--- a/pkg/serializer/serializer.go
+++ b/pkg/serializer/serializer.go
@@ -510,7 +510,7 @@ func (s *Serializer) SendContainerImage(msgs []ContainerImageMessage, hostname s
 
 	for i := range msgs {
 		msgs[i].Host = hostname
-		encoded, err := proto.Marshal(&msgs[i])
+		encoded, err := googleproto.Marshal(&msgs[i])
 		if err != nil {
 			return log.Errorf("Unable to encode message: %+v", err)
 		}


### PR DESCRIPTION
### What does this PR do?

Fixes a panic when serializing SBOMs:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x26fd5a1]

goroutine 5010 [running]:
github.com/gogo/protobuf/proto.makeOneOfMarshaler.func1({0xc000d66c00?}, 0xc0029ea448?)
	/go/pkg/mod/github.com/gogo/protobuf@v1.3.2/proto/table_marshal.go:2598 +0xa1
github.com/gogo/protobuf/proto.(*marshalInfo).size(0xc000d66c00, {0x48?})
	/go/pkg/mod/github.com/gogo/protobuf@v1.3.2/proto/table_marshal.go:200 +0x187
github.com/gogo/protobuf/proto.makeMessageSliceMarshaler.func1({0xc000d66b80?}, 0x1)
	/go/pkg/mod/github.com/gogo/protobuf@v1.3.2/proto/table_marshal.go:2455 +0x68
github.com/gogo/protobuf/proto.(*marshalInfo).size(0xc000d66b80, {0xc0018b2120?})
	/go/pkg/mod/github.com/gogo/protobuf@v1.3.2/proto/table_marshal.go:200 +0x187
github.com/gogo/protobuf/proto.(*InternalMessageInfo).Size(0x8?, {0x727dc00, 0xc0018b2120})
	/go/pkg/mod/github.com/gogo/protobuf@v1.3.2/proto/table_marshal.go:131 +0x4a
github.com/gogo/protobuf/proto.Marshal({0x727dc00, 0xc0018b2120})
	/go/pkg/mod/github.com/gogo/protobuf@v1.3.2/proto/table_marshal.go:2952 +0x86
github.com/DataDog/datadog-agent/pkg/serializer.(*Serializer).SendSBOM(0xc000d66a80, {0xc0018b2120?, 0x1, 0x1}, {0xc00154e140, 0x4c})
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/serializer/serializer.go:548 +0x185
github.com/DataDog/datadog-agent/pkg/aggregator.(*BufferedAggregator).dequeueSBOM(0xc000ce1c00)
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/aggregator/aggregator.go:862 +0xd6
created by github.com/DataDog/datadog-agent/pkg/aggregator.(*AgentDemultiplexer).Run.func3
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/aggregator/demultiplexer_agent.go:375 +0x65
```

### Describe how to test/QA your changes

Enable the SBOM check and the SBOM collection in workloadmeta and check that the panic above does not happen.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
