### PR TITLE
[CWS] fix functests config load

### DIFF
--- a/cmd/system-probe/config/config.go
+++ b/cmd/system-probe/config/config.go
@@ -239,7 +239,12 @@ func (c Config) ModuleIsEnabled(modName ModuleName) bool {
 
 // SetupOptionalDatadogConfig loads the datadog.yaml config file but will not fail on a missing file
 func SetupOptionalDatadogConfig() error {
-	aconfig.Datadog.AddConfigPath(defaultConfigDir)
+	return SetupOptionalDatadogConfigWithDir(defaultConfigDir)
+}
+
+// SetupOptionalDatadogConfig loads the datadog.yaml config file from a given config directory but will not fail on a missing file
+func SetupOptionalDatadogConfigWithDir(configDir string) error {
+	aconfig.Datadog.AddConfigPath(configDir)
 	// load the configuration
 	_, err := aconfig.LoadDatadogCustom(aconfig.Datadog, "datadog.yaml", true)
 	// If `!failOnMissingFile`, do not issue an error if we cannot find the default config file.

--- a/cmd/system-probe/config/config.go
+++ b/cmd/system-probe/config/config.go
@@ -239,12 +239,15 @@ func (c Config) ModuleIsEnabled(modName ModuleName) bool {
 
 // SetupOptionalDatadogConfig loads the datadog.yaml config file but will not fail on a missing file
 func SetupOptionalDatadogConfig() error {
-	return SetupOptionalDatadogConfigWithDir(defaultConfigDir)
+	return SetupOptionalDatadogConfigWithDir(defaultConfigDir, "")
 }
 
 // SetupOptionalDatadogConfig loads the datadog.yaml config file from a given config directory but will not fail on a missing file
-func SetupOptionalDatadogConfigWithDir(configDir string) error {
+func SetupOptionalDatadogConfigWithDir(configDir, configFile string) error {
 	aconfig.Datadog.AddConfigPath(configDir)
+	if configFile != "" {
+		aconfig.Datadog.SetConfigFile(configFile)
+	}
 	// load the configuration
 	_, err := aconfig.LoadDatadogCustom(aconfig.Datadog, "datadog.yaml", true)
 	// If `!failOnMissingFile`, do not issue an error if we cannot find the default config file.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1388,10 +1388,10 @@ func findUnknownEnvVars(config Config, environ []string) []string {
 		"DD_SERVICE":                   {},
 		"DD_DOTNET_TRACER_HOME":        {},
 		"DD_SERVERLESS_APPSEC_ENABLED": {},
-		// this variable is used by CWS functional tests
-		"DD_TESTS_RUNTIME_COMPILED":                              {},
-		"DD_SYSTEM_PROBE_BPF_DIR":                                {},
+		// these variables are used by CWS functional tests
 		"DD_RUNTIME_SECURITY_CONFIG_RUNTIME_COMPILATION_ENABLED": {},
+		"DD_SYSTEM_PROBE_BPF_DIR":                                {},
+		"DD_TESTS_RUNTIME_COMPILED":                              {},
 	}
 	for _, key := range config.GetEnvVars() {
 		knownVars[key] = struct{}{}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1390,6 +1390,7 @@ func findUnknownEnvVars(config Config, environ []string) []string {
 		"DD_SERVERLESS_APPSEC_ENABLED": {},
 		// this variable is used by CWS functional tests
 		"DD_TESTS_RUNTIME_COMPILED": {},
+		"DD_SYSTEM_PROBE_BPF_DIR":   {},
 	}
 	for _, key := range config.GetEnvVars() {
 		knownVars[key] = struct{}{}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1389,8 +1389,9 @@ func findUnknownEnvVars(config Config, environ []string) []string {
 		"DD_DOTNET_TRACER_HOME":        {},
 		"DD_SERVERLESS_APPSEC_ENABLED": {},
 		// this variable is used by CWS functional tests
-		"DD_TESTS_RUNTIME_COMPILED": {},
-		"DD_SYSTEM_PROBE_BPF_DIR":   {},
+		"DD_TESTS_RUNTIME_COMPILED":                              {},
+		"DD_SYSTEM_PROBE_BPF_DIR":                                {},
+		"DD_RUNTIME_SECURITY_CONFIG_RUNTIME_COMPILATION_ENABLED": {},
 	}
 	for _, key := range config.GetEnvVars() {
 		knownVars[key] = struct{}{}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1388,10 +1388,8 @@ func findUnknownEnvVars(config Config, environ []string) []string {
 		"DD_SERVICE":                   {},
 		"DD_DOTNET_TRACER_HOME":        {},
 		"DD_SERVERLESS_APPSEC_ENABLED": {},
-		// these variables are used by CWS functional tests
-		"DD_RUNTIME_SECURITY_CONFIG_RUNTIME_COMPILATION_ENABLED": {},
-		"DD_SYSTEM_PROBE_BPF_DIR":                                {},
-		"DD_TESTS_RUNTIME_COMPILED":                              {},
+		// this variable is used by CWS functional tests
+		"DD_TESTS_RUNTIME_COMPILED": {},
 	}
 	for _, key := range config.GetEnvVars() {
 		knownVars[key] = struct{}{}

--- a/pkg/security/tests/constants_test.go
+++ b/pkg/security/tests/constants_test.go
@@ -48,7 +48,7 @@ func TestOctogonConstants(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	config, err := genTestConfig(dir, testOpts{})
+	config, err := genTestConfig(dir, testOpts{}, "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -717,30 +717,30 @@ func genTestConfig(dir string, opts testOpts, testDir string) (*config.Config, e
 		return nil, err
 	}
 
-	sysprobeConfigName, err := func() (string, error) {
+	ddConfigName, sysprobeConfigName, err := func() (string, string, error) {
 		ddConfig, err := os.OpenFile(path.Join(testDir, "datadog.yaml"), os.O_CREATE|os.O_RDWR, 0o644)
 		if err != nil {
-			return "", err
+			return "", "", err
 		}
 		defer ddConfig.Close()
 
 		sysprobeConfig, err := os.Create(path.Join(testDir, "system-probe.yaml"))
 		if err != nil {
-			return "", err
+			return "", "", err
 		}
 		defer sysprobeConfig.Close()
 
 		_, err = io.Copy(sysprobeConfig, buffer)
 		if err != nil {
-			return "", err
+			return "", "", err
 		}
-		return sysprobeConfig.Name(), nil
+		return ddConfig.Name(), sysprobeConfig.Name(), nil
 	}()
 	if err != nil {
 		return nil, err
 	}
 
-	err = sysconfig.SetupOptionalDatadogConfigWithDir(testDir)
+	err = sysconfig.SetupOptionalDatadogConfigWithDir(testDir, ddConfigName)
 	if err != nil {
 		return nil, fmt.Errorf("unable to set up datadog.yaml configuration: %s", err)
 	}

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -718,6 +718,12 @@ func genTestConfig(dir string, opts testOpts, testDir string) (*config.Config, e
 	}
 
 	sysprobeConfigName, err := func() (string, error) {
+		ddConfig, err := os.Create(path.Join(testDir, "datadog.yaml"))
+		if err != nil {
+			return "", err
+		}
+		defer ddConfig.Close()
+
 		sysprobeConfig, err := os.Create(path.Join(testDir, "system-probe.yaml"))
 		if err != nil {
 			return "", err

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -647,7 +647,7 @@ func setTestPolicy(dir string, macros []*rules.MacroDefinition, rules []*rules.R
 	return testPolicyFile.Name(), nil
 }
 
-func genTestConfig(dir string, opts testOpts) (*config.Config, error) {
+func genTestConfig(dir string, opts testOpts, testDir string) (*config.Config, error) {
 	tmpl, err := template.New("test-config").Parse(testConfig)
 	if err != nil {
 		return nil, err
@@ -717,7 +717,8 @@ func genTestConfig(dir string, opts testOpts) (*config.Config, error) {
 		return nil, err
 	}
 
-	sysprobeConfig, err := os.Create(path.Join(opts.testDir, "system-probe.yaml"))
+	fmt.Printf("testDir: %s\n", testDir)
+	sysprobeConfig, err := os.Create(path.Join(testDir, "system-probe.yaml"))
 	if err != nil {
 		return nil, err
 	}
@@ -777,7 +778,7 @@ func newTestModule(t testing.TB, macroDefs []*rules.MacroDefinition, ruleDefs []
 		return nil, err
 	}
 
-	config, err := genTestConfig(st.root, opts)
+	config, err := genTestConfig(st.root, opts, st.root)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -718,7 +718,7 @@ func genTestConfig(dir string, opts testOpts, testDir string) (*config.Config, e
 	}
 
 	sysprobeConfigName, err := func() (string, error) {
-		ddConfig, err := os.Create(path.Join(testDir, "datadog.yaml"))
+		ddConfig, err := os.OpenFile(path.Join(testDir, "datadog.yaml"), os.O_CREATE|os.O_RDWR, 0o644)
 		if err != nil {
 			return "", err
 		}

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -728,7 +728,7 @@ func genTestConfig(dir string, opts testOpts) (*config.Config, error) {
 		return nil, err
 	}
 
-	err = sysconfig.SetupOptionalDatadogConfig()
+	err = sysconfig.SetupOptionalDatadogConfigWithDir(opts.testDir)
 	if err != nil {
 		return nil, fmt.Errorf("unable to set up datadog.yaml configuration: %s", err)
 	}

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -718,12 +718,6 @@ func genTestConfig(dir string, opts testOpts, testDir string) (*config.Config, e
 	}
 
 	sysprobeConfigName, err := func() (string, error) {
-		ddConfig, err := os.Create(path.Join(testDir, "datadog.yaml"))
-		if err != nil {
-			return "", err
-		}
-		defer ddConfig.Close()
-
 		fmt.Printf("testDir: %s\n", testDir)
 		sysprobeConfig, err := os.Create(path.Join(testDir, "system-probe.yaml"))
 		if err != nil {

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -718,7 +718,6 @@ func genTestConfig(dir string, opts testOpts, testDir string) (*config.Config, e
 	}
 
 	sysprobeConfigName, err := func() (string, error) {
-		fmt.Printf("testDir: %s\n", testDir)
 		sysprobeConfig, err := os.Create(path.Join(testDir, "system-probe.yaml"))
 		if err != nil {
 			return "", err


### PR DESCRIPTION
### What does this PR do?

This PR fixes the log about missing datadog.yaml file in the CWS functional tests by:
- improving where the config file is stored (instead of the CWD)
- create a `datadog.yaml` file with the correct permissions in the tests and force-use it
- remove the `DD_SYSTEM_PROBE_BPF_DIR` and `DD_RUNTIME_SECURITY_CONFIG_RUNTIME_COMPILATION_ENABLED` log (by adding it to the known vars) 

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
