### PR TITLE
[Serverless] Ensure all serverless trace agent tests use unique port.

### DIFF
--- a/pkg/serverless/trace/cold_start_span_creator_test.go
+++ b/pkg/serverless/trace/cold_start_span_creator_test.go
@@ -21,6 +21,8 @@ import (
 )
 
 func TestColdStartSpanCreatorCreateValid(t *testing.T) {
+	setupTraceAgentTest(t)
+
 	cfg := config.New()
 	cfg.GlobalTags = map[string]string{}
 	cfg.Endpoints[0].APIKey = "test"
@@ -77,6 +79,8 @@ func TestColdStartSpanCreatorCreateValid(t *testing.T) {
 }
 
 func TestColdStartSpanCreatorCreateDuplicate(t *testing.T) {
+	setupTraceAgentTest(t)
+
 	cfg := config.New()
 	cfg.GlobalTags = map[string]string{}
 	cfg.Endpoints[0].APIKey = "test"
@@ -125,6 +129,8 @@ func TestColdStartSpanCreatorCreateDuplicate(t *testing.T) {
 }
 
 func TestColdStartSpanCreatorNotColdStart(t *testing.T) {
+	setupTraceAgentTest(t)
+
 	cfg := config.New()
 	cfg.GlobalTags = map[string]string{}
 	cfg.Endpoints[0].APIKey = "test"

--- a/pkg/serverless/trace/trace_test.go
+++ b/pkg/serverless/trace/trace_test.go
@@ -10,7 +10,6 @@ package trace
 
 import (
 	"fmt"
-	"os"
 	"strconv"
 	"testing"
 	"time"
@@ -23,7 +22,16 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/trace/testutil"
 )
 
+func setupTraceAgentTest(t *testing.T) {
+	// ensure a free port is used for starting the trace agent
+	if port, err := testutil.FindTCPPort(); err == nil {
+		t.Setenv("DD_RECEIVER_PORT", strconv.Itoa(port))
+	}
+}
+
 func TestStartEnabledFalse(t *testing.T) {
+	setupTraceAgentTest(t)
+
 	lambdaSpanChan := make(chan *pb.Span)
 	var agent = &ServerlessTraceAgent{}
 	agent.Start(false, nil, lambdaSpanChan, random.Random.Uint64())
@@ -42,6 +50,8 @@ func (l *LoadConfigMocked) Load() (*config.AgentConfig, error) {
 }
 
 func TestStartEnabledTrueInvalidConfig(t *testing.T) {
+	setupTraceAgentTest(t)
+
 	var agent = &ServerlessTraceAgent{}
 	lambdaSpanChan := make(chan *pb.Span)
 	agent.Start(true, &LoadConfigMocked{}, lambdaSpanChan, random.Random.Uint64())
@@ -52,6 +62,8 @@ func TestStartEnabledTrueInvalidConfig(t *testing.T) {
 }
 
 func TestStartEnabledTrueValidConfigUnvalidPath(t *testing.T) {
+	setupTraceAgentTest(t)
+
 	var agent = &ServerlessTraceAgent{}
 	lambdaSpanChan := make(chan *pb.Span)
 
@@ -64,6 +76,8 @@ func TestStartEnabledTrueValidConfigUnvalidPath(t *testing.T) {
 }
 
 func TestStartEnabledTrueValidConfigValidPath(t *testing.T) {
+	setupTraceAgentTest(t)
+
 	var agent = &ServerlessTraceAgent{}
 	lambdaSpanChan := make(chan *pb.Span)
 
@@ -75,10 +89,7 @@ func TestStartEnabledTrueValidConfigValidPath(t *testing.T) {
 }
 
 func TestLoadConfigShouldBeFast(t *testing.T) {
-	// ensure a free port is used for starting the trace agent
-	if port, err := testutil.FindTCPPort(); err == nil {
-		os.Setenv("DD_RECEIVER_PORT", strconv.Itoa(port))
-	}
+	setupTraceAgentTest(t)
 
 	startTime := time.Now()
 	lambdaSpanChan := make(chan *pb.Span)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Tests in the serverless trace package now use a random port when starting the trace agent.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Flaky tests are bad.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

Note that I touched this same code yesterday in #15712. But I did it wrong. I used `os.Setenv` when I should have used `t.Setenv`.

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
