### PR TITLE
[admission][auto-instrumentation] Support .NET

### DIFF
--- a/pkg/clusteragent/admission/mutate/auto_instrumentation.go
+++ b/pkg/clusteragent/admission/mutate/auto_instrumentation.go
@@ -54,6 +54,9 @@ const (
 	dotnetTracerHomeKey   = "DD_DOTNET_TRACER_HOME"
 	dotnetTracerHomeValue = "/datadog-lib"
 
+	dotnetTracerLogDirectoryKey   = "DD_TRACE_LOG_DIRECTORY"
+	dotnetTracerLogDirectoryValue = "/datadog-lib/logs"
+
 	dotnetProfilingLdPreloadKey   = "LD_PRELOAD"
 	dotnetProfilingLdPreloadValue = "/datadog-lib/continuousprofiler/Datadog.Linux.ApiWrapper.x64.so"
 )
@@ -211,6 +214,10 @@ func injectAutoInstruConfig(pod *corev1.Pod, libsToInject []libInfo) error {
 				{
 					key:     dotnetTracerHomeKey,
 					valFunc: identityValFunc(dotnetTracerHomeValue),
+				},
+				{
+					key:     dotnetTracerLogDirectoryKey,
+					valFunc: identityValFunc(dotnetTracerLogDirectoryValue),
 				},
 				{
 					key:     dotnetProfilingLdPreloadKey,

--- a/pkg/clusteragent/admission/mutate/auto_instrumentation_test.go
+++ b/pkg/clusteragent/admission/mutate/auto_instrumentation_test.go
@@ -148,6 +148,43 @@ func TestInjectAutoInstruConfig(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "nominal case: dotnet",
+			pod:  fakePod("dotnet-pod"),
+			libsToInject: []libInfo{
+				{
+					lang:  "dotnet",
+					image: "gcr.io/datadoghq/dd-lib-dotnet-init:v1",
+				},
+			},
+			expectedEnvKey: "CORECLR_PROFILER",
+			expectedEnvVal: "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+			wantErr:        false,
+		},
+		{
+			name: "CORECLR_ENABLE_PROFILING not empty",
+			pod:  fakePodWithEnvValue("dotnet-pod", "CORECLR_PROFILER", "predefined"),
+			libsToInject: []libInfo{
+				{
+					lang:  "dotnet",
+					image: "gcr.io/datadoghq/dd-lib-dotnet-init:v1",
+				},
+			},
+			expectedEnvKey: "CORECLR_PROFILER",
+			expectedEnvVal: "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+			wantErr:        false,
+		},
+		{
+			name: "CORECLR_ENABLE_PROFILING set via ValueFrom",
+			pod:  fakePodWithEnvFieldRefValue("dotnet-pod", "CORECLR_PROFILER", "path"),
+			libsToInject: []libInfo{
+				{
+					lang:  "dotnet",
+					image: "gcr.io/datadoghq/dd-lib-dotnet-init:v1",
+				},
+			},
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/releasenotes/notes/auto-instru-dotnet-d3679fa99c9b716b.yaml
+++ b/releasenotes/notes/auto-instru-dotnet-d3679fa99c9b716b.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Experimental: The Datadog Admission Controller can inject the .NET APM library into Kubernetes containers for auto-instrumentation.
+

--- a/test/e2e/argo-workflows/templates/mutate-busybox.yaml
+++ b/test/e2e/argo-workflows/templates/mutate-busybox.yaml
@@ -130,6 +130,31 @@ spec:
                 image: busybox
                 name: busybox
 
+    - name: create-busybox-with-auto-instru-dotnet
+      inputs:
+        parameters:
+          - name: namespace
+      resource:
+        action: apply
+        manifest: |
+          apiVersion: v1
+          kind: Pod
+          metadata:
+            name: busybox-auto-instru-dotnet
+            namespace: {{inputs.parameters.namespace}}
+            labels:
+              "app": "busybox"
+              "admission.datadoghq.com/enabled": "true"
+            annotations:
+              admission.datadoghq.com/dotnet-lib.custom-image: "ghcr.io/datadog/dd-trace-dotnet/dd-lib-dotnet-init:a43a0170de4c469864385fa2cc38cad48fb91bad" # TODO: Use the default repo when ready
+          spec:
+            containers:
+              - command:
+                  - sleep
+                  - "3600"
+                image: busybox
+                name: busybox
+
     - name: create
       inputs:
         parameters:
@@ -179,6 +204,12 @@ spec:
                   value: "{{inputs.parameters.namespace}}"
           - name: busybox-auto-instru-python
             template: create-busybox-with-auto-instru-python
+            arguments:
+              parameters:
+                - name: namespace
+                  value: "{{inputs.parameters.namespace}}"
+          - name: busybox-auto-instru-dotnet
+            template: create-busybox-with-auto-instru-dotnet
             arguments:
               parameters:
                 - name: namespace
@@ -562,6 +593,56 @@ spec:
                   value: "/datadog-lib"
                 - name: target
                   value: busybox-auto-instru-python
+          - name: env-auto-instru-dotnet
+            template: test-env-value
+            arguments:
+              parameters:
+                - name: namespace
+                  value: "{{inputs.parameters.namespace}}"
+                - name: envValue
+                  value: "/datadog-lib/Datadog.Trace.ClrProfiler.Native.so"
+                - name: envKey
+                  value: CORECLR_PROFILER_PATH
+                - name: target
+                  value: busybox-auto-instru-dotnet
+          - name: env-ldpreload-auto-instru-dotnet
+            template: test-env-value
+            arguments:
+              parameters:
+                - name: namespace
+                  value: "{{inputs.parameters.namespace}}"
+                - name: envValue
+                  value: "/datadog-lib/continuousprofiler/Datadog.Linux.ApiWrapper.x64.so"
+                - name: envKey
+                  value: LD_PRELOAD
+                - name: target
+                  value: busybox-auto-instru-dotnet
+          - name: volume-mount-auto-instru-dotnet
+            template: test-volume-mount
+            arguments:
+              parameters:
+                - name: namespace
+                  value: "{{inputs.parameters.namespace}}"
+                - name: volumeName
+                  value: datadog-auto-instrumentation
+                - name: volumePath
+                  value: "/datadog-lib"
+                - name: withInitContainers
+                  value: "true"
+                - name: target
+                  value: busybox-auto-instru-dotnet
+          - name: empty-dir-auto-instru-dotnet
+            template: test-empty-dir
+            arguments:
+              parameters:
+                - name: namespace
+                  value: "{{inputs.parameters.namespace}}"
+                - name: volumeName
+                  value: datadog-auto-instrumentation
+                - name: volumePath
+                  value: "/datadog-lib"
+                - name: target
+                  value: busybox-auto-instru-dotnet
 
     - name: diagnose
       inputs:


### PR DESCRIPTION
### What does this PR do?
This PR sets the required environment variables to automatically instrument a .NET application with the .NET Tracer using the Admission Controller.

### Motivation

### Additional Notes
The E2E test will need to be updated when the official .NET init image is published to GCR. For now, it's pinned to a dev build.

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes
Deploy the cluster agent and auto-instrument a .NET app, validate tracing and continuous profiler is working e2e.

### Reviewer's Checklist
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
