### PR TITLE
Fix silent mutation of integration.Config in secret decryption

### DIFF
--- a/pkg/autodiscovery/secrets.go
+++ b/pkg/autodiscovery/secrets.go
@@ -32,12 +32,16 @@ func decryptConfig(conf integration.Config) (integration.Config, error) {
 	}
 
 	// instances
-	for idx := range conf.Instances {
-		conf.Instances[idx], err = secretsDecrypt(conf.Instances[idx], conf.Name)
+	// we cannot update in place as, being a slice, it would modify the input config as well
+	instances := make([]integration.Data, 0, len(conf.Instances))
+	for _, inputInstance := range conf.Instances {
+		decryptedInstance, err := secretsDecrypt(inputInstance, conf.Name)
 		if err != nil {
 			return conf, fmt.Errorf("error while decrypting secrets in an instance: %s", err)
 		}
+		instances = append(instances, decryptedInstance)
 	}
+	conf.Instances = instances
 
 	// metrics
 	conf.MetricConfig, err = secretsDecrypt(conf.MetricConfig, conf.Name)

--- a/pkg/autodiscovery/secrets_test.go
+++ b/pkg/autodiscovery/secrets_test.go
@@ -67,7 +67,6 @@ func (m *MockSecretDecrypt) install() func() {
 	originalSecretsDecrypt := secretsDecrypt
 	secretsDecrypt = m.getDecryptFunc()
 	return func() { secretsDecrypt = originalSecretsDecrypt }
-
 }
 
 var sharedTpl = integration.Config{
@@ -114,8 +113,10 @@ func TestSecretDecrypt(t *testing.T) {
 	mockDecrypt := MockSecretDecrypt{t, makeSharedScenarios()}
 	defer mockDecrypt.install()()
 
-	_, err := decryptConfig(sharedTpl)
+	newConfig, err := decryptConfig(sharedTpl)
 	require.NoError(t, err)
+
+	assert.NotEqual(t, newConfig.Instances, sharedTpl.Instances)
 
 	assert.True(t, mockDecrypt.haveAllScenariosBeenCalled())
 }

--- a/releasenotes/notes/fix-clusterchecks-not-unscheduled-e2133ca522bcb160.yaml
+++ b/releasenotes/notes/fix-clusterchecks-not-unscheduled-e2133ca522bcb160.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix an issue in Autodiscovery that could prevent Cluster Checks containing secrets (ENC[] syntax) to be unscheduled properly.


### PR DESCRIPTION
### What does this PR do?

Fix a bug that would prevent a non-templated check (often, cluster checks) to be unscheduled when containing secrets, due to the content of the original config to be modified by decryption process.

### Motivation

Bugfix.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

It's visible in our staging environment. Will QA during rollout.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
