### PR TITLE
[corechecks/snmp] Use dd_id instead of idType ndm

### DIFF
--- a/pkg/collector/corechecks/snmp/internal/metadata/payload.go
+++ b/pkg/collector/corechecks/snmp/internal/metadata/payload.go
@@ -24,11 +24,6 @@ const (
 type IDType string
 
 const (
-	// IDTypeNDM is used as IDType value for topology data
-	// to indicate the ID uses NDM internal type
-	// e.g. interfaceID of `ndm` type is in this format: `<NAMESPACE>:<DEVICE_IP>:<INTERFACE_INDEX>`
-	IDTypeNDM = "ndm"
-
 	// IDTypeMacAddress represent mac address in `00:00:00:00:00:00` format
 	IDTypeMacAddress = "mac_address"
 )

--- a/pkg/collector/corechecks/snmp/internal/metadata/payload.go
+++ b/pkg/collector/corechecks/snmp/internal/metadata/payload.go
@@ -89,6 +89,7 @@ type IPAddressMetadata struct {
 
 // TopologyLinkDevice contain device link data
 type TopologyLinkDevice struct {
+	DDID        string `json:"dd_id,omitempty"`
 	ID          string `json:"id,omitempty"`
 	IDType      string `json:"id_type,omitempty"`
 	Name        string `json:"name,omitempty"`
@@ -98,6 +99,7 @@ type TopologyLinkDevice struct {
 
 // TopologyLinkInterface contain interface link data
 type TopologyLinkInterface struct {
+	DDID        string `json:"dd_id,omitempty"`
 	ID          string `json:"id"`
 	IDType      string `json:"id_type,omitempty"`
 	Description string `json:"description,omitempty"`
@@ -111,10 +113,8 @@ type TopologyLinkSide struct {
 
 // TopologyLinkMetadata contains topology interface to interface links metadata
 type TopologyLinkMetadata struct {
-	ID               string            `json:"id"`
-	SourceType       string            `json:"source_type"`
-	LocalDeviceID    string            `json:"local_device_id"`
-	LocalInterfaceID string            `json:"local_interface_id"`
-	Local            *TopologyLinkSide `json:"local"`
-	Remote           *TopologyLinkSide `json:"remote"`
+	ID         string            `json:"id"`
+	SourceType string            `json:"source_type"`
+	Local      *TopologyLinkSide `json:"local"`
+	Remote     *TopologyLinkSide `json:"remote"`
 }

--- a/pkg/collector/corechecks/snmp/internal/metadata/payload.go
+++ b/pkg/collector/corechecks/snmp/internal/metadata/payload.go
@@ -111,8 +111,9 @@ type TopologyLinkSide struct {
 
 // TopologyLinkMetadata contains topology interface to interface links metadata
 type TopologyLinkMetadata struct {
-	ID         string            `json:"id"`
-	SourceType string            `json:"source_type"`
-	Local      *TopologyLinkSide `json:"local"`
-	Remote     *TopologyLinkSide `json:"remote"`
+	ID               string            `json:"id"`
+	SourceType       string            `json:"source_type"`
+	LocalInterfaceID string            `json:"local_interface_id"`
+	Local            *TopologyLinkSide `json:"local"`
+	Remote           *TopologyLinkSide `json:"remote"`
 }

--- a/pkg/collector/corechecks/snmp/internal/metadata/payload.go
+++ b/pkg/collector/corechecks/snmp/internal/metadata/payload.go
@@ -113,6 +113,7 @@ type TopologyLinkSide struct {
 type TopologyLinkMetadata struct {
 	ID               string            `json:"id"`
 	SourceType       string            `json:"source_type"`
+	LocalDeviceID    string            `json:"local_device_id"`
 	LocalInterfaceID string            `json:"local_interface_id"`
 	Local            *TopologyLinkSide `json:"local"`
 	Remote           *TopologyLinkSide `json:"remote"`

--- a/pkg/collector/corechecks/snmp/internal/report/report_device_metadata.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_device_metadata.go
@@ -305,7 +305,7 @@ func buildNetworkTopologyMetadata(deviceID string, store *metadata.Store, interf
 		localInterfaceIDType := lldp.PortIDSubTypeMap[store.GetColumnAsString("lldp_local.interface_id_type", localPortNum)]
 		localInterfaceID := formatID(localInterfaceIDType, store, "lldp_local.interface_id", localPortNum)
 
-		localInterfaceIDType, localInterfaceID = resolveLocalInterface(deviceID, interfaceIndexByIDType, localInterfaceIDType, localInterfaceID)
+		resolvedLocalInterfaceID := resolveLocalInterface(deviceID, interfaceIndexByIDType, localInterfaceIDType, localInterfaceID)
 
 		// remEntryUniqueID: The combination of localPortNum and lldpRemIndex is expected to be unique for each entry in
 		//                   lldpRemTable. We don't include lldpRemTimeMark (used for filtering only recent data) since it can change often.
@@ -328,6 +328,7 @@ func buildNetworkTopologyMetadata(deviceID string, store *metadata.Store, interf
 					Description: store.GetColumnAsString("lldp_remote.interface_desc", strIndex),
 				},
 			},
+			LocalInterfaceID: resolvedLocalInterfaceID,
 			Local: &metadata.TopologyLinkSide{
 				Interface: &metadata.TopologyLinkInterface{
 					ID:     localInterfaceID,
@@ -344,9 +345,9 @@ func buildNetworkTopologyMetadata(deviceID string, store *metadata.Store, interf
 	return links
 }
 
-func resolveLocalInterface(deviceID string, interfaceIndexByIDType map[string]map[string][]int32, localInterfaceIDType string, localInterfaceID string) (string, string) {
+func resolveLocalInterface(deviceID string, interfaceIndexByIDType map[string]map[string][]int32, localInterfaceIDType string, localInterfaceID string) string {
 	if localInterfaceID == "" {
-		return localInterfaceIDType, localInterfaceID
+		return ""
 	}
 
 	var typesToTry []string
@@ -375,9 +376,9 @@ func resolveLocalInterface(deviceID string, interfaceIndexByIDType map[string]ma
 		for key := range matchedIfIndexesMap {
 			matchedIfIndexes = append(matchedIfIndexes, key)
 		}
-		return metadata.IDTypeNDM, deviceID + ":" + strconv.Itoa(int(matchedIfIndexes[0]))
+		return deviceID + ":" + strconv.Itoa(int(matchedIfIndexes[0]))
 	}
-	return localInterfaceIDType, localInterfaceID
+	return ""
 }
 
 func buildInterfaceIndexByIDType(interfaces []metadata.InterfaceMetadata) map[string]map[string][]int32 {

--- a/pkg/collector/corechecks/snmp/internal/report/report_device_metadata.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_device_metadata.go
@@ -328,12 +328,14 @@ func buildNetworkTopologyMetadata(deviceID string, store *metadata.Store, interf
 					Description: store.GetColumnAsString("lldp_remote.interface_desc", strIndex),
 				},
 			},
-			LocalDeviceID:    deviceID,
-			LocalInterfaceID: resolvedLocalInterfaceID,
 			Local: &metadata.TopologyLinkSide{
 				Interface: &metadata.TopologyLinkInterface{
+					DDID:   resolvedLocalInterfaceID,
 					ID:     localInterfaceID,
 					IDType: localInterfaceIDType,
+				},
+				Device: &metadata.TopologyLinkDevice{
+					DDID: deviceID,
 				},
 			},
 		}

--- a/pkg/collector/corechecks/snmp/internal/report/report_device_metadata.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_device_metadata.go
@@ -328,15 +328,12 @@ func buildNetworkTopologyMetadata(deviceID string, store *metadata.Store, interf
 					Description: store.GetColumnAsString("lldp_remote.interface_desc", strIndex),
 				},
 			},
+			LocalDeviceID:    deviceID,
 			LocalInterfaceID: resolvedLocalInterfaceID,
 			Local: &metadata.TopologyLinkSide{
 				Interface: &metadata.TopologyLinkInterface{
 					ID:     localInterfaceID,
 					IDType: localInterfaceIDType,
-				},
-				Device: &metadata.TopologyLinkDevice{
-					ID:     deviceID,
-					IDType: metadata.IDTypeNDM,
 				},
 			},
 		}

--- a/pkg/collector/corechecks/snmp/internal/report/report_device_metadata_test.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_device_metadata_test.go
@@ -579,102 +579,87 @@ func Test_resolveLocalInterface(t *testing.T) {
 	deviceID := "default:1.2.3.4"
 
 	tests := []struct {
-		name           string
-		localIDType    string
-		localID        string
-		expectedIDType string
-		expectedID     string
+		name        string
+		localIDType string
+		localID     string
+		expectedID  string
 	}{
 		{
-			name:           "mac_address",
-			localIDType:    "mac_address",
-			localID:        "00:00:00:00:00:01",
-			expectedIDType: "ndm",
-			expectedID:     "default:1.2.3.4:1",
+			name:        "mac_address",
+			localIDType: "mac_address",
+			localID:     "00:00:00:00:00:01",
+			expectedID:  "default:1.2.3.4:1",
 		},
 		{
-			name:           "mac_address cannot resolve due to multiple results",
-			localIDType:    "mac_address",
-			localID:        "00:00:00:00:00:03",
-			expectedIDType: "mac_address",
-			expectedID:     "00:00:00:00:00:03",
+			name:        "mac_address cannot resolve due to multiple results",
+			localIDType: "mac_address",
+			localID:     "00:00:00:00:00:03",
+			expectedID:  "",
 		},
 		{
-			name:           "interface_name",
-			localIDType:    "interface_name",
-			localID:        "eth2",
-			expectedIDType: "ndm",
-			expectedID:     "default:1.2.3.4:2",
+			name:        "interface_name",
+			localIDType: "interface_name",
+			localID:     "eth2",
+			expectedID:  "default:1.2.3.4:2",
 		},
 		{
-			name:           "interface_alias",
-			localIDType:    "interface_alias",
-			localID:        "alias2",
-			expectedIDType: "ndm",
-			expectedID:     "default:1.2.3.4:2",
+			name:        "interface_alias",
+			localIDType: "interface_alias",
+			localID:     "alias2",
+			expectedID:  "default:1.2.3.4:2",
 		},
 		{
-			name:           "mac_address by trying",
-			localIDType:    "",
-			localID:        "00:00:00:00:00:01",
-			expectedIDType: "ndm",
-			expectedID:     "default:1.2.3.4:1",
+			name:        "mac_address by trying",
+			localIDType: "",
+			localID:     "00:00:00:00:00:01",
+			expectedID:  "default:1.2.3.4:1",
 		},
 		{
-			name:           "interface_name by trying",
-			localIDType:    "",
-			localID:        "eth2",
-			expectedIDType: "ndm",
-			expectedID:     "default:1.2.3.4:2",
+			name:        "interface_name by trying",
+			localIDType: "",
+			localID:     "eth2",
+			expectedID:  "default:1.2.3.4:2",
 		},
 		{
-			name:           "interface_alias by trying",
-			localIDType:    "",
-			localID:        "alias2",
-			expectedIDType: "ndm",
-			expectedID:     "default:1.2.3.4:2",
+			name:        "interface_alias by trying",
+			localIDType: "",
+			localID:     "alias2",
+			expectedID:  "default:1.2.3.4:2",
 		},
 		{
-			name:           "interface_alias+interface_name match with same interface should resolve",
-			localIDType:    "",
-			localID:        "eth3",
-			expectedIDType: "ndm",
-			expectedID:     "default:1.2.3.4:3",
+			name:        "interface_alias+interface_name match with same interface should resolve",
+			localIDType: "",
+			localID:     "eth3",
+			expectedID:  "default:1.2.3.4:3",
 		},
 		{
-			name:           "interface_alias+interface_name match with different interface should not resolve",
-			localIDType:    "",
-			localID:        "eth4",
-			expectedIDType: "",
-			expectedID:     "eth4",
+			name:        "interface_alias+interface_name match with different interface should not resolve",
+			localIDType: "",
+			localID:     "eth4",
+			expectedID:  "",
 		},
 		{
-			name:           "interface_index by trying",
-			localIDType:    "",
-			localID:        "2",
-			expectedIDType: "ndm",
-			expectedID:     "default:1.2.3.4:2",
+			name:        "interface_index by trying",
+			localIDType: "",
+			localID:     "2",
+			expectedID:  "default:1.2.3.4:2",
 		},
 		{
-			name:           "mac_address not found",
-			localIDType:    "mac_address",
-			localID:        "00:00:00:00:00:99",
-			expectedIDType: "mac_address",
-			expectedID:     "00:00:00:00:00:99",
+			name:        "mac_address not found",
+			localIDType: "mac_address",
+			localID:     "00:00:00:00:00:99",
+			expectedID:  "",
 		},
 		{
-			name:           "invalid",
-			localIDType:    "invalid_type",
-			localID:        "invalidID",
-			expectedIDType: "invalid_type",
-			expectedID:     "invalidID",
+			name:        "invalid",
+			localIDType: "invalid_type",
+			localID:     "invalidID",
+			expectedID:  "",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			actualIDType, actualID := resolveLocalInterface(deviceID, interfaceIndexByIDType, tt.localIDType, tt.localID)
-			assert.Equal(t, tt.expectedIDType, actualIDType)
-			assert.Equal(t, tt.expectedID, actualID)
+			assert.Equal(t, tt.expectedID, resolveLocalInterface(deviceID, interfaceIndexByIDType, tt.localIDType, tt.localID))
 		})
 	}
 }

--- a/pkg/collector/corechecks/snmp/profile_metadata_test.go
+++ b/pkg/collector/corechecks/snmp/profile_metadata_test.go
@@ -566,10 +566,12 @@ profiles:
         {
             "id": "profile-metadata:1.2.3.4:101.1",
             "source_type": "lldp",
-            "local_device_id": "profile-metadata:1.2.3.4",
-            "local_interface_id": "profile-metadata:1.2.3.4:1",
             "local": {
+                "device": {
+                    "dd_id": "profile-metadata:1.2.3.4"
+                },
                 "interface": {
+                    "dd_id": "profile-metadata:1.2.3.4:1",
                     "id": "82:a5:6e:a5:c9:01",
                     "id_type": "mac_address"
                 }
@@ -592,10 +594,12 @@ profiles:
         {
             "id": "profile-metadata:1.2.3.4:102.2",
             "source_type": "lldp",
-            "local_device_id": "profile-metadata:1.2.3.4",
-            "local_interface_id": "profile-metadata:1.2.3.4:2",
             "local": {
+                "device": {
+                    "dd_id": "profile-metadata:1.2.3.4"
+                },
                 "interface": {
+                    "dd_id": "profile-metadata:1.2.3.4:2",
                     "id": "82:a5:6e:a5:c9:02",
                     "id_type": "mac_address"
                 }

--- a/pkg/collector/corechecks/snmp/profile_metadata_test.go
+++ b/pkg/collector/corechecks/snmp/profile_metadata_test.go
@@ -566,12 +566,9 @@ profiles:
         {
             "id": "profile-metadata:1.2.3.4:101.1",
             "source_type": "lldp",
+            "local_device_id": "profile-metadata:1.2.3.4",
             "local_interface_id": "profile-metadata:1.2.3.4:1",
             "local": {
-                "device": {
-                    "id": "profile-metadata:1.2.3.4",
-                    "id_type": "ndm"
-                },
                 "interface": {
                     "id": "82:a5:6e:a5:c9:01",
                     "id_type": "mac_address"
@@ -595,12 +592,9 @@ profiles:
         {
             "id": "profile-metadata:1.2.3.4:102.2",
             "source_type": "lldp",
+            "local_device_id": "profile-metadata:1.2.3.4",
             "local_interface_id": "profile-metadata:1.2.3.4:2",
             "local": {
-                "device": {
-                    "id": "profile-metadata:1.2.3.4",
-                    "id_type": "ndm"
-                },
                 "interface": {
                     "id": "82:a5:6e:a5:c9:02",
                     "id_type": "mac_address"

--- a/pkg/collector/corechecks/snmp/profile_metadata_test.go
+++ b/pkg/collector/corechecks/snmp/profile_metadata_test.go
@@ -566,14 +566,15 @@ profiles:
         {
             "id": "profile-metadata:1.2.3.4:101.1",
             "source_type": "lldp",
+            "local_interface_id": "profile-metadata:1.2.3.4:1",
             "local": {
                 "device": {
                     "id": "profile-metadata:1.2.3.4",
                     "id_type": "ndm"
                 },
                 "interface": {
-                    "id": "profile-metadata:1.2.3.4:1",
-                    "id_type": "ndm"
+                    "id": "82:a5:6e:a5:c9:01",
+                    "id_type": "mac_address"
                 }
             },
             "remote": {
@@ -594,14 +595,15 @@ profiles:
         {
             "id": "profile-metadata:1.2.3.4:102.2",
             "source_type": "lldp",
+            "local_interface_id": "profile-metadata:1.2.3.4:2",
             "local": {
                 "device": {
                     "id": "profile-metadata:1.2.3.4",
                     "id_type": "ndm"
                 },
                 "interface": {
-                    "id": "profile-metadata:1.2.3.4:2",
-                    "id_type": "ndm"
+                    "id": "82:a5:6e:a5:c9:02",
+                    "id_type": "mac_address"
                 }
             },
             "remote": {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

[corechecks/snmp] Add dd_id to Topology Links to avoid overriding raw idType/id

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Keeping the raw local idType/id can be useful for troubleshooting later.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
