### PR TITLE
remove deprecated EBPFSection from use

### DIFF
--- a/pkg/collector/corechecks/ebpf/probe/oom_kill.go
+++ b/pkg/collector/corechecks/ebpf/probe/oom_kill.go
@@ -102,7 +102,7 @@ func getCFlags(config *ebpf.Config) []string {
 func startOOMKillProbe(buf bytecode.AssetReader, managerOptions manager.Options) (*OOMKillProbe, error) {
 	m := &manager.Manager{
 		Probes: []*manager.Probe{
-			{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFSection: "kprobe/oom_kill_process", EBPFFuncName: "kprobe__oom_kill_process", UID: "oom"}},
+			{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: "kprobe__oom_kill_process", UID: "oom"}},
 		},
 		Maps: []*manager.Map{
 			{Name: "oom_stats"},

--- a/pkg/collector/corechecks/ebpf/probe/tcp_queue_length.go
+++ b/pkg/collector/corechecks/ebpf/probe/tcp_queue_length.go
@@ -63,10 +63,10 @@ func NewTCPQueueLengthTracer(cfg *ebpf.Config) (*TCPQueueLengthTracer, error) {
 
 func startTCPQueueLengthProbe(buf bytecode.AssetReader, managerOptions manager.Options) (*TCPQueueLengthTracer, error) {
 	probes := []*manager.Probe{
-		{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFSection: "kprobe/tcp_recvmsg", EBPFFuncName: "kprobe__tcp_recvmsg", UID: "tcpq"}},
-		{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFSection: "kretprobe/tcp_recvmsg", EBPFFuncName: "kretprobe__tcp_recvmsg", UID: "tcpq"}},
-		{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFSection: "kprobe/tcp_sendmsg", EBPFFuncName: "kprobe__tcp_sendmsg", UID: "tcpq"}},
-		{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFSection: "kretprobe/tcp_sendmsg", EBPFFuncName: "kretprobe__tcp_sendmsg", UID: "tcpq"}},
+		{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: "kprobe__tcp_recvmsg", UID: "tcpq"}},
+		{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: "kretprobe__tcp_recvmsg", UID: "tcpq"}},
+		{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: "kprobe__tcp_sendmsg", UID: "tcpq"}},
+		{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: "kretprobe__tcp_sendmsg", UID: "tcpq"}},
 	}
 
 	maps := []*manager.Map{

--- a/pkg/network/dns/ebpf.go
+++ b/pkg/network/dns/ebpf.go
@@ -20,7 +20,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/network/ebpf/probes"
 )
 
