### PR TITLE
[CSPM] Bootstrap functional tests on rego compliance checks

### DIFF
--- a/pkg/compliance/tests/.gitignore
+++ b/pkg/compliance/tests/.gitignore
@@ -1,0 +1,1 @@
+testsuite

--- a/pkg/compliance/tests/audit_test.go
+++ b/pkg/compliance/tests/audit_test.go
@@ -1,0 +1,14 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+// +build linux
+
+package tests
+
+import "testing"
+
+func TestAuditInput(t *testing.T) {
+}

--- a/pkg/compliance/tests/badenv_test.go
+++ b/pkg/compliance/tests/badenv_test.go
@@ -1,0 +1,150 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !docker && !linux && !kubeapiserver
+// +build !docker,!linux,!kubeapiserver
+
+package tests
+
+import "testing"
+
+func TestNoDocker(t *testing.T) {
+	b := NewTestBench(t)
+	defer b.Run()
+
+	b.AddRule("NoDockerNoneScope").
+		WithInput(`
+- docker:
+		kind: info
+	type: array
+	tag: infos
+`).
+		WithRego(`
+package datadog
+import data.datadog as dd
+
+has_key(o, k) {
+	_ := o[k]
+}
+
+valid_info(p) {
+	has_key(p, "inspect")
+}
+
+valid_infos = [i | i := input.infos[_]; valid_info(i)]
+
+findings[f] {
+	count(input.infos) > 0
+	count(valid_infos) == count(input.infos)
+	f := dd.passed_finding(
+		"my_resource_type",
+		"my_resource_id",
+		{"plop": input.context.hostname}
+	)
+}
+`).
+		AssertErrorEvent()
+
+	b.AddRule("NoDockerWithScope").
+		WithScope("docker").
+		WithInput(`
+- docker:
+		kind: info
+	type: array
+	tag: infos
+`).
+		WithRego(`
+package datadog
+import data.datadog as dd
+
+has_key(o, k) {
+	_ := o[k]
+}
+
+valid_info(p) {
+	has_key(p, "inspect")
+}
+
+valid_infos = [i | i := input.infos[_]; valid_info(i)]
+
+findings[f] {
+	count(input.infos) > 0
+	count(valid_infos) == count(input.infos)
+	f := dd.passed_finding(
+		"my_resource_type",
+		"my_resource_id",
+		{"plop": input.context.hostname}
+	)
+}
+`).
+		AssertNoEvent()
+}
+
+func TestNoKubernetes(t *testing.T) {
+	b := NewTestBench(t)
+	defer b.Run()
+
+	b.AddRule("NoKubernetesNode").
+		WithScope("kubernetesNode").
+		WithInput(`
+- kubeApiserver:
+		kind: serviceaccounts
+		version: v1
+		fieldSelector: metadata.name=default
+		apiRequest:
+			verb: list
+	type: array
+	tag: serviceaccounts
+`).
+		WithRego(`
+package datadog
+import data.datadog as dd
+
+has_key(o, k) {
+	_ := o[k]
+}
+
+findings[f] {
+	has_key(p, "serviceaccounts")
+	f := dd.passed_finding(
+		"my_resource_type",
+		"my_resource_id",
+		{"plop": input.context.hostname}
+	)
+}
+`).
+		AssertNoEvent()
+
+	b.AddRule("NoKubernetesCluster").
+		WithScope("kubernetesCluster").
+		WithInput(`
+- kubeApiserver:
+		kind: serviceaccounts
+		version: v1
+		fieldSelector: metadata.name=default
+		apiRequest:
+			verb: list
+	type: array
+	tag: serviceaccounts
+`).
+		WithRego(`
+package datadog
+import data.datadog as dd
+
+has_key(o, k) {
+	_ := o[k]
+}
+
+findings[f] {
+	has_key(p, "serviceaccounts")
+	f := dd.passed_finding(
+		"my_resource_type",
+		"my_resource_id",
+		{"plop": input.context.hostname}
+	)
+}
+`).
+		AssertNoEvent()
+}

--- a/pkg/compliance/tests/base_test.go
+++ b/pkg/compliance/tests/base_test.go
@@ -1,0 +1,110 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package tests
+
+import (
+	"testing"
+
+	_ "github.com/DataDog/datadog-agent/pkg/compliance/resources/file"
+)
+
+func TestBase(t *testing.T) {
+	b := NewTestBench(t)
+	defer b.Run()
+
+	b.AddRule("BadYamlSuiteInput").
+		WithInput(`zsd`).
+		WithRego(``).
+		AssertError()
+
+	b.AddRule("DuplicatedTag").
+		WithInput(`
+- file:
+		path: plop
+	tag: abc
+- file:
+		name: foobar
+	tag: abc
+`).
+		AssertErrorEvent()
+
+	b.AddRule("UnknownInput").
+		WithInput(`
+- asdpoakspo:
+		path: plop
+	tag: abc
+`).
+		AssertErrorEvent()
+
+	b.AddRule("NoInput").
+		WithInput("").
+		WithRego(`
+package datadog
+import data.datadog as dd
+
+findings[f] {
+	true
+	f := dd.passed_finding(
+		"foo",
+		"bar",
+		{},
+	)
+}
+`).
+		AssertNoEvent()
+
+	b.AddRule("Constants").
+		WithInput(`
+- constants:
+		foo: bar
+		baz: baz
+	tag: constant1
+- constants:
+		quz: 123
+	tag: constant2
+`).
+		WithRego(`
+package datadog
+import data.datadog as dd
+
+findings[f] {
+	input.constant1.foo == "bar"
+	input.constant1.baz == "baz"
+	input.constant2.quz == 123
+	f := dd.passed_finding(
+		"foo",
+		"bar",
+		{},
+	)
+}
+`).
+		AssertPassedEvent(nil)
+
+	b.AddRule("NoOutputRego").
+		WithInput(`
+- constants:
+		foo: bar
+`).
+		WithRego(`
+package datadog
+import data.datadog as dd
+
+findings[f] {
+	input.nopenope
+	f := dd.passed_finding("foo", "bar", {})
+}
+`).
+		AssertNoEvent()
+
+	b.AddRule("BadRego").
+		WithInput(`
+- file:
+		path: plop
+	tag: abcd
+`).
+		WithRego(`{`).
+		AssertErrorEvent()
+}

