### PR TITLE
[CSPM] [SEC-6966] Allow specifying processes environment variables as rule inputs

### DIFF
--- a/pkg/compliance/checks/builder_test.go
+++ b/pkg/compliance/checks/builder_test.go
@@ -60,7 +60,7 @@ func TestResolveValueFrom(t *testing.T) {
 			setup: func(t *testing.T) {
 				processutils.Fetcher = func() (processutils.Processes, error) {
 					return processutils.Processes{
-						42: processutils.NewCheckedFakeProcess(42, "buddy", []string{"--path=/home/root/hiya-buddy.txt"}),
+						42: processutils.NewCheckedFakeProcess(42, "buddy", []string{"--path=/home/root/hiya-buddy.txt"}, nil),
 					}, nil
 				}
 			},
@@ -82,7 +82,7 @@ func TestResolveValueFrom(t *testing.T) {
 			setup: func(t *testing.T) {
 				processutils.Fetcher = func() (processutils.Processes, error) {
 					return processutils.Processes{
-						42: processutils.NewCheckedFakeProcess(42, "buddy", nil),
+						42: processutils.NewCheckedFakeProcess(42, "buddy", nil, nil),
 					}, nil
 				}
 			},

--- a/pkg/compliance/rego/rego_check_input_test.go
+++ b/pkg/compliance/rego/rego_check_input_test.go
@@ -110,6 +110,7 @@ func TestRegoInputCheck(t *testing.T) {
 					ResourceCommon: compliance.ResourceCommon{
 						Process: &compliance.Process{
 							Name: "proc1",
+							Envs: []string{"FOO"},
 						},
 					},
 					TagName: "processes",
@@ -117,7 +118,7 @@ func TestRegoInputCheck(t *testing.T) {
 				},
 			},
 			processes: processutils.Processes{
-				42: processutils.NewCheckedFakeProcess(42, "proc1", []string{"arg1", "--path=foo"}),
+				42: processutils.NewCheckedFakeProcess(42, "proc1", []string{"arg1", "--path=foo"}, []string{"FOO=foo", "BAR=bar"}),
 			},
 			expectedInput: `
 				{
@@ -127,7 +128,8 @@ func TestRegoInputCheck(t *testing.T) {
 						"input": {
 							"processes": {
 								"process": {
-									"name": "proc1"
+									"name": "proc1",
+									"envs": ["FOO"]
 								},
 								"tag": "processes",
 								"type": "array"
@@ -140,6 +142,9 @@ func TestRegoInputCheck(t *testing.T) {
 								"arg1",
 								"--path=foo"
 							],
+							"envs": {
+								"FOO": "foo"
+							},
 							"exe": "",
 							"flags": {
 								"--path": "foo",

--- a/pkg/compliance/rego/rego_check_test.go
+++ b/pkg/compliance/rego/rego_check_test.go
@@ -132,7 +132,7 @@ func TestRegoCheck(t *testing.T) {
 				},
 			},
 			processes: processutils.Processes{
-				42: processutils.NewCheckedFakeProcess(42, "proc1", []string{"arg1", "--path=foo"}),
+				42: processutils.NewCheckedFakeProcess(42, "proc1", []string{"arg1", "--path=foo"}, nil),
 			},
 		},
 		{
@@ -176,7 +176,7 @@ func TestRegoCheck(t *testing.T) {
 			`,
 			findings: "data.test.findings",
 			processes: processutils.Processes{
-				42: processutils.NewCheckedFakeProcess(42, "proc1", []string{"arg1", "--path=foo"}),
+				42: processutils.NewCheckedFakeProcess(42, "proc1", []string{"arg1", "--path=foo"}, nil),
 			},
 			expectReports: compliance.Reports{
 				{
@@ -230,7 +230,7 @@ func TestRegoCheck(t *testing.T) {
 			`,
 			findings: "data.test.findings",
 			processes: processutils.Processes{
-				42: processutils.NewCheckedFakeProcess(42, "proc1", []string{"arg1", "--path=foo"}),
+				42: processutils.NewCheckedFakeProcess(42, "proc1", []string{"arg1", "--path=foo"}, nil),
 			},
 			expectReports: compliance.Reports{
 				{
@@ -275,7 +275,7 @@ func TestRegoCheck(t *testing.T) {
 			`,
 			findings: "data.test.findings",
 			processes: processutils.Processes{
-				42: processutils.NewCheckedFakeProcess(42, "proc1", []string{"arg1", "--path=foo"}),
+				42: processutils.NewCheckedFakeProcess(42, "proc1", []string{"arg1", "--path=foo"}, nil),
 			},
 			expectReports: compliance.Reports{
 				{
@@ -318,7 +318,7 @@ func TestRegoCheck(t *testing.T) {
 			`,
 			findings: "data.test.findings",
 			processes: processutils.Processes{
-				42: processutils.NewCheckedFakeProcess(42, "proc1", []string{"arg1", "--path=foo"}),
+				42: processutils.NewCheckedFakeProcess(42, "proc1", []string{"arg1", "--path=foo"}, nil),
 			},
 			expectReports: nil,
 		},

--- a/pkg/compliance/resource.go
+++ b/pkg/compliance/resource.go
@@ -129,7 +129,8 @@ const (
 
 // Process describes a process resource
 type Process struct {
-	Name string `yaml:"name"`
+	Name string   `yaml:"name"`
+	Envs []string `yaml:"envs"`
 }
 
 // Fields & functions available for KubernetesResource

--- a/pkg/compliance/resource.go
+++ b/pkg/compliance/resource.go
@@ -130,7 +130,7 @@ const (
 // Process describes a process resource
 type Process struct {
 	Name string   `yaml:"name"`
-	Envs []string `yaml:"envs"`
+	Envs []string `yaml:"envs,omitempty"`
 }
 
 // Fields & functions available for KubernetesResource

--- a/pkg/compliance/resources/file/file_check_test.go
+++ b/pkg/compliance/resources/file/file_check_test.go
@@ -341,7 +341,7 @@ func TestFileCheck(t *testing.T) {
 				Transform: `h.file_process_flag("--config-file")`,
 			},
 			processes: processutils.Processes{
-				42: processutils.NewCheckedFakeProcess(42, "dockerd", []string{"dockerd", "--config-file=/etc/docker/daemon.json"}),
+				42: processutils.NewCheckedFakeProcess(42, "dockerd", []string{"dockerd", "--config-file=/etc/docker/daemon.json"}, nil),
 			},
 			module: fmt.Sprintf(objectModule, `file.content["experimental"] == false`),
 			setup: func(t *testing.T, env *mocks.Env, file *compliance.File) {
@@ -426,7 +426,7 @@ func TestFileCheck(t *testing.T) {
 			},
 			expectError: errors.New(`failed to resolve path`),
 			processes: processutils.Processes{
-				42: processutils.NewCheckedFakeProcess(42, "dockerd", []string{"dockerd", "--config-file=/etc/docker/daemon.json"}),
+				42: processutils.NewCheckedFakeProcess(42, "dockerd", []string{"dockerd", "--config-file=/etc/docker/daemon.json"}, nil),
 			},
 		},
 		{

--- a/pkg/compliance/resources/process/process_check.go
+++ b/pkg/compliance/resources/process/process_check.go
@@ -53,6 +53,10 @@ func resolve(_ context.Context, e env.Env, id string, res compliance.ResourceCom
 		exe := mp.Exe()
 		cmdLine := mp.CmdlineSlice()
 		flagValues := processutils.ParseProcessCmdLine(cmdLine)
+		envs, err := mp.EnvsMap(res.Process.Envs)
+		if err != nil {
+			return nil, err
+		}
 
 		instance := eval.NewInstance(
 			eval.VarMap{
@@ -71,6 +75,7 @@ func resolve(_ context.Context, e env.Env, id string, res compliance.ResourceCom
 				"cmdLine": cmdLine,
 				"flags":   flagValues,
 				"pid":     mp.Pid(),
+				"envs":    envs,
 			},
 		)
 		instances = append(instances, resources.NewResolvedInstance(instance, strconv.Itoa(int(mp.Pid())), "process"))

--- a/pkg/compliance/resources/process/process_check_test.go
+++ b/pkg/compliance/resources/process/process_check_test.go
@@ -121,7 +121,7 @@ func TestProcessCheck(t *testing.T) {
 			},
 			module: fmt.Sprintf(processModule, `process.flags["--path"] == "foo"`),
 			processes: processutils.Processes{
-				42: processutils.NewCheckedFakeProcess(42, "proc1", []string{"arg1", "--path=foo"}),
+				42: processutils.NewCheckedFakeProcess(42, "proc1", []string{"arg1", "--path=foo"}, nil),
 			},
 			expectReport: &compliance.Report{
 				Passed: true,
@@ -151,8 +151,8 @@ func TestProcessCheck(t *testing.T) {
 			},
 			module: fmt.Sprintf(processModule, `process.flags["--path"] == "foo"`),
 			processes: processutils.Processes{
-				42: processutils.NewCheckedFakeProcess(42, "proc2", []string{"arg1", "--path=foo"}),
-				43: processutils.NewCheckedFakeProcess(43, "proc3", []string{"arg1", "--path=foo"}),
+				42: processutils.NewCheckedFakeProcess(42, "proc2", []string{"arg1", "--path=foo"}, nil),
+				43: processutils.NewCheckedFakeProcess(43, "proc3", []string{"arg1", "--path=foo"}, nil),
 			},
 			expectReport: &compliance.Report{
 				Passed:    false,
@@ -176,7 +176,7 @@ func TestProcessCheck(t *testing.T) {
 			},
 			module: fmt.Sprintf(processModule, `process.flags["--path"] == "foo"`),
 			processes: processutils.Processes{
-				42: processutils.NewCheckedFakeProcess(42, "proc1", []string{"arg1", "--paths=foo"}),
+				42: processutils.NewCheckedFakeProcess(42, "proc1", []string{"arg1", "--paths=foo"}, nil),
 			},
 			expectReport: &compliance.Report{
 				Passed: false,
@@ -216,7 +216,7 @@ func TestProcessCheckCache(t *testing.T) {
 		},
 		module: fmt.Sprintf(processModule, `process.flags["--path"] == "foo"`),
 		processes: processutils.Processes{
-			42: processutils.NewCheckedFakeProcess(42, "proc1", []string{"arg1", "--path=foo"}),
+			42: processutils.NewCheckedFakeProcess(42, "proc1", []string{"arg1", "--path=foo"}, nil),
 		},
 		expectReport: &compliance.Report{
 			Passed: true,

--- a/pkg/compliance/utils/process/process_utils.go
+++ b/pkg/compliance/utils/process/process_utils.go
@@ -121,6 +121,8 @@ func (p *CheckedProcess) EnvsMap(envs []string) (map[string]string, error) {
 			prefix := envName + "="
 			if strings.HasPrefix(envValue, prefix) {
 				envsMap[envName] = strings.TrimPrefix(envValue, prefix)
+			} else if envValue == envName {
+				envsMap[envName] = ""
 			}
 		}
 	}


### PR DESCRIPTION
### What does this PR do?

Allow specifying `envs` as process input.

```yaml
input:
  - process:
      name: etcd
      envs:
        - ETCD_PEER_CLIENT_CERT_AUTH
```

### Motivation

Some configuration setup can be specified via an environment variable. Without exposing these inputs, we cannot express some 

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
