### PR TITLE
[CWS] Convert SecAgent config subcommand to fx

### DIFF
--- a/cmd/security-agent/subcommands/config/config.go
+++ b/cmd/security-agent/subcommands/config/config.go
@@ -11,60 +11,128 @@ package config
 import (
 	"fmt"
 	"github.com/spf13/cobra"
+	"go.uber.org/fx"
 
 	"github.com/DataDog/datadog-agent/cmd/security-agent/command"
+	"github.com/DataDog/datadog-agent/comp/core"
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/log"
 	"github.com/DataDog/datadog-agent/pkg/api/util"
-	"github.com/DataDog/datadog-agent/pkg/config"
+	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/config/settings"
 	settingshttp "github.com/DataDog/datadog-agent/pkg/config/settings/http"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
-func Commands(globalParams *command.GlobalParams) []*cobra.Command {
-	cmd := Config(getSettingsClient)
-	return []*cobra.Command{cmd}
+type cliParams struct {
+	*command.GlobalParams
+
+	command   *cobra.Command
+	args      []string
+	getClient settings.ClientBuilder
 }
 
-// Config returns the main cobra config command.
-func Config(getClient settings.ClientBuilder) *cobra.Command {
-	// TODO: Convert to fx
+func Commands(globalParams *command.GlobalParams) []*cobra.Command {
+	cliParams := &cliParams{
+		GlobalParams: globalParams,
+	}
+
 	cmd := &cobra.Command{
 		Use:   "config",
 		Short: "Print the runtime configuration of a running agent",
 		Long:  ``,
-		RunE:  func(cmd *cobra.Command, args []string) error { return showRuntimeConfiguration(getClient, cmd, args) },
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			cliParams.command = cmd
+			cliParams.args = args
+			cliParams.getClient = func(cmd *cobra.Command, args []string) (settings.Client, error) {
+				return getSettingsClient(cmd, args)
+			}
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return fxutil.OneShot(
+				showRuntimeConfiguration,
+				fx.Supply(cliParams),
+				fx.Supply(core.BundleParams{
+					ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths),
+					LogParams:    log.LogForOneShot(command.LoggerName, "off", true)}),
+				core.Bundle,
+			)
+		},
 	}
 
-	cmd.AddCommand(listRuntime(getClient))
-	cmd.AddCommand(set(getClient))
-	cmd.AddCommand(get(getClient))
+	// listRuntime returns a cobra command to list the settings that can be changed at runtime.
+	cmd.AddCommand(
+		&cobra.Command{
+			Use:   "list-runtime",
+			Short: "List settings that can be changed at runtime",
+			Long:  ``,
+			RunE: func(cmd *cobra.Command, args []string) error {
+				return fxutil.OneShot(
+					listRuntimeConfigurableValue,
+					fx.Supply(cliParams),
+					fx.Supply(core.BundleParams{
+						ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths),
+						LogParams:    log.LogForOneShot(command.LoggerName, "off", true)}),
+					core.Bundle,
+				)
+			},
+		},
+	)
 
-	return cmd
+	// set returns a cobra command to set a config value at runtime.
+	cmd.AddCommand(
+		&cobra.Command{
+			Use:   "set [setting] [value]",
+			Short: "Set, for the current runtime, the value of a given configuration setting",
+			Long:  ``,
+			RunE: func(cmd *cobra.Command, args []string) error {
+				return fxutil.OneShot(
+					setConfigValue,
+					fx.Supply(cliParams),
+					fx.Supply(core.BundleParams{
+						ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths),
+						LogParams:    log.LogForOneShot(command.LoggerName, "off", true)}),
+					core.Bundle,
+				)
+			},
+		},
+	)
+
+	// get returns a cobra command to get a runtime config value.
+	cmd.AddCommand(
+		&cobra.Command{
+			Use:   "get [setting]",
+			Short: "Get, for the current runtime, the value of a given configuration setting",
+			Long:  ``,
+			RunE: func(cmd *cobra.Command, args []string) error {
+				return fxutil.OneShot(
+					getConfigValue,
+					fx.Supply(cliParams),
+					fx.Supply(core.BundleParams{
+						ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths),
+						LogParams:    log.LogForOneShot(command.LoggerName, "off", true)}),
+					core.Bundle,
+				)
+			},
+		},
+	)
+
+	return []*cobra.Command{cmd}
 }
