### PR TITLE
[CWS] remove random usage in SECL package

### DIFF
--- a/pkg/security/activitydump/activity_dump.go
+++ b/pkg/security/activitydump/activity_dump.go
@@ -43,7 +43,6 @@ import (
 	adproto "github.com/DataDog/datadog-agent/pkg/security/proto/security_profile/v1"
 	sprocess "github.com/DataDog/datadog-agent/pkg/security/resolvers/process"
 	stime "github.com/DataDog/datadog-agent/pkg/security/resolvers/time"
-	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/seclog"
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
@@ -185,7 +184,7 @@ func NewActivityDump(adm *ActivityDumpManager, options ...WithDumpOption) *Activ
 		AgentCommit:       version.Commit,
 		KernelVersion:     adm.kernelVersion.Code.String(),
 		LinuxDistribution: adm.kernelVersion.OsRelease["PRETTY_NAME"],
-		Name:              fmt.Sprintf("activity-dump-%s", eval.RandString(10)),
+		Name:              fmt.Sprintf("activity-dump-%s", utils.RandString(10)),
 		ProtobufVersion:   ProtobufVersion,
 		Start:             now,
 		End:               now.Add(adm.config.ActivityDumpCgroupDumpTimeout),
@@ -205,7 +204,7 @@ func NewActivityDump(adm *ActivityDumpManager, options ...WithDumpOption) *Activ
 		now,
 		adm.timeResolver,
 	)
