### PR TITLE
Leverage board vendor when available to detect EC2 UUID

### DIFF
--- a/pkg/util/ec2/dmi.go
+++ b/pkg/util/ec2/dmi.go
@@ -51,6 +51,11 @@ func getInstanceIDFromDMI() (string, error) {
 // Depending on the instance type either the DMI product UUID or the hypervisor UUID is available. In both case, if they
 // start with "ec2" we return true.
 func isEC2UUID() bool {
+	// if we have a board vendor we can skip this UUID check
+	if dmi.GetBoardVendor() != "" && !isBoardVendorEC2() {
+		return false
+	}
+
 	uuidData := dmi.GetProductUUID()
 	if uuidData == "" {
 		uuidData = dmi.GetHypervisorUUID()

--- a/pkg/util/ec2/dmi_test.go
+++ b/pkg/util/ec2/dmi_test.go
@@ -58,6 +58,12 @@ func TestIsEC2UUID(t *testing.T) {
 	assert.True(t, isEC2UUID())
 	dmi.SetupMock(t, "", "8550b498-1488-4e75-82ba-a6931a9daf36", "", "")
 	assert.False(t, isEC2UUID())
+
+	// product_uuid with other board vendor
+	dmi.SetupMock(t, "", "ec20b498-1488-4e75-82ba-a6931a9daf36", "", "not AWS")
+	assert.False(t, isEC2UUID())
+	dmi.SetupMock(t, "", "ec20b498-1488-4e75-82ba-a6931a9daf36", "", DMIBoardVendor)
+	assert.True(t, isEC2UUID())
 }
 
 func TestIsEC2UUIDSwapEndian(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

Some UUID clash can happened (ie: starting with EC2). To reduce this we use the board vendor to filter some false positive.

### Describe how to test/QA your changes

Hard to test since it targets UUID clash. Run the agent on EC2 and check that the `cloud_provider_source` is still filled correctly.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
