### PR TITLE
[corechecks/snmp] No local resolution if multiple results

### DIFF
--- a/pkg/collector/corechecks/snmp/internal/report/report_device_metadata.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_device_metadata.go
@@ -358,17 +358,23 @@ func resolveLocalInterface(deviceID string, interfaceIndexByIDType map[string]ma
 	} else {
 		typesToTry = []string{localInterfaceIDType}
 	}
-	var matchedIfIndexes []int32
+	matchedIfIndexesMap := make(map[int32]struct{})
 	for _, idType := range typesToTry {
 		interfaceIndexByIDValue, ok := interfaceIndexByIDType[idType]
 		if ok {
 			ifIndexes, ok := interfaceIndexByIDValue[localInterfaceID]
 			if ok {
-				matchedIfIndexes = append(matchedIfIndexes, ifIndexes...)
+				for _, ifIndex := range ifIndexes {
+					matchedIfIndexesMap[ifIndex] = struct{}{}
+				}
 			}
 		}
 	}
-	if len(matchedIfIndexes) == 1 {
+	if len(matchedIfIndexesMap) == 1 {
+		var matchedIfIndexes []int32
+		for key := range matchedIfIndexesMap {
+			matchedIfIndexes = append(matchedIfIndexes, key)
+		}
 		return metadata.IDTypeNDM, deviceID + ":" + strconv.Itoa(int(matchedIfIndexes[0]))
 	}
 	return localInterfaceIDType, localInterfaceID

--- a/pkg/collector/corechecks/snmp/internal/report/report_device_metadata_test.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_device_metadata_test.go
@@ -553,22 +553,23 @@ func Test_getRemManIPAddrByLLDPRemIndex(t *testing.T) {
 }
 
 func Test_resolveLocalInterface(t *testing.T) {
-	interfaceIndexByIDType := map[string]map[string]int32{
+	interfaceIndexByIDType := map[string]map[string][]int32{
 		"mac_address": {
-			"00:00:00:00:00:01": 1,
-			"00:00:00:00:00:02": 2,
+			"00:00:00:00:00:01": []int32{1},
+			"00:00:00:00:00:02": []int32{2},
+			"00:00:00:00:00:03": []int32{3, 4},
 		},
 		"interface_name": {
-			"eth1": 1,
-			"eth2": 2,
+			"eth1": []int32{1},
+			"eth2": []int32{2},
 		},
 		"interface_alias": {
-			"alias1": 1,
-			"alias2": 2,
+			"alias1": []int32{1},
+			"alias2": []int32{2},
 		},
 		"interface_index": {
-			"1": 1,
-			"2": 2,
+			"1": []int32{1},
+			"2": []int32{2},
 		},
 	}
 	deviceID := "default:1.2.3.4"
@@ -586,6 +587,13 @@ func Test_resolveLocalInterface(t *testing.T) {
 			localID:        "00:00:00:00:00:01",
 			expectedIDType: "ndm",
 			expectedID:     "default:1.2.3.4:1",
+		},
+		{
+			name:           "mac_address cannot resolve due to multiple results",
+			localIDType:    "mac_address",
+			localID:        "00:00:00:00:00:03",
+			expectedIDType: "mac_address",
+			expectedID:     "00:00:00:00:00:03",
 		},
 		{
 			name:           "interface_name",
@@ -677,28 +685,38 @@ func Test_buildInterfaceIndexByIDType(t *testing.T) {
 			Name:       "eth2",
 			Alias:      "alias2",
 		},
+		{
+			DeviceID:   "default:1.2.3.4",
+			Index:      3,
+			MacAddress: "00:00:00:00:00:02",
+			Name:       "eth3",
+			Alias:      "alias3",
+		},
 	}
 
 	// Act
 	interfaceIndexByIDType := buildInterfaceIndexByIDType(interfaces)
 
 	// Assert
-	expectedInterfaceIndexByIDType := map[string]map[string]int32{
+	expectedInterfaceIndexByIDType := map[string]map[string][]int32{
 		"mac_address": {
-			"00:00:00:00:00:01": 1,
-			"00:00:00:00:00:02": 2,
+			"00:00:00:00:00:01": []int32{1},
+			"00:00:00:00:00:02": []int32{2, 3},
 		},
 		"interface_name": {
-			"eth1": 1,
-			"eth2": 2,
+			"eth1": []int32{1},
+			"eth2": []int32{2},
+			"eth3": []int32{3},
 		},
 		"interface_alias": {
-			"alias1": 1,
-			"alias2": 2,
+			"alias1": []int32{1},
+			"alias2": []int32{2},
+			"alias3": []int32{3},
 		},
 		"interface_index": {
-			"1": 1,
-			"2": 2,
+			"1": []int32{1},
+			"2": []int32{2},
+			"3": []int32{3},
 		},
 	}
 	assert.Equal(t, expectedInterfaceIndexByIDType, interfaceIndexByIDType)

--- a/pkg/collector/corechecks/snmp/internal/report/report_device_metadata_test.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_device_metadata_test.go
@@ -562,10 +562,14 @@ func Test_resolveLocalInterface(t *testing.T) {
 		"interface_name": {
 			"eth1": []int32{1},
 			"eth2": []int32{2},
+			"eth3": []int32{3},
+			"eth4": []int32{4},
 		},
 		"interface_alias": {
 			"alias1": []int32{1},
 			"alias2": []int32{2},
+			"eth3":   []int32{3},
+			"eth4":   []int32{44},
 		},
 		"interface_index": {
 			"1": []int32{1},
@@ -631,11 +635,18 @@ func Test_resolveLocalInterface(t *testing.T) {
 			expectedID:     "default:1.2.3.4:2",
 		},
 		{
-			name:           "interface_alias by trying",
+			name:           "interface_alias+interface_name match with same interface should resolve",
 			localIDType:    "",
-			localID:        "alias2",
+			localID:        "eth3",
 			expectedIDType: "ndm",
-			expectedID:     "default:1.2.3.4:2",
+			expectedID:     "default:1.2.3.4:3",
+		},
+		{
+			name:           "interface_alias+interface_name match with different interface should not resolve",
+			localIDType:    "",
+			localID:        "eth4",
+			expectedIDType: "",
+			expectedID:     "eth4",
 		},
 		{
 			name:           "interface_index by trying",

--- a/pkg/collector/corechecks/snmp/internal/report/report_device_metadata_test.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_device_metadata_test.go
@@ -562,8 +562,8 @@ func Test_resolveLocalInterface(t *testing.T) {
 		"interface_name": {
 			"eth1": []int32{1},
 			"eth2": []int32{2},
-			"eth3": []int32{3},
-			"eth4": []int32{4},
+			"eth3": []int32{3}, // eth3 is both a name and alias, and reference the same interface
+			"eth4": []int32{4}, // eth4 is both a name and alias, and reference two different interfaces
 		},
 		"interface_alias": {
 			"alias1": []int32{1},


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

[corechecks/snmp] No resolution if multiple results

Make `resolveLocalInterface` return original type/id if there are multiple interfaces that can be candidate.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

1/ Returning the first interface matched might lead to unpredictable result, and we should avoid that.
2/ More consistent with the backend remote side resolution since we are also not resolving when multiple interfaces are matched.

In the future, we might want to find a better resolution solution when multiple interfaces are matched.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
