### PR TITLE
Fix IPv6 detection

### DIFF
--- a/pkg/api/util/util.go
+++ b/pkg/api/util/util.go
@@ -7,6 +7,7 @@ package util
 
 import (
 	"fmt"
+	"net"
 	"net/http"
 	"strings"
 
@@ -138,8 +139,8 @@ func IsForbidden(ip string) bool {
 	return forbidden[ip]
 }
 
-// IsIPv6 is used to differentiate between ipv4 and ipv6 addresses based on colons.
-// The function does NOT verify if the argument string is a valid address
+// IsIPv6 is used to differentiate between ipv4 and ipv6 addresses.
 func IsIPv6(ip string) bool {
-	return strings.Count(ip, ":") >= 2
+	parsed := net.ParseIP(ip)
+	return parsed != nil && parsed.To4() == nil
 }

--- a/pkg/api/util/util_test.go
+++ b/pkg/api/util/util_test.go
@@ -1,0 +1,52 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsIPv6(t *testing.T) {
+	tests := []struct {
+		name           string
+		input          string
+		expectedOutput bool
+	}{
+		{
+			name:           "IPv4",
+			input:          "192.168.0.1",
+			expectedOutput: false,
+		},
+		{
+			name:           "IPv6",
+			input:          "2600:1f19:35d4:b900:527a:764f:e391:d369",
+			expectedOutput: true,
+		},
+		{
+			name:           "zero compressed IPv6",
+			input:          "2600:1f19:35d4:b900::1",
+			expectedOutput: true,
+		},
+		{
+			name:           "IPv6 loopback",
+			input:          "::1",
+			expectedOutput: true,
+		},
+		{
+			name:           "short hostname with only hexadecimal digits",
+			input:          "cafe",
+			expectedOutput: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, IsIPv6(tt.input), tt.expectedOutput)
+		})
+	}
+}


### PR DESCRIPTION
### What does this PR do?

Make the function used to detect IPv6 more robust.

### Motivation

A correct regex that accurately identifies IPv6 and IPv6 only is slightly more sophisticated than one was used so far. [See here for an example](https://stackoverflow.com/a/17871737).
A consequence of using the current regex is that hostnames composed of only digits and letters below `f` were wrongly identified as an IPv6.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Validate the agent still works correctly on an IPv6 kubernetes cluster.

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
