### PR TITLE
[CWS] extract approvers from probe package

### DIFF
--- a/cmd/security-agent/subcommands/runtime/command.go
+++ b/cmd/security-agent/subcommands/runtime/command.go
@@ -22,8 +22,6 @@ import (
 	"github.com/spf13/cobra"
 	"go.uber.org/fx"
 
-	ddgostatsd "github.com/DataDog/datadog-go/v5/statsd"
-
 	"github.com/DataDog/datadog-agent/cmd/security-agent/command"
 	"github.com/DataDog/datadog-agent/cmd/security-agent/flags"
 	"github.com/DataDog/datadog-agent/comp/core"
@@ -40,7 +38,7 @@ import (
 	secagent "github.com/DataDog/datadog-agent/pkg/security/agent"
 	seccommon "github.com/DataDog/datadog-agent/pkg/security/common"
 	secconfig "github.com/DataDog/datadog-agent/pkg/security/config"
-	sprobe "github.com/DataDog/datadog-agent/pkg/security/probe"
+	"github.com/DataDog/datadog-agent/pkg/security/probe/kfilters"
 	"github.com/DataDog/datadog-agent/pkg/security/proto/api"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
@@ -52,6 +50,7 @@ import (
 	httputils "github.com/DataDog/datadog-agent/pkg/util/http"
 	"github.com/DataDog/datadog-agent/pkg/util/startstop"
 	"github.com/DataDog/datadog-agent/pkg/version"
+	ddgostatsd "github.com/DataDog/datadog-go/v5/statsd"
 )
 
 func Commands(globalParams *command.GlobalParams) []*cobra.Command {
@@ -478,7 +477,7 @@ func checkPoliciesInner(dir string) error {
 		return err
 	}
 
-	report, err := sprobe.NewApplyRuleSetReport(cfg, ruleSet)
+	report, err := kfilters.NewApplyRuleSetReport(cfg, ruleSet)
 	if err != nil {
 		return err
 	}
@@ -604,7 +603,7 @@ func evalRule(log log.Component, config config.Component, evalArgs *evalCliParam
 		Event: event,
 	}
 
-	approvers, err := ruleSet.GetApprovers(sprobe.GetCapababilities())
+	approvers, err := ruleSet.GetApprovers(kfilters.GetCapababilities())
 	if err != nil {
 		report.Error = err
 	} else {

--- a/pkg/security/module/module.go
+++ b/pkg/security/module/module.go
@@ -32,6 +32,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/events"
 	"github.com/DataDog/datadog-agent/pkg/security/metrics"
 	sprobe "github.com/DataDog/datadog-agent/pkg/security/probe"
+	"github.com/DataDog/datadog-agent/pkg/security/probe/kfilters"
 	"github.com/DataDog/datadog-agent/pkg/security/probe/selftests"
 	sapi "github.com/DataDog/datadog-agent/pkg/security/proto/api"
 	"github.com/DataDog/datadog-agent/pkg/security/rconfig"
@@ -256,7 +257,7 @@ func (m *Module) Start() error {
 	return nil
 }
 
-func (m *Module) displayApplyRuleSetReport(report *sprobe.ApplyRuleSetReport) {
+func (m *Module) displayApplyRuleSetReport(report *kfilters.ApplyRuleSetReport) {
 	content, _ := json.Marshal(report)
 	seclog.Debugf("Policy report: %s", content)
 }

--- a/pkg/security/probe/discarders_test.go
+++ b/pkg/security/probe/discarders_test.go
@@ -9,35 +9,15 @@
 package probe
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/ast"
+	"github.com/DataDog/datadog-agent/pkg/security/probe/kfilters"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
 	"github.com/DataDog/datadog-agent/pkg/security/seclog"
 )
-
-func addRuleExpr(t testing.TB, rs *rules.RuleSet, exprs ...string) {
-	var ruleDefs []*rules.RuleDefinition
-
-	for i, expr := range exprs {
-		ruleDef := &rules.RuleDefinition{
-			ID:         fmt.Sprintf("ID%d", i),
-			Expression: expr,
-			Tags:       make(map[string]string),
-		}
-		ruleDefs = append(ruleDefs, ruleDef)
-	}
-
-	pc := ast.NewParsingContext()
-
-	if err := rs.AddRules(pc, ruleDefs); err != nil {
-		t.Fatal(err)
-	}
-}
 
 func TestIsParentDiscarder(t *testing.T) {
 	id := newInodeDiscarders(nil, nil)
@@ -56,49 +36,49 @@ func TestIsParentDiscarder(t *testing.T) {
 		WithLogger(seclog.DefaultLogger)
 
 	rs := rules.NewRuleSet(&model.Model{}, model.NewDefaultEvent, &opts, &evalOpts)
-	addRuleExpr(t, rs, `unlink.file.path =~ "/var/log/*" && unlink.file.path != "/var/log/datadog/system-probe.log"`)
+	kfilters.AddRuleExpr(t, rs, `unlink.file.path =~ "/var/log/*" && unlink.file.path != "/var/log/datadog/system-probe.log"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/var/log/datadog/system-probe.log", 1); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
 	rs = rules.NewRuleSet(&model.Model{}, model.NewDefaultEvent, &opts, &evalOpts)
-	addRuleExpr(t, rs, `unlink.file.path =~ "/var/log/*" && unlink.file.path != "/var/log/datadog/system-probe.log"`)
+	kfilters.AddRuleExpr(t, rs, `unlink.file.path =~ "/var/log/*" && unlink.file.path != "/var/log/datadog/system-probe.log"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/var/lib/datadog/system-probe.sock", 1); !is {
 		t.Error("should be a parent discarder")
 	}
 
 	rs = rules.NewRuleSet(&model.Model{}, model.NewDefaultEvent, &opts, &evalOpts)
-	addRuleExpr(t, rs, `unlink.file.path == "/var/log/datadog/system-probe.log"`, `unlink.file.name == "datadog"`)
+	kfilters.AddRuleExpr(t, rs, `unlink.file.path == "/var/log/datadog/system-probe.log"`, `unlink.file.name == "datadog"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/var/log/datadog/datadog-agent.log", 1); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
 	rs = rules.NewRuleSet(&model.Model{}, model.NewDefaultEvent, &opts, &evalOpts)
-	addRuleExpr(t, rs, `unlink.file.path =~ "/var/log/*" && unlink.file.name =~ ".*"`)
+	kfilters.AddRuleExpr(t, rs, `unlink.file.path =~ "/var/log/*" && unlink.file.name =~ ".*"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/var/lib/.runc/1234", 1); is {
 		t.Error("shouldn't be able to find a parent discarder, due to partial evaluation: true && unlink.file.name =~ '.*'")
 	}
 
 	rs = rules.NewRuleSet(&model.Model{}, model.NewDefaultEvent, &opts, &evalOpts)
-	addRuleExpr(t, rs, `unlink.file.path == "/etc/conf.d/httpd.conf" || unlink.file.name == "conf.d"`)
+	kfilters.AddRuleExpr(t, rs, `unlink.file.path == "/etc/conf.d/httpd.conf" || unlink.file.name == "conf.d"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/etc/conf.d/nginx.conf", 1); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
 	rs = rules.NewRuleSet(&model.Model{}, model.NewDefaultEvent, &opts, &evalOpts)
-	addRuleExpr(t, rs, `unlink.file.path == "/etc/conf.d/httpd.conf" || unlink.file.name == "sys.d"`)
+	kfilters.AddRuleExpr(t, rs, `unlink.file.path == "/etc/conf.d/httpd.conf" || unlink.file.name == "sys.d"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/etc/sys.d/nginx.conf", 1); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
 	rs = rules.NewRuleSet(&model.Model{}, model.NewDefaultEvent, &opts, &evalOpts)
-	addRuleExpr(t, rs, `unlink.file.name == "conf.d"`)
+	kfilters.AddRuleExpr(t, rs, `unlink.file.name == "conf.d"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/etc/conf.d/nginx.conf", 1); is {
 		t.Error("shouldn't be a parent discarder")
@@ -106,77 +86,77 @@ func TestIsParentDiscarder(t *testing.T) {
 
 	// field that doesn't exists shouldn't return any discarders
 	rs = rules.NewRuleSet(&model.Model{}, model.NewDefaultEvent, &opts, &evalOpts)
-	addRuleExpr(t, rs, `rename.file.path == "/etc/conf.d/abc"`)
+	kfilters.AddRuleExpr(t, rs, `rename.file.path == "/etc/conf.d/abc"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileRenameEventType, "rename.file.path", "/etc/conf.d/nginx.conf", 1); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
 	rs = rules.NewRuleSet(&model.Model{}, model.NewDefaultEvent, &opts, &evalOpts)
-	addRuleExpr(t, rs, `rename.file.path == "/etc/conf.d/abc"`)
+	kfilters.AddRuleExpr(t, rs, `rename.file.path == "/etc/conf.d/abc"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileRenameEventType, "rename.file.path", "/etc/nginx/nginx.conf", 1); !is {
 		t.Error("should be a parent discarder")
 	}
 
 	rs = rules.NewRuleSet(&model.Model{}, model.NewDefaultEvent, &opts, &evalOpts)
-	addRuleExpr(t, rs, `unlink.file.path =~ "/etc/conf.d/*"`)
+	kfilters.AddRuleExpr(t, rs, `unlink.file.path =~ "/etc/conf.d/*"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/etc/sys.d/nginx.conf", 1); !is {
 		t.Error("should be a parent discarder")
 	}
 
 	rs = rules.NewRuleSet(&model.Model{}, model.NewDefaultEvent, &opts, &evalOpts)
-	addRuleExpr(t, rs, `unlink.file.path =~ "*/conf.*"`)
+	kfilters.AddRuleExpr(t, rs, `unlink.file.path =~ "*/conf.*"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/etc/conf.d/abc", 1); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
 	rs = rules.NewRuleSet(&model.Model{}, model.NewDefaultEvent, &opts, &evalOpts)
-	addRuleExpr(t, rs, `unlink.file.path =~ "/etc/conf.d/ab*"`)
+	kfilters.AddRuleExpr(t, rs, `unlink.file.path =~ "/etc/conf.d/ab*"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/etc/conf.d/abc", 1); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
 	rs = rules.NewRuleSet(&model.Model{}, model.NewDefaultEvent, &opts, &evalOpts)
-	addRuleExpr(t, rs, `unlink.file.path =~ "*/conf.d/ab*"`)
+	kfilters.AddRuleExpr(t, rs, `unlink.file.path =~ "*/conf.d/ab*"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/etc/conf.d/abc", 1); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
 	rs = rules.NewRuleSet(&model.Model{}, model.NewDefaultEvent, &opts, &evalOpts)
-	addRuleExpr(t, rs, `unlink.file.path =~ "*/conf.d"`)
+	kfilters.AddRuleExpr(t, rs, `unlink.file.path =~ "*/conf.d"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/etc/conf.d/abc", 1); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
 	rs = rules.NewRuleSet(&model.Model{}, model.NewDefaultEvent, &opts, &evalOpts)
-	addRuleExpr(t, rs, `unlink.file.path =~ "/etc/*"`)
+	kfilters.AddRuleExpr(t, rs, `unlink.file.path =~ "/etc/*"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/etc/cron.d/log", 1); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
 	rs = rules.NewRuleSet(&model.Model{}, model.NewDefaultEvent, &opts, &evalOpts)
-	addRuleExpr(t, rs, `open.file.path == "/tmp/passwd"`, `open.file.path == "/tmp/secret"`)
+	kfilters.AddRuleExpr(t, rs, `open.file.path == "/tmp/passwd"`, `open.file.path == "/tmp/secret"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileOpenEventType, "open.file.path", "/tmp/runc", 1); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
 	rs = rules.NewRuleSet(&model.Model{}, model.NewDefaultEvent, &opts, &evalOpts)
-	addRuleExpr(t, rs, `open.file.path =~ "/run/secrets/kubernetes.io/serviceaccount/*/token"`, `open.file.path == "/etc/secret"`)
+	kfilters.AddRuleExpr(t, rs, `open.file.path =~ "/run/secrets/kubernetes.io/serviceaccount/*/token"`, `open.file.path == "/etc/secret"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileOpenEventType, "open.file.path", "/tmp/token", 1); !is {
 		t.Error("should be a parent discarder")
 	}
 
 	rs = rules.NewRuleSet(&model.Model{}, model.NewDefaultEvent, &opts, &evalOpts)
-	addRuleExpr(t, rs, `open.file.path =~ "*/token"`, `open.file.path == "/etc/secret"`)
+	kfilters.AddRuleExpr(t, rs, `open.file.path =~ "*/token"`, `open.file.path == "/etc/secret"`)
 
 	is, err := id.isParentPathDiscarder(rs, model.FileOpenEventType, "open.file.path", "/tmp/token", 1)
 	if err != nil {
@@ -187,35 +167,35 @@ func TestIsParentDiscarder(t *testing.T) {
 	}
 
 	rs = rules.NewRuleSet(&model.Model{}, model.NewDefaultEvent, &opts, &evalOpts)
-	addRuleExpr(t, rs, `open.file.path =~ "/tmp/dir/no-approver-*"`)
+	kfilters.AddRuleExpr(t, rs, `open.file.path =~ "/tmp/dir/no-approver-*"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileOpenEventType, "open.file.path", "/tmp/dir/a/test", 1); !is {
 		t.Error("should be a parent discarder")
 	}
 
 	rs = rules.NewRuleSet(&model.Model{}, model.NewDefaultEvent, &opts, &evalOpts)
-	addRuleExpr(t, rs, `open.file.path =~ "/"`)
+	kfilters.AddRuleExpr(t, rs, `open.file.path =~ "/"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileOpenEventType, "open.file.path", "/tmp", 1); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
 	rs = rules.NewRuleSet(&model.Model{}, model.NewDefaultEvent, &opts, &evalOpts)
-	addRuleExpr(t, rs, `open.file.path =~ "*/conf.d/aaa"`)
+	kfilters.AddRuleExpr(t, rs, `open.file.path =~ "*/conf.d/aaa"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileOpenEventType, "open.file.path", "/tmp/dir/bbb", 1); !is {
 		t.Error("should be a parent discarder")
 	}
 
 	rs = rules.NewRuleSet(&model.Model{}, model.NewDefaultEvent, &opts, &evalOpts)
-	addRuleExpr(t, rs, `open.file.path =~ "/etc/**"`)
+	kfilters.AddRuleExpr(t, rs, `open.file.path =~ "/etc/**"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileOpenEventType, "open.file.path", "/etc/conf.d/dir/aaa", 1); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
 	rs = rules.NewRuleSet(&model.Model{}, model.NewDefaultEvent, &opts, &evalOpts)
-	addRuleExpr(t, rs, `open.file.path == "/proc/${process.pid}/maps"`)
+	kfilters.AddRuleExpr(t, rs, `open.file.path == "/proc/${process.pid}/maps"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileOpenEventType, "open.file.path", "/proc/1/maps", 1); is {
 		t.Error("shouldn't be a parent discarder")
@@ -223,14 +203,14 @@ func TestIsParentDiscarder(t *testing.T) {
 
 	// test basename conflict, a basename based rule matches the parent discarder
 	rs = rules.NewRuleSet(&model.Model{}, model.NewDefaultEvent, &opts, &evalOpts)
-	addRuleExpr(t, rs, `open.file.path =~ "/var/log/datadog/**" && open.file.name == "token"`)
+	kfilters.AddRuleExpr(t, rs, `open.file.path =~ "/var/log/datadog/**" && open.file.name == "token"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileOpenEventType, "open.file.path", "/tmp/test1/test2", 1); !is {
 		t.Error("should be a parent discarder")
 	}
 
 	rs = rules.NewRuleSet(&model.Model{}, model.NewDefaultEvent, &opts, &evalOpts)
-	addRuleExpr(t, rs, `open.file.path =~ "/var/log/datadog/**" && open.file.name == "test1"`)
+	kfilters.AddRuleExpr(t, rs, `open.file.path =~ "/var/log/datadog/**" && open.file.name == "test1"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileOpenEventType, "open.file.path", "/tmp/test1/test2", 1); is {
 		t.Error("shouldn't be a parent discarder")
@@ -253,105 +233,105 @@ func TestIsGrandParentDiscarder(t *testing.T) {
 		WithLogger(seclog.DefaultLogger)
 
 	rs := rules.NewRuleSet(&model.Model{}, model.NewDefaultEvent, &opts, &evalOpts)
-	addRuleExpr(t, rs, `unlink.file.path == "/var/lib/datadog/system-probe.cache"`)
+	kfilters.AddRuleExpr(t, rs, `unlink.file.path == "/var/lib/datadog/system-probe.cache"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/var/run/datadog/system-probe.pid", 2); !is {
 		t.Error("should be a grand parent discarder")
 	}
 
 	rs = rules.NewRuleSet(&model.Model{}, model.NewDefaultEvent, &opts, &evalOpts)
-	addRuleExpr(t, rs, `unlink.file.path =~ "/tmp/test"`)
+	kfilters.AddRuleExpr(t, rs, `unlink.file.path =~ "/tmp/test"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/var/lib", 2); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
 	rs = rules.NewRuleSet(&model.Model{}, model.NewDefaultEvent, &opts, &evalOpts)
-	addRuleExpr(t, rs, `unlink.file.path == "/var/run/datadog/system-probe.pid"`)
+	kfilters.AddRuleExpr(t, rs, `unlink.file.path == "/var/run/datadog/system-probe.pid"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/var/run/pids/system-probe.pid", 2); is {
 		t.Error("shouldn't be a grand parent discarder")
 	}
 
 	rs = rules.NewRuleSet(&model.Model{}, model.NewDefaultEvent, &opts, &evalOpts)
-	addRuleExpr(t, rs, `unlink.file.path =~ "/var/lib/datadog/system-probe.cache"`)
+	kfilters.AddRuleExpr(t, rs, `unlink.file.path =~ "/var/lib/datadog/system-probe.cache"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/var/run/datadog/system-probe.pid", 2); !is {
 		t.Error("should be a grand parent discarder")
 	}
 
 	rs = rules.NewRuleSet(&model.Model{}, model.NewDefaultEvent, &opts, &evalOpts)
-	addRuleExpr(t, rs, `unlink.file.path =~ "/var/run/datadog/system-probe.pid"`)
+	kfilters.AddRuleExpr(t, rs, `unlink.file.path =~ "/var/run/datadog/system-probe.pid"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/var/run/pids/system-probe.pid", 2); is {
 		t.Error("shouldn't be a grand parent discarder")
 	}
 
 	rs = rules.NewRuleSet(&model.Model{}, model.NewDefaultEvent, &opts, &evalOpts)
-	addRuleExpr(t, rs, `unlink.file.path =~ "*/run/datadog/system-probe.pid"`)
+	kfilters.AddRuleExpr(t, rs, `unlink.file.path =~ "*/run/datadog/system-probe.pid"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/var/run/datadog/system-probe.pid", 2); is {
 		t.Error("shouldn't be a grand parent discarder")
 	}
 
 	rs = rules.NewRuleSet(&model.Model{}, model.NewDefaultEvent, &opts, &evalOpts)
-	addRuleExpr(t, rs, `unlink.file.path =~ "*/run/datadog/system-probe.pid"`)
+	kfilters.AddRuleExpr(t, rs, `unlink.file.path =~ "*/run/datadog/system-probe.pid"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/var/lib/datadog/system-probe.pid", 2); !is {
 		t.Error("should be a grand parent discarder")
 	}
 
 	rs = rules.NewRuleSet(&model.Model{}, model.NewDefaultEvent, &opts, &evalOpts)
-	addRuleExpr(t, rs, `unlink.file.path =~ "/var/*/datadog/system-probe.pid"`)
+	kfilters.AddRuleExpr(t, rs, `unlink.file.path =~ "/var/*/datadog/system-probe.pid"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/var/run/datadog/system-probe.pid", 2); is {
 		t.Error("shouldn't be a grand parent discarder")
 	}
 
 	rs = rules.NewRuleSet(&model.Model{}, model.NewDefaultEvent, &opts, &evalOpts)
-	addRuleExpr(t, rs, `unlink.file.path =~ "/var/lib/datadog/system-probe.pid"`, `unlink.file.name =~ "run"`)
+	kfilters.AddRuleExpr(t, rs, `unlink.file.path =~ "/var/lib/datadog/system-probe.pid"`, `unlink.file.name =~ "run"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/var/run/datadog/system-probe.pid", 2); is {
 		t.Error("shouldn't be a grand parent discarder")
 	}
 
 	rs = rules.NewRuleSet(&model.Model{}, model.NewDefaultEvent, &opts, &evalOpts)
-	addRuleExpr(t, rs, `unlink.file.path =~ "/var/*"`, `unlink.file.name =~ "run"`)
+	kfilters.AddRuleExpr(t, rs, `unlink.file.path =~ "/var/*"`, `unlink.file.name =~ "run"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/var/run/datadog/system-probe.pid", 2); is {
 		t.Error("shouldn't be a grand parent discarder")
 	}
 
 	rs = rules.NewRuleSet(&model.Model{}, model.NewDefaultEvent, &opts, &evalOpts)
-	addRuleExpr(t, rs, `open.file.path =~ "/tmp/dir/*"`)
+	kfilters.AddRuleExpr(t, rs, `open.file.path =~ "/tmp/dir/*"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileOpenEventType, "open.file.path", "/tmp/dir/a/test", 2); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
 	rs = rules.NewRuleSet(&model.Model{}, model.NewDefaultEvent, &opts, &evalOpts)
-	addRuleExpr(t, rs, `unlink.file.name == "dir"`) // + variants
+	kfilters.AddRuleExpr(t, rs, `unlink.file.name == "dir"`) // + variants
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/tmp/dir/a/test", 2); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
 	rs = rules.NewRuleSet(&model.Model{}, model.NewDefaultEvent, &opts, &evalOpts)
-	addRuleExpr(t, rs, `unlink.file.path == "/tmp/dir/a"`)
+	kfilters.AddRuleExpr(t, rs, `unlink.file.path == "/tmp/dir/a"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/tmp", 2); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
 	rs = rules.NewRuleSet(&model.Model{}, model.NewDefaultEvent, &opts, &evalOpts)
-	addRuleExpr(t, rs, `unlink.file.path == "/tmp"`)
+	kfilters.AddRuleExpr(t, rs, `unlink.file.path == "/tmp"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/tmp/dir/a", 2); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
 	rs = rules.NewRuleSet(&model.Model{}, model.NewDefaultEvent, &opts, &evalOpts)
-	addRuleExpr(t, rs, `unlink.file.path == "/tmp"`)
+	kfilters.AddRuleExpr(t, rs, `unlink.file.path == "/tmp"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/tmp", 2); is {
 		t.Error("shouldn't be a parent discarder")
@@ -388,7 +368,7 @@ func TestIsDiscarderOverride(t *testing.T) {
 
 	rs := rules.NewRuleSet(&model.Model{}, model.NewDefaultEvent, &opts, &evalOpts)
 	rs.AddListener(&listener)
-	addRuleExpr(t, rs, `unlink.file.path == "/var/log/httpd" && process.file.path == "/bin/touch"`)
+	kfilters.AddRuleExpr(t, rs, `unlink.file.path == "/var/log/httpd" && process.file.path == "/bin/touch"`)
 
 	event := rs.NewEvent().(*model.Event)
 	event.Init()
@@ -428,7 +408,7 @@ func BenchmarkParentDiscarder(b *testing.B) {
 		WithLogger(seclog.DefaultLogger)
 
 	rs := rules.NewRuleSet(&model.Model{}, model.NewDefaultEvent, &opts, &evalOpts)
-	addRuleExpr(b, rs, `unlink.file.path =~ "/var/log/*" && unlink.file.path != "/var/log/datadog/system-probe.log"`)
+	kfilters.AddRuleExpr(b, rs, `unlink.file.path =~ "/var/log/*" && unlink.file.path != "/var/log/datadog/system-probe.log"`)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/pkg/security/probe/kfilters/approvers.go
+++ b/pkg/security/probe/kfilters/approvers.go
@@ -17,11 +17,11 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
 )
 
-type onApproverHandler func(approvers rules.Approvers) (activeApprovers, error)
+type onApproverHandler func(approvers rules.Approvers) (ActiveApprovers, error)
 type activeApprover = activeKFilter
-type activeApprovers = activeKFilters
+type ActiveApprovers = activeKFilters
 
-var allApproversHandlers = make(map[eval.EventType]onApproverHandler)
+var AllApproversHandlers = make(map[eval.EventType]onApproverHandler)
 
 func approveBasename(tableName string, eventType model.EventType, basename string) (activeApprover, error) {
 	return &mapEventMask{
@@ -106,7 +106,7 @@ func onNewBasenameApprovers(eventType model.EventType, field string, approvers r
 }
 
 func onNewBasenameApproversWrapper(event model.EventType) onApproverHandler {
-	return func(approvers rules.Approvers) (activeApprovers, error) {
+	return func(approvers rules.Approvers) (ActiveApprovers, error) {
 		basenameApprovers, err := onNewBasenameApprovers(event, "file", approvers)
 		if err != nil {
 			return nil, err
@@ -116,7 +116,7 @@ func onNewBasenameApproversWrapper(event model.EventType) onApproverHandler {
 }
 
 func onNewTwoBasenamesApproversWrapper(event model.EventType, field1, field2 string) onApproverHandler {
-	return func(approvers rules.Approvers) (activeApprovers, error) {
+	return func(approvers rules.Approvers) (ActiveApprovers, error) {
 		basenameApprovers, err := onNewBasenameApprovers(event, field1, approvers)
 		if err != nil {
 			return nil, err
@@ -131,16 +131,16 @@ func onNewTwoBasenamesApproversWrapper(event model.EventType, field1, field2 str
 }
 
 func init() {
-	allApproversHandlers["chmod"] = onNewBasenameApproversWrapper(model.FileChmodEventType)
-	allApproversHandlers["chown"] = onNewBasenameApproversWrapper(model.FileChownEventType)
-	allApproversHandlers["link"] = onNewTwoBasenamesApproversWrapper(model.FileLinkEventType, "file", "file.destination")
-	allApproversHandlers["mkdir"] = onNewBasenameApproversWrapper(model.FileMkdirEventType)
-	allApproversHandlers["open"] = openOnNewApprovers
-	allApproversHandlers["rename"] = onNewTwoBasenamesApproversWrapper(model.FileRenameEventType, "file", "file.destination")
-	allApproversHandlers["rmdir"] = onNewBasenameApproversWrapper(model.FileRmdirEventType)
-	allApproversHandlers["unlink"] = onNewBasenameApproversWrapper(model.FileUnlinkEventType)
-	allApproversHandlers["utimes"] = onNewBasenameApproversWrapper(model.FileUtimesEventType)
-	allApproversHandlers["mmap"] = mmapOnNewApprovers
-	allApproversHandlers["mprotect"] = mprotectOnNewApprovers
-	allApproversHandlers["splice"] = spliceOnNewApprovers
+	AllApproversHandlers["chmod"] = onNewBasenameApproversWrapper(model.FileChmodEventType)
+	AllApproversHandlers["chown"] = onNewBasenameApproversWrapper(model.FileChownEventType)
+	AllApproversHandlers["link"] = onNewTwoBasenamesApproversWrapper(model.FileLinkEventType, "file", "file.destination")
+	AllApproversHandlers["mkdir"] = onNewBasenameApproversWrapper(model.FileMkdirEventType)
+	AllApproversHandlers["open"] = openOnNewApprovers
+	AllApproversHandlers["rename"] = onNewTwoBasenamesApproversWrapper(model.FileRenameEventType, "file", "file.destination")
+	AllApproversHandlers["rmdir"] = onNewBasenameApproversWrapper(model.FileRmdirEventType)
+	AllApproversHandlers["unlink"] = onNewBasenameApproversWrapper(model.FileUnlinkEventType)
+	AllApproversHandlers["utimes"] = onNewBasenameApproversWrapper(model.FileUtimesEventType)
+	AllApproversHandlers["mmap"] = mmapOnNewApprovers
+	AllApproversHandlers["mprotect"] = mprotectOnNewApprovers
+	AllApproversHandlers["splice"] = spliceOnNewApprovers
 }

--- a/pkg/security/probe/kfilters/approvers.go
+++ b/pkg/security/probe/kfilters/approvers.go
@@ -6,7 +6,7 @@
 //go:build linux
 // +build linux
 
-package probe
+package kfilters
 
 import (
 	"path"

--- a/pkg/security/probe/kfilters/approvers_test.go
+++ b/pkg/security/probe/kfilters/approvers_test.go
@@ -22,7 +22,7 @@ func TestApproverAncestors1(t *testing.T) {
 	ruleOpts, evalOpts := rules.NewEvalOpts(enabled)
 
 	rs := rules.NewRuleSet(&model.Model{}, model.NewDefaultEvent, ruleOpts, evalOpts)
-	addRuleExpr(t, rs, `open.file.path == "/etc/passwd" && process.ancestors.file.name == "vipw"`, `open.file.path == "/etc/shadow" && process.ancestors.file.name == "vipw"`)
+	AddRuleExpr(t, rs, `open.file.path == "/etc/passwd" && process.ancestors.file.name == "vipw"`, `open.file.path == "/etc/shadow" && process.ancestors.file.name == "vipw"`)
 
 	capabilities, exists := allCapabilities["open"]
 	if !exists {
@@ -45,7 +45,7 @@ func TestApproverAncestors2(t *testing.T) {
 	ruleOpts, evalOpts := rules.NewEvalOpts(enabled)
 
 	rs := rules.NewRuleSet(&model.Model{}, model.NewDefaultEvent, ruleOpts, evalOpts)
-	addRuleExpr(t, rs, `(open.file.path == "/etc/shadow" || open.file.path == "/etc/gshadow") && process.ancestors.file.path not in ["/usr/bin/dpkg"]`)
+	AddRuleExpr(t, rs, `(open.file.path == "/etc/shadow" || open.file.path == "/etc/gshadow") && process.ancestors.file.path not in ["/usr/bin/dpkg"]`)
 	capabilities, exists := allCapabilities["open"]
 	if !exists {
 		t.Fatal("no capabilities for open")
@@ -65,7 +65,7 @@ func TestApproverAncestors3(t *testing.T) {
 	ruleOpts, evalOpts := rules.NewEvalOpts(enabled)
 
 	rs := rules.NewRuleSet(&model.Model{}, model.NewDefaultEvent, ruleOpts, evalOpts)
-	addRuleExpr(t, rs, `open.file.path =~ "/var/run/secrets/eks.amazonaws.com/serviceaccount/*/token" && process.file.path not in ["/bin/kubectl"]`)
+	AddRuleExpr(t, rs, `open.file.path =~ "/var/run/secrets/eks.amazonaws.com/serviceaccount/*/token" && process.file.path not in ["/bin/kubectl"]`)
 	capabilities, exists := allCapabilities["open"]
 	if !exists {
 		t.Fatal("no capabilities for open")

--- a/pkg/security/probe/kfilters/approvers_test.go
+++ b/pkg/security/probe/kfilters/approvers_test.go
@@ -6,7 +6,7 @@
 //go:build linux
 // +build linux
 
-package probe
+package kfilters
 
 import (
 	"testing"

--- a/pkg/security/probe/kfilters/capabilities.go
+++ b/pkg/security/probe/kfilters/capabilities.go
@@ -6,7 +6,7 @@
 //go:build linux
 // +build linux
 
-package probe
+package kfilters
 
 import (
 	"path"

--- a/pkg/security/probe/kfilters/kfilters.go
+++ b/pkg/security/probe/kfilters/kfilters.go
@@ -6,7 +6,7 @@
 //go:build linux
 // +build linux
 
-package probe
+package kfilters
 
 // FilterPolicy describes a filtering policy
 type FilterPolicy struct {

--- a/pkg/security/probe/kfilters/kfilters_bpf.go
+++ b/pkg/security/probe/kfilters/kfilters_bpf.go
@@ -6,7 +6,7 @@
 //go:build linux
 // +build linux
 
-package probe
+package kfilters
 
 import (
 	"github.com/DataDog/datadog-agent/pkg/security/probe/managerhelper"

--- a/pkg/security/probe/kfilters/mmap.go
+++ b/pkg/security/probe/kfilters/mmap.go
@@ -36,7 +36,7 @@ var mmapCapabilities = Capabilities{
 	},
 }
 
-func mmapOnNewApprovers(approvers rules.Approvers) (activeApprovers, error) {
+func mmapOnNewApprovers(approvers rules.Approvers) (ActiveApprovers, error) {
 	intValues := func(fvs rules.FilterValues) []int {
 		var values []int
 		for _, v := range fvs {

--- a/pkg/security/probe/kfilters/mprotect.go
+++ b/pkg/security/probe/kfilters/mprotect.go
@@ -26,7 +26,7 @@ var mprotectCapabilities = Capabilities{
 	},
 }
 
-func mprotectOnNewApprovers(approvers rules.Approvers) (activeApprovers, error) {
+func mprotectOnNewApprovers(approvers rules.Approvers) (ActiveApprovers, error) {
 	intValues := func(fvs rules.FilterValues) []int {
 		var values []int
 		for _, v := range fvs {

--- a/pkg/security/probe/kfilters/mprotect.go
+++ b/pkg/security/probe/kfilters/mprotect.go
@@ -6,7 +6,7 @@
 //go:build linux
 // +build linux
 
-package probe
+package kfilters
 
 import (
 	"fmt"

--- a/pkg/security/probe/kfilters/open.go
+++ b/pkg/security/probe/kfilters/open.go
@@ -34,7 +34,7 @@ var openCapabilities = Capabilities{
 	},
 }
 
-func openOnNewApprovers(approvers rules.Approvers) (activeApprovers, error) {
+func openOnNewApprovers(approvers rules.Approvers) (ActiveApprovers, error) {
 	intValues := func(fvs rules.FilterValues) []int {
 		var values []int
 		for _, v := range fvs {

--- a/pkg/security/probe/kfilters/policy.go
+++ b/pkg/security/probe/kfilters/policy.go
@@ -6,7 +6,7 @@
 //go:build linux
 // +build linux
 
-package probe
+package kfilters
 
 import (
 	"errors"

--- a/pkg/security/probe/kfilters/report.go
+++ b/pkg/security/probe/kfilters/report.go
@@ -6,7 +6,7 @@
 //go:build linux
 // +build linux
 
-package probe
+package kfilters
 
 import (
 	"math"

--- a/pkg/security/probe/kfilters/splice.go
+++ b/pkg/security/probe/kfilters/splice.go
@@ -36,7 +36,7 @@ var spliceCapabilities = Capabilities{
 	},
 }
 
-func spliceOnNewApprovers(approvers rules.Approvers) (activeApprovers, error) {
+func spliceOnNewApprovers(approvers rules.Approvers) (ActiveApprovers, error) {
 	intValues := func(fvs rules.FilterValues) []int {
 		var values []int
 		for _, v := range fvs {

--- a/pkg/security/probe/kfilters/testutil.go
+++ b/pkg/security/probe/kfilters/testutil.go
@@ -1,0 +1,36 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux && test
+// +build linux,test
+
+package kfilters
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/ast"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
+)
+
+func AddRuleExpr(t testing.TB, rs *rules.RuleSet, exprs ...string) {
+	var ruleDefs []*rules.RuleDefinition
+
+	for i, expr := range exprs {
+		ruleDef := &rules.RuleDefinition{
+			ID:         fmt.Sprintf("ID%d", i),
+			Expression: expr,
+			Tags:       make(map[string]string),
+		}
+		ruleDefs = append(ruleDefs, ruleDef)
+	}
+
+	pc := ast.NewParsingContext()
+
+	if err := rs.AddRules(pc, ruleDefs); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -39,6 +39,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/events"
 	"github.com/DataDog/datadog-agent/pkg/security/probe/constantfetch"
 	"github.com/DataDog/datadog-agent/pkg/security/probe/erpc"
+	"github.com/DataDog/datadog-agent/pkg/security/probe/kfilters"
 	"github.com/DataDog/datadog-agent/pkg/security/probe/managerhelper"
 	"github.com/DataDog/datadog-agent/pkg/security/probe/reorderer"
 	"github.com/DataDog/datadog-agent/pkg/security/probe/ringbuffer"
@@ -108,7 +109,7 @@ type Probe struct {
 	erpcRequest                        *erpc.ERPCRequest
 	pidDiscarders                      *pidDiscarders
 	inodeDiscarders                    *inodeDiscarders
-	approvers                          map[eval.EventType]activeApprovers
+	approvers                          map[eval.EventType]kfilters.ActiveApprovers
 	discarderRateLimiter               *rate.Limiter
 	notifyDiscarderPushedCallbacks     []NotifyDiscarderPushedCallback
 	notifyDiscarderPushedCallbacksLock sync.Mutex
@@ -865,7 +866,7 @@ func (p *Probe) OnNewDiscarder(rs *rules.RuleSet, ev *model.Event, field eval.Fi
 }
 
 // ApplyFilterPolicy is called when a passing policy for an event type is applied
-func (p *Probe) ApplyFilterPolicy(eventType eval.EventType, mode PolicyMode, flags PolicyFlag) error {
+func (p *Probe) ApplyFilterPolicy(eventType eval.EventType, mode kfilters.PolicyMode, flags kfilters.PolicyFlag) error {
 	seclog.Infof("Setting in-kernel filter policy to `%s` for `%s`", mode, eventType)
 	table, err := managerhelper.Map(p.Manager, "filter_policy")
 	if err != nil {
@@ -877,7 +878,7 @@ func (p *Probe) ApplyFilterPolicy(eventType eval.EventType, mode PolicyMode, fla
 		return errors.New("unable to parse the eval event type")
 	}
 
-	policy := &FilterPolicy{
+	policy := &kfilters.FilterPolicy{
 		Mode:  mode,
 		Flags: flags,
 	}
@@ -887,14 +888,14 @@ func (p *Probe) ApplyFilterPolicy(eventType eval.EventType, mode PolicyMode, fla
 
 // SetApprovers applies approvers and removes the unused ones
 func (p *Probe) SetApprovers(eventType eval.EventType, approvers rules.Approvers) error {
-	handler, exists := allApproversHandlers[eventType]
+	handler, exists := kfilters.AllApproversHandlers[eventType]
 	if !exists {
 		return nil
 	}
 
 	newApprovers, err := handler(approvers)
 	if err != nil {
-		seclog.Errorf("Error while adding approvers fallback in-kernel policy to `%s` for `%s`: %s", PolicyModeAccept, eventType, err)
+		seclog.Errorf("Error while adding approvers fallback in-kernel policy to `%s` for `%s`: %s", kfilters.PolicyModeAccept, eventType, err)
 	}
 
 	for _, newApprover := range newApprovers {
@@ -1198,8 +1199,8 @@ func (p *Probe) handleNewMount(ev *model.Event, m *model.Mount) error {
 }
 
 // ApplyRuleSet setup the filters for the provided set of rules and returns the policy report.
-func (p *Probe) ApplyRuleSet(rs *rules.RuleSet) (*ApplyRuleSetReport, error) {
-	ars, err := NewApplyRuleSetReport(p.Config, rs)
+func (p *Probe) ApplyRuleSet(rs *rules.RuleSet) (*kfilters.ApplyRuleSetReport, error) {
+	ars, err := kfilters.NewApplyRuleSetReport(p.Config, rs)
 	if err != nil {
 		return nil, err
 	}
@@ -1238,7 +1239,7 @@ func NewProbe(config *config.Config, opts Opts) (*Probe, error) {
 	p := &Probe{
 		Opts:                 opts,
 		Config:               config,
-		approvers:            make(map[eval.EventType]activeApprovers),
+		approvers:            make(map[eval.EventType]kfilters.ActiveApprovers),
 		managerOptions:       ebpf.NewDefaultOptions(),
 		ctx:                  ctx,
 		cancelFnc:            cancel,


### PR DESCRIPTION
### What does this PR do?

This PR extracts the approvers and related files into a new `pkg/security/probe/kfilters` package

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
