### PR TITLE
Fix TestCCCache_RefreshOnCacheMiss flaky tests

### DIFF
--- a/pkg/util/cloudproviders/cloudfoundry/cccache.go
+++ b/pkg/util/cloudproviders/cloudfoundry/cccache.go
@@ -90,7 +90,7 @@ type CCCache struct {
 	segmentBySpaceGUID   map[string]*cfclient.IsolationSegment
 	segmentByOrgGUID     map[string]*cfclient.IsolationSegment
 	appsBatchSize        int
-	locksByResourceGUID  map[string]*sync.RWMutex
+	locksByGUID          map[string]*sync.RWMutex
 }
 
 // CCClientI is an interface for a Cloud Foundry Client that queries the Cloud Foundry API
@@ -148,7 +148,7 @@ func ConfigureGlobalCCCache(ctx context.Context, ccURL, ccClientID, ccClientSecr
 	globalCCCache.serveNozzleData = serveNozzleData
 	globalCCCache.sidecarsTags = sidecarsTags
 	globalCCCache.segmentsTags = segmentsTags
-	globalCCCache.locksByResourceGUID = make(map[string]*sync.RWMutex)
+	globalCCCache.locksByGUID = make(map[string]*sync.RWMutex)
 
 	go globalCCCache.start()
 
@@ -187,13 +187,13 @@ func (ccc *CCCache) getLockForResource(resourceName, guid string) *sync.RWMutex 
 	lockID := resourceName + "/" + guid
 
 	ccc.RLock()
-	mu, ok := ccc.locksByResourceGUID[lockID]
+	mu, ok := ccc.locksByGUID[lockID]
 	ccc.RUnlock()
 
 	if !ok {
 		mu = &sync.RWMutex{}
 		ccc.Lock()
-		ccc.locksByResourceGUID[lockID] = mu
+		ccc.locksByGUID[lockID] = mu
 		ccc.Unlock()
 	}
 	return mu

--- a/pkg/util/cloudproviders/cloudfoundry/cccache_test.go
+++ b/pkg/util/cloudproviders/cloudfoundry/cccache_test.go
@@ -34,6 +34,7 @@ func (ccc *CCCache) reset() {
 	ccc.processesByAppGUID = make(map[string][]*cfclient.Process)
 	ccc.cfApplicationsByGUID = make(map[string]*CFApplication)
 	ccc.lastUpdated = time.Time{}
+	ccc.updatedOnce = make(chan struct{})
 }
 
 type testCCClientCounter struct {

--- a/pkg/util/cloudproviders/cloudfoundry/cccache_test.go
+++ b/pkg/util/cloudproviders/cloudfoundry/cccache_test.go
@@ -267,7 +267,6 @@ func TestCCCache_GetProcesses(t *testing.T) {
 	assert.NotNil(t, err)
 }
 
-// TODO: unrelax constraints, change all assertions of type GreaterOrEqual 2 to EqualValues 1
 func TestCCCache_RefreshCacheOnMiss_GetProcesses(t *testing.T) {
 	cc.refreshCacheOnMiss = true
 	cc.reset()

--- a/pkg/util/cloudproviders/cloudfoundry/cccache_test.go
+++ b/pkg/util/cloudproviders/cloudfoundry/cccache_test.go
@@ -24,7 +24,6 @@ import (
 func (ccc *CCCache) reset() {
 	ccc.Lock()
 	defer ccc.Unlock()
-	ccc.activeResources = make(map[string]chan interface{})
 	ccc.segmentBySpaceGUID = make(map[string]*cfclient.IsolationSegment)
 	ccc.segmentByOrgGUID = make(map[string]*cfclient.IsolationSegment)
 	ccc.sidecarsByAppGUID = make(map[string][]*CFSidecar)
@@ -168,11 +167,13 @@ func TestCCCachePolling(t *testing.T) {
 }
 
 func TestCCCache_GetApp(t *testing.T) {
-	app1, _ := cc.GetApp("random_app_guid")
+	app1, err := cc.GetApp("random_app_guid")
+	assert.Nil(t, err)
 	assert.EqualValues(t, v3App1, *app1)
-	app2, _ := cc.GetApp("guid2")
+	app2, err := cc.GetApp("guid2")
+	assert.Nil(t, err)
 	assert.EqualValues(t, v3App2, *app2)
-	_, err := cc.GetApp("not-existing-guid")
+	_, err = cc.GetApp("not-existing-guid")
 	assert.NotNil(t, err)
 }
 
@@ -284,7 +285,7 @@ func TestCCCache_RefreshCacheOnMiss_GetProcesses(t *testing.T) {
 	}
 	wg.Wait()
 
-	assert.GreaterOrEqual(t, 2, globalCCClientCounter.GetHits("ListProcessByAppGUID"))
+	assert.EqualValues(t, 1, globalCCClientCounter.GetHits("ListProcessByAppGUID"))
 
 	cc.refreshCacheOnMiss = false
 	cc.readData()
@@ -308,7 +309,7 @@ func TestCCCache_RefreshCacheOnMiss_GetApp(t *testing.T) {
 	}
 	wg.Wait()
 
-	assert.GreaterOrEqual(t, 2, globalCCClientCounter.GetHits("GetV3AppByGUID"))
+	assert.EqualValues(t, 1, globalCCClientCounter.GetHits("GetV3AppByGUID"))
 
 	cc.refreshCacheOnMiss = false
 	cc.readData()
@@ -332,7 +333,7 @@ func TestCCCache_RefreshCacheOnMiss_GetSpace(t *testing.T) {
 	}
 	wg.Wait()
 
-	assert.GreaterOrEqual(t, 2, globalCCClientCounter.GetHits("GetV3SpaceByGUID"))
+	assert.EqualValues(t, 1, globalCCClientCounter.GetHits("GetV3SpaceByGUID"))
 
 	cc.refreshCacheOnMiss = false
 	cc.readData()
@@ -356,7 +357,7 @@ func TestCCCache_RefreshCacheOnMiss_GetOrg(t *testing.T) {
 	}
 	wg.Wait()
 
-	assert.GreaterOrEqual(t, 2, globalCCClientCounter.GetHits("GetV3OrganizationByGUID"))
+	assert.EqualValues(t, 1, globalCCClientCounter.GetHits("GetV3OrganizationByGUID"))
 
 	cc.refreshCacheOnMiss = false
 	cc.readData()
@@ -384,10 +385,10 @@ func TestCCCache_RefreshCacheOnMiss_GetCFApplication(t *testing.T) {
 	assert.EqualValues(t, 0, globalCCClientCounter.GetHits("ListV3SpacesByQuery"))
 	assert.EqualValues(t, 0, globalCCClientCounter.GetHits("ListV3AppsByQuery"))
 	assert.EqualValues(t, 0, globalCCClientCounter.GetHits("ListAllProcessesByQuery"))
-	assert.GreaterOrEqual(t, 2, globalCCClientCounter.GetHits("GetV3AppByGUID"))
-	assert.GreaterOrEqual(t, 2, globalCCClientCounter.GetHits("GetV3OrganizationByGUID"))
-	assert.GreaterOrEqual(t, 2, globalCCClientCounter.GetHits("GetV3SpaceByGUID"))
-	assert.GreaterOrEqual(t, 2, globalCCClientCounter.GetHits("ListProcessByAppGUID"))
+	assert.EqualValues(t, 1, globalCCClientCounter.GetHits("GetV3AppByGUID"))
+	assert.EqualValues(t, 1, globalCCClientCounter.GetHits("GetV3OrganizationByGUID"))
+	assert.EqualValues(t, 1, globalCCClientCounter.GetHits("GetV3SpaceByGUID"))
+	assert.EqualValues(t, 1, globalCCClientCounter.GetHits("ListProcessByAppGUID"))
 
 	cc.refreshCacheOnMiss = false
 	cc.readData()


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

- Changes the synchronisation mechanism to use one `sync.RWMutex` per resource GUID, this is how we ensure the single writer multiple readers pattern for each resource GUID fetch), as a result this fixes the `TestCCCache_RefreshOnCacheMiss_*` flaky test.
- Refactors the `readData` method in `cccache.go` into multiple smaller methods.
- Tighten up the test constraints to be `Equal = 1` instead of the relaxed constraints of `<= 2`.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Fix flaky tests in the CI. (`TestCCCache_RefreshOnCacheMiss_*`)

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

tl;dr: Test repetition until failure.

Rerunning the `pkg/util/cloudproviders/cloudfoundry/` test suite indefinitely until failure is found. 
Usually it takes around 300 runs for the tests to fail when spawning 10 goroutines in the `cccache_test.go` tests.

To increase the chances of failure, I increased the number of goroutines to 1 000 000 for each `TestCCCache_RefreshOnCacheMiss` test , and I rerun the test suite ~4000 time successfully (failure was not reached), meanwhile `main` fails in around ~10-30 runs.

I needed  to increase the `poll Internval` for the CCCache in the `main_test.go`, because with 1M goroutine, the tests are slow that the CCCache might get refreshed a 2nd time.

![image](https://user-images.githubusercontent.com/25211181/216360699-1c6c507f-4523-4c2a-b6d4-9966e299cd28.png)


<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
