### PR TITLE
[Windows] Fix the connection established check.

### DIFF
--- a/pkg/network/driver/types.go
+++ b/pkg/network/driver/types.go
@@ -84,6 +84,11 @@ type ConnTupleType C.struct__ConnTupleType
 type HttpMethodType C.enum__HttpMethodType
 type ClassificationSettings C.struct__ClassificationConfigurationSettings
 
+type TcpConnectionStatus C.enum__ConnectionStatus
+
+const (
+	TcpStatusEstablished = C.CONN_STAT_ESTABLISHED
+)
 const (
 	HttpTransactionTypeSize        = C.sizeof_struct__HttpTransactionType
 	HttpSettingsTypeSize           = C.sizeof_struct__HttpConfigurationSettings

--- a/pkg/network/driver/types_windows.go
+++ b/pkg/network/driver/types_windows.go
@@ -189,6 +189,11 @@ type ClassificationSettings struct {
 	Enabled uint64
 }
 
+type TcpConnectionStatus uint32
+
+const (
+	TcpStatusEstablished = 0x2
+)
 const (
 	HttpTransactionTypeSize        = 0x50
 	HttpSettingsTypeSize           = 0x14

--- a/pkg/network/event_windows.go
+++ b/pkg/network/event_windows.go
@@ -46,8 +46,15 @@ func isFlowClosed(flags uint32) bool {
 	return (flags & driver.FlowClosedMask) == driver.FlowClosedMask
 }
 
-func isTCPFlowEstablished(flags uint32) bool {
-	return (flags & driver.TCPFlowEstablishedMask) == driver.TCPFlowEstablishedMask
+func isTCPFlowEstablished(flow *driver.PerFlowData) bool {
+	//return (flags & driver.TCPFlowEstablishedMask) == driver.TCPFlowEstablishedMask
+	tcpdata := flow.TCPFlow()
+	if nil != tcpdata {
+		if tcpdata.ConnectionStatus == driver.TcpStatusEstablished {
+			return true
+		}
+	}
+	return false
 }
 
 func convertV4Addr(addr [16]uint8) util.Address {
@@ -116,7 +123,7 @@ func FlowToConnStat(cs *ConnectionStats, flow *driver.PerFlowData, enableMonoton
 			cs.RTTVar = uint32(tf.RttVariance)
 		}
 
-		if isTCPFlowEstablished(flow.Flags) {
+		if isTCPFlowEstablished(flow) {
 			cs.Monotonic.TCPEstablished = 1
 		}
 		if isFlowClosed(flow.Flags) {

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -400,6 +400,9 @@ func TestTCPOverIPv6(t *testing.T) {
 }
 
 func TestTCPCollectionDisabled(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Test disabled on Windows")
+	}
 	// Enable BPF-based system probe with TCP disabled
 	config := testConfig()
 	config.CollectTCPConns = false


### PR DESCRIPTION
Fixes the reporting of the established state on windows. Also disables the test for `TCPCollectionDisabled`, as it is a (now) known problem on Windows.

### What does this PR do?

### Motivation


### Additional Notes


### Possible Drawbacks / Trade-offs


### Describe how to test/QA your changes

Fix is caught by automated tests.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
