### PR TITLE
[corechecks/snmp] Add `id` and `source_type` to Topology Links data

### DIFF
--- a/pkg/collector/corechecks/snmp/internal/metadata/payload.go
+++ b/pkg/collector/corechecks/snmp/internal/metadata/payload.go
@@ -111,7 +111,8 @@ type TopologyLinkSide struct {
 
 // TopologyLinkMetadata contains topology interface to interface links metadata
 type TopologyLinkMetadata struct {
-	ID     string            `json:"id"`
-	Local  *TopologyLinkSide `json:"local"`
-	Remote *TopologyLinkSide `json:"remote"`
+	ID         string            `json:"id"`
+	SourceType string            `json:"source_type"`
+	Local      *TopologyLinkSide `json:"local"`
+	Remote     *TopologyLinkSide `json:"remote"`
 }

--- a/pkg/collector/corechecks/snmp/internal/metadata/payload.go
+++ b/pkg/collector/corechecks/snmp/internal/metadata/payload.go
@@ -111,6 +111,7 @@ type TopologyLinkSide struct {
 
 // TopologyLinkMetadata contains topology interface to interface links metadata
 type TopologyLinkMetadata struct {
-	Local  *TopologyLinkSide `json:"local,omitempty"`
-	Remote *TopologyLinkSide `json:"remote,omitempty"`
+	ID     string            `json:"id"`
+	Local  *TopologyLinkSide `json:"local"`
+	Remote *TopologyLinkSide `json:"remote"`
 }

--- a/pkg/collector/corechecks/snmp/internal/report/report_device_metadata.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_device_metadata.go
@@ -25,6 +25,7 @@ import (
 )
 
 const interfaceStatusMetric = "snmp.interface.status"
+const topologyLinkSourceTypeLLDP = "lldp"
 
 // ReportNetworkDeviceMetadata reports device metadata
 func (ms *MetricSender) ReportNetworkDeviceMetadata(config *checkconfig.CheckConfig, store *valuestore.ResultValueStore, origTags []string, collectTime time.Time, deviceStatus metadata.DeviceStatus) {
@@ -311,7 +312,8 @@ func buildNetworkTopologyMetadata(deviceID string, store *metadata.Store, interf
 		remEntryUniqueID := localPortNum + "." + lldpRemIndex
 
 		newLink := metadata.TopologyLinkMetadata{
-			ID: deviceID + ":" + remEntryUniqueID,
+			ID:         deviceID + ":" + remEntryUniqueID,
+			SourceType: topologyLinkSourceTypeLLDP,
 			Remote: &metadata.TopologyLinkSide{
 				Device: &metadata.TopologyLinkDevice{
 					Name:        store.GetColumnAsString("lldp_remote.device_name", strIndex),

--- a/pkg/collector/corechecks/snmp/internal/report/report_device_metadata.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_device_metadata.go
@@ -306,7 +306,12 @@ func buildNetworkTopologyMetadata(deviceID string, store *metadata.Store, interf
 
 		localInterfaceIDType, localInterfaceID = resolveLocalInterface(deviceID, interfaceIndexByIDType, localInterfaceIDType, localInterfaceID)
 
+		// remEntryUniqueID: The combination of localPortNum and lldpRemIndex is expected to be unique for each entry in
+		//                   lldpRemTable. We don't include lldpRemTimeMark (used for filtering only recent data) since it's can change often.
+		remEntryUniqueID := localPortNum + "." + lldpRemIndex
+
 		newLink := metadata.TopologyLinkMetadata{
+			ID: deviceID + ":" + remEntryUniqueID,
 			Remote: &metadata.TopologyLinkSide{
 				Device: &metadata.TopologyLinkDevice{
 					Name:        store.GetColumnAsString("lldp_remote.device_name", strIndex),

--- a/pkg/collector/corechecks/snmp/internal/report/report_device_metadata.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_device_metadata.go
@@ -308,7 +308,7 @@ func buildNetworkTopologyMetadata(deviceID string, store *metadata.Store, interf
 		localInterfaceIDType, localInterfaceID = resolveLocalInterface(deviceID, interfaceIndexByIDType, localInterfaceIDType, localInterfaceID)
 
 		// remEntryUniqueID: The combination of localPortNum and lldpRemIndex is expected to be unique for each entry in
-		//                   lldpRemTable. We don't include lldpRemTimeMark (used for filtering only recent data) since it's can change often.
+		//                   lldpRemTable. We don't include lldpRemTimeMark (used for filtering only recent data) since it can change often.
 		remEntryUniqueID := localPortNum + "." + lldpRemIndex
 
 		newLink := metadata.TopologyLinkMetadata{

--- a/pkg/collector/corechecks/snmp/profile_metadata_test.go
+++ b/pkg/collector/corechecks/snmp/profile_metadata_test.go
@@ -565,6 +565,7 @@ profiles:
   "links": [
         {
             "id": "profile-metadata:1.2.3.4:101.1",
+            "source_type": "lldp",
             "local": {
                 "device": {
                     "id": "profile-metadata:1.2.3.4",
@@ -592,6 +593,7 @@ profiles:
         },
         {
             "id": "profile-metadata:1.2.3.4:102.2",
+            "source_type": "lldp",
             "local": {
                 "device": {
                     "id": "profile-metadata:1.2.3.4",

--- a/pkg/collector/corechecks/snmp/profile_metadata_test.go
+++ b/pkg/collector/corechecks/snmp/profile_metadata_test.go
@@ -564,6 +564,7 @@ profiles:
   ],
   "links": [
         {
+            "id": "profile-metadata:1.2.3.4:101.1",
             "local": {
                 "device": {
                     "id": "profile-metadata:1.2.3.4",
@@ -590,6 +591,7 @@ profiles:
             }
         },
         {
+            "id": "profile-metadata:1.2.3.4:102.2",
             "local": {
                 "device": {
                     "id": "profile-metadata:1.2.3.4",

--- a/releasenotes/notes/add_id_and_source_type_to_ndm_topology_data-87db2503e46ab4d2.yaml
+++ b/releasenotes/notes/add_id_and_source_type_to_ndm_topology_data-87db2503e46ab4d2.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    [corechecks/snmp] Add `id` and `source_type` to NDM Topology Links


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

1/ Add `id` to Topology Links data

The ID is composed `<DEVICE_ID>:<localPortNum>.<lldpRemIndex>`.

We currently build an ID in in backend based on:
- LocalDeviceIDType
- LocalDeviceID
- LocalInterfaceIDType
- LocalInterfaceID
- RemoteDeviceIDType
- RemoteDeviceID
- RemoteInterfaceIDType
- RemoteInterfaceID
and  it's ideal since it's very long, cumbersome to build, not 100% guaranteed to be unique.

Why building the ID in the Agent instead of backend?
- This way, when implementing new data source types, there less risk of requiring backend changes.
- It's also consistent with devices/ip_address metadata that have an ID build by the Agent.
- Have a unique ID earlier means we can use it in any stage of the data pipeline if needed.


2/ Add `source_type` to Topology Links data

This can be helpful for troubleshooting and stats (to know the source of the data).

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
