### PR TITLE
Fix dmi implementation to not collect information on serverless

### DIFF
--- a/pkg/util/dmi/dmi_mock.go
+++ b/pkg/util/dmi/dmi_mock.go
@@ -3,8 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build !windows
-// +build !windows
+//go:build !windows && !serverless
+// +build !windows,!serverless
 
 package dmi
 

--- a/pkg/util/dmi/dmi_nix.go
+++ b/pkg/util/dmi/dmi_nix.go
@@ -3,8 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build !windows
-// +build !windows
+//go:build !windows && !serverless
+// +build !windows,!serverless
 
 package dmi
 

--- a/pkg/util/dmi/dmi_nix_test.go
+++ b/pkg/util/dmi/dmi_nix_test.go
@@ -3,8 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build !windows
-// +build !windows
+//go:build !windows && !serverless
+// +build !windows,!serverless
 
 package dmi
 

--- a/pkg/util/dmi/no_dmi.go
+++ b/pkg/util/dmi/no_dmi.go
@@ -3,8 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build windows
-// +build windows
+//go:build windows || serverless
+// +build windows serverless
 
 package dmi
 

--- a/pkg/util/dmi/no_dmi_mock.go
+++ b/pkg/util/dmi/no_dmi_mock.go
@@ -3,8 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build windows
-// +build windows
+//go:build windows || serverless
+// +build windows serverless
 
 package dmi
 


### PR DESCRIPTION

### What does this PR do?

Fix dmi implementation to not collect information on serverless. We don't want to collect host aliases on fargate.

### Describe how to test/QA your changes

Run the agent on Fargate and check that the instance id doesn't show as an host alias.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
