### PR TITLE
[workloadmeta/collectors/containerd] Disable sbom correctly when Trivy is not built

### DIFF
--- a/pkg/workloadmeta/collectors/internal/containerd/image.go
+++ b/pkg/workloadmeta/collectors/internal/containerd/image.go
@@ -16,7 +16,6 @@ import (
 	"sync"
 
 	"github.com/CycloneDX/cyclonedx-go"
-	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 
@@ -392,8 +391,4 @@ func getLayersWithHistory(ctx context.Context, store content.Store, manifest oci
 	}
 
 	return layers, nil
-}
-
-func sbomCollectionIsEnabled() bool {
-	return imageMetadataCollectionIsEnabled() && config.Datadog.GetBool("container_image_collection.sbom.enabled")
 }

--- a/pkg/workloadmeta/collectors/internal/containerd/image_sbom_stub.go
+++ b/pkg/workloadmeta/collectors/internal/containerd/image_sbom_stub.go
@@ -8,6 +8,10 @@
 
 package containerd
 
+func sbomCollectionIsEnabled() bool {
+	return false
+}
+
 func (c *collector) startSBOMCollection() error {
 	return nil
 }

--- a/pkg/workloadmeta/collectors/internal/containerd/image_sbom_trivy.go
+++ b/pkg/workloadmeta/collectors/internal/containerd/image_sbom_trivy.go
@@ -24,6 +24,10 @@ const (
 	imagesToScanBufferSize = 5000
 )
 
+func sbomCollectionIsEnabled() bool {
+	return imageMetadataCollectionIsEnabled() && config.Datadog.GetBool("container_image_collection.sbom.enabled")
+}
+
 func (c *collector) startSBOMCollection() error {
 	if !sbomCollectionIsEnabled() {
 		return nil


### PR DESCRIPTION
### What does this PR do?

Fixes a bug that triggers when SBOM collection is enabled and Trivy is not built.

In that case, the agent was still pushing images to the `imagesToScan` channel, which was not initialized, so this was blocking the agent.

Ref:
https://github.com/DataDog/datadog-agent/blob/bd1daa28d33aad7f8ad41899181f7e2db988344e/pkg/workloadmeta/collectors/internal/containerd/image.go#L295

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

process-agent and security-agent should not block when SBOM collection is enabled.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