-const funcName = "socket__dns_filter"
 const probeUID = "dns"
 
 type ebpfProgram struct {
@@ -39,8 +38,7 @@ func newEBPFProgram(c *config.Config) (*ebpfProgram, error) {
 		Probes: []*manager.Probe{
 			{
 				ProbeIdentificationPair: manager.ProbeIdentificationPair{
-					EBPFSection:  probes.SocketDNSFilter,
-					EBPFFuncName: funcName,
+					EBPFFuncName: probes.SocketDNSFilter,
 					UID:          probeUID,
 				},
 			},
@@ -77,8 +75,7 @@ func (e *ebpfProgram) Init() error {
 		ActivatedProbes: []manager.ProbesSelector{
 			&manager.ProbeSelector{
 				ProbeIdentificationPair: manager.ProbeIdentificationPair{
-					EBPFSection:  probes.SocketDNSFilter,
-					EBPFFuncName: funcName,
+					EBPFFuncName: probes.SocketDNSFilter,
 					UID:          probeUID,
 				},
 			},

--- a/pkg/network/dns/monitor_linux.go
+++ b/pkg/network/dns/monitor_linux.go
@@ -59,7 +59,7 @@ func NewReverseDNS(cfg *config.Config) (ReverseDNS, error) {
 			return nil, fmt.Errorf("error initializing ebpf programs: %w", err)
 		}
 
-		filter, _ = p.GetProbe(manager.ProbeIdentificationPair{EBPFSection: probes.SocketDNSFilter, EBPFFuncName: funcName, UID: probeUID})
+		filter, _ = p.GetProbe(manager.ProbeIdentificationPair{EBPFFuncName: probes.SocketDNSFilter, UID: probeUID})
 		if filter == nil {
 			return nil, fmt.Errorf("error retrieving socket filter")
 		}

--- a/pkg/network/ebpf/probes/probes.go
+++ b/pkg/network/ebpf/probes/probes.go
@@ -8,149 +8,149 @@
 
 package probes
 
-// ProbeName stores the name of the kernel probes setup for tracing
-type ProbeName = string
+// ProbeFuncName stores the function name of the kernel probes setup for tracing
+type ProbeFuncName = string
 
 const (
 	// InetCskListenStop traces the inet_csk_listen_stop system call (called for both ipv4 and ipv6)
-	InetCskListenStop ProbeName = "kprobe/inet_csk_listen_stop"
+	InetCskListenStop ProbeFuncName = "kprobe__inet_csk_listen_stop"
 
 	// TCPConnect traces the connect() system call
-	TCPConnect ProbeName = "kprobe/tcp_connect"
+	TCPConnect ProbeFuncName = "kprobe__tcp_connect"
 	// TCPFinishConnect traces tcp_finish_connect() kernel function. This is
 	// used to know when a TCP connection switches to the ESTABLISHED state
-	TCPFinishConnect ProbeName = "kprobe/tcp_finish_connect"
+	TCPFinishConnect ProbeFuncName = "kprobe__tcp_finish_connect"
 	// TCPv6Connect traces the v6 connect() system call
-	TCPv6Connect ProbeName = "kprobe/tcp_v6_connect"
+	TCPv6Connect ProbeFuncName = "kprobe__tcp_v6_connect"
 	// TCPv6ConnectReturn traces the return value for the v6 connect() system call
-	TCPv6ConnectReturn ProbeName = "kretprobe/tcp_v6_connect"
+	TCPv6ConnectReturn ProbeFuncName = "kretprobe__tcp_v6_connect"
 
 	// ProtocolClassifierEntrySocketFilter runs a classifier algorithm as a socket filter
-	ProtocolClassifierEntrySocketFilter ProbeName = "socket/classifier_entry"
+	ProtocolClassifierEntrySocketFilter ProbeFuncName = "socket__classifier_entry"
 	// ProtocolClassifierSocketFilter runs a classifier algorithm as a socket filter
-	ProtocolClassifierSocketFilter ProbeName = "socket/classifier"
+	ProtocolClassifierSocketFilter ProbeFuncName = "socket__classifier"
 
 	// NetDevQueue runs a tracepoint that allows us to correlate __sk_buf (in a socket filter) with the `struct sock*`
 	// belongs (but hidden) for it.
-	NetDevQueue ProbeName = "tracepoint/net/net_dev_queue"
+	NetDevQueue ProbeFuncName = "tracepoint__net__net_dev_queue"
 
 	// TCPSendMsg traces the tcp_sendmsg() system call
-	TCPSendMsg ProbeName = "kprobe/tcp_sendmsg"
+	TCPSendMsg ProbeFuncName = "kprobe__tcp_sendmsg"
 
 	// TCPSendMsgPre410 traces the tcp_sendmsg() system call on kernels prior to 4.1.0. This is created because
 	// we need to load a different kprobe implementation
-	TCPSendMsgPre410 ProbeName = "kprobe/tcp_sendmsg/pre_4_1_0"
+	TCPSendMsgPre410 ProbeFuncName = "kprobe__tcp_sendmsg__pre_4_1_0"
 
 	// TCPSendMsgReturn traces the return value for the tcp_sendmsg() system call
 	// XXX: This is only used for telemetry for now to count the number of errors returned
 	// by the tcp_sendmsg func (so we can have a # of tcp sent bytes we miscounted)
-	TCPSendMsgReturn ProbeName = "kretprobe/tcp_sendmsg"
+	TCPSendMsgReturn ProbeFuncName = "kretprobe__tcp_sendmsg"
 
 	// TCPGetSockOpt traces the tcp_getsockopt() kernel function
 	// This probe is used for offset guessing only
-	TCPGetSockOpt ProbeName = "kprobe/tcp_getsockopt"
+	TCPGetSockOpt ProbeFuncName = "kprobe__tcp_getsockopt"
 
 	// SockGetSockOpt traces the sock_common_getsockopt() kernel function
 	// This probe is used for offset guessing only
-	SockGetSockOpt ProbeName = "kprobe/sock_common_getsockopt"
+	SockGetSockOpt ProbeFuncName = "kprobe__sock_common_getsockopt"
 
 	// TCPSetState traces the tcp_set_state() kernel function
-	TCPSetState ProbeName = "kprobe/tcp_set_state"
+	TCPSetState ProbeFuncName = "kprobe__tcp_set_state"
 
 	// TCPRecvMsg traces the tcp_recvmsg() kernel function
-	TCPRecvMsg ProbeName = "kprobe/tcp_recvmsg"
+	TCPRecvMsg ProbeFuncName = "kprobe__tcp_recvmsg"
 	// TCPRecvMsgPre410 traces the tcp_recvmsg() system call on kernels prior to 4.1.0. This is created because
 	// we need to load a different kprobe implementation
-	TCPRecvMsgPre410 ProbeName = "kprobe/tcp_recvmsg/pre_4_1_0"
+	TCPRecvMsgPre410 ProbeFuncName = "kprobe__tcp_recvmsg__pre_4_1_0"
 	// TCPRecvMsgReturn traces the return for the tcp_recvmsg() kernel function
-	TCPRecvMsgReturn ProbeName = "kretprobe/tcp_recvmsg"
+	TCPRecvMsgReturn ProbeFuncName = "kretprobe__tcp_recvmsg"
 	// TCPReadSock traces the tcp_read_sock() kernel function
-	TCPReadSock ProbeName = "kprobe/tcp_read_sock"
+	TCPReadSock ProbeFuncName = "kprobe__tcp_read_sock"
 	// TCPReadSockReturn traces the return for the tcp_read_sock() kernel function
-	TCPReadSockReturn ProbeName = "kretprobe/tcp_read_sock"
+	TCPReadSockReturn ProbeFuncName = "kretprobe__tcp_read_sock"
 
 	// TCPClose traces the tcp_close() system call
-	TCPClose ProbeName = "kprobe/tcp_close"
+	TCPClose ProbeFuncName = "kprobe__tcp_close"
 	// TCPCloseReturn traces the return of tcp_close() system call
-	TCPCloseReturn ProbeName = "kretprobe/tcp_close"
+	TCPCloseReturn ProbeFuncName = "kretprobe__tcp_close"
 
 	// We use the following two probes for UDP sends
 
 	// IPMakeSkb traces ip_make_skb
-	IPMakeSkb ProbeName = "kprobe/ip_make_skb"
+	IPMakeSkb ProbeFuncName = "kprobe__ip_make_skb"
 	// IPMakeSkbReturn traces return of ip_make_skb
-	IPMakeSkbReturn ProbeName = "kretprobe/ip_make_skb"
+	IPMakeSkbReturn ProbeFuncName = "kretprobe__ip_make_skb"
 	// IP6MakeSkb traces ip6_make_skb
-	IP6MakeSkb ProbeName = "kprobe/ip6_make_skb"
+	IP6MakeSkb ProbeFuncName = "kprobe__ip6_make_skb"
 	// IP6MakeSkbReturn traces return of ip6_make_skb
-	IP6MakeSkbReturn ProbeName = "kretprobe/ip6_make_skb"
+	IP6MakeSkbReturn ProbeFuncName = "kretprobe__ip6_make_skb"
 	// IP6MakeSkbPre470 traces ip6_make_skb on kernel versions < 4.7
-	IP6MakeSkbPre470 ProbeName = "kprobe/ip6_make_skb/pre_4_7_0"
+	IP6MakeSkbPre470 ProbeFuncName = "kprobe__ip6_make_skb__pre_4_7_0"
 
 	// UDPRecvMsg traces the udp_recvmsg() system call
-	UDPRecvMsg ProbeName = "kprobe/udp_recvmsg"
+	UDPRecvMsg ProbeFuncName = "kprobe__udp_recvmsg"
 	// UDPRecvMsgPre410 traces the udp_recvmsg() system call on kernels prior to 4.1.0
-	UDPRecvMsgPre410 ProbeName = "kprobe/udp_recvmsg/pre_4_1_0"
+	UDPRecvMsgPre410 ProbeFuncName = "kprobe__udp_recvmsg_pre_4_1_0"
 	// UDPRecvMsgReturn traces the return value for the udp_recvmsg() system call
-	UDPRecvMsgReturn ProbeName = "kretprobe/udp_recvmsg"
+	UDPRecvMsgReturn ProbeFuncName = "kretprobe__udp_recvmsg"
 
 	// UDPv6RecvMsg traces the udpv6_recvmsg() system call
-	UDPv6RecvMsg ProbeName = "kprobe/udpv6_recvmsg"
+	UDPv6RecvMsg ProbeFuncName = "kprobe__udpv6_recvmsg"
 	// UDPv6RecvMsgPre410 traces the udpv6_recvmsg() system call on kernels prior to 4.1.0
-	UDPv6RecvMsgPre410 ProbeName = "kprobe/udpv6_recvmsg/pre_4_1_0"
+	UDPv6RecvMsgPre410 ProbeFuncName = "kprobe__udpv6_recvmsg_pre_4_1_0"
 	// UDPv6RecvMsgReturn traces the return value for the udpv6_recvmsg() system call
-	UDPv6RecvMsgReturn ProbeName = "kretprobe/udpv6_recvmsg"
+	UDPv6RecvMsgReturn ProbeFuncName = "kretprobe__udpv6_recvmsg"
 
 	// SKBConsumeUDP traces skb_consume_udp()
-	SKBConsumeUDP ProbeName = "kprobe/skb_consume_udp"
+	SKBConsumeUDP ProbeFuncName = "kprobe__skb_consume_udp"
 	// SKBFreeDatagramLocked traces skb_free_datagram_locked()
-	SKBFreeDatagramLocked ProbeName = "kprobe/skb_free_datagram_locked"
+	SKBFreeDatagramLocked ProbeFuncName = "kprobe__skb_free_datagram_locked"
 	// UnderscoredSKBFreeDatagramLocked traces __skb_free_datagram_locked()
-	UnderscoredSKBFreeDatagramLocked ProbeName = "kprobe/__skb_free_datagram_locked"
+	UnderscoredSKBFreeDatagramLocked ProbeFuncName = "kprobe____skb_free_datagram_locked"
 
 	// UDPDestroySock traces the udp_destroy_sock() function
-	UDPDestroySock ProbeName = "kprobe/udp_destroy_sock"
+	UDPDestroySock ProbeFuncName = "kprobe__udp_destroy_sock"
 	// UDPDestroySockReturn traces the return of the udp_destroy_sock() system call
-	UDPDestroySockReturn ProbeName = "kretprobe/udp_destroy_sock"
+	UDPDestroySockReturn ProbeFuncName = "kretprobe__udp_destroy_sock"
 
 	// TCPRetransmit traces the return value for the tcp_retransmit_skb() system call
-	TCPRetransmit ProbeName = "kprobe/tcp_retransmit_skb"
+	TCPRetransmit ProbeFuncName = "kprobe__tcp_retransmit_skb"
 	// TCPRetransmitPre470 traces the return value for the tcp_retransmit_skb() system call on kernel version < 4.7
-	TCPRetransmitPre470 ProbeName = "kprobe/tcp_retransmit_skb/pre_4_7_0"
+	TCPRetransmitPre470 ProbeFuncName = "kprobe__tcp_retransmit_skb_pre_4_7_0"
 
 	// InetCskAcceptReturn traces the return value for the inet_csk_accept syscall
-	InetCskAcceptReturn ProbeName = "kretprobe/inet_csk_accept"
+	InetCskAcceptReturn ProbeFuncName = "kretprobe__inet_csk_accept"
 
 	// InetBind is the kprobe of the bind() syscall for IPv4
-	InetBind ProbeName = "kprobe/inet_bind"
+	InetBind ProbeFuncName = "kprobe__inet_bind"
 	// Inet6Bind is the kprobe of the bind() syscall for IPv6
-	Inet6Bind ProbeName = "kprobe/inet6_bind"
+	Inet6Bind ProbeFuncName = "kprobe__inet6_bind"
 
 	// InetBindRet is the kretprobe of the bind() syscall for IPv4
-	InetBindRet ProbeName = "kretprobe/inet_bind"
+	InetBindRet ProbeFuncName = "kretprobe__inet_bind"
 	// Inet6BindRet is the kretprobe of the bind() syscall for IPv6
-	Inet6BindRet ProbeName = "kretprobe/inet6_bind"
+	Inet6BindRet ProbeFuncName = "kretprobe__inet6_bind"
 
 	// SocketDNSFilter is the socket probe for dns
-	SocketDNSFilter ProbeName = "socket/dns_filter"
+	SocketDNSFilter ProbeFuncName = "socket__dns_filter"
 
 	// ConntrackHashInsert is the probe for new conntrack entries
-	ConntrackHashInsert ProbeName = "kprobe/__nf_conntrack_hash_insert"
+	ConntrackHashInsert ProbeFuncName = "kprobe___nf_conntrack_hash_insert"
 
 	// ConntrackFillInfo is the probe for dumping existing conntrack entries
-	ConntrackFillInfo ProbeName = "kprobe/ctnetlink_fill_info"
+	ConntrackFillInfo ProbeFuncName = "kprobe_ctnetlink_fill_info"
 
 	// SockFDLookup is the kprobe used for mapping socket FDs to kernel sock structs
-	SockFDLookup ProbeName = "kprobe/sockfd_lookup_light"
+	SockFDLookup ProbeFuncName = "kprobe__sockfd_lookup_light"
 
 	// SockFDLookupRet is the kretprobe used for mapping socket FDs to kernel sock structs
-	SockFDLookupRet ProbeName = "kretprobe/sockfd_lookup_light"
+	SockFDLookupRet ProbeFuncName = "kretprobe__sockfd_lookup_light"
 
 	// DoSendfile is the kprobe used to trace traffic via SENDFILE(2) syscall
-	DoSendfile ProbeName = "kprobe/do_sendfile"
+	DoSendfile ProbeFuncName = "kprobe__do_sendfile"
 
 	// DoSendfileRet is the kretprobe used to trace traffic via SENDFILE(2) syscall
-	DoSendfileRet ProbeName = "kretprobe/do_sendfile"
+	DoSendfileRet ProbeFuncName = "kretprobe__do_sendfile"
 )
 
 // BPFMapName stores the name of the BPF maps storing statistics and other info

--- a/pkg/network/protocols/events/consumer_test.go
+++ b/pkg/network/protocols/events/consumer_test.go
@@ -18,15 +18,16 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/DataDog/datadog-agent/pkg/ebpf/bytecode"
-	"github.com/DataDog/datadog-agent/pkg/network/config"
-	bpftelemetry "github.com/DataDog/datadog-agent/pkg/network/telemetry"
-	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 	manager "github.com/DataDog/ebpf-manager"
 	"github.com/cilium/ebpf"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sys/unix"
+
+	"github.com/DataDog/datadog-agent/pkg/ebpf/bytecode"
+	"github.com/DataDog/datadog-agent/pkg/network/config"
+	bpftelemetry "github.com/DataDog/datadog-agent/pkg/network/telemetry"
+	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 )
 
 func TestConsumer(t *testing.T) {
@@ -138,7 +139,6 @@ func newEBPFProgram(c *config.Config) (*manager.Manager, error) {
 		Probes: []*manager.Probe{
 			{
 				ProbeIdentificationPair: manager.ProbeIdentificationPair{
-					EBPFSection:  "tracepoint/syscalls/sys_enter_write",
 					EBPFFuncName: "tracepoint__syscalls__sys_enter_write",
 				},
 			},
@@ -152,7 +152,6 @@ func newEBPFProgram(c *config.Config) (*manager.Manager, error) {
 		ActivatedProbes: []manager.ProbesSelector{
 			&manager.ProbeSelector{
 				ProbeIdentificationPair: manager.ProbeIdentificationPair{
-					EBPFSection:  "tracepoint/syscalls/sys_enter_write",
 					EBPFFuncName: "tracepoint__syscalls__sys_enter_write",
 				},
 			},

--- a/pkg/network/protocols/http/ebpf_gotls.go
+++ b/pkg/network/protocols/http/ebpf_gotls.go
@@ -23,6 +23,8 @@ import (
 	"github.com/cilium/ebpf"
 	"golang.org/x/sys/unix"
 
+	manager "github.com/DataDog/ebpf-manager"
+
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 	"github.com/DataDog/datadog-agent/pkg/network/go/bininspect"
 	"github.com/DataDog/datadog-agent/pkg/network/go/binversion"
@@ -31,7 +33,6 @@ import (
 	errtelemetry "github.com/DataDog/datadog-agent/pkg/network/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/process/monitor"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	manager "github.com/DataDog/ebpf-manager"
 )
 
 const (
@@ -461,7 +462,6 @@ func (p *GoTLSProgram) attachHooks(result *bininspect.Result, binPath string) (p
 		if functionsConfig[function].IncludeReturnLocations && uprobes.returnInfo != nil {
 			for i, offset := range result.Functions[function].ReturnLocations {
 				returnProbeID := manager.ProbeIdentificationPair{
-					EBPFSection:  uprobes.returnInfo.ebpfSection,
 					EBPFFuncName: uprobes.returnInfo.ebpfFunctionName,
 					UID:          makeReturnUID(uid, i),
 				}
@@ -482,7 +482,6 @@ func (p *GoTLSProgram) attachHooks(result *bininspect.Result, binPath string) (p
 
 		if uprobes.functionInfo != nil {
 			probeID := manager.ProbeIdentificationPair{
-				EBPFSection:  uprobes.functionInfo.ebpfSection,
 				EBPFFuncName: uprobes.functionInfo.ebpfFunctionName,
 				UID:          uid,
 			}
@@ -525,7 +524,6 @@ func (p *GoTLSProgram) detachHooks(probeIDs []manager.ProbeIdentificationPair) {
 
 func (i *uprobeInfo) getIdentificationPair() manager.ProbeIdentificationPair {
 	return manager.ProbeIdentificationPair{
-		EBPFSection:  i.ebpfSection,
 		EBPFFuncName: i.ebpfFunctionName,
 	}
 }

--- a/pkg/network/protocols/http/ebpf_ssl.go
+++ b/pkg/network/protocols/http/ebpf_ssl.go
@@ -31,25 +31,21 @@ var openSSLProbes = []manager.ProbesSelector{
 		Selectors: []manager.ProbesSelector{
 			&manager.ProbeSelector{
 				ProbeIdentificationPair: manager.ProbeIdentificationPair{
-					EBPFSection:  "uprobe/SSL_read_ex",
 					EBPFFuncName: "uprobe__SSL_read_ex",
 				},
 			},
 			&manager.ProbeSelector{
 				ProbeIdentificationPair: manager.ProbeIdentificationPair{
-					EBPFSection:  "uretprobe/SSL_read_ex",
 					EBPFFuncName: "uretprobe__SSL_read_ex",
 				},
 			},
 			&manager.ProbeSelector{
 				ProbeIdentificationPair: manager.ProbeIdentificationPair{
-					EBPFSection:  "uprobe/SSL_write_ex",
 					EBPFFuncName: "uprobe__SSL_write_ex",
 				},
 			},
 			&manager.ProbeSelector{
 				ProbeIdentificationPair: manager.ProbeIdentificationPair{
-					EBPFSection:  "uretprobe/SSL_write_ex",
 					EBPFFuncName: "uretprobe__SSL_write_ex",
 				},
 			},
@@ -59,67 +55,56 @@ var openSSLProbes = []manager.ProbesSelector{
 		Selectors: []manager.ProbesSelector{
 			&manager.ProbeSelector{
 				ProbeIdentificationPair: manager.ProbeIdentificationPair{
-					EBPFSection:  "uprobe/SSL_do_handshake",
 					EBPFFuncName: "uprobe__SSL_do_handshake",
 				},
 			},
 			&manager.ProbeSelector{
 				ProbeIdentificationPair: manager.ProbeIdentificationPair{
-					EBPFSection:  "uretprobe/SSL_do_handshake",
 					EBPFFuncName: "uretprobe__SSL_do_handshake",
 				},
 			},
 			&manager.ProbeSelector{
 				ProbeIdentificationPair: manager.ProbeIdentificationPair{
-					EBPFSection:  "uprobe/SSL_connect",
 					EBPFFuncName: "uprobe__SSL_connect",
 				},
 			},
 			&manager.ProbeSelector{
 				ProbeIdentificationPair: manager.ProbeIdentificationPair{
-					EBPFSection:  "uretprobe/SSL_connect",
 					EBPFFuncName: "uretprobe__SSL_connect",
 				},
 			},
 			&manager.ProbeSelector{
 				ProbeIdentificationPair: manager.ProbeIdentificationPair{
-					EBPFSection:  "uprobe/SSL_set_bio",
 					EBPFFuncName: "uprobe__SSL_set_bio",
 				},
 			},
 			&manager.ProbeSelector{
 				ProbeIdentificationPair: manager.ProbeIdentificationPair{
-					EBPFSection:  "uprobe/SSL_set_fd",
 					EBPFFuncName: "uprobe__SSL_set_fd",
 				},
 			},
 			&manager.ProbeSelector{
 				ProbeIdentificationPair: manager.ProbeIdentificationPair{
-					EBPFSection:  "uprobe/SSL_read",
 					EBPFFuncName: "uprobe__SSL_read",
 				},
 			},
 			&manager.ProbeSelector{
 				ProbeIdentificationPair: manager.ProbeIdentificationPair{
-					EBPFSection:  "uretprobe/SSL_read",
 					EBPFFuncName: "uretprobe__SSL_read",
 				},
 			},
 			&manager.ProbeSelector{
 				ProbeIdentificationPair: manager.ProbeIdentificationPair{
-					EBPFSection:  "uprobe/SSL_write",
 					EBPFFuncName: "uprobe__SSL_write",
 				},
 			},
 			&manager.ProbeSelector{
 				ProbeIdentificationPair: manager.ProbeIdentificationPair{
-					EBPFSection:  "uretprobe/SSL_write",
 					EBPFFuncName: "uretprobe__SSL_write",
 				},
 			},
 			&manager.ProbeSelector{
 				ProbeIdentificationPair: manager.ProbeIdentificationPair{
-					EBPFSection:  "uprobe/SSL_shutdown",
 					EBPFFuncName: "uprobe__SSL_shutdown",
 				},
 			},
@@ -132,13 +117,11 @@ var cryptoProbes = []manager.ProbesSelector{
 		Selectors: []manager.ProbesSelector{
 			&manager.ProbeSelector{
 				ProbeIdentificationPair: manager.ProbeIdentificationPair{
-					EBPFSection:  "uprobe/BIO_new_socket",
 					EBPFFuncName: "uprobe__BIO_new_socket",
 				},
 			},
 			&manager.ProbeSelector{
 				ProbeIdentificationPair: manager.ProbeIdentificationPair{
-					EBPFSection:  "uretprobe/BIO_new_socket",
 					EBPFFuncName: "uretprobe__BIO_new_socket",
 				},
 			},
@@ -151,67 +134,56 @@ var gnuTLSProbes = []manager.ProbesSelector{
 		Selectors: []manager.ProbesSelector{
 			&manager.ProbeSelector{
 				ProbeIdentificationPair: manager.ProbeIdentificationPair{
-					EBPFSection:  "uprobe/gnutls_handshake",
 					EBPFFuncName: "uprobe__gnutls_handshake",
 				},
 			},
 			&manager.ProbeSelector{
 				ProbeIdentificationPair: manager.ProbeIdentificationPair{
-					EBPFSection:  "uretprobe/gnutls_handshake",
 					EBPFFuncName: "uretprobe__gnutls_handshake",
 				},
 			},
 			&manager.ProbeSelector{
 				ProbeIdentificationPair: manager.ProbeIdentificationPair{
-					EBPFSection:  "uprobe/gnutls_transport_set_int2",
 					EBPFFuncName: "uprobe__gnutls_transport_set_int2",
 				},
 			},
 			&manager.ProbeSelector{
 				ProbeIdentificationPair: manager.ProbeIdentificationPair{
-					EBPFSection:  "uprobe/gnutls_transport_set_ptr",
 					EBPFFuncName: "uprobe__gnutls_transport_set_ptr",
 				},
 			},
 			&manager.ProbeSelector{
 				ProbeIdentificationPair: manager.ProbeIdentificationPair{
-					EBPFSection:  "uprobe/gnutls_transport_set_ptr2",
 					EBPFFuncName: "uprobe__gnutls_transport_set_ptr2",
 				},
 			},
 			&manager.ProbeSelector{
 				ProbeIdentificationPair: manager.ProbeIdentificationPair{
-					EBPFSection:  "uprobe/gnutls_record_recv",
 					EBPFFuncName: "uprobe__gnutls_record_recv",
 				},
 			},
 			&manager.ProbeSelector{
 				ProbeIdentificationPair: manager.ProbeIdentificationPair{
-					EBPFSection:  "uretprobe/gnutls_record_recv",
 					EBPFFuncName: "uretprobe__gnutls_record_recv",
 				},
 			},
 			&manager.ProbeSelector{
 				ProbeIdentificationPair: manager.ProbeIdentificationPair{
-					EBPFSection:  "uprobe/gnutls_record_send",
 					EBPFFuncName: "uprobe__gnutls_record_send",
 				},
 			},
 			&manager.ProbeSelector{
 				ProbeIdentificationPair: manager.ProbeIdentificationPair{
-					EBPFSection:  "uretprobe/gnutls_record_send",
 					EBPFFuncName: "uretprobe__gnutls_record_send",
 				},
 			},
 			&manager.ProbeSelector{
 				ProbeIdentificationPair: manager.ProbeIdentificationPair{
-					EBPFSection:  "uprobe/gnutls_bye",
 					EBPFFuncName: "uprobe__gnutls_bye",
 				},
 			},
 			&manager.ProbeSelector{
 				ProbeIdentificationPair: manager.ProbeIdentificationPair{
-					EBPFSection:  "uprobe/gnutls_deinit",
 					EBPFFuncName: "uprobe__gnutls_deinit",
 				},
 			},
@@ -281,7 +253,6 @@ func (o *sslProgram) ConfigureManager(m *errtelemetry.Manager) {
 	for _, kprobe := range kprobeKretprobePrefix {
 		m.Probes = append(m.Probes,
 			&manager.Probe{ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFSection:  kprobe + "/" + probeSysOpen.section,
 				EBPFFuncName: kprobe + "__" + probeSysOpen.function,
 				UID:          probeUID,
 			},
@@ -306,7 +277,6 @@ func (o *sslProgram) ConfigureOptions(options *manager.Options) {
 		options.ActivatedProbes = append(options.ActivatedProbes,
 			&manager.ProbeSelector{
 				ProbeIdentificationPair: manager.ProbeIdentificationPair{
-					EBPFSection:  kprobe + "/" + probeSysOpen.section,
 					EBPFFuncName: kprobe + "__" + probeSysOpen.function,
 					UID:          probeUID,
 				},
@@ -363,9 +333,8 @@ func addHooks(m *errtelemetry.Manager, probes []manager.ProbesSelector) func(pat
 		for _, singleProbe := range probes {
 			_, isBestEffort := singleProbe.(*manager.BestEffort)
 			for _, selector := range singleProbe.GetProbesIdentificationPairList() {
-				sp := strings.Split(selector.EBPFSection, "/")
-				symbol := sp[len(sp)-1]
-				if len(symbol) == 0 {
+				_, symbol, ok := strings.Cut(selector.EBPFFuncName, "__")
+				if !ok {
 					continue
 				}
 				if isBestEffort {
@@ -386,7 +355,6 @@ func addHooks(m *errtelemetry.Manager, probes []manager.ProbesSelector) func(pat
 			_, isBestEffort := singleProbe.(*manager.BestEffort)
 			for _, selector := range singleProbe.GetProbesIdentificationPairList() {
 				identifier := manager.ProbeIdentificationPair{
-					EBPFSection:  selector.EBPFSection,
 					EBPFFuncName: selector.EBPFFuncName,
 					UID:          uid,
 				}
@@ -403,9 +371,8 @@ func addHooks(m *errtelemetry.Manager, probes []manager.ProbesSelector) func(pat
 					continue
 				}
 
-				sp := strings.Split(selector.EBPFSection, "/")
-				symbol := sp[len(sp)-1]
-				if len(symbol) == 0 {
+				_, symbol, ok := strings.Cut(selector.EBPFFuncName, "__")
+				if !ok {
 					continue
 				}
 
@@ -445,7 +412,6 @@ func removeHooks(m *errtelemetry.Manager, probes []manager.ProbesSelector) func(
 		for _, singleProbe := range probes {
 			for _, selector := range singleProbe.GetProbesIdentificationPairList() {
 				identifier := manager.ProbeIdentificationPair{
-					EBPFSection:  selector.EBPFSection,
 					EBPFFuncName: selector.EBPFFuncName,
 					UID:          uid,
 				}
@@ -457,7 +423,7 @@ func removeHooks(m *errtelemetry.Manager, probes []manager.ProbesSelector) func(
 				program := probe.Program()
 				err := m.DetachHook(identifier)
 				if err != nil {
-					log.Debugf("detach hook %s/%s/%s : %s", selector.EBPFSection, selector.EBPFFuncName, uid, err)
+					log.Debugf("detach hook %s/%s : %s", selector.EBPFFuncName, uid, err)
 				}
 				if program != nil {
 					program.Close()
@@ -489,7 +455,6 @@ func (*sslProgram) GetAllUndefinedProbes() []manager.ProbeIdentificationPair {
 		for _, singleProbe := range sslProbeList {
 			for _, identifier := range singleProbe.GetProbesIdentificationPairList() {
 				probeList = append(probeList, manager.ProbeIdentificationPair{
-					EBPFSection:  identifier.EBPFSection,
 					EBPFFuncName: identifier.EBPFFuncName,
 				})
 			}
@@ -499,7 +464,6 @@ func (*sslProgram) GetAllUndefinedProbes() []manager.ProbeIdentificationPair {
 	for _, hook := range []ebpfSectionFunction{doSysOpen, doSysOpenAt2} {
 		for _, kprobe := range kprobeKretprobePrefix {
 			probeList = append(probeList, manager.ProbeIdentificationPair{
-				EBPFSection:  kprobe + "/" + hook.section,
 				EBPFFuncName: kprobe + "__" + hook.function,
 			})
 		}

--- a/pkg/network/protocols/http/monitor.go
+++ b/pkg/network/protocols/http/monitor.go
@@ -79,7 +79,7 @@ func NewMonitor(c *config.Config, offsets []manager.ConstantEditor, sockFD *ebpf
 		return nil, fmt.Errorf("error initializing http ebpf program: %w", err)
 	}
 
-	filter, _ := mgr.GetProbe(manager.ProbeIdentificationPair{EBPFSection: protocolDispatcherSocketFilterSection, EBPFFuncName: protocolDispatcherSocketFilterFunction, UID: probeUID})
+	filter, _ := mgr.GetProbe(manager.ProbeIdentificationPair{EBPFFuncName: protocolDispatcherSocketFilterFunction, UID: probeUID})
 	if filter == nil {
 		return nil, fmt.Errorf("error retrieving socket filter")
 	}

--- a/pkg/network/protocols/http/shared_libraries_test.go
+++ b/pkg/network/protocols/http/shared_libraries_test.go
@@ -207,7 +207,6 @@ func initEBPFProgram(t *testing.T) (*ddebpf.PerfHandler, func()) {
 		Probes: []*manager.Probe{
 			{
 				ProbeIdentificationPair: manager.ProbeIdentificationPair{
-					EBPFSection:  "kprobe/" + probe,
 					EBPFFuncName: "kprobe__" + probe,
 					UID:          probeUID,
 				},
@@ -215,7 +214,6 @@ func initEBPFProgram(t *testing.T) (*ddebpf.PerfHandler, func()) {
 			},
 			{
 				ProbeIdentificationPair: manager.ProbeIdentificationPair{
-					EBPFSection:  "kretprobe/" + probe,
 					EBPFFuncName: "kretprobe__" + probe,
 					UID:          probeUID,
 				},
@@ -255,14 +253,12 @@ func initEBPFProgram(t *testing.T) (*ddebpf.PerfHandler, func()) {
 		ActivatedProbes: []manager.ProbesSelector{
 			&manager.ProbeSelector{
 				ProbeIdentificationPair: manager.ProbeIdentificationPair{
-					EBPFSection:  "kprobe/" + probe,
 					EBPFFuncName: "kprobe__" + probe,
 					UID:          probeUID,
 				},
 			},
 			&manager.ProbeSelector{
 				ProbeIdentificationPair: manager.ProbeIdentificationPair{
-					EBPFSection:  "kretprobe/" + probe,
 					EBPFFuncName: "kretprobe__" + probe,
 					UID:          probeUID,
 				},

--- a/pkg/network/tracer/connection/fentry/manager.go
+++ b/pkg/network/tracer/connection/fentry/manager.go
@@ -11,10 +11,11 @@ package fentry
 import (
 	"os"
 
+	manager "github.com/DataDog/ebpf-manager"
+
 	"github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 	"github.com/DataDog/datadog-agent/pkg/network/ebpf/probes"
-	manager "github.com/DataDog/ebpf-manager"
 )
 
 func initManager(mgr *manager.Manager, config *config.Config, closedHandler *ebpf.PerfHandler) {
@@ -47,10 +48,9 @@ func initManager(mgr *manager.Manager, config *config.Config, closedHandler *ebp
 		},
 	}
 
-	for sec, funcName := range programs {
+	for funcName := range programs {
 		p := &manager.Probe{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFSection:  sec,
 				EBPFFuncName: funcName,
 				UID:          probeUID,
 			},

--- a/pkg/network/tracer/connection/fentry/probes.go
+++ b/pkg/network/tracer/connection/fentry/probes.go
@@ -14,92 +14,92 @@ import (
 
 const (
 	// inetCskListenStop traces the inet_csk_listen_stop system call (called for both ipv4 and ipv6)
-	inetCskListenStop = "fentry/inet_csk_listen_stop"
+	inetCskListenStop = "inet_csk_listen_stop_enter"
 
 	// tcpConnect traces the connect() system call
-	tcpConnect = "fentry/tcp_connect"
+	tcpConnect = "tcp_connect"
 	// tcpFinishConnect traces tcp_finish_connect() kernel function. This is
 	// used to know when a TCP connection switches to the ESTABLISHED state
-	tcpFinishConnect = "fentry/tcp_finish_connect"
+	tcpFinishConnect = "tcp_finish_connect"
 
 	// tcpSendMsgReturn traces the return value for the tcp_sendmsg() system call
-	tcpSendMsgReturn = "fexit/tcp_sendmsg"
+	tcpSendMsgReturn = "tcp_sendmsg_exit"
 
 	// tcpSetState traces the tcp_set_state() kernel function
-	tcpSetState = "fentry/tcp_set_state"
+	tcpSetState = "tcp_set_state"
 
 	// tcpRecvMsgReturn traces the return value for the tcp_recvmsg() system call
-	tcpRecvMsgReturn = "fexit/tcp_recvmsg"
+	tcpRecvMsgReturn = "tcp_recvmsg_exit"
 	// tcpClose traces the tcp_close() system call
-	tcpClose = "fentry/tcp_close"
+	tcpClose = "tcp_close"
 	// tcpCloseReturn traces the return of tcp_close() system call
-	tcpCloseReturn = "fexit/tcp_close"
+	tcpCloseReturn = "tcp_close_exit"
 
 	// We use the following two probes for UDP
-	udpRecvMsgReturn   = "fexit/udp_recvmsg"
-	udpSendMsgReturn   = "fexit/udp_sendmsg"
-	udpSendSkb         = "kprobe/udp_send_skb"
-	udpv6RecvMsgReturn = "fexit/udpv6_recvmsg"
-	udpv6SendMsgReturn = "fexit/udpv6_sendmsg"
-	udpv6SendSkb       = "kprobe/udp_v6_send_skb"
+	udpRecvMsgReturn   = "udp_recvmsg_exit"
+	udpSendMsgReturn   = "udp_sendmsg_exit"
+	udpSendSkb         = "kprobe__udp_send_skb"
+	udpv6RecvMsgReturn = "udpv6_recvmsg_exit"
+	udpv6SendMsgReturn = "udpv6_sendmsg_exit"
+	udpv6SendSkb       = "kprobe__udp_v6_send_skb"
 
 	// udpDestroySock traces the udp_destroy_sock() function
-	udpDestroySock = "fentry/udp_destroy_sock"
+	udpDestroySock = "udp_destroy_sock"
 	// udpDestroySockReturn traces the return of the udp_destroy_sock() system call
-	udpDestroySockReturn = "fexit/udp_destroy_sock"
+	udpDestroySockReturn = "udp_destroy_sock_exit"
 
 	// tcpRetransmit traces the the tcp_retransmit_skb() kernel function
-	tcpRetransmit = "fentry/tcp_retransmit_skb"
+	tcpRetransmit = "tcp_retransmit_skb"
 
 	// inetCskAcceptReturn traces the return value for the inet_csk_accept syscall
-	inetCskAcceptReturn = "fexit/inet_csk_accept"
+	inetCskAcceptReturn = "inet_csk_accept_exit"
 
 	// inetBindRet is the kretprobe of the bind() syscall for IPv4
-	inetBindRet = "fexit/inet_bind"
+	inetBindRet = "inet_bind_exit"
 	// inet6BindRet is the kretprobe of the bind() syscall for IPv6
-	inet6BindRet = "fexit/inet6_bind"
+	inet6BindRet = "inet6_bind_exit"
 
 	// sockFDLookupRet is the kretprobe used for mapping socket FDs to kernel sock structs
-	sockFDLookupRet = "fexit/sockfd_lookup_light"
+	sockFDLookupRet = "sockfd_lookup_light_exit"
 
 	// doSendfileRet is the kretprobe used to trace traffic via SENDFILE(2) syscall
-	doSendfileRet = "fexit/do_sendfile"
+	doSendfileRet = "do_sendfile_exit"
 )
 
-var programs = map[string]string{
-	doSendfileRet:        "do_sendfile_exit", // TODO: available but sockfd_lookup_light not available on some kernels
-	inet6BindRet:         "inet6_bind_exit",
-	inetBindRet:          "inet_bind_exit",
-	inetCskAcceptReturn:  "inet_csk_accept_exit",
-	inetCskListenStop:    "inet_csk_listen_stop_enter",
-	sockFDLookupRet:      "sockfd_lookup_light_exit", // TODO: not available on certain kernels, will have to one or more hooks to get equivalent functionality; affects do_sendfile and HTTPS monitoring (OpenSSL/GnuTLS/GoTLS)
-	tcpRecvMsgReturn:     "tcp_recvmsg_exit",
-	tcpClose:             "tcp_close",
-	tcpCloseReturn:       "tcp_close_exit",
-	tcpConnect:           "tcp_connect",
-	tcpFinishConnect:     "tcp_finish_connect",
-	tcpRetransmit:        "tcp_retransmit_skb",
-	tcpSendMsgReturn:     "tcp_sendmsg_exit",
-	tcpSetState:          "tcp_set_state",
-	udpDestroySock:       "udp_destroy_sock",
-	udpDestroySockReturn: "udp_destroy_sock_exit",
-	udpRecvMsgReturn:     "udp_recvmsg_exit",
-	udpSendMsgReturn:     "udp_sendmsg_exit",
-	udpSendSkb:           "kprobe__udp_send_skb",
-	udpv6RecvMsgReturn:   "udpv6_recvmsg_exit",
-	udpv6SendMsgReturn:   "udpv6_sendmsg_exit",
-	udpv6SendSkb:         "kprobe__udp_v6_send_skb",
+var programs = map[string]struct{}{
+	doSendfileRet:        {}, // TODO: available but sockfd_lookup_light not available on some kernels
+	inet6BindRet:         {},
+	inetBindRet:          {},
+	inetCskAcceptReturn:  {},
+	inetCskListenStop:    {},
+	sockFDLookupRet:      {}, // TODO: not available on certain kernels, will have to one or more hooks to get equivalent functionality; affects do_sendfile and HTTPS monitoring (OpenSSL/GnuTLS/GoTLS)
+	tcpRecvMsgReturn:     {},
+	tcpClose:             {},
+	tcpCloseReturn:       {},
+	tcpConnect:           {},
+	tcpFinishConnect:     {},
+	tcpRetransmit:        {},
+	tcpSendMsgReturn:     {},
+	tcpSetState:          {},
+	udpDestroySock:       {},
+	udpDestroySockReturn: {},
+	udpRecvMsgReturn:     {},
+	udpSendMsgReturn:     {},
+	udpSendSkb:           {},
+	udpv6RecvMsgReturn:   {},
+	udpv6SendMsgReturn:   {},
+	udpv6SendSkb:         {},
 }
 
-func enableProgram(enabled map[string]string, name string) {
-	if fn, ok := programs[name]; ok {
-		enabled[name] = fn
+func enableProgram(enabled map[string]struct{}, name string) {
+	if _, ok := programs[name]; ok {
+		enabled[name] = struct{}{}
 	}
 }
 
 // enabledPrograms returns a map of probes that are enabled per config settings.
-func enabledPrograms(c *config.Config) (map[string]string, error) {
-	enabled := make(map[string]string, 0)
+func enabledPrograms(c *config.Config) (map[string]struct{}, error) {
+	enabled := make(map[string]struct{}, 0)
 	if c.CollectTCPConns {
 		enableProgram(enabled, tcpSendMsgReturn)
 		enableProgram(enabled, tcpRecvMsgReturn)

--- a/pkg/network/tracer/connection/fentry/tracer.go
+++ b/pkg/network/tracer/connection/fentry/tracer.go
@@ -58,16 +58,15 @@ func LoadTracer(config *config.Config, m *manager.Manager, mgrOpts manager.Optio
 
 		// exclude all non-enabled probes to ensure we don't run into problems with unsupported probe types
 		for _, p := range m.Probes {
-			if _, enabled := enabledProbes[p.EBPFSection]; !enabled {
+			if _, enabled := enabledProbes[p.EBPFFuncName]; !enabled {
 				o.ExcludedFunctions = append(o.ExcludedFunctions, p.EBPFFuncName)
 			}
 		}
-		for probeName, funcName := range enabledProbes {
+		for funcName := range enabledProbes {
 			o.ActivatedProbes = append(
 				o.ActivatedProbes,
 				&manager.ProbeSelector{
 					ProbeIdentificationPair: manager.ProbeIdentificationPair{
-						EBPFSection:  probeName,
 						EBPFFuncName: funcName,
 						UID:          probeUID,
 					},

--- a/pkg/network/tracer/connection/kprobe/config.go
+++ b/pkg/network/tracer/connection/kprobe/config.go
@@ -18,20 +18,14 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 )
 
-func enableProbe(enabled map[probes.ProbeName]string, name probes.ProbeName) {
-	if fn, ok := mainProbes[name]; ok {
-		enabled[name] = fn
-		return
-	}
-	if fn, ok := altProbes[name]; ok {
-		enabled[name] = fn
-	}
+func enableProbe(enabled map[probes.ProbeFuncName]struct{}, name probes.ProbeFuncName) {
+	enabled[name] = struct{}{}
 }
 
 // enabledProbes returns a map of probes that are enabled per config settings.
 // This map does not include the probes used exclusively in the offset guessing process.
-func enabledProbes(c *config.Config, runtimeTracer bool) (map[probes.ProbeName]string, error) {
-	enabled := make(map[probes.ProbeName]string, 0)
+func enabledProbes(c *config.Config, runtimeTracer bool) (map[probes.ProbeFuncName]struct{}, error) {
+	enabled := make(map[probes.ProbeFuncName]struct{}, 0)
 	ksymPath := filepath.Join(c.ProcRoot, "kallsyms")
 
 	kv410 := kernel.VersionCode(4, 1, 0)
@@ -121,7 +115,7 @@ func enabledProbes(c *config.Config, runtimeTracer bool) (map[probes.ProbeName]s
 	return enabled, nil
 }
 
-func selectVersionBasedProbe(runtimeTracer bool, kv kernel.Version, dfault probes.ProbeName, versioned probes.ProbeName, reqVer kernel.Version) probes.ProbeName {
+func selectVersionBasedProbe(runtimeTracer bool, kv kernel.Version, dfault probes.ProbeFuncName, versioned probes.ProbeFuncName, reqVer kernel.Version) probes.ProbeFuncName {
 	if runtimeTracer {
 		return dfault
 	}

--- a/pkg/network/tracer/connection/kprobe/manager.go
+++ b/pkg/network/tracer/connection/kprobe/manager.go
@@ -25,54 +25,42 @@ const (
 	maxActive = 128
 )
 
-var mainProbes = map[probes.ProbeName]string{
-	probes.NetDevQueue:                         "tracepoint__net__net_dev_queue",
-	probes.ProtocolClassifierEntrySocketFilter: "socket__classifier_entry",
-	probes.ProtocolClassifierSocketFilter:      "socket__classifier",
-	probes.TCPSendMsg:                          "kprobe__tcp_sendmsg",
-	probes.TCPSendMsgReturn:                    "kretprobe__tcp_sendmsg",
-	probes.TCPRecvMsg:                          "kprobe__tcp_recvmsg",
-	probes.TCPRecvMsgReturn:                    "kretprobe__tcp_recvmsg",
-	probes.TCPReadSock:                         "kprobe__tcp_read_sock",
-	probes.TCPReadSockReturn:                   "kretprobe__tcp_read_sock",
-	probes.TCPClose:                            "kprobe__tcp_close",
-	probes.TCPCloseReturn:                      "kretprobe__tcp_close",
-	probes.TCPConnect:                          "kprobe__tcp_connect",
-	probes.TCPFinishConnect:                    "kprobe__tcp_finish_connect",
-	probes.TCPSetState:                         "kprobe__tcp_set_state",
-	probes.IPMakeSkb:                           "kprobe__ip_make_skb",
-	probes.IPMakeSkbReturn:                     "kretprobe__ip_make_skb",
-	probes.IP6MakeSkb:                          "kprobe__ip6_make_skb",
-	probes.IP6MakeSkbReturn:                    "kretprobe__ip6_make_skb",
-	probes.UDPRecvMsg:                          "kprobe__udp_recvmsg",
-	probes.UDPRecvMsgReturn:                    "kretprobe__udp_recvmsg",
-	probes.UDPv6RecvMsg:                        "kprobe__udpv6_recvmsg",
-	probes.UDPv6RecvMsgReturn:                  "kretprobe__udpv6_recvmsg",
-	probes.TCPRetransmit:                       "kprobe__tcp_retransmit_skb",
-	probes.InetCskAcceptReturn:                 "kretprobe__inet_csk_accept",
-	probes.InetCskListenStop:                   "kprobe__inet_csk_listen_stop",
-	probes.UDPDestroySock:                      "kprobe__udp_destroy_sock",
-	probes.UDPDestroySockReturn:                "kretprobe__udp_destroy_sock",
-	probes.InetBind:                            "kprobe__inet_bind",
-	probes.Inet6Bind:                           "kprobe__inet6_bind",
-	probes.InetBindRet:                         "kretprobe__inet_bind",
-	probes.Inet6BindRet:                        "kretprobe__inet6_bind",
-	probes.SockFDLookup:                        "kprobe__sockfd_lookup_light",
-	probes.SockFDLookupRet:                     "kretprobe__sockfd_lookup_light",
-	probes.DoSendfile:                          "kprobe__do_sendfile",
-	probes.DoSendfileRet:                       "kretprobe__do_sendfile",
-}
-
-var altProbes = map[probes.ProbeName]string{
-	probes.TCPRetransmitPre470:              "kprobe__tcp_retransmit_skb_pre_4_7_0",
-	probes.IP6MakeSkbPre470:                 "kprobe__ip6_make_skb__pre_4_7_0",
-	probes.UDPRecvMsgPre410:                 "kprobe__udp_recvmsg_pre_4_1_0",
-	probes.UDPv6RecvMsgPre410:               "kprobe__udpv6_recvmsg_pre_4_1_0",
-	probes.TCPSendMsgPre410:                 "kprobe__tcp_sendmsg__pre_4_1_0",
-	probes.TCPRecvMsgPre410:                 "kprobe__tcp_recvmsg__pre_4_1_0",
-	probes.SKBConsumeUDP:                    "kprobe__skb_consume_udp",
-	probes.SKBFreeDatagramLocked:            "kprobe__skb_free_datagram_locked",
-	probes.UnderscoredSKBFreeDatagramLocked: "kprobe____skb_free_datagram_locked",
+var mainProbes = []probes.ProbeFuncName{
+	probes.NetDevQueue,
+	probes.ProtocolClassifierEntrySocketFilter,
+	probes.ProtocolClassifierSocketFilter,
+	probes.TCPSendMsg,
+	probes.TCPSendMsgReturn,
+	probes.TCPRecvMsg,
+	probes.TCPRecvMsgReturn,
+	probes.TCPReadSock,
+	probes.TCPReadSockReturn,
+	probes.TCPClose,
+	probes.TCPCloseReturn,
+	probes.TCPConnect,
+	probes.TCPFinishConnect,
+	probes.TCPSetState,
+	probes.IPMakeSkb,
+	probes.IPMakeSkbReturn,
+	probes.IP6MakeSkb,
+	probes.IP6MakeSkbReturn,
+	probes.UDPRecvMsg,
+	probes.UDPRecvMsgReturn,
+	probes.UDPv6RecvMsg,
+	probes.UDPv6RecvMsgReturn,
+	probes.TCPRetransmit,
+	probes.InetCskAcceptReturn,
+	probes.InetCskListenStop,
+	probes.UDPDestroySock,
+	probes.UDPDestroySockReturn,
+	probes.InetBind,
+	probes.Inet6Bind,
+	probes.InetBindRet,
+	probes.Inet6BindRet,
+	probes.SockFDLookup,
+	probes.SockFDLookupRet,
+	probes.DoSendfile,
+	probes.DoSendfileRet,
 }
 
 func initManager(mgr *manager.Manager, config *config.Config, closedHandler *ebpf.PerfHandler, runtimeTracer bool) {
@@ -110,10 +98,9 @@ func initManager(mgr *manager.Manager, config *config.Config, closedHandler *ebp
 			},
 		},
 	}
-	for probeName, funcName := range mainProbes {
+	for _, funcName := range mainProbes {
 		p := &manager.Probe{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFSection:  probeName,
 				EBPFFuncName: funcName,
 				UID:          probeUID,
 			},
@@ -126,21 +113,21 @@ func initManager(mgr *manager.Manager, config *config.Config, closedHandler *ebp
 
 	if runtimeTracer {
 		mgr.Probes = append(mgr.Probes,
-			&manager.Probe{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFSection: probes.SKBFreeDatagramLocked, EBPFFuncName: altProbes[probes.SKBFreeDatagramLocked], UID: probeUID}},
-			&manager.Probe{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFSection: probes.UnderscoredSKBFreeDatagramLocked, EBPFFuncName: altProbes[probes.UnderscoredSKBFreeDatagramLocked], UID: probeUID}},
-			&manager.Probe{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFSection: probes.SKBConsumeUDP, EBPFFuncName: altProbes[probes.SKBConsumeUDP], UID: probeUID}},
+			&manager.Probe{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: probes.SKBFreeDatagramLocked, UID: probeUID}},
+			&manager.Probe{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: probes.UnderscoredSKBFreeDatagramLocked, UID: probeUID}},
+			&manager.Probe{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: probes.SKBConsumeUDP, UID: probeUID}},
 		)
 	} else {
 		// the runtime compiled tracer has no need for separate probes targeting specific kernel versions, since it can
 		// do that with #ifdefs inline. Thus, the following probes should only be declared as existing in the prebuilt
 		// tracer.
 		mgr.Probes = append(mgr.Probes,
-			&manager.Probe{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFSection: probes.TCPRetransmitPre470, EBPFFuncName: altProbes[probes.TCPRetransmitPre470], UID: probeUID}, MatchFuncName: "^tcp_retransmit_skb$"},
-			&manager.Probe{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFSection: probes.IP6MakeSkbPre470, EBPFFuncName: altProbes[probes.IP6MakeSkbPre470], UID: probeUID}, MatchFuncName: "^ip6_make_skb$"},
-			&manager.Probe{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFSection: probes.UDPRecvMsgPre410, EBPFFuncName: altProbes[probes.UDPRecvMsgPre410], UID: probeUID}, MatchFuncName: "^udp_recvmsg$"},
-			&manager.Probe{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFSection: probes.UDPv6RecvMsgPre410, EBPFFuncName: altProbes[probes.UDPv6RecvMsgPre410], UID: probeUID}, MatchFuncName: "^udpv6_recvmsg$"},
-			&manager.Probe{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFSection: probes.TCPSendMsgPre410, EBPFFuncName: altProbes[probes.TCPSendMsgPre410], UID: probeUID}, MatchFuncName: "^tcp_sendmsg$"},
-			&manager.Probe{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFSection: probes.TCPRecvMsgPre410, EBPFFuncName: altProbes[probes.TCPRecvMsgPre410], UID: probeUID}, MatchFuncName: "^tcp_recvmsg$"},
+			&manager.Probe{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: probes.TCPRetransmitPre470, UID: probeUID}, MatchFuncName: "^tcp_retransmit_skb$"},
+			&manager.Probe{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: probes.IP6MakeSkbPre470, UID: probeUID}, MatchFuncName: "^ip6_make_skb$"},
+			&manager.Probe{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: probes.UDPRecvMsgPre410, UID: probeUID}, MatchFuncName: "^udp_recvmsg$"},
+			&manager.Probe{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: probes.UDPv6RecvMsgPre410, UID: probeUID}, MatchFuncName: "^udpv6_recvmsg$"},
+			&manager.Probe{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: probes.TCPSendMsgPre410, UID: probeUID}, MatchFuncName: "^tcp_sendmsg$"},
+			&manager.Probe{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: probes.TCPRecvMsgPre410, UID: probeUID}, MatchFuncName: "^tcp_recvmsg$"},
 		)
 	}
 }

--- a/pkg/network/tracer/ebpf_conntracker.go
+++ b/pkg/network/tracer/ebpf_conntracker.go
@@ -167,8 +167,8 @@ func (e *ebpfConntracker) dumpInitialTables(ctx context.Context, cfg *config.Con
 			return err
 		}
 	}
-	if err := e.m.DetachHook(manager.ProbeIdentificationPair{EBPFSection: probes.ConntrackFillInfo, EBPFFuncName: "kprobe_ctnetlink_fill_info"}); err != nil {
-		log.Debugf("detachHook %s/kprobe_ctnetlink_fill_info : %s", probes.ConntrackFillInfo, err)
+	if err := e.m.DetachHook(manager.ProbeIdentificationPair{EBPFFuncName: probes.ConntrackFillInfo}); err != nil {
+		log.Debugf("detachHook %s : %s", probes.ConntrackFillInfo, err)
 	}
 	return nil
 }
@@ -388,15 +388,13 @@ func getManager(cfg *config.Config, buf io.ReaderAt, maxStateSize int, mapErrTel
 		Probes: []*manager.Probe{
 			{
 				ProbeIdentificationPair: manager.ProbeIdentificationPair{
-					EBPFSection:  probes.ConntrackHashInsert,
-					EBPFFuncName: "kprobe___nf_conntrack_hash_insert",
+					EBPFFuncName: probes.ConntrackHashInsert,
 					UID:          "conntracker",
 				},
 			},
 			{
 				ProbeIdentificationPair: manager.ProbeIdentificationPair{
-					EBPFSection:  probes.ConntrackFillInfo,
-					EBPFFuncName: "kprobe_ctnetlink_fill_info",
+					EBPFFuncName: probes.ConntrackFillInfo,
 					UID:          "conntracker",
 				},
 			},

--- a/pkg/network/tracer/offsetguess.go
+++ b/pkg/network/tracer/offsetguess.go
@@ -124,21 +124,9 @@ type fieldValues struct {
 	dportFl6 uint16
 }
 
-var offsetProbes = map[probes.ProbeName]string{
-	probes.TCPGetSockOpt:      "kprobe__tcp_getsockopt",
-	probes.SockGetSockOpt:     "kprobe__sock_common_getsockopt",
-	probes.TCPv6Connect:       "kprobe__tcp_v6_connect",
-	probes.IPMakeSkb:          "kprobe__ip_make_skb",
-	probes.IP6MakeSkb:         "kprobe__ip6_make_skb",
-	probes.IP6MakeSkbPre470:   "kprobe__ip6_make_skb__pre_4_7_0",
-	probes.TCPv6ConnectReturn: "kretprobe__tcp_v6_connect",
-	probes.NetDevQueue:        "tracepoint__net__net_dev_queue",
-}
-
-func idPair(name probes.ProbeName) manager.ProbeIdentificationPair {
+func idPair(name probes.ProbeFuncName) manager.ProbeIdentificationPair {
 	return manager.ProbeIdentificationPair{
-		EBPFSection:  name,
-		EBPFFuncName: offsetProbes[name],
+		EBPFFuncName: name,
 		UID:          "offset",
 	}
 }
@@ -259,14 +247,12 @@ func waitUntilStable(conn net.Conn, window time.Duration, attempts int) (*fieldV
 	return nil, errors.New("unstable TCP socket params")
 }
 
-func enableProbe(enabled map[probes.ProbeName]string, name probes.ProbeName) {
-	if fn, ok := offsetProbes[name]; ok {
-		enabled[name] = fn
-	}
+func enableProbe(enabled map[probes.ProbeFuncName]struct{}, name probes.ProbeFuncName) {
+	enabled[name] = struct{}{}
 }
 
-func offsetGuessProbes(c *config.Config) (map[probes.ProbeName]string, error) {
-	p := map[probes.ProbeName]string{}
+func offsetGuessProbes(c *config.Config) (map[probes.ProbeFuncName]struct{}, error) {
+	p := map[probes.ProbeFuncName]struct{}{}
 	enableProbe(p, probes.TCPGetSockOpt)
 	enableProbe(p, probes.SockGetSockOpt)
 	enableProbe(p, probes.IPMakeSkb)

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -309,16 +309,15 @@ func runOffsetGuessing(config *config.Config, buf bytecode.AssetReader) ([]manag
 	}
 
 	for _, p := range offsetMgr.Probes {
-		if _, enabled := enabledProbes[p.EBPFSection]; !enabled {
+		if _, enabled := enabledProbes[p.EBPFFuncName]; !enabled {
 			offsetOptions.ExcludedFunctions = append(offsetOptions.ExcludedFunctions, p.EBPFFuncName)
 		}
 	}
-	for probeName, funcName := range enabledProbes {
+	for funcName := range enabledProbes {
 		offsetOptions.ActivatedProbes = append(
 			offsetOptions.ActivatedProbes,
 			&manager.ProbeSelector{
 				ProbeIdentificationPair: manager.ProbeIdentificationPair{
-					EBPFSection:  string(probeName),
 					EBPFFuncName: funcName,
 					UID:          "offset",
 				},

--- a/pkg/security/ebpf/probes/all.go
+++ b/pkg/security/ebpf/probes/all.go
@@ -93,7 +93,6 @@ func AllProbes() []*manager.Probe {
 		&manager.Probe{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
 				UID:          SecurityAgentUID,
-				EBPFSection:  "tracepoint/raw_syscalls/sys_exit",
 				EBPFFuncName: "sys_exit",
 			},
 		},
@@ -101,7 +100,6 @@ func AllProbes() []*manager.Probe {
 		&manager.Probe{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
 				UID:          SecurityAgentUID,
-				EBPFSection:  "kprobe/security_inode_getattr",
 				EBPFFuncName: "kprobe_security_inode_getattr",
 			},
 		},

--- a/pkg/security/ebpf/probes/attr.go
+++ b/pkg/security/ebpf/probes/attr.go
@@ -15,7 +15,6 @@ var attrProbes = []*manager.Probe{
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/security_inode_setattr",
 			EBPFFuncName: "kprobe_security_inode_setattr",
 		},
 	},

--- a/pkg/security/ebpf/probes/bind.go
+++ b/pkg/security/ebpf/probes/bind.go
@@ -24,7 +24,6 @@ func getBindProbes() []*manager.Probe {
 	bindProbes = append(bindProbes, &manager.Probe{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/security_socket_bind",
 			EBPFFuncName: "kprobe_security_socket_bind",
 		},
 	})

--- a/pkg/security/ebpf/probes/bpf.go
+++ b/pkg/security/ebpf/probes/bpf.go
@@ -15,21 +15,18 @@ var bpfProbes = []*manager.Probe{
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/security_bpf_map",
 			EBPFFuncName: "kprobe_security_bpf_map",
 		},
 	},
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/security_bpf_prog",
 			EBPFFuncName: "kprobe_security_bpf_prog",
 		},
 	},
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/check_helper_call",
 			EBPFFuncName: "kprobe_check_helper_call",
 		},
 		MatchFuncName: "check_helper_call",

--- a/pkg/security/ebpf/probes/dentry.go
+++ b/pkg/security/ebpf/probes/dentry.go
@@ -18,7 +18,6 @@ func getDentryResolverTailCallRoutes(ERPCDentryResolutionEnabled, supportMmapabl
 			ProgArrayName: "dentry_resolver_kprobe_progs",
 			Key:           ActivityDumpFilterKprobeKey,
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFSection:  "kprobe/dentry_resolver_ad_filter",
 				EBPFFuncName: "kprobe_dentry_resolver_ad_filter",
 			},
 		},
@@ -26,7 +25,6 @@ func getDentryResolverTailCallRoutes(ERPCDentryResolutionEnabled, supportMmapabl
 			ProgArrayName: "dentry_resolver_tracepoint_progs",
 			Key:           ActivityDumpFilterTracepointKey,
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFSection:  "tracepoint/dentry_resolver_ad_filter",
 				EBPFFuncName: "tracepoint_dentry_resolver_ad_filter",
 			},
 		},
@@ -36,7 +34,6 @@ func getDentryResolverTailCallRoutes(ERPCDentryResolutionEnabled, supportMmapabl
 			ProgArrayName: "dentry_resolver_kprobe_progs",
 			Key:           DentryResolverKernKprobeKey,
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFSection:  "kprobe/dentry_resolver_kern",
 				EBPFFuncName: "kprobe_dentry_resolver_kern",
 			},
 		},
@@ -44,7 +41,6 @@ func getDentryResolverTailCallRoutes(ERPCDentryResolutionEnabled, supportMmapabl
 			ProgArrayName: "dentry_resolver_tracepoint_progs",
 			Key:           DentryResolverKernTracepointKey,
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFSection:  "tracepoint/dentry_resolver_kern",
 				EBPFFuncName: "tracepoint_dentry_resolver_kern",
 			},
 		},
@@ -54,7 +50,6 @@ func getDentryResolverTailCallRoutes(ERPCDentryResolutionEnabled, supportMmapabl
 			ProgArrayName: "dentry_resolver_kprobe_callbacks",
 			Key:           DentryResolverOpenCallbackKprobeKey,
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFSection:  "kprobe/dr_open_callback",
 				EBPFFuncName: "kprobe_dr_open_callback",
 			},
 		},
@@ -62,7 +57,6 @@ func getDentryResolverTailCallRoutes(ERPCDentryResolutionEnabled, supportMmapabl
 			ProgArrayName: "dentry_resolver_kprobe_callbacks",
 			Key:           DentryResolverSetAttrCallbackKprobeKey,
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFSection:  "kprobe/dr_setattr_callback",
 				EBPFFuncName: "kprobe_dr_setattr_callback",
 			},
 		},
@@ -70,7 +64,6 @@ func getDentryResolverTailCallRoutes(ERPCDentryResolutionEnabled, supportMmapabl
 			ProgArrayName: "dentry_resolver_kprobe_callbacks",
 			Key:           DentryResolverMkdirCallbackKprobeKey,
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFSection:  "kprobe/dr_mkdir_callback",
 				EBPFFuncName: "kprobe_dr_mkdir_callback",
 			},
 		},
@@ -78,7 +71,6 @@ func getDentryResolverTailCallRoutes(ERPCDentryResolutionEnabled, supportMmapabl
 			ProgArrayName: "dentry_resolver_kprobe_callbacks",
 			Key:           DentryResolverMountCallbackKprobeKey,
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFSection:  "kprobe/dr_mount_callback",
 				EBPFFuncName: "kprobe_dr_mount_callback",
 			},
 		},
@@ -86,7 +78,6 @@ func getDentryResolverTailCallRoutes(ERPCDentryResolutionEnabled, supportMmapabl
 			ProgArrayName: "dentry_resolver_kprobe_callbacks",
 			Key:           DentryResolverSecurityInodeRmdirCallbackKprobeKey,
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFSection:  "kprobe/dr_security_inode_rmdir_callback",
 				EBPFFuncName: "kprobe_dr_security_inode_rmdir_callback",
 			},
 		},
@@ -94,7 +85,6 @@ func getDentryResolverTailCallRoutes(ERPCDentryResolutionEnabled, supportMmapabl
 			ProgArrayName: "dentry_resolver_kprobe_callbacks",
 			Key:           DentryResolverSetXAttrCallbackKprobeKey,
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFSection:  "kprobe/dr_setxattr_callback",
 				EBPFFuncName: "kprobe_dr_setxattr_callback",
 			},
 		},
@@ -102,7 +92,6 @@ func getDentryResolverTailCallRoutes(ERPCDentryResolutionEnabled, supportMmapabl
 			ProgArrayName: "dentry_resolver_kprobe_callbacks",
 			Key:           DentryResolverUnlinkCallbackKprobeKey,
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFSection:  "kprobe/dr_unlink_callback",
 				EBPFFuncName: "kprobe_dr_unlink_callback",
 			},
 		},
@@ -110,7 +99,6 @@ func getDentryResolverTailCallRoutes(ERPCDentryResolutionEnabled, supportMmapabl
 			ProgArrayName: "dentry_resolver_kprobe_callbacks",
 			Key:           DentryResolverLinkSrcCallbackKprobeKey,
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFSection:  "kprobe/dr_link_src_callback",
 				EBPFFuncName: "kprobe_dr_link_src_callback",
 			},
 		},
@@ -118,7 +106,6 @@ func getDentryResolverTailCallRoutes(ERPCDentryResolutionEnabled, supportMmapabl
 			ProgArrayName: "dentry_resolver_kprobe_callbacks",
 			Key:           DentryResolverLinkDstCallbackKprobeKey,
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFSection:  "kprobe/dr_link_dst_callback",
 				EBPFFuncName: "kprobe_dr_link_dst_callback",
 			},
 		},
@@ -126,7 +113,6 @@ func getDentryResolverTailCallRoutes(ERPCDentryResolutionEnabled, supportMmapabl
 			ProgArrayName: "dentry_resolver_kprobe_callbacks",
 			Key:           DentryResolverRenameCallbackKprobeKey,
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFSection:  "kprobe/dr_rename_callback",
 				EBPFFuncName: "kprobe_dr_rename_callback",
 			},
 		},
@@ -134,7 +120,6 @@ func getDentryResolverTailCallRoutes(ERPCDentryResolutionEnabled, supportMmapabl
 			ProgArrayName: "dentry_resolver_kprobe_callbacks",
 			Key:           DentryResolverSELinuxCallbackKprobeKey,
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFSection:  "kprobe/dr_selinux_callback",
 				EBPFFuncName: "kprobe_dr_selinux_callback",
 			},
 		},
@@ -142,7 +127,6 @@ func getDentryResolverTailCallRoutes(ERPCDentryResolutionEnabled, supportMmapabl
 			ProgArrayName: "dentry_resolver_kprobe_callbacks",
 			Key:           DentryResolverUnshareMntNSStageOneCallbackKprobeKey,
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFSection:  "kprobe/dr_unshare_mntns_stage_one_callback",
 				EBPFFuncName: "kprobe_dr_unshare_mntns_stage_one_callback",
 			},
 		},
@@ -150,7 +134,6 @@ func getDentryResolverTailCallRoutes(ERPCDentryResolutionEnabled, supportMmapabl
 			ProgArrayName: "dentry_resolver_kprobe_callbacks",
 			Key:           DentryResolverUnshareMntNSStageTwoCallbackKprobeKey,
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFSection:  "kprobe/dr_unshare_mntns_stage_two_callback",
 				EBPFFuncName: "kprobe_dr_unshare_mntns_stage_two_callback",
 			},
 		},
@@ -160,7 +143,6 @@ func getDentryResolverTailCallRoutes(ERPCDentryResolutionEnabled, supportMmapabl
 			ProgArrayName: "dentry_resolver_tracepoint_callbacks",
 			Key:           DentryResolverOpenCallbackTracepointKey,
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFSection:  "tracepoint/dr_open_callback",
 				EBPFFuncName: "tracepoint_dr_open_callback",
 			},
 		},
@@ -168,7 +150,6 @@ func getDentryResolverTailCallRoutes(ERPCDentryResolutionEnabled, supportMmapabl
 			ProgArrayName: "dentry_resolver_tracepoint_callbacks",
 			Key:           DentryResolverMkdirCallbackTracepointKey,
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFSection:  "tracepoint/dr_mkdir_callback",
 				EBPFFuncName: "tracepoint_dr_mkdir_callback",
 			},
 		},
@@ -176,7 +157,6 @@ func getDentryResolverTailCallRoutes(ERPCDentryResolutionEnabled, supportMmapabl
 			ProgArrayName: "dentry_resolver_tracepoint_callbacks",
 			Key:           DentryResolverMountCallbackTracepointKey,
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFSection:  "tracepoint/dr_mount_callback",
 				EBPFFuncName: "tracepoint_dr_mount_callback",
 			},
 		},
@@ -184,7 +164,6 @@ func getDentryResolverTailCallRoutes(ERPCDentryResolutionEnabled, supportMmapabl
 			ProgArrayName: "dentry_resolver_tracepoint_callbacks",
 			Key:           DentryResolverLinkDstCallbackTracepointKey,
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFSection:  "tracepoint/dr_link_dst_callback",
 				EBPFFuncName: "tracepoint_dr_link_dst_callback",
 			},
 		},
@@ -192,7 +171,6 @@ func getDentryResolverTailCallRoutes(ERPCDentryResolutionEnabled, supportMmapabl
 			ProgArrayName: "dentry_resolver_tracepoint_callbacks",
 			Key:           DentryResolverRenameCallbackTracepointKey,
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFSection:  "tracepoint/dr_rename_callback",
 				EBPFFuncName: "tracepoint_dr_rename_callback",
 			},
 		},
@@ -210,7 +188,6 @@ func getDentryResolverTailCallRoutes(ERPCDentryResolutionEnabled, supportMmapabl
 				ProgArrayName: "dentry_resolver_kprobe_progs",
 				Key:           DentryResolverERPCKey,
 				ProbeIdentificationPair: manager.ProbeIdentificationPair{
-					EBPFSection:  "kprobe/dentry_resolver_erpc" + ebpfSuffix,
 					EBPFFuncName: "kprobe_dentry_resolver_erpc" + ebpfSuffix,
 				},
 			},
@@ -218,7 +195,6 @@ func getDentryResolverTailCallRoutes(ERPCDentryResolutionEnabled, supportMmapabl
 				ProgArrayName: "dentry_resolver_kprobe_progs",
 				Key:           DentryResolverParentERPCKey,
 				ProbeIdentificationPair: manager.ProbeIdentificationPair{
-					EBPFSection:  "kprobe/dentry_resolver_parent_erpc" + ebpfSuffix,
 					EBPFFuncName: "kprobe_dentry_resolver_parent_erpc" + ebpfSuffix,
 				},
 			},
@@ -226,7 +202,6 @@ func getDentryResolverTailCallRoutes(ERPCDentryResolutionEnabled, supportMmapabl
 				ProgArrayName: "dentry_resolver_kprobe_progs",
 				Key:           DentryResolverSegmentERPCKey,
 				ProbeIdentificationPair: manager.ProbeIdentificationPair{
-					EBPFSection:  "kprobe/dentry_resolver_segment_erpc" + ebpfSuffix,
 					EBPFFuncName: "kprobe_dentry_resolver_segment_erpc" + ebpfSuffix,
 				},
 			},

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -17,15 +17,15 @@ import (
 // NetworkNFNatSelectors is the list of probes that should be activated if the `nf_nat` module is loaded
 var NetworkNFNatSelectors = []manager.ProbesSelector{
 	&manager.OneOf{Selectors: []manager.ProbesSelector{
-		&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/nf_nat_manip_pkt", EBPFFuncName: "kprobe_nf_nat_manip_pkt"}},
-		&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/nf_nat_packet", EBPFFuncName: "kprobe_nf_nat_packet"}},
+		&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_nf_nat_manip_pkt"}},
+		&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_nf_nat_packet"}},
 	}},
 }
 
 // NetworkVethSelectors is the list of probes that should be activated if the `veth` module is loaded
 var NetworkVethSelectors = []manager.ProbesSelector{
 	&manager.AllOf{Selectors: []manager.ProbesSelector{
-		&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/veth_newlink", EBPFFuncName: "kprobe_veth_newlink"}},
+		&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_veth_newlink"}},
 	}},
 }
 
@@ -33,39 +33,39 @@ var NetworkVethSelectors = []manager.ProbesSelector{
 var NetworkSelectors = []manager.ProbesSelector{
 	// flow classification probes
 	&manager.AllOf{Selectors: []manager.ProbesSelector{
-		&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/security_socket_bind", EBPFFuncName: "kprobe_security_socket_bind"}},
-		&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/security_sk_classify_flow", EBPFFuncName: "kprobe_security_sk_classify_flow"}},
-		&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/path_get", EBPFFuncName: "kprobe_path_get"}},
-		&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/proc_fd_link", EBPFFuncName: "kprobe_proc_fd_link"}},
+		&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_security_socket_bind"}},
+		&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_security_sk_classify_flow"}},
+		&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_path_get"}},
+		&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_proc_fd_link"}},
 	}},
 
 	// network device probes
 	&manager.AllOf{Selectors: []manager.ProbesSelector{
-		&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/register_netdevice", EBPFFuncName: "kprobe_register_netdevice"}},
+		&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_register_netdevice"}},
 		&manager.OneOf{Selectors: []manager.ProbesSelector{
-			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/dev_change_net_namespace", EBPFFuncName: "kprobe_dev_change_net_namespace"}},
-			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/__dev_change_net_namespace", EBPFFuncName: "kprobe___dev_change_net_namespace"}},
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_dev_change_net_namespace"}},
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe___dev_change_net_namespace"}},
 		}},
-		&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kretprobe/register_netdevice", EBPFFuncName: "kretprobe_register_netdevice"}},
+		&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kretprobe_register_netdevice"}},
 	}},
 	&manager.BestEffort{Selectors: []manager.ProbesSelector{
-		&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/dev_get_valid_name", EBPFFuncName: "kprobe_dev_get_valid_name"}},
-		&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/dev_new_index", EBPFFuncName: "kprobe_dev_new_index"}},
-		&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kretprobe/dev_new_index", EBPFFuncName: "kretprobe_dev_new_index"}},
-		&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/__dev_get_by_index", EBPFFuncName: "kprobe___dev_get_by_index"}},
-		&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/__dev_get_by_name", EBPFFuncName: "kprobe___dev_get_by_name"}},
+		&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_dev_get_valid_name"}},
+		&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_dev_new_index"}},
+		&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kretprobe_dev_new_index"}},
+		&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe___dev_get_by_index"}},
+		&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe___dev_get_by_name"}},
 	}},
 }
 
 // SyscallMonitorSelectors is the list of probes that should be activated for the syscall monitor feature
 var SyscallMonitorSelectors = []manager.ProbesSelector{
-	&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "tracepoint/raw_syscalls/sys_enter", EBPFFuncName: "sys_enter"}},
+	&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "sys_enter"}},
 }
 
 // SnapshotSelectors selectors required during the snapshot
 var SnapshotSelectors = []manager.ProbesSelector{
 	// required to stat /proc/.../exe
-	&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/security_inode_getattr", EBPFFuncName: "kprobe_security_inode_getattr"}},
+	&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_security_inode_getattr"}},
 }
 
 var selectorsPerEventTypeStore map[eval.EventType][]manager.ProbesSelector
@@ -78,531 +78,366 @@ func GetSelectorsPerEventType() map[eval.EventType][]manager.ProbesSelector {
 			"*": {
 				// Exec probes
 				&manager.AllOf{Selectors: []manager.ProbesSelector{
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "tracepoint/raw_syscalls/sys_exit", EBPFFuncName: "sys_exit"}},
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "tracepoint/sched/sched_process_fork", EBPFFuncName: "sched_process_fork"}},
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/do_exit", EBPFFuncName: "kprobe_do_exit"}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "sys_exit"}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "sched_process_fork"}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_do_exit"}},
 					&manager.BestEffort{Selectors: []manager.ProbesSelector{
-						&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/prepare_binprm", EBPFFuncName: "kprobe_prepare_binprm"}},
-						&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/bprm_execve", EBPFFuncName: "kprobe_bprm_execve"}},
-						&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/security_bprm_check", EBPFFuncName: "kprobe_security_bprm_check"}},
+						&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_prepare_binprm"}},
+						&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_bprm_execve"}},
+						&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_security_bprm_check"}},
 					}},
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/setup_new_exec", EBPFFuncName: "kprobe_setup_new_exec_interp"}},
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID + "_a", EBPFSection: "kprobe/setup_new_exec", EBPFFuncName: "kprobe_setup_new_exec_args_envs"}},
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/setup_arg_pages", EBPFFuncName: "kprobe_setup_arg_pages"}},
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/mprotect_fixup", EBPFFuncName: "kprobe_mprotect_fixup"}},
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/exit_itimers", EBPFFuncName: "kprobe_exit_itimers"}},
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/vfs_open", EBPFFuncName: "kprobe_vfs_open"}},
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/do_dentry_open", EBPFFuncName: "kprobe_do_dentry_open"}},
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/commit_creds", EBPFFuncName: "kprobe_commit_creds"}},
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kretprobe/__task_pid_nr_ns", EBPFFuncName: "kretprobe__task_pid_nr_ns"}},
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kretprobe/alloc_pid", EBPFFuncName: "kretprobe_alloc_pid"}},
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/switch_task_namespaces", EBPFFuncName: "kprobe_switch_task_namespaces"}},
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/do_coredump", EBPFFuncName: "kprobe_do_coredump"}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_setup_new_exec_interp"}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID + "_a", EBPFFuncName: "kprobe_setup_new_exec_args_envs"}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_setup_arg_pages"}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_mprotect_fixup"}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_exit_itimers"}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_vfs_open"}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_do_dentry_open"}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_commit_creds"}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kretprobe__task_pid_nr_ns"}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kretprobe_alloc_pid"}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_switch_task_namespaces"}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_do_coredump"}},
 				}},
 				&manager.OneOf{Selectors: []manager.ProbesSelector{
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/cgroup_procs_write", EBPFFuncName: "kprobe_cgroup_procs_write"}},
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/cgroup1_procs_write", EBPFFuncName: "kprobe_cgroup1_procs_write"}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_cgroup_procs_write"}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_cgroup1_procs_write"}},
 				}},
 				&manager.OneOf{Selectors: []manager.ProbesSelector{
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/_do_fork", EBPFFuncName: "kprobe__do_fork"}},
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/do_fork", EBPFFuncName: "kprobe_do_fork"}},
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/kernel_clone", EBPFFuncName: "kprobe_kernel_clone"}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe__do_fork"}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_do_fork"}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_kernel_clone"}},
 				}},
 				&manager.OneOf{Selectors: []manager.ProbesSelector{
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/cgroup_tasks_write", EBPFFuncName: "kprobe_cgroup_tasks_write"}},
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/cgroup1_tasks_write", EBPFFuncName: "kprobe_cgroup1_tasks_write"}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_cgroup_tasks_write"}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_cgroup1_tasks_write"}},
 				}},
-				&manager.OneOf{Selectors: ExpandSyscallProbesSelector(
-					manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "execve"}, Entry),
-				},
-				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(
-					manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "execveat"}, Entry),
-				},
-				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(
-					manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "setuid"}, EntryAndExit),
-				},
-				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(
-					manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "setuid16"}, EntryAndExit),
-				},
-				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(
-					manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "setgid"}, EntryAndExit),
-				},
-				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(
-					manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "setgid16"}, EntryAndExit),
-				},
-				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(
-					manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "seteuid"}, EntryAndExit),
-				},
-				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(
-					manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "seteuid16"}, EntryAndExit),
-				},
-				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(
-					manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "setegid"}, EntryAndExit),
-				},
-				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(
-					manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "setegid16"}, EntryAndExit),
-				},
-				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(
-					manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "setfsuid"}, EntryAndExit),
-				},
-				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(
-					manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "setfsuid16"}, EntryAndExit),
-				},
-				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(
-					manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "setfsgid"}, EntryAndExit),
-				},
-				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(
-					manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "setfsgid16"}, EntryAndExit),
-				},
-				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(
-					manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "setreuid"}, EntryAndExit),
-				},
-				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(
-					manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "setreuid16"}, EntryAndExit),
-				},
-				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(
-					manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "setregid"}, EntryAndExit),
-				},
-				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(
-					manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "setregid16"}, EntryAndExit),
-				},
-				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(
-					manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "setresuid"}, EntryAndExit),
-				},
-				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(
-					manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "setresuid16"}, EntryAndExit),
-				},
-				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(
-					manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "setresgid"}, EntryAndExit),
-				},
-				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(
-					manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "setresgid16"}, EntryAndExit),
-				},
-				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(
-					manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "capset"}, EntryAndExit),
-				},
-				&manager.OneOf{Selectors: ExpandSyscallProbesSelector(
-					manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "fork"}, Entry),
-				},
-				&manager.OneOf{Selectors: ExpandSyscallProbesSelector(
-					manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "vfork"}, Entry),
-				},
-				&manager.OneOf{Selectors: ExpandSyscallProbesSelector(
-					manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "clone"}, Entry),
-				},
-				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(
-					manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "clone3"}, Entry),
-				},
+				&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "execve", Entry)},
+				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "execveat", Entry)},
+				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "setuid", EntryAndExit)},
+				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "setuid16", EntryAndExit)},
+				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "setgid", EntryAndExit)},
+				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "setgid16", EntryAndExit)},
+				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "seteuid", EntryAndExit)},
+				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "seteuid16", EntryAndExit)},
+				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "setegid", EntryAndExit)},
+				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "setegid16", EntryAndExit)},
+				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "setfsuid", EntryAndExit)},
+				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "setfsuid16", EntryAndExit)},
+				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "setfsgid", EntryAndExit)},
+				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "setfsgid16", EntryAndExit)},
+				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "setreuid", EntryAndExit)},
+				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "setreuid16", EntryAndExit)},
+				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "setregid", EntryAndExit)},
+				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "setregid16", EntryAndExit)},
+				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "setresuid", EntryAndExit)},
+				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "setresuid16", EntryAndExit)},
+				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "setresgid", EntryAndExit)},
+				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "setresgid16", EntryAndExit)},
+				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "capset", EntryAndExit)},
+				&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "fork", Entry)},
+				&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "vfork", Entry)},
+				&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "clone", Entry)},
+				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "clone3", Entry)},
 
 				// File Attributes
