### PR TITLE
[Kitchen] Add note for `ffi-yajl` and remove note for `nio4r`

### DIFF
--- a/test/kitchen/README.md
+++ b/test/kitchen/README.md
@@ -23,10 +23,11 @@ bundle config set --local gemfile './Gemfile.local'
 
 `bundle install`
 
-Note: you might run into an error building the `nio4r` native extensions. You
-should be able to get around that by setting the build cflags for the gem
-in bundler:
- ` bundle config build.nio4r --with-cflags="-std=c99" `
+Note: When building on M1 you might run into an error installing `ffi-yajl` gem. You should be able to get around that by setting the build `ldflags` for this gem in bundler (see [this Github Issue](https://github.com/chef/ffi-yajl/issues/115)):
+```bash
+bundle config build.ffi-yajl --with-ldflags="-Wl,-undefined,dynamic_lookup"
+```
+
 
 #### Azure
 

--- a/test/kitchen/README.md
+++ b/test/kitchen/README.md
@@ -23,7 +23,7 @@ bundle config set --local gemfile './Gemfile.local'
 
 `bundle install`
 
-Note: When building on M1 you might run into an error installing `ffi-yajl` gem. You should be able to get around that by setting the build `ldflags` for this gem in bundler (see [this Github Issue](https://github.com/chef/ffi-yajl/issues/115)):
+Note: When building on macOS M1, you might run into an error when installing the `ffi-yajl` gem. You should be able to get around that by setting the build `ldflags` for this gem in bundler configuration (see [this Github Issue](https://github.com/chef/ffi-yajl/issues/115)):
 ```bash
 bundle config build.ffi-yajl --with-ldflags="-Wl,-undefined,dynamic_lookup"
 ```


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This PR removes a note about `nio4r` gem which is not used anymore in our kitchen tests. It also adds a note about `ffi-yajl` that is failing to install the gem dependencies on Mac M1.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

It was failing to build on Mac M1.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
