### PR TITLE
Allow returning partial data from cgroups rather than nothing

### DIFF
--- a/pkg/util/cgroups/cgroup_mock.go
+++ b/pkg/util/cgroups/cgroup_mock.go
@@ -12,14 +12,19 @@ import "time"
 
 // MockCgroup is a mock implementing the Cgroup interface
 type MockCgroup struct {
-	ID       string
-	Parent   Cgroup
-	CPU      *CPUStats
-	Memory   *MemoryStats
-	IOStats  *IOStats
-	PIDStats *PIDStats
-	PIDs     []int
-	Error    error
+	ID          string
+	Parent      Cgroup
+	ParentError error
+	CPU         *CPUStats
+	CPUError    error
+	Memory      *MemoryStats
+	MemoryError error
+	IOStats     *IOStats
+	IOError     error
+	PIDStats    *PIDStats
+	PIDError    error
+	PIDs        []int
+	PIDsError   error
 }
 
 // Identifier mock
@@ -29,16 +34,7 @@ func (mc *MockCgroup) Identifier() string {
 
 // GetParent mock
 func (mc *MockCgroup) GetParent() (Cgroup, error) {
-	return mc.Parent, mc.Error
-}
-
-// GetStats mock
-func (mc *MockCgroup) GetStats(stats *Stats) error {
-	stats.CPU = mc.CPU
-	stats.Memory = mc.Memory
-	stats.IO = mc.IOStats
-	stats.PID = mc.PIDStats
-	return mc.Error
+	return mc.Parent, mc.ParentError
 }
 
 // GetCPUStats mock
@@ -46,7 +42,7 @@ func (mc *MockCgroup) GetCPUStats(cpuStats *CPUStats) error {
 	if mc.CPU != nil {
 		*cpuStats = *mc.CPU
 	}
-	return mc.Error
+	return mc.CPUError
 }
 
 // GetMemoryStats mock
@@ -54,7 +50,7 @@ func (mc *MockCgroup) GetMemoryStats(memoryStats *MemoryStats) error {
 	if mc.Memory != nil {
 		*memoryStats = *mc.Memory
 	}
-	return mc.Error
+	return mc.MemoryError
 }
 
 // GetIOStats mock
@@ -62,7 +58,7 @@ func (mc *MockCgroup) GetIOStats(ioStats *IOStats) error {
 	if mc.IOStats != nil {
 		*ioStats = *mc.IOStats
 	}
-	return mc.Error
+	return mc.IOError
 }
 
 // GetPIDStats mock
@@ -70,10 +66,10 @@ func (mc *MockCgroup) GetPIDStats(pidStats *PIDStats) error {
 	if mc.PIDStats != nil {
 		*pidStats = *mc.PIDStats
 	}
-	return mc.Error
+	return mc.PIDError
 }
 
 // GetPIDs mock
 func (mc *MockCgroup) GetPIDs(cacheValidity time.Duration) ([]int, error) {
-	return mc.PIDs, mc.Error
+	return mc.PIDs, mc.PIDsError
 }

--- a/pkg/util/cgroups/cgroupv1.go
+++ b/pkg/util/cgroups/cgroupv1.go
@@ -37,42 +37,6 @@ func (c *cgroupV1) GetParent() (Cgroup, error) {
 	return newCgroupV1(filepath.Base(parentPath), parentPath, c.mountPoints, c.pidMapper), nil
 }
 
-func (c *cgroupV1) GetStats(stats *Stats) error {
-	if stats == nil {
-		return &InvalidInputError{Desc: "input stats cannot be nil"}
-	}
-
-	cpuStats := CPUStats{}
-	err := c.GetCPUStats(&cpuStats)
-	if err != nil {
-		return err
-	}
-	stats.CPU = &cpuStats
-
-	memoryStats := MemoryStats{}
-	err = c.GetMemoryStats(&memoryStats)
-	if err != nil {
-		return err
-	}
-	stats.Memory = &memoryStats
-
-	ioStats := IOStats{}
-	err = c.GetIOStats(&ioStats)
-	if err != nil {
-		return err
-	}
-	stats.IO = &ioStats
-
-	pidStats := PIDStats{}
-	err = c.GetPIDStats(&pidStats)
-	if err != nil {
-		return err
-	}
-	stats.PID = &pidStats
-
-	return nil
-}
-
 func (c *cgroupV1) controllerMounted(controller string) bool {
 	_, found := c.mountPoints[controller]
 	return found

--- a/pkg/util/cgroups/cgroupv2.go
+++ b/pkg/util/cgroups/cgroupv2.go
@@ -41,42 +41,6 @@ func (c *cgroupV2) GetParent() (Cgroup, error) {
 	return newCgroupV2(filepath.Base(parentPath), c.cgroupRoot, parentPath, c.controllers, c.pidMapper), nil
 }
 
-func (c *cgroupV2) GetStats(stats *Stats) error {
-	if stats == nil {
-		return &InvalidInputError{Desc: "input stats cannot be nil"}
-	}
-
-	cpuStats := CPUStats{}
-	err := c.GetCPUStats(&cpuStats)
-	if err != nil {
-		return err
-	}
-	stats.CPU = &cpuStats
-
-	memoryStats := MemoryStats{}
-	err = c.GetMemoryStats(&memoryStats)
-	if err != nil {
-		return err
-	}
-	stats.Memory = &memoryStats
-
-	ioStats := IOStats{}
-	err = c.GetIOStats(&ioStats)
-	if err != nil {
-		return err
-	}
-	stats.IO = &ioStats
-
-	pidStats := PIDStats{}
-	err = c.GetPIDStats(&pidStats)
-	if err != nil {
-		return err
-	}
-	stats.PID = &pidStats
-
-	return nil
-}
-
 func (c *cgroupV2) controllerActivated(controller string) bool {
 	_, found := c.controllers[controller]
 	return found

--- a/releasenotes/notes/fix-partial-cgroups-data-1415d53b695378b2.yaml
+++ b/releasenotes/notes/fix-partial-cgroups-data-1415d53b695378b2.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Allow to report all gathered data in case of partial failure of container metrics retrieval.


### PR DESCRIPTION
### What does this PR do?

This PR allows to return partial data from cgroups, which can be useful in environments where only one of the cgroup controller is not available (for instance, `pid` controller for Kernels < 4.3).

### Motivation

Improvement.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

To test this feature you need to trigger an error in cgroup data retrieval. The easiest is to use a VM with an old Kernel version (< 4.3). Running this Agent version you should still get `container.cpu / memory` metrics.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
