### PR TITLE
backport Fargate fix to 7.43.x

### DIFF
--- a/pkg/util/dmi/dmi_mock.go
+++ b/pkg/util/dmi/dmi_mock.go
@@ -3,8 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build !windows
-// +build !windows
+//go:build !windows && !serverless
+// +build !windows,!serverless
 
 package dmi
 

--- a/pkg/util/dmi/dmi_nix.go
+++ b/pkg/util/dmi/dmi_nix.go
@@ -3,8 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build !windows
-// +build !windows
+//go:build !windows && !serverless
+// +build !windows,!serverless
 
 package dmi
 

--- a/pkg/util/dmi/dmi_nix_test.go
+++ b/pkg/util/dmi/dmi_nix_test.go
@@ -3,8 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build !windows
-// +build !windows
+//go:build !windows && !serverless
+// +build !windows,!serverless
 
 package dmi
 

--- a/pkg/util/dmi/no_dmi.go
+++ b/pkg/util/dmi/no_dmi.go
@@ -3,8 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build windows
-// +build windows
+//go:build windows || serverless
+// +build windows serverless
 
 package dmi
 

--- a/pkg/util/dmi/no_dmi_mock.go
+++ b/pkg/util/dmi/no_dmi_mock.go
@@ -3,8 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build windows
-// +build windows
+//go:build windows || serverless
+// +build windows serverless
 
 package dmi
 


### PR DESCRIPTION
### What does this PR do?

Backport https://github.com/DataDog/datadog-agent/pull/15415 PR for 7.43.0