### PR TITLE
Filter line break and trailing whitespaces from secrets

### DIFF
--- a/pkg/secrets/fetch_secret.go
+++ b/pkg/secrets/fetch_secret.go
@@ -150,15 +150,20 @@ func fetchSecret(secretsHandle []string, origin string) (map[string]string, erro
 		if v.ErrorMsg != "" {
 			return nil, fmt.Errorf("an error occurred while decrypting '%s': %s", sec, v.ErrorMsg)
 		}
-		if v.Value == "" {
+
+		value := strings.TrimSpace(v.Value)
+		if value == "" {
 			return nil, fmt.Errorf("decrypted secret for '%s' is empty", sec)
+		}
+		if strings.Contains(value, "\n") {
+			return nil, fmt.Errorf("decrypted secret for '%s' contains line break", sec)
 		}
 
 		// add it to the cache
-		secretCache[sec] = v.Value
+		secretCache[sec] = value
 		// keep track of place where a handle was found
 		secretOrigin[sec] = common.NewStringSet(origin)
-		res[sec] = v.Value
+		res[sec] = value
 	}
 	return res, nil
 }

--- a/pkg/secrets/fetch_secret_test.go
+++ b/pkg/secrets/fetch_secret_test.go
@@ -217,6 +217,29 @@ func TestFetchSecretEmptyValue(t *testing.T) {
 	assert.Equal(t, "decrypted secret for 'handle1' is empty", err.Error())
 }
 
+func TestFetchSecretLineBreakValue(t *testing.T) {
+	defer func() {
+		secretCache = map[string]string{}
+		secretOrigin = map[string]common.StringSet{}
+	}()
+
+	runCommand = func(string) ([]byte, error) {
+		return []byte("{\"handle1\":{\"value\": \"\\nsome data\\n\"}}"), nil
+	}
+	resp, err := fetchSecret([]string{"handle1"}, "test")
+	assert.Nil(t, err)
+	assert.Equal(t, map[string]string{
+		"handle1": "some data",
+	}, resp)
+
+	runCommand = func(string) ([]byte, error) {
+		return []byte("{\"handle1\":{\"value\": \"test\\ndata\"}}"), nil
+	}
+	_, err = fetchSecret([]string{"handle1"}, "test")
+	assert.NotNil(t, err)
+	assert.Equal(t, "decrypted secret for 'handle1' contains line break", err.Error())
+}
+
 func TestFetchSecret(t *testing.T) {
 	defer func() {
 		secretCache = map[string]string{}


### PR DESCRIPTION
### What does this PR do?

Filter line break and trailing whitespaces from secrets

### Describe how to test/QA your changes

Set a secrets value with trailing spaces and check they were correctly removed.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
