### PR TITLE
[CWS] remove unsafe cache

### DIFF
--- a/pkg/security/secl/compiler/eval/context.go
+++ b/pkg/security/secl/compiler/eval/context.go
@@ -18,6 +18,7 @@ type Context struct {
 	Registers Registers
 
 	// cache available across all the evaluations
+	StringCache map[string][]string
 	Cache map[string]unsafe.Pointer
 
 	now time.Time

--- a/pkg/security/secl/compiler/eval/context.go
+++ b/pkg/security/secl/compiler/eval/context.go
@@ -8,7 +8,6 @@ package eval
 import (
 	"sync"
 	"time"
-	"unsafe"
 )
 
 // Context describes the context used during a rule evaluation
@@ -21,7 +20,6 @@ type Context struct {
 	StringCache map[string][]string
 	IntCache    map[string][]int
 	BoolCache   map[string][]bool
-	Cache       map[string]unsafe.Pointer
 
 	now time.Time
 }
@@ -46,16 +44,24 @@ func (c *Context) Reset() {
 	c.now = time.Time{}
 
 	// as the cache should be low in entry, prefer to delete than re-alloc
-	for key := range c.Cache {
-		delete(c.Cache, key)
+	for key := range c.StringCache {
+		delete(c.StringCache, key)
+	}
+	for key := range c.IntCache {
+		delete(c.IntCache, key)
+	}
+	for key := range c.BoolCache {
+		delete(c.BoolCache, key)
 	}
 }
 
 // NewContext return a new Context
 func NewContext(evt Event) *Context {
 	return &Context{
-		Event: evt,
-		Cache: make(map[string]unsafe.Pointer),
+		Event:       evt,
+		StringCache: make(map[string][]string),
+		IntCache:    make(map[string][]int),
+		BoolCache:   make(map[string][]bool),
 	}
 }
 

--- a/pkg/security/secl/compiler/eval/context.go
+++ b/pkg/security/secl/compiler/eval/context.go
@@ -19,7 +19,9 @@ type Context struct {
 
 	// cache available across all the evaluations
 	StringCache map[string][]string
-	Cache map[string]unsafe.Pointer
+	IntCache    map[string][]int
+	BoolCache   map[string][]bool
+	Cache       map[string]unsafe.Pointer
 
 	now time.Time
 }

--- a/pkg/security/secl/compiler/generators/accessors/accessors.tmpl
+++ b/pkg/security/secl/compiler/generators/accessors/accessors.tmpl
@@ -116,6 +116,10 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					{{if eq $Field.ReturnType "string"}}
 					ctx.StringCache[field] = results
+					{{else if eq $Field.ReturnType "int"}}
+					ctx.IntCache[field] = results
+					{{else if eq $Field.ReturnType "bool"}}
+					ctx.BoolCache[field] = results
 					{{else}}
 					ctx.Cache[field] = unsafe.Pointer(&results)
 					{{end}}

--- a/pkg/security/secl/compiler/generators/accessors/accessors.tmpl
+++ b/pkg/security/secl/compiler/generators/accessors/accessors.tmpl
@@ -7,15 +7,9 @@ package {{.Name}}
 import (
 	"net"
 	"reflect"
-	"unsafe"
 
 	{{if ne $.SourcePkg $.TargetPkg}}"{{.SourcePkg}}"{{end}}
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
-)
-
-// suppress unused package warning
-var (
-	_ *unsafe.Pointer
 )
 
 func (m *Model) GetIterator(field eval.Field) (eval.Iterator, error) {

--- a/pkg/security/secl/compiler/generators/accessors/accessors.tmpl
+++ b/pkg/security/secl/compiler/generators/accessors/accessors.tmpl
@@ -48,7 +48,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			OpOverrides: {{$Field.OpOverrides}},
 			{{- end}}
 			{{- if $Field.Iterator}}
-				EvalFnc: func(ctx *eval.Context) []{{$Field.ReturnType}} {	
+				EvalFnc: func(ctx *eval.Context) []{{$Field.ReturnType}} {
 					{{if $Field.Handler}}
 						ev := ctx.Event.(*Event)
 					{{end}}
@@ -114,7 +114,11 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 						value = iterator.Next()
 					}
 
+					{{if eq $Field.ReturnType "string"}}
+					ctx.StringCache[field] = results
+					{{else}}
 					ctx.Cache[field] = unsafe.Pointer(&results)
+					{{end}}
 
 					return results
 				},
@@ -132,7 +136,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 							return {{$Field.GetDefaultReturnValue}}
 						}
 					{{end}}
-					
+
 					{{- if $Field.Handler}}
 						{{$Ptr := "&"}}
 						{{$Parent := index $.AllFields $Field.Prefix}}

--- a/pkg/security/secl/compiler/generators/accessors/accessors.tmpl
+++ b/pkg/security/secl/compiler/generators/accessors/accessors.tmpl
@@ -115,7 +115,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					{{else if eq $Field.ReturnType "bool"}}
 					ctx.BoolCache[field] = results
 					{{else}}
-					ctx.Cache[field] = unsafe.Pointer(&results)
+					{{ template "error_undefined_array_cache" }}
 					{{end}}
 
 					return results

--- a/pkg/security/secl/compiler/generators/accessors/accessors.tmpl
+++ b/pkg/security/secl/compiler/generators/accessors/accessors.tmpl
@@ -49,10 +49,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					{{$Checks := $Field | GetChecks $.AllFields}}
 
-					if ptr := ctx.Cache[field]; ptr != nil {
-						if result := (*[]{{$Field.ReturnType}})(ptr); result != nil {
-							return *result
-						}
+					if result, ok := ctx.{{$Field.GetCacheName}}[field]; ok {
+						return result
 					}
 
 					var results []{{$Field.ReturnType}}
@@ -108,15 +106,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 						value = iterator.Next()
 					}
 
-					{{if eq $Field.ReturnType "string"}}
-					ctx.StringCache[field] = results
-					{{else if eq $Field.ReturnType "int"}}
-					ctx.IntCache[field] = results
-					{{else if eq $Field.ReturnType "bool"}}
-					ctx.BoolCache[field] = results
-					{{else}}
-					{{ template "error_undefined_array_cache" }}
-					{{end}}
+					ctx.{{$Field.GetCacheName}}[field] = results
 
 					return results
 				},

--- a/pkg/security/secl/compiler/generators/accessors/common/types.go
+++ b/pkg/security/secl/compiler/generators/accessors/common/types.go
@@ -127,3 +127,17 @@ func (sf *StructField) GetArrayPrefix() string {
 	}
 	return ""
 }
