### PR TITLE
[tagger/telemetry] Extract subsystem const

### DIFF
--- a/pkg/tagger/telemetry/telemetry.go
+++ b/pkg/tagger/telemetry/telemetry.go
@@ -11,6 +11,7 @@ import (
 )
 
 const (
+	subsystem = "tagger"
 	// queryEmptyEntityID refers to a query made with an empty entity id
 	queryEmptyEntityID = "empty_entity_id"
 	// queryEmptyTags refers to a query that returned no tags
@@ -21,56 +22,56 @@ const (
 
 var (
 	// StoredEntities tracks how many entities are stored in the tagger.
-	StoredEntities = telemetry.NewGaugeWithOpts("tagger", "stored_entities",
+	StoredEntities = telemetry.NewGaugeWithOpts(subsystem, "stored_entities",
 		[]string{"source", "prefix"}, "Number of entities in the store.",
 		telemetry.Options{NoDoubleUnderscoreSep: true})
 
 	// UpdatedEntities tracks the number of updates to tagger entities.
-	UpdatedEntities = telemetry.NewCounterWithOpts("tagger", "updated_entities",
+	UpdatedEntities = telemetry.NewCounterWithOpts(subsystem, "updated_entities",
 		[]string{}, "Number of updates made to entities.",
 		telemetry.Options{NoDoubleUnderscoreSep: true})
 
 	// PrunedEntities tracks the number of pruned tagger entities.
-	PrunedEntities = telemetry.NewGaugeWithOpts("tagger", "pruned_entities",
+	PrunedEntities = telemetry.NewGaugeWithOpts(subsystem, "pruned_entities",
 		[]string{}, "Number of pruned tagger entities.",
 		telemetry.Options{NoDoubleUnderscoreSep: true})
 
 	// queries tracks the number of queries made against the tagger.
-	queries = telemetry.NewCounterWithOpts("tagger", "queries",
+	queries = telemetry.NewCounterWithOpts(subsystem, "queries",
 		[]string{"cardinality", "status"}, "Queries made against the tagger.",
 		telemetry.Options{NoDoubleUnderscoreSep: true})
 
 	// ClientStreamErrors tracks how many errors were received when streaming
 	// tagger events.
-	ClientStreamErrors = telemetry.NewCounterWithOpts("tagger", "client_stream_errors",
+	ClientStreamErrors = telemetry.NewCounterWithOpts(subsystem, "client_stream_errors",
 		[]string{}, "Errors received when streaming tagger events",
 		telemetry.Options{NoDoubleUnderscoreSep: true})
 
 	// ServerStreamErrors tracks how many errors happened when streaming
 	// out tagger events.
-	ServerStreamErrors = telemetry.NewCounterWithOpts("tagger", "server_stream_errors",
+	ServerStreamErrors = telemetry.NewCounterWithOpts(subsystem, "server_stream_errors",
 		[]string{}, "Errors when streaming out tagger events",
 		telemetry.Options{NoDoubleUnderscoreSep: true})
 
 	// Subscribers tracks how many subscribers the tagger has.
-	Subscribers = telemetry.NewGaugeWithOpts("tagger", "subscribers",
+	Subscribers = telemetry.NewGaugeWithOpts(subsystem, "subscribers",
 		[]string{}, "Number of channels subscribing to tagger events",
 		telemetry.Options{NoDoubleUnderscoreSep: true})
 
 	// Events tracks the number of tagger events being sent out.
-	Events = telemetry.NewCounterWithOpts("tagger", "events",
+	Events = telemetry.NewCounterWithOpts(subsystem, "events",
 		[]string{"cardinality"}, "Number of tagger events being sent out",
 		telemetry.Options{NoDoubleUnderscoreSep: true})
 
 	// Sends tracks the number of times the tagger has sent a
 	// notification with a group of events.
-	Sends = telemetry.NewCounterWithOpts("tagger", "sends",
+	Sends = telemetry.NewCounterWithOpts(subsystem, "sends",
 		[]string{}, "Number of of times the tagger has sent a notification with a group of events",
 		telemetry.Options{NoDoubleUnderscoreSep: true})
 
 	// Receives tracks the number of times the tagger has received a
 	// notification with a group of events.
-	Receives = telemetry.NewCounterWithOpts("tagger", "receives",
+	Receives = telemetry.NewCounterWithOpts(subsystem, "receives",
 		[]string{}, "Number of of times the tagger has received a notification with a group of events",
 		telemetry.Options{NoDoubleUnderscoreSep: true})
 )


### PR DESCRIPTION
### What does this PR do?

Small refactor. Extracts a constant in `pkg/tagger/telemetry/telemetry.go`.

### Describe how to test/QA your changes

Skip.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
