### PR TITLE
[CSPM] [SEC-6973] Make the process cache coherent and error proof

### DIFF
--- a/pkg/compliance/checks/builder.go
+++ b/pkg/compliance/checks/builder.go
@@ -29,7 +29,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/compliance/rego"
 	"github.com/DataDog/datadog-agent/pkg/compliance/resources/audit"
 	"github.com/DataDog/datadog-agent/pkg/compliance/resources/file"
-	"github.com/DataDog/datadog-agent/pkg/compliance/resources/process"
 	commandutils "github.com/DataDog/datadog-agent/pkg/compliance/utils/command"
 	dockerutils "github.com/DataDog/datadog-agent/pkg/compliance/utils/docker"
 	fileutils "github.com/DataDog/datadog-agent/pkg/compliance/utils/file"
@@ -695,7 +694,7 @@ func evalProcessFlag(_ eval.Instance, args ...interface{}) (interface{}, error) 
 	if !ok {
 		return nil, fmt.Errorf(`expecting string value for process flag argument`)
 	}
-	return processutils.ValueFromProcessFlag(name, flag, process.CacheValidity)
+	return processutils.ValueFromProcessFlag(name, flag)
 }
 
 func (b *builder) evalValueFromFile(get fileutils.Getter) eval.Function {

--- a/pkg/compliance/checks/builder_test.go
+++ b/pkg/compliance/checks/builder_test.go
@@ -58,9 +58,9 @@ func TestResolveValueFrom(t *testing.T) {
 			name:       "from process",
 			expression: `process.flag("buddy", "--path")`,
 			setup: func(t *testing.T) {
-				processutils.Fetcher = func() (processutils.Processes, error) {
+				processutils.FetchProcessesWithName = func(searchedName string) (processutils.Processes, error) {
 					return processutils.Processes{
-						42: processutils.NewCheckedFakeProcess(42, "buddy", []string{"--path=/home/root/hiya-buddy.txt"}, nil),
+						processutils.NewProcessMetadata(42, 0, searchedName, []string{"--path=/home/root/hiya-buddy.txt"}, nil, ""),
 					}, nil
 				}
 			},
@@ -70,7 +70,7 @@ func TestResolveValueFrom(t *testing.T) {
 			name:       "from process missing process",
 			expression: `process.flag("buddy", "--path")`,
 			setup: func(t *testing.T) {
-				processutils.Fetcher = func() (processutils.Processes, error) {
+				processutils.FetchProcessesWithName = func(searchedName string) (processutils.Processes, error) {
 					return processutils.Processes{}, nil
 				}
 			},
@@ -80,9 +80,9 @@ func TestResolveValueFrom(t *testing.T) {
 			name:       "from process missing flag",
 			expression: `process.flag("buddy", "--path")`,
 			setup: func(t *testing.T) {
-				processutils.Fetcher = func() (processutils.Processes, error) {
+				processutils.FetchProcessesWithName = func(searchedName string) (processutils.Processes, error) {
 					return processutils.Processes{
-						42: processutils.NewCheckedFakeProcess(42, "buddy", nil, nil),
+						processutils.NewProcessMetadata(42, 0, searchedName, nil, nil, ""),
 					}, nil
 				}
 			},
@@ -102,6 +102,8 @@ func TestResolveValueFrom(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			processutils.PurgeCache()
+
 			reporter := &mocks.Reporter{}
 			b, err := NewBuilder(reporter, WithHostRootMount("../resources/"))
 			assert.NoError(err)

--- a/pkg/compliance/rego/rego_check_test.go
+++ b/pkg/compliance/rego/rego_check_test.go
@@ -7,12 +7,12 @@ package rego
 import (
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/compliance"
 	"github.com/DataDog/datadog-agent/pkg/compliance/event"
 	"github.com/DataDog/datadog-agent/pkg/compliance/mocks"
 	processutils "github.com/DataDog/datadog-agent/pkg/compliance/utils/process"
-	"github.com/DataDog/datadog-agent/pkg/util/cache"
 
 	"github.com/stretchr/testify/mock"
 	assert "github.com/stretchr/testify/require"
@@ -59,9 +59,15 @@ func (f *regoFixture) run(t *testing.T) {
 	t.Helper()
 	assert := assert.New(t)
 
-	cache.Cache.Delete(processutils.ProcessCacheKey)
-	processutils.Fetcher = func() (processutils.Processes, error) {
-		return f.processes, nil
+	processutils.PurgeCache()
+	processutils.FetchProcessesWithName = func(searchedName string) (processutils.Processes, error) {
+		var processes processutils.Processes
+		for _, p := range f.processes {
+			if p.Name == searchedName {
+				processes = append(processes, p)
+			}
+		}
+		return processes, nil
 	}
 
 	env := &mocks.Env{}
@@ -132,7 +138,7 @@ func TestRegoCheck(t *testing.T) {
 				},
 			},
 			processes: processutils.Processes{
-				42: processutils.NewCheckedFakeProcess(42, "proc1", []string{"arg1", "--path=foo"}, nil),
+				processutils.NewProcessMetadata(42, time.Now().UnixMilli(), "proc1", []string{"arg1", "--path=foo"}, nil, ""),
 			},
 		},
 		{
@@ -176,7 +182,7 @@ func TestRegoCheck(t *testing.T) {
 			`,
 			findings: "data.test.findings",
 			processes: processutils.Processes{
-				42: processutils.NewCheckedFakeProcess(42, "proc1", []string{"arg1", "--path=foo"}, nil),
+				processutils.NewProcessMetadata(42, time.Now().UnixMilli(), "proc1", []string{"arg1", "--path=foo"}, nil, ""),
 			},
 			expectReports: compliance.Reports{
 				{
@@ -230,7 +236,7 @@ func TestRegoCheck(t *testing.T) {
 			`,
 			findings: "data.test.findings",
 			processes: processutils.Processes{
-				42: processutils.NewCheckedFakeProcess(42, "proc1", []string{"arg1", "--path=foo"}, nil),
+				processutils.NewProcessMetadata(42, time.Now().UnixMilli(), "proc1", []string{"arg1", "--path=foo"}, nil, ""),
 			},
 			expectReports: compliance.Reports{
 				{
@@ -275,7 +281,7 @@ func TestRegoCheck(t *testing.T) {
 			`,
 			findings: "data.test.findings",
 			processes: processutils.Processes{
-				42: processutils.NewCheckedFakeProcess(42, "proc1", []string{"arg1", "--path=foo"}, nil),
+				processutils.NewProcessMetadata(42, time.Now().UnixMilli(), "proc1", []string{"arg1", "--path=foo"}, nil, ""),
 			},
 			expectReports: compliance.Reports{
 				{
@@ -318,7 +324,7 @@ func TestRegoCheck(t *testing.T) {
 			`,
 			findings: "data.test.findings",
 			processes: processutils.Processes{
-				42: processutils.NewCheckedFakeProcess(42, "proc1", []string{"arg1", "--path=foo"}, nil),
+				processutils.NewProcessMetadata(42, time.Now().UnixMilli(), "proc1", []string{"arg1", "--path=foo"}, nil, ""),
 			},
 			expectReports: nil,
 		},

--- a/pkg/compliance/resources/file/file_check_test.go
+++ b/pkg/compliance/resources/file/file_check_test.go
@@ -341,7 +341,7 @@ func TestFileCheck(t *testing.T) {
 				Transform: `h.file_process_flag("--config-file")`,
 			},
 			processes: processutils.Processes{
-				42: processutils.NewCheckedFakeProcess(42, "dockerd", []string{"dockerd", "--config-file=/etc/docker/daemon.json"}, nil),
+				processutils.NewProcessMetadata(42, 0, "dockerd", []string{"dockerd", "--config-file=/etc/docker/daemon.json"}, nil, ""),
 			},
 			module: fmt.Sprintf(objectModule, `file.content["experimental"] == false`),
 			setup: func(t *testing.T, env *mocks.Env, file *compliance.File) {
@@ -426,7 +426,7 @@ func TestFileCheck(t *testing.T) {
 			},
 			expectError: errors.New(`failed to resolve path`),
 			processes: processutils.Processes{
-				42: processutils.NewCheckedFakeProcess(42, "dockerd", []string{"dockerd", "--config-file=/etc/docker/daemon.json"}, nil),
+				processutils.NewProcessMetadata(42, 0, "dockerd", []string{"dockerd", "--config-file=/etc/docker/daemon.json"}, nil, ""),
 			},
 		},
 		{
@@ -539,12 +539,18 @@ func TestFileCheck(t *testing.T) {
 			}
 
 			if len(test.processes) > 0 {
-				previousFetcher := processutils.Fetcher
-				processutils.Fetcher = func() (processutils.Processes, error) {
-					return test.processes, nil
+				previousFetcher := processutils.FetchProcessesWithName
+				processutils.FetchProcessesWithName = func(searchedName string) (processutils.Processes, error) {
+					var processes processutils.Processes
+					for _, p := range test.processes {
+						if p.Name == searchedName {
+							processes = append(processes, p)
+						}
+					}
+					return processes, nil
 				}
 				defer func() {
-					processutils.Fetcher = previousFetcher
+					processutils.FetchProcessesWithName = previousFetcher
 				}()
 			}
 

--- a/pkg/compliance/resources/process/process_check_test.go
+++ b/pkg/compliance/resources/process/process_check_test.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/compliance"
 	"github.com/DataDog/datadog-agent/pkg/compliance/event"
@@ -16,7 +17,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/compliance/rego"
 	resource_test "github.com/DataDog/datadog-agent/pkg/compliance/resources/tests"
 	processutils "github.com/DataDog/datadog-agent/pkg/compliance/utils/process"
-	"github.com/DataDog/datadog-agent/pkg/util/cache"
 
 	assert "github.com/stretchr/testify/require"
 )
@@ -79,10 +79,17 @@ func (f *processFixture) run(t *testing.T) {
 	assert := assert.New(t)
 
 	if !f.useCache {
-		cache.Cache.Delete(processutils.ProcessCacheKey)
+		processutils.PurgeCache()
 	}
-	processutils.Fetcher = func() (processutils.Processes, error) {
-		return f.processes, nil
+	processutils.IsProcessMetadataValid = func(_ *processutils.ProcessMetadata) bool { return true }
+	processutils.FetchProcessesWithName = func(searchedName string) (processutils.Processes, error) {
+		var processes processutils.Processes
+		for _, p := range f.processes {
+			if p.Name == searchedName {
+				processes = append(processes, p)
+			}
+		}
+		return processes, nil
 	}
 
 	env := &mocks.Env{}
@@ -121,7 +128,7 @@ func TestProcessCheck(t *testing.T) {
 			},
 			module: fmt.Sprintf(processModule, `process.flags["--path"] == "foo"`),
 			processes: processutils.Processes{
-				42: processutils.NewCheckedFakeProcess(42, "proc1", []string{"arg1", "--path=foo"}, nil),
+				processutils.NewProcessMetadata(42, time.Now().UnixMilli(), "proc1", []string{"arg1", "--path=foo"}, []string{}, ""),
 			},
 			expectReport: &compliance.Report{
 				Passed: true,
@@ -151,8 +158,8 @@ func TestProcessCheck(t *testing.T) {
 			},
 			module: fmt.Sprintf(processModule, `process.flags["--path"] == "foo"`),
 			processes: processutils.Processes{
-				42: processutils.NewCheckedFakeProcess(42, "proc2", []string{"arg1", "--path=foo"}, nil),
-				43: processutils.NewCheckedFakeProcess(43, "proc3", []string{"arg1", "--path=foo"}, nil),
+				processutils.NewProcessMetadata(42, time.Now().UnixMilli(), "proc2", []string{"arg1", "--path=foo"}, []string{}, ""),
+				processutils.NewProcessMetadata(43, time.Now().UnixMilli(), "proc3", []string{"arg1", "--path=foo"}, []string{}, ""),
 			},
 			expectReport: &compliance.Report{
 				Passed:    false,
@@ -176,7 +183,7 @@ func TestProcessCheck(t *testing.T) {
 			},
 			module: fmt.Sprintf(processModule, `process.flags["--path"] == "foo"`),
 			processes: processutils.Processes{
-				42: processutils.NewCheckedFakeProcess(42, "proc1", []string{"arg1", "--paths=foo"}, nil),
+				processutils.NewProcessMetadata(42, time.Now().UnixMilli(), "proc1", []string{"arg1", "--paths=foo"}, []string{}, ""),
 			},
 			expectReport: &compliance.Report{
 				Passed: false,
@@ -216,7 +223,7 @@ func TestProcessCheckCache(t *testing.T) {
 		},
 		module: fmt.Sprintf(processModule, `process.flags["--path"] == "foo"`),
 		processes: processutils.Processes{
-			42: processutils.NewCheckedFakeProcess(42, "proc1", []string{"arg1", "--path=foo"}, nil),
+			processutils.NewProcessMetadata(42, time.Now().UnixMilli(), "proc1", []string{"arg1", "--path=foo"}, []string{}, ""),
 		},
 		expectReport: &compliance.Report{
 			Passed: true,

--- a/pkg/compliance/utils/process/process_utils_test.go
+++ b/pkg/compliance/utils/process/process_utils_test.go
@@ -33,7 +33,7 @@ func TestParseCmdLine(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			parsed := ParseProcessCmdLine(tt.args)
+			parsed := parseCmdLineFlags(tt.args)
 			assert.Equal(t, tt.expected, parsed)
 		})
 	}


### PR DESCRIPTION
### What does this PR do?

We observed some process related findings reporting false negatives because error handling was not properly plugged for cmdline parsing.

This commit makes sure we handle errors properly when getting CLI arguments and avoid cache incoherency.

### Describe how to test/QA your changes

No impact

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