-				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/security_inode_setattr", EBPFFuncName: "kprobe_security_inode_setattr"}},
+				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_security_inode_setattr"}},
 
 				// Open probes
 				&manager.AllOf{Selectors: []manager.ProbesSelector{
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/vfs_truncate", EBPFFuncName: "kprobe_vfs_truncate"}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_vfs_truncate"}},
 				}},
-				&manager.OneOf{Selectors: ExpandSyscallProbesSelector(
-					manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "open"}, EntryAndExit, true),
-				},
-				&manager.OneOf{Selectors: ExpandSyscallProbesSelector(
-					manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "creat"}, EntryAndExit),
-				},
-				&manager.OneOf{Selectors: ExpandSyscallProbesSelector(
-					manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "truncate"}, EntryAndExit, true),
-				},
-				&manager.OneOf{Selectors: ExpandSyscallProbesSelector(
-					manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "openat"}, EntryAndExit, true),
-				},
-				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(
-					manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "openat2"}, EntryAndExit),
-				},
-				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(
-					manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "open_by_handle_at"}, EntryAndExit, true),
-				},
+				&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "open", EntryAndExit, true)},
+				&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "creat", EntryAndExit)},
+				&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "truncate", EntryAndExit, true)},
+				&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "openat", EntryAndExit, true)},
+				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "openat2", EntryAndExit)},
+				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "open_by_handle_at", EntryAndExit, true)},
 				&manager.BestEffort{Selectors: []manager.ProbesSelector{
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/io_openat", EBPFFuncName: "kprobe_io_openat"}},
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/io_openat2", EBPFFuncName: "kprobe_io_openat2"}},
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kretprobe/io_openat2", EBPFFuncName: "kretprobe_io_openat2"}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_io_openat"}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_io_openat2"}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kretprobe_io_openat2"}},
 				}},
 				&manager.AllOf{Selectors: []manager.ProbesSelector{
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/filp_close", EBPFFuncName: "kprobe_filp_close"}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_filp_close"}},
 				}},
 
 				// iouring
 				&manager.BestEffort{Selectors: []manager.ProbesSelector{
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "tracepoint/io_uring/io_uring_create", EBPFFuncName: "io_uring_create"}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "io_uring_create"}},
 					&manager.OneOf{Selectors: []manager.ProbesSelector{
-						&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/io_allocate_scq_urings", EBPFFuncName: "kprobe_io_allocate_scq_urings"}},
-						&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/io_sq_offload_start", EBPFFuncName: "kprobe_io_sq_offload_start"}},
-						&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kretprobe/io_ring_ctx_alloc", EBPFFuncName: "kretprobe_io_ring_ctx_alloc"}},
+						&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_io_allocate_scq_urings"}},
+						&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_io_sq_offload_start"}},
+						&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kretprobe_io_ring_ctx_alloc"}},
 					}},
 				}},
 
 				// Mount probes
 				&manager.AllOf{Selectors: []manager.ProbesSelector{
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/attach_recursive_mnt", EBPFFuncName: "kprobe_attach_recursive_mnt"}},
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/propagate_mnt", EBPFFuncName: "kprobe_propagate_mnt"}},
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/security_sb_umount", EBPFFuncName: "kprobe_security_sb_umount"}},
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/clone_mnt", EBPFFuncName: "kprobe_clone_mnt"}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_attach_recursive_mnt"}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_propagate_mnt"}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_security_sb_umount"}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_clone_mnt"}},
 				}},
