### PR TITLE
USM: adding service_monitoring.java_agent_args=string parameter

### DIFF
--- a/pkg/config/system_probe.go
+++ b/pkg/config/system_probe.go
@@ -29,6 +29,9 @@ const (
 	// defaultSystemProbeJavaDir is the default path for java agent program
 	defaultSystemProbeJavaDir = "/opt/datadog-agent/embedded/share/system-probe/java"
 
+	// defaultServiceMonitoringJavaAgentArgs is default arguments that are passing to the injected java USM agent
+	defaultServiceMonitoringJavaAgentArgs = "dd.appsec.enabled=false dd.trace.enabled=false dd.usm.enabled=true"
+
 	// defaultRuntimeCompilerOutputDir is the default path for output from the system-probe runtime compiler
 	defaultRuntimeCompilerOutputDir = "/var/tmp/datadog-agent/system-probe/build"
 
@@ -154,6 +157,7 @@ func InitSystemProbeConfig(cfg Config) {
 	cfg.BindEnvAndSetDefault(join(smNS, "enable_go_tls_support"), false)
 
 	cfg.BindEnvAndSetDefault(join(smNS, "enable_java_tls_support"), false)
+	cfg.BindEnvAndSetDefault(join(smNS, "java_agent_args"), defaultServiceMonitoringJavaAgentArgs)
 
 	cfg.BindEnvAndSetDefault(join(netNS, "enable_gateway_lookup"), true, "DD_SYSTEM_PROBE_NETWORK_ENABLE_GATEWAY_LOOKUP")
 	cfg.BindEnvAndSetDefault(join(netNS, "max_http_stats_buffered"), 100000, "DD_SYSTEM_PROBE_NETWORK_MAX_HTTP_STATS_BUFFERED")

--- a/pkg/network/config/config.go
+++ b/pkg/network/config/config.go
@@ -99,6 +99,9 @@ type Config struct {
 	// Currently Windows only
 	HTTPMaxRequestFragment int64
 
+	// JavaAgentArgs arguments pass through injected USM agent
+	JavaAgentArgs string
+
 	// UDPConnTimeout determines the length of traffic inactivity between two
 	// (IP, port)-pairs before declaring a UDP connection as inactive. This is
 	// set to /proc/sys/net/netfilter/nf_conntrack_udp_timeout on Linux by
@@ -291,6 +294,7 @@ func New() *Config {
 
 		// Service Monitoring
 		EnableJavaTLSSupport: cfg.GetBool(join(smNS, "enable_java_tls_support")),
+		JavaAgentArgs:        cfg.GetString(join(smNS, "java_agent_args")),
 		EnableGoTLSSupport:   cfg.GetBool(join(smNS, "enable_go_tls_support")),
 	}
 

--- a/pkg/network/java/hotspot.go
+++ b/pkg/network/java/hotspot.go
@@ -265,7 +265,8 @@ func (h *Hotspot) commandWriteRead(cmd string, tailingNull bool) error {
 		return err
 	}
 
-	for _, c := range strings.Split(cmd, " ") {
+	// We split by space for at most 4 words, since our longest command is "load instrument false <javaagent=args>" which is 4 words
+	for _, c := range strings.SplitN(cmd, " ", 4) {
 		cmd := append([]byte(c), 0)
 		if _, err := h.conn.Write(cmd); err != nil {
 			return err

--- a/pkg/network/protocols/http/ebpf_javatls.go
+++ b/pkg/network/protocols/http/ebpf_javatls.go
@@ -31,6 +31,9 @@ const (
 var (
 	// path to our java USM agent TLS tracer
 	javaUSMAgentJarPath = ""
+
+	// default arguments passed to the injected agent-usm.jar
+	javaUSMAgentArgs = ""
 	// authID is used here as an identifier, simple proof of authenticity
 	// between the injected java process and the ebpf ioctl that receive the payload
 	authID = int64(0)
@@ -49,6 +52,7 @@ func newJavaTLSProgram(c *config.Config) *JavaTLSProgram {
 		return nil
 	}
 
+	javaUSMAgentArgs = c.JavaAgentArgs
 	javaUSMAgentJarPath = filepath.Join(c.JavaDir, AgentUSMJar)
 	jar, err := os.Open(javaUSMAgentJarPath)
 	if err != nil {
@@ -75,7 +79,12 @@ func (p *JavaTLSProgram) GetAllUndefinedProbes() (probeList []manager.ProbeIdent
 }
 
 func newJavaProcess(pid uint32) {
-	if err := java.InjectAgent(int(pid), javaUSMAgentJarPath, strconv.FormatInt(authID, 10)); err != nil {
+	args := javaUSMAgentArgs
+	if len(args) > 0 {
+		args += " "
+	}
+	args += "dd.usm.authID=" + strconv.FormatInt(authID, 10)
+	if err := java.InjectAgent(int(pid), javaUSMAgentJarPath, args); err != nil {
 		log.Error(err)
 	}
 }


### PR DESCRIPTION

### What does this PR do?

USM: adding service_monitoring.java_agent_args=string parameter
 to pass through injected agent-usm.jar agentmain()

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
