### PR TITLE
[listeners/snmp] Make SNMP Listener support all authProtocol

### DIFF
--- a/pkg/snmp/snmp.go
+++ b/pkg/snmp/snmp.go
@@ -13,13 +13,14 @@ import (
 	"reflect"
 	"sort"
 	"strconv"
-	"strings"
 	"time"
-
-	coreconfig "github.com/DataDog/datadog-agent/pkg/config"
 
 	"github.com/DataDog/viper"
 	"github.com/gosnmp/gosnmp"
+
+	coreconfig "github.com/DataDog/datadog-agent/pkg/config"
+
+	"github.com/DataDog/datadog-agent/pkg/snmp/gosnmplib"
 )
 
 const (
@@ -212,36 +213,14 @@ func (c *Config) BuildSNMPParams(deviceIP string) (*gosnmp.GoSNMP, error) {
 		return nil, fmt.Errorf("SNMP version not supported: %s", c.Version)
 	}
 
-	var authProtocol gosnmp.SnmpV3AuthProtocol
-	lowerAuthProtocol := strings.ToLower(c.AuthProtocol)
-	if lowerAuthProtocol == "" {
-		authProtocol = gosnmp.NoAuth
-	} else if lowerAuthProtocol == "md5" {
-		authProtocol = gosnmp.MD5
-	} else if lowerAuthProtocol == "sha" {
-		authProtocol = gosnmp.SHA
-	} else {
-		return nil, fmt.Errorf("Unsupported authentication protocol: %s", c.AuthProtocol)
+	authProtocol, err := gosnmplib.GetAuthProtocol(c.AuthProtocol)
+	if err != nil {
+		return nil, err
 	}
 
-	var privProtocol gosnmp.SnmpV3PrivProtocol
-	lowerPrivProtocol := strings.ToLower(c.PrivProtocol)
-	if lowerPrivProtocol == "" {
-		privProtocol = gosnmp.NoPriv
-	} else if lowerPrivProtocol == "des" {
-		privProtocol = gosnmp.DES
-	} else if lowerPrivProtocol == "aes" {
-		privProtocol = gosnmp.AES
-	} else if lowerPrivProtocol == "aes192" {
-		privProtocol = gosnmp.AES192
-	} else if lowerPrivProtocol == "aes192c" {
-		privProtocol = gosnmp.AES192C
-	} else if lowerPrivProtocol == "aes256" {
-		privProtocol = gosnmp.AES256
-	} else if lowerPrivProtocol == "aes256c" {
-		privProtocol = gosnmp.AES256C
-	} else {
-		return nil, fmt.Errorf("Unsupported privacy protocol: %s", c.PrivProtocol)
+	privProtocol, err := gosnmplib.GetPrivProtocol(c.PrivProtocol)
+	if err != nil {
+		return nil, err
 	}
 
 	msgFlags := gosnmp.NoAuthNoPriv

--- a/pkg/snmp/snmp_test.go
+++ b/pkg/snmp/snmp_test.go
@@ -47,13 +47,33 @@ func TestBuildSNMPParams(t *testing.T) {
 	assert.Equal(t, gosnmp.NoAuthNoPriv, params.MsgFlags)
 	assert.Equal(t, "192.168.0.2", params.Target)
 
+	for _, authProto := range []string{"", "md5", "sha", "sha224", "sha256", "sha384", "sha512"} {
+		config = Config{
+			Network:      "192.168.0.0/24",
+			User:         "admin",
+			AuthProtocol: authProto,
+		}
+		_, err = config.BuildSNMPParams("192.168.0.1")
+		assert.NoError(t, err)
+	}
+
+	for _, privProto := range []string{"", "des", "aes", "aes192", "aes192c", "aes256", "aes256c"} {
+		config = Config{
+			Network:      "192.168.0.0/24",
+			User:         "admin",
+			PrivProtocol: privProto,
+		}
+		_, err = config.BuildSNMPParams("192.168.0.1")
+		assert.NoError(t, err)
+	}
+
 	config = Config{
 		Network:      "192.168.0.0/24",
 		User:         "admin",
 		AuthProtocol: "foo",
 	}
 	_, err = config.BuildSNMPParams("192.168.0.1")
-	assert.Equal(t, "Unsupported authentication protocol: foo", err.Error())
+	assert.Equal(t, "unsupported authentication protocol: foo", err.Error())
 
 	config = Config{
 		Network:      "192.168.0.0/24",
@@ -61,7 +81,7 @@ func TestBuildSNMPParams(t *testing.T) {
 		PrivProtocol: "bar",
 	}
 	_, err = config.BuildSNMPParams("192.168.0.1")
-	assert.Equal(t, "Unsupported privacy protocol: bar", err.Error())
+	assert.Equal(t, "unsupported privacy protocol: bar", err.Error())
 }
 
 func TestNewListenerConfig(t *testing.T) {

--- a/releasenotes/notes/snmp-listener-support-all-auth-protocols-c73eb23131cc575d.yaml
+++ b/releasenotes/notes/snmp-listener-support-all-auth-protocols-c73eb23131cc575d.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Make SNMP Listener support all authProtocol.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

[listeners/snmp] Make SNMP Listener support all authProtocol

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
