### PR TITLE
[contimage] Split container image metadata in one event per registry

### DIFF
--- a/pkg/collector/corechecks/containerimage/processor_test.go
+++ b/pkg/collector/corechecks/containerimage/processor_test.go
@@ -6,8 +6,6 @@
 package containerimage
 
 import (
-	"fmt"
-	"strconv"
 	"testing"
 	"time"
 
@@ -28,49 +26,59 @@ func TestProcessEvents(t *testing.T) {
 	sender.On("ContainerImage", mock.Anything, mock.Anything).Return()
 	p := newProcessor(sender, 2, 50*time.Millisecond)
 
-	for i := 0; i < 3; i++ {
-		p.processEvents(workloadmeta.EventBundle{
-			Events: []workloadmeta.Event{
-				{
-					Type: workloadmeta.EventTypeSet,
-					Entity: &workloadmeta.ContainerImageMetadata{
-						EntityID: workloadmeta.EntityID{
-							Kind: workloadmeta.KindContainerImageMetadata,
-							ID:   strconv.Itoa(i),
-						},
-						ShortName:    fmt.Sprintf("short_name_%d", i),
-						RepoTags:     []string{"tag_1", "tag_2"},
-						RepoDigests:  []string{fmt.Sprintf("digest_%d", i)},
-						SizeBytes:    42,
-						OS:           "DOS",
-						OSVersion:    "6.22",
-						Architecture: "80486DX",
-						Layers: []workloadmeta.ContainerImageLayer{
-							{
-								MediaType: "media",
-								Digest:    fmt.Sprintf("digest_layer_1_%d", i),
-								SizeBytes: 43,
-								URLs:      []string{"url"},
-								History: v1.History{
-									Created: pointer.Ptr(time.Unix(42, 43)),
-								},
+	p.processEvents(workloadmeta.EventBundle{
+		Events: []workloadmeta.Event{
+			{
+				Type: workloadmeta.EventTypeSet,
+				Entity: &workloadmeta.ContainerImageMetadata{
+					EntityID: workloadmeta.EntityID{
+						Kind: workloadmeta.KindContainerImageMetadata,
+						ID:   "sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
+					},
+					Registry:  "registry guessed by workloadmeta is ignored",
+					ShortName: "short name guessed by workloadmeta is ignored",
+					RepoTags: []string{
+						"datadog/agent:7-rc",
+						"datadog/agent:7.41.1-rc.1",
+						"gcr.io/datadoghq/agent:7-rc",
+						"gcr.io/datadoghq/agent:7.41.1-rc.1",
+						"public.ecr.aws/datadog/agent:7-rc",
+						"public.ecr.aws/datadog/agent:7.41.1-rc.1",
+					},
+					RepoDigests: []string{
+						"datadog/agent@sha256:052f1fdf4f9a7117d36a1838ab60782829947683007c34b69d4991576375c409",
+						"gcr.io/datadoghq/agent@sha256:052f1fdf4f9a7117d36a1838ab60782829947683007c34b69d4991576375c409",
+						"public.ecr.aws/datadog/agent@sha256:052f1fdf4f9a7117d36a1838ab60782829947683007c34b69d4991576375c409",
+					},
+					SizeBytes:    42,
+					OS:           "DOS",
+					OSVersion:    "6.22",
+					Architecture: "80486DX",
+					Layers: []workloadmeta.ContainerImageLayer{
+						{
+							MediaType: "media",
+							Digest:    "digest_layer_1",
+							SizeBytes: 43,
+							URLs:      []string{"url"},
+							History: v1.History{
+								Created: pointer.Ptr(time.Unix(42, 43)),
 							},
-							{
-								MediaType: "media",
-								Digest:    fmt.Sprintf("digest_layer_2_%d", i),
-								URLs:      []string{"url"},
-								SizeBytes: 44,
-								History: v1.History{
-									Created: pointer.Ptr(time.Unix(43, 44)),
-								},
+						},
+						{
+							MediaType: "media",
+							Digest:    "digest_layer_2",
+							URLs:      []string{"url"},
+							SizeBytes: 44,
+							History: v1.History{
+								Created: pointer.Ptr(time.Unix(43, 44)),
 							},
 						},
 					},
 				},
 			},
-			Ch: make(chan struct{}),
-		})
-	}
+		},
+		Ch: make(chan struct{}),
+	})
 
 	sender.AssertNumberOfCalls(t, "ContainerImage", 1)
 	sender.AssertContainerImage(t, []model.ContainerImagePayload{
@@ -78,12 +86,17 @@ func TestProcessEvents(t *testing.T) {
 			Version: "v1",
 			Images: []*model.ContainerImage{
 				{
-					Id:          "0",
-					ShortName:   "short_name_0",
-					Tags:        []string{"tag_1", "tag_2"},
-					Digest:      "0",
+					Id:        "datadog/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
+					Name:      "datadog/agent",
+					Registry:  "",
+					ShortName: "agent",
+					Tags: []string{
+						"7-rc",
+						"7.41.1-rc.1",
+					},
+					Digest:      "sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
 					Size:        42,
-					RepoDigests: []string{"digest_0"},
+					RepoDigests: []string{"datadog/agent@sha256:052f1fdf4f9a7117d36a1838ab60782829947683007c34b69d4991576375c409"},
 					Os: &model.ContainerImage_OperatingSystem{
 						Name:         "DOS",
 						Version:      "6.22",
@@ -93,7 +106,7 @@ func TestProcessEvents(t *testing.T) {
 						{
 							Urls:      []string{"url"},
 							MediaType: "media",
-							Digest:    "digest_layer_1_0",
+							Digest:    "digest_layer_1",
 							Size:      43,
 							History: &model.ContainerImage_ContainerImageLayer_History{
 								Created: &timestamp.Timestamp{
@@ -105,7 +118,7 @@ func TestProcessEvents(t *testing.T) {
 						{
 							Urls:      []string{"url"},
 							MediaType: "media",
-							Digest:    "digest_layer_2_0",
+							Digest:    "digest_layer_2",
 							Size:      44,
 							History: &model.ContainerImage_ContainerImageLayer_History{
 								Created: &timestamp.Timestamp{
@@ -121,12 +134,17 @@ func TestProcessEvents(t *testing.T) {
 					},
 				},
 				{
-					Id:          "1",
-					ShortName:   "short_name_1",
-					Tags:        []string{"tag_1", "tag_2"},
-					Digest:      "1",
+					Id:        "gcr.io/datadoghq/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
+					Name:      "gcr.io/datadoghq/agent",
+					Registry:  "gcr.io",
+					ShortName: "agent",
+					Tags: []string{
+						"7-rc",
+						"7.41.1-rc.1",
+					},
+					Digest:      "sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
 					Size:        42,
-					RepoDigests: []string{"digest_1"},
+					RepoDigests: []string{"gcr.io/datadoghq/agent@sha256:052f1fdf4f9a7117d36a1838ab60782829947683007c34b69d4991576375c409"},
 					Os: &model.ContainerImage_OperatingSystem{
 						Name:         "DOS",
 						Version:      "6.22",
@@ -136,7 +154,7 @@ func TestProcessEvents(t *testing.T) {
 						{
 							Urls:      []string{"url"},
 							MediaType: "media",
-							Digest:    "digest_layer_1_1",
+							Digest:    "digest_layer_1",
 							Size:      43,
 							History: &model.ContainerImage_ContainerImageLayer_History{
 								Created: &timestamp.Timestamp{
@@ -148,7 +166,7 @@ func TestProcessEvents(t *testing.T) {
 						{
 							Urls:      []string{"url"},
 							MediaType: "media",
-							Digest:    "digest_layer_2_1",
+							Digest:    "digest_layer_2",
 							Size:      44,
 							History: &model.ContainerImage_ContainerImageLayer_History{
 								Created: &timestamp.Timestamp{
@@ -175,12 +193,17 @@ func TestProcessEvents(t *testing.T) {
 			Version: "v1",
 			Images: []*model.ContainerImage{
 				{
-					Id:          "2",
-					ShortName:   "short_name_2",
-					Tags:        []string{"tag_1", "tag_2"},
-					Digest:      "2",
+					Id:        "public.ecr.aws/datadog/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
+					Name:      "public.ecr.aws/datadog/agent",
+					Registry:  "public.ecr.aws",
+					ShortName: "agent",
+					Tags: []string{
+						"7-rc",
+						"7.41.1-rc.1",
+					},
+					Digest:      "sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
 					Size:        42,
-					RepoDigests: []string{"digest_2"},
+					RepoDigests: []string{"public.ecr.aws/datadog/agent@sha256:052f1fdf4f9a7117d36a1838ab60782829947683007c34b69d4991576375c409"},
 					Os: &model.ContainerImage_OperatingSystem{
 						Name:         "DOS",
 						Version:      "6.22",
@@ -190,7 +213,7 @@ func TestProcessEvents(t *testing.T) {
 						{
 							Urls:      []string{"url"},
 							MediaType: "media",
-							Digest:    "digest_layer_1_2",
+							Digest:    "digest_layer_1",
 							Size:      43,
 							History: &model.ContainerImage_ContainerImageLayer_History{
 								Created: &timestamp.Timestamp{
@@ -202,7 +225,7 @@ func TestProcessEvents(t *testing.T) {
 						{
 							Urls:      []string{"url"},
 							MediaType: "media",
-							Digest:    "digest_layer_2_2",
+							Digest:    "digest_layer_2",
 							Size:      44,
 							History: &model.ContainerImage_ContainerImageLayer_History{
 								Created: &timestamp.Timestamp{


### PR DESCRIPTION
### What does this PR do?

When a container image is pushed and then pulled on several registries with different tags, the container runtime merges them all.

For ex.:
```command
$ docker inspect public.ecr.aws/datadog/agent:7.41.1-rc.1 | head -n 20
```
```json
[
    {
        "Id": "sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
        "RepoTags": [
            "datadog/agent:7-rc",
            "datadog/agent:7.41.1-rc.1",
            "gcr.io/datadoghq/agent:7-rc",
            "gcr.io/datadoghq/agent:7.41.1-rc.1",
            "public.ecr.aws/datadog/agent:7-rc",
            "public.ecr.aws/datadog/agent:7.41.1-rc.1"
        ],
        "RepoDigests": [
            "datadog/agent@sha256:052f1fdf4f9a7117d36a1838ab60782829947683007c34b69d4991576375c409",
            "gcr.io/datadoghq/agent@sha256:052f1fdf4f9a7117d36a1838ab60782829947683007c34b69d4991576375c409",
            "public.ecr.aws/datadog/agent@sha256:052f1fdf4f9a7117d36a1838ab60782829947683007c34b69d4991576375c409"
        ],
        "Parent": "",
        "Comment": "",
        "Created": "2022-12-16T09:31:30.811299Z",
        "Container": "",
```

When getting such an image, there isn’t a single registry or a single short name.
[Some heuristics were implemented in workload meta to choose the most user friendly one](https://github.com/DataDog/datadog-agent/blob/06d21d272b7dede7d9e0389431eb27357dc0c3ea/pkg/workloadmeta/collectors/internal/containerd/image.go#L198-L209).

**This PR makes the `container_image` check send one event per registry.**

### Motivation

Because the same image could come from several registries, its ID contained only the `sha256` checksum of the image.
But #processes, who will consume the events, expects the ID to contain also the image name.

### Additional Notes

We might want to do some cleanup and remove the `Name`, `Registry` and `ShortName` fields from the workloadmeta entity definition in a followup PR as we’re not using them anymore.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Validate with #processes that the ID of the `contimage` events they get is now matching their expectation.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