+
+// GetCacheName returns the cache name
+func (sf *StructField) GetCacheName() string {
+	switch sf.ReturnType {
+	case "string":
+		return "StringCache"
+	case "int":
+		return "IntCache"
+	case "bool":
+		return "BoolCache"
+	default:
+		panic("no cache name defined for this return type")
+	}
+}

--- a/pkg/security/secl/model/accessors.go
+++ b/pkg/security/secl/model/accessors.go
@@ -3176,10 +3176,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
 				ev := ctx.Event.(*Event)
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
 				}
 				var results []string
 				iterator := &ProcessAncestorsIterator{}
@@ -3199,10 +3197,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
 				ev := ctx.Event.(*Event)
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
 				}
 				var results []string
 				iterator := &ProcessAncestorsIterator{}
@@ -3222,10 +3218,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
 				ev := ctx.Event.(*Event)
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
 				}
 				var results []string
 				iterator := &ProcessAncestorsIterator{}
@@ -3245,10 +3239,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.BoolArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []bool {
 				ev := ctx.Event.(*Event)
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]bool)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.BoolCache[field]; ok {
+					return result
 				}
 				var results []bool
 				iterator := &ProcessAncestorsIterator{}
@@ -3268,10 +3260,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
 				ev := ctx.Event.(*Event)
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
 				}
 				var results []string
 				iterator := &ProcessAncestorsIterator{}
@@ -3291,10 +3281,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
 				ev := ctx.Event.(*Event)
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
 				}
 				var results []string
 				iterator := &ProcessAncestorsIterator{}
@@ -3313,10 +3301,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "process.ancestors.cap_effective":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -3335,10 +3321,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "process.ancestors.cap_permitted":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -3357,10 +3341,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "process.ancestors.comm":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
 				}
 				var results []string
 				iterator := &ProcessAncestorsIterator{}
@@ -3379,10 +3361,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "process.ancestors.container.id":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
 				}
 				var results []string
 				iterator := &ProcessAncestorsIterator{}
@@ -3401,10 +3381,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "process.ancestors.cookie":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -3424,10 +3402,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
 				ev := ctx.Event.(*Event)
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -3446,10 +3422,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "process.ancestors.egid":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -3468,10 +3442,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "process.ancestors.egroup":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
 				}
 				var results []string
 				iterator := &ProcessAncestorsIterator{}
@@ -3491,10 +3463,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
 				ev := ctx.Event.(*Event)
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
 				}
 				var results []string
 				iterator := &ProcessAncestorsIterator{}
@@ -3514,10 +3484,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
 				ev := ctx.Event.(*Event)
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
 				}
 				var results []string
 				iterator := &ProcessAncestorsIterator{}
@@ -3537,10 +3505,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.BoolArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []bool {
 				ev := ctx.Event.(*Event)
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]bool)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.BoolCache[field]; ok {
+					return result
 				}
 				var results []bool
 				iterator := &ProcessAncestorsIterator{}
@@ -3559,10 +3525,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "process.ancestors.euid":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -3581,10 +3545,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "process.ancestors.euser":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
 				}
 				var results []string
 				iterator := &ProcessAncestorsIterator{}
@@ -3603,10 +3565,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "process.ancestors.file.change_time":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -3631,10 +3591,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
 				ev := ctx.Event.(*Event)
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
 				}
 				var results []string
 				iterator := &ProcessAncestorsIterator{}
@@ -3658,10 +3616,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "process.ancestors.file.gid":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -3686,10 +3642,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
 				ev := ctx.Event.(*Event)
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
 				}
 				var results []string
 				iterator := &ProcessAncestorsIterator{}
@@ -3714,10 +3668,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.BoolArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []bool {
 				ev := ctx.Event.(*Event)
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]bool)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.BoolCache[field]; ok {
+					return result
 				}
 				var results []bool
 				iterator := &ProcessAncestorsIterator{}
@@ -3741,10 +3693,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "process.ancestors.file.inode":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -3768,10 +3718,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "process.ancestors.file.mode":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -3795,10 +3743,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "process.ancestors.file.modification_time":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -3822,10 +3768,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "process.ancestors.file.mount_id":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -3851,10 +3795,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			OpOverrides: ProcessSymlinkBasename,
 			EvalFnc: func(ctx *eval.Context) []string {
 				ev := ctx.Event.(*Event)
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
 				}
 				var results []string
 				iterator := &ProcessAncestorsIterator{}
