### PR TITLE
pkg/clusteragent/admission: fix rc tracking annotations on deployments

### DIFF
--- a/pkg/clusteragent/admission/common/const.go
+++ b/pkg/clusteragent/admission/common/const.go
@@ -21,9 +21,9 @@ const (
 	// LibConfigV1AnnotKeyFormat is the format of the library config annotation
 	LibConfigV1AnnotKeyFormat = "admission.datadoghq.com/%s-lib.config.v1"
 
-	// RcIDAnnotKey is the format of the RC ID annotation
-	RcIDAnnotKeyFormat = "admission.datadoghq.com/%s-lib.rc.id"
+	// RcIDAnnotKey is the key of the RC ID annotation
+	RcIDAnnotKey = "admission.datadoghq.com/rc.id"
 
-	// RcRevisionAnnotKey is the format of the RC revision annotation
-	RcRevisionAnnotKeyFormat = "admission.datadoghq.com/%s-lib.rc.rev"
+	// RcRevisionAnnotKey is the key of the RC revision annotation
+	RcRevisionAnnotKey = "admission.datadoghq.com/rc.rev"
 )

--- a/pkg/clusteragent/admission/patch/patcher.go
+++ b/pkg/clusteragent/admission/patch/patcher.go
@@ -65,13 +65,11 @@ func (p *patcher) patchDeployment(req PatchRequest) error {
 	if err != nil {
 		return fmt.Errorf("failed to encode object: %v", err)
 	}
-	rcIDAnnotKey := fmt.Sprintf(common.RcIDAnnotKeyFormat, req.LibConfig.Language)
-	rcRevAnnotKey := fmt.Sprintf(common.RcRevisionAnnotKeyFormat, req.LibConfig.Language)
 	revision := fmt.Sprint(req.Revision)
 	if deploy.Annotations == nil {
 		deploy.Annotations = make(map[string]string)
 	}
-	if deploy.Annotations[rcIDAnnotKey] == req.ID && deploy.Annotations[rcRevAnnotKey] == revision {
+	if deploy.Annotations[common.RcIDAnnotKey] == req.ID && deploy.Annotations[common.RcRevisionAnnotKey] == revision {
 		log.Infof("Remote Config ID %q with revision %q has already been applied to object %s, skipping", req.ID, revision, req.K8sTarget)
 		return nil
 	}
@@ -86,8 +84,8 @@ func (p *patcher) patchDeployment(req PatchRequest) error {
 	default:
 		return fmt.Errorf("unknown action %q", req.Action)
 	}
-	deploy.Annotations[rcIDAnnotKey] = req.ID
-	deploy.Annotations[rcRevAnnotKey] = revision
+	deploy.Annotations[common.RcIDAnnotKey] = req.ID
+	deploy.Annotations[common.RcRevisionAnnotKey] = revision
 	newObj, err := json.Marshal(deploy)
 	if err != nil {
 		return fmt.Errorf("failed to encode object: %v", err)

--- a/pkg/clusteragent/admission/patch/patcher_test.go
+++ b/pkg/clusteragent/admission/patch/patcher_test.go
@@ -55,8 +55,8 @@ func TestPatchDeployment(t *testing.T) {
 	require.Equal(t, got.Spec.Template.Labels["admission.datadoghq.com/enabled"], "true")
 	require.Equal(t, got.Spec.Template.Annotations["admission.datadoghq.com/java-lib.version"], "latest")
 	require.Equal(t, got.Spec.Template.Annotations["admission.datadoghq.com/java-lib.config.v1"], `{"library_language":"java","library_version":"latest"}`)
-	require.Equal(t, got.Annotations["admission.datadoghq.com/java-lib.rc.id"], "id")
-	require.Equal(t, got.Annotations["admission.datadoghq.com/java-lib.rc.rev"], "123")
+	require.Equal(t, got.Annotations["admission.datadoghq.com/rc.id"], "id")
+	require.Equal(t, got.Annotations["admission.datadoghq.com/rc.rev"], "123")
 
 	// Patch again to disable lib injection (aka revert)
 	req.Action = DisableConfig
@@ -69,8 +69,8 @@ func TestPatchDeployment(t *testing.T) {
 	require.Equal(t, got.Spec.Template.Labels["admission.datadoghq.com/enabled"], "false")
 	require.NotContains(t, got.Spec.Template.Annotations, "admission.datadoghq.com/java-lib.version")
 	require.NotContains(t, got.Spec.Template.Annotations, "admission.datadoghq.com/java-lib.config.v1")
-	require.Equal(t, got.Annotations["admission.datadoghq.com/java-lib.rc.id"], "id")
-	require.Equal(t, got.Annotations["admission.datadoghq.com/java-lib.rc.rev"], "1234")
+	require.Equal(t, got.Annotations["admission.datadoghq.com/rc.id"], "id")
+	require.Equal(t, got.Annotations["admission.datadoghq.com/rc.rev"], "1234")
 
 	// Apply a new patch with a new config
 	req.Action = EnableConfig
@@ -84,6 +84,6 @@ func TestPatchDeployment(t *testing.T) {
 	require.Equal(t, got.Spec.Template.Labels["admission.datadoghq.com/enabled"], "true")
 	require.Equal(t, got.Spec.Template.Annotations["admission.datadoghq.com/java-lib.version"], "latest")
 	require.Equal(t, got.Spec.Template.Annotations["admission.datadoghq.com/java-lib.config.v1"], `{"library_language":"java","library_version":"latest","tracing_tags":["k1:v1","k2:v2"]}`)
-	require.Equal(t, got.Annotations["admission.datadoghq.com/java-lib.rc.id"], "id")
-	require.Equal(t, got.Annotations["admission.datadoghq.com/java-lib.rc.rev"], "12345")
+	require.Equal(t, got.Annotations["admission.datadoghq.com/rc.id"], "id")
+	require.Equal(t, got.Annotations["admission.datadoghq.com/rc.rev"], "12345")
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

RC ID and Rev annotations are not language specific.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

One RC config per k8s object.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Check the deploy annotations applied by the patcher, make sure lang-lib substring is not included.

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
