### PR TITLE
Add single-machine-performance to codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -98,6 +98,8 @@
 
 /.gitlab/benchmarks/benchmarks.yml                   @DataDog/agent-apm
 
+/.gitlab/functional_test/regression_detector.yml     @DataDog/single-machine-performance
+
 /chocolatey/                            @DataDog/windows-agent
 
 /cmd/                                   @DataDog/agent-shared-components
@@ -375,6 +377,7 @@
 /test/system/                           @DataDog/agent-shared-components
 /test/system/dogstatsd/                 @DataDog/agent-metrics-logs
 /test/benchmarks/apm_scripts/           @DataDog/agent-apm
+/test/regression/                       @DataDog/single-machine-performance
 
 /tools/                                 @DataDog/agent-platform
 /tools/ebpf/                            @DataDog/ebpf-platform


### PR DESCRIPTION
### What does this PR do?

Add the @DataDog/single-machine-performance team as codeowners for relevant files.

### Motivation

Help our team review changes