-				&manager.OneOf{Selectors: ExpandSyscallProbesSelector(
-					manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "mount"}, EntryAndExit, true),
-				},
-				&manager.OneOf{Selectors: ExpandSyscallProbesSelector(
-					manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "umount"}, EntryAndExit),
-				},
-				&manager.OneOf{Selectors: ExpandSyscallProbesSelector(
-					manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "unshare"}, Entry),
-				},
+				&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "mount", EntryAndExit, true)},
+				&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "umount", EntryAndExit)},
+				&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "unshare", Entry)},
 				&manager.OneOf{Selectors: []manager.ProbesSelector{
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/__attach_mnt", EBPFFuncName: "kprobe___attach_mnt"}},
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/attach_mnt", EBPFFuncName: "kprobe_attach_mnt"}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe___attach_mnt"}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_attach_mnt"}},
 				}},
 
 				// Rename probes
 				&manager.AllOf{Selectors: []manager.ProbesSelector{
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/vfs_rename", EBPFFuncName: "kprobe_vfs_rename"}},
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/mnt_want_write", EBPFFuncName: "kprobe_mnt_want_write"}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_vfs_rename"}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_mnt_want_write"}},
 				}},
-				&manager.OneOf{Selectors: ExpandSyscallProbesSelector(
-					manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "rename"}, EntryAndExit),
-				},
-				&manager.OneOf{Selectors: ExpandSyscallProbesSelector(
-					manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "renameat"}, EntryAndExit),
-				},
+				&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "rename", EntryAndExit)},
+				&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "renameat", EntryAndExit)},
 				&manager.BestEffort{Selectors: append(
 					[]manager.ProbesSelector{
-						&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/do_renameat2", EBPFFuncName: "kprobe_do_renameat2"}},
-						&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kretprobe/do_renameat2", EBPFFuncName: "kretprobe_do_renameat2"}},
-					},
-					ExpandSyscallProbesSelector(manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "renameat2"}, EntryAndExit)...),
-				},
+						&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_do_renameat2"}},
+						&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kretprobe_do_renameat2"}}},
+					ExpandSyscallProbesSelector(SecurityAgentUID, "renameat2", EntryAndExit)...)},
 
 				// unlink rmdir probes
 				&manager.AllOf{Selectors: []manager.ProbesSelector{
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/mnt_want_write", EBPFFuncName: "kprobe_mnt_want_write"}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_mnt_want_write"}},
 				}},