@@ -3880,10 +3822,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			OpOverrides: ProcessSymlinkBasename,
 			EvalFnc: func(ctx *eval.Context) []int {
 				ev := ctx.Event.(*Event)
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -3904,10 +3844,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			OpOverrides: ProcessSymlinkPathname,
 			EvalFnc: func(ctx *eval.Context) []string {
 				ev := ctx.Event.(*Event)
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
 				}
 				var results []string
 				iterator := &ProcessAncestorsIterator{}
@@ -3933,10 +3871,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			OpOverrides: ProcessSymlinkPathname,
 			EvalFnc: func(ctx *eval.Context) []int {
 				ev := ctx.Event.(*Event)
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -3956,10 +3892,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
 				ev := ctx.Event.(*Event)
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -3983,10 +3917,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "process.ancestors.file.uid":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -4011,10 +3943,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
 				ev := ctx.Event.(*Event)
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
 				}
 				var results []string
 				iterator := &ProcessAncestorsIterator{}
@@ -4038,10 +3968,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "process.ancestors.fsgid":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -4060,10 +3988,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "process.ancestors.fsgroup":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
 				}
 				var results []string
 				iterator := &ProcessAncestorsIterator{}
@@ -4082,10 +4008,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "process.ancestors.fsuid":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -4104,10 +4028,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "process.ancestors.fsuser":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
 				}
 				var results []string
 				iterator := &ProcessAncestorsIterator{}
@@ -4126,10 +4048,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "process.ancestors.gid":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -4148,10 +4068,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "process.ancestors.group":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
 				}
 				var results []string
 				iterator := &ProcessAncestorsIterator{}
@@ -4170,10 +4088,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "process.ancestors.interpreter.file.change_time":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -4198,10 +4114,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
 				ev := ctx.Event.(*Event)
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
 				}
 				var results []string
 				iterator := &ProcessAncestorsIterator{}
@@ -4225,10 +4139,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "process.ancestors.interpreter.file.gid":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -4253,10 +4165,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
 				ev := ctx.Event.(*Event)
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
 				}
 				var results []string
 				iterator := &ProcessAncestorsIterator{}
@@ -4281,10 +4191,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.BoolArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []bool {
 				ev := ctx.Event.(*Event)
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]bool)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.BoolCache[field]; ok {
+					return result
 				}
 				var results []bool
 				iterator := &ProcessAncestorsIterator{}
@@ -4308,10 +4216,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "process.ancestors.interpreter.file.inode":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -4335,10 +4241,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "process.ancestors.interpreter.file.mode":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -4362,10 +4266,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "process.ancestors.interpreter.file.modification_time":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -4389,10 +4291,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "process.ancestors.interpreter.file.mount_id":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -4418,10 +4318,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			OpOverrides: ProcessSymlinkBasename,
 			EvalFnc: func(ctx *eval.Context) []string {
 				ev := ctx.Event.(*Event)
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
 				}
 				var results []string
 				iterator := &ProcessAncestorsIterator{}
@@ -4447,10 +4345,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			OpOverrides: ProcessSymlinkBasename,
 			EvalFnc: func(ctx *eval.Context) []int {
 				ev := ctx.Event.(*Event)
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -4471,10 +4367,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			OpOverrides: ProcessSymlinkPathname,
 			EvalFnc: func(ctx *eval.Context) []string {
 				ev := ctx.Event.(*Event)
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
 				}
 				var results []string
 				iterator := &ProcessAncestorsIterator{}
@@ -4500,10 +4394,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			OpOverrides: ProcessSymlinkPathname,
 			EvalFnc: func(ctx *eval.Context) []int {
 				ev := ctx.Event.(*Event)
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -4523,10 +4415,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
 				ev := ctx.Event.(*Event)
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -4550,10 +4440,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "process.ancestors.interpreter.file.uid":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -4578,10 +4466,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
 				ev := ctx.Event.(*Event)
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
 				}
 				var results []string
 				iterator := &ProcessAncestorsIterator{}
@@ -4605,10 +4491,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "process.ancestors.is_kworker":
 		return &eval.BoolArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []bool {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]bool)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.BoolCache[field]; ok {
+					return result
 				}
 				var results []bool
 				iterator := &ProcessAncestorsIterator{}
@@ -4627,10 +4511,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "process.ancestors.is_thread":
 		return &eval.BoolArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []bool {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]bool)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.BoolCache[field]; ok {
+					return result
 				}
 				var results []bool
 				iterator := &ProcessAncestorsIterator{}
@@ -4649,10 +4531,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "process.ancestors.pid":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -4671,10 +4551,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "process.ancestors.ppid":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -4693,10 +4571,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "process.ancestors.tid":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -4715,10 +4591,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "process.ancestors.tty_name":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
 				}
 				var results []string
 				iterator := &ProcessAncestorsIterator{}
@@ -4737,10 +4611,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "process.ancestors.uid":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -4759,10 +4631,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "process.ancestors.user":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
 				}
 				var results []string
 				iterator := &ProcessAncestorsIterator{}
@@ -6337,10 +6207,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
 				ev := ctx.Event.(*Event)
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
 				}
 				var results []string
 				iterator := &ProcessAncestorsIterator{}
@@ -6360,10 +6228,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
 				ev := ctx.Event.(*Event)
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
 				}
 				var results []string
 				iterator := &ProcessAncestorsIterator{}
@@ -6383,10 +6249,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
 				ev := ctx.Event.(*Event)
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
 				}
 				var results []string
 				iterator := &ProcessAncestorsIterator{}
