### PR TITLE
[CWS] move reorderer to different package

### DIFF
--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -37,6 +37,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/probe/constantfetch"
 	"github.com/DataDog/datadog-agent/pkg/security/probe/erpc"
 	"github.com/DataDog/datadog-agent/pkg/security/probe/managerhelper"
+	"github.com/DataDog/datadog-agent/pkg/security/probe/reorderer"
 	"github.com/DataDog/datadog-agent/pkg/security/probe/resolvers"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
@@ -62,7 +63,7 @@ type EventHandler interface {
 // EventStream describes the interface implemented by reordered perf maps or ring buffers
 type EventStream interface {
 	Init(*manager.Manager, *config.Config) error
-	SetMonitor(*PerfBufferMonitor)
+	SetMonitor(reorderer.LostEventCounter)
 	Start(*sync.WaitGroup) error
 	Pause() error
 	Resume() error
@@ -433,7 +434,7 @@ func (p *Probe) handleEvent(CPU int, data []byte) {
 	offset += read
 
 	eventType := event.GetEventType()
-	p.monitor.perfBufferMonitor.CountEvent(eventType, event.TimestampRaw, 1, dataLen, eventStreamMap, CPU)
+	p.monitor.perfBufferMonitor.CountEvent(eventType, event.TimestampRaw, 1, dataLen, reorderer.EventStreamMap, CPU)
 
 	// no need to dispatch events
 	switch eventType {
@@ -1425,7 +1426,7 @@ func NewProbe(config *config.Config, opts Opts) (*Probe, error) {
 	if useRingBuffers {
 		p.eventStream = NewRingBuffer(p.handleEvent)
 	} else {
-		p.eventStream, err = NewOrderedPerfMap(p.ctx, p.handleEvent, p.StatsdClient)
+		p.eventStream, err = reorderer.NewOrderedPerfMap(p.ctx, p.handleEvent, p.StatsdClient)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/security/probe/reorderer/monitor.go
+++ b/pkg/security/probe/reorderer/monitor.go
@@ -6,7 +6,7 @@
 //go:build linux
 // +build linux
 
-package probe
+package reorderer
 
 import (
 	"context"

--- a/pkg/security/probe/reorderer/perf.go
+++ b/pkg/security/probe/reorderer/perf.go
@@ -6,7 +6,7 @@
 //go:build linux
 // +build linux
 
-package probe
+package reorderer
 
 import (
 	"sync"

--- a/pkg/security/probe/reorderer/reorderer.go
+++ b/pkg/security/probe/reorderer/reorderer.go
@@ -6,7 +6,7 @@
 //go:build linux
 // +build linux
 
-package probe
+package reorderer
 
 import (
 	"context"
@@ -211,7 +211,7 @@ func (r *ReOrderer) Start(wg *sync.WaitGroup) {
 				if err != nil {
 					continue
 				}
-				tm = info.timestamp
+				tm = info.Timestamp
 			} else {
 				tm = lastTm
 			}
@@ -259,8 +259,8 @@ func (r *ReOrderer) HandleEvent(record *perf.Record, perfMap *manager.PerfMap, m
 
 // QuickInfo represents the info quickly extractable from an event, that can be used for reordering
 type QuickInfo struct {
-	cpu       uint64
-	timestamp uint64
+	Cpu       uint64
+	Timestamp uint64
 }
 
 // QuickInfoExtractor represents a function that takes a record, and returns the quick infos

--- a/pkg/security/probe/reorderer/reorderer_test.go
+++ b/pkg/security/probe/reorderer/reorderer_test.go
@@ -6,7 +6,7 @@
 //go:build linux
 // +build linux
 
-package probe
+package reorderer
 
 import (
 	"context"
@@ -109,8 +109,8 @@ func TestOrderRate(t *testing.T) {
 	},
 		func(record *perf.Record) (QuickInfo, error) {
 			return QuickInfo{
-				cpu:       uint64(record.RawSample[0]),
-				timestamp: uint64(record.RawSample[1]),
+				Cpu:       uint64(record.RawSample[0]),
+				Timestamp: uint64(record.RawSample[1]),
 			}, nil
 		},
 		ReOrdererOpts{

--- a/pkg/security/probe/ringbuffer.go
+++ b/pkg/security/probe/ringbuffer.go
@@ -15,6 +15,7 @@ import (
 	manager "github.com/DataDog/ebpf-manager"
 
 	"github.com/DataDog/datadog-agent/pkg/security/config"
+	"github.com/DataDog/datadog-agent/pkg/security/probe/reorderer"
 )
 
 // RingBuffer implements the EventStream interface
@@ -48,7 +49,7 @@ func (rb *RingBuffer) Start(wg *sync.WaitGroup) error {
 }
 
 // SetMonitor set the monitor
-func (rb *RingBuffer) SetMonitor(perfBufferMonitor *PerfBufferMonitor) {}
+func (rb *RingBuffer) SetMonitor(counter reorderer.LostEventCounter) {}
 
 func (rb *RingBuffer) handleEvent(CPU int, data []byte, ringBuffer *manager.RingBuffer, manager *manager.Manager) {
 	rb.handler(CPU, data)


### PR DESCRIPTION
### What does this PR do?

Again with the goal of extracting more things from the huge `probe` monolith, this PR extracts the reorderer and the orderedmap items and related files

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
