### PR TITLE
[CWS] New 'kill' action that allows sending a signal when a rule is triggered

### DIFF
--- a/pkg/security/ebpf/kernel/kernel.go
+++ b/pkg/security/ebpf/kernel/kernel.go
@@ -21,6 +21,7 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
+	ksyms "github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 )
@@ -268,4 +269,10 @@ func (k *Version) HaveMmapableMaps() bool {
 func (k *Version) HaveRingBuffers() bool {
 	// This checks ring buffer maps, which appeared in 5.8
 	return k.Code != 0 && k.Code >= Kernel5_8 && features.HaveMapType(ebpf.RingBuf) == nil
+}
+
+// SupportBPFSendSignal returns true if the eBPF function bpf_send_signal is available
+func SupportBPFSendSignal() bool {
+	missings, err := ksyms.VerifyKernelFuncs(filepath.Join(util.GetProcRoot(), "kallsyms"), []string{"bpf_send_signal"})
+	return len(missings) == 0 && err == nil
 }

--- a/pkg/security/ebpf/probes/all.go
+++ b/pkg/security/ebpf/probes/all.go
@@ -134,6 +134,7 @@ func AllMaps() []*manager.Map {
 		{Name: "selinux_enforce_status"},
 		// Enabled event mask
 		{Name: "enabled_events"},
+		{Name: "kill_list"},
 	}
 }
 

