### PR TITLE
Fix broken tests in comp/core

### DIFF
--- a/comp/core/config/config.go
+++ b/comp/core/config/config.go
@@ -55,6 +55,7 @@ func newMock(deps dependencies, t testing.TB) Component {
 	old := config.Datadog
 	config.Datadog = config.NewConfig("mock", "XXXX", strings.NewReplacer())
 	c := &cfg{
+		Config:   config.Datadog,
 		warnings: &config.Warnings{},
 	}
 

--- a/comp/core/flare/helpers/builder_test.go
+++ b/comp/core/flare/helpers/builder_test.go
@@ -141,8 +141,8 @@ func TestAddFileWithoutScrubbing(t *testing.T) {
 	fb.AddFileWithoutScrubbing(FromSlash("test/AddFile"), []byte("some data"))
 	assertFileContent(t, fb, "some data", "test/AddFile")
 
-	fb.AddFileWithoutScrubbing(FromSlash("test/AddFile_scrubbed_api_key"), []byte("api_key : 123456789006789009"))
-	assertFileContent(t, fb, "api_key: \"123456789006789009\"", "test/AddFile_scrubbed_api_key")
+	fb.AddFileWithoutScrubbing(FromSlash("test/AddFile_scrubbed_api_key"), []byte("api_key: 123456789006789009"))
+	assertFileContent(t, fb, "api_key: 123456789006789009", "test/AddFile_scrubbed_api_key")
 }
 
 // Test that writeScrubbedFile actually scrubs third-party API keys.

--- a/comp/core/flare/helpers/perm_info_nix_test.go
+++ b/comp/core/flare/helpers/perm_info_nix_test.go
@@ -25,8 +25,12 @@ func createPermsTestFile(t *testing.T) (string, string, string) {
 	f2 := filepath.Join(tempDir, "file_2")
 	f3 := filepath.Join(tempDir, "file_3")
 
+	// Because of umask the rights for newly created file might not be the one we asked for. We enforce it with
+	// os.Chmod.
 	os.WriteFile(f1, nil, 0765)
+	os.Chmod(f1, 0765)
 	os.WriteFile(f2, nil, 0400)
+	os.Chmod(f2, 0400)
 	return f1, f2, f3
 }
 
@@ -42,7 +46,7 @@ func TestPermsFileAdd(t *testing.T) {
 	require.Len(t, pi, 3)
 
 	assert.Equal(t, f1, pi[f1].path)
-	assert.Equal(t, "-rwxrw----", pi[f1].mode)
+	assert.Equal(t, "-rwxrw-r-x", pi[f1].mode)
 	assert.NotNil(t, pi[f1].owner)
 	assert.NotNil(t, pi[f1].group)
 	assert.Nil(t, pi[f1].err)


### PR DESCRIPTION
### What does this PR do?

Fix broken tests in comp/core.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
