### PR TITLE
SLS-3042: Respect DD_PROXY_HTTP/DD_PROXY_HTTPS for secrets manager and KMS clients

### DIFF
--- a/cmd/serverless/api_key.go
+++ b/cmd/serverless/api_key.go
@@ -8,9 +8,11 @@ package main
 import (
 	"encoding/base64"
 	"fmt"
+	"net/http"
 	"os"
 	"regexp"
 
+	datadogHttp "github.com/DataDog/datadog-agent/pkg/util/http"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -77,7 +79,9 @@ func readAPIKeyFromKMS(cipherText string) (string, error) {
 	if cipherText == "" {
 		return "", nil
 	}
-	sess, err := session.NewSession(nil)
+	sess, err := session.NewSession(aws.NewConfig().WithHTTPClient(&http.Client{
+		Transport: datadogHttp.CreateHTTPTransport(),
+	}))
 	if err != nil {
 		return "", err
 	}
@@ -102,12 +106,15 @@ func readAPIKeyFromSecretsManager(arn string) (string, error) {
 		return "", err
 	}
 
-	sess, err := session.NewSession(nil)
+	sess, err := session.NewSession(aws.NewConfig().WithHTTPClient(&http.Client{
+		Transport: datadogHttp.CreateHTTPTransport(),
+	}))
 	if err != nil {
 		return "", err
 	}
 
 	secretsManagerClient := secretsmanager.New(sess, aws.NewConfig().WithRegion(region))
+
 	secret := &secretsmanager.GetSecretValueInput{}
 	secret.SetSecretId(arn)
 

--- a/cmd/serverless/main.go
+++ b/cmd/serverless/main.go
@@ -160,6 +160,8 @@ func runAgent(stopCh chan struct{}) (serverlessDaemon *daemon.Daemon, err error)
 		log.Warn("An API Key has been set in multiple places:", strings.Join(apikeySetIn, ", "))
 	}
 
+	config.LoadProxyFromEnv(config.Datadog)
+
 	// Set secrets from the environment that are suffixed with
 	// KMS_ENCRYPTED or SECRET_ARN
 	setSecretsFromEnv(os.Environ())
@@ -183,14 +185,13 @@ func runAgent(stopCh chan struct{}) (serverlessDaemon *daemon.Daemon, err error)
 		// execution to be stopped. TODO(remy): discuss with AWS if there is way
 		// of reporting non-critical init errors.
 		// serverless.ReportInitError(serverlessID, serverless.FatalNoAPIKey)
-		log.Error("No API key configured, exiting")
+		log.Error("No API key configured")
 	}
 	config.Datadog.SetConfigFile(datadogConfigPath)
 	// Load datadog.yaml file into the config, so that metricAgent can pick these configurations
 	if _, err := config.Load(); err != nil {
 		log.Errorf("Error happened when loading configuration from datadog.yaml for metric agent: %s", err)
 	}
-	config.LoadProxyFromEnv(config.Datadog)
 	logChannel := make(chan *logConfig.ChannelMessage)
 	// Channels for ColdStartCreator
 	lambdaSpanChan := make(chan *pb.Span)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This PR makes the secrets manager and KMS decrypt functions in Serverless respect using DD_PROXY_HTTP(S) values. If those are set, it'll try to retrieve the secrets / the key via the proxy instead of a bare connection.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
