### PR TITLE
[corechecks/{containerimage,sbom}] Use queue of size 1 in tests to fix flakyness (#15466)

### DIFF
--- a/pkg/collector/corechecks/containerimage/processor_test.go
+++ b/pkg/collector/corechecks/containerimage/processor_test.go
@@ -10,81 +10,74 @@ import (
 	"time"
 
 	model "github.com/DataDog/agent-payload/v5/contimage"
-	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
-	"github.com/DataDog/datadog-agent/pkg/collector/check"
-	"github.com/DataDog/datadog-agent/pkg/util/pointer"
-	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
-
 	"github.com/golang/protobuf/ptypes/timestamp"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
-
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"go.uber.org/atomic"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
+	"github.com/DataDog/datadog-agent/pkg/util/pointer"
+	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 )
 
 func TestProcessEvents(t *testing.T) {
-	sender := mocksender.NewMockSender(check.ID(""))
-	sender.On("ContainerImage", mock.Anything, mock.Anything).Return()
-	p := newProcessor(sender, 2, 50*time.Millisecond)
-
-	p.processEvents(workloadmeta.EventBundle{
-		Events: []workloadmeta.Event{
-			{
-				Type: workloadmeta.EventTypeSet,
-				Entity: &workloadmeta.ContainerImageMetadata{
-					EntityID: workloadmeta.EntityID{
-						Kind: workloadmeta.KindContainerImageMetadata,
-						ID:   "sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
-					},
-					Registry:  "registry guessed by workloadmeta is ignored",
-					ShortName: "short name guessed by workloadmeta is ignored",
-					RepoTags: []string{
-						"datadog/agent:7-rc",
-						"datadog/agent:7.41.1-rc.1",
-						"gcr.io/datadoghq/agent:7-rc",
-						"gcr.io/datadoghq/agent:7.41.1-rc.1",
-						"public.ecr.aws/datadog/agent:7-rc",
-						"public.ecr.aws/datadog/agent:7.41.1-rc.1",
-					},
-					RepoDigests: []string{
-						"datadog/agent@sha256:052f1fdf4f9a7117d36a1838ab60782829947683007c34b69d4991576375c409",
-						"gcr.io/datadoghq/agent@sha256:052f1fdf4f9a7117d36a1838ab60782829947683007c34b69d4991576375c409",
-						"public.ecr.aws/datadog/agent@sha256:052f1fdf4f9a7117d36a1838ab60782829947683007c34b69d4991576375c409",
-					},
-					SizeBytes:    42,
-					OS:           "DOS",
-					OSVersion:    "6.22",
-					Architecture: "80486DX",
-					Layers: []workloadmeta.ContainerImageLayer{
-						{
-							MediaType: "media",
-							Digest:    "digest_layer_1",
-							SizeBytes: 43,
-							URLs:      []string{"url"},
-							History: v1.History{
-								Created: pointer.Ptr(time.Unix(42, 43)),
-							},
+	tests := []struct {
+		name           string
+		inputEvents    []workloadmeta.Event
+		expectedImages []*model.ContainerImage
+	}{
+		{
+			name: "standard case",
+			inputEvents: []workloadmeta.Event{
+				{
+					Type: workloadmeta.EventTypeSet,
+					Entity: &workloadmeta.ContainerImageMetadata{
+						EntityID: workloadmeta.EntityID{
+							Kind: workloadmeta.KindContainerImageMetadata,
+							ID:   "sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
 						},
-						{
-							MediaType: "media",
-							Digest:    "digest_layer_2",
-							URLs:      []string{"url"},
-							SizeBytes: 44,
-							History: v1.History{
-								Created: pointer.Ptr(time.Unix(43, 44)),
+						RepoTags: []string{
+							"datadog/agent:7-rc",
+							"datadog/agent:7.41.1-rc.1",
+							"gcr.io/datadoghq/agent:7-rc",
+							"gcr.io/datadoghq/agent:7.41.1-rc.1",
+							"public.ecr.aws/datadog/agent:7-rc",
+							"public.ecr.aws/datadog/agent:7.41.1-rc.1",
+						},
+						RepoDigests: []string{
+							"datadog/agent@sha256:052f1fdf4f9a7117d36a1838ab60782829947683007c34b69d4991576375c409",
+							"gcr.io/datadoghq/agent@sha256:052f1fdf4f9a7117d36a1838ab60782829947683007c34b69d4991576375c409",
+							"public.ecr.aws/datadog/agent@sha256:052f1fdf4f9a7117d36a1838ab60782829947683007c34b69d4991576375c409",
+						},
+						SizeBytes:    42,
+						OS:           "DOS",
+						OSVersion:    "6.22",
+						Architecture: "80486DX",
+						Layers: []workloadmeta.ContainerImageLayer{
+							{
+								MediaType: "media",
+								Digest:    "digest_layer_1",
+								SizeBytes: 43,
+								URLs:      []string{"url"},
+								History: v1.History{
+									Created: pointer.Ptr(time.Unix(42, 43)),
+								},
+							},
+							{
+								MediaType: "media",
+								Digest:    "digest_layer_2",
+								URLs:      []string{"url"},
+								SizeBytes: 44,
+								History: v1.History{
+									Created: pointer.Ptr(time.Unix(43, 44)),
+								},
 							},
 						},
 					},
 				},
 			},
-		},
-		Ch: make(chan struct{}),
-	})
-
-	sender.AssertNumberOfCalls(t, "ContainerImage", 1)
-	sender.AssertContainerImage(t, []model.ContainerImagePayload{
-		{
-			Version: "v1",
-			Images: []*model.ContainerImage{
+			expectedImages: []*model.ContainerImage{
 				{
 					Id:        "datadog/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
 					Name:      "datadog/agent",
@@ -181,17 +174,6 @@ func TestProcessEvents(t *testing.T) {
 						Nanos:   44,
 					},
 				},
-			},
-		},
-	})
-
-	time.Sleep(100 * time.Millisecond)
-
-	sender.AssertNumberOfCalls(t, "ContainerImage", 2)
-	sender.AssertContainerImage(t, []model.ContainerImagePayload{
-		{
-			Version: "v1",
-			Images: []*model.ContainerImage{
 				{
 					Id:        "public.ecr.aws/datadog/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
 					Name:      "public.ecr.aws/datadog/agent",
@@ -242,77 +224,58 @@ func TestProcessEvents(t *testing.T) {
 				},
 			},
 		},
-	})
-
-	p.stop()
-}
-
-func TestProcessEvents_repoTagWithNoMatchingRepoDigest(t *testing.T) {
-	// In containerd some images are created without a repo digest, and it's
-	// also possible to remove repo digests manually. To test that scenario, in
-	// this test, we define an image with 2 repo tags: one for the gcr.io
-	// registry and another for the public.ecr.aws registry, but there's only
-	// one repo digest.
-	// We expect to send 2 events, one for each registry.
-
-	sender := mocksender.NewMockSender("")
-	sender.On("ContainerImage", mock.Anything, mock.Anything).Return()
-	p := newProcessor(sender, 2, 50*time.Millisecond)
-
-	p.processEvents(workloadmeta.EventBundle{
-		Events: []workloadmeta.Event{
-			{
-				Type: workloadmeta.EventTypeSet,
-				Entity: &workloadmeta.ContainerImageMetadata{
-					EntityID: workloadmeta.EntityID{
-						Kind: workloadmeta.KindContainerImageMetadata,
-						ID:   "sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
-					},
-					RepoTags: []string{
-						"gcr.io/datadoghq/agent:7-rc",
-						"public.ecr.aws/datadog/agent:7-rc",
-					},
-					RepoDigests: []string{
-						// Notice that there's a repo tag for gcr.io, but no repo digest.
-						"public.ecr.aws/datadog/agent@sha256:052f1fdf4f9a7117d36a1838ab60782829947683007c34b69d4991576375c409",
-					},
-					SizeBytes:    42,
-					OS:           "DOS",
-					OSVersion:    "6.22",
-					Architecture: "80486DX",
-					Layers: []workloadmeta.ContainerImageLayer{
-						{
-							MediaType: "media",
-							Digest:    "digest_layer_1",
-							SizeBytes: 43,
-							URLs:      []string{"url"},
-							History: v1.History{
-								Created: pointer.Ptr(time.Unix(42, 43)),
-							},
+		{
+			// In containerd some images are created without a repo digest, and it's
+			// also possible to remove repo digests manually. To test that scenario, in
+			// this test, we define an image with 2 repo tags: one for the gcr.io
+			// registry and another for the public.ecr.aws registry, but there's only
+			// one repo digest.
+			// We expect to send 2 events, one for each registry.
+			name: "repo tag with no matching repo digest",
+			inputEvents: []workloadmeta.Event{
+				{
+					Type: workloadmeta.EventTypeSet,
+					Entity: &workloadmeta.ContainerImageMetadata{
+						EntityID: workloadmeta.EntityID{
+							Kind: workloadmeta.KindContainerImageMetadata,
+							ID:   "sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
 						},
-						{
-							MediaType: "media",
-							Digest:    "digest_layer_2",
-							URLs:      []string{"url"},
-							SizeBytes: 44,
-							History: v1.History{
-								Created: pointer.Ptr(time.Unix(43, 44)),
+						RepoTags: []string{
+							"gcr.io/datadoghq/agent:7-rc",
+							"public.ecr.aws/datadog/agent:7-rc",
+						},
+						RepoDigests: []string{
+							// Notice that there's a repo tag for gcr.io, but no repo digest.
+							"public.ecr.aws/datadog/agent@sha256:052f1fdf4f9a7117d36a1838ab60782829947683007c34b69d4991576375c409",
+						},
+						SizeBytes:    42,
+						OS:           "DOS",
+						OSVersion:    "6.22",
+						Architecture: "80486DX",
+						Layers: []workloadmeta.ContainerImageLayer{
+							{
+								MediaType: "media",
+								Digest:    "digest_layer_1",
+								SizeBytes: 43,
+								URLs:      []string{"url"},
+								History: v1.History{
+									Created: pointer.Ptr(time.Unix(42, 43)),
+								},
+							},
+							{
+								MediaType: "media",
+								Digest:    "digest_layer_2",
+								URLs:      []string{"url"},
+								SizeBytes: 44,
+								History: v1.History{
+									Created: pointer.Ptr(time.Unix(43, 44)),
+								},
 							},
 						},
 					},
 				},
 			},
-		},
-		Ch: make(chan struct{}),
-	})
-
-	time.Sleep(100 * time.Millisecond)
-
-	sender.AssertNumberOfCalls(t, "ContainerImage", 1)
-	sender.AssertContainerImage(t, []model.ContainerImagePayload{
-		{
-			Version: "v1",
-			Images: []*model.ContainerImage{
+			expectedImages: []*model.ContainerImage{
 				{
 					Id:        "public.ecr.aws/datadog/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
 					Name:      "public.ecr.aws/datadog/agent",
@@ -409,7 +372,42 @@ func TestProcessEvents_repoTagWithNoMatchingRepoDigest(t *testing.T) {
 				},
 			},
 		},
-	})
+	}
 
-	p.stop()
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var imagesSent = atomic.NewInt32(0)
+
+			sender := mocksender.NewMockSender("")
+			sender.On("ContainerImage", mock.Anything, mock.Anything).Return().Run(func(_ mock.Arguments) {
+				imagesSent.Inc()
+			})
+
+			// Define a max size of 1 for the queue. With a size > 1, it's difficult to
+			// control the number of events sent on each call.
+			p := newProcessor(sender, 1, 50*time.Millisecond)
+
+			p.processEvents(workloadmeta.EventBundle{
+				Events: test.inputEvents,
+				Ch:     make(chan struct{}),
+			})
+
+			p.stop()
+
+			// The queue is processing the events in a different go routine and might
+			// need some time
+			assert.Eventually(t, func() bool {
+				return imagesSent.Load() == int32(len(test.expectedImages))
+			}, 1*time.Second, 5*time.Millisecond)
+
+			for _, expectedImage := range test.expectedImages {
+				sender.AssertContainerImage(t, []model.ContainerImagePayload{
+					{
+						Version: "v1",
+						Images:  []*model.ContainerImage{expectedImage},
+					},
+				})
+			}
+		})
+	}
 }

--- a/pkg/collector/corechecks/sbom/processor_test.go
+++ b/pkg/collector/corechecks/sbom/processor_test.go
@@ -12,75 +12,71 @@ import (
 	"github.com/CycloneDX/cyclonedx-go"
 	"github.com/DataDog/agent-payload/v5/cyclonedx_v1_4"
 	model "github.com/DataDog/agent-payload/v5/sbom"
-	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
-	"github.com/DataDog/datadog-agent/pkg/collector/check"
-	"github.com/DataDog/datadog-agent/pkg/util/pointer"
-	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"go.uber.org/atomic"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
+	"github.com/DataDog/datadog-agent/pkg/util/pointer"
+	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 )
 
 func TestProcessEvents(t *testing.T) {
-	sender := mocksender.NewMockSender(check.ID(""))
-	sender.On("SBOM", mock.Anything, mock.Anything).Return()
-	p := newProcessor(sender, 2, 50*time.Millisecond)
-
 	sbomGenerationTime := time.Now()
 
-	p.processEvents(workloadmeta.EventBundle{
-		Events: []workloadmeta.Event{
-			{
-				Type: workloadmeta.EventTypeSet,
-				Entity: &workloadmeta.ContainerImageMetadata{
-					EntityID: workloadmeta.EntityID{
-						Kind: workloadmeta.KindContainerImageMetadata,
-						ID:   "sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
-					},
-					RepoTags: []string{
-						"datadog/agent:7-rc",
-						"datadog/agent:7.41.1-rc.1",
-						"gcr.io/datadoghq/agent:7-rc",
-						"gcr.io/datadoghq/agent:7.41.1-rc.1",
-						"public.ecr.aws/datadog/agent:7-rc",
-						"public.ecr.aws/datadog/agent:7.41.1-rc.1",
-					},
-					RepoDigests: []string{
-						"datadog/agent@sha256:052f1fdf4f9a7117d36a1838ab60782829947683007c34b69d4991576375c409",
-						"gcr.io/datadoghq/agent@sha256:052f1fdf4f9a7117d36a1838ab60782829947683007c34b69d4991576375c409",
-						"public.ecr.aws/datadog/agent@sha256:052f1fdf4f9a7117d36a1838ab60782829947683007c34b69d4991576375c409",
-					},
-					SBOM: &workloadmeta.SBOM{
-						CycloneDXBOM: &cyclonedx.BOM{
-							SpecVersion: cyclonedx.SpecVersion1_4,
-							Version:     42,
-							Components: &[]cyclonedx.Component{
-								{
-									Name: "Foo",
-								},
-								{
-									Name: "Bar",
-								},
-								{
-									Name: "Baz",
+	tests := []struct {
+		name          string
+		inputEvents   []workloadmeta.Event
+		expectedSBOMs []*model.SBOMEntity
+	}{
+		{
+			name: "standard case",
+			inputEvents: []workloadmeta.Event{
+				{
+					Type: workloadmeta.EventTypeSet,
+					Entity: &workloadmeta.ContainerImageMetadata{
+						EntityID: workloadmeta.EntityID{
+							Kind: workloadmeta.KindContainerImageMetadata,
+							ID:   "sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
+						},
+						RepoTags: []string{
+							"datadog/agent:7-rc",
+							"datadog/agent:7.41.1-rc.1",
+							"gcr.io/datadoghq/agent:7-rc",
+							"gcr.io/datadoghq/agent:7.41.1-rc.1",
+							"public.ecr.aws/datadog/agent:7-rc",
+							"public.ecr.aws/datadog/agent:7.41.1-rc.1",
+						},
+						RepoDigests: []string{
+							"datadog/agent@sha256:052f1fdf4f9a7117d36a1838ab60782829947683007c34b69d4991576375c409",
+							"gcr.io/datadoghq/agent@sha256:052f1fdf4f9a7117d36a1838ab60782829947683007c34b69d4991576375c409",
+							"public.ecr.aws/datadog/agent@sha256:052f1fdf4f9a7117d36a1838ab60782829947683007c34b69d4991576375c409",
+						},
+						SBOM: &workloadmeta.SBOM{
+							CycloneDXBOM: &cyclonedx.BOM{
+								SpecVersion: cyclonedx.SpecVersion1_4,
+								Version:     42,
+								Components: &[]cyclonedx.Component{
+									{
+										Name: "Foo",
+									},
+									{
+										Name: "Bar",
+									},
+									{
+										Name: "Baz",
+									},
 								},
 							},
+							GenerationTime:     sbomGenerationTime,
+							GenerationDuration: 10 * time.Second,
 						},
-						GenerationTime:     sbomGenerationTime,
-						GenerationDuration: 10 * time.Second,
 					},
 				},
 			},
-		},
-		Ch: make(chan struct{}),
-	})
-
-	sender.AssertNumberOfCalls(t, "SBOM", 1)
-	sender.AssertSBOM(t, []model.SBOMPayload{
-		{
-			Version: 1,
-			Source:  &sourceAgent,
-			Entities: []*model.SBOMEntity{
+			expectedSBOMs: []*model.SBOMEntity{
 				{
 					Type: model.SBOMSourceType_CONTAINER_IMAGE_LAYERS,
 					Id:   "datadog/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
@@ -137,18 +133,6 @@ func TestProcessEvents(t *testing.T) {
 						},
 					},
 				},
-			},
-		},
-	})
-
-	time.Sleep(100 * time.Millisecond)
-
-	sender.AssertNumberOfCalls(t, "SBOM", 2)
-	sender.AssertSBOM(t, []model.SBOMPayload{
-		{
-			Version: 1,
-			Source:  &sourceAgent,
-			Entities: []*model.SBOMEntity{
 				{
 					Type: model.SBOMSourceType_CONTAINER_IMAGE_LAYERS,
 					Id:   "public.ecr.aws/datadog/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
@@ -179,75 +163,53 @@ func TestProcessEvents(t *testing.T) {
 				},
 			},
 		},
-	})
-
-	p.stop()
-}
-
-func TestProcessEvents_repoTagWithNoMatchingRepoDigest(t *testing.T) {
-	// In containerd some images are created without a repo digest, and it's
-	// also possible to remove repo digests manually. To test that scenario, in
-	// this test, we define an image with 2 repo tags: one for the gcr.io
-	// registry and another for the public.ecr.aws registry, but there's only
-	// one repo digest.
-	// We expect to send 2 events, one for each registry.
-
-	sender := mocksender.NewMockSender("")
-	sender.On("SBOM", mock.Anything, mock.Anything).Return()
-	p := newProcessor(sender, 2, 50*time.Millisecond)
-
-	sbomGenerationTime := time.Now()
-
-	p.processEvents(workloadmeta.EventBundle{
-		Events: []workloadmeta.Event{
-			{
-				Type: workloadmeta.EventTypeSet,
-				Entity: &workloadmeta.ContainerImageMetadata{
-					EntityID: workloadmeta.EntityID{
-						Kind: workloadmeta.KindContainerImageMetadata,
-						ID:   "sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
-					},
-					RepoTags: []string{
-						"gcr.io/datadoghq/agent:7-rc",
-						"public.ecr.aws/datadog/agent:7-rc",
-					},
-					RepoDigests: []string{
-						// Notice that there's a repo tag for gcr.io, but no repo digest.
-						"public.ecr.aws/datadog/agent@sha256:052f1fdf4f9a7117d36a1838ab60782829947683007c34b69d4991576375c409",
-					},
-					SBOM: &workloadmeta.SBOM{
-						CycloneDXBOM: &cyclonedx.BOM{
-							SpecVersion: cyclonedx.SpecVersion1_4,
-							Version:     42,
-							Components: &[]cyclonedx.Component{
-								{
-									Name: "Foo",
-								},
-								{
-									Name: "Bar",
-								},
-								{
-									Name: "Baz",
+		{
+			// In containerd some images are created without a repo digest, and it's
+			// also possible to remove repo digests manually. To test that scenario, in
+			// this test, we define an image with 2 repo tags: one for the gcr.io
+			// registry and another for the public.ecr.aws registry, but there's only
+			// one repo digest.
+			// We expect to send 2 events, one for each registry.
+			name: "repo tag with no matching repo digest",
+			inputEvents: []workloadmeta.Event{
+				{
+					Type: workloadmeta.EventTypeSet,
+					Entity: &workloadmeta.ContainerImageMetadata{
+						EntityID: workloadmeta.EntityID{
+							Kind: workloadmeta.KindContainerImageMetadata,
+							ID:   "sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
+						},
+						RepoTags: []string{
+							"gcr.io/datadoghq/agent:7-rc",
+							"public.ecr.aws/datadog/agent:7-rc",
+						},
+						RepoDigests: []string{
+							// Notice that there's a repo tag for gcr.io, but no repo digest.
+							"public.ecr.aws/datadog/agent@sha256:052f1fdf4f9a7117d36a1838ab60782829947683007c34b69d4991576375c409",
+						},
+						SBOM: &workloadmeta.SBOM{
+							CycloneDXBOM: &cyclonedx.BOM{
+								SpecVersion: cyclonedx.SpecVersion1_4,
+								Version:     42,
+								Components: &[]cyclonedx.Component{
+									{
+										Name: "Foo",
+									},
+									{
+										Name: "Bar",
+									},
+									{
+										Name: "Baz",
+									},
 								},
 							},
+							GenerationTime:     sbomGenerationTime,
+							GenerationDuration: 10 * time.Second,
 						},
-						GenerationTime:     sbomGenerationTime,
-						GenerationDuration: 10 * time.Second,
 					},
 				},
 			},
-		},
-		Ch: make(chan struct{}),
-	})
-
-	time.Sleep(100 * time.Millisecond)
-
-	sender.AssertNumberOfCalls(t, "SBOM", 1)
-	sender.AssertSBOM(t, []model.SBOMPayload{
-		{
-			Version: 1,
-			Source:  &sourceAgent,
-			Entities: []*model.SBOMEntity{
+			expectedSBOMs: []*model.SBOMEntity{
 				{
 					Type: model.SBOMSourceType_CONTAINER_IMAGE_LAYERS,
 					Id:   "public.ecr.aws/datadog/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
@@ -304,7 +266,43 @@ func TestProcessEvents_repoTagWithNoMatchingRepoDigest(t *testing.T) {
 				},
 			},
 		},
-	})
+	}
 
-	p.stop()
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var SBOMsSent = atomic.NewInt32(0)
+
+			sender := mocksender.NewMockSender("")
+			sender.On("SBOM", mock.Anything, mock.Anything).Return().Run(func(_ mock.Arguments) {
+				SBOMsSent.Inc()
+			})
+
+			// Define a max size of 1 for the queue. With a size > 1, it's difficult to
+			// control the number of events sent on each call.
+			p := newProcessor(sender, 1, 50*time.Millisecond)
+
+			p.processEvents(workloadmeta.EventBundle{
+				Events: test.inputEvents,
+				Ch:     make(chan struct{}),
+			})
+
+			p.stop()
+
+			// The queue is processing the events in a different go routine and might
+			// need some time
+			assert.Eventually(t, func() bool {
+				return SBOMsSent.Load() == int32(len(test.expectedSBOMs))
+			}, 1*time.Second, 5*time.Millisecond)
+
+			for _, expectedSBOM := range test.expectedSBOMs {
+				sender.AssertSBOM(t, []model.SBOMPayload{
+					{
+						Version:  1,
+						Source:   &sourceAgent,
+						Entities: []*model.SBOMEntity{expectedSBOM},
+					},
+				})
+			}
+		})
+	}
 }


### PR DESCRIPTION
### What does this PR do?

* Backport #15466 to `7.43.x`

### Motivation

Avoid flaky tests on release branches.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
