### PR TITLE
[CWS] refactor random infrastructure

### DIFF
--- a/pkg/security/probe/activity_dump.go
+++ b/pkg/security/probe/activity_dump.go
@@ -197,7 +197,7 @@ func NewActivityDump(adm *ActivityDumpManager, options ...WithDumpOption) *Activ
 		now,
 		adm.resolvers.TimeResolver,
 	)
-	ad.LoadConfigCookie = eval.NewCookie()
+	ad.LoadConfigCookie = utils.NewCookie()
 
 	for _, option := range options {
 		option(ad)

--- a/pkg/security/probe/activity_dump.go
+++ b/pkg/security/probe/activity_dump.go
@@ -197,7 +197,7 @@ func NewActivityDump(adm *ActivityDumpManager, options ...WithDumpOption) *Activ
 		now,
 		adm.resolvers.TimeResolver,
 	)
-	ad.LoadConfigCookie = utils.NewCookie()
+	ad.LoadConfigCookie = adm.cookieGenerator.NewCookie()
 
 	for _, option := range options {
 		option(ad)

--- a/pkg/security/probe/activity_dump_graph.go
+++ b/pkg/security/probe/activity_dump_graph.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/security/config"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
-	"github.com/DataDog/datadog-agent/pkg/security/utils"
 )
 
 var (
@@ -334,13 +333,6 @@ func (id GraphID) String() string {
 // NodeID represents the ID of a Node
 type NodeID struct {
 	inner uint64
-}
-
-// NewRandomNodeID returns a new random NodeID
-func NewRandomNodeID() NodeID {
-	return NodeID{
-		inner: utils.RandNonZeroUint64(),
-	}
 }
 
 // NewNodeIDFromPtr returns a new NodeID based on a pointer value

--- a/pkg/security/probe/activity_dump_graph.go
+++ b/pkg/security/probe/activity_dump_graph.go
@@ -16,8 +16,8 @@ import (
 	"unsafe"
 
 	"github.com/DataDog/datadog-agent/pkg/security/config"
-	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+	"github.com/DataDog/datadog-agent/pkg/security/utils"
 )
 
 var (
@@ -339,7 +339,7 @@ type NodeID struct {
 // NewRandomNodeID returns a new random NodeID
 func NewRandomNodeID() NodeID {
 	return NodeID{
-		inner: eval.RandNonZeroUint64(),
+		inner: utils.RandNonZeroUint64(),
 	}
 }
 

--- a/pkg/security/probe/activity_dump_manager.go
+++ b/pkg/security/probe/activity_dump_manager.go
@@ -49,6 +49,7 @@ type ActivityDumpManager struct {
 	resolvers          *Resolvers
 	kernelVersion      *kernel.Version
 	manager            *manager.Manager
+	cookieGenerator    *utils.CookieGenerator
 
 	tracedPIDsMap          *ebpf.Map
 	tracedCommsMap         *ebpf.Map
@@ -249,6 +250,7 @@ func NewActivityDumpManager(p *Probe, config *config.Config, statsdClient statsd
 		resolvers:              resolvers,
 		kernelVersion:          kernelVersion,
 		manager:                manager,
+		cookieGenerator:        utils.NewCookieGenerator(),
 		tracedPIDsMap:          tracedPIDs,
 		tracedCommsMap:         tracedComms,
 		tracedCgroupsMap:       tracedCgroupsMap,

--- a/pkg/security/probe/process_resolver.go
+++ b/pkg/security/probe/process_resolver.go
@@ -273,7 +273,7 @@ func (p *ProcessResolver) DequeueExited() {
 func (p *ProcessResolver) NewProcessCacheEntry(pidContext model.PIDContext) *model.ProcessCacheEntry {
 	entry := p.processCacheEntryPool.Get()
 	entry.PIDContext = pidContext
-	entry.Cookie = eval.NewCookie()
+	entry.Cookie = utils.NewCookie()
 	return entry
 }
 

--- a/pkg/security/secl/compiler/eval/rand.go
+++ b/pkg/security/secl/compiler/eval/rand.go
@@ -24,18 +24,3 @@ func RandString(n int) string {
 func init() {
 	rand.Seed(time.Now().UnixNano())
 }
-
-// NewCookie returns a new random cookie
-func NewCookie() uint32 {
-	return rand.Uint32()
-}
-
-// RandNonZeroUint64 returns a new non-zero uint64
-func RandNonZeroUint64() uint64 {
-	for {
-		value := rand.Uint64()
-		if value != 0 {
-			return value
-		}
-	}
-}

--- a/pkg/security/secl/compiler/eval/rand.go
+++ b/pkg/security/secl/compiler/eval/rand.go
@@ -7,6 +7,7 @@ package eval
 
 import (
 	"math/rand"
+	"runtime"
 	"time"
 )
 
@@ -14,11 +15,19 @@ var letterRunes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
 
 // RandString returns a random string of the given length size
 func RandString(n int) string {
-	gen := rand.New(rand.NewSource(time.Now().UnixNano()))
+	// Time may not be precise enough on windows, meaning that multiple calls to this function may seed the
+	// random generator with the same value. We fallback to the global rand on windows
+	var gen func(int) int
+	if runtime.GOOS == "windows" {
+		gen = rand.Intn
+	} else {
+		src := rand.New(rand.NewSource(time.Now().UnixNano()))
+		gen = src.Intn
+	}
 
 	b := make([]rune, n)
 	for i := range b {
-		b[i] = letterRunes[gen.Intn(len(letterRunes))]
+		b[i] = letterRunes[gen(len(letterRunes))]
 	}
 	return string(b)
 }

--- a/pkg/security/secl/compiler/eval/rand.go
+++ b/pkg/security/secl/compiler/eval/rand.go
@@ -14,13 +14,11 @@ var letterRunes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
 
 // RandString returns a random string of the given length size
 func RandString(n int) string {
+	gen := rand.New(rand.NewSource(time.Now().UnixNano()))
+
 	b := make([]rune, n)
 	for i := range b {
-		b[i] = letterRunes[rand.Intn(len(letterRunes))]
+		b[i] = letterRunes[gen.Intn(len(letterRunes))]
 	}
 	return string(b)
-}
-
-func init() {
-	rand.Seed(time.Now().UnixNano())
 }

--- a/pkg/security/utils/rand.go
+++ b/pkg/security/utils/rand.go
@@ -20,7 +20,7 @@ type CookieGenerator struct {
 
 func NewCookieGenerator() *CookieGenerator {
 	return &CookieGenerator{
-		inner: rand.New(rand.NewSource(time.Now().UnixNano())),
+		inner: NewTimeSeedGenerator(),
 	}
 }
 
@@ -29,12 +29,6 @@ func (cg *CookieGenerator) NewCookie() uint32 {
 	return cg.inner.Uint32()
 }
 
-// RandNonZeroUint64 returns a new non-zero uint64
-func RandNonZeroUint64() uint64 {
-	for {
-		value := rand.Uint64()
-		if value != 0 {
-			return value
-		}
-	}
+func NewTimeSeedGenerator() *rand.Rand {
+	return rand.New(rand.NewSource(time.Now().UnixNano()))
 }

--- a/pkg/security/utils/rand.go
+++ b/pkg/security/utils/rand.go
@@ -1,0 +1,30 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package utils
+
+import (
+	"math/rand"
+	"time"
+)
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
+
+// NewCookie returns a new random cookie
+func NewCookie() uint32 {
+	return rand.Uint32()
+}
+
+// RandNonZeroUint64 returns a new non-zero uint64
+func RandNonZeroUint64() uint64 {
+	for {
+		value := rand.Uint64()
+		if value != 0 {
+			return value
+		}
+	}
+}

--- a/pkg/security/utils/rand.go
+++ b/pkg/security/utils/rand.go
@@ -14,9 +14,19 @@ func init() {
 	rand.Seed(time.Now().UnixNano())
 }
 
+type CookieGenerator struct {
+	inner *rand.Rand
+}
+
+func NewCookieGenerator() *CookieGenerator {
+	return &CookieGenerator{
+		inner: rand.New(rand.NewSource(time.Now().UnixNano())),
+	}
+}
+
 // NewCookie returns a new random cookie
-func NewCookie() uint32 {
-	return rand.Uint32()
+func (cg *CookieGenerator) NewCookie() uint32 {
+	return cg.inner.Uint32()
 }
 
 // RandNonZeroUint64 returns a new non-zero uint64


### PR DESCRIPTION
### What does this PR do?

The goal of this PR is 2-fold:
- remove the seeding of the global rand state in the `init` of the SECL lib. This is just of bad taste and now that this library may be used by more downstream service, this could cause issues.
- https://pkg.go.dev/math/rand@go1.20#Seed is now deprecated from go1.20 on
- setup random pools per usage

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
