### PR TITLE
Configure analyzers used for SBOM generation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -578,7 +578,7 @@ replace github.com/vishvananda/netlink => github.com/DataDog/netlink v1.0.1-0.20
 // Use custom Trivy fork to reduce binary size
 // Pull in replacements needed by upstream Trivy
 replace (
-	github.com/aquasecurity/trivy => github.com/DataDog/trivy v0.0.0-20230118103707-807a7ff8aa02
+	github.com/aquasecurity/trivy => github.com/DataDog/trivy v0.0.0-20230120171913-9b1b011fb2fe
 	github.com/spdx/tools-golang => github.com/spdx/tools-golang v0.3.0
 	oras.land/oras-go => oras.land/oras-go v1.1.1
 )

--- a/go.sum
+++ b/go.sum
@@ -167,6 +167,8 @@ github.com/DataDog/sketches-go v1.4.1 h1:j5G6as+9FASM2qC36lvpvQAj9qsv/jUs3FtO8Cw
 github.com/DataDog/sketches-go v1.4.1/go.mod h1:xJIXldczJyyjnbDop7ZZcLxJdV3+7Kra7H1KMgpgkLk=
 github.com/DataDog/trivy v0.0.0-20230118103707-807a7ff8aa02 h1:cj0pjOLI1GaJKOZHiuMbPdgU8i/ddy0VkjH6WuSytEw=
 github.com/DataDog/trivy v0.0.0-20230118103707-807a7ff8aa02/go.mod h1:f1nyvEyWU3w5L8dYIQljloMO/BX0i0OK9NwGeZtvmFw=
+github.com/DataDog/trivy v0.0.0-20230120171913-9b1b011fb2fe h1:37VGGoe+SJ/blsYK0xZDy84m8hp/suVx6MBSeiZJKLc=
+github.com/DataDog/trivy v0.0.0-20230120171913-9b1b011fb2fe/go.mod h1:f1nyvEyWU3w5L8dYIQljloMO/BX0i0OK9NwGeZtvmFw=
 github.com/DataDog/viper v1.12.0 h1:FufyZpZPxyszafSV5B8Q8it75IhhuJwH0T7QpT6HnD0=
 github.com/DataDog/viper v1.12.0/go.mod h1:wDdUVJ2SHaMaPrCZrlRCObwkubsX8j5sme3LaR/SGTc=
 github.com/DataDog/watermarkpodautoscaler v0.5.0-rc.1.0.20220530183114-687bca6395e8 h1:2+uhTsVJvKbLIIGJxRoI3NTSPB9rNWqmLqFAqgPWkPM=

--- a/go.sum
+++ b/go.sum
@@ -165,8 +165,6 @@ github.com/DataDog/nikos v1.10.0/go.mod h1:Akd6ZjhqCE5wkpy+r2vLzrOyZNrPg+APYr+i+
 github.com/DataDog/sketches-go v1.0.0/go.mod h1:O+XkJHWk9w4hDwY2ZUDU31ZC9sNYlYo8DiFsxjYeo1k=
 github.com/DataDog/sketches-go v1.4.1 h1:j5G6as+9FASM2qC36lvpvQAj9qsv/jUs3FtO8CwZNAY=
 github.com/DataDog/sketches-go v1.4.1/go.mod h1:xJIXldczJyyjnbDop7ZZcLxJdV3+7Kra7H1KMgpgkLk=
-github.com/DataDog/trivy v0.0.0-20230118103707-807a7ff8aa02 h1:cj0pjOLI1GaJKOZHiuMbPdgU8i/ddy0VkjH6WuSytEw=
-github.com/DataDog/trivy v0.0.0-20230118103707-807a7ff8aa02/go.mod h1:f1nyvEyWU3w5L8dYIQljloMO/BX0i0OK9NwGeZtvmFw=
 github.com/DataDog/trivy v0.0.0-20230120171913-9b1b011fb2fe h1:37VGGoe+SJ/blsYK0xZDy84m8hp/suVx6MBSeiZJKLc=
 github.com/DataDog/trivy v0.0.0-20230120171913-9b1b011fb2fe/go.mod h1:f1nyvEyWU3w5L8dYIQljloMO/BX0i0OK9NwGeZtvmFw=
 github.com/DataDog/viper v1.12.0 h1:FufyZpZPxyszafSV5B8Q8it75IhhuJwH0T7QpT6HnD0=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1109,6 +1109,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("workloadmeta.image_metadata_collection.collect_sboms_use_mount", false)
 	config.BindEnvAndSetDefault("workloadmeta.image_metadata_collection.collect_sboms_scan_interval", 0)    // Integer seconds
 	config.BindEnvAndSetDefault("workloadmeta.image_metadata_collection.collect_sboms_scan_timeout", 10*60) // Integer seconds
