### PR TITLE
Bump resource limits for circleci unit_tests job (#15342)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,7 +100,7 @@ jobs:
 
   unit_tests:
     <<: *job_template
-    resource_class: large
+    resource_class: xlarge
     steps:
       - restore_cache: *restore_source
       - restore_cache: *restore_deps


### PR DESCRIPTION
Backport of the fix for circle-ci unit tests failures.