### PR TITLE
[usm] Flush all available event batches

### DIFF
--- a/pkg/network/ebpf/c/protocols/events-types.h
+++ b/pkg/network/ebpf/c/protocols/events-types.h
@@ -30,6 +30,7 @@ typedef struct {
     __u16 len;
     __u16 cap;
     __u16 event_size;
+    __u16 dropped_events;
     char data[BATCH_BUFFER_SIZE];
 } batch_data_t;
 

--- a/pkg/network/ebpf/c/protocols/events.h
+++ b/pkg/network/ebpf/c/protocols/events.h
@@ -26,29 +26,35 @@
     static __always_inline void name##_flush_batch(struct pt_regs *ctx) {               \
         u32 zero = 0;                                                                   \
         batch_state_t *batch_state = bpf_map_lookup_elem(&name##_batch_state, &zero);   \
-        if (!batch_state || batch_state->idx_to_flush == batch_state->idx) {            \
+        if (!batch_state) {                                                             \
             /* batch is not ready to be flushed */                                      \
             return;                                                                     \
         }                                                                               \
+        _Pragma( STR(unroll(BATCH_PAGES_PER_CPU)) )                                     \
+            for (int i = 0; i < BATCH_PAGES_PER_CPU; i++) {                             \
+                if (batch_state->idx_to_flush == batch_state->idx) return;              \
                                                                                         \
-        batch_key_t key = get_batch_key(batch_state->idx_to_flush);                     \
-        batch_data_t *batch = bpf_map_lookup_elem(&name##_batches, &key);               \
-        if (!batch) {                                                                   \
-            return;                                                                     \
-        }                                                                               \
+                batch_key_t key = get_batch_key(batch_state->idx_to_flush);             \
+                batch_data_t *batch = bpf_map_lookup_elem(&name##_batches, &key);       \
+                if (!batch) {                                                           \
+                    return;                                                             \
+                }                                                                       \
                                                                                         \
-        long ret = bpf_perf_event_output_with_telemetry(ctx,                            \
-                                                        &name##_batch_events, key.cpu,  \
-                                                        batch, sizeof(batch_data_t));   \
-        if (ret < 0) {                                                                  \
-            _LOG(name, "batch flush error: cpu: %d idx: %d err:%d",                     \
-                 key.cpu, batch->idx, ret);                                             \
-            return;                                                                     \
-        }                                                                               \
+                long ret = bpf_perf_event_output_with_telemetry(ctx,                    \
+                                                                &name##_batch_events,   \
+                                                                key.cpu,                \
+                                                                batch,                  \
+                                                                sizeof(batch_data_t));  \
+                if (ret < 0) {                                                          \
+                    _LOG(name, "batch flush error: cpu: %d idx: %d err:%d",             \
+                         key.cpu, batch->idx, ret);                                     \
+                    return;                                                             \
+                }                                                                       \
                                                                                         \
-        _LOG(name, "batch flushed: cpu: %d idx: %d", key.cpu, batch->idx);              \
-        batch->len = 0;                                                                 \
-        batch_state->idx_to_flush++;                                                    \
+                _LOG(name, "batch flushed: cpu: %d idx: %d", key.cpu, batch->idx);      \
+                batch->len = 0;                                                         \
+                batch_state->idx_to_flush++;                                            \
+            }                                                                           \
     }                                                                                   \
                                                                                         \
     static __always_inline void name##_batch_enqueue(value *event) {                    \

--- a/pkg/network/ebpf/c/protocols/events.h
+++ b/pkg/network/ebpf/c/protocols/events.h
@@ -52,6 +52,7 @@
                 }                                                                       \
                                                                                         \
                 _LOG(name, "batch flushed: cpu: %d idx: %d", key.cpu, batch->idx);      \
+                batch->dropped_events = 0;                                              \
                 batch->len = 0;                                                         \
                 batch_state->idx_to_flush++;                                            \
             }                                                                           \
@@ -74,6 +75,7 @@
         executing often enough and/or that BATCH_PAGES_PER_CPU is not large
         enough */                                                                       \
         if (name##_batch_full(batch)) {                                                 \
+            batch->dropped_events++;                                                    \
             _LOG(name, "enqueue error: dropping event because batch is full.",          \
                  bpf_get_smp_processor_id(), batch->idx);                               \
             return;                                                                     \

--- a/pkg/network/protocols/events/iterator.go
+++ b/pkg/network/protocols/events/iterator.go
@@ -49,7 +49,7 @@ func newIterator(b *batch, i, j int) *iterator {
 func (it *iterator) Next() []byte {
 	it.i++
 
-	chunkSize := int(it.b.Size)
+	chunkSize := int(it.b.Event_size)
 	if it.i >= it.j || it.i > int(it.b.Cap) || (it.i+1)*chunkSize > len(it.b.Data) {
 		return nil
 	}

--- a/pkg/network/protocols/events/types_linux.go
+++ b/pkg/network/protocols/events/types_linux.go
@@ -4,12 +4,12 @@
 package events
 
 type batch struct {
-	Idx       uint64
-	Len       uint16
-	Cap       uint16
-	Size      uint16
-	Data      [4096]int8
-	Pad_cgo_0 [2]byte
+	Idx            uint64
+	Len            uint16
+	Cap            uint16
+	Event_size     uint16
+	Dropped_events uint16
+	Data           [4096]int8
 }
 type batchKey struct {
 	Cpu uint32


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Ensure that all completed batches for a given CPU (there can be up to `BATCH_PAGES_PER_CPU` at a given moment) are flushed without requiring multiple calls to `<protocol>_flush_batch`.

In addition to that we're adding telemetry to track events that are dropped when there are no available batch slots.

### Motivation

Reduce the chance of dropping events when the probe calling `<protocol>_flush_batch` doesn't execute often enough

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
