### PR TITLE
[sbom] Split sbom in one event per registry

### DIFF
--- a/pkg/collector/corechecks/sbom/processor_test.go
+++ b/pkg/collector/corechecks/sbom/processor_test.go
@@ -6,7 +6,6 @@
 package sbom
 
 import (
-	"strconv"
 	"testing"
 	"time"
 
@@ -29,41 +28,52 @@ func TestProcessEvents(t *testing.T) {
 
 	sbomGenerationTime := time.Now()
 
-	for i := 0; i < 3; i++ {
-		p.processEvents(workloadmeta.EventBundle{
-			Events: []workloadmeta.Event{
-				{
-					Type: workloadmeta.EventTypeSet,
-					Entity: &workloadmeta.ContainerImageMetadata{
-						EntityID: workloadmeta.EntityID{
-							Kind: workloadmeta.KindContainerImageMetadata,
-							ID:   strconv.Itoa(i),
-						},
-						SBOM: &workloadmeta.SBOM{
-							CycloneDXBOM: &cyclonedx.BOM{
-								SpecVersion: cyclonedx.SpecVersion1_4,
-								Version:     42,
-								Components: &[]cyclonedx.Component{
-									{
-										Name: strconv.Itoa(100 * i),
-									},
-									{
-										Name: strconv.Itoa(100*i + 1),
-									},
-									{
-										Name: strconv.Itoa(100*i + 2),
-									},
+	p.processEvents(workloadmeta.EventBundle{
+		Events: []workloadmeta.Event{
+			{
+				Type: workloadmeta.EventTypeSet,
+				Entity: &workloadmeta.ContainerImageMetadata{
+					EntityID: workloadmeta.EntityID{
+						Kind: workloadmeta.KindContainerImageMetadata,
+						ID:   "sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
+					},
+					RepoTags: []string{
+						"datadog/agent:7-rc",
+						"datadog/agent:7.41.1-rc.1",
+						"gcr.io/datadoghq/agent:7-rc",
+						"gcr.io/datadoghq/agent:7.41.1-rc.1",
+						"public.ecr.aws/datadog/agent:7-rc",
+						"public.ecr.aws/datadog/agent:7.41.1-rc.1",
+					},
+					RepoDigests: []string{
+						"datadog/agent@sha256:052f1fdf4f9a7117d36a1838ab60782829947683007c34b69d4991576375c409",
+						"gcr.io/datadoghq/agent@sha256:052f1fdf4f9a7117d36a1838ab60782829947683007c34b69d4991576375c409",
+						"public.ecr.aws/datadog/agent@sha256:052f1fdf4f9a7117d36a1838ab60782829947683007c34b69d4991576375c409",
+					},
+					SBOM: &workloadmeta.SBOM{
+						CycloneDXBOM: &cyclonedx.BOM{
+							SpecVersion: cyclonedx.SpecVersion1_4,
+							Version:     42,
+							Components: &[]cyclonedx.Component{
+								{
+									Name: "Foo",
+								},
+								{
+									Name: "Bar",
+								},
+								{
+									Name: "Baz",
 								},
 							},
-							GenerationTime:     sbomGenerationTime,
-							GenerationDuration: 10 * time.Second,
 						},
+						GenerationTime:     sbomGenerationTime,
+						GenerationDuration: 10 * time.Second,
 					},
 				},
 			},
-			Ch: make(chan struct{}),
-		})
-	}
+		},
+		Ch: make(chan struct{}),
+	})
 
 	sender.AssertNumberOfCalls(t, "SBOM", 1)
 	sender.AssertSBOM(t, []model.SBOMPayload{
@@ -72,8 +82,12 @@ func TestProcessEvents(t *testing.T) {
 			Source:  &sourceAgent,
 			Entities: []*model.SBOMEntity{
 				{
-					Type:               model.SBOMSourceType_CONTAINER_IMAGE_LAYERS,
-					Id:                 "0",
+					Type: model.SBOMSourceType_CONTAINER_IMAGE_LAYERS,
+					Id:   "datadog/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
+					Tags: []string{
+						"7-rc",
+						"7.41.1-rc.1",
+					},
 					InUse:              true,
 					GeneratedAt:        timestamppb.New(sbomGenerationTime),
 					GenerationDuration: durationpb.New(10 * time.Second),
@@ -83,21 +97,25 @@ func TestProcessEvents(t *testing.T) {
 							Version:     pointer.Ptr(int32(42)),
 							Components: []*cyclonedx_v1_4.Component{
 								{
-									Name: "0",
+									Name: "Foo",
 								},
 								{
-									Name: "1",
+									Name: "Bar",
 								},
 								{
-									Name: "2",
+									Name: "Baz",
 								},
 							},
 						},
 					},
 				},
 				{
-					Type:               model.SBOMSourceType_CONTAINER_IMAGE_LAYERS,
-					Id:                 "1",
+					Type: model.SBOMSourceType_CONTAINER_IMAGE_LAYERS,
+					Id:   "gcr.io/datadoghq/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
+					Tags: []string{
+						"7-rc",
+						"7.41.1-rc.1",
+					},
 					InUse:              true,
 					GeneratedAt:        timestamppb.New(sbomGenerationTime),
 					GenerationDuration: durationpb.New(10 * time.Second),
@@ -107,13 +125,13 @@ func TestProcessEvents(t *testing.T) {
 							Version:     pointer.Ptr(int32(42)),
 							Components: []*cyclonedx_v1_4.Component{
 								{
-									Name: "100",
+									Name: "Foo",
 								},
 								{
-									Name: "101",
+									Name: "Bar",
 								},
 								{
-									Name: "102",
+									Name: "Baz",
 								},
 							},
 						},
@@ -132,8 +150,12 @@ func TestProcessEvents(t *testing.T) {
 			Source:  &sourceAgent,
 			Entities: []*model.SBOMEntity{
 				{
-					Type:               model.SBOMSourceType_CONTAINER_IMAGE_LAYERS,
-					Id:                 "2",
+					Type: model.SBOMSourceType_CONTAINER_IMAGE_LAYERS,
+					Id:   "public.ecr.aws/datadog/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
+					Tags: []string{
+						"7-rc",
+						"7.41.1-rc.1",
+					},
 					InUse:              true,
 					GeneratedAt:        timestamppb.New(sbomGenerationTime),
 					GenerationDuration: durationpb.New(10 * time.Second),
@@ -143,13 +165,13 @@ func TestProcessEvents(t *testing.T) {
 							Version:     pointer.Ptr(int32(42)),
 							Components: []*cyclonedx_v1_4.Component{
 								{
-									Name: "200",
+									Name: "Foo",
 								},
 								{
-									Name: "201",
+									Name: "Bar",
 								},
 								{
-									Name: "202",
+									Name: "Baz",
 								},
 							},
 						},


### PR DESCRIPTION
### What does this PR do?

When a container image is pushed and then pulled on several registries with different tags, the container runtime merges them all.

For ex.:
```command
$ docker inspect public.ecr.aws/datadog/agent:7.41.1-rc.1 | head -n 20
```
```json
[
    {
        "Id": "sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
        "RepoTags": [
            "datadog/agent:7-rc",
            "datadog/agent:7.41.1-rc.1",
            "gcr.io/datadoghq/agent:7-rc",
            "gcr.io/datadoghq/agent:7.41.1-rc.1",
            "public.ecr.aws/datadog/agent:7-rc",
            "public.ecr.aws/datadog/agent:7.41.1-rc.1"
        ],
        "RepoDigests": [
            "datadog/agent@sha256:052f1fdf4f9a7117d36a1838ab60782829947683007c34b69d4991576375c409",
            "gcr.io/datadoghq/agent@sha256:052f1fdf4f9a7117d36a1838ab60782829947683007c34b69d4991576375c409",
            "public.ecr.aws/datadog/agent@sha256:052f1fdf4f9a7117d36a1838ab60782829947683007c34b69d4991576375c409"
        ],
        "Parent": "",
        "Comment": "",
        "Created": "2022-12-16T09:31:30.811299Z",
        "Container": "",
```

When getting such an image, there isn’t a single registry or a single short name.

**This PR makes the `sbom` check send one event per registry.**

### Motivation

Because the same image could come from several registries, its ID contained only the `sha256` checksum of the image.
But #processes, who will consume the `container_image` events, expects the ID to contain also the image name.
In order to be able to match `container_image` and `sbom` on backend side, it’s easier to use the same ID.
This PR makes the ID used in the `sbom` message match the ID used in the `container_image` message as per #15292.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Validate with AppSec that the ID of the sbom events they get is matching their expectation.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
