### PR TITLE
Seperate kitchen-prepare and linting into seperate jobs

### DIFF
--- a/.gitlab/functional_test/security_agent.yml
+++ b/.gitlab/functional_test/security_agent.yml
@@ -25,7 +25,7 @@ kitchen_test_security_agent_x64:
     - .kitchen_test_security_agent
     - .kitchen_azure_x64
     - .kitchen_azure_location_north_central_us
-  needs: ["tests_ebpf_x64", "prepare_ebpf_tests_x64"]
+  needs: ["tests_ebpf_x64", "prepare_ebpf_functional_tests_x64"]
   variables:
     KITCHEN_ARCH: x86_64
   before_script:
@@ -68,7 +68,7 @@ kitchen_test_security_agent_arm64:
     - .kitchen_ec2_spot_instances
   rules:
     !reference [.on_security_agent_changes_or_manual]
-  needs: [ "tests_ebpf_arm64", "prepare_ebpf_tests_arm64" ]
+  needs: [ "tests_ebpf_arm64", "prepare_ebpf_functional_tests_arm64" ]
   variables:
     KITCHEN_ARCH: arm64
     KITCHEN_EC2_INSTANCE_TYPE: "t4g.xlarge"
@@ -88,7 +88,7 @@ kitchen_test_security_agent_amazonlinux_x64:
     - .kitchen_ec2_spot_instances
   rules:
     !reference [.on_security_agent_changes_or_manual]
-  needs: [ "tests_ebpf_x64", "prepare_ebpf_tests_x64" ]
+  needs: [ "tests_ebpf_x64", "prepare_ebpf_functional_tests_x64" ]
   variables:
     KITCHEN_ARCH: x86_64
     KITCHEN_EC2_INSTANCE_TYPE: "t3.medium"
@@ -110,7 +110,7 @@ kitchen_stress_security_agent:
   rules:
     !reference [.manual]
   stage: functional_test
-  needs: ["tests_ebpf_x64", "prepare_ebpf_tests_x64"]
+  needs: ["tests_ebpf_x64", "prepare_ebpf_functional_tests_x64"]
   variables:
     AGENT_MAJOR_VERSION: 7
     DD_PIPELINE_ID: $CI_PIPELINE_ID-fnct

--- a/.gitlab/functional_test/security_agent.yml
+++ b/.gitlab/functional_test/security_agent.yml
@@ -25,7 +25,7 @@ kitchen_test_security_agent_x64:
     - .kitchen_test_security_agent
     - .kitchen_azure_x64
     - .kitchen_azure_location_north_central_us
-  needs: ["tests_ebpf_x64"]
+  needs: ["prepare_ebpf_tests_x64"]
   variables:
     KITCHEN_ARCH: x86_64
   before_script:
@@ -68,7 +68,7 @@ kitchen_test_security_agent_arm64:
     - .kitchen_ec2_spot_instances
   rules:
     !reference [.on_security_agent_changes_or_manual]
-  needs: [ "tests_ebpf_arm64" ]
+  needs: [ "prepare_ebpf_tests_arm64" ]
   variables:
     KITCHEN_ARCH: arm64
     KITCHEN_EC2_INSTANCE_TYPE: "t4g.xlarge"
@@ -88,7 +88,7 @@ kitchen_test_security_agent_amazonlinux_x64:
     - .kitchen_ec2_spot_instances
   rules:
     !reference [.on_security_agent_changes_or_manual]
-  needs: [ "tests_ebpf_x64" ]
+  needs: [ "prepare_ebpf_tests_x64" ]
   variables:
     KITCHEN_ARCH: x86_64
     KITCHEN_EC2_INSTANCE_TYPE: "t3.medium"
@@ -110,7 +110,7 @@ kitchen_stress_security_agent:
   rules:
     !reference [.manual]
   stage: functional_test
-  needs: ["tests_ebpf_x64"]
+  needs: ["prepare_ebpf_tests_x64"]
   variables:
     AGENT_MAJOR_VERSION: 7
     DD_PIPELINE_ID: $CI_PIPELINE_ID-fnct

--- a/.gitlab/functional_test/security_agent.yml
+++ b/.gitlab/functional_test/security_agent.yml
@@ -25,7 +25,7 @@ kitchen_test_security_agent_x64:
     - .kitchen_test_security_agent
     - .kitchen_azure_x64
     - .kitchen_azure_location_north_central_us
