### PR TITLE
Bumping the max size of the DogStatsD binary check to 37MiB

### DIFF
--- a/tasks/dogstatsd.py
+++ b/tasks/dogstatsd.py
@@ -27,7 +27,7 @@ from .utils import (
 # constants
 DOGSTATSD_BIN_PATH = os.path.join(".", "bin", "dogstatsd")
 STATIC_BIN_PATH = os.path.join(".", "bin", "static")
-MAX_BINARY_SIZE = 35 * 1024
+MAX_BINARY_SIZE = 37 * 1024
 DOGSTATSD_TAG = "datadog/dogstatsd:master"
 
 


### PR DESCRIPTION

### What does this PR do?

Increases the allowed size of the DogStatsD binary. It now can be a max size of 37MiB

### Motivation

To fix the current build issues.

### Additional Notes

The DogStatsD binary size has increased 15% in last four months. It might be a good time to look at what we feel the target binary size for DogStatsD should be.

### Possible Drawbacks / Trade-offs

Binary size for DogStatsD will now be bigger.

### Describe how to test/QA your changes

Does not change any code.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
