### PR TITLE
pkg/trace/event: fix flaky test

### DIFF
--- a/pkg/trace/event/extractor_fixed_rate_test.go
+++ b/pkg/trace/event/extractor_fixed_rate_test.go
@@ -15,7 +15,11 @@ import (
 )
 
 func createTestSpans(serviceName string, operationName string) []*pb.Span {
-	spans := make([]*pb.Span, 1000)
+	return createNTestSpans(1000, serviceName, operationName)
+}
+
+func createNTestSpans(n int, serviceName string, operationName string) []*pb.Span {
+	spans := make([]*pb.Span, n)
 	for i := range spans {
 		spans[i] = &pb.Span{TraceID: rand.Uint64(), Service: serviceName, Name: operationName}
 	}

--- a/pkg/trace/event/processor_test.go
+++ b/pkg/trace/event/processor_test.go
@@ -85,7 +85,7 @@ func TestProcessor(t *testing.T) {
 			testSampler := &MockEventSampler{Rate: test.samplerRate}
 			p := newProcessor(extractors, testSampler)
 
-			testSpans := createTestSpans("test", "test")
+			testSpans := createNTestSpans(10000, "test", "test")
 			numSpans := len(testSpans)
 			testChunk := testutil.TraceChunkWithSpans(testSpans)
 			root := testSpans[0]


### PR DESCRIPTION

### What does this PR do?

This takes the test from failing roughly 1/30 times to failing < 1/10000 times - I couldn't get a failure by rerunning the test 10000 times.


### Motivation

Flaky test

### Additional Notes

This test is inherently probabilistic, since we're measuring statistical outcomes. However, in this PR, we bump up the sample size to ensure it should basically never fall out of range. This does not ensure it will never fail (we can't without redesigning the test), but it will at least not flake out all the time.


### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