--- a/pkg/security/secl/model/consts_common.go
+++ b/pkg/security/secl/model/consts_common.go
@@ -820,11 +820,11 @@ func initMMapFlagsConstants() {
 }
 
 func initSignalConstants() {
-	for k, v := range signalConstants {
+	for k, v := range SignalConstants {
 		SECLConstants[k] = &eval.IntEvaluator{Value: v}
 	}
 
-	for k, v := range signalConstants {
+	for k, v := range SignalConstants {
 		signalStrings[v] = k
 	}
 }

--- a/pkg/security/secl/model/consts_linux.go
+++ b/pkg/security/secl/model/consts_linux.go
@@ -338,7 +338,7 @@ var (
 
 	// signalConstants are the supported signals for the kill syscall
 	// generate_constants:Signal constants,Signal constants are the supported signals for the kill syscall.
-	signalConstants = map[string]int{
+	SignalConstants = map[string]int{
 		"SIGHUP":    int(unix.SIGHUP),
 		"SIGINT":    int(unix.SIGINT),
 		"SIGQUIT":   int(unix.SIGQUIT),

--- a/pkg/security/secl/model/consts_other.go
+++ b/pkg/security/secl/model/consts_other.go
@@ -20,6 +20,6 @@ var (
 	protConstants             = map[string]int{}
 	mmapFlagConstants         = map[string]uint64{}
 	mmapFlagArchConstants     = map[string]uint64{}
-	signalConstants           = map[string]int{}
+	SignalConstants           = map[string]int{}
 	addressFamilyConstants    = map[string]uint16{}
 )

--- a/pkg/security/tests/bpf_test.go
+++ b/pkg/security/tests/bpf_test.go
@@ -9,6 +9,7 @@
 package tests
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -43,7 +44,7 @@ func TestBPFEventLoad(t *testing.T) {
 
 	t.Run("prog_load", func(t *testing.T) {
 		test.WaitSignal(t, func() error {
-			return runSyscallTesterFunc(t, syscallTester, "-load-bpf")
+			return runSyscallTesterFunc(context.Background(), t, syscallTester, "-load-bpf")
 		}, func(event *model.Event, r *rules.Rule) {
 			assert.Equal(t, "bpf", event.GetType(), "wrong event type")
 			assert.Equal(t, uint32(model.BpfProgTypeKprobe), event.BPF.Program.Type, "wrong program type")
@@ -78,7 +79,7 @@ func TestBPFEventMap(t *testing.T) {
 
 	t.Run("map_lookup", func(t *testing.T) {
 		test.WaitSignal(t, func() error {
-			return runSyscallTesterFunc(t, syscallTester, "-load-bpf", "-clone-bpf")
+			return runSyscallTesterFunc(context.Background(), t, syscallTester, "-load-bpf", "-clone-bpf")
 		}, func(event *model.Event, r *rules.Rule) {
 			assert.Equal(t, "bpf", event.GetType(), "wrong event type")
 			assert.Equal(t, uint32(model.BpfMapTypeHash), event.BPF.Map.Type, "wrong map type")

--- a/pkg/security/tests/chown32_test.go
+++ b/pkg/security/tests/chown32_test.go
@@ -9,6 +9,7 @@
 package tests
 
 import (
+	"context"
 	"os"
 	"testing"
 
@@ -63,7 +64,7 @@ func TestChown32(t *testing.T) {
 
 		test.WaitSignal(t, func() error {
 			// fchown syscall
-			return runSyscallTesterFunc(t, syscallTester, "chown", testFile, "100", "200")
+			return runSyscallTesterFunc(context.Background(), t, syscallTester, "chown", testFile, "100", "200")
 		}, func(event *model.Event, r *rules.Rule) {
 			assert.Equal(t, "chown", event.GetType(), "wrong event type")
 			assert.Equal(t, int64(100), event.Chown.UID, "wrong user")
@@ -88,7 +89,7 @@ func TestChown32(t *testing.T) {
 
 		test.WaitSignal(t, func() error {
 			// fchown syscall
-			return runSyscallTesterFunc(t, syscallTester, "fchown", testFile, "101", "201")
+			return runSyscallTesterFunc(context.Background(), t, syscallTester, "fchown", testFile, "101", "201")
 		}, func(event *model.Event, r *rules.Rule) {
 			assert.Equal(t, "chown", event.GetType(), "wrong event type")
 			assert.Equal(t, int64(101), event.Chown.UID, "wrong user")
@@ -113,7 +114,7 @@ func TestChown32(t *testing.T) {
 
 		test.WaitSignal(t, func() error {
 			// fchown syscall
-			return runSyscallTesterFunc(t, syscallTester, "fchownat", testFile, "102", "202")
+			return runSyscallTesterFunc(context.Background(), t, syscallTester, "fchownat", testFile, "102", "202")
 		}, func(event *model.Event, r *rules.Rule) {
 			assert.Equal(t, "chown", event.GetType(), "wrong event type")
 			assert.Equal(t, int64(102), event.Chown.UID, "wrong user")
@@ -143,7 +144,7 @@ func TestChown32(t *testing.T) {
 
 		test.WaitSignal(t, func() error {
 			// fchown syscall
-			return runSyscallTesterFunc(t, syscallTester, "lchown", testSymlink, "103", "203")
+			return runSyscallTesterFunc(context.Background(), t, syscallTester, "lchown", testSymlink, "103", "203")
 		}, func(event *model.Event, r *rules.Rule) {
 			assert.Equal(t, "chown", event.GetType(), "wrong event type")
 			assert.Equal(t, int64(103), event.Chown.UID, "wrong user")
@@ -173,7 +174,7 @@ func TestChown32(t *testing.T) {
 
 		test.WaitSignal(t, func() error {
 			// fchown syscall
-			return runSyscallTesterFunc(t, syscallTester, "lchown32", testSymlink, "104", "204")
+			return runSyscallTesterFunc(context.Background(), t, syscallTester, "lchown32", testSymlink, "104", "204")
 		}, func(event *model.Event, r *rules.Rule) {
 			assert.Equal(t, "chown", event.GetType(), "wrong event type")
 			assert.Equal(t, int64(104), event.Chown.UID, "wrong user")
@@ -199,7 +200,7 @@ func TestChown32(t *testing.T) {
 
 		test.WaitSignal(t, func() error {
 			// fchown syscall
-			return runSyscallTesterFunc(t, syscallTester, "fchown32", testFile, "105", "205")
+			return runSyscallTesterFunc(context.Background(), t, syscallTester, "fchown32", testFile, "105", "205")
 		}, func(event *model.Event, r *rules.Rule) {
 			assert.Equal(t, "chown", event.GetType(), "wrong event type")
 			assert.Equal(t, int64(105), event.Chown.UID, "wrong user")
@@ -224,7 +225,7 @@ func TestChown32(t *testing.T) {
 
 		test.WaitSignal(t, func() error {
 			// fchown syscall
-			return runSyscallTesterFunc(t, syscallTester, "chown32", testFile, "106", "206")
+			return runSyscallTesterFunc(context.Background(), t, syscallTester, "chown32", testFile, "106", "206")
 		}, func(event *model.Event, r *rules.Rule) {
 			assert.Equal(t, "chown", event.GetType(), "wrong event type")
 			assert.Equal(t, int64(106), event.Chown.UID, "wrong user")

--- a/pkg/security/tests/mkdir_test.go
+++ b/pkg/security/tests/mkdir_test.go
@@ -10,6 +10,7 @@ package tests
 
 import (
 	"errors"
+	"context"
 	"fmt"
 	"os"
 	"syscall"
@@ -182,6 +183,8 @@ func TestMkdirError(t *testing.T) {
 
 		test.WaitSignal(t, func() error {
 			return runSyscallTesterFunc(t, syscallTester, "mkdirat-error", testatFile)
+		}, func(event *model.Event, rule *rules.Rule) {
+			return runSyscallTesterFunc(context.Background(), t, syscallTester, "mkdirat-error", testatFile)
 		}, func(event *model.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_rule_mkdirat_error")
 			assert.Equal(t, event.Mkdir.Retval, -int64(syscall.EACCES))

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -165,6 +165,12 @@ rules:
           scope: {{$Action.Set.Scope}}
           append: {{$Action.Set.Append}}
 {{- end}}
+{{- if $Action.Kill}}
+      - kill:
+		  {{- if $Action.Kill.Signal}}
+          signal: {{$Action.Kill.Signal}}
+          {{- end}}
+{{- end}}
 {{- end}}
 {{end}}
 `

--- a/pkg/security/tests/probe_monitor_test.go
+++ b/pkg/security/tests/probe_monitor_test.go
@@ -9,9 +9,12 @@
 package tests
 
 import (
+	"context"
 	"os"
+	"os/signal"
 	"path"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 	"testing"
@@ -19,10 +22,13 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/security/ebpf/kernel"
 	"github.com/DataDog/datadog-agent/pkg/security/events"
 	"github.com/DataDog/datadog-agent/pkg/security/metrics"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
+	"github.com/DataDog/datadog-agent/pkg/security/utils"
 )
 
 func TestRulesetLoaded(t *testing.T) {
@@ -198,5 +204,66 @@ func TestNoisyProcess(t *testing.T) {
 		// make sure the discarder has expired before moving on to other tests
 		t.Logf("waiting for the discarder to expire (%s)", testMod.config.LoadControllerDiscarderTimeout)
 		time.Sleep(testMod.config.LoadControllerDiscarderTimeout + 1*time.Second)
+	})
+}
+
+func TestKillAction(t *testing.T) {
+	if !kernel.SupportBPFSendSignal() && config.IsContainerized() {
+		t.Skip("bpf_send_signal is not supported on this kernel and agent is running in container mode")
+	}
+
+	rule := &rules.RuleDefinition{
+		ID: "kill_action",
+		// using a wilcard to avoid approvers on basename. events will not match thus will be noisy
+		Expression: `process.file.name == "syscall_tester" && mkdir.file.path == "{{.Root}}/test-kill-action"`,
+		Actions: []rules.ActionDefinition{
+			{
+				Kill: &rules.KillDefinition{
+					Signal: "SIGUSR2",
+				},
+			},
+		},
+	}
+
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule}, testOpts{disableDiscarders: true, eventsCountThreshold: 1000})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer test.Close()
+
+	syscallTester, err := loadSyscallTester(t, test, "syscall_tester")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testFile, _, err := test.Path("test-kill-action")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("kill_action", func(t *testing.T) {
+		sigpipeCh := make(chan os.Signal, 1)
+		signal.Notify(sigpipeCh, syscall.SIGUSR2)
+
+		timeoutCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		if err := runSyscallTesterFunc(
+			timeoutCtx, t, syscallTester,
+			"set-signal-handler", ";",
+			"mkdirat", testFile, ";",
+			"sleep", "2", ";",
+			"wait-signal", ";",
+			"signal", "sigusr2", strconv.Itoa(int(utils.Getpid())),
+		); err != nil {
+			t.Error("no signal")
+			return
+		}
+
+		select {
+		case <-sigpipeCh:
+		case <-time.After(time.Second * 3):
+			t.Error("signal timeout")
+		}
 	})
 }

--- a/pkg/security/tests/process_test.go
+++ b/pkg/security/tests/process_test.go
@@ -10,6 +10,7 @@ package tests
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -1379,7 +1380,7 @@ func TestProcessCredentialsUpdate(t *testing.T) {
 
 	t.Run("setuid", func(t *testing.T) {
 		test.WaitSignal(t, func() error {
-			return runSyscallTesterFunc(t, syscallTester, "process-credentials", "setuid", "1001", "0")
+			return runSyscallTesterFunc(context.Background(), t, syscallTester, "process-credentials", "setuid", "1001", "0")
 		}, func(event *model.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_setuid")
 			assert.Equal(t, uint32(1001), event.SetUID.UID, "wrong uid")
@@ -1388,7 +1389,7 @@ func TestProcessCredentialsUpdate(t *testing.T) {
 
 	t.Run("setreuid", func(t *testing.T) {
 		test.WaitSignal(t, func() error {
-			return runSyscallTesterFunc(t, syscallTester, "process-credentials", "setreuid", "1002", "1003")
+			return runSyscallTesterFunc(context.Background(), t, syscallTester, "process-credentials", "setreuid", "1002", "1003")
 		}, func(event *model.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_setreuid")
 			assert.Equal(t, uint32(1002), event.SetUID.UID, "wrong uid")
@@ -1398,7 +1399,7 @@ func TestProcessCredentialsUpdate(t *testing.T) {
 
 	t.Run("setresuid", func(t *testing.T) {
 		test.WaitSignal(t, func() error {
-			return runSyscallTesterFunc(t, syscallTester, "process-credentials", "setresuid", "1002", "1003")
+			return runSyscallTesterFunc(context.Background(), t, syscallTester, "process-credentials", "setresuid", "1002", "1003")
 		}, func(event *model.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_setreuid")
 			assert.Equal(t, uint32(1002), event.SetUID.UID, "wrong uid")
@@ -1408,7 +1409,7 @@ func TestProcessCredentialsUpdate(t *testing.T) {
 
 	t.Run("setfsuid", func(t *testing.T) {
 		test.WaitSignal(t, func() error {
-			return runSyscallTesterFunc(t, syscallTester, "process-credentials", "setfsuid", "1004", "0")
+			return runSyscallTesterFunc(context.Background(), t, syscallTester, "process-credentials", "setfsuid", "1004", "0")
 		}, func(event *model.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_setfsuid")
 			assert.Equal(t, uint32(1004), event.SetUID.FSUID, "wrong fsuid")
@@ -1417,7 +1418,7 @@ func TestProcessCredentialsUpdate(t *testing.T) {
 
 	t.Run("setgid", func(t *testing.T) {
 		test.WaitSignal(t, func() error {
-			return runSyscallTesterFunc(t, syscallTester, "process-credentials", "setgid", "1005", "0")
+			return runSyscallTesterFunc(context.Background(), t, syscallTester, "process-credentials", "setgid", "1005", "0")
 		}, func(event *model.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_setgid")
 			assert.Equal(t, uint32(1005), event.SetGID.GID, "wrong gid")
@@ -1426,7 +1427,7 @@ func TestProcessCredentialsUpdate(t *testing.T) {
 
 	t.Run("setregid", func(t *testing.T) {
 		test.WaitSignal(t, func() error {
-			return runSyscallTesterFunc(t, syscallTester, "process-credentials", "setregid", "1006", "1007")
+			return runSyscallTesterFunc(context.Background(), t, syscallTester, "process-credentials", "setregid", "1006", "1007")
 		}, func(event *model.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_setregid")
 			assert.Equal(t, uint32(1006), event.SetGID.GID, "wrong gid")
@@ -1436,7 +1437,7 @@ func TestProcessCredentialsUpdate(t *testing.T) {
 
 	t.Run("setresgid", func(t *testing.T) {
 		test.WaitSignal(t, func() error {
-			return runSyscallTesterFunc(t, syscallTester, "process-credentials", "setresgid", "1006", "1007")
+			return runSyscallTesterFunc(context.Background(), t, syscallTester, "process-credentials", "setresgid", "1006", "1007")
 		}, func(event *model.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_setregid")
 			assert.Equal(t, uint32(1006), event.SetGID.GID, "wrong gid")
@@ -1446,7 +1447,7 @@ func TestProcessCredentialsUpdate(t *testing.T) {
 
 	t.Run("setfsgid", func(t *testing.T) {
 		test.WaitSignal(t, func() error {
-			return runSyscallTesterFunc(t, syscallTester, "process-credentials", "setfsgid", "1008", "0")
+			return runSyscallTesterFunc(context.Background(), t, syscallTester, "process-credentials", "setfsgid", "1008", "0")
 		}, func(event *model.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_setfsgid")
 			assert.Equal(t, uint32(1008), event.SetGID.FSGID, "wrong gid")
@@ -1467,7 +1468,7 @@ func TestProcessCredentialsUpdate(t *testing.T) {
 		threadCapabilities.Unset(capability.EFFECTIVE, capability.CAP_WAKE_ALARM)
 
 		test.WaitSignal(t, func() error {
-			return runSyscallTesterFunc(t, goSyscallTester, "-process-credentials-capset")
+			return runSyscallTesterFunc(context.Background(), t, goSyscallTester, "-process-credentials-capset")
 		}, func(event *model.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_capset")
 

--- a/pkg/security/tests/splice_test.go
+++ b/pkg/security/tests/splice_test.go
@@ -9,6 +9,7 @@
 package tests
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -38,7 +39,7 @@ func TestSpliceEvent(t *testing.T) {
 
 	t.Run("test_splice", func(t *testing.T) {
 		test.WaitSignal(t, func() error {
-			return runSyscallTesterFunc(t, syscallTester, "splice")
+			return runSyscallTesterFunc(context.Background(), t, syscallTester, "splice")
 		}, func(event *model.Event, r *rules.Rule) {
 			assert.Equal(t, "splice", event.GetType(), "wrong event type")
 			assert.Equal(t, uint32(0), event.Splice.PipeEntryFlag, "wrong pipe entry flag")

--- a/pkg/security/tests/syscall_tester.go
+++ b/pkg/security/tests/syscall_tester.go
@@ -9,6 +9,7 @@
 package tests
 
 import (
+	"context"
 	"embed"
 	"fmt"
 	"os"
@@ -62,9 +63,9 @@ func checkSyscallTester(t *testing.T, path string) error {
 	return nil
 }
 
-func runSyscallTesterFunc(t *testing.T, path string, args ...string) error {
+func runSyscallTesterFunc(ctx context.Context, t *testing.T, path string, args ...string) error {
 	t.Helper()
-	sideTester := exec.Command(path, args...)
+	sideTester := exec.CommandContext(ctx, path, args...)
 	output, err := sideTester.CombinedOutput()
 
 	if err != nil {

--- a/pkg/security/tests/syscall_tester/c/syscall_tester.c
+++ b/pkg/security/tests/syscall_tester/c/syscall_tester.c
@@ -163,20 +163,18 @@ void sig_handler(int signum){
     exit(0);
 }
 
-int test_signal_sigusr(int sig) {
-    pid_t child = fork();
+int test_signal_sigusr(int child, int sig) {
     if (child == 0) {
-        signal(sig, sig_handler);
-        sleep(60);
-
-        return EXIT_SUCCESS;
+        child = fork();
+        if (child == 0) {
+            sleep(5);
+            return EXIT_SUCCESS;
+        }
     }
 
     int ret = kill(child, sig);
-    if (ret < 0) {
-        return ret;
-    }
-    return wait(NULL);
+    sleep(1);
+    return ret;
 }
 
 int test_signal_eperm(void) {
@@ -202,10 +200,19 @@ int test_signal(int argc, char **argv) {
         return EXIT_FAILURE;
     }
 
+    int pid = 0;
+    if (argc >= 2) {
+        pid = atoi(argv[2]);
+        if (pid < 1) {
+            fprintf(stderr, "invalid pid: %s\n", argv[2]);
+            return EXIT_FAILURE;
+        }
+    }
+
     if (!strcmp(argv[1], "sigusr"))
-        return test_signal_sigusr(SIGUSR1);
+        return test_signal_sigusr(pid, SIGUSR1);
     if (!strcmp(argv[1], "sigusr2"))
-        return test_signal_sigusr(SIGUSR2);
+        return test_signal_sigusr(pid, SIGUSR2);
     else if (!strcmp(argv[1], "eperm"))
         return test_signal_eperm();
     fprintf(stderr, "%s: Unknown argument: %s.\n", __FUNCTION__, argv[1]);
@@ -423,7 +430,6 @@ int test_bind_af_unix(void) {
     addr.sun_family = AF_UNIX;
     strncpy(addr.sun_path, TEST_BIND_AF_UNIX_SERVER_PATH, strlen(TEST_BIND_AF_UNIX_SERVER_PATH));
     int ret = bind(s, (struct sockaddr*)&addr, sizeof(addr));
-    printf("bind retval: %i\n", ret);
     if (ret)
         perror("bind");
 

--- a/releasenotes/notes/cws-kill-action-9c6c61effc2a288e.yaml
+++ b/releasenotes/notes/cws-kill-action-9c6c61effc2a288e.yaml
@@ -1,0 +1,15 @@
+---
+features:
+  - |
+    A new rule post action - 'kill' - can now be used to send a specific
+    signal to a process that caused a rule to be triggered. By default, this
+    signal is SIGTERM.
+
+    ```
+    - id: my_rule
+      expression: ...
+      actions:
+        - kill:
+            signal: SIGUSR1
+    ```
+


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This is a rebase to revive the old [kill action branch](https://github.com/DataDog/datadog-agent/pull/12105).

Send signal from eBPF raw_syscalls tracepoint
Only use bpf_send_signal on supported kernels >= 5.3

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
