### PR TITLE
[CSPM] [SEC-7053] Rely on our own scheduler and remove pkg/collector dependencies

### DIFF
--- a/cmd/security-agent/subcommands/compliance/compliance.go
+++ b/cmd/security-agent/subcommands/compliance/compliance.go
@@ -13,8 +13,7 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/security-agent/command"
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/log"
-	"github.com/DataDog/datadog-agent/pkg/collector/runner"
-	"github.com/DataDog/datadog-agent/pkg/collector/scheduler"
+	"github.com/DataDog/datadog-agent/pkg/compliance"
 	"github.com/DataDog/datadog-agent/pkg/compliance/agent"
 	"github.com/DataDog/datadog-agent/pkg/compliance/checks"
 	"github.com/DataDog/datadog-agent/pkg/compliance/event"
@@ -41,12 +40,7 @@ func StartCompliance(log log.Component, config config.Component, hostname string
 		return nil, err
 	}
 
-	runner := runner.NewRunner()
-	stopper.Add(runner)
-
-	scheduler := scheduler.NewScheduler(runner.GetChan())
-	runner.SetScheduler(scheduler)
-
+	scheduler := compliance.NewPeriodicScheduler()
 	checkInterval := config.GetDuration("compliance_config.check_interval")
 	checkMaxEvents := config.GetInt("compliance_config.check_max_events_per_run")
 	configDir := config.GetString("compliance_config.dir")

--- a/pkg/compliance/agent/agent_test.go
+++ b/pkg/compliance/agent/agent_test.go
@@ -15,7 +15,7 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
-	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	"github.com/DataDog/datadog-agent/pkg/compliance"
 	"github.com/DataDog/datadog-agent/pkg/compliance/checks"
 	"github.com/DataDog/datadog-agent/pkg/compliance/event"
 	"github.com/DataDog/datadog-agent/pkg/compliance/mocks"
