### PR TITLE
[orchestration] nil check all optional VPA fields during extraction

### DIFF
--- a/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/verticalpodautoscaler.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/verticalpodautoscaler.go
@@ -123,7 +123,9 @@ func extractVerticalPodAutoscalerStatus(s *v1.VerticalPodAutoscalerStatus) *mode
 			status.LastRecommendedDate = condition.LastTransitionTime.Unix()
 		}
 	}
-	status.Recommendations = extractContainerRecommendations(s.Recommendation.ContainerRecommendations)
+	if s.Recommendation != nil {
+		status.Recommendations = extractContainerRecommendations(s.Recommendation.ContainerRecommendations)
+	}
 	return &status
 }
 

--- a/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/verticalpodautoscaler_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/verticalpodautoscaler_test.go
@@ -175,6 +175,128 @@ func TestExtractVerticalPodAutoscaler(t *testing.T) {
 				},
 			},
 		},
+		"minimum-required": {
+			input: v1.VerticalPodAutoscaler{
+				TypeMeta: metav1.TypeMeta{},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "VPATest",
+					Namespace:         "Namespace",
+					UID:               "326331f4-77e2-11ed-a1eb-0242ac120002",
+					CreationTimestamp: exampleTime,
+					DeletionTimestamp: &exampleTime,
+					Labels: map[string]string{
+						"app": "my-app",
+					},
+					Annotations: map[string]string{
+						"annotation": "my-annotation",
+					},
+					Finalizers: []string{"final", "izers"},
+				},
+				Spec: v1.VerticalPodAutoscalerSpec{
+					TargetRef: &autoscaling.CrossVersionObjectReference{
+						Kind: "Deployment",
+						Name: "My Service",
+					},
+					UpdatePolicy:   nil, // +optional
+					ResourcePolicy: nil, // +optional expanded in second unit test case
+					Recommenders:   nil, // +optional
+				},
+				Status: v1.VerticalPodAutoscalerStatus{
+					Recommendation: nil, // +optional
+				},
+			},
+			expected: model.VerticalPodAutoscaler{
+				Metadata: &model.Metadata{
+					Name:              "VPATest",
+					Namespace:         "Namespace",
+					Uid:               "326331f4-77e2-11ed-a1eb-0242ac120002",
+					CreationTimestamp: exampleTime.Unix(),
+					DeletionTimestamp: exampleTime.Unix(),
+					Labels:            []string{"app:my-app"},
+					Annotations:       []string{"annotation:my-annotation"},
+					Finalizers:        []string{"final", "izers"},
+				},
+				Spec: &model.VerticalPodAutoscalerSpec{
+					Target: &model.VerticalPodAutoscalerTarget{
+						Kind: "Deployment",
+						Name: "My Service",
+					},
+				},
+				Status: &model.VerticalPodAutoscalerStatus{},
+			},
+		},
+		"minimum-required-inner-resourcepolicy": {
+			input: v1.VerticalPodAutoscaler{
+				TypeMeta: metav1.TypeMeta{},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "VPATest",
+					Namespace:         "Namespace",
+					UID:               "326331f4-77e2-11ed-a1eb-0242ac120002",
+					CreationTimestamp: exampleTime,
+					DeletionTimestamp: &exampleTime,
+					Labels: map[string]string{
+						"app": "my-app",
+					},
+					Annotations: map[string]string{
+						"annotation": "my-annotation",
+					},
+					Finalizers: []string{"final", "izers"},
+				},
+				Spec: v1.VerticalPodAutoscalerSpec{
+					TargetRef: &autoscaling.CrossVersionObjectReference{
+						Kind: "Deployment",
+						Name: "My Service",
+					},
+					UpdatePolicy: nil, // +optional
+					ResourcePolicy: &v1.PodResourcePolicy{
+						ContainerPolicies: []v1.ContainerResourcePolicy{
+							{
+								ContainerName: "TestContainer",
+								Mode:          nil, // +optional
+								MinAllowed:    nil, // +optional
+								MaxAllowed:    nil, // +optional
+								ControlledResources: &[]corev1.ResourceName{
+									corev1.ResourceCPU,
+								},
+								ControlledValues: nil, // +optional
+							},
+						},
+					},
+					Recommenders: nil, // +optional
+				},
+				Status: v1.VerticalPodAutoscalerStatus{
+					Recommendation: nil, // +optional
+				},
+			},
+			expected: model.VerticalPodAutoscaler{
+				Metadata: &model.Metadata{
+					Name:              "VPATest",
+					Namespace:         "Namespace",
+					Uid:               "326331f4-77e2-11ed-a1eb-0242ac120002",
+					CreationTimestamp: exampleTime.Unix(),
+					DeletionTimestamp: exampleTime.Unix(),
+					Labels:            []string{"app:my-app"},
+					Annotations:       []string{"annotation:my-annotation"},
+					Finalizers:        []string{"final", "izers"},
+				},
+				Spec: &model.VerticalPodAutoscalerSpec{
+					Target: &model.VerticalPodAutoscalerTarget{
+						Kind: "Deployment",
+						Name: "My Service",
+					},
+					ResourcePolicies: []*model.ContainerResourcePolicy{
+						{
+							ContainerName:      "TestContainer",
+							ControlledResource: []string{"cpu"},
+						},
+					},
+				},
+				Status: &model.VerticalPodAutoscalerStatus{
+					LastRecommendedDate: exampleTime.Unix(),
+					Recommendations:     nil,
+				},
+			},
+		},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {

--- a/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/verticalpodautoscaler_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/verticalpodautoscaler_test.go
@@ -221,6 +221,7 @@ func TestExtractVerticalPodAutoscaler(t *testing.T) {
 						Kind: "Deployment",
 						Name: "My Service",
 					},
+					ResourcePolicies: []*model.ContainerResourcePolicy{},
 				},
 				Status: &model.VerticalPodAutoscalerStatus{},
 			},
@@ -286,14 +287,19 @@ func TestExtractVerticalPodAutoscaler(t *testing.T) {
 					},
 					ResourcePolicies: []*model.ContainerResourcePolicy{
 						{
-							ContainerName:      "TestContainer",
+							ContainerName: "TestContainer",
+							MinAllowed: &model.ResourceList{
+								MetricValues: map[string]float64{},
+							},
+							MaxAllowed: &model.ResourceList{
+								MetricValues: map[string]float64{},
+							},
 							ControlledResource: []string{"cpu"},
 						},
 					},
 				},
 				Status: &model.VerticalPodAutoscalerStatus{
-					LastRecommendedDate: exampleTime.Unix(),
-					Recommendations:     nil,
+					Recommendations: nil,
 				},
 			},
 		},


### PR DESCRIPTION

### What does this PR do?

Fixes a remaining nil panic, and adds a unit test to verify all possible optional field cases.

### Motivation

nil panics continue in RC5

