### PR TITLE
[CWS] remove `AppendFieldValues`

### DIFF
--- a/pkg/security/secl/compiler/eval/evaluators.go
+++ b/pkg/security/secl/compiler/eval/evaluators.go
@@ -207,13 +207,6 @@ func (s *StringValuesEvaluator) IsStatic() bool {
 	return s.EvalFnc == nil
 }
 
-// AppendFieldValues append field values
-func (s *StringValuesEvaluator) AppendFieldValues(values ...FieldValue) {
-	for _, value := range values {
-		s.Values.AppendFieldValue(value)
-	}
-}
-
 // Compile the underlying StringValues
 func (s *StringValuesEvaluator) Compile(opts StringCmpOpts) error {
 	return s.Values.Compile(opts)
@@ -226,10 +219,8 @@ func (s *StringValuesEvaluator) SetFieldValues(values ...FieldValue) error {
 
 // AppendMembers add members to the evaluator
 func (s *StringValuesEvaluator) AppendMembers(members ...ast.StringMember) {
-	values := make([]FieldValue, 0, len(members))
-	var value FieldValue
-
 	for _, member := range members {
+		var value FieldValue
 		if member.Pattern != nil {
 			value = FieldValue{
 				Value: *member.Pattern,
@@ -246,10 +237,8 @@ func (s *StringValuesEvaluator) AppendMembers(members ...ast.StringMember) {
 				Type:  ScalarValueType,
 			}
 		}
-		values = append(values, value)
+		s.Values.AppendFieldValue(value)
 	}
-
-	s.AppendFieldValues(values...)
 }
 
 // IntArrayEvaluator returns an array of int

--- a/pkg/security/secl/compiler/eval/macro.go
+++ b/pkg/security/secl/compiler/eval/macro.go
@@ -57,7 +57,7 @@ func NewStringValuesMacro(id string, values []string, opts *Opts) (*Macro, error
 			Value: value,
 		}
 
-		evaluator.AppendFieldValues(fieldValue)
+		evaluator.Values.AppendFieldValue(fieldValue)
 	}
 
 	if err := evaluator.Compile(DefaultStringCmpOpts); err != nil {


### PR DESCRIPTION
### What does this PR do?

`AppendFieldValues` is a middleware that requires creating an array to use. This PR removes it in favor of calling directly `.Values.AppendFieldValue` matching more correctly the actual use case.

This whole `nodeToEvaluator` call path is responsible for a lot of allocation during system probe launch

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
