### PR TITLE
[system-probe] make sure stats are reported as soon a module registration happens

### DIFF
--- a/cmd/system-probe/api/module/loader.go
+++ b/cmd/system-probe/api/module/loader.go
@@ -158,8 +158,10 @@ func Close() {
 func updateStats() {
 	start := time.Now()
 	then := time.Now()
+	now := time.Now()
 	ticker := time.NewTicker(15 * time.Second)
-	for now := range ticker.C {
+
+	for {
 		l.Lock()
 		if l.closed {
 			l.Unlock()
@@ -179,5 +181,8 @@ func updateStats() {
 		l.stats["uptime"] = now.Sub(start).String()
 		then = now
 		l.Unlock()
+
+		then = now
+		now = <-ticker.C
 	}
 }

--- a/cmd/system-probe/api/module/loader.go
+++ b/cmd/system-probe/api/module/loader.go
@@ -179,7 +179,6 @@ func updateStats() {
 		l.stats["updated_at"] = now.Unix()
 		l.stats["delta_seconds"] = now.Sub(then).Seconds()
 		l.stats["uptime"] = now.Sub(start).String()
-		then = now
 		l.Unlock()
 
 		then = now

--- a/releasenotes/notes/sysprobe-status-8dc80c3b7515f0ec.yaml
+++ b/releasenotes/notes/sysprobe-status-8dc80c3b7515f0ec.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    Fix an issue where ``agent status`` would show incorrect system-probe status for 15 seconds as the system-probe started up.


### PR DESCRIPTION
When modules are registered in the system-probe, a process to update stats in the global `l` field every 15 seconds starts.

Those stats are pulled in by the `agent status` command which user can use to see what's running in the agent.

The loop was written as:

```
for now := <-ticker {
  // update stuff
}
```

Which mean that for the first 15 seconds fo the agents life, stats would come back incomplete. Meaning that for the first 15 seconds of the agent's.

This PR changes the stats loop to compute stats *then* wait for 15 seconds.

QA instructions (meant to run on a vanilla linux host):

* in one terminal window run `watch "sudo -u dd-agent /opt/datadog-agent/bin/agent/agent  status  | head -n10"`
* in another terminal window, restart the system-probe
* you should *not*  see errors about systemprobe.tmpl failing to render. Running these steps on 7.42 and below shows:

  ``` Getting the status from the agent. template: /systemprobe.tmpl:11:34: executing "/systemprobe.tmpl" at <.updated_at>: invalid value; expected float64 ```

  For the first 15 seconds.

  You should *not see* see these errors in the first 15 seconds of the system probe running (or ever).

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
