### PR TITLE
[CSPM] Fix building the process table on linux in container mode

### DIFF
--- a/pkg/compliance/checks/builder_test.go
+++ b/pkg/compliance/checks/builder_test.go
@@ -60,7 +60,7 @@ func TestResolveValueFrom(t *testing.T) {
 			setup: func(t *testing.T) {
 				processutils.FetchProcessesWithName = func(searchedName string) (processutils.Processes, error) {
 					return processutils.Processes{
-						processutils.NewProcessMetadata(42, 0, searchedName, []string{"--path=/home/root/hiya-buddy.txt"}, nil, ""),
+						processutils.NewProcessMetadata(42, 0, searchedName, []string{"--path=/home/root/hiya-buddy.txt"}, nil),
 					}, nil
 				}
 			},
@@ -82,7 +82,7 @@ func TestResolveValueFrom(t *testing.T) {
 			setup: func(t *testing.T) {
 				processutils.FetchProcessesWithName = func(searchedName string) (processutils.Processes, error) {
 					return processutils.Processes{
-						processutils.NewProcessMetadata(42, 0, searchedName, nil, nil, ""),
+						processutils.NewProcessMetadata(42, 0, searchedName, nil, nil),
 					}, nil
 				}
 			},

--- a/pkg/compliance/rego/rego_check_input_test.go
+++ b/pkg/compliance/rego/rego_check_input_test.go
@@ -124,7 +124,7 @@ func TestRegoInputCheck(t *testing.T) {
 				},
 			},
 			processes: processutils.Processes{
-				processutils.NewProcessMetadata(42, time.Now().UnixMilli(), "proc1", []string{"arg1", "--path=foo"}, []string{"FOO=foo", "BAR=bar"}, ""),
+				processutils.NewProcessMetadata(42, time.Now().UnixMilli(), "proc1", []string{"arg1", "--path=foo"}, []string{"FOO=foo", "BAR=bar"}),
 			},
 			expectedInput: `
 				{

--- a/pkg/compliance/rego/rego_check_test.go
+++ b/pkg/compliance/rego/rego_check_test.go
@@ -138,7 +138,7 @@ func TestRegoCheck(t *testing.T) {
 				},
 			},
 			processes: processutils.Processes{
-				processutils.NewProcessMetadata(42, time.Now().UnixMilli(), "proc1", []string{"arg1", "--path=foo"}, nil, ""),
+				processutils.NewProcessMetadata(42, time.Now().UnixMilli(), "proc1", []string{"arg1", "--path=foo"}, nil),
 			},
 		},
 		{
@@ -182,7 +182,7 @@ func TestRegoCheck(t *testing.T) {
 			`,
 			findings: "data.test.findings",
 			processes: processutils.Processes{
-				processutils.NewProcessMetadata(42, time.Now().UnixMilli(), "proc1", []string{"arg1", "--path=foo"}, nil, ""),
+				processutils.NewProcessMetadata(42, time.Now().UnixMilli(), "proc1", []string{"arg1", "--path=foo"}, nil),
 			},
 			expectReports: compliance.Reports{
 				{
@@ -236,7 +236,7 @@ func TestRegoCheck(t *testing.T) {
 			`,
 			findings: "data.test.findings",
 			processes: processutils.Processes{
-				processutils.NewProcessMetadata(42, time.Now().UnixMilli(), "proc1", []string{"arg1", "--path=foo"}, nil, ""),
+				processutils.NewProcessMetadata(42, time.Now().UnixMilli(), "proc1", []string{"arg1", "--path=foo"}, nil),
 			},
 			expectReports: compliance.Reports{
 				{
@@ -281,7 +281,7 @@ func TestRegoCheck(t *testing.T) {
 			`,
 			findings: "data.test.findings",
 			processes: processutils.Processes{
-				processutils.NewProcessMetadata(42, time.Now().UnixMilli(), "proc1", []string{"arg1", "--path=foo"}, nil, ""),
+				processutils.NewProcessMetadata(42, time.Now().UnixMilli(), "proc1", []string{"arg1", "--path=foo"}, nil),
 			},
 			expectReports: compliance.Reports{
 				{
@@ -324,7 +324,7 @@ func TestRegoCheck(t *testing.T) {
 			`,
 			findings: "data.test.findings",
 			processes: processutils.Processes{
-				processutils.NewProcessMetadata(42, time.Now().UnixMilli(), "proc1", []string{"arg1", "--path=foo"}, nil, ""),
+				processutils.NewProcessMetadata(42, time.Now().UnixMilli(), "proc1", []string{"arg1", "--path=foo"}, nil),
 			},
 			expectReports: nil,
 		},

--- a/pkg/compliance/resource.go
+++ b/pkg/compliance/resource.go
@@ -119,7 +119,6 @@ type File struct {
 // Fields & functions available for Process
 const (
 	ProcessFieldName    = "process.name"
-	ProcessFieldExe     = "process.exe"
 	ProcessFieldCmdLine = "process.cmdLine"
 	ProcessFieldFlags   = "process.flags"
 

--- a/pkg/compliance/resources/file/file_check_test.go
+++ b/pkg/compliance/resources/file/file_check_test.go
@@ -341,7 +341,7 @@ func TestFileCheck(t *testing.T) {
 				Transform: `h.file_process_flag("--config-file")`,
 			},
 			processes: processutils.Processes{
-				processutils.NewProcessMetadata(42, 0, "dockerd", []string{"dockerd", "--config-file=/etc/docker/daemon.json"}, nil, ""),
+				processutils.NewProcessMetadata(42, 0, "dockerd", []string{"dockerd", "--config-file=/etc/docker/daemon.json"}, nil),
 			},
 			module: fmt.Sprintf(objectModule, `file.content["experimental"] == false`),
 			setup: func(t *testing.T, env *mocks.Env, file *compliance.File) {
@@ -426,7 +426,7 @@ func TestFileCheck(t *testing.T) {
 			},
 			expectError: errors.New(`failed to resolve path`),
 			processes: processutils.Processes{
-				processutils.NewProcessMetadata(42, 0, "dockerd", []string{"dockerd", "--config-file=/etc/docker/daemon.json"}, nil, ""),
+				processutils.NewProcessMetadata(42, 0, "dockerd", []string{"dockerd", "--config-file=/etc/docker/daemon.json"}, nil),
 			},
 		},
 		{

--- a/pkg/compliance/resources/process/process_check.go
+++ b/pkg/compliance/resources/process/process_check.go
@@ -27,7 +27,6 @@ const (
 
 var reportedFields = []string{
 	compliance.ProcessFieldName,
-	compliance.ProcessFieldExe,
 	compliance.ProcessFieldCmdLine,
 }
 
@@ -44,7 +43,6 @@ func resolve(_ context.Context, e env.Env, id string, res compliance.ResourceCom
 	var instances []resources.ResolvedInstance
 	for _, mp := range matchedProcesses {
 		name := mp.Name
-		exe := mp.Exe
 		cmdLine := mp.Cmdline
 		flagValues := mp.CmdlineFlags()
 		envs := mp.EnvsMap(res.Process.Envs)
@@ -52,7 +50,6 @@ func resolve(_ context.Context, e env.Env, id string, res compliance.ResourceCom
 		instance := eval.NewInstance(
 			eval.VarMap{
 				compliance.ProcessFieldName:    name,
-				compliance.ProcessFieldExe:     exe,
 				compliance.ProcessFieldCmdLine: cmdLine,
 				compliance.ProcessFieldFlags:   flagValues,
 			},
@@ -62,7 +59,7 @@ func resolve(_ context.Context, e env.Env, id string, res compliance.ResourceCom
 			},
 			eval.RegoInputMap{
 				"name":    name,
-				"exe":     exe,
+				"exe":     "", // NOTE(pierre): this field will be removed in next release. Only kept for compat reasons.
 				"cmdLine": cmdLine,
 				"flags":   flagValues,
 				"pid":     mp.Pid,

--- a/pkg/compliance/resources/process/process_check_test.go
+++ b/pkg/compliance/resources/process/process_check_test.go
@@ -128,7 +128,7 @@ func TestProcessCheck(t *testing.T) {
 			},
 			module: fmt.Sprintf(processModule, `process.flags["--path"] == "foo"`),
 			processes: processutils.Processes{
-				processutils.NewProcessMetadata(42, time.Now().UnixMilli(), "proc1", []string{"arg1", "--path=foo"}, []string{}, ""),
+				processutils.NewProcessMetadata(42, time.Now().UnixMilli(), "proc1", []string{"arg1", "--path=foo"}, []string{}),
 			},
 			expectReport: &compliance.Report{
 				Passed: true,
@@ -158,8 +158,8 @@ func TestProcessCheck(t *testing.T) {
 			},
 			module: fmt.Sprintf(processModule, `process.flags["--path"] == "foo"`),
 			processes: processutils.Processes{
-				processutils.NewProcessMetadata(42, time.Now().UnixMilli(), "proc2", []string{"arg1", "--path=foo"}, []string{}, ""),
-				processutils.NewProcessMetadata(43, time.Now().UnixMilli(), "proc3", []string{"arg1", "--path=foo"}, []string{}, ""),
+				processutils.NewProcessMetadata(42, time.Now().UnixMilli(), "proc2", []string{"arg1", "--path=foo"}, []string{}),
+				processutils.NewProcessMetadata(43, time.Now().UnixMilli(), "proc3", []string{"arg1", "--path=foo"}, []string{}),
 			},
 			expectReport: &compliance.Report{
 				Passed:    false,
@@ -183,7 +183,7 @@ func TestProcessCheck(t *testing.T) {
 			},
 			module: fmt.Sprintf(processModule, `process.flags["--path"] == "foo"`),
 			processes: processutils.Processes{
-				processutils.NewProcessMetadata(42, time.Now().UnixMilli(), "proc1", []string{"arg1", "--paths=foo"}, []string{}, ""),
+				processutils.NewProcessMetadata(42, time.Now().UnixMilli(), "proc1", []string{"arg1", "--paths=foo"}, []string{}),
 			},
 			expectReport: &compliance.Report{
 				Passed: false,
@@ -223,7 +223,7 @@ func TestProcessCheckCache(t *testing.T) {
 		},
 		module: fmt.Sprintf(processModule, `process.flags["--path"] == "foo"`),
 		processes: processutils.Processes{
-			processutils.NewProcessMetadata(42, time.Now().UnixMilli(), "proc1", []string{"arg1", "--path=foo"}, []string{}, ""),
+			processutils.NewProcessMetadata(42, time.Now().UnixMilli(), "proc1", []string{"arg1", "--path=foo"}, []string{}),
 		},
 		expectReport: &compliance.Report{
 			Passed: true,

--- a/pkg/compliance/utils/process/process_utils.go
+++ b/pkg/compliance/utils/process/process_utils.go
@@ -48,7 +48,6 @@ type ProcessMetadata struct {
 	Name       string
 	Cmdline    []string
 	Envs       []string
-	Exe        string
 
 	cacheTime time.Time
 }
@@ -80,14 +79,13 @@ func (p *ProcessMetadata) EnvsMap(filteredEnvs []string) map[string]string {
 }
 
 // NewProcessMetadata returns a new ProcessMetadata struct.
-func NewProcessMetadata(pid int32, createTime int64, name string, cmdline []string, envs []string, exe string) *ProcessMetadata {
+func NewProcessMetadata(pid int32, createTime int64, name string, cmdline []string, envs []string) *ProcessMetadata {
 	return &ProcessMetadata{
 		Pid:        pid,
 		CreateTime: createTime,
 		Name:       name,
 		Cmdline:    cmdline,
 		Envs:       envs,
-		Exe:        exe,
 
 		cacheTime: time.Now(),
 	}
@@ -102,13 +100,10 @@ func defaultFetchProcessesWithName(searchedName string) (Processes, error) {
 	for _, pid := range pids {
 		p, err := process.NewProcess(pid)
 		if err != nil {
-			return nil, err
+			continue
 		}
 		name, err := p.Name()
-		if err != nil {
-			return nil, err
-		}
-		if name != searchedName {
+		if err != nil || name != searchedName {
 			continue
 		}
 		createTime, err := p.CreateTime()
@@ -123,11 +118,7 @@ func defaultFetchProcessesWithName(searchedName string) (Processes, error) {
 		if err != nil {
 			return nil, err
 		}
-		exe, err := p.Exe()
-		if err != nil {
-			return nil, err
-		}
-		table = append(table, NewProcessMetadata(pid, createTime, name, cmdline, envs, exe))
+		table = append(table, NewProcessMetadata(pid, createTime, name, cmdline, envs))
 	}
 	return table, nil
 }


### PR DESCRIPTION
### What does this PR do?

- removes the `Exe` metadata from process informations as it may not be accessible in unpriviledged container mode
- removes the `process.exe` builtin function

### Motivation

Since #15224, the process table snapshotting was failing when reading the `/proc/<pid>/exe` link in container mode.
Let's just get rid of this metadata, since this info is not used in any benchmark and is not consistent between container / non-container execution mode of the security-agent.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
