### PR TITLE
[CWS] force DNS resolver to read `/etc/resolv.conf`

### DIFF
--- a/pkg/security/tests/network_test.go
+++ b/pkg/security/tests/network_test.go
@@ -36,7 +36,7 @@ func TestNetworkCIDR(t *testing.T) {
 	}
 
 	// write the rules using the local resolv.conf file
-	resolvFile, err := resolvconf.Get()
+	resolvFile, err := resolvconf.GetSpecific("/etc/resolv.conf")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
### What does this PR do?

https://github.com/DataDog/datadog-agent/pull/15139 moved the dependency used to read the DNS resolver CIDRs to a new version. This new version reads a different file when systemd-resolver is used https://github.com/moby/moby/blob/cba986b340906e5718ad8496d3b4cb4207d92b62/libnetwork/resolvconf/resolvconf.go#L44 instead of only `/etc/resolv.conf` like before. This PR reverts to only reading resolv.conf to fix the test

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