+	config.BindEnvAndSetDefault("container_image_collection.sbom.analyzers", []string{"os"})
 
 	// Datadog security agent (common)
 	config.BindEnvAndSetDefault("security_agent.cmd_port", 5010)

--- a/pkg/util/trivy/trivy.go
+++ b/pkg/util/trivy/trivy.go
@@ -79,7 +79,7 @@ func DefaultCollectorConfig(enabledAnalyzers []string) (CollectorConfig, error) 
 		return CollectorConfig{}, err
 	}
 
-	return CollectorConfig{
+	collectorConfig := CollectorConfig{
 		ArtifactCache:      cache,
 		LocalArtifactCache: cache,
 		ArtifactOption: artifact.Option{
@@ -90,7 +90,13 @@ func DefaultCollectorConfig(enabledAnalyzers []string) (CollectorConfig, error) 
 			SBOMSources:       []string{},
 			DisabledHandlers:  DefaultDisabledHandlers(),
 		},
-	}, nil
+	}
+
+	if len(enabledAnalyzers) == 1 && enabledAnalyzers[0] == OSAnalyzers {
+		collectorConfig.ArtifactOption.OnlyDirs = []string{"/etc", "/var/lib/dpkg", "/var/lib/rpm", "/lib/apk"}
+	}
+
+	return collectorConfig, nil
 }
 
 func DefaultDisabledCollectors(enabledAnalyzers []string) []analyzer.Type {

--- a/pkg/util/trivy/trivy.go
+++ b/pkg/util/trivy/trivy.go
@@ -17,6 +17,7 @@ import (
 
 	containerdUtil "github.com/DataDog/datadog-agent/pkg/util/containerd"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 
 	cyclonedxgo "github.com/CycloneDX/cyclonedx-go"
 	"github.com/aquasecurity/trivy-db/pkg/db"
@@ -46,11 +47,6 @@ const (
 	ConfigFileAnalyzers = "config"
 	LicenseAnalyzers    = "license"
 )
-
-// Collector interface
-type Collector interface {
-	ScanContainerdImage(ctx context.Context, imageMeta *workloadmeta.ContainerImageMetadata, img containerd.Image) (*cyclonedxgo.BOM, error)
-}
 
 // CollectorConfig allows to pass configuration
 type CollectorConfig struct {

--- a/pkg/util/trivy/trivy.go
+++ b/pkg/util/trivy/trivy.go
@@ -12,11 +12,11 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"sort"
 	"time"
 
 	containerdUtil "github.com/DataDog/datadog-agent/pkg/util/containerd"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 
 	cyclonedxgo "github.com/CycloneDX/cyclonedx-go"
 	"github.com/aquasecurity/trivy-db/pkg/db"
@@ -39,8 +39,18 @@ import (
 )
 
 const (
-	cleanupTimeout = 30 * time.Second
+	cleanupTimeout      = 30 * time.Second
+	OSAnalyzers         = "os"
+	LanguagesAnalyzers  = "languages"
+	SecretAnalyzers     = "secret"
+	ConfigFileAnalyzers = "config"
+	LicenseAnalyzers    = "license"
 )
+
+// Collector interface
+type Collector interface {
+	ScanContainerdImage(ctx context.Context, imageMeta *workloadmeta.ContainerImageMetadata, img containerd.Image) (*cyclonedxgo.BOM, error)
+}
 
 // CollectorConfig allows to pass configuration
 type CollectorConfig struct {
@@ -63,7 +73,7 @@ type collector struct {
 
 // DefaultCollectorConfig returns a default collector configuration
 // However, accessors still need to be filled in externally
-func DefaultCollectorConfig() (CollectorConfig, error) {
+func DefaultCollectorConfig(enabledAnalyzers []string) (CollectorConfig, error) {
 	cache, err := operation.NewCache(flag.CacheOptions{CacheBackend: "fs"})
 	if err != nil {
 		return CollectorConfig{}, err
@@ -75,7 +85,7 @@ func DefaultCollectorConfig() (CollectorConfig, error) {
 		ArtifactOption: artifact.Option{
 			Offline:           true,
 			NoProgress:        true,
-			DisabledAnalyzers: DefaultDisabledCollectors(),
+			DisabledAnalyzers: DefaultDisabledCollectors(enabledAnalyzers),
 			Slow:              true,
 			SBOMSources:       []string{},
 			DisabledHandlers:  DefaultDisabledHandlers(),
@@ -83,12 +93,30 @@ func DefaultCollectorConfig() (CollectorConfig, error) {
 	}, nil
 }
 
-func DefaultDisabledCollectors() []analyzer.Type {
-	disabledAnalyzers := make([]analyzer.Type, 2+len(analyzer.TypeLanguages)+len(analyzer.TypeConfigFiles))
-	disabledAnalyzers = append(disabledAnalyzers, analyzer.TypeLanguages...)
-	disabledAnalyzers = append(disabledAnalyzers, analyzer.TypeSecret)
-	disabledAnalyzers = append(disabledAnalyzers, analyzer.TypeConfigFiles...)
-	disabledAnalyzers = append(disabledAnalyzers, analyzer.TypeLicenseFile)
+func DefaultDisabledCollectors(enabledAnalyzers []string) []analyzer.Type {
+	sort.Strings(enabledAnalyzers)
+	analyzersDisabled := func(analyzers string) bool {
+		index := sort.SearchStrings(enabledAnalyzers, analyzers)
+		return index >= len(enabledAnalyzers) || enabledAnalyzers[index] != analyzers
+	}
+
+	var disabledAnalyzers []analyzer.Type
+	if analyzersDisabled(OSAnalyzers) {
+		disabledAnalyzers = append(disabledAnalyzers, analyzer.TypeOSes...)
+	}
+	if analyzersDisabled(LanguagesAnalyzers) {
+		disabledAnalyzers = append(disabledAnalyzers, analyzer.TypeLanguages...)
+	}
+	if analyzersDisabled(SecretAnalyzers) {
+		disabledAnalyzers = append(disabledAnalyzers, analyzer.TypeSecret)
+	}
+	if analyzersDisabled(ConfigFileAnalyzers) {
+		disabledAnalyzers = append(disabledAnalyzers, analyzer.TypeConfigFiles...)
+	}
+	if analyzersDisabled(LicenseAnalyzers) {
+		disabledAnalyzers = append(disabledAnalyzers, analyzer.TypeLicenseFile)
+	}
+
 	return disabledAnalyzers
 }
 

--- a/pkg/workloadmeta/collectors/internal/containerd/image_sbom_trivy.go
+++ b/pkg/workloadmeta/collectors/internal/containerd/image_sbom_trivy.go
@@ -30,7 +30,8 @@ func (c *collector) startSBOMCollection() error {
 	}
 
 	var err error
-	trivyConfiguration, err := trivy.DefaultCollectorConfig()
+	enabledAnalyzers := config.Datadog.GetStringSlice("container_image_collection.sbom.analyzers")
+	trivyConfiguration, err := trivy.DefaultCollectorConfig(enabledAnalyzers)
 	if err != nil {
 		return fmt.Errorf("error initializing trivy client: %w", err)
 	}


### PR DESCRIPTION
### What does this PR do?

This PR allow to configure which SBOM analysers will be use to scan container images. By default only the "OS" analysers are enabled.

to enable more analysers, the config option `container_image_collection.sbom.analyzers` can be used.

### Motivation

Only run by default the necessary SBOM analysers and so limit the datadog agent CPU consumption.

### Additional Notes

N/A

### Possible Drawbacks / Trade-offs

Partial container image SBOM

### Describe how to test/QA your changes

This feature can be tested by changing the value the config option `container_image_collection.sbom.analyzers`. But it is not easy to see the result of this change, `agent workload-list` only say if an SBOM was stored for a given image, but not the granularity of the SBOM.
A solution can be to check what payload has been send to datadog.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
