### PR TITLE
Create invoke tasks for bundle and component scaffolding

### DIFF
--- a/docs/components/components.md
+++ b/docs/components/components.md
@@ -52,7 +52,7 @@ There are utility functions available in `pkg/util/fxutil` to eliminate some com
 Let's consider sets and subsets of components.
 Each of the following sets is a subset of the previous set:
 
-1. All implemented components (everything in [`COMPONENTS.md`](../COMPONENTS.md))
+1. All implemented components (everything in [`COMPONENTS.md`](../../comp/README.md))
 1. All components in a binary (everything directly or indirectly referenced by a binary's `main()`) -- the _build-time dependencies_
 1. All components available in an app (everything provided by a bundle in the app's `fx.New` call)
 1. All components instantiated in an app (all explicitly required components and their transitive dependencies) -- the _runtime dependencies_

--- a/docs/components/defining-bundles.md
+++ b/docs/components/defining-bundles.md
@@ -27,7 +27,7 @@ The package must have the following defined in `bundle.go`:
 Typically, a bundle will automatically instantiate the top-level components that represent the bundle's purpose.
 For example, the trace-agent bundle `comp/trace` might automatically instantiate `comp/trace/agent`.
 
-You can use the invoke task `inv new-bundle comp/<bundleName>` to generate a pre-filled `bundle.go` file for the given bundle.
+You can use the invoke task `inv components.new-bundle comp/<bundleName>` to generate a pre-filled `bundle.go` file for the given bundle.
 
 ## Bundle Parameters
 

--- a/docs/components/defining-bundles.md
+++ b/docs/components/defining-bundles.md
@@ -27,6 +27,8 @@ The package must have the following defined in `bundle.go`:
 Typically, a bundle will automatically instantiate the top-level components that represent the bundle's purpose.
 For example, the trace-agent bundle `comp/trace` might automatically instantiate `comp/trace/agent`.
 
+You can use the invoke task `inv new-bundle comp/<bundleName>` to generate a pre-filled `bundle.go` file for the given bundle.
+
 ## Bundle Parameters
 
 Apps can provide some intialization-time parameters to bundles.

--- a/docs/components/defining-components.md
+++ b/docs/components/defining-components.md
@@ -77,6 +77,8 @@ If the list of return values grows unwieldy, `fx.Out` can be used to create an o
 
 The constructor may call methods on other components, as long as the called method's documentation indicates it is OK.
 
+You can use the invoke task `inv new-component comp/<bundleName>/<component>` to generate a pre-filled `component.go` file for the given component.
+
 ## Documentation
 
 The documentation (both package-level and method-level) should include everything a user of the component needs to know.
@@ -148,5 +150,6 @@ func (m *mock) AddedFoos() []Foo { ... }
 func newFoo(deps dependencies) Component {
     return &mock{ ... }
 }
+```
 
 Users of the mock module can cast the `Component` to a `Mock` to access the mock methods, as described in [Using Components](./using.md).

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -10,6 +10,7 @@ from . import (
     bench,
     cluster_agent,
     cluster_agent_cloudfoundry,
+    components,
     customaction,
     docker,
     dogstatsd,
@@ -29,7 +30,7 @@ from . import (
     vscode,
 )
 from .build_tags import audit_tag_impact, print_default_build_tags
-from .components import lint_components, new_bundle, new_component
+from .components import lint_components
 from .fuzz import fuzz
 from .go import (
     check_go_version,
@@ -75,8 +76,6 @@ ns.add_task(deps_vendored)
 ns.add_task(lint_licenses)
 ns.add_task(generate_licenses)
 ns.add_task(lint_components)
-ns.add_task(new_bundle)
-ns.add_task(new_component)
 ns.add_task(generate_protobuf)
 ns.add_task(reset)
 ns.add_task(lint_copyrights),
@@ -103,6 +102,7 @@ ns.add_task(fuzz)
 ns.add_collection(agent)
 ns.add_collection(cluster_agent)
 ns.add_collection(cluster_agent_cloudfoundry)
+ns.add_collection(components)
 ns.add_collection(customaction)
 ns.add_collection(bench)
 ns.add_collection(trace_agent)

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -29,7 +29,7 @@ from . import (
     vscode,
 )
 from .build_tags import audit_tag_impact, print_default_build_tags
-from .components import lint_components
+from .components import lint_components, new_bundle, new_component
 from .fuzz import fuzz
 from .go import (
     check_go_version,
@@ -75,6 +75,8 @@ ns.add_task(deps_vendored)
 ns.add_task(lint_licenses)
 ns.add_task(generate_licenses)
 ns.add_task(lint_components)
+ns.add_task(new_bundle)
+ns.add_task(new_component)
 ns.add_task(generate_protobuf)
 ns.add_task(reset)
 ns.add_task(lint_copyrights),

--- a/tasks/components.py
+++ b/tasks/components.py
@@ -252,10 +252,12 @@ def create_components_framework_files(comp_path, new_files, template_var_mapping
     if os.path.isdir(comp_path) and not overwrite:
         raise Exit(f"Error: Cannot create {component_name} {comp_type}: '{comp_path}' package already exists. Use `--overwrite` if you want to overwrite files in this package.", code=1)
 
-    # Create the root folder. We temporary set the umask to 0 to prevent 'os.makedirs' from given wrong permissions to subfolders
+    # Create the root folder. We temporary set the umask to 0 to prevent 'os.makedirs' from giving wrong permissions to subfolders
     try:
         print(f"Creating {comp_path} folder")
-        original_umask = os.umask(0)
+        # os.makedirs creates all parents directory with 0o777 permissions, 'mode' is only used for the leaf folder.
+        # We set the umask to create folder with 0o755 permissions instead of 0o777
+        original_umask = os.umask(0o022)
         os.makedirs(comp_path, mode=0o755, exist_ok=True)
     finally:
         os.umask(original_umask)

--- a/tasks/components.py
+++ b/tasks/components.py
@@ -199,7 +199,7 @@ def new_bundle(_, bundle_path, overwrite=False, team="/* TODO: add team name */"
     """
     Create a new bundle package with bundle.go and bundle_test.go files.
 
-    Notes: 
+    Notes:
         - This task must be called from the datadog-agent repository root folder.
         - 'bundle-path' is not modified by the task. You should explicitly set this to 'comp/...' if you want to create it in the right folder.
         - You can use the --team flag to set the team name for the new bundle.
@@ -207,7 +207,7 @@ def new_bundle(_, bundle_path, overwrite=False, team="/* TODO: add team name */"
     Examples:
         inv components.new-bundle comp/foo/bar             # Create the 'bar' bundle in the 'comp/foo' folder
         inv components.new-bundle comp/foo/bar --overwrite # Create the 'bar' bundle in the 'comp/foo' folder and overwrite 'comp/foo/bar/bundle{_test}.go' even if they already exist.
-        inv components.new-bundle /tmp/baz                 # Create the 'baz' bundle in the '/tmp/' folder. './comp' prefix is not enforced by the task. 
+        inv components.new-bundle /tmp/baz                 # Create the 'baz' bundle in the '/tmp/' folder. './comp' prefix is not enforced by the task.
     """
     template_var_mapping = {"BUNDLE_NAME": os.path.basename(bundle_path), "TEAM_NAME": team}
     create_components_framework_files(bundle_path, ["bundle.go", "bundle_test.go"], template_var_mapping, overwrite)
@@ -218,7 +218,7 @@ def new_component(_, comp_path, overwrite=False, team="/* TODO: add team name */
     """
     Create a new component package with the component.go file.
 
-    Notes: 
+    Notes:
         - This task must be called from the datadog-agent repository root folder.
         - 'comp-path' is not modified by the task. You should explicitly set this to 'comp/...' if you want to create it in the right folder.
         - You can use the --team flag to set the team name for the new component/
@@ -226,11 +226,11 @@ def new_component(_, comp_path, overwrite=False, team="/* TODO: add team name */
     Examples:
         inv components.new-component comp/foo/bar             # Create the 'bar' component in the 'comp/foo' folder
         inv components.new-component comp/foo/bar --overwrite # Create the 'bar' component in the 'comp/foo' folder and overwrite 'comp/foo/bar/component.go' even if it already exists
-        inv components.new-component /tmp/baz                 # Create the 'baz' component in the '/tmp/' folder. './comp' prefix is not enforced by the task. 
+        inv components.new-component /tmp/baz                 # Create the 'baz' component in the '/tmp/' folder. './comp' prefix is not enforced by the task.
     """
     template_var_mapping = {"COMPONENT_NAME": os.path.basename(comp_path), "TEAM_NAME": team}
     create_components_framework_files(comp_path, ["component.go"], template_var_mapping, overwrite)
-    
+
 
 def create_components_framework_files(comp_path, new_files, template_var_mapping, overwrite):
     """
@@ -248,11 +248,16 @@ def create_components_framework_files(comp_path, new_files, template_var_mapping
     comp_type = "component" if "COMPONENT_NAME" in template_var_mapping else "bundle"
 
     if not comp_path.startswith("comp/") and not comp_path.startswith("./comp/"):
-        print(f"Warn: Input path '{comp_path}' does not start with 'comp/'. Your {comp_type} might not be created in the right place.")
+        print(
+            f"Warn: Input path '{comp_path}' does not start with 'comp/'. Your {comp_type} might not be created in the right place."
+        )
 
     component_name = os.path.basename(comp_path)
     if os.path.isdir(comp_path) and not overwrite:
-        raise Exit(f"Error: Cannot create {component_name} {comp_type}: '{comp_path}' package already exists. Use `--overwrite` if you want to overwrite files in this package.", code=1)
+        raise Exit(
+            f"Error: Cannot create {component_name} {comp_type}: '{comp_path}' package already exists. Use `--overwrite` if you want to overwrite files in this package.",
+            code=1,
+        )
 
     # Create the root folder. We temporary set the umask to 0 to prevent 'os.makedirs' from giving wrong permissions to subfolders
     try:
@@ -281,21 +286,21 @@ def write_template(new_file_path, var_mapping, overwrite=False):
 
     var_mapping["COPYRIGHT_HEADER"] = COPYRIGHT_HEADER
     resolved_template = Template(raw_template_value).substitute(var_mapping)
-    
+
     # Fails if file exists and 'overwrite' is False
     mode = "w" if overwrite else "x"
     with open(new_file_path, mode) as file:
         file.write(resolved_template)
         print(f"Writing to {new_file_path}")
-        
+
 
 def get_template_path(file_path):
     """
-    Return a path to the template associated with 'file_path'. 
-    
-    Templates are static files containing variables whose value can be substituted at runtime. 
-    These templates are used to generate Golang files that are always the same except for some parts such as package name. 
-    
+    Return a path to the template associated with 'file_path'.
+
+    Templates are static files containing variables whose value can be substituted at runtime.
+    These templates are used to generate Golang files that are always the same except for some parts such as package name.
+
     These templates are located in the `tasks/components_templates` folder.
 
     For instance, if called with `component.go`, the functions returns 'tasks/components_templates/component.go.tmpl'
@@ -303,7 +308,7 @@ def get_template_path(file_path):
 
     template_folder_path = "tasks/components_templates/"
     template_name = os.path.basename(file_path) + ".tmpl"
-    return os.path.join(template_folder_path, template_name) 
+    return os.path.join(template_folder_path, template_name)
 
 
 def read_file_content(template_path):

--- a/tasks/components.py
+++ b/tasks/components.py
@@ -195,7 +195,7 @@ def lint_components(ctx, fix=False):
 
 
 @task
-def new_bundle(ctx, bundle_path, overwrite=False):
+def new_bundle(_, bundle_path, overwrite=False):
     """
     Create a new bundle package with bundle.go and bundle_test.go files.
 
@@ -213,7 +213,7 @@ def new_bundle(ctx, bundle_path, overwrite=False):
 
 
 @task
-def new_component(ctx, comp_path, overwrite=False):
+def new_component(_, comp_path, overwrite=False):
     """
     Create a new component package with the component.go file.
 
@@ -259,6 +259,8 @@ def create_components_framework_files(comp_path, new_files, template_var_mapping
         # We set the umask to create folder with 0o755 permissions instead of 0o777
         original_umask = os.umask(0o022)
         os.makedirs(comp_path, mode=0o755, exist_ok=True)
+    except Exception as err:
+        print(err)
     finally:
         os.umask(original_umask)
 

--- a/tasks/components.py
+++ b/tasks/components.py
@@ -204,9 +204,9 @@ def new_bundle(ctx, bundle_path, overwrite=False):
         - 'bundle-path' is not modified by the task. You should explicitly set this to 'comp/...' if you want to create it in the right folder.
 
     Examples:
-        inv new-bundle comp/foo/bar             # Create the 'bar' bundle in the 'comp/foo' folder
-        inv new-bundle comp/foo/bar --overwrite # Create the 'bar' bundle in the 'comp/foo' folder and overwrite 'comp/foo/bar/bundle{_test}.go' even if they already exist.
-        inv new-bundle /tmp/baz                 # Create the 'baz' bundle in the '/tmp/' folder. './comp' prefix is not enforced by the task. 
+        inv components.new-bundle comp/foo/bar             # Create the 'bar' bundle in the 'comp/foo' folder
+        inv components.new-bundle comp/foo/bar --overwrite # Create the 'bar' bundle in the 'comp/foo' folder and overwrite 'comp/foo/bar/bundle{_test}.go' even if they already exist.
+        inv components.new-bundle /tmp/baz                 # Create the 'baz' bundle in the '/tmp/' folder. './comp' prefix is not enforced by the task. 
     """
     template_var_mapping = {"BUNDLE_NAME": os.path.basename(bundle_path)} 
     create_components_framework_files(bundle_path, ["bundle.go", "bundle_test.go"], template_var_mapping, overwrite)
@@ -222,9 +222,9 @@ def new_component(ctx, comp_path, overwrite=False):
         - 'comp-path' is not modified by the task. You should explicitly set this to 'comp/...' if you want to create it in the right folder.
 
     Examples:
-        inv new-component comp/foo/bar             # Create the 'bar' component in the 'comp/foo' folder
-        inv new-component comp/foo/bar --overwrite # Create the 'bar' component in the 'comp/foo' folder and overwrite 'comp/foo/bar/component.go' even if it already exists
-        inv new-component /tmp/baz                 # Create the 'baz' component in the '/tmp/' folder. './comp' prefix is not enforced by the task. 
+        inv components.new-component comp/foo/bar             # Create the 'bar' component in the 'comp/foo' folder
+        inv components.new-component comp/foo/bar --overwrite # Create the 'bar' component in the 'comp/foo' folder and overwrite 'comp/foo/bar/component.go' even if it already exists
+        inv components.new-component /tmp/baz                 # Create the 'baz' component in the '/tmp/' folder. './comp' prefix is not enforced by the task. 
     """
     template_var_mapping = {"COMPONENT_NAME": os.path.basename(comp_path)} 
     create_components_framework_files(comp_path, ["component.go"], template_var_mapping, overwrite)
@@ -305,6 +305,4 @@ def read_file_content(template_path):
     Read all lines in files and return them as a single string.
     """
     with open(template_path, "r") as file:
-        content = file.readlines()
-
-    return "".join(content)
+        return file.read()

--- a/tasks/components.py
+++ b/tasks/components.py
@@ -195,38 +195,40 @@ def lint_components(ctx, fix=False):
 
 
 @task
-def new_bundle(_, bundle_path, overwrite=False):
+def new_bundle(_, bundle_path, overwrite=False, team="/* TODO: add team name */"):
     """
     Create a new bundle package with bundle.go and bundle_test.go files.
 
     Notes: 
         - This task must be called from the datadog-agent repository root folder.
         - 'bundle-path' is not modified by the task. You should explicitly set this to 'comp/...' if you want to create it in the right folder.
+        - You can use the --team flag to set the team name for the new bundle.
 
     Examples:
         inv components.new-bundle comp/foo/bar             # Create the 'bar' bundle in the 'comp/foo' folder
         inv components.new-bundle comp/foo/bar --overwrite # Create the 'bar' bundle in the 'comp/foo' folder and overwrite 'comp/foo/bar/bundle{_test}.go' even if they already exist.
         inv components.new-bundle /tmp/baz                 # Create the 'baz' bundle in the '/tmp/' folder. './comp' prefix is not enforced by the task. 
     """
-    template_var_mapping = {"BUNDLE_NAME": os.path.basename(bundle_path)} 
+    template_var_mapping = {"BUNDLE_NAME": os.path.basename(bundle_path), "TEAM_NAME": team}
     create_components_framework_files(bundle_path, ["bundle.go", "bundle_test.go"], template_var_mapping, overwrite)
 
 
 @task
-def new_component(_, comp_path, overwrite=False):
+def new_component(_, comp_path, overwrite=False, team="/* TODO: add team name */"):
     """
     Create a new component package with the component.go file.
 
     Notes: 
         - This task must be called from the datadog-agent repository root folder.
         - 'comp-path' is not modified by the task. You should explicitly set this to 'comp/...' if you want to create it in the right folder.
+        - You can use the --team flag to set the team name for the new component/
 
     Examples:
         inv components.new-component comp/foo/bar             # Create the 'bar' component in the 'comp/foo' folder
         inv components.new-component comp/foo/bar --overwrite # Create the 'bar' component in the 'comp/foo' folder and overwrite 'comp/foo/bar/component.go' even if it already exists
         inv components.new-component /tmp/baz                 # Create the 'baz' component in the '/tmp/' folder. './comp' prefix is not enforced by the task. 
     """
-    template_var_mapping = {"COMPONENT_NAME": os.path.basename(comp_path)} 
+    template_var_mapping = {"COMPONENT_NAME": os.path.basename(comp_path), "TEAM_NAME": team}
     create_components_framework_files(comp_path, ["component.go"], template_var_mapping, overwrite)
     
 

--- a/tasks/components.py
+++ b/tasks/components.py
@@ -2,9 +2,13 @@
 Invoke entrypoint, import here all the tasks we want to make available
 """
 from collections import namedtuple
+import os
+from string import Template
 
 from invoke import task
 from invoke.exceptions import Exit
+
+from tasks.libs.copyright import COPYRIGHT_HEADER
 
 Component = namedtuple('Component', ['path', 'doc', 'team'])
 Bundle = namedtuple('Component', ['path', 'doc', 'team', 'components'])
@@ -188,3 +192,119 @@ def lint_components(ctx, fix=False):
         if fixable:
             print("Run `inv lint-components --fix` to fix errors")
         raise Exit(code=1)
+
+
+@task
+def new_bundle(ctx, bundle_path, overwrite=False):
+    """
+    Create a new bundle package with bundle.go and bundle_test.go files.
+
+    Notes: 
+        - This task must be called from the datadog-agent repository root folder.
+        - 'bundle-path' is not modified by the task. You should explicitly set this to 'comp/...' if you want to create it in the right folder.
+
+    Examples:
+        inv new-bundle comp/foo/bar             # Create the 'bar' bundle in the 'comp/foo' folder
+        inv new-bundle comp/foo/bar --overwrite # Create the 'bar' bundle in the 'comp/foo' folder and overwrite 'comp/foo/bar/bundle{_test}.go' even if they already exist.
+        inv new-bundle /tmp/baz                 # Create the 'baz' bundle in the '/tmp/' folder. './comp' prefix is not enforced by the task. 
+    """
+    template_var_mapping = {"BUNDLE_NAME": os.path.basename(bundle_path)} 
+    create_components_framework_files(bundle_path, ["bundle.go", "bundle_test.go"], template_var_mapping, overwrite)
+
+
+@task
+def new_component(ctx, comp_path, overwrite=False):
+    """
+    Create a new component package with the component.go file.
+
+    Notes: 
+        - This task must be called from the datadog-agent repository root folder.
+        - 'comp-path' is not modified by the task. You should explicitly set this to 'comp/...' if you want to create it in the right folder.
+
+    Examples:
+        inv new-component comp/foo/bar             # Create the 'bar' component in the 'comp/foo' folder
+        inv new-component comp/foo/bar --overwrite # Create the 'bar' component in the 'comp/foo' folder and overwrite 'comp/foo/bar/component.go' even if it already exists
+        inv new-component /tmp/baz                 # Create the 'baz' component in the '/tmp/' folder. './comp' prefix is not enforced by the task. 
+    """
+    template_var_mapping = {"COMPONENT_NAME": os.path.basename(comp_path)} 
+    create_components_framework_files(comp_path, ["component.go"], template_var_mapping, overwrite)
+    
+
+def create_components_framework_files(comp_path, new_files, template_var_mapping, overwrite):
+    """
+    Create the folder and files common to all components and bundles.
+
+    First this function create the 'comp_path' folder. Then, for each file path in the 'new_files' list, it creates files
+    with a specific content. The content of each file is given by a predefined template located in the 'tasks/components_templates' folder.
+
+    These templates are Golang files with variables that can be substituted. These variables names and values are defined in the
+    'template_var_mapping' dictionary.
+
+    Lastly, 'overwrite' is a boolean which allows the tasks to erase files in 'new_files' if they already exists
+    """
+    # Only for logging purpose
+    comp_type = "component" if "COMPONENT_NAME" in template_var_mapping else "bundle"
+
+    if not comp_path.startswith("comp/") and not comp_path.startswith("./comp/"):
+        print(f"Warn: Input path '{comp_path}' does not start with 'comp/'. Your {comp_type} might not be created in the right place.")
+
+    component_name = os.path.basename(comp_path)
+    if os.path.isdir(comp_path) and not overwrite:
+        raise Exit(f"Error: Cannot create {component_name} {comp_type}: '{comp_path}' package already exists. Use `--overwrite` if you want to overwrite files in this package.", code=1)
+
+    # Create the root folder. We temporary set the umask to 0 to prevent 'os.makedirs' from given wrong permissions to subfolders
+    try:
+        print(f"Creating {comp_path} folder")
+        original_umask = os.umask(0)
+        os.makedirs(comp_path, mode=0o755, exist_ok=True)
+    finally:
+        os.umask(original_umask)
+
+    # Create the components framework common files from predefined templates
+    for filename in new_files:
+        write_template(f"{comp_path}/{filename}", template_var_mapping, overwrite)
+
+
+def write_template(new_file_path, var_mapping, overwrite=False):
+    """
+    Get the content of a templated file, substitute its variables and then writes the result into 'new_file_path' file.
+    """
+    # Get the content of the template and resolve it
+    template_path = get_template_path(new_file_path)
+    raw_template_value = read_file_content(template_path)
+
+    var_mapping["COPYRIGHT_HEADER"] = COPYRIGHT_HEADER
+    resolved_template = Template(raw_template_value).substitute(var_mapping)
+    
+    # Fails if file exists and 'overwrite' is False
+    mode = "w" if overwrite else "x"
+    with open(new_file_path, mode) as file:
+        file.write(resolved_template)
+        print(f"Writing to {new_file_path}")
+        
+
+def get_template_path(file_path):
+    """
+    Return a path to the template associated with 'file_path'. 
+    
+    Templates are static files containing variables whose value can be substituted at runtime. 
+    These templates are used to generate Golang files that are always the same except for some parts such as package name. 
+    
+    These templates are located in the `tasks/components_templates` folder.
+
+    For instance, if called with `component.go`, the functions returns 'tasks/components_templates/component.go.tmpl'
+    """
+
+    template_folder_path = "tasks/components_templates/"
+    template_name = os.path.basename(file_path) + ".tmpl"
+    return os.path.join(template_folder_path, template_name) 
+
+
+def read_file_content(template_path):
+    """
+    Read all lines in files and return them as a single string.
+    """
+    with open(template_path, "r") as file:
+        content = file.readlines()
+
+    return "".join(content)

--- a/tasks/components.py
+++ b/tasks/components.py
@@ -1,8 +1,8 @@
 """
 Invoke entrypoint, import here all the tasks we want to make available
 """
-from collections import namedtuple
 import os
+from collections import namedtuple
 from string import Template
 
 from invoke import task

--- a/tasks/components_templates/README.md
+++ b/tasks/components_templates/README.md
@@ -1,0 +1,4 @@
+This folder contains templates that are used by `new-bundle` and `new-component` tasks that are defined in [components.py](../components.py).
+
+These templates are used to generate Golang files when scaffolding a new bundle or component. They contain variables, defined as `${VAR_NAME}`, which
+are substituted with the `string.Template` python class.

--- a/tasks/components_templates/bundle.go.tmpl
+++ b/tasks/components_templates/bundle.go.tmpl
@@ -9,7 +9,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
-// team: /* TODO: add team name */
+// team: ${TEAM_NAME}
 
 // Bundle defines the fx options for this bundle.
 var Bundle = fxutil.Bundle(

--- a/tasks/components_templates/bundle.go.tmpl
+++ b/tasks/components_templates/bundle.go.tmpl
@@ -1,0 +1,17 @@
+${COPYRIGHT_HEADER}
+
+// Package ${BUNDLE_NAME} implements the "${BUNDLE_NAME}" bundle, 
+package ${BUNDLE_NAME}
+
+import (
+	"go.uber.org/fx"
+
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+// team: /* TODO: add team name */
+
+// Bundle defines the fx options for this bundle.
+var Bundle = fxutil.Bundle(
+    /* TODO: define your bundle */
+)

--- a/tasks/components_templates/bundle_test.go.tmpl
+++ b/tasks/components_templates/bundle_test.go.tmpl
@@ -1,0 +1,22 @@
+${COPYRIGHT_HEADER}
+
+package ${BUNDLE_NAME}
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/fx"
+)
+
+func TestBundleDependencies(t *testing.T) {
+	require.NoError(t, fx.ValidateApp(
+		// instantiate all of the ${BUNDLE_NAME} components, since this is not done
+		// automatically.
+		// fx.Invoke(func(<component1>) {}),
+		// fx.Invoke(func(<component2>) {}),
+
+		//fx.Supply(BundleParams{}),
+		//Bundle
+        ))
+}

--- a/tasks/components_templates/component.go.tmpl
+++ b/tasks/components_templates/component.go.tmpl
@@ -9,7 +9,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
-// team: /* TODO: add team name */
+// team: ${TEAM_NAME}
 
 // Component is the component type.
 type Component interface {

--- a/tasks/components_templates/component.go.tmpl
+++ b/tasks/components_templates/component.go.tmpl
@@ -1,0 +1,32 @@
+${COPYRIGHT_HEADER}
+
+// Package ${COMPONENT_NAME} ... /* TODO: detailed doc comment for the component */
+package ${COMPONENT_NAME}
+
+import (
+	"go.uber.org/fx"
+
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+// team: /* TODO: add team name */
+
+// Component is the component type.
+type Component interface {
+    /* TODO: define Component interface */
+}
+
+// Mock implements mock-specific methods.
+type Mock interface {
+	Component
+}
+
+// Module defines the fx options for this component.
+var Module = fxutil.Component(
+    fx.Provide(/* TODO: provide Component constructor */),
+)
+
+// MockModule defines the fx options for the mock component.
+var MockModule = fxutil.Component(
+	fx.Provide(newMock),
+)


### PR DESCRIPTION
### What does this PR do?

This PR adds two tasks to create basic component and bundle file architecture.

- `inv new-bundle comp/path/to/<bundleName>` create the folder `comp/path/to/<bundleName` with `bundle.go` and `bundle_test.go` inside
- `inv new-bundle comp/path/to/<component>` create the folder `inv new-bundle comp/path/to/<component>` with `component.go` inside

### Motivation

Quickly create component basic blocks

### Additional Notes

Should I use `ctx.run("mkdir -p ...")` instead of `os.makedirs` ?

### Possible Drawbacks / Trade-offs



### Describe how to test/QA your changes

N/A

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