-  needs: ["prepare_ebpf_tests_x64"]
+  needs: ["tests_ebpf_x64", "prepare_ebpf_tests_x64"]
   variables:
     KITCHEN_ARCH: x86_64
   before_script:
@@ -68,7 +68,7 @@ kitchen_test_security_agent_arm64:
     - .kitchen_ec2_spot_instances
   rules:
     !reference [.on_security_agent_changes_or_manual]
-  needs: [ "prepare_ebpf_tests_arm64" ]
+  needs: [ "tests_ebpf_arm64", "prepare_ebpf_tests_arm64" ]
   variables:
     KITCHEN_ARCH: arm64
     KITCHEN_EC2_INSTANCE_TYPE: "t4g.xlarge"
@@ -88,7 +88,7 @@ kitchen_test_security_agent_amazonlinux_x64:
     - .kitchen_ec2_spot_instances
   rules:
     !reference [.on_security_agent_changes_or_manual]
-  needs: [ "prepare_ebpf_tests_x64" ]
+  needs: [ "tests_ebpf_x64", "prepare_ebpf_tests_x64" ]
   variables:
     KITCHEN_ARCH: x86_64
     KITCHEN_EC2_INSTANCE_TYPE: "t3.medium"
@@ -110,7 +110,7 @@ kitchen_stress_security_agent:
   rules:
     !reference [.manual]
   stage: functional_test
-  needs: ["prepare_ebpf_tests_x64"]
+  needs: ["tests_ebpf_x64", "prepare_ebpf_tests_x64"]
   variables:
     AGENT_MAJOR_VERSION: 7
     DD_PIPELINE_ID: $CI_PIPELINE_ID-fnct

--- a/.gitlab/functional_test/system_probe.yml
+++ b/.gitlab/functional_test/system_probe.yml
@@ -68,7 +68,7 @@ kitchen_test_system_probe_linux_x64:
     - .kitchen_test_system_probe
     - .kitchen_azure_x64
     - .kitchen_azure_location_north_central_us
-  needs: [ "tests_ebpf_x64", "generate_minimized_btfs_x64", "pull_test_dockers_x64" ]
+  needs: [ "prepare_ebpf_tests_x64", "generate_minimized_btfs_x64", "pull_test_dockers_x64" ]
   variables:
     ARCH: amd64
     KITCHEN_ARCH: x86_64
@@ -94,7 +94,7 @@ kitchen_test_system_probe_linux_x64_ec2:
     - .kitchen_test_system_probe
     - .kitchen_ec2_location_us_east_1
     - .kitchen_ec2
-  needs: [ "tests_ebpf_x64", "generate_minimized_btfs_x64", "pull_test_dockers_x64" ]
+  needs: [ "prepare_ebpf_tests_x64", "generate_minimized_btfs_x64", "pull_test_dockers_x64" ]
   variables:
     ARCH: amd64
     KITCHEN_ARCH: x86_64
@@ -115,7 +115,7 @@ kitchen_test_system_probe_linux_arm64:
     - .kitchen_test_system_probe
     - .kitchen_ec2_location_us_east_1
     - .kitchen_ec2_spot_instances
-  needs: [ "tests_ebpf_arm64", "generate_minimized_btfs_arm64", "pull_test_dockers_arm64" ]
+  needs: [ "prepare_ebpf_tests_arm64", "generate_minimized_btfs_arm64", "pull_test_dockers_arm64" ]
   variables:
     ARCH: arm64
     KITCHEN_ARCH: arm64

--- a/.gitlab/functional_test/system_probe.yml
+++ b/.gitlab/functional_test/system_probe.yml
@@ -68,7 +68,7 @@ kitchen_test_system_probe_linux_x64:
     - .kitchen_test_system_probe
     - .kitchen_azure_x64
     - .kitchen_azure_location_north_central_us
-  needs: [ "tests_ebpf_x64", "prepare_ebpf_tests_x64", "generate_minimized_btfs_x64", "pull_test_dockers_x64" ]
+  needs: [ "tests_ebpf_x64", "prepare_ebpf_functional_tests_x64", "generate_minimized_btfs_x64", "pull_test_dockers_x64" ]
   variables:
     ARCH: amd64
     KITCHEN_ARCH: x86_64
@@ -94,7 +94,7 @@ kitchen_test_system_probe_linux_x64_ec2:
     - .kitchen_test_system_probe
     - .kitchen_ec2_location_us_east_1
     - .kitchen_ec2
