### PR TITLE
Merge system-probe config before resolving secrets

### DIFF
--- a/cmd/process-agent/main_common.go
+++ b/cmd/process-agent/main_common.go
@@ -80,17 +80,7 @@ func runAgent(globalParams *command.GlobalParams, exit chan struct{}) {
 		}()
 	}
 
-	// We need to load in the system probe environment variables before we load the config, otherwise an
-	// "Unknown environment variable" warning will show up whenever valid system probe environment variables are defined.
-	ddconfig.InitSystemProbeConfig(ddconfig.Datadog)
-
-	if err := command.BootstrapConfig(globalParams.ConfFilePath, false); err != nil {
-		_ = log.Critical(err)
-		cleanupAndExit(1)
-	}
-
-	// For system probe, there is an additional config file that is shared with the system-probe
-	syscfg, err := sysconfig.Merge(globalParams.SysProbeConfFilePath)
+	syscfg, err := command.BootstrapConfig(globalParams.ConfFilePath, globalParams.SysProbeConfFilePath, false)
 	if err != nil {
 		_ = log.Critical(err)
 		cleanupAndExit(1)

--- a/cmd/process-agent/subcommands/check/check.go
+++ b/cmd/process-agent/subcommands/check/check.go
@@ -85,18 +85,9 @@ func runCheckCmd(cliParams *cliParams) error {
 	// Override the disable_file_logging setting so that the check command doesn't dump so much noise into the log file.
 	ddconfig.Datadog.Set("disable_file_logging", true)
 
-	// We need to load in the system probe environment variables before we load the config, otherwise an
-	// "Unknown environment variable" warning will show up whenever valid system probe environment variables are defined.
-	ddconfig.InitSystemProbeConfig(ddconfig.Datadog)
-
-	if err := command.BootstrapConfig(cliParams.GlobalParams.ConfFilePath, true); err != nil {
-		return log.Criticalf("Error parsing config: %s", err)
-	}
-
-	// For system probe, there is an additional config file that is shared with the system-probe
-	syscfg, err := sysconfig.Merge(cliParams.SysProbeConfFilePath)
+	syscfg, err := command.BootstrapConfig(cliParams.GlobalParams.ConfFilePath, cliParams.SysProbeConfFilePath, true)
 	if err != nil {
-		return log.Critical(err)
+		return log.Criticalf("Error parsing config: %s", err)
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/cmd/process-agent/subcommands/config/config.go
+++ b/cmd/process-agent/subcommands/config/config.go
@@ -146,7 +146,7 @@ func getConfigValue(globalParams *command.GlobalParams, args []string) error {
 }
 
 func getClient(globalParams *command.GlobalParams) (settings.Client, error) {
-	if err := command.BootstrapConfig(globalParams.ConfFilePath, true); err != nil {
+	if _, err := command.BootstrapConfig(globalParams.ConfFilePath, globalParams.SysProbeConfFilePath, true); err != nil {
 		return nil, log.Criticalf("Error parsing config: %s", err)
 	}
 

--- a/cmd/process-agent/subcommands/events/events.go
+++ b/cmd/process-agent/subcommands/events/events.go
@@ -18,8 +18,6 @@ import (
 	"go.uber.org/fx"
 
 	"github.com/DataDog/datadog-agent/cmd/process-agent/command"
-	sysconfig "github.com/DataDog/datadog-agent/cmd/system-probe/config"
-	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/process/checks"
 	"github.com/DataDog/datadog-agent/pkg/process/events"
 	"github.com/DataDog/datadog-agent/pkg/process/events/model"
@@ -86,16 +84,8 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 }
 
 func bootstrapEventsCmd(cliParams *cliParams) error {
-	ddconfig.InitSystemProbeConfig(ddconfig.Datadog)
-
-	if err := command.BootstrapConfig(cliParams.GlobalParams.ConfFilePath, true); err != nil {
+	if _, err := command.BootstrapConfig(cliParams.GlobalParams.ConfFilePath, cliParams.SysProbeConfFilePath, true); err != nil {
 		return log.Criticalf("Error parsing config: %s", err)
-	}
-
-	// Load system-probe.yaml file and merge it to the global Datadog config
-	_, err := sysconfig.Merge(cliParams.SysProbeConfFilePath)
-	if err != nil {
-		return log.Critical(err)
 	}
 
 	return nil

--- a/cmd/process-agent/subcommands/status/status.go
+++ b/cmd/process-agent/subcommands/status/status.go
@@ -153,7 +153,7 @@ func getStatusURL() (string, error) {
 }
 
 func runStatus(cliParams *cliParams) error {
-	if err := command.BootstrapConfig(cliParams.GlobalParams.ConfFilePath, true); err != nil {
+	if _, err := command.BootstrapConfig(cliParams.GlobalParams.ConfFilePath, cliParams.SysProbeConfFilePath, true); err != nil {
 		return log.Criticalf("Error parsing config: %s", err)
 	}
 

--- a/cmd/process-agent/subcommands/taggerlist/tagger_list.go
+++ b/cmd/process-agent/subcommands/taggerlist/tagger_list.go
@@ -49,7 +49,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 func taggerList(cliParams *cliParams) error {
 	log.Info("Got a request for the tagger-list. Calling tagger.")
 
-	if err := command.BootstrapConfig(cliParams.GlobalParams.ConfFilePath, true); err != nil {
+	if _, err := command.BootstrapConfig(cliParams.GlobalParams.ConfFilePath, cliParams.SysProbeConfFilePath, true); err != nil {
 		return log.Criticalf("Error parsing config: %s", err)
 	}
 


### PR DESCRIPTION


<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Ensures system-probe config is merged in before resolving secrets. This issue no longer exists on `main` because the system-probe config was separated out.

### Motivation

Fixes issue where process-agent was unable to read any value from system-probe.yaml (such as UDS location) because the config was already "frozen" from the earlier `config.ResolveSecrets` call.

### Additional Notes

I believe this bug was introduced in https://github.com/DataDog/datadog-agent/pull/14904

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Configure a secrets backend and add at least one secret to `datadog.yaml`. Use a custom location for the `system-probe` socket via `system_probe_config.sysprobe_socket` in `system-probe.yaml`. Enable NPM in `system-probe.yaml` with `network_config.enabled = true`. Launch both `process-agent` and `system-probe` and ensure the `connections` check finishes properly.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
