### PR TITLE
[usm] Fix concurrency issue in test

### DIFF
--- a/pkg/network/protocols/events/consumer_test.go
+++ b/pkg/network/protocols/events/consumer_test.go
@@ -13,6 +13,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 	"unsafe"
@@ -40,8 +41,11 @@ func TestConsumer(t *testing.T) {
 	program, err := newEBPFProgram(c)
 	require.NoError(t, err)
 
+	var mux sync.Mutex
 	result := make(map[uint64]int)
 	callback := func(b []byte) {
+		mux.Lock()
+		defer mux.Unlock()
 		// each event is just a uint64
 		n := binary.LittleEndian.Uint64(b)
 		result[n] = +1


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Fix a concurrency issue in a test:
```
[5.4.0-1038-aws] === FAIL: pkg/network/protocols/events TestConsumer (0.17s)
       [5.4.0-1038-aws] fatal error: concurrent map writes
       [5.4.0-1038-aws] 
       [5.4.0-1038-aws] goroutine 147 [running]:
       [5.4.0-1038-aws] github.com/DataDog/datadog-agent/pkg/network/protocols/events.TestConsumer.func1({0x40000c200e?, 0xee4fc4?, 0xb?})
       [5.4.0-1038-aws] /go/src/github.com/h5gzZyNG/0/DataDog/datadog-agent/pkg/network/protocols/events/consumer_test.go:47 +0x40
       [5.4.0-1038-aws] github.com/DataDog/datadog-agent/pkg/network/protocols/events.(*Consumer).process(0x40001af950, 0x0?, 0x40000c2000, 0x40?)
       [5.4.0-1038-aws] /go/src/github.com/h5gzZyNG/0/DataDog/datadog-agent/pkg/network/protocols/events/consumer.go:185 +0x190
       [5.4.0-1038-aws] github.com/DataDog/datadog-agent/pkg/network/protocols/events.(*Consumer).Start.func1.1(0x4000098e60?, 0x10ed940?)
       [5.4.0-1038-aws] /go/src/github.com/h5gzZyNG/0/DataDog/datadog-agent/pkg/network/protocols/events/consumer.go:134 +0x30
       [5.4.0-1038-aws] github.com/DataDog/datadog-agent/pkg/network/protocols/events.(*batchReader).ReadAll.func1()
       [5.4.0-1038-aws] /go/src/github.com/h5gzZyNG/0/DataDog/datadog-agent/pkg/network/protocols/events/batch_reader.go:94 +0x170
       [5.4.0-1038-aws] github.com/DataDog/datadog-agent/pkg/network/protocols/events.newWorkerPool.func1()
       [5.4.0-1038-aws] /go/src/github.com/h5gzZyNG/0/DataDog/datadog-agent/pkg/network/protocols/events/worker_pool.go:38 +0x70
       [5.4.0-1038-aws] created by github.com/DataDog/datadog-agent/pkg/network/protocols/events.newWorkerPool
       [5.4.0-1038-aws] /go/src/github.com/h5gzZyNG/0/DataDog/datadog-agent/pkg/network/protocols/events/worker_pool.go:35 +0xdc
```

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

The callback used by the `events.Consumer` object must be thread-safe as documented here: https://github.com/DataDog/datadog-agent/blob/cb5c4e1d5d6ccc853b56fc6bed77250fb99bb97e/pkg/network/protocols/events/README.md?plain=1#L60

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
