### PR TITLE
Speed up system-probe build by not copying unnecessary files

### DIFF
--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -1084,16 +1084,22 @@ def build_object_files(
 
         if ctx.run("command -v rsync >/dev/null 2>&1", warn=True, hide=True).ok:
             rsync_filter = "--filter='+ */' --filter='+ *.o' --filter='+ *.c' --filter='- *'"
-            ctx.run(f"{sudo} rsync --chmod=F644 --chown=root:root -rvt {rsync_filter} {build_dir}/ {EMBEDDED_SHARE_DIR}")
+            ctx.run(
+                f"{sudo} rsync --chmod=F644 --chown=root:root -rvt {rsync_filter} {build_dir}/ {EMBEDDED_SHARE_DIR}"
+            )
         else:
             with ctx.cd(build_dir):
+
                 def cp_cmd(out_dir):
                     dest = os.path.join(EMBEDDED_SHARE_DIR, out_dir)
-                    return " ".join([
-                        f"-execdir cp -p {{}} {dest}/ \\;",
-                        f"-execdir chown root:root {dest}/{{}} \\;",
-                        f"-execdir chmod 0644 {dest}/{{}} \\;",
-                        ])
+                    return " ".join(
+                        [
+                            f"-execdir cp -p {{}} {dest}/ \\;",
+                            f"-execdir chown root:root {dest}/{{}} \\;",
+                            f"-execdir chmod 0644 {dest}/{{}} \\;",
+                        ]
+                    )
+
                 ctx.run(f"{sudo} find . -maxdepth 1 -type f -name '*.o' {cp_cmd('.')}")
                 ctx.run(f"{sudo} mkdir -p {EMBEDDED_SHARE_DIR}/co-re")
                 ctx.run(f"{sudo} find ./co-re -maxdepth 1 -type f -name '*.o' {cp_cmd('co-re')}")

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -1081,8 +1081,24 @@ def build_object_files(
     if not windows:
         sudo = "" if is_root() else "sudo"
         ctx.run(f"{sudo} mkdir -p {EMBEDDED_SHARE_DIR}")
-        rsync_filter = "--filter='+ */' --filter='+ *.o' --filter='+ *.c' --filter='- *'"
-        ctx.run(f"{sudo} rsync --chmod=F644 --chown=root:root -rvt {rsync_filter} {build_dir}/ {EMBEDDED_SHARE_DIR}")
+
+        if ctx.run("command -v rsync >/dev/null 2>&1", warn=True, hide=True).ok:
+            rsync_filter = "--filter='+ */' --filter='+ *.o' --filter='+ *.c' --filter='- *'"
+            ctx.run(f"{sudo} rsync --chmod=F644 --chown=root:root -rvt {rsync_filter} {build_dir}/ {EMBEDDED_SHARE_DIR}")
+        else:
+            with ctx.cd(build_dir):
+                def cp_cmd(out_dir):
+                    dest = os.path.join(EMBEDDED_SHARE_DIR, out_dir)
+                    return " ".join([
+                        f"-execdir cp -p {{}} {dest}/ \\;",
+                        f"-execdir chown root:root {dest}/{{}} \\;",
+                        f"-execdir chmod 0644 {dest}/{{}} \\;",
+                        ])
+                ctx.run(f"{sudo} find . -maxdepth 1 -type f -name '*.o' {cp_cmd('.')}")
+                ctx.run(f"{sudo} mkdir -p {EMBEDDED_SHARE_DIR}/co-re")
+                ctx.run(f"{sudo} find ./co-re -maxdepth 1 -type f -name '*.o' {cp_cmd('co-re')}")
+                ctx.run(f"{sudo} mkdir -p {EMBEDDED_SHARE_DIR}/runtime")
+                ctx.run(f"{sudo} find ./runtime -maxdepth 1 -type f -name '*.c' {cp_cmd('runtime')}")
 
 
 def build_cws_object_files(


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Speeds up the system-probe.build command by:
- using `rsync` to prevent copying of temporary build artifacts
- using `grep` for the `inline` check against all files at once

### Motivation

Slow builds even when nothing changed.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
