### PR TITLE
kitchen system-probe grow / if needed and use /system-probe-tests as default

### DIFF
--- a/test/kitchen/drivers/ec2-driver.yml
+++ b/test/kitchen/drivers/ec2-driver.yml
@@ -111,7 +111,7 @@ platforms:
       <% end %>
         ebs:
           volume_type: gp2
-          volume_size: 55
+          volume_size: 75
           delete_on_termination: true
     <% if allow_rsa_key || al2022 %>
     user_data: |

--- a/test/kitchen/site-cookbooks/dd-system-probe-check/recipes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-system-probe-check/recipes/default.rb
@@ -9,11 +9,66 @@ if !platform?('windows')
   include_recipe "::linux_use_azure_mnt"
 end
 
+# grow root fs if needed
+if !platform?('windows')
+  package 'growpart' do
+    case node[:platform]
+    when 'amazon', 'redhat', 'centos', 'fedora'
+      package_name 'cloud-utils-growpart'
+    else
+      package_name 'cloud-guest-utils'
+    end
+  end
+
+  execute 'increase space' do
+    command <<-EOF
+      df -Th /
+
+      d=$(df -T --block-size=1M / | tail -n1)
+      dev_name=$(echo $d | awk '{print $1}')
+      fstype=$(echo $d | awk '{print $2}')
+      avail=$(echo $d | awk '{print $5}')
+      mnt=$(echo $d | awk '{print $7}')
+
+      if [[ $(awk "BEGIN {print 10000.0<$avail}") -eq 1 ]]; then
+         echo "skip because use $avail > 10G"
+         exit 0
+      fi
+
+      if [[ ${dev_name} =~ ^/dev/mapper ]]; then
+         lvresize -L +10G ${dev_name}
+         if [[ ${fstype} = "xfs" ]]; then
+            xfs_growfs -d ${mnt}
+         else
+            resize2fs ${dev_name}
+         fi
+      fi
+      if [[ ${dev_name} =~ ^/dev/nvme ]]; then
+         disk=$(echo $dev_name | awk -Fp '{print $1}')
+         partnum=$(echo $dev_name | awk -Fp '{print $2}')
+
+         growpart ${disk} ${partnum}
+         if [[ ${fstype} = "xfs" ]]; then
+            xfs_growfs -d ${mnt}
+         else
+            resize2fs ${dev_name}
+         fi
+      fi
+
+      df -Th /
+    EOF
+    user "root"
+    live_stream true
+    ignore_failure true
+  end
+end
+
+
 # This will copy the whole file tree from COOKBOOK_NAME/files/default/tests
 # to the directory where RSpec is expecting them.
 testdir = value_for_platform(
   'windows' => { 'default' => ::File.join(Chef::Config[:file_cache_path], 'system-probe-tests') },
-  'default' => '/tmp/system-probe-tests'
+  'default' => '/system-probe-tests'
 )
 
 remote_directory testdir do

--- a/test/kitchen/site-cookbooks/dd-system-probe-check/recipes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-system-probe-check/recipes/default.rb
@@ -20,6 +20,8 @@ if !platform?('windows')
     end
   end
 
+  package 'gdisk'
+
   execute 'increase space' do
     command <<-EOF
       df -Th /

--- a/test/kitchen/site-cookbooks/dd-system-probe-check/recipes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-system-probe-check/recipes/default.rb
@@ -63,6 +63,7 @@ if !platform?('windows')
     live_stream true
     ignore_failure true
   end
+
 end
 
 
@@ -72,6 +73,14 @@ testdir = value_for_platform(
   'windows' => { 'default' => ::File.join(Chef::Config[:file_cache_path], 'system-probe-tests') },
   'default' => '/system-probe-tests'
 )
+
+# retro compatibility
+execute "/tmp/system-probe-tests symlink" do
+  command "ln -s /system-probe-tests /tmp/system-probe-tests"
+  live_stream true
+  action :run
+  ignore_failure false
+end
 
 remote_directory testdir do
   source 'tests'

--- a/test/kitchen/site-cookbooks/dd-system-probe-check/recipes/linux.rb
+++ b/test/kitchen/site-cookbooks/dd-system-probe-check/recipes/linux.rb
@@ -190,7 +190,7 @@ end
 # Install relevant packages for docker
 include_recipe "::docker_installation"
 
-remote_directory "/tmp/kitchen-dockers" do
+remote_directory "/kitchen-dockers" do
   source 'dockers'
   files_owner 'root'
   files_group 'root'
@@ -201,7 +201,7 @@ end
 
 # Load docker images
 execute 'install docker-compose' do
-  cwd '/tmp/kitchen-dockers'
+  cwd '/kitchen-dockers'
   command <<-EOF
     for docker_file in $(ls); do
       echo docker load -i $docker_file

--- a/test/kitchen/site-cookbooks/dd-system-probe-check/recipes/linux.rb
+++ b/test/kitchen/site-cookbooks/dd-system-probe-check/recipes/linux.rb
@@ -23,11 +23,13 @@ execute 'increase space' do
   command <<-EOF
     df -Th /tmp
 
-    dev_name=$(df -Th / | tail -n1 | awk '{print $1}')
-    fstype=$(df -Th / | tail -n1 | awk '{print $2}')
-    use=$(df -Th / | tail -n1 | awk '{print $6}' | tr -d %)
+    d=$(df -Th /tmp | tail -n1)
+    dev_name=$(echo $d | awk '{print $1}')
+    fstype=$(echo $d | awk '{print $2}')
+    use=$(echo $d | awk '{print $6}' | tr -d %)
 
     if [[ $use -lt 70 ]]; then
+       echo "skip because use $use < 70%"
        exit 0
     fi
 

