### PR TITLE
hpa-example: specify port for custom metrics server

### DIFF
--- a/Dockerfiles/manifests/hpa-example/rbac-hpa.yaml
+++ b/Dockerfiles/manifests/hpa-example/rbac-hpa.yaml
@@ -37,6 +37,7 @@ spec:
   service:
     name: datadog-custom-metrics-server
     namespace: default
+    port: 8443
   version: v1beta1
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/Dockerfiles/manifests/hpa-example/rbac-hpa.yaml
+++ b/Dockerfiles/manifests/hpa-example/rbac-hpa.yaml
@@ -28,7 +28,7 @@ subjects:
 apiVersion: apiregistration.k8s.io/v1
 kind: APIService
 metadata:
-  name: v1beta1.external.metrics.k8s.io
+  name: v1.external.metrics.k8s.io
 spec:
   insecureSkipTLSVerify: true
   group: external.metrics.k8s.io
@@ -38,7 +38,7 @@ spec:
     name: datadog-custom-metrics-server
     namespace: default
     port: 8443
-  version: v1beta1
+  version: v1
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
This updates the rbac-hpa example to include the current port number that we run the custom-metrics-server on.  It previously did not require the port in the spec because it defaults to 443 (https://pkg.go.dev/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1#ServiceReference)

### Motivation

A customer contacted support with the suggestion to update this to match our documentation page (https://docs.datadoghq.com/containers/guide/cluster_agent_autoscaling_metrics/?tab=daemonset#register-the-external-metrics-provider-service)

### Additional Notes


### Possible Drawbacks / Trade-offs

n/a: this is just an example we provide

### Describe how to test/QA your changes

n/a: this is just an example we provide

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
