### PR TITLE
pkg/clusteragent/admission/patch: make file provider ready for e2e testing

### DIFF
--- a/pkg/clusteragent/admission/patch/file_provider.go
+++ b/pkg/clusteragent/admission/patch/file_provider.go
@@ -28,9 +28,9 @@ type filePatchProvider struct {
 
 var _ patchProvider = &filePatchProvider{}
 
-func newfileProvider(isLeaderNotif <-chan struct{}, clusterName string) *filePatchProvider {
+func newfileProvider(file string, isLeaderNotif <-chan struct{}, clusterName string) *filePatchProvider {
 	return &filePatchProvider{
-		file:          "/etc/datadog-agent/auto-instru.json",
+		file:          file,
 		isLeaderNotif: isLeaderNotif,
 		pollInterval:  15 * time.Second,
 		subscribers:   make(map[TargetObjKind]chan PatchRequest),
@@ -45,7 +45,7 @@ func (fpp *filePatchProvider) subscribe(kind TargetObjKind) chan PatchRequest {
 }
 
 func (fpp *filePatchProvider) start(stopCh <-chan struct{}) {
-	log.Info("Starting file patch provider")
+	log.Infof("Starting file patch provider: watching %s", fpp.file)
 	ticker := time.NewTicker(fpp.pollInterval)
 	defer ticker.Stop()
 	for {

--- a/pkg/clusteragent/admission/patch/file_provider.go
+++ b/pkg/clusteragent/admission/patch/file_provider.go
@@ -19,6 +19,7 @@ import (
 // filePatchProvider this is a stub and will be used for e2e testing only
 type filePatchProvider struct {
 	file                  string
+	isLeaderNotif         <-chan struct{}
 	pollInterval          time.Duration
 	subscribers           map[TargetObjKind]chan PatchRequest
 	lastSuccessfulRefresh time.Time
@@ -27,12 +28,13 @@ type filePatchProvider struct {
 
 var _ patchProvider = &filePatchProvider{}
 
-func newfileProvider(clusterName string) *filePatchProvider {
+func newfileProvider(isLeaderNotif <-chan struct{}, clusterName string) *filePatchProvider {
 	return &filePatchProvider{
-		file:         "/etc/datadog-agent/auto-instru.json",
-		pollInterval: 15 * time.Second,
-		subscribers:  make(map[TargetObjKind]chan PatchRequest),
-		clusterName:  clusterName,
+		file:          "/etc/datadog-agent/auto-instru.json",
+		isLeaderNotif: isLeaderNotif,
+		pollInterval:  15 * time.Second,
+		subscribers:   make(map[TargetObjKind]chan PatchRequest),
+		clusterName:   clusterName,
 	}
 }
 
@@ -43,48 +45,52 @@ func (fpp *filePatchProvider) subscribe(kind TargetObjKind) chan PatchRequest {
 }
 
 func (fpp *filePatchProvider) start(stopCh <-chan struct{}) {
+	log.Info("Starting file patch provider")
 	ticker := time.NewTicker(fpp.pollInterval)
 	defer ticker.Stop()
 	for {
 		select {
+		case <-fpp.isLeaderNotif:
+			log.Info("Got a leader notification, polling from file")
+			fpp.process(true)
 		case <-ticker.C:
-			if err := fpp.refresh(); err != nil {
-				log.Errorf(err.Error())
-			}
+			fpp.process(false)
 		case <-stopCh:
-			log.Info("Shutting down patch provider")
+			log.Info("Shutting down file patch provider")
 			return
 		}
 	}
 }
 
-func (fpp *filePatchProvider) refresh() error {
-	requests, err := fpp.poll()
+func (fpp *filePatchProvider) process(forcePoll bool) {
+	requests, err := fpp.poll(forcePoll)
 	if err != nil {
-		return err
+		log.Errorf("Error refreshing patch requests: %v", err)
+		return
 	}
-	log.Debugf("Got %d new patch requests", len(requests))
+	if len(requests) == 0 {
+		return
+	}
+	log.Infof("Got %d updates from local file", len(requests))
 	for _, req := range requests {
 		if err := req.Validate(fpp.clusterName); err != nil {
 			log.Errorf("Skipping invalid patch request: %s", err)
 			continue
 		}
 		if ch, found := fpp.subscribers[req.K8sTarget.Kind]; found {
-			log.Infof("Publishing patch requests for target %s", req.K8sTarget)
+			log.Infof("Publishing patch request for target %s", req.K8sTarget)
 			ch <- req
 		}
 	}
 	fpp.lastSuccessfulRefresh = time.Now()
-	return nil
 }
 
-func (fpp *filePatchProvider) poll() ([]PatchRequest, error) {
+func (fpp *filePatchProvider) poll(forcePoll bool) ([]PatchRequest, error) {
 	info, err := os.Stat(fpp.file)
 	if err != nil {
 		return nil, err
 	}
-	modTime := info.ModTime()
-	if fpp.lastSuccessfulRefresh.After(modTime) {
+	if !forcePoll && fpp.lastSuccessfulRefresh.After(info.ModTime()) {
 		log.Debugf("File %q hasn't changed since the last Successful refresh at %v", fpp.file, fpp.lastSuccessfulRefresh)
 		return []PatchRequest{}, nil
 	}

--- a/pkg/clusteragent/admission/patch/file_provider_test.go
+++ b/pkg/clusteragent/admission/patch/file_provider_test.go
@@ -1,0 +1,34 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+// +build kubeapiserver
+
+package patch
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFileProviderProcess(t *testing.T) {
+	fpp := newfileProvider(make(chan struct{}), "dev")
+	fpp.file = "testdata/auto-instru.json"
+	notifs := fpp.subscribe(KindDeployment)
+	fpp.process(false)
+	require.Len(t, notifs, 1)
+	pr := <-notifs
+	require.Equal(t, "11777398274940883091", pr.ID)
+	require.Equal(t, int64(1674236639474287600), pr.Revision)
+	require.Equal(t, "v1.0.0", pr.SchemaVersion)
+	require.Equal(t, "java", pr.LibConfig.Language)
+	require.Equal(t, "v1.4.0", pr.LibConfig.Version)
+	require.Equal(t, "dev", pr.K8sTarget.Cluster)
+	require.Equal(t, KindDeployment, pr.K8sTarget.Kind)
+	require.Equal(t, "my-java-service", pr.K8sTarget.Name)
+	require.Equal(t, "default", pr.K8sTarget.Namespace)
+	require.Len(t, notifs, 0)
+}

--- a/pkg/clusteragent/admission/patch/file_provider_test.go
+++ b/pkg/clusteragent/admission/patch/file_provider_test.go
@@ -15,8 +15,7 @@ import (
 )
 
 func TestFileProviderProcess(t *testing.T) {
-	fpp := newfileProvider(make(chan struct{}), "dev")
-	fpp.file = "testdata/auto-instru.json"
+	fpp := newfileProvider("testdata/auto-instru.json", make(chan struct{}), "dev")
 	notifs := fpp.subscribe(KindDeployment)
 	fpp.process(false)
 	require.Len(t, notifs, 1)

--- a/pkg/clusteragent/admission/patch/provider.go
+++ b/pkg/clusteragent/admission/patch/provider.go
@@ -26,7 +26,8 @@ func newPatchProvider(rcClient *remote.Client, isLeaderNotif <-chan struct{}, cl
 	}
 	if config.Datadog.GetBool("admission_controller.auto_instrumentation.patcher.fallback_to_file_provider") {
 		// Use the file config provider for e2e testing only (it replaces RC as a source of configs)
-		return newfileProvider(isLeaderNotif, clusterName), nil
+		file := config.Datadog.GetString("admission_controller.auto_instrumentation.patcher.file_provider_path")
+		return newfileProvider(file, isLeaderNotif, clusterName), nil
 	}
 	return nil, errors.New("remote config is disabled")
 }

--- a/pkg/clusteragent/admission/patch/provider.go
+++ b/pkg/clusteragent/admission/patch/provider.go
@@ -26,7 +26,7 @@ func newPatchProvider(rcClient *remote.Client, isLeaderNotif <-chan struct{}, cl
 	}
 	if config.Datadog.GetBool("admission_controller.auto_instrumentation.patcher.fallback_to_file_provider") {
 		// Use the file config provider for e2e testing only (it replaces RC as a source of configs)
-		return newfileProvider(clusterName), nil
+		return newfileProvider(isLeaderNotif, clusterName), nil
 	}
 	return nil, errors.New("remote config is disabled")
 }

--- a/pkg/clusteragent/admission/patch/testdata/auto-instru.json
+++ b/pkg/clusteragent/admission/patch/testdata/auto-instru.json
@@ -1,0 +1,20 @@
+[
+    {
+        "id": "11777398274940883091",
+        "revision": 1674236639474287600,
+        "schema_version": "v1.0.0",
+        "action": "enable",
+        "lib_config": {
+            "library_language": "java",
+            "library_version": "v1.4.0",
+            "service_name": "my-java-service",
+            "env": "dev"
+        },
+        "k8s_target": {
+            "cluster": "dev",
+            "kind": "deployment",
+            "name": "my-java-service",
+            "namespace": "default"
+        }
+    }
+]

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1025,7 +1025,8 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("admission_controller.auto_instrumentation.endpoint", "/injectlib")
 	config.BindEnvAndSetDefault("admission_controller.auto_instrumentation.container_registry", "gcr.io/datadoghq")
 	config.BindEnvAndSetDefault("admission_controller.auto_instrumentation.patcher.enabled", false)
-	config.BindEnvAndSetDefault("admission_controller.auto_instrumentation.patcher.fallback_to_file_provider", false) // to be enabled only in e2e tests
+	config.BindEnvAndSetDefault("admission_controller.auto_instrumentation.patcher.fallback_to_file_provider", false)                                // to be enabled only in e2e tests
+	config.BindEnvAndSetDefault("admission_controller.auto_instrumentation.patcher.file_provider_path", "/etc/datadog-agent/patch/auto-instru.json") // to be used only in e2e tests
 
 	// Telemetry
 	// Enable telemetry metrics on the internals of the Agent.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

- Align file provider with the RC provider
- Add unit tests

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

File provider will be leveraged for e2e testing (act as a stub for RC)
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
