### PR TITLE
[corechecks/{containerimage,sbom}] Use queue of size 1 in tests to fix flakyness

### DIFF
--- a/pkg/collector/corechecks/containerimage/processor_test.go
+++ b/pkg/collector/corechecks/containerimage/processor_test.go
@@ -17,414 +17,397 @@ import (
 	"go.uber.org/atomic"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
-	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/util/pointer"
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 )
 
 func TestProcessEvents(t *testing.T) {
-	var imagesSent = atomic.NewInt32(0)
-
-	sender := mocksender.NewMockSender(check.ID(""))
-	sender.On("ContainerImage", mock.Anything, mock.Anything).Return().Run(func(_ mock.Arguments) {
-		imagesSent.Inc()
-	})
-
-	// Define a max size of 1 for the queue. With a size > 1, it's difficult to
-	// control the number of events sent on each call.
-	p := newProcessor(sender, 1, 50*time.Millisecond)
-
-	p.processEvents(workloadmeta.EventBundle{
-		Events: []workloadmeta.Event{
-			{
-				Type: workloadmeta.EventTypeSet,
-				Entity: &workloadmeta.ContainerImageMetadata{
-					EntityID: workloadmeta.EntityID{
-						Kind: workloadmeta.KindContainerImageMetadata,
-						ID:   "sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
+	tests := []struct {
+		name           string
+		inputEvents    []workloadmeta.Event
+		expectedImages []*model.ContainerImage
+	}{
+		{
+			name: "standard case",
+			inputEvents: []workloadmeta.Event{
+				{
+					Type: workloadmeta.EventTypeSet,
+					Entity: &workloadmeta.ContainerImageMetadata{
+						EntityID: workloadmeta.EntityID{
+							Kind: workloadmeta.KindContainerImageMetadata,
+							ID:   "sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
+						},
+						RepoTags: []string{
+							"datadog/agent:7-rc",
+							"datadog/agent:7.41.1-rc.1",
+							"gcr.io/datadoghq/agent:7-rc",
+							"gcr.io/datadoghq/agent:7.41.1-rc.1",
+							"public.ecr.aws/datadog/agent:7-rc",
+							"public.ecr.aws/datadog/agent:7.41.1-rc.1",
+						},
+						RepoDigests: []string{
+							"datadog/agent@sha256:052f1fdf4f9a7117d36a1838ab60782829947683007c34b69d4991576375c409",
+							"gcr.io/datadoghq/agent@sha256:052f1fdf4f9a7117d36a1838ab60782829947683007c34b69d4991576375c409",
+							"public.ecr.aws/datadog/agent@sha256:052f1fdf4f9a7117d36a1838ab60782829947683007c34b69d4991576375c409",
+						},
+						SizeBytes:    42,
+						OS:           "DOS",
+						OSVersion:    "6.22",
+						Architecture: "80486DX",
+						Layers: []workloadmeta.ContainerImageLayer{
+							{
+								MediaType: "media",
+								Digest:    "digest_layer_1",
+								SizeBytes: 43,
+								URLs:      []string{"url"},
+								History: v1.History{
+									Created: pointer.Ptr(time.Unix(42, 43)),
+								},
+							},
+							{
+								MediaType: "media",
+								Digest:    "digest_layer_2",
+								URLs:      []string{"url"},
+								SizeBytes: 44,
+								History: v1.History{
+									Created: pointer.Ptr(time.Unix(43, 44)),
+								},
+							},
+						},
 					},
-					RepoTags: []string{
-						"datadog/agent:7-rc",
-						"datadog/agent:7.41.1-rc.1",
-						"gcr.io/datadoghq/agent:7-rc",
-						"gcr.io/datadoghq/agent:7.41.1-rc.1",
-						"public.ecr.aws/datadog/agent:7-rc",
-						"public.ecr.aws/datadog/agent:7.41.1-rc.1",
+				},
+			},
+			expectedImages: []*model.ContainerImage{
+				{
+					Id:        "datadog/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
+					Name:      "datadog/agent",
+					Registry:  "",
+					ShortName: "agent",
+					Tags: []string{
+						"7-rc",
+						"7.41.1-rc.1",
 					},
-					RepoDigests: []string{
-						"datadog/agent@sha256:052f1fdf4f9a7117d36a1838ab60782829947683007c34b69d4991576375c409",
-						"gcr.io/datadoghq/agent@sha256:052f1fdf4f9a7117d36a1838ab60782829947683007c34b69d4991576375c409",
-						"public.ecr.aws/datadog/agent@sha256:052f1fdf4f9a7117d36a1838ab60782829947683007c34b69d4991576375c409",
+					Digest:      "sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
+					Size:        42,
+					RepoDigests: []string{"datadog/agent@sha256:052f1fdf4f9a7117d36a1838ab60782829947683007c34b69d4991576375c409"},
+					Os: &model.ContainerImage_OperatingSystem{
+						Name:         "DOS",
+						Version:      "6.22",
+						Architecture: "80486DX",
 					},
-					SizeBytes:    42,
-					OS:           "DOS",
-					OSVersion:    "6.22",
-					Architecture: "80486DX",
-					Layers: []workloadmeta.ContainerImageLayer{
+					Layers: []*model.ContainerImage_ContainerImageLayer{
 						{
+							Urls:      []string{"url"},
 							MediaType: "media",
 							Digest:    "digest_layer_1",
-							SizeBytes: 43,
-							URLs:      []string{"url"},
-							History: v1.History{
-								Created: pointer.Ptr(time.Unix(42, 43)),
+							Size:      43,
+							History: &model.ContainerImage_ContainerImageLayer_History{
+								Created: &timestamp.Timestamp{
+									Seconds: 42,
+									Nanos:   43,
+								},
 							},
 						},
 						{
+							Urls:      []string{"url"},
 							MediaType: "media",
 							Digest:    "digest_layer_2",
-							URLs:      []string{"url"},
-							SizeBytes: 44,
-							History: v1.History{
-								Created: pointer.Ptr(time.Unix(43, 44)),
+							Size:      44,
+							History: &model.ContainerImage_ContainerImageLayer_History{
+								Created: &timestamp.Timestamp{
+									Seconds: 43,
+									Nanos:   44,
+								},
 							},
 						},
 					},
-				},
-			},
-		},
-		Ch: make(chan struct{}),
-	})
-
-	expectedImages := []*model.ContainerImage{
-		{
-			Id:        "datadog/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
-			Name:      "datadog/agent",
-			Registry:  "",
-			ShortName: "agent",
-			Tags: []string{
-				"7-rc",
-				"7.41.1-rc.1",
-			},
-			Digest:      "sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
-			Size:        42,
-			RepoDigests: []string{"datadog/agent@sha256:052f1fdf4f9a7117d36a1838ab60782829947683007c34b69d4991576375c409"},
-			Os: &model.ContainerImage_OperatingSystem{
-				Name:         "DOS",
-				Version:      "6.22",
-				Architecture: "80486DX",
-			},
-			Layers: []*model.ContainerImage_ContainerImageLayer{
-				{
-					Urls:      []string{"url"},
-					MediaType: "media",
-					Digest:    "digest_layer_1",
-					Size:      43,
-					History: &model.ContainerImage_ContainerImageLayer_History{
-						Created: &timestamp.Timestamp{
-							Seconds: 42,
-							Nanos:   43,
-						},
+					BuiltAt: &timestamp.Timestamp{
+						Seconds: 43,
+						Nanos:   44,
 					},
 				},
 				{
-					Urls:      []string{"url"},
-					MediaType: "media",
-					Digest:    "digest_layer_2",
-					Size:      44,
-					History: &model.ContainerImage_ContainerImageLayer_History{
-						Created: &timestamp.Timestamp{
-							Seconds: 43,
-							Nanos:   44,
-						},
+					Id:        "gcr.io/datadoghq/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
+					Name:      "gcr.io/datadoghq/agent",
+					Registry:  "gcr.io",
+					ShortName: "agent",
+					Tags: []string{
+						"7-rc",
+						"7.41.1-rc.1",
 					},
-				},
-			},
-			BuiltAt: &timestamp.Timestamp{
-				Seconds: 43,
-				Nanos:   44,
-			},
-		},
-		{
-			Id:        "gcr.io/datadoghq/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
-			Name:      "gcr.io/datadoghq/agent",
-			Registry:  "gcr.io",
-			ShortName: "agent",
-			Tags: []string{
-				"7-rc",
-				"7.41.1-rc.1",
-			},
-			Digest:      "sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
-			Size:        42,
-			RepoDigests: []string{"gcr.io/datadoghq/agent@sha256:052f1fdf4f9a7117d36a1838ab60782829947683007c34b69d4991576375c409"},
-			Os: &model.ContainerImage_OperatingSystem{
-				Name:         "DOS",
-				Version:      "6.22",
-				Architecture: "80486DX",
-			},
-			Layers: []*model.ContainerImage_ContainerImageLayer{
-				{
-					Urls:      []string{"url"},
-					MediaType: "media",
-					Digest:    "digest_layer_1",
-					Size:      43,
-					History: &model.ContainerImage_ContainerImageLayer_History{
-						Created: &timestamp.Timestamp{
-							Seconds: 42,
-							Nanos:   43,
-						},
+					Digest:      "sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
+					Size:        42,
+					RepoDigests: []string{"gcr.io/datadoghq/agent@sha256:052f1fdf4f9a7117d36a1838ab60782829947683007c34b69d4991576375c409"},
+					Os: &model.ContainerImage_OperatingSystem{
+						Name:         "DOS",
+						Version:      "6.22",
+						Architecture: "80486DX",
 					},
-				},
-				{
-					Urls:      []string{"url"},
-					MediaType: "media",
-					Digest:    "digest_layer_2",
-					Size:      44,
-					History: &model.ContainerImage_ContainerImageLayer_History{
-						Created: &timestamp.Timestamp{
-							Seconds: 43,
-							Nanos:   44,
-						},
-					},
-				},
-			},
-			BuiltAt: &timestamp.Timestamp{
-				Seconds: 43,
-				Nanos:   44,
-			},
-		},
-		{
-			Id:        "public.ecr.aws/datadog/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
-			Name:      "public.ecr.aws/datadog/agent",
-			Registry:  "public.ecr.aws",
-			ShortName: "agent",
-			Tags: []string{
-				"7-rc",
-				"7.41.1-rc.1",
-			},
-			Digest:      "sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
-			Size:        42,
-			RepoDigests: []string{"public.ecr.aws/datadog/agent@sha256:052f1fdf4f9a7117d36a1838ab60782829947683007c34b69d4991576375c409"},
-			Os: &model.ContainerImage_OperatingSystem{
-				Name:         "DOS",
-				Version:      "6.22",
-				Architecture: "80486DX",
-			},
-			Layers: []*model.ContainerImage_ContainerImageLayer{
-				{
-					Urls:      []string{"url"},
-					MediaType: "media",
-					Digest:    "digest_layer_1",
-					Size:      43,
-					History: &model.ContainerImage_ContainerImageLayer_History{
-						Created: &timestamp.Timestamp{
-							Seconds: 42,
-							Nanos:   43,
-						},
-					},
-				},
-				{
-					Urls:      []string{"url"},
-					MediaType: "media",
-					Digest:    "digest_layer_2",
-					Size:      44,
-					History: &model.ContainerImage_ContainerImageLayer_History{
-						Created: &timestamp.Timestamp{
-							Seconds: 43,
-							Nanos:   44,
-						},
-					},
-				},
-			},
-			BuiltAt: &timestamp.Timestamp{
-				Seconds: 43,
-				Nanos:   44,
-			},
-		},
-	}
-
-	p.stop()
-
-	// The queue is processing the events in a different go routine and might
-	// need some time
-	assert.Eventually(t, func() bool {
-		return imagesSent.Load() == int32(len(expectedImages))
-	}, 1*time.Second, 5*time.Millisecond)
-
-	for _, expectedImage := range expectedImages {
-		sender.AssertContainerImage(t, []model.ContainerImagePayload{
-			{
-				Version: "v1",
-				Images:  []*model.ContainerImage{expectedImage},
-			},
-		})
-	}
-}
-
-func TestProcessEvents_repoTagWithNoMatchingRepoDigest(t *testing.T) {
-	// In containerd some images are created without a repo digest, and it's
-	// also possible to remove repo digests manually. To test that scenario, in
-	// this test, we define an image with 2 repo tags: one for the gcr.io
-	// registry and another for the public.ecr.aws registry, but there's only
-	// one repo digest.
-	// We expect to send 2 events, one for each registry.
-
-	var imagesSent = atomic.NewInt32(0)
-
-	sender := mocksender.NewMockSender("")
-	sender.On("ContainerImage", mock.Anything, mock.Anything).Return().Run(func(_ mock.Arguments) {
-		imagesSent.Inc()
-	})
-	p := newProcessor(sender, 1, 50*time.Millisecond)
-
-	p.processEvents(workloadmeta.EventBundle{
-		Events: []workloadmeta.Event{
-			{
-				Type: workloadmeta.EventTypeSet,
-				Entity: &workloadmeta.ContainerImageMetadata{
-					EntityID: workloadmeta.EntityID{
-						Kind: workloadmeta.KindContainerImageMetadata,
-						ID:   "sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
-					},
-					RepoTags: []string{
-						"gcr.io/datadoghq/agent:7-rc",
-						"public.ecr.aws/datadog/agent:7-rc",
-					},
-					RepoDigests: []string{
-						// Notice that there's a repo tag for gcr.io, but no repo digest.
-						"public.ecr.aws/datadog/agent@sha256:052f1fdf4f9a7117d36a1838ab60782829947683007c34b69d4991576375c409",
-					},
-					SizeBytes:    42,
-					OS:           "DOS",
-					OSVersion:    "6.22",
-					Architecture: "80486DX",
-					Layers: []workloadmeta.ContainerImageLayer{
+					Layers: []*model.ContainerImage_ContainerImageLayer{
 						{
+							Urls:      []string{"url"},
 							MediaType: "media",
 							Digest:    "digest_layer_1",
-							SizeBytes: 43,
-							URLs:      []string{"url"},
-							History: v1.History{
-								Created: pointer.Ptr(time.Unix(42, 43)),
+							Size:      43,
+							History: &model.ContainerImage_ContainerImageLayer_History{
+								Created: &timestamp.Timestamp{
+									Seconds: 42,
+									Nanos:   43,
+								},
 							},
 						},
 						{
+							Urls:      []string{"url"},
 							MediaType: "media",
 							Digest:    "digest_layer_2",
-							URLs:      []string{"url"},
-							SizeBytes: 44,
-							History: v1.History{
-								Created: pointer.Ptr(time.Unix(43, 44)),
+							Size:      44,
+							History: &model.ContainerImage_ContainerImageLayer_History{
+								Created: &timestamp.Timestamp{
+									Seconds: 43,
+									Nanos:   44,
+								},
+							},
+						},
+					},
+					BuiltAt: &timestamp.Timestamp{
+						Seconds: 43,
+						Nanos:   44,
+					},
+				},
+				{
+					Id:        "public.ecr.aws/datadog/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
+					Name:      "public.ecr.aws/datadog/agent",
+					Registry:  "public.ecr.aws",
+					ShortName: "agent",
+					Tags: []string{
+						"7-rc",
+						"7.41.1-rc.1",
+					},
+					Digest:      "sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
+					Size:        42,
+					RepoDigests: []string{"public.ecr.aws/datadog/agent@sha256:052f1fdf4f9a7117d36a1838ab60782829947683007c34b69d4991576375c409"},
+					Os: &model.ContainerImage_OperatingSystem{
+						Name:         "DOS",
+						Version:      "6.22",
+						Architecture: "80486DX",
+					},
+					Layers: []*model.ContainerImage_ContainerImageLayer{
+						{
+							Urls:      []string{"url"},
+							MediaType: "media",
+							Digest:    "digest_layer_1",
+							Size:      43,
+							History: &model.ContainerImage_ContainerImageLayer_History{
+								Created: &timestamp.Timestamp{
+									Seconds: 42,
+									Nanos:   43,
+								},
+							},
+						},
+						{
+							Urls:      []string{"url"},
+							MediaType: "media",
+							Digest:    "digest_layer_2",
+							Size:      44,
+							History: &model.ContainerImage_ContainerImageLayer_History{
+								Created: &timestamp.Timestamp{
+									Seconds: 43,
+									Nanos:   44,
+								},
+							},
+						},
+					},
+					BuiltAt: &timestamp.Timestamp{
+						Seconds: 43,
+						Nanos:   44,
+					},
+				},
+			},
+		},
+		{
+			// In containerd some images are created without a repo digest, and it's
+			// also possible to remove repo digests manually. To test that scenario, in
+			// this test, we define an image with 2 repo tags: one for the gcr.io
+			// registry and another for the public.ecr.aws registry, but there's only
+			// one repo digest.
+			// We expect to send 2 events, one for each registry.
+			name: "repo tag with no matching repo digest",
+			inputEvents: []workloadmeta.Event{
+				{
+					Type: workloadmeta.EventTypeSet,
+					Entity: &workloadmeta.ContainerImageMetadata{
+						EntityID: workloadmeta.EntityID{
+							Kind: workloadmeta.KindContainerImageMetadata,
+							ID:   "sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
+						},
+						RepoTags: []string{
+							"gcr.io/datadoghq/agent:7-rc",
+							"public.ecr.aws/datadog/agent:7-rc",
+						},
+						RepoDigests: []string{
+							// Notice that there's a repo tag for gcr.io, but no repo digest.
+							"public.ecr.aws/datadog/agent@sha256:052f1fdf4f9a7117d36a1838ab60782829947683007c34b69d4991576375c409",
+						},
+						SizeBytes:    42,
+						OS:           "DOS",
+						OSVersion:    "6.22",
+						Architecture: "80486DX",
+						Layers: []workloadmeta.ContainerImageLayer{
+							{
+								MediaType: "media",
+								Digest:    "digest_layer_1",
+								SizeBytes: 43,
+								URLs:      []string{"url"},
+								History: v1.History{
+									Created: pointer.Ptr(time.Unix(42, 43)),
+								},
+							},
+							{
+								MediaType: "media",
+								Digest:    "digest_layer_2",
+								URLs:      []string{"url"},
+								SizeBytes: 44,
+								History: v1.History{
+									Created: pointer.Ptr(time.Unix(43, 44)),
+								},
 							},
 						},
 					},
 				},
 			},
-		},
-		Ch: make(chan struct{}),
-	})
-
-	expectedImages := []*model.ContainerImage{
-		{
-			Id:        "public.ecr.aws/datadog/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
-			Name:      "public.ecr.aws/datadog/agent",
-			Registry:  "public.ecr.aws",
-			ShortName: "agent",
-			Tags: []string{
-				"7-rc",
-			},
-			Digest:      "sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
-			Size:        42,
-			RepoDigests: []string{"public.ecr.aws/datadog/agent@sha256:052f1fdf4f9a7117d36a1838ab60782829947683007c34b69d4991576375c409"},
-			Os: &model.ContainerImage_OperatingSystem{
-				Name:         "DOS",
-				Version:      "6.22",
-				Architecture: "80486DX",
-			},
-			Layers: []*model.ContainerImage_ContainerImageLayer{
+			expectedImages: []*model.ContainerImage{
 				{
-					Urls:      []string{"url"},
-					MediaType: "media",
-					Digest:    "digest_layer_1",
-					Size:      43,
-					History: &model.ContainerImage_ContainerImageLayer_History{
-						Created: &timestamp.Timestamp{
-							Seconds: 42,
-							Nanos:   43,
+					Id:        "public.ecr.aws/datadog/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
+					Name:      "public.ecr.aws/datadog/agent",
+					Registry:  "public.ecr.aws",
+					ShortName: "agent",
+					Tags: []string{
+						"7-rc",
+					},
+					Digest:      "sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
+					Size:        42,
+					RepoDigests: []string{"public.ecr.aws/datadog/agent@sha256:052f1fdf4f9a7117d36a1838ab60782829947683007c34b69d4991576375c409"},
+					Os: &model.ContainerImage_OperatingSystem{
+						Name:         "DOS",
+						Version:      "6.22",
+						Architecture: "80486DX",
+					},
+					Layers: []*model.ContainerImage_ContainerImageLayer{
+						{
+							Urls:      []string{"url"},
+							MediaType: "media",
+							Digest:    "digest_layer_1",
+							Size:      43,
+							History: &model.ContainerImage_ContainerImageLayer_History{
+								Created: &timestamp.Timestamp{
+									Seconds: 42,
+									Nanos:   43,
+								},
+							},
 						},
+						{
+							Urls:      []string{"url"},
+							MediaType: "media",
+							Digest:    "digest_layer_2",
+							Size:      44,
+							History: &model.ContainerImage_ContainerImageLayer_History{
+								Created: &timestamp.Timestamp{
+									Seconds: 43,
+									Nanos:   44,
+								},
+							},
+						},
+					},
+					BuiltAt: &timestamp.Timestamp{
+						Seconds: 43,
+						Nanos:   44,
 					},
 				},
 				{
-					Urls:      []string{"url"},
-					MediaType: "media",
-					Digest:    "digest_layer_2",
-					Size:      44,
-					History: &model.ContainerImage_ContainerImageLayer_History{
-						Created: &timestamp.Timestamp{
-							Seconds: 43,
-							Nanos:   44,
+					Id:        "gcr.io/datadoghq/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
+					Name:      "gcr.io/datadoghq/agent",
+					Registry:  "gcr.io",
+					ShortName: "agent",
+					Tags: []string{
+						"7-rc",
+					},
+					Digest:      "sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
+					Size:        42,
+					RepoDigests: []string{},
+					Os: &model.ContainerImage_OperatingSystem{
+						Name:         "DOS",
+						Version:      "6.22",
+						Architecture: "80486DX",
+					},
+					Layers: []*model.ContainerImage_ContainerImageLayer{
+						{
+							Urls:      []string{"url"},
+							MediaType: "media",
+							Digest:    "digest_layer_1",
+							Size:      43,
+							History: &model.ContainerImage_ContainerImageLayer_History{
+								Created: &timestamp.Timestamp{
+									Seconds: 42,
+									Nanos:   43,
+								},
+							},
+						},
+						{
+							Urls:      []string{"url"},
+							MediaType: "media",
+							Digest:    "digest_layer_2",
+							Size:      44,
+							History: &model.ContainerImage_ContainerImageLayer_History{
+								Created: &timestamp.Timestamp{
+									Seconds: 43,
+									Nanos:   44,
+								},
+							},
 						},
 					},
-				},
-			},
-			BuiltAt: &timestamp.Timestamp{
-				Seconds: 43,
-				Nanos:   44,
-			},
-		},
-		{
-			Id:        "gcr.io/datadoghq/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
-			Name:      "gcr.io/datadoghq/agent",
-			Registry:  "gcr.io",
-			ShortName: "agent",
-			Tags: []string{
-				"7-rc",
-			},
-			Digest:      "sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
-			Size:        42,
-			RepoDigests: []string{},
-			Os: &model.ContainerImage_OperatingSystem{
-				Name:         "DOS",
-				Version:      "6.22",
-				Architecture: "80486DX",
-			},
-			Layers: []*model.ContainerImage_ContainerImageLayer{
-				{
-					Urls:      []string{"url"},
-					MediaType: "media",
-					Digest:    "digest_layer_1",
-					Size:      43,
-					History: &model.ContainerImage_ContainerImageLayer_History{
-						Created: &timestamp.Timestamp{
-							Seconds: 42,
-							Nanos:   43,
-						},
+					BuiltAt: &timestamp.Timestamp{
+						Seconds: 43,
+						Nanos:   44,
 					},
 				},
-				{
-					Urls:      []string{"url"},
-					MediaType: "media",
-					Digest:    "digest_layer_2",
-					Size:      44,
-					History: &model.ContainerImage_ContainerImageLayer_History{
-						Created: &timestamp.Timestamp{
-							Seconds: 43,
-							Nanos:   44,
-						},
-					},
-				},
-			},
-			BuiltAt: &timestamp.Timestamp{
-				Seconds: 43,
-				Nanos:   44,
 			},
 		},
 	}
 
-	p.stop()
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var imagesSent = atomic.NewInt32(0)
 
-	// The queue is processing the events in a different go routine and might
-	// need some time
-	assert.Eventually(t, func() bool {
-		return imagesSent.Load() == int32(len(expectedImages))
-	}, 1*time.Second, 5*time.Millisecond)
+			sender := mocksender.NewMockSender("")
+			sender.On("ContainerImage", mock.Anything, mock.Anything).Return().Run(func(_ mock.Arguments) {
+				imagesSent.Inc()
+			})
 
-	for _, expectedImage := range expectedImages {
-		sender.AssertContainerImage(t, []model.ContainerImagePayload{
-			{
-				Version: "v1",
-				Images:  []*model.ContainerImage{expectedImage},
-			},
+			// Define a max size of 1 for the queue. With a size > 1, it's difficult to
+			// control the number of events sent on each call.
+			p := newProcessor(sender, 1, 50*time.Millisecond)
+
+			p.processEvents(workloadmeta.EventBundle{
+				Events: test.inputEvents,
+				Ch:     make(chan struct{}),
+			})
+
+			p.stop()
+
+			// The queue is processing the events in a different go routine and might
+			// need some time
+			assert.Eventually(t, func() bool {
+				return imagesSent.Load() == int32(len(test.expectedImages))
+			}, 1*time.Second, 5*time.Millisecond)
+
+			for _, expectedImage := range test.expectedImages {
+				sender.AssertContainerImage(t, []model.ContainerImagePayload{
+					{
+						Version: "v1",
+						Images:  []*model.ContainerImage{expectedImage},
+					},
+				})
+			}
 		})
 	}
 }

--- a/pkg/collector/corechecks/containerimage/processor_test.go
+++ b/pkg/collector/corechecks/containerimage/processor_test.go
@@ -10,21 +10,29 @@ import (
 	"time"
 
 	model "github.com/DataDog/agent-payload/v5/contimage"
+	"github.com/golang/protobuf/ptypes/timestamp"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"go.uber.org/atomic"
+
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/util/pointer"
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
-
-	"github.com/golang/protobuf/ptypes/timestamp"
-	v1 "github.com/opencontainers/image-spec/specs-go/v1"
-
-	"github.com/stretchr/testify/mock"
 )
 
 func TestProcessEvents(t *testing.T) {
+	var imagesSent = atomic.NewInt32(0)
+
 	sender := mocksender.NewMockSender(check.ID(""))
-	sender.On("ContainerImage", mock.Anything, mock.Anything).Return()
-	p := newProcessor(sender, 2, 50*time.Millisecond)
+	sender.On("ContainerImage", mock.Anything, mock.Anything).Return().Run(func(_ mock.Arguments) {
+		imagesSent.Inc()
+	})
+
+	// Define a max size of 1 for the queue. With a size > 1, it's difficult to
+	// control the number of events sent on each call.
+	p := newProcessor(sender, 1, 50*time.Millisecond)
 
 	p.processEvents(workloadmeta.EventBundle{
 		Events: []workloadmeta.Event{
@@ -78,171 +86,169 @@ func TestProcessEvents(t *testing.T) {
 		Ch: make(chan struct{}),
 	})
 
-	sender.AssertNumberOfCalls(t, "ContainerImage", 1)
-	sender.AssertContainerImage(t, []model.ContainerImagePayload{
+	expectedImages := []*model.ContainerImage{
 		{
-			Version: "v1",
-			Images: []*model.ContainerImage{
+			Id:        "datadog/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
+			Name:      "datadog/agent",
+			Registry:  "",
+			ShortName: "agent",
+			Tags: []string{
+				"7-rc",
+				"7.41.1-rc.1",
+			},
+			Digest:      "sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
+			Size:        42,
+			RepoDigests: []string{"datadog/agent@sha256:052f1fdf4f9a7117d36a1838ab60782829947683007c34b69d4991576375c409"},
+			Os: &model.ContainerImage_OperatingSystem{
+				Name:         "DOS",
+				Version:      "6.22",
+				Architecture: "80486DX",
+			},
+			Layers: []*model.ContainerImage_ContainerImageLayer{
 				{
-					Id:        "datadog/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
-					Name:      "datadog/agent",
-					Registry:  "",
-					ShortName: "agent",
-					Tags: []string{
-						"7-rc",
-						"7.41.1-rc.1",
-					},
-					Digest:      "sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
-					Size:        42,
-					RepoDigests: []string{"datadog/agent@sha256:052f1fdf4f9a7117d36a1838ab60782829947683007c34b69d4991576375c409"},
-					Os: &model.ContainerImage_OperatingSystem{
-						Name:         "DOS",
-						Version:      "6.22",
-						Architecture: "80486DX",
-					},
-					Layers: []*model.ContainerImage_ContainerImageLayer{
-						{
-							Urls:      []string{"url"},
-							MediaType: "media",
-							Digest:    "digest_layer_1",
-							Size:      43,
-							History: &model.ContainerImage_ContainerImageLayer_History{
-								Created: &timestamp.Timestamp{
-									Seconds: 42,
-									Nanos:   43,
-								},
-							},
+					Urls:      []string{"url"},
+					MediaType: "media",
+					Digest:    "digest_layer_1",
+					Size:      43,
+					History: &model.ContainerImage_ContainerImageLayer_History{
+						Created: &timestamp.Timestamp{
+							Seconds: 42,
+							Nanos:   43,
 						},
-						{
-							Urls:      []string{"url"},
-							MediaType: "media",
-							Digest:    "digest_layer_2",
-							Size:      44,
-							History: &model.ContainerImage_ContainerImageLayer_History{
-								Created: &timestamp.Timestamp{
-									Seconds: 43,
-									Nanos:   44,
-								},
-							},
-						},
-					},
-					BuiltAt: &timestamp.Timestamp{
-						Seconds: 43,
-						Nanos:   44,
 					},
 				},
 				{
-					Id:        "gcr.io/datadoghq/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
-					Name:      "gcr.io/datadoghq/agent",
-					Registry:  "gcr.io",
-					ShortName: "agent",
-					Tags: []string{
-						"7-rc",
-						"7.41.1-rc.1",
-					},
-					Digest:      "sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
-					Size:        42,
-					RepoDigests: []string{"gcr.io/datadoghq/agent@sha256:052f1fdf4f9a7117d36a1838ab60782829947683007c34b69d4991576375c409"},
-					Os: &model.ContainerImage_OperatingSystem{
-						Name:         "DOS",
-						Version:      "6.22",
-						Architecture: "80486DX",
-					},
-					Layers: []*model.ContainerImage_ContainerImageLayer{
-						{
-							Urls:      []string{"url"},
-							MediaType: "media",
-							Digest:    "digest_layer_1",
-							Size:      43,
-							History: &model.ContainerImage_ContainerImageLayer_History{
-								Created: &timestamp.Timestamp{
-									Seconds: 42,
-									Nanos:   43,
-								},
-							},
+					Urls:      []string{"url"},
+					MediaType: "media",
+					Digest:    "digest_layer_2",
+					Size:      44,
+					History: &model.ContainerImage_ContainerImageLayer_History{
+						Created: &timestamp.Timestamp{
+							Seconds: 43,
+							Nanos:   44,
 						},
-						{
-							Urls:      []string{"url"},
-							MediaType: "media",
-							Digest:    "digest_layer_2",
-							Size:      44,
-							History: &model.ContainerImage_ContainerImageLayer_History{
-								Created: &timestamp.Timestamp{
-									Seconds: 43,
-									Nanos:   44,
-								},
-							},
-						},
-					},
-					BuiltAt: &timestamp.Timestamp{
-						Seconds: 43,
-						Nanos:   44,
 					},
 				},
 			},
+			BuiltAt: &timestamp.Timestamp{
+				Seconds: 43,
+				Nanos:   44,
+			},
 		},
-	})
-
-	time.Sleep(100 * time.Millisecond)
-
-	sender.AssertNumberOfCalls(t, "ContainerImage", 2)
-	sender.AssertContainerImage(t, []model.ContainerImagePayload{
 		{
-			Version: "v1",
-			Images: []*model.ContainerImage{
+			Id:        "gcr.io/datadoghq/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
+			Name:      "gcr.io/datadoghq/agent",
+			Registry:  "gcr.io",
+			ShortName: "agent",
+			Tags: []string{
+				"7-rc",
+				"7.41.1-rc.1",
+			},
+			Digest:      "sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
+			Size:        42,
+			RepoDigests: []string{"gcr.io/datadoghq/agent@sha256:052f1fdf4f9a7117d36a1838ab60782829947683007c34b69d4991576375c409"},
+			Os: &model.ContainerImage_OperatingSystem{
+				Name:         "DOS",
+				Version:      "6.22",
+				Architecture: "80486DX",
+			},
+			Layers: []*model.ContainerImage_ContainerImageLayer{
 				{
-					Id:        "public.ecr.aws/datadog/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
-					Name:      "public.ecr.aws/datadog/agent",
-					Registry:  "public.ecr.aws",
-					ShortName: "agent",
-					Tags: []string{
-						"7-rc",
-						"7.41.1-rc.1",
-					},
-					Digest:      "sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
-					Size:        42,
-					RepoDigests: []string{"public.ecr.aws/datadog/agent@sha256:052f1fdf4f9a7117d36a1838ab60782829947683007c34b69d4991576375c409"},
-					Os: &model.ContainerImage_OperatingSystem{
-						Name:         "DOS",
-						Version:      "6.22",
-						Architecture: "80486DX",
-					},
-					Layers: []*model.ContainerImage_ContainerImageLayer{
-						{
-							Urls:      []string{"url"},
-							MediaType: "media",
-							Digest:    "digest_layer_1",
-							Size:      43,
-							History: &model.ContainerImage_ContainerImageLayer_History{
-								Created: &timestamp.Timestamp{
-									Seconds: 42,
-									Nanos:   43,
-								},
-							},
-						},
-						{
-							Urls:      []string{"url"},
-							MediaType: "media",
-							Digest:    "digest_layer_2",
-							Size:      44,
-							History: &model.ContainerImage_ContainerImageLayer_History{
-								Created: &timestamp.Timestamp{
-									Seconds: 43,
-									Nanos:   44,
-								},
-							},
+					Urls:      []string{"url"},
+					MediaType: "media",
+					Digest:    "digest_layer_1",
+					Size:      43,
+					History: &model.ContainerImage_ContainerImageLayer_History{
+						Created: &timestamp.Timestamp{
+							Seconds: 42,
+							Nanos:   43,
 						},
 					},
-					BuiltAt: &timestamp.Timestamp{
-						Seconds: 43,
-						Nanos:   44,
+				},
+				{
+					Urls:      []string{"url"},
+					MediaType: "media",
+					Digest:    "digest_layer_2",
+					Size:      44,
+					History: &model.ContainerImage_ContainerImageLayer_History{
+						Created: &timestamp.Timestamp{
+							Seconds: 43,
+							Nanos:   44,
+						},
 					},
 				},
 			},
+			BuiltAt: &timestamp.Timestamp{
+				Seconds: 43,
+				Nanos:   44,
+			},
 		},
-	})
+		{
+			Id:        "public.ecr.aws/datadog/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
+			Name:      "public.ecr.aws/datadog/agent",
+			Registry:  "public.ecr.aws",
+			ShortName: "agent",
+			Tags: []string{
+				"7-rc",
+				"7.41.1-rc.1",
+			},
+			Digest:      "sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
+			Size:        42,
+			RepoDigests: []string{"public.ecr.aws/datadog/agent@sha256:052f1fdf4f9a7117d36a1838ab60782829947683007c34b69d4991576375c409"},
+			Os: &model.ContainerImage_OperatingSystem{
+				Name:         "DOS",
+				Version:      "6.22",
+				Architecture: "80486DX",
+			},
+			Layers: []*model.ContainerImage_ContainerImageLayer{
+				{
+					Urls:      []string{"url"},
+					MediaType: "media",
+					Digest:    "digest_layer_1",
+					Size:      43,
+					History: &model.ContainerImage_ContainerImageLayer_History{
+						Created: &timestamp.Timestamp{
+							Seconds: 42,
+							Nanos:   43,
+						},
+					},
+				},
+				{
+					Urls:      []string{"url"},
+					MediaType: "media",
+					Digest:    "digest_layer_2",
+					Size:      44,
+					History: &model.ContainerImage_ContainerImageLayer_History{
+						Created: &timestamp.Timestamp{
+							Seconds: 43,
+							Nanos:   44,
+						},
+					},
+				},
+			},
+			BuiltAt: &timestamp.Timestamp{
+				Seconds: 43,
+				Nanos:   44,
+			},
+		},
+	}
 
 	p.stop()
+
+	// The queue is processing the events in a different go routine and might
+	// need some time
+	assert.Eventually(t, func() bool {
+		return imagesSent.Load() == int32(len(expectedImages))
+	}, 1*time.Second, 5*time.Millisecond)
+
+	for _, expectedImage := range expectedImages {
+		sender.AssertContainerImage(t, []model.ContainerImagePayload{
+			{
+				Version: "v1",
+				Images:  []*model.ContainerImage{expectedImage},
+			},
+		})
+	}
 }
 
 func TestProcessEvents_repoTagWithNoMatchingRepoDigest(t *testing.T) {
@@ -253,9 +259,13 @@ func TestProcessEvents_repoTagWithNoMatchingRepoDigest(t *testing.T) {
 	// one repo digest.
 	// We expect to send 2 events, one for each registry.
 
+	var imagesSent = atomic.NewInt32(0)
+
 	sender := mocksender.NewMockSender("")
-	sender.On("ContainerImage", mock.Anything, mock.Anything).Return()
-	p := newProcessor(sender, 2, 50*time.Millisecond)
+	sender.On("ContainerImage", mock.Anything, mock.Anything).Return().Run(func(_ mock.Arguments) {
+		imagesSent.Inc()
+	})
+	p := newProcessor(sender, 1, 50*time.Millisecond)
 
 	p.processEvents(workloadmeta.EventBundle{
 		Events: []workloadmeta.Event{
@@ -304,110 +314,117 @@ func TestProcessEvents_repoTagWithNoMatchingRepoDigest(t *testing.T) {
 		Ch: make(chan struct{}),
 	})
 
-	time.Sleep(100 * time.Millisecond)
-
-	sender.AssertNumberOfCalls(t, "ContainerImage", 1)
-	sender.AssertContainerImage(t, []model.ContainerImagePayload{
+	expectedImages := []*model.ContainerImage{
 		{
-			Version: "v1",
-			Images: []*model.ContainerImage{
+			Id:        "public.ecr.aws/datadog/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
+			Name:      "public.ecr.aws/datadog/agent",
+			Registry:  "public.ecr.aws",
+			ShortName: "agent",
+			Tags: []string{
+				"7-rc",
+			},
+			Digest:      "sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
+			Size:        42,
+			RepoDigests: []string{"public.ecr.aws/datadog/agent@sha256:052f1fdf4f9a7117d36a1838ab60782829947683007c34b69d4991576375c409"},
+			Os: &model.ContainerImage_OperatingSystem{
+				Name:         "DOS",
+				Version:      "6.22",
+				Architecture: "80486DX",
+			},
+			Layers: []*model.ContainerImage_ContainerImageLayer{
 				{
-					Id:        "public.ecr.aws/datadog/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
-					Name:      "public.ecr.aws/datadog/agent",
-					Registry:  "public.ecr.aws",
-					ShortName: "agent",
-					Tags: []string{
-						"7-rc",
-					},
-					Digest:      "sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
-					Size:        42,
-					RepoDigests: []string{"public.ecr.aws/datadog/agent@sha256:052f1fdf4f9a7117d36a1838ab60782829947683007c34b69d4991576375c409"},
-					Os: &model.ContainerImage_OperatingSystem{
-						Name:         "DOS",
-						Version:      "6.22",
-						Architecture: "80486DX",
-					},
-					Layers: []*model.ContainerImage_ContainerImageLayer{
-						{
-							Urls:      []string{"url"},
-							MediaType: "media",
-							Digest:    "digest_layer_1",
-							Size:      43,
-							History: &model.ContainerImage_ContainerImageLayer_History{
-								Created: &timestamp.Timestamp{
-									Seconds: 42,
-									Nanos:   43,
-								},
-							},
+					Urls:      []string{"url"},
+					MediaType: "media",
+					Digest:    "digest_layer_1",
+					Size:      43,
+					History: &model.ContainerImage_ContainerImageLayer_History{
+						Created: &timestamp.Timestamp{
+							Seconds: 42,
+							Nanos:   43,
 						},
-						{
-							Urls:      []string{"url"},
-							MediaType: "media",
-							Digest:    "digest_layer_2",
-							Size:      44,
-							History: &model.ContainerImage_ContainerImageLayer_History{
-								Created: &timestamp.Timestamp{
-									Seconds: 43,
-									Nanos:   44,
-								},
-							},
-						},
-					},
-					BuiltAt: &timestamp.Timestamp{
-						Seconds: 43,
-						Nanos:   44,
 					},
 				},
 				{
-					Id:        "gcr.io/datadoghq/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
-					Name:      "gcr.io/datadoghq/agent",
-					Registry:  "gcr.io",
-					ShortName: "agent",
-					Tags: []string{
-						"7-rc",
-					},
-					Digest:      "sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
-					Size:        42,
-					RepoDigests: []string{},
-					Os: &model.ContainerImage_OperatingSystem{
-						Name:         "DOS",
-						Version:      "6.22",
-						Architecture: "80486DX",
-					},
-					Layers: []*model.ContainerImage_ContainerImageLayer{
-						{
-							Urls:      []string{"url"},
-							MediaType: "media",
-							Digest:    "digest_layer_1",
-							Size:      43,
-							History: &model.ContainerImage_ContainerImageLayer_History{
-								Created: &timestamp.Timestamp{
-									Seconds: 42,
-									Nanos:   43,
-								},
-							},
+					Urls:      []string{"url"},
+					MediaType: "media",
+					Digest:    "digest_layer_2",
+					Size:      44,
+					History: &model.ContainerImage_ContainerImageLayer_History{
+						Created: &timestamp.Timestamp{
+							Seconds: 43,
+							Nanos:   44,
 						},
-						{
-							Urls:      []string{"url"},
-							MediaType: "media",
-							Digest:    "digest_layer_2",
-							Size:      44,
-							History: &model.ContainerImage_ContainerImageLayer_History{
-								Created: &timestamp.Timestamp{
-									Seconds: 43,
-									Nanos:   44,
-								},
-							},
-						},
-					},
-					BuiltAt: &timestamp.Timestamp{
-						Seconds: 43,
-						Nanos:   44,
 					},
 				},
 			},
+			BuiltAt: &timestamp.Timestamp{
+				Seconds: 43,
+				Nanos:   44,
+			},
 		},
-	})
+		{
+			Id:        "gcr.io/datadoghq/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
+			Name:      "gcr.io/datadoghq/agent",
+			Registry:  "gcr.io",
+			ShortName: "agent",
+			Tags: []string{
+				"7-rc",
+			},
+			Digest:      "sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
+			Size:        42,
+			RepoDigests: []string{},
+			Os: &model.ContainerImage_OperatingSystem{
+				Name:         "DOS",
+				Version:      "6.22",
+				Architecture: "80486DX",
+			},
+			Layers: []*model.ContainerImage_ContainerImageLayer{
+				{
+					Urls:      []string{"url"},
+					MediaType: "media",
+					Digest:    "digest_layer_1",
+					Size:      43,
+					History: &model.ContainerImage_ContainerImageLayer_History{
+						Created: &timestamp.Timestamp{
+							Seconds: 42,
+							Nanos:   43,
+						},
+					},
+				},
+				{
+					Urls:      []string{"url"},
+					MediaType: "media",
+					Digest:    "digest_layer_2",
+					Size:      44,
+					History: &model.ContainerImage_ContainerImageLayer_History{
+						Created: &timestamp.Timestamp{
+							Seconds: 43,
+							Nanos:   44,
+						},
+					},
+				},
+			},
+			BuiltAt: &timestamp.Timestamp{
+				Seconds: 43,
+				Nanos:   44,
+			},
+		},
+	}
 
 	p.stop()
+
+	// The queue is processing the events in a different go routine and might
+	// need some time
+	assert.Eventually(t, func() bool {
+		return imagesSent.Load() == int32(len(expectedImages))
+	}, 1*time.Second, 5*time.Millisecond)
+
+	for _, expectedImage := range expectedImages {
+		sender.AssertContainerImage(t, []model.ContainerImagePayload{
+			{
+				Version: "v1",
+				Images:  []*model.ContainerImage{expectedImage},
+			},
+		})
+	}
 }

--- a/pkg/collector/corechecks/sbom/processor_test.go
+++ b/pkg/collector/corechecks/sbom/processor_test.go
@@ -19,52 +19,79 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
-	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/util/pointer"
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 )
 
 func TestProcessEvents(t *testing.T) {
-	var SBOMsSent = atomic.NewInt32(0)
-
-	sender := mocksender.NewMockSender(check.ID(""))
-	sender.On("SBOM", mock.Anything, mock.Anything).Return().Run(func(_ mock.Arguments) {
-		SBOMsSent.Inc()
-	})
-
-	// Define a max size of 1 for the queue. With a size > 1, it's difficult to
-	// control the number of events sent on each call.
-	p := newProcessor(sender, 1, 50*time.Millisecond)
-
 	sbomGenerationTime := time.Now()
 
-	p.processEvents(workloadmeta.EventBundle{
-		Events: []workloadmeta.Event{
-			{
-				Type: workloadmeta.EventTypeSet,
-				Entity: &workloadmeta.ContainerImageMetadata{
-					EntityID: workloadmeta.EntityID{
-						Kind: workloadmeta.KindContainerImageMetadata,
-						ID:   "sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
+	tests := []struct {
+		name          string
+		inputEvents   []workloadmeta.Event
+		expectedSBOMs []*model.SBOMEntity
+	}{
+		{
+			name: "standard case",
+			inputEvents: []workloadmeta.Event{
+				{
+					Type: workloadmeta.EventTypeSet,
+					Entity: &workloadmeta.ContainerImageMetadata{
+						EntityID: workloadmeta.EntityID{
+							Kind: workloadmeta.KindContainerImageMetadata,
+							ID:   "sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
+						},
+						RepoTags: []string{
+							"datadog/agent:7-rc",
+							"datadog/agent:7.41.1-rc.1",
+							"gcr.io/datadoghq/agent:7-rc",
+							"gcr.io/datadoghq/agent:7.41.1-rc.1",
+							"public.ecr.aws/datadog/agent:7-rc",
+							"public.ecr.aws/datadog/agent:7.41.1-rc.1",
+						},
+						RepoDigests: []string{
+							"datadog/agent@sha256:052f1fdf4f9a7117d36a1838ab60782829947683007c34b69d4991576375c409",
+							"gcr.io/datadoghq/agent@sha256:052f1fdf4f9a7117d36a1838ab60782829947683007c34b69d4991576375c409",
+							"public.ecr.aws/datadog/agent@sha256:052f1fdf4f9a7117d36a1838ab60782829947683007c34b69d4991576375c409",
+						},
+						SBOM: &workloadmeta.SBOM{
+							CycloneDXBOM: &cyclonedx.BOM{
+								SpecVersion: cyclonedx.SpecVersion1_4,
+								Version:     42,
+								Components: &[]cyclonedx.Component{
+									{
+										Name: "Foo",
+									},
+									{
+										Name: "Bar",
+									},
+									{
+										Name: "Baz",
+									},
+								},
+							},
+							GenerationTime:     sbomGenerationTime,
+							GenerationDuration: 10 * time.Second,
+						},
 					},
-					RepoTags: []string{
-						"datadog/agent:7-rc",
-						"datadog/agent:7.41.1-rc.1",
-						"gcr.io/datadoghq/agent:7-rc",
-						"gcr.io/datadoghq/agent:7.41.1-rc.1",
-						"public.ecr.aws/datadog/agent:7-rc",
-						"public.ecr.aws/datadog/agent:7.41.1-rc.1",
+				},
+			},
+			expectedSBOMs: []*model.SBOMEntity{
+				{
+					Type: model.SBOMSourceType_CONTAINER_IMAGE_LAYERS,
+					Id:   "datadog/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
+					Tags: []string{
+						"7-rc",
+						"7.41.1-rc.1",
 					},
-					RepoDigests: []string{
-						"datadog/agent@sha256:052f1fdf4f9a7117d36a1838ab60782829947683007c34b69d4991576375c409",
-						"gcr.io/datadoghq/agent@sha256:052f1fdf4f9a7117d36a1838ab60782829947683007c34b69d4991576375c409",
-						"public.ecr.aws/datadog/agent@sha256:052f1fdf4f9a7117d36a1838ab60782829947683007c34b69d4991576375c409",
-					},
-					SBOM: &workloadmeta.SBOM{
-						CycloneDXBOM: &cyclonedx.BOM{
-							SpecVersion: cyclonedx.SpecVersion1_4,
-							Version:     42,
-							Components: &[]cyclonedx.Component{
+					InUse:              true,
+					GeneratedAt:        timestamppb.New(sbomGenerationTime),
+					GenerationDuration: durationpb.New(10 * time.Second),
+					Sbom: &model.SBOMEntity_Cyclonedx{
+						Cyclonedx: &cyclonedx_v1_4.Bom{
+							SpecVersion: "1.4",
+							Version:     pointer.Ptr(int32(42)),
+							Components: []*cyclonedx_v1_4.Component{
 								{
 									Name: "Foo",
 								},
@@ -76,161 +103,23 @@ func TestProcessEvents(t *testing.T) {
 								},
 							},
 						},
-						GenerationTime:     sbomGenerationTime,
-						GenerationDuration: 10 * time.Second,
 					},
 				},
-			},
-		},
-		Ch: make(chan struct{}),
-	})
-
-	expectedSBOMs := []*model.SBOMEntity{
-		{
-			Type: model.SBOMSourceType_CONTAINER_IMAGE_LAYERS,
-			Id:   "datadog/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
-			Tags: []string{
-				"7-rc",
-				"7.41.1-rc.1",
-			},
-			InUse:              true,
-			GeneratedAt:        timestamppb.New(sbomGenerationTime),
-			GenerationDuration: durationpb.New(10 * time.Second),
-			Sbom: &model.SBOMEntity_Cyclonedx{
-				Cyclonedx: &cyclonedx_v1_4.Bom{
-					SpecVersion: "1.4",
-					Version:     pointer.Ptr(int32(42)),
-					Components: []*cyclonedx_v1_4.Component{
-						{
-							Name: "Foo",
-						},
-						{
-							Name: "Bar",
-						},
-						{
-							Name: "Baz",
-						},
+				{
+					Type: model.SBOMSourceType_CONTAINER_IMAGE_LAYERS,
+					Id:   "gcr.io/datadoghq/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
+					Tags: []string{
+						"7-rc",
+						"7.41.1-rc.1",
 					},
-				},
-			},
-		},
-		{
-			Type: model.SBOMSourceType_CONTAINER_IMAGE_LAYERS,
-			Id:   "gcr.io/datadoghq/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
-			Tags: []string{
-				"7-rc",
-				"7.41.1-rc.1",
-			},
-			InUse:              true,
-			GeneratedAt:        timestamppb.New(sbomGenerationTime),
-			GenerationDuration: durationpb.New(10 * time.Second),
-			Sbom: &model.SBOMEntity_Cyclonedx{
-				Cyclonedx: &cyclonedx_v1_4.Bom{
-					SpecVersion: "1.4",
-					Version:     pointer.Ptr(int32(42)),
-					Components: []*cyclonedx_v1_4.Component{
-						{
-							Name: "Foo",
-						},
-						{
-							Name: "Bar",
-						},
-						{
-							Name: "Baz",
-						},
-					},
-				},
-			},
-		},
-		{
-			Type: model.SBOMSourceType_CONTAINER_IMAGE_LAYERS,
-			Id:   "public.ecr.aws/datadog/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
-			Tags: []string{
-				"7-rc",
-				"7.41.1-rc.1",
-			},
-			InUse:              true,
-			GeneratedAt:        timestamppb.New(sbomGenerationTime),
-			GenerationDuration: durationpb.New(10 * time.Second),
-			Sbom: &model.SBOMEntity_Cyclonedx{
-				Cyclonedx: &cyclonedx_v1_4.Bom{
-					SpecVersion: "1.4",
-					Version:     pointer.Ptr(int32(42)),
-					Components: []*cyclonedx_v1_4.Component{
-						{
-							Name: "Foo",
-						},
-						{
-							Name: "Bar",
-						},
-						{
-							Name: "Baz",
-						},
-					},
-				},
-			},
-		},
-	}
-
-	p.stop()
-
-	// The queue is processing the events in a different go routine and might
-	// need some time
-	assert.Eventually(t, func() bool {
-		return SBOMsSent.Load() == int32(len(expectedSBOMs))
-	}, 1*time.Second, 5*time.Millisecond)
-
-	for _, expectedSBOM := range expectedSBOMs {
-		sender.AssertSBOM(t, []model.SBOMPayload{
-			{
-				Version:  1,
-				Source:   &sourceAgent,
-				Entities: []*model.SBOMEntity{expectedSBOM},
-			},
-		})
-	}
-}
-
-func TestProcessEvents_repoTagWithNoMatchingRepoDigest(t *testing.T) {
-	// In containerd some images are created without a repo digest, and it's
-	// also possible to remove repo digests manually. To test that scenario, in
-	// this test, we define an image with 2 repo tags: one for the gcr.io
-	// registry and another for the public.ecr.aws registry, but there's only
-	// one repo digest.
-	// We expect to send 2 events, one for each registry.
-
-	var SBOMsSent = atomic.NewInt32(0)
-
-	sender := mocksender.NewMockSender("")
-	sender.On("SBOM", mock.Anything, mock.Anything).Return().Run(func(_ mock.Arguments) {
-		SBOMsSent.Inc()
-	})
-	p := newProcessor(sender, 1, 50*time.Millisecond)
-
-	sbomGenerationTime := time.Now()
-
-	p.processEvents(workloadmeta.EventBundle{
-		Events: []workloadmeta.Event{
-			{
-				Type: workloadmeta.EventTypeSet,
-				Entity: &workloadmeta.ContainerImageMetadata{
-					EntityID: workloadmeta.EntityID{
-						Kind: workloadmeta.KindContainerImageMetadata,
-						ID:   "sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
-					},
-					RepoTags: []string{
-						"gcr.io/datadoghq/agent:7-rc",
-						"public.ecr.aws/datadog/agent:7-rc",
-					},
-					RepoDigests: []string{
-						// Notice that there's a repo tag for gcr.io, but no repo digest.
-						"public.ecr.aws/datadog/agent@sha256:052f1fdf4f9a7117d36a1838ab60782829947683007c34b69d4991576375c409",
-					},
-					SBOM: &workloadmeta.SBOM{
-						CycloneDXBOM: &cyclonedx.BOM{
-							SpecVersion: cyclonedx.SpecVersion1_4,
-							Version:     42,
-							Components: &[]cyclonedx.Component{
+					InUse:              true,
+					GeneratedAt:        timestamppb.New(sbomGenerationTime),
+					GenerationDuration: durationpb.New(10 * time.Second),
+					Sbom: &model.SBOMEntity_Cyclonedx{
+						Cyclonedx: &cyclonedx_v1_4.Bom{
+							SpecVersion: "1.4",
+							Version:     pointer.Ptr(int32(42)),
+							Components: []*cyclonedx_v1_4.Component{
 								{
 									Name: "Foo",
 								},
@@ -242,65 +131,136 @@ func TestProcessEvents_repoTagWithNoMatchingRepoDigest(t *testing.T) {
 								},
 							},
 						},
-						GenerationTime:     sbomGenerationTime,
-						GenerationDuration: 10 * time.Second,
 					},
 				},
-			},
-		},
-		Ch: make(chan struct{}),
-	})
-
-	expectedSBOMs := []*model.SBOMEntity{
-		{
-			Type: model.SBOMSourceType_CONTAINER_IMAGE_LAYERS,
-			Id:   "public.ecr.aws/datadog/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
-			Tags: []string{
-				"7-rc",
-			},
-			InUse:              true,
-			GeneratedAt:        timestamppb.New(sbomGenerationTime),
-			GenerationDuration: durationpb.New(10 * time.Second),
-			Sbom: &model.SBOMEntity_Cyclonedx{
-				Cyclonedx: &cyclonedx_v1_4.Bom{
-					SpecVersion: "1.4",
-					Version:     pointer.Ptr(int32(42)),
-					Components: []*cyclonedx_v1_4.Component{
-						{
-							Name: "Foo",
-						},
-						{
-							Name: "Bar",
-						},
-						{
-							Name: "Baz",
+				{
+					Type: model.SBOMSourceType_CONTAINER_IMAGE_LAYERS,
+					Id:   "public.ecr.aws/datadog/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
+					Tags: []string{
+						"7-rc",
+						"7.41.1-rc.1",
+					},
+					InUse:              true,
+					GeneratedAt:        timestamppb.New(sbomGenerationTime),
+					GenerationDuration: durationpb.New(10 * time.Second),
+					Sbom: &model.SBOMEntity_Cyclonedx{
+						Cyclonedx: &cyclonedx_v1_4.Bom{
+							SpecVersion: "1.4",
+							Version:     pointer.Ptr(int32(42)),
+							Components: []*cyclonedx_v1_4.Component{
+								{
+									Name: "Foo",
+								},
+								{
+									Name: "Bar",
+								},
+								{
+									Name: "Baz",
+								},
+							},
 						},
 					},
 				},
 			},
 		},
 		{
-			Type: model.SBOMSourceType_CONTAINER_IMAGE_LAYERS,
-			Id:   "gcr.io/datadoghq/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
-			Tags: []string{
-				"7-rc",
+			// In containerd some images are created without a repo digest, and it's
+			// also possible to remove repo digests manually. To test that scenario, in
+			// this test, we define an image with 2 repo tags: one for the gcr.io
+			// registry and another for the public.ecr.aws registry, but there's only
+			// one repo digest.
+			// We expect to send 2 events, one for each registry.
+			name: "repo tag with no matching repo digest",
+			inputEvents: []workloadmeta.Event{
+				{
+					Type: workloadmeta.EventTypeSet,
+					Entity: &workloadmeta.ContainerImageMetadata{
+						EntityID: workloadmeta.EntityID{
+							Kind: workloadmeta.KindContainerImageMetadata,
+							ID:   "sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
+						},
+						RepoTags: []string{
+							"gcr.io/datadoghq/agent:7-rc",
+							"public.ecr.aws/datadog/agent:7-rc",
+						},
+						RepoDigests: []string{
+							// Notice that there's a repo tag for gcr.io, but no repo digest.
+							"public.ecr.aws/datadog/agent@sha256:052f1fdf4f9a7117d36a1838ab60782829947683007c34b69d4991576375c409",
+						},
+						SBOM: &workloadmeta.SBOM{
+							CycloneDXBOM: &cyclonedx.BOM{
+								SpecVersion: cyclonedx.SpecVersion1_4,
+								Version:     42,
+								Components: &[]cyclonedx.Component{
+									{
+										Name: "Foo",
+									},
+									{
+										Name: "Bar",
+									},
+									{
+										Name: "Baz",
+									},
+								},
+							},
+							GenerationTime:     sbomGenerationTime,
+							GenerationDuration: 10 * time.Second,
+						},
+					},
+				},
 			},
-			InUse:              true,
-			GeneratedAt:        timestamppb.New(sbomGenerationTime),
-			GenerationDuration: durationpb.New(10 * time.Second),
-			Sbom: &model.SBOMEntity_Cyclonedx{
-				Cyclonedx: &cyclonedx_v1_4.Bom{
-					SpecVersion: "1.4",
-					Version:     pointer.Ptr(int32(42)),
-					Components: []*cyclonedx_v1_4.Component{
-						{
-							Name: "Foo",
+			expectedSBOMs: []*model.SBOMEntity{
+				{
+					Type: model.SBOMSourceType_CONTAINER_IMAGE_LAYERS,
+					Id:   "public.ecr.aws/datadog/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
+					Tags: []string{
+						"7-rc",
+					},
+					InUse:              true,
+					GeneratedAt:        timestamppb.New(sbomGenerationTime),
+					GenerationDuration: durationpb.New(10 * time.Second),
+					Sbom: &model.SBOMEntity_Cyclonedx{
+						Cyclonedx: &cyclonedx_v1_4.Bom{
+							SpecVersion: "1.4",
+							Version:     pointer.Ptr(int32(42)),
+							Components: []*cyclonedx_v1_4.Component{
+								{
+									Name: "Foo",
+								},
+								{
+									Name: "Bar",
+								},
+								{
+									Name: "Baz",
+								},
+							},
 						},
-						{
-							Name: "Bar",
-						},
-						{
-							Name: "Baz",
+					},
+				},
+				{
+					Type: model.SBOMSourceType_CONTAINER_IMAGE_LAYERS,
+					Id:   "gcr.io/datadoghq/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
+					Tags: []string{
+						"7-rc",
+					},
+					InUse:              true,
+					GeneratedAt:        timestamppb.New(sbomGenerationTime),
+					GenerationDuration: durationpb.New(10 * time.Second),
+					Sbom: &model.SBOMEntity_Cyclonedx{
+						Cyclonedx: &cyclonedx_v1_4.Bom{
+							SpecVersion: "1.4",
+							Version:     pointer.Ptr(int32(42)),
+							Components: []*cyclonedx_v1_4.Component{
+								{
+									Name: "Foo",
+								},
+								{
+									Name: "Bar",
+								},
+								{
+									Name: "Baz",
+								},
+							},
 						},
 					},
 				},
@@ -308,21 +268,41 @@ func TestProcessEvents_repoTagWithNoMatchingRepoDigest(t *testing.T) {
 		},
 	}
 
-	p.stop()
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var SBOMsSent = atomic.NewInt32(0)
 
-	// The queue is processing the events in a different go routine and might
-	// need some time
-	assert.Eventually(t, func() bool {
-		return SBOMsSent.Load() == int32(len(expectedSBOMs))
-	}, 1*time.Second, 5*time.Millisecond)
+			sender := mocksender.NewMockSender("")
+			sender.On("SBOM", mock.Anything, mock.Anything).Return().Run(func(_ mock.Arguments) {
+				SBOMsSent.Inc()
+			})
 
-	for _, expectedSBOM := range expectedSBOMs {
-		sender.AssertSBOM(t, []model.SBOMPayload{
-			{
-				Version:  1,
-				Source:   &sourceAgent,
-				Entities: []*model.SBOMEntity{expectedSBOM},
-			},
+			// Define a max size of 1 for the queue. With a size > 1, it's difficult to
+			// control the number of events sent on each call.
+			p := newProcessor(sender, 1, 50*time.Millisecond)
+
+			p.processEvents(workloadmeta.EventBundle{
+				Events: test.inputEvents,
+				Ch:     make(chan struct{}),
+			})
+
+			p.stop()
+
+			// The queue is processing the events in a different go routine and might
+			// need some time
+			assert.Eventually(t, func() bool {
+				return SBOMsSent.Load() == int32(len(test.expectedSBOMs))
+			}, 1*time.Second, 5*time.Millisecond)
+
+			for _, expectedSBOM := range test.expectedSBOMs {
+				sender.AssertSBOM(t, []model.SBOMPayload{
+					{
+						Version:  1,
+						Source:   &sourceAgent,
+						Entities: []*model.SBOMEntity{expectedSBOM},
+					},
+				})
+			}
 		})
 	}
 }

--- a/pkg/collector/corechecks/sbom/processor_test.go
+++ b/pkg/collector/corechecks/sbom/processor_test.go
@@ -12,19 +12,29 @@ import (
 	"github.com/CycloneDX/cyclonedx-go"
 	"github.com/DataDog/agent-payload/v5/cyclonedx_v1_4"
 	model "github.com/DataDog/agent-payload/v5/sbom"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"go.uber.org/atomic"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/util/pointer"
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
-	"github.com/stretchr/testify/mock"
-	"google.golang.org/protobuf/types/known/durationpb"
-	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func TestProcessEvents(t *testing.T) {
+	var SBOMsSent = atomic.NewInt32(0)
+
 	sender := mocksender.NewMockSender(check.ID(""))
-	sender.On("SBOM", mock.Anything, mock.Anything).Return()
-	p := newProcessor(sender, 2, 50*time.Millisecond)
+	sender.On("SBOM", mock.Anything, mock.Anything).Return().Run(func(_ mock.Arguments) {
+		SBOMsSent.Inc()
+	})
+
+	// Define a max size of 1 for the queue. With a size > 1, it's difficult to
+	// control the number of events sent on each call.
+	p := newProcessor(sender, 1, 50*time.Millisecond)
 
 	sbomGenerationTime := time.Now()
 
@@ -75,113 +85,110 @@ func TestProcessEvents(t *testing.T) {
 		Ch: make(chan struct{}),
 	})
 
-	sender.AssertNumberOfCalls(t, "SBOM", 1)
-	sender.AssertSBOM(t, []model.SBOMPayload{
+	expectedSBOMs := []*model.SBOMEntity{
 		{
-			Version: 1,
-			Source:  &sourceAgent,
-			Entities: []*model.SBOMEntity{
-				{
-					Type: model.SBOMSourceType_CONTAINER_IMAGE_LAYERS,
-					Id:   "datadog/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
-					Tags: []string{
-						"7-rc",
-						"7.41.1-rc.1",
-					},
-					InUse:              true,
-					GeneratedAt:        timestamppb.New(sbomGenerationTime),
-					GenerationDuration: durationpb.New(10 * time.Second),
-					Sbom: &model.SBOMEntity_Cyclonedx{
-						Cyclonedx: &cyclonedx_v1_4.Bom{
-							SpecVersion: "1.4",
-							Version:     pointer.Ptr(int32(42)),
-							Components: []*cyclonedx_v1_4.Component{
-								{
-									Name: "Foo",
-								},
-								{
-									Name: "Bar",
-								},
-								{
-									Name: "Baz",
-								},
-							},
+			Type: model.SBOMSourceType_CONTAINER_IMAGE_LAYERS,
+			Id:   "datadog/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
+			Tags: []string{
+				"7-rc",
+				"7.41.1-rc.1",
+			},
+			InUse:              true,
+			GeneratedAt:        timestamppb.New(sbomGenerationTime),
+			GenerationDuration: durationpb.New(10 * time.Second),
+			Sbom: &model.SBOMEntity_Cyclonedx{
+				Cyclonedx: &cyclonedx_v1_4.Bom{
+					SpecVersion: "1.4",
+					Version:     pointer.Ptr(int32(42)),
+					Components: []*cyclonedx_v1_4.Component{
+						{
+							Name: "Foo",
 						},
-					},
-				},
-				{
-					Type: model.SBOMSourceType_CONTAINER_IMAGE_LAYERS,
-					Id:   "gcr.io/datadoghq/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
-					Tags: []string{
-						"7-rc",
-						"7.41.1-rc.1",
-					},
-					InUse:              true,
-					GeneratedAt:        timestamppb.New(sbomGenerationTime),
-					GenerationDuration: durationpb.New(10 * time.Second),
-					Sbom: &model.SBOMEntity_Cyclonedx{
-						Cyclonedx: &cyclonedx_v1_4.Bom{
-							SpecVersion: "1.4",
-							Version:     pointer.Ptr(int32(42)),
-							Components: []*cyclonedx_v1_4.Component{
-								{
-									Name: "Foo",
-								},
-								{
-									Name: "Bar",
-								},
-								{
-									Name: "Baz",
-								},
-							},
+						{
+							Name: "Bar",
+						},
+						{
+							Name: "Baz",
 						},
 					},
 				},
 			},
 		},
-	})
-
-	time.Sleep(100 * time.Millisecond)
-
-	sender.AssertNumberOfCalls(t, "SBOM", 2)
-	sender.AssertSBOM(t, []model.SBOMPayload{
 		{
-			Version: 1,
-			Source:  &sourceAgent,
-			Entities: []*model.SBOMEntity{
-				{
-					Type: model.SBOMSourceType_CONTAINER_IMAGE_LAYERS,
-					Id:   "public.ecr.aws/datadog/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
-					Tags: []string{
-						"7-rc",
-						"7.41.1-rc.1",
-					},
-					InUse:              true,
-					GeneratedAt:        timestamppb.New(sbomGenerationTime),
-					GenerationDuration: durationpb.New(10 * time.Second),
-					Sbom: &model.SBOMEntity_Cyclonedx{
-						Cyclonedx: &cyclonedx_v1_4.Bom{
-							SpecVersion: "1.4",
-							Version:     pointer.Ptr(int32(42)),
-							Components: []*cyclonedx_v1_4.Component{
-								{
-									Name: "Foo",
-								},
-								{
-									Name: "Bar",
-								},
-								{
-									Name: "Baz",
-								},
-							},
+			Type: model.SBOMSourceType_CONTAINER_IMAGE_LAYERS,
+			Id:   "gcr.io/datadoghq/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
+			Tags: []string{
+				"7-rc",
+				"7.41.1-rc.1",
+			},
+			InUse:              true,
+			GeneratedAt:        timestamppb.New(sbomGenerationTime),
+			GenerationDuration: durationpb.New(10 * time.Second),
+			Sbom: &model.SBOMEntity_Cyclonedx{
+				Cyclonedx: &cyclonedx_v1_4.Bom{
+					SpecVersion: "1.4",
+					Version:     pointer.Ptr(int32(42)),
+					Components: []*cyclonedx_v1_4.Component{
+						{
+							Name: "Foo",
+						},
+						{
+							Name: "Bar",
+						},
+						{
+							Name: "Baz",
 						},
 					},
 				},
 			},
 		},
-	})
+		{
+			Type: model.SBOMSourceType_CONTAINER_IMAGE_LAYERS,
+			Id:   "public.ecr.aws/datadog/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
+			Tags: []string{
+				"7-rc",
+				"7.41.1-rc.1",
+			},
+			InUse:              true,
+			GeneratedAt:        timestamppb.New(sbomGenerationTime),
+			GenerationDuration: durationpb.New(10 * time.Second),
+			Sbom: &model.SBOMEntity_Cyclonedx{
+				Cyclonedx: &cyclonedx_v1_4.Bom{
+					SpecVersion: "1.4",
+					Version:     pointer.Ptr(int32(42)),
+					Components: []*cyclonedx_v1_4.Component{
+						{
+							Name: "Foo",
+						},
+						{
+							Name: "Bar",
+						},
+						{
+							Name: "Baz",
+						},
+					},
+				},
+			},
+		},
+	}
 
 	p.stop()
+
+	// The queue is processing the events in a different go routine and might
+	// need some time
+	assert.Eventually(t, func() bool {
+		return SBOMsSent.Load() == int32(len(expectedSBOMs))
+	}, 1*time.Second, 5*time.Millisecond)
+
+	for _, expectedSBOM := range expectedSBOMs {
+		sender.AssertSBOM(t, []model.SBOMPayload{
+			{
+				Version:  1,
+				Source:   &sourceAgent,
+				Entities: []*model.SBOMEntity{expectedSBOM},
+			},
+		})
+	}
 }
 
 func TestProcessEvents_repoTagWithNoMatchingRepoDigest(t *testing.T) {
@@ -192,9 +199,13 @@ func TestProcessEvents_repoTagWithNoMatchingRepoDigest(t *testing.T) {
 	// one repo digest.
 	// We expect to send 2 events, one for each registry.
 
+	var SBOMsSent = atomic.NewInt32(0)
+
 	sender := mocksender.NewMockSender("")
-	sender.On("SBOM", mock.Anything, mock.Anything).Return()
-	p := newProcessor(sender, 2, 50*time.Millisecond)
+	sender.On("SBOM", mock.Anything, mock.Anything).Return().Run(func(_ mock.Arguments) {
+		SBOMsSent.Inc()
+	})
+	p := newProcessor(sender, 1, 50*time.Millisecond)
 
 	sbomGenerationTime := time.Now()
 
@@ -240,71 +251,78 @@ func TestProcessEvents_repoTagWithNoMatchingRepoDigest(t *testing.T) {
 		Ch: make(chan struct{}),
 	})
 
-	time.Sleep(100 * time.Millisecond)
-
-	sender.AssertNumberOfCalls(t, "SBOM", 1)
-	sender.AssertSBOM(t, []model.SBOMPayload{
+	expectedSBOMs := []*model.SBOMEntity{
 		{
-			Version: 1,
-			Source:  &sourceAgent,
-			Entities: []*model.SBOMEntity{
-				{
-					Type: model.SBOMSourceType_CONTAINER_IMAGE_LAYERS,
-					Id:   "public.ecr.aws/datadog/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
-					Tags: []string{
-						"7-rc",
-					},
-					InUse:              true,
-					GeneratedAt:        timestamppb.New(sbomGenerationTime),
-					GenerationDuration: durationpb.New(10 * time.Second),
-					Sbom: &model.SBOMEntity_Cyclonedx{
-						Cyclonedx: &cyclonedx_v1_4.Bom{
-							SpecVersion: "1.4",
-							Version:     pointer.Ptr(int32(42)),
-							Components: []*cyclonedx_v1_4.Component{
-								{
-									Name: "Foo",
-								},
-								{
-									Name: "Bar",
-								},
-								{
-									Name: "Baz",
-								},
-							},
+			Type: model.SBOMSourceType_CONTAINER_IMAGE_LAYERS,
+			Id:   "public.ecr.aws/datadog/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
+			Tags: []string{
+				"7-rc",
+			},
+			InUse:              true,
+			GeneratedAt:        timestamppb.New(sbomGenerationTime),
+			GenerationDuration: durationpb.New(10 * time.Second),
+			Sbom: &model.SBOMEntity_Cyclonedx{
+				Cyclonedx: &cyclonedx_v1_4.Bom{
+					SpecVersion: "1.4",
+					Version:     pointer.Ptr(int32(42)),
+					Components: []*cyclonedx_v1_4.Component{
+						{
+							Name: "Foo",
 						},
-					},
-				},
-				{
-					Type: model.SBOMSourceType_CONTAINER_IMAGE_LAYERS,
-					Id:   "gcr.io/datadoghq/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
-					Tags: []string{
-						"7-rc",
-					},
-					InUse:              true,
-					GeneratedAt:        timestamppb.New(sbomGenerationTime),
-					GenerationDuration: durationpb.New(10 * time.Second),
-					Sbom: &model.SBOMEntity_Cyclonedx{
-						Cyclonedx: &cyclonedx_v1_4.Bom{
-							SpecVersion: "1.4",
-							Version:     pointer.Ptr(int32(42)),
-							Components: []*cyclonedx_v1_4.Component{
-								{
-									Name: "Foo",
-								},
-								{
-									Name: "Bar",
-								},
-								{
-									Name: "Baz",
-								},
-							},
+						{
+							Name: "Bar",
+						},
+						{
+							Name: "Baz",
 						},
 					},
 				},
 			},
 		},
-	})
+		{
+			Type: model.SBOMSourceType_CONTAINER_IMAGE_LAYERS,
+			Id:   "gcr.io/datadoghq/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
+			Tags: []string{
+				"7-rc",
+			},
+			InUse:              true,
+			GeneratedAt:        timestamppb.New(sbomGenerationTime),
+			GenerationDuration: durationpb.New(10 * time.Second),
+			Sbom: &model.SBOMEntity_Cyclonedx{
+				Cyclonedx: &cyclonedx_v1_4.Bom{
+					SpecVersion: "1.4",
+					Version:     pointer.Ptr(int32(42)),
+					Components: []*cyclonedx_v1_4.Component{
+						{
+							Name: "Foo",
+						},
+						{
+							Name: "Bar",
+						},
+						{
+							Name: "Baz",
+						},
+					},
+				},
+			},
+		},
+	}
 
 	p.stop()
+
+	// The queue is processing the events in a different go routine and might
+	// need some time
+	assert.Eventually(t, func() bool {
+		return SBOMsSent.Load() == int32(len(expectedSBOMs))
+	}, 1*time.Second, 5*time.Millisecond)
+
+	for _, expectedSBOM := range expectedSBOMs {
+		sender.AssertSBOM(t, []model.SBOMPayload{
+			{
+				Version:  1,
+				Source:   &sourceAgent,
+				Entities: []*model.SBOMEntity{expectedSBOM},
+			},
+		})
+	}
 }


### PR DESCRIPTION
### What does this PR do?

Fixes the flaky tests in `pkg/collector/corechecks/containerimage/processor_test.go` and `pkg/collector/corechecks/sbom/processor_test.go`

The fix consists of using a queue of size 1 because With a size > 1 (we had 2), it's difficult to control the number of events sent on each call.

The fix above also makes it easier to define the tests to be table-driven, so I added that in a separate commit.

### Describe how to test/QA your changes

Skip.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