-  needs: [ "tests_ebpf_x64", "prepare_ebpf_tests_x64", "generate_minimized_btfs_x64", "pull_test_dockers_x64" ]
+  needs: [ "tests_ebpf_x64", "prepare_ebpf_functional_tests_x64", "generate_minimized_btfs_x64", "pull_test_dockers_x64" ]
   variables:
     ARCH: amd64
     KITCHEN_ARCH: x86_64
@@ -115,7 +115,7 @@ kitchen_test_system_probe_linux_arm64:
     - .kitchen_test_system_probe
     - .kitchen_ec2_location_us_east_1
     - .kitchen_ec2_spot_instances
-  needs: [ "tests_ebpf_arm64", "prepare_ebpf_tests_arm64", "generate_minimized_btfs_arm64", "pull_test_dockers_arm64" ]
+  needs: [ "tests_ebpf_arm64", "prepare_ebpf_functional_tests_arm64", "generate_minimized_btfs_arm64", "pull_test_dockers_arm64" ]
   variables:
     ARCH: arm64
     KITCHEN_ARCH: arm64

--- a/.gitlab/functional_test/system_probe.yml
+++ b/.gitlab/functional_test/system_probe.yml
@@ -68,7 +68,7 @@ kitchen_test_system_probe_linux_x64:
     - .kitchen_test_system_probe
     - .kitchen_azure_x64
     - .kitchen_azure_location_north_central_us
-  needs: [ "prepare_ebpf_tests_x64", "generate_minimized_btfs_x64", "pull_test_dockers_x64" ]
+  needs: [ "tests_ebpf_x64", "prepare_ebpf_tests_x64", "generate_minimized_btfs_x64", "pull_test_dockers_x64" ]
   variables:
     ARCH: amd64
     KITCHEN_ARCH: x86_64
@@ -94,7 +94,7 @@ kitchen_test_system_probe_linux_x64_ec2:
     - .kitchen_test_system_probe
     - .kitchen_ec2_location_us_east_1
     - .kitchen_ec2
-  needs: [ "prepare_ebpf_tests_x64", "generate_minimized_btfs_x64", "pull_test_dockers_x64" ]
+  needs: [ "tests_ebpf_x64", "prepare_ebpf_tests_x64", "generate_minimized_btfs_x64", "pull_test_dockers_x64" ]
   variables:
     ARCH: amd64
     KITCHEN_ARCH: x86_64
@@ -115,7 +115,7 @@ kitchen_test_system_probe_linux_arm64:
     - .kitchen_test_system_probe
     - .kitchen_ec2_location_us_east_1
     - .kitchen_ec2_spot_instances
-  needs: [ "prepare_ebpf_tests_arm64", "generate_minimized_btfs_arm64", "pull_test_dockers_arm64" ]
+  needs: [ "tests_ebpf_arm64", "prepare_ebpf_tests_arm64", "generate_minimized_btfs_arm64", "pull_test_dockers_arm64" ]
   variables:
     ARCH: arm64
     KITCHEN_ARCH: arm64

--- a/.gitlab/functional_test_cleanup.yml
+++ b/.gitlab/functional_test_cleanup.yml
@@ -13,6 +13,6 @@ cleanup_kitchen_functional_test:
   rules:
     !reference [.manual]
   stage: functional_test_cleanup
-  needs: ["tests_ebpf_x64", "prepare_ebpf_tests_x64"]
+  needs: ["tests_ebpf_x64", "prepare_ebpf_functional_tests_x64"]
   variables:
     DD_PIPELINE_ID: $CI_PIPELINE_ID-fnct

--- a/.gitlab/functional_test_cleanup.yml
+++ b/.gitlab/functional_test_cleanup.yml
@@ -13,6 +13,6 @@ cleanup_kitchen_functional_test:
   rules:
     !reference [.manual]
   stage: functional_test_cleanup
-  needs: ["tests_ebpf_x64"]
+  needs: ["prepare_ebpf_tests_x64"]
   variables:
     DD_PIPELINE_ID: $CI_PIPELINE_ID-fnct

--- a/.gitlab/functional_test_cleanup.yml
+++ b/.gitlab/functional_test_cleanup.yml
@@ -13,6 +13,6 @@ cleanup_kitchen_functional_test:
   rules:
     !reference [.manual]
   stage: functional_test_cleanup
