### PR TITLE
CWS: run functional tests on all main branches

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -752,6 +752,7 @@ workflow:
   - <<: *if_testing_cleanup
 
 .on_security_agent_changes_or_manual:
+  - <<: *if_main_branch
   - changes:
       - pkg/ebpf/**/*
       - pkg/security/**/*

--- a/.gitlab/functional_test/security_agent.yml
+++ b/.gitlab/functional_test/security_agent.yml
@@ -78,7 +78,6 @@ kitchen_test_security_agent_arm64:
     - .kitchen_ec2_location_us_east_1
     - .kitchen_ec2_spot_instances
   rules:
-    !reference [.on_main]
     !reference [.on_security_agent_changes_or_manual]
   needs: [ "tests_ebpf_arm64", "prepare_ebpf_functional_tests_arm64" ]
   variables:
@@ -99,7 +98,6 @@ kitchen_test_security_agent_amazonlinux_x64:
     - .kitchen_ec2_location_us_east_1
     - .kitchen_ec2_spot_instances
   rules:
-    !reference [.on_main]
     !reference [.on_security_agent_changes_or_manual]
   needs: [ "tests_ebpf_x64", "prepare_ebpf_functional_tests_x64" ]
   variables:

--- a/.gitlab/functional_test/security_agent.yml
+++ b/.gitlab/functional_test/security_agent.yml
@@ -78,6 +78,7 @@ kitchen_test_security_agent_arm64:
     - .kitchen_ec2_location_us_east_1
     - .kitchen_ec2_spot_instances
   rules:
+    !reference [.on_main]
     !reference [.on_security_agent_changes_or_manual]
   needs: [ "tests_ebpf_arm64", "prepare_ebpf_functional_tests_arm64" ]
   variables:
@@ -98,6 +99,7 @@ kitchen_test_security_agent_amazonlinux_x64:
     - .kitchen_ec2_location_us_east_1
     - .kitchen_ec2_spot_instances
   rules:
+    !reference [.on_main]
     !reference [.on_security_agent_changes_or_manual]
   needs: [ "tests_ebpf_x64", "prepare_ebpf_functional_tests_x64" ]
   variables:


### PR DESCRIPTION
### What does this PR do?

This PR will run the security agent functional tests on all main branches (added to the current run rules i.e. manual + file changes). This will allow CI app to pick up more runs and to more easily detect flaky tests and patterns

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