-				&manager.OneOf{Selectors: ExpandSyscallProbesSelector(
-					manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "unlinkat"}, EntryAndExit),
-				},
+				&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "unlinkat", EntryAndExit)},
 				&manager.BestEffort{Selectors: []manager.ProbesSelector{
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/do_unlinkat", EBPFFuncName: "kprobe_do_unlinkat"}},
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kretprobe/do_unlinkat", EBPFFuncName: "kretprobe_do_unlinkat"}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_do_unlinkat"}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kretprobe_do_unlinkat"}},
 				}},
 
 				// Rmdir probes
 				&manager.AllOf{Selectors: []manager.ProbesSelector{
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/security_inode_rmdir", EBPFFuncName: "kprobe_security_inode_rmdir"}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_security_inode_rmdir"}},
 				}},
-				&manager.OneOf{Selectors: ExpandSyscallProbesSelector(
-					manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "rmdir"}, EntryAndExit),
-				},
+				&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "rmdir", EntryAndExit)},
 				&manager.BestEffort{Selectors: []manager.ProbesSelector{
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/do_rmdir", EBPFFuncName: "kprobe_do_rmdir"}},
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kretprobe/do_rmdir", EBPFFuncName: "kretprobe_do_rmdir"}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_do_rmdir"}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kretprobe_do_rmdir"}},
 				}},
 
 				// Unlink probes
 				&manager.AllOf{Selectors: []manager.ProbesSelector{
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/vfs_unlink", EBPFFuncName: "kprobe_vfs_unlink"}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_vfs_unlink"}},
 				}},
