### PR TITLE
[single-machine-performance] file_to_blackhole: change optimization goal to egress throughput

### DIFF
--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -10,7 +10,7 @@ single-machine-performance-regression_detector:
     paths:
       - submission_metadata
   variables:
-    SMP_VERSION: 0.7.0
+    SMP_VERSION: 0.7.1
     LADING_VERSION: 0.12.0
     TOTAL_SAMPLES: 600
     WARMUP_SECONDS: 45

--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -63,7 +63,6 @@ single-machine-performance-regression_detector:
             --comparison-sha ${CI_COMMIT_SHA}
             --target-name datadog-agent
             --target-command "/bin/entrypoint.sh"
-            --target-inherit-environment
             --target-environment-variables "DD_HOSTNAME=smp-regression,DD_DD_URL=http://127.0.0.1:9092,DD_API_KEY=00000001"
             --target-config-dir test/regression/
             --target-cpu-allotment ${CPUS}

--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -10,8 +10,8 @@ single-machine-performance-regression_detector:
     paths:
       - submission_metadata
   variables:
-    SMP_VERSION: 0.6.6-rc1
-    LADING_VERSION: 0.11.2
+    SMP_VERSION: 0.7.0
+    LADING_VERSION: 0.12.0
     TOTAL_SAMPLES: 600
     WARMUP_SECONDS: 45
     REPLICAS: 10

--- a/test/regression/README.md
+++ b/test/regression/README.md
@@ -25,6 +25,20 @@ The structure of each case is as follows:
 * `datadog-agent/` -- __Required__ This is the configuration directory of your
   program. Will be mounted read-only in the container build from `Dockerfile`
   above at `/etc/datadog-agent`.
+* `experiment.yaml` -- __Optional__ This file can be used to set a
+  single optimization goal for each experiment.
+
+  In this file, the optimization goal is set via a snippet like
+
+  ```yaml
+  optimization_goal: ingress_throughput
+  ```
+
+  Supported values of `optimization_goal` are `ingress_throughput` and
+  `egress_throughput`.
+
+  If an experiment omits this file, the optimization goal defaults to
+  `ingress_throughput`.
 
 [Vector]: https://github.com/vectordotdev/vector/tree/master/regression
 [lading]: https://github.com/DataDog/lading

--- a/test/regression/cases/file_to_blackhole/experiment.yaml
+++ b/test/regression/cases/file_to_blackhole/experiment.yaml
@@ -1,0 +1,1 @@
+optimization_goal: egress_throughput


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This pull request changes the optimization goal of the `file_to_blackhole` experiment to egress throughput by adding an `experiment.yaml` file to that experiment. In addition, this pull request updates the Regression Detection README to include information on how to set an optimization goal for each experiment.

### Motivation

Measuring egress throughput for the `file_to_blackhole` experiment is of more interest than measuring ingress throughput; the latter is the current optimization goal for that experiment.

### Additional Notes

These changes follow upon recent work on single-machine-performance to enables users to set a single optimization goal per experiment instead of a single optimization goal for all experiments. These changes also follow up on PR #14528.

For each experiment, an `experiment.yaml` file is optional. If that file is absent for an experiment, the optimization goal for that experiment defaults to ingress throughput. As illustrated in this pull request, the optimization goal for an experiment can be changed for an experiment by placing an `experiment.yaml` file at the root of the directory tree for that experiment, e.g., for the `file_to_blackhole` experiment, at `test/regression/cases/file_to_blackhole/experiment.yaml`.

The contents of an example `experiment.yaml` file are

```yaml
optimization_goal: egress_throughput
```

The only other value of `optimization_goal` currently supported is `ingress_throughput`.

Backend changes required to support `experiment.yaml` files have already been deployed, so in theory, once this PR is merged, `file_to_blackhole` results for egress throughput should replace the ingress throughput results currently emitted.

### Possible Drawbacks / Trade-offs

This pull request trades off additional complexity -- an optional additional file per experiment -- for flexibility in defining an optimization goal for each experiment, which supports more use cases.

### Describe how to test/QA your changes

Changes have been dogfed using our dogfood project, so hopefully, this change will work without any disruptions. If it doesn't, reach out and we'd be glad to help.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
