### PR TITLE
Remove Windows Agent zip from Docker image layer to save space.

### DIFF
--- a/.gitlab/container_build/docker_windows.yml
+++ b/.gitlab/container_build/docker_windows.yml
@@ -34,6 +34,15 @@
     - '$_instance_id = (iwr  -UseBasicParsing http://169.254.169.254/latest/meta-data/instance-id).content ; Write-Host "Running on instance $($_instance_id)"'
     - cp ${OMNIBUS_PACKAGE_DIR}/${AGENT_ZIP} ${BUILD_CONTEXT}/datadog-agent-latest.amd64.zip
     - cp entrypoint.exe ${BUILD_CONTEXT}/entrypoint.exe
+
+    # Much faster but doesn't exist in build container
+    # - & 'C:\Program Files\7-Zip\7z.exe' x .\datadog-agent-latest.amd64.zip -o"Datadog Agent"
+    - pushd ${BUILD_CONTEXT}
+    - Expand-Archive datadog-agent-latest.amd64.zip
+    - Remove-Item datadog-agent-latest.amd64.zip
+    - Get-ChildItem -Path datadog-agent-* | Rename-Item -NewName "Datadog Agent"
+    - popd
+
     - get-childitem ${BUILD_CONTEXT}
     # Docker setup
     - cat ci-scripts/docker-login.ps1
@@ -47,11 +56,6 @@
       powershell
       -C C:\mnt\ci-scripts\docker-login.ps1
     - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
-    # Much faster but doesn't exist in build container
-    # - & 'C:\Program Files\7-Zip\7z.exe' x .\datadog-agent-latest.amd64.zip -o"Datadog Agent"
-    - Expand-Archive ${BUILD_CONTEXT}/datadog-agent-latest.amd64.zip
-    - Remove-Item ${BUILD_CONTEXT}/datadog-agent-latest.amd64.zip
-    - Get-ChildItem -Path ${BUILD_CONTEXT}/datadog-agent-* | Rename-Item -NewName ${BUILD_CONTEXT}/"Datadog Agent"
     - powershell -Command "docker build --no-cache --build-arg GENERAL_ARTIFACTS_CACHE_BUCKET_URL=${GENERAL_ARTIFACTS_CACHE_BUCKET_URL} ${BUILD_ARG} --pull --file ${BUILD_CONTEXT}/windows/amd64/Dockerfile --tag ${TARGET_TAG} ${BUILD_CONTEXT}"
     - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
     - docker push ${TARGET_TAG}

--- a/.gitlab/container_build/docker_windows.yml
+++ b/.gitlab/container_build/docker_windows.yml
@@ -47,6 +47,11 @@
       powershell
       -C C:\mnt\ci-scripts\docker-login.ps1
     - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
+    # Much faster but doesn't exist in build container
+    # - & 'C:\Program Files\7-Zip\7z.exe' x .\datadog-agent-latest.amd64.zip -o"Datadog Agent"
+    - Expand-Archive datadog-agent-latest.amd64.zip
+    - Remove-Item datadog-agent-latest.amd64.zip
+    - Get-ChildItem -Path datadog-agent-* | Rename-Item -NewName "Datadog Agent"
     - powershell -Command "docker build --no-cache --build-arg GENERAL_ARTIFACTS_CACHE_BUCKET_URL=${GENERAL_ARTIFACTS_CACHE_BUCKET_URL} ${BUILD_ARG} --pull --file ${BUILD_CONTEXT}/windows/amd64/Dockerfile --tag ${TARGET_TAG} ${BUILD_CONTEXT}"
     - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
     - docker push ${TARGET_TAG}

--- a/.gitlab/container_build/docker_windows.yml
+++ b/.gitlab/container_build/docker_windows.yml
@@ -49,9 +49,9 @@
     - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
     # Much faster but doesn't exist in build container
     # - & 'C:\Program Files\7-Zip\7z.exe' x .\datadog-agent-latest.amd64.zip -o"Datadog Agent"
