### PR TITLE
Disable host alias detection on Fargate

### DIFF
--- a/pkg/util/ec2/dmi.go
+++ b/pkg/util/ec2/dmi.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/dmi"
+	"github.com/DataDog/datadog-agent/pkg/util/fargate"
 	"github.com/google/uuid"
 )
 
@@ -26,6 +27,11 @@ func isBoardVendorEC2() bool {
 // On AWS Nitro instances dmi information contains the instanceID for the host. We check that the board vendor is
 // EC2 and that the board_asset_tag match an instanceID format before using it
 func getInstanceIDFromDMI() (string, error) {
+	// we don't want to collect anything on Fargate
+	if fargate.IsFargateInstance() {
+		return "", fmt.Errorf("host alias detection through DMI is disabled on Fargate")
+	}
+
 	if !config.Datadog.GetBool("ec2_use_dmi") {
 		return "", fmt.Errorf("'ec2_use_dmi' is disabled")
 	}


### PR DESCRIPTION
### What does this PR do?

This disables host aliasing throught DMI on Fargate.

### Additional Notes

The tests for this will come in a future PR after the `test` build tag has been enabled everywhere.

### Describe how to test/QA your changes

Run the agent on Fargate and check that no host alias is show in the status page.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
