### PR TITLE
[USM] old java hotspot need credential

### DIFF
--- a/pkg/network/java/hotspot.go
+++ b/pkg/network/java/hotspot.go
@@ -149,11 +149,12 @@ func (h *Hotspot) copyAgent(agent string, uid int, gid int) (dstPath string, cle
 }
 
 func (h *Hotspot) dialunix(raddr *net.UnixAddr, withCredential bool) (*net.UnixConn, error) {
-	// Hotspot reject connection if credential by checking uid/gid of the connect() SOL_SOCKET/SO_PEERCRED
-	// but older hotspot JRE (1.8.0) doesn't accept root and want explicitly uid/gid matching
+	// Hotspot reject connection credentials by checking uid/gid of the client calling connect()
+	// via getsockopt(SOL_SOCKET/SO_PEERCRED).
+	// but older hotspot JRE (1.8.0) accept only the same uid/gid and reject root
 	//
-	// side effect for go, during the connect() syscall we don't want to fork() and stay on the same pthread
-	// to avoid side effect of set effective uid/gid.
+	// For go, during the connect() syscall we don't want to fork() and stay on the same pthread
+	// to avoid side effect (pollution) of set effective uid/gid.
 	if withCredential {
 		runtime.LockOSThread()
 		syscall.ForkLock.Lock()

--- a/pkg/network/java/hotspot.go
+++ b/pkg/network/java/hotspot.go
@@ -160,8 +160,8 @@ func (h *Hotspot) dialunix(raddr *net.UnixAddr, withCredential bool) (*net.UnixC
 		origeuid := syscall.Geteuid()
 		origegid := syscall.Getegid()
 		defer func() {
-			syscall.Seteuid(origeuid)
-			syscall.Setegid(origegid)
+			_ = syscall.Seteuid(origeuid)
+			_ = syscall.Setegid(origegid)
 			syscall.ForkLock.Unlock()
 			runtime.UnlockOSThread()
 		}()

--- a/pkg/network/java/hotspot.go
+++ b/pkg/network/java/hotspot.go
@@ -11,18 +11,21 @@ package java
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
 	"net"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"syscall"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/process/util"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // Hotspot java has a specific protocol, described here:
@@ -43,6 +46,8 @@ type Hotspot struct {
 	conn  *net.UnixConn
 
 	socketPath string
+	uid        int
+	gid        int
 }
 
 // NewHotspot create an object to connect to a JVM hotspot
@@ -143,14 +148,43 @@ func (h *Hotspot) copyAgent(agent string, uid int, gid int) (dstPath string, cle
 	}, nil
 }
 
+func (h *Hotspot) dialunix(raddr *net.UnixAddr, withCredential bool) (*net.UnixConn, error) {
+	// Hotspot reject connection if credential by checking uid/gid of the connect() SOL_SOCKET/SO_PEERCRED
+	// but older hotspot JRE (1.8.0) doesn't accept root and want explicitly uid/gid matching
+	//
+	// side effect for go, during the connect() syscall we don't want to fork() and stay on the same pthread
+	// to avoid side effect of set effective uid/gid.
+	if withCredential {
+		runtime.LockOSThread()
+		syscall.ForkLock.Lock()
+		origeuid := syscall.Geteuid()
+		origegid := syscall.Getegid()
+		defer func() {
+			syscall.Seteuid(origeuid)
+			syscall.Setegid(origegid)
+			syscall.ForkLock.Unlock()
+			runtime.UnlockOSThread()
+		}()
+
+		if err := syscall.Setegid(h.gid); err != nil {
+			return nil, err
+		}
+		if err := syscall.Seteuid(h.uid); err != nil {
+			return nil, err
+		}
+	}
+	return net.DialUnix("unix", nil, raddr)
+}
+
 // connect to the previously created hotspot unix socket
 // return close function must be call when finished
-func (h *Hotspot) connect() (close func(), err error) {
+func (h *Hotspot) connect(withCredential bool) (close func(), err error) {
+	h.conn = nil
 	addr, err := net.ResolveUnixAddr("unix", h.socketPath)
 	if err != nil {
 		return nil, err
 	}
-	conn, err := net.DialUnix("unix", nil, addr)
+	conn, err := h.dialunix(addr, withCredential)
 	if err != nil {
 		return nil, err
 	}
@@ -160,7 +194,11 @@ func (h *Hotspot) connect() (close func(), err error) {
 		return nil, err
 	}
 	h.conn = conn
-	return func() { h.conn.Close() }, nil
+	return func() {
+		if h.conn != nil {
+			h.conn.Close()
+		}
+	}, nil
 }
 
 // parseResponse parse the response from the hotspot command
@@ -297,8 +335,10 @@ func (h *Hotspot) Attach(agentPath string, args string, uid int, gid int) error 
 	}
 	defer agentCleanup()
 
+	h.uid = uid
+	h.gid = gid
 	// connect and ask to load the agent .jar or .so
-	cleanConn, err := h.connect()
+	cleanConn, err := h.connect(false)
 	if err != nil {
 		return err
 	}
@@ -317,5 +357,24 @@ func (h *Hotspot) Attach(agentPath string, args string, uid int, gid int) error 
 			loadCommand += " " + args
 		}
 	}
