### PR TITLE
[single-machine-performance] Workaround baseline race condition

### DIFF
--- a/.gitlab/container_build/docker_linux.yml
+++ b/.gitlab/container_build/docker_linux.yml
@@ -127,6 +127,21 @@ docker_build_agent7:
     TEST_IMG: "true"
     BUILD_ARG: --target release --build-arg PYTHON_VERSION=3 --build-arg DD_AGENT_ARTIFACT=datadog-agent_7*_amd64.deb
 
+single_machine_performance-push-main-sha:
+  stage: container_build
+  rules:
+    - !reference [.on_main_a7]
+  needs:
+    - docker_build_agent7
+  script:
+    - echo -n ${CI_COMMIT_SHA} > .main_sha
+    - SMP_ACCOUNT_ID=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.single-machine-performance-account-id --with-decryption --query "Parameter.Value" --out text)
+    - SMP_AGENT_TEAM_ID=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.single-machine-performance-agent-team-id --with-decryption --query "Parameter.Value" --out text)
+    - aws configure set aws_access_key_id $(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.single-machine-performance-bot-access-key-id --with-decryption --query "Parameter.Value" --out text) --profile single-machine-performance
+    - aws configure set aws_secret_access_key $(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.single-machine-performance-bot-access-key --with-decryption --query "Parameter.Value" --out text) --profile single-machine-performance
+    - aws configure set region us-west-2 --profile single-machine-performance
+    - aws s3 sync --profile single-machine-performance --only-show-errors .main_sha s3://${SMP_AGENT_TEAM_ID}-smp-artifacts/information/latest_main_sha
+
 single_machine_performance-amd64-a7:
   extends: .docker_publish_job_definition
   stage: container_build

--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -10,7 +10,6 @@ single-machine-performance-regression_detector:
     paths:
       - submission_metadata
   variables:
-    GIT_STRATEGY: clone # pull the whole repo so we can compute baseline SHA
     SMP_VERSION: 0.6.6-rc1
     LADING_VERSION: 0.11.2
     TOTAL_SAMPLES: 600
@@ -21,12 +20,13 @@ single-machine-performance-regression_detector:
   # At present we require two artifacts to exist for the 'baseline' and the
   # 'comparison'. We are guaranteed by the structure of the pipeline that
   # 'comparison' exists, not so much with 'baseline' as it has to come from main
-  # merge pipeline run. This is solved in Vector by building Vector twice each
-  # Regression Detector run but remains an unsolved problem for
-  # datadog-agent. So, we allow failure for now.
+  # merge pipeline run. This is solved in datadog-agent by updating a file in S3
+  # with the SHA of the latest passing build from main. It's solved in Vector by
+  # building Vector twice for each Regression Detector run.
   #
-  # _Unfortunately_ this also means that if the Regression Detector finds a
-  # performance issue with a PR it will not be flagged.
+  # We allow failure for now. _Unfortunately_ this also means that if the
+  # Regression Detector finds a performance issue with a PR it will not be
+  # flagged.
   allow_failure: true
   script:
     # Setup AWS credentials for single-machine-performance AWS account
@@ -40,11 +40,11 @@ single-machine-performance-regression_detector:
     # Download smp binary and prepare it for use
     - aws --profile single-machine-performance s3 cp s3://smp-cli-releases/v${SMP_VERSION}/x86_64-unknown-linux-musl/smp smp
     - chmod +x smp
-    # Submit job, using the current main SHA as baseline. This will have been
-    # previously submitted in a separate pipeline run. The comparison will have
-    # been submitted in this pipeline run.
-    - git fetch origin main:main
-    - BASELINE_SHA=$(git rev-parse main)
+    # Submit job, using the SHA of the last successful main commit as baseline.
+    # This will have been built in a separate pipeline run. The comparison will
+    # have been built previously in this pipeline run.
+    - aws --profile ${AWS_NAMED_PROFILE} s3 cp --only-show-errors s3://${SMP_AGENT_TEAM_ID}-smp-artifacts/information/latest_main_sha .latest_main_sha
+    - BASELINE_SHA=$(cat .latest_main_sha)
     - BASELINE_IMAGE=${SMP_ECR_URL}/${SMP_AGENT_TEAM_ID}-agent:${BASELINE_SHA}-7-amd64
     - echo "${BASELINE_SHA} | ${BASELINE_IMAGE}"
     - COMPARISON_IMAGE=${SMP_ECR_URL}/${SMP_AGENT_TEAM_ID}-agent:${CI_COMMIT_SHA}-7-amd64


### PR DESCRIPTION
### What does this PR do?

Introduce a workaround for a race condition affecting the Regression Detector pipeline. This pipeline was previously silenced in https://github.com/DataDog/datadog-agent/pull/14828.

The strategy used by this workaround is to update a file in the Single Machine Performance team's Agent S3 bucket with the latest `main` SHA that passed CI. This is used as the baseline for the Regression Detector.

### Motivation

This workaround should allow the Regression Detector pipeline to run reliably. We will monitor the results and un-silence it in a followup PR.

### Additional Notes

Tracked in https://datadoghq.atlassian.net/browse/SMP-322