### PR TITLE
[corechecks/snmp] Add interface_configs to override interface speed

### DIFF
--- a/pkg/collector/corechecks/snmp/internal/checkconfig/config.go
+++ b/pkg/collector/corechecks/snmp/internal/checkconfig/config.go
@@ -59,6 +59,14 @@ var uptimeMetricConfig = MetricsConfig{Symbol: SymbolConfig{OID: "1.3.6.1.2.1.1.
 // DeviceDigest is the digest of a minimal config used for autodiscovery
 type DeviceDigest string
 
+// InterfaceConfig interface related configs (e.g. interface speed override)
+type InterfaceConfig struct {
+	MatchField string `yaml:"match_field"` // e.g. name, index
+	MatchValue string `yaml:"match_value"` // e.g. eth0 (name), 10 (index)
+	InSpeed    uint64 `yaml:"in_speed"`    // inbound speed override in bps
+	OutSpeed   uint64 `yaml:"out_speed"`   // outbound speed override in bps
+}
+
 // InitConfig is used to deserialize integration init config
 type InitConfig struct {
 	Profiles                     profileConfigMap `yaml:"profiles"`
@@ -130,6 +138,10 @@ type InstanceConfig struct {
 	// the integration will fetch OIDs from the devices and deduct which metrics  can be monitored (from all OOTB profile metrics definition)
 	DetectMetricsEnabled         *Boolean `yaml:"experimental_detect_metrics_enabled"`
 	DetectMetricsRefreshInterval int      `yaml:"experimental_detect_metrics_refresh_interval"`
+
+	// `interface_configs` option is not supported by SNMP corecheck autodiscovery (`network_address`)
+	// it's only supported for single device instance (`ip_address`)
+	InterfaceConfigs []InterfaceConfig `yaml:"interface_configs"`
 }
 
 // CheckConfig holds config needed for an integration instance to run
@@ -178,6 +190,7 @@ type CheckConfig struct {
 	DiscoveryInterval        int
 	IgnoredIPAddresses       map[string]bool
 	DiscoveryAllowedFailures int
+	InterfaceConfigs         []InterfaceConfig
 }
 
 // RefreshWithProfile refreshes config based on profile
@@ -477,6 +490,7 @@ func NewCheckConfig(rawInstance integration.Data, rawInitConfig integration.Data
 
 	c.InstanceTags = instance.Tags
 	c.MetricTags = instance.MetricTags
+	c.InterfaceConfigs = instance.InterfaceConfigs
 
 	c.AddUptimeMetric()
 
@@ -629,6 +643,7 @@ func (c *CheckConfig) Copy() *CheckConfig {
 	newConfig.DetectMetricsEnabled = c.DetectMetricsEnabled
 	newConfig.DetectMetricsRefreshInterval = c.DetectMetricsRefreshInterval
 	newConfig.MinCollectionInterval = c.MinCollectionInterval
+	newConfig.InterfaceConfigs = c.InterfaceConfigs
 
 	return &newConfig
 }

--- a/pkg/collector/corechecks/snmp/internal/checkconfig/config.go
+++ b/pkg/collector/corechecks/snmp/internal/checkconfig/config.go
@@ -63,8 +63,8 @@ type DeviceDigest string
 type InterfaceConfig struct {
 	MatchField string `yaml:"match_field"` // e.g. name, index
 	MatchValue string `yaml:"match_value"` // e.g. eth0 (name), 10 (index)
-	InSpeed    uint64 `yaml:"in_speed"`    // inbound speed override in bps
-	OutSpeed   uint64 `yaml:"out_speed"`   // outbound speed override in bps
+	InSpeed    uint64 `yaml:"in_speed"`    // inbound speed override in bits per sec
+	OutSpeed   uint64 `yaml:"out_speed"`   // outbound speed override in bits per sec
 }
 
 // InitConfig is used to deserialize integration init config

--- a/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck_test.go
+++ b/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck_test.go
@@ -60,7 +60,7 @@ profiles:
 	sender.On("EventPlatformEvent", mock.Anything, mock.Anything).Return()
 	sender.On("Commit").Return()
 
-	deviceCk.SetSender(report.NewMetricSender(sender, ""))
+	deviceCk.SetSender(report.NewMetricSender(sender, "", nil))
 
 	sysObjectIDPacket := gosnmp.SnmpPacket{
 		Variables: []gosnmp.SnmpPDU{
@@ -356,7 +356,7 @@ experimental_detect_metrics_enabled: true
 	sender.On("EventPlatformEvent", mock.Anything, mock.Anything).Return()
 	sender.On("Commit").Return()
 
-	deviceCk.SetSender(report.NewMetricSender(sender, ""))
+	deviceCk.SetSender(report.NewMetricSender(sender, "", nil))
 
 	sysObjectIDPacket := gosnmp.SnmpPacket{
 		Variables: []gosnmp.SnmpPDU{
@@ -738,7 +738,7 @@ profiles:
 	assert.Nil(t, err)
 
 	sender := mocksender.NewMockSender("123") // required to initiate aggregator
-	deviceCk.SetSender(report.NewMetricSender(sender, ""))
+	deviceCk.SetSender(report.NewMetricSender(sender, "", nil))
 	sess.On("GetNext", []string{"1.0"}).Return(session.CreateGetNextPacket("9999", gosnmp.EndOfMibView, nil), nil)
 
 	deviceCk.detectMetricsToMonitor(sess)
@@ -790,12 +790,12 @@ community_string: public
 	sender.On("Gauge", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 
 	// without hostname
-	deviceCk.SetSender(report.NewMetricSender(sender, ""))
+	deviceCk.SetSender(report.NewMetricSender(sender, "", nil))
 	deviceCk.sender.Gauge("snmp.devices_monitored", float64(1), []string{"snmp_device:1.2.3.4"})
 	sender.AssertMetric(t, "Gauge", "snmp.devices_monitored", float64(1), "", []string{"snmp_device:1.2.3.4"})
 
 	// with hostname
-	deviceCk.SetSender(report.NewMetricSender(sender, "device:123"))
+	deviceCk.SetSender(report.NewMetricSender(sender, "device:123", nil))
 	deviceCk.sender.Gauge("snmp.devices_monitored", float64(1), []string{"snmp_device:1.2.3.4"})
 	sender.AssertMetric(t, "Gauge", "snmp.devices_monitored", float64(1), "device:123", []string{"snmp_device:1.2.3.4"})
 }
@@ -889,7 +889,7 @@ profiles:
 	sender.On("EventPlatformEvent", mock.Anything, mock.Anything).Return()
 	sender.On("Commit").Return()
 
-	deviceCk.SetSender(report.NewMetricSender(sender, ""))
+	deviceCk.SetSender(report.NewMetricSender(sender, "", nil))
 
 	sysObjectIDPacket := gosnmp.SnmpPacket{
 		Variables: []gosnmp.SnmpPDU{
@@ -1183,7 +1183,7 @@ profiles:
 	sender := mocksender.NewMockSender("123") // required to initiate aggregator
 	sender.SetupAcceptAll()
 
-	deviceCk.SetSender(report.NewMetricSender(sender, ""))
+	deviceCk.SetSender(report.NewMetricSender(sender, "", nil))
 
 	packet := gosnmp.SnmpPacket{
 		Variables: []gosnmp.SnmpPDU{},
@@ -1223,7 +1223,7 @@ community_string: public
 	sender := mocksender.NewMockSender("123") // required to initiate aggregator
 	sender.SetupAcceptAll()
 
-	deviceCk.SetSender(report.NewMetricSender(sender, ""))
+	deviceCk.SetSender(report.NewMetricSender(sender, "", nil))
 
 	sess.On("GetNext", []string{"1.0"}).Return(&gosnmplib.MockValidReachableGetNextPacket, nil)
 	sess.On("GetNext", []string{"1.3.6.1.2.1.1.2.0"}).Return(session.CreateGetNextPacket("1.3.6.1.2.1.1.5.0", gosnmp.OctetString, []byte(`123`)), nil)

--- a/pkg/collector/corechecks/snmp/internal/report/report_bandwidth_usage.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_bandwidth_usage.go
@@ -14,6 +14,9 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/internal/valuestore"
 )
 
+// TODO: Rename file to report_interface_volume_metrics.go in a separate PR.
+//       Making the change in the current PR will make review harder (it makes the whole file considered as deleted).
+
 var bandwidthMetricNameToUsage = map[string]string{
 	"ifHCInOctets":  "ifBandwidthInUsage",
 	"ifHCOutOctets": "ifBandwidthOutUsage",
@@ -21,11 +24,16 @@ var bandwidthMetricNameToUsage = map[string]string{
 
 const ifHighSpeedOID = "1.3.6.1.2.1.31.1.1.1.15"
 
-func (ms *MetricSender) trySendBandwidthUsageMetric(symbol checkconfig.SymbolConfig, fullIndex string, values *valuestore.ResultValueStore, tags []string) {
+// sendInterfaceVolumeMetrics is responsible for handling special interface related metrics like:
+//   - bandwidth usage metric
+//   - if speed metrics based on custom interface speed and ifHighSpeed
+func (ms *MetricSender) sendInterfaceVolumeMetrics(symbol checkconfig.SymbolConfig, fullIndex string, values *valuestore.ResultValueStore, tags []string) {
 	err := ms.sendBandwidthUsageMetric(symbol, fullIndex, values, tags)
 	if err != nil {
 		log.Debugf("failed to send bandwidth usage metric: %s", err)
 	}
+
+	ms.sendIfSpeedMetrics(symbol, fullIndex, values, tags)
 }
 
 /*
@@ -51,10 +59,23 @@ func (ms *MetricSender) sendBandwidthUsageMetric(symbol checkconfig.SymbolConfig
 	if !ok {
 		return nil
 	}
+	var ifSpeed uint64
 
-	ifHighSpeedValues, err := values.GetColumnValues(ifHighSpeedOID)
-	if err != nil {
-		return fmt.Errorf("bandwidth usage: missing `ifHighSpeed` metric, skipping metric. fullIndex=%s", fullIndex)
+	interfaceConfig, err := getInterfaceConfig(ms.interfaceConfigs, fullIndex, tags)
+	if err == nil {
+		switch symbol.Name {
+		case "ifHCInOctets":
+			ifSpeed = interfaceConfig.InSpeed
+		case "ifHCOutOctets":
+			ifSpeed = interfaceConfig.OutSpeed
+		}
+	}
+	if ifSpeed == 0 {
+		ifHighSpeed, err := ms.getIfHighSpeed(fullIndex, values)
+		if err != nil {
+			return err
+		}
+		ifSpeed = ifHighSpeed
 	}
 
 	metricValues, err := getColumnValueFromSymbol(values, symbol)
@@ -67,23 +88,11 @@ func (ms *MetricSender) sendBandwidthUsageMetric(symbol checkconfig.SymbolConfig
 		return fmt.Errorf("bandwidth usage: missing value for `%s` metric, skipping this row. fullIndex=%s", symbol.Name, fullIndex)
 	}
 
-	ifHighSpeedValue, ok := ifHighSpeedValues[fullIndex]
-	if !ok {
-		return fmt.Errorf("bandwidth usage: missing value for `ifHighSpeed`, skipping this row. fullIndex=%s", fullIndex)
-	}
-
-	ifHighSpeedFloatValue, err := ifHighSpeedValue.ToFloat64()
-	if err != nil {
-		return fmt.Errorf("failed to convert ifHighSpeedValue to float64: %s", err)
-	}
-	if ifHighSpeedFloatValue == 0.0 {
-		return fmt.Errorf("bandwidth usage: zero or invalid value for ifHighSpeed, skipping this row. fullIndex=%s, ifHighSpeedValue=%#v", fullIndex, ifHighSpeedValue)
-	}
 	octetsFloatValue, err := octetsValue.ToFloat64()
 	if err != nil {
 		return fmt.Errorf("failed to convert octetsValue to float64: %s", err)
 	}
-	usageValue := ((octetsFloatValue * 8) / (ifHighSpeedFloatValue * (1e6))) * 100.0
+	usageValue := ((octetsFloatValue * 8) / (float64(ifSpeed))) * 100.0
 
 	sample := MetricSample{
 		value:      valuestore.ResultValue{SubmissionType: "counter", Value: usageValue},
@@ -95,4 +104,65 @@ func (ms *MetricSender) sendBandwidthUsageMetric(symbol checkconfig.SymbolConfig
 
 	ms.sendMetric(sample)
 	return nil
+}
+
+func (ms *MetricSender) sendIfSpeedMetrics(symbol checkconfig.SymbolConfig, fullIndex string, values *valuestore.ResultValueStore, tags []string) {
+	// We are piggybacking on presence of ifHCInOctets as a way to 1/ submit ifSpeed metrics only once, 2/ have corresponding fullIndex and 3/ tags.
+	// If needed, we can improve (at cost of complexity) by sending ifSpeed metrics based on presence of multiple metrics like ifHCInOctets/ifHCOutOctets/ifHighSpeed.
+	// I think it's reasonable for now, for simplify, to only rely on ifHCInOctets that should be present in the vast majority of cases.
+	if symbol.Name != "ifHCInOctets" {
+		return
+	}
+	interfaceConfig, err := getInterfaceConfig(ms.interfaceConfigs, fullIndex, tags)
+	if err != nil {
+		log.Tracef("continue with empty interfaceConfig: %s", err)
+		interfaceConfig = checkconfig.InterfaceConfig{}
+	}
+
+	ifHighSpeed, err := ms.getIfHighSpeed(fullIndex, values)
+	if err != nil {
+		log.Tracef("continue with empty interfaceConfig: %s", err)
+		ifHighSpeed = 0
+	}
+	ms.sendIfSpeedMetric("ifInSpeed", interfaceConfig.InSpeed, ifHighSpeed, tags)
+	ms.sendIfSpeedMetric("ifOutSpeed", interfaceConfig.OutSpeed, ifHighSpeed, tags)
+}
+
+func (ms *MetricSender) sendIfSpeedMetric(symbolName string, customSpeed uint64, ifHighSpeed uint64, tags []string) {
+	ifSpeed := customSpeed
+	if customSpeed == 0 {
+		ifSpeed = ifHighSpeed
+	}
+	if ifSpeed == 0 {
+		return
+	}
+
+	ms.sendMetric(MetricSample{
+		value:      valuestore.ResultValue{Value: float64(ifSpeed)},
+		tags:       tags,
+		symbol:     checkconfig.SymbolConfig{Name: symbolName},
+		forcedType: "gauge",
+		options:    checkconfig.MetricsConfigOption{},
+	})
+}
+
+// getIfHighSpeed returns getIfHighSpeed collected via SNMP
+func (ms *MetricSender) getIfHighSpeed(fullIndex string, values *valuestore.ResultValueStore) (uint64, error) {
+	ifHighSpeedValues, err := values.GetColumnValues(ifHighSpeedOID)
+	if err != nil {
+		return 0, fmt.Errorf("bandwidth usage: missing `ifHighSpeed` metric, skipping metric. fullIndex=%s", fullIndex)
+	}
+	ifHighSpeedValue, ok := ifHighSpeedValues[fullIndex]
+	if !ok {
+		return 0, fmt.Errorf("bandwidth usage: missing value for `ifHighSpeed`, skipping this row. fullIndex=%s", fullIndex)
+	}
+
+	ifHighSpeedFloatValue, err := ifHighSpeedValue.ToFloat64()
+	if err != nil {
+		return 0, fmt.Errorf("failed to convert ifHighSpeedValue to float64: %s", err)
+	}
+	if ifHighSpeedFloatValue == 0.0 {
+		return 0, fmt.Errorf("bandwidth usage: zero or invalid value for ifHighSpeed, skipping this row. fullIndex=%s, ifHighSpeedValue=%#v", fullIndex, ifHighSpeedValue)
+	}
+	return uint64(ifHighSpeedFloatValue) * (1e6), nil
 }

--- a/pkg/collector/corechecks/snmp/internal/report/report_bandwidth_usage.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_bandwidth_usage.go
@@ -130,16 +130,19 @@ func (ms *MetricSender) sendIfSpeedMetrics(symbol checkconfig.SymbolConfig, full
 
 func (ms *MetricSender) sendIfSpeedMetric(symbolName string, customSpeed uint64, ifHighSpeed uint64, tags []string) {
 	ifSpeed := customSpeed
+	speedSource := "custom"
 	if customSpeed == 0 {
 		ifSpeed = ifHighSpeed
+		speedSource = "snmp"
 	}
 	if ifSpeed == 0 {
 		return
 	}
 
+	newTags := append([]string{"speed_source:" + speedSource}, tags...)
 	ms.sendMetric(MetricSample{
 		value:      valuestore.ResultValue{Value: float64(ifSpeed)},
-		tags:       tags,
+		tags:       newTags,
 		symbol:     checkconfig.SymbolConfig{Name: symbolName},
 		forcedType: "gauge",
 		options:    checkconfig.MetricsConfigOption{},

--- a/pkg/collector/corechecks/snmp/internal/report/report_bandwidth_usage_test.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_bandwidth_usage_test.go
@@ -24,18 +24,21 @@ func Test_metricSender_sendBandwidthUsageMetric(t *testing.T) {
 		value float64
 	}
 	tests := []struct {
-		name           string
-		symbol         checkconfig.SymbolConfig
-		fullIndex      string
-		values         *valuestore.ResultValueStore
-		expectedMetric []Metric
-		expectedError  error
+		name             string
+		symbols          []checkconfig.SymbolConfig
+		fullIndex        string
+		values           *valuestore.ResultValueStore
+		tags             []string
+		interfaceConfigs []checkconfig.InterfaceConfig
+		expectedMetric   []Metric
+		expectedError    error
 	}{
 		{
-			"snmp.ifBandwidthInUsage.Rate submitted",
-			checkconfig.SymbolConfig{OID: "1.3.6.1.2.1.31.1.1.1.6", Name: "ifHCInOctets"},
-			"9",
-			&valuestore.ResultValueStore{
+			name:      "snmp.ifBandwidthInUsage.Rate submitted",
+			symbols:   []checkconfig.SymbolConfig{{OID: "1.3.6.1.2.1.31.1.1.1.6", Name: "ifHCInOctets"}},
+			fullIndex: "9",
+			tags:      []string{"abc"},
+			values: &valuestore.ResultValueStore{
 				ColumnValues: valuestore.ColumnResultValuesType{
 					// ifHCInOctets
 					"1.3.6.1.2.1.31.1.1.1.6": map[string]valuestore.ResultValue{
@@ -57,17 +60,16 @@ func Test_metricSender_sendBandwidthUsageMetric(t *testing.T) {
 					},
 				},
 			},
-			[]Metric{
+			expectedMetric: []Metric{
 				// ((5000000 * 8) / (80 * 1000000)) * 100 = 50.0
 				{"snmp.ifBandwidthInUsage.rate", 50.0},
 			},
-			nil,
 		},
 		{
-			"snmp.ifBandwidthOutUsage.Rate submitted",
-			checkconfig.SymbolConfig{OID: "1.3.6.1.2.1.31.1.1.1.10", Name: "ifHCOutOctets"},
-			"9",
-			&valuestore.ResultValueStore{
+			name:      "snmp.ifBandwidthOutUsage.Rate submitted",
+			symbols:   []checkconfig.SymbolConfig{{OID: "1.3.6.1.2.1.31.1.1.1.10", Name: "ifHCOutOctets"}},
+			fullIndex: "9",
+			values: &valuestore.ResultValueStore{
 				ColumnValues: valuestore.ColumnResultValuesType{
 					// ifHCInOctets
 					"1.3.6.1.2.1.31.1.1.1.6": map[string]valuestore.ResultValue{
@@ -89,27 +91,25 @@ func Test_metricSender_sendBandwidthUsageMetric(t *testing.T) {
 					},
 				},
 			},
-			[]Metric{
+			expectedMetric: []Metric{
 				// ((1000000 * 8) / (80 * 1000000)) * 100 = 10.0
 				{"snmp.ifBandwidthOutUsage.rate", 10.0},
 			},
-			nil,
 		},
 		{
-			"not a bandwidth metric",
-			checkconfig.SymbolConfig{OID: "1.3.6.1.2.1.31.1.1.1.99", Name: "notABandwidthMetric"},
-			"9",
-			&valuestore.ResultValueStore{
+			name:      "not a bandwidth metric",
+			symbols:   []checkconfig.SymbolConfig{{OID: "1.3.6.1.2.1.31.1.1.1.99", Name: "notABandwidthMetric"}},
+			fullIndex: "9",
+			values: &valuestore.ResultValueStore{
 				ColumnValues: valuestore.ColumnResultValuesType{},
 			},
-			[]Metric{},
-			nil,
+			expectedMetric: []Metric{},
 		},
 		{
-			"missing ifHighSpeed",
-			checkconfig.SymbolConfig{OID: "1.3.6.1.2.1.31.1.1.1.6", Name: "ifHCInOctets"},
-			"9",
-			&valuestore.ResultValueStore{
+			name:      "missing ifHighSpeed",
+			symbols:   []checkconfig.SymbolConfig{{OID: "1.3.6.1.2.1.31.1.1.1.6", Name: "ifHCInOctets"}},
+			fullIndex: "9",
+			values: &valuestore.ResultValueStore{
 				ColumnValues: valuestore.ColumnResultValuesType{
 					// ifHCInOctets
 					"1.3.6.1.2.1.31.1.1.1.6": map[string]valuestore.ResultValue{
@@ -125,14 +125,14 @@ func Test_metricSender_sendBandwidthUsageMetric(t *testing.T) {
 					},
 				},
 			},
-			[]Metric{},
-			fmt.Errorf("bandwidth usage: missing `ifHighSpeed` metric, skipping metric. fullIndex=9"),
+			expectedMetric: []Metric{},
+			expectedError:  fmt.Errorf("bandwidth usage: missing `ifHighSpeed` metric, skipping metric. fullIndex=9"),
 		},
 		{
-			"missing ifHCInOctets",
-			checkconfig.SymbolConfig{OID: "1.3.6.1.2.1.31.1.1.1.6", Name: "ifHCInOctets"},
-			"9",
-			&valuestore.ResultValueStore{
+			name:      "missing ifHCInOctets",
+			symbols:   []checkconfig.SymbolConfig{{OID: "1.3.6.1.2.1.31.1.1.1.6", Name: "ifHCInOctets"}},
+			fullIndex: "9",
+			values: &valuestore.ResultValueStore{
 				ColumnValues: valuestore.ColumnResultValuesType{
 					// ifHCOutOctets
 					"1.3.6.1.2.1.31.1.1.1.10": map[string]valuestore.ResultValue{
@@ -148,14 +148,14 @@ func Test_metricSender_sendBandwidthUsageMetric(t *testing.T) {
 					},
 				},
 			},
-			[]Metric{},
-			fmt.Errorf("bandwidth usage: missing `ifHCInOctets` metric, skipping this row. fullIndex=9"),
+			expectedMetric: []Metric{},
+			expectedError:  fmt.Errorf("bandwidth usage: missing `ifHCInOctets` metric, skipping this row. fullIndex=9"),
 		},
 		{
-			"missing ifHCOutOctets",
-			checkconfig.SymbolConfig{OID: "1.3.6.1.2.1.31.1.1.1.6", Name: "ifHCOutOctets"},
-			"9",
-			&valuestore.ResultValueStore{
+			name:      "missing ifHCOutOctets",
+			symbols:   []checkconfig.SymbolConfig{{OID: "1.3.6.1.2.1.31.1.1.1.6", Name: "ifHCOutOctets"}},
+			fullIndex: "9",
+			values: &valuestore.ResultValueStore{
 				ColumnValues: valuestore.ColumnResultValuesType{
 					// ifHCOutOctets
 					"1.3.6.1.2.1.31.1.1.1.10": map[string]valuestore.ResultValue{
@@ -171,14 +171,14 @@ func Test_metricSender_sendBandwidthUsageMetric(t *testing.T) {
 					},
 				},
 			},
-			[]Metric{},
-			fmt.Errorf("bandwidth usage: missing `ifHCOutOctets` metric, skipping this row. fullIndex=9"),
+			expectedMetric: []Metric{},
+			expectedError:  fmt.Errorf("bandwidth usage: missing `ifHCOutOctets` metric, skipping this row. fullIndex=9"),
 		},
 		{
-			"missing ifHCInOctets value",
-			checkconfig.SymbolConfig{OID: "1.3.6.1.2.1.31.1.1.1.6", Name: "ifHCInOctets"},
-			"9",
-			&valuestore.ResultValueStore{
+			name:      "missing ifHCInOctets value",
+			symbols:   []checkconfig.SymbolConfig{{OID: "1.3.6.1.2.1.31.1.1.1.6", Name: "ifHCInOctets"}},
+			fullIndex: "9",
+			values: &valuestore.ResultValueStore{
 				ColumnValues: valuestore.ColumnResultValuesType{
 					// ifHCInOctets
 					"1.3.6.1.2.1.31.1.1.1.6": map[string]valuestore.ResultValue{
@@ -200,14 +200,14 @@ func Test_metricSender_sendBandwidthUsageMetric(t *testing.T) {
 					},
 				},
 			},
-			[]Metric{},
-			fmt.Errorf("bandwidth usage: missing value for `ifHCInOctets` metric, skipping this row. fullIndex=9"),
+			expectedMetric: []Metric{},
+			expectedError:  fmt.Errorf("bandwidth usage: missing value for `ifHCInOctets` metric, skipping this row. fullIndex=9"),
 		},
 		{
-			"missing ifHighSpeed value",
-			checkconfig.SymbolConfig{OID: "1.3.6.1.2.1.31.1.1.1.6", Name: "ifHCInOctets"},
-			"9",
-			&valuestore.ResultValueStore{
+			name:      "missing ifHighSpeed value",
+			symbols:   []checkconfig.SymbolConfig{{OID: "1.3.6.1.2.1.31.1.1.1.6", Name: "ifHCInOctets"}},
+			fullIndex: "9",
+			values: &valuestore.ResultValueStore{
 				ColumnValues: valuestore.ColumnResultValuesType{
 					// ifHCInOctets
 					"1.3.6.1.2.1.31.1.1.1.6": map[string]valuestore.ResultValue{
@@ -229,14 +229,14 @@ func Test_metricSender_sendBandwidthUsageMetric(t *testing.T) {
 					},
 				},
 			},
-			[]Metric{},
-			fmt.Errorf("bandwidth usage: missing value for `ifHighSpeed`, skipping this row. fullIndex=9"),
+			expectedMetric: []Metric{},
+			expectedError:  fmt.Errorf("bandwidth usage: missing value for `ifHighSpeed`, skipping this row. fullIndex=9"),
 		},
 		{
-			"cannot convert ifHighSpeed to float",
-			checkconfig.SymbolConfig{OID: "1.3.6.1.2.1.31.1.1.1.6", Name: "ifHCInOctets"},
-			"9",
-			&valuestore.ResultValueStore{
+			name:      "cannot convert ifHighSpeed to float",
+			symbols:   []checkconfig.SymbolConfig{{OID: "1.3.6.1.2.1.31.1.1.1.6", Name: "ifHCInOctets"}},
+			fullIndex: "9",
+			values: &valuestore.ResultValueStore{
 				ColumnValues: valuestore.ColumnResultValuesType{
 					// ifHCInOctets
 					"1.3.6.1.2.1.31.1.1.1.6": map[string]valuestore.ResultValue{
@@ -258,14 +258,14 @@ func Test_metricSender_sendBandwidthUsageMetric(t *testing.T) {
 					},
 				},
 			},
-			[]Metric{},
-			fmt.Errorf("failed to convert ifHighSpeedValue to float64: failed to parse `abc`: strconv.ParseFloat: parsing \"abc\": invalid syntax"),
+			expectedMetric: []Metric{},
+			expectedError:  fmt.Errorf("failed to convert ifHighSpeedValue to float64: failed to parse `abc`: strconv.ParseFloat: parsing \"abc\": invalid syntax"),
 		},
 		{
-			"cannot convert ifHCInOctets to float",
-			checkconfig.SymbolConfig{OID: "1.3.6.1.2.1.31.1.1.1.6", Name: "ifHCInOctets"},
-			"9",
-			&valuestore.ResultValueStore{
+			name:      "cannot convert ifHCInOctets to float",
+			symbols:   []checkconfig.SymbolConfig{{OID: "1.3.6.1.2.1.31.1.1.1.6", Name: "ifHCInOctets"}},
+			fullIndex: "9",
+			values: &valuestore.ResultValueStore{
 				ColumnValues: valuestore.ColumnResultValuesType{
 					// ifHCInOctets
 					"1.3.6.1.2.1.31.1.1.1.6": map[string]valuestore.ResultValue{
@@ -287,8 +287,98 @@ func Test_metricSender_sendBandwidthUsageMetric(t *testing.T) {
 					},
 				},
 			},
-			[]Metric{},
-			fmt.Errorf("failed to convert octetsValue to float64: failed to parse `abc`: strconv.ParseFloat: parsing \"abc\": invalid syntax"),
+			expectedMetric: []Metric{},
+			expectedError:  fmt.Errorf("failed to convert octetsValue to float64: failed to parse `abc`: strconv.ParseFloat: parsing \"abc\": invalid syntax"),
+		},
+		{
+			name: "[custom speed] snmp.ifBandwidthIn/OutUsage.rate with custom interface speed matched by name",
+			symbols: []checkconfig.SymbolConfig{
+				{OID: "1.3.6.1.2.1.31.1.1.1.6", Name: "ifHCInOctets"},
+				{OID: "1.3.6.1.2.1.31.1.1.1.10", Name: "ifHCOutOctets"},
+			},
+			fullIndex: "9",
+			interfaceConfigs: []checkconfig.InterfaceConfig{{
+				MatchField: "name",
+				MatchValue: "eth0",
+				InSpeed:    160_000_000,
+				OutSpeed:   40_000_000,
+			}},
+			tags: []string{
+				"interface:eth0",
+			},
+			values: &valuestore.ResultValueStore{
+				ColumnValues: valuestore.ColumnResultValuesType{
+					// ifHCInOctets
+					"1.3.6.1.2.1.31.1.1.1.6": map[string]valuestore.ResultValue{
+						"9": {
+							Value: 5000000.0,
+						},
+					},
+					// ifHCOutOctets
+					"1.3.6.1.2.1.31.1.1.1.10": map[string]valuestore.ResultValue{
+						"9": {
+							Value: 1000000.0,
+						},
+					},
+					// ifHighSpeed
+					"1.3.6.1.2.1.31.1.1.1.15": map[string]valuestore.ResultValue{
+						"9": {
+							Value: 80.0,
+						},
+					},
+				},
+			},
+			expectedMetric: []Metric{
+				// ((5000000 * 8) / (160 * 1000000)) * 100 = 25.0
+				{"snmp.ifBandwidthInUsage.rate", 25.0},
+				// ((1000000 * 8) / (40 * 1000000)) * 100 = 20.0
+				{"snmp.ifBandwidthOutUsage.rate", 20.0},
+			},
+		},
+		{
+			name: "[custom speed] snmp.ifBandwidthIn/OutUsage.rate with custom interface speed matched by index",
+			symbols: []checkconfig.SymbolConfig{
+				{OID: "1.3.6.1.2.1.31.1.1.1.6", Name: "ifHCInOctets"},
+				{OID: "1.3.6.1.2.1.31.1.1.1.10", Name: "ifHCOutOctets"},
+			},
+			fullIndex: "9",
+			interfaceConfigs: []checkconfig.InterfaceConfig{{
+				MatchField: "index",
+				MatchValue: "9",
+				InSpeed:    160_000_000,
+				OutSpeed:   40_000_000,
+			}},
+			tags: []string{
+				"interface:eth0",
+			},
+			values: &valuestore.ResultValueStore{
+				ColumnValues: valuestore.ColumnResultValuesType{
+					// ifHCInOctets
+					"1.3.6.1.2.1.31.1.1.1.6": map[string]valuestore.ResultValue{
+						"9": {
+							Value: 5000000.0,
+						},
+					},
+					// ifHCOutOctets
+					"1.3.6.1.2.1.31.1.1.1.10": map[string]valuestore.ResultValue{
+						"9": {
+							Value: 1000000.0,
+						},
+					},
+					// ifHighSpeed
+					"1.3.6.1.2.1.31.1.1.1.15": map[string]valuestore.ResultValue{
+						"9": {
+							Value: 80.0,
+						},
+					},
+				},
+			},
+			expectedMetric: []Metric{
+				// ((5000000 * 8) / (160 * 1000000)) * 100 = 25.0
+				{"snmp.ifBandwidthInUsage.rate", 25.0},
+				// ((1000000 * 8) / (40 * 1000000)) * 100 = 20.0
+				{"snmp.ifBandwidthOutUsage.rate", 20.0},
+			},
 		},
 	}
 	for _, tt := range tests {
@@ -297,22 +387,138 @@ func Test_metricSender_sendBandwidthUsageMetric(t *testing.T) {
 			sender.On("Rate", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 
 			ms := &MetricSender{
-				sender: sender,
+				sender:           sender,
+				interfaceConfigs: tt.interfaceConfigs,
 			}
-			tags := []string{"foo:bar"}
-			err := ms.sendBandwidthUsageMetric(tt.symbol, tt.fullIndex, tt.values, tags)
-			assert.Equal(t, tt.expectedError, err)
+			for _, symbol := range tt.symbols {
+				err := ms.sendBandwidthUsageMetric(symbol, tt.fullIndex, tt.values, tt.tags)
+				assert.Equal(t, tt.expectedError, err)
+			}
 
 			for _, metric := range tt.expectedMetric {
-				sender.AssertMetric(t, "Rate", metric.name, metric.value, "", tags)
+				sender.AssertMetric(t, "Rate", metric.name, metric.value, "", tt.tags)
 			}
 		})
 	}
 }
-func Test_metricSender_trySendBandwidthUsageMetric(t *testing.T) {
+
+func Test_metricSender_sendIfSpeedMetrics(t *testing.T) {
 	type Metric struct {
 		name  string
 		value float64
+	}
+	tests := []struct {
+		name             string
+		symbol           checkconfig.SymbolConfig
+		fullIndex        string
+		values           *valuestore.ResultValueStore
+		tags             []string
+		interfaceConfigs []checkconfig.InterfaceConfig
+		expectedMetric   []Metric
+	}{
+		{
+			name:      "InSpeed and OutSpeed Override",
+			symbol:    checkconfig.SymbolConfig{OID: "1.3.6.1.2.1.31.1.1.1.6", Name: "ifHCInOctets"},
+			fullIndex: "9",
+			interfaceConfigs: []checkconfig.InterfaceConfig{{
+				MatchField: "index",
+				MatchValue: "9",
+				InSpeed:    160_000_000,
+				OutSpeed:   40_000_000,
+			}},
+			values: &valuestore.ResultValueStore{
+				ColumnValues: valuestore.ColumnResultValuesType{
+					// ifHighSpeed
+					"1.3.6.1.2.1.31.1.1.1.15": map[string]valuestore.ResultValue{
+						"9": {
+							Value: 80.0,
+						},
+					},
+				},
+			},
+			expectedMetric: []Metric{
+				{"snmp.ifInSpeed", 160_000_000},
+				{"snmp.ifOutSpeed", 40_000_000},
+			},
+		},
+		{
+			name:      "InSpeed and OutSpeed config with zero values",
+			symbol:    checkconfig.SymbolConfig{OID: "1.3.6.1.2.1.31.1.1.1.6", Name: "ifHCInOctets"},
+			fullIndex: "9",
+			interfaceConfigs: []checkconfig.InterfaceConfig{{
+				MatchField: "index",
+				MatchValue: "9",
+				InSpeed:    0,
+				OutSpeed:   0,
+			}},
+			values: &valuestore.ResultValueStore{
+				ColumnValues: valuestore.ColumnResultValuesType{
+					// ifHighSpeed
+					"1.3.6.1.2.1.31.1.1.1.15": map[string]valuestore.ResultValue{
+						"9": {
+							Value: 80.0,
+						},
+					},
+				},
+			},
+			expectedMetric: []Metric{
+				{"snmp.ifInSpeed", 80_000_000},
+				{"snmp.ifOutSpeed", 80_000_000},
+			},
+		},
+		{
+			name:             "no interface config found",
+			symbol:           checkconfig.SymbolConfig{OID: "1.3.6.1.2.1.31.1.1.1.6", Name: "ifHCInOctets"},
+			fullIndex:        "9",
+			interfaceConfigs: []checkconfig.InterfaceConfig{},
+			values: &valuestore.ResultValueStore{
+				ColumnValues: valuestore.ColumnResultValuesType{
+					// ifHighSpeed
+					"1.3.6.1.2.1.31.1.1.1.15": map[string]valuestore.ResultValue{
+						"9": {
+							Value: 80.0,
+						},
+					},
+				},
+			},
+			expectedMetric: []Metric{
+				{"snmp.ifInSpeed", 80_000_000},
+				{"snmp.ifOutSpeed", 80_000_000},
+			},
+		},
+		{
+			name:             "no interface config found and no ifHighSpeed",
+			symbol:           checkconfig.SymbolConfig{OID: "1.3.6.1.2.1.31.1.1.1.6", Name: "ifHCInOctets"},
+			fullIndex:        "9",
+			interfaceConfigs: []checkconfig.InterfaceConfig{},
+			values:           &valuestore.ResultValueStore{},
+			expectedMetric:   []Metric{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sender := mocksender.NewMockSender("testID") // required to initiate aggregator
+			sender.On("Gauge", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+
+			ms := &MetricSender{
+				sender:           sender,
+				interfaceConfigs: tt.interfaceConfigs,
+			}
+			ms.sendIfSpeedMetrics(tt.symbol, tt.fullIndex, tt.values, tt.tags)
+
+			for _, metric := range tt.expectedMetric {
+				sender.AssertMetric(t, "Gauge", metric.name, metric.value, "", tt.tags)
+			}
+			assert.Equal(t, len(tt.expectedMetric), len(sender.Mock.Calls))
+		})
+	}
+}
+
+func Test_metricSender_sendInterfaceVolumeMetrics(t *testing.T) {
+	type Metric struct {
+		metricMethod string
+		name         string
+		value        float64
 	}
 	tests := []struct {
 		name           string
@@ -349,7 +555,9 @@ func Test_metricSender_trySendBandwidthUsageMetric(t *testing.T) {
 			},
 			[]Metric{
 				// ((5000000 * 8) / (80 * 1000000)) * 100 = 50.0
-				{"snmp.ifBandwidthInUsage.rate", 50.0},
+				{"Rate", "snmp.ifBandwidthInUsage.rate", 50.0},
+				{"Gauge", "snmp.ifInSpeed", 80_000_000},
+				{"Gauge", "snmp.ifOutSpeed", 80_000_000},
 			},
 		},
 		{
@@ -385,15 +593,16 @@ func Test_metricSender_trySendBandwidthUsageMetric(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			sender := mocksender.NewMockSender("testID") // required to initiate aggregator
 			sender.On("Rate", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+			sender.On("Gauge", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 
 			ms := &MetricSender{
 				sender: sender,
 			}
 			tags := []string{"foo:bar"}
-			ms.trySendBandwidthUsageMetric(tt.symbol, tt.fullIndex, tt.values, tags)
+			ms.sendInterfaceVolumeMetrics(tt.symbol, tt.fullIndex, tt.values, tags)
 
 			for _, metric := range tt.expectedMetric {
-				sender.AssertMetric(t, "Rate", metric.name, metric.value, "", tags)
+				sender.AssertMetric(t, metric.metricMethod, metric.name, metric.value, "", tags)
 			}
 		})
 	}

--- a/pkg/collector/corechecks/snmp/internal/report/report_metrics.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_metrics.go
@@ -22,6 +22,7 @@ type MetricSender struct {
 	sender           aggregator.Sender
 	hostname         string
 	submittedMetrics int
+	interfaceConfigs []checkconfig.InterfaceConfig
 }
 
 // MetricSample is a collected metric sample with its metadata, ready to be submitted through the metric sender
@@ -34,8 +35,12 @@ type MetricSample struct {
 }
 
 // NewMetricSender create a new MetricSender
-func NewMetricSender(sender aggregator.Sender, hostname string) *MetricSender {
-	return &MetricSender{sender: sender, hostname: hostname}
+func NewMetricSender(sender aggregator.Sender, hostname string, interfaceConfigs []checkconfig.InterfaceConfig) *MetricSender {
+	return &MetricSender{
+		sender:           sender,
+		hostname:         hostname,
+		interfaceConfigs: interfaceConfigs,
+	}
 }
 
 // ReportMetrics reports metrics using Sender
@@ -140,7 +145,7 @@ func (ms *MetricSender) reportColumnMetrics(metricConfig checkconfig.MetricsConf
 				samples[sample.symbol.Name] = make(map[string]MetricSample)
 			}
 			samples[sample.symbol.Name][fullIndex] = sample
-			ms.trySendBandwidthUsageMetric(symbol, fullIndex, values, rowTags)
+			ms.sendInterfaceVolumeMetrics(symbol, fullIndex, values, rowTags)
 		}
 	}
 	return samples

--- a/pkg/collector/corechecks/snmp/internal/report/report_utils.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_utils.go
@@ -154,3 +154,22 @@ func netmaskToPrefixlen(netmask string) int {
 	length, _ := stringMask.Size()
 	return length
 }
+
+// getInterfaceConfig retrieves checkconfig.InterfaceConfig by index and tags
+func getInterfaceConfig(interfaceConfigs []checkconfig.InterfaceConfig, index string, tags []string) (checkconfig.InterfaceConfig, error) {
+	var ifName string
+	for _, tag := range tags {
+		tagElems := strings.SplitN(tag, ":", 2)
+		if len(tagElems) == 2 && tagElems[0] == "interface" {
+			ifName = tagElems[1]
+			break
+		}
+	}
+	for _, ifConfig := range interfaceConfigs {
+		if (ifConfig.MatchField == "name" && ifConfig.MatchValue == ifName) ||
+			(ifConfig.MatchField == "index" && ifConfig.MatchValue == index) {
+			return ifConfig, nil
+		}
+	}
+	return checkconfig.InterfaceConfig{}, fmt.Errorf("no matching interface found for index=%s, tags=%s", index, tags)
+}

--- a/pkg/collector/corechecks/snmp/internal/report/report_utils_test.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_utils_test.go
@@ -727,3 +727,77 @@ func Test_netmaskToPrefixlen(t *testing.T) {
 	assert.Equal(t, 1, netmaskToPrefixlen("128.0.0.0"))
 	assert.Equal(t, 0, netmaskToPrefixlen("0.0.0.0"))
 }
+
+func Test_getInterfaceConfig(t *testing.T) {
+	tests := []struct {
+		name                    string
+		interfaceConfigs        []checkconfig.InterfaceConfig
+		index                   string
+		tags                    []string
+		expectedInterfaceConfig checkconfig.InterfaceConfig
+		expectedError           string
+	}{
+		{
+			name: "matched by name",
+			interfaceConfigs: []checkconfig.InterfaceConfig{
+				{
+					MatchField: "name",
+					MatchValue: "eth0",
+					InSpeed:    80,
+				},
+			},
+			index: "10",
+			tags: []string{
+				"interface:eth0",
+			},
+			expectedInterfaceConfig: checkconfig.InterfaceConfig{
+				MatchField: "name",
+				MatchValue: "eth0",
+				InSpeed:    80,
+			},
+		},
+		{
+			name: "matched by index",
+			interfaceConfigs: []checkconfig.InterfaceConfig{
+				{
+					MatchField: "index",
+					MatchValue: "10",
+					InSpeed:    80,
+				},
+			},
+			index: "10",
+			tags: []string{
+				"interface:eth0",
+			},
+			expectedInterfaceConfig: checkconfig.InterfaceConfig{
+				MatchField: "index",
+				MatchValue: "10",
+				InSpeed:    80,
+			},
+		},
+		{
+			name: "not matched",
+			interfaceConfigs: []checkconfig.InterfaceConfig{
+				{
+					MatchField: "index",
+					MatchValue: "99",
+					InSpeed:    80,
+				},
+			},
+			index: "10",
+			tags: []string{
+				"interface:eth0",
+			},
+			expectedError: "no matching interface found for index=10, tags=[interface:eth0]",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config, err := getInterfaceConfig(tt.interfaceConfigs, tt.index, tt.tags)
+			if tt.expectedError != "" {
+				assert.EqualError(t, err, tt.expectedError)
+			}
+			assert.Equal(t, tt.expectedInterfaceConfig, config)
+		})
+	}
+}

--- a/pkg/collector/corechecks/snmp/snmp.go
+++ b/pkg/collector/corechecks/snmp/snmp.go
@@ -65,7 +65,8 @@ func (c *Check) Run() error {
 				log.Warnf("error getting hostname for device %s: %s", deviceCk.GetIPAddress(), err)
 				continue
 			}
-			deviceCk.SetSender(report.NewMetricSender(sender, hostname))
+			// `interface_configs` option not supported by SNMP corecheck autodiscovery
+			deviceCk.SetSender(report.NewMetricSender(sender, hostname, nil))
 			jobs <- deviceCk
 		}
 		close(jobs)
@@ -79,7 +80,7 @@ func (c *Check) Run() error {
 		if err != nil {
 			return err
 		}
-		c.singleDeviceCk.SetSender(report.NewMetricSender(sender, hostname))
+		c.singleDeviceCk.SetSender(report.NewMetricSender(sender, hostname, c.config.InterfaceConfigs))
 		checkErr = c.runCheckDevice(c.singleDeviceCk)
 	}
 

--- a/releasenotes/notes/snmp_interface_configs_to_override_interface_speed-0e86bbe648ea1704.yaml
+++ b/releasenotes/notes/snmp_interface_configs_to_override_interface_speed-0e86bbe648ea1704.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    [corechecks/snmp] Add ``interface_configs`` to override interface speed.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

[corechecks/snmp] Add interface_configs to override interface speed

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

User request.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

Idea for future, extend with `match_pattern` to match by regex.

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Test 1:
1/ Use config like this one by targeting a valid interface:

```
init_config:
  loader: core  # use core check implementation of SNMP integration. recommended
  use_device_id_as_hostname: true  # recommended
instances:
  - ip_address: '127.0.0.1'
    port: 1161
    community_string: 'public'
    # collect_topology: true
    interface_configs:
      - match_field: "name"
        match_value: "eth0"
        in_speed: 50
        out_speed: 25
```

2/ Check that:
- ifInSpeed/ifOutSpeed metric are present and has corresponding value from config above
- ifBandwidthInUsage/ifBandwidthOutUsage is computed using speed in config

Test 2:
1/ Use config like this one:

```
init_config:
  loader: core  # use core check implementation of SNMP integration. recommended
  use_device_id_as_hostname: true  # recommended
instances:
  - ip_address: '127.0.0.1'
    port: 1161
    community_string: 'public'
    # collect_topology: true
```

2/ Check that:
- ifInSpeed/ifOutSpeed metric are present and have the same value as ifHighSpeed
- ifBandwidthInUsage/ifBandwidthOutUsage is still computed using ifHighSpeed

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
