### PR TITLE
[workloadmeta/collectors/docker] Collect image metadata

### DIFF
--- a/pkg/util/docker/docker_util.go
+++ b/pkg/util/docker/docker_util.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/client"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
@@ -251,6 +252,32 @@ func (d *DockerUtil) GetPreferredImageName(imageID string, repoTags []string, re
 
 	d.imageNameBySha[imageID] = preferredName
 	return preferredName
+}
+
+// ImageInspect returns an image inspect object for a given image ID
+func (d *DockerUtil) ImageInspect(ctx context.Context, imageID string) (types.ImageInspect, error) {
+	ctx, cancel := context.WithTimeout(ctx, d.queryTimeout)
+	defer cancel()
+
+	imageInspect, _, err := d.cli.ImageInspectWithRaw(ctx, imageID)
+	if err != nil {
+		return imageInspect, fmt.Errorf("error inspecting image: %w", err)
+	}
+
+	return imageInspect, nil
+}
+
+// ImageHistory returns the history for a given image ID
+func (d *DockerUtil) ImageHistory(ctx context.Context, imageID string) ([]image.HistoryResponseItem, error) {
+	ctx, cancel := context.WithTimeout(ctx, d.queryTimeout)
+	defer cancel()
+
+	history, err := d.cli.ImageHistory(ctx, imageID)
+	if err != nil {
+		return history, fmt.Errorf("error getting image history: %w", err)
+	}
+
+	return history, nil
 }
 
 // ResolveImageNameFromContainer will resolve the container sha image name to their user-friendly name.

