### PR TITLE
classification: Split classifier over tail calls due to instruction limit

### DIFF
--- a/pkg/network/ebpf/c/prebuilt/tracer.c
+++ b/pkg/network/ebpf/c/prebuilt/tracer.c
@@ -20,8 +20,6 @@
 #include "conn-tuple.h"
 
 #include "tracer.h"
-#include "protocols/classification/tracer-maps.h"
-#include "protocols/classification/protocol-classification.h"
 #include "tracer-events.h"
 #include "tracer-maps.h"
 #include "tracer-stats.h"
@@ -35,13 +33,16 @@
 #include "skb.h"
 #include "offsets.h"
 
+#include "protocols/classification/tracer-maps.h"
+#include "protocols/classification/protocol-classification.h"
+
 // This entry point is needed to bypass a memory limit on socket filters.
 // There is a limitation on number of instructions can be attached to a socket filter,
 // as we classify more protocols, we reached that limit, thus we workaround it
 // by using tail call.
 SEC("socket/classifier_entry")
 int socket__classifier_entry(struct __sk_buff *skb) {
-    bpf_tail_call_compat(skb, &classification_progs, CLASSIFICATION_PROG);
+    bpf_tail_call_compat(skb, &classification_progs, CLASSIFICATION_ENTRY_PROG);
     return 0;
 }
 
