### PR TITLE
[kitchen] Update docs for local usage

### DIFF
--- a/test/kitchen/Gemfile.local
+++ b/test/kitchen/Gemfile.local
@@ -1,6 +1,6 @@
 require 'open-uri'
 
 # Actual gemfile is stored in the buildimages repo because it comes pre-installed in the dd-agent-testing Docker image, read it from there
-gemfile = URI.open('https://raw.githubusercontent.com/DataDog/datadog-agent-buildimages/main/dd-agent-testing/Gemfile')
+gemfile = ::URI.open('https://raw.githubusercontent.com/DataDog/datadog-agent-buildimages/main/dd-agent-testing/Gemfile')
 eval gemfile.read
 

--- a/test/kitchen/README.md
+++ b/test/kitchen/README.md
@@ -16,7 +16,12 @@ Non-bundled dependencies:
  - [Bundler](http://bundler.io/)
 
 Then install bundled gem dependencies:
- ` bundle install --path ./Gemfile.local`
+```
+bundle config set --local path '.'
+bundle config set --local gemfile './Gemfile.local'
+```
+
+`bundle install`
 
 Note: you might run into an error building the `nio4r` native extensions. You
 should be able to get around that by setting the build cflags for the gem


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Fixes local kitchen usage: the `URI.open` operation done in `Gemfile.local` was missing a part.
Updates the kitchen docs with modern `bundler` options to use local Gemfiles.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Fix local kitchen setup.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

n/a

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

n/a

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

n/a

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
