### PR TITLE
Fixes incorrect err code from compressor.AddItem

### DIFF
--- a/pkg/serializer/internal/stream/compressor.go
+++ b/pkg/serializer/internal/stream/compressor.go
@@ -103,7 +103,10 @@ func NewCompressor(input, output *bytes.Buffer, maxPayloadSize, maxUncompressedS
 // that could actually fit after compression. That said it is probably impossible
 // to have a 2MB+ item that is valid for the backend.
 func (c *Compressor) checkItemSize(data []byte) bool {
-	return len(data) < c.maxUnzippedItemSize && compression.CompressBound(len(data)) < c.maxZippedItemSize
+	maxEffectivePayloadSize := (c.maxPayloadSize - len(c.footer) - len(c.header))
+	compressedWillFit := compression.CompressBound(len(data)) < c.maxZippedItemSize && compression.CompressBound(len(data)) < maxEffectivePayloadSize
+
+	return len(data) < c.maxUnzippedItemSize && compressedWillFit
 }
 
 // hasRoomForItem checks if the current payload has enough room to store the given item

--- a/pkg/util/compression/zlib.go
+++ b/pkg/util/compression/zlib.go
@@ -50,6 +50,8 @@ func Decompress(src []byte) ([]byte, error) {
 }
 
 // CompressBound returns the worst case size needed for a destination buffer
+// This is allowed to  return a value _larger_ than 'sourceLen'.
+// Ref: https://refspecs.linuxbase.org/LSB_3.0.0/LSB-Core-generic/LSB-Core-generic/zlib-compressbound-1.html
 func CompressBound(sourceLen int) int {
 	// From https://code.woboq.org/gcc/zlib/compress.c.html#compressBound
 	return sourceLen + (sourceLen >> 12) + (sourceLen >> 14) + (sourceLen >> 25) + 13

--- a/pkg/util/compression/zlib.go
+++ b/pkg/util/compression/zlib.go
@@ -50,7 +50,7 @@ func Decompress(src []byte) ([]byte, error) {
 }
 
 // CompressBound returns the worst case size needed for a destination buffer
-// This is allowed to  return a value _larger_ than 'sourceLen'.
+// This is allowed to return a value _larger_ than 'sourceLen'.
 // Ref: https://refspecs.linuxbase.org/LSB_3.0.0/LSB-Core-generic/LSB-Core-generic/zlib-compressbound-1.html
 func CompressBound(sourceLen int) int {
 	// From https://code.woboq.org/gcc/zlib/compress.c.html#compressBound


### PR DESCRIPTION
### What does this PR do?
This change ensures `compressor.AddItem` will return correct err code for the case where the compressor is empty.
With an empty compressor, `AddItem` should never return `ErrPayloadFull` and should always return `ErrItemTooBig` because there is no scenario where the item _would_ fit.

There are values for which `compressor.checkItemSize` would incorrectly return "ok" without this change. This change considers the `maxPayloadSize` (and header/footer overhead) in addition to the existing `maxItemSize` checks.

It is fair to wonder why checking `maxItemSize` is not enough, and the answer is that the `maxItemSize` is calculated from the constructor argument `maxUncompressedSize` whereas `maxPayloadSize` is a separate, unrelated argument.

### Motivation
During sketch serialization, the calling code appropriately handles the case where it tries to add an item that is too large, however it treats anything else (ie, `ErrPayloadFull`) as a fatal error and aborts the process, leading to a fallback to an older, less reliable codepath.
By returning the correct error code from `AddItem`, the calling codepath works as expected and can drop these payloads.

This indirectly fixes a "divide-by-zero" panic with a very specific sketch serialization bug where the metrics to be serialized are read properly by the first serialization pass, but this error is hit on the last metric, which leads to the fallback codepath being invoked with a collection of metrics that is _now empty_, leading to a divide by zero.

See https://github.com/DataDog/datadog-agent/pull/15614 for more fixes related to the aforementioned panic.

### Additional Notes
One alternative here would be a larger refactor to take `maxPayloadSize` into account when calculating `maxZippedItemSize`.
That would potentially get rid of the `maxUncompressedSize` argument in the compressor, and shrink the API of the compressor, but that would be a larger change with higher risk.

### Possible Drawbacks / Trade-offs


### Describe how to test/QA your changes
Use `lading` to submit sketches via dogstatsd. The following lading config is known to reproduce this type of failure without this change. Note that https://github.com/DataDog/datadog-agent/pull/15614 also fixes this and QA for these two are the same.

1. Clone and build [`lading`](https://github.com/DataDog/lading) from the specified commit
    a. `git clone git@github.com:DataDog/lading.git`
    b. `cd lading && git checkout 2e8462ab60fff6630d1e8138176735f07a37ce4d`
    c. `cargo build`
3. Using the below configs, run lading against the RC build and ensure that there are no errors in the agent logs and there is no panic during execution.

Lading cmd:
`./target/debug/lading --experiment-duration-seconds 400 --config-path=./lading.yaml --target-stderr-path=./stderr.txt --target-stdout-path=./stdout.txt  --target-path ~/dev/datadog-agent/bin/agent/agent -- -c ./agent-under-test-config.yaml run`

`lading.yaml`:
```
generator:
  - unix_datagram:
      seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
             59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
      path: "/tmp/dsd.socket"
      variant: "dogstatsd"
      bytes_per_second: "256 Kb"
      block_sizes: ["256b", "512b", "1Kb", "2Kb", "3Kb", "4Kb", "5Kb", "6Kb"]
      maximum_prebuild_cache_size_bytes: "500 Mb"

blackhole:
  - http:
      binding_addr: "127.0.0.1:9091"
  - http:
      binding_addr: "127.0.0.1:9092"
```

`datadog.yaml`:
```
api_key: 00000000000000000000000000000000
auth_token_file_path: /tmp/agent-auth-token
hostname: smp-regression
log_level: debug

dd_url: http://127.0.0.1:9092

confd_path: /etc/datadog-agent/conf.d

# Disable cloud detection. This stops the Agent from poking around the
# execution environment & network. This is particularly important if the target
# has network access.
cloud_provider_metadata: []

dogstatsd_socket: '/tmp/dsd.socket'
```


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
