### PR TITLE
[workloadmeta] Delete unnecessary attrs of ContainerImageMetadata

### DIFF
--- a/pkg/collector/corechecks/containerimage/processor_test.go
+++ b/pkg/collector/corechecks/containerimage/processor_test.go
@@ -35,8 +35,6 @@ func TestProcessEvents(t *testing.T) {
 						Kind: workloadmeta.KindContainerImageMetadata,
 						ID:   "sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
 					},
-					Registry:  "registry guessed by workloadmeta is ignored",
-					ShortName: "short name guessed by workloadmeta is ignored",
 					RepoTags: []string{
 						"datadog/agent:7-rc",
 						"datadog/agent:7.41.1-rc.1",

--- a/pkg/workloadmeta/collectors/internal/containerd/image.go
+++ b/pkg/workloadmeta/collectors/internal/containerd/image.go
@@ -184,13 +184,6 @@ func (c *collector) notifyEventForImage(ctx context.Context, namespace string, i
 	}
 
 	imageName := img.Name()
-	registry := ""
-	shortName := ""
-	if parsedImg, err := workloadmeta.NewContainerImage(imageName); err == nil {
-		registry = parsedImg.Registry
-		shortName = parsedImg.ShortName
-	}
-
 	imageID := manifest.Config.Digest.String()
 
 	existingBOM := bom
@@ -211,7 +204,6 @@ func (c *collector) notifyEventForImage(ctx context.Context, namespace string, i
 	if err == nil {
 		if strings.Contains(imageName, "sha256:") && !strings.Contains(existingImg.Name, "sha256:") {
 			imageName = existingImg.Name
-			shortName = existingImg.ShortName
 		}
 
 		if existingBOM == nil && existingImg.SBOM != nil {
@@ -262,8 +254,6 @@ func (c *collector) notifyEventForImage(ctx context.Context, namespace string, i
 			Namespace: namespace,
 			Labels:    img.Labels(),
 		},
-		Registry:     registry,
-		ShortName:    shortName,
 		RepoTags:     c.repoTags[imageID],
 		RepoDigests:  repoDigests,
 		MediaType:    manifest.MediaType,

--- a/pkg/workloadmeta/types.go
+++ b/pkg/workloadmeta/types.go
@@ -626,7 +626,6 @@ var _ Entity = &ECSTask{}
 type ContainerImageMetadata struct {
 	EntityID
 	EntityMeta
-	Registry     string
 	ShortName    string
 	RepoTags     []string
 	RepoDigests  []string
@@ -687,7 +686,6 @@ func (i ContainerImageMetadata) String(verbose bool) string {
 	_, _ = fmt.Fprintln(&sb, "----------- Entity Meta -----------")
 	_, _ = fmt.Fprint(&sb, i.EntityMeta.String(verbose))
 
-	_, _ = fmt.Fprintln(&sb, "Short name:", i.ShortName)
 	_, _ = fmt.Fprintln(&sb, "Repo tags:", i.RepoTags)
 	_, _ = fmt.Fprintln(&sb, "Repo digests:", i.RepoDigests)
 


### PR DESCRIPTION
### What does this PR do?

Small cleanup. Deletes a couple of unnecessary attributes of the `ContainerImageMetadata` workloadmeta Entity.
The deleted attrs are `shortName` and `Registry`. They're now calculated in the container image check.

### Describe how to test/QA your changes

- Run the agent with image metadata collection enabled: `DD_CONTAINER_IMAGE_COLLECTION_METADATA_ENABLED=true`.
- Check that `agent workload-list` doesn't show short name or registry for `container_image_metadata` entities.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
