### PR TITLE
Jlineaweaver/vpa nulls forrc

### DIFF
--- a/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/verticalpodautoscaler.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/verticalpodautoscaler.go
@@ -33,10 +33,6 @@ func ExtractVerticalPodAutoscaler(v *v1.VerticalPodAutoscaler) *model.VerticalPo
 // extractVerticalPodAutoscalerSpec converts the Kubernetes spec to our custom one
 // https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go#L73
 func extractVerticalPodAutoscalerSpec(s *v1.VerticalPodAutoscalerSpec) *model.VerticalPodAutoscalerSpec {
-	if s == nil {
-		return &model.VerticalPodAutoscalerSpec{}
-	}
-
 	spec := &model.VerticalPodAutoscalerSpec{
 		Target: &model.VerticalPodAutoscalerTarget{
 			Kind: s.TargetRef.Kind,

--- a/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/verticalpodautoscaler.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/verticalpodautoscaler.go
@@ -17,6 +17,10 @@ import (
 
 // ExtractVerticalPodAutoscaler returns the protobuf model corresponding to a Kubernetes Vertical Pod Autoscaler resource.
 func ExtractVerticalPodAutoscaler(v *v1.VerticalPodAutoscaler) *model.VerticalPodAutoscaler {
+	if v == nil {
+		return &model.VerticalPodAutoscaler{}
+	}
+
 	m := &model.VerticalPodAutoscaler{
 		Metadata: extractMetadata(&v.ObjectMeta),
 		Spec:     extractVerticalPodAutoscalerSpec(&v.Spec),
@@ -29,6 +33,10 @@ func ExtractVerticalPodAutoscaler(v *v1.VerticalPodAutoscaler) *model.VerticalPo
 // extractVerticalPodAutoscalerSpec converts the Kubernetes spec to our custom one
 // https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go#L73
 func extractVerticalPodAutoscalerSpec(s *v1.VerticalPodAutoscalerSpec) *model.VerticalPodAutoscalerSpec {
+	if s == nil {
+		return &model.VerticalPodAutoscalerSpec{}
+	}
+
 	spec := &model.VerticalPodAutoscalerSpec{
 		Target: &model.VerticalPodAutoscalerTarget{
 			Kind: s.TargetRef.Kind,
@@ -46,6 +54,10 @@ func extractVerticalPodAutoscalerSpec(s *v1.VerticalPodAutoscalerSpec) *model.Ve
 // and converts it to our protobuf model
 // https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go#L149
 func extractContainerResourcePolicies(p *v1.PodResourcePolicy) []*model.ContainerResourcePolicy {
+	if p == nil {
+		return []*model.ContainerResourcePolicy{}
+	}
+
 	policies := []*model.ContainerResourcePolicy{}
 
 	for _, policy := range p.ContainerPolicies {
@@ -122,6 +134,10 @@ func extractVerticalPodAutoscalerStatus(s *v1.VerticalPodAutoscalerStatus) *mode
 // extractContainerRecommendations converts Kuberentes Recommendations to our protobuf model
 // https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go#L245
 func extractContainerRecommendations(cr []v1.RecommendedContainerResources) []*model.ContainerRecommendations {
+	if cr == nil {
+		return []*model.ContainerRecommendations{}
+	}
+
 	recs := []*model.ContainerRecommendations{}
 	for _, r := range cr {
 		rec := model.ContainerRecommendations{


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
We're seeing occasional panics when running on a larger set of clusters. Add additional null checks to make sure our agent doesn't panic
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Want to fix any panics our agent might encounter

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
