### PR TITLE
[Serverless init] lower log level

### DIFF
--- a/cmd/serverless-init/cloudservice/helper/gcp.go
+++ b/cmd/serverless-init/cloudservice/helper/gcp.go
@@ -124,7 +124,7 @@ func getSingleMetadata(httpClient *http.Client, url string) string {
 	req.Header.Add("Metadata-Flavor", "Google")
 	res, err := httpClient.Do(req)
 	if err != nil {
-		log.Error("unable to get the requested metadata, defaulting to unknown")
+		log.Info("unable to get the requested metadata, defaulting to unknown")
 		return "unknown"
 	}
 	defer res.Body.Close()


### PR DESCRIPTION
### What does this PR do?

This PR lowers the log level when not being able to reach the metadata (which is the case while running locally)

### Motivation

Avoid confusion for customers
