### PR TITLE
[kitchen] Use official datadog cookbook for initial Agent install in upgrade scenario

### DIFF
--- a/test/kitchen/test-definitions/windows-install-test.yml
+++ b/test/kitchen/test-definitions/windows-install-test.yml
@@ -27,7 +27,6 @@ suites:
       - "recipe[dd-agent-upgrade]"
     attributes:
       datadog:
-        agent_major_version: 7
         agent_version: <%= ENV['LAST_STABLE_VERSION'] %>
         api_key: <%= api_key %>
       dd-agent-upgrade:

--- a/test/kitchen/test-definitions/windows-install-test.yml
+++ b/test/kitchen/test-definitions/windows-install-test.yml
@@ -23,18 +23,13 @@ suites:
 
   - name: win-upgrade-rollback
     run_list:
-      - "recipe[dd-agent-install::_install_windows]"
+      - "recipe[dd-agent-install]"
       - "recipe[dd-agent-upgrade]"
     attributes:
       datadog:
-        <% dd_agent_config.each do |key, value| %>
-        <%= key %>: "<%= value %>"
-        <% end %>
-      dd-agent-install:
-        windows_agent_url: https://s3.amazonaws.com/dd-agent-mstesting/builds/stable/
-        windows_version: "<%= ENV['LAST_STABLE_VERSION'] %>"
-        agent_install_options: >
-          APIKEY=<%= api_key %>
+        agent_major_version: 7
+        agent_version: <%= ENV['LAST_STABLE_VERSION'] %>
+        api_key: <%= api_key %>
       dd-agent-upgrade:
         <% dd_agent_config.each do |key, value| %>
         <%= key %>: "<%= value %>"


### PR DESCRIPTION

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Updates the `win-upgrade-rollback` kitchen test suite to use the official `datadog` cookbook for the initial install.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

After the 7.42.0 release, due to our release tooling changes, packages in the `dd-agent-mstesting` repository have changed names (to follow the production package naming).

After #15289, 6/7.42.0 are used as the base for upgrade tests, which broke the `win-upgrade-rollback` test, as it was still relying on packages in the `dd-agent-mstesting` repository, named with the old naming scheme.

Using the official cookbook resolves that problem, using the prod repository with the prod naming scheme.

Other upgrade tests are not affected, as they already use the official `datadog` cookbook.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

n/a

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

n/a

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

All kitchen tests pass.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
