### PR TITLE
[fakeintake] add client for fakeintake

### DIFF
--- a/tasks/modules.py
+++ b/tasks/modules.py
@@ -126,7 +126,9 @@ DEFAULT_MODULES = {
         "test/e2e/containers/otlp_sender", condition=lambda: False, should_tag=False
     ),
     "test/new-e2e": GoModule("test/new-e2e", condition=lambda: False, should_tag=False),
-    "test/fakeintake": GoModule("test/fakeintake", targets=["./server"], independent=True, should_tag=False),
+    "test/fakeintake": GoModule(
+        "test/fakeintake", targets=["./server", "./client"], independent=True, should_tag=False
+    ),
     "pkg/obfuscate": GoModule("pkg/obfuscate", independent=True),
     "pkg/trace": GoModule("pkg/trace", independent=True),
     "pkg/otlp/model": GoModule("pkg/otlp/model", independent=True),

--- a/test/fakeintake/client/client.go
+++ b/test/fakeintake/client/client.go
@@ -32,6 +32,11 @@ func (c *Client) getFakePayloads(endpoint string) (rawPayloads [][]byte, err err
 	if err != nil {
 		return nil, err
 	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("error querying fake payloads, status code %s", resp.Status)
+	}
+
 	defer resp.Body.Close()
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/test/fakeintake/client/client.go
+++ b/test/fakeintake/client/client.go
@@ -37,9 +37,7 @@ func (c *Client) GetFakePayloads(endpoint string) (rawPayloads [][]byte, err err
 	if err != nil {
 		return nil, err
 	}
-	response := api.GetPayloadResponse{
-		Payloads: [][]byte{},
-	}
+	var response api.APIFakeIntakePayloadsGETResponse
 	err = json.Unmarshal(body, &response)
 	if err != nil {
 		return nil, err

--- a/test/fakeintake/client/client.go
+++ b/test/fakeintake/client/client.go
@@ -27,7 +27,7 @@ func NewClient(fakeIntakeURL string) *Client {
 	}
 }
 
-func (c *Client) GetFakePayloads(endpoint string) (rawPayloads [][]byte, err error) {
+func (c *Client) getFakePayloads(endpoint string) (rawPayloads [][]byte, err error) {
 	resp, err := http.Get(fmt.Sprintf("%s/fakeintake/payloads?endpoint=%s", c.fakeIntakeURL, endpoint))
 	if err != nil {
 		return nil, err

--- a/test/fakeintake/client/client.go
+++ b/test/fakeintake/client/client.go
@@ -1,0 +1,48 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/DataDog/datadog-agent/test/fakeintake/api"
+)
+
+type Client struct {
+	fakeIntakeURL string
+}
+
+// NewClient creates a new fake intake client
+// fakeIntakeURL: the host of the fake Datadog intake server
+func NewClient(fakeIntakeURL string) *Client {
+	return &Client{
+		fakeIntakeURL: strings.TrimSuffix(fakeIntakeURL, "/"),
+	}
+}
+
+func (c *Client) GetFakePayloads(endpoint string) (rawPayloads [][]byte, err error) {
+	resp, err := http.Get(fmt.Sprintf("%s/fakeintake/payloads?endpoint=%s", c.fakeIntakeURL, endpoint))
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	response := api.GetPayloadResponse{
+		Payloads: [][]byte{},
+	}
+	err = json.Unmarshal(body, &response)
+	if err != nil {
+		return nil, err
+	}
+	return response.Payloads, nil
+}

--- a/test/fakeintake/client/client_integration_test.go
+++ b/test/fakeintake/client/client_integration_test.go
@@ -1,0 +1,44 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package client
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/test/fakeintake/server"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIntegrationClient(t *testing.T) {
+	t.Run("should get empty payloads from a server", func(t *testing.T) {
+		fi := server.NewServer(8080)
+		defer fi.Stop()
+
+		client := NewClient("http://localhost:8080")
+		payloads, err := client.GetFakePayloads("/foo/bar")
+		assert.NoError(t, err, "Error getting payloads")
+		assert.Equal(t, 0, len(payloads))
+	})
+
+	t.Run("should get all available payloads from a server on a given endpoint", func(t *testing.T) {
+		fi := server.NewServer(8080)
+		defer fi.Stop()
+
+		// post a test payloads to fakeintake
+		serverUrl := "http://localhost:8080"
+		testEndpoint := "/foo/bar"
+		http.Post(fmt.Sprintf("%s%s", serverUrl, testEndpoint), "text/plain", strings.NewReader("totoro|5|tag:valid,owner:pducolin"))
+
+		client := NewClient(serverUrl)
+		payloads, err := client.GetFakePayloads(testEndpoint)
+		assert.NoError(t, err, "Error getting payloads")
+		assert.Equal(t, 1, len(payloads))
+		assert.Equal(t, "totoro|5|tag:valid,owner:pducolin", string(payloads[0]))
+	})
+}

--- a/test/fakeintake/client/client_integration_test.go
+++ b/test/fakeintake/client/client_integration_test.go
@@ -21,7 +21,7 @@ func TestIntegrationClient(t *testing.T) {
 		defer fi.Stop()
 
 		client := NewClient("http://localhost:8080")
-		payloads, err := client.GetFakePayloads("/foo/bar")
+		payloads, err := client.getFakePayloads("/foo/bar")
 		assert.NoError(t, err, "Error getting payloads")
 		assert.Equal(t, 0, len(payloads))
 	})
@@ -36,7 +36,7 @@ func TestIntegrationClient(t *testing.T) {
 		http.Post(fmt.Sprintf("%s%s", serverUrl, testEndpoint), "text/plain", strings.NewReader("totoro|5|tag:valid,owner:pducolin"))
 
 		client := NewClient(serverUrl)
-		payloads, err := client.GetFakePayloads(testEndpoint)
+		payloads, err := client.getFakePayloads(testEndpoint)
 		assert.NoError(t, err, "Error getting payloads")
 		assert.Equal(t, 1, len(payloads))
 		assert.Equal(t, "totoro|5|tag:valid,owner:pducolin", string(payloads[0]))

--- a/test/fakeintake/client/client_integration_test.go
+++ b/test/fakeintake/client/client_integration_test.go
@@ -33,7 +33,10 @@ func TestIntegrationClient(t *testing.T) {
 		// post a test payloads to fakeintake
 		serverUrl := "http://localhost:8080"
 		testEndpoint := "/foo/bar"
-		http.Post(fmt.Sprintf("%s%s", serverUrl, testEndpoint), "text/plain", strings.NewReader("totoro|5|tag:valid,owner:pducolin"))
+		resp, err := http.Post(fmt.Sprintf("%s%s", serverUrl, testEndpoint), "text/plain", strings.NewReader("totoro|5|tag:valid,owner:pducolin"))
+		assert.NoError(t, err)
+		defer resp.Body.Close()
+		assert.Equal(t, http.StatusAccepted, resp.StatusCode)
 
 		client := NewClient(serverUrl)
 		payloads, err := client.getFakePayloads(testEndpoint)

--- a/test/fakeintake/client/client_test.go
+++ b/test/fakeintake/client/client_test.go
@@ -1,0 +1,46 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/test/fakeintake/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClient(t *testing.T) {
+	t.Run("should properly format the request", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// allow requests only to "/foo/bar"
+			routes := r.URL.Query()["endpoint"]
+
+			payloads := [][]byte{}
+
+			payloads = append(payloads, []byte(fmt.Sprintf("%d", len(routes))))
+			payloads = append(payloads, []byte(routes[0]))
+			// create fake response
+			resp, err := json.Marshal(api.GetPayloadResponse{
+				Payloads: payloads,
+			})
+			require.NoError(t, err)
+			w.Write(resp)
+		}))
+		defer ts.Close()
+
+		client := NewClient(ts.URL)
+		payloads, err := client.GetFakePayloads("/foo/bar")
+		assert.NoError(t, err, "Error getting payloads")
+		assert.Equal(t, 2, len(payloads))
+		assert.Equal(t, "1", string(payloads[0]))
+		assert.Equal(t, "/foo/bar", string(payloads[1]))
+	})
+}