-	return h.command(loadCommand, !isJar)
+
+	hasRetried := false
+retry:
+	if err := h.command(loadCommand, !isJar); err != nil {
+		// if we receive EPIPE (write) or ECONNRESET (read) from the kernel may from old hotspot JVM
+		// let's retry with credentials, see dialunix() for more info
+		if !hasRetried && (errors.Is(err, syscall.EPIPE) || errors.Is(err, syscall.ECONNRESET)) {
+			log.Debugf("java attach hotspot pid %d/%d old hotspot JVM detected, requires credentials", h.pid, h.nsPid)
+			hasRetried = true
+			cleanConn()
+			cleanConn, err = h.connect(true)
+			if err != nil {
+				return err
+			}
+			goto retry
+		}
+		log.Debugf("java attach hotspot pid %d/%d command '%s' failed isJar=%v : %s", h.pid, h.nsPid, loadCommand, isJar, err)
+		return err
+	}
+	return nil
 }

--- a/pkg/network/java/jattach_test.go
+++ b/pkg/network/java/jattach_test.go
@@ -129,14 +129,4 @@ func TestInject(t *testing.T) {
 		testInject(t, p)
 	})
 
-	// old hotspot JVM require connect() with the same uid/gid as executed
-	p = "unshare -p --fork -U "
-	// flush the caches to slow start java
-	testutil.RunCommand("sudo sysctl -w vm.drop_caches=3")
-	t.Run("PIDnamespace", func(t *testing.T) {
-		// running the tagert process in a new PID namespace
-		// and testing if the test/plaform give enough permission to do that
-		testInject(t, p)
-	})
-
 }

--- a/pkg/network/java/jattach_test.go
+++ b/pkg/network/java/jattach_test.go
@@ -128,4 +128,15 @@ func TestInject(t *testing.T) {
 		// and testing if the test/plaform give enough permission to do that
 		testInject(t, p)
 	})
+
+	// old hotspot JVM require connect() with the same uid/gid as executed
+	p := "unshare -p --fork -U "
+	// flush the caches to slow start java
+	testutil.RunCommand("sudo sysctl -w vm.drop_caches=3")
+	t.Run("PIDnamespace", func(t *testing.T) {
+		// running the tagert process in a new PID namespace
+		// and testing if the test/plaform give enough permission to do that
+		testInject(t, p)
+	})
+
 }

--- a/pkg/network/java/jattach_test.go
+++ b/pkg/network/java/jattach_test.go
@@ -130,7 +130,7 @@ func TestInject(t *testing.T) {
 	})
 
 	// old hotspot JVM require connect() with the same uid/gid as executed
-	p := "unshare -p --fork -U "
+	p = "unshare -p --fork -U "
 	// flush the caches to slow start java
 	testutil.RunCommand("sudo sysctl -w vm.drop_caches=3")
 	t.Run("PIDnamespace", func(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

Hotspot reject connection if credential by checking uid/gid of the connect() SOL_SOCKET/SO_PEERCRED
but older hotspot JRE (1.8.0) doesn't accept root and want explicitly uid/gid matching

side effect for go, during the connect() syscall we don't want to fork() and stay on the same pthread
to avoid side effect of set effective uid/gid.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