--- a/pkg/util/docker/event_pull.go
+++ b/pkg/util/docker/event_pull.go
@@ -47,7 +47,7 @@ func (d *DockerUtil) openEventChannel(ctx context.Context, since, until time.Tim
 func (d *DockerUtil) processContainerEvent(ctx context.Context, msg events.Message, filter *containers.Filter) (*ContainerEvent, error) {
 	// Type filtering
 	// Filtering out prune events as well as they don't have a container name
-	if msg.Type != "container" || msg.Action == "prune" {
+	if msg.Type != events.ContainerEventType || msg.Action == "prune" {
 		return nil, nil
 	}
 
@@ -76,16 +76,6 @@ func (d *DockerUtil) processContainerEvent(ctx context.Context, msg events.Messa
 		return nil, nil
 	}
 
-	// msg.TimeNano does not hold the nanosecond portion of the timestamp
-	// like it's usual to do in Go, but the whole timestamp value as ns value
-	// We need to subtract the second value to get only the nanoseconds.
-	// Keeping that behind a value test in case docker developers fix that
-	// inconsistency in the future.
-	ns := msg.TimeNano
-	if ns > 1e10 {
-		ns = ns - msg.Time*1e9
-	}
-
 	action := msg.Action
 
 	// Fix the "exec_start: /bin/sh -c true" case
@@ -98,18 +88,32 @@ func (d *DockerUtil) processContainerEvent(ctx context.Context, msg events.Messa
 		ContainerName: containerName,
 		ImageName:     imageName,
 		Action:        action,
-		Timestamp:     time.Unix(msg.Time, ns),
+		Timestamp:     timeFromMessage(msg),
 		Attributes:    msg.Actor.Attributes,
 	}
 
 	return event, nil
 }
 
+// processImageEvent formats the events from a channel.
+// It can return nil, nil if the event is filtered out, one should check for nil pointers before using the event.
+func (d *DockerUtil) processImageEvent(msg events.Message) *ImageEvent {
+	if msg.Type != events.ImageEventType {
+		return nil
+	}
+
+	return &ImageEvent{
+		ImageID:   msg.Actor.ID,
+		Action:    msg.Action,
+		Timestamp: timeFromMessage(msg),
+	}
+}
+
 // LatestContainerEvents returns events matching the filter that occurred after the time passed.
 // It returns the latest event timestamp in the slice for the user to store and pass again in the next call.
 func (d *DockerUtil) LatestContainerEvents(ctx context.Context, since time.Time, filter *containers.Filter) ([]*ContainerEvent, time.Time, error) {
-	var events []*ContainerEvent
-	filters := map[string]string{"type": "container"}
+	var containerEvents []*ContainerEvent
+	filters := map[string]string{"type": events.ContainerEventType}
 
 	ctx, cancel := context.WithTimeout(ctx, d.queryTimeout)
 	defer cancel()
@@ -127,7 +131,7 @@ func (d *DockerUtil) LatestContainerEvents(ctx context.Context, since time.Time,
 			} else if event == nil {
 				continue
 			}
-			events = append(events, event)
+			containerEvents = append(containerEvents, event)
 			if event.Timestamp.After(maxTimestamp) {
 				maxTimestamp = event.Timestamp
 			}
@@ -135,8 +139,23 @@ func (d *DockerUtil) LatestContainerEvents(ctx context.Context, since time.Time,
 			if err == io.EOF {
 				break
 			} else {
-				return events, maxTimestamp, err
+				return containerEvents, maxTimestamp, err
 			}
 		}
 	}
+}
+
+func timeFromMessage(msg events.Message) time.Time {
+	// msg.TimeNano does not hold the nanosecond portion of the timestamp
+	// like it's usual to do in Go, but the whole timestamp value as ns value
+	// We need to subtract the second value to get only the nanoseconds.
+	// Keeping that behind a value test in case docker developers fix that
+	// inconsistency in the future.
+
+	ns := msg.TimeNano
+	if ns > 1e10 {
+		ns = ns - msg.Time*1e9
+	}
+
+	return time.Unix(msg.Time, ns)
 }

--- a/pkg/util/docker/event_stream.go
+++ b/pkg/util/docker/event_stream.go
@@ -15,8 +15,10 @@ import (
 	"time"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/events"
 	"github.com/docker/docker/api/types/filters"
 
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -25,16 +27,16 @@ import (
 // // DockerUtil logic covered by the listeners/docker and dogstatsd/origin_detection integration tests.
 const eventSendBuffer = 5
 
-// SubscribeToContainerEvents allows a package to subscribe to events from the event stream.
+// SubscribeToEvents allows a package to subscribe to events from the event stream.
 // A unique subscriber name should be provided.
-func (d *DockerUtil) SubscribeToContainerEvents(name string, filter *containers.Filter) (<-chan *ContainerEvent, <-chan error, error) {
+func (d *DockerUtil) SubscribeToEvents(name string, filter *containers.Filter) (<-chan *ContainerEvent, <-chan *ImageEvent, <-chan error, error) {
 	sub, err := d.eventState.subscribe(name, filter)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	go d.dispatchEvents(sub)
-	return sub.eventChan, sub.errorChan, err
+	return sub.containerEventsChan, sub.imageEventsChan, sub.errorChan, err
 }
 
 func (e *eventStreamState) subscribe(name string, filter *containers.Filter) (*eventSubscriber, error) {
@@ -46,11 +48,12 @@ func (e *eventStreamState) subscribe(name string, filter *containers.Filter) (*e
 	e.RUnlock()
 
 	sub := &eventSubscriber{
-		name:       name,
-		eventChan:  make(chan *ContainerEvent, eventSendBuffer),
-		errorChan:  make(chan error, 1), // TODO: remove errorChan once design is stable
-		cancelChan: make(chan struct{}),
-		filter:     filter,
+		name:                name,
+		containerEventsChan: make(chan *ContainerEvent, eventSendBuffer),
+		imageEventsChan:     make(chan *ImageEvent, eventSendBuffer),
+		errorChan:           make(chan error, 1), // TODO: remove errorChan once design is stable
+		cancelChan:          make(chan struct{}),
+		filter:              filter,
 	}
 	e.Lock()
 	e.subscribers[name] = sub
@@ -81,14 +84,6 @@ func (e *eventStreamState) unsubscribe(name string) error {
 }
 
 func (d *DockerUtil) dispatchEvents(sub *eventSubscriber) {
-	fltrs := filters.NewArgs()
-	fltrs.Add("type", "container")
-	fltrs.Add("event", ContainerEventActionStart)
-	fltrs.Add("event", ContainerEventActionDie)
-	fltrs.Add("event", ContainerEventActionDied)
-	fltrs.Add("event", ContainerEventActionRename)
-	fltrs.Add("event", ContainerEventActionHealthStatus)
-
 	// On initial subscribe, don't go back in time. On reconnect, we'll
 	// resume at the latest timestamp we got.
 	latestTimestamp := time.Now().Unix()
@@ -98,7 +93,7 @@ CONNECT: // Outer loop handles re-connecting in case the docker daemon closes th
 	for {
 		eventOptions := types.EventsOptions{
 			Since:   strconv.FormatInt(latestTimestamp, 10),
-			Filters: fltrs,
+			Filters: eventFilters(),
 		}
 
 		var ctx context.Context
@@ -123,22 +118,54 @@ CONNECT: // Outer loop handles re-connecting in case the docker daemon closes th
 				continue CONNECT // Re-connect to docker
 			case msg := <-messages:
 				latestTimestamp = msg.Time
-				event, err := d.processContainerEvent(ctx, msg, sub.filter)
-				if err != nil {
-					log.Debugf("Skipping event: %s", err)
+				switch msg.Type {
+				case events.ContainerEventType:
+					event, err := d.processContainerEvent(ctx, msg, sub.filter)
+					if err != nil {
+						log.Debugf("Skipping event: %s", err)
+						continue
+					}
+					if event == nil {
+						continue
+					}
+					// Block if the buffered channel is full, pausing the http
+					// stream. If docker closes because of client timeout, we
+					// will reconnect later and stream from latestTimestamp.
+					sub.containerEventsChan <- event
+				case events.ImageEventType:
+					event := d.processImageEvent(msg)
+
+					if event == nil {
+						continue
+					}
+
+					sub.imageEventsChan <- event
+				default:
+					log.Debugf("Skipping event with type %s", msg.Type)
 					continue
 				}
-				if event == nil {
-					continue
-				}
-				// Block if the buffered channel is full, pausing the http
-				// stream. If docker closes because of client timeout, we
-				// will reconnect later and stream from latestTimestamp.
-				sub.eventChan <- event
 			}
 		}
 	}
 	cancelFunc()
 	close(sub.errorChan)
-	close(sub.eventChan)
+	close(sub.containerEventsChan)
+}
+
+func eventFilters() filters.Args {
+	res := filters.NewArgs()
+
+	res.Add("type", events.ContainerEventType)
+	for _, containerEventAction := range containerEventActions {
+		res.Add("event", containerEventAction)
+	}
+
+	if config.Datadog.GetBool("container_image_collection.metadata.enabled") {
+		res.Add("type", events.ImageEventType)
+		for _, imageEventAction := range imageEventActions {
+			res.Add("event", imageEventAction)
+		}
+	}
+
+	return res
 }

--- a/pkg/util/docker/event_types.go
+++ b/pkg/util/docker/event_types.go
@@ -28,9 +28,33 @@ const (
 	// ContainerEventActionHealthStatus is the action of changing a docker
 	// container's health status
 	ContainerEventActionHealthStatus = "health_status"
+
+	// ImageEventActionPull is the action of pulling a docker image
+	ImageEventActionPull = "pull"
+	// ImageEventActionDelete is the action of deleting a docker image
+	ImageEventActionDelete = "delete"
+	// ImageEventActionTag is the action of tagging a docker image
+	ImageEventActionTag = "tag"
+	// ImageEventActionUntag is the action of untagging a docker image
+	ImageEventActionUntag = "untag"
 )
 
-// ContainerEvent describes an event from the docker daemon
+var containerEventActions = []string{
+	ContainerEventActionStart,
+	ContainerEventActionDie,
+	ContainerEventActionDied,
+	ContainerEventActionRename,
+	ContainerEventActionHealthStatus,
+}
+
+var imageEventActions = []string{
+	ImageEventActionPull,
+	ImageEventActionDelete,
+	ImageEventActionDelete,
+	ImageEventActionUntag,
+}
+
+// ContainerEvent describes a container event from the docker daemon
 type ContainerEvent struct {
 	ContainerID   string
 	ContainerName string
@@ -38,6 +62,14 @@ type ContainerEvent struct {
 	Action        string
 	Timestamp     time.Time
 	Attributes    map[string]string
+}
+
+// ImageEvent describes an image event from the docker daemon
+type ImageEvent struct {
+	ImageID   string // In some events this is a sha, in others it's a name with tag
+	Action    string
+	Timestamp time.Time
+	// There are more attributes in the original event. Add them here if they're needed
 }
 
 // Errors client might receive
@@ -49,11 +81,12 @@ var (
 
 // eventSubscriber holds the state for a subscriber
 type eventSubscriber struct {
-	name       string
-	eventChan  chan *ContainerEvent
-	errorChan  chan error
-	cancelChan chan struct{}
-	filter     *containers.Filter
+	name                string
+	containerEventsChan chan *ContainerEvent
+	imageEventsChan     chan *ImageEvent
+	errorChan           chan error
+	cancelChan          chan struct{}
+	filter              *containers.Filter
 }
 
 // eventStreamState holds the state for event streaming towards subscribers

--- a/releasenotes/notes/docker-collector-image-metadata-df66486543bcc7cc.yaml
+++ b/releasenotes/notes/docker-collector-image-metadata-df66486543bcc7cc.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Added support for collecting container image metadata when using Docker.


### PR DESCRIPTION

### What does this PR do?

Adds support for image metadata collection in the Docker workloadmeta collector.
This is the same feature that we support in the containerd collector already.


### Describe how to test/QA your changes

- Deploy the agent on an environment with Docker with image metadata collection enabled `DD_CONTAINER_IMAGE_COLLECTION_METADATA_ENABLED=true`.
- Run `agent workload-list --verbose` and check that the image metadata reported looks correct.
- Pull, delete, tag, and untag images and check that the output of `agent workload-list --verbose` is correct.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
