### PR TITLE
[workloadmeta/telemetry] Add pull duration histogram

### DIFF
--- a/pkg/workloadmeta/store.go
+++ b/pkg/workloadmeta/store.go
@@ -442,6 +442,8 @@ func (s *store) pull(ctx context.Context) {
 			}
 
 			s.ongoingPullsMut.Lock()
+			pullDuration := time.Now().Sub(s.ongoingPulls[id])
+			telemetry.PullDuration.Observe(pullDuration.Seconds(), id)
 			s.ongoingPulls[id] = time.Time{}
 			s.ongoingPullsMut.Unlock()
 		}(id, c)

--- a/pkg/workloadmeta/telemetry/telemetry.go
+++ b/pkg/workloadmeta/telemetry/telemetry.go
@@ -56,6 +56,17 @@ var (
 		commonOpts,
 	)
 
+	// PullDuration measures the time that it takes to pull from the
+	// workloadmeta collectors.
+	PullDuration = telemetry.NewHistogramWithOpts(
+		subsystem,
+		"pull_duration",
+		[]string{"collector_id"},
+		"The time it takes to pull from the collectors (in seconds)",
+		[]float64{0.25, 0.5, 0.75, 1, 2, 5, 10, 15, 30, 45, 60},
+		commonOpts,
+	)
+
 	// NotificationsSent tracks the number of notifications sent from the
 	// workloadmeta store to its subscribers. Note that each notification can
 	// include multiple events.

--- a/releasenotes/notes/workloadmeta-telemetry-pull-duration-e88b0b61fe5938c2.yaml
+++ b/releasenotes/notes/workloadmeta-telemetry-pull-duration-e88b0b61fe5938c2.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Added the "pull_duration" metric in the workloadmeta telemetry. It measures
+    the time that it takes to pull from the collectors.


### PR DESCRIPTION

### What does this PR do?

Adds the "pull_duration" metric in the workloadmeta telemetry. It measures the time that it takes to pull from the collectors.

It might be useful to debug slow collectors.


### Describe how to test/QA your changes

Deploy with telemetry enabled (`DD_TELEMETRY_ENABLED=true`). Check that the `workloadmeta_pull_duration` histogram appears in `http://localhost:6000/telemetry`.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