@@ -126,12 +126,12 @@ func TestRunK8s(t *testing.T) {
 	scheduler := &mocks.Scheduler{}
 	defer scheduler.AssertExpectations(t)
 
-	scheduler.On("Run").Once().Return(nil)
-	scheduler.On("Stop").Once().Return(nil)
-
-	scheduler.On("Enter", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
-		check := args.Get(0).(check.Check)
-		check.Run()
+	scheduler.On("StopScheduling", mock.Anything).Once()
+	scheduler.On("StartScheduling", mock.Anything).Once().Run(func(args mock.Arguments) {
+		checks := args.Get(0).([]compliance.Check)
+		for _, check := range checks {
+			check.Run()
+		}
 	})
 
 	kubeClient := &mocks.KubeClient{}
@@ -218,12 +218,12 @@ func TestRunDocker(t *testing.T) {
 	scheduler := &mocks.Scheduler{}
 	defer scheduler.AssertExpectations(t)
 
-	scheduler.On("Run").Once().Return(nil)
-	scheduler.On("Stop").Once().Return(nil)
-
-	scheduler.On("Enter", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
-		check := args.Get(0).(check.Check)
-		check.Run()
+	scheduler.On("StopScheduling", mock.Anything).Once()
+	scheduler.On("StartScheduling", mock.Anything).Once().Run(func(args mock.Arguments) {
+		checks := args.Get(0).([]compliance.Check)
+		for _, check := range checks {
+			check.Run()
+		}
 	})
 
 	dockerClient := &mocks.DockerClient{}

--- a/pkg/compliance/check.go
+++ b/pkg/compliance/check.go
@@ -8,7 +8,6 @@ package compliance
 import (
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/compliance/event"
 )
 
@@ -18,7 +17,13 @@ const (
 )
 
 // Check is the interface for compliance checks
-type Check check.Check
+type Check interface {
+	ID() string
+	String() string
+	Version() string
+	Period() time.Duration
+	Run() error
+}
 
 // CheckStatus describes current status for a check
 type CheckStatus struct {

--- a/pkg/compliance/checks/check.go
+++ b/pkg/compliance/checks/check.go
@@ -9,8 +9,6 @@ import (
 	"sort"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
-	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/compliance"
 	"github.com/DataDog/datadog-agent/pkg/compliance/checks/env"
 	"github.com/DataDog/datadog-agent/pkg/compliance/event"
@@ -51,54 +49,20 @@ type complianceCheck struct {
 	eventNotify eventNotify
 }
 
-func (c *complianceCheck) Stop() {
-}
-
-func (c *complianceCheck) Cancel() {
-}
-
 func (c *complianceCheck) String() string {
 	return compliance.CheckName(c.ruleID, c.description)
 }
 
-func (c *complianceCheck) Configure(integrationConfigDigest uint64, config, initConfig integration.Data, source string) error {
-	return nil
-}
-
-func (c *complianceCheck) Interval() time.Duration {
+func (c *complianceCheck) Period() time.Duration {
 	return c.interval
 }
 
-func (c *complianceCheck) ID() check.ID {
-	return check.ID(c.ruleID)
-}
-
-func (c *complianceCheck) InitConfig() string {
-	return ""
-}
-
-func (c *complianceCheck) InstanceConfig() string {
-	return ""
-}
-
-func (c *complianceCheck) GetWarnings() []error {
-	return nil
-}
-
-func (c *complianceCheck) GetSenderStats() (check.SenderStats, error) {
-	return check.NewSenderStats(), nil
+func (c *complianceCheck) ID() string {
+	return c.ruleID
 }
 
 func (c *complianceCheck) Version() string {
 	return c.suiteMeta.Version
-}
-
-func (c *complianceCheck) ConfigSource() string {
-	return c.suiteMeta.Source
-}
-
-func (c *complianceCheck) IsTelemetryEnabled() bool {
-	return false
 }
 
 func (c *complianceCheck) reportToResource(report *compliance.Report) compliance.ReportResource {

--- a/pkg/compliance/mocks/scheduler.go
+++ b/pkg/compliance/mocks/scheduler.go
@@ -3,7 +3,10 @@
 package mocks
 
 import (
-	check "github.com/DataDog/datadog-agent/pkg/collector/check"
+	context "context"
+
+	compliance "github.com/DataDog/datadog-agent/pkg/compliance"
+
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -12,65 +15,14 @@ type Scheduler struct {
 	mock.Mock
 }
 
-// Cancel provides a mock function with given fields: id
-func (_m *Scheduler) Cancel(id check.ID) error {
-	ret := _m.Called(id)
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(check.ID) error); ok {
-		r0 = rf(id)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
+// StartScheduling provides a mock function with given fields: checks
+func (_m *Scheduler) StartScheduling(checks []compliance.Check) {
+	_m.Called(checks)
 }
 
-// Enter provides a mock function with given fields: _a0
-func (_m *Scheduler) Enter(_a0 check.Check) error {
-	ret := _m.Called(_a0)
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(check.Check) error); ok {
-		r0 = rf(_a0)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// IsCheckScheduled provides a mock function with given fields: id
-func (_m *Scheduler) IsCheckScheduled(id check.ID) bool {
-	ret := _m.Called(id)
-
-	var r0 bool
-	if rf, ok := ret.Get(0).(func(check.ID) bool); ok {
-		r0 = rf(id)
-	} else {
-		r0 = ret.Get(0).(bool)
-	}
-
-	return r0
-}
-
-// Run provides a mock function with given fields:
-func (_m *Scheduler) Run() {
-	_m.Called()
-}
-
-// Stop provides a mock function with given fields:
-func (_m *Scheduler) Stop() error {
-	ret := _m.Called()
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func() error); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
+// StopScheduling provides a mock function with given fields: ctx
+func (_m *Scheduler) StopScheduling(ctx context.Context) {
+	_m.Called(ctx)
 }
 
 type mockConstructorTestingTNewScheduler interface {

--- a/pkg/compliance/scheduler.go
+++ b/pkg/compliance/scheduler.go
@@ -1,0 +1,109 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package compliance
+
+import (
+	"context"
+	"math/rand"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// Scheduler is a simple scheduling interface for starting/stopping rule evaluation scheduling.
+type Scheduler interface {
+	StartScheduling(checks []Check)
+	StopScheduling(ctx context.Context)
+}
+
+type periodicScheduler struct {
+	started bool
+	stop    chan struct{}
+	done    chan struct{}
+}
+
+// NewPeriodicScheduler returns a default scheduler used for scheduling rule evaluation,
+// for this compliance module. It is a bare minimum setup that schedules checks at constant
+// and periodic and constant intervals, depending on their period.
+//
+// Checks with identical time periods are groupped together and scheduled in the same
+// goroutine. In other words, we schedule as many goroutine as defined periods.
+func NewPeriodicScheduler() Scheduler {
+	return &periodicScheduler{
+		stop: make(chan struct{}),
+		done: make(chan struct{}),
+	}
+}
+
+// Start will start the scheduling of our checks.
+func (s *periodicScheduler) StartScheduling(checks []Check) {
+	if s.started {
+		panic("(programmer error) compliance: scheduler already started")
+	}
+	s.started = true
+	// We group checks per time period, and run one goroutine for each period.
+	// A jittered sleep time is added before starting the first rule to avoid
+	// synchronized run at the beginning.
+	buckets := make(map[time.Duration][]Check, len(checks))
+	for _, check := range checks {
+		period := check.Period()
+		buckets[period] = append(buckets[period], check)
+	}
+	finish := make(chan struct{}, len(buckets))
+	for period, checks := range buckets {
+		go s.runPeriodicChecks(checks, period, finish)
+	}
+	go func() {
+		for i := 0; i < len(buckets); i++ {
+			<-finish
+		}
+		close(s.done)
+	}()
+}
+
+func (s *periodicScheduler) runPeriodicChecks(
+	checks []Check,
+	period time.Duration,
+	finish chan struct{},
+) {
+	jitterRng := rand.New(rand.NewSource(period.Nanoseconds()))
+
+	checkIndex := 0
+	runCheck := func() {
+		check := checks[checkIndex]
+		log.Infof("compliance: running check %q", check)
+		if err := check.Run(); err != nil {
+			log.Errorf("compliance: error running check %q: %v", check, err)
+		}
+		checkIndex = (checkIndex + 1) % len(checks)
+	}
+
+	interval := time.Duration(int(period.Milliseconds())/len(checks)) * time.Millisecond
+	jitter := time.Duration(jitterRng.Int63n(interval.Milliseconds())) * time.Millisecond
+	time.Sleep(jitter)
+	runCheck()
+	ticker := time.NewTicker(interval)
+	for {
+		select {
+		case <-ticker.C:
+			runCheck()
+		case <-s.stop:
+			ticker.Stop()
+			finish <- struct{}{}
+			return
+		}
+	}
+}
+
+func (s *periodicScheduler) StopScheduling(parentCtx context.Context) {
+	ctx, cancel := context.WithDeadline(parentCtx, time.Now().Add(5*time.Second))
+	defer cancel()
+	close(s.stop)
+	select {
+	case <-s.done:
+	case <-ctx.Done():
+	}
+}

--- a/pkg/compliance/scheduler_test.go
+++ b/pkg/compliance/scheduler_test.go
@@ -1,0 +1,81 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package compliance
+
+import (
+	"context"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type fakeCheck struct {
+	id       int
+	period   time.Duration
+	runCount int
+}
+
+var checkID = 0
+
+func newCheck(period time.Duration) Check {
+	checkID++
+	return &fakeCheck{id: checkID, period: period}
+}
+
+func (c *fakeCheck) ID() string {
+	return strconv.Itoa(c.id)
+}
+
+func (c *fakeCheck) String() string {
+	return "fakecheck:" + strconv.Itoa(c.id)
+}
+
+func (c *fakeCheck) Version() string {
+	return "0"
+}
+
+func (c *fakeCheck) Period() time.Duration {
+	return c.period
+}
+
+func (c *fakeCheck) Run() error {
+	c.runCount++
+	return nil
+}
+
+func TestScheduler(t *testing.T) {
+	checks := []Check{
+		newCheck(20 * time.Millisecond),
+		newCheck(20 * time.Millisecond),
+		newCheck(20 * time.Millisecond),
+		newCheck(20 * time.Millisecond),
+
+		newCheck(200 * time.Millisecond),
+		newCheck(200 * time.Millisecond),
+	}
+	s := NewPeriodicScheduler()
+	s.StartScheduling(checks)
+	time.Sleep(500 * time.Millisecond)
+	s.StopScheduling(context.Background())
+	checksCopy := make([]fakeCheck, len(checks))
+	for i, check := range checks {
+		checksCopy[i] = *(check.(*fakeCheck))
+		switch check.Period() {
+		case 20 * time.Millisecond:
+			assert.Greater(t, check.(*fakeCheck).runCount, 20)
+		case 200 * time.Millisecond:
+			assert.Greater(t, check.(*fakeCheck).runCount, 1)
+		default:
+			t.Fail()
+		}
+	}
+	time.Sleep(500 * time.Millisecond)
+	for i, check := range checks {
+		assert.Equal(t, checksCopy[i].runCount, check.(*fakeCheck).runCount)
+	}
+}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Implements a new scheduler for `pkg/compliance` and stop relying on `pkg/collector`'s scheduler.

It is a bare minimum setup that schedules checks at constant and maximum intervals, depending on their period. Checks with identical time periods are groupped together and scheduled in the same goroutine. In other words, we schedule as many goroutine as defined periods.

### Motivation

Compliance rule evaluation checks have other constraints than the collector checks. We wanted to bring the scheduler implementation closer to home. 

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