-  needs: ["prepare_ebpf_tests_x64"]
+  needs: ["tests_ebpf_x64", "prepare_ebpf_tests_x64"]
   variables:
     DD_PIPELINE_ID: $CI_PIPELINE_ID-fnct

--- a/.gitlab/source_test/ebpf.yml
+++ b/.gitlab/source_test/ebpf.yml
@@ -87,7 +87,7 @@ tests_ebpf_arm64:
     ARCH: arm64
     TASK_ARCH: arm64
 
-.prepare_ebpf_tests:
+.prepare_ebpf_functional_tests:
   stage: source_test
   needs: ["go_deps"]
   artifacts:
@@ -107,15 +107,15 @@ tests_ebpf_arm64:
     - cp /tmp/clang-bpf $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files/clang-bpf
     - cp /tmp/llc-bpf $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files/llc-bpf
 
-prepare_ebpf_tests_arm64:
-  extends: .prepare_ebpf_tests
+prepare_ebpf_functional_tests_arm64:
+  extends: .prepare_ebpf_functional_tests:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/system-probe_arm64:$DATADOG_AGENT_SYSPROBE_BUILDIMAGES
   tags: ["runner:docker-arm", "platform:arm64"]
   variables:
     ARCH: arm64
 
-prepare_ebpf_tests_x64:
-  extends: .prepare_ebpf_tests
+prepare_ebpf_functional_tests_x64:
+  extends: .prepare_ebpf_functional_tests:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/system-probe_x64:$DATADOG_AGENT_SYSPROBE_BUILDIMAGES
   tags: ["runner:main"]
   variables:

--- a/.gitlab/source_test/ebpf.yml
+++ b/.gitlab/source_test/ebpf.yml
@@ -103,7 +103,7 @@ tests_ebpf_arm64:
   script:
     - inv -e system-probe.object-files
     - !reference [.build_sysprobe_artifacts]
-    - invoke -e security-agent.kitchen-prepare
+    - invoke -e security-agent.kitchen-prepare --skip-linters
     - cp /tmp/clang-bpf $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files/clang-bpf
     - cp /tmp/llc-bpf $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files/llc-bpf
 

--- a/.gitlab/source_test/ebpf.yml
+++ b/.gitlab/source_test/ebpf.yml
@@ -44,7 +44,7 @@
     - inv -e system-probe.object-files
     - invoke -e golangci-lint --build system-probe ./pkg
     - invoke -e security-agent.run-ebpf-unit-tests --verbose
-    - invoke -e golangci-lint --targets=./plg/security/tests --build-tags="stresstests linux_bpf ebpf_bindata" --arch=$TASK_ARCH
+    - invoke -e golangci-lint --targets=./pkg/security/tests --build-tags="stresstests linux_bpf ebpf_bindata" --arch=$TASK_ARCH
 
 .tests_windows_sysprobe:
   stage: source_test

--- a/.gitlab/source_test/ebpf.yml
+++ b/.gitlab/source_test/ebpf.yml
@@ -44,7 +44,7 @@
     - inv -e system-probe.object-files
     - invoke -e golangci-lint --build system-probe ./pkg
     - invoke -e security-agent.run-ebpf-unit-tests --verbose
-    - invoke -e go.golangci_lint --targets=./plg/security/tests --build-tags="stresstests linux_bpf ebpf_bindata" --arch=$TASK_ARCH
+    - invoke -e golangci-lint --targets=./plg/security/tests --build-tags="stresstests linux_bpf ebpf_bindata" --arch=$TASK_ARCH
 
 .tests_windows_sysprobe:
   stage: source_test

--- a/.gitlab/source_test/ebpf.yml
+++ b/.gitlab/source_test/ebpf.yml
@@ -89,7 +89,7 @@ tests_ebpf_arm64:
 
 .prepare_ebpf_tests:
   stage: source_test
-  needs: ["go_deps", "go_tools_deps"]
+  needs: ["go_deps"]
   artifacts:
     when: always
     paths:
@@ -98,7 +98,6 @@ tests_ebpf_arm64:
       - $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files
   before_script:
     - !reference [.retrieve_linux_go_deps]
-    - !reference [.retrieve_linux_go_tools_deps]
     - mkdir -p $CI_PROJECT_DIR/.tmp/binary-ebpf/co-re
     - !reference [.retrieve_sysprobe_deps]
   script:

--- a/.gitlab/source_test/ebpf.yml
+++ b/.gitlab/source_test/ebpf.yml
@@ -108,14 +108,14 @@ tests_ebpf_arm64:
     - cp /tmp/llc-bpf $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files/llc-bpf
 
 prepare_ebpf_functional_tests_arm64:
