### PR TITLE
fix http response error!

### DIFF
--- a/pkg/config/remote/client.go
+++ b/pkg/config/remote/client.go
@@ -130,8 +130,8 @@ func NewGRPCClient(agentName string, agentVersion string, products []data.Produc
 	return newClient(agentName, grpcClient, true, agentVersion, products, pollInterval)
 }
 
-// NewUnverifiedClient creates a new client that does not perform any TUF verification
-func NewUnverifiedClient(agentName string, agentVersion string, products []data.Product, pollInterval time.Duration) (*Client, error) {
+// NewUnverifiedGRPCClient creates a new client that does not perform any TUF verification
+func NewUnverifiedGRPCClient(agentName string, agentVersion string, products []data.Product, pollInterval time.Duration) (*Client, error) {
 	grpcClient, err := NewAgentGRPCConfigFetcher()
 	if err != nil {
 		return nil, err

--- a/pkg/network/ebpf/c/protocols/http/http.h
+++ b/pkg/network/ebpf/c/protocols/http/http.h
@@ -142,7 +142,7 @@ static __always_inline int http_process(http_transaction_t *http_stack, skb_info
 
     http->tags |= tags;
 
-    if (http_responding(http)) {
+    if (http_responding(http) && packet_type == HTTP_RESPONSE) {
         http->response_last_seen = bpf_ktime_get_ns();
     }
 

--- a/pkg/network/ebpf/c/protocols/http/http.h
+++ b/pkg/network/ebpf/c/protocols/http/http.h
@@ -138,13 +138,12 @@ static __always_inline int http_process(http_transaction_t *http_stack, skb_info
     } else if (packet_type == HTTP_RESPONSE) {
         http_begin_response(http, buffer);
         http_update_seen_before(http, skb_info);
+        if (http_responding(http)) {
+            http->response_last_seen = bpf_ktime_get_ns();
+        }
     }
 
     http->tags |= tags;
-
-    if (http_responding(http) && packet_type == HTTP_RESPONSE) {
-        http->response_last_seen = bpf_ktime_get_ns();
-    }
 
     if (http_closed(http, skb_info, http_stack->owned_by_src_port)) {
         http_batch_enqueue(http);

--- a/pkg/security/rconfig/rconfig.go
+++ b/pkg/security/rconfig/rconfig.go
@@ -45,7 +45,7 @@ var _ rules.PolicyProvider = (*RCPolicyProvider)(nil)
 
 // NewRCPolicyProvider returns a new Remote Config based policy provider
 func NewRCPolicyProvider(name string, agentVersion *semver.Version) (*RCPolicyProvider, error) {
-	c, err := remote.NewGRPCClient(name, agentVersion.String(), []data.Product{data.ProductCWSDD, data.ProductCWSCustom}, securityAgentRCPollInterval)
+	c, err := remote.NewUnverifiedGRPCClient(name, agentVersion.String(), []data.Product{data.ProductCWSDD, data.ProductCWSCustom}, securityAgentRCPollInterval)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?


* Fix the bug when ebpf responds to http


### Motivation

Fix the bug when ebpf responds to http

### Additional Notes

Only make one HTTP request

HTTP request:

```
GET /test200 HTTP/1.1
Host: localhost:8080
Connection: keep-alive
Cache-Control: max-age=0
sec-ch-ua: ".Not/A)Brand";v="99", "Google Chrome";v="103", "Chromium";v="103"
sec-ch-ua-mobile: ?0
sec-ch-ua-platform: "Linux"
Upgrade-Insecure-Requests: 1
User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.0.0 Safari/537.36
Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9
Sec-Fetch-Site: none
Sec-Fetch-Mode: navigate
Sec-Fetch-User: ?1
Sec-Fetch-Dest: document
Accept-Encoding: gzip, deflate, br
Accept-Language: zh-CN,zh;q=0.9,en-GB;q=0.8,en-US;q=0.7,en;q=0.6
Cookie: _ga=GA1.1.1233282742.1669543902

```

HTTP Response
```
	HTTP/1.1 200 
	Content-Type: application/json
	Transfer-Encoding: chunked
	Date: Tue, 07 Feb 2023 09:28:45 GMT
	Keep-Alive: timeout=60
	Connection: keep-alive
	
	42
	{"success":true,"errorCode":null,"errorMessage":null,"data":"200"}

```

For example, this request only took 5ms，Since we set a 60s timeout in the HTTP response.

If disconnected after 60s, datadog will update the response time, which results in the reported time being 60s instead of the 5ms we want.

The reason for all this is here:

```
  if (http_responding(http)) {
        http->response_last_seen = bpf_ktime_get_ns();
    }
```

Because some irrelevant network data will also refresh this value.

So we need to add http type judgment.

```
if (http_responding(http) && packet_type == HTTP_RESPONSE) {
        http->response_last_seen = bpf_ktime_get_ns();
    }
```


### Possible Drawbacks / Trade-offs



### Describe how to test/QA your changes



### Reviewer's Checklist



