### PR TITLE
Add history workload-list container-image entity

### DIFF
--- a/pkg/workloadmeta/types.go
+++ b/pkg/workloadmeta/types.go
@@ -8,6 +8,7 @@ package workloadmeta
 import (
 	"context"
 	"fmt"
+	"io"
 	"strings"
 	"time"
 
@@ -707,9 +708,7 @@ func (i ContainerImageMetadata) String(verbose bool) string {
 
 		_, _ = fmt.Fprintln(&sb, "----------- Layers -----------")
 		for _, layer := range i.Layers {
-			if layer.SizeBytes != 0 { // Skip layers that have a history command associated but are empty
-				_, _ = fmt.Fprintln(&sb, layer)
-			}
+			_, _ = fmt.Fprintln(&sb, layer)
 		}
 	}
 
@@ -725,10 +724,17 @@ func (layer ContainerImageLayer) String() string {
 	_, _ = fmt.Fprintln(&sb, "Size in bytes:", layer.SizeBytes)
 	_, _ = fmt.Fprintln(&sb, "URLs:", layer.URLs)
 
-	// layer.History is not included here because it's way too verbose (includes
-	// the command in the Dockerfile that generated the layer).
+	printHistory(&sb, layer.History)
 
 	return sb.String()
+}
+
+func printHistory(out io.Writer, history v1.History) {
+	_, _ = fmt.Fprintln(out, "History:")
+	_, _ = fmt.Fprintln(out, "- createdAt:", history.Created)
+	_, _ = fmt.Fprintln(out, "- createdBy:", history.CreatedBy)
+	_, _ = fmt.Fprintln(out, "- comment:", history.Comment)
+	_, _ = fmt.Fprintln(out, "- emptyLayer:", history.EmptyLayer)
 }
 
 var _ Entity = &ContainerImageMetadata{}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Add layer's history to the container-image entity in workload-list.
This info will be only displayed with the `-verbose` option.

### Motivation

It will ease investigation of the `container-image-metadata` feature,

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Enabled `container_image_metadata` collection. and check the output of the `agent workload-list --verbose`

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