-				&manager.OneOf{Selectors: ExpandSyscallProbesSelector(
-					manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "unlink"}, EntryAndExit),
-				},
+				&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "unlink", EntryAndExit)},
 				&manager.BestEffort{Selectors: []manager.ProbesSelector{
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/do_linkat", EBPFFuncName: "kprobe_do_linkat"}},
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kretprobe/do_linkat", EBPFFuncName: "kretprobe_do_linkat"}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_do_linkat"}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kretprobe_do_linkat"}},
 				}},
 
 				// ioctl probes
 				&manager.AllOf{Selectors: []manager.ProbesSelector{
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/do_vfs_ioctl", EBPFFuncName: "kprobe_do_vfs_ioctl"}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_do_vfs_ioctl"}},
 				}},
 
 				// Link
 				&manager.AllOf{Selectors: []manager.ProbesSelector{
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/vfs_link", EBPFFuncName: "kprobe_vfs_link"}},
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/filename_create", EBPFFuncName: "kprobe_filename_create"}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_vfs_link"}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_filename_create"}},
 				}},
-				&manager.OneOf{Selectors: ExpandSyscallProbesSelector(
-					manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "link"}, EntryAndExit),
-				},
-				&manager.OneOf{Selectors: ExpandSyscallProbesSelector(
-					manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "linkat"}, EntryAndExit),
-				},
+				&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "link", EntryAndExit)},
+				&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "linkat", EntryAndExit)},
 
 				// selinux
 				// This needs to be best effort, as sel_write_disable is in the process to be removed
 				&manager.BestEffort{Selectors: []manager.ProbesSelector{
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/sel_write_disable", EBPFFuncName: "kprobe_sel_write_disable"}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_sel_write_disable"}},
 				}},
 				&manager.BestEffort{Selectors: []manager.ProbesSelector{
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/sel_write_enforce", EBPFFuncName: "kprobe_sel_write_enforce"}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_sel_write_enforce"}},
 				}},
 				&manager.BestEffort{Selectors: []manager.ProbesSelector{
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/sel_write_bool", EBPFFuncName: "kprobe_sel_write_bool"}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_sel_write_bool"}},
 				}},
 				&manager.BestEffort{Selectors: []manager.ProbesSelector{
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/sel_commit_bools_write", EBPFFuncName: "kprobe_sel_commit_bools_write"}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_sel_commit_bools_write"}},
 				}},
 
 				// pipes
 				// This is needed to skip FIM events relatives to pipes (avoiding abnormal path events)
 				&manager.BestEffort{Selectors: []manager.ProbesSelector{
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/mntget", EBPFFuncName: "kprobe_mntget"}},
-				}},
-			},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_mntget"}},
+				}}},
 
 			// List of probes required to capture chmod events
 			"chmod": {
 				&manager.AllOf{Selectors: []manager.ProbesSelector{
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/mnt_want_write", EBPFFuncName: "kprobe_mnt_want_write"}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_mnt_want_write"}},
 				}},
-				&manager.OneOf{Selectors: ExpandSyscallProbesSelector(
-					manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "chmod"}, EntryAndExit),
-				},
-				&manager.OneOf{Selectors: ExpandSyscallProbesSelector(
-					manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "fchmod"}, EntryAndExit),
-				},
-				&manager.OneOf{Selectors: ExpandSyscallProbesSelector(
-					manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "fchmodat"}, EntryAndExit),
-				},
+				&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "chmod", EntryAndExit)},
+				&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "fchmod", EntryAndExit)},
+				&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "fchmodat", EntryAndExit)},
 			},
 
 			// List of probes required to capture chown events
 			"chown": {
 				&manager.AllOf{Selectors: []manager.ProbesSelector{
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/mnt_want_write", EBPFFuncName: "kprobe_mnt_want_write"}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_mnt_want_write"}},
 				}},
 				&manager.OneOf{Selectors: []manager.ProbesSelector{
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/mnt_want_write_file", EBPFFuncName: "kprobe_mnt_want_write_file"}},
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/mnt_want_write_file_path", EBPFFuncName: "kprobe_mnt_want_write_file_path"}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_mnt_want_write_file"}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_mnt_want_write_file_path"}},
 				}},
-				&manager.OneOf{Selectors: ExpandSyscallProbesSelector(
-					manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "chown"}, EntryAndExit),
-				},
-				&manager.OneOf{Selectors: ExpandSyscallProbesSelector(
-					manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "chown16"}, EntryAndExit),
-				},
-				&manager.OneOf{Selectors: ExpandSyscallProbesSelector(
-					manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "fchown"}, EntryAndExit),
-				},
-				&manager.OneOf{Selectors: ExpandSyscallProbesSelector(
-					manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "fchown16"}, EntryAndExit),
-				},
-				&manager.OneOf{Selectors: ExpandSyscallProbesSelector(
-					manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "fchownat"}, EntryAndExit),
-				},
-				&manager.OneOf{Selectors: ExpandSyscallProbesSelector(
-					manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "lchown"}, EntryAndExit),
-				},
-				&manager.OneOf{Selectors: ExpandSyscallProbesSelector(
-					manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "lchown16"}, EntryAndExit),
-				},
+				&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "chown", EntryAndExit)},
+				&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "chown16", EntryAndExit)},
+				&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "fchown", EntryAndExit)},
+				&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "fchown16", EntryAndExit)},
+				&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "fchownat", EntryAndExit)},
+				&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "lchown", EntryAndExit)},
+				&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "lchown16", EntryAndExit)},
 			},
 
 			// List of probes required to capture mkdir events
 			"mkdir": {
 				&manager.AllOf{Selectors: []manager.ProbesSelector{
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/vfs_mkdir", EBPFFuncName: "kprobe_vfs_mkdir"}},
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/filename_create", EBPFFuncName: "kprobe_filename_create"}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_vfs_mkdir"}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_filename_create"}},
 				}},
-				&manager.OneOf{Selectors: ExpandSyscallProbesSelector(
-					manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "mkdir"}, EntryAndExit),
-				},
-				&manager.OneOf{Selectors: ExpandSyscallProbesSelector(
-					manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "mkdirat"}, EntryAndExit),
-				},
+				&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "mkdir", EntryAndExit)},
+				&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "mkdirat", EntryAndExit)},
 				&manager.BestEffort{Selectors: []manager.ProbesSelector{
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/do_mkdirat", EBPFFuncName: "kprobe_do_mkdirat"}},
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kretprobe/do_mkdirat", EBPFFuncName: "kretprobe_do_mkdirat"}},
-				}},
-			},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_do_mkdirat"}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kretprobe_do_mkdirat"}},
+				}}},
 
 			// List of probes required to capture removexattr events
 			"removexattr": {
 				&manager.AllOf{Selectors: []manager.ProbesSelector{
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/vfs_removexattr", EBPFFuncName: "kprobe_vfs_removexattr"}},
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/mnt_want_write", EBPFFuncName: "kprobe_mnt_want_write"}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_vfs_removexattr"}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_mnt_want_write"}},
 				}},
 				&manager.OneOf{Selectors: []manager.ProbesSelector{
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/mnt_want_write_file", EBPFFuncName: "kprobe_mnt_want_write_file"}},
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/mnt_want_write_file_path", EBPFFuncName: "kprobe_mnt_want_write_file_path"}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_mnt_want_write_file"}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_mnt_want_write_file_path"}},
 				}},
-				&manager.OneOf{Selectors: ExpandSyscallProbesSelector(
-					manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "removexattr"}, EntryAndExit),
-				},
-				&manager.OneOf{Selectors: ExpandSyscallProbesSelector(
-					manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "fremovexattr"}, EntryAndExit),
-				},
-				&manager.OneOf{Selectors: ExpandSyscallProbesSelector(
-					manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "lremovexattr"}, EntryAndExit),
-				},
+				&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "removexattr", EntryAndExit)},
+				&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "fremovexattr", EntryAndExit)},
+				&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "lremovexattr", EntryAndExit)},
 			},
 
 			// List of probes required to capture setxattr events
 			"setxattr": {
 				&manager.AllOf{Selectors: []manager.ProbesSelector{
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/vfs_setxattr", EBPFFuncName: "kprobe_vfs_setxattr"}},
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/mnt_want_write", EBPFFuncName: "kprobe_mnt_want_write"}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_vfs_setxattr"}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_mnt_want_write"}},
 				}},
 				&manager.OneOf{Selectors: []manager.ProbesSelector{
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/mnt_want_write_file", EBPFFuncName: "kprobe_mnt_want_write_file"}},
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/mnt_want_write_file_path", EBPFFuncName: "kprobe_mnt_want_write_file_path"}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_mnt_want_write_file"}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_mnt_want_write_file_path"}},
 				}},
-				&manager.OneOf{Selectors: ExpandSyscallProbesSelector(
-					manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "setxattr"}, EntryAndExit),
-				},
-				&manager.OneOf{Selectors: ExpandSyscallProbesSelector(
-					manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "fsetxattr"}, EntryAndExit),
-				},
-				&manager.OneOf{Selectors: ExpandSyscallProbesSelector(
-					manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "lsetxattr"}, EntryAndExit),
-				},
+				&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "setxattr", EntryAndExit)},
+				&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "fsetxattr", EntryAndExit)},
+				&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "lsetxattr", EntryAndExit)},
 			},
 
 			// List of probes required to capture utimes events
 			"utimes": {
 				&manager.AllOf{Selectors: []manager.ProbesSelector{
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/mnt_want_write", EBPFFuncName: "kprobe_mnt_want_write"}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_mnt_want_write"}},
 				}},
