### PR TITLE
[KSM] Fix `labelsAsTags`

### DIFF
--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
@@ -30,6 +30,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/clustername"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"golang.org/x/exp/maps"
 
 	"gopkg.in/yaml.v2"
 	"k8s.io/client-go/discovery"
@@ -77,26 +78,26 @@ type KSMConfig struct {
 	//       - deployment
 	//     labels_to_get:
 	//       - label_addonmanager_kubernetes_io_mode
-	LabelJoins map[string]*JoinsConfig `yaml:"label_joins"`
+	LabelJoins map[string]*JoinsConfigWithoutLabelsMapping `yaml:"label_joins"`
 
 	// LabelsAsTags
 	// Example:
 	// labels_as_tags:
 	//   pod:
-	//     - "app_*"
+	//     app: pod_app
 	//   node:
-	//     - "zone"
-	//     - "team_*"
+	//     app: node_app
+	//     team: node_team
 	LabelsAsTags map[string]map[string]string `yaml:"labels_as_tags"`
 
 	// AnnotationsAsTags
 	// Example:
 	// annotations_as_tags:
 	//   pod:
-	//     - "app_*"
+	//     app: pod_app
 	//   node:
-	//     - "zone"
-	//     - "team_*"
+	//     app: node_app
+	//     team: node_team
 	AnnotationsAsTags map[string]map[string]string `yaml:"annotations_as_tags"`
 
 	// LabelsMapper can be used to translate kube-state-metrics labels to other tags.
@@ -104,15 +105,6 @@ type KSMConfig struct {
 	// labels_mapper:
 	//   namespace: kube_namespace
 	LabelsMapper map[string]string `yaml:"labels_mapper"`
-
-	// LabelsMapperByResourceKind can be used to translate kube-state-metrics labels to other tags, depending on the resource kind.
-	// Example: Adding kube_pod_namespace tag instead of namespace for pods and kube_deployment_namespace for deployments.
-	// labels_mapper:
-	//   pod:
-	//     namespace: kube_pod_namespace
-	//   deployment:
-	//     namespace: kube_deployment_namespace
-	labelsMapperByResourceKind map[string]map[string]string
 
 	// Tags contains the list of tags to attach to every metric, event and service check emitted by this integration.
 	// Example:
@@ -141,6 +133,9 @@ type KSMConfig struct {
 	// LeaderSkip forces ignoring the leader election when running the check
 	// Can be useful when running the check as cluster check
 	LeaderSkip bool `yaml:"skip_leader_election"`
+
+	// Private field containing the label joins configuration built from `LabelJoins`, `LabelsAsTags` and `AnnotationsAsTags`.
+	labelJoins map[string]*joinsConfig
 }
 
 // KSMCheck wraps the config and the metric stores needed to run the check
@@ -161,7 +156,7 @@ type KSMCheck struct {
 }
 
 // JoinsConfig contains the config parameters for label joins
-type JoinsConfig struct {
+type JoinsConfigWithoutLabelsMapping struct {
 	// LabelsToMatch contains the labels that must
 	// match the labels of the targeted metric
 	LabelsToMatch []string `yaml:"labels_to_match"`
@@ -173,7 +168,7 @@ type JoinsConfig struct {
 	GetAllLabels bool `yaml:"get_all_labels"`
 }
 
-func (jc *JoinsConfig) setupGetAllLabels() {
+func (jc *JoinsConfigWithoutLabelsMapping) setupGetAllLabels() {
 	if jc.GetAllLabels {
 		return
 	}
@@ -216,17 +211,14 @@ func (k *KSMCheck) Configure(integrationConfigDigest uint64, config, initConfig 
 		joinConf.setupGetAllLabels()
 	}
 
-	labelJoins := defaultLabelJoins()
-	k.mergeLabelJoins(labelJoins)
+	k.mergeLabelJoins(defaultLabelJoins())
 
-	k.instance.labelsMapperByResourceKind = defaultLabelsMapperByResourceKind()
-
+	k.processLabelJoins()
 	k.processLabelsAsTags()
 	k.processAnnotationsAsTags()
 
 	// Prepare labels mapper
-	labelsMapper := defaultLabelsMapper()
-	k.mergeLabelsMapper(labelsMapper)
+	k.mergeLabelsMapper(defaultLabelsMapper())
 
 	// Retrieve cluster name
 	k.getClusterName()
@@ -464,7 +456,7 @@ func (k *KSMCheck) Run() error {
 	// Note that by design, some metrics cannot have hostnames (e.g kubernetes_state.pod.unschedulable)
 	sender.DisableDefaultHostname(true)
 
-	labelJoiner := newLabelJoiner(k.instance.LabelJoins)
+	labelJoiner := newLabelJoiner(k.instance.labelJoins)
 	for _, stores := range k.allStores {
 		for _, store := range stores {
 			metrics := store.(*ksmstore.MetricsStore).Push(k.familyFilter, k.metricFilter)
@@ -505,7 +497,7 @@ func (k *KSMCheck) processMetrics(sender aggregator.Sender, metrics map[string][
 				// So, let’s continue the processing.
 			}
 			if transform, found := k.metricTransformers[metricFamily.Name]; found {
-				lMapperOverride := k.labelsMapperOverride(metricFamily.Name)
+				lMapperOverride := labelsMapperOverride(metricFamily.Name)
 				for _, m := range metricFamily.ListMetrics {
 					hostname, tags := k.hostnameAndTags(m.Labels, labelJoiner, lMapperOverride)
 					transform(sender, metricFamily.Name, m, hostname, tags, now)
@@ -513,7 +505,7 @@ func (k *KSMCheck) processMetrics(sender aggregator.Sender, metrics map[string][
 				continue
 			}
 			if ddname, found := k.metricNamesMapper[metricFamily.Name]; found {
-				lMapperOverride := k.labelsMapperOverride(metricFamily.Name)
+				lMapperOverride := labelsMapperOverride(metricFamily.Name)
 				for _, m := range metricFamily.ListMetrics {
 					hostname, tags := k.hostnameAndTags(m.Labels, labelJoiner, lMapperOverride)
 					sender.Gauge(ksmMetricPrefix+ddname, m.Val, hostname, tags)
@@ -600,7 +592,7 @@ func (k *KSMCheck) hostnameAndTags(labels map[string]string, labelJoiner *labelJ
 // It ensures that we only get the configured metric names to
 // get labels based on the label joins config
 func (k *KSMCheck) familyFilter(f ksmstore.DDMetricsFam) bool {
-	_, found := k.instance.LabelJoins[f.Name]
+	_, found := k.instance.labelJoins[f.Name]
 	return found
 }
 
@@ -652,10 +644,25 @@ func (k *KSMCheck) mergeLabelsMapper(extra map[string]string) {
 
 // mergeLabelJoins adds extra label joins to the configured label joins
 // User-defined label joins are prioritized over additional label joins
-func (k *KSMCheck) mergeLabelJoins(extra map[string]*JoinsConfig) {
+func (k *KSMCheck) mergeLabelJoins(extra map[string]*JoinsConfigWithoutLabelsMapping) {
 	for key, value := range extra {
 		if _, found := k.instance.LabelJoins[key]; !found {
 			k.instance.LabelJoins[key] = value
+		}
+	}
+}
+
+func (k *KSMCheck) processLabelJoins() {
+	k.instance.labelJoins = make(map[string]*joinsConfig)
+	for metric, joinConf := range k.instance.LabelJoins {
+		labelsToGet := make(map[string]string)
+		for _, label := range joinConf.LabelsToGet {
+			labelsToGet[label] = label
+		}
+		k.instance.labelJoins[metric] = &joinsConfig{
+			labelsToMatch: joinConf.LabelsToMatch,
+			labelsToGet:   labelsToGet,
+			getAllLabels:  joinConf.GetAllLabels,
 		}
 	}
 }
@@ -670,27 +677,20 @@ func (k *KSMCheck) processAnnotationsAsTags() {
 
 func (k *KSMCheck) processLabelsOrAnnotationsAsTags(what string, configStuffAsTags map[string]map[string]string) {
 	for resourceKind, labelsMapper := range configStuffAsTags {
-		labels := make([]string, 0, len(labelsMapper))
+		labels := make(map[string]string)
 		for label, tag := range labelsMapper {
 			label = what + "_" + labelRegexp.ReplaceAllString(label, "_")
-			if _, ok := k.instance.labelsMapperByResourceKind[resourceKind]; !ok {
-				k.instance.labelsMapperByResourceKind[resourceKind] = map[string]string{
-					label: tag,
-				}
-			} else {
-				k.instance.labelsMapperByResourceKind[resourceKind][label] = tag
-			}
-			labels = append(labels, label)
+			labels[label] = tag
 		}
 
-		if joinsConfig, ok := k.instance.LabelJoins["kube_"+resourceKind+"_"+what+"s"]; ok {
-			joinsConfig.LabelsToGet = append(joinsConfig.LabelsToGet, labels...)
+		if joinsCfg, ok := k.instance.labelJoins["kube_"+resourceKind+"_"+what+"s"]; ok {
+			maps.Copy(joinsCfg.labelsToGet, labels)
 		} else {
-			joinsConfig := &JoinsConfig{
-				LabelsToMatch: getLabelToMatchForKind(resourceKind),
-				LabelsToGet:   labels,
+			joinsConfig := &joinsConfig{
+				labelsToMatch: getLabelToMatchForKind(resourceKind),
+				labelsToGet:   labels,
 			}
-			k.instance.LabelJoins["kube_"+resourceKind+"_"+what+"s"] = joinsConfig
+			k.instance.labelJoins["kube_"+resourceKind+"_"+what+"s"] = joinsConfig
 		}
 	}
 }
@@ -773,13 +773,13 @@ func KubeStateMetricsFactory() check.Check {
 		core.NewCheckBase(kubeStateMetricsCheckName),
 		&KSMConfig{
 			LabelsMapper: make(map[string]string),
-			LabelJoins:   make(map[string]*JoinsConfig),
+			LabelJoins:   make(map[string]*JoinsConfigWithoutLabelsMapping),
 			Namespaces:   []string{},
 		})
 }
 
 // KubeStateMetricsFactoryWithParam is used only by test/benchmarks/kubernetes_state
-func KubeStateMetricsFactoryWithParam(labelsMapper map[string]string, labelJoins map[string]*JoinsConfig, allStores [][]cache.Store) *KSMCheck {
+func KubeStateMetricsFactoryWithParam(labelsMapper map[string]string, labelJoins map[string]*JoinsConfigWithoutLabelsMapping, allStores [][]cache.Store) *KSMCheck {
 	check := newKSMCheck(
 		core.NewCheckBase(kubeStateMetricsCheckName),
 		&KSMConfig{
@@ -909,15 +909,18 @@ func ownerTags(kind, name string) []string {
 //   - `phase` tag should be mapped to `pod_phase` on pod metrics only.
 //   - Ingress metrics have generic tag names (host/path/service_name/service_port).
 //     It's important to have them in a dedicated mapper override for ingresses.
-func (k *KSMCheck) labelsMapperOverride(metricName string) map[string]string {
-	// KSM metrics are named, `kube_<RESOURCE_KIND>_<METRIC_NAME>` like for ex.:
-	// kube_pod_info, kube_pod_status_ready, or kube_pod_container_resource_requests_memory_bytes
-	// Splitting by underscores and getting the second token returns the resource kind.
-	tok := strings.SplitN(metricName, "_", 3)
-	if len(tok) < 2 {
-		return nil
+func labelsMapperOverride(metricName string) map[string]string {
+	if strings.HasPrefix(metricName, "kube_pod") {
+		return map[string]string{"phase": "pod_phase"}
 	}
-	resourceKind := tok[1]
 
-	return k.instance.labelsMapperByResourceKind[resourceKind]
+	if strings.HasPrefix(metricName, "kube_ingress") {
+		return map[string]string{
+			"host":         "kube_ingress_host",
+			"path":         "kube_ingress_path",
+			"service_name": "kube_service",
+			"service_port": "kube_service_port",
+		}
+	}
+	return nil
 }

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_aggregators.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_aggregators.go
@@ -188,7 +188,7 @@ func (a *counterAggregator) flush(sender aggregator.Sender, k *KSMCheck, labelJo
 			labels[allowedLabel] = labelValues[i]
 		}
 
-		hostname, tags := k.hostnameAndTags(labels, labelJoiner, k.labelsMapperOverride(a.ksmMetricName))
+		hostname, tags := k.hostnameAndTags(labels, labelJoiner, labelsMapperOverride(a.ksmMetricName))
 
 		sender.Gauge(ksmMetricPrefix+a.ddMetricName, count, hostname, tags)
 	}

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_aggregators_test.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_aggregators_test.go
@@ -184,7 +184,7 @@ func Test_counterAggregator(t *testing.T) {
 				agg.accumulate(metric)
 			}
 
-			agg.flush(s, ksmCheck, newLabelJoiner(ksmCheck.instance.LabelJoins))
+			agg.flush(s, ksmCheck, newLabelJoiner(ksmCheck.instance.labelJoins))
 
 			s.AssertNumberOfCalls(t, "Gauge", len(tt.expected))
 			for _, expected := range tt.expected {
@@ -295,7 +295,7 @@ func Test_lastCronJobAggregator(t *testing.T) {
 				aggFailed.accumulate(metric)
 			}
 
-			agg.flush(s, ksmCheck, newLabelJoiner(ksmCheck.instance.LabelJoins))
+			agg.flush(s, ksmCheck, newLabelJoiner(ksmCheck.instance.labelJoins))
 
 			s.AssertServiceCheck(t, tt.expected.name, tt.expected.status, "", tt.expected.tags, tt.expected.message)
 			s.AssertNumberOfCalls(t, "ServiceCheck", 1)
@@ -308,7 +308,7 @@ func Test_lastCronJobAggregator(t *testing.T) {
 				aggComplete.accumulate(metric)
 			}
 
-			agg.flush(s, ksmCheck, newLabelJoiner(ksmCheck.instance.LabelJoins))
+			agg.flush(s, ksmCheck, newLabelJoiner(ksmCheck.instance.labelJoins))
 
 			s.AssertServiceCheck(t, tt.expected.name, tt.expected.status, "", tt.expected.tags, tt.expected.message)
 			s.AssertNumberOfCalls(t, "ServiceCheck", 2)

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_defaults.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_defaults.go
@@ -125,23 +125,8 @@ func defaultLabelsMapper() map[string]string {
 	}
 }
 
-// defaultLabelsMapperByResourceKind returns a map that contains the default labels to tag names by resource kind mapping
-func defaultLabelsMapperByResourceKind() map[string]map[string]string {
-	return map[string]map[string]string{
-		"pod": {
-			"phase": "pod_phase",
-		},
-		"ingress": {
-			"host":         "kube_ingress_host",
-			"path":         "kube_ingress_path",
-			"service_name": "kube_service",
-			"service_port": "kube_service_port",
-		},
-	}
-}
-
 // defaultLabelJoins returns a map that contains the default label joins configuration
-func defaultLabelJoins() map[string]*JoinsConfig {
+func defaultLabelJoins() map[string]*JoinsConfigWithoutLabelsMapping {
 	defaultStandardLabels := []string{
 		// Standard Datadog labels
 		"label_tags_datadoghq_com_env",
@@ -160,7 +145,7 @@ func defaultLabelJoins() map[string]*JoinsConfig {
 		"label_helm_sh_chart",
 	}
 
-	return map[string]*JoinsConfig{
+	return map[string]*JoinsConfigWithoutLabelsMapping{
 		"kube_pod_status_phase": {
 			LabelsToMatch: getLabelToMatchForKind("pod"),
 			LabelsToGet:   []string{"phase"},

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_label_joins_test.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_label_joins_test.go
@@ -19,7 +19,7 @@ import (
 func Test_labelJoiner(t *testing.T) {
 	tests := []struct {
 		name     string
-		config   map[string]*JoinsConfig
+		config   map[string]*joinsConfig
 		families map[string][]ksmstore.DDMetricsFam
 		expected []struct {
 			inputLabels map[string]string
@@ -28,10 +28,10 @@ func Test_labelJoiner(t *testing.T) {
 	}{
 		{
 			name: "One label to match, one label to get",
-			config: map[string]*JoinsConfig{
+			config: map[string]*joinsConfig{
 				"kube_pod_info": {
-					LabelsToMatch: []string{"foo_key"},
-					LabelsToGet:   []string{"qux_key"},
+					labelsToMatch: []string{"foo_key"},
+					labelsToGet:   map[string]string{"qux_key": "qux_tag"},
 				},
 			},
 			families: map[string][]ksmstore.DDMetricsFam{
@@ -75,23 +75,23 @@ func Test_labelJoiner(t *testing.T) {
 				{
 					inputLabels: map[string]string{"foo_key": "foo_value1"},
 					labelsToAdd: []label{
-						{key: "qux_key", value: "qux_value1"},
+						{key: "qux_tag", value: "qux_value1"},
 					},
 				},
 				{
 					inputLabels: map[string]string{"foo_key": "foo_value2"},
 					labelsToAdd: []label{
-						{key: "qux_key", value: "qux_value2"},
+						{key: "qux_tag", value: "qux_value2"},
 					},
 				},
 			},
 		},
 		{
 			name: "Two labels to match, two labels to get",
-			config: map[string]*JoinsConfig{
+			config: map[string]*joinsConfig{
 				"kube_pod_info": {
-					LabelsToMatch: []string{"foo_key", "bar_key"},
-					LabelsToGet:   []string{"qux_key", "quux_key"},
+					labelsToMatch: []string{"foo_key", "bar_key"},
+					labelsToGet:   map[string]string{"qux_key": "qux_tag", "quux_key": "quux_tag"},
 				},
 			},
 			families: map[string][]ksmstore.DDMetricsFam{
@@ -170,8 +170,8 @@ func Test_labelJoiner(t *testing.T) {
 						"bar_key": "bar_value1",
 					},
 					labelsToAdd: []label{
-						{key: "qux_key", value: "qux_value1"},
-						{key: "quux_key", value: "quux_value1"},
+						{key: "qux_tag", value: "qux_value1"},
+						{key: "quux_tag", value: "quux_value1"},
 					},
 				},
 				{
@@ -180,8 +180,8 @@ func Test_labelJoiner(t *testing.T) {
 						"bar_key": "bar_value2",
 					},
 					labelsToAdd: []label{
-						{key: "qux_key", value: "qux_value2"},
-						{key: "quux_key", value: "quux_value2"},
+						{key: "qux_tag", value: "qux_value2"},
+						{key: "quux_tag", value: "quux_value2"},
 					},
 				},
 				{
@@ -190,18 +190,18 @@ func Test_labelJoiner(t *testing.T) {
 						"bar_key": "bar_value2",
 					},
 					labelsToAdd: []label{
-						{key: "qux_key", value: "qux_value12"},
-						{key: "quux_key", value: "quux_value12"},
+						{key: "qux_tag", value: "qux_value12"},
+						{key: "quux_tag", value: "quux_value12"},
 					},
 				},
 			},
 		},
 		{
 			name: "Three labels to match, all labels to get",
-			config: map[string]*JoinsConfig{
+			config: map[string]*joinsConfig{
 				"kube_pod_info": {
-					LabelsToMatch: []string{"foo_key", "bar_key", "baz_key"},
-					GetAllLabels:  true,
+					labelsToMatch: []string{"foo_key", "bar_key", "baz_key"},
+					getAllLabels:  true,
 				},
 			},
 			families: map[string][]ksmstore.DDMetricsFam{
@@ -325,10 +325,10 @@ func Test_labelJoiner(t *testing.T) {
 		},
 		{
 			name: "Several metrics with the same value for labels to match",
-			config: map[string]*JoinsConfig{
+			config: map[string]*joinsConfig{
 				"kube_pod_info": {
-					LabelsToMatch: []string{"foo_key"},
-					LabelsToGet:   []string{"qux_key"},
+					labelsToMatch: []string{"foo_key"},
+					labelsToGet:   map[string]string{"qux_key": "qux_tag"},
 				},
 			},
 			families: map[string][]ksmstore.DDMetricsFam{
@@ -375,18 +375,18 @@ func Test_labelJoiner(t *testing.T) {
 						"bar_key": "no_matter",
 					},
 					labelsToAdd: []label{
-						{key: "qux_key", value: "qux_value1"},
-						{key: "qux_key", value: "qux_value2"},
+						{key: "qux_tag", value: "qux_value1"},
+						{key: "qux_tag", value: "qux_value2"},
 					},
 				},
 			},
 		},
 		{
 			name: "Skip tags with empty value",
-			config: map[string]*JoinsConfig{
+			config: map[string]*joinsConfig{
 				"kube_pod_info": {
-					LabelsToMatch: []string{"foo_key"},
-					LabelsToGet:   []string{"qux_key"},
+					labelsToMatch: []string{"foo_key"},
+					labelsToGet:   map[string]string{"qux_key": "qux_tag"},
 				},
 			},
 			families: map[string][]ksmstore.DDMetricsFam{
@@ -424,7 +424,7 @@ func Test_labelJoiner(t *testing.T) {
 				{
 					inputLabels: map[string]string{"foo_key": "foo_value1"},
 					labelsToAdd: []label{
-						{key: "qux_key", value: "qux_value1"},
+						{key: "qux_tag", value: "qux_value1"},
 					},
 				},
 				{

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_test.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_test.go
@@ -422,11 +422,8 @@ func TestProcessMetrics(t *testing.T) {
 			},
 		},
 		{
-			name: "phase tag for pod",
-			config: &KSMConfig{
-				LabelsMapper:               defaultLabelsMapper(),
-				labelsMapperByResourceKind: defaultLabelsMapperByResourceKind(),
-			},
+			name:   "phase tag for pod",
+			config: &KSMConfig{LabelsMapper: defaultLabelsMapper()},
 			metricsToProcess: map[string][]ksmstore.DDMetricsFam{
 				"kube_pod_status_phase": {
 					{
@@ -509,11 +506,8 @@ func TestProcessMetrics(t *testing.T) {
 			},
 		},
 		{
-			name: "ingress metric",
-			config: &KSMConfig{
-				LabelsMapper:               defaultLabelsMapper(),
-				labelsMapperByResourceKind: defaultLabelsMapperByResourceKind(),
-			},
+			name:   "ingress metric",
+			config: &KSMConfig{LabelsMapper: defaultLabelsMapper()},
 			metricsToProcess: map[string][]ksmstore.DDMetricsFam{
 				"kube_pod_status_phase": {
 					{
@@ -546,7 +540,8 @@ func TestProcessMetrics(t *testing.T) {
 		mocked.SetupAcceptAll()
 
 		kubeStateMetricsCheck.metricTransformers = test.metricTransformers
-		labelJoiner := newLabelJoiner(test.config.LabelJoins)
+		kubeStateMetricsCheck.processLabelJoins()
+		labelJoiner := newLabelJoiner(test.config.labelJoins)
 		for _, metricFam := range test.metricsToGet {
 			labelJoiner.insertFamily(metricFam)
 		}
@@ -836,10 +831,10 @@ func TestKSMCheck_hostnameAndTags(t *testing.T) {
 		{
 			name: "join labels, multiple match",
 			config: &KSMConfig{
-				LabelJoins: map[string]*JoinsConfig{
+				labelJoins: map[string]*joinsConfig{
 					"foo": {
-						LabelsToMatch: []string{"foo_label", "bar_label"},
-						LabelsToGet:   []string{"baz_label"},
+						labelsToMatch: []string{"foo_label", "bar_label"},
+						labelsToGet:   map[string]string{"baz_label": "baz_tag"},
 					},
 				},
 			},
@@ -852,16 +847,16 @@ func TestKSMCheck_hostnameAndTags(t *testing.T) {
 					},
 				},
 			},
-			wantTags:     []string{"foo_label:foo_value", "bar_label:bar_value", "baz_label:baz_value"},
+			wantTags:     []string{"foo_label:foo_value", "bar_label:bar_value", "baz_tag:baz_value"},
 			wantHostname: "",
 		},
 		{
 			name: "join labels, multiple get",
 			config: &KSMConfig{
-				LabelJoins: map[string]*JoinsConfig{
+				labelJoins: map[string]*joinsConfig{
 					"foo": {
-						LabelsToMatch: []string{"foo_label"},
-						LabelsToGet:   []string{"bar_label", "baz_label"},
+						labelsToMatch: []string{"foo_label"},
+						labelsToGet:   map[string]string{"bar_label": "bar_tag", "baz_label": "baz_tag"},
 					},
 				},
 			},
@@ -874,16 +869,16 @@ func TestKSMCheck_hostnameAndTags(t *testing.T) {
 					},
 				},
 			},
-			wantTags:     []string{"foo_label:foo_value", "bar_label:bar_value", "baz_label:baz_value"},
+			wantTags:     []string{"foo_label:foo_value", "bar_tag:bar_value", "baz_tag:baz_value"},
 			wantHostname: "",
 		},
 		{
 			name: "no label match",
 			config: &KSMConfig{
-				LabelJoins: map[string]*JoinsConfig{
+				labelJoins: map[string]*joinsConfig{
 					"foo": {
-						LabelsToMatch: []string{"foo_label"},
-						LabelsToGet:   []string{"bar_label"},
+						labelsToMatch: []string{"foo_label"},
+						labelsToGet:   map[string]string{"bar_label": "bar_tag"},
 					},
 				},
 			},
@@ -902,10 +897,10 @@ func TestKSMCheck_hostnameAndTags(t *testing.T) {
 		{
 			name: "no metric name match",
 			config: &KSMConfig{
-				LabelJoins: map[string]*JoinsConfig{
+				labelJoins: map[string]*joinsConfig{
 					"foo": {
-						LabelsToMatch: []string{"foo_label"},
-						LabelsToGet:   []string{"bar_label"},
+						labelsToMatch: []string{"foo_label"},
+						labelsToGet:   map[string]string{"bar_label": "bar_tag"},
 					},
 				},
 			},
@@ -924,14 +919,14 @@ func TestKSMCheck_hostnameAndTags(t *testing.T) {
 		{
 			name: "join labels, multiple metric match",
 			config: &KSMConfig{
-				LabelJoins: map[string]*JoinsConfig{
+				labelJoins: map[string]*joinsConfig{
 					"foo": {
-						LabelsToMatch: []string{"foo_label", "bar_label"},
-						LabelsToGet:   []string{"baz_label"},
+						labelsToMatch: []string{"foo_label", "bar_label"},
+						labelsToGet:   map[string]string{"baz_label": "baz_tag"},
 					},
 					"bar": {
-						LabelsToMatch: []string{"bar_label"},
-						LabelsToGet:   []string{"baf_label"},
+						labelsToMatch: []string{"bar_label"},
+						labelsToGet:   map[string]string{"baf_label": "baf_tag"},
 					},
 				},
 			},
@@ -948,16 +943,16 @@ func TestKSMCheck_hostnameAndTags(t *testing.T) {
 					},
 				},
 			},
-			wantTags:     []string{"foo_label:foo_value", "bar_label:bar_value", "baz_label:baz_value", "baf_label:baf_value"},
+			wantTags:     []string{"foo_label:foo_value", "bar_label:bar_value", "baz_tag:baz_value", "baf_tag:baf_value"},
 			wantHostname: "",
 		},
 		{
 			name: "join all labels",
 			config: &KSMConfig{
-				LabelJoins: map[string]*JoinsConfig{
+				labelJoins: map[string]*joinsConfig{
 					"foo": {
-						LabelsToMatch: []string{"foo_label"},
-						GetAllLabels:  true,
+						labelsToMatch: []string{"foo_label"},
+						getAllLabels:  true,
 					},
 				},
 			},
@@ -996,10 +991,10 @@ func TestKSMCheck_hostnameAndTags(t *testing.T) {
 		{
 			name: "hostname from label joins",
 			config: &KSMConfig{
-				LabelJoins: map[string]*JoinsConfig{
+				labelJoins: map[string]*joinsConfig{
 					"foo": {
-						LabelsToMatch: []string{"foo_label"},
-						LabelsToGet:   []string{"bar_label", "node"},
+						labelsToMatch: []string{"foo_label"},
+						labelsToGet:   map[string]string{"bar_label": "bar_tag", "node": "node"},
 					},
 				},
 			},
@@ -1012,7 +1007,7 @@ func TestKSMCheck_hostnameAndTags(t *testing.T) {
 					},
 				},
 			},
-			wantTags:     []string{"foo_label:foo_value", "bar_label:bar_value", "node:foo"},
+			wantTags:     []string{"foo_label:foo_value", "bar_tag:bar_value", "node:foo"},
 			wantHostname: "foo",
 		},
 		{
@@ -1028,10 +1023,10 @@ func TestKSMCheck_hostnameAndTags(t *testing.T) {
 		{
 			name: "cluster name appended to hostname from label joins",
 			config: &KSMConfig{
-				LabelJoins: map[string]*JoinsConfig{
+				labelJoins: map[string]*joinsConfig{
 					"foo": {
-						LabelsToMatch: []string{"foo_label"},
-						LabelsToGet:   []string{"bar_label", "node"},
+						labelsToMatch: []string{"foo_label"},
+						labelsToGet:   map[string]string{"bar_label": "bar_tag", "node": "node"},
 					},
 				},
 			},
@@ -1045,16 +1040,16 @@ func TestKSMCheck_hostnameAndTags(t *testing.T) {
 				},
 				clusterName: "bar",
 			},
-			wantTags:     []string{"foo_label:foo_value", "bar_label:bar_value", "node:foo"},
+			wantTags:     []string{"foo_label:foo_value", "bar_tag:bar_value", "node:foo"},
 			wantHostname: "foo-bar",
 		},
 		{
 			name: "created_by_kind/created_by_name",
 			config: &KSMConfig{
-				LabelJoins: map[string]*JoinsConfig{
+				labelJoins: map[string]*joinsConfig{
 					"foo": {
-						LabelsToMatch: []string{"foo_label"},
-						LabelsToGet:   []string{"created_by_kind", "created_by_name"},
+						labelsToMatch: []string{"foo_label"},
+						labelsToGet:   map[string]string{"created_by_kind": "created_by_kind", "created_by_name": "created_by_name"},
 					},
 				},
 			},
@@ -1073,10 +1068,10 @@ func TestKSMCheck_hostnameAndTags(t *testing.T) {
 		{
 			name: "owner_kind/owner_name",
 			config: &KSMConfig{
-				LabelJoins: map[string]*JoinsConfig{
+				labelJoins: map[string]*joinsConfig{
 					"foo": {
-						LabelsToMatch: []string{"foo_label"},
-						LabelsToGet:   []string{"owner_kind", "owner_name"},
+						labelsToMatch: []string{"foo_label"},
+						labelsToGet:   map[string]string{"owner_kind": "owner_kind", "owner_name": "owner_name"},
 					},
 				},
 			},
@@ -1108,7 +1103,7 @@ func TestKSMCheck_hostnameAndTags(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			kubeStateMetricsSCheck := newKSMCheck(core.NewCheckBase(kubeStateMetricsCheckName), tt.config)
 			kubeStateMetricsSCheck.clusterNameRFC1123 = tt.args.clusterName
-			labelJoiner := newLabelJoiner(tt.config.LabelJoins)
+			labelJoiner := newLabelJoiner(tt.config.labelJoins)
 			for _, metricFam := range tt.args.metricsToGet {
 				labelJoiner.insertFamily(metricFam)
 			}
@@ -1122,68 +1117,49 @@ func TestKSMCheck_hostnameAndTags(t *testing.T) {
 
 func TestKSMCheck_processLabelsAsTags(t *testing.T) {
 	tests := []struct {
-		name                         string
-		config                       *KSMConfig
-		expectedJoins                map[string]*JoinsConfig
-		expectedMapper               map[string]string
-		expectedMapperByResourceKind map[string]map[string]string
+		name           string
+		config         *KSMConfig
+		expectedJoins  map[string]*joinsConfig
+		expectedMapper map[string]string
 	}{
 		{
 			name: "Initially empty",
 			config: &KSMConfig{
-				LabelJoins:                 map[string]*JoinsConfig{},
-				LabelsMapper:               map[string]string{},
-				labelsMapperByResourceKind: map[string]map[string]string{},
+				labelJoins:   map[string]*joinsConfig{},
+				LabelsMapper: map[string]string{},
 				LabelsAsTags: map[string]map[string]string{
 					"pod": {"my_pod_label": "my_pod_tag"},
 				},
 			},
-			expectedJoins: map[string]*JoinsConfig{
+			expectedJoins: map[string]*joinsConfig{
 				"kube_pod_labels": {
-					LabelsToMatch: []string{"pod", "namespace"},
-					LabelsToGet:   []string{"label_my_pod_label"},
-				},
-			},
-			expectedMapper: map[string]string{},
-			expectedMapperByResourceKind: map[string]map[string]string{
-				"pod": {
-					"label_my_pod_label": "my_pod_tag",
+					labelsToMatch: []string{"pod", "namespace"},
+					labelsToGet:   map[string]string{"label_my_pod_label": "my_pod_tag"},
 				},
 			},
 		},
 		{
 			name: "Already initialized",
 			config: &KSMConfig{
-				LabelJoins: map[string]*JoinsConfig{
+				labelJoins: map[string]*joinsConfig{
 					"kube_pod_labels": {
-						LabelsToMatch: []string{"pod", "namespace"},
-						LabelsToGet:   []string{"standard_pod_label"},
+						labelsToMatch: []string{"pod", "namespace"},
+						labelsToGet:   map[string]string{"standard_pod_label": "standard_pod_tag"},
 					},
 				},
-				LabelsMapper:               map[string]string{},
-				labelsMapperByResourceKind: map[string]map[string]string{},
 				LabelsAsTags: map[string]map[string]string{
 					"pod":  {"my_pod_label": "my_pod_tag"},
 					"node": {"my_node_label": "my_node_tag"},
 				},
 			},
-			expectedJoins: map[string]*JoinsConfig{
+			expectedJoins: map[string]*joinsConfig{
 				"kube_pod_labels": {
-					LabelsToMatch: []string{"pod", "namespace"},
-					LabelsToGet:   []string{"standard_pod_label", "label_my_pod_label"},
+					labelsToMatch: []string{"pod", "namespace"},
+					labelsToGet:   map[string]string{"standard_pod_label": "standard_pod_tag", "label_my_pod_label": "my_pod_tag"},
 				},
 				"kube_node_labels": {
-					LabelsToMatch: []string{"node"},
-					LabelsToGet:   []string{"label_my_node_label"},
-				},
-			},
-			expectedMapper: map[string]string{},
-			expectedMapperByResourceKind: map[string]map[string]string{
-				"pod": {
-					"label_my_pod_label": "my_pod_tag",
-				},
-				"node": {
-					"label_my_node_label": "my_node_tag",
+					labelsToMatch: []string{"node"},
+					labelsToGet:   map[string]string{"label_my_node_label": "my_node_tag"},
 				},
 			},
 		},
@@ -1192,9 +1168,7 @@ func TestKSMCheck_processLabelsAsTags(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			k := &KSMCheck{instance: tt.config}
 			k.processLabelsAsTags()
-			assert.Equal(t, tt.expectedJoins, k.instance.LabelJoins)
-			assert.Equal(t, tt.expectedMapper, k.instance.LabelsMapper)
-			assert.Equal(t, tt.expectedMapperByResourceKind, k.instance.labelsMapperByResourceKind)
+			assert.Equal(t, tt.expectedJoins, k.instance.labelJoins)
 		})
 	}
 }

--- a/releasenotes/notes/ksm_fix_labels_as_tags-2d0c00093f944e9f.yaml
+++ b/releasenotes/notes/ksm_fix_labels_as_tags-2d0c00093f944e9f.yaml
@@ -9,4 +9,4 @@
 fixes:
   - |
     Fixes the `labelsAsTags` parameter of the kube-state metrics core check.
-    Tags were not properly formatted when they came from a label on one resource kind (ex. namespace) and turned into a tag on another resource kind (ex. pod).
+    Tags were not properly formatted when they came from a label on one resource type (for example, namespace) and turned into a tag on another resource type (for example, pod).

--- a/releasenotes/notes/ksm_fix_labels_as_tags-2d0c00093f944e9f.yaml
+++ b/releasenotes/notes/ksm_fix_labels_as_tags-2d0c00093f944e9f.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixes the `labelsAsTags` parameter of the kube-state metrics core check.
+    Tags were not properly formatted when they came from a label on one resource kind (ex. namespace) and turned into a tag on another resource kind (ex. pod).


### PR DESCRIPTION
### What does this PR do?

This is a redesign and rewrite of #13973.

When `labels_as_tags` contained something like:
```yaml
labels_as_tags:
  node:
    node_label: node_tag
  namespace:
    ns_label: ns_tag
```

The node metrics, generated from nodes with a `node_label` label were properly tagged with `node_tag`.
But, pods metrics, generated from pods running inside a namespace with a `ns_label` label were not properly tagged with `ns_tag`.

There was a bug in the tag naming when the monitored resource and the source of the tag were of two different kind.

### Motivation

Makes things work as expected.

### Additional Notes

What the bug shown is that the current approach which consists in splitting the metrics processing in two steps:
* first, getting the prometheus labels to use with the “label joins” algorithm and then
* second, apply a “label mapping” to turn prometheus labels into datadog tags

cannot work when the kind of the resource the label comes from and the kind of the decorated resource are not the same.

So, the configuration of the “label joins” algorithm had to be modified to also embed the remapping part.

Concretely, what this means is that the “label joins” algorithm now need a configuration that looks like:
```go
type joinsConfig struct {
	labelsToMatch []string
	labelsToGet   map[string]string
	getAllLabels  bool
}
```

instead of:
```go
type JoinsConfig struct {
	// LabelsToMatch contains the labels that must
	// match the labels of the targeted metric
	LabelsToMatch []string `yaml:"labels_to_match"`

	// LabelsToGet contains the labels we want to get from the targeted metric
	LabelsToGet []string `yaml:"labels_to_get"`

	// GetAllLabels replaces LabelsToGet if enabled
	GetAllLabels bool `yaml:"get_all_labels"`
}
```

Note that `labelsToGet` became a map (of correspondance between a Prometheus label and a Datadog tag) whereas it used to be a slice (because the mapping was in the `LabelsMapper` map.

However, the old structure (with `LabelsToGet` as a slice) is what is exposed in the user-defined configuration of the check.
So, for backward compatibility reasons, it’s not possible to modify it.
But in order to make things slightly more explicit, the internal GO type has been renamed `JoinsConfigWithoutLabelsMapping`.

So, now, inside the `KSMConfig struct`,
* the only field used by the “label joins” algorithm is the `labelJoins map[string]*joinsConfig` field. But this field is private and cannot be set by the end user. Instead, this private field is set from the 
* `LabelJoins map[string]*JoinsConfigWithoutLabelsMapping 'yaml:"label_joins"'` user visible field thanks to the `(k *KSMCheck) processLabelJoins()` function
* `LabelsAsTags map[string]map[string]string 'yaml:"labels_as_tags"'` user visible field thanks to the `(k *KSMCheck) processLabelsAsTags()` function and
* `AnnotationsAsTags map[string]map[string]string 'yaml:"annotations_as_tags"'` user visible field thanks to the `(k *KSMCheck) processAnnotationsAsTags()` function

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Create a KSM config with:
```yaml
labels_as_tags:
  node:
    my_label: node_tag
  deployment:
    my_label: deployment_tag
  namespace:
    ns_label: ns_tag
```
Then, label some nodes with `my_label`, some deployments with `my_label` (the same label) and validate that the corresponding metrics have the proper tags (`node_tag` for the former and `deployment_tag` for the latter)

Label some namespaces with `ns_label` and validate that the metrics for the deployment, replicaset and pods running inside this namespace are properly tagged with `ns_tag`.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
