### PR TITLE
[CWS] Add metric on ring buffer usage

### DIFF
--- a/pkg/security/ebpf/c/defs.h
+++ b/pkg/security/ebpf/c/defs.h
@@ -387,7 +387,6 @@ void __attribute__((always_inline)) send_event_with_size_ptr(void *ctx, u64 even
     int perf_ret;
     if (use_ring_buffer) {
         perf_ret = bpf_ringbuf_output(&events, kernel_event, kernel_event_size, 0);
-        store_ring_buffer_stats();
     } else {
         perf_ret = bpf_perf_event_output(ctx, &events, header->cpu, kernel_event, kernel_event_size);
     }

--- a/pkg/security/ebpf/c/defs.h
+++ b/pkg/security/ebpf/c/defs.h
@@ -178,6 +178,12 @@
 
 #define IS_KTHREAD(ppid, pid) ppid == 2 || pid == 2
 
+#ifndef USE_RING_BUFFER
+ #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 8, 0)
+  #define USE_RING_BUFFER 1
+ #endif
+#endif
+
 enum event_type
 {
     EVENT_ANY = 0,
@@ -361,6 +367,7 @@ struct bpf_map_def SEC("maps/events_stats") events_stats = {
     .max_entries = EVENT_MAX,
 };
 
+#if USE_RING_BUFFER == 1
 struct bpf_map_def SEC("maps/events_ringbuf_stats") events_ringbuf_stats = {
     .type = BPF_MAP_TYPE_ARRAY,
     .key_size = sizeof(u32),
@@ -369,11 +376,17 @@ struct bpf_map_def SEC("maps/events_ringbuf_stats") events_ringbuf_stats = {
 };
 
 void __attribute__((always_inline)) store_ring_buffer_stats() {
-    int zero = 0;
-    struct ring_buffer_stats_t *stats = bpf_map_lookup_elem(&events_ringbuf_stats, &zero);
-    if (stats)
-        stats->usage = bpf_ringbuf_query(&events, 0);
+    // check needed for code elimination
+    u64 use_ring_buffer;
+    LOAD_CONSTANT("use_ring_buffer", use_ring_buffer);
+    if (use_ring_buffer) {
+        int zero = 0;
+        struct ring_buffer_stats_t *stats = bpf_map_lookup_elem(&events_ringbuf_stats, &zero);
+        if (stats)
+            stats->usage = bpf_ringbuf_query(&events, 0);
+    }
 }
+#endif
 
 void __attribute__((always_inline)) send_event_with_size_ptr(void *ctx, u64 event_type, void *kernel_event, u64 kernel_event_size) {
     struct kevent_t *header = kernel_event;
@@ -381,7 +394,7 @@ void __attribute__((always_inline)) send_event_with_size_ptr(void *ctx, u64 even
     header->cpu = bpf_get_smp_processor_id();
     header->timestamp = bpf_ktime_get_ns();
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 8, 0)
+#if USE_RING_BUFFER == 1
     u64 use_ring_buffer;
     LOAD_CONSTANT("use_ring_buffer", use_ring_buffer);
     int perf_ret;

--- a/pkg/security/ebpf/c/erpc.h
+++ b/pkg/security/ebpf/c/erpc.h
@@ -108,6 +108,7 @@ int __attribute__((always_inline)) handle_bump_discarders_revision(void *data) {
     return 0;
 }
 
+#if USE_RING_BUFFER == 1
 int __attribute__((always_inline)) handle_get_ringbuf_usage(void *data) {
     if (!is_runtime_request()) {
         return 0;
@@ -117,6 +118,7 @@ int __attribute__((always_inline)) handle_get_ringbuf_usage(void *data) {
 
     return 0;
 }
+#endif
 
 int __attribute__((always_inline)) is_erpc_request(struct pt_regs *ctx) {
     u32 cmd = PT_REGS_PARM3(ctx);
@@ -171,8 +173,10 @@ int __attribute__((always_inline)) handle_erpc_request(struct pt_regs *ctx) {
             return handle_expire_pid_discarder(data);
         case BUMP_DISCARDERS_REVISION:
             return handle_bump_discarders_revision(data);
+#if USE_RING_BUFFER == 1
         case GET_RINGBUF_USAGE:
             return handle_get_ringbuf_usage(data);
+#endif
     }
 
     return 0;

--- a/pkg/security/ebpf/c/erpc.h
+++ b/pkg/security/ebpf/c/erpc.h
@@ -17,6 +17,7 @@ enum erpc_op {
     EXPIRE_INODE_DISCARDER_OP,
     EXPIRE_PID_DISCARDER_OP,
     BUMP_DISCARDERS_REVISION,
+    GET_RINGBUF_USAGE,
 };
 
 struct discard_request_t {
@@ -107,6 +108,16 @@ int __attribute__((always_inline)) handle_bump_discarders_revision(void *data) {
     return 0;
 }
 
+int __attribute__((always_inline)) handle_get_ringbuf_usage(void *data) {
+    if (!is_runtime_request()) {
+        return 0;
+    }
+
+    store_ring_buffer_stats();
+
+    return 0;
+}
+
 int __attribute__((always_inline)) is_erpc_request(struct pt_regs *ctx) {
     u32 cmd = PT_REGS_PARM3(ctx);
     if (cmd != RPC_CMD) {
@@ -160,7 +171,8 @@ int __attribute__((always_inline)) handle_erpc_request(struct pt_regs *ctx) {
             return handle_expire_pid_discarder(data);
         case BUMP_DISCARDERS_REVISION:
             return handle_bump_discarders_revision(data);
-
+        case GET_RINGBUF_USAGE:
+            return handle_get_ringbuf_usage(data);
     }
 
     return 0;

--- a/pkg/security/ebpf/compile.go
+++ b/pkg/security/ebpf/compile.go
@@ -19,7 +19,7 @@ import (
 //go:generate go run ../../ebpf/include_headers.go ./c/prebuilt/probe.c ../../ebpf/bytecode/build/runtime/runtime-security.c ./c ../../ebpf/c
 //go:generate go run ../../ebpf/bytecode/runtime/integrity.go ../../ebpf/bytecode/build/runtime/runtime-security.c ../../ebpf/bytecode/runtime/runtime-security.go runtime
 
-func getRuntimeCompiledPrograms(config *config.Config, useSyscallWrapper bool, client statsd.ClientInterface) (bytecode.AssetReader, error) {
+func getRuntimeCompiledPrograms(config *config.Config, useSyscallWrapper, useRingBuffer bool, client statsd.ClientInterface) (bytecode.AssetReader, error) {
 	var cflags []string
 
 	if useSyscallWrapper {
@@ -30,6 +30,10 @@ func getRuntimeCompiledPrograms(config *config.Config, useSyscallWrapper bool, c
 
 	if !config.NetworkEnabled {
 		cflags = append(cflags, "-DDO_NOT_USE_TC")
+	}
+
+	if useRingBuffer {
+		cflags = append(cflags, "-DUSE_RING_BUFFER=1")
 	}
 
 	return runtime.RuntimeSecurity.Compile(&config.Config, cflags, client)

--- a/pkg/security/ebpf/compile_test.go
+++ b/pkg/security/ebpf/compile_test.go
@@ -22,6 +22,6 @@ func TestLoaderCompile(t *testing.T) {
 	require.NoError(t, err)
 	cfg, err := config.NewConfig(syscfg)
 	require.NoError(t, err)
-	_, err = getRuntimeCompiledPrograms(cfg, false, nil)
+	_, err = getRuntimeCompiledPrograms(cfg, false, false, nil)
 	require.NoError(t, err)
 }

--- a/pkg/security/ebpf/compile_unsupported.go
+++ b/pkg/security/ebpf/compile_unsupported.go
@@ -16,6 +16,6 @@ import (
 	"github.com/DataDog/datadog-go/v5/statsd"
 )
 
-func getRuntimeCompiledPrograms(config *config.Config, useSyscallWrapper bool, client statsd.ClientInterface) (bytecode.AssetReader, error) {
+func getRuntimeCompiledPrograms(config *config.Config, useSyscallWrapper, useRingBuffer bool, client statsd.ClientInterface) (bytecode.AssetReader, error) {
 	return nil, fmt.Errorf("runtime compilation unsupported")
 }

--- a/pkg/security/ebpf/kernel/kernel.go
+++ b/pkg/security/ebpf/kernel/kernel.go
@@ -266,6 +266,5 @@ func (k *Version) HaveMmapableMaps() bool {
 
 // HaveRingBuffers returns whether the kernel supports ring buffer.
 func (k *Version) HaveRingBuffers() bool {
-	// This checks ring buffer maps, which appeared in 5.8
-	return k.Code != 0 && k.Code >= Kernel5_8 && features.HaveMapType(ebpf.RingBuf) == nil
+	return features.HaveMapType(ebpf.RingBuf) == nil
 }

--- a/pkg/security/ebpf/loader.go
+++ b/pkg/security/ebpf/loader.go
@@ -23,14 +23,16 @@ type ProbeLoader struct {
 	config            *config.Config
 	bytecodeReader    bytecode.AssetReader
 	useSyscallWrapper bool
+	useRingBuffer     bool
 	statsdClient      statsd.ClientInterface
 }
 
 // NewProbeLoader returns a new Loader
-func NewProbeLoader(config *config.Config, useSyscallWrapper bool, statsdClient statsd.ClientInterface) *ProbeLoader {
+func NewProbeLoader(config *config.Config, useSyscallWrapper, useRingBuffer bool, statsdClient statsd.ClientInterface) *ProbeLoader {
 	return &ProbeLoader{
 		config:            config,
 		useSyscallWrapper: useSyscallWrapper,
+		useRingBuffer:     useRingBuffer,
 		statsdClient:      statsdClient,
 	}
 }
@@ -48,7 +50,7 @@ func (l *ProbeLoader) Load() (bytecode.AssetReader, bool, error) {
 	var err error
 	var runtimeCompiled bool
 	if l.config.RuntimeCompilationEnabled {
-		l.bytecodeReader, err = getRuntimeCompiledPrograms(l.config, l.useSyscallWrapper, l.statsdClient)
+		l.bytecodeReader, err = getRuntimeCompiledPrograms(l.config, l.useSyscallWrapper, l.useRingBuffer, l.statsdClient)
 		if err != nil {
 			seclog.Warnf("error compiling runtime-security probe, falling back to pre-compiled: %s", err)
 		} else {

--- a/pkg/security/ebpf/probes/all.go
+++ b/pkg/security/ebpf/probes/all.go
@@ -248,3 +248,10 @@ func GetPerfBufferStatisticsMaps() map[string]string {
 		"events": "events_stats",
 	}
 }
+
+// GetRingBufferStatisticsMaps returns the list of maps used to monitor the performances of each ring buffer
+func GetRingBufferStatisticsMaps() map[string]string {
+	return map[string]string{
+		"events": "events_ringbuf_stats",
+	}
+}

--- a/pkg/security/ebpf/tests/helpers_test.go
+++ b/pkg/security/ebpf/tests/helpers_test.go
@@ -62,7 +62,7 @@ func newVM(t *testing.T) *baloum.VM {
 		t.Fatal(err)
 	}
 
-	loader := secebpf.NewProbeLoader(&config.Config{}, useSyscallWrapper, &statsd.NoOpClient{})
+	loader := secebpf.NewProbeLoader(&config.Config{}, useSyscallWrapper, false, &statsd.NoOpClient{})
 	reader, _, err := loader.Load()
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/security/metrics/metrics.go
+++ b/pkg/security/metrics/metrics.go
@@ -101,6 +101,9 @@ var (
 	// MetricPerfBufferBytesRead is the name of the metric used to count the number of bytes read from a perf buffer
 	// Tags: map
 	MetricPerfBufferBytesRead = newRuntimeMetric(".perf_buffer.bytes.read")
+	// MetricPerfBufferBytesFree is the name of the metric used to count the number of bytes left in the ring buffer
+	// Tags: map
+	MetricPerfBufferBytesFree = newRuntimeMetric(".perf_buffer.bytes.free")
 	// MetricPerfBufferSortingError is the name of the metric used to report events reordering issues.
 	// Tags: map, event_type
 	MetricPerfBufferSortingError = newRuntimeMetric(".perf_buffer.sorting_error")

--- a/pkg/security/metrics/metrics.go
+++ b/pkg/security/metrics/metrics.go
@@ -101,9 +101,9 @@ var (
 	// MetricPerfBufferBytesRead is the name of the metric used to count the number of bytes read from a perf buffer
 	// Tags: map
 	MetricPerfBufferBytesRead = newRuntimeMetric(".perf_buffer.bytes.read")
-	// MetricPerfBufferBytesUsed is the name of the metric used to count the percentage of space left in the ring buffer
+	// MetricPerfBufferBytesInUse is the name of the metric used to count the percentage of space left in the ring buffer
 	// Tags: map
-	MetricPerfBufferBytesUsed = newRuntimeMetric(".perf_buffer.bytes.used")
+	MetricPerfBufferBytesInUse = newRuntimeMetric(".perf_buffer.bytes.in_use")
 	// MetricPerfBufferSortingError is the name of the metric used to report events reordering issues.
 	// Tags: map, event_type
 	MetricPerfBufferSortingError = newRuntimeMetric(".perf_buffer.sorting_error")

--- a/pkg/security/metrics/metrics.go
+++ b/pkg/security/metrics/metrics.go
@@ -101,9 +101,9 @@ var (
 	// MetricPerfBufferBytesRead is the name of the metric used to count the number of bytes read from a perf buffer
 	// Tags: map
 	MetricPerfBufferBytesRead = newRuntimeMetric(".perf_buffer.bytes.read")
-	// MetricPerfBufferBytesFree is the name of the metric used to count the number of bytes left in the ring buffer
+	// MetricPerfBufferBytesUsed is the name of the metric used to count the percentage of space left in the ring buffer
 	// Tags: map
-	MetricPerfBufferBytesFree = newRuntimeMetric(".perf_buffer.bytes.free")
+	MetricPerfBufferBytesUsed = newRuntimeMetric(".perf_buffer.bytes.used")
 	// MetricPerfBufferSortingError is the name of the metric used to report events reordering issues.
 	// Tags: map, event_type
 	MetricPerfBufferSortingError = newRuntimeMetric(".perf_buffer.sorting_error")

--- a/pkg/security/probe/erpc/erpc.go
+++ b/pkg/security/probe/erpc/erpc.go
@@ -40,6 +40,8 @@ const (
 	ExpirePidDiscarderOp
 	// BumpDiscardersRevision is used to bump the discarders revision
 	BumpDiscardersRevision
+	// GetRingbufUsage is used to retrieve the ring buffer usage
+	GetRingbufUsage
 )
 
 // ERPC defines a krpc object

--- a/pkg/security/probe/perf_buffer_monitor.go
+++ b/pkg/security/probe/perf_buffer_monitor.go
@@ -559,7 +559,7 @@ func (pbm *PerfBufferMonitor) collectAndSendKernelStats(client statsd.ClientInte
 			// The capacity of ring buffer has to be a power of 2 and a multiple of 4096,
 			// the cardinality is low so we use it as a tag.
 			tags := []string{pbm.config.StatsTagsCardinality, mapNameTag, units.ToString(int64(statsMap.ebpfRingBufferMap.capacity), 1024, "", "M")}
-			if err := client.Gauge(metrics.MetricPerfBufferBytesUsed, float64(ringUsage*100/statsMap.ebpfRingBufferMap.capacity), tags, 1.0); err != nil {
+			if err := client.Gauge(metrics.MetricPerfBufferBytesInUse, float64(ringUsage*100/statsMap.ebpfRingBufferMap.capacity), tags, 1.0); err != nil {
 				return err
 			}
 		}

--- a/pkg/security/probe/perf_buffer_monitor.go
+++ b/pkg/security/probe/perf_buffer_monitor.go
@@ -559,7 +559,7 @@ func (pbm *PerfBufferMonitor) collectAndSendKernelStats(client statsd.ClientInte
 			// The capacity of ring buffer has to be a power of 2 and a multiple of 4096,
 			// the cardinality is low so we use it as a tag.
 			tags := []string{pbm.config.StatsTagsCardinality, mapNameTag, units.ToString(int64(statsMap.ebpfRingBufferMap.capacity), 1024, "", "M")}
-			if err := client.Gauge(metrics.MetricPerfBufferBytesFree, float64(statsMap.ebpfRingBufferMap.capacity-ringUsage), tags, 1.0); err != nil {
+			if err := client.Gauge(metrics.MetricPerfBufferBytesUsed, float64(ringUsage*100/statsMap.ebpfRingBufferMap.capacity), tags, 1.0); err != nil {
 				return err
 			}
 		}

--- a/pkg/security/probe/perf_buffer_monitor.go
+++ b/pkg/security/probe/perf_buffer_monitor.go
@@ -61,14 +61,13 @@ type PerfBufferMonitor struct {
 	// numCPU holds the current count of CPU
 	numCPU int
 	// perfBufferStatsMaps holds the pointers to the statistics kernel maps
-	perfBufferStatsMaps map[string]*lib.Map
-	// perfBufferSize holds the size of each perf buffer, indexed by the name of the perf buffer
-	perfBufferSize map[string]float64
+	perfBufferStatsMaps map[string]*perfBufferStatMap
 
 	// perfBufferMapNameToStatsMapsName maps a perf buffer to its statistics maps
 	perfBufferMapNameToStatsMapsName map[string]string
-	// statsMapsNamePerfBufferMapName maps a statistic map to its perf buffer
-	statsMapsNameToPerfBufferMapName map[string]string
+
+	// ringBufferMapNameToStatsMapsName maps a ring buffer to its statistics maps
+	ringBufferMapNameToStatsMapsName map[string]string
 
 	// stats holds the collected user space metrics
 	stats map[string][][model.MaxKernelEventType]PerfMapStats
@@ -87,17 +86,26 @@ type PerfBufferMonitor struct {
 	shouldBumpGeneration *atomic.Bool
 }
 
+type ringBufferStatMap struct {
+	*lib.Map
+	capacity uint64
+}
+
+type perfBufferStatMap struct {
+	ebpfMap           *lib.Map
+	ebpfRingBufferMap *ringBufferStatMap
+}
+
 // NewPerfBufferMonitor instantiates a new event statistics counter
 func NewPerfBufferMonitor(p *Probe) (*PerfBufferMonitor, error) {
 	pbm := PerfBufferMonitor{
 		probe:               p,
 		config:              p.Config,
 		statsdClient:        p.StatsdClient,
-		perfBufferStatsMaps: make(map[string]*lib.Map),
-		perfBufferSize:      make(map[string]float64),
+		perfBufferStatsMaps: make(map[string]*perfBufferStatMap),
 
 		perfBufferMapNameToStatsMapsName: probes.GetPerfBufferStatisticsMaps(),
-		statsMapsNameToPerfBufferMapName: make(map[string]string),
+		ringBufferMapNameToStatsMapsName: probes.GetRingBufferStatisticsMaps(),
 
 		stats:             make(map[string][][model.MaxKernelEventType]PerfMapStats),
 		kernelStats:       make(map[string][][model.MaxKernelEventType]PerfMapStats),
@@ -112,9 +120,13 @@ func NewPerfBufferMonitor(p *Probe) (*PerfBufferMonitor, error) {
 	}
 	pbm.numCPU = numCPU
 
-	// compute statsMapPerfMap
-	for perfMap, statsMap := range pbm.perfBufferMapNameToStatsMapsName {
-		pbm.statsMapsNameToPerfBufferMapName[statsMap] = perfMap
+	maps := make(map[string]int, len(p.Manager.PerfMaps)+len(p.Manager.RingBuffers))
+	for _, pm := range p.Manager.PerfMaps {
+		maps[pm.Name] = pm.PerfRingBufferSize
+	}
+
+	for _, rb := range p.Manager.RingBuffers {
+		maps[rb.Name] = rb.RingBufferSize
 	}
 
 	// Select perf buffer statistics maps
@@ -127,26 +139,31 @@ func NewPerfBufferMonitor(p *Probe) (*PerfBufferMonitor, error) {
 			return nil, err
 		}
 
-		pbm.perfBufferStatsMaps[perfMapName] = stats
-		// set default perf buffer size, it will be readjusted in the next loop if needed
-		if stats.Type() == lib.RingBuf {
-			pbm.perfBufferSize[perfMapName] = float64(p.managerOptions.DefaultRingBufferSize)
-		} else {
-			pbm.perfBufferSize[perfMapName] = float64(p.managerOptions.DefaultPerfRingBufferSize)
+		pbm.perfBufferStatsMaps[perfMapName] = &perfBufferStatMap{ebpfMap: stats}
+
+		if p.UseRingBuffers() {
+			// set default perf buffer size, it will be readjusted in the next loop if needed
+			if ringbufStatsMapName := pbm.ringBufferMapNameToStatsMapsName[perfMapName]; ringbufStatsMapName != "" {
+				ringBufferStats, found, _ := p.Manager.GetMap(ringbufStatsMapName)
+				if !found {
+					return nil, fmt.Errorf("map %s not found", ringbufStatsMapName)
+				}
+
+				ringBufferMap, found, _ := p.Manager.GetMap(perfMapName)
+				if !found {
+					return nil, fmt.Errorf("map %s not found", perfMapName)
+				}
+
+				pbm.perfBufferStatsMaps[perfMapName].ebpfRingBufferMap = &ringBufferStatMap{
+					Map:      ringBufferStats,
+					capacity: uint64(ringBufferMap.MaxEntries()),
+				}
+			}
 		}
 	}
 
-	maps := make(map[string]int, len(p.Manager.PerfMaps)+len(p.Manager.RingBuffers))
-	for _, pm := range p.Manager.PerfMaps {
-		maps[pm.Name] = pm.PerfRingBufferSize
-	}
-
-	for _, rb := range p.Manager.RingBuffers {
-		maps[rb.Name] = rb.RingBufferSize
-	}
-
 	// Prepare user space counters
-	for mapName, size := range maps {
+	for mapName := range maps {
 		var stats, kernelStats [][model.MaxKernelEventType]PerfMapStats
 		var usrLostEvents []*atomic.Uint64
 		var sortingErrorStats [model.MaxKernelEventType]*atomic.Int64
@@ -165,11 +182,6 @@ func NewPerfBufferMonitor(p *Probe) (*PerfBufferMonitor, error) {
 		pbm.kernelStats[mapName] = kernelStats
 		pbm.readLostEvents[mapName] = usrLostEvents
 		pbm.sortingErrorStats[mapName] = sortingErrorStats
-
-		// update perf buffer size if needed
-		if size != 0 {
-			pbm.perfBufferSize[mapName] = float64(size)
-		}
 	}
 	log.Debugf("monitoring perf ring buffer on %d CPU, %d events", pbm.numCPU, model.MaxKernelEventType)
 	return &pbm, nil
@@ -189,7 +201,7 @@ func (pbm *PerfBufferMonitor) getLostCount(perfMap string, cpu int) uint64 {
 }
 
 // GetLostCount returns the number of lost events for a given map and cpu. If a cpu of -1 is provided, the function will
-// return the sum of all the lost events of all the cpus.
+// return the sum of all the lost events of all the cpus. (only used in tests)
 func (pbm *PerfBufferMonitor) GetLostCount(perfMap string, cpu int) uint64 {
 	var total uint64
 
@@ -217,7 +229,7 @@ func (pbm *PerfBufferMonitor) GetKernelLostCount(perfMap string, cpu int, evtTyp
 	var shouldCount bool
 
 	// query the kernel maps
-	_ = pbm.collectAndSendKernelStats(nil)
+	_ = pbm.collectAndSendKernelStats(&statsd.NoOpClient{})
 
 	for cpuID := range pbm.kernelStats[perfMap] {
 		if cpu == -1 || cpu == cpuID {
@@ -247,7 +259,7 @@ func (pbm *PerfBufferMonitor) getAndResetReadLostCount(perfMap string, cpu int) 
 
 // GetAndResetLostCount returns the number of lost events and resets the counter for a given map and cpu. If a cpu of -1 is
 // provided, the function will reset the counters of all the cpus for the provided map, and return the sum of all the
-// lost events of all the cpus of the provided map.
+// lost events of all the cpus of the provided map.  (only used in tests)
 func (pbm *PerfBufferMonitor) GetAndResetLostCount(perfMap string, cpu int) uint64 {
 	var total uint64
 
@@ -297,7 +309,7 @@ func (pbm *PerfBufferMonitor) swapKernelLostCount(eventType model.EventType, per
 	return pbm.kernelStats[perfMap][cpu][eventType].Lost.Swap(value)
 }
 
-// GetEventStats returns the number of received events of the specified type
+// GetEventStats returns the number of received events of the specified type (only used in tests)
 func (pbm *PerfBufferMonitor) GetEventStats(eventType model.EventType, perfMap string, cpu int) (PerfMapStats, PerfMapStats) {
 	stats, kernelStats := NewPerfMapStats(), NewPerfMapStats()
 	var maps []string
@@ -463,10 +475,11 @@ func (pbm *PerfBufferMonitor) collectAndSendKernelStats(client statsd.ClientInte
 		// total and perEvent are used for alerting
 		var total uint64
 		perEvent := map[string]uint64{}
-		tags[1] = fmt.Sprintf("map:%s", perfMapName)
+		mapNameTag := fmt.Sprintf("map:%s", perfMapName)
+		tags[1] = mapNameTag
 
 		// loop through all the values of the active buffer
-		iterator = statsMap.Iterate()
+		iterator = statsMap.ebpfMap.Iterate()
 		for iterator.Next(&id, &cpuStats) {
 			if id == 0 {
 				// first event type is 1
@@ -508,10 +521,8 @@ func (pbm *PerfBufferMonitor) collectAndSendKernelStats(client statsd.ClientInte
 					}
 				}
 
-				if client != nil {
-					if err := pbm.sendKernelStats(client, stats, tags); err != nil {
-						return err
-					}
+				if err := pbm.sendKernelStats(client, stats, tags); err != nil {
+					return err
 				}
 				total += stats.Lost.Load()
 				perEvent[evtType.String()] += stats.Lost.Load()
@@ -519,6 +530,17 @@ func (pbm *PerfBufferMonitor) collectAndSendKernelStats(client statsd.ClientInte
 		}
 		if err := iterator.Err(); err != nil {
 			return fmt.Errorf("failed to dump the statistics buffer of map %s: %w", perfMapName, err)
+		}
+
+		if statsMap.ebpfRingBufferMap != nil {
+			var ringUsage uint64
+			if err := statsMap.ebpfRingBufferMap.Lookup(int32(0), &ringUsage); err != nil {
+				return fmt.Errorf("failed to retrieve ring buffer usage for '%s'", perfMapName)
+			}
+
+			if err := client.Gauge(metrics.MetricPerfBufferBytesFree, float64(statsMap.ebpfRingBufferMap.capacity-ringUsage), []string{pbm.config.StatsTagsCardinality, mapNameTag}, 1.0); err != nil {
+				return err
+			}
 		}
 
 		// send an alert if events were lost

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -231,7 +231,7 @@ func (p *Probe) Init() error {
 		return err
 	}
 
-	loader := ebpf.NewProbeLoader(p.Config, useSyscallWrapper, p.StatsdClient)
+	loader := ebpf.NewProbeLoader(p.Config, useSyscallWrapper, p.UseRingBuffers(), p.StatsdClient)
 	defer loader.Close()
 
 	bytecodeReader, runtimeCompiled, err := loader.Load()


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Add a metric datadog.runtime_security.perf_buffer.bytes.free that measures the free
space of an eBPF ring buffer.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
