### PR TITLE
[corechecks/snmp] Add interface_configs to override interface speed

### DIFF
--- a/pkg/collector/corechecks/snmp/internal/checkconfig/config.go
+++ b/pkg/collector/corechecks/snmp/internal/checkconfig/config.go
@@ -492,6 +492,7 @@ func NewCheckConfig(rawInstance integration.Data, rawInitConfig integration.Data
 	c.InstanceTags = instance.Tags
 	c.MetricTags = instance.MetricTags
 	c.InterfaceConfigs = instance.InterfaceConfigs
+	log.Warnf("c.InterfaceConfigs from config: %+v", c.InterfaceConfigs)
 
 	c.AddUptimeMetric()
 
@@ -645,6 +646,7 @@ func (c *CheckConfig) Copy() *CheckConfig {
 	newConfig.DetectMetricsEnabled = c.DetectMetricsEnabled
 	newConfig.DetectMetricsRefreshInterval = c.DetectMetricsRefreshInterval
 	newConfig.MinCollectionInterval = c.MinCollectionInterval
+	newConfig.InterfaceConfigs = c.InterfaceConfigs
 
 	return &newConfig
 }

--- a/pkg/collector/corechecks/snmp/internal/checkconfig/config.go
+++ b/pkg/collector/corechecks/snmp/internal/checkconfig/config.go
@@ -61,7 +61,9 @@ type DeviceDigest string
 
 // InterfaceConfig interface related configs (e.g. interface speed override)
 type InterfaceConfig struct {
-	Match    string `yaml:"match"`     // e.g. match: 'name:eth0'
+	Match    string `yaml:"match"` // e.g. match: 'name:eth0'
+	Name     string
+	Index    int
 	InSpeed  uint64 `yaml:"in_speed"`  // inbound speed override
 	OutSpeed uint64 `yaml:"out_speed"` // outbound speed override
 }
@@ -138,6 +140,8 @@ type InstanceConfig struct {
 	DetectMetricsEnabled         *Boolean `yaml:"experimental_detect_metrics_enabled"`
 	DetectMetricsRefreshInterval int      `yaml:"experimental_detect_metrics_refresh_interval"`
 
+	// `interface_configs` option is not supported by SNMP corecheck autodiscovery (`network_address`)
+	// it's only supported for single device instance (`ip_address`)
 	InterfaceConfigs []InterfaceConfig `yaml:"interface_configs"`
 }
 
@@ -521,6 +525,7 @@ func NewCheckConfig(rawInstance integration.Data, rawInitConfig integration.Data
 
 	errors := ValidateEnrichMetrics(c.Metrics)
 	errors = append(errors, ValidateEnrichMetricTags(c.MetricTags)...)
+	errors = append(errors, validateEnrichInterfaceConfigs(c.InterfaceConfigs)...)
 	if len(errors) > 0 {
 		return nil, fmt.Errorf("validation errors: %s", strings.Join(errors, "\n"))
 	}

--- a/pkg/collector/corechecks/snmp/internal/checkconfig/config.go
+++ b/pkg/collector/corechecks/snmp/internal/checkconfig/config.go
@@ -59,6 +59,13 @@ var uptimeMetricConfig = MetricsConfig{Symbol: SymbolConfig{OID: "1.3.6.1.2.1.1.
 // DeviceDigest is the digest of a minimal config used for autodiscovery
 type DeviceDigest string
 
+// InterfaceConfig interface related configs (e.g. interface speed override)
+type InterfaceConfig struct {
+	Match    string `yaml:"match"`     // e.g. match: 'name:eth0'
+	InSpeed  uint64 `yaml:"in_speed"`  // inbound speed override
+	OutSpeed uint64 `yaml:"out_speed"` // outbound speed override
+}
+
 // InitConfig is used to deserialize integration init config
 type InitConfig struct {
 	Profiles                     profileConfigMap `yaml:"profiles"`
@@ -130,6 +137,8 @@ type InstanceConfig struct {
 	// the integration will fetch OIDs from the devices and deduct which metrics  can be monitored (from all OOTB profile metrics definition)
 	DetectMetricsEnabled         *Boolean `yaml:"experimental_detect_metrics_enabled"`
 	DetectMetricsRefreshInterval int      `yaml:"experimental_detect_metrics_refresh_interval"`
+
+	InterfaceConfigs []InterfaceConfig `yaml:"interface_configs"`
 }
 
 // CheckConfig holds config needed for an integration instance to run
@@ -178,6 +187,7 @@ type CheckConfig struct {
 	DiscoveryInterval        int
 	IgnoredIPAddresses       map[string]bool
 	DiscoveryAllowedFailures int
+	InterfaceConfigs         []InterfaceConfig
 }
 
 // RefreshWithProfile refreshes config based on profile
@@ -477,6 +487,7 @@ func NewCheckConfig(rawInstance integration.Data, rawInitConfig integration.Data
 
 	c.InstanceTags = instance.Tags
 	c.MetricTags = instance.MetricTags
+	c.InterfaceConfigs = instance.InterfaceConfigs
 
 	c.AddUptimeMetric()
 

--- a/pkg/collector/corechecks/snmp/internal/checkconfig/config.go
+++ b/pkg/collector/corechecks/snmp/internal/checkconfig/config.go
@@ -64,8 +64,8 @@ type InterfaceConfig struct {
 	Match    string `yaml:"match"` // e.g. match: 'name:eth0'
 	Name     string
 	Index    int
-	InSpeed  uint64 `yaml:"in_speed"`  // inbound speed override
-	OutSpeed uint64 `yaml:"out_speed"` // outbound speed override
+	InSpeed  uint64 `yaml:"in_speed"`  // inbound speed override in bps
+	OutSpeed uint64 `yaml:"out_speed"` // outbound speed override in bps
 }
 
 // InitConfig is used to deserialize integration init config

--- a/pkg/collector/corechecks/snmp/internal/checkconfig/config_validate_enrich.go
+++ b/pkg/collector/corechecks/snmp/internal/checkconfig/config_validate_enrich.go
@@ -179,10 +179,11 @@ func validateEnrichInterfaceConfigs(interfaceConfigs []InterfaceConfig) []string
 
 func validateEnrichInterfaceConfig(interfaceConfig *InterfaceConfig) []string {
 	var errors []string
-	matchTokens := strings.SplitN(interfaceConfig.Match, ":", 1)
+	matchTokens := strings.SplitN(interfaceConfig.Match, ":", 2)
 	if len(matchTokens) != 2 {
 		// TODO: TEST ME
 		errors = append(errors, fmt.Sprintf("invalid interface match (expected values like `name:eth0`, `index:10`): %s", interfaceConfig.Match))
+		return errors
 	}
 	matchField := matchTokens[0]
 	matchValue := matchTokens[1]

--- a/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck_test.go
+++ b/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck_test.go
@@ -60,7 +60,7 @@ profiles:
 	sender.On("EventPlatformEvent", mock.Anything, mock.Anything).Return()
 	sender.On("Commit").Return()
 
-	deviceCk.SetSender(report.NewMetricSender(sender, ""))
+	deviceCk.SetSender(report.NewMetricSender(sender, "", nil))
 
 	sysObjectIDPacket := gosnmp.SnmpPacket{
 		Variables: []gosnmp.SnmpPDU{
@@ -356,7 +356,7 @@ experimental_detect_metrics_enabled: true
 	sender.On("EventPlatformEvent", mock.Anything, mock.Anything).Return()
 	sender.On("Commit").Return()
 
-	deviceCk.SetSender(report.NewMetricSender(sender, ""))
+	deviceCk.SetSender(report.NewMetricSender(sender, "", nil))
 
 	sysObjectIDPacket := gosnmp.SnmpPacket{
 		Variables: []gosnmp.SnmpPDU{
@@ -738,7 +738,7 @@ profiles:
 	assert.Nil(t, err)
 
 	sender := mocksender.NewMockSender("123") // required to initiate aggregator
-	deviceCk.SetSender(report.NewMetricSender(sender, ""))
+	deviceCk.SetSender(report.NewMetricSender(sender, "", nil))
 	sess.On("GetNext", []string{"1.0"}).Return(session.CreateGetNextPacket("9999", gosnmp.EndOfMibView, nil), nil)
 
 	deviceCk.detectMetricsToMonitor(sess)
@@ -790,12 +790,12 @@ community_string: public
 	sender.On("Gauge", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 
 	// without hostname
-	deviceCk.SetSender(report.NewMetricSender(sender, ""))
+	deviceCk.SetSender(report.NewMetricSender(sender, "", nil))
 	deviceCk.sender.Gauge("snmp.devices_monitored", float64(1), []string{"snmp_device:1.2.3.4"})
 	sender.AssertMetric(t, "Gauge", "snmp.devices_monitored", float64(1), "", []string{"snmp_device:1.2.3.4"})
 
 	// with hostname
-	deviceCk.SetSender(report.NewMetricSender(sender, "device:123"))
+	deviceCk.SetSender(report.NewMetricSender(sender, "device:123", nil))
 	deviceCk.sender.Gauge("snmp.devices_monitored", float64(1), []string{"snmp_device:1.2.3.4"})
 	sender.AssertMetric(t, "Gauge", "snmp.devices_monitored", float64(1), "device:123", []string{"snmp_device:1.2.3.4"})
 }
@@ -889,7 +889,7 @@ profiles:
 	sender.On("EventPlatformEvent", mock.Anything, mock.Anything).Return()
 	sender.On("Commit").Return()
 
-	deviceCk.SetSender(report.NewMetricSender(sender, ""))
+	deviceCk.SetSender(report.NewMetricSender(sender, "", nil))
 
 	sysObjectIDPacket := gosnmp.SnmpPacket{
 		Variables: []gosnmp.SnmpPDU{
@@ -1183,7 +1183,7 @@ profiles:
 	sender := mocksender.NewMockSender("123") // required to initiate aggregator
 	sender.SetupAcceptAll()
 
-	deviceCk.SetSender(report.NewMetricSender(sender, ""))
+	deviceCk.SetSender(report.NewMetricSender(sender, "", nil))
 
 	packet := gosnmp.SnmpPacket{
 		Variables: []gosnmp.SnmpPDU{},
@@ -1223,7 +1223,7 @@ community_string: public
 	sender := mocksender.NewMockSender("123") // required to initiate aggregator
 	sender.SetupAcceptAll()
 
-	deviceCk.SetSender(report.NewMetricSender(sender, ""))
+	deviceCk.SetSender(report.NewMetricSender(sender, "", nil))
 
 	sess.On("GetNext", []string{"1.0"}).Return(&gosnmplib.MockValidReachableGetNextPacket, nil)
 	sess.On("GetNext", []string{"1.3.6.1.2.1.1.2.0"}).Return(session.CreateGetNextPacket("1.3.6.1.2.1.1.5.0", gosnmp.OctetString, []byte(`123`)), nil)

--- a/pkg/collector/corechecks/snmp/internal/report/report_bandwidth_usage.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_bandwidth_usage.go
@@ -7,9 +7,6 @@ package report
 
 import (
 	"fmt"
-	"strconv"
-	"strings"
-
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/internal/checkconfig"
@@ -110,21 +107,4 @@ func (ms *MetricSender) sendBandwidthUsageMetric(symbol checkconfig.SymbolConfig
 
 	ms.sendMetric(sample)
 	return nil
-}
-
-func getInterfaceConfig(interfaceConfigs []checkconfig.InterfaceConfig, index string, tags []string) *checkconfig.InterfaceConfig {
-	var ifName string
-	for _, tag := range tags {
-		tagElems := strings.SplitN(tag, ":", 2)
-		if len(tagElems) == 2 && tagElems[0] == "interface" {
-			ifName = tagElems[1]
-		}
-	}
-	var matchedConfig *checkconfig.InterfaceConfig
-	for _, ifConfig := range interfaceConfigs {
-		if (ifConfig.Name != "" && ifConfig.Name == ifName) || (strconv.Itoa(ifConfig.Index) == index) {
-			matchedConfig = &ifConfig
-		}
-	}
-	return matchedConfig
 }

--- a/pkg/collector/corechecks/snmp/internal/report/report_bandwidth_usage.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_bandwidth_usage.go
@@ -23,8 +23,8 @@ var bandwidthMetricNameToUsage = map[string]string{
 
 const ifHighSpeedOID = "1.3.6.1.2.1.31.1.1.1.15"
 
-func (ms *MetricSender) trySendBandwidthUsageMetric(symbol checkconfig.SymbolConfig, fullIndex string, values *valuestore.ResultValueStore, tags []string) {
-	err := ms.sendBandwidthUsageMetric(symbol, fullIndex, values, tags)
+func (ms *MetricSender) trySendBandwidthUsageMetric(symbol checkconfig.SymbolConfig, fullIndex string, values *valuestore.ResultValueStore, tags []string, interfaceConfig *checkconfig.InterfaceConfig) {
+	err := ms.sendBandwidthUsageMetric(symbol, fullIndex, values, tags, interfaceConfig)
 	if err != nil {
 		log.Debugf("failed to send bandwidth usage metric: %s", err)
 	}
@@ -48,14 +48,11 @@ per second). It is constant in time, can be overwritten by the system admin.
 It is the total available bandwidth.
 Bandwidth usage is evaluated as: ifHC[In|Out]Octets/ifHighSpeed and reported as *Rate*
 */
-func (ms *MetricSender) sendBandwidthUsageMetric(symbol checkconfig.SymbolConfig, fullIndex string, values *valuestore.ResultValueStore, tags []string) error {
+func (ms *MetricSender) sendBandwidthUsageMetric(symbol checkconfig.SymbolConfig, fullIndex string, values *valuestore.ResultValueStore, tags []string, interfaceConfig *checkconfig.InterfaceConfig) error {
 	usageName, ok := bandwidthMetricNameToUsage[symbol.Name]
 	if !ok {
 		return nil
 	}
-
-	log.Warnf("ms.interfaceConfigs: %+v", ms.interfaceConfigs)
-	interfaceConfig := getInterfaceConfig(ms.interfaceConfigs, fullIndex, tags)
 	var ifHighSpeedFloatValue float64
 	if interfaceConfig != nil {
 		switch symbol.Name {

--- a/pkg/collector/corechecks/snmp/internal/report/report_bandwidth_usage_test.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_bandwidth_usage_test.go
@@ -296,7 +296,7 @@ func Test_metricSender_sendBandwidthUsageMetric(t *testing.T) {
 			fullIndex: "9",
 			interfaceConfigs: &checkconfig.InterfaceConfig{
 				Name:    "eth0",
-				InSpeed: 160,
+				InSpeed: 160_000_000,
 			},
 			tags: []string{
 				"interface:eth0",
@@ -334,7 +334,7 @@ func Test_metricSender_sendBandwidthUsageMetric(t *testing.T) {
 			fullIndex: "9",
 			interfaceConfigs: &checkconfig.InterfaceConfig{
 				Index:   9,
-				InSpeed: 160,
+				InSpeed: 160_000_000,
 			},
 			tags: []string{
 				"interface:eth0",

--- a/pkg/collector/corechecks/snmp/internal/report/report_metrics.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_metrics.go
@@ -145,10 +145,38 @@ func (ms *MetricSender) reportColumnMetrics(metricConfig checkconfig.MetricsConf
 				samples[sample.symbol.Name] = make(map[string]MetricSample)
 			}
 			samples[sample.symbol.Name][fullIndex] = sample
-			ms.trySendBandwidthUsageMetric(symbol, fullIndex, values, rowTags)
+			log.Warnf("ms.interfaceConfigs: %+v", ms.interfaceConfigs)
+			interfaceConfig := getInterfaceConfig(ms.interfaceConfigs, fullIndex, tags)
+			ms.sendCustomInterfaceSpeed(interfaceConfig, tags)
+			ms.trySendBandwidthUsageMetric(symbol, fullIndex, values, rowTags, interfaceConfig)
 		}
 	}
 	return samples
+}
+
+func (ms *MetricSender) sendCustomInterfaceSpeed(interfaceConfig *checkconfig.InterfaceConfig, tags []string) {
+	// TODO: TESTME
+	if interfaceConfig == nil {
+		return
+	}
+	if interfaceConfig.InSpeed != 0 {
+		ms.sendMetric(MetricSample{
+			value:      valuestore.ResultValue{Value: interfaceConfig.InSpeed},
+			tags:       tags,
+			symbol:     checkconfig.SymbolConfig{Name: "snmp.ifInSpeed.custom"},
+			forcedType: "gauge",
+			options:    checkconfig.MetricsConfigOption{},
+		})
+	}
+	if interfaceConfig.OutSpeed != 0 {
+		ms.sendMetric(MetricSample{
+			value:      valuestore.ResultValue{Value: interfaceConfig.InSpeed},
+			tags:       tags,
+			symbol:     checkconfig.SymbolConfig{Name: "snmp.ifOutSpeed.custom"},
+			forcedType: "gauge",
+			options:    checkconfig.MetricsConfigOption{},
+		})
+	}
 }
 
 func (ms *MetricSender) sendMetric(metricSample MetricSample) {

--- a/pkg/collector/corechecks/snmp/internal/report/report_metrics.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_metrics.go
@@ -168,7 +168,7 @@ func (ms *MetricSender) sendCustomInterfaceSpeed(interfaceConfig *checkconfig.In
 		ms.sendMetric(MetricSample{
 			value:      valuestore.ResultValue{Value: float64(interfaceConfig.InSpeed)},
 			tags:       tags,
-			symbol:     checkconfig.SymbolConfig{Name: "ifInSpeed.custom"},
+			symbol:     checkconfig.SymbolConfig{Name: "ifCustomInSpeed"},
 			forcedType: "gauge",
 			options:    checkconfig.MetricsConfigOption{},
 		})
@@ -177,7 +177,7 @@ func (ms *MetricSender) sendCustomInterfaceSpeed(interfaceConfig *checkconfig.In
 		ms.sendMetric(MetricSample{
 			value:      valuestore.ResultValue{Value: float64(interfaceConfig.InSpeed)},
 			tags:       tags,
-			symbol:     checkconfig.SymbolConfig{Name: "ifOutSpeed.custom"},
+			symbol:     checkconfig.SymbolConfig{Name: "ifCustomOutSpeed"},
 			forcedType: "gauge",
 			options:    checkconfig.MetricsConfigOption{},
 		})

--- a/pkg/collector/corechecks/snmp/internal/report/report_metrics.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_metrics.go
@@ -22,6 +22,7 @@ type MetricSender struct {
 	sender           aggregator.Sender
 	hostname         string
 	submittedMetrics int
+	interfaceConfigs []checkconfig.InterfaceConfig
 }
 
 // MetricSample is a collected metric sample with its metadata, ready to be submitted through the metric sender
@@ -34,8 +35,12 @@ type MetricSample struct {
 }
 
 // NewMetricSender create a new MetricSender
-func NewMetricSender(sender aggregator.Sender, hostname string) *MetricSender {
-	return &MetricSender{sender: sender, hostname: hostname}
+func NewMetricSender(sender aggregator.Sender, hostname string, interfaceConfigs []checkconfig.InterfaceConfig) *MetricSender {
+	return &MetricSender{
+		sender:           sender,
+		hostname:         hostname,
+		interfaceConfigs: interfaceConfigs,
+	}
 }
 
 // ReportMetrics reports metrics using Sender

--- a/pkg/collector/corechecks/snmp/internal/report/report_metrics_test.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_metrics_test.go
@@ -439,3 +439,36 @@ func Test_metricSender_getCheckInstanceMetricTags(t *testing.T) {
 		})
 	}
 }
+
+func Test_getInterfaceConfig(t *testing.T) {
+	tests := []struct {
+		name                    string
+		interfaceConfigs        []checkconfig.InterfaceConfig
+		index                   string
+		tags                    []string
+		expectedInterfaceConfig *checkconfig.InterfaceConfig
+	}{
+		{
+			name: "matched",
+			interfaceConfigs: []checkconfig.InterfaceConfig{
+				{
+					Name:    "eth0",
+					InSpeed: 80,
+				},
+			},
+			index: "10",
+			tags: []string{
+				"interface:eth0",
+			},
+			expectedInterfaceConfig: &checkconfig.InterfaceConfig{
+				Name:    "eth0",
+				InSpeed: 80,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expectedInterfaceConfig, getInterfaceConfig(tt.interfaceConfigs, tt.index, tt.tags))
+		})
+	}
+}

--- a/pkg/collector/corechecks/snmp/snmp.go
+++ b/pkg/collector/corechecks/snmp/snmp.go
@@ -65,7 +65,8 @@ func (c *Check) Run() error {
 				log.Warnf("error getting hostname for device %s: %s", deviceCk.GetIPAddress(), err)
 				continue
 			}
-			deviceCk.SetSender(report.NewMetricSender(sender, hostname))
+			// `interface_configs` option not supported by SNMP corecheck autodiscovery
+			deviceCk.SetSender(report.NewMetricSender(sender, hostname, nil))
 			jobs <- deviceCk
 		}
 		close(jobs)
@@ -79,7 +80,7 @@ func (c *Check) Run() error {
 		if err != nil {
 			return err
 		}
-		c.singleDeviceCk.SetSender(report.NewMetricSender(sender, hostname))
+		c.singleDeviceCk.SetSender(report.NewMetricSender(sender, hostname, c.config.InterfaceConfigs))
 		checkErr = c.runCheckDevice(c.singleDeviceCk)
 	}
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

[corechecks/snmp] Add interface_configs to override interface speed

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