--- a/test/fakeintake/client/client_test.go
+++ b/test/fakeintake/client/client_test.go
@@ -25,6 +25,7 @@ func TestClient(t *testing.T) {
 
 			payloads := [][]byte{}
 
+			payloads = append(payloads, []byte(r.URL.Path))
 			payloads = append(payloads, []byte(fmt.Sprintf("%d", len(routes))))
 			payloads = append(payloads, []byte(routes[0]))
 			// create fake response
@@ -39,9 +40,10 @@ func TestClient(t *testing.T) {
 		client := NewClient(ts.URL)
 		payloads, err := client.getFakePayloads("/foo/bar")
 		assert.NoError(t, err, "Error getting payloads")
-		assert.Equal(t, 2, len(payloads))
-		assert.Equal(t, "1", string(payloads[0]))
-		assert.Equal(t, "/foo/bar", string(payloads[1]))
+		assert.Equal(t, 3, len(payloads))
+		assert.Equal(t, "/fakeintake/payloads", string(payloads[0]))
+		assert.Equal(t, "1", string(payloads[1]))
+		assert.Equal(t, "/foo/bar", string(payloads[2]))
 	})
 
 	t.Run("should handle response with errors", func(t *testing.T) {

--- a/test/fakeintake/client/client_test.go
+++ b/test/fakeintake/client/client_test.go
@@ -43,4 +43,16 @@ func TestClient(t *testing.T) {
 		assert.Equal(t, "1", string(payloads[0]))
 		assert.Equal(t, "/foo/bar", string(payloads[1]))
 	})
+
+	t.Run("should handle response with errors", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadRequest)
+		}))
+		defer ts.Close()
+
+		client := NewClient(ts.URL)
+		payloads, err := client.getFakePayloads("/foo/bar")
+		assert.Error(t, err, "Expecting error")
+		assert.Nil(t, payloads)
+	})
 }

--- a/test/fakeintake/client/client_test.go
+++ b/test/fakeintake/client/client_test.go
@@ -28,7 +28,7 @@ func TestClient(t *testing.T) {
 			payloads = append(payloads, []byte(fmt.Sprintf("%d", len(routes))))
 			payloads = append(payloads, []byte(routes[0]))
 			// create fake response
-			resp, err := json.Marshal(api.GetPayloadResponse{
+			resp, err := json.Marshal(api.APIFakeIntakePayloadsGETResponse{
 				Payloads: payloads,
 			})
 			require.NoError(t, err)

--- a/test/fakeintake/client/client_test.go
+++ b/test/fakeintake/client/client_test.go
@@ -37,7 +37,7 @@ func TestClient(t *testing.T) {
 		defer ts.Close()
 
 		client := NewClient(ts.URL)
-		payloads, err := client.GetFakePayloads("/foo/bar")
+		payloads, err := client.getFakePayloads("/foo/bar")
 		assert.NoError(t, err, "Error getting payloads")
 		assert.Equal(t, 2, len(payloads))
 		assert.Equal(t, "1", string(payloads[0]))


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Adds a basic fakeintake client, it can be used in integrations and e2e tests. A further wrapper will allow for more high level requests, getting and parsing metrics, logs and check runs.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
