### PR TITLE
Fix the invocation of the secret backend from the cluster agent

### DIFF
--- a/comp/core/config/params.go
+++ b/comp/core/config/params.go
@@ -94,9 +94,10 @@ func NewSecurityAgentParams(securityAgentConfigFilePaths []string, options ...fu
 }
 
 func NewClusterAgentParams(configFilePath string, options ...func(*Params)) Params {
-	return NewParams(common.DefaultConfPath,
-		WithConfFilePath(configFilePath),
-		WithConfigName("datadog-cluster"))
+	params := NewParams(common.DefaultConfPath, options...)
+	params.confFilePath = configFilePath
+	params.configName = "datadog-cluster"
+	return params
 }
 
 func WithConfigName(name string) func(*Params) {


### PR DESCRIPTION
### What does this PR do?

Fix the invocation of the secret backend to decrypt `ENC[…]` secrets from the cluster agent.

### Motivation

The cluster agent is currently not invoking the secret backend, even when encountering an `ENC[…]` token.

### Additional Notes

Here is how the `start` command of the cluster-agent is invoking the `Fx` framework with an explicit mention that secrets should be decoded:
https://github.com/DataDog/datadog-agent/blob/dc88d14851354cada1d15265220a39dce8840dcc/cmd/cluster-agent/subcommands/start/command.go#L77-L84

The problem was that the `config.WithConfigLoadSecrets(true)` parameter of `config.NewClusterAgentParams(…)` was ignored.

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Deploy the `cluster-agent` on a cluster where it needs to use a secret backend to get all its config and validate that the config has properly been resolved by the secret backend.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
