### PR TITLE
flare: Do not scrub pprof files

### DIFF
--- a/comp/core/flare/helpers/builder.go
+++ b/comp/core/flare/helpers/builder.go
@@ -180,10 +180,13 @@ func (fb *builder) AddFileFromFunc(destFile string, cb func() ([]byte, error)) e
 	return fb.AddFile(destFile, content)
 }
 
-func (fb *builder) AddFile(destFile string, content []byte) error {
-	content, err := fb.scrubber.ScrubBytes(content)
-	if err != nil {
-		return fb.logError("error scrubbing content for '%s': %s", destFile, err)
+func (fb *builder) addFile(shouldScrub bool, destFile string, content []byte) error {
+	if shouldScrub {
+		var err error
+		content, err = fb.scrubber.ScrubBytes(content)
+		if err != nil {
+			return fb.logError("error scrubbing content for '%s': %s", destFile, err)
+		}
 	}
 
 	f, err := fb.PrepareFilePath(destFile)
@@ -195,6 +198,14 @@ func (fb *builder) AddFile(destFile string, content []byte) error {
 		return fb.logError("error writing data to '%s': %s", destFile, err)
 	}
 	return nil
+}
+
+func (fb *builder) AddFile(destFile string, content []byte) error {
+	return fb.addFile(true, destFile, content)
+}
+
+func (fb *builder) AddFileWithoutScrubbing(destFile string, content []byte) error {
+	return fb.addFile(false, destFile, content)
 }
 
 func (fb *builder) copyFileTo(shouldScrub bool, srcFile string, destFile string) error {

--- a/comp/core/flare/helpers/builder_test.go
+++ b/comp/core/flare/helpers/builder_test.go
@@ -134,6 +134,17 @@ func TestAddFile(t *testing.T) {
 	assertFileContent(t, fb, "api_key: \"********\"", "test/AddFile_scrubbed_api_key")
 }
 
+func TestAddFileWithoutScrubbing(t *testing.T) {
+	fb := getNewBuilder(t)
+	defer fb.clean()
+
+	fb.AddFileWithoutScrubbing(FromSlash("test/AddFile"), []byte("some data"))
+	assertFileContent(t, fb, "some data", "test/AddFile")
+
+	fb.AddFileWithoutScrubbing(FromSlash("test/AddFile_scrubbed_api_key"), []byte("api_key : 123456789006789009"))
+	assertFileContent(t, fb, "api_key: \"123456789006789009\"", "test/AddFile_scrubbed_api_key")
+}
+
 // Test that writeScrubbedFile actually scrubs third-party API keys.
 func TestRedactingOtherServicesApiKey(t *testing.T) {
 	fb := getNewBuilder(t)

--- a/comp/core/flare/helpers/helpers.go
+++ b/comp/core/flare/helpers/helpers.go
@@ -37,6 +37,15 @@ type FlareBuilder interface {
 	// 'content' is automatically scrubbed of any sensitive informations before being added to the flare.
 	AddFile(destFile string, content []byte) error
 
+	// AddFileWithoutScrubbing creates a new file in the flare with the content.
+	//
+	// 'destFile' is a path relative to the flare root (ex: "some/path/to/a/file"). Any necessary directory will
+	// automatically be created.
+	//
+	// 'content' is NOT scrubbed of any sensitive informations before being added to the flare.
+	// Can be used for binary files that mustn’t be corrupted, like pprof profiles for ex.
+	AddFileWithoutScrubbing(destFile string, content []byte) error
+
 	// AddFileFromFunc creates a new file in the flare with the content returned by the callback.
 	//
 	// 'destFile' is a path relative to the flare root (ex: "some/path/to/a/file"). Any necessary directory will

--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -212,7 +212,7 @@ func getVersionHistory(fb flarehelpers.FlareBuilder) {
 
 func getPerformanceProfile(fb flarehelpers.FlareBuilder, pdata ProfileData) {
 	for name, data := range pdata {
-		fb.AddFile(filepath.Join("profiles", name), data)
+		fb.AddFileWithoutScrubbing(filepath.Join("profiles", name), data)
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?

Fix the `pprof` profile collection with `agent flare --profile`.

### Motivation

`pprof` profiles are currently corrupted by the flare scrubber.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Generate a flare with `pprof` profiles with `agent flare --profile 60`.

The `pprof` files should now be readable by `go tool pprof`.
Before this fix (check with `7.43.0-rc.3` if you want to compare), `go tool pprof` was failing with this error:
```
$ go tool pprof -raw lenaic-agent-dev_lhuard_fr-7.43.0-rc.3/profiles/core-cpu.pprof | head
lenaic-agent-dev_lhuard_fr-7.43.0-rc.3/profiles/core-cpu.pprof: decompressing profile: flate: corrupt input before offset 566
failed to fetch any source profiles
```

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
