### PR TITLE
[serverless] fix: do not try to enable log api for local testing

### DIFF
--- a/cmd/serverless/main.go
+++ b/cmd/serverless/main.go
@@ -239,27 +239,27 @@ func runAgent(stopCh chan struct{}) (serverlessDaemon *daemon.Daemon, err error)
 		defer wg.Done()
 		if len(os.Getenv("DD_LOCAL_TEST")) > 0 {
 			log.Debug("Running in local test mode. Telemetry collection HTTP route won't be enabled")
-		} else {
-			log.Debug("Enabling telemetry collection HTTP route")
-			logRegistrationURL := registration.BuildURL(os.Getenv(runtimeAPIEnvVar), logsAPIRegistrationRoute)
-			logRegistrationError := registration.EnableTelemetryCollection(
-				registration.EnableTelemetryCollectionArgs{
-					ID:                  serverlessID,
-					RegistrationURL:     logRegistrationURL,
-					RegistrationTimeout: logsAPIRegistrationTimeout,
-					LogsType:            os.Getenv(logsLogsTypeSubscribed),
-					Port:                logsAPIHttpServerPort,
-					CollectionRoute:     logsAPICollectionRoute,
-					Timeout:             logsAPITimeout,
-					MaxBytes:            logsAPIMaxBytes,
-					MaxItems:            logsAPIMaxItems,
-				})
+			return
+		}
+		log.Debug("Enabling telemetry collection HTTP route")
+		logRegistrationURL := registration.BuildURL(os.Getenv(runtimeAPIEnvVar), logsAPIRegistrationRoute)
+		logRegistrationError := registration.EnableTelemetryCollection(
+			registration.EnableTelemetryCollectionArgs{
+				ID:                  serverlessID,
+				RegistrationURL:     logRegistrationURL,
+				RegistrationTimeout: logsAPIRegistrationTimeout,
+				LogsType:            os.Getenv(logsLogsTypeSubscribed),
+				Port:                logsAPIHttpServerPort,
+				CollectionRoute:     logsAPICollectionRoute,
+				Timeout:             logsAPITimeout,
+				MaxBytes:            logsAPIMaxBytes,
+				MaxItems:            logsAPIMaxItems,
+			})
 
-			if logRegistrationError != nil {
-				log.Error("Can't subscribe to logs:", logRegistrationError)
-			} else {
-				serverlessLogs.SetupLogAgent(logChannel, "AWS Logs", "lambda")
-			}
+		if logRegistrationError != nil {
+			log.Error("Can't subscribe to logs:", logRegistrationError)
+		} else {
+			serverlessLogs.SetupLogAgent(logChannel, "AWS Logs", "lambda")
 		}
 	}()
 

