### PR TITLE
[process-agent] Fix data race in TestDisableRealTimeProcessCheck

### DIFF
--- a/cmd/process-agent/collector_test.go
+++ b/cmd/process-agent/collector_test.go
@@ -156,13 +156,13 @@ func TestDisableRealTimeProcessCheck(t *testing.T) {
 		},
 	}
 
-	assert := assert.New(t)
-	expectedChecks := []checks.Check{checks.NewProcessCheck()}
-
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			mockConfig := ddconfig.Mock(t)
 			mockConfig.Set("process_config.disable_realtime_checks", tc.disableRealtime)
+
+			assert := assert.New(t)
+			expectedChecks := []checks.Check{checks.NewProcessCheck()}
 
 			c, err := NewCollector(nil, &checks.HostInfo{}, expectedChecks)
 			assert.NoError(err)


### PR DESCRIPTION
### What does this PR do?

- Fixes data race in the `TestDisableRealTimeProcessCheck` caused by reuse of the ProcessCheck instance.

Reproduced with:
```
go test -race ./cmd/process-agent
..
==================
WARNING: DATA RACE
Write at 0x00c0010a0768 by goroutine 102:
  github.com/DataDog/datadog-agent/pkg/process/checks.(*ProcessCheck).initConnRates()
      /git/datadog-agent/pkg/process/checks/process.go:115 +0xc4
  github.com/DataDog/datadog-agent/pkg/process/checks.(*ProcessCheck).Init()
      /git/datadog-agent/pkg/process/checks/process.go:109 +0x3dc
  github.com/DataDog/datadog-agent/cmd/process-agent.NewCollector()
      /git/datadog-agent/cmd/process-agent/collector.go:91 +0x254
  github.com/DataDog/datadog-agent/cmd/process-agent.TestDisableRealTimeProcessCheck.func1()
      /git/datadog-agent/cmd/process-agent/collector_test.go:167 +0x134
  testing.tRunner()
      /home/vagrant/.gimme/versions/go1.18.5.linux.arm64/src/testing/testing.go:1439 +0x18c
  testing.(*T).Run.func1()
      /home/vagrant/.gimme/versions/go1.18.5.linux.arm64/src/testing/testing.go:1486 +0x44

Previous read at 0x00c0010a0768 by goroutine 13:
  github.com/DataDog/datadog-agent/pkg/process/checks.(*ProcessCheck).updateConnRates()
      /git/datadog-agent/pkg/process/checks/process.go:122 +0x70
  github.com/DataDog/datadog-agent/pkg/process/checks.(*ProcessCheck).initConnRates.func1()
      /git/datadog-agent/pkg/process/checks/process.go:117 +0x38
```

### Motivation

Clean CI/CD

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

N/A, no impact.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
