### PR TITLE
SNMP - Set default values for the snmpwalk based on snmp integration default parameters

### DIFF
--- a/cmd/agent/subcommands/snmp/command.go
+++ b/cmd/agent/subcommands/snmp/command.go
@@ -86,7 +86,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 	}
 	snmpWalkCmd := &cobra.Command{
 		Use:   "walk <IP Address>[:Port] [OID] [OPTIONS]",
-		Short: "Perform a snmpwalk, if only a valid IP address is provided with the oid, the agent snmp config will be used",
+		Short: "Perform a snmpwalk, if only a valid IP address is provided with the oid then the agent snmp config will be used",
 		Long:  ``,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cliParams.args = args

--- a/cmd/agent/subcommands/snmp/command.go
+++ b/cmd/agent/subcommands/snmp/command.go
@@ -86,7 +86,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 	}
 	snmpWalkCmd := &cobra.Command{
 		Use:   "walk <IP Address>[:Port] [OID] [OPTIONS]",
-		Short: "Perform a snmpwalk , if only the IP Address is provided, the agent snmp config will be used as options",
+		Short: "Perform a snmpwalk , if only the IP Address is provided with the oid, the agent snmp config will be used",
 		Long:  ``,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cliParams.args = args

--- a/cmd/agent/subcommands/snmp/command.go
+++ b/cmd/agent/subcommands/snmp/command.go
@@ -86,7 +86,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 	}
 	snmpWalkCmd := &cobra.Command{
 		Use:   "walk <IP Address>[:Port] [OID] [OPTIONS]",
-		Short: "Perform a snmpwalk. If only the IP Address is provided with the oid, the agent snmp config will be used",
+		Short: "Perform a snmpwalk, if only the IP Address is provided with the oid, the agent snmp config will be used",
 		Long:  ``,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cliParams.args = args

--- a/cmd/agent/subcommands/snmp/command.go
+++ b/cmd/agent/subcommands/snmp/command.go
@@ -86,7 +86,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 	}
 	snmpWalkCmd := &cobra.Command{
 		Use:   "walk <IP Address>[:Port] [OID] [OPTIONS]",
-		Short: "Perform a snmpwalk, if only a valid IP address is provided with the oid then the agent snmp config will be used",
+		Short: "Perform a snmpwalk, if only a valid IP address is provided with the oid then the agent default snmp config will be used",
 		Long:  ``,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cliParams.args = args

--- a/cmd/agent/subcommands/snmp/command.go
+++ b/cmd/agent/subcommands/snmp/command.go
@@ -86,7 +86,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 	}
 	snmpWalkCmd := &cobra.Command{
 		Use:   "walk <IP Address>[:Port] [OID] [OPTIONS]",
-		Short: "Perform a snmpwalk",
+		Short: "Perform a snmpwalk , if only the IP Address is provided, the agent snmp config will be used as options",
 		Long:  ``,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cliParams.args = args

--- a/cmd/agent/subcommands/snmp/command.go
+++ b/cmd/agent/subcommands/snmp/command.go
@@ -86,7 +86,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 	}
 	snmpWalkCmd := &cobra.Command{
 		Use:   "walk <IP Address>[:Port] [OID] [OPTIONS]",
-		Short: "Perform a snmpwalk, if only the IP Address is provided with the oid, the agent snmp config will be used",
+		Short: "Perform a snmpwalk, if only a valid IP address is provided with the oid, the agent snmp config will be used",
 		Long:  ``,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cliParams.args = args

--- a/cmd/agent/subcommands/snmp/command.go
+++ b/cmd/agent/subcommands/snmp/command.go
@@ -86,7 +86,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 	}
 	snmpWalkCmd := &cobra.Command{
 		Use:   "walk <IP Address>[:Port] [OID] [OPTIONS]",
-		Short: "Perform a snmpwalk, if only the IP Address is provided with the oid, the agent snmp config will be used",
+		Short: "Perform a snmpwalk. If only the IP Address is provided with the oid, the agent snmp config will be used",
 		Long:  ``,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cliParams.args = args

--- a/cmd/agent/subcommands/snmp/command.go
+++ b/cmd/agent/subcommands/snmp/command.go
@@ -86,7 +86,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 	}
 	snmpWalkCmd := &cobra.Command{
 		Use:   "walk <IP Address>[:Port] [OID] [OPTIONS]",
-		Short: "Perform a snmpwalk , if only the IP Address is provided with the oid, the agent snmp config will be used",
+		Short: "Perform a snmpwalk, if only the IP Address is provided with the oid, the agent snmp config will be used",
 		Long:  ``,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cliParams.args = args

--- a/pkg/snmp/snmpparse/config_snmp.go
+++ b/pkg/snmp/snmpparse/config_snmp.go
@@ -49,9 +49,8 @@ type SNMPConfig struct {
 func SetDefault(sc *SNMPConfig) {
 	sc.Port = 161
 	sc.Version = "2"
-	sc.Timeout = 10
+	sc.Timeout = 2
 	sc.Retries = 3
-	sc.CommunityString = "public"
 
 }
 

--- a/pkg/snmp/snmpparse/config_snmp.go
+++ b/pkg/snmp/snmpparse/config_snmp.go
@@ -45,6 +45,7 @@ type SNMPConfig struct {
 	NetAddress string `yaml:"network_address"`
 }
 
+// set default values used by the agent
 func SetDefault(sc *SNMPConfig) {
 	sc.Port = 161
 	sc.Version = "2"

--- a/pkg/snmp/snmpparse/config_snmp.go
+++ b/pkg/snmp/snmpparse/config_snmp.go
@@ -45,12 +45,22 @@ type SNMPConfig struct {
 	NetAddress string `yaml:"network_address"`
 }
 
+func SetDefault(sc *SNMPConfig) {
+	sc.Port = 161
+	sc.Version = "2"
+	sc.Timeout = 10
+	sc.Retries = 3
+	sc.CommunityString = "public"
+
+}
+
 func ParseConfigSnmp(c integration.Config) []SNMPConfig {
 	//an array containing all the snmp instances
 	snmpconfigs := []SNMPConfig{}
 
 	for _, inst := range c.Instances {
 		instance := SNMPConfig{}
+		SetDefault(&instance)
 		err := yaml.Unmarshal(inst, &instance)
 		if err != nil {
 			fmt.Printf("unable to get snmp config: %v", err)
@@ -73,6 +83,7 @@ func parseConfigSnmpMain() ([]SNMPConfig, error) {
 	}
 	for c := range configs {
 		snmpconfig := SNMPConfig{}
+		SetDefault(&snmpconfig)
 
 		snmpconfig.NetAddress = configs[c].Network
 		snmpconfig.Port = configs[c].Port

--- a/pkg/snmp/snmpparse/config_snmp_test.go
+++ b/pkg/snmp/snmpparse/config_snmp_test.go
@@ -257,7 +257,7 @@ func TestGetSNMPConfigEmpty(t *testing.T) {
 }
 
 func TestGetSNMPConfigDefault(t *testing.T) {
-	//check if the default setter is working
+	//check if the default setter is valid
 	input := SNMPConfig{}
 	SetDefault(&input)
 	Exoutput := SNMPConfig{

--- a/pkg/snmp/snmpparse/config_snmp_test.go
+++ b/pkg/snmp/snmpparse/config_snmp_test.go
@@ -258,8 +258,8 @@ func TestGetSNMPConfigEmpty(t *testing.T) {
 
 func TestGetSNMPConfigDefault(t *testing.T) {
 	//check if the default setter is working
-	Input := SNMPConfig{}
-	SetDefault(&Input)
+	input := SNMPConfig{}
+	SetDefault(&input)
 	Exoutput := SNMPConfig{
 		Version:         "2",
 		CommunityString: "public",
@@ -267,7 +267,7 @@ func TestGetSNMPConfigDefault(t *testing.T) {
 		Timeout:         10,
 		Retries:         3,
 	}
-	assert.Equal(t, Exoutput, Input)
+	assert.Equal(t, Exoutput, input)
 
 }
 func assertIP(t *testing.T, input string, snmpConfigList []SNMPConfig, expectedOutput SNMPConfig) {

--- a/pkg/snmp/snmpparse/config_snmp_test.go
+++ b/pkg/snmp/snmpparse/config_snmp_test.go
@@ -46,12 +46,11 @@ func TestDefaultSet(t *testing.T) {
 	//define the output
 	Exoutput := []SNMPConfig{
 		{
-			Version:         "2",
-			CommunityString: "public",
-			IPAddress:       "98.6.18.158",
-			Port:            161,
-			Timeout:         10,
-			Retries:         3,
+			Version:   "2",
+			IPAddress: "98.6.18.158",
+			Port:      161,
+			Timeout:   2,
+			Retries:   3,
 		},
 	}
 	assertSNMP(t, input, Exoutput)

--- a/pkg/snmp/snmpparse/config_snmp_test.go
+++ b/pkg/snmp/snmpparse/config_snmp_test.go
@@ -250,7 +250,7 @@ func TestGetSNMPConfigNoAddress(t *testing.T) {
 func TestGetSNMPConfigEmpty(t *testing.T) {
 	//if the snmp configuration is empty
 	IPList := []SNMPConfig{}
-	input := "192.168.6.3"
+	input := "192.168.6.4"
 	Exoutput := SNMPConfig{}
 	assertIP(t, input, IPList, Exoutput)
 

--- a/pkg/snmp/snmpparse/config_snmp_test.go
+++ b/pkg/snmp/snmpparse/config_snmp_test.go
@@ -250,7 +250,7 @@ func TestGetSNMPConfigNoAddress(t *testing.T) {
 func TestGetSNMPConfigEmpty(t *testing.T) {
 	//if the snmp configuration is empty
 	IPList := []SNMPConfig{}
-	input := "192.168.6.1"
+	input := "192.168.6.3"
 	Exoutput := SNMPConfig{}
 	assertIP(t, input, IPList, Exoutput)
 

--- a/pkg/snmp/snmpparse/config_snmp_test.go
+++ b/pkg/snmp/snmpparse/config_snmp_test.go
@@ -261,11 +261,10 @@ func TestGetSNMPConfigDefault(t *testing.T) {
 	input := SNMPConfig{}
 	SetDefault(&input)
 	Exoutput := SNMPConfig{
-		Version:         "2",
-		CommunityString: "public",
-		Port:            161,
-		Timeout:         10,
-		Retries:         3,
+		Version: "2",
+		Port:    161,
+		Timeout: 2,
+		Retries: 3,
 	}
 	assert.Equal(t, Exoutput, input)
 

--- a/pkg/snmp/snmpparse/config_snmp_test.go
+++ b/pkg/snmp/snmpparse/config_snmp_test.go
@@ -307,7 +307,6 @@ snmp_listener:
 			NetAddress: "127.0.0.4/30",
 		},
 	}
-
 	assert.Equal(t, Exoutput, Output)
 
 }

--- a/pkg/snmp/snmpparse/config_snmp_test.go
+++ b/pkg/snmp/snmpparse/config_snmp_test.go
@@ -35,6 +35,27 @@ func TestOneInstance(t *testing.T) {
 	}
 	assertSNMP(t, input, Exoutput)
 }
+
+func TestDefaultSet(t *testing.T) {
+	//define the input
+	type Data = integration.Data
+	input := integration.Config{
+		Name:      "snmp",
+		Instances: []Data{Data("{\"ip_address\":\"98.6.18.158\"}")},
+	}
+	//define the output
+	Exoutput := []SNMPConfig{
+		{
+			Version:         "2",
+			CommunityString: "public",
+			IPAddress:       "98.6.18.158",
+			Port:            161,
+			Timeout:         10,
+			Retries:         3,
+		},
+	}
+	assertSNMP(t, input, Exoutput)
+}
 func TestSeveralInstances(t *testing.T) {
 	//define the input
 	type Data = integration.Data
@@ -235,6 +256,20 @@ func TestGetSNMPConfigEmpty(t *testing.T) {
 
 }
 
+func TestGetSNMPConfigDefault(t *testing.T) {
+	//check if the default setter is working
+	Input := SNMPConfig{}
+	SetDefault(&Input)
+	Exoutput := SNMPConfig{
+		Version:         "2",
+		CommunityString: "public",
+		Port:            161,
+		Timeout:         10,
+		Retries:         3,
+	}
+	assert.Equal(t, Exoutput, Input)
+
+}
 func assertIP(t *testing.T, input string, snmpConfigList []SNMPConfig, expectedOutput SNMPConfig) {
 	output := GetIPConfig(input, snmpConfigList)
 	assert.Equal(t, expectedOutput, output)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

If the integrated snmpwalk is run with only the IP address, and the agent configuration doesn't contain some of the required options for snmpwalk, the command would fail. Some of these required parameter default to specific values if no explicit value is mentioned in our snmp integration (such as SNMP version that defaults to 2 if nothing is specified in the config file)

This PR sets these required values to match the datadog agent default values.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Update the current snmpparse code to include a default setter for the SNMPConfig structure in case the agent configuration doesn't explicitly mention the required fields.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

A follow-up on this PR: https://github.com/DataDog/datadog-agent/pull/14491 
### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
