### PR TITLE
pkg/trace/api: add probabilistic sampling for OTLP

### DIFF
--- a/cmd/trace-agent/config/config.go
+++ b/cmd/trace-agent/config/config.go
@@ -275,6 +275,7 @@ func applyDatadogConfig(c *config.AgentConfig) error {
 		MaxRequestBytes:         c.MaxRequestBytes,
 		SpanNameRemappings:      coreconfig.Datadog.GetStringMapString("otlp_config.traces.span_name_remappings"),
 		SpanNameAsResourceName:  coreconfig.Datadog.GetBool("otlp_config.traces.span_name_as_resource_name"),
+		ProbabilisticSampling:   coreconfig.Datadog.GetFloat64("otlp_config.traces.probabilistic_sampler.sampling_percentage"),
 	}
 
 	if coreconfig.Datadog.GetBool("apm_config.telemetry.enabled") {

--- a/cmd/trace-agent/config/config_test.go
+++ b/cmd/trace-agent/config/config_test.go
@@ -748,6 +748,16 @@ func TestLoadEnv(t *testing.T) {
 		assert.Equal("0.0.0.0", cfg.ReceiverHost)
 	})
 
+	env = "DD_OTLP_CONFIG_TRACES_PROBABILISTIC_SAMPLER_SAMPLING_PERCENTAGE"
+	t.Run(env, func(t *testing.T) {
+		defer cleanConfig()()
+		assert := assert.New(t)
+		t.Setenv(env, "12.3")
+		cfg, err := LoadConfigFile("./testdata/undocumented.yaml")
+		assert.NoError(err)
+		assert.Equal(12.3, cfg.OTLPReceiver.ProbabilisticSampling)
+	})
+
 	for _, envKey := range []string{
 		"DD_IGNORE_RESOURCE", // deprecated
 		"DD_APM_IGNORE_RESOURCES",

--- a/cmd/trace-agent/config/config_test.go
+++ b/cmd/trace-agent/config/config_test.go
@@ -438,6 +438,7 @@ func TestFullYamlConfig(t *testing.T) {
 	assert.True(c.LogThrottling)
 	assert.True(c.OTLPReceiver.SpanNameAsResourceName)
 	assert.Equal(map[string]string{"a": "b", "and:colons": "in:values", "c": "d", "with.dots": "in.side"}, c.OTLPReceiver.SpanNameRemappings)
+	assert.Equal(88.4, c.OTLPReceiver.ProbabilisticSampling)
 
 	noProxy := true
 	if _, ok := os.LookupEnv("NO_PROXY"); ok {

--- a/cmd/trace-agent/config/testdata/full.yaml
+++ b/cmd/trace-agent/config/testdata/full.yaml
@@ -20,6 +20,8 @@ otlp_config:
       "with.dots": "in.side"
       "and:colons": "in:values"
     span_name_as_resource_name: true
+    probabilistic_sampler:
+      sampling_percentage: 88.4
 apm_config:
   enabled: false
   log_file: abc

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -3491,7 +3491,9 @@ api_key:
     # probabilistic_sampler:
       ## @param sampling_percentage - number - optional - default: 100
       ## @env DD_OTLP_CONFIG_TRACES_PROBABILISTIC_SAMPLER_SAMPLING_PERCENTAGE - number - optional - default: 100
-      ## Percentage of traces to ingest (0 100]. A value of 0 disables sampling and everything is ingested.
+      ## Percentage of traces to ingest (0 100]. Invalid values (<= 0 || > 100) are disconsidered and the default is used.
+      ## If incoming spans have a sampling.priority set by the user, it will be followed and the sampling percentage will
+      ## be overridden.
       #
       # sampling_percentage: 100
 

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -3483,6 +3483,18 @@ api_key:
     # span_name_remappings:
     #   <OLD_NAME>: <NEW_NAME>
 
+    ## @param probabilistic_sampler - custom object - optional
+    ## Probabilistic sampler controlling the rate of ingestion. Using this sampler works consistently
+    ## in a distributed system where the sampling rate is shared. Exceptions are made for errors and
+    ## rare traces (if enabled via apm_config.enable_rare_sampler).
+    #
+    # probabilistic_sampler:
+      ## @param sampling_percentage - number - optional - default: 100
+      ## @env DD_OTLP_CONFIG_TRACES_PROBABILISTIC_SAMPLER_SAMPLING_PERCENTAGE - number - optional - default: 100
+      ## Percentage of traces to ingest (0 100]. A value of 0 disables sampling and everything is ingested.
+      #
+      # sampling_percentage: 100
+
   ## @param debug - custom object - optional
   ## Debug-specific configuration for OTLP ingest in the Datadog Agent.
   ## This template lists the most commonly used settings; see the OpenTelemetry Collector documentation

--- a/pkg/config/otlp.go
+++ b/pkg/config/otlp.go
@@ -62,9 +62,10 @@ func setupOTLPEnvironmentVariables(config Config) {
 	config.BindEnv(OTLPSection + ".receiver.protocols.grpc.write_buffer_size")
 	config.BindEnv(OTLPSection + ".receiver.protocols.grpc.include_metadata")
 
-	// Traces settingds
+	// Traces settings
 	config.BindEnvAndSetDefault("otlp_config.traces.span_name_remappings", map[string]string{})
 	config.BindEnv("otlp_config.traces.span_name_as_resource_name")
+	config.BindEnvAndSetDefault("otlp_config.traces.probabilistic_sampler.sampling_percentage", 100.)
 
 	// HTTP settings
 	config.BindEnv(OTLPSection + ".receiver.protocols.http.endpoint")

--- a/pkg/trace/api/otlp.go
+++ b/pkg/trace/api/otlp.go
@@ -328,11 +328,11 @@ func (o *OTLPReceiver) createChunks(tracesByID map[uint64]pb.Trace, prioritiesBy
 		if p, ok := prioritiesByID[k]; ok {
 			// a manual decision has been made by the user
 			chunk.Priority = int32(p)
-			spans[0].Meta["_dd.p.dm"] = "-4"
+			traceutil.SetMeta(spans[0], "_dd.p.dm", "-4")
 		} else {
 			// we use the probabilistic sampler to decide
 			chunk.Priority = int32(o.sample(k))
-			spans[0].Meta["_dd.p.dm"] = "-9"
+			traceutil.SetMeta(spans[0], "_dd.p.dm", "-9")
 		}
 		traceChunks = append(traceChunks, chunk)
 	}

--- a/pkg/trace/api/otlp_test.go
+++ b/pkg/trace/api/otlp_test.go
@@ -153,6 +153,47 @@ func TestOTLPNameRemapping(t *testing.T) {
 	}
 }
 
+func TestCreateChunks(t *testing.T) {
+	cfg := config.New()
+	cfg.OTLPReceiver.ProbabilisticSampling = 50
+	o := NewOTLPReceiver(nil, cfg)
+	const (
+		traceID1 = 123           // sampled by 50% rate
+		traceID2 = 1237892138897 // not sampled by 50% rate
+		traceID3 = 1237892138898 // not sampled by 50% rate
+	)
+	traces := map[uint64]pb.Trace{
+		traceID1: {{TraceID: traceID1, SpanID: 1}, {TraceID: traceID1, SpanID: 2}},
+		traceID2: {{TraceID: traceID2, SpanID: 1}, {TraceID: traceID2, SpanID: 2}},
+		traceID3: {{TraceID: traceID3, SpanID: 1}, {TraceID: traceID3, SpanID: 2}},
+	}
+	priorities := map[uint64]sampler.SamplingPriority{
+		traceID3: sampler.PriorityUserKeep,
+	}
+	chunks := o.createChunks(traces, priorities)
+	var found int
+	for _, c := range chunks {
+		id := c.Spans[0].TraceID
+		require.ElementsMatch(t, c.Spans, traces[id])
+		require.Equal(t, "0.50", c.Tags["_dd.otlp_sr"])
+		switch id {
+		case traceID1:
+			found += 1
+			require.Equal(t, "-9", c.Spans[0].Meta["_dd.p.dm"])
+			require.Equal(t, int32(1), c.Priority)
+		case traceID2:
+			found += 2
+			require.Equal(t, "-9", c.Spans[0].Meta["_dd.p.dm"])
+			require.Equal(t, int32(0), c.Priority)
+		case traceID3:
+			found += 3
+			require.Equal(t, "-4", c.Spans[0].Meta["_dd.p.dm"])
+			require.Equal(t, int32(2), c.Priority)
+		}
+	}
+	require.Equal(t, 6, found)
+}
+
 func TestOTLPReceiveResourceSpans(t *testing.T) {
 	cfg := config.New()
 	out := make(chan *Payload, 1)

--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -75,8 +75,9 @@ type OTLP struct {
 	UsePreviewHostnameLogic bool `mapstructure:"-"`
 
 	// ProbabilisticSampling specifies the percentage of traces to ingest. Exceptions are made for errors
-	// and rare traces (outliers) if "RareSamplerEnabled" is true.
-	// Valid in range (0, 100].
+	// and rare traces (outliers) if "RareSamplerEnabled" is true. Invalid values are equivalent to 100.
+	// If spans have the "sampling.priority" attribute set, probabilistic sampling is skipped and the user's
+	// decision is followed.
 	ProbabilisticSampling float64
 }
 

--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -73,6 +73,11 @@ type OTLP struct {
 	// The 'preview' rules change the canonical hostname chosen in cloud providers to be consistent with the
 	// one sent by Datadog cloud integrations.
 	UsePreviewHostnameLogic bool `mapstructure:"-"`
+
+	// ProbabilisticSampling specifies the percentage of traces to ingest. Exceptions are made for errors
+	// and rare traces (outliers) if "RareSamplerEnabled" is true.
+	// Valid in range (0, 100].
+	ProbabilisticSampling float64
 }
 
 // ObfuscationConfig holds the configuration for obfuscating sensitive data

--- a/releasenotes/notes/apm-otlp-ingest-sampling-faa985afe905feb1.yaml
+++ b/releasenotes/notes/apm-otlp-ingest-sampling-faa985afe905feb1.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    APM OTLP: Introduce OTLP Ingest probabilistic sampling, configurable via `otlp_config.traces.probabilistic_sampler.sampling_percentage`.


### PR DESCRIPTION
This change introduces a new probabilistic sampler as part of the OTLP Ingest in the trace-agent. This sampler allows the user to control ingestion reliably in a distributed system, considering that the same percentage is used in all agents.

Use the following configuration:
```yaml
otlp_config:
  traces:
    probabilistic_sampler:
      # @param sampling_percentage - number - optional - default: 100
      # @env DD_OTLP_CONFIG_TRACES_PROBABILISTIC_SAMPLER_SAMPLING_PERCENTAGE - number - optional - default: 100
      # Percentage of traces to ingest (0 100]. Invalid values (<= 0 || > 100) are disconsidered
      # and the default is used. If incoming spans have a sampling.priority set by the user, it 
      # will be followed and the sampling percentage will be overridden.
      sampling_percentage: 100
```