### PR TITLE
USM : flush http batch on https_process path

### DIFF
--- a/pkg/network/ebpf/c/prebuilt/http.c
+++ b/pkg/network/ebpf/c/prebuilt/http.c
@@ -196,6 +196,7 @@ int uretprobe__SSL_read(struct pt_regs* ctx) {
     }
 
     https_process(t, args->buf, len, LIBSSL);
+    http_flush_batch(ctx);
 cleanup:
     bpf_map_delete_elem(&ssl_read_args, &pid_tgid);
     return 0;
@@ -232,6 +233,7 @@ int uretprobe__SSL_write(struct pt_regs* ctx) {
     }
 
     https_process(t, args->buf, write_len, LIBSSL);
+    http_flush_batch(ctx);
 cleanup:
     bpf_map_delete_elem(&ssl_write_args, &pid_tgid);
     return 0;
@@ -284,6 +286,7 @@ int uretprobe__SSL_read_ex(struct pt_regs* ctx) {
     }
 
     https_process(conn_tuple, args->buf, bytes_count, LIBSSL);
+    http_flush_batch(ctx);
 cleanup:
     bpf_map_delete_elem(&ssl_read_ex_args, &pid_tgid);
     return 0;
@@ -333,6 +336,7 @@ int uretprobe__SSL_write_ex(struct pt_regs* ctx) {
     }
 
     https_process(conn_tuple, args->buf, bytes_count, LIBSSL);
+    http_flush_batch(ctx);
 cleanup:
     bpf_map_delete_elem(&ssl_write_ex_args, &pid_tgid);
     return 0;
@@ -453,6 +457,7 @@ int uretprobe__gnutls_record_recv(struct pt_regs *ctx) {
     }
 
     https_process(t, args->buf, read_len, LIBGNUTLS);
+    http_flush_batch(ctx);
 cleanup:
     bpf_map_delete_elem(&ssl_read_args, &pid_tgid);
     return 0;
@@ -490,6 +495,7 @@ int uretprobe__gnutls_record_send(struct pt_regs *ctx) {
     }
 
     https_process(t, args->buf, write_len, LIBGNUTLS);
+    http_flush_batch(ctx);
 cleanup:
     bpf_map_delete_elem(&ssl_write_args, &pid_tgid);
     return 0;

--- a/pkg/network/ebpf/c/runtime/http.c
+++ b/pkg/network/ebpf/c/runtime/http.c
@@ -196,6 +196,7 @@ int uretprobe__SSL_read(struct pt_regs *ctx) {
     }
 
     https_process(t, args->buf, len, LIBSSL);
+    http_flush_batch(ctx);
 cleanup:
     bpf_map_delete_elem(&ssl_read_args, &pid_tgid);
     return 0;
@@ -232,6 +233,7 @@ int uretprobe__SSL_write(struct pt_regs* ctx) {
     }
 
     https_process(t, args->buf, write_len, LIBSSL);
+    http_flush_batch(ctx);
 cleanup:
     bpf_map_delete_elem(&ssl_write_args, &pid_tgid);
     return 0;
@@ -283,6 +285,7 @@ int uretprobe__SSL_read_ex(struct pt_regs* ctx) {
     }
 
     https_process(conn_tuple, args->buf, bytes_count, LIBSSL);
+    http_flush_batch(ctx);
 cleanup:
     bpf_map_delete_elem(&ssl_read_ex_args, &pid_tgid);
     return 0;
@@ -334,6 +337,7 @@ int uretprobe__SSL_write_ex(struct pt_regs* ctx) {
     }
 
     https_process(conn_tuple, args->buf, bytes_count, LIBSSL);
+    http_flush_batch(ctx);
 cleanup:
     bpf_map_delete_elem(&ssl_write_ex_args, &pid_tgid);
     return 0;
@@ -454,6 +458,7 @@ int uretprobe__gnutls_record_recv(struct pt_regs *ctx) {
     }
 
     https_process(t, args->buf, read_len, LIBGNUTLS);
+    http_flush_batch(ctx);
 cleanup:
     bpf_map_delete_elem(&ssl_read_args, &pid_tgid);
     return 0;
@@ -491,6 +496,7 @@ int uretprobe__gnutls_record_send(struct pt_regs *ctx) {
     }
 
     https_process(t, args->buf, write_len, LIBGNUTLS);
+    http_flush_batch(ctx);
 cleanup:
     bpf_map_delete_elem(&ssl_write_args, &pid_tgid);
     return 0;
