### PR TITLE
SLS-3057: Adds periodic metric flushing

### DIFF
--- a/cmd/serverless-init/main.go
+++ b/cmd/serverless-init/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/serverless/metrics"
 	"github.com/DataDog/datadog-agent/pkg/serverless/random"
 	"github.com/DataDog/datadog-agent/pkg/serverless/trace"
+	logger "github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 const (
@@ -34,6 +35,7 @@ func main() {
 
 	// load proxy settings
 	setupProxy()
+
 	// The datadog-agent requires Load to be called or it could
 	// panic down the line.
 	_, _ = config.Load()
@@ -45,6 +47,13 @@ func main() {
 
 	logConfig := log.CreateConfig(origin)
 	log.SetupLog(logConfig, tags)
+
+	// The datadog-agent requires Load to be called or it could
+	// panic down the line.
+	_, err := config.Load()
+	if err != nil {
+		logger.Debugf("Error loading config: %v\n", err)
+	}
 
 	traceAgent := &trace.ServerlessTraceAgent{}
 	go setupTraceAgent(traceAgent, tags)

--- a/cmd/serverless-init/main.go
+++ b/cmd/serverless-init/main.go
@@ -34,6 +34,9 @@ func main() {
 
 	// load proxy settings
 	setupProxy()
+	// The datadog-agent requires Load to be called or it could
+	// panic down the line.
+	_, _ = config.Load()
 
 	cloudService := cloudservice.GetCloudServiceType()
 	tags := cloudService.GetTags()

--- a/cmd/serverless-init/main.go
+++ b/cmd/serverless-init/main.go
@@ -49,8 +49,14 @@ func main() {
 	metricAgent := setupMetricAgent(tags)
 	metric.AddColdStartMetric(prefix, metricAgent.GetExtraTags(), time.Now(), metricAgent.Demux)
 
-	go metricAgent.Flush()
+	go flushMetricsAgent(metricAgent)
 	initcontainer.Run(cloudService, logConfig, metricAgent, traceAgent, os.Args[1:])
+}
+
+func flushMetricsAgent(metricAgent *metrics.ServerlessMetricAgent) {
+	for range time.Tick(3 * time.Second) {
+		metricAgent.Flush()
+	}
 }
 
 func setupTraceAgent(traceAgent *trace.ServerlessTraceAgent, tags map[string]string) {
@@ -62,6 +68,7 @@ func setupTraceAgent(traceAgent *trace.ServerlessTraceAgent, tags map[string]str
 }
 
 func setupMetricAgent(tags map[string]string) *metrics.ServerlessMetricAgent {
+	config.Datadog.Set("use_v2_api.series", false)
 	metricAgent := &metrics.ServerlessMetricAgent{}
 	// we don't want to add the container_id tag to metrics for cardinality reasons
 	delete(tags, "container_id")

--- a/cmd/serverless-init/main.go
+++ b/cmd/serverless-init/main.go
@@ -36,10 +36,6 @@ func main() {
 	// load proxy settings
 	setupProxy()
 
-	// The datadog-agent requires Load to be called or it could
-	// panic down the line.
-	_, _ = config.Load()
-
 	cloudService := cloudservice.GetCloudServiceType()
 	tags := cloudService.GetTags()
 	origin := cloudService.GetOrigin()


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This PR adds flushing to metrics. The logic is the same one used for flushing traces.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
