### PR TITLE
[CWS] Lower the error log level of tracefs checks

### DIFF
--- a/pkg/util/kernel/fs.go
+++ b/pkg/util/kernel/fs.go
@@ -106,25 +106,25 @@ func isTraceFSMounted() bool {
 	_, err := os.Stat("/sys/kernel/tracing/kprobe_events")
 	if err != nil {
 		if os.IsPermission(err) {
-			seclog.Errorf("eBPF not supported, does not have permission to access tracefs")
+			seclog.Infof("eBPF not supported, does not have permission to access tracefs kprobe_events (/sys/kernel/tracing/kprobe_events)")
 			return false
 		} else if os.IsNotExist(err) {
-			seclog.Errorf("tracefs is not mounted and is needed for eBPF-based checks, run \"sudo mount -t tracefs none /sys/kernel/tracing\" to mount tracefs")
+			seclog.Infof("tracefs is not mounted in /sys/kernel/tracing/ and is needed for eBPF-based checks, run \"sudo mount -t tracefs none /sys/kernel/tracing\" to mount tracefs")
 			return false
 		} else {
-			seclog.Errorf("an error occurred while accessing tracefs: %s", err)
+			seclog.Infof("an error occurred while accessing tracefs sysfs entry (/sys/kernel/tracing/kprobe_events): %s", err)
 			return false
 		}
 	}
 
 	mi, err := GetMountPoint("/sys/kernel/tracing/kprobe_events")
 	if err != nil {
-		seclog.Errorf("unable to detect tracefs mount point: %s", err)
+		seclog.Infof("unable to detect tracefs mount point (/sys/kernel/tracing/): %s", err)
 		return false
 	}
 
 	if mi.FSType != "tracefs" {
-		seclog.Errorf("kprobe_events mount point(%s): wrong fs type(%s)", mi.Mountpoint, mi.FSType)
+		seclog.Infof("kprobe_events mount point(%s): wrong fs type(%s)", mi.Mountpoint, mi.FSType)
 		return false
 	}
 
@@ -133,7 +133,7 @@ func isTraceFSMounted() bool {
 		options := strings.Split(mi.Options, ",")
 		for _, option := range options {
 			if option == "ro" {
-				seclog.Errorf("kprobe_events mount point(%s) is in read-only mode", mi.Mountpoint)
+				seclog.Infof("tracefs mount point(%s) is in read-only mode", mi.Mountpoint)
 				return false
 			}
 		}


### PR DESCRIPTION
### What does this PR do?

Lower the error log level of tracefs checks  until default one (`/sys/kernel/tracing`) is fully supported. This would require the merge/integration of new versions cilium/ebpf and ebpf-manager with those patches: [ebpf-manager](https://github.com/DataDog/ebpf-manager/pull/91) and [cilium/ebpf](https://github.com/cilium/ebpf/pull/906).

### Motivation

Do not log error messages for something's that is not fully supported yet, and for what we have a working fallback (debugfs).

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