-  extends: .prepare_ebpf_functional_tests:
+  extends: .prepare_ebpf_functional_tests
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/system-probe_arm64:$DATADOG_AGENT_SYSPROBE_BUILDIMAGES
   tags: ["runner:docker-arm", "platform:arm64"]
   variables:
     ARCH: arm64
 
 prepare_ebpf_functional_tests_x64:
-  extends: .prepare_ebpf_functional_tests:
+  extends: .prepare_ebpf_functional_tests
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/system-probe_x64:$DATADOG_AGENT_SYSPROBE_BUILDIMAGES
   tags: ["runner:main"]
   variables:

--- a/.gitlab/source_test/ebpf.yml
+++ b/.gitlab/source_test/ebpf.yml
@@ -119,10 +119,11 @@ prepare_ebpf_tests_x64:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/system-probe_x64:$DATADOG_AGENT_SYSPROBE_BUILDIMAGES
   tags: ["runner:main"]
   variables:
-    amd64
+    ARCH: amd64
 
 tests_windows_sysprobe_x64:
   extends: .tests_windows_sysprobe
   variables:
     PYTHON_RUNTIMES: 3
     ARCH: "x64"
+

--- a/.gitlab/source_test/ebpf.yml
+++ b/.gitlab/source_test/ebpf.yml
@@ -36,26 +36,14 @@
 .tests_linux_ebpf:
   stage: source_test
   needs: ["go_deps", "go_tools_deps"]
-  artifacts:
-    when: always
-    paths:
-      - $CI_PROJECT_DIR/.tmp/binary-ebpf
-      - $DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files
-      - $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files
   before_script:
     - !reference [.retrieve_linux_go_deps]
     - !reference [.retrieve_linux_go_tools_deps]
-    - mkdir -p $CI_PROJECT_DIR/.tmp/binary-ebpf/co-re
-    - !reference [.retrieve_sysprobe_deps]
   script:
     - inv -e install-tools
-    - inv -e system-probe.object-files
     - invoke -e golangci-lint --build system-probe ./pkg
-    - !reference [.build_sysprobe_artifacts]
     - invoke -e security-agent.run-ebpf-unit-tests --verbose
-    - invoke -e security-agent.kitchen-prepare
-    - cp /tmp/clang-bpf $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files/clang-bpf
-    - cp /tmp/llc-bpf $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files/llc-bpf
+    - invoke -e go.golangci_lint --targets=./plg/security/tests --build-tags="stresstests linux_bpf ebpf_bindata" --arch=$TASK_ARCH
 
 .tests_windows_sysprobe:
   stage: source_test
@@ -88,6 +76,7 @@ tests_ebpf_x64:
   tags: ["runner:main"]
   variables:
     ARCH: amd64
+    TASK_ARCH: x64
 
 tests_ebpf_arm64:
   extends: .tests_linux_ebpf
@@ -95,6 +84,42 @@ tests_ebpf_arm64:
   tags: ["runner:docker-arm", "platform:arm64"]
   variables:
     ARCH: arm64
+    TASK_ARCH: arm64
+
+.prepare_ebpf_tests:
+  stage: source_test
+  needs: ["go_deps", "go_tools_deps"]
+  artifacts:
+    when: always
+    paths:
+      - $CI_PROJECT_DIR/.tmp/binary-ebpf
+      - $DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files
+      - $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files
+  before_script:
+    - !reference [.retrieve_linux_go_deps]
+    - !reference [.retrieve_linux_go_tools_deps]
+    - mkdir -p $CI_PROJECT_DIR/.tmp/binary-ebpf/co-re
+    - !reference [.retrieve_sysprobe_deps]
+  script:
+    - inv -e system-probe.object-files
+    - !reference [.build_sysprobe_artifacts]
+    - invoke -e security-agent.kitchen-prepare
+    - cp /tmp/clang-bpf $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files/clang-bpf
+    - cp /tmp/llc-bpf $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files/llc-bpf
+
+prepare_ebpf_tests_arm64:
+  extends: .prepare_ebpf_tests
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/system-probe_arm64:$DATADOG_AGENT_SYSPROBE_BUILDIMAGES
+  tags: ["runner:docker-arm", "platform:arm64"]
+  variables:
+    ARCH: arm64
+
+prepare_ebpf_tests_x64:
+  extends: .prepare_ebpf_tests
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/system-probe_x64:$DATADOG_AGENT_SYSPROBE_BUILDIMAGES
+  tags: ["runner:main"]
+  variables:
+    amd64
 
 tests_windows_sysprobe_x64:
   extends: .tests_windows_sysprobe

