### PR TITLE
[CWS] improve signal event pid ns translation

### DIFF
--- a/pkg/security/ebpf/c/process.h
+++ b/pkg/security/ebpf/c/process.h
@@ -217,14 +217,19 @@ u64 __attribute__((always_inline)) get_sizeof_upid() {
     return sizeof_upid;
 }
 
+u32 __attribute__((always_inline)) get_pid_from_root_pidns(struct pid *pid) {
+    // read the root pid namespace nr from &pid->numbers[0].nr
+    u32 root_nr = 0;
+    bpf_probe_read(&root_nr, sizeof(root_nr), (void *)pid + get_pid_numbers_offset());
+    return root_nr;
+}
+
 void __attribute__((always_inline)) cache_nr_translations(struct pid *pid) {
     if (pid == NULL) {
         return;
     }
 
-    // read the root namespace nr from &pid->numbers[0].nr
-    u32 root_nr = 0;
-    bpf_probe_read(&root_nr, sizeof(root_nr), (void *)pid + get_pid_numbers_offset());
+    u32 root_nr = get_pid_from_root_pidns(pid);
 
     // TODO(will): iterate over the list to insert the nr of each namespace, for now get only the deepest one
     u32 pid_level = 0;

--- a/pkg/security/ebpf/c/ptrace.h
+++ b/pkg/security/ebpf/c/ptrace.h
@@ -23,12 +23,28 @@ SYSCALL_KPROBE3(ptrace, u32, request, pid_t, pid, void *, addr) {
         .type = EVENT_PTRACE,
         .ptrace = {
             .request = request,
-            .pid = pid,
+            .namespaced_pid = pid, // keep the namespaced pid for now
             .addr = (u64)addr,
         }
     };
 
     cache_syscall(&syscall);
+    return 0;
+}
+
+SEC("kprobe/pid_task")
+int kprobe_pid_task(struct pt_regs *ctx) {
+    struct syscall_cache_t *syscall = peek_syscall(EVENT_PTRACE);
+    if (!syscall || syscall->ptrace.root_ns_pid) {
+        return 0;
+    }
+
+    struct pid *pid = (struct pid *)PT_REGS_PARM1(ctx);
+    if (!pid) {
+        return 0;
+    }
+    syscall->ptrace.root_ns_pid = get_pid_from_root_pidns(pid);
+
     return 0;
 }
 
@@ -38,17 +54,19 @@ int __attribute__((always_inline)) sys_ptrace_ret(void *ctx, int retval) {
         return 0;
     }
 
-    // try to resolve namespaced nr
-    u32 namespace_nr = get_root_nr(syscall->ptrace.pid);
-    if (namespace_nr == 0) {
-        namespace_nr = syscall->ptrace.pid;
+    u32 pid = syscall->ptrace.root_ns_pid;
+    if (!pid) {
+        pid = get_root_nr(syscall->ptrace.namespaced_pid);
+        if (!pid) {
+            pid = syscall->ptrace.namespaced_pid;
+        }
     }
 
     struct ptrace_event_t event = {
         .syscall.retval = retval,
         .event.async = 0,
         .request = syscall->ptrace.request,
-        .pid = namespace_nr,
+        .pid = pid,
         .addr = syscall->ptrace.addr,
     };
 

--- a/pkg/security/ebpf/c/signal.h
+++ b/pkg/security/ebpf/c/signal.h
@@ -23,24 +23,34 @@ SYSCALL_KPROBE2(kill, int, pid, int, type) {
         return 0;
     }
 
-    /* make a lookup for the target PID in case we are namespaced */
-    /* TODO: make a lookup with the key addition of ns or cgroup id */
-    u32 root_nr = get_root_nr((u32)pid);
-    if (!root_nr) {
-        root_nr = pid;
-    }
-
     /* cache the signal and wait to grab the retval to send it */
     struct syscall_cache_t syscall = {
         .type = EVENT_SIGNAL,
         .signal = {
-            .pid = root_nr,
+            .namespaced_pid = pid, // keep the namespaced pid for now
             .type = type,
         },
     };
     cache_syscall(&syscall);
     return 0;
 }
+
+SEC("kprobe/kill_pid_info")
+int kprobe_kill_pid_info(struct pt_regs *ctx) {
+    struct syscall_cache_t *syscall = peek_syscall(EVENT_SIGNAL);
+    if (!syscall || syscall->signal.root_ns_pid) {
+        return 0;
+    }
+
+    struct pid *pid = (struct pid *)PT_REGS_PARM3(ctx);
+    if (!pid) {
+        return 0;
+    }
+    syscall->signal.root_ns_pid = get_pid_from_root_pidns(pid);
+
+    return 0;
+}
+
 
 /* hook here to grab the EPERM retval */
 SEC("kretprobe/check_kill_permission")