-    - Expand-Archive datadog-agent-latest.amd64.zip
-    - Remove-Item datadog-agent-latest.amd64.zip
-    - Get-ChildItem -Path datadog-agent-* | Rename-Item -NewName "Datadog Agent"
+    - Expand-Archive ${BUILD_CONTEXT}/datadog-agent-latest.amd64.zip
+    - Remove-Item ${BUILD_CONTEXT}/datadog-agent-latest.amd64.zip
+    - Get-ChildItem -Path ${BUILD_CONTEXT}/datadog-agent-* | Rename-Item -NewName ${BUILD_CONTEXT}/"Datadog Agent"
     - powershell -Command "docker build --no-cache --build-arg GENERAL_ARTIFACTS_CACHE_BUCKET_URL=${GENERAL_ARTIFACTS_CACHE_BUCKET_URL} ${BUILD_ARG} --pull --file ${BUILD_CONTEXT}/windows/amd64/Dockerfile --tag ${TARGET_TAG} ${BUILD_CONTEXT}"
     - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
     - docker push ${TARGET_TAG}

--- a/Dockerfiles/agent/install.ps1
+++ b/Dockerfiles/agent/install.ps1
@@ -34,14 +34,6 @@ if ("$env:WITH_JMX" -ne "false") {
     $Env:Path="$Env:Path;C:/java/bin"
 }
 
-Expand-Archive datadog-agent-latest.amd64.zip
-Remove-Item datadog-agent-latest.amd64.zip
-
-Get-ChildItem -Path datadog-agent-* | Rename-Item -NewName "Datadog Agent"
-
-New-Item -ItemType directory -Path "C:/Program Files/Datadog"
-Move-Item "Datadog Agent" "C:/Program Files/Datadog/"
-
 New-Item -ItemType directory -Path 'C:/ProgramData/Datadog'
 Move-Item "C:/Program Files/Datadog/Datadog Agent/EXAMPLECONFSLOCATION" "C:/ProgramData/Datadog/conf.d"
 

--- a/Dockerfiles/agent/windows/amd64/Dockerfile
+++ b/Dockerfiles/agent/windows/amd64/Dockerfile
@@ -14,7 +14,8 @@ USER ContainerAdministrator
 
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop';"]
 
-COPY datadog-agent-latest.amd64.zip install.ps1 ./
+COPY ["Datadog Agent", "C:/Program Files/Datadog/Datadog Agent"]
+COPY install.ps1 ./
 RUN . ./install.ps1
 
 EXPOSE 8125/udp 8126/tcp


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
This PR removes the Agent binaries zip from the layers of the Windows Agent docker image, so that it doesn't take space in the final image.

The [datadog/agent-dev:master-py3-win](https://hub.docker.com/layers/datadog/agent-dev/master-py3-win/images/sha256-e4e91267c82fc5c33ab60cc4eda313acfe7edf227c2fd7b13f9e81ae109f6f6e?context=explore) is 533.48MB compressed.

The [same image from this PR](https://hub.docker.com/layers/datadog/agent-dev/julien-lebot-lighter-win-docker-img-py3-win/images/sha256-8dbdd9782e7ff4e06f89c891b9406fe19cb9122cb7a4719fef333b7b24cf1878?context=explore) is 369.87 MB compressed.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Smaller Windows Agent docker image.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
It's also possible to do the same with multi-stage builds, i.e.:

```
FROM ${BASE_IMAGE} AS extract_agent_install
USER ContainerAdministrator
SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop';"]
COPY datadog-agent-latest.amd64.zip extract_agent_install.ps1 ./
RUN . ./extract_agent_install.ps1

...
FROM ${BASE_IMAGE}
COPY --from=extract_agent_install ["C:/Program Files/Datadog", "C:/Program Files/Datadog"]
```

However that crashed Docker on my machine and when it worked it ended up being much slower than extracting the archive on the CI machine.

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
