### PR TITLE
Fix a bug in workloadmeta containerd collector when setting `shortName` and `Registry`

### DIFF
--- a/pkg/workloadmeta/collectors/internal/containerd/image.go
+++ b/pkg/workloadmeta/collectors/internal/containerd/image.go
@@ -187,11 +187,7 @@ func (c *collector) notifyEventForImage(ctx context.Context, namespace string, i
 	imageName := img.Name()
 	registry := ""
 	shortName := ""
-	parsedImg, err := workloadmeta.NewContainerImage(imageName)
-	if err == nil {
-		// Don't set a short name. We know that some images handled here contain
-		// "sha256" in the name, and those don't have a short name.
-	} else {
+	if parsedImg, err := workloadmeta.NewContainerImage(imageName); err == nil {
 		registry = parsedImg.Registry
 		shortName = parsedImg.ShortName
 	}


### PR DESCRIPTION
### What does this PR do?

Fix a bug in the workloadmeta containerd collector where it was trying to fill the short name and the registry of the image only in case there was an error. The error testing logic was inverted.

### Motivation

Properly set those two fields.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Validate that the container image metadata sent to the #processes pipeline have their short name and registry properly filled.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