@@ -6406,10 +6270,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.BoolArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []bool {
 				ev := ctx.Event.(*Event)
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]bool)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.BoolCache[field]; ok {
+					return result
 				}
 				var results []bool
 				iterator := &ProcessAncestorsIterator{}
@@ -6429,10 +6291,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
 				ev := ctx.Event.(*Event)
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
 				}
 				var results []string
 				iterator := &ProcessAncestorsIterator{}
@@ -6452,10 +6312,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
 				ev := ctx.Event.(*Event)
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
 				}
 				var results []string
 				iterator := &ProcessAncestorsIterator{}
@@ -6474,10 +6332,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "ptrace.tracee.ancestors.cap_effective":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -6496,10 +6352,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "ptrace.tracee.ancestors.cap_permitted":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -6518,10 +6372,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "ptrace.tracee.ancestors.comm":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
 				}
 				var results []string
 				iterator := &ProcessAncestorsIterator{}
@@ -6540,10 +6392,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "ptrace.tracee.ancestors.container.id":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
 				}
 				var results []string
 				iterator := &ProcessAncestorsIterator{}
@@ -6562,10 +6412,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "ptrace.tracee.ancestors.cookie":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -6585,10 +6433,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
 				ev := ctx.Event.(*Event)
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -6607,10 +6453,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "ptrace.tracee.ancestors.egid":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -6629,10 +6473,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "ptrace.tracee.ancestors.egroup":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
 				}
 				var results []string
 				iterator := &ProcessAncestorsIterator{}
@@ -6652,10 +6494,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
 				ev := ctx.Event.(*Event)
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
 				}
 				var results []string
 				iterator := &ProcessAncestorsIterator{}
@@ -6675,10 +6515,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
 				ev := ctx.Event.(*Event)
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
 				}
 				var results []string
 				iterator := &ProcessAncestorsIterator{}
@@ -6698,10 +6536,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.BoolArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []bool {
 				ev := ctx.Event.(*Event)
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]bool)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.BoolCache[field]; ok {
+					return result
 				}
 				var results []bool
 				iterator := &ProcessAncestorsIterator{}
@@ -6720,10 +6556,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "ptrace.tracee.ancestors.euid":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -6742,10 +6576,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "ptrace.tracee.ancestors.euser":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
 				}
 				var results []string
 				iterator := &ProcessAncestorsIterator{}
@@ -6764,10 +6596,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "ptrace.tracee.ancestors.file.change_time":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -6792,10 +6622,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
 				ev := ctx.Event.(*Event)
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
 				}
 				var results []string
 				iterator := &ProcessAncestorsIterator{}
@@ -6819,10 +6647,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "ptrace.tracee.ancestors.file.gid":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -6847,10 +6673,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
 				ev := ctx.Event.(*Event)
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
 				}
 				var results []string
 				iterator := &ProcessAncestorsIterator{}
@@ -6875,10 +6699,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.BoolArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []bool {
 				ev := ctx.Event.(*Event)
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]bool)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.BoolCache[field]; ok {
+					return result
 				}
 				var results []bool
 				iterator := &ProcessAncestorsIterator{}
@@ -6902,10 +6724,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "ptrace.tracee.ancestors.file.inode":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -6929,10 +6749,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "ptrace.tracee.ancestors.file.mode":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -6956,10 +6774,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "ptrace.tracee.ancestors.file.modification_time":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -6983,10 +6799,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "ptrace.tracee.ancestors.file.mount_id":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -7012,10 +6826,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			OpOverrides: ProcessSymlinkBasename,
 			EvalFnc: func(ctx *eval.Context) []string {
 				ev := ctx.Event.(*Event)
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
 				}
 				var results []string
 				iterator := &ProcessAncestorsIterator{}
@@ -7041,10 +6853,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			OpOverrides: ProcessSymlinkBasename,
 			EvalFnc: func(ctx *eval.Context) []int {
 				ev := ctx.Event.(*Event)
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -7065,10 +6875,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			OpOverrides: ProcessSymlinkPathname,
 			EvalFnc: func(ctx *eval.Context) []string {
 				ev := ctx.Event.(*Event)
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
 				}
 				var results []string
 				iterator := &ProcessAncestorsIterator{}
@@ -7094,10 +6902,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			OpOverrides: ProcessSymlinkPathname,
 			EvalFnc: func(ctx *eval.Context) []int {
 				ev := ctx.Event.(*Event)
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -7117,10 +6923,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
 				ev := ctx.Event.(*Event)
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -7144,10 +6948,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "ptrace.tracee.ancestors.file.uid":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -7172,10 +6974,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
 				ev := ctx.Event.(*Event)
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
 				}
 				var results []string
 				iterator := &ProcessAncestorsIterator{}
@@ -7199,10 +6999,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "ptrace.tracee.ancestors.fsgid":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -7221,10 +7019,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "ptrace.tracee.ancestors.fsgroup":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
 				}
 				var results []string
 				iterator := &ProcessAncestorsIterator{}
@@ -7243,10 +7039,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "ptrace.tracee.ancestors.fsuid":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -7265,10 +7059,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "ptrace.tracee.ancestors.fsuser":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
 				}
 				var results []string
 				iterator := &ProcessAncestorsIterator{}
@@ -7287,10 +7079,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "ptrace.tracee.ancestors.gid":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -7309,10 +7099,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "ptrace.tracee.ancestors.group":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
 				}
 				var results []string
 				iterator := &ProcessAncestorsIterator{}
