### PR TITLE
[Windows][Installer] Set permissions on the system probe configuration

### DIFF
--- a/tools/windows/DatadogAgentInstaller/CustomActions/UserCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/UserCustomActions.cs
@@ -304,7 +304,7 @@ namespace Datadog.CustomActions
                     Path.Combine(session.Property("APPLICATIONDATADIRECTORY"), "conf.d"),
                     Path.Combine(session.Property("APPLICATIONDATADIRECTORY"), "auth_token"),
                     Path.Combine(session.Property("APPLICATIONDATADIRECTORY"), "datadog.yaml"),
-
+                    Path.Combine(session.Property("APPLICATIONDATADIRECTORY"), "system-probe.yaml"),
                     Path.Combine(session.Property("PROJECTLOCATION"), "embedded2"),
                     Path.Combine(session.Property("PROJECTLOCATION"), "embedded3"),
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
This PR ensures the installer sets the correct permissions on the `system-probe.yaml` configuration file.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Consistent permissions.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
No changelog since it's going to be part of the NG installer, which will have its own changelog.

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
- Install the Agent and check the permissions on the `system-probe.yaml` file, they should match those of the `datadog.yaml` file.
- On an installed stable Agent, change the permissions on the `system-probe.yaml` file to deny read access to the `ddagentuser`. Then, upgrade the Agent to the latest RC and check the permissions on `system-probe.yaml`, they should match those of the `datadog.yaml` (the `ddagentuser` should have read access to the file).

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