@@ -724,6 +730,7 @@ int uprobe__crypto_tls_Conn_Write__return(struct pt_regs *ctx) {
 
     log_debug("[go-tls-write] processing %s\n", call_data_ptr->b_data);
     https_process(t, (void*) call_data_ptr->b_data, call_data_ptr->b_len, GO);
+    http_flush_batch(ctx);
     return 0;
 }
 
@@ -813,6 +820,7 @@ int uprobe__crypto_tls_Conn_Read__return(struct pt_regs *ctx) {
 
     log_debug("[go-tls-read] processing %s\n", call_data_ptr->b_data);
     https_process(t, (void*) call_data_ptr->b_data, bytes_read, GO);
+    http_flush_batch(ctx);
     return 0;
 }
 

--- a/pkg/network/ebpf/c/runtime/http.c
+++ b/pkg/network/ebpf/c/runtime/http.c
@@ -721,16 +721,18 @@ int uprobe__crypto_tls_Conn_Write__return(struct pt_regs *ctx) {
         return 1;
     }
 
-    bpf_map_delete_elem(&go_tls_write_args, &call_key);
-
     conn_tuple_t* t = conn_tup_from_tls_conn(od, (void*) call_data_ptr->conn_pointer, pid_tgid);
     if (t == NULL) {
+        bpf_map_delete_elem(&go_tls_write_args, &call_key);
         return 1;
     }
 
     log_debug("[go-tls-write] processing %s\n", call_data_ptr->b_data);
-    https_process(t, (void*) call_data_ptr->b_data, call_data_ptr->b_len, GO);
-    http_flush_batch(ctx);
+    https_process(t, (void*) call_data_ptr->b_data, bytes_written, GO);
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 0)
+    http_flush_batch(ctx);  // 4.14.304-226.531.amzn2.x86_64 verifier fail here in non debug mode
+#endif
+    bpf_map_delete_elem(&go_tls_write_args, &call_key);
     return 0;
 }
 
@@ -811,16 +813,17 @@ int uprobe__crypto_tls_Conn_Read__return(struct pt_regs *ctx) {
         return 1;
     }
 
-    bpf_map_delete_elem(&go_tls_read_args, &call_key);
-
     conn_tuple_t* t = conn_tup_from_tls_conn(od, (void*) call_data_ptr->conn_pointer, pid_tgid);
     if (t == NULL) {
+        bpf_map_delete_elem(&go_tls_read_args, &call_key);
         return 1;
     }
 
     log_debug("[go-tls-read] processing %s\n", call_data_ptr->b_data);
     https_process(t, (void*) call_data_ptr->b_data, bytes_read, GO);
     http_flush_batch(ctx);
+
+    bpf_map_delete_elem(&go_tls_read_args, &call_key);
     return 0;
 }
 

--- a/pkg/network/ebpf/c/runtime/http.c
+++ b/pkg/network/ebpf/c/runtime/http.c
@@ -729,9 +729,7 @@ int uprobe__crypto_tls_Conn_Write__return(struct pt_regs *ctx) {
 
     log_debug("[go-tls-write] processing %s\n", call_data_ptr->b_data);
     https_process(t, (void*) call_data_ptr->b_data, bytes_written, GO);
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 0)
-    http_flush_batch(ctx);  // 4.14.304-226.531.amzn2.x86_64 verifier fail here in non debug mode
-#endif
+
     bpf_map_delete_elem(&go_tls_write_args, &call_key);
     return 0;
 }
@@ -821,7 +819,6 @@ int uprobe__crypto_tls_Conn_Read__return(struct pt_regs *ctx) {
 
     log_debug("[go-tls-read] processing %s\n", call_data_ptr->b_data);
     https_process(t, (void*) call_data_ptr->b_data, bytes_read, GO);
-    http_flush_batch(ctx);
 
     bpf_map_delete_elem(&go_tls_read_args, &call_key);
     return 0;


### PR DESCRIPTION
### What does this PR do?

Call` http_flush_batch()` after` https_process()` this will flush http batch if filled up


The http_req/resp parsing, enqueuing, flushing in on the same cpu core/ID as
most of the time the packets call path is like that 
 * hard `irq handler -> soft irq netif -> ebpf_socket_filter() -> http_process(), http_enequeue()`
 * then flush happen in tracepoint context` netif_receive_skb()` ->` http_batch_flush()` on the same core

On https, uprobes are called on the cpu ID of the process, mostly different from the` netif_receive_skb(`) tracepoint cpu id
This PR the issue by calling `http_batch_flush() `explicitly after parsing and enqueue http requests/responses in` https_process()`

Note : `http_batch_flush()` will flush only full batch to userspace and return early (after one `bpf_lookup`) if not


<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