-				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(
-					manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "utime"}, EntryAndExit, true),
-				},
-				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(
-					manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "utime32"}, EntryAndExit),
-				},
-				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(
-					manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "utimes"}, EntryAndExit, true),
-				},
-				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(
-					manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "utimes"}, EntryAndExit|ExpandTime32),
-				},
-				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(
-					manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "utimensat"}, EntryAndExit, true),
-				},
-				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(
-					manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "utimensat"}, EntryAndExit|ExpandTime32),
-				},
-				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(
-					manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "futimesat"}, EntryAndExit, true),
-				},
-				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(
-					manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "futimesat"}, EntryAndExit|ExpandTime32),
-				},
+				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "utime", EntryAndExit, true)},
+				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "utime32", EntryAndExit)},
+				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "utimes", EntryAndExit, true)},
+				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "utimes", EntryAndExit|ExpandTime32)},
+				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "utimensat", EntryAndExit, true)},
+				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "utimensat", EntryAndExit|ExpandTime32)},
+				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "futimesat", EntryAndExit, true)},
+				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "futimesat", EntryAndExit|ExpandTime32)},
 			},
 
 			// List of probes required to capture bpf events
 			"bpf": {
 				&manager.BestEffort{Selectors: []manager.ProbesSelector{
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/security_bpf_map", EBPFFuncName: "kprobe_security_bpf_map"}},
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/security_bpf_prog", EBPFFuncName: "kprobe_security_bpf_prog"}},
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/check_helper_call", EBPFFuncName: "kprobe_check_helper_call"}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_security_bpf_map"}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_security_bpf_prog"}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_check_helper_call"}},
 				}},
-				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(
-					manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "bpf"}, EntryAndExit),
-				},
+				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "bpf", EntryAndExit)},
 			},
 
 			// List of probes required to capture ptrace events
 			"ptrace": {
-				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(
-					manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "ptrace"}, EntryAndExit),
-				},
+				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "ptrace", EntryAndExit)},
 			},
 
 			// List of probes required to capture mmap events
 			"mmap": {
-				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(
-					manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "mmap"}, Exit),
-				},
+				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "mmap", Exit)},
 				&manager.AllOf{Selectors: []manager.ProbesSelector{
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "tracepoint/syscalls/sys_enter_mmap", EBPFFuncName: "tracepoint_syscalls_sys_enter_mmap"}},
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kretprobe/fget", EBPFFuncName: "kretprobe_fget"}},
-				}},
-			},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "tracepoint_syscalls_sys_enter_mmap"}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kretprobe_fget"}},
+				}}},
 
 			// List of probes required to capture mprotect events
 			"mprotect": {
 				&manager.AllOf{Selectors: []manager.ProbesSelector{
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/security_file_mprotect", EBPFFuncName: "kprobe_security_file_mprotect"}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_security_file_mprotect"}},
 				}},
-				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(
-					manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "mprotect"}, EntryAndExit),
-				},
+				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "mprotect", EntryAndExit)},
 			},
 
 			// List of probes required to capture kernel load_module events
 			"load_module": {
 				&manager.AllOf{Selectors: []manager.ProbesSelector{
 					&manager.OneOf{Selectors: []manager.ProbesSelector{
-						&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/security_kernel_read_file", EBPFFuncName: "kprobe_security_kernel_read_file"}},
-						&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/security_kernel_module_from_file", EBPFFuncName: "kprobe_security_kernel_module_from_file"}},
+						&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_security_kernel_read_file"}},
+						&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_security_kernel_module_from_file"}},
 					}},
 					&manager.OneOf{Selectors: []manager.ProbesSelector{
-						&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/do_init_module", EBPFFuncName: "kprobe_do_init_module"}},
-						&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/module_put", EBPFFuncName: "kprobe_module_put"}},
+						&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_do_init_module"}},
+						&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_module_put"}},
 					}},
 				}},
-				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(
-					manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "init_module"}, EntryAndExit),
-				},
-				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(
-					manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "finit_module"}, EntryAndExit),
-				},
+				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "init_module", EntryAndExit)},
+				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "finit_module", EntryAndExit)},
 			},
 
 			// List of probes required to capture kernel unload_module events
 			"unload_module": {
-				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(
-					manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "delete_module"}, EntryAndExit),
-				},
+				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "delete_module", EntryAndExit)},
 			},
 
 			// List of probes required to capture signal events
 			"signal": {
 				&manager.AllOf{Selectors: []manager.ProbesSelector{
 					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID,
-						EBPFSection: "kretprobe/check_kill_permission", EBPFFuncName: "kretprobe_check_kill_permission"}},
+						EBPFFuncName: "kretprobe_check_kill_permission"}},
 				}},
-				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(
-					manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kill"}, Entry),
-				},
+				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "kill", Entry)},
 			},
 
 			// List of probes required to capture splice events
 			"splice": {
-				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(
-					manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "splice"}, EntryAndExit),
-				},
+				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "splice", EntryAndExit)},
 				&manager.AllOf{Selectors: []manager.ProbesSelector{
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/get_pipe_info", EBPFFuncName: "kprobe_get_pipe_info"}},
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kretprobe/get_pipe_info", EBPFFuncName: "kretprobe_get_pipe_info"}},
-				}},
-			},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_get_pipe_info"}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kretprobe_get_pipe_info"}},
+				}}},
 
 			// List of probes required to capture bind events
 			"bind": {
 				&manager.AllOf{Selectors: []manager.ProbesSelector{
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/security_socket_bind", EBPFFuncName: "kprobe_security_socket_bind"}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_security_socket_bind"}},
 				}},
-				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(
-					manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "bind"}, EntryAndExit),
-				},
+				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "bind", EntryAndExit)},
 			},
 
 			// List of probes required to capture DNS events
 			"dns": {
 				&manager.AllOf{Selectors: []manager.ProbesSelector{
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/security_socket_bind", EBPFFuncName: "kprobe_security_socket_bind"}},
-				}},
-			},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_security_socket_bind"}},
+				}}},
 		}
 	}
 
 	if ShouldUseModuleLoadTracepoint() {
 		selectorsPerEventTypeStore["load_module"] = append(selectorsPerEventTypeStore["load_module"], &manager.BestEffort{Selectors: []manager.ProbesSelector{
-			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "tracepoint/module/module_load", EBPFFuncName: "module_load"}},
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "module_load"}},
 		}})
 	}
 

--- a/pkg/security/ebpf/probes/exec.go
+++ b/pkg/security/ebpf/probes/exec.go
@@ -15,154 +15,132 @@ var execProbes = []*manager.Probe{
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/prepare_binprm",
 			EBPFFuncName: "kprobe_prepare_binprm",
 		},
 	},
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/bprm_execve",
 			EBPFFuncName: "kprobe_bprm_execve",
 		},
 	},
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/security_bprm_check",
 			EBPFFuncName: "kprobe_security_bprm_check",
 		},
 	},
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "tracepoint/sched/sched_process_fork",
 			EBPFFuncName: "sched_process_fork",
 		},
 	},
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/do_exit",
 			EBPFFuncName: "kprobe_do_exit",
 		},
 	},
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/do_fork",
 			EBPFFuncName: "kprobe_do_fork",
 		},
 	},
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/_do_fork",
 			EBPFFuncName: "kprobe__do_fork",
 		},
 	},
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/kernel_clone",
 			EBPFFuncName: "kprobe_kernel_clone",
 		},
 	},
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/cgroup_procs_write",
 			EBPFFuncName: "kprobe_cgroup_procs_write",
 		},
 	},
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/cgroup1_procs_write",
 			EBPFFuncName: "kprobe_cgroup1_procs_write",
 		},
 	},
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/cgroup_tasks_write",
 			EBPFFuncName: "kprobe_cgroup_tasks_write",
 		},
 	},
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/cgroup1_tasks_write",
 			EBPFFuncName: "kprobe_cgroup1_tasks_write",
 		},
 	},
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/exit_itimers",
 			EBPFFuncName: "kprobe_exit_itimers",
 		},
 	},
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/setup_new_exec",
 			EBPFFuncName: "kprobe_setup_new_exec_interp",
 		},
 	},
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID + "_a",
-			EBPFSection:  "kprobe/setup_new_exec",
 			EBPFFuncName: "kprobe_setup_new_exec_args_envs",
 		},
 	},
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/setup_arg_pages",
 			EBPFFuncName: "kprobe_setup_arg_pages",
 		},
 	},
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/mprotect_fixup",
 			EBPFFuncName: "kprobe_mprotect_fixup",
 		},
 	},
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/commit_creds",
 			EBPFFuncName: "kprobe_commit_creds",
 		},
 	},
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kretprobe/__task_pid_nr_ns",
 			EBPFFuncName: "kretprobe__task_pid_nr_ns",
 		},
 	},
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kretprobe/alloc_pid",
 			EBPFFuncName: "kretprobe_alloc_pid",
 		},
 	},
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/switch_task_namespaces",
 			EBPFFuncName: "kprobe_switch_task_namespaces",
 		},
 	},
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/do_coredump",
 			EBPFFuncName: "kprobe_do_coredump",
 		},
 	},
@@ -246,7 +224,6 @@ func getExecTailCallRoutes() []manager.TailCallRoute {
 			ProgArrayName: "args_envs_progs",
 			Key:           ExecGetEnvsOffsetKey,
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFSection:  "kprobe/get_envs_offset",
 				EBPFFuncName: "kprobe_get_envs_offset",
 			},
 		},
@@ -254,7 +231,6 @@ func getExecTailCallRoutes() []manager.TailCallRoute {
 			ProgArrayName: "args_envs_progs",
 			Key:           ExecParseArgsEnvsSplitKey,
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFSection:  "kprobe/parse_args_envs_split",
 				EBPFFuncName: "kprobe_parse_args_envs_split",
 			},
 		},
@@ -262,7 +238,6 @@ func getExecTailCallRoutes() []manager.TailCallRoute {
 			ProgArrayName: "args_envs_progs",
 			Key:           ExecParseArgsEnvsKey,
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFSection:  "kprobe/parse_args_envs",
 				EBPFFuncName: "kprobe_parse_args_envs",
 			},
 		},

--- a/pkg/security/ebpf/probes/flow.go
+++ b/pkg/security/ebpf/probes/flow.go
@@ -15,35 +15,30 @@ var flowProbes = []*manager.Probe{
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/security_sk_classify_flow",
 			EBPFFuncName: "kprobe_security_sk_classify_flow",
 		},
 	},
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/nf_nat_manip_pkt",
 			EBPFFuncName: "kprobe_nf_nat_manip_pkt",
 		},
 	},
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/nf_nat_packet",
 			EBPFFuncName: "kprobe_nf_nat_packet",
 		},
 	},
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/path_get",
 			EBPFFuncName: "kprobe_path_get",
 		},
 	},
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/proc_fd_link",
 			EBPFFuncName: "kprobe_proc_fd_link",
 		},
 	},

--- a/pkg/security/ebpf/probes/ioctl.go
+++ b/pkg/security/ebpf/probes/ioctl.go
@@ -15,7 +15,6 @@ var ioctlProbes = []*manager.Probe{
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/do_vfs_ioctl",
 			EBPFFuncName: "kprobe_do_vfs_ioctl",
 		},
 	},

--- a/pkg/security/ebpf/probes/iouring.go
+++ b/pkg/security/ebpf/probes/iouring.go
@@ -15,27 +15,23 @@ var iouringProbes = []*manager.Probe{
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "tracepoint/io_uring/io_uring_create",
 			EBPFFuncName: "io_uring_create"},
 	},
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kretprobe/io_ring_ctx_alloc",
 			EBPFFuncName: "kretprobe_io_ring_ctx_alloc",
 		},
 	},
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/io_allocate_scq_urings",
 			EBPFFuncName: "kprobe_io_allocate_scq_urings",
 		},
 	},
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/io_sq_offload_start",
 			EBPFFuncName: "kprobe_io_sq_offload_start",
 		},
 	},

--- a/pkg/security/ebpf/probes/link.go
+++ b/pkg/security/ebpf/probes/link.go
@@ -15,21 +15,18 @@ var linkProbes = []*manager.Probe{
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/vfs_link",
 			EBPFFuncName: "kprobe_vfs_link",
 		},
 	},
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/do_linkat",
 			EBPFFuncName: "kprobe_do_linkat",
 		},
 	},
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kretprobe/do_linkat",
 			EBPFFuncName: "kretprobe_do_linkat",
 		},
 	},

--- a/pkg/security/ebpf/probes/mkdir.go
+++ b/pkg/security/ebpf/probes/mkdir.go
@@ -15,21 +15,18 @@ var mkdirProbes = []*manager.Probe{
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/vfs_mkdir",
 			EBPFFuncName: "kprobe_vfs_mkdir",
 		},
 	},
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/do_mkdirat",
 			EBPFFuncName: "kprobe_do_mkdirat",
 		},
 	},
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kretprobe/do_mkdirat",
 			EBPFFuncName: "kretprobe_do_mkdirat",
 		},
 	},

--- a/pkg/security/ebpf/probes/mmap.go
+++ b/pkg/security/ebpf/probes/mmap.go
@@ -15,14 +15,12 @@ var mmapProbes = []*manager.Probe{
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kretprobe/fget",
 			EBPFFuncName: "kretprobe_fget",
 		},
 	},
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "tracepoint/syscalls/sys_enter_mmap",
 			EBPFFuncName: "tracepoint_syscalls_sys_enter_mmap",
 		},
 	},

--- a/pkg/security/ebpf/probes/module.go
+++ b/pkg/security/ebpf/probes/module.go
@@ -15,35 +15,30 @@ var moduleProbes = []*manager.Probe{
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/security_kernel_read_file",
 			EBPFFuncName: "kprobe_security_kernel_read_file",
 		},
 	},
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/security_kernel_module_from_file",
 			EBPFFuncName: "kprobe_security_kernel_module_from_file",
 		},
 	},
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/do_init_module",
 			EBPFFuncName: "kprobe_do_init_module",
 		},
 	},
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/module_put",
 			EBPFFuncName: "kprobe_module_put",
 		},
 	},
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "tracepoint/module/module_load",
 			EBPFFuncName: "module_load",
 		},
 	},

--- a/pkg/security/ebpf/probes/mount.go
+++ b/pkg/security/ebpf/probes/mount.go
@@ -15,42 +15,36 @@ var mountProbes = []*manager.Probe{
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/attach_recursive_mnt",
 			EBPFFuncName: "kprobe_attach_recursive_mnt",
 		},
 	},
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/propagate_mnt",
 			EBPFFuncName: "kprobe_propagate_mnt",
 		},
 	},
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/security_sb_umount",
 			EBPFFuncName: "kprobe_security_sb_umount",
 		},
 	},
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/clone_mnt",
 			EBPFFuncName: "kprobe_clone_mnt",
 		},
 	},
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/__attach_mnt",
 			EBPFFuncName: "kprobe___attach_mnt",
 		},
 	},
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/attach_mnt",
 			EBPFFuncName: "kprobe_attach_mnt",
 		},
 	},

--- a/pkg/security/ebpf/probes/mprotect.go
+++ b/pkg/security/ebpf/probes/mprotect.go
@@ -15,7 +15,6 @@ var mprotectProbes = []*manager.Probe{
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/security_file_mprotect",
 			EBPFFuncName: "kprobe_security_file_mprotect",
 		},
 	},

--- a/pkg/security/ebpf/probes/net_device.go
+++ b/pkg/security/ebpf/probes/net_device.go
@@ -15,70 +15,60 @@ var netDeviceProbes = []*manager.Probe{
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/veth_newlink",
 			EBPFFuncName: "kprobe_veth_newlink",
 		},
 	},
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/register_netdevice",
 			EBPFFuncName: "kprobe_register_netdevice",
 		},
 	},
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/dev_get_valid_name",
 			EBPFFuncName: "kprobe_dev_get_valid_name",
 		},
 	},
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/dev_new_index",
 			EBPFFuncName: "kprobe_dev_new_index",
 		},
 	},
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kretprobe/dev_new_index",
 			EBPFFuncName: "kretprobe_dev_new_index",
 		},
 	},
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/__dev_get_by_index",
 			EBPFFuncName: "kprobe___dev_get_by_index",
 		},
 	},
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/__dev_get_by_name",
 			EBPFFuncName: "kprobe___dev_get_by_name",
 		},
 	},
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kretprobe/register_netdevice",
 			EBPFFuncName: "kretprobe_register_netdevice",
 		},
 	},
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/dev_change_net_namespace",
 			EBPFFuncName: "kprobe_dev_change_net_namespace",
 		},
 	},
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/__dev_change_net_namespace",
 			EBPFFuncName: "kprobe___dev_change_net_namespace",
 		},
 	},

--- a/pkg/security/ebpf/probes/open.go
+++ b/pkg/security/ebpf/probes/open.go
@@ -15,49 +15,42 @@ var openProbes = []*manager.Probe{
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/vfs_truncate",
 			EBPFFuncName: "kprobe_vfs_truncate",
 		},
 	},
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/vfs_open",
 			EBPFFuncName: "kprobe_vfs_open",
 		},
 	},
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/do_dentry_open",
 			EBPFFuncName: "kprobe_do_dentry_open",
 		},
 	},
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/io_openat",
 			EBPFFuncName: "kprobe_io_openat",
 		},
 	},
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/io_openat2",
 			EBPFFuncName: "kprobe_io_openat2",
 		},
 	},
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kretprobe/io_openat2",
 			EBPFFuncName: "kretprobe_io_openat2",
 		},
 	},
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/filp_close",
 			EBPFFuncName: "kprobe_filp_close",
 		},
 	},

--- a/pkg/security/ebpf/probes/pipe.go
+++ b/pkg/security/ebpf/probes/pipe.go
@@ -15,7 +15,6 @@ var pipeProbes = []*manager.Probe{
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/mntget",
 			EBPFFuncName: "kprobe_mntget",
 		},
 	},

--- a/pkg/security/ebpf/probes/raw_sys_exit.go
+++ b/pkg/security/ebpf/probes/raw_sys_exit.go
@@ -20,7 +20,6 @@ func getSysExitTailCallRoutes() []manager.TailCallRoute {
 			ProgArrayName: "sys_exit_progs",
 			Key:           uint32(model.FileChmodEventType),
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFSection:  "tracepoint/handle_sys_chmod_exit",
 				EBPFFuncName: "tracepoint_handle_sys_chmod_exit",
 			},
 		},
