### PR TITLE
[CSPM] Make sure the failing reports are reported first using a stable stort

### DIFF
--- a/pkg/compliance/checks/check.go
+++ b/pkg/compliance/checks/check.go
@@ -127,7 +127,7 @@ func (c *complianceCheck) Run() error {
 	var err error
 
 	reports := c.checkable.Check(c)
-	sort.Sort(reports)
+	sort.Stable(reports)
 
 	resourceQuadIDs := make(map[resourceQuadID]bool)
 

--- a/pkg/compliance/report.go
+++ b/pkg/compliance/report.go
@@ -36,6 +36,10 @@ type ReportResource struct {
 // Reports aggregates compliance reports
 type Reports []*Report
 
+func isFailing(r *Report) bool {
+	return !r.Passed && r.Error == nil
+}
+
 func (r Reports) Len() int           { return len(r) }
-func (r Reports) Less(i, j int) bool { return !r[i].Passed && r[i].Error == nil }
+func (r Reports) Less(i, j int) bool { return isFailing(r[i]) && !isFailing(r[j]) }
 func (r Reports) Swap(i, j int)      { r[i], r[j] = r[j], r[i] }


### PR DESCRIPTION
### What does this PR do?

Followup on #14700: using a stable sort to make sure we report a the first failing report.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
