### PR TITLE
[CWS] increase volume size on ec2

### DIFF
--- a/test/kitchen/drivers/ec2-driver.yml
+++ b/test/kitchen/drivers/ec2-driver.yml
@@ -111,7 +111,7 @@ platforms:
       <% end %>
         ebs:
           volume_type: gp2
-          volume_size: 45
+          volume_size: 55
           delete_on_termination: true
     <% if allow_rsa_key || al2022 %>
     user_data: |

--- a/test/kitchen/site-cookbooks/dd-security-agent-check/recipes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-security-agent-check/recipes/default.rb
@@ -11,6 +11,14 @@ directory wrk_dir do
   recursive true
 end
 
+if node[:platform] == "amazon" and node[:platform_version] == "2022"
+  execute "increase /tmp size" do
+    command "mount -o remount,size=10G /tmp/"
+    live_stream true
+    action :run
+  end
+end
+
 file "#{wrk_dir}/cws_platform" do
   content node[:cws_platform].to_s || ""
   mode 644
@@ -59,14 +67,6 @@ end
 cookbook_file "#{wrk_dir}/nikos.tar.gz" do
   source "nikos.tar.gz"
   mode '755'
-end
-
-if node[:platform] == "amazon" and node[:platform_version] == "2022"
-  execute "increase /tmp size" do
-    command "mount -o remount,size=10G /tmp/"
-    live_stream true
-    action :run
-  end
 end
 
 execute "Extract nikos.tar.gz" do

--- a/test/kitchen/site-cookbooks/dd-security-agent-check/recipes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-security-agent-check/recipes/default.rb
@@ -63,7 +63,7 @@ end
 
 if node[:platform] == "amazon" and node[:platform_version] == "2022"
   execute "increase /tmp size" do
-    command "mount -o remount,size=5G /tmp/"
+    command "mount -o remount,size=10G /tmp/"
     live_stream true
     action :run
   end


### PR DESCRIPTION
### What does this PR do?

We are, again, hitting disk space limits. This PR increases both the ec2 disk, and the `/tmp/` mount point for amazon linux 2022

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
