### PR TITLE
lint: allow passing concurrency parameter to golangci-lint

### DIFF
--- a/tasks/go.py
+++ b/tasks/go.py
@@ -18,7 +18,7 @@ from .modules import DEFAULT_MODULES, generate_dummy_package
 from .utils import get_build_flags
 
 
-def run_golangci_lint(ctx, targets, rtloader_root=None, build_tags=None, build="test", arch="x64"):
+def run_golangci_lint(ctx, targets, rtloader_root=None, build_tags=None, build="test", arch="x64", concurrency=None):
     if isinstance(targets, str):
         # when this function is called from the command line, targets are passed
         # as comma separated tokens in a string
@@ -33,8 +33,10 @@ def run_golangci_lint(ctx, targets, rtloader_root=None, build_tags=None, build="
     results = []
     for target in targets:
         print(f"running golangci on {target}")
+        concurrency_arg = "" if concurrency is None else f"--concurrency {concurrency}"
+        tags_arg = " ".join(tags)
         result = ctx.run(
-            f'golangci-lint run --timeout 20m0s --build-tags "{" ".join(tags)}" {target}/...',
+            f'golangci-lint run --timeout 20m0s {concurrency_arg} --build-tags "{tags_arg}" {target}/...',
             env=env,
             warn=True,
         )
@@ -44,14 +46,14 @@ def run_golangci_lint(ctx, targets, rtloader_root=None, build_tags=None, build="
 
 
 @task
-def golangci_lint(ctx, targets, rtloader_root=None, build_tags=None, build="test", arch="x64"):
+def golangci_lint(ctx, targets, rtloader_root=None, build_tags=None, build="test", arch="x64", concurrency=None):
     """
     Run golangci-lint on targets using .golangci.yml configuration.
 
     Example invocation:
         inv golangci-lint --targets=./pkg/collector/check,./pkg/aggregator
     """
-    results = run_golangci_lint(ctx, targets, rtloader_root, build_tags, build, arch)
+    results = run_golangci_lint(ctx, targets, rtloader_root, build_tags, build, arch, concurrency)
 
     should_fail = False
     for result in results:


### PR DESCRIPTION
### What does this PR do?

golangci-lint uses `runtime.NumCPU` as the default concurrency. But this function returns the number of usable virtual CPUs, not the cgroup quota (or k8s limit). This means that for example running a container with a CPU limit of 2, on a server with 72 cores will allocate tons of goroutines (and thus tons of memory) to run lints.

This PR allows passing an optional parameter fixing the concurrency when running golangci-lint manually

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
