### PR TITLE
[workloadmeta] Log only bundle size on ack timeout

### DIFF
--- a/pkg/workloadmeta/store.go
+++ b/pkg/workloadmeta/store.go
@@ -623,7 +623,7 @@ func notifyChannel(name string, ch chan EventBundle, events []Event, wait bool) 
 			timer.Stop()
 			telemetry.NotificationsSent.Inc(name, telemetry.StatusSuccess)
 		case <-timer.C:
-			log.Warnf("collector %q did not close the event bundle channel in time, continuing with downstream collectors. bundle dump: %+v", name, bundle)
+			log.Warnf("collector %q did not close the event bundle channel in time, continuing with downstream collectors. bundle size: %d", name, len(bundle.Events))
 			telemetry.NotificationsSent.Inc(name, telemetry.StatusError)
 		}
 	}


### PR DESCRIPTION
### What does this PR do?

When a workloadmeta subscriber cannot close the EventBundle's channel in time, the store logs a warning message that it will move on to the next subscribers even though the one being notified at the moment did not acknowledge in time.

Originally, we used to log the entire contents of the bundle: all of the events and their associated entities, and the bundle's source. Several refactorings later, bundles no longer have a source, and the events now only contain a pointer to the entity, which makes the log message just a list of pointers, which is not very useful for debugging. Additionally, with the introduction of a cluster-level workloadmeta, the number of entities has grown very large, making these errors consume a lot of space.

This warning is still useful information though, so now instead of dumping the whole bundle, we now just show its size.

### Describe how to test/QA your changes

Since this is just a log change on a rare condition, I'll apply skip-qa. To observe in staging/prod, search for the log message.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