@@ -7331,10 +7119,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "ptrace.tracee.ancestors.interpreter.file.change_time":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -7359,10 +7145,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
 				ev := ctx.Event.(*Event)
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
 				}
 				var results []string
 				iterator := &ProcessAncestorsIterator{}
@@ -7386,10 +7170,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "ptrace.tracee.ancestors.interpreter.file.gid":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -7414,10 +7196,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
 				ev := ctx.Event.(*Event)
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
 				}
 				var results []string
 				iterator := &ProcessAncestorsIterator{}
@@ -7442,10 +7222,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.BoolArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []bool {
 				ev := ctx.Event.(*Event)
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]bool)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.BoolCache[field]; ok {
+					return result
 				}
 				var results []bool
 				iterator := &ProcessAncestorsIterator{}
@@ -7469,10 +7247,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "ptrace.tracee.ancestors.interpreter.file.inode":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -7496,10 +7272,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "ptrace.tracee.ancestors.interpreter.file.mode":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -7523,10 +7297,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "ptrace.tracee.ancestors.interpreter.file.modification_time":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -7550,10 +7322,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "ptrace.tracee.ancestors.interpreter.file.mount_id":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -7579,10 +7349,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			OpOverrides: ProcessSymlinkBasename,
 			EvalFnc: func(ctx *eval.Context) []string {
 				ev := ctx.Event.(*Event)
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
 				}
 				var results []string
 				iterator := &ProcessAncestorsIterator{}
@@ -7608,10 +7376,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			OpOverrides: ProcessSymlinkBasename,
 			EvalFnc: func(ctx *eval.Context) []int {
 				ev := ctx.Event.(*Event)
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -7632,10 +7398,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			OpOverrides: ProcessSymlinkPathname,
 			EvalFnc: func(ctx *eval.Context) []string {
 				ev := ctx.Event.(*Event)
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
 				}
 				var results []string
 				iterator := &ProcessAncestorsIterator{}
@@ -7661,10 +7425,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			OpOverrides: ProcessSymlinkPathname,
 			EvalFnc: func(ctx *eval.Context) []int {
 				ev := ctx.Event.(*Event)
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -7684,10 +7446,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
 				ev := ctx.Event.(*Event)
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -7711,10 +7471,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "ptrace.tracee.ancestors.interpreter.file.uid":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -7739,10 +7497,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
 				ev := ctx.Event.(*Event)
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
 				}
 				var results []string
 				iterator := &ProcessAncestorsIterator{}
@@ -7766,10 +7522,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "ptrace.tracee.ancestors.is_kworker":
 		return &eval.BoolArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []bool {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]bool)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.BoolCache[field]; ok {
+					return result
 				}
 				var results []bool
 				iterator := &ProcessAncestorsIterator{}
@@ -7788,10 +7542,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "ptrace.tracee.ancestors.is_thread":
 		return &eval.BoolArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []bool {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]bool)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.BoolCache[field]; ok {
+					return result
 				}
 				var results []bool
 				iterator := &ProcessAncestorsIterator{}
@@ -7810,10 +7562,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "ptrace.tracee.ancestors.pid":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -7832,10 +7582,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "ptrace.tracee.ancestors.ppid":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -7854,10 +7602,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "ptrace.tracee.ancestors.tid":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -7876,10 +7622,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "ptrace.tracee.ancestors.tty_name":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
 				}
 				var results []string
 				iterator := &ProcessAncestorsIterator{}
@@ -7898,10 +7642,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "ptrace.tracee.ancestors.uid":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -7920,10 +7662,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "ptrace.tracee.ancestors.user":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
 				}
 				var results []string
 				iterator := &ProcessAncestorsIterator{}
@@ -10454,10 +10194,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
 				ev := ctx.Event.(*Event)
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
 				}
 				var results []string
 				iterator := &ProcessAncestorsIterator{}
@@ -10477,10 +10215,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
 				ev := ctx.Event.(*Event)
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
 				}
 				var results []string
 				iterator := &ProcessAncestorsIterator{}
@@ -10500,10 +10236,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
 				ev := ctx.Event.(*Event)
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
 				}
 				var results []string
 				iterator := &ProcessAncestorsIterator{}
@@ -10523,10 +10257,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.BoolArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []bool {
 				ev := ctx.Event.(*Event)
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]bool)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.BoolCache[field]; ok {
+					return result
 				}
 				var results []bool
 				iterator := &ProcessAncestorsIterator{}
@@ -10546,10 +10278,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
 				ev := ctx.Event.(*Event)
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
 				}
 				var results []string
 				iterator := &ProcessAncestorsIterator{}
@@ -10569,10 +10299,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
 				ev := ctx.Event.(*Event)
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
 				}
 				var results []string
 				iterator := &ProcessAncestorsIterator{}
@@ -10591,10 +10319,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "signal.target.ancestors.cap_effective":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -10613,10 +10339,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "signal.target.ancestors.cap_permitted":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -10635,10 +10359,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "signal.target.ancestors.comm":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
 				}
 				var results []string
 				iterator := &ProcessAncestorsIterator{}
@@ -10657,10 +10379,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "signal.target.ancestors.container.id":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
 				}
 				var results []string
 				iterator := &ProcessAncestorsIterator{}
@@ -10679,10 +10399,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "signal.target.ancestors.cookie":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -10702,10 +10420,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
 				ev := ctx.Event.(*Event)
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -10724,10 +10440,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "signal.target.ancestors.egid":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -10746,10 +10460,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "signal.target.ancestors.egroup":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
 				}
 				var results []string
 				iterator := &ProcessAncestorsIterator{}
