### PR TITLE
pkg/clusteragent/admission: add rc and patcher telemetry

### DIFF
--- a/pkg/clusteragent/admission/metrics/metrics.go
+++ b/pkg/clusteragent/admission/metrics/metrics.go
@@ -62,4 +62,19 @@ var (
 	LibInjectionErrors = telemetry.NewCounterWithOpts("admission_webhooks", "library_injection_errors",
 		[]string{"language"}, "Number of library injection failures by language",
 		telemetry.Options{NoDoubleUnderscoreSep: true})
+	RemoteConfigs = telemetry.NewGaugeWithOpts("admission_webhooks", "rc_provider_configs",
+		[]string{}, "Number of valid remote configurations.",
+		telemetry.Options{NoDoubleUnderscoreSep: true})
+	InvalidRemoteConfigs = telemetry.NewGaugeWithOpts("admission_webhooks", "rc_provider_configs_invalid",
+		[]string{}, "Number of invalid remote configurations.",
+		telemetry.Options{NoDoubleUnderscoreSep: true})
+	PatchAttempts = telemetry.NewCounterWithOpts("admission_webhooks", "patcher_attempts",
+		[]string{}, "Number of patch attempts.",
+		telemetry.Options{NoDoubleUnderscoreSep: true})
+	PatchCompleted = telemetry.NewCounterWithOpts("admission_webhooks", "patcher_completed",
+		[]string{}, "Number of completed patch attempts.",
+		telemetry.Options{NoDoubleUnderscoreSep: true})
+	PatchErrors = telemetry.NewCounterWithOpts("admission_webhooks", "patcher_errors",
+		[]string{}, "Number of patch errors.",
+		telemetry.Options{NoDoubleUnderscoreSep: true})
 )

--- a/pkg/clusteragent/admission/patch/patcher.go
+++ b/pkg/clusteragent/admission/patch/patcher.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/common"
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/metrics"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
 	jsonpatch "github.com/evanphx/json-patch"
@@ -41,7 +42,9 @@ func (p *patcher) start(stopCh <-chan struct{}) {
 	for {
 		select {
 		case req := <-p.deploymentsQueue:
+			metrics.PatchAttempts.Inc()
 			if err := p.patchDeployment(req); err != nil {
+				metrics.PatchErrors.Inc()
 				log.Error(err.Error())
 			}
 		case <-stopCh:
@@ -95,8 +98,11 @@ func (p *patcher) patchDeployment(req PatchRequest) error {
 		return fmt.Errorf("failed to build the JSON patch: %v", err)
 	}
 	log.Infof("Patching %s with patch %s", req.K8sTarget, string(patch))
-	_, err = p.k8sClient.AppsV1().Deployments(req.K8sTarget.Namespace).Patch(context.TODO(), req.K8sTarget.Name, types.StrategicMergePatchType, patch, metav1.PatchOptions{})
-	return err
+	if _, err = p.k8sClient.AppsV1().Deployments(req.K8sTarget.Namespace).Patch(context.TODO(), req.K8sTarget.Name, types.StrategicMergePatchType, patch, metav1.PatchOptions{}); err != nil {
+		return err
+	}
+	metrics.PatchCompleted.Inc()
+	return nil
 }
 
 func enableConfig(deploy *corev1.Deployment, req PatchRequest) error {

--- a/releasenotes-dca/notes/auto-instru-telem-eac08645853a4cac.yaml
+++ b/releasenotes-dca/notes/auto-instru-telem-eac08645853a4cac.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Admission Controller: Add telemetry around auto-instrumentation via remote config.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Telemetry around the remote config auto-instrumentation logic
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Required by RC
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

The `datadog_cluster_agent` check will be updated accordingly
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Trigger RC auto-instrumentation and run `agent telemetry` 

```
# HELP admission_webhooks_patcher_attempts Number of patch attempts.
# TYPE admission_webhooks_patcher_attempts counter
admission_webhooks_patcher_attempts 6
# HELP admission_webhooks_patcher_completed Number of completed patch attempts.
# TYPE admission_webhooks_patcher_completed counter
admission_webhooks_patcher_completed 1
# HELP admission_webhooks_patcher_errors Number of patch errors.
# TYPE admission_webhooks_patcher_errors counter
admission_webhooks_patcher_errors 2
# HELP admission_webhooks_rc_provider_configs Number of valid remote configurations.
# TYPE admission_webhooks_rc_provider_configs gauge
admission_webhooks_rc_provider_configs 2
# HELP admission_webhooks_rc_provider_configs_invalid Number of invalid remote configurations.
# TYPE admission_webhooks_rc_provider_configs_invalid gauge
admission_webhooks_rc_provider_configs_invalid 1
```

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
