### PR TITLE
[CWS] Adding some activity dumps debug metrics

### DIFF
--- a/pkg/security/metrics/metrics.go
+++ b/pkg/security/metrics/metrics.go
@@ -198,27 +198,12 @@ var (
 	// MetricActivityDumpBrokenLineageDrop is the name of the metric used to report the number of events dropped due to broken ancestors lineage
 	// Tags: -
 	MetricActivityDumpBrokenLineageDrop = newRuntimeMetric(".activity_dump.broken_lineage_drop")
-	// MetricActivityDumpInsertCount is the name of the metric used to report the number of events that we may add to a dump
-	// Tags: -
-	MetricActivityDumpInsertCount = newRuntimeMetric(".activity_dump.insert_count")
 	// MetricActivityDumpEventTypeDrop is the name of the metric used to report the number of event dropped because their event types is not traced
 	// Tags: -
 	MetricActivityDumpEventTypeDrop = newRuntimeMetric(".activity_dump.event_type_drop")
-	// MetricActivityDumpResolveProcessCacheEntryDrop is the name of the metric used to report the number of event dropped because the process resolution failed
-	// Tags: -
-	MetricActivityDumpResolveProcessCacheEntryDrop = newRuntimeMetric(".activity_dump.resolve_process_cache_entry_drop")
-	// MetricActivityDumpAbnormalPathDrop is the name of the metric used to report the number of dropped event with an abnormal path
-	// Tags: -
-	MetricActivityDumpAbnormalPathDrop = newRuntimeMetric(".activity_dump.abnormal_path_drop")
-	// MetricActivityDumpEntryMatchDrop is the name of the metric used to report the number of dropped event with no matching on comm/containerID
-	// Tags: -
-	MetricActivityDumpEntryMatchDrop = newRuntimeMetric(".activity_dump.entry_match_drop")
 	// MetricActivityDumpValidRootNodeDrop is the name of the metric used to report the number of dropped root not valide node
 	// Tags: -
 	MetricActivityDumpValidRootNodeDrop = newRuntimeMetric(".activity_dump.valid_root_node_drop")
-	// MetricActivityDumpFindOrCreateDrop is the name of the metric used to report the number of event dropped by findOrCreateProcessActivityNode
-	// Tags: -
-	MetricActivityDumpFindOrCreateDrop = newRuntimeMetric(".activity_dump.find_or_create_drop")
 	// MetricActivityDumpBindFamilyDrop is the name of the metric used to report the number of event dropped because the address family is not handled
 	// Tags: -
 	MetricActivityDumpBindFamilyDrop = newRuntimeMetric(".activity_dump.bind_family_drop")

--- a/pkg/security/metrics/metrics.go
+++ b/pkg/security/metrics/metrics.go
@@ -195,6 +195,30 @@ var (
 	// MetricActivityDumpBrokenLineageDrop is the name of the metric used to report the number of events dropped due to broken ancestors lineage
 	// Tags: -
 	MetricActivityDumpBrokenLineageDrop = newRuntimeMetric(".activity_dump.broken_lineage_drop")
+	// MetricActivityDumpInsertCount is the name of the metric used to report the number of events that we may add to a dump
+	// Tags: -
+	MetricActivityDumpInsertCount = newRuntimeMetric(".activity_dump.insert_count")
+	// MetricActivityDumpEventTypeDrop is the name of the metric used to report the number of event dropped because their event types is not traced
+	// Tags: -
+	MetricActivityDumpEventTypeDrop = newRuntimeMetric(".activity_dump.event_type_drop")
+	// MetricActivityDumpResolveProcessCacheEntryDrop is the name of the metric used to report the number of event dropped because the process resolution failed
+	// Tags: -
+	MetricActivityDumpResolveProcessCacheEntryDrop = newRuntimeMetric(".activity_dump.resolve_process_cache_entry_drop")
+	// MetricActivityDumpAbnormalPathDrop is the name of the metric used to report the number of dropped event with an abnormal path
+	// Tags: -
+	MetricActivityDumpAbnormalPathDrop = newRuntimeMetric(".activity_dump.abnormal_path_drop")
+	// MetricActivityDumpEntryMatchDrop is the name of the metric used to report the number of dropped event with no matching on comm/containerID
+	// Tags: -
+	MetricActivityDumpEntryMatchDrop = newRuntimeMetric(".activity_dump.entry_match_drop")
+	// MetricActivityDumpValidRootNodeDrop is the name of the metric used to report the number of dropped root not valide node
+	// Tags: -
+	MetricActivityDumpValidRootNodeDrop = newRuntimeMetric(".activity_dump.valid_root_node_drop")
+	// MetricActivityDumpFindOrCreateDrop is the name of the metric used to report the number of event dropped by findOrCreateProcessActivityNode
+	// Tags: -
+	MetricActivityDumpFindOrCreateDrop = newRuntimeMetric(".activity_dump.find_or_create_drop")
+	// MetricActivityDumpBindFamilyDrop is the name of the metric used to report the number of event dropped because the address family is not handled
+	// Tags: -
+	MetricActivityDumpBindFamilyDrop = newRuntimeMetric(".activity_dump.bind_family_drop")
 	// MetricActivityDumpEmptyDropped is the name of the metric used to report the number of activity dumps dropped because they were empty
 	// Tags: -
 	MetricActivityDumpEmptyDropped = newRuntimeMetric(".activity_dump.empty_dump_dropped")

--- a/pkg/security/metrics/metrics.go
+++ b/pkg/security/metrics/metrics.go
@@ -148,6 +148,9 @@ var (
 	// MetricProcessResolverEnvsSize is the name of the metric used to report the number of envs size
 	// Tags: -
 	MetricProcessResolverEnvsSize = newRuntimeMetric(".process_resolver.envs.size")
+	// MetricProcessEventBrokenLineage is the name of the metric used to report a broken lineage
+	// Tags: -
+	MetricProcessEventBrokenLineage = newRuntimeMetric(".process_resolver.event_broken_lineage")
 
 	// Mount resolver metrics
 

--- a/pkg/security/metrics/metrics.go
+++ b/pkg/security/metrics/metrics.go
@@ -198,12 +198,27 @@ var (
 	// MetricActivityDumpBrokenLineageDrop is the name of the metric used to report the number of events dropped due to broken ancestors lineage
 	// Tags: -
 	MetricActivityDumpBrokenLineageDrop = newRuntimeMetric(".activity_dump.broken_lineage_drop")
+	// MetricActivityDumpInsertCount is the name of the metric used to report the number of events that we may add to a dump
+	// Tags: -
+	MetricActivityDumpInsertCount = newRuntimeMetric(".activity_dump.insert_count")
 	// MetricActivityDumpEventTypeDrop is the name of the metric used to report the number of event dropped because their event types is not traced
 	// Tags: -
 	MetricActivityDumpEventTypeDrop = newRuntimeMetric(".activity_dump.event_type_drop")
+	// MetricActivityDumpResolveProcessCacheEntryDrop is the name of the metric used to report the number of event dropped because the process resolution failed
+	// Tags: -
+	MetricActivityDumpResolveProcessCacheEntryDrop = newRuntimeMetric(".activity_dump.resolve_process_cache_entry_drop")
+	// MetricActivityDumpAbnormalPathDrop is the name of the metric used to report the number of dropped event with an abnormal path
+	// Tags: -
+	MetricActivityDumpAbnormalPathDrop = newRuntimeMetric(".activity_dump.abnormal_path_drop")
+	// MetricActivityDumpEntryMatchDrop is the name of the metric used to report the number of dropped event with no matching on comm/containerID
+	// Tags: -
+	MetricActivityDumpEntryMatchDrop = newRuntimeMetric(".activity_dump.entry_match_drop")
 	// MetricActivityDumpValidRootNodeDrop is the name of the metric used to report the number of dropped root not valide node
 	// Tags: -
 	MetricActivityDumpValidRootNodeDrop = newRuntimeMetric(".activity_dump.valid_root_node_drop")
+	// MetricActivityDumpFindOrCreateDrop is the name of the metric used to report the number of event dropped by findOrCreateProcessActivityNode
+	// Tags: -
+	MetricActivityDumpFindOrCreateDrop = newRuntimeMetric(".activity_dump.find_or_create_drop")
 	// MetricActivityDumpBindFamilyDrop is the name of the metric used to report the number of event dropped because the address family is not handled
 	// Tags: -
 	MetricActivityDumpBindFamilyDrop = newRuntimeMetric(".activity_dump.bind_family_drop")

--- a/pkg/security/probe/activity_dump.go
+++ b/pkg/security/probe/activity_dump.go
@@ -97,15 +97,20 @@ type DumpMetadata struct {
 // easyjson:json
 type ActivityDump struct {
 	*sync.Mutex
-	state              ActivityDumpStatus
-	adm                *ActivityDumpManager
-	processedCount     map[model.EventType]*atomic.Uint64
-	addedRuntimeCount  map[model.EventType]*atomic.Uint64
-	addedSnapshotCount map[model.EventType]*atomic.Uint64
-	brokenLineageDrop  *atomic.Uint64
-	eventTypeDrop      *atomic.Uint64
-	validRootNodeDrop  *atomic.Uint64
-	bindFamilyDrop     *atomic.Uint64
+	state                        ActivityDumpStatus
+	adm                          *ActivityDumpManager
+	processedCount               map[model.EventType]*atomic.Uint64
+	addedRuntimeCount            map[model.EventType]*atomic.Uint64
+	addedSnapshotCount           map[model.EventType]*atomic.Uint64
+	brokenLineageDrop            *atomic.Uint64
+	insertCount                  *atomic.Uint64
+	eventTypeDrop                *atomic.Uint64
+	resolveProcessCacheEntryDrop *atomic.Uint64
+	abnormalPathDrop             *atomic.Uint64
+	entryMatchDrop               *atomic.Uint64
+	validRootNodeDrop            *atomic.Uint64
+	findOrCreateDrop             *atomic.Uint64
+	bindFamilyDrop               *atomic.Uint64
 
 	countedByLimiter bool
 
@@ -150,17 +155,22 @@ func NewActivityDumpLoadConfig(evt []model.EventType, timeout time.Duration, wai
 // NewEmptyActivityDump returns a new zero-like instance of an ActivityDump
 func NewEmptyActivityDump() *ActivityDump {
 	ad := &ActivityDump{
-		Mutex:              &sync.Mutex{},
-		CookiesNode:        make(map[uint32]*ProcessActivityNode),
-		processedCount:     make(map[model.EventType]*atomic.Uint64),
-		addedRuntimeCount:  make(map[model.EventType]*atomic.Uint64),
-		addedSnapshotCount: make(map[model.EventType]*atomic.Uint64),
-		brokenLineageDrop:  atomic.NewUint64(0),
-		eventTypeDrop:      atomic.NewUint64(0),
-		validRootNodeDrop:  atomic.NewUint64(0),
-		bindFamilyDrop:     atomic.NewUint64(0),
-		pathMergedCount:    atomic.NewUint64(0),
-		StorageRequests:    make(map[config.StorageFormat][]config.StorageRequest),
+		Mutex:                        &sync.Mutex{},
+		CookiesNode:                  make(map[uint32]*ProcessActivityNode),
+		processedCount:               make(map[model.EventType]*atomic.Uint64),
+		addedRuntimeCount:            make(map[model.EventType]*atomic.Uint64),
+		addedSnapshotCount:           make(map[model.EventType]*atomic.Uint64),
+		brokenLineageDrop:            atomic.NewUint64(0),
+		insertCount:                  atomic.NewUint64(0),
+		eventTypeDrop:                atomic.NewUint64(0),
+		resolveProcessCacheEntryDrop: atomic.NewUint64(0),
+		abnormalPathDrop:             atomic.NewUint64(0),
+		entryMatchDrop:               atomic.NewUint64(0),
+		validRootNodeDrop:            atomic.NewUint64(0),
+		findOrCreateDrop:             atomic.NewUint64(0),
+		bindFamilyDrop:               atomic.NewUint64(0),
+		pathMergedCount:              atomic.NewUint64(0),
+		StorageRequests:              make(map[config.StorageFormat][]config.StorageRequest),
 	}
 
 	// generate counters
@@ -542,6 +552,8 @@ func (ad *ActivityDump) Insert(event *model.Event) (newEntry bool) {
 	ad.Lock()
 	defer ad.Unlock()
 
+	ad.insertCount.Inc()
+
 	if ad.state != Running {
 		// this activity dump is not running, ignore event
 		return false
@@ -568,6 +580,7 @@ func (ad *ActivityDump) Insert(event *model.Event) (newEntry bool) {
 	// find the node where the event should be inserted
 	entry, _ := event.FieldHandlers.ResolveProcessCacheEntry(event)
 	if entry == nil {
+		ad.resolveProcessCacheEntryDrop.Inc()
 		return false
 	}
 	if !entry.HasCompleteLineage() { // check that the process context lineage is complete, otherwise drop it
@@ -577,6 +590,7 @@ func (ad *ActivityDump) Insert(event *model.Event) (newEntry bool) {
 	node := ad.findOrCreateProcessActivityNode(entry, Runtime)
 	if node == nil {
 		// a process node couldn't be found for the provided event as it doesn't match the ActivityDump query
+		ad.findOrCreateDrop.Inc()
 		return false
 	}
 
@@ -610,6 +624,7 @@ func (ad *ActivityDump) findOrCreateProcessActivityNode(entry *model.ProcessCach
 
 	// drop processes with abnormal paths
 	if entry.GetPathResolutionError() != "" {
+		ad.abnormalPathDrop.Inc()
 		return node
 	}
 
@@ -639,6 +654,7 @@ func (ad *ActivityDump) findOrCreateProcessActivityNode(entry *model.ProcessCach
 
 		// since the parent of the current entry wasn't inserted, we need to know if the current entry needs to be inserted.
 		if !ad.Matches(entry) {
+			ad.entryMatchDrop.Inc()
 			return node
 		}
 
@@ -777,15 +793,45 @@ func (ad *ActivityDump) SendStats() error {
 		}
 	}
 
+	if value := ad.insertCount.Swap(0); value > 0 {
+		if err := ad.adm.statsdClient.Count(metrics.MetricActivityDumpInsertCount, int64(value), nil, 1.0); err != nil {
+			return fmt.Errorf("couldn't send %s metric: %w", metrics.MetricActivityDumpInsertCount, err)
+		}
+	}
+
 	if value := ad.eventTypeDrop.Swap(0); value > 0 {
 		if err := ad.adm.statsdClient.Count(metrics.MetricActivityDumpEventTypeDrop, int64(value), nil, 1.0); err != nil {
 			return fmt.Errorf("couldn't send %s metric: %w", metrics.MetricActivityDumpEventTypeDrop, err)
 		}
 	}
 
+	if value := ad.resolveProcessCacheEntryDrop.Swap(0); value > 0 {
+		if err := ad.adm.statsdClient.Count(metrics.MetricActivityDumpResolveProcessCacheEntryDrop, int64(value), nil, 1.0); err != nil {
+			return fmt.Errorf("couldn't send %s metric: %w", metrics.MetricActivityDumpResolveProcessCacheEntryDrop, err)
+		}
+	}
+
+	if value := ad.abnormalPathDrop.Swap(0); value > 0 {
+		if err := ad.adm.statsdClient.Count(metrics.MetricActivityDumpAbnormalPathDrop, int64(value), nil, 1.0); err != nil {
+			return fmt.Errorf("couldn't send %s metric: %w", metrics.MetricActivityDumpAbnormalPathDrop, err)
+		}
+	}
+
+	if value := ad.entryMatchDrop.Swap(0); value > 0 {
+		if err := ad.adm.statsdClient.Count(metrics.MetricActivityDumpEntryMatchDrop, int64(value), nil, 1.0); err != nil {
+			return fmt.Errorf("couldn't send %s metric: %w", metrics.MetricActivityDumpEntryMatchDrop, err)
+		}
+	}
+
 	if value := ad.validRootNodeDrop.Swap(0); value > 0 {
 		if err := ad.adm.statsdClient.Count(metrics.MetricActivityDumpValidRootNodeDrop, int64(value), nil, 1.0); err != nil {
 			return fmt.Errorf("couldn't send %s metric: %w", metrics.MetricActivityDumpValidRootNodeDrop, err)
+		}
+	}
+
+	if value := ad.findOrCreateDrop.Swap(0); value > 0 {
+		if err := ad.adm.statsdClient.Count(metrics.MetricActivityDumpFindOrCreateDrop, int64(value), nil, 1.0); err != nil {
+			return fmt.Errorf("couldn't send %s metric: %w", metrics.MetricActivityDumpFindOrCreateDrop, err)
 		}
 	}
 

--- a/pkg/security/probe/serializers.go
+++ b/pkg/security/probe/serializers.go
@@ -708,9 +708,9 @@ func newProcessContextSerializer(pc *model.ProcessContext, e *model.Event, resol
 		return nil
 	}
 
-	var ps ProcessContextSerializer
+	lastPid := pc.Pid
 
-	ps = ProcessContextSerializer{
+	ps := ProcessContextSerializer{
 		ProcessSerializer: newProcessSerializer(&pc.Process, e, resolvers),
 	}
 
@@ -726,6 +726,7 @@ func newProcessContextSerializer(pc *model.ProcessContext, e *model.Event, resol
 
 	for ptr != nil {
 		pce := (*model.ProcessCacheEntry)(ptr)
+		lastPid = pce.Pid
 
 		s := newProcessSerializer(&pce.Process, e, resolvers)
 		ps.Ancestors = append(ps.Ancestors, s)
@@ -746,6 +747,11 @@ func newProcessContextSerializer(pc *model.ProcessContext, e *model.Event, resol
 
 		ptr = it.Next()
 	}
+
+	if lastPid != 1 {
+		resolvers.ProcessResolver.countBrokenLineage()
+	}
+
 	return &ps
 }
 


### PR DESCRIPTION

### What does this PR do?

Branch only for debug purposes.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
