### PR TITLE
[tagger] Add "availability-zone" tag to ECS Fargate

### DIFF
--- a/pkg/tagger/collectors/workloadmeta_extract.go
+++ b/pkg/tagger/collectors/workloadmeta_extract.go
@@ -335,7 +335,8 @@ func (c *WorkloadMetaCollector) handleECSTask(ev workloadmeta.Event) []*TagInfo 
 
 	if task.LaunchType == workloadmeta.ECSLaunchTypeFargate {
 		taskTags.AddLow("region", task.Region)
-		taskTags.AddLow("availability_zone", task.AvailabilityZone)
+		taskTags.AddLow("availability_zone", task.AvailabilityZone) // Deprecated
+		taskTags.AddLow("availability-zone", task.AvailabilityZone)
 	} else if c.collectEC2ResourceTags {
 		addResourceTags(taskTags, task.ContainerInstanceTags)
 		addResourceTags(taskTags, task.Tags)

--- a/pkg/tagger/collectors/workloadmeta_test.go
+++ b/pkg/tagger/collectors/workloadmeta_test.go
@@ -479,6 +479,7 @@ func TestHandleECSTask(t *testing.T) {
 						Name: containerName,
 					},
 				},
+				AvailabilityZone: "us-east-1c",
 			},
 			expected: []*TagInfo{
 				{
@@ -495,6 +496,8 @@ func TestHandleECSTask(t *testing.T) {
 						"task_family:datadog-agent",
 						"task_name:datadog-agent",
 						"task_version:1",
+						"availability_zone:us-east-1c",
+						"availability-zone:us-east-1c",
 					},
 					StandardTags: []string{},
 				},
@@ -511,6 +514,8 @@ func TestHandleECSTask(t *testing.T) {
 						"task_family:datadog-agent",
 						"task_name:datadog-agent",
 						"task_version:1",
+						"availability_zone:us-east-1c",
+						"availability-zone:us-east-1c",
 					},
 					StandardTags: []string{},
 				},

--- a/releasenotes/notes/ecs-fargate-availability-zone-tag-d4bf4e95d0892c69.yaml
+++ b/releasenotes/notes/ecs-fargate-availability-zone-tag-d4bf4e95d0892c69.yaml
@@ -13,4 +13,4 @@ enhancements:
 deprecations:
   - |
     Marked the "availability_zone" tag as deprecated for the Fargate
-    integration, in favor of "availability_zone".
+    integration, in favor of "availability-zone".

--- a/releasenotes/notes/ecs-fargate-availability-zone-tag-d4bf4e95d0892c69.yaml
+++ b/releasenotes/notes/ecs-fargate-availability-zone-tag-d4bf4e95d0892c69.yaml
@@ -1,0 +1,16 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Added the "availability-zone" tag to the Fargate integration. This
+    matches the tag emitted by other AWS infrastructure integrations.
+deprecations:
+  - |
+    Marked the "availability_zone" tag as deprecated for the Fargate
+    integration, in favor of "availability_zone".


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Adds the "availability-zone" tag to the Fargate integration and deprecates the "availability_zone" tag.

### Motivation

This change makes the tagging consistent between Fargate and other AWS infrastructure offerings, such as EC2 and ECS. It should therefore make it easier to create dashboards and monitors that encompass multiple of these offerings.

### Describe how to test/QA your changes

I deployed a new Fargate cluster to our sandbox AWS account, and deployed some test workloads there with this change packaged and running as a sidecar. I then validated in the datadog UI that both the "availability-zone" as well as the "availability_zone" tags were in place.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
