### PR TITLE
Fixes for partial sketch serialization

### DIFF
--- a/pkg/serializer/internal/metrics/series_test.go
+++ b/pkg/serializer/internal/metrics/series_test.go
@@ -308,7 +308,7 @@ func makeSeries(numItems, numPoints int) *IterableSeries {
 func TestMarshalSplitCompress(t *testing.T) {
 	series := makeSeries(10000, 50)
 
-	payloads, err := series.MarshalSplitCompress(marshaler.DefaultBufferContext())
+	payloads, err := series.MarshalSplitCompress(marshaler.NewBufferContext())
 	require.NoError(t, err)
 	// check that we got multiple payloads, so splitting occurred
 	require.Greater(t, len(payloads), 1)
@@ -331,7 +331,7 @@ func TestMarshalSplitCompressPointsLimit(t *testing.T) {
 	// ten series, each with 50 points, so two should fit in each payload
 	series := makeSeries(10, 50)
 
-	payloads, err := series.MarshalSplitCompress(marshaler.DefaultBufferContext())
+	payloads, err := series.MarshalSplitCompress(marshaler.NewBufferContext())
 	require.NoError(t, err)
 	require.Equal(t, 5, len(payloads))
 }
@@ -343,7 +343,7 @@ func TestMarshalSplitCompressPointsLimitTooBig(t *testing.T) {
 	mockConfig.Set("serializer_max_series_points_per_payload", 1)
 
 	series := makeSeries(1, 2)
-	payloads, err := series.MarshalSplitCompress(marshaler.DefaultBufferContext())
+	payloads, err := series.MarshalSplitCompress(marshaler.NewBufferContext())
 	require.NoError(t, err)
 	require.Len(t, payloads, 0)
 }

--- a/pkg/serializer/internal/metrics/sketch_benchmark_test.go
+++ b/pkg/serializer/internal/metrics/sketch_benchmark_test.go
@@ -43,7 +43,7 @@ func benchmarkSplitPayloadsSketchesNew(b *testing.B, numPoints int) {
 	b.ResetTimer()
 
 	for n := 0; n < b.N; n++ {
-		payloads, err := serializer.MarshalSplitCompress(marshaler.DefaultBufferContext())
+		payloads, err := serializer.MarshalSplitCompress(marshaler.NewBufferContext())
 		require.NoError(b, err)
 		var pb int
 		for _, p := range payloads {

--- a/pkg/serializer/internal/metrics/sketch_series_list.go
+++ b/pkg/serializer/internal/metrics/sketch_series_list.go
@@ -8,7 +8,6 @@ package metrics
 import (
 	"bytes"
 	"expvar"
-	"fmt"
 
 	"github.com/DataDog/agent-payload/v5/gogen"
 	"github.com/richardartoul/molecule"
@@ -326,7 +325,7 @@ func (sl SketchSeriesList) SplitPayload(times int) ([]marshaler.AbstractMarshale
 		sketches = append(sketches, ss)
 	}
 	if len(sketches) == 0 {
-		return nil, fmt.Errorf("Not possible to split payload since all sketches have been read already")
+		return []marshaler.AbstractMarshaler{}, nil
 	}
 	return sketches.SplitPayload(times)
 }

--- a/pkg/serializer/internal/metrics/sketch_series_list.go
+++ b/pkg/serializer/internal/metrics/sketch_series_list.go
@@ -8,6 +8,7 @@ package metrics
 import (
 	"bytes"
 	"expvar"
+	"fmt"
 
 	"github.com/DataDog/agent-payload/v5/gogen"
 	"github.com/richardartoul/molecule"
@@ -323,6 +324,9 @@ func (sl SketchSeriesList) SplitPayload(times int) ([]marshaler.AbstractMarshale
 	for sl.MoveNext() {
 		ss := sl.Current()
 		sketches = append(sketches, ss)
+	}
+	if len(sketches) == 0 {
+		return nil, fmt.Errorf("Not possible to split payload since all sketches have been read already")
 	}
 	return sketches.SplitPayload(times)
 }

--- a/pkg/serializer/internal/metrics/sketch_series_list.go
+++ b/pkg/serializer/internal/metrics/sketch_series_list.go
@@ -18,6 +18,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/serializer/internal/stream"
 	"github.com/DataDog/datadog-agent/pkg/serializer/marshaler"
 	"github.com/DataDog/datadog-agent/pkg/telemetry"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // A SketchSeriesList implements marshaler.Marshaler
@@ -252,6 +253,7 @@ func (sl SketchSeriesList) MarshalSplitCompress(bufferContext *marshaler.BufferC
 				// Unexpected error bail out
 				expvarsUnexpectedItemDrops.Add(1)
 				tlmUnexpectedItemDrops.Inc()
+				log.Debugf("Unexpected error trying to addItem to new payload after previous payload filled up: %v", err)
 				return nil, err
 			}
 			pointCount += len(ss.Points)
@@ -266,12 +268,14 @@ func (sl SketchSeriesList) MarshalSplitCompress(bufferContext *marshaler.BufferC
 			// Unexpected error bail out
 			expvarsUnexpectedItemDrops.Add(1)
 			tlmUnexpectedItemDrops.Inc()
+			log.Debugf("Unexpected error: %v", err)
 			return nil, err
 		}
 	}
 
 	err = finishPayload()
 	if err != nil {
+		log.Debugf("Failed to finish payload with err %v", err)
 		return nil, err
 	}
 

--- a/pkg/serializer/internal/metrics/sketch_series_test.go
+++ b/pkg/serializer/internal/metrics/sketch_series_test.go
@@ -86,8 +86,9 @@ func TestSketchSeriesListMarshal(t *testing.T) {
 
 func TestSketchSeriesSplitEmptyPayload(t *testing.T) {
 	sl := SketchSeriesList{SketchesSource: metrics.NewSketchesSourceTest()}
-	_, err := sl.SplitPayload(10)
-	require.Error(t, err)
+	pieces, err := sl.SplitPayload(10)
+	require.Len(t, pieces, 0)
+	require.Nil(t, err)
 }
 
 func TestSketchSeriesMarshalSplitCompressEmpty(t *testing.T) {

--- a/pkg/serializer/internal/metrics/sketch_series_test.go
+++ b/pkg/serializer/internal/metrics/sketch_series_test.go
@@ -88,7 +88,7 @@ func TestSketchSeriesMarshalSplitCompressEmpty(t *testing.T) {
 
 	sl := SketchSeriesList{SketchesSource: metrics.NewSketchesSourceTest()}
 	payload, _ := sl.Marshal()
-	payloads, err := sl.MarshalSplitCompress(marshaler.DefaultBufferContext())
+	payloads, err := sl.MarshalSplitCompress(marshaler.NewBufferContext())
 
 	assert.Nil(t, err)
 
@@ -122,7 +122,7 @@ func TestSketchSeriesMarshalSplitCompressItemTooBigIsDropped(t *testing.T) {
 	})
 
 	serializer := SketchSeriesList{SketchesSource: sl}
-	payloads, err := serializer.MarshalSplitCompress(marshaler.DefaultBufferContext())
+	payloads, err := serializer.MarshalSplitCompress(marshaler.NewBufferContext())
 
 	assert.Nil(t, err)
 
@@ -153,7 +153,7 @@ func TestSketchSeriesMarshalSplitCompress(t *testing.T) {
 	payload, _ := serializer1.Marshal()
 	sl.Reset()
 	serializer2 := SketchSeriesList{SketchesSource: sl}
-	payloads, err := serializer2.MarshalSplitCompress(marshaler.DefaultBufferContext())
+	payloads, err := serializer2.MarshalSplitCompress(marshaler.NewBufferContext())
 	require.NoError(t, err)
 
 	firstPayload := payloads[0]
@@ -203,7 +203,7 @@ func TestSketchSeriesMarshalSplitCompressSplit(t *testing.T) {
 	}
 
 	serializer := SketchSeriesList{SketchesSource: sl}
-	payloads, err := serializer.MarshalSplitCompress(marshaler.DefaultBufferContext())
+	payloads, err := serializer.MarshalSplitCompress(marshaler.NewBufferContext())
 	assert.Nil(t, err)
 
 	recoveredSketches := []gogen.SketchPayload{}

--- a/pkg/serializer/internal/metrics/sketch_series_test.go
+++ b/pkg/serializer/internal/metrics/sketch_series_test.go
@@ -84,6 +84,12 @@ func TestSketchSeriesListMarshal(t *testing.T) {
 	}
 }
 
+func TestSketchSeriesSplitEmptyPayload(t *testing.T) {
+	sl := SketchSeriesList{SketchesSource: metrics.NewSketchesSourceTest()}
+	_, err := sl.SplitPayload(10)
+	require.Error(t, err)
+}
+
 func TestSketchSeriesMarshalSplitCompressEmpty(t *testing.T) {
 
 	sl := SketchSeriesList{SketchesSource: metrics.NewSketchesSourceTest()}

--- a/pkg/serializer/marshaler/marshaler.go
+++ b/pkg/serializer/marshaler/marshaler.go
@@ -67,8 +67,8 @@ type BufferContext struct {
 	PrecompressionBuf *bytes.Buffer
 }
 
-// DefaultBufferContext initialize the default compression buffers
-func DefaultBufferContext() *BufferContext {
+// NewBufferContext initialize the default compression buffers
+func NewBufferContext() *BufferContext {
 	return &BufferContext{
 		bytes.NewBuffer(make([]byte, 0, 1024)),
 		bytes.NewBuffer(make([]byte, 0, 1024)),

--- a/pkg/serializer/serializer.go
+++ b/pkg/serializer/serializer.go
@@ -336,7 +336,7 @@ func (s *Serializer) SendIterableSeries(serieSource metrics.SerieSource) error {
 	} else if useV1API && !s.enableJSONStream {
 		seriesBytesPayloads, extraHeaders, err = s.serializePayloadJSON(seriesSerializer, true)
 	} else {
-		seriesBytesPayloads, err = seriesSerializer.MarshalSplitCompress(marshaler.DefaultBufferContext())
+		seriesBytesPayloads, err = seriesSerializer.MarshalSplitCompress(marshaler.NewBufferContext())
 		extraHeaders = protobufExtraHeadersWithCompression
 	}
 
@@ -363,7 +363,7 @@ func (s *Serializer) SendSketch(sketches metrics.SketchesSource) error {
 	}
 	sketchesSerializer := metricsserializer.SketchSeriesList{SketchesSource: sketches}
 	if s.enableSketchProtobufStream {
-		payloads, err := sketchesSerializer.MarshalSplitCompress(marshaler.DefaultBufferContext())
+		payloads, err := sketchesSerializer.MarshalSplitCompress(marshaler.NewBufferContext())
 		if err == nil {
 			return s.Forwarder.SubmitSketchSeries(payloads, protobufExtraHeadersWithCompression)
 		}

--- a/pkg/serializer/serializer.go
+++ b/pkg/serializer/serializer.go
@@ -369,7 +369,7 @@ func (s *Serializer) SendSketch(sketches metrics.SketchesSource) error {
 	if s.enableSketchProtobufStream {
 		payloads, err := sketchesSerializer.MarshalSplitCompress(marshaler.NewBufferContext())
 		if err != nil {
-			log.Errorf("dropping sketch payload: %v", err)
+			return fmt.Errorf("dropping sketch payload: %v", err)
 		}
 
 		return s.Forwarder.SubmitSketchSeries(payloads, protobufExtraHeadersWithCompression)

--- a/pkg/serializer/serializer.go
+++ b/pkg/serializer/serializer.go
@@ -172,7 +172,7 @@ func NewSerializer(forwarder forwarder.Forwarder, orchestratorForwarder, contlcy
 	}
 
 	if !config.Datadog.GetBool("enable_sketch_stream_payload_serialization") {
-		log.Warn("'enable_sketch_stream_payload_serialization' is set to false which is not recommended. This option will be deprecated and removed in the future. If you need this option, please reach out to support or file an issue on github.com/DataDog/datadog-agent")
+		log.Warn("'enable_sketch_stream_payload_serialization' is set to false which is not recommended. This option is deprecated and will removed in the future. If you need this option, please reach out to support")
 	}
 
 	return s

--- a/pkg/serializer/series_benchmark_test.go
+++ b/pkg/serializer/series_benchmark_test.go
@@ -74,7 +74,7 @@ func BenchmarkSeries(b *testing.B) {
 			b.ReportMetric(float64(payloadCompressedSize)/float64(b.N), "compressed-payload-bytes")
 		}
 	}
-	bufferContext := marshaler.DefaultBufferContext()
+	bufferContext := marshaler.NewBufferContext()
 	pb := func(series metrics.Series) (transaction.BytesPayloads, error) {
 		iterableSeries := metricsserializer.CreateIterableSeries(metricsserializer.CreateSerieSource(series))
 		return iterableSeries.MarshalSplitCompress(bufferContext)

--- a/releasenotes/notes/fix-partial-serialization-abdb58352ddfe757.yaml
+++ b/releasenotes/notes/fix-partial-serialization-abdb58352ddfe757.yaml
@@ -9,3 +9,6 @@
 fixes:
   - |
     Fixes a divide-by-zero panic when sketch serialization fails on the last metric of a given batch
+
+deprecations:
+  - Configuration ``enable_sketch_stream_payload_serialization`` is now deprecated.

--- a/releasenotes/notes/fix-partial-serialization-abdb58352ddfe757.yaml
+++ b/releasenotes/notes/fix-partial-serialization-abdb58352ddfe757.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixes a bug where some sketch payloads may not be submitted if an error occurs during serialization
+  - |
+    Fixes a divide-by-zero panic when sketch serialization fails on the last metric of a given batch

--- a/releasenotes/notes/fix-partial-serialization-abdb58352ddfe757.yaml
+++ b/releasenotes/notes/fix-partial-serialization-abdb58352ddfe757.yaml
@@ -8,6 +8,4 @@
 ---
 fixes:
   - |
-    Fixes a bug where some sketch payloads may not be submitted if an error occurs during serialization
-  - |
     Fixes a divide-by-zero panic when sketch serialization fails on the last metric of a given batch


### PR DESCRIPTION
### What does this PR do?
Removes a fallback to an older serialization strategy if the newer approach fails. 
Also fixes a bug when `serializePayloadProto` is called with an empty `SketchSeriesList`. Previously this could cause `split.SplitPayloads` to be called with an empty payload, leading to a runtime `divide-by-zero` panic. Fixed by 1e358031cf84ecad8ea0d5a8f9af6bbce2a58033

### Motivation
Investigating runtime divide-by-zero panic.

### Additional Notes
Two related changes that are not directly bug fixes: renaming a confusingly-named function and extra debug logging that could be useful for future issues are split out into separate commits.

### Possible Drawbacks / Trade-offs


### Describe how to test/QA your changes
Use `lading` to submit sketches via dogstatsd. The following lading config is known to reproduce this type of failure without this change. Note that https://github.com/DataDog/datadog-agent/pull/15613 also fixes this and QA for these two are the same.

1. Clone and build [`lading`](https://github.com/DataDog/lading) from the specified commit
    a. `git clone git@github.com:DataDog/lading.git`
    b. `cd lading && git checkout 2e8462ab60fff6630d1e8138176735f07a37ce4d`
    c. `cargo build`
3. Using the below configs, run lading against the RC build and ensure that there are no errors in the agent logs and there is no panic during execution.

Lading cmd:
`./target/debug/lading --experiment-duration-seconds 400 --config-path=./lading.yaml --target-stderr-path=./stderr.txt --target-stdout-path=./stdout.txt  --target-path ~/dev/datadog-agent/bin/agent/agent -- -c ./agent-under-test-config.yaml run`

`lading.yaml`:
```
generator:
  - unix_datagram:
      seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
             59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
      path: "/tmp/dsd.socket"
      variant: "dogstatsd"
      bytes_per_second: "256 Kb"
      block_sizes: ["256b", "512b", "1Kb", "2Kb", "3Kb", "4Kb", "5Kb", "6Kb"]
      maximum_prebuild_cache_size_bytes: "500 Mb"

blackhole:
  - http:
      binding_addr: "127.0.0.1:9091"
  - http:
      binding_addr: "127.0.0.1:9092"
```

`datadog.yaml`:
```
api_key: 00000000000000000000000000000000
auth_token_file_path: /tmp/agent-auth-token
hostname: smp-regression
log_level: debug

dd_url: http://127.0.0.1:9092

confd_path: /etc/datadog-agent/conf.d

# Disable cloud detection. This stops the Agent from poking around the
# execution environment & network. This is particularly important if the target
# has network access.
cloud_provider_metadata: []

dogstatsd_socket: '/tmp/dsd.socket'
```

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
