### PR TITLE
[RCM] Seed the root version as 1 when using an unverified TUF store

### DIFF
--- a/pkg/remoteconfig/state/repository.go
+++ b/pkg/remoteconfig/state/repository.go
@@ -107,6 +107,9 @@ func NewRepository(embeddedRoot []byte) (*Repository, error) {
 
 // NewUnverifiedRepository creates a new remote config repository that will
 // track config files for a client WITHOUT verifying any TUF related metadata.
+//
+// When creating this we pretend we have a root version of 1, as the backend expects
+// to not have to send the initial "embedded" root.
 func NewUnverifiedRepository() (*Repository, error) {
 	configs := make(map[string]map[string]interface{})
 	for _, product := range allProducts {
@@ -118,6 +121,7 @@ func NewUnverifiedRepository() (*Repository, error) {
 		metadata:               make(map[string]Metadata),
 		configs:                configs,
 		tufVerificationEnabled: false,
+		latestRootVersion:      1, // The backend expects usto start with a root version of 1.
 	}, nil
 }
 

--- a/pkg/remoteconfig/state/repository.go
+++ b/pkg/remoteconfig/state/repository.go
@@ -121,7 +121,7 @@ func NewUnverifiedRepository() (*Repository, error) {
 		metadata:               make(map[string]Metadata),
 		configs:                configs,
 		tufVerificationEnabled: false,
-		latestRootVersion:      1, // The backend expects usto start with a root version of 1.
+		latestRootVersion:      1, // The backend expects us to start with a root version of 1.
 	}, nil
 }
 

--- a/pkg/remoteconfig/state/repository_test.go
+++ b/pkg/remoteconfig/state/repository_test.go
@@ -58,10 +58,7 @@ func TestEmptyUpdate(t *testing.T) {
 	assert.EqualValues(t, 1, state.RootsVersion)
 	assert.Nil(t, state.OpaqueBackendState)
 
-	// Do the same with the unverified repository, there should be no functional difference EXCEPT
-	// since we don't have to start with the open source root we'll only report version 0 of the root.
-	// In practice an agent will send up the root files on the first update, but this tests that if for some
-	// reason it's not sent we don't do anything odd.
+	// Do the same with the unverified repository, there should be no functional difference.
 	r = ta.unverifiedRepository
 
 	updatedProducts, err = r.Update(emptyUpdate)
@@ -75,7 +72,7 @@ func TestEmptyUpdate(t *testing.T) {
 	assert.Equal(t, 0, len(state.Configs))
 	assert.Equal(t, 0, len(state.CachedFiles))
 	assert.EqualValues(t, 0, state.TargetsVersion)
-	assert.EqualValues(t, 0, state.RootsVersion) // 0 because we don't start with the open source root
+	assert.EqualValues(t, 1, state.RootsVersion)
 	assert.Nil(t, state.OpaqueBackendState)
 }
 
@@ -153,7 +150,7 @@ func TestUpdateNewConfig(t *testing.T) {
 	assert.Equal(t, 1, len(state.Configs))
 	assert.Equal(t, 1, len(state.CachedFiles))
 	assert.EqualValues(t, 1, state.TargetsVersion)
-	assert.EqualValues(t, 0, state.RootsVersion) // 0 because we don't start with the open source root
+	assert.EqualValues(t, 1, state.RootsVersion)
 	assert.Equal(t, testOpaqueBackendStateContents, state.OpaqueBackendState)
 	configState = state.Configs[0]
 	assert.Equal(t, ProductCWSDD, configState.Product)
@@ -225,7 +222,7 @@ func TestUpdateNewConfigThenRemove(t *testing.T) {
 	assert.Equal(t, 0, len(state.Configs))
 	assert.Equal(t, 0, len(state.CachedFiles))
 	assert.EqualValues(t, 2, state.TargetsVersion)
-	assert.EqualValues(t, 0, state.RootsVersion) // 0 because we don't start with the open source root
+	assert.EqualValues(t, 1, state.RootsVersion)
 	assert.Equal(t, testOpaqueBackendStateContents, state.OpaqueBackendState)
 }
 
@@ -315,7 +312,7 @@ func TestUpdateNewConfigThenModify(t *testing.T) {
 	assert.Equal(t, 1, len(state.Configs))
 	assert.Equal(t, 1, len(state.CachedFiles))
 	assert.EqualValues(t, 2, state.TargetsVersion)
-	assert.EqualValues(t, 0, state.RootsVersion) // 0 because we don't start with the open source root
+	assert.EqualValues(t, 1, state.RootsVersion)
 	assert.Equal(t, testOpaqueBackendStateContents, state.OpaqueBackendState)
 	configState = state.Configs[0]
 	assert.Equal(t, ProductCWSDD, configState.Product)
@@ -363,7 +360,7 @@ func TestUpdateWithIncorrectlySignedTargets(t *testing.T) {
 	assert.Equal(t, 1, len(state.Configs))
 	assert.Equal(t, 1, len(state.CachedFiles))
 	assert.EqualValues(t, 1, state.TargetsVersion)
-	assert.EqualValues(t, 0, state.RootsVersion) // 0 because we don't start with the open source root
+	assert.EqualValues(t, 1, state.RootsVersion)
 	assert.Equal(t, testOpaqueBackendStateContents, state.OpaqueBackendState)
 }
 
@@ -403,7 +400,7 @@ func TestUpdateWithMalformedTargets(t *testing.T) {
 	assert.Equal(t, 0, len(state.Configs))
 	assert.Equal(t, 0, len(state.CachedFiles))
 	assert.EqualValues(t, 0, state.TargetsVersion)
-	assert.EqualValues(t, 0, state.RootsVersion) // 0 because we don't start with the open source root
+	assert.EqualValues(t, 1, state.RootsVersion)
 	assert.Nil(t, state.OpaqueBackendState)
 }
 
@@ -443,7 +440,7 @@ func TestUpdateWithMalformedExtraRoot(t *testing.T) {
 	assert.Equal(t, 0, len(state.Configs))
 	assert.Equal(t, 0, len(state.CachedFiles))
 	assert.EqualValues(t, 0, state.TargetsVersion)
-	assert.EqualValues(t, 0, state.RootsVersion) // 0 because we don't start with the open source root
+	assert.EqualValues(t, 1, state.RootsVersion)
 	assert.Nil(t, state.OpaqueBackendState)
 }
 
@@ -578,7 +575,7 @@ func TestClientOnlyTakesActionOnFilesInClientConfig(t *testing.T) {
 	assert.Equal(t, 0, len(state.Configs))
 	assert.Equal(t, 0, len(state.CachedFiles))
 	assert.EqualValues(t, 1, state.TargetsVersion)
-	assert.EqualValues(t, 0, state.RootsVersion) // 0 because we don't start with the open source root
+	assert.EqualValues(t, 1, state.RootsVersion)
 	assert.Equal(t, testOpaqueBackendStateContents, state.OpaqueBackendState)
 }
 
@@ -697,7 +694,7 @@ func TestUpdateWithTwoProducts(t *testing.T) {
 	assert.Equal(t, 2, len(state.Configs))
 	assert.Equal(t, 2, len(state.CachedFiles))
 	assert.EqualValues(t, 1, state.TargetsVersion)
-	assert.EqualValues(t, 0, state.RootsVersion) // 0 because we don't start with the open source root
+	assert.EqualValues(t, 1, state.RootsVersion)
 	assert.Equal(t, testOpaqueBackendStateContents, state.OpaqueBackendState)
 	assert.Contains(t, state.Configs, expectedConfigStateCWSDD)
 	assert.Contains(t, state.Configs, expectedConfigStateAPM)


### PR DESCRIPTION
The backend expects the agent and all of its clients to have version 1 of the root file to kick off the root update process. Even if we aren't verifying the root chain yet in all clients, we need to pretend as if we have the 1st root to pass the backend checks.

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
