### PR TITLE
Revert "Disable DMI ussage for EC2 by default"

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -740,7 +740,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("ec2_metadata_token_lifetime", 21600) // value in seconds
 	config.BindEnvAndSetDefault("ec2_prefer_imdsv2", false)
 	config.BindEnvAndSetDefault("ec2_prioritize_instance_id_as_hostname", false) // used to bypass the hostname detection logic and force the EC2 instance ID as a hostname.
-	config.BindEnvAndSetDefault("ec2_use_dmi", false)                            // should the agent leverage DMI information to know if it's running on EC2 or not. Enabling this will add the instance ID from DMI to the host alias list.
+	config.BindEnvAndSetDefault("ec2_use_dmi", true)                             // should the agent leverage DMI information to know if it's running on EC2 or not.
 	config.BindEnvAndSetDefault("collect_ec2_tags", false)
 	config.BindEnvAndSetDefault("collect_ec2_tags_use_imds", false)
 	config.BindEnvAndSetDefault("exclude_ec2_tags", []string{})

--- a/pkg/util/ec2/dmi.go
+++ b/pkg/util/ec2/dmi.go
@@ -57,10 +57,6 @@ func getInstanceIDFromDMI() (string, error) {
 // Depending on the instance type either the DMI product UUID or the hypervisor UUID is available. In both case, if they
 // start with "ec2" we return true.
 func isEC2UUID() bool {
-	if !config.Datadog.GetBool("ec2_use_dmi") {
-		return false
-	}
-
 	// if we have a board vendor we can skip this UUID check
 	if dmi.GetBoardVendor() != "" && !isBoardVendorEC2() {
 		return false

--- a/pkg/util/ec2/dmi_test.go
+++ b/pkg/util/ec2/dmi_test.go
@@ -14,9 +14,6 @@ import (
 )
 
 func TestIsBoardVendorEC2(t *testing.T) {
-	config.Mock(t)
-	config.Datadog.Set("ec2_use_dmi", true)
-
 	setupDMIForNotEC2(t)
 	assert.False(t, isBoardVendorEC2())
 
@@ -29,9 +26,6 @@ func TestIsBoardVendorEC2(t *testing.T) {
 }
 
 func TestGetInstanceIDFromDMI(t *testing.T) {
-	config.Mock(t)
-	config.Datadog.Set("ec2_use_dmi", true)
-
 	setupDMIForNotEC2(t)
 	instanceID, err := getInstanceIDFromDMI()
 	assert.Error(t, err)
@@ -49,9 +43,6 @@ func TestGetInstanceIDFromDMI(t *testing.T) {
 }
 
 func TestIsEC2UUID(t *testing.T) {
-	config.Mock(t)
-	config.Datadog.Set("ec2_use_dmi", true)
-
 	// no UUID
 	dmi.SetupMock(t, "", "", "", "")
 	assert.False(t, isEC2UUID())
@@ -76,9 +67,6 @@ func TestIsEC2UUID(t *testing.T) {
 }
 
 func TestIsEC2UUIDSwapEndian(t *testing.T) {
-	config.Mock(t)
-	config.Datadog.Set("ec2_use_dmi", true)
-
 	// hypervisor
 	dmi.SetupMock(t, "45E12AEC-DCD1-B213-94ED-012345ABCDEF", "", "", "")
 	assert.True(t, isEC2UUID())

--- a/pkg/util/ec2/ec2_test.go
+++ b/pkg/util/ec2/ec2_test.go
@@ -166,8 +166,6 @@ func TestGetHostAliases(t *testing.T) {
 			config.Mock(t)
 			if tc.disableDMI {
 				config.Datadog.Set("ec2_use_dmi", false)
-			} else {
-				config.Datadog.Set("ec2_use_dmi", true)
 			}
 
 			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -460,9 +458,6 @@ func TestGetNTPHostsFromIMDS(t *testing.T) {
 }
 
 func TestGetNTPHostsDMI(t *testing.T) {
-	config.Mock(t)
-	config.Datadog.Set("ec2_use_dmi", true)
-
 	setupDMIForEC2(t)
 	defer resetPackageVars()
 	metadataURL = ""
@@ -472,9 +467,6 @@ func TestGetNTPHostsDMI(t *testing.T) {
 }
 
 func TestGetNTPHostsEC2UUID(t *testing.T) {
-	config.Mock(t)
-	config.Datadog.Set("ec2_use_dmi", true)
-
 	dmi.SetupMock(t, "ec2something", "", "", "")
 	defer resetPackageVars()
 	metadataURL = ""
@@ -546,9 +538,6 @@ func TestMetadataSourceIMDS(t *testing.T) {
 }
 
 func TestMetadataSourceUUID(t *testing.T) {
-	config.Mock(t)
-	config.Datadog.Set("ec2_use_dmi", true)
-
 	ctx := context.Background()
 
 	metadataURL = ""
@@ -568,9 +557,6 @@ func TestMetadataSourceUUID(t *testing.T) {
 }
 
 func TestMetadataSourceDMI(t *testing.T) {
-	config.Mock(t)
-	config.Datadog.Set("ec2_use_dmi", true)
-
 	ctx := context.Background()
 
 	metadataURL = ""
@@ -582,9 +568,6 @@ func TestMetadataSourceDMI(t *testing.T) {
 }
 
 func TestMetadataSourceDMIPreventFallback(t *testing.T) {
-	config.Mock(t)
-	config.Datadog.Set("ec2_use_dmi", true)
-
 	ctx := context.Background()
 
 	metadataURL = ""


### PR DESCRIPTION
Reverts DataDog/datadog-agent#15639

We have finally decided to keep enabled by default.