### PR TITLE
[devex] copyright snippet

### DIFF
--- a/.vscode/.gitignore
+++ b/.vscode/.gitignore
@@ -1,3 +1,4 @@
 *
 !launch.json.template
 !tasks.json.template
+!copyright.code-snippets

--- a/.vscode/copyright.code-snippets
+++ b/.vscode/copyright.code-snippets
@@ -1,0 +1,14 @@
+
+{
+	"Copyright header": {
+		"scope": "go",
+		"prefix": ["copy","copyheader"],
+		"body": [
+			"$LINE_COMMENT Unless explicitly stated otherwise all files in this repository are licensed",
+      "$LINE_COMMENT under the Apache License Version 2.0.",
+      "$LINE_COMMENT This product includes software developed at Datadog (https://www.datadoghq.com/).",
+      "$LINE_COMMENT Copyright 2016-present Datadog, Inc.",
+		],
+		"description": "Add Datadog copyright header. Place your cursor at the beginning of your `.go` file",
+	}
+}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Add a vscode to add the Datadog copyright header to go files. 

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

The CI fails if `go` files do not have the copyright header. While working on few new files, I regularly forgot to add the header. This is a first attempt to improve the dev experience - next step is having a linter rule running and adding the header on save, but that requires some extra time to figure out how to have it running on save. 

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

Place the cursor on the first line of your go file, type `co`: the autocomplete menu should list the copyright header snippet

![image](https://user-images.githubusercontent.com/45568537/218440754-b0fb9eea-5658-4d52-b1d4-7778969f4104.png)


### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
