### PR TITLE
[cmd/agent] Convert klog logs to datadog logs

### DIFF
--- a/cmd/agent/klog.go
+++ b/cmd/agent/klog.go
@@ -3,8 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build !windows && kubeapiserver
-// +build !windows,kubeapiserver
+//go:build kubeapiserver
+// +build kubeapiserver
 
 package main
 

--- a/pkg/util/log/klog_redirect.go
+++ b/pkg/util/log/klog_redirect.go
@@ -1,0 +1,58 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package log
+
+import "strings"
+
+// redirectLogger is used to redirect klog logs to datadog logs. klog is
+// client-go's logger, logging to STDERR by default, which makes all severities
+// into ERROR, along with the formatting just being off. To make the
+// conversion, we set a redirectLogger as klog's output, and parse the severity
+// and log message out of every log line.
+// NOTE: on klog v2 this parsing is no longer necessary, as it allows us to use
+// kSetLogger() instead of kSetOutputBySeverity(). unfortunately we
+// still have some dependencies stuck on v1, so we keep the parsing.
+type KlogRedirectLogger struct {
+	stackDepth int
+}
+
+func NewKlogRedirectLogger(stackDepth int) KlogRedirectLogger {
+	return KlogRedirectLogger{
+		stackDepth: stackDepth,
+	}
+}
+
+func (l KlogRedirectLogger) Write(b []byte) (int, error) {
+	// klog log lines have the following format:
+	//     Lmmdd hh:mm:ss.uuuuuu threadid file:line] msg...
+	// so we parse L to decide in which level to log, and we try to find
+	// the ']' character, to ignore anything up to that point, as we don't
+	// care about the header outside of the log level.
+
+	msg := string(b)
+
+	i := strings.IndexByte(msg, ']')
+	if i >= 0 {
+		// if we find a ']', we ignore anything 2 positions from it
+		// (itself, plus a blank space)
+		msg = msg[i+2:]
+	}
+
+	switch b[0] {
+	case 'I':
+		InfoStackDepth(l.stackDepth, msg)
+	case 'W':
+		WarnStackDepth(l.stackDepth, msg)
+	case 'E':
+		ErrorStackDepth(l.stackDepth, msg)
+	case 'F':
+		CriticalStackDepth(l.stackDepth, msg)
+	default:
+		InfoStackDepth(l.stackDepth, msg)
+	}
+
+	return 0, nil
+}


### PR DESCRIPTION
### What does this PR do?

This has been done for the DCA already in 7cfdf11d22955977f3a430e6e2434d672233b749 and 97e4bfdc0f074c021a9d16bde6a954d2b2f3498b. The problem is also present in the core agent when being run as a clc runner with certain checks, such as ksm core.

### Describe how to test/QA your changes

The underlying conditions that trigger logs are very hard to reproduce on demand, but they happen often in staging. After this fix, there should be no lines in the following format (you can search for "pkg/mod/k8s.io/client-go" before and after, it's the most common log) in the agent, clc runners, and dca:

```
W0131 13:31:03.232559       1 reflector.go:324] pkg/mod/k8s.io/client-go@v0.23.15/tools/cache/reflector.go:167: failed to list *v1beta2.VerticalPodAutoscaler: the server could not find the requested resource (get verticalpodautoscalers.autoscaling.k8s.io)
```

Instead, they should be in the format below. Also check that the correct file name is reported:

```
2023-01-30 23:09:42 UTC | CLUSTER | ERROR | (apimachinery@v0.23.15/pkg/util/runtime/runtime.go:108 in HandleError) | workloadmeta-kubeapiserver: Failed to watch *v1.Pod: failed to list *v1.Pod: unexpected error when reading response body. Please retry. Original error: net/http: request canceled (Client.Timeout or context cancellation while reading body)
```

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
