### PR TITLE
[tasks] Read go unit test reports in utf-8 format

### DIFF
--- a/tasks/test.py
+++ b/tasks/test.py
@@ -494,7 +494,7 @@ def test(
                 # TODO(AP-1959): this logic is now repreated, with some variations, in three places:
                 # here, in system-probe.py, and in libs/pipeline_notifications.py
                 # We should have some common result.json parsing lib.
-                with open(module_test_result.result_json_path) as tf:
+                with open(module_test_result.result_json_path, encoding="utf-8") as tf:
                     for line in tf:
                         json_test = json.loads(line.strip())
                         # This logic assumes that the lines in result.json are "in order", i.e. that retries


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Explicitly sets the file reading encoding to `utf-8` when reading the Go unit test report json file.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Prevent errors like:
```
Traceback (most recent call last):
  File "c:\embeddedpy\py3.8.1\lib\runpy.py", line 193, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "c:\embeddedpy\py3.8.1\lib\runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "c:\embeddedpy\py3.8.1\Scripts\inv.exe\__main__.py", line 7, in <module>
  File "c:\embeddedpy\py3.8.1\lib\site-packages\invoke\program.py", line 384, in run
    self.execute()
  File "c:\embeddedpy\py3.8.1\lib\site-packages\invoke\program.py", line 569, in execute
    executor.execute(*self.tasks)
  File "c:\embeddedpy\py3.8.1\lib\site-packages\invoke\executor.py", line 129, in execute
    result = call.task(*args, **call.kwargs)
  File "c:\embeddedpy\py3.8.1\lib\site-packages\invoke\tasks.py", line 127, in __call__
    result = self.body(*args, **kwargs)
  File "C:\dev\go\src\github.com\DataDog\datadog-agent\tasks\test.py", line 498, in test
    for line in tf:
  File "c:\embeddedpy\py3.8.1\lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x90 in position 4738: character maps to <undefined>
```

on Windows.

This doesn't seem to cause failing jobs by itself (as it causes an additional error on jobs that would already fail), but makes the output harder to read.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

n/a

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

n/a

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

n/a

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
