### PR TITLE
Report logs sent/dropped metrics

### DIFF
--- a/pkg/aggregator/mocksender/mocked_methods.go
+++ b/pkg/aggregator/mocksender/mocked_methods.go
@@ -21,6 +21,11 @@ func (m *MockSender) Count(metric string, value float64, hostname string, tags [
 	m.Called(metric, value, hostname, tags)
 }
 
+// Count adds an unindexed count type to the mock calls.
+func (m *MockSender) CountNoIndex(metric string, value float64, hostname string, tags []string) {
+	m.Called(metric, value, hostname, tags)
+}
+
 // MonotonicCount adds a monotonic count type to the mock calls.
 func (m *MockSender) MonotonicCount(metric string, value float64, hostname string, tags []string) {
 	m.Called(metric, value, hostname, tags)

--- a/pkg/aggregator/sender.go
+++ b/pkg/aggregator/sender.go
@@ -24,6 +24,7 @@ type Sender interface {
 	GaugeNoIndex(metric string, value float64, hostname string, tags []string)
 	Rate(metric string, value float64, hostname string, tags []string)
 	Count(metric string, value float64, hostname string, tags []string)
+	CountNoIndex(metric string, value float64, hostname string, tags []string)
 	MonotonicCount(metric string, value float64, hostname string, tags []string)
 	MonotonicCountWithFlushFirstValue(metric string, value float64, hostname string, tags []string, flushFirstValue bool)
 	Counter(metric string, value float64, hostname string, tags []string)
@@ -306,6 +307,11 @@ func (s *checkSender) Rate(metric string, value float64, hostname string, tags [
 // Count should be used to count a number of events that occurred during the check run
 func (s *checkSender) Count(metric string, value float64, hostname string, tags []string) {
 	s.sendMetricSample(metric, value, hostname, tags, metrics.CountType, false, false)
+}
+
+// Count should be used to count a number of events that occurred during the check run
+func (s *checkSender) CountNoIndex(metric string, value float64, hostname string, tags []string) {
+	s.sendMetricSample(metric, value, hostname, tags, metrics.CountType, false, true)
 }
 
 // MonotonicCount should be used to track the increase of a monotonic raw counter

--- a/pkg/forwarder/internal/retry/test_common.go
+++ b/pkg/forwarder/internal/retry/test_common.go
@@ -19,6 +19,8 @@ type StatsTelemetrySenderMock struct{}
 
 func (m StatsTelemetrySenderMock) Count(metric string, value float64, hostname string, tags []string) {
 }
+func (m StatsTelemetrySenderMock) CountNoIndex(metric string, value float64, hostname string, tags []string) {
+}
 func (m StatsTelemetrySenderMock) Gauge(metric string, value float64, hostname string, tags []string) {
 }
 func (m StatsTelemetrySenderMock) GaugeNoIndex(metric string, value float64, hostname string, tags []string) {

--- a/pkg/logs/client/http/destination.go
+++ b/pkg/logs/client/http/destination.go
@@ -239,6 +239,7 @@ func (d *Destination) sendAndRetry(payload *message.Payload, output chan *messag
 
 		metrics.LogsSent.Add(int64(len(payload.Messages)))
 		metrics.TlmLogsSent.Add(float64(len(payload.Messages)))
+		d.provider.CountNoIndex("datadog.logs_agent.logs_sent", float64(len(payload.Messages)), nil)
 		output <- payload
 		return
 	}

--- a/pkg/telemetry/stats_telemetry.go
+++ b/pkg/telemetry/stats_telemetry.go
@@ -10,6 +10,7 @@ import "sync"
 // StatsTelemetrySender contains methods needed for sending stats metrics
 type StatsTelemetrySender interface {
 	Count(metric string, value float64, hostname string, tags []string)
+	CountNoIndex(metric string, value float64, hostname string, tags []string)
 	Gauge(metric string, value float64, hostname string, tags []string)
 	GaugeNoIndex(metric string, value float64, hostname string, tags []string)
 	HistogramNoIndex(metric string, value float64, hostname string, tags []string)
@@ -45,6 +46,11 @@ func GetStatsTelemetryProvider() *StatsTelemetryProvider {
 // Count reports a count metric to the sender
 func (s *StatsTelemetryProvider) Count(metric string, value float64, tags []string) {
 	s.send(func(sender StatsTelemetrySender) { sender.Count(metric, value, "", tags) })
+}
+
+// Count reports a count metric to the sender
+func (s *StatsTelemetryProvider) CountNoIndex(metric string, value float64, tags []string) {
+	s.send(func(sender StatsTelemetrySender) { sender.CountNoIndex(metric, value, "", tags) })
 }
 
 // Gauge reports a gauge metric to the sender


### PR DESCRIPTION
### What does this PR do?

Reports the number of logs sent and dropped as metrics via the statsd telemetry system. These metrics are not indexed, so not automatically presented to users.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

This is based off of https://github.com/DataDog/datadog-agent/pull/15503, so I'll rebase to main once that is merged.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

With the agent running and sending logs, `datadog.logs_agent.logs_{sent,dropped}` metrics will be available in the UI. They won't autocomplete due to being `NoIndex`, but can be entered directly.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
