### PR TITLE
Bump snowflake to 2.8.3 and add back installing library

### DIFF
--- a/omnibus/config/software/snowflake-connector-python-py3.rb
+++ b/omnibus/config/software/snowflake-connector-python-py3.rb
@@ -6,12 +6,12 @@
 # modify the wheel build.
 
 name "snowflake-connector-python-py3"
-default_version "2.8.2"
+default_version "2.8.3"
 
 dependency "pip3"
 
 source :url => "https://github.com/snowflakedb/snowflake-connector-python/archive/refs/tags/v#{version}.tar.gz",
-       :sha256 => "2920e32145c500cb4953b08cf55f09729d731f8c0f49922144372ac8a2e3057b",
+       :sha256 => "1c868db9620d75dfc556696b92cd72f045443792141a2c5f6977b6afab6ca6ed",
        :extract => :seven_zip
 
 relative_path "snowflake-connector-python-#{version}"
@@ -29,4 +29,5 @@ build do
     pip = "#{install_dir}/embedded/bin/pip3"
   end
 
+  command "#{pip} install ."
 end

--- a/omnibus/config/software/snowflake-connector-python-py3.rb
+++ b/omnibus/config/software/snowflake-connector-python-py3.rb
@@ -6,12 +6,12 @@
 # modify the wheel build.
 
 name "snowflake-connector-python-py3"
-default_version "2.8.2"
+default_version "2.8.1"
 
 dependency "pip3"
 
 source :url => "https://github.com/snowflakedb/snowflake-connector-python/archive/refs/tags/v#{version}.tar.gz",
-       :sha256 => "2920e32145c500cb4953b08cf55f09729d731f8c0f49922144372ac8a2e3057b",
+       :sha256 => "1c868db9620d75dfc556696b92cd72f045443792141a2c5f6977b6afab6ca6ed",
        :extract => :seven_zip
 
 relative_path "snowflake-connector-python-#{version}"

--- a/omnibus/config/software/snowflake-connector-python-py3.rb
+++ b/omnibus/config/software/snowflake-connector-python-py3.rb
@@ -6,12 +6,12 @@
 # modify the wheel build.
 
 name "snowflake-connector-python-py3"
-default_version "2.8.3"
+default_version "2.8.2"
 
 dependency "pip3"
 
 source :url => "https://github.com/snowflakedb/snowflake-connector-python/archive/refs/tags/v#{version}.tar.gz",
-       :sha256 => "1c868db9620d75dfc556696b92cd72f045443792141a2c5f6977b6afab6ca6ed",
+       :sha256 => "2920e32145c500cb4953b08cf55f09729d731f8c0f49922144372ac8a2e3057b",
        :extract => :seven_zip
 
 relative_path "snowflake-connector-python-#{version}"

--- a/omnibus/config/software/snowflake-connector-python-py3.rb
+++ b/omnibus/config/software/snowflake-connector-python-py3.rb
@@ -6,7 +6,7 @@
 # modify the wheel build.
 
 name "snowflake-connector-python-py3"
-default_version "2.8.1"
+default_version "2.8.3"
 
 dependency "pip3"
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
This PR updates the version of `snowflake-connector-python` to 2.8.3 since [2.8.2 was yanked](https://pypi.org/project/snowflake-connector-python/2.8.2/), and it also adds back the `pip install .` command.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
