### PR TITLE
[Admission Controller] Mount the UDS socket in readonly mode

### DIFF
--- a/pkg/clusteragent/admission/mutate/config.go
+++ b/pkg/clusteragent/admission/mutate/config.go
@@ -99,7 +99,7 @@ func injectConfig(pod *corev1.Pod, _ string, _ dynamic.Interface) error {
 	case service:
 		injectedConfig = injectEnv(pod, agentServiceEnvVar)
 	case socket:
-		volume, volumeMount := buildVolume(datadogVolumeName, config.Datadog.GetString("admission_controller.inject_config.socket_path"), true)
+		volume, volumeMount := buildVolume(datadogVolumeName, config.Datadog.GetString("admission_controller.inject_config.socket_path"))
 		injectedVol := injectVolume(pod, volume, volumeMount)
 		injectedEnv := injectEnv(pod, traceURLEnvVar)
 		injectedConfig = injectedEnv || injectedVol
@@ -146,7 +146,7 @@ func injectionMode(pod *corev1.Pod, globalMode string) string {
 	return globalMode
 }
 
-func buildVolume(volumeName, path string, readOnly bool) (corev1.Volume, corev1.VolumeMount) {
+func buildVolume(volumeName, path string) (corev1.Volume, corev1.VolumeMount) {
 	pathType := corev1.HostPathDirectoryOrCreate
 	volume := corev1.Volume{
 		Name: volumeName,
@@ -161,7 +161,6 @@ func buildVolume(volumeName, path string, readOnly bool) (corev1.Volume, corev1.
 	volumeMount := corev1.VolumeMount{
 		Name:      volumeName,
 		MountPath: path,
-		ReadOnly:  readOnly,
 	}
 
 	return volume, volumeMount

--- a/pkg/clusteragent/admission/mutate/config.go
+++ b/pkg/clusteragent/admission/mutate/config.go
@@ -99,7 +99,7 @@ func injectConfig(pod *corev1.Pod, _ string, _ dynamic.Interface) error {
 	case service:
 		injectedConfig = injectEnv(pod, agentServiceEnvVar)
 	case socket:
-		volume, volumeMount := buildVolume(datadogVolumeName, config.Datadog.GetString("admission_controller.inject_config.socket_path"))
+		volume, volumeMount := buildVolume(datadogVolumeName, config.Datadog.GetString("admission_controller.inject_config.socket_path"), true)
 		injectedVol := injectVolume(pod, volume, volumeMount)
 		injectedEnv := injectEnv(pod, traceURLEnvVar)
 		injectedConfig = injectedEnv || injectedVol
@@ -146,7 +146,7 @@ func injectionMode(pod *corev1.Pod, globalMode string) string {
 	return globalMode
 }
 
-func buildVolume(volumeName, path string) (corev1.Volume, corev1.VolumeMount) {
+func buildVolume(volumeName, path string, readOnly bool) (corev1.Volume, corev1.VolumeMount) {
 	pathType := corev1.HostPathDirectoryOrCreate
 	volume := corev1.Volume{
 		Name: volumeName,
@@ -161,6 +161,7 @@ func buildVolume(volumeName, path string) (corev1.Volume, corev1.VolumeMount) {
 	volumeMount := corev1.VolumeMount{
 		Name:      volumeName,
 		MountPath: path,
+		ReadOnly:  readOnly,
 	}
 
 	return volume, volumeMount

--- a/pkg/clusteragent/admission/mutate/config.go
+++ b/pkg/clusteragent/admission/mutate/config.go
@@ -1,10 +1,11 @@
-//go:build kubeapiserver
-// +build kubeapiserver
-
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+// +build kubeapiserver
+
 package mutate
 
 import (
@@ -18,6 +19,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config"
 	apiCommon "github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/common"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/dynamic"
 )
@@ -27,10 +29,12 @@ const (
 	agentHostEnvVarName  = "DD_AGENT_HOST"
 	ddEntityIDEnvVarName = "DD_ENTITY_ID"
 	traceURLEnvVarName   = "DD_TRACE_AGENT_URL"
+
 	// Config injection modes
 	hostIP  = "hostip"
 	socket  = "socket"
 	service = "service"
+
 	// Volume name
 	datadogVolumeName = "datadog"
 )
@@ -45,6 +49,7 @@ var (
 			},
 		},
 	}
+
 	ddEntityIDEnvVar = corev1.EnvVar{
 		Name:  ddEntityIDEnvVarName,
 		Value: "",
@@ -54,10 +59,12 @@ var (
 			},
 		},
 	}
+
 	traceURLEnvVar = corev1.EnvVar{
 		Name:  traceURLEnvVarName,
 		Value: config.Datadog.GetString("admission_controller.inject_config.trace_agent_socket"),
 	}
+
 	agentServiceEnvVar = corev1.EnvVar{
 		Name:  agentHostEnvVarName,
 		Value: config.Datadog.GetString("admission_controller.inject_config.local_service_name") + "." + apiCommon.GetMyNamespace() + ".svc.cluster.local",
@@ -75,13 +82,16 @@ func injectConfig(pod *corev1.Pod, _ string, _ dynamic.Interface) error {
 	defer func() {
 		metrics.MutationAttempts.Inc(metrics.ConfigMutationType, strconv.FormatBool(injectedConfig || injectedEntity))
 	}()
+
 	if pod == nil {
 		metrics.MutationErrors.Inc(metrics.ConfigMutationType, "nil pod")
 		return errors.New("cannot inject config into nil pod")
 	}
+
 	if !shouldInjectConf(pod) {
 		return nil
 	}
+
 	mode := injectionMode(pod, config.Datadog.GetString("admission_controller.inject_config.mode"))
 	switch mode {
 	case hostIP:
@@ -97,7 +107,9 @@ func injectConfig(pod *corev1.Pod, _ string, _ dynamic.Interface) error {
 		metrics.MutationErrors.Inc(metrics.ConfigMutationType, "unknown mode")
 		return fmt.Errorf("invalid injection mode %q", mode)
 	}
+
 	injectedEntity = injectEnv(pod, ddEntityIDEnvVar)
+
 	return nil
 }
 
@@ -130,8 +142,10 @@ func injectionMode(pod *corev1.Pod, globalMode string) string {
 			return globalMode
 		}
 	}
+
 	return globalMode
 }
+
 func buildVolume(volumeName, path string, readOnly bool) (corev1.Volume, corev1.VolumeMount) {
 	pathType := corev1.HostPathDirectoryOrCreate
 	volume := corev1.Volume{
@@ -143,10 +157,12 @@ func buildVolume(volumeName, path string, readOnly bool) (corev1.Volume, corev1.
 			},
 		},
 	}
+
 	volumeMount := corev1.VolumeMount{
 		Name:      volumeName,
 		MountPath: path,
 		ReadOnly:  readOnly,
 	}
+
 	return volume, volumeMount
 }

--- a/pkg/clusteragent/admission/mutate/config_test.go
+++ b/pkg/clusteragent/admission/mutate/config_test.go
@@ -135,7 +135,6 @@ func TestInjectSocket(t *testing.T) {
 	assert.Contains(t, pod.Spec.Containers[0].Env, fakeEnvWithValue("DD_TRACE_AGENT_URL", "unix:///var/run/datadog/apm.socket"))
 	assert.Equal(t, pod.Spec.Containers[0].VolumeMounts[0].MountPath, "/var/run/datadog")
 	assert.Equal(t, pod.Spec.Containers[0].VolumeMounts[0].Name, "datadog")
-	assert.Equal(t, pod.Spec.Containers[0].VolumeMounts[0].ReadOnly, true)
 	assert.Equal(t, pod.Spec.Volumes[0].Name, "datadog")
 	assert.Equal(t, pod.Spec.Volumes[0].VolumeSource.HostPath.Path, "/var/run/datadog")
 	assert.Equal(t, *pod.Spec.Volumes[0].VolumeSource.HostPath.Type, corev1.HostPathDirectoryOrCreate)

--- a/pkg/clusteragent/admission/mutate/config_test.go
+++ b/pkg/clusteragent/admission/mutate/config_test.go
@@ -135,6 +135,7 @@ func TestInjectSocket(t *testing.T) {
 	assert.Contains(t, pod.Spec.Containers[0].Env, fakeEnvWithValue("DD_TRACE_AGENT_URL", "unix:///var/run/datadog/apm.socket"))
 	assert.Equal(t, pod.Spec.Containers[0].VolumeMounts[0].MountPath, "/var/run/datadog")
 	assert.Equal(t, pod.Spec.Containers[0].VolumeMounts[0].Name, "datadog")
+	assert.Equal(t, pod.Spec.Containers[0].VolumeMounts[0].ReadOnly, true)
 	assert.Equal(t, pod.Spec.Volumes[0].Name, "datadog")
 	assert.Equal(t, pod.Spec.Volumes[0].VolumeSource.HostPath.Path, "/var/run/datadog")
 	assert.Equal(t, *pod.Spec.Volumes[0].VolumeSource.HostPath.Type, corev1.HostPathDirectoryOrCreate)

--- a/releasenotes-dca/notes/mount_uds_socket_in_readonly_mode-5f2bf3b50e368413.yaml
+++ b/releasenotes-dca/notes/mount_uds_socket_in_readonly_mode-5f2bf3b50e368413.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG-DCA.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    The UDS socket volume when using the Admission Controller is now mounted in readOnly mode.


### PR DESCRIPTION
This PR mounts the UDS socket in readonly mode when enabling the Admisson Controller and when setting admissonController.configMode to socket

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
