### PR TITLE
[WIP] Fixes #15474 -- Ensure OSX installer supports GNU sed

### DIFF
--- a/cmd/agent/install_mac_os.sh
+++ b/cmd/agent/install_mac_os.sh
@@ -239,7 +239,7 @@ function plist_modify_user_group() {
     ## to insert user/group into the xml file, we'll find the last "</dict>" occurrence and insert before it
     closing_dict_line=$($sudo_cmd cat "$plist_file" | grep -n "</dict>" | tail -1 | cut -f1 -d:)
     # there's no way to do in-place sed without a backup file on an arbitrary MacOS version
-    $sudo_cmd sed -i .backup -e "${closing_dict_line},${closing_dict_line}s|</dict>|<key>$user_parameter</key><string>$user_value</string>\n</dict>|" -e "${closing_dict_line},${closing_dict_line}s|</dict>|<key>$group_parameter</key><string>$group_value</string>\n</dict>|" "$plist_file"
+    $sudo_cmd sed -i.backup -e "${closing_dict_line},${closing_dict_line}s|</dict>|<key>$user_parameter</key><string>$user_value</string>\n</dict>|" -e "${closing_dict_line},${closing_dict_line}s|</dict>|<key>$group_parameter</key><string>$group_value</string>\n</dict>|" "$plist_file"
     $sudo_cmd rm "${plist_file}.backup"
 }
 

--- a/releasenotes/notes/Ensure-OSX-installer-supports-GNU-sed-1ea63ecb2a113df0.yaml
+++ b/releasenotes/notes/Ensure-OSX-installer-supports-GNU-sed-1ea63ecb2a113df0.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix GNU sed support in OSX installer script


### PR DESCRIPTION
### What does this PR do?

Ensures OSX installer does not crash if `sed` is GNU sed.

### Motivation

Fixes #15474 

### Additional Notes

I was unsure whether there are existing tests for the mac installer script, but I'm happy to update if someone can point the way.

### Describe how to test/QA your changes

Tested script locally using both GNU sed and OSX standard sed to ensure `UserName` and `GroupName` nodes are correctly added to the plist file.

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
