### PR TITLE
fix kubelet client config when proxy is enabled and address is ipv6

### DIFF
--- a/pkg/util/kubernetes/kubelet/kubelet_client.go
+++ b/pkg/util/kubernetes/kubelet/kubelet_client.go
@@ -207,12 +207,12 @@ func getKubeletClient(ctx context.Context) (*kubeletClient, error) {
 
 		if config.Datadog.Get("kubernetes_kubelet_nodename") != "" {
 			kubeletPathPrefix = fmt.Sprintf("/api/v1/nodes/%s/proxy", kubeletNodeName)
-			apiServerHost := os.Getenv("KUBERNETES_SERVICE_HOST")
+			apiServerIP := os.Getenv("KUBERNETES_SERVICE_HOST")
 
 			potentialHosts = &connectionInfo{
-				hostnames: []string{apiServerHost},
+				ips: []string{apiServerIP},
 			}
-			log.Infof("EKS on Fargate mode detected, will proxy calls to the Kubelet through the APIServer at %s:%d%s", apiServerHost, kubeletHTTPSPort, kubeletPathPrefix)
+			log.Infof("EKS on Fargate mode detected, will proxy calls to the Kubelet through the APIServer at %s:%d%s", apiServerIP, kubeletHTTPSPort, kubeletPathPrefix)
 		} else {
 			return nil, errors.New("kubelet proxy mode enabled but nodename is empty - unable to query")
 		}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

When running the agent in an EKS Fargate pod, requests to the kubelet are proxied through the API server. The address of the Kubernetes API server is sourced from the `KUBERNETES_SERVICE_HOST` environment variable. The value of this variable is an IP address, not a hostname. You can see this in the docs [here](https://kubernetes.io/docs/tutorials/services/connect-applications-service/#environment-variables). 

This PR ensures the value of `KUBERNETES_SERVICE_HOST` is handled as an IP address. Previously, this value was treated as a hostname, and therefore skipped the necessary handling of IPv6 addresses [here](https://github.com/DataDog/datadog-agent/blob/7.42.1/pkg/util/kubernetes/kubelet/kubelet_client.go#L266).

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

When running an agent as a sidecar in a IPv6-enabled EKS Fargate pod, the agent hangs in the middle of startup. The last line in the agent logs looks like the following, and you can see right in the log message the address is invalid, as the IP address is not bracketed.
```
2023-02-12 21:45:13 UTC | CORE | DEBUG | (pkg/util/kubernetes/kubelet/kubelet_client.go:292 in checkKubeletConnection) | Trying to reach Kubelet at: fd7a:105d:f76e::1:443/api/v1/nodes/fargate-ip-10-15-192-250.us-west-2.compute.internal/proxy
```


### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Run an agent in an EKS Fargate pod and observe both a valid address in the debug logs when verifying the connection and that the agent successfully starts.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
