### PR TITLE
[Serverless] Use a unique tempfile name for testing persisted execution context.

### DIFF
--- a/pkg/serverless/executioncontext/executioncontext.go
+++ b/pkg/serverless/executioncontext/executioncontext.go
@@ -25,6 +25,8 @@ type ExecutionContext struct {
 	coldstart          bool
 	startTime          time.Time
 	endTime            time.Time
+
+	persistedStateFilePath string
 }
 
 // State represents the state of the execution context at a point in time
@@ -89,6 +91,16 @@ func (ec *ExecutionContext) UpdateEndTime(time time.Time) {
 	ec.endTime = time
 }
 
+// getPersistedStateFilePath returns the full path and filename of the
+// persisted state file.
+func (ec *ExecutionContext) getPersistedStateFilePath() string {
+	filepath := ec.persistedStateFilePath
+	if filepath == "" {
+		filepath = persistedStateFilePath
+	}
+	return filepath
+}
+
 // SaveCurrentExecutionContext stores the current context to a file
 func (ec *ExecutionContext) SaveCurrentExecutionContext() error {
 	ecs := ec.GetCurrentState()
@@ -96,7 +108,8 @@ func (ec *ExecutionContext) SaveCurrentExecutionContext() error {
 	if err != nil {
 		return err
 	}
-	err = os.WriteFile(persistedStateFilePath, file, 0600)
+	filepath := ec.getPersistedStateFilePath()
+	err = os.WriteFile(filepath, file, 0600)
 	if err != nil {
 		return err
 	}
@@ -107,7 +120,8 @@ func (ec *ExecutionContext) SaveCurrentExecutionContext() error {
 func (ec *ExecutionContext) RestoreCurrentStateFromFile() error {
 	ec.m.Lock()
 	defer ec.m.Unlock()
-	file, err := os.ReadFile(persistedStateFilePath)
+	filepath := ec.getPersistedStateFilePath()
+	file, err := os.ReadFile(filepath)
 	if err != nil {
 		return err
 	}

--- a/pkg/serverless/executioncontext/executioncontext_test.go
+++ b/pkg/serverless/executioncontext/executioncontext_test.go
@@ -9,6 +9,8 @@
 package executioncontext
 
 import (
+	"io/ioutil"
+	"os"
 	"testing"
 	"time"
 
@@ -71,16 +73,20 @@ func TestUpdateFromStartLog(t *testing.T) {
 func TestSaveAndRestoreFromFile(t *testing.T) {
 	assert := assert.New(t)
 
+	tempfile, err := ioutil.TempFile("/tmp", "dd-lambda-extension-cache-*.json")
+	assert.Nil(err)
+	defer os.Remove(tempfile.Name())
+
 	testArn := "arn:aws:lambda:us-east-1:123456789012:function:my-super-function"
 	testRequestID := "8286a188-ba32-4475-8077-530cd35c09a9"
 	startTime := time.Now()
 	endTime := startTime.Add(10 * time.Second)
-	ec := ExecutionContext{}
+	ec := ExecutionContext{persistedStateFilePath: tempfile.Name()}
 	ec.SetFromInvocation(testArn, testRequestID)
 	ec.UpdateStartTime(startTime)
 	ec.UpdateEndTime(endTime)
 
-	err := ec.SaveCurrentExecutionContext()
+	err = ec.SaveCurrentExecutionContext()
 	assert.Nil(err)
 
 	ec.UpdateStartTime(startTime.Add(time.Hour))


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

When testing the serverless execution context file persistence, use a unique random tempfile. This tempfile is removed at the end of the test.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

There was a flaky test failure of this test within the last week (see [error output in our ci monitoring](https://app.datadoghq.com/ci/test/AQAAAYZVlXLPL2BNtQAAAABBWVpWbFhMUEFBRDRFQlZ6WW5jVUw5RHU?colorBy=service&currentTab=overview&env=ci&eventStack=AQAAAYZVlXLPL2BNtQAAAABBWVpWbFhMUEFBRDRFQlZ6WW5jVUw5RHU&index=citest&spanID=17208293033897210964&spanViewType=metadata&testId=AQAAAYZVlXLPL2BNtQAAAABBWVpWbFhMUEFBRDRFQlZ6WW5jVUw5RHU)). I have not been able to reproduce the error locally and the error message is not all that helpful (`&json.SyntaxError{msg:"unexpected end of JSON input", Offset:0}`). Therefore, we can only guess as to what caused this single failure.

One thing that _could_ cause the error is if two things were writing to this same persistence file at the same time. To prevent situations like that, we should be using a unique tempfile name when testing, while continuing to use the consistent name in prod.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

The test is now slightly slower.

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Run the tests locally or wait for ci to run them for you.

```bash
go test ./pkg/serverless/executioncontext -count=10000 -failfast -cpu=1
```

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
