### PR TITLE
[corechecks/{containerimage,sbom}] Fix parsing of config

### DIFF
--- a/pkg/collector/corechecks/containerimage/check.go
+++ b/pkg/collector/corechecks/containerimage/check.go
@@ -29,9 +29,9 @@ func init() {
 
 // Config holds the container_image check configuration
 type Config struct {
-	chunkSize                  int `yaml:"chunk_size"`
-	newImagesMaxLatencySeconds int `yaml:"new_images_max_latency_seconds"`
-	periodicRefreshSeconds     int `yaml:"periodic_refresh_seconds"`
+	ChunkSize                  int `yaml:"chunk_size"`
+	NewImagesMaxLatencySeconds int `yaml:"new_images_max_latency_seconds"`
+	PeriodicRefreshSeconds     int `yaml:"periodic_refresh_seconds"`
 }
 
 type configValueRange struct {
@@ -75,9 +75,9 @@ func (c *Config) Parse(data []byte) error {
 		return err
 	}
 
-	validateValue(&c.chunkSize, chunkSizeValueRange)
-	validateValue(&c.newImagesMaxLatencySeconds, newImagesMaxLatencySecondsValueRange)
-	validateValue(&c.periodicRefreshSeconds, periodicRefreshSecondsValueRange)
+	validateValue(&c.ChunkSize, chunkSizeValueRange)
+	validateValue(&c.NewImagesMaxLatencySeconds, newImagesMaxLatencySecondsValueRange)
+	validateValue(&c.PeriodicRefreshSeconds, periodicRefreshSecondsValueRange)
 
 	return nil
 }
@@ -120,7 +120,7 @@ func (c *Check) Configure(integrationConfigDigest uint64, config, initConfig int
 		return err
 	}
 
-	c.processor = newProcessor(sender, c.instance.chunkSize, time.Duration(c.instance.newImagesMaxLatencySeconds)*time.Second)
+	c.processor = newProcessor(sender, c.instance.ChunkSize, time.Duration(c.instance.NewImagesMaxLatencySeconds)*time.Second)
 
 	return nil
 }
@@ -140,7 +140,7 @@ func (c *Check) Run() error {
 		),
 	)
 
-	imgRefreshTicker := time.NewTicker(time.Duration(c.instance.periodicRefreshSeconds) * time.Second)
+	imgRefreshTicker := time.NewTicker(time.Duration(c.instance.PeriodicRefreshSeconds) * time.Second)
 
 	for {
 		select {

--- a/pkg/collector/corechecks/sbom/check.go
+++ b/pkg/collector/corechecks/sbom/check.go
@@ -29,9 +29,9 @@ func init() {
 
 // Config holds the container_image check configuration
 type Config struct {
-	chunkSize                int `yaml:"chunk_size"`
-	newSBOMMaxLatencySeconds int `yaml:"new_sbom_max_latency_seconds"`
-	periodicRefreshSeconds   int `yaml:"periodic_refresh_seconds"`
+	ChunkSize                int `yaml:"chunk_size"`
+	NewSBOMMaxLatencySeconds int `yaml:"new_sbom_max_latency_seconds"`
+	PeriodicRefreshSeconds   int `yaml:"periodic_refresh_seconds"`
 }
 
 type configValueRange struct {
@@ -75,9 +75,9 @@ func (c *Config) Parse(data []byte) error {
 		return err
 	}
 
-	validateValue(&c.chunkSize, chunkSizeValueRange)
-	validateValue(&c.newSBOMMaxLatencySeconds, newSBOMMaxLatencySecondsValueRange)
-	validateValue(&c.periodicRefreshSeconds, periodicRefreshSecondsValueRange)
+	validateValue(&c.ChunkSize, chunkSizeValueRange)
+	validateValue(&c.NewSBOMMaxLatencySeconds, newSBOMMaxLatencySecondsValueRange)
+	validateValue(&c.PeriodicRefreshSeconds, periodicRefreshSecondsValueRange)
 
 	return nil
 }
@@ -120,7 +120,7 @@ func (c *Check) Configure(integrationConfigDigest uint64, config, initConfig int
 		return err
 	}
 
-	c.processor = newProcessor(sender, c.instance.chunkSize, time.Duration(c.instance.newSBOMMaxLatencySeconds)*time.Second)
+	c.processor = newProcessor(sender, c.instance.ChunkSize, time.Duration(c.instance.NewSBOMMaxLatencySeconds)*time.Second)
 
 	return nil
 }
@@ -140,7 +140,7 @@ func (c *Check) Run() error {
 		),
 	)
 
-	imgRefreshTicker := time.NewTicker(time.Duration(c.instance.periodicRefreshSeconds) * time.Second)
+	imgRefreshTicker := time.NewTicker(time.Duration(c.instance.PeriodicRefreshSeconds) * time.Second)
 
 	for {
 		select {


### PR DESCRIPTION
### What does this PR do?

Fixes the parsing of the config in the container image and the sbom checks. Both of them have the same issue.

Config fields need to be public in order for the unmarshal to work.


### Describe how to test/QA your changes

Skip in 7.44.0 This PR has been backported to 7.43.x.

Enable the check with a custom configuration and make sure that it applies that config instead of the default values.

For example, for the container image check, you can set a custom `chunk_size` of 1. The default is 10. If this change works, shortly after starting the agent, you should see that the number of transactions reported in the ` Transaction Successes` section of `agent status` is the number of images that you have in your cluster (or more if there are updates).


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
