### PR TITLE
rtloader: Use execinfo only on glibc

### DIFF
--- a/releasenotes/notes/rtloader-use-execinfo-only-on-glibc-5b734df32fc1555a.yaml
+++ b/releasenotes/notes/rtloader-use-execinfo-only-on-glibc-5b734df32fc1555a.yaml
@@ -8,6 +8,6 @@
 ---
 fixes:
   - |
-    rtloader: Use execinfo only on glibc to fix builds on
-    C libraries like musl.
+    rtloader: Use `execinfo` only if provided to fix builds on
+    C libraries like `musl`.
 

--- a/releasenotes/notes/rtloader-use-execinfo-only-on-glibc-5b734df32fc1555a.yaml
+++ b/releasenotes/notes/rtloader-use-execinfo-only-on-glibc-5b734df32fc1555a.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    rtloader: Use execinfo only on glibc to fix builds on
+    C libraries like musl.
+

--- a/rtloader/rtloader/CMakeLists.txt
+++ b/rtloader/rtloader/CMakeLists.txt
@@ -40,6 +40,7 @@ endif()
 if(${CMAKE_SYSTEM_NAME} STREQUAL FreeBSD)
   find_package(Backtrace REQUIRED)
   target_link_libraries(datadog-agent-rtloader ${Backtrace_LIBRARIES})
+  add_compile_definitions(HAS_BACKTRACE_LIB)
 endif()
 
 set_target_properties(datadog-agent-rtloader PROPERTIES

--- a/rtloader/rtloader/CMakeLists.txt
+++ b/rtloader/rtloader/CMakeLists.txt
@@ -32,6 +32,7 @@ add_library(datadog-agent-rtloader SHARED
 find_library(EXECINFO execinfo)
 if(EXECINFO)
     target_link_libraries(datadog-agent-rtloader execinfo)
+    add_compile_definitions(HAS_BACKTRACE_LIB)
 endif()
 endif()
 

--- a/rtloader/rtloader/api.cpp
+++ b/rtloader/rtloader/api.cpp
@@ -12,7 +12,7 @@
 #ifndef _WIN32
 // clang-format off
 // handler stuff
-#ifdef __GLIBC__
+#ifdef HAS_BACKTRACE_LIB
 #include <execinfo.h>
 #endif
 #include <csignal>
@@ -373,14 +373,14 @@ static inline void core(int sig)
 #    define STACKTRACE_SIZE 500
 void signalHandler(int sig, siginfo_t *, void *)
 {
-#    ifdef __GLIBC__
+#    ifdef HAS_BACKTRACE_LIB
     void *buffer[STACKTRACE_SIZE];
     char **symbols;
 
     size_t nptrs = backtrace(buffer, STACKTRACE_SIZE);
 #    endif
     std::cerr << "HANDLER CAUGHT signal Error: signal " << sig << std::endl;
-#    ifdef __GLIBC__
+#    ifdef HAS_BACKTRACE_LIB
     symbols = backtrace_symbols(buffer, nptrs);
     if (symbols == NULL) {
         std::cerr << "Error getting backtrace symbols" << std::endl;

--- a/rtloader/rtloader/api.cpp
+++ b/rtloader/rtloader/api.cpp
@@ -12,7 +12,9 @@
 #ifndef _WIN32
 // clang-format off
 // handler stuff
+#ifdef __GLIBC__
 #include <execinfo.h>
+#endif
 #include <csignal>
 #include <cstring>
 #include <sys/types.h>
@@ -371,11 +373,14 @@ static inline void core(int sig)
 #    define STACKTRACE_SIZE 500
 void signalHandler(int sig, siginfo_t *, void *)
 {
+#    ifdef __GLIBC__
     void *buffer[STACKTRACE_SIZE];
     char **symbols;
 
     size_t nptrs = backtrace(buffer, STACKTRACE_SIZE);
+#    endif
     std::cerr << "HANDLER CAUGHT signal Error: signal " << sig << std::endl;
+#    ifdef __GLIBC__
     symbols = backtrace_symbols(buffer, nptrs);
     if (symbols == NULL) {
         std::cerr << "Error getting backtrace symbols" << std::endl;
@@ -387,6 +392,7 @@ void signalHandler(int sig, siginfo_t *, void *)
 
         _free(symbols);
     }
+#    endif
 
     // dump core if so configured
     __sync_synchronize();


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Use execinfo only on glibc.
Functions in execinfo.h are GNU extensions and not available on other C libraries like musl.


### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
We used to use [`libexecinfo` package](https://pkgs.alpinelinux.org/package/v3.16/main/x86_64/libexecinfo) (`A quick-n-dirty BSD licensed clone of the GNU libc backtrace facility.`) of Alpine Linux to build [datadog-agent on Alpine](https://github.com/seqsense/datadog-agent-alpine), but [it has been removed since Alpine 3.17](https://gitlab.alpinelinux.org/alpine/aports/-/merge_requests/36722).
This PR allow to build datadog-agent on Alpine Linux and other non-glibc environments.

### Additional Notes

A docker image based on Alpine Linux (musl libc) with this patch is available at
https://github.com/seqsense/datadog-agent-alpine/pkgs/container/datadog-agent/69345371?tag=7.41.1-alpine.
I tested with out DD_API_KEY to confirm logs and python based metrics integrations work.
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs
No change to the official builds.
<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
Build result will have no change to the official docker images and the binaries for Ubuntu and other glibc based linux distros.

To ensure that stacktraces are still printed for glibc-based distros, run the following steps on either the docker image or a host install on ubuntu.
1. Add a python check that segfaults, an example has been provided below
2. Configure an instance of this check to run
3. Enable the config option: `c_stacktrace_collection: true`
4. Run the agent, once the segfaulting check runs, the agent should print out `HANDLER CAUGHT signal Error: signal 11
C-LAND STACKTRACE:` followed by a stacktrace.

```python
from datadog_checks.base import AgentCheck
import ctypes;

class HelloCheck(AgentCheck):
    def check(self, instance):
        # This tries to read a word from nil, leading to segv
        # from: https://bugs.python.org/issue1215#msg143236
        ctypes.string_at(0)
```

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
