### PR TITLE
[USM] go TLS cleanup debug messages

### DIFF
--- a/pkg/network/protocols/http/ebpf_gotls.go
+++ b/pkg/network/protocols/http/ebpf_gotls.go
@@ -280,7 +280,7 @@ func (p *GoTLSProgram) handleProcessStart(pid pid) {
 	}
 	if err != nil {
 		// we can't access to the binary path here (pid probably ended already)
-		// there are not much we can't do and we don't want to flood the logs
+		// there are not much we can do and we don't want to flood the logs
 		return
 	}
 

--- a/pkg/network/protocols/http/ebpf_gotls.go
+++ b/pkg/network/protocols/http/ebpf_gotls.go
@@ -413,7 +413,6 @@ func (p *GoTLSProgram) unregisterProcess(pid pid) {
 	bin.processCount -= 1
 
 	if bin.processCount == 0 {
-		log.Debugf("no processes left for binID %v", bin.binID)
 		p.unhookBinary(bin)
 		delete(p.binaries, binID)
 	}

--- a/pkg/process/monitor/process_monitor.go
+++ b/pkg/process/monitor/process_monitor.go
@@ -142,16 +142,17 @@ func (p *ProcessMonitor) evalEXECCallback(c *ProcessCallback, pid uint32) {
 		return
 	}
 
-	var err error
-	var proc *process.Process
-	// We receive the Exec event first and /proc could be slow to update
-	end := time.Now().Add(10 * time.Millisecond)
-	for end.After(time.Now()) {
-		proc, err = process.NewProcess(int32(pid))
-		if err == nil {
-			break
+	proc, err := process.NewProcess(int32(pid))
+	if err != nil {
+		// We receive the Exec event first and /proc could be slow to update
+		end := time.Now().Add(10 * time.Millisecond)
+		for end.After(time.Now()) {
+			proc, err = process.NewProcess(int32(pid))
+			if err == nil {
+				break
+			}
+			time.Sleep(time.Millisecond)
 		}
-		time.Sleep(time.Millisecond)
 	}
 	if err != nil {
 		// short living process can hit here (or later proc.Name() parsing)


### PR DESCRIPTION
### What does this PR do?

* check during 10ms /proc/pid exist on Exec event
* removing log.Debug that flood the sysprobe logs

### Motivation

cleanup and review

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
