### PR TITLE
pkg/trace: Improve logs when getting net connections

### DIFF
--- a/pkg/trace/api/listener.go
+++ b/pkg/trace/api/listener.go
@@ -73,6 +73,7 @@ func (ln *measuredListener) flushMetrics() {
 func (ln *measuredListener) Accept() (net.Conn, error) {
 	conn, err := ln.Listener.Accept()
 	if err != nil {
+		log.Debugf("Error connection named %q: %s", ln.name, err)
 		if ne, ok := err.(net.Error); ok && ne.Timeout() && !ne.Temporary() {
 			ln.timedout.Inc()
 		} else {
@@ -80,8 +81,8 @@ func (ln *measuredListener) Accept() (net.Conn, error) {
 		}
 	} else {
 		ln.accepted.Inc()
+		log.Tracef("Accepted connection named %q.", ln.name)
 	}
-	log.Tracef("Accepted connection named %q.", ln.name)
 	return conn, err
 }
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

- Make trace-agent write "Accepted ..." log only when `ln.Listener.Accept()` returns no error.
- Add "Error ..." log when `ln.Listener.Accept()` returns an error.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

For better troubleshooting.

Before this change, trace-agent writes "Accepted ..." logs every time `(net.Listener) Accept()` is called. And it ignores an error content. It seems to be misleading. Now, trace-agent writes "Accepted ..." logs only when no error happens after `(net.Listener) Accept()` and writes "Error ..." logs when an error happens.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Verifying "Accepted ..." logs after curl requests.

```bash
% python3 -m invoke trace-agent.build --build-exclude=systemd,python
% git rev-parse HEAD
f5554ff55ecb86f7cc7eff69e8eeca56dc75c9b9
% sudo bin/trace-agent/trace-agent -version
7.43.0-rc.3+git.259.f5554ff
% cat /opt/datadog-agent/etc/datadog.yaml
api_key: XXX
site: datadoghq.com
apm_config:
  enabled: true
  receiver_port: 8126
  receiver_socket: /opt/datadog-agent/run/apm.sock
log_level: trace
log_to_console: false
% sudo bin/trace-agent/trace-agent &
[1] 15722
% tail /opt/datadog-agent/logs/trace-agent.log
...
2023-02-22 10:04:08 JST | TRACE | INFO | (run.go:269 in Infof) | Listening for traces at http://localhost:8126
2023-02-22 10:04:08 JST | TRACE | INFO | (run.go:269 in Infof) | Listening for traces at unix:///opt/datadog-agent/run/apm.sock
...
% curl --head localhost:8126/info
HTTP/1.1 200 OK
Date: Wed, 22 Feb 2023 01:05:32 GMT
Content-Length: 1199
Content-Type: text/plain; charset=utf-8
% tail /opt/datadog-agent/logs/trace-agent.log
...
2023-02-22 10:05:32 JST | TRACE | TRACE | (run.go:257 in Tracef) | Accepted connection named "datadog.trace_agent.receiver.tcp_connections".
...
% curl --head --unix-socket /opt/datadog-agent/run/apm.sock http:8126/info

HTTP/1.1 200 OK
Date: Wed, 22 Feb 2023 01:08:11 GMT
Content-Length: 1199
Content-Type: text/plain; charset=utf-8
% tail /opt/datadog-agent/logs/trace-agent.log
...
2023-02-22 10:08:11 JST | TRACE | TRACE | (run.go:257 in Tracef) | Accepted connection named "datadog.trace_agent.receiver.uds_connections".
...
```


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
