### PR TITLE
[workloadmeta/containerd] Improve error handling when generating initial images events

### DIFF
--- a/pkg/workloadmeta/collectors/internal/containerd/containerd.go
+++ b/pkg/workloadmeta/collectors/internal/containerd/containerd.go
@@ -271,7 +271,8 @@ func (c *collector) notifyInitialImageEvents(ctx context.Context, namespace stri
 
 	for _, image := range existingImages {
 		if err := c.notifyEventForImage(ctx, namespace, image, nil); err != nil {
-			return err
+			log.Warnf("error getting information for image with name %q: %s", image.Name(), err.Error())
+			continue
 		}
 	}
 

--- a/releasenotes/notes/workloadmeta-containerd-err-handling-initial-events-b08fa6537e11eddf.yaml
+++ b/releasenotes/notes/workloadmeta-containerd-err-handling-initial-events-b08fa6537e11eddf.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixes a bug that prevents the containerd workloadmeta collector from
+    starting sometimes when `container_image_collection.metadata.enabled` is
+    set to true.


### PR DESCRIPTION
### What does this PR do?

Fixes an issue in the containerd workloadmeta collector when the container image collection is enabled.

The collector does not start when there is an error extracting the information for one of the images. With this PR, instead of returning an error, we log a warning and return the rest of images. This is the same strategy followed when generating the information for the initial containers.

### Describe how to test/QA your changes

Check our internal logs. The `workloadmeta collector "containerd" could not start` errors shouldn't be caused by errors while fetching the images.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