--- a/cmd/serverless/main.go
+++ b/cmd/serverless/main.go
@@ -6,8 +6,6 @@
 package main
 
 import (
-	"github.com/DataDog/datadog-agent/pkg/serverless/proxy"
-	"github.com/DataDog/datadog-agent/pkg/serverless/trace/inferredspan"
 	"os"
 	"os/signal"
 	"strings"
@@ -25,9 +23,11 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/serverless/invocationlifecycle"
 	serverlessLogs "github.com/DataDog/datadog-agent/pkg/serverless/logs"
 	"github.com/DataDog/datadog-agent/pkg/serverless/metrics"
+	"github.com/DataDog/datadog-agent/pkg/serverless/proxy"
 	"github.com/DataDog/datadog-agent/pkg/serverless/random"
 	"github.com/DataDog/datadog-agent/pkg/serverless/registration"
 	"github.com/DataDog/datadog-agent/pkg/serverless/trace"
+	"github.com/DataDog/datadog-agent/pkg/serverless/trace/inferredspan"
 	"github.com/DataDog/datadog-agent/pkg/trace/pb"
 	"github.com/DataDog/datadog-agent/pkg/util/flavor"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -237,7 +237,7 @@ func runAgent(stopCh chan struct{}) (serverlessDaemon *daemon.Daemon, err error)
 	// enable telemetry collection
 	go func() {
 		defer wg.Done()
-		if len(os.Getenv("DD_LOCAL_TEST")) > 0 {
+		if len(os.Getenv(daemon.LocalTestEnvVar)) > 0 {
 			log.Debug("Running in local test mode. Telemetry collection HTTP route won't be enabled")
 			return
 		}

--- a/cmd/serverless/main.go
+++ b/cmd/serverless/main.go
@@ -6,8 +6,6 @@
 package main
 
 import (
-	"github.com/DataDog/datadog-agent/pkg/serverless/proxy"
-	"github.com/DataDog/datadog-agent/pkg/serverless/trace/inferredspan"
 	"os"
 	"os/signal"
 	"strings"
@@ -25,9 +23,11 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/serverless/invocationlifecycle"
 	serverlessLogs "github.com/DataDog/datadog-agent/pkg/serverless/logs"
 	"github.com/DataDog/datadog-agent/pkg/serverless/metrics"
+	"github.com/DataDog/datadog-agent/pkg/serverless/proxy"
 	"github.com/DataDog/datadog-agent/pkg/serverless/random"
 	"github.com/DataDog/datadog-agent/pkg/serverless/registration"
 	"github.com/DataDog/datadog-agent/pkg/serverless/trace"
+	"github.com/DataDog/datadog-agent/pkg/serverless/trace/inferredspan"
 	"github.com/DataDog/datadog-agent/pkg/trace/pb"
 	"github.com/DataDog/datadog-agent/pkg/util/flavor"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -224,59 +224,12 @@ func runAgent(stopCh chan struct{}) (serverlessDaemon *daemon.Daemon, err error)
 
 	// Concurrently start heavyweight features
 	var wg sync.WaitGroup
-	wg.Add(3)
-
-	// starts trace agent
-	go func() {
-		defer wg.Done()
-		traceAgent := &trace.ServerlessTraceAgent{}
-		traceAgent.Start(config.Datadog.GetBool("apm_config.enabled"), &trace.LoadConfig{Path: datadogConfigPath}, lambdaSpanChan, coldStartSpanId)
-		serverlessDaemon.SetTraceAgent(traceAgent)
-	}()
-
-	// enable telemetry collection
-	go func() {
-		defer wg.Done()
-		if len(os.Getenv("DD_LOCAL_TEST")) > 0 {
-			log.Debug("Running in local test mode. Telemetry collection HTTP route won't be enabled")
-		} else {
-			log.Debug("Enabling telemetry collection HTTP route")
-			logRegistrationURL := registration.BuildURL(os.Getenv(runtimeAPIEnvVar), logsAPIRegistrationRoute)
-			logRegistrationError := registration.EnableTelemetryCollection(
-				registration.EnableTelemetryCollectionArgs{
-					ID:                  serverlessID,
-					RegistrationURL:     logRegistrationURL,
-					RegistrationTimeout: logsAPIRegistrationTimeout,
-					LogsType:            os.Getenv(logsLogsTypeSubscribed),
-					Port:                logsAPIHttpServerPort,
-					CollectionRoute:     logsAPICollectionRoute,
-					Timeout:             logsAPITimeout,
-					MaxBytes:            logsAPIMaxBytes,
-					MaxItems:            logsAPIMaxItems,
-				})
-
-			if logRegistrationError != nil {
-				log.Error("Can't subscribe to logs:", logRegistrationError)
-			} else {
-				serverlessLogs.SetupLogAgent(logChannel, "AWS Logs", "lambda")
-			}
-		}
-	}()
-
-	// start appsec
-	var httpsecSubProcessor invocationlifecycle.InvocationSubProcessor
-	go func() {
-		defer wg.Done()
-		appsec, err := appsec.New()
-		if err != nil {
-			log.Error("appsec: could not start: ", err)
-		} else if appsec != nil {
-			log.Info("appsec: started successfully")
-			httpsecSubProcessor = httpsec.NewInvocationSubProcessor(appsec) // note that the receiving variable is in the parent scope
-		}
-	}()
-
+	wg.Add(2)
+	go startTraceAgent(&wg, lambdaSpanChan, coldStartSpanId, serverlessDaemon)
+	go enableTelemetryCollection(&wg, serverlessID, logChannel)
 	wg.Wait()
+
+	httpsecSubProcessor := startAppSec()
 
 	coldStartSpanCreator := &trace.ColdStartSpanCreator{
 		LambdaSpanChan:   lambdaSpanChan,
@@ -323,6 +276,54 @@ func runAgent(stopCh chan struct{}) (serverlessDaemon *daemon.Daemon, err error)
 	// please be careful before modifying/removing it
 	log.Debugf("serverless agent ready in %v", time.Since(startTime))
 	return
+}
+
+func startTraceAgent(wg *sync.WaitGroup, lambdaSpanChan chan *pb.Span, coldStartSpanId uint64, serverlessDaemon *daemon.Daemon) {
+	// starts trace agent
+	defer wg.Done()
+	traceAgent := &trace.ServerlessTraceAgent{}
+	traceAgent.Start(config.Datadog.GetBool("apm_config.enabled"), &trace.LoadConfig{Path: datadogConfigPath}, lambdaSpanChan, coldStartSpanId)
+	serverlessDaemon.SetTraceAgent(traceAgent)
+}
+
+func startAppSec() invocationlifecycle.InvocationSubProcessor {
+	var httpsecSubProcessor invocationlifecycle.InvocationSubProcessor
+	appsecApi, err := appsec.New()
+	if err != nil {
+		log.Error("appsec: could not start: ", err)
+	} else if appsecApi != nil {
+		log.Info("appsec: started successfully")
+		httpsecSubProcessor = httpsec.NewInvocationSubProcessor(appsecApi) // note that the receiving variable is in the parent scope
+	}
+	return httpsecSubProcessor
+}
+
+func enableTelemetryCollection(wg *sync.WaitGroup, serverlessID registration.ID, logChannel chan *logConfig.ChannelMessage) {
+	defer wg.Done()
+	if len(os.Getenv("DD_LOCAL_TEST")) > 0 {
+		log.Debug("Running in local test mode. Telemetry collection HTTP route won't be enabled")
+	} else {
+		log.Debug("Enabling telemetry collection HTTP route")
+		logRegistrationURL := registration.BuildURL(os.Getenv(runtimeAPIEnvVar), logsAPIRegistrationRoute)
+		logRegistrationError := registration.EnableTelemetryCollection(
+			registration.EnableTelemetryCollectionArgs{
+				ID:                  serverlessID,
+				RegistrationURL:     logRegistrationURL,
+				RegistrationTimeout: logsAPIRegistrationTimeout,
+				LogsType:            os.Getenv(logsLogsTypeSubscribed),
+				Port:                logsAPIHttpServerPort,
+				CollectionRoute:     logsAPICollectionRoute,
+				Timeout:             logsAPITimeout,
+				MaxBytes:            logsAPIMaxBytes,
+				MaxItems:            logsAPIMaxItems,
+			})
+
+		if logRegistrationError != nil {
+			log.Error("Can't subscribe to logs:", logRegistrationError)
+		} else {
+			serverlessLogs.SetupLogAgent(logChannel, "AWS Logs", "lambda")
+		}
+	}
 }
 
 // handleSignals handles OS signals, if a SIGTERM is received,

--- a/pkg/serverless/daemon/daemon_test.go
+++ b/pkg/serverless/daemon/daemon_test.go
@@ -74,7 +74,7 @@ func TestTellDaemonRuntimeDoneOnceStartAndEnd(t *testing.T) {
 }
 
 func TestTellDaemonRuntimeDoneIfLocalTest(t *testing.T) {
-	t.Setenv(localTestEnvVar, "1")
+	t.Setenv(LocalTestEnvVar, "1")
 	assert := assert.New(t)
 	port := testutil.FreeTCPPort(t)
 	d := StartDaemon(fmt.Sprint("127.0.0.1:", port))

--- a/pkg/serverless/daemon/routes.go
+++ b/pkg/serverless/daemon/routes.go
@@ -16,8 +16,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-const localTestEnvVar = "DD_LOCAL_TEST"
-
 // Hello is a route called by the Datadog Lambda Library when it starts.
 // It is used to detect the Datadog Lambda Library in the environment.
 type Hello struct {
@@ -37,7 +35,7 @@ type Flush struct {
 
 func (f *Flush) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	log.Debug("Hit on the serverless.Flush route.")
-	if len(os.Getenv(localTestEnvVar)) > 0 {
+	if len(os.Getenv(LocalTestEnvVar)) > 0 {
 		// used only for testing purpose as the Logs API is not supported by the Lambda Emulator
 		// thus we canot get the REPORT log line telling that the invocation is finished
 		f.daemon.HandleRuntimeDone()

--- a/pkg/serverless/daemon/utils.go
+++ b/pkg/serverless/daemon/utils.go
@@ -10,6 +10,8 @@ import (
 	"time"
 )
 
+const LocalTestEnvVar = "DD_LOCAL_TEST"
+
 // waitWithTimeout waits for a WaitGroup with a specified max timeout.
 // Returns true if waiting timed out.
 func waitWithTimeout(wg *sync.WaitGroup, timeout time.Duration) bool {


### PR DESCRIPTION
### What does this PR do?
When in local testing mode, do not try to initialize logs api to avoid errors in log
