### PR TITLE
trace: run debug endpoints in a separate server + redact /debug/vars payload

### DIFF
--- a/cmd/agent/gui/views/private/js/javascript.js
+++ b/cmd/agent/gui/views/private/js/javascript.js
@@ -157,9 +157,9 @@ function loadStatus(page) {
       // Get the trace-agent status
       sendMessage("agent/getConfig/apm_config.receiver_port", "", "GET",
           function(data, status, xhr) {
-              var apmPort = data["apm_config.receiver_port"];
+              var apmPort = data["apm_config.debug_server.port"];
               if (apmPort == null) {
-                  apmPort = "8126";
+                  apmPort = "5012";
               }
               var url = "http://127.0.0.1:"+apmPort+"/debug/vars"
               $.ajax({

--- a/cmd/agent/gui/views/private/js/javascript.js
+++ b/cmd/agent/gui/views/private/js/javascript.js
@@ -157,7 +157,7 @@ function loadStatus(page) {
       // Get the trace-agent status
       sendMessage("agent/getConfig/apm_config.receiver_port", "", "GET",
           function(data, status, xhr) {
-              var apmPort = data["apm_config.debug_server.port"];
+              var apmPort = data["apm_config.debug.port"];
               if (apmPort == null) {
                   apmPort = "5012";
               }

--- a/cmd/agent/subcommands/status/command.go
+++ b/cmd/agent/subcommands/status/command.go
@@ -185,7 +185,7 @@ func requestStatus(config config.Component, cliParams *cliParams) error {
 // If the status can not be obtained for any reason, the returned map will contain an "error"
 // key with an explanation.
 func getAPMStatus(config config.Component) map[string]interface{} {
-	port := config.GetInt("apm_config.debug_server.port")
+	port := config.GetInt("apm_config.debug.port")
 	url := fmt.Sprintf("http://localhost:%d/debug/vars", port)
 	resp, err := (&http.Client{Timeout: 2 * time.Second}).Get(url)
 	if err != nil {

--- a/cmd/agent/subcommands/status/command.go
+++ b/cmd/agent/subcommands/status/command.go
@@ -185,10 +185,7 @@ func requestStatus(config config.Component, cliParams *cliParams) error {
 // If the status can not be obtained for any reason, the returned map will contain an "error"
 // key with an explanation.
 func getAPMStatus(config config.Component) map[string]interface{} {
-	port := 8126
-	if config.IsSet("apm_config.receiver_port") {
-		port = config.GetInt("apm_config.receiver_port")
-	}
+	port := config.GetInt("apm_config.debug_server.port")
 	url := fmt.Sprintf("http://localhost:%d/debug/vars", port)
 	resp, err := (&http.Client{Timeout: 2 * time.Second}).Get(url)
 	if err != nil {

--- a/cmd/trace-agent/config/config.go
+++ b/cmd/trace-agent/config/config.go
@@ -427,7 +427,7 @@ func applyDatadogConfig(c *config.AgentConfig) error {
 	if k := "evp_proxy_config.max_payload_size"; coreconfig.Datadog.IsSet(k) {
 		c.EVPProxy.MaxPayloadSize = coreconfig.Datadog.GetInt64(k)
 	}
-	c.DebugServerPort = coreconfig.Datadog.GetInt("apm_config.debug_server.port")
+	c.DebugServerPort = coreconfig.Datadog.GetInt("apm_config.debug.port")
 	return nil
 }
 

--- a/cmd/trace-agent/config/config.go
+++ b/cmd/trace-agent/config/config.go
@@ -427,6 +427,7 @@ func applyDatadogConfig(c *config.AgentConfig) error {
 	if k := "evp_proxy_config.max_payload_size"; coreconfig.Datadog.IsSet(k) {
 		c.EVPProxy.MaxPayloadSize = coreconfig.Datadog.GetInt64(k)
 	}
+	c.DebugServerPort = coreconfig.Datadog.GetInt("apm_config.debug_server.port")
 	return nil
 }
 

--- a/pkg/config/apm.go
+++ b/pkg/config/apm.go
@@ -105,6 +105,7 @@ func setupAPM(config Config) {
 	config.BindEnv("apm_config.telemetry.additional_endpoints", "DD_APM_TELEMETRY_ADDITIONAL_ENDPOINTS")
 	config.BindEnv("apm_config.obfuscation.credit_cards.enabled", "DD_APM_OBFUSCATION_CREDIT_CARDS_ENABLED")
 	config.BindEnv("apm_config.obfuscation.credit_cards.luhn", "DD_APM_OBFUSCATION_CREDIT_CARDS_LUHN")
+	config.BindEnvAndSetDefault("apm_config.debug_server.port", 5012, "DD_APM_DEBUG_SERVER_PORT")
 
 	config.SetEnvKeyTransformer("apm_config.ignore_resources", func(in string) interface{} {
 		r, err := splitCSVString(in, ',')

--- a/pkg/config/apm.go
+++ b/pkg/config/apm.go
@@ -105,7 +105,7 @@ func setupAPM(config Config) {
 	config.BindEnv("apm_config.telemetry.additional_endpoints", "DD_APM_TELEMETRY_ADDITIONAL_ENDPOINTS")
 	config.BindEnv("apm_config.obfuscation.credit_cards.enabled", "DD_APM_OBFUSCATION_CREDIT_CARDS_ENABLED")
 	config.BindEnv("apm_config.obfuscation.credit_cards.luhn", "DD_APM_OBFUSCATION_CREDIT_CARDS_LUHN")
-	config.BindEnvAndSetDefault("apm_config.debug_server.port", 5012, "DD_APM_DEBUG_SERVER_PORT")
+	config.BindEnvAndSetDefault("apm_config.debug.port", 5012, "DD_APM_DEBUG_PORT")
 
 	config.SetEnvKeyTransformer("apm_config.ignore_resources", func(in string) interface{} {
 		r, err := splitCSVString(in, ',')

--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -59,6 +59,7 @@ type Agent struct {
 	StatsWriter           *writer.StatsWriter
 	RemoteConfigHandler   *remoteconfighandler.RemoteConfigHandler
 	TelemetryCollector    telemetry.TelemetryCollector
+	DebugServer           *api.DebugServer
 
 	// obfuscator is used to obfuscate sensitive data from various span
 	// tags based on their type.
@@ -108,6 +109,7 @@ func NewAgent(ctx context.Context, conf *config.AgentConfig, telemetryCollector 
 		In:                    in,
 		conf:                  conf,
 		ctx:                   ctx,
+		DebugServer:           api.NewDebugServer(conf),
 	}
 	agnt.Receiver = api.NewHTTPReceiver(conf, dynConf, in, agnt, telemetryCollector)
 	agnt.OTLPReceiver = api.NewOTLPReceiver(in, conf)
@@ -128,6 +130,7 @@ func (a *Agent) Run() {
 		a.EventProcessor,
 		a.OTLPReceiver,
 		a.RemoteConfigHandler,
+		a.DebugServer,
 	} {
 		starter.Start()
 	}
@@ -195,6 +198,7 @@ func (a *Agent) loop() {
 				a.obfuscator,
 				a.obfuscator,
 				a.cardObfuscator,
+				a.DebugServer,
 			} {
 				stopper.Stop()
 			}

--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -9,7 +9,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"expvar"
 	"fmt"
 	"io"
 	stdlog "log"
@@ -17,9 +16,7 @@ import (
 	"mime"
 	"net"
 	"net/http"
-	"net/http/pprof"
 	"os"
-	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -118,7 +115,6 @@ func (r *HTTPReceiver) buildMux() *http.ServeMux {
 	mux := http.NewServeMux()
 
 	hash, infoHandler := r.makeInfoHandler()
-	r.attachDebugHandlers(mux)
 	for _, e := range endpoints {
 		if e.IsEnabled != nil && !e.IsEnabled(r.conf) {
 			continue
@@ -216,43 +212,6 @@ func (r *HTTPReceiver) Start() {
 		defer watchdog.LogOnPanic()
 		r.loop()
 	}()
-}
-
-func (r *HTTPReceiver) attachDebugHandlers(mux *http.ServeMux) {
-	mux.HandleFunc("/debug/pprof/", pprof.Index)
-	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
-	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
-	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
-	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
-
-	mux.HandleFunc("/debug/blockrate", func(w http.ResponseWriter, r *http.Request) {
-		// this endpoint calls runtime.SetBlockProfileRate(v), where v is an optional
-		// query string parameter defaulting to 10000 (1 sample per 10μs blocked).
-		rate := 10000
-		v := r.URL.Query().Get("v")
-		if v != "" {
-			n, err := strconv.Atoi(v)
-			if err != nil {
-				http.Error(w, "v must be an integer", http.StatusBadRequest)
-				return
-			}
-			rate = n
-		}
-		runtime.SetBlockProfileRate(rate)
-		fmt.Fprintf(w, "Block profile rate set to %d. It will automatically be disabled again after calling /debug/pprof/block\n", rate)
-	})
-
-	mux.HandleFunc("/debug/pprof/block", func(w http.ResponseWriter, r *http.Request) {
-		// serve the block profile and reset the rate to 0.
-		pprof.Handler("block").ServeHTTP(w, r)
-		runtime.SetBlockProfileRate(0)
-	})
-
-	mux.Handle("/debug/vars", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		// allow the GUI to call this endpoint so that the status can be reported
-		w.Header().Set("Access-Control-Allow-Origin", "http://127.0.0.1:"+r.conf.GUIPort)
-		expvar.Handler().ServeHTTP(w, req)
-	}))
 }
 
 // listenUnix returns a net.Listener listening on the given "unix" socket path.

--- a/pkg/trace/api/debug_server.go
+++ b/pkg/trace/api/debug_server.go
@@ -41,7 +41,7 @@ func NewDebugServer(conf *config.AgentConfig) *DebugServer {
 // Start configures and starts the http server
 func (ds *DebugServer) Start() {
 	if ds.conf.DebugServerPort == 0 {
-		log.Debug("Debug server is disabled by config (apm_config.debug_server.port: 0).")
+		log.Debug("Debug server is disabled by config (apm_config.debug.port: 0).")
 		return
 	}
 	ds.server = &http.Server{

--- a/pkg/trace/api/debug_server.go
+++ b/pkg/trace/api/debug_server.go
@@ -1,0 +1,110 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package api
+
+import (
+	"context"
+	"expvar"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/pprof"
+	"runtime"
+	"strconv"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/trace/config"
+	"github.com/DataDog/datadog-agent/pkg/trace/log"
+)
+
+const (
+	defaultTimeout          = 5 * time.Second
+	defaultShutdownDeadline = 5 * time.Second
+)
+
+// DebugServer serves /debug/* endpoints
+type DebugServer struct {
+	conf   *config.AgentConfig
+	server *http.Server
+}
+
+// NewDebugServer returns a debug server
+func NewDebugServer(conf *config.AgentConfig) *DebugServer {
+	return &DebugServer{
+		conf: conf,
+	}
+}
+
+// Start configures and starts the http server
+func (ds *DebugServer) Start() {
+	if ds.conf.DebugServerPort == 0 {
+		log.Debug("Debug server is disabled by config (apm_config.debug_server.port: 0).")
+		return
+	}
+	ds.server = &http.Server{
+		ReadTimeout:  defaultTimeout,
+		WriteTimeout: defaultTimeout,
+		Handler:      ds.mux(),
+	}
+	listener, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", ds.conf.DebugServerPort))
+	if err != nil {
+		log.Errorf("Error creating debug server listener: %s", err)
+		return
+	}
+	go func() {
+		if err := ds.server.Serve(listener); err != nil && err != http.ErrServerClosed {
+			log.Errorf("Could not start debug server: %s. Debug server disabled.", err)
+		}
+	}()
+}
+
+// Stop shuts down the debug server
+func (ds *DebugServer) Stop() {
+	if ds.server == nil {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), defaultShutdownDeadline)
+	defer cancel()
+	if err := ds.server.Shutdown(ctx); err != nil {
+		log.Errorf("Error stopping debug server: %s", err)
+	}
+}
+
+func (ds *DebugServer) mux() *http.ServeMux {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/debug/pprof/", pprof.Index)
+	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+	mux.HandleFunc("/debug/blockrate", func(w http.ResponseWriter, r *http.Request) {
+		// this endpoint calls runtime.SetBlockProfileRate(v), where v is an optional
+		// query string parameter defaulting to 10000 (1 sample per 10μs blocked).
+		rate := 10000
+		v := r.URL.Query().Get("v")
+		if v != "" {
+			n, err := strconv.Atoi(v)
+			if err != nil {
+				http.Error(w, "v must be an integer", http.StatusBadRequest)
+				return
+			}
+			rate = n
+		}
+		runtime.SetBlockProfileRate(rate)
+		fmt.Fprintf(w, "Block profile rate set to %d. It will automatically be disabled again after calling /debug/pprof/block\n", rate)
+	})
+	mux.HandleFunc("/debug/pprof/block", func(w http.ResponseWriter, r *http.Request) {
+		// serve the block profile and reset the rate to 0.
+		pprof.Handler("block").ServeHTTP(w, r)
+		runtime.SetBlockProfileRate(0)
+	})
+	mux.Handle("/debug/vars", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		// allow the GUI to call this endpoint so that the status can be reported
+		w.Header().Set("Access-Control-Allow-Origin", "http://127.0.0.1:"+ds.conf.GUIPort)
+		expvar.Handler().ServeHTTP(w, req)
+	}))
+	return mux
+}

--- a/pkg/trace/api/debug_server.go
+++ b/pkg/trace/api/debug_server.go
@@ -1,7 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2016-present Datadog, Inc.
+// Copyright 2023-present Datadog, Inc.
 
 package api
 

--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -426,6 +426,9 @@ type AgentConfig struct {
 
 	// Azure App Services
 	InAzureAppServices bool
+
+	// DebugServerPort defines the port used by the debug server
+	DebugServerPort int
 }
 
 // RemoteClient client is used to APM Sampling Updates from a remote source.

--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -281,7 +281,7 @@ type DebuggerProxyConfig struct {
 	// DDURL ...
 	DDURL string
 	// APIKey ...
-	APIKey string
+	APIKey string `json:"-"` // Never marshal this field
 }
 
 // AgentConfig handles the interpretation of the configuration (with default

--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -267,9 +267,9 @@ type EVPProxy struct {
 	// DDURL is the Datadog site to forward payloads to (defaults to the Site setting if not set).
 	DDURL string
 	// APIKey is the main API Key (defaults to the main API key).
-	APIKey string
+	APIKey string `json:"-"` // Never marshal this field
 	// ApplicationKey to be used for requests with the X-Datadog-NeedsAppKey set (defaults to the top-level Application Key).
-	ApplicationKey string
+	ApplicationKey string `json:"-"` // Never marshal this field
 	// AdditionalEndpoints is a map of additional Datadog sites to API keys.
 	AdditionalEndpoints map[string][]string
 	// MaxPayloadSize indicates the size at which payloads will be rejected, in bytes.

--- a/pkg/trace/go.mod
+++ b/pkg/trace/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups v0.43.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/util/log v0.43.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/util/pointer v0.43.0-rc.3
+	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.43.0-rc.3
 	github.com/DataDog/datadog-go/v5 v5.1.1
 	github.com/DataDog/sketches-go v1.4.1
 	github.com/Microsoft/go-winio v0.5.2
@@ -39,7 +40,6 @@ require (
 )
 
 require (
-	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.43.0-rc.3 // indirect
 	github.com/DataDog/go-tuf v0.3.0--fix-localmeta-fork // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575 // indirect

--- a/pkg/trace/info/info_test.go
+++ b/pkg/trace/info/info_test.go
@@ -149,7 +149,7 @@ func TestInfo(t *testing.T) {
 	assert.Equal(2, len(hostPort))
 	port, err := strconv.Atoi(hostPort[1])
 	assert.NoError(err)
-	conf.ReceiverPort = port
+	conf.DebugServerPort = port
 
 	var buf bytes.Buffer
 	err = Info(&buf, conf)
@@ -194,7 +194,7 @@ func TestWarning(t *testing.T) {
 	assert.Equal(2, len(hostPort))
 	port, err := strconv.Atoi(hostPort[1])
 	assert.NoError(err)
-	conf.ReceiverPort = port
+	conf.DebugServerPort = port
 
 	var buf bytes.Buffer
 	err = Info(&buf, conf)
@@ -228,7 +228,7 @@ func TestNotRunning(t *testing.T) {
 	assert.Equal(2, len(hostPort))
 	port, err := strconv.Atoi(hostPort[1])
 	assert.NoError(err)
-	conf.ReceiverPort = port
+	conf.DebugServerPort = port
 
 	var buf bytes.Buffer
 	err = Info(&buf, conf)
@@ -245,7 +245,7 @@ func TestNotRunning(t *testing.T) {
 	assert.Equal(len(lines[1]), len(lines[0]))
 	assert.Equal(len(lines[1]), len(lines[2]))
 	assert.Equal("", lines[3])
-	assert.Equal(fmt.Sprintf("  Not running (port %d)", port), lines[4])
+	assert.Equal(fmt.Sprintf("  Not running or unreachable on 127.0.0.1:%d", port), lines[4])
 	assert.Equal("", lines[5])
 	assert.Equal("", lines[6])
 }
@@ -267,7 +267,7 @@ func TestError(t *testing.T) {
 	assert.Equal(2, len(hostPort))
 	port, err := strconv.Atoi(hostPort[1])
 	assert.NoError(err)
-	conf.ReceiverPort = port
+	conf.DebugServerPort = port
 
 	var buf bytes.Buffer
 	err = Info(&buf, conf)
@@ -285,7 +285,7 @@ func TestError(t *testing.T) {
 	assert.Equal(len(lines[1]), len(lines[2]))
 	assert.Equal("", lines[3])
 	assert.Regexp(regexp.MustCompile(`^  Error: .*$`), lines[4])
-	assert.Equal(fmt.Sprintf("  URL: http://localhost:%d/debug/vars", port), lines[5])
+	assert.Equal(fmt.Sprintf("  URL: http://127.0.0.1:%d/debug/vars", port), lines[5])
 	assert.Equal("", lines[6])
 	assert.Equal("", lines[7])
 }

--- a/pkg/trace/info/info_test.go
+++ b/pkg/trace/info/info_test.go
@@ -136,6 +136,7 @@ func testInit(t *testing.T) *config.AgentConfig {
 	conf.EVPProxy.ApplicationKey = "evp_app_key"
 	conf.EVPProxy.AdditionalEndpoints = clearAddEp
 	conf.ProfilingProxy.AdditionalEndpoints = clearAddEp
+	conf.DebuggerProxy.APIKey = "debugger_proxy_key"
 	assert.NotNil(conf)
 
 	err := InitInfo(conf)
@@ -392,6 +393,8 @@ func TestInfoConfig(t *testing.T) {
 	conf.EVPProxy.APIKey = ""
 	assert.Equal("", confCopy.EVPProxy.ApplicationKey, "EVP APP Key should *NEVER* be exported")
 	conf.EVPProxy.ApplicationKey = ""
+	assert.Equal("", confCopy.DebuggerProxy.APIKey, "Debugger Proxy API Key should *NEVER* be exported")
+	conf.DebuggerProxy.APIKey = ""
 
 	// Any key-like data should scrubbed
 	conf.EVPProxy.AdditionalEndpoints = scrubbedAddEp

--- a/pkg/trace/info/info_test.go
+++ b/pkg/trace/info/info_test.go
@@ -27,6 +27,14 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/trace/watchdog"
 )
 
+var clearAddEp = map[string][]string{
+	"ep": {"aaaaaaaaaaaaaaaaaaaaaaaaaaaabbbb", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbb"},
+}
+
+var scrubbedAddEp = map[string][]string{
+	"ep": {"***************************abbbb", "***********************************abbbb"},
+}
+
 type testServerHandler struct {
 	t *testing.T
 }
@@ -124,6 +132,10 @@ func testInit(t *testing.T) *config.AgentConfig {
 	conf.Endpoints = append(conf.Endpoints, &config.Endpoint{Host: "ABC", APIKey: "key2"})
 	conf.TelemetryConfig.Endpoints[0].APIKey = "key1"
 	conf.Proxy = nil
+	conf.EVPProxy.APIKey = "evp_api_key"
+	conf.EVPProxy.ApplicationKey = "evp_app_key"
+	conf.EVPProxy.AdditionalEndpoints = clearAddEp
+	conf.ProfilingProxy.AdditionalEndpoints = clearAddEp
 	assert.NotNil(conf)
 
 	err := InitInfo(conf)
@@ -376,6 +388,15 @@ func TestInfoConfig(t *testing.T) {
 		assert.Equal("", e.APIKey, "API Keys should *NEVER* be exported")
 		conf.TelemetryConfig.Endpoints[i].APIKey = "" // make conf equal to confCopy to assert equality of other fields
 	}
+	assert.Equal("", confCopy.EVPProxy.APIKey, "EVP API Key should *NEVER* be exported")
+	conf.EVPProxy.APIKey = ""
+	assert.Equal("", confCopy.EVPProxy.ApplicationKey, "EVP APP Key should *NEVER* be exported")
+	conf.EVPProxy.ApplicationKey = ""
+
+	// Any key-like data should scrubbed
+	conf.EVPProxy.AdditionalEndpoints = scrubbedAddEp
+	conf.ProfilingProxy.AdditionalEndpoints = scrubbedAddEp
+
 	conf.ContainerTags = nil
 
 	assert.Equal(*conf, confCopy) // ensure all fields have been exported then parsed correctly
@@ -515,4 +536,18 @@ func TestPublishRateLimiterStats(t *testing.T) {
 			"RecentTracesSeen":    3.0,
 			"RecentTracesDropped": 4.0,
 		})
+}
+
+func TestScrubCreds(t *testing.T) {
+	assert := assert.New(t)
+	conf := testInit(t)
+	assert.NotNil(conf)
+
+	confExpvar := expvar.Get("config").String()
+	var got config.AgentConfig
+	err := json.Unmarshal([]byte(confExpvar), &got)
+	assert.NoError(err)
+
+	assert.EqualValues(got.EVPProxy.AdditionalEndpoints, scrubbedAddEp)
+	assert.EqualValues(got.ProfilingProxy.AdditionalEndpoints, scrubbedAddEp)
 }

--- a/releasenotes/notes/apm-debug-srvr-89996165b41ac272.yaml
+++ b/releasenotes/notes/apm-debug-srvr-89996165b41ac272.yaml
@@ -2,5 +2,5 @@
 enhancements:
   - |
     APM:
-      - Run the /debug/* endpoints in a separate server which uses port 5012 by default and only listens on ``127.0.0.1``. The port is configurable through ``apm_config.debug_server.port`` and ``DD_APM_DEBUG_SERVER_PORT``, set it to 0 to disable the server.
+      - Run the /debug/* endpoints in a separate server which uses port 5012 by default and only listens on ``127.0.0.1``. The port is configurable through ``apm_config.debug.port`` and ``DD_APM_DEBUG_PORT``, set it to 0 to disable the server.
       - Scrub the content served by the expvar endpoint.

--- a/releasenotes/notes/apm-debug-srvr-89996165b41ac272.yaml
+++ b/releasenotes/notes/apm-debug-srvr-89996165b41ac272.yaml
@@ -2,5 +2,5 @@
 enhancements:
   - |
     APM:
-      - Run the /debug/* endpoints in a separate server: it uses port 5012 by default and only listens on ``127.0.0.1``. Port is configurable via ``apm_config.debug_server.port`` and ``DD_APM_DEBUG_SERVER_PORT``, set it to 0 to disable the server.
+      - Run the /debug/* endpoints in a separate server which uses port 5012 by default and only listens on ``127.0.0.1``. The port is configurable through ``apm_config.debug_server.port`` and ``DD_APM_DEBUG_SERVER_PORT``, set it to 0 to disable the server.
       - Scrub the content served by the expvar endpoint.

--- a/releasenotes/notes/apm-debug-srvr-89996165b41ac272.yaml
+++ b/releasenotes/notes/apm-debug-srvr-89996165b41ac272.yaml
@@ -1,0 +1,6 @@
+---
+enhancements:
+  - |
+    APM:
+      - Run the /debug/* endpoints in a separate server: it uses port 5012 by default and only listens on ``127.0.0.1``. Port is configurable via ``apm_config.debug_server.port`` and ``DD_APM_DEBUG_SERVER_PORT``, set it to 0 to disable the server.
+      - Scrub the content served by the expvar endpoint.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

- Run the /debug/* endpoints in a separate server: it uses port 5012 by default and only listens on localhost.
- Port is configurable via `apm_config.debug.port` and `DD_APM_DEBUG_PORT` (set it to 0 to disable the server)
- Scrub the content of the config variable exposed via `expvar` (i.e `/debug/vars`)

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

Port 5012 bc the port range from 5000 to 5009 is used by the agent, the cluster agent and cluster check runner. The security agent's expvar port is 5011, so 5012 is just 5011+1.

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

**Step 1:** By default, debug endpoints aren't registered

Make sure the `agent status` and `trace-agent -info` commands aren't broken, since they rely on the expvar endpoint.

**Step 2:** Secrets are redacted
Define a valid api key in `evp_proxy_config.additionnal_endpoints`, make sure it's redacted in the payload returned by `debug/vars`
```
curl -s localhost:5012/debug/vars | jq .config.EVPProxy.AdditionalEndpoints
{
  "ep": [
    "***************************cb652"
  ]
}
```

**Step 3:** EVP creds are unexported
Define a valid api key in `evp_proxy_config.api_key`, make sure it's not in the payload returned by `debug/vars`
```
curl -s localhost:5012/debug/vars | jq -e .config.EVPProxy.APIKey

```

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
