### PR TITLE
[sbom] Store generation duration and report it

### DIFF
--- a/pkg/collector/corechecks/sbom/convert.go
+++ b/pkg/collector/corechecks/sbom/convert.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/CycloneDX/cyclonedx-go"
 	"github.com/DataDog/agent-payload/v5/cyclonedx_v1_4"
+	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -847,6 +848,10 @@ func convertTimestamp(in string) *timestamppb.Timestamp {
 	} else {
 		return timestamppb.New(ts)
 	}
+}
+
+func convertDuration(in time.Duration) *durationpb.Duration {
+	return durationpb.New(in)
 }
 
 func convertTool(in *cyclonedx.Tool) *cyclonedx_v1_4.Tool {

--- a/pkg/collector/corechecks/sbom/processor.go
+++ b/pkg/collector/corechecks/sbom/processor.go
@@ -62,11 +62,12 @@ func (p *processor) processSBOM(img *workloadmeta.ContainerImageMetadata) {
 	}
 
 	p.queue <- &model.SBOMEntity{
-		Type:        model.SBOMSourceType_CONTAINER_IMAGE_LAYERS,
-		Id:          img.ID,
-		GeneratedAt: nil,
-		Tags:        img.RepoTags,
-		InUse:       true, // TODO: compute this field
+		Type:               model.SBOMSourceType_CONTAINER_IMAGE_LAYERS,
+		Id:                 img.ID,
+		GeneratedAt:        nil,
+		Tags:               img.RepoTags,
+		InUse:              true, // TODO: compute this field
+		GenerationDuration: convertDuration(img.SBOM.GenerationDuration),
 		Sbom: &sbom.SBOMEntity_Cyclonedx{
 			Cyclonedx: convertBOM(img.SBOM.CycloneDXBOM),
 		},

--- a/pkg/collector/corechecks/sbom/processor.go
+++ b/pkg/collector/corechecks/sbom/processor.go
@@ -12,6 +12,7 @@ import (
 	queue "github.com/DataDog/datadog-agent/pkg/util/aggregatingqueue"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/DataDog/agent-payload/v5/sbom"
 	model "github.com/DataDog/agent-payload/v5/sbom"
@@ -64,7 +65,7 @@ func (p *processor) processSBOM(img *workloadmeta.ContainerImageMetadata) {
 	p.queue <- &model.SBOMEntity{
 		Type:               model.SBOMSourceType_CONTAINER_IMAGE_LAYERS,
 		Id:                 img.ID,
-		GeneratedAt:        nil,
+		GeneratedAt:        timestamppb.New(img.SBOM.GenerationTime),
 		Tags:               img.RepoTags,
 		InUse:              true, // TODO: compute this field
 		GenerationDuration: convertDuration(img.SBOM.GenerationDuration),

--- a/pkg/collector/corechecks/sbom/processor.go
+++ b/pkg/collector/corechecks/sbom/processor.go
@@ -57,7 +57,7 @@ func (p *processor) processRefresh(allImages []*workloadmeta.ContainerImageMetad
 }
 
 func (p *processor) processSBOM(img *workloadmeta.ContainerImageMetadata) {
-	if img.CycloneDXBOM == nil {
+	if img.SBOM == nil || img.SBOM.CycloneDXBOM == nil {
 		return
 	}
 
@@ -68,7 +68,7 @@ func (p *processor) processSBOM(img *workloadmeta.ContainerImageMetadata) {
 		Tags:        img.RepoTags,
 		InUse:       true, // TODO: compute this field
 		Sbom: &sbom.SBOMEntity_Cyclonedx{
-			Cyclonedx: convertBOM(img.CycloneDXBOM),
+			Cyclonedx: convertBOM(img.SBOM.CycloneDXBOM),
 		},
 	}
 }

--- a/pkg/collector/corechecks/sbom/processor_test.go
+++ b/pkg/collector/corechecks/sbom/processor_test.go
@@ -19,12 +19,15 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 	"github.com/stretchr/testify/mock"
 	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func TestProcessEvents(t *testing.T) {
 	sender := mocksender.NewMockSender(check.ID(""))
 	sender.On("SBOM", mock.Anything, mock.Anything).Return()
 	p := newProcessor(sender, 2, 50*time.Millisecond)
+
+	sbomGenerationTime := time.Now()
 
 	for i := 0; i < 3; i++ {
 		p.processEvents(workloadmeta.EventBundle{
@@ -52,6 +55,7 @@ func TestProcessEvents(t *testing.T) {
 									},
 								},
 							},
+							GenerationTime:     sbomGenerationTime,
 							GenerationDuration: 10 * time.Second,
 						},
 					},
@@ -71,6 +75,7 @@ func TestProcessEvents(t *testing.T) {
 					Type:               model.SBOMSourceType_CONTAINER_IMAGE_LAYERS,
 					Id:                 "0",
 					InUse:              true,
+					GeneratedAt:        timestamppb.New(sbomGenerationTime),
 					GenerationDuration: durationpb.New(10 * time.Second),
 					Sbom: &model.SBOMEntity_Cyclonedx{
 						Cyclonedx: &cyclonedx_v1_4.Bom{
@@ -94,6 +99,7 @@ func TestProcessEvents(t *testing.T) {
 					Type:               model.SBOMSourceType_CONTAINER_IMAGE_LAYERS,
 					Id:                 "1",
 					InUse:              true,
+					GeneratedAt:        timestamppb.New(sbomGenerationTime),
 					GenerationDuration: durationpb.New(10 * time.Second),
 					Sbom: &model.SBOMEntity_Cyclonedx{
 						Cyclonedx: &cyclonedx_v1_4.Bom{
@@ -129,6 +135,7 @@ func TestProcessEvents(t *testing.T) {
 					Type:               model.SBOMSourceType_CONTAINER_IMAGE_LAYERS,
 					Id:                 "2",
 					InUse:              true,
+					GeneratedAt:        timestamppb.New(sbomGenerationTime),
 					GenerationDuration: durationpb.New(10 * time.Second),
 					Sbom: &model.SBOMEntity_Cyclonedx{
 						Cyclonedx: &cyclonedx_v1_4.Bom{

--- a/pkg/collector/corechecks/sbom/processor_test.go
+++ b/pkg/collector/corechecks/sbom/processor_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/pointer"
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 	"github.com/stretchr/testify/mock"
+	"google.golang.org/protobuf/types/known/durationpb"
 )
 
 func TestProcessEvents(t *testing.T) {
@@ -51,6 +52,7 @@ func TestProcessEvents(t *testing.T) {
 									},
 								},
 							},
+							GenerationDuration: 10 * time.Second,
 						},
 					},
 				},
@@ -66,9 +68,10 @@ func TestProcessEvents(t *testing.T) {
 			Source:  &sourceAgent,
 			Entities: []*model.SBOMEntity{
 				{
-					Type:  model.SBOMSourceType_CONTAINER_IMAGE_LAYERS,
-					Id:    "0",
-					InUse: true,
+					Type:               model.SBOMSourceType_CONTAINER_IMAGE_LAYERS,
+					Id:                 "0",
+					InUse:              true,
+					GenerationDuration: durationpb.New(10 * time.Second),
 					Sbom: &model.SBOMEntity_Cyclonedx{
 						Cyclonedx: &cyclonedx_v1_4.Bom{
 							SpecVersion: "1.4",
@@ -88,9 +91,10 @@ func TestProcessEvents(t *testing.T) {
 					},
 				},
 				{
-					Type:  model.SBOMSourceType_CONTAINER_IMAGE_LAYERS,
-					Id:    "1",
-					InUse: true,
+					Type:               model.SBOMSourceType_CONTAINER_IMAGE_LAYERS,
+					Id:                 "1",
+					InUse:              true,
+					GenerationDuration: durationpb.New(10 * time.Second),
 					Sbom: &model.SBOMEntity_Cyclonedx{
 						Cyclonedx: &cyclonedx_v1_4.Bom{
 							SpecVersion: "1.4",
@@ -122,9 +126,10 @@ func TestProcessEvents(t *testing.T) {
 			Source:  &sourceAgent,
 			Entities: []*model.SBOMEntity{
 				{
-					Type:  model.SBOMSourceType_CONTAINER_IMAGE_LAYERS,
-					Id:    "2",
-					InUse: true,
+					Type:               model.SBOMSourceType_CONTAINER_IMAGE_LAYERS,
+					Id:                 "2",
+					InUse:              true,
+					GenerationDuration: durationpb.New(10 * time.Second),
 					Sbom: &model.SBOMEntity_Cyclonedx{
 						Cyclonedx: &cyclonedx_v1_4.Bom{
 							SpecVersion: "1.4",

--- a/pkg/collector/corechecks/sbom/processor_test.go
+++ b/pkg/collector/corechecks/sbom/processor_test.go
@@ -35,18 +35,20 @@ func TestProcessEvents(t *testing.T) {
 							Kind: workloadmeta.KindContainerImageMetadata,
 							ID:   strconv.Itoa(i),
 						},
-						CycloneDXBOM: &cyclonedx.BOM{
-							SpecVersion: cyclonedx.SpecVersion1_4,
-							Version:     42,
-							Components: &[]cyclonedx.Component{
-								{
-									Name: strconv.Itoa(100 * i),
-								},
-								{
-									Name: strconv.Itoa(100*i + 1),
-								},
-								{
-									Name: strconv.Itoa(100*i + 2),
+						SBOM: &workloadmeta.SBOM{
+							CycloneDXBOM: &cyclonedx.BOM{
+								SpecVersion: cyclonedx.SpecVersion1_4,
+								Version:     42,
+								Components: &[]cyclonedx.Component{
+									{
+										Name: strconv.Itoa(100 * i),
+									},
+									{
+										Name: strconv.Itoa(100*i + 1),
+									},
+									{
+										Name: strconv.Itoa(100*i + 2),
+									},
 								},
 							},
 						},

--- a/pkg/workloadmeta/collectors/internal/containerd/image.go
+++ b/pkg/workloadmeta/collectors/internal/containerd/image.go
@@ -15,7 +15,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/CycloneDX/cyclonedx-go"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 
@@ -154,7 +153,7 @@ func (c *collector) handleImageEvent(ctx context.Context, containerdEvent *conta
 	}
 }
 
-func (c *collector) handleImageCreateOrUpdate(ctx context.Context, namespace string, imageName string, bom *cyclonedx.BOM) error {
+func (c *collector) handleImageCreateOrUpdate(ctx context.Context, namespace string, imageName string, bom *workloadmeta.SBOM) error {
 	img, err := c.containerdClient.Image(namespace, imageName)
 	if err != nil {
 		return fmt.Errorf("error getting image: %w", err)
@@ -163,7 +162,7 @@ func (c *collector) handleImageCreateOrUpdate(ctx context.Context, namespace str
 	return c.notifyEventForImage(ctx, namespace, img, bom)
 }
 
-func (c *collector) notifyEventForImage(ctx context.Context, namespace string, img containerd.Image, bom *cyclonedx.BOM) error {
+func (c *collector) notifyEventForImage(ctx context.Context, namespace string, img containerd.Image, bom *workloadmeta.SBOM) error {
 	ctxWithNamespace := namespaces.WithNamespace(ctx, namespace)
 
 	manifest, err := images.Manifest(ctxWithNamespace, img.ContentStore(), img.Target(), img.Platform())
@@ -219,8 +218,8 @@ func (c *collector) notifyEventForImage(ctx context.Context, namespace string, i
 			shortName = existingImg.ShortName
 		}
 
-		if existingBOM == nil && existingImg.CycloneDXBOM != nil {
-			existingBOM = existingImg.CycloneDXBOM
+		if existingBOM == nil && existingImg.SBOM != nil {
+			existingBOM = existingImg.SBOM
 		}
 	}
 
@@ -278,7 +277,7 @@ func (c *collector) notifyEventForImage(ctx context.Context, namespace string, i
 		Architecture: architecture,
 		Variant:      variant,
 		Layers:       layers,
-		CycloneDXBOM: existingBOM,
+		SBOM:         existingBOM,
 	}
 
 	c.store.Notify([]workloadmeta.CollectorEvent{

--- a/pkg/workloadmeta/collectors/internal/containerd/image_sbom_trivy.go
+++ b/pkg/workloadmeta/collectors/internal/containerd/image_sbom_trivy.go
@@ -17,6 +17,7 @@ import (
 	cutil "github.com/DataDog/datadog-agent/pkg/util/containerd"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/trivy"
+	"github.com/DataDog/datadog-agent/pkg/workloadmeta/telemetry"
 )
 
 // scan buffer needs to be very large as we cannot block containerd collector
@@ -82,10 +83,12 @@ func (c *collector) extractBOMWithTrivy(ctx context.Context, imageToScan namespa
 		scanFunc = c.trivyClient.ScanContainerdImageFromFilesystem
 	}
 
+	tStartScan := time.Now()
 	bom, err := scanFunc(ctx, storedImage, imageToScan.image)
 	if err != nil {
 		return err
 	}
+	telemetry.SBOMGenerationDuration.Observe(time.Since(tStartScan).Seconds())
 
 	time.Sleep(timeBetweenScans())
 

--- a/pkg/workloadmeta/collectors/internal/containerd/image_sbom_trivy.go
+++ b/pkg/workloadmeta/collectors/internal/containerd/image_sbom_trivy.go
@@ -96,6 +96,7 @@ func (c *collector) extractBOMWithTrivy(ctx context.Context, imageToScan namespa
 
 	sbom := workloadmeta.SBOM{
 		CycloneDXBOM:       cycloneDXBOM,
+		GenerationTime:     tStartScan,
 		GenerationDuration: scanDuration,
 	}
 

--- a/pkg/workloadmeta/telemetry/telemetry.go
+++ b/pkg/workloadmeta/telemetry/telemetry.go
@@ -86,4 +86,15 @@ var (
 		"Number of errors on the remote workloadmeta server while streaming events",
 		commonOpts,
 	)
+
+	// SBOMGenerationDuration measures the time that it takes to generate SBOMs
+	// in seconds.
+	SBOMGenerationDuration = telemetry.NewHistogramWithOpts(
+		subsystem,
+		"sbom_generation_duration",
+		[]string{},
+		"SBOM generation duration (in seconds)",
+		[]float64{10, 30, 60, 120, 180, 240, 300, 360, 420, 480, 540, 600},
+		commonOpts,
+	)
 )

--- a/pkg/workloadmeta/types.go
+++ b/pkg/workloadmeta/types.go
@@ -652,6 +652,7 @@ type ContainerImageLayer struct {
 // SBOM represents the Software Bill Of Materials (SBOM) of a container
 type SBOM struct {
 	CycloneDXBOM       *cyclonedx.BOM
+	GenerationTime     time.Time
 	GenerationDuration time.Duration
 }
 

--- a/pkg/workloadmeta/types.go
+++ b/pkg/workloadmeta/types.go
@@ -637,7 +637,7 @@ type ContainerImageMetadata struct {
 	Architecture string
 	Variant      string
 	Layers       []ContainerImageLayer
-	CycloneDXBOM *cyclonedx.BOM
+	SBOM         *SBOM
 }
 
 // ContainerImageLayer represents a layer of a container image
@@ -647,6 +647,12 @@ type ContainerImageLayer struct {
 	SizeBytes int64
 	URLs      []string
 	History   v1.History
+}
+
+// SBOM represents the Software Bill Of Materials (SBOM) of a container
+type SBOM struct {
+	CycloneDXBOM       *cyclonedx.BOM
+	GenerationDuration time.Duration
 }
 
 // GetID implements Entity#GetID.
@@ -692,8 +698,8 @@ func (i ContainerImageMetadata) String(verbose bool) string {
 		_, _ = fmt.Fprintln(&sb, "Architecture:", i.Architecture)
 		_, _ = fmt.Fprintln(&sb, "Variant:", i.Variant)
 
-		if i.CycloneDXBOM != nil {
-			_, _ = fmt.Fprintln(&sb, "SBOM: stored")
+		if i.SBOM != nil {
+			_, _ = fmt.Fprintf(&sb, "SBOM: stored. Generated in: %.2f seconds\n", i.SBOM.GenerationDuration.Seconds())
 		} else {
 			_, _ = fmt.Fprintln(&sb, "SBOM: not stored")
 		}


### PR DESCRIPTION
### What does this PR do?

Stores in workloadmeta the time that it takes to generate SBOMs so that the SBOM check can send them to the intake.

The PR also includes the generation duration in the telemetry (`workloadmeta.sbom_generation_duration`).

### Describe how to test/QA your changes

Enable image metadata collection, sbom collection, the SBOM check, and the agent telemetry:
- `DD_CONTAINER_IMAGE_COLLECTION_METADATA_ENABLED=true`.
- `DD_CONTAINER_IMAGE_COLLECTION_SBOM_ENABLED=true`.
- `DD_SBOM_ENABLED=true`.
- `DD_TELEMETRY_ENABLED=true`.
- Mount `sbom.yaml` with the default config.

Then:

- Check that the SBOM generation duration is included in the telemetry. `curl http://localhost:6000/telemetry` and look for `workloadmeta_sbom_generation_duration` (histogram).
- Check that the duration is included in workloadmeta: `agent workload-list --verbose | grep SBOM`.
- Check that the duration is reported. For now, the best way to verify this is to check the payloads in our internal logs.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
