### PR TITLE
[corechecks/helm] Fix flaky tests

### DIFF
--- a/pkg/collector/corechecks/cluster/helm/helm_test.go
+++ b/pkg/collector/corechecks/cluster/helm/helm_test.go
@@ -28,6 +28,9 @@ import (
 	coreMetrics "github.com/DataDog/datadog-agent/pkg/metrics"
 )
 
+var testTimeout = 10 * time.Second
+var testTicker = 5 * time.Millisecond
+
 func TestRun(t *testing.T) {
 	releases := []release{
 		{
@@ -272,7 +275,17 @@ func TestRun(t *testing.T) {
 			mockedSender := mocksender.NewMockSender(checkName)
 			mockedSender.SetupAcceptAll()
 
+			// The informers are set up in the first run, but the first metrics
+			// are not necessarily emitted in the first run. It depends on
+			// whether the check had time to process the events.
 			err := check.Run()
+			assert.NoError(t, err)
+
+			assert.Eventually(t, func() bool { // Wait until the events are processed
+				return len(check.store.getAll(k8sSecrets))+len(check.store.getAll(k8sConfigmaps)) == len(test.expectedTags)
+			}, testTimeout, testTicker)
+
+			err = check.Run()
 			assert.NoError(t, err)
 
 			for _, tags := range test.expectedTags {
@@ -313,19 +326,24 @@ func TestRun_withCollectEvents(t *testing.T) {
 	mockedSender := mocksender.NewMockSender(checkName)
 	mockedSender.SetupAcceptAll()
 
+	// First run to set up the informers.
+	err = check.Run()
+	assert.NoError(t, err)
+
 	// Create a new release and check that it creates the appropriate event.
 	_, err = k8sClient.CoreV1().Secrets("default").Create(context.TODO(), secret, metav1.CreateOptions{})
 	assert.NoError(t, err)
-	assert.Eventually(t, func() bool {
-		err = check.Run()
-		assert.NoError(t, err)
-		expectedTags := check.allTags(&rel, k8sSecrets, true)
-		return mockedSender.AssertEvent(
-			t,
-			eventForRelease(&rel, "New Helm release \"my_datadog\" has been deployed in \"default\" namespace. Its status is \"deployed\".", expectedTags),
-			10*time.Second,
-		)
-	}, 5*time.Second, time.Millisecond*100)
+	assert.Eventually(t, func() bool { // Wait until the create event has been processed
+		return len(check.store.getAll(k8sSecrets)) == 1
+	}, testTimeout, testTicker)
+	err = check.Run()
+	assert.NoError(t, err)
+	expectedTags := check.allTags(&rel, k8sSecrets, true)
+	mockedSender.AssertEvent(
+		t,
+		eventForRelease(&rel, "New Helm release \"my_datadog\" has been deployed in \"default\" namespace. Its status is \"deployed\".", expectedTags),
+		10*time.Second,
+	)
 
 	// Upgrade the release and check that it creates the appropriate event.
 	upgradedRel := rel
@@ -334,16 +352,17 @@ func TestRun_withCollectEvents(t *testing.T) {
 	assert.NoError(t, err)
 	_, err = k8sClient.CoreV1().Secrets("default").Create(context.TODO(), secretUpgradedRel, metav1.CreateOptions{})
 	assert.NoError(t, err)
-	assert.Eventually(t, func() bool {
-		err = check.Run()
-		assert.NoError(t, err)
-		expectedTags := check.allTags(&rel, k8sSecrets, true)
-		return mockedSender.AssertEvent(
-			t,
-			eventForRelease(&rel, "Helm release \"my_datadog\" in \"default\" namespace upgraded to revision 2. Its status is \"deployed\".", expectedTags),
-			10*time.Second,
-		)
-	}, 5*time.Second, time.Millisecond*100)
+	assert.Eventually(t, func() bool { // Wait until the create event has been processed (revision 2 created)
+		return check.store.get("default/my_datadog", 2, k8sSecrets) != nil
+	}, testTimeout, testTicker)
+	err = check.Run()
+	assert.NoError(t, err)
+	expectedTags = check.allTags(&rel, k8sSecrets, true)
+	mockedSender.AssertEvent(
+		t,
+		eventForRelease(&rel, "Helm release \"my_datadog\" in \"default\" namespace upgraded to revision 2. Its status is \"deployed\".", expectedTags),
+		10*time.Second,
+	)
 
 	// Delete the release (all revisions) and check that it creates the
 	// appropriate event.
@@ -351,16 +370,15 @@ func TestRun_withCollectEvents(t *testing.T) {
 	assert.NoError(t, err)
 	err = k8sClient.CoreV1().Secrets("default").Delete(context.TODO(), rel.Name+".2", metav1.DeleteOptions{})
 	assert.NoError(t, err)
-	assert.Eventually(t, func() bool {
-		err = check.Run()
-		assert.NoError(t, err)
-		expectedTags := check.allTags(&rel, k8sSecrets, false)
-		return mockedSender.AssertEvent(
-			t,
-			eventForRelease(&rel, "Helm release \"my_datadog\" in \"default\" namespace has been deleted.", expectedTags),
-			10*time.Second,
-		)
-	}, 5*time.Second, time.Millisecond*100)
+	assert.Eventually(t, func() bool { // Wait until the delete events have been processed (store should be empty)
+		return len(check.store.getAll(k8sSecrets)) == 0
+	}, testTimeout, testTicker)
+	expectedTags = check.allTags(&rel, k8sSecrets, false)
+	mockedSender.AssertEvent(
+		t,
+		eventForRelease(&rel, "Helm release \"my_datadog\" in \"default\" namespace has been deleted.", expectedTags),
+		10*time.Second,
+	)
 }
 
 func TestRun_skipEventForExistingRelease(t *testing.T) {

--- a/pkg/collector/corechecks/cluster/helm/helm_test.go
+++ b/pkg/collector/corechecks/cluster/helm/helm_test.go
@@ -317,6 +317,8 @@ func TestRun_withCollectEvents(t *testing.T) {
 		Namespace: "default",
 	}
 
+	eventsAllowedDelta := 10 * time.Second
+
 	secret, err := secretForRelease(&rel, time.Now().Add(10))
 	assert.NoError(t, err)
 
@@ -342,7 +344,7 @@ func TestRun_withCollectEvents(t *testing.T) {
 	mockedSender.AssertEvent(
 		t,
 		eventForRelease(&rel, "New Helm release \"my_datadog\" has been deployed in \"default\" namespace. Its status is \"deployed\".", expectedTags),
-		10*time.Second,
+		eventsAllowedDelta,
 	)
 
 	// Upgrade the release and check that it creates the appropriate event.
@@ -361,7 +363,7 @@ func TestRun_withCollectEvents(t *testing.T) {
 	mockedSender.AssertEvent(
 		t,
 		eventForRelease(&rel, "Helm release \"my_datadog\" in \"default\" namespace upgraded to revision 2. Its status is \"deployed\".", expectedTags),
-		10*time.Second,
+		eventsAllowedDelta,
 	)
 
 	// Delete the release (all revisions) and check that it creates the
@@ -377,7 +379,7 @@ func TestRun_withCollectEvents(t *testing.T) {
 	mockedSender.AssertEvent(
 		t,
 		eventForRelease(&rel, "Helm release \"my_datadog\" in \"default\" namespace has been deleted.", expectedTags),
-		10*time.Second,
+		eventsAllowedDelta,
 	)
 }
 


### PR DESCRIPTION
### What does this PR do?

Fixes some flaky tests of the Helm check.

### Describe how to test/QA your changes

Skip.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
