### PR TITLE
[usm] Improve USM compilation failover

### DIFF
--- a/pkg/network/protocols/http/shared_libraries_test.go
+++ b/pkg/network/protocols/http/shared_libraries_test.go
@@ -28,6 +28,7 @@ import (
 
 	ddebpf "github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
+	netebpf "github.com/DataDog/datadog-agent/pkg/network/ebpf"
 	errtelemetry "github.com/DataDog/datadog-agent/pkg/network/telemetry"
 )
 
@@ -298,7 +299,7 @@ func initEBPFProgram(t *testing.T) (*ddebpf.PerfHandler, func()) {
 		return errtelemetry.PatchEBPFTelemetry(m, false, nil)
 	}
 
-	bc, err := getBytecode(c)
+	bc, err := netebpf.ReadHTTPModule(c.BPFDir, c.BPFDebug)
 	require.NoError(t, err)
 	err = mgr.InitWithOptions(bc, options)
 	require.NoError(t, err)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Improve USM compilation failover.

Prior to this change we were only handling a subset of errors such as missing BTF information or runtime _compilation_ failures, but we were not correctly failing over to other compilation modes in the context of program _load_ errors such as when a program gets rejected by the eBPF verifier.

### Motivation

In theory these errors shouldn't impact customers because we test our programs across a wide range of Kernel versions, and by the time something is merged to the main branch we're pretty confident that the eBPF programs shipped with the agent won't be rejected by verifier on customer hosts, but this PR should improve things if this ever happens.

### Additional Notes


### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

1. Edit the program `socket/http_filter` in `pkg/network/ebpf/c/runtime/http.c` and remove the following line:
```
bpf_memset(&http, 0, sizeof(http));
```
This will trigger a `invalid read from stack` error during program load time.

2. Recompile system-probe running `inv -e system-probe.build`

3. Start system-probe and make sure that HTTP monitor starts despite CO-RE and runtime compilation failures. You should see a log message like this:

```
2023-02-13 19:16:29 UTC | SYS-PROBE | INFO | (pkg/network/tracer/tracer.go:898 in newHTTPMonitor) | http monitoring enabled
```

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
