### PR TITLE
{cmd/trace-agent/internal/osutil,pkg/trace/log}: print critical errors

### DIFF
--- a/cmd/trace-agent/internal/osutil/osutil.go
+++ b/cmd/trace-agent/internal/osutil/osutil.go
@@ -21,7 +21,7 @@ func Exists(path string) bool {
 
 // Exit prints the message and exits the program with status code 1.
 func Exit(msg string) {
-	if flags.Info || flags.Version {
+	if toStdOut() {
 		fmt.Println(msg)
 	} else {
 		log.Error(msg)
@@ -32,7 +32,7 @@ func Exit(msg string) {
 
 // Exitf prints the formatted text and exits the program with status code 1.
 func Exitf(format string, args ...interface{}) {
-	if flags.Info || flags.Version {
+	if toStdOut() {
 		fmt.Printf(format, args...)
 		fmt.Println("")
 	} else {
@@ -40,4 +40,11 @@ func Exitf(format string, args ...interface{}) {
 		log.Flush()
 	}
 	os.Exit(1)
+}
+
+// toStdOut returns whether errors should be written to stdout.
+// Returns true if the agent's info or version commands are invoked,
+// or if the logger hasn't been set up yet (typically on startup).
+func toStdOut() bool {
+	return flags.Info || flags.Version || !log.IsSet()
 }

--- a/pkg/trace/log/logger.go
+++ b/pkg/trace/log/logger.go
@@ -21,6 +21,13 @@ func SetLogger(l Logger) {
 	mu.Unlock()
 }
 
+// IsSet returns whether the logger has been set up.
+func IsSet() bool {
+	mu.Lock()
+	defer mu.Unlock()
+	return logger != NoopLogger
+}
+
 // Logger implements the core logger interface.
 type Logger interface {
 	Trace(v ...interface{})

--- a/releasenotes/notes/apm-init-errors-500026891d619c19.yaml
+++ b/releasenotes/notes/apm-init-errors-500026891d619c19.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    APM: Trace Agent not printing critical init errors.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Make `Exit` and `Exitf` print the critical error message before calling `os.Exit(1)`, even if the logger hasn't been set up yet.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

fixes https://github.com/DataDog/datadog-agent/issues/15303

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

The example provided in https://github.com/DataDog/datadog-agent/issues/15303 can be used for validation here

```
DD_APM_REPLACE_TAGS='[{"name": "resource.name","pattern": "/users/(.+?)(/(page1|otherpage|something|anotherthing))|$)","repl": "/users/[user]$2"}]' DD_API_KEY=$DD_API_KEY ./bin/trace-agent/trace-agent -config dev/dist/datadog.yaml
replace_tags: key "resource.name": error parsing regexp: unexpected ): `/users/(.+?)(/(page1|otherpage|something|anotherthing))|$)`
```

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
