### PR TITLE
Use container_image_collection in config options

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1103,12 +1103,12 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("inventories_max_interval", DefaultInventoriesMaxInterval) // integer seconds
 	config.BindEnvAndSetDefault("inventories_min_interval", DefaultInventoriesMinInterval) // integer seconds
 
-	// workloadmeta
-	config.BindEnvAndSetDefault("workloadmeta.image_metadata_collection.enabled", false)
-	config.BindEnvAndSetDefault("workloadmeta.image_metadata_collection.collect_sboms", false)
-	config.BindEnvAndSetDefault("workloadmeta.image_metadata_collection.collect_sboms_use_mount", false)
-	config.BindEnvAndSetDefault("workloadmeta.image_metadata_collection.collect_sboms_scan_interval", 0)    // Integer seconds
-	config.BindEnvAndSetDefault("workloadmeta.image_metadata_collection.collect_sboms_scan_timeout", 10*60) // Integer seconds
+	// container_image_collection
+	config.BindEnvAndSetDefault("container_image_collection.metadata.enabled", false)
+	config.BindEnvAndSetDefault("container_image_collection.sbom.enabled", false)
+	config.BindEnvAndSetDefault("container_image_collection.sbom.use_mount", false)
+	config.BindEnvAndSetDefault("container_image_collection.sbom.scan_interval", 0)    // Integer seconds
+	config.BindEnvAndSetDefault("container_image_collection.sbom.scan_timeout", 10*60) // Integer seconds
 	config.BindEnvAndSetDefault("container_image_collection.sbom.analyzers", []string{"os"})
 
 	// Datadog security agent (common)

--- a/pkg/workloadmeta/collectors/internal/containerd/containerd.go
+++ b/pkg/workloadmeta/collectors/internal/containerd/containerd.go
@@ -399,5 +399,5 @@ func (c *collector) cacheExitInfo(id string, exitCode *uint32, exitTS time.Time)
 }
 
 func imageMetadataCollectionIsEnabled() bool {
-	return config.Datadog.GetBool("workloadmeta.image_metadata_collection.enabled")
+	return config.Datadog.GetBool("container_image_collection.metadata.enabled")
 }

--- a/pkg/workloadmeta/collectors/internal/containerd/image.go
+++ b/pkg/workloadmeta/collectors/internal/containerd/image.go
@@ -395,5 +395,5 @@ func getLayersWithHistory(ctx context.Context, store content.Store, manifest oci
 }
 
 func sbomCollectionIsEnabled() bool {
-	return imageMetadataCollectionIsEnabled() && config.Datadog.GetBool("workloadmeta.image_metadata_collection.collect_sboms")
+	return imageMetadataCollectionIsEnabled() && config.Datadog.GetBool("container_image_collection.sbom.enabled")
 }

--- a/pkg/workloadmeta/collectors/internal/containerd/image_sbom_trivy.go
+++ b/pkg/workloadmeta/collectors/internal/containerd/image_sbom_trivy.go
@@ -74,7 +74,7 @@ func (c *collector) extractBOMWithTrivy(ctx context.Context, imageToScan namespa
 	}
 
 	scanFunc := c.trivyClient.ScanContainerdImage
-	if config.Datadog.GetBool("workloadmeta.image_metadata_collection.collect_sboms_use_mount") {
+	if config.Datadog.GetBool("container_image_collection.sbom.use_mount") {
 		scanFunc = c.trivyClient.ScanContainerdImageFromFilesystem
 	}
 
@@ -91,9 +91,9 @@ func (c *collector) extractBOMWithTrivy(ctx context.Context, imageToScan namespa
 }
 
 func scanningTimeout() time.Duration {
-	return time.Duration(config.Datadog.GetInt("workloadmeta.image_metadata_collection.collect_sboms_scan_timeout")) * time.Second
+	return time.Duration(config.Datadog.GetInt("container_image_collection.sbom.scan_timeout")) * time.Second
 }
 
 func timeBetweenScans() time.Duration {
-	return time.Duration(config.Datadog.GetInt("workloadmeta.image_metadata_collection.collect_sboms_scan_interval")) * time.Second
+	return time.Duration(config.Datadog.GetInt("container_image_collection.sbom.scan_interval")) * time.Second
 }

--- a/releasenotes/notes/workloadmeta-containerd-sbom-a1ec4b725d0110f2.yaml
+++ b/releasenotes/notes/workloadmeta-containerd-sbom-a1ec4b725d0110f2.yaml
@@ -11,5 +11,5 @@ features:
     Adds the option to collect and store in workloadmeta the software bill of
     materials (SBOM) of containerd images using Trivy. This feature is disabled
     by default. It can be enabled by setting
-    `workloadmeta.image_metadata_collection.collect_sboms` to true.
+    `container_image_collection.sbom.enabled` to true.
     Note: This feature is CPU and IO intensive.


### PR DESCRIPTION
### What does this PR do?

rename `workload.image_collection` config options to `container_image_collection` to be more product feature oriented.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

be able to expose configuration like this:

```yaml
container_image_collection:
    metadata:
        enabled: true
    sbom:
        enabled: true
        use_mount: false
        scan_interval: 0
        scan_timeout: 10*60
```

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

I renamed existing new config options that was introduced in 7.43.0. So testing the new features (other PRs) with the new options name should be fined


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
