### PR TITLE
[Serverless] Always use a known free port when testing serverless trace agent start.

### DIFF
--- a/pkg/serverless/trace/trace_test.go
+++ b/pkg/serverless/trace/trace_test.go
@@ -10,6 +10,8 @@ package trace
 
 import (
 	"fmt"
+	"os"
+	"strconv"
 	"testing"
 	"time"
 
@@ -18,6 +20,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/serverless/random"
 	"github.com/DataDog/datadog-agent/pkg/trace/config"
 	"github.com/DataDog/datadog-agent/pkg/trace/pb"
+	"github.com/DataDog/datadog-agent/pkg/trace/testutil"
 )
 
 func TestStartEnabledFalse(t *testing.T) {
@@ -72,6 +75,11 @@ func TestStartEnabledTrueValidConfigValidPath(t *testing.T) {
 }
 
 func TestLoadConfigShouldBeFast(t *testing.T) {
+	// ensure a free port is used for starting the trace agent
+	if port, err := testutil.FindTCPPort(); err == nil {
+		os.Setenv("DD_RECEIVER_PORT", strconv.Itoa(port))
+	}
+
 	startTime := time.Now()
 	lambdaSpanChan := make(chan *pb.Span)
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

When starting the trace agent in a test, we should always be sure to use a free port.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Infrequently, the test `TestLoadConfigShouldBeFast` will fail with no error output whatsoever (see [this example](https://app.datadoghq.com/ci/test/AQAAAYZTqq5glCAM0QAAAABBWVpUcXE1Z0FBRDdhZjZaem9FNHZxblg?colorBy=service&currentTab=overview&env=ci&eventStack=AQAAAYZTqq5glCAM0QAAAABBWVpUcXE1Z0FBRDdhZjZaem9FNHZxblg&index=citest&spanID=15540041777454663008&spanViewType=metadata&testId=AQAAAYZTqq5glCAM0QAAAABBWVpUcXE1Z0FBRDdhZjZaem9FNHZxblg)).

I have seen this happen before, test failures with no error output. These failures seem to happen when the trace agent attempts to start using a port that's already in use. This is because `os.Exit(1)` is called when the trace agent cannot start (see https://github.com/DataDog/datadog-agent/blob/main/pkg/trace/api/api.go#L167).

The solution is to use a known free port when starting the trace agent.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

To ensure the flake has been removed, you'll want to run the tests over and over and over a lot.

```bash
go test ./pkg/serverless/trace -run TestLoadConfigShouldBeFast -failfast -cpu=1 -count=10000
```

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
