### PR TITLE
SLS-3100: Add support for container apps in serverless-init logs channel

### DIFF
--- a/pkg/logs/internal/tailers/channel/tailer_test.go
+++ b/pkg/logs/internal/tailers/channel/tailer_test.go
@@ -15,40 +15,14 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
 )
 
-func TestComputeServiceName(t *testing.T) {
-	assert.Equal(t, "agent", computeServiceName(nil, "toto"))
-	lambdaConfig := &config.Lambda{}
-	assert.Equal(t, "my-service-name", computeServiceName(lambdaConfig, "my-service-name"))
-	assert.Equal(t, "my-service-name", computeServiceName(lambdaConfig, "MY-SERVICE-NAME"))
-	assert.Equal(t, "", computeServiceName(lambdaConfig, ""))
-}
-
-func TestComputeServiceNameFromCloudRunRevision(t *testing.T) {
-	t.Setenv("K_REVISION", "version-abc")
-	t.Setenv("K_SERVICE", "superService")
-	assert.Equal(t, "service-value", computeServiceName(nil, "service-value"))
-	assert.Equal(t, "superservice", computeServiceName(nil, ""))
-}
-
-func TestNotServerlessModeKVersionUndefined(t *testing.T) {
-	t.Setenv("K_SERVICE", "superService")
-	assert.False(t, isServerlessOrigin(nil))
-}
-
-func TestNotServerlessModeKServiceUndefined(t *testing.T) {
-	t.Setenv("K_REVISION", "version-abc")
-	assert.False(t, isServerlessOrigin(nil))
-}
-
-func TestServerlessModeCloudRun(t *testing.T) {
-	t.Setenv("K_REVISION", "version-abc")
-	t.Setenv("K_SERVICE", "superService")
-	assert.True(t, isServerlessOrigin(nil))
-}
-
-func TestServerlessModeLambda(t *testing.T) {
-	lambdaConfig := &config.Lambda{}
-	assert.True(t, isServerlessOrigin(lambdaConfig))
+func TestComputeServiceNameOrderOfPrecedent(t *testing.T) {
+	assert.Equal(t, "agent", getServiceName())
+	t.Setenv("CONTAINER_APP_NAME", "CONTAINER-app-name")
+	assert.Equal(t, "container-app-name", getServiceName())
+	t.Setenv("K_SERVICE", "CLOUD-run-service-name")
+	assert.Equal(t, "cloud-run-service-name", getServiceName())
+	t.Setenv("DD_SERVICE", "DD-service-name")
+	assert.Equal(t, "dd-service-name", getServiceName())
 }
 
 func TestBuildMessageNoLambda(t *testing.T) {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Fixes a bug where we accidentally tagged `service:agent` on things running in Container Apps. 

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