@@ -10769,10 +10481,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
 				ev := ctx.Event.(*Event)
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
 				}
 				var results []string
 				iterator := &ProcessAncestorsIterator{}
@@ -10792,10 +10502,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
 				ev := ctx.Event.(*Event)
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
 				}
 				var results []string
 				iterator := &ProcessAncestorsIterator{}
@@ -10815,10 +10523,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.BoolArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []bool {
 				ev := ctx.Event.(*Event)
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]bool)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.BoolCache[field]; ok {
+					return result
 				}
 				var results []bool
 				iterator := &ProcessAncestorsIterator{}
@@ -10837,10 +10543,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "signal.target.ancestors.euid":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -10859,10 +10563,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "signal.target.ancestors.euser":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
 				}
 				var results []string
 				iterator := &ProcessAncestorsIterator{}
@@ -10881,10 +10583,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "signal.target.ancestors.file.change_time":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -10909,10 +10609,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
 				ev := ctx.Event.(*Event)
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
 				}
 				var results []string
 				iterator := &ProcessAncestorsIterator{}
@@ -10936,10 +10634,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "signal.target.ancestors.file.gid":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -10964,10 +10660,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
 				ev := ctx.Event.(*Event)
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
 				}
 				var results []string
 				iterator := &ProcessAncestorsIterator{}
@@ -10992,10 +10686,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.BoolArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []bool {
 				ev := ctx.Event.(*Event)
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]bool)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.BoolCache[field]; ok {
+					return result
 				}
 				var results []bool
 				iterator := &ProcessAncestorsIterator{}
@@ -11019,10 +10711,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "signal.target.ancestors.file.inode":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -11046,10 +10736,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "signal.target.ancestors.file.mode":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -11073,10 +10761,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "signal.target.ancestors.file.modification_time":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -11100,10 +10786,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "signal.target.ancestors.file.mount_id":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -11129,10 +10813,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			OpOverrides: ProcessSymlinkBasename,
 			EvalFnc: func(ctx *eval.Context) []string {
 				ev := ctx.Event.(*Event)
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
 				}
 				var results []string
 				iterator := &ProcessAncestorsIterator{}
@@ -11158,10 +10840,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			OpOverrides: ProcessSymlinkBasename,
 			EvalFnc: func(ctx *eval.Context) []int {
 				ev := ctx.Event.(*Event)
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -11182,10 +10862,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			OpOverrides: ProcessSymlinkPathname,
 			EvalFnc: func(ctx *eval.Context) []string {
 				ev := ctx.Event.(*Event)
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
 				}
 				var results []string
 				iterator := &ProcessAncestorsIterator{}
@@ -11211,10 +10889,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			OpOverrides: ProcessSymlinkPathname,
 			EvalFnc: func(ctx *eval.Context) []int {
 				ev := ctx.Event.(*Event)
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -11234,10 +10910,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
 				ev := ctx.Event.(*Event)
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -11261,10 +10935,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "signal.target.ancestors.file.uid":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -11289,10 +10961,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
 				ev := ctx.Event.(*Event)
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
 				}
 				var results []string
 				iterator := &ProcessAncestorsIterator{}
@@ -11316,10 +10986,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "signal.target.ancestors.fsgid":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -11338,10 +11006,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "signal.target.ancestors.fsgroup":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
 				}
 				var results []string
 				iterator := &ProcessAncestorsIterator{}
@@ -11360,10 +11026,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "signal.target.ancestors.fsuid":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -11382,10 +11046,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "signal.target.ancestors.fsuser":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
 				}
 				var results []string
 				iterator := &ProcessAncestorsIterator{}
@@ -11404,10 +11066,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "signal.target.ancestors.gid":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -11426,10 +11086,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "signal.target.ancestors.group":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
 				}
 				var results []string
 				iterator := &ProcessAncestorsIterator{}
@@ -11448,10 +11106,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "signal.target.ancestors.interpreter.file.change_time":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -11476,10 +11132,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
 				ev := ctx.Event.(*Event)
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
 				}
 				var results []string
 				iterator := &ProcessAncestorsIterator{}
@@ -11503,10 +11157,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "signal.target.ancestors.interpreter.file.gid":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -11531,10 +11183,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
 				ev := ctx.Event.(*Event)
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
 				}
 				var results []string
 				iterator := &ProcessAncestorsIterator{}
@@ -11559,10 +11209,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.BoolArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []bool {
 				ev := ctx.Event.(*Event)
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]bool)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.BoolCache[field]; ok {
+					return result
 				}
 				var results []bool
 				iterator := &ProcessAncestorsIterator{}
@@ -11586,10 +11234,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "signal.target.ancestors.interpreter.file.inode":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -11613,10 +11259,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "signal.target.ancestors.interpreter.file.mode":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -11640,10 +11284,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "signal.target.ancestors.interpreter.file.modification_time":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -11667,10 +11309,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "signal.target.ancestors.interpreter.file.mount_id":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -11696,10 +11336,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			OpOverrides: ProcessSymlinkBasename,
 			EvalFnc: func(ctx *eval.Context) []string {
 				ev := ctx.Event.(*Event)
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
 				}
 				var results []string
 				iterator := &ProcessAncestorsIterator{}
