### PR TITLE
[process-agent] Add config component as dependency to existing components

### DIFF
--- a/comp/core/bundle_test.go
+++ b/comp/core/bundle_test.go
@@ -6,7 +6,6 @@
 package core
 
 import (
-	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -22,7 +21,6 @@ func TestBundleDependencies(t *testing.T) {
 		// instantiate all of the core components, since this is not done
 		// automatically.
 		fx.Invoke(func(config.Component) {}),
-		fx.Invoke(func(sysprobeconfig.Component) {}),
 		fx.Invoke(func(log.Component) {}),
 		fx.Invoke(func(flare.Component) {}),
 
@@ -37,7 +35,6 @@ func TestMockBundleDependencies(t *testing.T) {
 		// instantiate all of the core components, since this is not done
 		// automatically.
 		fx.Invoke(func(config.Component) {}),
-		fx.Invoke(func(sysprobeconfig.Component) {}),
 		fx.Invoke(func(log.Component) {}),
 
 		fx.Supply(BundleParams{}),

--- a/comp/core/bundle_test.go
+++ b/comp/core/bundle_test.go
@@ -6,6 +6,7 @@
 package core
 
 import (
+	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -21,6 +22,7 @@ func TestBundleDependencies(t *testing.T) {
 		// instantiate all of the core components, since this is not done
 		// automatically.
 		fx.Invoke(func(config.Component) {}),
+		fx.Invoke(func(sysprobeconfig.Component) {}),
 		fx.Invoke(func(log.Component) {}),
 		fx.Invoke(func(flare.Component) {}),
 
@@ -35,6 +37,7 @@ func TestMockBundleDependencies(t *testing.T) {
 		// instantiate all of the core components, since this is not done
 		// automatically.
 		fx.Invoke(func(config.Component) {}),
+		fx.Invoke(func(sysprobeconfig.Component) {}),
 		fx.Invoke(func(log.Component) {}),
 
 		fx.Supply(BundleParams{}),

--- a/comp/process/containercheck/check.go
+++ b/comp/process/containercheck/check.go
@@ -8,6 +8,8 @@ package containercheck
 import (
 	"go.uber.org/fx"
 
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig"
 	"github.com/DataDog/datadog-agent/comp/process/types"
 )
 
@@ -28,6 +30,9 @@ func (c *check) Name() string {
 
 type dependencies struct {
 	fx.In
+
+	coreConfig     config.Component
+	sysProbeConfig sysprobeconfig.Component
 }
 
 func newCheck(deps dependencies) types.ProvidesCheck {

--- a/comp/process/containercheck/check.go
+++ b/comp/process/containercheck/check.go
@@ -31,8 +31,8 @@ func (c *check) Name() string {
 type dependencies struct {
 	fx.In
 
-	coreConfig     config.Component
-	sysProbeConfig sysprobeconfig.Component
+	CoreConfig     config.Component
+	SysProbeConfig sysprobeconfig.Component
 }
 
 func newCheck(deps dependencies) types.ProvidesCheck {

--- a/comp/process/processcheck/check.go
+++ b/comp/process/processcheck/check.go
@@ -8,6 +8,8 @@ package processcheck
 import (
 	"go.uber.org/fx"
 
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig"
 	"github.com/DataDog/datadog-agent/comp/process/types"
 )
 
@@ -28,6 +30,9 @@ func (c *check) Name() string {
 
 type dependencies struct {
 	fx.In
+
+	coreConfig     config.Component
+	sysProbeConfig sysprobeconfig.Component
 }
 
 func newCheck(deps dependencies) types.ProvidesCheck {

--- a/comp/process/processcheck/check.go
+++ b/comp/process/processcheck/check.go
@@ -31,8 +31,8 @@ func (c *check) Name() string {
 type dependencies struct {
 	fx.In
 
-	coreConfig     config.Component
-	sysProbeConfig sysprobeconfig.Component
+	CoreConfig     config.Component
+	SysProbeConfig sysprobeconfig.Component
 }
 
 func newCheck(deps dependencies) types.ProvidesCheck {

--- a/comp/process/runner/runner.go
+++ b/comp/process/runner/runner.go
@@ -12,6 +12,8 @@ import (
 
 	"go.uber.org/fx"
 
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig"
 	"github.com/DataDog/datadog-agent/comp/process/submitter"
 	"github.com/DataDog/datadog-agent/comp/process/types"
 )
@@ -24,6 +26,9 @@ type runner struct {
 
 type dependencies struct {
 	fx.In
+
+	coreConfig     config.Component
+	sysProbeConfig sysprobeconfig.Component
 
 	Checks    []types.Check `group:"check"`
 	Submitter submitter.Component

--- a/comp/process/runner/runner.go
+++ b/comp/process/runner/runner.go
@@ -27,8 +27,8 @@ type runner struct {
 type dependencies struct {
 	fx.In
 
-	coreConfig     config.Component
-	sysProbeConfig sysprobeconfig.Component
+	CoreConfig     config.Component
+	SysProbeConfig sysprobeconfig.Component
 
 	Checks    []types.Check `group:"check"`
 	Submitter submitter.Component

--- a/comp/process/submitter/submitter.go
+++ b/comp/process/submitter/submitter.go
@@ -6,13 +6,13 @@
 package submitter
 
 import (
-	"github.com/DataDog/datadog-agent/comp/core/config"
-	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig"
 	"testing"
 	"time"
 
 	"go.uber.org/fx"
 
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig"
 	"github.com/DataDog/datadog-agent/comp/process/types"
 )
 

--- a/comp/process/submitter/submitter.go
+++ b/comp/process/submitter/submitter.go
@@ -6,6 +6,8 @@
 package submitter
 
 import (
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig"
 	"testing"
 	"time"
 
@@ -20,6 +22,9 @@ type submitter struct {
 
 type dependencies struct {
 	fx.In
+
+	coreConfig     config.Component
+	sysProbeConfig sysprobeconfig.Component
 }
 
 func newSubmitter(deps dependencies) (Component, error) {
@@ -27,7 +32,6 @@ func newSubmitter(deps dependencies) (Component, error) {
 }
 
 func (s *submitter) Submit(start time.Time, checkName string, payload *types.Payload) {
-
 }
 
 func (s *submitter) Start() error {

--- a/comp/process/submitter/submitter.go
+++ b/comp/process/submitter/submitter.go
@@ -23,8 +23,8 @@ type submitter struct {
 type dependencies struct {
 	fx.In
 
-	coreConfig     config.Component
-	sysProbeConfig sysprobeconfig.Component
+	CoreConfig     config.Component
+	SysProbeConfig sysprobeconfig.Component
 }
 
 func newSubmitter(deps dependencies) (Component, error) {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR adds a dependency on the core and system probe configs for instantiating `*check`, `submitter`, and `runner` components.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
Migration to components 

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
N/A this change does nothing by itself

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
