### PR TITLE
tracer: protocol classification: Adding a workaround to handle hitting instructions limits on socket filter

### DIFF
--- a/pkg/network/ebpf/c/prebuilt/tracer.c
+++ b/pkg/network/ebpf/c/prebuilt/tracer.c
@@ -30,6 +30,16 @@
 #include "sock.h"
 #include "skb.h"
 
+// This entry point is needed to bypass a memory limit on socket filters.
+// There is a limitation on number of instructions can be attached to a socket filter,
+// as we classify more protocols, we reached that limit, thus we workaround it
+// by using tail call.
+SEC("socket/classifier_entry")
+int socket__classifier_entry(struct __sk_buff *skb) {
+    bpf_tail_call_compat(skb, &classification_progs, CLASSIFICATION_PROG);
+    return 0;
+}
+
 // The entrypoint for all packets.
 SEC("socket/classifier")
 int socket__classifier(struct __sk_buff *skb) {

--- a/pkg/network/ebpf/c/runtime/tracer.c
+++ b/pkg/network/ebpf/c/runtime/tracer.c
@@ -41,6 +41,16 @@
 #include "conn-tuple.h"
 #include "sock.h"
 
+// This entry point is needed to bypass a memory limit on socket filters.
+// There is a limitation on number of instructions can be attached to a socket filter,
+// as we classify more protocols, we reached that limit, thus we workaround it
+// by using tail call.
+SEC("socket/classifier_entry")
+int socket__classifier_entry(struct __sk_buff *skb) {
+    bpf_tail_call_compat(skb, &classification_progs, CLASSIFICATION_PROG);
+    return 0;
+}
+
 // The entrypoint for all packets.
 SEC("socket/classifier")
 int socket__classifier(struct __sk_buff *skb) {

--- a/pkg/network/ebpf/c/tracer-maps.h
+++ b/pkg/network/ebpf/c/tracer-maps.h
@@ -92,4 +92,11 @@ BPF_HASH_MAP(do_sendfile_args, __u64, struct sock *, 1024)
 // corresponding kretprobes
 BPF_HASH_MAP(ip_make_skb_args, __u64, ip_make_skb_args_t, 1024)
 
+// This entry point is needed to bypass a memory limit on socket filters.
+// There is a limitation on number of instructions can be attached to a socket filter,
+// as we classify more protocols, we reached that limit, thus we workaround it
+// by using tail call.
+#define CLASSIFICATION_PROG 0
+BPF_PROG_ARRAY(classification_progs, 1)
+
 #endif

--- a/pkg/network/ebpf/probes/probes.go
+++ b/pkg/network/ebpf/probes/probes.go
@@ -27,7 +27,9 @@ const (
 	// TCPv6ConnectReturn traces the return value for the v6 connect() system call
 	TCPv6ConnectReturn ProbeName = "kretprobe/tcp_v6_connect"
 
-	// ProtocolClassifierSocketFilter runs a classifier algorithm as a socket filer
+	// ProtocolClassifierEntrySocketFilter runs a classifier algorithm as a socket filter
+	ProtocolClassifierEntrySocketFilter ProbeName = "socket/classifier_entry"
+	// ProtocolClassifierSocketFilter runs a classifier algorithm as a socket filter
 	ProtocolClassifierSocketFilter ProbeName = "socket/classifier"
 
 	// NetDevQueue runs a tracepoint that allows us to correlate __sk_buf (in a socket filter) with the `struct sock*`
@@ -62,7 +64,7 @@ const (
 	// TCPRecvMsgPre410 traces the tcp_recvmsg() system call on kernels prior to 4.1.0. This is created because
 	// we need to load a different kprobe implementation
 	TCPRecvMsgPre410 ProbeName = "kprobe/tcp_recvmsg/pre_4_1_0"
-	// TCPRecvMsgreturn traces the return for the tcp_recvmsg() kernel function
+	// TCPRecvMsgReturn traces the return for the tcp_recvmsg() kernel function
 	TCPRecvMsgReturn ProbeName = "kretprobe/tcp_recvmsg"
 	// TCPReadSock traces the tcp_read_sock() kernel function
 	TCPReadSock ProbeName = "kprobe/tcp_read_sock"
@@ -137,7 +139,7 @@ const (
 	// ConntrackHashInsert is the probe for new conntrack entries
 	ConntrackHashInsert ProbeName = "kprobe/__nf_conntrack_hash_insert"
 
-	// ConntrackFillInfo is the probe for for dumping existing conntrack entries
+	// ConntrackFillInfo is the probe for dumping existing conntrack entries
 	ConntrackFillInfo ProbeName = "kprobe/ctnetlink_fill_info"
 
 	// SockFDLookup is the kprobe used for mapping socket FDs to kernel sock structs
@@ -182,6 +184,7 @@ const (
 	ProtocolClassificationBufMap      BPFMapName = "classification_buf"
 	ConnectionProtocolMap             BPFMapName = "connection_protocol"
 	ConnectionTupleToSocketSKBConnMap BPFMapName = "conn_tuple_to_socket_skb_conn_tuple"
+	ClassificationProgsMap            BPFMapName = "classification_progs"
 )
 
 // SectionName returns the SectionName for the given BPF map

--- a/pkg/network/tracer/connection/kprobe/config.go
+++ b/pkg/network/tracer/connection/kprobe/config.go
@@ -43,6 +43,7 @@ func enabledProbes(c *config.Config, runtimeTracer bool) (map[probes.ProbeName]s
 
 	if c.CollectTCPConns {
 		if ClassificationSupported(c) {
+			enableProbe(enabled, probes.ProtocolClassifierEntrySocketFilter)
 			enableProbe(enabled, probes.ProtocolClassifierSocketFilter)
 			enableProbe(enabled, probes.NetDevQueue)
 		}

--- a/pkg/network/tracer/connection/kprobe/manager.go
+++ b/pkg/network/tracer/connection/kprobe/manager.go
@@ -15,7 +15,6 @@ import (
 	manager "github.com/DataDog/ebpf-manager"
 
 	"github.com/DataDog/datadog-agent/pkg/ebpf"
-	"github.com/DataDog/datadog-agent/pkg/network/config"
 	"github.com/DataDog/datadog-agent/pkg/network/ebpf/probes"
 )
 
@@ -26,40 +25,41 @@ const (
 )
 
 var mainProbes = map[probes.ProbeName]string{
-	probes.NetDevQueue:                    "tracepoint__net__net_dev_queue",
-	probes.ProtocolClassifierSocketFilter: "socket__classifier",
-	probes.TCPSendMsg:                     "kprobe__tcp_sendmsg",
-	probes.TCPSendMsgReturn:               "kretprobe__tcp_sendmsg",
-	probes.TCPRecvMsg:                     "kprobe__tcp_recvmsg",
-	probes.TCPRecvMsgReturn:               "kretprobe__tcp_recvmsg",
-	probes.TCPReadSock:                    "kprobe__tcp_read_sock",
-	probes.TCPReadSockReturn:              "kretprobe__tcp_read_sock",
-	probes.TCPClose:                       "kprobe__tcp_close",
-	probes.TCPCloseReturn:                 "kretprobe__tcp_close",
-	probes.TCPConnect:                     "kprobe__tcp_connect",
-	probes.TCPFinishConnect:               "kprobe__tcp_finish_connect",
-	probes.TCPSetState:                    "kprobe__tcp_set_state",
-	probes.IPMakeSkb:                      "kprobe__ip_make_skb",
-	probes.IPMakeSkbReturn:                "kretprobe__ip_make_skb",
-	probes.IP6MakeSkb:                     "kprobe__ip6_make_skb",
-	probes.IP6MakeSkbReturn:               "kretprobe__ip6_make_skb",
-	probes.UDPRecvMsg:                     "kprobe__udp_recvmsg",
-	probes.UDPRecvMsgReturn:               "kretprobe__udp_recvmsg",
-	probes.UDPv6RecvMsg:                   "kprobe__udpv6_recvmsg",
-	probes.UDPv6RecvMsgReturn:             "kretprobe__udpv6_recvmsg",
-	probes.TCPRetransmit:                  "kprobe__tcp_retransmit_skb",
-	probes.InetCskAcceptReturn:            "kretprobe__inet_csk_accept",
-	probes.InetCskListenStop:              "kprobe__inet_csk_listen_stop",
-	probes.UDPDestroySock:                 "kprobe__udp_destroy_sock",
-	probes.UDPDestroySockReturn:           "kretprobe__udp_destroy_sock",
-	probes.InetBind:                       "kprobe__inet_bind",
-	probes.Inet6Bind:                      "kprobe__inet6_bind",
-	probes.InetBindRet:                    "kretprobe__inet_bind",
-	probes.Inet6BindRet:                   "kretprobe__inet6_bind",
-	probes.SockFDLookup:                   "kprobe__sockfd_lookup_light",
-	probes.SockFDLookupRet:                "kretprobe__sockfd_lookup_light",
-	probes.DoSendfile:                     "kprobe__do_sendfile",
-	probes.DoSendfileRet:                  "kretprobe__do_sendfile",
+	probes.NetDevQueue:                         "tracepoint__net__net_dev_queue",
+	probes.ProtocolClassifierEntrySocketFilter: "socket__classifier_entry",
+	probes.ProtocolClassifierSocketFilter:      "socket__classifier",
+	probes.TCPSendMsg:                          "kprobe__tcp_sendmsg",
+	probes.TCPSendMsgReturn:                    "kretprobe__tcp_sendmsg",
+	probes.TCPRecvMsg:                          "kprobe__tcp_recvmsg",
+	probes.TCPRecvMsgReturn:                    "kretprobe__tcp_recvmsg",
+	probes.TCPReadSock:                         "kprobe__tcp_read_sock",
+	probes.TCPReadSockReturn:                   "kretprobe__tcp_read_sock",
+	probes.TCPClose:                            "kprobe__tcp_close",
+	probes.TCPCloseReturn:                      "kretprobe__tcp_close",
+	probes.TCPConnect:                          "kprobe__tcp_connect",
+	probes.TCPFinishConnect:                    "kprobe__tcp_finish_connect",
+	probes.TCPSetState:                         "kprobe__tcp_set_state",
+	probes.IPMakeSkb:                           "kprobe__ip_make_skb",
+	probes.IPMakeSkbReturn:                     "kretprobe__ip_make_skb",
+	probes.IP6MakeSkb:                          "kprobe__ip6_make_skb",
+	probes.IP6MakeSkbReturn:                    "kretprobe__ip6_make_skb",
+	probes.UDPRecvMsg:                          "kprobe__udp_recvmsg",
+	probes.UDPRecvMsgReturn:                    "kretprobe__udp_recvmsg",
+	probes.UDPv6RecvMsg:                        "kprobe__udpv6_recvmsg",
+	probes.UDPv6RecvMsgReturn:                  "kretprobe__udpv6_recvmsg",
+	probes.TCPRetransmit:                       "kprobe__tcp_retransmit_skb",
+	probes.InetCskAcceptReturn:                 "kretprobe__inet_csk_accept",
+	probes.InetCskListenStop:                   "kprobe__inet_csk_listen_stop",
+	probes.UDPDestroySock:                      "kprobe__udp_destroy_sock",
+	probes.UDPDestroySockReturn:                "kretprobe__udp_destroy_sock",
+	probes.InetBind:                            "kprobe__inet_bind",
+	probes.Inet6Bind:                           "kprobe__inet6_bind",
+	probes.InetBindRet:                         "kretprobe__inet_bind",
+	probes.Inet6BindRet:                        "kretprobe__inet6_bind",
+	probes.SockFDLookup:                        "kprobe__sockfd_lookup_light",
+	probes.SockFDLookupRet:                     "kretprobe__sockfd_lookup_light",
+	probes.DoSendfile:                          "kprobe__do_sendfile",
+	probes.DoSendfileRet:                       "kretprobe__do_sendfile",
 }
 
 var altProbes = map[probes.ProbeName]string{
@@ -74,7 +74,7 @@ var altProbes = map[probes.ProbeName]string{
 	probes.UnderscoredSKBFreeDatagramLocked: "kprobe____skb_free_datagram_locked",
 }
 
-func newManager(config *config.Config, closedHandler *ebpf.PerfHandler, runtimeTracer bool) *manager.Manager {
+func newManager(closedHandler *ebpf.PerfHandler, runtimeTracer bool) *manager.Manager {
 	mgr := &manager.Manager{
 		Maps: []*manager.Map{
 			{Name: string(probes.ConnMap)},
@@ -96,6 +96,7 @@ func newManager(config *config.Config, closedHandler *ebpf.PerfHandler, runtimeT
 			{Name: string(probes.MapErrTelemetryMap)},
 			{Name: string(probes.HelperErrTelemetryMap)},
 			{Name: string(probes.TcpRecvMsgArgsMap)},
+			{Name: string(probes.ClassificationProgsMap)},
 		},
 		PerfMaps: []*manager.PerfMap{
 			{

--- a/pkg/network/tracer/connection/kprobe/tracer.go
+++ b/pkg/network/tracer/connection/kprobe/tracer.go
@@ -184,7 +184,7 @@ func New(config *config.Config, constants []manager.ConstantEditor, bpfTelemetry
 	var undefinedProbes []manager.ProbeIdentificationPair
 
 	var closeProtocolClassifierSocketFilterFn func()
-	if ClassificationSupported(config) {
+	if ClassificationSupported(config) && config.CollectTCPConns {
 		socketFilterProbe, _ := m.GetProbe(manager.ProbeIdentificationPair{
 			EBPFSection:  string(probes.ProtocolClassifierEntrySocketFilter),
 			EBPFFuncName: mainProbes[probes.ProtocolClassifierEntrySocketFilter],


### PR DESCRIPTION

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

 Adding a workaround to handle hitting instructions limits on socket filter

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
recently when running system probe locally, we started to see the error
```
2023-01-31 22:55:16 IST | SYS-PROBE | ERROR | (cmd/system-probe/api/module/loader.go:60 in Register) | new module `network_tracer` error: could not start ebpf manager: could not start ebpf manager: probes activation validation failed: 1 error occurred:
        * {UID:net EBPFFuncName:socket__classifier EBPFSection:socket/classifier}: cannot allocate memory
```
which is resolved by running `sudo sysctl -w net.core.optmem_max=200000`

There is a limit to the size of programs that can be attached to a socket, which is what you are adjusting.

We had a workaround in place [Optimizing read_into_buffer helper by usamasaqib · Pull Request #12617 · DataDog/datadog-agent](https://github.com/DataDog/datadog-agent/pull/12617/files#diff-57092909da14c775ac22a8ef2cedf474f405c40350db7f9b152642d9580447ff)
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