--- a/pkg/compliance/tests/base_test.go
+++ b/pkg/compliance/tests/base_test.go
@@ -8,6 +8,7 @@ package tests
 import (
 	"testing"
 
+	_ "github.com/DataDog/datadog-agent/pkg/compliance/resources/constants"
 	_ "github.com/DataDog/datadog-agent/pkg/compliance/resources/file"
 )
 
@@ -79,6 +80,24 @@ findings[f] {
 		"bar",
 		{},
 	)
+}
+`).
+		AssertPassedEvent(nil)
+
+	b.AddRule("Constants2").
+		WithInput(`
+- constants:
+		foo: bar
+		quz: 1
+`).
+		WithRego(`
+package datadog
+import data.datadog as dd
+
+findings[f] {
+	input.constants.foo == "bar"
+	input.constants.quz == 1
+	f := dd.passed_finding("foo", "bar", {})
 }
 `).
 		AssertPassedEvent(nil)

--- a/pkg/compliance/tests/docker_test.go
+++ b/pkg/compliance/tests/docker_test.go
@@ -1,0 +1,212 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build docker
+// +build docker
+
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/compliance/event"
+	_ "github.com/DataDog/datadog-agent/pkg/compliance/resources/docker"
+
+	"github.com/DataDog/datadog-agent/pkg/util/docker"
+	"github.com/stretchr/testify/assert"
+)
+
+const dockerHostname = "host-docker-test-42"
+
+func TestDockerInfoInput(t *testing.T) {
+	dockerCl, err := docker.ConnectToDocker(context.Background())
+	if err != nil {
+		t.Skipf("could not connect to docker to start testing: %v", err)
+	}
+
+	b := NewTestBench(t).
+		WithHostname(dockerHostname).
+		WithDockerClient(dockerCl)
+	defer b.Run()
+
+	b.AddRule("TaggedInfos").
+		WithInput(`
+- docker:
+    kind: info
+  type: array
+  tag: infos
+`).
+		WithRego(`
+package datadog
+import data.datadog as dd
+
+has_key(o, k) {
+	_ := o[k]
+}
+
+valid_info(p) {
+	has_key(p, "inspect")
+}
+
+valid_infos = [i | i := input.infos[_]; valid_info(i)]
+
+findings[f] {
+	count(input.infos) > 0
+	count(valid_infos) == count(input.infos)
+	f := dd.passed_finding(
+		"my_resource_type",
+		"my_resource_id",
+		{"plop": input.context.hostname}
+	)
+}
+`).
+		AssertPassedEvent(func(t *testing.T, e *event.Event) {
+			assert.Equal(t, "TaggedInfos", e.AgentRuleID)
+			assert.Equal(t, "my_resource_type", e.ResourceType)
+			assert.Equal(t, "my_resource_id", e.ResourceID)
+			assert.Equal(t, event.Data{"plop": dockerHostname}, e.Data)
+		})
+
+	b.AddRule("RegoContext").
+		WithInput(`
+- docker:
+    kind: info
+  type: array
+  tag: infos
+`).
+		WithRego(`
+package datadog
+import data.datadog as dd
+
+has_key(o, k) {
+	_ := o[k]
+}
+
+valid_context(ctx) {
+	ctx.hostname == "{{.Hostname}}"
+	ctx.ruleID == "{{.RuleID}}"
+	ctx.input.infos.docker.kind == "info"
+	ctx.input.infos.type == "array"
+}
+
+findings[f] {
+	valid_context(input.context)
+	f := dd.passed_finding(
+		"valid_context",
+		"valid_context_id",
+		{"foo": "bar"}
+	)
+}
+`).
+		AssertPassedEvent(func(t *testing.T, evt *event.Event) {
+			assert.Equal(t, "valid_context", evt.ResourceType)
+			assert.Equal(t, "valid_context_id", evt.ResourceID)
+			assert.Equal(t, event.Data{"foo": "bar"}, evt.Data)
+		})
+
+	b.
+		AddRule("UnknownKind").
+		WithInput(`
+- docker:
+		kind: plop
+	type: array
+	tag: plop
+`).
+		WithRego(`package datadog`).
+		AssertErrorEvent()
+
+	b.
+		AddRule("TaggedImages").
+		WithInput(`
+- docker:
+		kind: image
+	type: array
+	tag: dockerimages
+`).
+		WithRego(`
+package datadog
+import data.datadog as dd
+
+has_key(o, k) {
+	_ := o[k]
+}
+
+valid_image(i) {
+	has_key(i, "id")
+	has_key(i, "inspect")
+	has_key(i.inspect, "Architecture")
+	has_key(i.inspect, "Comment")
+	has_key(i.inspect, "Config")
+}
+
+valid_images = [i | i := input.dockerimages[_]; valid_image(i)]
+
+findings[f] {
+	count(input.dockerimages) > 0
+	count(valid_images) == count(input.dockerimages)
+	f := dd.passed_finding(
+		"my_resource_type",
+		"my_resource_id",
+		{"ids": [i.id | i := input.dockerimages[_]]}
+	)
+}
+`).
+		AssertPassedEvent(func(t *testing.T, evt *event.Event) {
+			assert.NotEmpty(t, evt.Data.(event.Data)["ids"])
+		})
+
+	b.
+		AddRule("Network").
+		WithInput(`
+- docker:
+		kind: network
+	type: array
+	tag: nets
+`).
+		WithRego(`
+package datadog
+import data.datadog as dd
+
+findings[f] {
+	count(input.nets) > 0
+	_ := input.nets[0]["id"]
+	_ := input.nets[0]["inspect"]
+	input.nets[0].inspect
+	f := dd.passed_finding(
+		"net_resource",
+		"net_resource_id",
+		{},
+	)
+}
+`).
+		AssertPassedEvent(nil)
+
+	b.AddRule("Version").
+		WithInput(`
+- docker:
+		kind: version
+	tag: version
+`).
+		WithRego(`
+package datadog
+import data.datadog as dd
+
+findings[f] {
+	_ := input.version.apiVersion
+	_ := input.version.arch
+	_ := input.version.kernelVersion
+	_ := input.version.os
+	_ := input.version.platform
+	_ := input.version.version
+	f := dd.passed_finding(
+		"version_resource",
+		"version_resource_id",
+		{},
+	)
+}
+`).
+		AssertPassedEvent(nil)
+}

--- a/pkg/compliance/tests/file_test.go
+++ b/pkg/compliance/tests/file_test.go
@@ -124,6 +124,11 @@ findings[f] {
 		WithInput(`
 - file:
 		path: /
