### PR TITLE
ignore system probe env vars when loading core config

### DIFF
--- a/cmd/system-probe/config/config.go
+++ b/cmd/system-probe/config/config.go
@@ -82,7 +82,7 @@ func New(configPath string) (*Config, error) {
 	}
 	aconfig.SystemProbe.AddConfigPath(defaultConfigDir)
 	// load the configuration
-	_, err := aconfig.LoadCustom(aconfig.SystemProbe, "system-probe", true)
+	_, err := aconfig.LoadCustom(aconfig.SystemProbe, "system-probe", true, aconfig.Datadog.GetEnvVars())
 	if err != nil {
 		var e viper.ConfigFileNotFoundError
 		if errors.As(err, &e) || errors.Is(err, os.ErrNotExist) {
@@ -215,7 +215,7 @@ func SetupOptionalDatadogConfigWithDir(configDir, configFile string) error {
 		aconfig.Datadog.SetConfigFile(configFile)
 	}
 	// load the configuration
-	_, err := aconfig.LoadDatadogCustom(aconfig.Datadog, "datadog.yaml", true)
+	_, err := aconfig.LoadDatadogCustomWithKownEnvVars(aconfig.Datadog, "datadog.yaml", true, aconfig.SystemProbe.GetEnvVars())
 	// If `!failOnMissingFile`, do not issue an error if we cannot find the default config file.
 	var e viper.ConfigFileNotFoundError
 	if err != nil && !errors.As(err, &e) {

--- a/cmd/system-probe/config/config.go
+++ b/cmd/system-probe/config/config.go
@@ -215,7 +215,7 @@ func SetupOptionalDatadogConfigWithDir(configDir, configFile string) error {
 		aconfig.Datadog.SetConfigFile(configFile)
 	}
 	// load the configuration
-	_, err := aconfig.LoadDatadogCustomWithKownEnvVars(aconfig.Datadog, "datadog.yaml", true, aconfig.SystemProbe.GetEnvVars())
+	_, err := aconfig.LoadDatadogCustomWithKnownEnvVars(aconfig.Datadog, "datadog.yaml", true, aconfig.SystemProbe.GetEnvVars())
 	// If `!failOnMissingFile`, do not issue an error if we cannot find the default config file.
 	var e viper.ConfigFileNotFoundError
 	if err != nil && !errors.As(err, &e) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1462,10 +1462,10 @@ func checkConflictingOptions(config Config) error {
 
 // LoadDatadogCustom has several datadog.yaml customizations that other configs may not need with LoadCusto
 func LoadDatadogCustom(config Config, origin string, loadSecret bool) (*Warnings, error) {
-	return LoadDatadogCustomWithKownEnvVars(config, origin, loadSecret, nil)
+	return LoadDatadogCustomWithKnownEnvVars(config, origin, loadSecret, nil)
 }
 
-func LoadDatadogCustomWithKownEnvVars(config Config, origin string, loadSecret bool, additionalKnownEnvVars []string) (*Warnings, error) {
+func LoadDatadogCustomWithKnownEnvVars(config Config, origin string, loadSecret bool, additionalKnownEnvVars []string) (*Warnings, error) {
 	// Feature detection running in a defer func as it always  need to run (whether config load has been successful or not)
 	// Because some Agents (e.g. trace-agent) will run even if config file does not exist
 	defer func() {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1419,8 +1419,6 @@ func findUnknownEnvVars(config Config, environ []string) []string {
 	// Force ignore the system probe env vars because
 	// we don't want to have warning about unused env vars when loading both core and
 	// sysprobe config
-	// On processes other than system-probe this is a no-op since `SystemProbe` is never
-	// initialized
 	for _, key := range SystemProbe.GetEnvVars() {
 		knownVars[key] = struct{}{}
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1416,6 +1416,14 @@ func findUnknownEnvVars(config Config, environ []string) []string {
 	for _, key := range config.GetEnvVars() {
 		knownVars[key] = struct{}{}
 	}
+	// Force ignore the system probe env vars because
+	// we don't want to have warning about unused env vars when loading both core and
+	// sysprobe config
+	// On processes other than system-probe this is a no-op since `SystemProbe` is never
+	// initialized
+	for _, key := range SystemProbe.GetEnvVars() {
+		knownVars[key] = struct{}{}
+	}
 
 	for _, equality := range environ {
 		key := strings.SplitN(equality, "=", 2)[0]

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -191,24 +191,25 @@ unknown_key.unknown_subkey: true
 }
 
 func TestUnknownVarsWarning(t *testing.T) {
-	test := func(v string, unknown bool) func(*testing.T) {
+	test := func(v string, unknown bool, additional []string) func(*testing.T) {
 		return func(t *testing.T) {
 			env := []string{fmt.Sprintf("%s=foo", v)}
 			var exp []string
 			if unknown {
 				exp = append(exp, v)
 			}
-			assert.Equal(t, exp, findUnknownEnvVars(Mock(t), env))
+			assert.Equal(t, exp, findUnknownEnvVars(Mock(t), env, additional))
 		}
 	}
-	t.Run("DD_API_KEY", test("DD_API_KEY", false))
-	t.Run("DD_SITE", test("DD_SITE", false))
-	t.Run("DD_UNKNOWN", test("DD_UNKNOWN", true))
-	t.Run("UNKNOWN", test("UNKNOWN", false)) // no DD_ prefix
-	t.Run("DD_PROXY_NO_PROXY", test("DD_PROXY_NO_PROXY", false))
-	t.Run("DD_PROXY_HTTP", test("DD_PROXY_HTTP", false))
-	t.Run("DD_PROXY_HTTPS", test("DD_PROXY_HTTPS", false))
-	t.Run("DD_INSIDE_CI", test("DD_INSIDE_CI", false))
+	t.Run("DD_API_KEY", test("DD_API_KEY", false, nil))
+	t.Run("DD_SITE", test("DD_SITE", false, nil))
+	t.Run("DD_UNKNOWN", test("DD_UNKNOWN", true, nil))
+	t.Run("UNKNOWN", test("UNKNOWN", false, nil)) // no DD_ prefix
+	t.Run("DD_PROXY_NO_PROXY", test("DD_PROXY_NO_PROXY", false, nil))
+	t.Run("DD_PROXY_HTTP", test("DD_PROXY_HTTP", false, nil))
+	t.Run("DD_PROXY_HTTPS", test("DD_PROXY_HTTPS", false, nil))
+	t.Run("DD_INSIDE_CI", test("DD_INSIDE_CI", false, nil))
+	t.Run("DD_SYSTEM_PROBE_EXTRA", test("DD_SYSTEM_PROBE_EXTRA", false, []string{"DD_SYSTEM_PROBE_EXTRA"}))
 }
 
 func TestSiteEnvVar(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

The system probe currently loads the core datadog config as well. Since the split, some configs values are only defined in the sysprobe config and not in the core one, resulting in some env vars recognized as unknown when they are just sysprobe specific. This PR force the core loading to ignore sysprobe env vars.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

This PR should be tested by: 
- checking that the configuration is still loading as expected (both core and system probe)
- checking that the unknown env variables is still working as expected (with full unknown vars, and not logging if the var is recognized by the system probe)

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
