### PR TITLE
add orchestrator and cws url overwrite when fips is enabled

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1571,6 +1571,8 @@ func setupFipsEndpoints(config Config) error {
 	// port_range_start + 9:  network devices snmp traps (unused)
 	// port_range_start + 10: instrumentation telemetry
 	// port_range_start + 11: appsec events (unused)
+	// port_range_start + 12: orchestrator explorer
+	// port_range_start + 13: runtime security
 
 	if !config.GetBool("fips.enabled") {
 		log.Debug("FIPS mode is disabled")

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1160,6 +1160,13 @@ network_devices:
   metadata:
     dd_url: somehost:1234
 
+orchestrator_explorer:
+    orchestrator_dd_url: https://somehost:1234
+
+runtime_security_config:
+    endpoints:
+        logs_dd_url: somehost:1234
+
 proxy:
   http: http://localhost:1234
   https: https://localhost:1234
@@ -1174,6 +1181,8 @@ proxy:
 	assertFipsProxyExpectedConfig(t, expectedHTTPURL, expectedURL, false, testConfig)
 	assert.Equal(t, false, testConfig.GetBool("logs_config.use_http"))
 	assert.Equal(t, false, testConfig.GetBool("logs_config.logs_no_ssl"))
+	assert.Equal(t, false, testConfig.GetBool("runtime_security_config.endpoints.use_http"))
+	assert.Equal(t, false, testConfig.GetBool("runtime_security_config.endpoints.logs_no_ssl"))
 	assert.NotNil(t, GetProxies())
 	// reseting proxies
 	proxies = nil
@@ -1196,6 +1205,8 @@ fips:
 	assertFipsProxyExpectedConfig(t, expectedHTTPURL, expectedURL, true, testConfig)
 	assert.Equal(t, true, testConfig.GetBool("logs_config.use_http"))
 	assert.Equal(t, true, testConfig.GetBool("logs_config.logs_no_ssl"))
+	assert.Equal(t, true, testConfig.GetBool("runtime_security_config.endpoints.use_http"))
+	assert.Equal(t, true, testConfig.GetBool("runtime_security_config.endpoints.logs_no_ssl"))
 	assert.Nil(t, GetProxies())
 
 	datadogYamlFips = datadogYaml + `
@@ -1217,6 +1228,8 @@ fips:
 	assertFipsProxyExpectedConfig(t, expectedHTTPURL, expectedURL, true, testConfig)
 	assert.Equal(t, true, testConfig.GetBool("logs_config.use_http"))
 	assert.Equal(t, false, testConfig.GetBool("logs_config.logs_no_ssl"))
+	assert.Equal(t, true, testConfig.GetBool("runtime_security_config.endpoints.use_http"))
+	assert.Equal(t, false, testConfig.GetBool("runtime_security_config.endpoints.logs_no_ssl"))
 	assert.Equal(t, true, testConfig.GetBool("skip_ssl_validation"))
 	assert.Nil(t, GetProxies())
 
@@ -1242,6 +1255,9 @@ func assertFipsProxyExpectedConfig(t *testing.T, expectedBaseHTTPURL, expectedBa
 		assert.Equal(t, expectedBaseURL+"06", c.GetString("database_monitoring.activity.dd_url"))
 		assert.Equal(t, expectedBaseURL+"07", c.GetString("database_monitoring.samples.dd_url"))
 		assert.Equal(t, expectedBaseURL+"08", c.GetString("network_devices.metadata.dd_url"))
+		assert.Equal(t, expectedBaseHTTPURL+"12", c.GetString("orchestrator_explorer.orchestrator_dd_url"))
+		assert.Equal(t, expectedBaseURL+"13", c.GetString("runtime_security_config.endpoints.logs_dd_url"))
+
 	} else {
 		assert.Equal(t, expectedBaseHTTPURL, c.GetString("dd_url"))
 		assert.Equal(t, expectedBaseHTTPURL, c.GetString("apm_config.apm_dd_url"))
@@ -1253,6 +1269,8 @@ func assertFipsProxyExpectedConfig(t *testing.T, expectedBaseHTTPURL, expectedBa
 		assert.Equal(t, expectedBaseURL, c.GetString("database_monitoring.activity.dd_url"))
 		assert.Equal(t, expectedBaseURL, c.GetString("database_monitoring.samples.dd_url"))
 		assert.Equal(t, expectedBaseURL, c.GetString("network_devices.metadata.dd_url"))
+		assert.Equal(t, expectedBaseHTTPURL, c.GetString("orchestrator_explorer.orchestrator_dd_url"))
+		assert.Equal(t, expectedBaseURL, c.GetString("runtime_security_config.endpoints.logs_dd_url"))
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?

Overwrite `orchestrator_explorer.orchestrator_dd_url` and `runtime_security_config.endpoints.*` when fips is enabled

### Motivation

`orchestrator_explorer.orchestrator_dd_url` is used in the process-agent and `runtime_security_config.endpoints.*` in system-probe which are both available in GovCloud, so they must be handled by the Agent config when `fips.enabled` is true.

### Additional Notes

The order of ports doesn't make any sense but I don't really wanna break the matching with the FIPS proxy config since they are not tied and then any version of the Agent should match the same ports with the FIPS proxy.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Run the Agent with `fips.enabled: true` and get the config with `datadog-agent config`.

In the config verify that the following values are correctly overwritten:

- `orchestrator_explorer.orchestrator_dd_url` (should be `https://localhost:9815`)
- `runtime_security_config.endpoints.logs_dd_url` (should be `https://localhost:9816`)
- `runtime_security_config.endpoints.use_http` (should be `true`)
- `runtime_security_config.endpoints.logs_no_ssl` (should be `true` if `fips.https: false` and vice versa)

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
