### PR TITLE
Address VPA fixes caught in QA

### DIFF
--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/verticalpodautoscaler.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/verticalpodautoscaler.go
@@ -73,7 +73,7 @@ func (c *VerticalPodAutoscalerCollector) Metadata() *collectors.CollectorMetadat
 	return c.metadata
 }
 
-// Run triggers the collection process.
+// Run triggers the vpa collection process.
 func (c *VerticalPodAutoscalerCollector) Run(rcfg *collectors.CollectorRunConfig) (*collectors.CollectorRunResult, error) {
 	list, err := c.lister.List(labels.Everything())
 	if err != nil {

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/verticalpodautoscaler.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/verticalpodautoscaler.go
@@ -48,7 +48,7 @@ func NewVerticalPodAutoscalerCollector() *VerticalPodAutoscalerCollector {
 			SupportsManifestBuffering: true,
 			Name:                      "verticalpodautoscalers",
 			NodeType:                  orchestrator.K8sVerticalPodAutoscaler,
-			Version:                   "v1",
+			Version:                   "autoscaling.k8s.io/v1",
 		},
 		processor: processors.NewProcessor(new(k8sProcessors.VerticalPodAutoscalerHandlers)),
 	}

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/verticalpodautoscaler.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/verticalpodautoscaler.go
@@ -44,7 +44,7 @@ func (h *VerticalPodAutoscalerHandlers) BuildMessageBody(ctx *processors.Process
 		GroupId:                ctx.MsgGroupID,
 		GroupSize:              int32(groupSize),
 		VerticalPodAutoscalers: models,
-		Tags:                   ctx.Cfg.ExtraTags,
+		Tags:                   append(ctx.Cfg.ExtraTags, ctx.ApiGroupVersionTag),
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?

- This PR addresses fixes caught in the QA process. We were missing a tag for the VPA resource. Also the incorrect version was being set.

### Motivation

- We want to fix any issues before the product reaches GA

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