-
-func getSettingsClient(cmd *cobra.Command, _ []string) (settings.Client, error) {
-	err := setupConfig(cmd)
+func getSettingsClient(_ *cobra.Command, _ []string) (settings.Client, error) {
+	err := util.SetAuthToken()
 	if err != nil {
 		return nil, err
 	}
 
 	c := util.GetClient(false)
-	apiConfigURL := fmt.Sprintf("https://localhost:%v/agent/config", config.Datadog.GetInt("security_agent.cmd_port"))
+	apiConfigURL := fmt.Sprintf("https://localhost:%v/agent/config", pkgconfig.Datadog.GetInt("security_agent.cmd_port"))
 
 	return settingshttp.NewClient(c, apiConfigURL, "security-agent"), nil
 }
 
-func setupConfig(cmd *cobra.Command) error {
-	err := config.SetupLogger(command.LoggerName, config.GetEnvDefault("DD_LOG_LEVEL", "off"), "", "", false, true, false)
-	if err != nil {
-		fmt.Printf("Cannot setup logger, exiting: %v\n", err)
-		return err
-	}
-
-	return util.SetAuthToken()
-}
-
-func showRuntimeConfiguration(getClient settings.ClientBuilder, cmd *cobra.Command, args []string) error {
-	c, err := getClient(cmd, args)
+func showRuntimeConfiguration(log log.Component, config config.Component, params *cliParams) error {
+	c, err := params.getClient(params.command, params.args)
 	if err != nil {
 		return err
 	}
@@ -79,49 +147,17 @@ func showRuntimeConfiguration(getClient settings.ClientBuilder, cmd *cobra.Comma
 	return nil
 }
 
-// listRuntime returns a cobra command to list the settings that can be changed at runtime.
-func listRuntime(getClient settings.ClientBuilder) *cobra.Command {
-	return &cobra.Command{
-		Use:   "list-runtime",
-		Short: "List settings that can be changed at runtime",
-		Long:  ``,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return listRuntimeConfigurableValue(getClient, cmd, args)
-		},
-	}
-}
-
-// set returns a cobra command to set a config value at runtime.
-func set(getClient settings.ClientBuilder) *cobra.Command {
-	return &cobra.Command{
-		Use:   "set [setting] [value]",
-		Short: "Set, for the current runtime, the value of a given configuration setting",
-		Long:  ``,
-		RunE:  func(cmd *cobra.Command, args []string) error { return setConfigValue(getClient, cmd, args) },
-	}
-}
-
-// get returns a cobra command to get a runtime config value.
-func get(getClient settings.ClientBuilder) *cobra.Command {
-	return &cobra.Command{
-		Use:   "get [setting]",
-		Short: "Get, for the current runtime, the value of a given configuration setting",
-		Long:  ``,
-		RunE:  func(cmd *cobra.Command, args []string) error { return getConfigValue(getClient, cmd, args) },
-	}
-}
-
-func setConfigValue(getClient settings.ClientBuilder, cmd *cobra.Command, args []string) error {
-	if len(args) != 2 {
+func setConfigValue(log log.Component, config config.Component, params *cliParams) error {
+	if len(params.args) != 2 {
 		return fmt.Errorf("exactly two parameters are required: the setting name and its value")
 	}
 
-	c, err := getClient(cmd, args)
+	c, err := params.getClient(params.command, params.args)
 	if err != nil {
 		return err
 	}
 
-	hidden, err := c.Set(args[0], args[1])
+	hidden, err := c.Set(params.args[0], params.args[1])
 	if err != nil {
 		return err
 	}
@@ -130,33 +166,33 @@ func setConfigValue(getClient settings.ClientBuilder, cmd *cobra.Command, args [
 		fmt.Printf("IMPORTANT: you have modified a hidden option, this may incur billing charges or have other unexpected side-effects.\n")
 	}
 
-	fmt.Printf("Configuration setting %s is now set to: %s\n", args[0], args[1])
+	fmt.Printf("Configuration setting %s is now set to: %s\n", params.args[0], params.args[1])
 
 	return nil
 }
 
-func getConfigValue(getClient settings.ClientBuilder, cmd *cobra.Command, args []string) error {
-	if len(args) != 1 {
+func getConfigValue(log log.Component, config config.Component, params *cliParams) error {
+	if len(params.args) != 1 {
 		return fmt.Errorf("a single setting name must be specified")
 	}
 
-	c, err := getClient(cmd, args)
+	c, err := params.getClient(params.command, params.args)
 	if err != nil {
 		return err
 	}
 
-	value, err := c.Get(args[0])
+	value, err := c.Get(params.args[0])
 	if err != nil {
 		return err
 	}
 
-	fmt.Printf("%s is set to: %v\n", args[0], value)
+	fmt.Printf("%s is set to: %v\n", params.args[0], value)
 
 	return nil
 }
 
-func listRuntimeConfigurableValue(getClient settings.ClientBuilder, cmd *cobra.Command, args []string) error {
-	c, err := getClient(cmd, args)
+func listRuntimeConfigurableValue(log log.Component, config config.Component, params *cliParams) error {
+	c, err := params.getClient(params.command, params.args)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Convert SecAgent config subcommand to fx

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