@@ -28,7 +27,6 @@ func getSysExitTailCallRoutes() []manager.TailCallRoute {
 			ProgArrayName: "sys_exit_progs",
 			Key:           uint32(model.FileChownEventType),
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFSection:  "tracepoint/handle_sys_chown_exit",
 				EBPFFuncName: "tracepoint_handle_sys_chown_exit",
 			},
 		},
@@ -36,7 +34,6 @@ func getSysExitTailCallRoutes() []manager.TailCallRoute {
 			ProgArrayName: "sys_exit_progs",
 			Key:           uint32(model.FileLinkEventType),
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFSection:  "tracepoint/handle_sys_link_exit",
 				EBPFFuncName: "tracepoint_handle_sys_link_exit",
 			},
 		},
@@ -44,7 +41,6 @@ func getSysExitTailCallRoutes() []manager.TailCallRoute {
 			ProgArrayName: "sys_exit_progs",
 			Key:           uint32(model.FileMkdirEventType),
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFSection:  "tracepoint/handle_sys_mkdir_exit",
 				EBPFFuncName: "tracepoint_handle_sys_mkdir_exit",
 			},
 		},
@@ -52,7 +48,6 @@ func getSysExitTailCallRoutes() []manager.TailCallRoute {
 			ProgArrayName: "sys_exit_progs",
 			Key:           uint32(model.FileMountEventType),
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFSection:  "tracepoint/handle_sys_mount_exit",
 				EBPFFuncName: "tracepoint_handle_sys_mount_exit",
 			},
 		},
@@ -60,7 +55,6 @@ func getSysExitTailCallRoutes() []manager.TailCallRoute {
 			ProgArrayName: "sys_exit_progs",
 			Key:           uint32(model.FileOpenEventType),
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFSection:  "tracepoint/handle_sys_open_exit",
 				EBPFFuncName: "tracepoint_handle_sys_open_exit",
 			},
 		},
@@ -68,7 +62,6 @@ func getSysExitTailCallRoutes() []manager.TailCallRoute {
 			ProgArrayName: "sys_exit_progs",
 			Key:           uint32(model.FileRenameEventType),
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFSection:  "tracepoint/handle_sys_rename_exit",
 				EBPFFuncName: "tracepoint_handle_sys_rename_exit",
 			},
 		},
@@ -76,7 +69,6 @@ func getSysExitTailCallRoutes() []manager.TailCallRoute {
 			ProgArrayName: "sys_exit_progs",
 			Key:           uint32(model.FileRmdirEventType),
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFSection:  "tracepoint/handle_sys_rmdir_exit",
 				EBPFFuncName: "tracepoint_handle_sys_rmdir_exit",
 			},
 		},
@@ -84,7 +76,6 @@ func getSysExitTailCallRoutes() []manager.TailCallRoute {
 			ProgArrayName: "sys_exit_progs",
 			Key:           uint32(model.FileSetXAttrEventType),
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFSection:  "tracepoint/handle_sys_setxattr_exit",
 				EBPFFuncName: "tracepoint_handle_sys_setxattr_exit",
 			},
 		},
@@ -92,7 +83,6 @@ func getSysExitTailCallRoutes() []manager.TailCallRoute {
 			ProgArrayName: "sys_exit_progs",
 			Key:           uint32(model.FileRemoveXAttrEventType),
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFSection:  "tracepoint/handle_sys_removexattr_exit",
 				EBPFFuncName: "tracepoint_handle_sys_removexattr_exit",
 			},
 		},
@@ -100,7 +90,6 @@ func getSysExitTailCallRoutes() []manager.TailCallRoute {
 			ProgArrayName: "sys_exit_progs",
 			Key:           uint32(model.FileUmountEventType),
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFSection:  "tracepoint/handle_sys_umount_exit",
 				EBPFFuncName: "tracepoint_handle_sys_umount_exit",
 			},
 		},
@@ -108,7 +97,6 @@ func getSysExitTailCallRoutes() []manager.TailCallRoute {
 			ProgArrayName: "sys_exit_progs",
 			Key:           uint32(model.FileUnlinkEventType),
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFSection:  "tracepoint/handle_sys_unlink_exit",
 				EBPFFuncName: "tracepoint_handle_sys_unlink_exit",
 			},
 		},
@@ -116,7 +104,6 @@ func getSysExitTailCallRoutes() []manager.TailCallRoute {
 			ProgArrayName: "sys_exit_progs",
 			Key:           uint32(model.FileUtimesEventType),
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFSection:  "tracepoint/handle_sys_utimes_exit",
 				EBPFFuncName: "tracepoint_handle_sys_utimes_exit",
 			},
 		},
@@ -124,7 +111,6 @@ func getSysExitTailCallRoutes() []manager.TailCallRoute {
 			ProgArrayName: "sys_exit_progs",
 			Key:           uint32(model.SetuidEventType),
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFSection:  "tracepoint/handle_sys_commit_creds_exit",
 				EBPFFuncName: "tracepoint_handle_sys_commit_creds_exit",
 			},
 		},
@@ -132,7 +118,6 @@ func getSysExitTailCallRoutes() []manager.TailCallRoute {
 			ProgArrayName: "sys_exit_progs",
 			Key:           uint32(model.SetgidEventType),
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFSection:  "tracepoint/handle_sys_commit_creds_exit",
 				EBPFFuncName: "tracepoint_handle_sys_commit_creds_exit",
 			},
 		},
@@ -140,7 +125,6 @@ func getSysExitTailCallRoutes() []manager.TailCallRoute {
 			ProgArrayName: "sys_exit_progs",
 			Key:           uint32(model.CapsetEventType),
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFSection:  "tracepoint/handle_sys_commit_creds_exit",
 				EBPFFuncName: "tracepoint_handle_sys_commit_creds_exit",
 			},
 		},
@@ -148,7 +132,6 @@ func getSysExitTailCallRoutes() []manager.TailCallRoute {
 			ProgArrayName: "sys_exit_progs",
 			Key:           uint32(model.MMapEventType),
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFSection:  "tracepoint/handle_sys_mmap_exit",
 				EBPFFuncName: "tracepoint_handle_sys_mmap_exit",
 			},
 		},
@@ -156,7 +139,6 @@ func getSysExitTailCallRoutes() []manager.TailCallRoute {
 			ProgArrayName: "sys_exit_progs",
 			Key:           uint32(model.MProtectEventType),
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFSection:  "tracepoint/handle_sys_mprotect_exit",
 				EBPFFuncName: "tracepoint_handle_sys_mprotect_exit",
 			},
 		},
@@ -164,7 +146,6 @@ func getSysExitTailCallRoutes() []manager.TailCallRoute {
 			ProgArrayName: "sys_exit_progs",
 			Key:           uint32(model.PTraceEventType),
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFSection:  "tracepoint/handle_sys_ptrace_exit",
 				EBPFFuncName: "tracepoint_handle_sys_ptrace_exit",
 			},
 		},
@@ -172,7 +153,6 @@ func getSysExitTailCallRoutes() []manager.TailCallRoute {
 			ProgArrayName: "sys_exit_progs",
 			Key:           uint32(model.SpliceEventType),
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFSection:  "tracepoint/handle_sys_splice_exit",
 				EBPFFuncName: "tracepoint_handle_sys_splice_exit",
 			},
 		},
@@ -180,7 +160,6 @@ func getSysExitTailCallRoutes() []manager.TailCallRoute {
 			ProgArrayName: "sys_exit_progs",
 			Key:           uint32(model.BPFEventType),
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFSection:  "tracepoint/handle_sys_bpf_exit",
 				EBPFFuncName: "tracepoint_handle_sys_bpf_exit",
 			},
 		},
@@ -188,7 +167,6 @@ func getSysExitTailCallRoutes() []manager.TailCallRoute {
 			ProgArrayName: "sys_exit_progs",
 			Key:           uint32(model.BindEventType),
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFSection:  "tracepoint/handle_sys_bind_exit",
 				EBPFFuncName: "tracepoint_handle_sys_bind_exit",
 			},
 		},
@@ -196,7 +174,6 @@ func getSysExitTailCallRoutes() []manager.TailCallRoute {
 			ProgArrayName: "sys_exit_progs",
 			Key:           uint32(model.LoadModuleEventType),
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFSection:  "tracepoint/handle_sys_init_module_exit",
 				EBPFFuncName: "tracepoint_handle_sys_init_module_exit",
 			},
 		},
@@ -204,7 +181,6 @@ func getSysExitTailCallRoutes() []manager.TailCallRoute {
 			ProgArrayName: "sys_exit_progs",
 			Key:           uint32(model.UnloadModuleEventType),
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFSection:  "tracepoint/handle_sys_delete_module_exit",
 				EBPFFuncName: "tracepoint_handle_sys_delete_module_exit",
 			},
 		},

--- a/pkg/security/ebpf/probes/rename.go
+++ b/pkg/security/ebpf/probes/rename.go
@@ -15,21 +15,18 @@ var renameProbes = []*manager.Probe{
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/vfs_rename",
 			EBPFFuncName: "kprobe_vfs_rename",
 		},
 	},
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/do_renameat2",
 			EBPFFuncName: "kprobe_do_renameat2",
 		},
 	},
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kretprobe/do_renameat2",
 			EBPFFuncName: "kretprobe_do_renameat2",
 		},
 	},

--- a/pkg/security/ebpf/probes/rmdir.go
+++ b/pkg/security/ebpf/probes/rmdir.go
@@ -15,21 +15,18 @@ var rmdirProbes = []*manager.Probe{
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/security_inode_rmdir",
 			EBPFFuncName: "kprobe_security_inode_rmdir",
 		},
 	},
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/do_rmdir",
 			EBPFFuncName: "kprobe_do_rmdir",
 		},
 	},
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kretprobe/do_rmdir",
 			EBPFFuncName: "kretprobe_do_rmdir",
 		},
 	},

--- a/pkg/security/ebpf/probes/selinux.go
+++ b/pkg/security/ebpf/probes/selinux.go
@@ -15,28 +15,24 @@ var selinuxProbes = []*manager.Probe{
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/sel_write_disable",
 			EBPFFuncName: "kprobe_sel_write_disable",
 		},
 	},
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/sel_write_enforce",
 			EBPFFuncName: "kprobe_sel_write_enforce",
 		},
 	},
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/sel_write_bool",
 			EBPFFuncName: "kprobe_sel_write_bool",
 		},
 	},
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/sel_commit_bools_write",
 			EBPFFuncName: "kprobe_sel_commit_bools_write",
 		},
 	},

--- a/pkg/security/ebpf/probes/shared.go
+++ b/pkg/security/ebpf/probes/shared.go
@@ -15,28 +15,24 @@ var sharedProbes = []*manager.Probe{
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/filename_create",
 			EBPFFuncName: "kprobe_filename_create",
 		},
 	},
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/mnt_want_write",
 			EBPFFuncName: "kprobe_mnt_want_write",
 		},
 	},
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/mnt_want_write_file",
 			EBPFFuncName: "kprobe_mnt_want_write_file",
 		},
 	},
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/mnt_want_write_file_path",
 			EBPFFuncName: "kprobe_mnt_want_write_file_path",
 		},
 	},

--- a/pkg/security/ebpf/probes/signal.go
+++ b/pkg/security/ebpf/probes/signal.go
@@ -15,7 +15,6 @@ var signalProbes = []*manager.Probe{
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kretprobe/check_kill_permission",
 			EBPFFuncName: "kretprobe_check_kill_permission",
 		},
 	},

--- a/pkg/security/ebpf/probes/splice.go
+++ b/pkg/security/ebpf/probes/splice.go
@@ -15,14 +15,12 @@ var spliceProbes = []*manager.Probe{
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kretprobe/get_pipe_info",
 			EBPFFuncName: "kretprobe_get_pipe_info",
 		},
 	},
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/get_pipe_info",
 			EBPFFuncName: "kprobe_get_pipe_info",
 		},
 	},

--- a/pkg/security/ebpf/probes/syscall_helpers.go
+++ b/pkg/security/ebpf/probes/syscall_helpers.go
@@ -167,7 +167,6 @@ func ExpandSyscallProbes(probe *manager.Probe, flag int, compat ...bool) []*mana
 
 	for _, section := range expandSyscallSections(syscallName, flag, compat...) {
 		probeCopy := probe.Copy()
-		probeCopy.EBPFSection = section
 		probeCopy.EBPFFuncName = getFunctionNameFromSection(section)
 		probes = append(probes, probeCopy)
 	}
@@ -176,7 +175,7 @@ func ExpandSyscallProbes(probe *manager.Probe, flag int, compat ...bool) []*mana
 }
 
 // ExpandSyscallProbesSelector returns the list of a ProbesSelector required to query all the probes available for a syscall
-func ExpandSyscallProbesSelector(id manager.ProbeIdentificationPair, flag int, compat ...bool) []manager.ProbesSelector {
+func ExpandSyscallProbesSelector(UID string, section string, flag int, compat ...bool) []manager.ProbesSelector {
 	var selectors []manager.ProbesSelector
 
 	if len(RuntimeArch) == 0 {
@@ -188,11 +187,11 @@ func ExpandSyscallProbesSelector(id manager.ProbeIdentificationPair, flag int, c
 		if getSyscallPrefix() == "sys_" {
 			return selectors
 		}
-		id.EBPFSection += "_time32"
+		section += "_time32"
 	}
 
-	for _, section := range expandSyscallSections(id.EBPFSection, flag, compat...) {
-		selector := &manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: id.UID, EBPFSection: section, EBPFFuncName: getFunctionNameFromSection(section)}}
+	for _, esection := range expandSyscallSections(section, flag, compat...) {
+		selector := &manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: UID, EBPFFuncName: getFunctionNameFromSection(esection)}}
 		selectors = append(selectors, selector)
 	}
 

--- a/pkg/security/ebpf/probes/syscall_monitor.go
+++ b/pkg/security/ebpf/probes/syscall_monitor.go
@@ -20,7 +20,6 @@ var syscallMonitorProbes = []*manager.Probe{
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "tracepoint/raw_syscalls/sys_enter",
 			EBPFFuncName: "sys_enter",
 		},
 	},

--- a/pkg/security/ebpf/probes/tc.go
+++ b/pkg/security/ebpf/probes/tc.go
@@ -18,7 +18,6 @@ var tcProbes = []*manager.Probe{
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "classifier/ingress",
 			EBPFFuncName: "classifier_ingress",
 		},
 		NetworkDirection: manager.Ingress,
@@ -28,7 +27,6 @@ var tcProbes = []*manager.Probe{
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "classifier/egress",
 			EBPFFuncName: "classifier_egress",
 		},
 		NetworkDirection: manager.Egress,
@@ -70,7 +68,6 @@ func getTCTailCallRoutes() []manager.TailCallRoute {
 			ProgArrayName: "classifier_router",
 			Key:           TCDNSRequestKey,
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFSection:  "classifier/dns_request",
 				EBPFFuncName: "classifier_dns_request",
 			},
 		},
@@ -78,7 +75,6 @@ func getTCTailCallRoutes() []manager.TailCallRoute {
 			ProgArrayName: "classifier_router",
 			Key:           TCDNSRequestParserKey,
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFSection:  "classifier/dns_request_parser",
 				EBPFFuncName: "classifier_dns_request_parser",
 			},
 		},

--- a/pkg/security/ebpf/probes/unlink.go
+++ b/pkg/security/ebpf/probes/unlink.go
@@ -15,21 +15,18 @@ var unlinkProbes = []*manager.Probe{
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/vfs_unlink",
 			EBPFFuncName: "kprobe_vfs_unlink",
 		},
 	},
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/do_unlinkat",
 			EBPFFuncName: "kprobe_do_unlinkat",
 		},
 	},
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kretprobe/do_unlinkat",
 			EBPFFuncName: "kretprobe_do_unlinkat",
 		},
 	},

--- a/pkg/security/ebpf/probes/xattr.go
+++ b/pkg/security/ebpf/probes/xattr.go
@@ -15,14 +15,12 @@ var xattrProbes = []*manager.Probe{
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/vfs_setxattr",
 			EBPFFuncName: "kprobe_vfs_setxattr",
 		},
 	},
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/vfs_removexattr",
 			EBPFFuncName: "kprobe_vfs_removexattr",
 		},
 	},

--- a/pkg/security/probe/constantfetch/offset_guesser.go
+++ b/pkg/security/probe/constantfetch/offset_guesser.go
@@ -32,7 +32,6 @@ var (
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
 				UID:          offsetGuesserUID,
-				EBPFSection:  "kprobe/get_pid_task",
 				EBPFFuncName: "kprobe_get_pid_task",
 			},
 		},

--- a/pkg/security/tests/syscall_tester/go/syscall_go_tester.go
+++ b/pkg/security/tests/syscall_tester/go/syscall_go_tester.go
@@ -10,10 +10,9 @@ package main
 
 import (
 	"bytes"
+	_ "embed"
 	"flag"
 	"fmt"
-
-	_ "embed"
 
 	manager "github.com/DataDog/ebpf-manager"
 	"github.com/syndtr/gocapability/capability"
@@ -41,7 +40,6 @@ func BPFLoad() error {
 			{
 				ProbeIdentificationPair: manager.ProbeIdentificationPair{
 					UID:          "MyVFSOpen",
-					EBPFSection:  "kprobe/vfs_open",
 					EBPFFuncName: "kprobe_vfs_open",
 				},
 			},


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Removes usage of `EBPFSection` to identify eBPF programs, and uses only the function name instead. This is possible because of https://github.com/DataDog/ebpf-manager/pull/82

### Motivation

Simpler eBPF program identification.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
