### PR TITLE
[process-agent] Fix `Drop Check Payloads` status

### DIFF
--- a/cmd/process-agent/collector.go
+++ b/cmd/process-agent/collector.go
@@ -67,9 +67,6 @@ type Collector struct {
 	// Enables running realtime checks
 	runRealTime bool
 
-	// Drop payloads from specified checks
-	dropCheckPayloads []string
-
 	// Submits check payloads to datadog
 	submitter Submitter
 }
@@ -240,7 +237,6 @@ func (l *Collector) run(exit chan struct{}) error {
 		}
 	}
 	updateEnabledChecks(checkNames)
-	updateDropCheckPayloads(l.dropCheckPayloads)
 	log.Infof("Starting process-agent with enabled checks=%v", checkNames)
 
 	go util.HandleSignals(exit)

--- a/cmd/process-agent/submitter.go
+++ b/cmd/process-agent/submitter.go
@@ -113,6 +113,7 @@ func NewSubmitter(hostname string, enableRealtimeCallback func([]*model.Collecto
 	if len(dropCheckPayloads) > 0 {
 		log.Debugf("Dropping payloads from checks: %v", dropCheckPayloads)
 	}
+	updateDropCheckPayloads(dropCheckPayloads)
 
 	// Forwarder initialization
 	processAPIEndpoints, err := getAPIEndpoints()


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR fixes the `Drop Check Payloads` field being empty even when the `process_config.drop_check_payloads` field is specified.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
QA found bug in https://github.com/DataDog/datadog-agent

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
Run the agent with `process_config.drop_check_payloads` set to `["process"]`. Next, run `process-agent status` and ensure that the `Drop Check Payloads` matches the setting.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
