### PR TITLE
[corechecks/sbom] Implement the `InUse` flag

### DIFF
--- a/pkg/collector/corechecks/sbom/check.go
+++ b/pkg/collector/corechecks/sbom/check.go
@@ -120,7 +120,7 @@ func (c *Check) Configure(integrationConfigDigest uint64, config, initConfig int
 		return err
 	}
 
-	c.processor = newProcessor(sender, c.instance.ChunkSize, time.Duration(c.instance.NewSBOMMaxLatencySeconds)*time.Second)
+	c.processor = newProcessor(c.workloadmetaStore, sender, c.instance.ChunkSize, time.Duration(c.instance.NewSBOMMaxLatencySeconds)*time.Second)
 
 	return nil
 }
@@ -134,9 +134,12 @@ func (c *Check) Run() error {
 		checkName,
 		workloadmeta.NormalPriority,
 		workloadmeta.NewFilter(
-			[]workloadmeta.Kind{workloadmeta.KindContainerImageMetadata},
+			[]workloadmeta.Kind{
+				workloadmeta.KindContainerImageMetadata,
+				workloadmeta.KindContainer,
+			},
 			workloadmeta.SourceAll,
-			workloadmeta.EventTypeSet, // We don’t care about SBOM removal because we just have to wait for them to expire on BE side once we stopped refreshing them periodically.
+			workloadmeta.EventTypeAll,
 		),
 	)
 


### PR DESCRIPTION
### What does this PR do?

Implement the `InUse` flag in the SBOM payload telling whether or not an image is used by a running container.

### Motivation

Be able to show in the UI if a vulnerable image is really used or not.

### Additional Notes

One issue was that the `.Image.ID` field found inside `workloadmeta.Container` isn’t an image ID in the sense that it cannot be used to get the `workloadmeta.ContainerImageMetadata` object via `(workloadmeta.Store).GetImage(id string)`.
It’s in fact a repo digest.

The new `imageRepoDigests` field of the `processor` struct contains the mapping between the image repo digests found in the `.Image.ID` field of `workloadmeta.Container` and the image ID.

The new `imageUsers` field of the `processor` struct tracks which running containers are using each image (identified by its repo digest).

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