@@ -57,11 +67,19 @@ int kretprobe_check_kill_permission(struct pt_regs* ctx) {
         return 0;
     }
 
+    u32 pid = syscall->signal.root_ns_pid;
+    if (!pid) {
+        pid = get_root_nr(syscall->signal.namespaced_pid);
+        if (!pid) {
+            pid = syscall->signal.namespaced_pid;
+        }
+    }
+
     /* constuct and send the event */
     struct signal_event_t event = {
         .syscall.retval = retval,
         .event.async = 0,
-        .pid = syscall->signal.pid,
+        .pid = pid,
         .type = syscall->signal.type,
     };
     struct proc_cache_t *entry = fill_process_context(&event.process);

--- a/pkg/security/ebpf/c/syscalls.h
+++ b/pkg/security/ebpf/c/syscalls.h
@@ -175,9 +175,8 @@ struct syscall_cache_t {
 
         struct {
             u32 request;
-            u32 namespaced_pid;
+            u32 pid;
             u64 addr;
-            u32 root_ns_pid;
         } ptrace;
 
         struct {

--- a/pkg/security/ebpf/c/syscalls.h
+++ b/pkg/security/ebpf/c/syscalls.h
@@ -175,8 +175,9 @@ struct syscall_cache_t {
 
         struct {
             u32 request;
-            u32 pid;
+            u32 namespaced_pid;
             u64 addr;
+            u32 root_ns_pid;
         } ptrace;
 
         struct {
@@ -207,7 +208,8 @@ struct syscall_cache_t {
         } delete_module;
 
         struct {
-            u32 pid;
+            u32 namespaced_pid;
+            u32 root_ns_pid;
             u32 type;
         } signal;
 

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -363,6 +363,9 @@ func GetSelectorsPerEventType() map[eval.EventType][]manager.ProbesSelector {
 			// List of probes required to capture ptrace events
 			"ptrace": {
 				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "ptrace", EntryAndExit)},
+				&manager.AllOf{Selectors: []manager.ProbesSelector{
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_pid_task"}},
+				}},
 			},
 
 			// List of probes required to capture mmap events
@@ -405,8 +408,8 @@ func GetSelectorsPerEventType() map[eval.EventType][]manager.ProbesSelector {
 			// List of probes required to capture signal events
 			"signal": {
 				&manager.AllOf{Selectors: []manager.ProbesSelector{
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID,
-						EBPFFuncName: "kretprobe_check_kill_permission"}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kretprobe_check_kill_permission"}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_kill_pid_info"}},
 				}},
 				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "kill", Entry)},
 			},

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -363,9 +363,6 @@ func GetSelectorsPerEventType() map[eval.EventType][]manager.ProbesSelector {
 			// List of probes required to capture ptrace events
 			"ptrace": {
 				&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "ptrace", EntryAndExit)},
-				&manager.AllOf{Selectors: []manager.ProbesSelector{
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_pid_task"}},
-				}},
 			},
 
 			// List of probes required to capture mmap events

--- a/pkg/security/ebpf/probes/ptrace.go
+++ b/pkg/security/ebpf/probes/ptrace.go
@@ -20,12 +20,5 @@ func getPTraceProbes() []*manager.Probe {
 		},
 		SyscallFuncName: "ptrace",
 	}, EntryAndExit)...)
-	ptraceProbes = append(ptraceProbes, &manager.Probe{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/pid_task",
-			EBPFFuncName: "kprobe_pid_task",
-		},
-	})
 	return ptraceProbes
 }

--- a/pkg/security/ebpf/probes/ptrace.go
+++ b/pkg/security/ebpf/probes/ptrace.go
@@ -20,5 +20,12 @@ func getPTraceProbes() []*manager.Probe {
 		},
 		SyscallFuncName: "ptrace",
 	}, EntryAndExit)...)
+	ptraceProbes = append(ptraceProbes, &manager.Probe{
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID:          SecurityAgentUID,
+			EBPFSection:  "kprobe/pid_task",
+			EBPFFuncName: "kprobe_pid_task",
+		},
+	})
 	return ptraceProbes
 }

--- a/pkg/security/ebpf/probes/signal.go
+++ b/pkg/security/ebpf/probes/signal.go
@@ -27,5 +27,12 @@ func getSignalProbes() []*manager.Probe {
 		},
 		SyscallFuncName: "kill",
 	}, Entry)...)
+	signalProbes = append(signalProbes, &manager.Probe{
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID:          SecurityAgentUID,
+			EBPFSection:  "kprobe/kill_pid_info",
+			EBPFFuncName: "kprobe_kill_pid_info",
+		},
+	})
 	return signalProbes
 }


### PR DESCRIPTION
This PR improves the reliability of the translation of the pid of a signal event from a child pid namespace to the root pid namespace. It does so by directly looking at the kernel struct pid instead of relying on the eBPF LRU map used to cache translations.

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
