### PR TITLE
pkg/clusteragent/admission: support ruby injection

### DIFF
--- a/pkg/clusteragent/admission/mutate/auto_instrumentation_test.go
+++ b/pkg/clusteragent/admission/mutate/auto_instrumentation_test.go
@@ -185,6 +185,43 @@ func TestInjectAutoInstruConfig(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "nominal case: ruby",
+			pod:  fakePod("ruby-pod"),
+			libsToInject: []libInfo{
+				{
+					lang:  "ruby",
+					image: "gcr.io/datadoghq/dd-lib-ruby-init:v1",
+				},
+			},
+			expectedEnvKey: "RUBYOPT",
+			expectedEnvVal: " -r/datadog-lib/auto_inject",
+			wantErr:        false,
+		},
+		{
+			name: "RUBYOPT not empty",
+			pod:  fakePodWithEnvValue("ruby-pod", "RUBYOPT", "predefined"),
+			libsToInject: []libInfo{
+				{
+					lang:  "ruby",
+					image: "gcr.io/datadoghq/dd-lib-ruby-init:v1",
+				},
+			},
+			expectedEnvKey: "RUBYOPT",
+			expectedEnvVal: "predefined -r/datadog-lib/auto_inject",
+			wantErr:        false,
+		},
+		{
+			name: "RUBYOPT set via ValueFrom",
+			pod:  fakePodWithEnvFieldRefValue("ruby-pod", "RUBYOPT", "path"),
+			libsToInject: []libInfo{
+				{
+					lang:  "ruby",
+					image: "gcr.io/datadoghq/dd-lib-ruby-init:v1",
+				},
+			},
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -349,6 +386,17 @@ func TestExtractLibInfo(t *testing.T) {
 					ctrName: "node-app",
 					lang:    "js",
 					image:   "registry/dd-lib-js-init:v1",
+				},
+			},
+		},
+		{
+			name:              "ruby",
+			pod:               fakePodWithAnnotation("admission.datadoghq.com/ruby-lib.version", "v1"),
+			containerRegistry: "registry",
+			expectedLibsToInject: []libInfo{
+				{
+					lang:  "ruby",
+					image: "registry/dd-lib-ruby-init:v1",
 				},
 			},
 		},

--- a/releasenotes-dca/notes/inject-ruby-e8f0a43d14c5e621.yaml
+++ b/releasenotes-dca/notes/inject-ruby-e8f0a43d14c5e621.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Experimental: Support Ruby library injection through the Admission Controller on Kubernetes.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

- Add library injection support for ruby

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Tested with custom init image, e2e tests will be added once the official init images are published.

```
apiVersion: v1
kind: Pod
metadata:
  labels:
    app: my-ruby-app
    admission.datadoghq.com/enabled: "true"
  annotations:
    admission.datadoghq.com/ruby-lib.custom-image: "ghcr.io/datadog/dd-trace-rb/dd-lib-ruby-init:4b648ee8433873eae3c2a9550f754d16b8b87cfa"
  name: my-ruby-app
spec:
  containers:
    - image: tonycthsu/auto_inject_demo_app:latest
      name: my-ruby-app
      imagePullPolicy: Always
```

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