--- a/test/kitchen/site-cookbooks/dd-system-probe-check/recipes/linux.rb
+++ b/test/kitchen/site-cookbooks/dd-system-probe-check/recipes/linux.rb
@@ -1,10 +1,16 @@
 
-if node[:platform] == "amazon" and node[:platform_version] == "2022"
-  execute "increase /tmp size" do
-    command "mount -o remount,size=10G /tmp/"
-    live_stream true
-    action :run
-  end
+execute "df -h" do
+  command "df -h"
+  live_stream true
+  action :run
+  ignore_failure true
+end
+
+execute "increase /tmp size" do
+  command "mount -o remount,size=10G /tmp/"
+  live_stream true
+  action :run
+  ignore_failure true
 end
 
 if platform?('centos')
@@ -91,6 +97,7 @@ kernel_module 'ipv6' do
   action :load
 end
 execute 'sysctl net.ipv6.conf.all.disable_ipv6=0'
+
 
 execute 'ensure conntrack is enabled' do
   command "iptables -I INPUT 1 -m conntrack --ctstate NEW,RELATED,ESTABLISHED -j ACCEPT"
@@ -227,4 +234,13 @@ execute 'install docker-compose' do
   EOF
   user "root"
   live_stream true
+end
+
+
+
+execute "df -hafter" do
+  command "df -h"
+  live_stream true
+  action :run
+  ignore_failure true
 end

--- a/test/kitchen/site-cookbooks/dd-system-probe-check/recipes/linux.rb
+++ b/test/kitchen/site-cookbooks/dd-system-probe-check/recipes/linux.rb
@@ -1,10 +1,3 @@
-# retro compatibility
-execute "/tmp/system-probe-tests symlink" do
-  command "ln -s /system-probe-tests /tmp/system-probe-tests"
-  live_stream true
-  action :run
-  ignore_failure false
-end
 
 execute "df -Th" do
   command "df -Th"

--- a/test/kitchen/site-cookbooks/dd-system-probe-check/recipes/linux.rb
+++ b/test/kitchen/site-cookbooks/dd-system-probe-check/recipes/linux.rb
@@ -1,7 +1,7 @@
 
 
 execute "df -h" do
-  command "df -h"
+  command "df -h /tmp"
   live_stream true
   action :run
   ignore_failure true
@@ -126,7 +126,7 @@ execute 'increase spaceallos' do
     df -h /tmp
 
     dev_name=$(df -h / | tail -n1 | awk '{print $1}')
-    if [[ ${dev_name} =~ "^/dev/mapper" ]]; then
+    if [[ ${dev_name} =~ ^/dev/mapper ]]; then
        lvresize -L +4G ${dev_name}
        resize2fs ${dev_name}
     fi
@@ -272,7 +272,7 @@ end
 
 
 execute "df -hafter" do
-  command "df -h"
+  command "df -h /tmp"
   live_stream true
   action :run
   ignore_failure true

--- a/test/kitchen/site-cookbooks/dd-system-probe-check/recipes/linux.rb
+++ b/test/kitchen/site-cookbooks/dd-system-probe-check/recipes/linux.rb
@@ -1,14 +1,14 @@
 
 
-execute "df -h" do
-  command "df -h /tmp"
+execute "mount -ttmpfs none /tmp size=10G" do
+  command "mount -ttmpfs none /tmp size=10G"
   live_stream true
   action :run
   ignore_failure true
 end
 
-execute "increase /tmp size" do
-  command "mount -o remount,size=10G /tmp/"
+execute "df -h" do
+  command "df -h /tmp"
   live_stream true
   action :run
   ignore_failure true

--- a/test/kitchen/site-cookbooks/dd-system-probe-check/recipes/linux.rb
+++ b/test/kitchen/site-cookbooks/dd-system-probe-check/recipes/linux.rb
@@ -1,3 +1,12 @@
+
+if node[:platform] == "amazon" and node[:platform_version] == "2022"
+  execute "increase /tmp size" do
+    command "mount -o remount,size=10G /tmp/"
+    live_stream true
+    action :run
+  end
+end
+
 if platform?('centos')
   include_recipe '::old_vault'
 end

--- a/test/kitchen/site-cookbooks/dd-system-probe-check/recipes/linux.rb
+++ b/test/kitchen/site-cookbooks/dd-system-probe-check/recipes/linux.rb
@@ -6,6 +6,21 @@ execute "df -Th" do
   ignore_failure true
 end
 
+execute 'move tmp system probe data to root' do
+  command <<-EOF
+    df -Th /
+
+    mkdir /system-probe-tests
+    chmod 0777 /system-probe-tests
+    mv /tmp/system-probe-tests/* /system-probe-tests
+    rm -rf /tmp/system-probe-tests
+    ln -s /system-probe-tests /tmp/system-probe-tests
+  EOF
+  live_stream true
+  action :run
+  ignore_failure true
+end
+
 package 'growpart' do
   case node[:platform]
   when 'amazon', 'redhat', 'centos', 'fedora'

--- a/test/kitchen/site-cookbooks/dd-system-probe-check/recipes/linux_use_azure_mnt.rb
+++ b/test/kitchen/site-cookbooks/dd-system-probe-check/recipes/linux_use_azure_mnt.rb
@@ -7,6 +7,6 @@ script 'use mnt' do
   code <<-EOH
     mkdir -p #{mnt_path}/system-probe-tests
     chmod 0777 #{mnt_path}/system-probe-tests
-    ln -s #{mnt_path}/system-probe-tests /tmp/system-probe-tests
+    ln -s #{mnt_path}/system-probe-tests /system-probe-tests
   EOH
 end


### PR DESCRIPTION
### What does this PR do?

Increase /tmp size as kitchen and chef package are quite big this need to be earlier
May need update the root image in the future as the kitchen/chef pkgs/artifacts will not fit

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
