### PR TITLE
Use sealed memfd file for runtime compilation

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -974,6 +974,8 @@ core,github.com/jmespath/go-jmespath,Apache-2.0,Copyright 2015 James Saryerwinni
 core,github.com/josharian/intern,MIT,Copyright (c) 2019 Josh Bleecher Snyder
 core,github.com/josharian/native,MIT,Copyright 2020 Josh Bleecher Snyder
 core,github.com/json-iterator/go,MIT,Copyright (c) 2016 json-iterator
+core,github.com/justincormack/go-memfd,MIT,Copyright (c) 2017 Justin Cormack
+core,github.com/justincormack/go-memfd/msyscall,MIT,Copyright (c) 2017 Justin Cormack
 core,github.com/kardianos/osext,BSD-3-Clause,Copyright (c) 2012 The Go Authors. All rights reserved
 core,github.com/karrick/godirwalk,BSD-2-Clause,"Copyright (c) 2017, Karrick McDermott"
 core,github.com/kballard/go-shellquote,MIT,Copyright (C) 2014 Kevin Ballard

--- a/go.mod
+++ b/go.mod
@@ -50,7 +50,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/util/pointer v0.43.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.43.0-rc.3
 	github.com/DataDog/datadog-go/v5 v5.1.1
-	github.com/DataDog/datadog-operator v0.7.1-0.20220602134901-4f6af09bf54f
+	github.com/DataDog/datadog-operator v0.8.4
 	github.com/DataDog/ebpf-manager v0.2.3
 	github.com/DataDog/go-libddwaf v0.0.0-20221118110754-0372d7c76b8a
 	github.com/DataDog/go-tuf v0.3.0--fix-localmeta-fork
