### PR TITLE
[CWS] remove args entry cache v2

### DIFF
--- a/pkg/network/tracer/process_cache.go
+++ b/pkg/network/tracer/process_cache.go
@@ -149,8 +149,7 @@ func (pc *processCache) handleProcessEvent(entry *smodel.ProcessCacheEntry) {
 func (pc *processCache) processEvent(entry *smodel.ProcessCacheEntry) *process {
 	var envs map[string]string
 	if entry.EnvsEntry != nil {
-		values, _ := entry.EnvsEntry.ToArray()
-		for _, v := range values {
+		for _, v := range entry.EnvsEntry.Values {
 			k, v, _ := strings.Cut(v, "=")
 			if len(pc.filteredEnvs) > 0 {
 				if _, found := pc.filteredEnvs[k]; !found {

--- a/pkg/network/tracer/process_cache_test.go
+++ b/pkg/network/tracer/process_cache_test.go
@@ -67,7 +67,7 @@ func TestProcessCacheProcessEvent(t *testing.T) {
 					values = append(values, e+"="+envs[e])
 				}
 
-				entry.EnvsEntry.SetValues(values)
+				entry.EnvsEntry.Values = values
 
 				p := pc.processEvent(entry)
 				if entry.ContainerID == "" && len(te.filter) > 0 && len(te.filtered) == 0 {

--- a/pkg/security/activitydump/activity_dump.go
+++ b/pkg/security/activitydump/activity_dump.go
@@ -1064,14 +1064,12 @@ type ProcessActivityNode struct {
 // NewProcessActivityNode returns a new ProcessActivityNode instance
 func NewProcessActivityNode(entry *model.ProcessCacheEntry, generationType NodeGenerationType, nodeStats *ActivityDumpNodeStats) *ProcessActivityNode {
 	nodeStats.processNodes++
-	pan := ProcessActivityNode{
+	return &ProcessActivityNode{
 		Process:        entry.Process,
 		GenerationType: generationType,
 		Files:          make(map[string]*FileActivityNode),
 		DNSNames:       make(map[string]*DNSNode),
 	}
-	pan.retain()
-	return &pan
 }
 
 // nolint: unused
@@ -1099,15 +1097,6 @@ func (pan *ProcessActivityNode) debug(w io.Writer, prefix string) {
 	}
 }
 
-func (pan *ProcessActivityNode) retain() {
-	if pan.Process.ArgsEntry != nil {
-		pan.Process.ArgsEntry.Retain()
-	}
-	if pan.Process.EnvsEntry != nil {
-		pan.Process.EnvsEntry.Retain()
-	}
-}
-
 // scrubAndReleaseArgsEnvs scrubs the process args and envs, and then releases them
 func (pan *ProcessActivityNode) scrubAndReleaseArgsEnvs(resolver *sprocess.Resolver) {
 	_, _ = resolver.GetProcessScrubbedArgv(&pan.Process)
@@ -1116,12 +1105,6 @@ func (pan *ProcessActivityNode) scrubAndReleaseArgsEnvs(resolver *sprocess.Resol
 	pan.Process.EnvsTruncated = envsTruncated
 	pan.Process.Argv0, _ = resolver.GetProcessArgv0(&pan.Process)
 
-	if pan.Process.ArgsEntry != nil {
-		pan.Process.ArgsEntry.Release()
-	}
-	if pan.Process.EnvsEntry != nil {
-		pan.Process.EnvsEntry.Release()
-	}
 	pan.Process.ArgsEntry = nil
 	pan.Process.EnvsEntry = nil
 }

--- a/pkg/security/module/process_monitor.go
+++ b/pkg/security/module/process_monitor.go
@@ -35,7 +35,7 @@ func (p *ProcessMonitoring) HandleEvent(event *smodel.Event) {
 	var cmdline []string
 	if entry.ArgsEntry != nil {
 		// ignore if the args have been truncated
-		cmdline, _ = entry.ArgsEntry.ToArray()
+		cmdline = entry.ArgsEntry.Values
 	}
 
 	e := &model.ProcessEvent{

--- a/pkg/security/probe/model_test.go
+++ b/pkg/security/probe/model_test.go
@@ -24,11 +24,11 @@ import (
 
 func TestProcessArgsFlags(t *testing.T) {
 	var argsEntry model.ArgsEntry
-	argsEntry.SetValues([]string{
+	argsEntry.Values = []string{
 		"cmd", "-abc", "--verbose", "test",
 		"-v=1", "--host=myhost",
 		"-9", "-", "--",
-	})
+	}
 
 	resolver, _ := process.NewResolver(&manager.Manager{}, &config.Config{}, &statsd.NoOpClient{},
 		&procutil.DataScrubber{}, nil, nil, nil, nil, nil, nil, process.NewResolverOpts(nil))
@@ -85,11 +85,11 @@ func TestProcessArgsFlags(t *testing.T) {
 
 func TestProcessArgsOptions(t *testing.T) {
 	var argsEntry model.ArgsEntry
-	argsEntry.SetValues([]string{
+	argsEntry.Values = []string{
 		"cmd", "--config", "/etc/myfile", "--host=myhost", "--verbose",
 		"-c", "/etc/myfile", "-e", "", "-h=myhost", "-v",
 		"--", "---", "-9",
-	})
+	}
 
 	resolver, _ := process.NewResolver(&manager.Manager{}, &config.Config{}, &statsd.NoOpClient{},
 		&procutil.DataScrubber{}, nil, nil, nil, nil, nil, nil, process.NewResolverOpts(nil))

--- a/pkg/security/secl/model/process_cache_entry.go
+++ b/pkg/security/secl/model/process_cache_entry.go
@@ -6,7 +6,6 @@
 package model
 
 import (
-	"container/list"
 	"strings"
 	"time"
 
@@ -93,22 +92,13 @@ func (pc *ProcessCacheEntry) Exec(entry *ProcessCacheEntry) {
 	copyProcessContext(pc, entry)
 }
 
-// ShareArgsEnvs share args and envs between the current entry and the given child entry
-func (pc *ProcessCacheEntry) ShareArgsEnvs(childEntry *ProcessCacheEntry) {
-	childEntry.ArgsEntry = pc.ArgsEntry
-	if childEntry.ArgsEntry != nil {
-		childEntry.ArgsEntry.Retain()
-	}
-	childEntry.EnvsEntry = pc.EnvsEntry
-	if childEntry.EnvsEntry != nil {
-		childEntry.EnvsEntry.Retain()
-	}
-}
-
 // SetParentOfForkChild set the parent of a fork child
 func (pc *ProcessCacheEntry) SetParentOfForkChild(parent *ProcessCacheEntry) {
 	pc.SetAncestor(parent)
-	parent.ShareArgsEnvs(pc)
+	if parent != nil {
+		pc.ArgsEntry = parent.ArgsEntry
+		pc.EnvsEntry = parent.EnvsEntry
+	}
 	pc.IsThread = true
 }
 
@@ -144,171 +134,10 @@ type ArgsEnvs struct {
 	ValuesRaw [MaxArgEnvSize]byte
 }
 
-// ArgsEnvsCacheEntry defines a args/envs base entry
-type ArgsEnvsCacheEntry struct {
-	Size      uint32
-	ValuesRaw []byte
-
-	TotalSize uint64
-
-	Container *list.Element
-
-	next *ArgsEnvsCacheEntry
-	last *ArgsEnvsCacheEntry
-
-	refCount  uint64
-	onRelease func(_ *ArgsEnvsCacheEntry)
-}
-
-// Reset the entry
-func (p *ArgsEnvsCacheEntry) forceReleaseAll() {
-	entry := p
-	for entry != nil {
-		next := entry.next
-
-		entry.Size = 0
-		entry.ValuesRaw = nil
-		entry.next = nil
-		entry.last = nil
-		entry.refCount = 0
-
-		// all the element of the list need to return to the
-		// pool
-		if p.onRelease != nil {
-			p.onRelease(entry)
-		}
-
-		entry = next
-	}
-}
-
-// Init the head of the list
-func (p *ArgsEnvsCacheEntry) Init(event *ArgsEnvsEvent) {
-	p.Size = event.ArgsEnvs.Size
-	p.ValuesRaw = make([]byte, p.Size)
-	copy(p.ValuesRaw, event.ArgsEnvs.ValuesRaw[:])
-
-	p.TotalSize = uint64(p.Size)
-}
-
-// Append an entry to the list
-func (p *ArgsEnvsCacheEntry) Append(entry *ArgsEnvsCacheEntry) {
-	p.TotalSize += uint64(entry.Size)
-
-	// this shouldn't happen, but is here to protect against infinite loops
-	entry.next = nil
-	entry.last = nil
-
-	if p.last != nil {
-		p.last.next = entry
-	} else {
-		p.next = entry
-	}
-	p.last = entry
-}
-
-// Retain increment ref counter
-func (p *ArgsEnvsCacheEntry) retain() {
-	p.refCount++
-}
-
-// Release decrement and eventually release the entry
-func (p *ArgsEnvsCacheEntry) release() bool {
-	p.refCount--
-	if p.refCount > 0 {
-		return false
-	}
-
-	p.forceReleaseAll()
-
-	return true
-}
-
-// NewArgsEnvsCacheEntry returns a new args/env cache entry
-func NewArgsEnvsCacheEntry(onRelease func(_ *ArgsEnvsCacheEntry)) *ArgsEnvsCacheEntry {
-	entry := &ArgsEnvsCacheEntry{
-		onRelease: onRelease,
-	}
-
-	return entry
-}
-
-func (p *ArgsEnvsCacheEntry) toArray() ([]string, bool) {
-	entry := p
-
-	var values []string
-	var truncated bool
-
-	for entry != nil {
-		v, err := UnmarshalStringArray(entry.ValuesRaw[:entry.Size])
-		if err != nil || entry.Size == MaxArgEnvSize {
-			if len(v) > 0 {
-				v[len(v)-1] = v[len(v)-1] + "..."
-			}
-			truncated = true
-		}
-		if len(v) > 0 {
-			values = append(values, v...)
-		}
-
-		entry = entry.next
-	}
-
-	return values, truncated
-}
-
 // ArgsEntry defines a args cache entry
 type ArgsEntry struct {
-	cacheEntry *ArgsEnvsCacheEntry
-
-	values    []string
-	truncated bool
-
-	parsed bool
-}
-
-// NewEnvsEntry returns a new entry
-func NewArgsEntry(cacheEntry *ArgsEnvsCacheEntry) *ArgsEntry {
-	return &ArgsEntry{
-		cacheEntry: cacheEntry,
-	}
-}
-
-// SetValues set the values
-func (p *ArgsEntry) SetValues(values []string) {
-	p.values = values
-	p.parsed = true
-}
-
-// Retain increment ref counter
-func (p *ArgsEntry) Retain() {
-	if p.cacheEntry != nil {
-		p.cacheEntry.retain()
-	}
-}
-
-// Release decrement and eventually release the entry
-func (p *ArgsEntry) Release() {
-	if p.cacheEntry != nil && p.cacheEntry.release() {
-		p.cacheEntry = nil
-	}
-}
-
-// ToArray returns args as array
-func (p *ArgsEntry) ToArray() ([]string, bool) {
-	if len(p.values) > 0 || p.parsed {
-		return p.values, p.truncated
-	}
-	p.values, p.truncated = p.cacheEntry.toArray()
-	p.parsed = true
-
-	// now we have the cache we can force the free without having to check the refcount
-	if p.cacheEntry != nil {
-		p.cacheEntry.forceReleaseAll()
-		p.cacheEntry = nil
-	}
-
-	return p.values, p.truncated
+	Values    []string
+	Truncated bool
 }
 
 // Equals compares two ArgsEntry
@@ -319,83 +148,31 @@ func (p *ArgsEntry) Equals(o *ArgsEntry) bool {
 		return false
 	}
 
-	pa, _ := p.ToArray()
-	oa, _ := o.ToArray()
-
-	return slices.Equal(pa, oa)
+	return slices.Equal(p.Values, o.Values)
 }
 
 // EnvsEntry defines a args cache entry
 type EnvsEntry struct {
-	cacheEntry *ArgsEnvsCacheEntry
+	Values    []string
+	Truncated bool
 
-	values    []string
-	truncated bool
-
-	parsed       bool
 	filteredEnvs []string
 	kv           map[string]string
-}
-
-// NewEnvsEntry returns a new entry
-func NewEnvsEntry(cacheEntry *ArgsEnvsCacheEntry) *EnvsEntry {
-	return &EnvsEntry{
-		cacheEntry: cacheEntry,
-	}
-}
-
-// SetValues set the values
-func (p *EnvsEntry) SetValues(values []string) {
-	p.values = values
-	p.parsed = true
-}
-
-// Retain increment ref counter
-func (p *EnvsEntry) Retain() {
-	if p.cacheEntry != nil {
-		p.cacheEntry.retain()
-	}
-}
-
-// Release decrement and eventually release the entry
-func (p *EnvsEntry) Release() {
-	if p.cacheEntry != nil && p.cacheEntry.release() {
-		p.cacheEntry = nil
-	}
-}
-
-// ToArray returns envs as an array
-func (p *EnvsEntry) ToArray() ([]string, bool) {
-	if p.parsed {
-		return p.values, p.truncated
-	}
-
-	p.values, p.truncated = p.cacheEntry.toArray()
-	p.parsed = true
-
-	// now we have the cache we can force the free without having to check the refcount
-	if p.cacheEntry != nil {
-		p.cacheEntry.forceReleaseAll()
-		p.cacheEntry = nil
-	}
-
-	return p.values, p.truncated
 }
 
 // FilterEnvs returns an array of envs, only the name of each variable is returned unless the variable name is part of the provided filter
 func (p *EnvsEntry) FilterEnvs(envsWithValue map[string]bool) ([]string, bool) {
 	if p.filteredEnvs != nil {
-		return p.filteredEnvs, p.truncated
+		return p.filteredEnvs, p.Truncated
 	}
 
-	values, _ := p.ToArray()
-	if len(values) == 0 {
-		return nil, p.truncated
+	if len(p.Values) == 0 {
+		return nil, p.Truncated
 	}
 
-	p.filteredEnvs = make([]string, 0, len(values))
+	p.filteredEnvs = make([]string, 0, len(p.Values))
 
-	for _, value := range values {
+	for _, value := range p.Values {
 		k, _, found := strings.Cut(value, "=")
 		if found {
 			if envsWithValue[k] {
@@ -408,7 +185,7 @@ func (p *EnvsEntry) FilterEnvs(envsWithValue map[string]bool) ([]string, bool) {
 		}
 	}
 
-	return p.filteredEnvs, p.truncated
+	return p.filteredEnvs, p.Truncated
 }
 
 func (p *EnvsEntry) toMap() {
@@ -416,10 +193,9 @@ func (p *EnvsEntry) toMap() {
 		return
 	}
 
-	values, _ := p.ToArray()
-	p.kv = make(map[string]string, len(values))
+	p.kv = make(map[string]string, len(p.Values))
 
-	for _, value := range values {
+	for _, value := range p.Values {
 		k, v, found := strings.Cut(value, "=")
 		if found {
 			p.kv[k] = v
@@ -441,8 +217,5 @@ func (p *EnvsEntry) Equals(o *EnvsEntry) bool {
 		return false
 	}
 
-	pa, _ := p.ToArray()
-	oa, _ := o.ToArray()
-
-	return slices.Equal(pa, oa)
+	return slices.Equal(p.Values, o.Values)
 }


### PR DESCRIPTION
### What does this PR do?

This PR removes the args/envs entry cache, simplifying greatly the code and reducing the opportunities for errors in the maintenance of the cache coherency and state.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