@@ -11725,10 +11363,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			OpOverrides: ProcessSymlinkBasename,
 			EvalFnc: func(ctx *eval.Context) []int {
 				ev := ctx.Event.(*Event)
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -11749,10 +11385,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			OpOverrides: ProcessSymlinkPathname,
 			EvalFnc: func(ctx *eval.Context) []string {
 				ev := ctx.Event.(*Event)
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
 				}
 				var results []string
 				iterator := &ProcessAncestorsIterator{}
@@ -11778,10 +11412,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			OpOverrides: ProcessSymlinkPathname,
 			EvalFnc: func(ctx *eval.Context) []int {
 				ev := ctx.Event.(*Event)
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -11801,10 +11433,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
 				ev := ctx.Event.(*Event)
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -11828,10 +11458,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "signal.target.ancestors.interpreter.file.uid":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -11856,10 +11484,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
 				ev := ctx.Event.(*Event)
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
 				}
 				var results []string
 				iterator := &ProcessAncestorsIterator{}
@@ -11883,10 +11509,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "signal.target.ancestors.is_kworker":
 		return &eval.BoolArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []bool {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]bool)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.BoolCache[field]; ok {
+					return result
 				}
 				var results []bool
 				iterator := &ProcessAncestorsIterator{}
@@ -11905,10 +11529,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "signal.target.ancestors.is_thread":
 		return &eval.BoolArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []bool {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]bool)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.BoolCache[field]; ok {
+					return result
 				}
 				var results []bool
 				iterator := &ProcessAncestorsIterator{}
@@ -11927,10 +11549,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "signal.target.ancestors.pid":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -11949,10 +11569,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "signal.target.ancestors.ppid":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -11971,10 +11589,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "signal.target.ancestors.tid":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -11993,10 +11609,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "signal.target.ancestors.tty_name":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
 				}
 				var results []string
 				iterator := &ProcessAncestorsIterator{}
@@ -12015,10 +11629,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "signal.target.ancestors.uid":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
 				}
 				var results []int
 				iterator := &ProcessAncestorsIterator{}
@@ -12037,10 +11649,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "signal.target.ancestors.user":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
 				}
 				var results []string
 				iterator := &ProcessAncestorsIterator{}

--- a/pkg/security/secl/model/accessors.go
+++ b/pkg/security/secl/model/accessors.go
@@ -3265,7 +3265,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.BoolCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -3333,7 +3333,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -3355,7 +3355,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -3421,7 +3421,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -3444,7 +3444,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -3466,7 +3466,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -3557,7 +3557,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.BoolCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -3579,7 +3579,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -3628,7 +3628,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -3683,7 +3683,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -3739,7 +3739,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.BoolCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -3766,7 +3766,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -3793,7 +3793,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -3820,7 +3820,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -3847,7 +3847,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -3900,7 +3900,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -3953,7 +3953,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -3981,7 +3981,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -4008,7 +4008,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -4058,7 +4058,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -4102,7 +4102,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -4146,7 +4146,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -4195,7 +4195,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -4250,7 +4250,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -4306,7 +4306,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.BoolCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -4333,7 +4333,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -4360,7 +4360,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -4387,7 +4387,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -4414,7 +4414,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -4467,7 +4467,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -4520,7 +4520,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -4548,7 +4548,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -4575,7 +4575,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -4625,7 +4625,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.BoolCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -4647,7 +4647,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.BoolCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -4669,7 +4669,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -4691,7 +4691,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -4713,7 +4713,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -4757,7 +4757,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -6426,7 +6426,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.BoolCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -6494,7 +6494,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -6516,7 +6516,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -6582,7 +6582,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -6605,7 +6605,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -6627,7 +6627,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -6718,7 +6718,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.BoolCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -6740,7 +6740,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -6789,7 +6789,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -6844,7 +6844,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -6900,7 +6900,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.BoolCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -6927,7 +6927,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -6954,7 +6954,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -6981,7 +6981,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -7008,7 +7008,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -7061,7 +7061,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -7114,7 +7114,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -7142,7 +7142,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -7169,7 +7169,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -7219,7 +7219,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -7263,7 +7263,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -7307,7 +7307,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -7356,7 +7356,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -7411,7 +7411,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -7467,7 +7467,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.BoolCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -7494,7 +7494,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -7521,7 +7521,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -7548,7 +7548,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -7575,7 +7575,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -7628,7 +7628,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -7681,7 +7681,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -7709,7 +7709,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -7736,7 +7736,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -7786,7 +7786,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.BoolCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -7808,7 +7808,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.BoolCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -7830,7 +7830,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -7852,7 +7852,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -7874,7 +7874,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -7918,7 +7918,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -10543,7 +10543,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.BoolCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -10611,7 +10611,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -10633,7 +10633,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -10699,7 +10699,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -10722,7 +10722,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -10744,7 +10744,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -10835,7 +10835,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.BoolCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -10857,7 +10857,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -10906,7 +10906,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -10961,7 +10961,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -11017,7 +11017,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.BoolCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -11044,7 +11044,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -11071,7 +11071,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -11098,7 +11098,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -11125,7 +11125,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -11178,7 +11178,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -11231,7 +11231,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -11259,7 +11259,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -11286,7 +11286,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -11336,7 +11336,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -11380,7 +11380,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -11424,7 +11424,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -11473,7 +11473,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -11528,7 +11528,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -11584,7 +11584,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.BoolCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -11611,7 +11611,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -11638,7 +11638,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -11665,7 +11665,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -11692,7 +11692,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -11745,7 +11745,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -11798,7 +11798,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -11826,7 +11826,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -11853,7 +11853,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -11903,7 +11903,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.BoolCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -11925,7 +11925,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.BoolCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -11947,7 +11947,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -11969,7 +11969,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -11991,7 +11991,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -12035,7 +12035,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.IntCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,

