### PR TITLE
[process-agent] Fix nil deref in check cmd

### DIFF
--- a/cmd/process-agent/subcommands/check/check.go
+++ b/cmd/process-agent/subcommands/check/check.go
@@ -220,9 +220,15 @@ func runCheck(cliParams *cliParams, ch checks.Check) error {
 		return fmt.Errorf("collection error: %s", err)
 	}
 
-	msgs := result.Payloads()
-	if options != nil && options.RunRealtime {
+	var msgs []process.MessageBody
+
+	switch {
+	case result == nil:
+		break
+	case options != nil && options.RunRealtime:
 		msgs = result.RealtimePayloads()
+	default:
+		msgs = result.Payloads()
 	}
 
 	return printResults(cliParams.checkName, msgs, cliParams.checkOutputJSON)


### PR DESCRIPTION
### What does this PR do?

Fixes nil deref in `process-agent check` command for checks not returning result on success.

### Motivation

Fixes panic:
```
Results for check rtcontainer
-----------------------------

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x30644f8]
```

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Test running `process-agent check <check>` for checks not returning result on success - container/rtcontainer/connections when these features are not available:
* container runtime not available for container checks
* system probe not running for connections

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
