### PR TITLE
Bump the version of `setuptools`

### DIFF
--- a/omnibus/config/software/pip3.rb
+++ b/omnibus/config/software/pip3.rb
@@ -1,6 +1,8 @@
 name "pip3"
 default_version "21.3.1"
 
+skip_transitive_dependency_licensing true
+
 dependency "setuptools3"
 
 source :url => "https://github.com/pypa/pip/archive/#{version}.tar.gz",

--- a/omnibus/config/software/setuptools2.rb
+++ b/omnibus/config/software/setuptools2.rb
@@ -1,5 +1,5 @@
 name "setuptools2"
-default_version "66.1.1"
+default_version "40.9.0"
 
 skip_transitive_dependency_licensing true
 
@@ -8,7 +8,7 @@ dependency "python2"
 relative_path "setuptools-#{version}"
 
 source :url => "https://github.com/pypa/setuptools/archive/v#{version}.tar.gz",
-       :sha256 => "081209b1c080b30ca78013dde35600a3070508fcce745a939498f4d76e05b6a6",
+       :sha256 => "9ef6623c057d6e46ada8156bb48dc72ef6dbe721768720cc66966cca4097061c",
        :extract => :seven_zip
 
 build do

--- a/omnibus/config/software/setuptools2.rb
+++ b/omnibus/config/software/setuptools2.rb
@@ -1,5 +1,5 @@
 name "setuptools2"
-default_version "40.9.0"
+default_version "66.1.1"
 
 skip_transitive_dependency_licensing true
 
@@ -8,7 +8,7 @@ dependency "python2"
 relative_path "setuptools-#{version}"
 
 source :url => "https://github.com/pypa/setuptools/archive/v#{version}.tar.gz",
-       :sha256 => "9ef6623c057d6e46ada8156bb48dc72ef6dbe721768720cc66966cca4097061c",
+       :sha256 => "081209b1c080b30ca78013dde35600a3070508fcce745a939498f4d76e05b6a6",
        :extract => :seven_zip
 
 build do

--- a/omnibus/config/software/setuptools3.rb
+++ b/omnibus/config/software/setuptools3.rb
@@ -23,7 +23,7 @@ build do
     python_prefix = "#{install_dir}/embedded"
   end
 
-  command "#{python_bin} setup.py install --prefix=#{python_prefix}"
+  command "mkdir -p build/scripts-3.8 && #{python_bin} setup.py install --prefix=#{python_prefix} --root=/"
 
   if ohai["platform"] != "windows"
     block do

--- a/omnibus/config/software/setuptools3.rb
+++ b/omnibus/config/software/setuptools3.rb
@@ -1,5 +1,5 @@
 name "setuptools3"
-default_version "40.9.0"
+default_version "66.1.1"
 
 skip_transitive_dependency_licensing true
 
@@ -8,7 +8,7 @@ dependency "python3"
 relative_path "setuptools-#{version}"
 
 source :url => "https://github.com/pypa/setuptools/archive/v#{version}.tar.gz",
-       :sha256 => "9ef6623c057d6e46ada8156bb48dc72ef6dbe721768720cc66966cca4097061c",
+       :sha256 => "081209b1c080b30ca78013dde35600a3070508fcce745a939498f4d76e05b6a6",
        :extract => :seven_zip
 
 build do

--- a/omnibus/config/software/setuptools3.rb
+++ b/omnibus/config/software/setuptools3.rb
@@ -23,7 +23,6 @@ build do
     python_prefix = "#{install_dir}/embedded"
   end
 
-  command "#{python_bin} bootstrap.py"
   command "#{python_bin} setup.py install --prefix=#{python_prefix}"
 
   if ohai["platform"] != "windows"


### PR DESCRIPTION
### What does this PR do?

Update the version of `setuptools`

### Motivation

* Fix vulnerability DataDog/image-vuln-scans#788.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
