### PR TITLE
cluster-agent: add an undocumented annotation to force datadogmetric to be active

### DIFF
--- a/pkg/clusteragent/externalmetrics/autoscaler_watcher.go
+++ b/pkg/clusteragent/externalmetrics/autoscaler_watcher.go
@@ -169,9 +169,15 @@ func (w *AutoscalerWatcher) processAutoscalers() {
 	// Go through all DatadogMetric and perform necessary actions
 	for _, datadogMetric := range w.store.GetAll() {
 		var autoscalerReferences string
+
 		externalMetric, active := datadogMetricReferences[datadogMetric.ID]
 		if externalMetric != nil {
 			autoscalerReferences = strings.Join(externalMetric.autoscalerReferences, autoscalerReferencesSep)
+		}
+
+		// Make sure we don't de-activate metrics that are forced to be always active
+		if datadogMetric.AlwaysActive {
+			active = true
 		}
 
 		// Update DatadogMetric active status

--- a/pkg/clusteragent/externalmetrics/datadogmetric_controller.go
+++ b/pkg/clusteragent/externalmetrics/datadogmetric_controller.go
@@ -270,7 +270,7 @@ func (c *DatadogMetricController) syncDatadogMetric(ns, name, datadogMetricKey s
 	// Objects exists in both places (local store and K8S), we need to sync them
 	// Spec source of truth is Kubernetes object
 	// Status source of truth is our local store
-	datadogMetricInternal.UpdateFrom(datadogMetric.Spec)
+	datadogMetricInternal.UpdateFrom(*datadogMetric)
 	defer c.store.UnlockSet(datadogMetricInternal.ID, *datadogMetricInternal, ddmControllerStoreID)
 
 	if datadogMetricInternal.IsNewerThan(datadogMetric.Status) {

--- a/pkg/clusteragent/externalmetrics/model/datadogmetricinternal.go
+++ b/pkg/clusteragent/externalmetrics/model/datadogmetricinternal.go
@@ -144,13 +144,16 @@ func (d *DatadogMetricInternal) RawQuery() string {
 	return d.query
 }
 
-// UpdateFrom updates the `DatadogMetricInternal` from `DatadogMetric` Spec
-func (d *DatadogMetricInternal) UpdateFrom(currentSpec datadoghq.DatadogMetricSpec) {
+// UpdateFrom updates the `DatadogMetricInternal` from `DatadogMetric`
+func (d *DatadogMetricInternal) UpdateFrom(current datadoghq.DatadogMetric) {
+	currentSpec := current.Spec
+
 	if d.shouldResolveQuery(currentSpec) {
 		d.resolveQuery(currentSpec.Query)
 	}
 	d.query = currentSpec.Query
 	d.MaxAge = currentSpec.MaxAge.Duration
+	d.AlwaysActive = hasForceActiveAnnotation(current)
 }
 
 // shouldResolveQuery returns whether we should try to resolve a new query

--- a/pkg/clusteragent/externalmetrics/model/datadogmetricinternal.go
+++ b/pkg/clusteragent/externalmetrics/model/datadogmetricinternal.go
@@ -27,7 +27,7 @@ import (
 // exported for testing purposes
 const (
 	DatadogMetricErrorConditionReason string = "Unable to fetch data from Datadog"
-	alwaysActiveAnnotation                   = "external-metrics.datadoghq.com/always-active"
+	alwaysActiveAnnotation            string = "external-metrics.datadoghq.com/always-active"
 )
 
 // DatadogMetricInternal is a flatten, easier to use, representation of `DatadogMetric` CRD

--- a/pkg/clusteragent/externalmetrics/model/datadogmetricinternal.go
+++ b/pkg/clusteragent/externalmetrics/model/datadogmetricinternal.go
@@ -106,7 +106,7 @@ func hasForceActiveAnnotation(metric datadoghq.DatadogMetric) bool {
 	if value, found := metric.Annotations[alwaysActiveAnnotation]; found {
 		enabled, err := strconv.ParseBool(value)
 		if err != nil {
-			log.Errorf("Unable to parse value from %s annotation: '%s'", alwaysActiveAnnotation, value)
+			log.Debugf("Unable to parse value from %s annotation: '%s'", alwaysActiveAnnotation, value)
 			return false
 		}
 		return enabled


### PR DESCRIPTION
### What does this PR do?

Currently metrics need to be referenced by an HPA or WPA to be active. This allows them to be always active and make them more useful to third-party controllers.

### Motivation

Third party controllers need to be able to use DatadogMetric

### Additional Notes


### Possible Drawbacks / Trade-offs


### Describe how to test/QA your changes

```
apiVersion: datadoghq.com/v1alpha1
kind: DatadogMetric
metadata:
  annotations:
    external-metrics.datadoghq.com/always-active: "false"
  name: hamster-test
  namespace: default
spec:
  maxAge: 10m
  query: avg:container.memory.usage{host:minikube}
```

-> metric is still inactive

```
kubectl annotate datadogmetric/hamster-test external-metrics.datadoghq.com/always-active="true" --overwrite
kubectl get datadogmetric
```

```
hamster-test     True     True    518021120                                   54s
```
### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