--- a/.gitlab/source_test/ebpf.yml
+++ b/.gitlab/source_test/ebpf.yml
@@ -89,7 +89,7 @@ tests_ebpf_arm64:
 
 .prepare_ebpf_tests:
   stage: source_test
-  needs: ["go_deps"]
+  needs: ["go_deps", "go_tools_deps"]
   artifacts:
     when: always
     paths:
@@ -98,6 +98,7 @@ tests_ebpf_arm64:
       - $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files
   before_script:
     - !reference [.retrieve_linux_go_deps]
+    - !reference [.retrieve_linux_go_tools_deps]
     - mkdir -p $CI_PROJECT_DIR/.tmp/binary-ebpf/co-re
     - !reference [.retrieve_sysprobe_deps]
   script:

--- a/.gitlab/source_test/ebpf.yml
+++ b/.gitlab/source_test/ebpf.yml
@@ -41,6 +41,7 @@
     - !reference [.retrieve_linux_go_tools_deps]
   script:
     - inv -e install-tools
+    - inv -e system-probe.object-files
     - invoke -e golangci-lint --build system-probe ./pkg
     - invoke -e security-agent.run-ebpf-unit-tests --verbose
     - invoke -e go.golangci_lint --targets=./plg/security/tests --build-tags="stresstests linux_bpf ebpf_bindata" --arch=$TASK_ARCH
@@ -101,7 +102,6 @@ tests_ebpf_arm64:
     - mkdir -p $CI_PROJECT_DIR/.tmp/binary-ebpf/co-re
     - !reference [.retrieve_sysprobe_deps]
   script:
-    - inv -e system-probe.object-files
     - !reference [.build_sysprobe_artifacts]
     - invoke -e security-agent.kitchen-prepare --skip-linters
     - cp /tmp/clang-bpf $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files/clang-bpf

--- a/.gitlab/source_test/ebpf.yml
+++ b/.gitlab/source_test/ebpf.yml
@@ -89,7 +89,7 @@ tests_ebpf_arm64:
 
 .prepare_ebpf_tests:
   stage: source_test
-  needs: ["go_deps", "go_tools_deps"]
+  needs: ["go_deps"]
   artifacts:
     when: always
     paths:
@@ -98,8 +98,8 @@ tests_ebpf_arm64:
       - $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files
   before_script:
     - !reference [.retrieve_linux_go_deps]
-    - !reference [.retrieve_linux_go_tools_deps]
     - mkdir -p $CI_PROJECT_DIR/.tmp/binary-ebpf/co-re
+    - inv -e install-tools
     - !reference [.retrieve_sysprobe_deps]
   script:
     - !reference [.build_sysprobe_artifacts]

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -704,7 +704,7 @@ def go_generate_check(ctx):
 
 
 @task
-def kitchen_prepare(ctx):
+def kitchen_prepare(ctx, skip_linters=False):
     ci_project_dir = os.environ.get("CI_PROJECT_DIR", ".")
 
     nikos_embedded_path = os.environ.get("NIKOS_EMBEDDED_PATH", None)
@@ -714,10 +714,15 @@ def kitchen_prepare(ctx):
 
     testsuite_out_path = os.path.join(cookbook_files_dir, "testsuite")
     build_functional_tests(
-        ctx, bundle_ebpf=False, race=True, output=testsuite_out_path, nikos_embedded_path=nikos_embedded_path
+        ctx,
+        bundle_ebpf=False,
+        race=True,
+        output=testsuite_out_path,
+        nikos_embedded_path=nikos_embedded_path,
+        skip_linters=skip_linters,
     )
     stresssuite_out_path = os.path.join(cookbook_files_dir, "stresssuite")
-    build_stress_tests(ctx, output=stresssuite_out_path)
+    build_stress_tests(ctx, output=stresssuite_out_path, skip_linters=skip_linters)
 
     # Copy clang binaries
     for bin in ["clang-bpf", "llc-bpf"]:


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
This PR creates a new job to run `kitchen-prepare`, seperate from the `test_ebpf_*` jobs.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
With these jobs running in parallel, we shaves 3-4 minutes before `functional_tests` can be triggered.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