--- a/pkg/security/secl/model/accessors.go
+++ b/pkg/security/secl/model/accessors.go
@@ -3196,7 +3196,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.StringCache[field] = results
 				return results
 			}, Field: field,
 			Weight: 100 * eval.IteratorWeight,
@@ -3219,7 +3219,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result...)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.StringCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -3242,7 +3242,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result...)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.StringCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -3288,7 +3288,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result...)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.StringCache[field] = results
 				return results
 			}, Field: field,
 			Weight: 100 * eval.IteratorWeight,
@@ -3311,7 +3311,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.StringCache[field] = results
 				return results
 			}, Field: field,
 			Weight: 100 * eval.IteratorWeight,
@@ -3377,7 +3377,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.StringCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -3399,7 +3399,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.StringCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -3488,7 +3488,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.StringCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -3511,7 +3511,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result...)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.StringCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -3534,7 +3534,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result...)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.StringCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -3601,7 +3601,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.StringCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -3656,7 +3656,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.StringCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -3711,7 +3711,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.StringCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -3876,7 +3876,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.StringCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -3929,7 +3929,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.StringCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -4036,7 +4036,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.StringCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -4080,7 +4080,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.StringCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -4124,7 +4124,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.StringCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -4168,7 +4168,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.StringCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -4223,7 +4223,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.StringCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -4278,7 +4278,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.StringCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -4443,7 +4443,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.StringCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -4496,7 +4496,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.StringCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -4603,7 +4603,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.StringCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -4735,7 +4735,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.StringCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -4779,7 +4779,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.StringCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -6357,7 +6357,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.StringCache[field] = results
 				return results
 			}, Field: field,
 			Weight: 100 * eval.IteratorWeight,
@@ -6380,7 +6380,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result...)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.StringCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -6403,7 +6403,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result...)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.StringCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -6449,7 +6449,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result...)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.StringCache[field] = results
 				return results
 			}, Field: field,
 			Weight: 100 * eval.IteratorWeight,
@@ -6472,7 +6472,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.StringCache[field] = results
 				return results
 			}, Field: field,
 			Weight: 100 * eval.IteratorWeight,
@@ -6538,7 +6538,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.StringCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -6560,7 +6560,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.StringCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -6649,7 +6649,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.StringCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -6672,7 +6672,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result...)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.StringCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -6695,7 +6695,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result...)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.StringCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -6762,7 +6762,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.StringCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -6817,7 +6817,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.StringCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -6872,7 +6872,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.StringCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -7037,7 +7037,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.StringCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -7090,7 +7090,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.StringCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -7197,7 +7197,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.StringCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -7241,7 +7241,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.StringCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -7285,7 +7285,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.StringCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -7329,7 +7329,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.StringCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -7384,7 +7384,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.StringCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -7439,7 +7439,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.StringCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -7604,7 +7604,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.StringCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -7657,7 +7657,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.StringCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -7764,7 +7764,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.StringCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -7896,7 +7896,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.StringCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -7940,7 +7940,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.StringCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -10474,7 +10474,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.StringCache[field] = results
 				return results
 			}, Field: field,
 			Weight: 100 * eval.IteratorWeight,
@@ -10497,7 +10497,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result...)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.StringCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -10520,7 +10520,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result...)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.StringCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -10566,7 +10566,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result...)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.StringCache[field] = results
 				return results
 			}, Field: field,
 			Weight: 100 * eval.IteratorWeight,
@@ -10589,7 +10589,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.StringCache[field] = results
 				return results
 			}, Field: field,
 			Weight: 100 * eval.IteratorWeight,
@@ -10655,7 +10655,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.StringCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -10677,7 +10677,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.StringCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -10766,7 +10766,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.StringCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -10789,7 +10789,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result...)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.StringCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -10812,7 +10812,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result...)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.StringCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -10879,7 +10879,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.StringCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -10934,7 +10934,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.StringCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -10989,7 +10989,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.StringCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -11154,7 +11154,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.StringCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -11207,7 +11207,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.StringCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -11314,7 +11314,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.StringCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -11358,7 +11358,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.StringCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -11402,7 +11402,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.StringCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -11446,7 +11446,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.StringCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -11501,7 +11501,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.StringCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -11556,7 +11556,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.StringCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -11721,7 +11721,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.StringCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -11774,7 +11774,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.StringCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -11881,7 +11881,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.StringCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -12013,7 +12013,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.StringCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,
@@ -12057,7 +12057,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					results = append(results, result)
 					value = iterator.Next()
 				}
-				ctx.Cache[field] = unsafe.Pointer(&results)
+				ctx.StringCache[field] = results
 				return results
 			}, Field: field,
 			Weight: eval.IteratorWeight,

--- a/pkg/security/secl/model/accessors.go
+++ b/pkg/security/secl/model/accessors.go
@@ -5,12 +5,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 	"net"
 	"reflect"
-	"unsafe"
-)
-
-// suppress unused package warning
-var (
-	_ *unsafe.Pointer
 )
 
 func (m *Model) GetIterator(field eval.Field) (eval.Iterator, error) {


### PR DESCRIPTION
### What does this PR do?

One of the last real big unsafe code block in `pkg/security`. This PR trades off a bit of duplication (maintain 3 caches instead of one) for a lot of unsafe code. And this without resorting to reflect/interfaces.
 
### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