@@ -532,7 +532,6 @@ require (
 	golang.org/x/mod v0.8.0 // indirect
 	golang.org/x/oauth2 v0.3.0 // indirect
 	golang.org/x/term v0.5.0 // indirect
-	gomodules.xyz/jsonpatch/v2 v2.2.0 // indirect
 	google.golang.org/api v0.103.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	gopkg.in/Knetic/govaluate.v3 v3.0.0 // indirect
@@ -563,6 +562,7 @@ require (
 require (
 	github.com/DataDog/appsec-internal-go v0.0.0-20230215162203-5149228be86a
 	github.com/aquasecurity/trivy v0.0.0-00010101000000-000000000000
+	github.com/justincormack/go-memfd v0.0.0-20170219213707-6e4af0518993
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -50,7 +50,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/util/pointer v0.43.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.43.0-rc.3
 	github.com/DataDog/datadog-go/v5 v5.1.1
-	github.com/DataDog/datadog-operator v0.8.4
+	github.com/DataDog/datadog-operator v0.7.1-0.20220602134901-4f6af09bf54f
 	github.com/DataDog/ebpf-manager v0.2.3
 	github.com/DataDog/go-libddwaf v0.0.0-20221118110754-0372d7c76b8a
 	github.com/DataDog/go-tuf v0.3.0--fix-localmeta-fork
@@ -295,6 +295,7 @@ require (
 	github.com/aquasecurity/go-version v0.0.0-20210121072130-637058cfe492 // indirect
 	github.com/aquasecurity/table v1.8.0 // indirect
 	github.com/aquasecurity/tml v0.6.1 // indirect
+	github.com/aquasecurity/trivy v0.0.0-00010101000000-000000000000
 	github.com/arduino/go-apt-client v0.0.0-20190812130613-5613f843fdc8 // indirect
 	github.com/armon/go-metrics v0.4.0 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d // indirect
@@ -398,6 +399,7 @@ require (
 	github.com/jonboulle/clockwork v0.3.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/josharian/native v1.0.0 // indirect
+	github.com/justincormack/go-memfd v0.0.0-20170219213707-6e4af0518993
 	github.com/karrick/godirwalk v1.17.0 // indirect
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
 	github.com/kevinburke/ssh_config v0.0.0-20201106050909-4977a11b4351 // indirect
@@ -468,6 +470,7 @@ require (
 	github.com/sergi/go-diff v1.1.0 // indirect
 	github.com/shibumi/go-pathspec v1.3.0 // indirect
 	github.com/shopspring/decimal v1.2.0 // indirect
+	github.com/sigstore/rekor v1.0.1 // indirect
 	github.com/smira/go-ftp-protocol v0.0.0-20140829150050-066b75c2b70d // indirect
 	github.com/spdx/tools-golang v0.3.1-0.20230104082527-d6f58551be3f // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
@@ -532,6 +535,7 @@ require (
 	golang.org/x/mod v0.8.0 // indirect
 	golang.org/x/oauth2 v0.3.0 // indirect
 	golang.org/x/term v0.5.0 // indirect
+	gonum.org/v1/gonum v0.12.0 // indirect
 	google.golang.org/api v0.103.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	gopkg.in/Knetic/govaluate.v3 v3.0.0 // indirect
@@ -559,16 +563,9 @@ require (
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
 
-require (
-	github.com/DataDog/appsec-internal-go v0.0.0-20230215162203-5149228be86a
-	github.com/aquasecurity/trivy v0.0.0-00010101000000-000000000000
-	github.com/justincormack/go-memfd v0.0.0-20170219213707-6e4af0518993
-)
+require github.com/DataDog/appsec-internal-go v0.0.0-20230215162203-5149228be86a
 
-require (
-	github.com/sigstore/rekor v1.0.1 // indirect
-	gonum.org/v1/gonum v0.12.0 // indirect
-)
+require gomodules.xyz/jsonpatch/v2 v2.2.0 // indirect
 
 replace github.com/pahanini/go-grpc-bidirectional-streaming-example v0.0.0-20211027164128-cc6111af44be => github.com/DataDog/go-grpc-bidirectional-streaming-example v0.0.0-20221024060302-b9cf785c02fe
 

--- a/go.sum
+++ b/go.sum
@@ -140,8 +140,8 @@ github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3
 github.com/DataDog/datadog-go/v5 v5.0.2/go.mod h1:ZI9JFB4ewXbw1sBnF4sxsR2k1H3xjV+PUAOUsHvKpcU=
 github.com/DataDog/datadog-go/v5 v5.1.1 h1:JLZ6s2K1pG2h9GkvEvMdEGqMDyVLEAccdX5TltWcLMU=
 github.com/DataDog/datadog-go/v5 v5.1.1/go.mod h1:KhiYb2Badlv9/rofz+OznKoEF5XKTonWyhx5K83AP8E=
-github.com/DataDog/datadog-operator v0.7.1-0.20220602134901-4f6af09bf54f h1:A7WPfKHAeZB+yD83KtY8Y4mZKFAbZgBziulshnpErK4=
-github.com/DataDog/datadog-operator v0.7.1-0.20220602134901-4f6af09bf54f/go.mod h1:KAQEFctpgWNlJ2/ef9PRKqy79UAa/URSOWZzgaCrwug=
+github.com/DataDog/datadog-operator v0.8.4 h1:0jm4mHll2hWZXtTDDtE0FYWGqkYike+PJBmVqRk66T8=
+github.com/DataDog/datadog-operator v0.8.4/go.mod h1:IRkzZHOweGLuszkSVuOQcDm1qGcYqBs3p4wuDozcd1M=
 github.com/DataDog/ebpf-manager v0.2.3 h1:xzPnk1JoLU1zei0BsUXKiBeG5HJ5zOTL747cyU9R2RY=
 github.com/DataDog/ebpf-manager v0.2.3/go.mod h1:QNbbXqQdl1RDRDna/vSHzhpTNXTnqxxJRVXdeANgCUA=
 github.com/DataDog/extendeddaemonset v0.7.1-0.20220530183123-9c60ea5abbc6 h1:XDD6SEIEpe5CAa7esIWlgdXLQgLKN4hvPw+Wd8pJQFU=
@@ -711,7 +711,6 @@ github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021/go.
 github.com/envoyproxy/go-control-plane v0.10.2-0.20220325020618-49ff273808a1/go.mod h1:KJwIaB5Mv44NWtYuAOFCVOjcI94vtpEz2JU/D2v6IjE=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/erikstmartin/go-testdb v0.0.0-20160219214506-8d10e4a1bae5/go.mod h1:a2zkGnVExMxdzMo3M0Hi/3sEU+cWnZpSni0O6/Yb/P0=
-github.com/evanphx/json-patch v0.5.2/go.mod h1:ZWS5hhDbVDyob71nXKNL0+PWn6ToqBHMikGIFbs31qQ=
 github.com/evanphx/json-patch v4.12.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch v5.6.0+incompatible h1:jBYDEEiFBPxA0v50tFdvOzQQTCvpL6mnFh5mB2/l16U=
 github.com/evanphx/json-patch v5.6.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
@@ -802,7 +801,6 @@ github.com/go-logr/logr v1.2.3 h1:2DntVwHkVopvECVRSlL5PSo9eG+cAkDCuckLubN+rq0=
 github.com/go-logr/logr v1.2.3/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
 github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre4VKE=
-github.com/go-logr/zapr v1.2.0 h1:n4JnPI1T3Qq1SFEi/F8rwLrZERp2bso19PJZDB9dayk=
 github.com/go-logr/zapr v1.2.0/go.mod h1:Qa4Bsj2Vb+FAVeAKsLD8RLQ+YRJB8YDmOAKxaBQf7Ro=
 github.com/go-martini/martini v0.0.0-20170121215854-22fa46961aab h1:xveKWz2iaueeTaUgdetzel+U7exyigDYBryyVfV/rZk=
 github.com/go-martini/martini v0.0.0-20170121215854-22fa46961aab/go.mod h1:/P9AEU963A2AYjv4d1V5eVL1CQbEJq6aCNHDDjibzu8=
@@ -1340,6 +1338,8 @@ github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7V
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/juliogreff/apiserver v0.23.6-0.20220531090536-be42650a25e5 h1:BXRtRw8fOU+OGw7iertQUrpXtdda1UVbawurjZN/lic=
 github.com/juliogreff/apiserver v0.23.6-0.20220531090536-be42650a25e5/go.mod h1:N08z57XwD9yMwxPK3MD8oHtm63ogVSFXyoKOOrHathU=
+github.com/justincormack/go-memfd v0.0.0-20170219213707-6e4af0518993 h1:YnMJVKw7M5rE15UsVY7w2cnxcnArci7v1g3butq0YbI=
+github.com/justincormack/go-memfd v0.0.0-20170219213707-6e4af0518993/go.mod h1:VYi8SD2j14Nh9hNT7l57A00YUx/tMxY6pPA1IGljdrg=
 github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0 h1:iQTw/8FWTuc7uiaSepXwyf3o52HaUYcV+Tu66S3F5GA=
 github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0/go.mod h1:1NbS8ALrpOvjt0rHPNLyCIeMtbizbir8U//inJ+zuB8=
 github.com/karrick/godirwalk v1.8.0/go.mod h1:H5KPZjojv4lE+QYImBI8xVtrBRgYrIVsaRPx4tDPEn4=
@@ -2768,8 +2768,6 @@ golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 h1:H2TDz8ibqkAF6YGhCdN3jS9O0/s90v0rJh3X/OLHEUk=
 golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=
-gomodules.xyz/jsonpatch/v2 v2.2.0 h1:4pT439QV83L+G9FkcCriY6EkpcK6r6bK+A5FBUMI7qY=
-gomodules.xyz/jsonpatch/v2 v2.2.0/go.mod h1:WXp+iVDkoLQqPudfQ9GBlwB2eZ5DKOnjQZCYdOS8GPY=
 gonum.org/v1/gonum v0.12.0 h1:xKuo6hzt+gMav00meVPUlXwSdoEJP46BR+wdxQEFK2o=
 gonum.org/v1/gonum v0.12.0/go.mod h1:73TDxJfAAHeA8Mk9mf8NlIppyhQNo5GLTcYeqgo2lvY=
 google.golang.org/api v0.0.0-20160322025152-9bf6e6e569ff/go.mod h1:4mhQ8q/RsB7i+udVvVy5NUi08OU8ZlA0gRVgrF7VFY0=

--- a/go.sum
+++ b/go.sum
@@ -140,8 +140,8 @@ github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3
 github.com/DataDog/datadog-go/v5 v5.0.2/go.mod h1:ZI9JFB4ewXbw1sBnF4sxsR2k1H3xjV+PUAOUsHvKpcU=
 github.com/DataDog/datadog-go/v5 v5.1.1 h1:JLZ6s2K1pG2h9GkvEvMdEGqMDyVLEAccdX5TltWcLMU=
 github.com/DataDog/datadog-go/v5 v5.1.1/go.mod h1:KhiYb2Badlv9/rofz+OznKoEF5XKTonWyhx5K83AP8E=
-github.com/DataDog/datadog-operator v0.8.4 h1:0jm4mHll2hWZXtTDDtE0FYWGqkYike+PJBmVqRk66T8=
-github.com/DataDog/datadog-operator v0.8.4/go.mod h1:IRkzZHOweGLuszkSVuOQcDm1qGcYqBs3p4wuDozcd1M=
+github.com/DataDog/datadog-operator v0.7.1-0.20220602134901-4f6af09bf54f h1:A7WPfKHAeZB+yD83KtY8Y4mZKFAbZgBziulshnpErK4=
+github.com/DataDog/datadog-operator v0.7.1-0.20220602134901-4f6af09bf54f/go.mod h1:KAQEFctpgWNlJ2/ef9PRKqy79UAa/URSOWZzgaCrwug=
 github.com/DataDog/ebpf-manager v0.2.3 h1:xzPnk1JoLU1zei0BsUXKiBeG5HJ5zOTL747cyU9R2RY=
 github.com/DataDog/ebpf-manager v0.2.3/go.mod h1:QNbbXqQdl1RDRDna/vSHzhpTNXTnqxxJRVXdeANgCUA=
 github.com/DataDog/extendeddaemonset v0.7.1-0.20220530183123-9c60ea5abbc6 h1:XDD6SEIEpe5CAa7esIWlgdXLQgLKN4hvPw+Wd8pJQFU=
@@ -711,6 +711,7 @@ github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021/go.
 github.com/envoyproxy/go-control-plane v0.10.2-0.20220325020618-49ff273808a1/go.mod h1:KJwIaB5Mv44NWtYuAOFCVOjcI94vtpEz2JU/D2v6IjE=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/erikstmartin/go-testdb v0.0.0-20160219214506-8d10e4a1bae5/go.mod h1:a2zkGnVExMxdzMo3M0Hi/3sEU+cWnZpSni0O6/Yb/P0=
+github.com/evanphx/json-patch v0.5.2/go.mod h1:ZWS5hhDbVDyob71nXKNL0+PWn6ToqBHMikGIFbs31qQ=
 github.com/evanphx/json-patch v4.12.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch v5.6.0+incompatible h1:jBYDEEiFBPxA0v50tFdvOzQQTCvpL6mnFh5mB2/l16U=
 github.com/evanphx/json-patch v5.6.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
@@ -801,6 +802,7 @@ github.com/go-logr/logr v1.2.3 h1:2DntVwHkVopvECVRSlL5PSo9eG+cAkDCuckLubN+rq0=
 github.com/go-logr/logr v1.2.3/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
 github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre4VKE=
+github.com/go-logr/zapr v1.2.0 h1:n4JnPI1T3Qq1SFEi/F8rwLrZERp2bso19PJZDB9dayk=
 github.com/go-logr/zapr v1.2.0/go.mod h1:Qa4Bsj2Vb+FAVeAKsLD8RLQ+YRJB8YDmOAKxaBQf7Ro=
 github.com/go-martini/martini v0.0.0-20170121215854-22fa46961aab h1:xveKWz2iaueeTaUgdetzel+U7exyigDYBryyVfV/rZk=
 github.com/go-martini/martini v0.0.0-20170121215854-22fa46961aab/go.mod h1:/P9AEU963A2AYjv4d1V5eVL1CQbEJq6aCNHDDjibzu8=
@@ -2768,6 +2770,8 @@ golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 h1:H2TDz8ibqkAF6YGhCdN3jS9O0/s90v0rJh3X/OLHEUk=
 golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=
+gomodules.xyz/jsonpatch/v2 v2.2.0 h1:4pT439QV83L+G9FkcCriY6EkpcK6r6bK+A5FBUMI7qY=
+gomodules.xyz/jsonpatch/v2 v2.2.0/go.mod h1:WXp+iVDkoLQqPudfQ9GBlwB2eZ5DKOnjQZCYdOS8GPY=
 gonum.org/v1/gonum v0.12.0 h1:xKuo6hzt+gMav00meVPUlXwSdoEJP46BR+wdxQEFK2o=
 gonum.org/v1/gonum v0.12.0/go.mod h1:73TDxJfAAHeA8Mk9mf8NlIppyhQNo5GLTcYeqgo2lvY=
 google.golang.org/api v0.0.0-20160322025152-9bf6e6e569ff/go.mod h1:4mhQ8q/RsB7i+udVvVy5NUi08OU8ZlA0gRVgrF7VFY0=

--- a/pkg/ebpf/bytecode/runtime/asset.go
+++ b/pkg/ebpf/bytecode/runtime/asset.go
@@ -109,7 +109,7 @@ func createProtectedFile(name, runtimeDir string, source io.Reader) (ProtectedFi
 	return protectedFile, err
 }
 
-// verify reads the asset in the provided directory and verifies the content hash matches what is expected.
+// verify reads the asset from the reader and verifies the content hash matches what is expected.
 func (a *asset) verify(source io.Reader) error {
 	h := sha256.New()
 	if _, err := io.Copy(h, source); err != nil {

--- a/pkg/ebpf/bytecode/runtime/asset.go
+++ b/pkg/ebpf/bytecode/runtime/asset.go
@@ -112,6 +112,10 @@ func setupSourceInfoFile(source io.Reader, path string) error {
 func createRamBackedFile(name, hash string, source io.Reader, runtimeDir string) (string, func(), error) {
 	var err error
 
+	if err = os.MkdirAll(runtimeDir, 0755); err != nil {
+		return "", nil, fmt.Errorf("unable to create compiler output directory %s: %w", runtimeDir, err)
+	}
+
 	memfdFile, err := memfd.Create()
 	if err != nil {
 		return "", nil, fmt.Errorf("failed to create memfd file: %w: ", err)

--- a/pkg/ebpf/bytecode/runtime/asset.go
+++ b/pkg/ebpf/bytecode/runtime/asset.go
@@ -73,6 +73,7 @@ func (a *asset) Compile(config *ebpf.Config, additionalFlags []string, client st
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file %s: %w", p, err)
 	}
+	defer f.Close()
 
 	if err := os.MkdirAll(outputDir, 0755); err != nil {
 		return nil, fmt.Errorf("unable to create compiler output directory %s: %w", outputDir, err)

--- a/pkg/ebpf/bytecode/runtime/asset.go
+++ b/pkg/ebpf/bytecode/runtime/asset.go
@@ -88,7 +88,7 @@ func (a *asset) Compile(config *ebpf.Config, additionalFlags []string, client st
 		}
 	}()
 
-	if err = a.verify(protectedFile.Reader()); err != nil {
+	if err = a.verify(protectedFile); err != nil {
 		a.tm.compilationResult = verificationError
 		return nil, fmt.Errorf("error reading input file: %s", err)
 	}
@@ -110,9 +110,9 @@ func createProtectedFile(name, runtimeDir string, source io.Reader) (ProtectedFi
 }
 
 // verify reads the asset from the reader and verifies the content hash matches what is expected.
-func (a *asset) verify(source io.Reader) error {
+func (a *asset) verify(source ProtectedFile) error {
 	h := sha256.New()
-	if _, err := io.Copy(h, source); err != nil {
+	if _, err := io.Copy(h, source.Reader()); err != nil {
 		return fmt.Errorf("error hashing file: %w", err)
 	}
 	if fmt.Sprintf("%x", h.Sum(nil)) != a.hash {

--- a/pkg/ebpf/bytecode/runtime/asset.go
+++ b/pkg/ebpf/bytecode/runtime/asset.go
@@ -26,10 +26,9 @@ import (
 
 // asset represents an asset that needs its content integrity checked at runtime
 type asset struct {
-	filename  string
-	hash      string
-	tm        CompilationTelemetry
-	memfdFile *os.File
+	filename string
+	hash     string
+	tm       CompilationTelemetry
 }
 
 func newAsset(filename, hash string) *asset {

--- a/pkg/ebpf/bytecode/runtime/asset.go
+++ b/pkg/ebpf/bytecode/runtime/asset.go
@@ -114,7 +114,7 @@ func createRamBackedFile(name, hash string, source io.Reader, runtimeDir string)
 
 	memfdFile, err := memfd.Create()
 	if err != nil {
-		return "", nil, err
+		return "", nil, fmt.Errorf("failed to create memfd file: %w: ", err)
 	}
 	defer func() {
 		if err != nil {

--- a/pkg/ebpf/bytecode/runtime/asset.go
+++ b/pkg/ebpf/bytecode/runtime/asset.go
@@ -75,7 +75,7 @@ func (a *asset) Compile(config *ebpf.Config, additionalFlags []string, client st
 		return nil, fmt.Errorf("failed to open file %s: %w", p, err)
 	}
 
-	inputFile, closeFn, err := createRamBackedFile(a.filename, a.hash, f, config.RuntimeCompilerOutputDir)
+	inputFile, closeFn, err := createRamBackedFile(a.filename, a.hash, f, outputDir)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create ram backed file from %s: %w", f.Name(), err)
 	}

--- a/pkg/ebpf/bytecode/runtime/asset.go
+++ b/pkg/ebpf/bytecode/runtime/asset.go
@@ -85,7 +85,7 @@ func (a *asset) Compile(config *ebpf.Config, additionalFlags []string, client st
 	}
 	defer func() {
 		if err := protectedFile.Close(); err != nil {
-			log.Debug(err)
+			log.Debugf("error closing protected file %s: %s", protectedFile.Name(), err)
 		}
 	}()
 
@@ -114,7 +114,7 @@ func createProtectedFile(name, runtimeDir string, source io.Reader) (ProtectedFi
 func (a *asset) verify(source ProtectedFile) error {
 	h := sha256.New()
 	if _, err := io.Copy(h, source.Reader()); err != nil {
-		return fmt.Errorf("error hashing file: %w", err)
+		return fmt.Errorf("error hashing file %s: %w", source.Name(), err)
 	}
 	if fmt.Sprintf("%x", h.Sum(nil)) != a.hash {
 		return fmt.Errorf("file content hash does not match expected value")

--- a/pkg/ebpf/bytecode/runtime/asset.go
+++ b/pkg/ebpf/bytecode/runtime/asset.go
@@ -9,7 +9,6 @@
 package runtime
 
 import (
-	"bytes"
 	"crypto/sha256"
 	"fmt"
 	"io"
@@ -18,6 +17,7 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-go/v5/statsd"
+	"github.com/justincormack/go-memfd"
 
 	"github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
@@ -26,9 +26,10 @@ import (
 
 // asset represents an asset that needs its content integrity checked at runtime
 type asset struct {
-	filename string
-	hash     string
-	tm       CompilationTelemetry
+	filename  string
+	hash      string
+	tm        CompilationTelemetry
+	memfdFile *os.File
 }
 
 func newAsset(filename, hash string) *asset {
@@ -69,39 +70,104 @@ func (a *asset) Compile(config *ebpf.Config, additionalFlags []string, client st
 
 	outputDir := config.RuntimeCompilerOutputDir
 
-	inputReader, err := a.verify(config.BPFDir)
+	p := filepath.Join(config.BPFDir, "runtime", a.filename)
+	f, err := os.Open(p)
 	if err != nil {
+		return nil, fmt.Errorf("failed to open file %s: %w", p, err)
+	}
+
+	inputFile, closeFn, err := createRamBackedFile(a.filename, a.hash, f, config.RuntimeCompilerOutputDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create ram backed file from %s: %w", f.Name(), err)
+	}
+	defer closeFn()
+
+	if err = a.verify(inputFile); err != nil {
 		a.tm.compilationResult = verificationError
 		return nil, fmt.Errorf("error reading input file: %s", err)
 	}
 
-	out, result, err := compileToObjectFile(inputReader, outputDir, a.filename, a.hash, additionalFlags, kernelHeaders)
+	out, result, err := compileToObjectFile(inputFile, outputDir, a.filename, a.hash, additionalFlags, kernelHeaders)
 	a.tm.compilationResult = result
 
 	return out, err
 }
 
-// verify reads the asset in the provided directory and verifies the content hash matches what is expected.
-// On success, it returns an io.Reader for the contents
-func (a *asset) verify(dir string) (io.Reader, error) {
-	p := filepath.Join(dir, "runtime", a.filename)
-	f, err := os.Open(p)
+func setupSourceInfoFile(source io.Reader, path string) error {
+	f, err := os.Create(path)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	defer f.Close()
 
-	var buf bytes.Buffer
-	h := sha256.New()
+	if _, err := io.Copy(f, source); err != nil {
+		return err
+	}
 
-	w := io.MultiWriter(&buf, h)
-	if _, err := io.Copy(w, f); err != nil {
-		return nil, fmt.Errorf("error hashing file %s: %w", f.Name(), err)
+	return nil
+}
+
+// creates a ram backed file from the given reader. The file is made immutable
+func createRamBackedFile(name, hash string, source io.Reader, runtimeDir string) (string, func(), error) {
+	var err error
+
+	memfdFile, err := memfd.Create()
+	if err != nil {
+		return "", nil, err
+	}
+	defer func() {
+		if err != nil {
+			memfdFile.Close()
+		}
+	}()
+
+	if _, err = io.Copy(memfdFile, source); err != nil {
+		return "", nil, fmt.Errorf("error copying bytes to memfd file: %w", err)
+	}
+
+	// seal the memfd file, making it immutable.
+	if err = memfdFile.SetSeals(memfd.SealAll); err != nil {
+		return "", nil, fmt.Errorf("failed to seal memfd file: %w", err)
+	}
+
+	target := fmt.Sprintf("/proc/%d/fd/%d", os.Getpid(), memfdFile.Fd())
+	tmpFile := filepath.Join(runtimeDir, fmt.Sprintf("%s-%s", name, hash))
+
+	os.Remove(tmpFile)
+	if err := os.Symlink(target, tmpFile); err != nil {
+		return "", nil, fmt.Errorf("failed to create symlink with target file %s: %w", target, err)
+	}
+
+	return tmpFile, func() {
+		os.Remove(tmpFile)
+		if _, err := memfdFile.Seek(0, os.SEEK_SET); err != nil {
+			log.Debug(err)
+		}
+		if err := setupSourceInfoFile(memfdFile, tmpFile); err != nil {
+			log.Debug("failed to setup source file: ", err)
+		}
+		memfdFile.Close()
+	}, nil
+}
+
+// verify reads the asset in the provided directory and verifies the content hash matches what is expected.
+// On success, it returns an io.Reader for the contents
+func (a *asset) verify(verifyFile string) error {
+	f, err := os.Open(verifyFile)
+	if err != nil {
+		return fmt.Errorf("error opening file %s: %w", verifyFile, err)
+	}
+	defer f.Close()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return fmt.Errorf("error hashing file: %w", err)
 	}
 	if fmt.Sprintf("%x", h.Sum(nil)) != a.hash {
-		return nil, fmt.Errorf("file content hash does not match expected value")
+		return fmt.Errorf("file content hash does not match expected value")
 	}
-	return &buf, nil
+
+	return nil
 }
 
 // GetTelemetry returns the compilation telemetry for this asset

--- a/pkg/ebpf/bytecode/runtime/generated_asset.go
+++ b/pkg/ebpf/bytecode/runtime/generated_asset.go
@@ -78,7 +78,7 @@ func (a *generatedAsset) Compile(config *ebpf.Config, inputCode string, addition
 	}
 	defer func() {
 		if err := protectedFile.Close(); err != nil {
-			log.Debug(err)
+			log.Debugf("error closing protected file %s: %s", protectedFile.Name(), err)
 		}
 	}()
 

--- a/pkg/ebpf/bytecode/runtime/generated_asset.go
+++ b/pkg/ebpf/bytecode/runtime/generated_asset.go
@@ -65,18 +65,18 @@ func (a *generatedAsset) Compile(config *ebpf.Config, inputCode string, addition
 
 	outputDir := config.RuntimeCompilerOutputDir
 
-	inputReader := strings.NewReader(inputCode)
-	tmpFile, closeFn, err := createRamBackedFile("generated", "", inputReader, "/tmp")
-	if err != nil {
-		return nil, fmt.Errorf("error creating ram backed file: %w", err)
-	}
-	defer closeFn()
-
 	inputHash, err := sha256hex([]byte(inputCode))
 	if err != nil {
 		a.tm.compilationResult = inputHashError
 		return nil, fmt.Errorf("error hashing input: %w", err)
 	}
+
+	inputReader := strings.NewReader(inputCode)
+	tmpFile, closeFn, err := createRamBackedFile(a.filename, inputHash, inputReader, outputDir)
+	if err != nil {
+		return nil, fmt.Errorf("error creating ram backed file: %w", err)
+	}
+	defer closeFn()
 
 	out, result, err := compileToObjectFile(tmpFile, outputDir, a.filename, inputHash, additionalFlags, kernelHeaders)
 	a.tm.compilationResult = result

--- a/pkg/ebpf/bytecode/runtime/generated_asset.go
+++ b/pkg/ebpf/bytecode/runtime/generated_asset.go
@@ -66,13 +66,19 @@ func (a *generatedAsset) Compile(config *ebpf.Config, inputCode string, addition
 	outputDir := config.RuntimeCompilerOutputDir
 
 	inputReader := strings.NewReader(inputCode)
+	tmpFile, closeFn, err := createRamBackedFile("generated", "", inputReader, "/tmp")
+	if err != nil {
+		return nil, fmt.Errorf("error creating ram backed file: %w", err)
+	}
+	defer closeFn()
+
 	inputHash, err := sha256hex([]byte(inputCode))
 	if err != nil {
 		a.tm.compilationResult = inputHashError
 		return nil, fmt.Errorf("error hashing input: %w", err)
 	}
 
-	out, result, err := compileToObjectFile(inputReader, outputDir, a.filename, inputHash, additionalFlags, kernelHeaders)
+	out, result, err := compileToObjectFile(tmpFile, outputDir, a.filename, inputHash, additionalFlags, kernelHeaders)
 	a.tm.compilationResult = result
 
 	return out, err

--- a/pkg/ebpf/bytecode/runtime/protected_file.go
+++ b/pkg/ebpf/bytecode/runtime/protected_file.go
@@ -36,7 +36,7 @@ func NewProtectedFile(name, dir string, source io.Reader) (ProtectedFile, error)
 
 	memfdFile, err := memfd.CreateNameFlags(name, memfd.AllowSealing|memfd.Cloexec)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create memfd file: %w: ", err)
+		return nil, fmt.Errorf("failed to create memfd file: %w", err)
 	}
 	defer func() {
 		if err != nil {
@@ -57,9 +57,6 @@ func NewProtectedFile(name, dir string, source io.Reader) (ProtectedFile, error)
 
 	target := fmt.Sprintf("/proc/%d/fd/%d", os.Getpid(), memfdFile.Fd())
 	tmpFile := filepath.Join(dir, name)
-
-	link, _ := os.Readlink(target)
-	log.Debugf("NewProtectedFile: created memfd file: %s => %s", target, link)
 
 	os.Remove(tmpFile)
 	if err := os.Symlink(target, tmpFile); err != nil {

--- a/pkg/ebpf/bytecode/runtime/protected_file.go
+++ b/pkg/ebpf/bytecode/runtime/protected_file.go
@@ -10,6 +10,7 @@ import (
 	"github.com/justincormack/go-memfd"
 )
 
+// This represent a symlink to a sealed ram-backed file
 type ProtectedFile interface {
 	Close() error
 	Reader() io.Reader

--- a/pkg/ebpf/bytecode/runtime/protected_file.go
+++ b/pkg/ebpf/bytecode/runtime/protected_file.go
@@ -1,0 +1,103 @@
+package runtime
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/justincormack/go-memfd"
+)
+
+type ProtectedFile interface {
+	Close() error
+	Reader() io.Reader
+	Name() string
+}
+
+type ramBackedFile struct {
+	symlink string
+	file    *memfd.Memfd
+}
+
+// This function returns a sealed ram backed file
+func NewProtectedFile(name, dir string, source io.Reader) (ProtectedFile, error) {
+	var err error
+
+	memfdFile, err := memfd.CreateNameFlags(name, memfd.AllowSealing|memfd.Cloexec)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create memfd file: %w: ", err)
+	}
+	defer func() {
+		if err != nil {
+			memfdFile.Close()
+		}
+	}()
+
+	if source != nil {
+		if _, err = io.Copy(memfdFile, source); err != nil {
+			return nil, fmt.Errorf("error copying bytes to memfd file: %w", err)
+		}
+	}
+
+	// seal the memfd file, making it immutable.
+	if err = memfdFile.SetSeals(memfd.SealAll); err != nil {
+		return nil, fmt.Errorf("failed to seal memfd file: %w", err)
+	}
+
+	target := fmt.Sprintf("/proc/%d/fd/%d", os.Getpid(), memfdFile.Fd())
+	tmpFile := filepath.Join(dir, name)
+
+	link, _ := os.Readlink(target)
+	log.Debugf("NewProtectedFile: created memfd file: %s => %s", target, link)
+
+	os.Remove(tmpFile)
+	if err := os.Symlink(target, tmpFile); err != nil {
+		return nil, fmt.Errorf("failed to create symlink %s from target %s: %w", tmpFile, target, err)
+	}
+
+	if _, err := memfdFile.Seek(0, os.SEEK_SET); err != nil {
+		return nil, fmt.Errorf("failed to reset cursor: %w", err)
+	}
+
+	return &ramBackedFile{
+		file:    memfdFile,
+		symlink: tmpFile,
+	}, nil
+}
+
+// replace the symlink file with a copy of the input file so that
+// debug info can be resolved by tools like objdump
+func setupSourceInfoFile(source io.Reader, path string) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	if _, err := io.Copy(f, source); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *ramBackedFile) Close() error {
+	os.Remove(m.symlink)
+	if _, err := m.file.Seek(0, os.SEEK_SET); err != nil {
+		log.Debug(err)
+	}
+	if err := setupSourceInfoFile(m.file, m.symlink); err != nil {
+		log.Debugf("failed to setup source file: %v", err)
+	}
+	return m.file.Close()
+}
+
+func (m *ramBackedFile) Name() string {
+	return m.symlink
+}
+
+func (m *ramBackedFile) Reader() io.Reader {
+	return m.file
+}

--- a/pkg/ebpf/bytecode/runtime/protected_file.go
+++ b/pkg/ebpf/bytecode/runtime/protected_file.go
@@ -1,3 +1,11 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+// +build linux_bpf
+
 package runtime
 
 import (

--- a/pkg/ebpf/bytecode/runtime/runtime_compilation_helpers.go
+++ b/pkg/ebpf/bytecode/runtime/runtime_compilation_helpers.go
@@ -55,7 +55,7 @@ var defaultFlags = []string{
 }
 
 // compileToObjectFile compiles the input ebpf program & returns the compiled output
-func compileToObjectFile(in io.Reader, outputDir, filename, inHash string, additionalFlags, kernelHeaders []string) (CompiledOutput, CompilationResult, error) {
+func compileToObjectFile(inFile, outputDir, filename, inHash string, additionalFlags, kernelHeaders []string) (CompiledOutput, CompilationResult, error) {
 	if err := os.MkdirAll(outputDir, 0755); err != nil {
 		return nil, outputDirErr, fmt.Errorf("unable to create compiler output directory %s: %w", outputDir, err)
 	}
@@ -93,7 +93,7 @@ func compileToObjectFile(in io.Reader, outputDir, filename, inHash string, addit
 			flags = append(flags, fmt.Sprintf("-include%s", helperPath))
 		}
 
-		if err := compiler.CompileToObjectFile(in, outputFile, flags, kernelHeaders); err != nil {
+		if err := compiler.CompileToObjectFile(inFile, outputFile, flags, kernelHeaders); err != nil {
 			return nil, compilationErr, fmt.Errorf("failed to compile runtime version of %s: %s", filename, err)
 		}
 

--- a/pkg/ebpf/bytecode/runtime/runtime_compilation_helpers.go
+++ b/pkg/ebpf/bytecode/runtime/runtime_compilation_helpers.go
@@ -56,10 +56,6 @@ var defaultFlags = []string{
 
 // compileToObjectFile compiles the input ebpf program & returns the compiled output
 func compileToObjectFile(inFile, outputDir, filename, inHash string, additionalFlags, kernelHeaders []string) (CompiledOutput, CompilationResult, error) {
-	if err := os.MkdirAll(outputDir, 0755); err != nil {
-		return nil, outputDirErr, fmt.Errorf("unable to create compiler output directory %s: %w", outputDir, err)
-	}
-
 	flags, flagHash := computeFlagsAndHash(additionalFlags)
 
 	outputFile, err := getOutputFilePath(outputDir, filename, inHash, flagHash)

--- a/pkg/ebpf/compiler/compiler_test.go
+++ b/pkg/ebpf/compiler/compiler_test.go
@@ -31,10 +31,6 @@ func TestCompilerMatch(t *testing.T) {
 		}
 		return
 	}
-	input, err := os.Open(cPath)
-	require.NoError(t, err)
-	defer input.Close()
-
 	cfg := ebpf.NewConfig()
 
 	cflags := []string{
@@ -47,7 +43,7 @@ func TestCompilerMatch(t *testing.T) {
 	defer os.Remove(tmpObjFile.Name())
 
 	onDiskObjFilename := tmpObjFile.Name()
-	err = CompileToObjectFile(input, onDiskObjFilename, cflags, nil)
+	err = CompileToObjectFile(cPath, onDiskObjFilename, cflags, nil)
 	require.NoError(t, err)
 
 	bs, err := os.ReadFile(onDiskObjFilename)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
This PR uses an appropriately named symlink to a sealed ram-backed file as input to clang during runtime compilation. 
The input file is read into memory, and sealed before the hash of the input contents is verified. At the end of the compilation process the symlink is replaced with the actual input file.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Runtime compiled files did not have any source code annotations in their disassembly, which made debugging painful in cases where the disassembly had to be used. This was because the runtime asset was compiled with input from stdin, which set the target file for resolving debug info to a non existent file.
This approach solves this by providing a correctly named input file to clang.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs
The RSS of system-probe will increase during runtime compilation, since the files will be mmaped before use. The increase will be the size of the input file.

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
