### PR TITLE
[corechecks/containerlifecycle] Fix parsing of config

### DIFF
--- a/pkg/collector/corechecks/containerlifecycle/check.go
+++ b/pkg/collector/corechecks/containerlifecycle/check.go
@@ -32,8 +32,8 @@ func init() {
 
 // Config holds the container_lifecycle check configuration
 type Config struct {
-	chunkSize    int `yaml:"chunk_size"`
-	pollInterval int `yaml:"poll_interval_seconds"`
+	ChunkSize    int `yaml:"chunk_size"`
+	PollInterval int `yaml:"poll_interval_seconds"`
 }
 
 // Parse parses the container_lifecycle check config and set default values
@@ -73,15 +73,15 @@ func (c *Check) Configure(integrationConfigDigest uint64, config, initConfig int
 		return err
 	}
 
-	if c.instance.chunkSize <= 0 || c.instance.chunkSize > maxChunkSize {
-		c.instance.chunkSize = maxChunkSize
+	if c.instance.ChunkSize <= 0 || c.instance.ChunkSize > maxChunkSize {
+		c.instance.ChunkSize = maxChunkSize
 	}
 
-	if c.instance.pollInterval <= 0 {
-		c.instance.pollInterval = defaultPollInterval
+	if c.instance.PollInterval <= 0 {
+		c.instance.PollInterval = defaultPollInterval
 	}
 
-	c.processor = newProcessor(sender, c.instance.chunkSize)
+	c.processor = newProcessor(sender, c.instance.ChunkSize)
 
 	return nil
 }
@@ -111,7 +111,7 @@ func (c *Check) Run() error {
 		),
 	)
 
-	pollInterval := time.Duration(c.instance.pollInterval) * time.Second
+	pollInterval := time.Duration(c.instance.PollInterval) * time.Second
 
 	processorCtx, stopProcessor := context.WithCancel(context.Background())
 	c.processor.start(processorCtx, pollInterval)

--- a/releasenotes/notes/fix-contlifecycle-config-parsing-90695828006dbbf3.yaml
+++ b/releasenotes/notes/fix-contlifecycle-config-parsing-90695828006dbbf3.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixes the configuration parsing of the "container_lifecycle" check. Custom
+    config values were not being applied.


### PR DESCRIPTION
### What does this PR do?

Fixes the config parsing in the container life cycle check.
This is the same fix that was applied in other checks: #15355 


### Describe how to test/QA your changes

Deploy the agent with the container life cycle check enabled (needs confd plus `DD_CONTAINER_LIFECYCLE_ENABLED=true`.

Set a custom config and check that the check applies the values specified instead of the default ones.

One way of testing this is to enable the telemetry (`DD_TELEMETRY=true`), and check in the telemetry the `container_lifecycle_emitted_events` metric. Delete some pods or containers. With the default config, the polling interval is set to 10s, so you should see the delete event in the telemetry pretty quickly. Set a different polling interval to see that this changes.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
