### PR TITLE
Backport host alias fix for Fargate

### DIFF
--- a/pkg/aggregator/aggregator_test.go
+++ b/pkg/aggregator/aggregator_test.go
@@ -36,7 +36,6 @@ var checkID1 check.ID = "1"
 var checkID2 check.ID = "2"
 
 const defaultHostname = "hostname"
-const altDefaultHostname = "althostname"
 
 func init() {
 	initF()

--- a/pkg/aggregator/context_resolver_test.go
+++ b/pkg/aggregator/context_resolver_test.go
@@ -265,15 +265,15 @@ func (s *mockSink) Append(ms *metrics.Serie) {
 }
 
 type mockSample struct {
-	name string
+	name       string
 	taggerTags []string
 	metricTags []string
 }
 
-func (s *mockSample) GetName() string { return s.name }
-func (s *mockSample) GetHost() string { return "noop" }
+func (s *mockSample) GetName() string                   { return s.name }
+func (s *mockSample) GetHost() string                   { return "noop" }
 func (s *mockSample) GetMetricType() metrics.MetricType { return metrics.GaugeType }
-func (s *mockSample) IsNoIndex() bool { return false }
+func (s *mockSample) IsNoIndex() bool                   { return false }
 func (s *mockSample) GetTags(tb, mb tagset.TagsAccumulator) {
 	tb.Append(s.taggerTags...)
 	mb.Append(s.metricTags...)
@@ -291,22 +291,22 @@ func TestOriginTelemetry(t *testing.T) {
 	r.sendOriginTelemetry(ts, &sink, "test", []string{"test"})
 
 	assert.ElementsMatch(t, sink, []*metrics.Serie{{
-		Name: "datadog.agent.aggregator.dogstatsd_contexts_by_origin",
-		Host: "test",
-		Tags: tagset.NewCompositeTags([]string{"test"}, []string{"foo"}),
-		MType: metrics.APIGaugeType,
-		Points: []metrics.Point{{Ts: ts, Value: 2.0 }},
+		Name:   "datadog.agent.aggregator.dogstatsd_contexts_by_origin",
+		Host:   "test",
+		Tags:   tagset.NewCompositeTags([]string{"test"}, []string{"foo"}),
+		MType:  metrics.APIGaugeType,
+		Points: []metrics.Point{{Ts: ts, Value: 2.0}},
 	}, {
-		Name: "datadog.agent.aggregator.dogstatsd_contexts_by_origin",
-		Host: "test",
-		Tags: tagset.NewCompositeTags([]string{"test"}, []string{"bar"}),
-		MType: metrics.APIGaugeType,
-		Points: []metrics.Point{{Ts: ts, Value: 2.0 }},
+		Name:   "datadog.agent.aggregator.dogstatsd_contexts_by_origin",
+		Host:   "test",
+		Tags:   tagset.NewCompositeTags([]string{"test"}, []string{"bar"}),
+		MType:  metrics.APIGaugeType,
+		Points: []metrics.Point{{Ts: ts, Value: 2.0}},
 	}, {
-		Name: "datadog.agent.aggregator.dogstatsd_contexts_by_origin",
-		Host: "test",
-		Tags: tagset.NewCompositeTags([]string{"test"}, []string{"baz"}),
-		MType: metrics.APIGaugeType,
-		Points: []metrics.Point{{Ts: ts, Value: 1.0 }},
+		Name:   "datadog.agent.aggregator.dogstatsd_contexts_by_origin",
+		Host:   "test",
+		Tags:   tagset.NewCompositeTags([]string{"test"}, []string{"baz"}),
+		MType:  metrics.APIGaugeType,
+		Points: []metrics.Point{{Ts: ts, Value: 1.0}},
 	}})
 }

--- a/pkg/collector/collector_demux_test.go
+++ b/pkg/collector/collector_demux_test.go
@@ -148,7 +148,7 @@ func (suite *CollectorDemuxTestSuite) TestRescheduledCheckReusesSampler() {
 	}, time.Second, 10*time.Millisecond)
 
 	//create new sender and try registering sampler before flush
-	sender, err = aggregator.GetSender(ch.ID())
+	_, err = aggregator.GetSender(ch.ID())
 	assert.NoError(suite.T(), err)
 
 	// flush

--- a/pkg/quantile/test_helper.go
+++ b/pkg/quantile/test_helper.go
@@ -35,7 +35,7 @@ func SketchesApproxEqual(exp, act *Sketch, e float64) bool {
 		return false
 	}
 
-	if exp.Basic.Cnt != exp.Basic.Cnt {
+	if exp.Basic.Cnt != act.Basic.Cnt {
 		return false
 	}
 
@@ -58,8 +58,4 @@ func SketchesApproxEqual(exp, act *Sketch, e float64) bool {
 	}
 
 	return true
-}
-
-type tHelper interface {
-	Helper()
 }

--- a/pkg/serializer/serializer_test.go
+++ b/pkg/serializer/serializer_test.go
@@ -238,13 +238,6 @@ func TestSendV1Events(t *testing.T) {
 	f.AssertExpectations(t)
 }
 
-type testPayloadMutipleValues struct {
-	testPayload
-	count int
-}
-
-func (p *testPayloadMutipleValues) Len() int { return p.count }
-
 func TestSendV1EventsCreateMarshalersBySourceType(t *testing.T) {
 	config.Datadog.Set("enable_events_stream_payload_serialization", true)
 	defer config.Datadog.Set("enable_events_stream_payload_serialization", nil)

--- a/pkg/util/dmi/dmi_mock.go
+++ b/pkg/util/dmi/dmi_mock.go
@@ -3,8 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build !windows
-// +build !windows
+//go:build !windows && !serverless
+// +build !windows,!serverless
 
 package dmi
 

--- a/pkg/util/dmi/dmi_nix.go
+++ b/pkg/util/dmi/dmi_nix.go
@@ -3,8 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build !windows
-// +build !windows
+//go:build !windows && !serverless
+// +build !windows,!serverless
 
 package dmi
 

--- a/pkg/util/dmi/dmi_nix_test.go
+++ b/pkg/util/dmi/dmi_nix_test.go
@@ -3,8 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build !windows
-// +build !windows
+//go:build !windows && !serverless
+// +build !windows,!serverless
 
 package dmi
 

--- a/pkg/util/dmi/no_dmi.go
+++ b/pkg/util/dmi/no_dmi.go
@@ -3,8 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build windows
-// +build windows
+//go:build windows || serverless
+// +build windows serverless
 
 package dmi
 

--- a/pkg/util/dmi/no_dmi_mock.go
+++ b/pkg/util/dmi/no_dmi_mock.go
@@ -3,8 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build windows
-// +build windows
+//go:build windows || serverless
+// +build windows serverless
 
 package dmi
 

--- a/pkg/util/ec2/dmi.go
+++ b/pkg/util/ec2/dmi.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/dmi"
+	"github.com/DataDog/datadog-agent/pkg/util/fargate"
 	"github.com/google/uuid"
 )
 
@@ -26,6 +27,11 @@ func isBoardVendorEC2() bool {
 // On AWS Nitro instances dmi information contains the instanceID for the host. We check that the board vendor is
 // EC2 and that the board_asset_tag match an instanceID format before using it
 func getInstanceIDFromDMI() (string, error) {
+	// we don't want to collect anything on Fargate
+	if fargate.IsFargateInstance() {
+		return "", fmt.Errorf("host alias detection through DMI is disabled on Fargate")
+	}
+
 	if !config.Datadog.GetBool("ec2_use_dmi") {
 		return "", fmt.Errorf("'ec2_use_dmi' is disabled")
 	}

--- a/pkg/util/ec2/dmi_test.go
+++ b/pkg/util/ec2/dmi_test.go
@@ -42,6 +42,24 @@ func TestGetInstanceIDFromDMI(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestGetInstanceIDFromDMIFargate(t *testing.T) {
+	setupDMIForEC2(t)
+	defer config.ClearFeatures()
+
+	// We test for both ECS and EKS
+
+	config.SetFeature(config.ECSFargate)
+
+	_, err := getInstanceIDFromDMI()
+	assert.Error(t, err)
+
+	config.ClearFeatures()
+	config.SetFeature(config.EKSFargate)
+
+	_, err = getInstanceIDFromDMI()
+	assert.Error(t, err)
+}
+
 func TestIsEC2UUID(t *testing.T) {
 	// no UUID
 	dmi.SetupMock(t, "", "", "", "")

--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -168,7 +168,7 @@ build_tags = {
         "trace-agent": TRACE_AGENT_TAGS,
         # Test setups
         "test": AGENT_TEST_TAGS,
-        "lint": AGENT_TEST_TAGS.union(PROCESS_AGENT_TAGS),
+        "lint": AGENT_TEST_TAGS.union(PROCESS_AGENT_TAGS).union(UNIT_TEST_TAGS),
         "unit-tests": AGENT_TEST_TAGS.union(PROCESS_AGENT_TAGS).union(UNIT_TEST_TAGS),
     },
     AgentFlavor.heroku: {

--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -133,8 +133,12 @@ TRACE_AGENT_HEROKU_TAGS = TRACE_AGENT_TAGS.difference(
     }
 )
 
+# Unit test build tags
+UNIT_TEST_TAGS = {"test"}
+
+
 # AGENT_TEST_TAGS lists the tags that have to be added to run tests
-AGENT_TEST_TAGS = AGENT_TAGS.union({"clusterchecks"})
+AGENT_TEST_TAGS = AGENT_TAGS.union({"clusterchecks"}).union(UNIT_TEST_TAGS)
 
 
 ### Tag exclusion lists
@@ -151,9 +155,6 @@ DARWIN_EXCLUDED_TAGS = {"docker", "containerd", "cri"}
 # List of tags to always remove when building on Windows 32-bits
 WINDOWS_32BIT_EXCLUDE_TAGS = {"docker", "kubeapiserver", "kubelet", "orchestrator"}
 
-# Unit test build tags
-UNIT_TEST_TAGS = {"test"}
-
 # Build type: maps flavor to build tags map
 build_tags = {
     AgentFlavor.base: {
@@ -168,25 +169,25 @@ build_tags = {
         "trace-agent": TRACE_AGENT_TAGS,
         # Test setups
         "test": AGENT_TEST_TAGS,
-        "lint": AGENT_TEST_TAGS.union(PROCESS_AGENT_TAGS).union(UNIT_TEST_TAGS),
-        "unit-tests": AGENT_TEST_TAGS.union(PROCESS_AGENT_TAGS).union(UNIT_TEST_TAGS),
+        "lint": AGENT_TEST_TAGS.union(PROCESS_AGENT_TAGS),
+        "unit-tests": AGENT_TEST_TAGS.union(PROCESS_AGENT_TAGS),
     },
     AgentFlavor.heroku: {
         "agent": AGENT_HEROKU_TAGS,
         "process-agent": PROCESS_AGENT_HEROKU_TAGS,
         "trace-agent": TRACE_AGENT_HEROKU_TAGS,
-        "lint": AGENT_HEROKU_TAGS,
+        "lint": AGENT_HEROKU_TAGS.union(UNIT_TEST_TAGS),
         "unit-tests": AGENT_HEROKU_TAGS.union(UNIT_TEST_TAGS),
     },
     AgentFlavor.iot: {
         "agent": IOT_AGENT_TAGS,
-        "lint": IOT_AGENT_TAGS,
+        "lint": IOT_AGENT_TAGS.union(UNIT_TEST_TAGS),
         "unit-tests": IOT_AGENT_TAGS.union(UNIT_TEST_TAGS),
     },
     AgentFlavor.dogstatsd: {
         "dogstatsd": DOGSTATSD_TAGS,
         "system-tests": AGENT_TAGS,
-        "lint": DOGSTATSD_TAGS,
+        "lint": DOGSTATSD_TAGS.union(UNIT_TEST_TAGS),
         "unit-tests": DOGSTATSD_TAGS.union(UNIT_TEST_TAGS),
     },
 }


### PR DESCRIPTION
### What does this PR do?

This backport:
- #15415
- #15422

### Describe how to test/QA your changes

Run the Agnet on Fargate and check that no host alias is shown in the status page.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
