### PR TITLE
[Single Machine Performance] Introduce UDS DogStatsD regression experiment

### DIFF
--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -11,7 +11,7 @@ single-machine-performance-regression_detector:
       - submission_metadata
   variables:
     SMP_VERSION: 0.7.1
-    LADING_VERSION: 0.12.0
+    LADING_VERSION: 0.13.0
     TOTAL_SAMPLES: 600
     WARMUP_SECONDS: 45
     REPLICAS: 10

--- a/test/regression/cases/uds_dogstatsd_to_api/datadog-agent/datadog.yaml
+++ b/test/regression/cases/uds_dogstatsd_to_api/datadog-agent/datadog.yaml
@@ -1,0 +1,14 @@
+api_key: 00000000000000000000000000000000
+auth_token_file_path: /tmp/agent-auth-token
+hostname: smp-regression
+
+dd_url: http://127.0.0.1:9092
+
+confd_path: /etc/datadog-agent/conf.d
+
+# Disable cloud detection. This stops the Agent from poking around the
+# execution environment & network. This is particularly important if the target
+# has network access.
+cloud_provider_metadata: []
+
+dogstatsd_socket: '/tmp/dsd.socket'

--- a/test/regression/cases/uds_dogstatsd_to_api/lading/lading.yaml
+++ b/test/regression/cases/uds_dogstatsd_to_api/lading/lading.yaml
@@ -1,0 +1,15 @@
+generator:
+  - unix_datagram:
+      seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
+             59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
+      path: "/tmp/dsd.socket"
+      variant: "dogstatsd"
+      bytes_per_second: "100 Mb"
+      block_sizes: ["256b", "512b", "1Kb", "2Kb", "3Kb", "4Kb", "5Kb", "6Kb"]
+      maximum_prebuild_cache_size_bytes: "500 Mb"
+
+blackhole:
+  - http:
+      binding_addr: "127.0.0.1:9091"
+  - http:
+      binding_addr: "127.0.0.1:9092"


### PR DESCRIPTION
### What does this PR do?

This commit adds an experiment for the Regression Detector that runs UDS DogStatsD load into the Agent. 

### Motivation

This is one of the more common configurations of the Agent. The approach taken is similar to our other RD runs. 

### Additional Notes

I have updated lading to a version that includes self-throttling based on target performance. This version of lading will search for Agent's stable throughput capacity and push load at that level. The previous version of lading pushed as hard as possible, causing chaotic results from Agent.

See also #15614 and #15613.

REF SMP-371