### PR TITLE
Allow controlling whether to create stack or not

### DIFF
--- a/test/new-e2e/ndm/snmp/snmpTestEnv.go
+++ b/test/new-e2e/ndm/snmp/snmpTestEnv.go
@@ -102,7 +102,7 @@ func NewTestEnv(name, keyPairName, ddAPIKey, ddAPPKey string) (*TestEnv, error) 
 		composeDependencies = append(composeDependencies, fileCommands...)
 		_, err = agent.NewDockerAgentInstallation(vm.CommonEnvironment, vm.DockerManager, snmpCompose, envVars, pulumi.DependsOn(composeDependencies))
 		return err
-	})
+	}, true)
 
 	if err != nil {
 		return nil, err

--- a/test/new-e2e/ndm/snmp/snmpTestEnv.go
+++ b/test/new-e2e/ndm/snmp/snmpTestEnv.go
@@ -102,7 +102,7 @@ func NewTestEnv(name, keyPairName, ddAPIKey, ddAPPKey string) (*TestEnv, error) 
 		composeDependencies = append(composeDependencies, fileCommands...)
 		_, err = agent.NewDockerAgentInstallation(vm.CommonEnvironment, vm.DockerManager, snmpCompose, envVars, pulumi.DependsOn(composeDependencies))
 		return err
-	}, true)
+	}, false)
 
 	if err != nil {
 		return nil, err

--- a/test/new-e2e/utils/infra/stack_manager.go
+++ b/test/new-e2e/utils/infra/stack_manager.go
@@ -60,14 +60,14 @@ func newStackManager(ctx context.Context) (*StackManager, error) {
 	}, nil
 }
 
-func getNewStack(ctx context.Context, name, project string, deployFunc pulumi.RunFunc, create bool) (auto.Stack, error) {
+func getNewStack(ctx context.Context, name, project string, deployFunc pulumi.RunFunc, failOnMissing bool) (auto.Stack, error) {
 	var newStack auto.Stack
 	var err error
 
-	if create {
-		newStack, err = auto.UpsertStackInlineSource(ctx, name, projectName, deployFunc)
-	} else {
+	if failOnMissing {
 		newStack, err = auto.SelectStackInlineSource(ctx, name, projectName, deployFunc)
+	} else {
+		newStack, err = auto.UpsertStackInlineSource(ctx, name, projectName, deployFunc)
 	}
 	if err != nil {
 		return auto.Stack{}, err
@@ -77,7 +77,7 @@ func getNewStack(ctx context.Context, name, project string, deployFunc pulumi.Ru
 }
 
 // GetStack creates or return a stack based on env+stack name
-func (sm *StackManager) GetStack(ctx context.Context, envName string, name string, config auto.ConfigMap, deployFunc pulumi.RunFunc, create bool) (auto.UpResult, error) {
+func (sm *StackManager) GetStack(ctx context.Context, envName string, name string, config auto.ConfigMap, deployFunc pulumi.RunFunc, failOnMissing bool) (auto.UpResult, error) {
 	sm.lock.RLock()
 	defer sm.lock.RUnlock()
 
@@ -91,7 +91,7 @@ func (sm *StackManager) GetStack(ctx context.Context, envName string, name strin
 	stackID := stackID(envName, name)
 	stack := sm.stacks[stackID]
 	if stack == nil {
-		newStack, err := getNewStack(ctx, finalStackName, projectName, deployFunc, create)
+		newStack, err := getNewStack(ctx, finalStackName, projectName, deployFunc, failOnMissing)
 		if err != nil {
 			return auto.UpResult{}, err
 		}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
This PR adds a new parameter to the GetStack function which controls whether to create the stack if not present, or fail.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
The ebpf-platform team has a scenario which destroys the stack in the CI, in a different job from the one in which it is created. In order to avoid bugs where the destruction process creates a new stack, rather than selecting the intended one, this change allows the user to explicitly specify whether a new stack should be created or not.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