-	ad.LoadConfigCookie = eval.NewCookie()
+	ad.LoadConfigCookie = utils.NewCookie()
 
 	for _, option := range options {
 		option(ad)

--- a/pkg/security/activitydump/profile.go
+++ b/pkg/security/activitydump/profile.go
@@ -13,8 +13,8 @@ import (
 	"fmt"
 	"text/template"
 
-	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+	"github.com/DataDog/datadog-agent/pkg/security/utils"
 )
 
 // Profile holds the list of rules generated from an activity dump
@@ -45,7 +45,7 @@ rules:{{ range .Rules }}
 // NewProfileRule returns a new ProfileRule
 func NewProfileRule(expression string, ruleIDPrefix string) ProfileRule {
 	return ProfileRule{
-		ID:         ruleIDPrefix + "_" + eval.RandString(5),
+		ID:         ruleIDPrefix + "_" + utils.RandString(5),
 		Expression: expression,
 	}
 }
@@ -189,7 +189,7 @@ func (ad *ActivityDump) GenerateProfileData() Profile {
 	defer ad.Unlock()
 
 	p := Profile{
-		Name: "profile_" + eval.RandString(5),
+		Name: "profile_" + utils.RandString(5),
 	}
 
 	// generate selector

--- a/pkg/security/resolvers/process/resolver.go
+++ b/pkg/security/resolvers/process/resolver.go
@@ -257,7 +257,7 @@ func (p *Resolver) DequeueExited() {
 func (p *Resolver) NewProcessCacheEntry(pidContext model.PIDContext) *model.ProcessCacheEntry {
 	entry := p.processCacheEntryPool.Get()
 	entry.PIDContext = pidContext
-	entry.Cookie = eval.NewCookie()
+	entry.Cookie = utils.NewCookie()
 	return entry
 }
 

--- a/pkg/security/secl/compiler/eval/eval.go
+++ b/pkg/security/secl/compiler/eval/eval.go
@@ -121,7 +121,7 @@ func identToEvaluator(obj *ident, opts *Opts, state *State) (interface{}, lexer.
 
 		// regID not specified or `_` generate one
 		if regID == "" || regID == "_" {
-			regID = RandString(8)
+			regID = state.newAnonymousRegID()
 		}
 
 		if info, exists := state.registersInfo[regID]; exists {

--- a/pkg/security/secl/compiler/eval/state.go
+++ b/pkg/security/secl/compiler/eval/state.go
@@ -5,7 +5,10 @@
 
 package eval
 
-import "regexp"
+import (
+	"fmt"
+	"regexp"
+)
 
 type registerInfo struct {
 	iterator  Iterator
@@ -21,13 +24,21 @@ type StateRegexpCache struct {
 
 // State defines the current state of the rule compilation
 type State struct {
-	model         Model
-	field         Field
-	events        map[EventType]bool
-	fieldValues   map[Field][]FieldValue
-	macros        map[MacroID]*MacroEvaluator
-	registersInfo map[RegisterID]*registerInfo
-	regexpCache   StateRegexpCache
+	model           Model
+	field           Field
+	events          map[EventType]bool
+	fieldValues     map[Field][]FieldValue
+	macros          map[MacroID]*MacroEvaluator
+	registersInfo   map[RegisterID]*registerInfo
+	registerCounter int
+	regexpCache     StateRegexpCache
+}
+
+func (s *State) newAnonymousRegID() string {
+	id := s.registerCounter
+	s.registerCounter++
+	// @ is not a valid register name from the parser, this guarantees unicity
+	return fmt.Sprintf("@anon_%d", id)
 }
 
 // UpdateFields updates the fields used in the rule

--- a/pkg/security/secl/compiler/eval/utils.go
+++ b/pkg/security/secl/compiler/eval/utils.go
@@ -18,7 +18,7 @@ func NotOfValue(value interface{}) (interface{}, error) {
 	case int:
 		return ^v, nil
 	case string:
-		return RandString(256), nil
+		return fmt.Sprintf("@$%s$@", v), nil
 	case bool:
 		return !v, nil
 	}

--- a/pkg/security/secl/compiler/eval/utils.go
+++ b/pkg/security/secl/compiler/eval/utils.go
@@ -18,7 +18,12 @@ func NotOfValue(value interface{}) (interface{}, error) {
 	case int:
 		return ^v, nil
 	case string:
-		return fmt.Sprintf("@$%s$@", v), nil
+		// ensure the not value is different
+		if v == "" {
+			return "<NOT>", nil
+		} else {
+			return "", nil
+		}
 	case bool:
 		return !v, nil
 	}

--- a/pkg/security/secl/rules/approvers.go
+++ b/pkg/security/secl/rules/approvers.go
@@ -44,11 +44,7 @@ func isAnApprover(event eval.Event, ctx *eval.Context, rule *Rule, field eval.Fi
 		return false, err
 	}
 
-	if origResult && !notResult {
-		return true, nil
-	}
-
-	return false, nil
+	return origResult && !notResult, nil
 }
 
 func bitmaskCombinations(bitmasks []int) []int {

--- a/pkg/security/tests/cmdwrapper.go
+++ b/pkg/security/tests/cmdwrapper.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
+	"github.com/DataDog/datadog-agent/pkg/security/utils"
 )
 
 type wrapperType string
@@ -93,7 +93,7 @@ func (d *dockerCmdWrapper) Command(bin string, args []string, envs []string) *ex
 }
 
 func (d *dockerCmdWrapper) start() ([]byte, error) {
-	d.containerName = fmt.Sprintf("docker-wrapper-%s", eval.RandString(6))
+	d.containerName = fmt.Sprintf("docker-wrapper-%s", utils.RandString(6))
 	cmd := exec.Command(d.executable, "run", "--rm", "-d", "--name", d.containerName, "-v", d.mountSrc+":"+d.mountDest, d.image, "sleep", "600")
 	out, err := cmd.CombinedOutput()
 	if err == nil {

--- a/pkg/security/tests/process_test.go
+++ b/pkg/security/tests/process_test.go
@@ -35,9 +35,9 @@ import (
 	"github.com/syndtr/gocapability/capability"
 	"golang.org/x/sys/unix"
 
-	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
+	"github.com/DataDog/datadog-agent/pkg/security/utils"
 )
 
 func TestProcess(t *testing.T) {
@@ -408,7 +408,7 @@ func TestProcessContext(t *testing.T) {
 		// number of args overflow
 		nArgs, args := 1024, []string{"-al"}
 		for i := 0; i != nArgs; i++ {
-			args = append(args, eval.RandString(50))
+			args = append(args, utils.RandString(50))
 		}
 
 		test.GetSignal(t, func() error {
@@ -449,7 +449,7 @@ func TestProcessContext(t *testing.T) {
 		// number of args overflow
 		nArgs, args := 1024, []string{"-al"}
 		for i := 0; i != nArgs; i++ {
-			args = append(args, eval.RandString(500))
+			args = append(args, utils.RandString(500))
 		}
 
 		test.GetSignal(t, func() error {
@@ -544,7 +544,7 @@ func TestProcessContext(t *testing.T) {
 		buf.Grow(50)
 		for i := 0; i != nEnvs; i++ {
 			buf.Reset()
-			fmt.Fprintf(&buf, "%s=%s", eval.RandString(19), eval.RandString(30))
+			fmt.Fprintf(&buf, "%s=%s", utils.RandString(19), utils.RandString(30))
 			envs = append(envs, buf.String())
 		}
 
@@ -595,7 +595,7 @@ func TestProcessContext(t *testing.T) {
 		buf.Grow(500)
 		for i := 0; i != nEnvs; i++ {
 			buf.Reset()
-			fmt.Fprintf(&buf, "%s=%s", eval.RandString(199), eval.RandString(300))
+			fmt.Fprintf(&buf, "%s=%s", utils.RandString(199), utils.RandString(300))
 			envs = append(envs, buf.String())
 		}
 

--- a/pkg/security/utils/graph.go
+++ b/pkg/security/utils/graph.go
@@ -9,8 +9,6 @@ import (
 	"fmt"
 	"strings"
 	"unsafe"
-
-	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 )
 
 // Node describes an edge of a dot node
@@ -89,7 +87,7 @@ func NewNodeID(inner uint64) NodeID {
 // NewRandomNodeID returns a new random NodeID
 func NewRandomNodeID() NodeID {
 	return NodeID{
-		inner: eval.RandNonZeroUint64(),
+		inner: RandNonZeroUint64(),
 	}
 }
 

--- a/pkg/security/utils/rand.go
+++ b/pkg/security/utils/rand.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-package eval
+package utils
 
 import (
 	"math/rand"


### PR DESCRIPTION
### What does this PR do?

This PR removes all random usage in the `pkg/security/secl` package.

### Motivation

- remove global rand seed in init function of this module (could have bad interactions with other importing modules)
- the evaluation should be reproducible, there is no real motivation for random usage in a rule evaluator
- the rest of the system probe no longer depends on the SECL package for basic random utilities

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
