### PR TITLE
Raises dogstatsd 'pipe limit' to allow for all current features (plus two)

### DIFF
--- a/pkg/dogstatsd/parse_metrics.go
+++ b/pkg/dogstatsd/parse_metrics.go
@@ -22,6 +22,17 @@ const (
 	timingType
 )
 
+const (
+	maxSeparatorCnt = 5
+	// Client libraries may be reporting to older agents
+	// and if we add a new dogstatsd feature, the client library may
+	// have that on by default which could lead to the Agent rejecting
+	// the dogstatsd messages due to too many separators.
+	//
+	// This gives some breathing room for (future) forward compatibility.
+	reservedFutureSeparatorCnt = 2
+)
+
 var (
 	gaugeSymbol        = []byte("g")
 	countSymbol        = []byte("c")
@@ -58,7 +69,7 @@ func hasMetricSampleFormat(message []byte) bool {
 		return false
 	}
 	separatorCount := bytes.Count(message, fieldSeparator)
-	if separatorCount < 1 || separatorCount > 6 {
+	if separatorCount < 1 || separatorCount > (maxSeparatorCnt+reservedFutureSeparatorCnt) {
 		return false
 	}
 	return true

--- a/pkg/dogstatsd/parse_metrics.go
+++ b/pkg/dogstatsd/parse_metrics.go
@@ -22,17 +22,6 @@ const (
 	timingType
 )
 
-const (
-	maxSeparatorCnt = 5
-	// Client libraries may be reporting to older agents
-	// and if we add a new dogstatsd feature, the client library may
-	// have that on by default which could lead to the Agent rejecting
-	// the dogstatsd messages due to too many separators.
-	//
-	// This gives some breathing room for (future) forward compatibility.
-	reservedFutureSeparatorCnt = 2
-)
-
 var (
 	gaugeSymbol        = []byte("g")
 	countSymbol        = []byte("c")
@@ -69,7 +58,7 @@ func hasMetricSampleFormat(message []byte) bool {
 		return false
 	}
 	separatorCount := bytes.Count(message, fieldSeparator)
-	if separatorCount < 1 || separatorCount > (maxSeparatorCnt+reservedFutureSeparatorCnt) {
+	if separatorCount < 1 {
 		return false
 	}
 	return true

--- a/pkg/dogstatsd/parse_metrics.go
+++ b/pkg/dogstatsd/parse_metrics.go
@@ -58,7 +58,7 @@ func hasMetricSampleFormat(message []byte) bool {
 		return false
 	}
 	separatorCount := bytes.Count(message, fieldSeparator)
-	if separatorCount < 1 || separatorCount > 4 {
+	if separatorCount < 1 || separatorCount > 6 {
 		return false
 	}
 	return true

--- a/pkg/dogstatsd/parse_metrics_test.go
+++ b/pkg/dogstatsd/parse_metrics_test.go
@@ -534,4 +534,22 @@ func TestParseManyPipes(t *testing.T) {
 		assert.Equal(t, "environment:dev", sample.tags[0])
 		assert.InEpsilon(t, 1.0, sample.sampleRate, epsilon)
 	})
+
+	t.Run("Sample rate and container ID and timestamp and 2 future extensions (7 pipes)", func(t *testing.T) {
+		config.Datadog.Set("dogstatsd_no_aggregation_pipeline", true)
+		defer config.Datadog.Set("dogstatsd_no_aggregation_pipeline", false)
+
+		sample, err := parseMetricSample([]byte("example.metric:2.39283|d|T1657100540|@1.000000|#environment:dev|c:2a25f7fc8fbf573d62053d7263dd2d440c07b6ab4d2b107e50b0d4df1f2ee15f|f:wowthisisacoolfeature|f2:omgthisoneiscooler"))
+
+		require.NoError(t, err)
+
+		assert.Equal(t, "example.metric", sample.name)
+		assert.InEpsilon(t, 2.39283, sample.value, epsilon)
+		require.Nil(t, sample.values)
+		assert.Equal(t, distributionType, sample.metricType)
+		require.Equal(t, 1, len(sample.tags))
+		assert.Equal(t, sample.ts, time.Unix(1657100540, 0))
+		assert.Equal(t, "environment:dev", sample.tags[0])
+		assert.InEpsilon(t, 1.0, sample.sampleRate, epsilon)
+	})
 }

--- a/pkg/dogstatsd/parse_metrics_test.go
+++ b/pkg/dogstatsd/parse_metrics_test.go
@@ -483,3 +483,55 @@ func TestParseGaugeTimestampMalformed(t *testing.T) {
 	_, err = parseMetricSample([]byte("metric:1234|g|#onetag|T-102348932"))
 	assert.Error(t, err)
 }
+
+func TestParseManyPipes(t *testing.T) {
+	t.Run("Sample rate and container ID (4 pipes)", func(t *testing.T) {
+		sample, err := parseMetricSample([]byte("example.metric:2.39283|d|@1.000000|#environment:dev|c:2a25f7fc8fbf573d62053d7263dd2d440c07b6ab4d2b107e50b0d4df1f2ee15f"))
+
+		require.NoError(t, err)
+
+		assert.Equal(t, "example.metric", sample.name)
+		assert.InEpsilon(t, 2.39283, sample.value, epsilon)
+		require.Nil(t, sample.values)
+		assert.Equal(t, distributionType, sample.metricType)
+		require.Equal(t, 1, len(sample.tags))
+		assert.Equal(t, "environment:dev", sample.tags[0])
+		assert.InEpsilon(t, 1.0, sample.sampleRate, epsilon)
+	})
+
+	t.Run("Sample rate and container ID and timestamp (5 pipes)", func(t *testing.T) {
+		config.Datadog.Set("dogstatsd_no_aggregation_pipeline", true)
+		defer config.Datadog.Set("dogstatsd_no_aggregation_pipeline", false)
+
+		sample, err := parseMetricSample([]byte("example.metric:2.39283|d|T1657100540|@1.000000|#environment:dev|c:2a25f7fc8fbf573d62053d7263dd2d440c07b6ab4d2b107e50b0d4df1f2ee15f"))
+
+		require.NoError(t, err)
+
+		assert.Equal(t, "example.metric", sample.name)
+		assert.InEpsilon(t, 2.39283, sample.value, epsilon)
+		require.Nil(t, sample.values)
+		assert.Equal(t, distributionType, sample.metricType)
+		require.Equal(t, 1, len(sample.tags))
+		assert.Equal(t, sample.ts, time.Unix(1657100540, 0))
+		assert.Equal(t, "environment:dev", sample.tags[0])
+		assert.InEpsilon(t, 1.0, sample.sampleRate, epsilon)
+	})
+
+	t.Run("Sample rate and container ID and timestamp and future extension (6 pipes)", func(t *testing.T) {
+		config.Datadog.Set("dogstatsd_no_aggregation_pipeline", true)
+		defer config.Datadog.Set("dogstatsd_no_aggregation_pipeline", false)
+
+		sample, err := parseMetricSample([]byte("example.metric:2.39283|d|T1657100540|@1.000000|#environment:dev|c:2a25f7fc8fbf573d62053d7263dd2d440c07b6ab4d2b107e50b0d4df1f2ee15f|f:wowthisisacoolfeature"))
+
+		require.NoError(t, err)
+
+		assert.Equal(t, "example.metric", sample.name)
+		assert.InEpsilon(t, 2.39283, sample.value, epsilon)
+		require.Nil(t, sample.values)
+		assert.Equal(t, distributionType, sample.metricType)
+		require.Equal(t, 1, len(sample.tags))
+		assert.Equal(t, sample.ts, time.Unix(1657100540, 0))
+		assert.Equal(t, "environment:dev", sample.tags[0])
+		assert.InEpsilon(t, 1.0, sample.sampleRate, epsilon)
+	})
+}

--- a/releasenotes/notes/fix-dogstatsd-validation-181f4595360de447.yaml
+++ b/releasenotes/notes/fix-dogstatsd-validation-181f4595360de447.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Corrects dogstatsd metric message validation to support all current (and some future) dogstatsd features


### PR DESCRIPTION
### What does this PR do?
When parsing a dogstatsd metric sample, there is a "fast path" validation that simply checks the number of pipe characters (`|`) to easily reject garbage input.

This PR increments this value by 2.  Once to support existing, valid usages and once to reserve for future extensions to the dogstatsd format.


### Motivation
It appears that when container origin detection support was added in [#10659](https://github.com/DataDog/datadog-agent/pull/10659/files#diff-ef08de60bbb54e70e45a42b9710172d1fcc1645c23a27dbbbf4a56baa0beb68e), the "pipe limit" on this validation was _not_ incremented, which leads to scenarios where our dogstatsd client libraries can emit dogstatsd messages that cannot be parsed correctly (see additional notes below).

Luckily there was another extension to the format in https://github.com/DataDog/datadog-agent/pull/12829 which increased the limit so there is already a workaround for any customers who encounter this bug (upgrade to agent 7.39 or greater)

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
Any Agent version older than 7.39 will incorrectly reject dogstatsd metric messages utilizing both container ID _and_ sample rate, which are valid messages emitted by our client libraries.

### Possible Drawbacks / Trade-offs


### Describe how to test/QA your changes
1. Start the agent with `dogstatsd_no_aggregation_pipeline: true`
2. Send a dogstatsd message with 5 pipes, eg `example.metric:2.39283|d|T1657100540|@1.000000|#environment:dev|c:2a25f7fc8fbf573d62053d7263dd2d440c07b6ab4d2b107e50b0d4df1f2ee15f`
3. Ensure that you do _not_ see the error log: `Dogstatsd: error parsing metric message`

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
