### PR TITLE
pkg/trace/api: fix edge case causing panic

### DIFF
--- a/pkg/trace/api/pipeline_stats.go
+++ b/pkg/trace/api/pipeline_stats.go
@@ -25,12 +25,12 @@ const (
 )
 
 // pipelineStatsEndpoint returns the pipeline intake url and the corresponding API key.
-func pipelineStatsEndpoint(cfg *config.AgentConfig) (url *url.URL, apiKey string, err error) {
+func pipelineStatsEndpoint(cfg *config.AgentConfig) (*url.URL, string, error) {
 	if e := cfg.Endpoints; len(e) == 0 || e[0].Host == "" || e[0].APIKey == "" {
 		return nil, "", errors.New("config was not properly validated")
 	}
 	urlStr := cfg.Endpoints[0].Host + pipelineStatsURLSuffix
-	url, err = url.Parse(urlStr)
+	url, err := url.Parse(urlStr)
 	if err != nil {
 		return nil, "", fmt.Errorf("error parsing pipeline stats intake URL %q: %v", urlStr, err)
 	}

--- a/pkg/trace/api/pipeline_stats_test.go
+++ b/pkg/trace/api/pipeline_stats_test.go
@@ -69,6 +69,12 @@ func TestPipelineStatsEndpoint(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, url.String(), "https://trace.agent.datadoghq.com/api/v0.1/pipeline_stats")
 	assert.Equal(t, key, "test_api_key")
+
+	cfg.Endpoints = []*config.Endpoint{{Host: "trace.agent.datadoghq.com", APIKey: "test_api_key"}}
+	url, key, err = pipelineStatsEndpoint(&cfg)
+	assert.NoError(t, err)
+	assert.Equal(t, url.String(), "trace.agent.datadoghq.com/api/v0.1/pipeline_stats")
+	assert.Equal(t, key, "test_api_key")
 }
 
 func TestPipelineStatsProxyHandler(t *testing.T) {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Fix a panic caused by specific url input + the way `pipelineStatsEndpoint` is written.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Panics are bad
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

The panic is reproducible by the additional test case and illustrated in this Go playground https://go.dev/play/p/Di_OTwm1QtJ?v=goprev
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
