### PR TITLE
backport dmi change to 7.43.x

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -737,7 +737,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("ec2_metadata_token_lifetime", 21600) // value in seconds
 	config.BindEnvAndSetDefault("ec2_prefer_imdsv2", false)
 	config.BindEnvAndSetDefault("ec2_prioritize_instance_id_as_hostname", false) // used to bypass the hostname detection logic and force the EC2 instance ID as a hostname.
-	config.BindEnvAndSetDefault("ec2_use_dmi", true)                             // should the agent leverage DMI information to know if it's running on EC2 or not.
+	config.BindEnvAndSetDefault("ec2_use_dmi", false)                            // should the agent leverage DMI information to know if it's running on EC2 or not. Enabling this will add the instance ID from DMI to the host alias list.
 	config.BindEnvAndSetDefault("collect_ec2_tags", false)
 	config.BindEnvAndSetDefault("collect_ec2_tags_use_imds", false)
 	config.BindEnvAndSetDefault("exclude_ec2_tags", []string{})

--- a/pkg/util/ec2/dmi.go
+++ b/pkg/util/ec2/dmi.go
@@ -57,6 +57,10 @@ func getInstanceIDFromDMI() (string, error) {
 // Depending on the instance type either the DMI product UUID or the hypervisor UUID is available. In both case, if they
 // start with "ec2" we return true.
 func isEC2UUID() bool {
+	if !config.Datadog.GetBool("ec2_use_dmi") {
+		return false
+	}
+
 	// if we have a board vendor we can skip this UUID check
 	if dmi.GetBoardVendor() != "" && !isBoardVendorEC2() {
 		return false

--- a/pkg/util/ec2/dmi_test.go
+++ b/pkg/util/ec2/dmi_test.go
@@ -14,6 +14,9 @@ import (
 )
 
 func TestIsBoardVendorEC2(t *testing.T) {
+	config.Mock(t)
+	config.Datadog.Set("ec2_use_dmi", true)
+
 	setupDMIForNotEC2(t)
 	assert.False(t, isBoardVendorEC2())
 
@@ -26,6 +29,9 @@ func TestIsBoardVendorEC2(t *testing.T) {
 }
 
 func TestGetInstanceIDFromDMI(t *testing.T) {
+	config.Mock(t)
+	config.Datadog.Set("ec2_use_dmi", true)
+
 	setupDMIForNotEC2(t)
 	instanceID, err := getInstanceIDFromDMI()
 	assert.Error(t, err)
@@ -43,6 +49,9 @@ func TestGetInstanceIDFromDMI(t *testing.T) {
 }
 
 func TestIsEC2UUID(t *testing.T) {
+	config.Mock(t)
+	config.Datadog.Set("ec2_use_dmi", true)
+
 	// no UUID
 	dmi.SetupMock(t, "", "", "", "")
 	assert.False(t, isEC2UUID())
@@ -67,6 +76,9 @@ func TestIsEC2UUID(t *testing.T) {
 }
 
 func TestIsEC2UUIDSwapEndian(t *testing.T) {
+	config.Mock(t)
+	config.Datadog.Set("ec2_use_dmi", true)
+
 	// hypervisor
 	dmi.SetupMock(t, "45E12AEC-DCD1-B213-94ED-012345ABCDEF", "", "", "")
 	assert.True(t, isEC2UUID())

--- a/pkg/util/ec2/ec2_test.go
+++ b/pkg/util/ec2/ec2_test.go
@@ -166,6 +166,8 @@ func TestGetHostAliases(t *testing.T) {
 			config.Mock(t)
 			if tc.disableDMI {
 				config.Datadog.Set("ec2_use_dmi", false)
+			} else {
+				config.Datadog.Set("ec2_use_dmi", true)
 			}
 
 			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -458,6 +460,9 @@ func TestGetNTPHostsFromIMDS(t *testing.T) {
 }
 
 func TestGetNTPHostsDMI(t *testing.T) {
+	config.Mock(t)
+	config.Datadog.Set("ec2_use_dmi", true)
+
 	setupDMIForEC2(t)
 	defer resetPackageVars()
 	metadataURL = ""
@@ -467,6 +472,9 @@ func TestGetNTPHostsDMI(t *testing.T) {
 }
 
 func TestGetNTPHostsEC2UUID(t *testing.T) {
+	config.Mock(t)
+	config.Datadog.Set("ec2_use_dmi", true)
+
 	dmi.SetupMock(t, "ec2something", "", "", "")
 	defer resetPackageVars()
 	metadataURL = ""
@@ -538,6 +546,9 @@ func TestMetadataSourceIMDS(t *testing.T) {
 }
 
 func TestMetadataSourceUUID(t *testing.T) {
+	config.Mock(t)
+	config.Datadog.Set("ec2_use_dmi", true)
+
 	ctx := context.Background()
 
 	metadataURL = ""
@@ -557,6 +568,9 @@ func TestMetadataSourceUUID(t *testing.T) {
 }
 
 func TestMetadataSourceDMI(t *testing.T) {
+	config.Mock(t)
+	config.Datadog.Set("ec2_use_dmi", true)
+
 	ctx := context.Background()
 
 	metadataURL = ""
@@ -568,6 +582,9 @@ func TestMetadataSourceDMI(t *testing.T) {
 }
 
 func TestMetadataSourceDMIPreventFallback(t *testing.T) {
+	config.Mock(t)
+	config.Datadog.Set("ec2_use_dmi", true)
+
 	ctx := context.Background()
 
 	metadataURL = ""


### PR DESCRIPTION
### What does this PR do?
Maxime/backport dmi change https://github.com/DataDog/datadog-agent/pull/15639

### Describe how to test/QA your changes

Run the Agent on Linux+Nitro on ec2. Disable IMDS endpoint (`aws ec2 modify-instance-metadata-options --instance-id <instance ID> --http-endpoint disabled`). Check that the instance ID is not part of the host alias in the status page.

Then enable `ec2_use_dmi` in the Agent configuration, restart the Agent and check the instance ID is now part of the host alias in the status page.

In both cases check that the DMI data is still correctly sent (`datadog-agent -c . diagnose show-metadata inventory`). Look for `dmi_product_uuid`, `dmi_board_asset_tag` and `dmi_board_vendor`.



### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
