### PR TITLE
[kitchen] Fix CWS integration tests on CentOS step-by-step tests

### DIFF
--- a/test/kitchen/site-cookbooks/dd-agent-install-script/recipes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-agent-install-script/recipes/default.rb
@@ -71,7 +71,7 @@ if platform?('centos') && node['dd-agent-rspec'] && node['dd-agent-rspec']['enab
   # TODO(lebauce): enable repositories to install package
   # package 'policycoreutils-python'
 
-  execute 'disable SElinux to be able to start system-probe' do
+  execute 'set SElinux to permissive mode to be able to start system-probe' do
     command "setenforce 0"
   end
 end

--- a/test/kitchen/site-cookbooks/dd-agent-step-by-step/recipes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-agent-step-by-step/recipes/default.rb
@@ -39,6 +39,15 @@ when 'debian'
   end
 
 when 'rhel'
+  if platform?('centos') && node['dd-agent-rspec'] && node['dd-agent-rspec']['enable_cws']
+    # TODO(lebauce): enable repositories to install package
+    # package 'policycoreutils-python'
+
+    execute 'disable SElinux to be able to start system-probe' do
+      command "setenforce 0"
+    end
+  end
+
   protocol = node['platform_version'].to_i < 6 ? 'http' : 'https'
   # Because of https://bugzilla.redhat.com/show_bug.cgi?id=1792506, we disable
   # repo_gpgcheck on RHEL/CentOS < 8.2

--- a/test/kitchen/site-cookbooks/dd-agent-step-by-step/recipes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-agent-step-by-step/recipes/default.rb
@@ -43,7 +43,7 @@ when 'rhel'
     # TODO(lebauce): enable repositories to install package
     # package 'policycoreutils-python'
 
-    execute 'disable SElinux to be able to start system-probe' do
+    execute 'set SElinux to permissive mode to be able to start system-probe' do
       command "setenforce 0"
     end
   end


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Follow-up of https://github.com/DataDog/datadog-agent/pull/14146, applies the SELinux fix (from the install script cookbook) to the step-by-step cookbook, to make sure system-probe works correctly on CentOS 7 (which has SELinux enabled by default).

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Fix step-by-step CentOS tests.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

n/a

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

n/a

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

n/a

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