@@ -49,6 +50,13 @@ int socket__classifier_entry(struct __sk_buff *skb) {
 SEC("socket/classifier")
 int socket__classifier(struct __sk_buff *skb) {
     protocol_classifier_entrypoint(skb);
+    return 0;
+}
+
+// The entrypoint for all packets.
+SEC("socket/classifier_cont")
+int socket__classifier_cont(struct __sk_buff *skb) {
+    protocol_classifier_entrypoint_cont(skb);
     return 0;
 }
 

--- a/pkg/network/ebpf/c/protocols/classification/defs.h
+++ b/pkg/network/ebpf/c/protocols/classification/defs.h
@@ -36,4 +36,11 @@ typedef enum {
     __MAX_UINT8 = 255,
 } __attribute__ ((packed)) protocol_t;
 
+typedef enum {
+    CLASSIFICATION_ENTRY_PROG = 0,
+    CLASSIFICATION_CONT_PROG,
+    // Add before this value.
+    CLASSIFICATION_PROG_MAX,
+} classification_prog_t;
+
 #endif

--- a/pkg/network/ebpf/c/protocols/classification/protocol-classification.h
+++ b/pkg/network/ebpf/c/protocols/classification/protocol-classification.h
@@ -17,32 +17,54 @@
 #include "protocols/redis/helpers.h"
 #include "protocols/postgres/helpers.h"
 
-// Determines the protocols of the given buffer. If we already classified the payload (a.k.a protocol out param
-// has a known protocol), then we do nothing.
-static __always_inline void classify_protocol(protocol_t *protocol, conn_tuple_t *tup, const char *buf, __u32 size) {
-    if (protocol == NULL || *protocol != PROTOCOL_UNKNOWN) {
-        return;
-    }
-
+// Checks if a given buffer is http, http2, gRPC.
+static __always_inline protocol_t classify_http_protocols(const char *buf, __u32 size) {
     if (is_http(buf, size)) {
-        *protocol = PROTOCOL_HTTP;
-    } else if (is_http2(buf, size)) {
-        *protocol = PROTOCOL_HTTP2;
-    } else if (is_amqp(buf, size)) {
-        *protocol = PROTOCOL_AMQP;
-    } else if (is_redis(buf, size)) {
-        *protocol = PROTOCOL_REDIS;
-    } else if (is_mongo(tup, buf, size)) {
-        *protocol = PROTOCOL_MONGO;
-    } else if (is_postgres(buf, size)) {
-        *protocol = PROTOCOL_POSTGRES;
-    } else if (is_mysql(tup, buf, size)) {
-        *protocol = PROTOCOL_MYSQL;
-    } else {
-        *protocol = PROTOCOL_UNKNOWN;
+        return PROTOCOL_HTTP;
+    }
+    if (is_http2(buf, size)) {
+        return PROTOCOL_HTTP2;
     }
 
-    log_debug("[protocol classification]: Classified protocol as %d %d; %s\n", *protocol, size, buf);
+    return PROTOCOL_UNKNOWN;
+}
+
+// Checks if a given buffer is redis, mongo, postgres, or mysql.
+static __always_inline protocol_t classify_db_protocols(conn_tuple_t *tup, const char *buf, __u32 size) {
+    if (is_redis(buf, size)) {
+        return PROTOCOL_REDIS;
+    }
+
+    if (is_mongo(tup, buf, size)) {
+        return PROTOCOL_MONGO;
+    }
+
+    if (is_postgres(buf, size)) {
+        return PROTOCOL_POSTGRES;
+    }
+
+    if (is_mysql(tup, buf, size)) {
+        return PROTOCOL_MYSQL;
+    }
+
+    return PROTOCOL_UNKNOWN;
+}
+
+// Checks if a given buffer is amqp, and soon - kafka..
+static __always_inline protocol_t classify_queue_protocols(const char *buf, __u32 size) {
+    if (is_amqp(buf, size)) {
+        return PROTOCOL_AMQP;
+    }
+
+    return PROTOCOL_UNKNOWN;
+}
+
+__maybe_unused static __always_inline void save_protocol(conn_tuple_t *skb_tup, protocol_t cur_fragment_protocol) {
+    bpf_map_update_with_telemetry(connection_protocol, skb_tup, &cur_fragment_protocol, BPF_NOEXIST);
+    conn_tuple_t inverse_skb_conn_tup;
+    bpf_memcpy(&inverse_skb_conn_tup, skb_tup, sizeof(conn_tuple_t));
+    flip_tuple(&inverse_skb_conn_tup);
+    bpf_map_update_with_telemetry(connection_protocol, &inverse_skb_conn_tup, &cur_fragment_protocol, BPF_NOEXIST);
 }
 
 // A shared implementation for the runtime & prebuilt socket filter that classifies the protocols of the connections.
@@ -65,8 +87,6 @@ __maybe_unused static __always_inline void protocol_classifier_entrypoint(struct
         return;
     }
 
-    protocol_t cur_fragment_protocol = PROTOCOL_UNKNOWN;
-
     // Get the buffer the fragment will be read into from a per-cpu array map.
     // This will avoid doing unaligned stack access while parsing the protocols,
     // which is forbidden and will make the verifier fail.
@@ -81,14 +101,49 @@ __maybe_unused static __always_inline void protocol_classifier_entrypoint(struct
     read_into_buffer_for_classification((char *)request_fragment, skb, &skb_info);
     const size_t payload_length = skb->len - skb_info.data_off;
     const size_t final_fragment_size = payload_length < CLASSIFICATION_MAX_BUFFER ? payload_length : CLASSIFICATION_MAX_BUFFER;
-    classify_protocol(&cur_fragment_protocol, &skb_tup, request_fragment, final_fragment_size);
+
+    protocol_t cur_fragment_protocol = classify_http_protocols(request_fragment, final_fragment_size);
+    if (cur_fragment_protocol == PROTOCOL_UNKNOWN) {
+        cur_fragment_protocol = classify_queue_protocols(request_fragment, final_fragment_size);
+    }
     // If there has been a change in the classification, save the new protocol.
     if (cur_fragment_protocol != PROTOCOL_UNKNOWN) {
-        bpf_map_update_with_telemetry(connection_protocol, &skb_tup, &cur_fragment_protocol, BPF_NOEXIST);
-        conn_tuple_t inverse_skb_conn_tup = skb_tup;
-        flip_tuple(&inverse_skb_conn_tup);
-        bpf_map_update_with_telemetry(connection_protocol, &inverse_skb_conn_tup, &cur_fragment_protocol, BPF_NOEXIST);
+        save_protocol(&skb_tup, cur_fragment_protocol);
+        return;
     }
+
+    bpf_tail_call_compat(skb, &classification_progs, CLASSIFICATION_CONT_PROG);
 }
 
+__maybe_unused static __always_inline void protocol_classifier_entrypoint_cont(struct __sk_buff *skb) {
+    skb_info_t skb_info = {0};
+    conn_tuple_t skb_tup = {0};
+
+    // Exporting the conn tuple from the skb, alongside couple of relevant fields from the skb.
+    if (!read_conn_tuple_skb(skb, &skb_info, &skb_tup)) {
+        return;
+    }
+
+    // Get the buffer the fragment will be read into from a per-cpu array map.
+    // This will avoid doing unaligned stack access while parsing the protocols,
+    // which is forbidden and will make the verifier fail.
+    const u32 key = 0;
+    char *request_fragment = bpf_map_lookup_elem(&classification_buf, &key);
+    if (request_fragment == NULL) {
+        log_debug("could not get classification buffer from map");
+        return;
+    }
+    bpf_memset(request_fragment, 0, sizeof(request_fragment));
+    read_into_buffer_for_classification((char *)request_fragment, skb, &skb_info);
+
+    const size_t payload_length = skb->len - skb_info.data_off;
+    const size_t final_fragment_size = payload_length < CLASSIFICATION_MAX_BUFFER ? payload_length : CLASSIFICATION_MAX_BUFFER;
+
+    protocol_t cur_fragment_protocol = classify_db_protocols(&skb_tup, request_fragment, final_fragment_size);
+
+    // If there has been a change in the classification, save the new protocol.
+    if (cur_fragment_protocol != PROTOCOL_UNKNOWN) {
+        save_protocol(&skb_tup, cur_fragment_protocol);
+    }
+}
 #endif

--- a/pkg/network/ebpf/c/protocols/classification/tracer-maps.h
+++ b/pkg/network/ebpf/c/protocols/classification/tracer-maps.h
@@ -17,4 +17,10 @@ BPF_HASH_MAP(conn_tuple_to_socket_skb_conn_tuple, conn_tuple_t, conn_tuple_t, 0)
 // connection. Assumption: each connection has a single protocol.
 BPF_HASH_MAP(connection_protocol, conn_tuple_t, protocol_t, 0)
 
+// This entry point is needed to bypass a memory limit on socket filters.
+// There is a limitation on number of instructions can be attached to a socket filter,
+// as we classify more protocols, we reached that limit, thus we workaround it
+// by using tail call.
+BPF_PROG_ARRAY(classification_progs, CLASSIFICATION_PROG_MAX)
+
 #endif

--- a/pkg/network/ebpf/c/runtime/tracer.c
+++ b/pkg/network/ebpf/c/runtime/tracer.c
@@ -16,8 +16,6 @@
 #include <uapi/linux/udp.h>
 
 #include "tracer.h"
-#include "protocols/classification/tracer-maps.h"
-#include "protocols/classification/protocol-classification.h"
 #include "tracer-events.h"
 #include "tracer-maps.h"
 #include "tracer-stats.h"
@@ -49,7 +47,7 @@
 // by using tail call.
 SEC("socket/classifier_entry")
 int socket__classifier_entry(struct __sk_buff *skb) {
-    bpf_tail_call_compat(skb, &classification_progs, CLASSIFICATION_PROG);
+    bpf_tail_call_compat(skb, &classification_progs, CLASSIFICATION_ENTRY_PROG);
     return 0;
 }
 
@@ -58,6 +56,15 @@ SEC("socket/classifier")
 int socket__classifier(struct __sk_buff *skb) {
     #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 6, 0)
     protocol_classifier_entrypoint(skb);
+    #endif
+    return 0;
+}
+
+// The entrypoint for all packets.
+SEC("socket/classifier_cont")
+int socket__classifier_cont(struct __sk_buff *skb) {
+    #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 6, 0)
+    protocol_classifier_entrypoint_cont(skb);
     #endif
     return 0;
 }

--- a/pkg/network/ebpf/c/tracer-maps.h
+++ b/pkg/network/ebpf/c/tracer-maps.h
@@ -92,11 +92,4 @@ BPF_HASH_MAP(do_sendfile_args, __u64, struct sock *, 1024)
 // corresponding kretprobes
 BPF_HASH_MAP(ip_make_skb_args, __u64, ip_make_skb_args_t, 1024)
 
-// This entry point is needed to bypass a memory limit on socket filters.
-// There is a limitation on number of instructions can be attached to a socket filter,
-// as we classify more protocols, we reached that limit, thus we workaround it
-// by using tail call.
-#define CLASSIFICATION_PROG 0
-BPF_PROG_ARRAY(classification_progs, 1)
-
 #endif

--- a/pkg/network/ebpf/probes/probes.go
+++ b/pkg/network/ebpf/probes/probes.go
@@ -28,7 +28,8 @@ const (
 	// ProtocolClassifierEntrySocketFilter runs a classifier algorithm as a socket filter
 	ProtocolClassifierEntrySocketFilter ProbeFuncName = "socket__classifier_entry"
 	// ProtocolClassifierSocketFilter runs a classifier algorithm as a socket filter
-	ProtocolClassifierSocketFilter ProbeFuncName = "socket__classifier"
+	ProtocolClassifierSocketFilter     ProbeFuncName = "socket__classifier"
+	ProtocolClassifierSocketContFilter ProbeFuncName = "socket__classifier_cont"
 
 	// NetDevQueue runs a tracepoint that allows us to correlate __sk_buf (in a socket filter) with the `struct sock*`
 	// belongs (but hidden) for it.

--- a/pkg/network/tracer/connection/kprobe/config.go
+++ b/pkg/network/tracer/connection/kprobe/config.go
@@ -39,6 +39,7 @@ func enabledProbes(c *config.Config, runtimeTracer bool) (map[probes.ProbeFuncNa
 		if ClassificationSupported(c) {
 			enableProbe(enabled, probes.ProtocolClassifierEntrySocketFilter)
 			enableProbe(enabled, probes.ProtocolClassifierSocketFilter)
+			enableProbe(enabled, probes.ProtocolClassifierSocketContFilter)
 			enableProbe(enabled, probes.NetDevQueue)
 		}
 		enableProbe(enabled, selectVersionBasedProbe(runtimeTracer, kv, probes.TCPSendMsg, probes.TCPSendMsgPre410, kv410))

--- a/pkg/network/tracer/connection/kprobe/manager.go
+++ b/pkg/network/tracer/connection/kprobe/manager.go
@@ -29,6 +29,7 @@ var mainProbes = []probes.ProbeFuncName{
 	probes.NetDevQueue,
 	probes.ProtocolClassifierEntrySocketFilter,
 	probes.ProtocolClassifierSocketFilter,
+	probes.ProtocolClassifierSocketContFilter,
 	probes.TCPSendMsg,
 	probes.TCPSendMsgReturn,
 	probes.TCPRecvMsg,

--- a/pkg/network/tracer/connection/kprobe/tracer.go
+++ b/pkg/network/tracer/connection/kprobe/tracer.go
@@ -41,6 +41,14 @@ var (
 				UID:          probeUID,
 			},
 		},
+		{
+			ProgArrayName: probes.ClassificationProgsMap,
+			Key:           1,
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				EBPFFuncName: probes.ProtocolClassifierSocketContFilter,
+				UID:          probeUID,
+			},
+		},
 	}
 )
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Split protocol classifier into multiple tail calls.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

When adding kafka classification we are facing errors caused by a limitation of the number of instructions can be loaded in a single prog.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
