### PR TITLE
[backport] [container_image_metadata] Fix handling of repo digests (#15347)

### DIFF
--- a/pkg/collector/corechecks/containerimage/processor.go
+++ b/pkg/collector/corechecks/containerimage/processor.go
@@ -78,8 +78,20 @@ func (p *processor) processImage(img *workloadmeta.ContainerImageMetadata) {
 		})
 	}
 
+	// In containerd some images are created without a repo digest, and it's
+	// also possible to remove repo digests manually.
+	// This means that the set of repos that we need to handle is the union of
+	// the repos present in the repo digests and the ones present in the repo
+	// tags.
+	repos := make(map[string]struct{})
 	for _, repoDigest := range img.RepoDigests {
-		repo := strings.SplitN(repoDigest, "@sha256:", 2)[0]
+		repos[strings.SplitN(repoDigest, "@sha256:", 2)[0]] = struct{}{}
+	}
+	for _, repoTag := range img.RepoTags {
+		repos[strings.SplitN(repoTag, ":", 2)[0]] = struct{}{}
+	}
+
+	for repo := range repos {
 		repoSplitted := strings.Split(repo, "/")
 		registry := ""
 		if len(repoSplitted) > 2 {

--- a/pkg/collector/corechecks/containerimage/processor_test.go
+++ b/pkg/collector/corechecks/containerimage/processor_test.go
@@ -246,3 +246,170 @@ func TestProcessEvents(t *testing.T) {
 
 	p.stop()
 }
+
+func TestProcessEvents_repoTagWithNoMatchingRepoDigest(t *testing.T) {
+	// In containerd some images are created without a repo digest, and it's
+	// also possible to remove repo digests manually. To test that scenario, in
+	// this test, we define an image with 2 repo tags: one for the gcr.io
+	// registry and another for the public.ecr.aws registry, but there's only
+	// one repo digest.
+	// We expect to send 2 events, one for each registry.
+
+	sender := mocksender.NewMockSender("")
+	sender.On("ContainerImage", mock.Anything, mock.Anything).Return()
+	p := newProcessor(sender, 2, 50*time.Millisecond)
+
+	p.processEvents(workloadmeta.EventBundle{
+		Events: []workloadmeta.Event{
+			{
+				Type: workloadmeta.EventTypeSet,
+				Entity: &workloadmeta.ContainerImageMetadata{
+					EntityID: workloadmeta.EntityID{
+						Kind: workloadmeta.KindContainerImageMetadata,
+						ID:   "sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
+					},
+					RepoTags: []string{
+						"gcr.io/datadoghq/agent:7-rc",
+						"public.ecr.aws/datadog/agent:7-rc",
+					},
+					RepoDigests: []string{
+						// Notice that there's a repo tag for gcr.io, but no repo digest.
+						"public.ecr.aws/datadog/agent@sha256:052f1fdf4f9a7117d36a1838ab60782829947683007c34b69d4991576375c409",
+					},
+					SizeBytes:    42,
+					OS:           "DOS",
+					OSVersion:    "6.22",
+					Architecture: "80486DX",
+					Layers: []workloadmeta.ContainerImageLayer{
+						{
+							MediaType: "media",
+							Digest:    "digest_layer_1",
+							SizeBytes: 43,
+							URLs:      []string{"url"},
+							History: v1.History{
+								Created: pointer.Ptr(time.Unix(42, 43)),
+							},
+						},
+						{
+							MediaType: "media",
+							Digest:    "digest_layer_2",
+							URLs:      []string{"url"},
+							SizeBytes: 44,
+							History: v1.History{
+								Created: pointer.Ptr(time.Unix(43, 44)),
+							},
+						},
+					},
+				},
+			},
+		},
+		Ch: make(chan struct{}),
+	})
+
+	time.Sleep(100 * time.Millisecond)
+
+	sender.AssertNumberOfCalls(t, "ContainerImage", 1)
+	sender.AssertContainerImage(t, []model.ContainerImagePayload{
+		{
+			Version: "v1",
+			Images: []*model.ContainerImage{
+				{
+					Id:        "public.ecr.aws/datadog/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
+					Name:      "public.ecr.aws/datadog/agent",
+					Registry:  "public.ecr.aws",
+					ShortName: "agent",
+					Tags: []string{
+						"7-rc",
+					},
+					Digest:      "sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
+					Size:        42,
+					RepoDigests: []string{"public.ecr.aws/datadog/agent@sha256:052f1fdf4f9a7117d36a1838ab60782829947683007c34b69d4991576375c409"},
+					Os: &model.ContainerImage_OperatingSystem{
+						Name:         "DOS",
+						Version:      "6.22",
+						Architecture: "80486DX",
+					},
+					Layers: []*model.ContainerImage_ContainerImageLayer{
+						{
+							Urls:      []string{"url"},
+							MediaType: "media",
+							Digest:    "digest_layer_1",
+							Size:      43,
+							History: &model.ContainerImage_ContainerImageLayer_History{
+								Created: &timestamp.Timestamp{
+									Seconds: 42,
+									Nanos:   43,
+								},
+							},
+						},
+						{
+							Urls:      []string{"url"},
+							MediaType: "media",
+							Digest:    "digest_layer_2",
+							Size:      44,
+							History: &model.ContainerImage_ContainerImageLayer_History{
+								Created: &timestamp.Timestamp{
+									Seconds: 43,
+									Nanos:   44,
+								},
+							},
+						},
+					},
+					BuiltAt: &timestamp.Timestamp{
+						Seconds: 43,
+						Nanos:   44,
+					},
+				},
+				{
+					Id:        "gcr.io/datadoghq/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
+					Name:      "gcr.io/datadoghq/agent",
+					Registry:  "gcr.io",
+					ShortName: "agent",
+					Tags: []string{
+						"7-rc",
+					},
+					Digest:      "sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
+					Size:        42,
+					RepoDigests: []string{},
+					Os: &model.ContainerImage_OperatingSystem{
+						Name:         "DOS",
+						Version:      "6.22",
+						Architecture: "80486DX",
+					},
+					Layers: []*model.ContainerImage_ContainerImageLayer{
+						{
+							Urls:      []string{"url"},
+							MediaType: "media",
+							Digest:    "digest_layer_1",
+							Size:      43,
+							History: &model.ContainerImage_ContainerImageLayer_History{
+								Created: &timestamp.Timestamp{
+									Seconds: 42,
+									Nanos:   43,
+								},
+							},
+						},
+						{
+							Urls:      []string{"url"},
+							MediaType: "media",
+							Digest:    "digest_layer_2",
+							Size:      44,
+							History: &model.ContainerImage_ContainerImageLayer_History{
+								Created: &timestamp.Timestamp{
+									Seconds: 43,
+									Nanos:   44,
+								},
+							},
+						},
+					},
+					BuiltAt: &timestamp.Timestamp{
+						Seconds: 43,
+						Nanos:   44,
+					},
+				},
+			},
+		},
+	})
+
+	p.stop()
+}

--- a/pkg/collector/corechecks/sbom/processor_test.go
+++ b/pkg/collector/corechecks/sbom/processor_test.go
@@ -183,3 +183,128 @@ func TestProcessEvents(t *testing.T) {
 
 	p.stop()
 }
+
+func TestProcessEvents_repoTagWithNoMatchingRepoDigest(t *testing.T) {
+	// In containerd some images are created without a repo digest, and it's
+	// also possible to remove repo digests manually. To test that scenario, in
+	// this test, we define an image with 2 repo tags: one for the gcr.io
+	// registry and another for the public.ecr.aws registry, but there's only
+	// one repo digest.
+	// We expect to send 2 events, one for each registry.
+
+	sender := mocksender.NewMockSender("")
+	sender.On("SBOM", mock.Anything, mock.Anything).Return()
+	p := newProcessor(sender, 2, 50*time.Millisecond)
+
+	sbomGenerationTime := time.Now()
+
+	p.processEvents(workloadmeta.EventBundle{
+		Events: []workloadmeta.Event{
+			{
+				Type: workloadmeta.EventTypeSet,
+				Entity: &workloadmeta.ContainerImageMetadata{
+					EntityID: workloadmeta.EntityID{
+						Kind: workloadmeta.KindContainerImageMetadata,
+						ID:   "sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
+					},
+					RepoTags: []string{
+						"gcr.io/datadoghq/agent:7-rc",
+						"public.ecr.aws/datadog/agent:7-rc",
+					},
+					RepoDigests: []string{
+						// Notice that there's a repo tag for gcr.io, but no repo digest.
+						"public.ecr.aws/datadog/agent@sha256:052f1fdf4f9a7117d36a1838ab60782829947683007c34b69d4991576375c409",
+					},
+					SBOM: &workloadmeta.SBOM{
+						CycloneDXBOM: &cyclonedx.BOM{
+							SpecVersion: cyclonedx.SpecVersion1_4,
+							Version:     42,
+							Components: &[]cyclonedx.Component{
+								{
+									Name: "Foo",
+								},
+								{
+									Name: "Bar",
+								},
+								{
+									Name: "Baz",
+								},
+							},
+						},
+						GenerationTime:     sbomGenerationTime,
+						GenerationDuration: 10 * time.Second,
+					},
+				},
+			},
+		},
+		Ch: make(chan struct{}),
+	})
+
+	time.Sleep(100 * time.Millisecond)
+
+	sender.AssertNumberOfCalls(t, "SBOM", 1)
+	sender.AssertSBOM(t, []model.SBOMPayload{
+		{
+			Version: 1,
+			Source:  &sourceAgent,
+			Entities: []*model.SBOMEntity{
+				{
+					Type: model.SBOMSourceType_CONTAINER_IMAGE_LAYERS,
+					Id:   "public.ecr.aws/datadog/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
+					Tags: []string{
+						"7-rc",
+					},
+					InUse:              true,
+					GeneratedAt:        timestamppb.New(sbomGenerationTime),
+					GenerationDuration: durationpb.New(10 * time.Second),
+					Sbom: &model.SBOMEntity_Cyclonedx{
+						Cyclonedx: &cyclonedx_v1_4.Bom{
+							SpecVersion: "1.4",
+							Version:     pointer.Ptr(int32(42)),
+							Components: []*cyclonedx_v1_4.Component{
+								{
+									Name: "Foo",
+								},
+								{
+									Name: "Bar",
+								},
+								{
+									Name: "Baz",
+								},
+							},
+						},
+					},
+				},
+				{
+					Type: model.SBOMSourceType_CONTAINER_IMAGE_LAYERS,
+					Id:   "gcr.io/datadoghq/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
+					Tags: []string{
+						"7-rc",
+					},
+					InUse:              true,
+					GeneratedAt:        timestamppb.New(sbomGenerationTime),
+					GenerationDuration: durationpb.New(10 * time.Second),
+					Sbom: &model.SBOMEntity_Cyclonedx{
+						Cyclonedx: &cyclonedx_v1_4.Bom{
+							SpecVersion: "1.4",
+							Version:     pointer.Ptr(int32(42)),
+							Components: []*cyclonedx_v1_4.Component{
+								{
+									Name: "Foo",
+								},
+								{
+									Name: "Bar",
+								},
+								{
+									Name: "Baz",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	p.stop()
+}

--- a/pkg/workloadmeta/collectors/internal/containerd/image.go
+++ b/pkg/workloadmeta/collectors/internal/containerd/image.go
@@ -13,7 +13,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
-	"sync"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
@@ -30,29 +29,45 @@ import (
 
 const imageTopicPrefix = "/images/"
 
-// Events from containerd contain an image name, but not IDs. When a delete
-// event arrives it'll contain a name, but we won't be able to access the ID
-// because the image is already gone, that's why we need to keep the IDs =>
-// names relationships.
+// We cannot get all the information that we need from a single call to
+// containerd. This type stores the information that we need to know about the
+// images that we have already processed.
+//
+// Things to take into account:
+//
+// - Events from containerd only include an image name, and it does not always
+// correspond to an image ID. When a delete event arrives it'll contain a name,
+// but we won't be able to access the ID because the image is already gone,
+// that's why we need to keep the IDs => names relationships.
+//
+// - An image ID can be referenced by multiple names.
+//
+// - A name can have multiple formats:
+//   - image ID: starts with "sha256:"
+//   - repo digest. They contain "@sha256:". Example: gcr.io/datadoghq/agent@sha256:3a19076bfee70900a600b8e3ee2cc30d5101d1d3d2b33654f1a316e596eaa4e0
+//   - repo tag. Example: gcr.io/datadoghq/agent:7
 type knownImages struct {
-	// Needed because this is accessed by the goroutine handling events and also the one that extracts SBOMs
-	mut sync.Mutex
-
-	// Store IDs and names in both directions for efficient access
-	idsByName map[string]string              // map name => ID
-	namesByID map[string]map[string]struct{} // map ID => set of names
+	// Store IDs and names in both directions for efficient access.
+	idsByName       map[string]string              // map name => ID
+	namesByID       map[string]map[string]struct{} // map ID => set of names
+	repoTagsByID    map[string]map[string]struct{} // map ID => set of repo tags
+	repoDigestsByID map[string]map[string]struct{} // map ID => set of repo digests
 }
 
 func newKnownImages() *knownImages {
 	return &knownImages{
-		idsByName: make(map[string]string),
-		namesByID: make(map[string]map[string]struct{}),
+		idsByName:       make(map[string]string),
+		namesByID:       make(map[string]map[string]struct{}),
+		repoTagsByID:    make(map[string]map[string]struct{}),
+		repoDigestsByID: make(map[string]map[string]struct{}),
 	}
 }
 
-func (images *knownImages) addAssociation(imageName string, imageID string) {
-	images.mut.Lock()
-	defer images.mut.Unlock()
+func (images *knownImages) addReference(imageName string, imageID string) {
+	previousIDReferenced, found := images.idsByName[imageName]
+	if found && previousIDReferenced != imageID {
+		images.deleteReference(imageName, previousIDReferenced)
+	}
 
 	images.idsByName[imageName] = imageID
 
@@ -60,41 +75,100 @@ func (images *knownImages) addAssociation(imageName string, imageID string) {
 		images.namesByID[imageID] = make(map[string]struct{})
 	}
 	images.namesByID[imageID][imageName] = struct{}{}
-}
 
-func (images *knownImages) deleteAssociation(imageName string, imageID string) {
-	images.mut.Lock()
-	defer images.mut.Unlock()
-
-	delete(images.idsByName, imageName)
-
-	if images.namesByID[imageID] == nil {
+	if isAnImageID(imageName) {
 		return
 	}
 
-	delete(images.namesByID[imageID], imageName)
-	if len(images.namesByID[imageID]) == 0 {
-		delete(images.namesByID, imageID)
+	if isARepoDigest(imageName) {
+		if images.repoDigestsByID[imageID] == nil {
+			images.repoDigestsByID[imageID] = make(map[string]struct{})
+		}
+		images.repoDigestsByID[imageID][imageName] = struct{}{}
+		return
+	}
+
+	// The name is not an image ID or a repo digest, so it has to be a repo tag
+	if images.repoTagsByID[imageID] == nil {
+		images.repoTagsByID[imageID] = make(map[string]struct{})
+	}
+	images.repoTagsByID[imageID][imageName] = struct{}{}
+	return
+}
+
+func (images *knownImages) deleteReference(imageName string, imageID string) {
+	delete(images.idsByName, imageName)
+
+	if images.namesByID[imageID] != nil {
+		delete(images.namesByID[imageID], imageName)
+	}
+
+	if isAnImageID(imageName) {
+		return
+	}
+
+	if isARepoDigest(imageName) {
+		if images.repoDigestsByID[imageID] == nil {
+			return
+		}
+		delete(images.repoDigestsByID[imageID], imageName)
+		if len(images.repoDigestsByID[imageID]) == 0 {
+			delete(images.repoDigestsByID, imageID)
+		}
+		return
+	}
+
+	// The name is not an image ID or a repo digest, so it has to be a repo tag
+	if images.repoTagsByID[imageID] == nil {
+		return
+	}
+	delete(images.repoTagsByID[imageID], imageName)
+	if len(images.repoTagsByID[imageID]) == 0 {
+		delete(images.repoTagsByID, imageID)
 	}
 }
 
 func (images *knownImages) getImageID(imageName string) (string, bool) {
-	images.mut.Lock()
-	defer images.mut.Unlock()
-
 	id, found := images.idsByName[imageName]
 	return id, found
 }
 
-func (images *knownImages) isReferenced(imageID string) bool {
-	images.mut.Lock()
-	defer images.mut.Unlock()
+func (images *knownImages) getRepoTags(imageID string) []string {
+	var res []string
+	for repoTag := range images.repoTagsByID[imageID] {
+		res = append(res, repoTag)
+	}
+	return res
+}
 
-	return len(images.namesByID[imageID]) > 0
+func (images *knownImages) getRepoDigests(imageID string) []string {
+	var res []string
+	for repoDigest := range images.repoDigestsByID[imageID] {
+		res = append(res, repoDigest)
+	}
+	return res
+}
+
+// returns any of the existing references for the imageID. Returns empty if the
+// ID is not referenced.
+func (images *knownImages) getAReference(imageID string) string {
+	for ref := range images.namesByID[imageID] {
+		return ref
+	}
+
+	return ""
 }
 
 func isImageTopic(topic string) bool {
 	return strings.HasPrefix(topic, imageTopicPrefix)
+}
+
+func isAnImageID(imageName string) bool {
+	return strings.HasPrefix(imageName, "sha256")
+}
+
+func isARepoDigest(imageName string) bool {
+	return strings.Contains(imageName, "@sha256:")
 }
 
 func (c *collector) handleImageEvent(ctx context.Context, containerdEvent *containerdevents.Envelope) error {
@@ -116,22 +190,29 @@ func (c *collector) handleImageEvent(ctx context.Context, containerdEvent *conta
 		return c.handleImageCreateOrUpdate(ctx, containerdEvent.Namespace, event.Name, nil)
 
 	case imageDeletionTopic:
+		c.handleImagesMut.Lock()
+
 		event := &events.ImageDelete{}
 		if err := proto.Unmarshal(containerdEvent.Event.Value, event); err != nil {
+			c.handleImagesMut.Unlock()
 			return fmt.Errorf("error unmarshaling containerd event: %w", err)
 		}
 
 		imageID, found := c.knownImages.getImageID(event.Name)
 		if !found {
+			c.handleImagesMut.Unlock()
 			return nil
 		}
 
-		c.knownImages.deleteAssociation(event.Name, imageID)
+		c.knownImages.deleteReference(event.Name, imageID)
 
-		if c.knownImages.isReferenced(imageID) {
-			// Image is still referenced by a different name. Don't delete the
-			// image, but update its repo tags.
-			return c.deleteRepoTagOfImage(ctx, containerdEvent.Namespace, imageID, event.Name)
+		if ref := c.knownImages.getAReference(imageID); ref != "" {
+			// Image is still referenced by a different name, so don't delete
+			// the image, but we need to update its repo tags and digest tags.
+			// Updating workloadmeta entities directly is not thread-safe,
+			// that's why we generate an update event here.
+			c.handleImagesMut.Unlock()
+			return c.handleImageCreateOrUpdate(ctx, containerdEvent.Namespace, ref, nil)
 		}
 
 		c.store.Notify([]workloadmeta.CollectorEvent{
@@ -147,6 +228,7 @@ func (c *collector) handleImageEvent(ctx context.Context, containerdEvent *conta
 			},
 		})
 
+		c.handleImagesMut.Unlock()
 		return nil
 	default:
 		return fmt.Errorf("unknown containerd image event topic %s, ignoring", containerdEvent.Topic)
@@ -163,6 +245,9 @@ func (c *collector) handleImageCreateOrUpdate(ctx context.Context, namespace str
 }
 
 func (c *collector) notifyEventForImage(ctx context.Context, namespace string, img containerd.Image, bom *workloadmeta.SBOM) error {
+	c.handleImagesMut.Lock()
+	defer c.handleImagesMut.Unlock()
+
 	ctxWithNamespace := namespaces.WithNamespace(ctx, namespace)
 
 	manifest, err := images.Manifest(ctxWithNamespace, img.ContentStore(), img.Target(), img.Platform())
@@ -193,6 +278,8 @@ func (c *collector) notifyEventForImage(ctx context.Context, namespace string, i
 
 	imageID := manifest.Config.Digest.String()
 
+	c.knownImages.addReference(imageName, imageID)
+
 	existingBOM := bom
 
 	// We can get "create" events for images that already exist. That happens
@@ -216,25 +303,6 @@ func (c *collector) notifyEventForImage(ctx context.Context, namespace string, i
 
 		if existingBOM == nil && existingImg.SBOM != nil {
 			existingBOM = existingImg.SBOM
-		}
-	}
-
-	var repoDigests []string
-	if strings.Contains(imageName, "@sha256:") {
-		repoDigests = append(repoDigests, imageName)
-	} else {
-		repoDigests = append(repoDigests, imageName+"@"+img.Target().Digest.String())
-
-		repoTagAlreadyPresent := false
-		for _, repoTag := range c.repoTags[imageID] {
-			if repoTag == imageName {
-				repoTagAlreadyPresent = true
-				break
-			}
-		}
-
-		if !repoTagAlreadyPresent {
-			c.repoTags[imageID] = append(c.repoTags[imageID], imageName)
 		}
 	}
 
@@ -264,8 +332,8 @@ func (c *collector) notifyEventForImage(ctx context.Context, namespace string, i
 		},
 		Registry:     registry,
 		ShortName:    shortName,
-		RepoTags:     c.repoTags[imageID],
-		RepoDigests:  repoDigests,
+		RepoTags:     c.knownImages.getRepoTags(imageID),
+		RepoDigests:  c.knownImages.getRepoDigests(imageID),
 		MediaType:    manifest.MediaType,
 		SizeBytes:    totalSizeBytes,
 		OS:           os,
@@ -290,44 +358,6 @@ func (c *collector) notifyEventForImage(ctx context.Context, namespace string, i
 			namespace: namespace,
 			image:     img,
 			imageID:   imageID,
-		}
-	}
-
-	return c.updateKnownImages(ctx, namespace, imageName, imageID)
-}
-
-// Updates the map with the image name => image ID relationships and also the repo tags
-func (c *collector) updateKnownImages(ctx context.Context, namespace string, imageName string, newImageID string) error {
-	oldImageID, found := c.knownImages.getImageID(imageName)
-	c.knownImages.addAssociation(imageName, newImageID)
-
-	// If the image name is already pointing to an ID, we need to delete the name from
-	// the repo tags of the image with that ID.
-	if found && newImageID != oldImageID {
-		c.knownImages.deleteAssociation(imageName, oldImageID)
-		return c.deleteRepoTagOfImage(ctx, namespace, oldImageID, imageName)
-	}
-
-	return nil
-}
-
-func (c *collector) deleteRepoTagOfImage(ctx context.Context, namespace string, imageID string, repoTagToDelete string) error {
-	repoTagDeleted := false
-
-	for i, repoTag := range c.repoTags[imageID] {
-		if repoTag == repoTagToDelete {
-			c.repoTags[imageID] = append(c.repoTags[imageID][:i], c.repoTags[imageID][i+1:]...)
-			repoTagDeleted = true
-			break
-		}
-	}
-
-	if repoTagDeleted && len(c.repoTags[imageID]) > 0 {
-		// We need to notify to workloadmeta that the image has changed.
-		// Updating workloadmeta entities directly is not thread-safe, that's
-		// why we generate an update event here instead.
-		if err := c.handleImageCreateOrUpdate(ctx, namespace, c.repoTags[imageID][len(c.repoTags[imageID])-1], nil); err != nil {
-			return err
 		}
 	}
 


### PR DESCRIPTION

### What does this PR do?

Backports #15347 to `7.43.x`.


### Describe how to test/QA your changes

See #15347 

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