+- file:
+		path: /foo
+	tag: plop
+- constants:
+		foo: bar
 `).
 		WithRego(`
 package datadog
@@ -132,6 +137,8 @@ import data.datadog as dd
 findings[f] {
 	input.context.hostname == "{{.Hostname}}"
 	input.context.input.file.file.path == "/"
+	input.context.input.plop.file.path == "/foo"
+	input.context.input.constants.constants.foo == "bar"
 	input.context.ruleID == "{{.RuleID}}"
 	f := dd.passed_finding(
 		"plop_type",

--- a/pkg/compliance/tests/file_test.go
+++ b/pkg/compliance/tests/file_test.go
@@ -1,0 +1,319 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package tests
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/compliance/event"
+	_ "github.com/DataDog/datadog-agent/pkg/compliance/resources/file"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFile(t *testing.T) {
+	b := NewTestBench(t)
+	defer b.Run()
+
+	b.AddRule("FileNotExists").
+		WithInput(`
+- file:
+		name: %q
+		parser: raw
+	tag: thefile
+`, filepath.Join(b.rootDir, "/foo/bar/baz/quz/quuz")).
+		WithRego(`
+package datadog
+import data.datadog as dd
+import data.helpers as h
+
+has_key(o, k) {
+	_ := o[k]
+}
+
+findings[f] {
+	not has_key(input, "thefile")
+	not has_key(input, "file")
+	f := dd.failing_finding(
+		"my_resource_type",
+		"my_resource_id",
+		{"foo": "bar"}
+	)
+}
+`).
+		AssertFailedEvent(func(t *testing.T, evt *event.Event) {
+			assert.Equal(t, "my_resource_id", evt.ResourceID)
+			assert.Equal(t, "my_resource_type", evt.ResourceType)
+			assert.Equal(t, "bar", evt.Data.(event.Data)["foo"])
+		})
+
+	tmpFile := b.WriteTempFile(t, "foobar")
+
+	b.AddRule("FileExistsNoParser").
+		WithInput(`
+- file:
+		path: %s
+	tag: meh
+`, tmpFile).
+		WithRego(`
+package datadog
+import data.datadog as dd
+
+has_key(o, k) {
+	_ := o[k]
+}
+
+compliant(f) {
+	f.content == ""
+	f.path == %q
+	has_key(f, "group")
+	has_key(f, "permissions")
+	has_key(f, "user")
+	has_key(f, "glob")
+	f.glob == ""
+}
+
+
+findings[f] {
+	compliant(input.meh)
+	f := dd.passed_finding(
+		"the_resource_type",
+		"the_resource_id",
+		{"content": input.meh.content}
+	)
+}
+`, tmpFile).
+		AssertPassedEvent(func(t *testing.T, evt *event.Event) {
+			assert.Equal(t, "the_resource_id", evt.ResourceID)
+			assert.Equal(t, "the_resource_type", evt.ResourceType)
+			assert.Equal(t, "", evt.Data.(event.Data)["content"])
+		})
+
+	b.AddRule("FileExists").
+		WithInput(`
+- file:
+		path: %s
+		parser: raw
+`, tmpFile).
+		WithRego(`
+package datadog
+import data.datadog as dd
+
+compliant(f) {
+	true
+}
+
+findings[f] {
+	compliant(input.file)
+	f := dd.passed_finding(
+		"the_resource_type",
+		"the_resource_id",
+		{"content": input.file.content}
+	)
+}
+`).
+		AssertPassedEvent(func(t *testing.T, evt *event.Event) {
+			assert.Equal(t, "foobar", evt.Data.(event.Data)["content"])
+		})
+
+	b.AddRule("Context").
+		WithInput(`
+- file:
+		path: /
+`).
+		WithRego(`
+package datadog
+import data.datadog as dd
+
+findings[f] {
+	input.context.hostname == "{{.Hostname}}"
+	input.context.input.file.file.path == "/"
+	input.context.ruleID == "{{.RuleID}}"
+	f := dd.passed_finding(
+		"plop_type",
+		"plop_id",
+		{}
+	)
+}
+`).
+		AssertPassedEvent(func(t *testing.T, evt *event.Event) {
+			assert.Equal(t, "plop_type", evt.ResourceType)
+			assert.Equal(t, "plop_id", evt.ResourceID)
+		})
+}
+
+func TestFileParser(t *testing.T) {
+	b := NewTestBench(t)
+	defer b.Run()
+
+	tmpFileJSON := b.WriteTempFile(t, `{"foo":"bar","baz": {"quz": 1}}`)
+	tmpFileYAML := b.WriteTempFile(t, `
+foo: bar
+baz:
+  quz: 1
+`)
+
+	b.
+		AddRule("JSONParser").
+		WithInput(`
+- file:
+		path: %s
+		parser: json
+	tag: object
+`, tmpFileJSON).
+		WithRego(`
+package datadog
+import data.datadog as dd
+
+findings[f] {
+	input.object.content.foo == "bar"
+	input.object.content.baz.quz == 1
+	input.object.glob == ""
+	input.object.path == %q
+	_ := input.object.group
+	_ := input.object.permissions
+	_ := input.object.user
+	f := dd.passed_finding(
+		"foo",
+		"bar",
+		{}
+	)
+}
+`, tmpFileJSON).
+		AssertPassedEvent(func(t *testing.T, evt *event.Event) {
+			assert.Equal(t, "foo", evt.ResourceType)
+			assert.Equal(t, "bar", evt.ResourceID)
+		})
+
+	b.
+		AddRule("YAMLParser").
+		WithInput(`
+- file:
+		path: %s
+		parser: yaml
+	tag: object
+`, tmpFileYAML).
+		WithRego(`
+package datadog
+import data.datadog as dd
+
+findings[f] {
+	input.object.content.foo == "bar"
+	input.object.content.baz.quz == 1
+	input.object.glob == ""
+	input.object.path == %q
+	_ := input.object.group
+	_ := input.object.permissions
+	_ := input.object.user
+	f := dd.passed_finding(
+		"foo",
+		"bar",
+		{}
+	)
+}
+`, tmpFileYAML).
+		AssertPassedEvent(func(t *testing.T, evt *event.Event) {
+			assert.Equal(t, "foo", evt.ResourceType)
+			assert.Equal(t, "bar", evt.ResourceID)
+		})
+}
+
+func TestFileGlob(t *testing.T) {
+	b := NewTestBench(t)
+	defer b.Run()
+
+	b.
+		AddRule("Glob").
+		WithInput(`
+- file:
+		path: %s/*
+		parser: raw
+	type: array
+	tag: files
+`, b.rootDir).
+		WithRego(`
+package datadog
+import data.datadog as dd
+
+findings[f] {
+	count(input.files) > 0
+	f := dd.passed_finding(
+		"foo",
+		"bar",
+		{}
+	)
+}
+`).
+		AssertPassedEvent(nil)
+
+	b.
+		AddRule("GlobEmpty").
+		WithInput(`
+- file:
+		glob: /foo/bar/baz/quz/*
+		parser: raw
+	type: array
+	tag: files
+`).
+		WithRego(`
+package datadog
+import data.datadog as dd
+
+has_key(o, k) {
+	_ := o[k]
+}
+
+findings[f] {
+	not has_key(input, "files")
+	f := dd.passed_finding(
+		"foo",
+		"bar",
+		{}
+	)
+}
+`).
+		AssertPassedEvent(nil)
+
+	b.
+		AddRule("Glob2").
+		WithInput(`
+- file:
+		glob: %s/Glob2*
+		parser: raw
+	type: array
+	tag: files
+`, b.rootDir).
+		WithRego(`
+package datadog
+import data.datadog as dd
+
+has_key(o, k) {
+	_ := o[k]
+}
+
+valid(f) {
+	has_key(f, "content")
+	has_key(f, "path")
+	has_key(f, "group")
+	has_key(f, "permissions")
+	has_key(f, "user")
+	has_key(f, "glob")
+}
+
+findings[f] {
+	file := input.files[_]
+	valid(file)
+	f := dd.passed_finding(
+		"foo",
+		file.path,
+		{}
+	)
+}
+`).
+		AssertPassedEvent(nil).
+		AssertPassedEvent(nil)
+}

--- a/pkg/compliance/tests/file_test.go
+++ b/pkg/compliance/tests/file_test.go
@@ -3,6 +3,9 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build !windows
+// +build !windows
+
 package tests
 
 import (

--- a/pkg/compliance/tests/helpers.go
+++ b/pkg/compliance/tests/helpers.go
@@ -1,0 +1,319 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package tests
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+	"text/template"
+
+	"github.com/DataDog/datadog-agent/pkg/compliance/agent"
+	"github.com/DataDog/datadog-agent/pkg/compliance/checks"
+	"github.com/DataDog/datadog-agent/pkg/compliance/checks/env"
+	"github.com/DataDog/datadog-agent/pkg/compliance/event"
+	"github.com/stretchr/testify/assert"
+)
+
+type suite struct {
+	t        *testing.T
+	hostname string
+	rootDir  string
+
+	dockerClient env.DockerClient
+	auditClient  env.AuditClient
+	kubeClient   env.KubeClient
+
+	rules []*assertedRule
+}
+
+type assertedRule struct {
+	rootDir  string
+	hostname string
+	name     string
+	input    string
+	rego     string
+	scope    string
+
+	setups  []func(*testing.T, context.Context)
+	asserts []func(*testing.T, *event.Event)
+	events  []*event.Event
+
+	noEvent   bool
+	expectErr bool
+}
+
+func NewTestBench(t *testing.T) *suite {
+	rootDir := t.TempDir()
+	return &suite{
+		t:       t,
+		rootDir: rootDir,
+	}
+}
+
+func (s *suite) WithHostname(hostname string) *suite {
+	s.hostname = hostname
+	return s
+}
+
+func (s *suite) WithDockerClient(cl env.DockerClient) *suite {
+	s.dockerClient = cl
+	return s
+}
+
+func (s *suite) WithAuditClient(cl env.AuditClient) *suite {
+	s.auditClient = cl
+	return s
+}
+
+func (s *suite) WithKubeClient(cl env.KubeClient) *suite {
+	s.kubeClient = cl
+	return s
+}
+
+func (s *suite) AddRule(name string) *assertedRule {
+	for _, rule := range s.rules {
+		if rule.name == name {
+			s.t.Fatalf("rule with name %q already exist", name)
+		}
+	}
+	rule := &assertedRule{
+		name:     name,
+		rootDir:  s.rootDir,
+		hostname: s.hostname,
+	}
+	s.rules = append(s.rules, rule)
+	return rule
+}
+
+func (s *suite) Run() {
+	if len(s.rules) == 0 {
+		s.t.Fatal("no rule to run")
+	}
+	s.t.Parallel()
+	for _, c := range s.rules {
+		s.t.Run(c.name, func(t *testing.T) {
+			var options []checks.BuilderOption
+			if s.auditClient != nil {
+				options = append(options, checks.WithAuditClient(s.auditClient))
+			}
+			if s.dockerClient != nil {
+				options = append(options, checks.WithDockerClient(s.dockerClient))
+			}
+			if s.kubeClient != nil {
+				options = append(options, checks.WithKubernetesClient(s.kubeClient, "my-cluster"))
+			}
+			c.run(t, options)
+		})
+	}
+}
+
+func (s *suite) WriteTempFile(t *testing.T, data string) string {
+	f, err := os.CreateTemp(s.rootDir, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	if _, err := f.WriteString(data); err != nil {
+		t.Fatal(err)
+	}
+	return f.Name()
+}
+
+func (c *assertedRule) Setup(setup func(t *testing.T, ctx context.Context)) *assertedRule {
+	c.setups = append(c.setups, setup)
+	return c
+}
+
+func (c *assertedRule) WriteFile(t *testing.T, name, data string) string {
+	n := filepath.Join(c.rootDir, name)
+	f, err := os.OpenFile(n, os.O_CREATE|os.O_EXCL|os.O_WRONLY, fs.FileMode(0o644))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteString(data); err != nil {
+		t.Fatal(err)
+	}
+	return f.Name()
+}
+
+func (c *assertedRule) WithScope(scope string) *assertedRule {
+	c.scope = scope
+	return c
+}
+
+func (c *assertedRule) WithInput(input string, args ...any) *assertedRule {
+	r := regexp.MustCompile("(?m)^\\t+")
+	input = r.ReplaceAllStringFunc(input, func(p string) string { return strings.Repeat("  ", len(p)) })
+	c.input = strings.TrimSpace(fmt.Sprintf(input, args...))
+	return c
+}
+
+func (c *assertedRule) WithRego(rego string, args ...any) *assertedRule {
+	var buf bytes.Buffer
+	rego = fmt.Sprintf(rego, args...)
+	tmpl := template.Must(template.New("name").Parse(rego))
+	err := tmpl.Execute(&buf, struct {
+		Hostname string
+		RuleID   string
+	}{
+		Hostname: c.hostname,
+		RuleID:   c.name,
+	})
+	if err != nil {
+		panic(err)
+	}
+	c.rego = buf.String()
+	return c
+}
+
+func (c *assertedRule) AssertPassedEvent(f func(t *testing.T, evt *event.Event)) *assertedRule {
+	c.asserts = append(c.asserts, func(t *testing.T, evt *event.Event) {
+		if assert.Equal(t, "passed", evt.Result) {
+			if f != nil {
+				f(t, evt)
+			}
+		} else {
+			t.Logf("received unexpected %q event : %v", evt.Result, evt)
+		}
+	})
+	return c
+}
+
+func (c *assertedRule) AssertFailedEvent(f func(t *testing.T, evt *event.Event)) *assertedRule {
+	c.asserts = append(c.asserts, func(t *testing.T, evt *event.Event) {
+		if assert.Equal(t, "failed", evt.Result) {
+			if f != nil {
+				f(t, evt)
+			}
+		} else {
+			t.Logf("received unexpected %q event : %v", evt.Result, evt)
+		}
+	})
+	return c
+}
+
+func (c *assertedRule) AssertErrorEvent() *assertedRule {
+	c.asserts = append(c.asserts, func(t *testing.T, evt *event.Event) {
+		if assert.Equal(t, "error", evt.Result) {
+			assert.NotNil(t, evt.Data.(event.Data)["error"])
+		}
+	})
+	return c
+}
+
+func (c *assertedRule) AssertNoEvent() *assertedRule {
+	c.noEvent = true
+	return c
+}
+
+func (c *assertedRule) AssertError() *assertedRule {
+	c.expectErr = true
+	return c
+}
+
+func (c *assertedRule) run(t *testing.T, options []checks.BuilderOption) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	for _, setup := range c.setups {
+		setup(t, ctx)
+	}
+
+	suiteName := strings.ReplaceAll(c.name, string(os.PathSeparator), "")
+	suiteData := buildSuite(suiteName, c)
+
+	_ = c.WriteFile(t, suiteName+".rego", c.rego)
+	file := c.WriteFile(t, suiteName+".yaml", suiteData)
+
+	err := agent.RunChecksFromFile(c, file, options...)
+	if c.expectErr {
+		if err == nil {
+			t.Fatalf("expected to fail running checks but resulting in no error")
+		}
+		return
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if c.noEvent && len(c.asserts) > 0 {
+		t.Fatalf("no event expected: asserts should be empty")
+	}
+	if !c.noEvent && len(c.asserts) == 0 {
+		t.Fatalf("missing assertions")
+	}
+
+	events := c.events
+	if c.noEvent {
+		if len(events) > 0 {
+			for _, event := range events {
+				t.Logf("unexpected event: %+v", event)
+			}
+			t.Fatalf("expected no event on this rule: received %d", len(events))
+		}
+	} else if len(events) != len(c.asserts) {
+		t.Logf("expected %d events but received %d", len(c.asserts), len(events))
+		t.Fail()
+	}
+
+	for i, event := range events {
+		if i < len(c.asserts) {
+			c.asserts[i](t, event)
+		} else {
+			t.Logf("unexpected event %d", i)
+			t.Fail()
+		}
+	}
+}
+
+func (c *assertedRule) Report(event *event.Event) {
+	c.events = append(c.events, event)
+}
+
+func (c *assertedRule) ReportRaw(content []byte, service string, tags ...string) {
+	panic("should not have been called")
+}
+
+func buildSuite(name string, rules ...*assertedRule) string {
+	const suiteTpl = `schema:
+  version: 1.0.0
+name: %s
+framework: %s
+version: %s
+rules:`
+	const ruleTpl = `id: %s
+version: 123
+scope:
+  - %s
+input:
+  %s`
+
+	suite := fmt.Sprintf(suiteTpl, name, "framework_"+name, "42.12")
+	for _, rule := range rules {
+		scope := rule.scope
+		if scope == "" {
+			scope = "none"
+		}
+		ruleData := fmt.Sprintf(ruleTpl, rule.name, scope, indent(1, rule.input))
+		suite += "\n  - " + indent(2, ruleData)
+	}
+	return suite
+}
+
+func indent(count int, s string) string {
+	lines := strings.SplitAfter(s, "\n")
+	if len(lines[len(lines)-1]) == 0 {
+		lines = lines[:len(lines)-1]
+	}
+	return strings.TrimSpace(strings.Join(lines, strings.Repeat("  ", count)))
+}

--- a/pkg/compliance/tests/helpers.go
+++ b/pkg/compliance/tests/helpers.go
@@ -111,7 +111,7 @@ func (s *suite) Run() {
 				options = append(options, checks.WithDockerClient(s.dockerClient))
 			}
 			if s.kubeClient != nil {
-				options = append(options, checks.WithKubernetesClient(s.kubeClient, "my-cluster"))
+				options = append(options, checks.WithKubernetesClient(s.kubeClient, ""))
 			}
 			c.run(t, options)
 		})

--- a/pkg/compliance/tests/helpers.go
+++ b/pkg/compliance/tests/helpers.go
@@ -100,7 +100,6 @@ func (s *suite) Run() {
 	if len(s.rules) == 0 {
 		s.t.Fatal("no rule to run")
 	}
-	s.t.Parallel()
 	for _, c := range s.rules {
 		s.t.Run(c.name, func(t *testing.T) {
 			var options []checks.BuilderOption

--- a/pkg/compliance/tests/helpers.go
+++ b/pkg/compliance/tests/helpers.go
@@ -22,6 +22,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/compliance/checks/env"
 	"github.com/DataDog/datadog-agent/pkg/compliance/event"
 	"github.com/stretchr/testify/assert"
+	"k8s.io/client-go/dynamic"
 )
 
 type suite struct {
@@ -31,7 +32,7 @@ type suite struct {
 
 	dockerClient env.DockerClient
 	auditClient  env.AuditClient
-	kubeClient   env.KubeClient
+	kubeClient   dynamic.Interface
 
 	rules []*assertedRule
 }
@@ -75,7 +76,7 @@ func (s *suite) WithAuditClient(cl env.AuditClient) *suite {
 	return s
 }
 
-func (s *suite) WithKubeClient(cl env.KubeClient) *suite {
+func (s *suite) WithKubeClient(cl dynamic.Interface) *suite {
 	s.kubeClient = cl
 	return s
 }
@@ -103,6 +104,7 @@ func (s *suite) Run() {
 	for _, c := range s.rules {
 		s.t.Run(c.name, func(t *testing.T) {
 			var options []checks.BuilderOption
+			options = append(options, checks.WithHostname(s.hostname))
 			if s.auditClient != nil {
 				options = append(options, checks.WithAuditClient(s.auditClient))
 			}

--- a/pkg/compliance/tests/helpers.go
+++ b/pkg/compliance/tests/helpers.go
@@ -141,6 +141,7 @@ func (c *assertedRule) WriteFile(t *testing.T, name, data string) string {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer f.Close()
 	if _, err := f.WriteString(data); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/compliance/tests/kubernetes_test.go
+++ b/pkg/compliance/tests/kubernetes_test.go
@@ -1,0 +1,9 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+// +build kubeapiserver
+
+package tests

--- a/pkg/compliance/tests/kubernetes_test.go
+++ b/pkg/compliance/tests/kubernetes_test.go
@@ -14,6 +14,7 @@ import (
 	_ "github.com/DataDog/datadog-agent/pkg/compliance/resources/constants"
 	_ "github.com/DataDog/datadog-agent/pkg/compliance/resources/kubeapiserver"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -38,6 +39,12 @@ func getMockedKubeClient(t *testing.T, objects ...runtime.Object) dynamic.Interf
 
 func TestKubernetesCluster(t *testing.T) {
 	kubeClient := getMockedKubeClient(t,
+		&corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				UID:  "my-cluster",
+				Name: "kube-system",
+			},
+		},
 		newMyObj("testns1", "dummy1", "100"),
 		newMyObj("testns2", "dummy1", "101"),
 		newMyObj("testns2", "dummy2", "102"),

--- a/pkg/compliance/tests/kubernetes_test.go
+++ b/pkg/compliance/tests/kubernetes_test.go
@@ -7,3 +7,271 @@
 // +build kubeapiserver
 
 package tests
+
+import (
+	"testing"
+
+	_ "github.com/DataDog/datadog-agent/pkg/compliance/resources/constants"
+	_ "github.com/DataDog/datadog-agent/pkg/compliance/resources/kubeapiserver"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/kubernetes/scheme"
+)
+
+func getMockedKubeClient(t *testing.T, objects ...runtime.Object) dynamic.Interface {
+	addKnownTypes := func(scheme *runtime.Scheme) error {
+		scheme.AddKnownTypes(schema.GroupVersion{Group: "mygroup.com", Version: "v1"},
+			&MyObj{},
+			&MyObjList{},
+		)
+		return nil
+	}
+	schemeBuilder := runtime.NewSchemeBuilder(addKnownTypes)
+	schemeBuilder.AddToScheme(scheme.Scheme)
+	return fake.NewSimpleDynamicClient(scheme.Scheme, objects...)
+}
+
+func TestKubernetesCluster(t *testing.T) {
+	kubeClient := getMockedKubeClient(t,
+		newMyObj("testns1", "dummy1", "100"),
+		newMyObj("testns2", "dummy1", "101"),
+		newMyObj("testns2", "dummy2", "102"),
+		newMyObj("testns3", "dummy1", "103"),
+		newMyObj("testns3", "dummy2", "104"),
+		newMyObj("testns3", "dummy3", "105"),
+	)
+
+	b := NewTestBench(t).WithKubeClient(kubeClient)
+	defer b.Run()
+
+	b.
+		AddRule("BadNamespace").
+		WithScope("kubernetesCluster").
+		WithInput(`
+- kubeApiserver:
+		kind: myobjs
+		group: "dd.compliance.com"
+		version: v1
+		namespace: testnsnotexist
+		apiRequest:
+			verb: list
+	type: array
+`).
+		WithRego(`
+package datadog
+
+import data.datadog as dd
+import data.helpers as h
+
+has_key(o, k) {
+	_ := o[k]
+}
+
+findings[f] {
+	has_key(input, "kubernetes")
+	count(input.kubernetes) == 0
+	f := dd.passed_finding(
+		"my_resource_type",
+		"my_resource_id",
+		{}
+	)
+}
+`).
+		AssertPassedEvent(nil)
+
+	b.
+		AddRule("OneObject").
+		WithScope("kubernetesCluster").
+		WithInput(`
+- kubeApiserver:
+		kind: myobjs
+		group: "dd.compliance.com"
+		version: v1
+		namespace: testns1
+		apiRequest:
+			verb: list
+	type: array
+	tag: foo1
+`).
+		WithRego(`
+package datadog
+
+import data.datadog as dd
+import data.helpers as h
+
+has_key(o, k) {
+	_ := o[k]
+}
+
+valid(p) {
+	p.group = "dd.compliance.com"
+	p.kind = "MyObj"
+	p.name = "dummy1"
+	p.version = "v1"
+	p.namespace = "testns1"
+	p.resource.Object.apiVersion = "dd.compliance.com/v1"
+	p.resource.Object.kind = "MyObj"
+	p.resource.Object.spec.boolAttribute = true
+	p.resource.Object.spec.listAttribute[0] = "listFoo"
+	p.resource.Object.spec.listAttribute[1] = "listBar"
+	p.resource.Object.spec.stringAttribute = "foo"
+	p.resource.Object.spec.structAttribute.name = "nestedFoo"
+}
+
+findings[f] {
+	input.context.kubernetes_cluster = "my-cluster"
+	count(input.foo1) = 1
+	[obj | obj := input.foo1[_]; valid(obj)]
+	f := dd.passed_finding(
+		"my_resource_type",
+		"my_resource_id",
+		{}
+	)
+}
+`).
+		AssertPassedEvent(nil)
+
+	b.
+		AddRule("MultiObjects").
+		WithScope("kubernetesCluster").
+		WithInput(`
+- kubeApiserver:
+		kind: myobjs
+		group: "dd.compliance.com"
+		version: v1
+		namespace: testns3
+		apiRequest:
+			verb: list
+	type: array
+	tag: foo1
+`).
+		WithRego(`
+package datadog
+
+import data.datadog as dd
+import data.helpers as h
+
+has_key(o, k) {
+	_ := o[k]
+}
+
+valid(p) {
+	p.group = "dd.compliance.com"
+	p.kind = "MyObj"
+	p.name = "dummy1"
+	p.version = "v1"
+	p.namespace = "testns3"
+	p.resource.Object.apiVersion = "dd.compliance.com/v1"
+	p.resource.Object.kind = "MyObj"
+	p.resource.Object.spec.boolAttribute = true
+	p.resource.Object.spec.listAttribute[0] = "listFoo"
+	p.resource.Object.spec.listAttribute[1] = "listBar"
+	p.resource.Object.spec.stringAttribute = "foo"
+	p.resource.Object.spec.structAttribute.name = "nestedFoo"
+}
+
+findings[f] {
+	input.context.kubernetes_cluster = "my-cluster"
+	count(input.foo1) = 3
+	[obj | obj := input.foo1[_]; valid(obj)]
+	f := dd.passed_finding(
+		"my_resource_type",
+		"my_resource_id",
+		{}
+	)
+}
+`).
+		AssertPassedEvent(nil)
+}
+
+type MyObj struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec MyObjSpec `json:"spec,omitempty"`
+}
+
+type MyObjSpec struct {
+	StringAttribute string                 `json:"stringAttribute,omitempty"`
+	BoolAttribute   bool                   `json:"boolAttribute,omitempty"`
+	ListAttribute   []interface{}          `json:"listAttribute,omitempty"`
+	StructAttribute map[string]interface{} `json:"structAttribute,omitempty"`
+}
+
+type MyObjList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []MyObj
+}
+
+func newMyObj(namespace, name, uid string) runtime.Object {
+	return &MyObj{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "MyObj",
+			APIVersion: "dd.compliance.com/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			UID:       types.UID(uid),
+		},
+		Spec: MyObjSpec{
+			StringAttribute: "foo",
+			BoolAttribute:   true,
+			ListAttribute:   []interface{}{"listFoo", "listBar"},
+			StructAttribute: map[string]interface{}{
+				"name": "nestedFoo",
+			},
+		},
+	}
+}
+
+func (in *MyObj) DeepCopyInto(out *MyObj) {
+	*out = *in
+	out.TypeMeta = in.TypeMeta
+	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
+}
+
+func (in *MyObj) DeepCopy() *MyObj {
+	if in == nil {
+		return nil
+	}
+	out := new(MyObj)
+	in.DeepCopyInto(out)
+	return out
+}
+
+func (in *MyObj) DeepCopyObject() runtime.Object {
+	return in.DeepCopy()
+}
+
+func (in *MyObjList) DeepCopy() *MyObjList {
+	if in == nil {
+		return nil
+	}
+	out := new(MyObjList)
+	in.DeepCopyInto(out)
+	return out
+}
+
+func (in *MyObjList) DeepCopyInto(out *MyObjList) {
+	*out = *in
+	out.TypeMeta = in.TypeMeta
+	in.ListMeta.DeepCopyInto(&out.ListMeta)
+	if in.Items != nil {
+		in, out := &in.Items, &out.Items
+		*out = make([]MyObj, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+}
+
+func (in *MyObjList) DeepCopyObject() runtime.Object {
+	return in.DeepCopy()
+}

--- a/pkg/compliance/tests/process_test.go
+++ b/pkg/compliance/tests/process_test.go
@@ -1,0 +1,269 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+// +build linux
+
+package tests
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/compliance/event"
+
+	_ "github.com/DataDog/datadog-agent/pkg/compliance/resources/group"
+	_ "github.com/DataDog/datadog-agent/pkg/compliance/resources/process"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProcessInput(t *testing.T) {
+	self, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	self = filepath.Base(self)
+
+	b := NewTestBench(t)
+	defer b.Run()
+
+	b.AddRule("Self").
+		WithInput(`
+- process:
+		name: %s
+`, self).
+		WithRego(`
+package datadog
+import data.datadog as dd
+import data.helpers as h
+
+has_key(o, k) {
+	_ := o[k]
+}
+
+valid(p) {
+	p.name = "tests.test"
+	has_key(p, "cmdLine")
+	has_key(p, "envs")
+	has_key(p, "exe")
+	has_key(p, "flags")
+	has_key(p, "name")
+	has_key(p, "pid")
+}
+
+findings[f] {
+	valid(input.process[_])
+	f := dd.passed_finding(
+		"my_resource_type",
+		"my_resource_id",
+		{}
+	)
+}
+`).
+		AssertPassedEvent(func(t *testing.T, evt *event.Event) {
+			assert.Equal(t, "Self", evt.AgentRuleID)
+			assert.Equal(t, 0, evt.AgentRuleVersion)
+			assert.Equal(t, "my_resource_id", evt.ResourceID)
+			assert.Equal(t, "my_resource_type", evt.ResourceType)
+			assert.Equal(t, "rego", evt.Evaluator)
+		})
+
+	b.AddRule("SelfDuplicated").
+		WithInput(`
+- process:
+    name: %s
+  tag: self1
+- process:
+    name: %s
+  tag: self2
+`, self, self).
+		WithRego(`
+package datadog
+import data.datadog as dd
+import data.helpers as h
+
+has_key(o, k) {
+	_ := o[k]
+}
+
+valid(p) {
+	p.name == "tests.test"
+	has_key(p, "cmdLine")
+	has_key(p, "envs")
+	has_key(p, "exe")
+	has_key(p, "flags")
+	has_key(p, "name")
+	has_key(p, "pid")
+}
+
+findings[f] {
+	proc := input.self1[_]
+	valid(proc)
+	f := dd.passed_finding(
+		"self1",
+		"self1_id",
+		{"name": proc.name},
+	)
+}
+
+findings[f] {
+	proc := input.self2[_]
+	valid(proc)
+	f := dd.passed_finding(
+		"self2",
+		"self2_id",
+		{"name": proc.name},
+	)
+}
+`).
+		AssertPassedEvent(func(t *testing.T, evt *event.Event) {
+			assert.Equal(t, "SelfDuplicated", evt.AgentRuleID)
+			assert.Equal(t, 0, evt.AgentRuleVersion)
+			assert.Equal(t, "self1_id", evt.ResourceID)
+			assert.Equal(t, "self1", evt.ResourceType)
+			assert.Equal(t, "rego", evt.Evaluator)
+			assert.Equal(t, self, evt.Data.(event.Data)["name"])
+		}).
+		AssertPassedEvent(func(t *testing.T, evt *event.Event) {
+			assert.Equal(t, "SelfDuplicated", evt.AgentRuleID)
+			assert.Equal(t, 0, evt.AgentRuleVersion)
+			assert.Equal(t, "self2_id", evt.ResourceID)
+			assert.Equal(t, "self2", evt.ResourceType)
+			assert.Equal(t, "rego", evt.Evaluator)
+			assert.Equal(t, self, evt.Data.(event.Data)["name"])
+		})
+
+	b.AddRule("NoProcess").
+		WithInput(`
+- process:
+		name: iprobablydonotexist
+`).
+		WithRego(`
+package datadog
+import data.datadog as dd
+import data.helpers as h
+
+findings[f] {
+	input.process
+	f := dd.passed_finding(
+		"plop",
+		"plop",
+		{},
+	)
+}
+`).
+		AssertNoEvent()
+
+	b.
+		AddRule("Sleeps").
+		Setup(func(t *testing.T, ctx context.Context) {
+			cmd1 := exec.CommandContext(ctx, "sleep", "10")
+			cmd2 := exec.CommandContext(ctx, "sleep", "10")
+			cmd1.Env = []string{"FOO=foo"}
+			cmd2.Env = []string{"FOO=foo"}
+			if err := cmd1.Start(); err != nil {
+				t.Fatal(err)
+			}
+			if err := cmd2.Start(); err != nil {
+				t.Fatal(err)
+			}
+		}).
+		WithInput(`
+- process:
+		name: sleep
+		envs:
+			- FOO
+			- BAR
+`).
+		WithRego(`
+package datadog
+import data.datadog as dd
+import data.helpers as h
+
+has_key(o, k) {
+	_ := o[k]
+}
+
+valid(p) {
+	p.name == "sleep"
+	p.cmdLine[0] == "sleep"
+	p.cmdLine[1] == "10"
+	p.envs["FOO"] == "foo"
+	not has_key(p.envs, "BAR")
+}
+
+findings[f] {
+	count(input.process) == 2
+	valid(input.process[0])
+	valid(input.process[1])
+	f := dd.passed_finding(
+		"sleep",
+		"sleep",
+		{},
+	)
+}
+`).
+		AssertPassedEvent(func(t *testing.T, evt *event.Event) {
+			assert.Equal(t, "sleep", evt.ResourceID)
+			assert.Equal(t, "sleep", evt.ResourceType)
+		})
+}
+
+func TestEtcGroup(t *testing.T) {
+	b := NewTestBench(t)
+	defer b.Run()
+
+	b.AddRule("EtcRootGroup").
+		WithInput(`
+- group:
+		name: root
+`).
+		WithRego(`
+package datadog
+import data.datadog as dd
+import data.helpers as h
+
+findings[f] {
+	input.group.id == 0
+	input.group.name == "root"
+	_ := input.group.users
+	f := dd.passed_finding(
+		"group_id",
+		"group_type",
+		{},
+	)
+}
+`).
+		AssertPassedEvent(nil)
+
+	b.AddRule("EtcGroupNotExist").
+		WithInput(`
+- group:
+		name: asdasdasdas
+`).
+		WithRego(`
+package datadog
+import data.datadog as dd
+import data.helpers as h
+
+has_key(o, k) {
+	_ := o[k]
+}
+
+findings[f] {
+	not has_key(input, "group")
+	f := dd.passed_finding(
+		"group_id",
+		"group_type",
+		{},
+	)
+}
+`).
+		AssertPassedEvent(nil)
+}


### PR DESCRIPTION
### What does this PR do?

Introduce functional tests on `pkg/compliance` for input collection and rego evaluations.

Still hesitant about the way to go for docker and k8s input tests. Also we probably want these tests to be part of the `test/kitchen`.

### Motivation

Current package relies heavily on unit testing with mocks and stubs. We want to improve the coverage and rely on functional tests that do not need to mock the actual code. It should both help to better cover the package behavior and ease the code maintenance/evolution.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
