### PR TITLE
Ignore `prune` events in Docker events

### DIFF
--- a/pkg/util/docker/event_pull.go
+++ b/pkg/util/docker/event_pull.go
@@ -46,7 +46,8 @@ func (d *DockerUtil) openEventChannel(ctx context.Context, since, until time.Tim
 // It can return nil, nil if the event is filtered out, one should check for nil pointers before using the event.
 func (d *DockerUtil) processContainerEvent(ctx context.Context, msg events.Message, filter *containers.Filter) (*ContainerEvent, error) {
 	// Type filtering
-	if msg.Type != "container" {
+	// Filtering out prune events as well as they don't have a container name
+	if msg.Type != "container" || msg.Action == "prune" {
 		return nil, nil
 	}
 

--- a/pkg/util/docker/event_pull_test.go
+++ b/pkg/util/docker/event_pull_test.go
@@ -56,6 +56,15 @@ func TestProcessContainerEvent(t *testing.T) {
 			err:   nil,
 		},
 		{
+			// Ignore prune events
+			source: events.Message{
+				Type:   "container",
+				Action: "prune",
+			},
+			event: nil,
+			err:   nil,
+		},
+		{
 			// Error if container name not found
 			source: events.Message{
 				Type: "container",


### PR DESCRIPTION
### What does this PR do?

Filter out `prune` Docker events as being reported with `type == container` but without `container name`, leading to spamming logs. The `prune` events are not useful to us in any case.

### Motivation

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Deploy the Agent on Docker. Deploy a bunch of other random containers. Run `docker system prune`, it should not generate any `WARN` log in the Agent.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
