### PR TITLE
pkg/trace/api: add support for OpenTelemetry Span Links.

### DIFF
--- a/pkg/trace/api/otlp.go
+++ b/pkg/trace/api/otlp.go
@@ -415,11 +415,11 @@ func marshalLinks(links ptrace.SpanLinkSlice) string {
 		str.WriteString(hex.EncodeToString(s[:]))
 		str.WriteString(`"`)
 		if l.Attributes().Len() > 0 {
-		   	str.WriteString(`,"attributes":{`)
+			str.WriteString(`,"attributes":{`)
 			b := false
 			l.Attributes().Range(func(k string, v pcommon.Value) bool {
 				if b {
-				       	str.WriteString(",")
+					str.WriteString(",")
 				}
 				b = true
 				str.WriteString(`"`)

--- a/pkg/trace/api/otlp.go
+++ b/pkg/trace/api/otlp.go
@@ -414,6 +414,11 @@ func marshalLinks(links ptrace.SpanLinkSlice) string {
 		str.WriteString(`","span_id":"`)
 		str.WriteString(hex.EncodeToString(s[:]))
 		str.WriteString(`"`)
+		if l.TraceState().AsRaw() != "" {
+			str.WriteString(`,"trace_state":"`)
+			str.WriteString(l.TraceState().AsRaw())
+			str.WriteString(`"`)
+		}
 		if l.Attributes().Len() > 0 {
 			str.WriteString(`,"attributes":{`)
 			b := false
@@ -501,7 +506,7 @@ func (o *OTLPReceiver) convertSpan(rattr map[string]string, lib pcommon.Instrume
 		setMetaOTLP(span, "events", marshalEvents(in.Events()))
 	}
 	if in.Links().Len() > 0 {
-		setMetaOTLP(span, "links", marshalLinks(in.Links()))
+		setMetaOTLP(span, "_dd.span_links", marshalLinks(in.Links()))
 	}
 	if svc, ok := in.Attributes().Get(semconv.AttributePeerService); ok {
 		// the span attribute "peer.service" takes precedence over any resource attributes,

--- a/pkg/trace/api/otlp.go
+++ b/pkg/trace/api/otlp.go
@@ -414,9 +414,9 @@ func marshalLinks(links ptrace.SpanLinkSlice) string {
 		str.WriteString(`","span_id":"`)
 		str.WriteString(hex.EncodeToString(s[:]))
 		str.WriteString(`"`)
-		if l.TraceState().AsRaw() != "" {
+		if ts := l.TraceState().AsRaw(); len(ts) > 0 {
 			str.WriteString(`,"trace_state":"`)
-			str.WriteString(l.TraceState().AsRaw())
+			str.WriteString(ts)
 			str.WriteString(`"`)
 		}
 		if l.Attributes().Len() > 0 {

--- a/pkg/trace/api/otlp.go
+++ b/pkg/trace/api/otlp.go
@@ -421,7 +421,7 @@ func marshalLinks(links ptrace.SpanLinkSlice) string {
 		}
 		if l.Attributes().Len() > 0 {
 			str.WriteString(`,"attributes":{`)
-			b := false
+			var b bool
 			l.Attributes().Range(func(k string, v pcommon.Value) bool {
 				if b {
 					str.WriteString(",")

--- a/pkg/trace/api/otlp_test.go
+++ b/pkg/trace/api/otlp_test.go
@@ -63,8 +63,9 @@ var otlpTestSpanConfig = &testutil.OTLPSpan{
 	},
 	Links: []testutil.OTLPSpanLink{
 		{
-			TraceID: "fedcba98765432100123456789abcdef",
-			SpanID:  "abcdef0123456789",
+			TraceID:    "fedcba98765432100123456789abcdef",
+			SpanID:     "abcdef0123456789",
+			TraceState: "dd=asdf256,ee=jkl;128",
 			Attributes: map[string]interface{}{
 				"a1": "v1",
 				"a2": "v2",
@@ -72,8 +73,9 @@ var otlpTestSpanConfig = &testutil.OTLPSpan{
 			Dropped: 24,
 		},
 		{
-			TraceID: "abcdef0123456789abcdef0123456789",
-			SpanID:  "fedcba9876543210",
+			TraceID:    "abcdef0123456789abcdef0123456789",
+			SpanID:     "fedcba9876543210",
+			TraceState: "",
 			Attributes: map[string]interface{}{
 				"a3": "v2",
 				"a4": "v4",
@@ -83,12 +85,14 @@ var otlpTestSpanConfig = &testutil.OTLPSpan{
 		{
 			TraceID:    "abcdef0123456789abcdef0123456789",
 			SpanID:     "fedcba9876543210",
+			TraceState: "",
 			Attributes: map[string]interface{}{},
 			Dropped:    2,
 		},
 		{
 			TraceID:    "abcdef0123456789abcdef0123456789",
 			SpanID:     "fedcba9876543210",
+			TraceState: "",
 			Attributes: map[string]interface{}{},
 			Dropped:    0,
 		},
@@ -857,7 +861,7 @@ func TestOTLPConvertSpan(t *testing.T) {
 					"w3c.tracestate":          "state",
 					"version":                 "v1.2.3",
 					"events":                  `[{"time_unix_nano":123,"name":"boom","attributes":{"key":"Out of memory","accuracy":"2.4"},"dropped_attributes_count":2},{"time_unix_nano":456,"name":"exception","attributes":{"exception.message":"Out of memory","exception.type":"mem","exception.stacktrace":"1/2/3"},"dropped_attributes_count":2}]`,
-					"links":                   `[{"trace_id":"fedcba98765432100123456789abcdef","span_id":"abcdef0123456789","attributes":{"a1":"v1","a2":"v2"},"dropped_attributes_count":24},{"trace_id":"abcdef0123456789abcdef0123456789","span_id":"fedcba9876543210","attributes":{"a3":"v2","a4":"v4"}},{"trace_id":"abcdef0123456789abcdef0123456789","span_id":"fedcba9876543210","dropped_attributes_count":2},{"trace_id":"abcdef0123456789abcdef0123456789","span_id":"fedcba9876543210"}]`,
+					"_dd.span_links":          `[{"trace_id":"fedcba98765432100123456789abcdef","span_id":"abcdef0123456789","trace_state":"dd=asdf256,ee=jkl;128", "attributes":{"a1":"v1","a2":"v2"},"dropped_attributes_count":24},{"trace_id":"abcdef0123456789abcdef0123456789","span_id":"fedcba9876543210","attributes":{"a3":"v2","a4":"v4"}},{"trace_id":"abcdef0123456789abcdef0123456789","span_id":"fedcba9876543210","dropped_attributes_count":2},{"trace_id":"abcdef0123456789abcdef0123456789","span_id":"fedcba9876543210"}]`,
 					"error.msg":               "Out of memory",
 					"error.type":              "mem",
 					"error.stack":             "1/2/3",
@@ -916,8 +920,9 @@ func TestOTLPConvertSpan(t *testing.T) {
 				},
 				Links: []testutil.OTLPSpanLink{
 					{
-						TraceID: "fedcba98765432100123456789abcdef",
-						SpanID:  "abcdef0123456789",
+						TraceID:    "fedcba98765432100123456789abcdef",
+						SpanID:     "abcdef0123456789",
+						TraceState: "dd=asdf256,ee=jkl;128",
 						Attributes: map[string]interface{}{
 							"a1": "v1",
 							"a2": "v2",
@@ -925,8 +930,9 @@ func TestOTLPConvertSpan(t *testing.T) {
 						Dropped: 24,
 					},
 					{
-						TraceID: "abcdef0123456789abcdef0123456789",
-						SpanID:  "fedcba9876543210",
+						TraceID:    "abcdef0123456789abcdef0123456789",
+						SpanID:     "fedcba9876543210",
+						TraceState: "",
 						Attributes: map[string]interface{}{
 							"a3": "v2",
 							"a4": "v4",
@@ -936,12 +942,14 @@ func TestOTLPConvertSpan(t *testing.T) {
 					{
 						TraceID:    "abcdef0123456789abcdef0123456789",
 						SpanID:     "fedcba9876543210",
+						TraceState: "",
 						Attributes: map[string]interface{}{},
 						Dropped:    2,
 					},
 					{
 						TraceID:    "abcdef0123456789abcdef0123456789",
 						SpanID:     "fedcba9876543210",
+						TraceState: "",
 						Attributes: map[string]interface{}{},
 						Dropped:    0,
 					},
@@ -972,7 +980,7 @@ func TestOTLPConvertSpan(t *testing.T) {
 					"w3c.tracestate":          "state",
 					"version":                 "v1.2.3",
 					"events":                  "[{\"time_unix_nano\":123,\"name\":\"boom\",\"attributes\":{\"message\":\"Out of memory\",\"accuracy\":\"2.4\"},\"dropped_attributes_count\":2},{\"time_unix_nano\":456,\"name\":\"exception\",\"attributes\":{\"exception.message\":\"Out of memory\",\"exception.type\":\"mem\",\"exception.stacktrace\":\"1/2/3\"},\"dropped_attributes_count\":2}]",
-					"links":                   `[{"trace_id":"fedcba98765432100123456789abcdef","span_id":"abcdef0123456789","attributes":{"a1":"v1","a2":"v2"},"dropped_attributes_count":24},{"trace_id":"abcdef0123456789abcdef0123456789","span_id":"fedcba9876543210","attributes":{"a3":"v2","a4":"v4"}},{"trace_id":"abcdef0123456789abcdef0123456789","span_id":"fedcba9876543210","dropped_attributes_count":2},{"trace_id":"abcdef0123456789abcdef0123456789","span_id":"fedcba9876543210"}]`,
+					"_dd.span_links":          `[{"trace_id":"fedcba98765432100123456789abcdef","span_id":"abcdef0123456789","trace_state":"dd=asdf256,ee=jkl;128","attributes":{"a1":"v1","a2":"v2"},"dropped_attributes_count":24},{"trace_id":"abcdef0123456789abcdef0123456789","span_id":"fedcba9876543210","attributes":{"a3":"v2","a4":"v4"}},{"trace_id":"abcdef0123456789abcdef0123456789","span_id":"fedcba9876543210","dropped_attributes_count":2},{"trace_id":"abcdef0123456789abcdef0123456789","span_id":"fedcba9876543210"}]`,
 					"error.msg":               "Out of memory",
 					"error.type":              "mem",
 					"error.stack":             "1/2/3",
@@ -1034,8 +1042,9 @@ func TestOTLPConvertSpan(t *testing.T) {
 				},
 				Links: []testutil.OTLPSpanLink{
 					{
-						TraceID: "fedcba98765432100123456789abcdef",
-						SpanID:  "abcdef0123456789",
+						TraceID:    "fedcba98765432100123456789abcdef",
+						SpanID:     "abcdef0123456789",
+						TraceState: "dd=asdf256,ee=jkl;128",
 						Attributes: map[string]interface{}{
 							"a1": "v1",
 							"a2": "v2",
@@ -1043,8 +1052,9 @@ func TestOTLPConvertSpan(t *testing.T) {
 						Dropped: 24,
 					},
 					{
-						TraceID: "abcdef0123456789abcdef0123456789",
-						SpanID:  "fedcba9876543210",
+						TraceID:    "abcdef0123456789abcdef0123456789",
+						SpanID:     "fedcba9876543210",
+						TraceState: "",
 						Attributes: map[string]interface{}{
 							"a3": "v2",
 							"a4": "v4",
@@ -1054,12 +1064,14 @@ func TestOTLPConvertSpan(t *testing.T) {
 					{
 						TraceID:    "abcdef0123456789abcdef0123456789",
 						SpanID:     "fedcba9876543210",
+						TraceState: "",
 						Attributes: map[string]interface{}{},
 						Dropped:    2,
 					},
 					{
 						TraceID:    "abcdef0123456789abcdef0123456789",
 						SpanID:     "fedcba9876543210",
+						TraceState: "",
 						Attributes: map[string]interface{}{},
 						Dropped:    0,
 					},
@@ -1089,7 +1101,7 @@ func TestOTLPConvertSpan(t *testing.T) {
 					"version":                 "v1.2.3",
 					"otel.trace_id":           "72df520af2bde7a5240031ead750e5f3",
 					"events":                  "[{\"time_unix_nano\":123,\"name\":\"boom\",\"attributes\":{\"message\":\"Out of memory\",\"accuracy\":\"2.4\"},\"dropped_attributes_count\":2},{\"time_unix_nano\":456,\"name\":\"exception\",\"attributes\":{\"exception.message\":\"Out of memory\",\"exception.type\":\"mem\",\"exception.stacktrace\":\"1/2/3\"},\"dropped_attributes_count\":2}]",
-					"links":                   `[{"trace_id":"fedcba98765432100123456789abcdef","span_id":"abcdef0123456789","attributes":{"a1":"v1","a2":"v2"},"dropped_attributes_count":24},{"trace_id":"abcdef0123456789abcdef0123456789","span_id":"fedcba9876543210","attributes":{"a3":"v2","a4":"v4"}},{"trace_id":"abcdef0123456789abcdef0123456789","span_id":"fedcba9876543210","dropped_attributes_count":2},{"trace_id":"abcdef0123456789abcdef0123456789","span_id":"fedcba9876543210"}]`,
+					"_dd.span_links":          `[{"trace_id":"fedcba98765432100123456789abcdef","span_id":"abcdef0123456789","trace_state":"dd=asdf256,ee=jkl;128","attributes":{"a1":"v1","a2":"v2"},"dropped_attributes_count":24},{"trace_id":"abcdef0123456789abcdef0123456789","span_id":"fedcba9876543210","attributes":{"a3":"v2","a4":"v4"}},{"trace_id":"abcdef0123456789abcdef0123456789","span_id":"fedcba9876543210","dropped_attributes_count":2},{"trace_id":"abcdef0123456789abcdef0123456789","span_id":"fedcba9876543210"}]`,
 					"error.msg":               "Out of memory",
 					"error.type":              "mem",
 					"error.stack":             "1/2/3",
@@ -1183,7 +1195,7 @@ func TestOTLPConvertSpan(t *testing.T) {
 						t.Fatalf("(%d) Error unmarshalling: %v", i, err)
 					}
 					assert.Equal(wante, gote)
-				case "links":
+				case "_dd.span_links":
 					// links contain maps with no guaranteed order of
 					// traversal; best to unpack to compare
 					var gotl, wantl []testutil.OTLPSpanLink

--- a/pkg/trace/api/otlp_test.go
+++ b/pkg/trace/api/otlp_test.go
@@ -62,7 +62,7 @@ var otlpTestSpanConfig = &testutil.OTLPSpan{
 		},
 	},
 	Links: []testutil.OTLPSpanLink{
-	       {
+		{
 			TraceID: "fedcba98765432100123456789abcdef",
 			SpanID:  "abcdef0123456789",
 			Attributes: map[string]interface{}{
@@ -81,18 +81,16 @@ var otlpTestSpanConfig = &testutil.OTLPSpan{
 			Dropped: 0,
 		},
 		{
-			TraceID: "abcdef0123456789abcdef0123456789",
-			SpanID:  "fedcba9876543210",
-			Attributes: map[string]interface{}{
-			},
-			Dropped: 2,
+			TraceID:    "abcdef0123456789abcdef0123456789",
+			SpanID:     "fedcba9876543210",
+			Attributes: map[string]interface{}{},
+			Dropped:    2,
 		},
 		{
-			TraceID: "abcdef0123456789abcdef0123456789",
-			SpanID:  "fedcba9876543210",
-			Attributes: map[string]interface{}{
-			},
-			Dropped: 0,
+			TraceID:    "abcdef0123456789abcdef0123456789",
+			SpanID:     "fedcba9876543210",
+			Attributes: map[string]interface{}{},
+			Dropped:    0,
 		},
 	},
 	StatusMsg:  "Error",
@@ -859,7 +857,7 @@ func TestOTLPConvertSpan(t *testing.T) {
 					"w3c.tracestate":          "state",
 					"version":                 "v1.2.3",
 					"events":                  `[{"time_unix_nano":123,"name":"boom","attributes":{"key":"Out of memory","accuracy":"2.4"},"dropped_attributes_count":2},{"time_unix_nano":456,"name":"exception","attributes":{"exception.message":"Out of memory","exception.type":"mem","exception.stacktrace":"1/2/3"},"dropped_attributes_count":2}]`,
-					"links":		   `[{"trace_id":"fedcba98765432100123456789abcdef","span_id":"abcdef0123456789","attributes":{"a1":"v1","a2":"v2"},"dropped_attributes_count":24},{"trace_id":"abcdef0123456789abcdef0123456789","span_id":"fedcba9876543210","attributes":{"a3":"v2","a4":"v4"}},{"trace_id":"abcdef0123456789abcdef0123456789","span_id":"fedcba9876543210","dropped_attributes_count":2},{"trace_id":"abcdef0123456789abcdef0123456789","span_id":"fedcba9876543210"}]`,
+					"links":                   `[{"trace_id":"fedcba98765432100123456789abcdef","span_id":"abcdef0123456789","attributes":{"a1":"v1","a2":"v2"},"dropped_attributes_count":24},{"trace_id":"abcdef0123456789abcdef0123456789","span_id":"fedcba9876543210","attributes":{"a3":"v2","a4":"v4"}},{"trace_id":"abcdef0123456789abcdef0123456789","span_id":"fedcba9876543210","dropped_attributes_count":2},{"trace_id":"abcdef0123456789abcdef0123456789","span_id":"fedcba9876543210"}]`,
 					"error.msg":               "Out of memory",
 					"error.type":              "mem",
 					"error.stack":             "1/2/3",
@@ -936,18 +934,16 @@ func TestOTLPConvertSpan(t *testing.T) {
 						Dropped: 0,
 					},
 					{
-						TraceID: "abcdef0123456789abcdef0123456789",
-						SpanID:  "fedcba9876543210",
-						Attributes: map[string]interface{}{
-						},
-						Dropped: 2,
+						TraceID:    "abcdef0123456789abcdef0123456789",
+						SpanID:     "fedcba9876543210",
+						Attributes: map[string]interface{}{},
+						Dropped:    2,
 					},
 					{
-						TraceID: "abcdef0123456789abcdef0123456789",
-						SpanID:  "fedcba9876543210",
-						Attributes: map[string]interface{}{
-						},
-						Dropped: 0,
+						TraceID:    "abcdef0123456789abcdef0123456789",
+						SpanID:     "fedcba9876543210",
+						Attributes: map[string]interface{}{},
+						Dropped:    0,
 					},
 				},
 				StatusMsg:  "Error",
@@ -976,7 +972,7 @@ func TestOTLPConvertSpan(t *testing.T) {
 					"w3c.tracestate":          "state",
 					"version":                 "v1.2.3",
 					"events":                  "[{\"time_unix_nano\":123,\"name\":\"boom\",\"attributes\":{\"message\":\"Out of memory\",\"accuracy\":\"2.4\"},\"dropped_attributes_count\":2},{\"time_unix_nano\":456,\"name\":\"exception\",\"attributes\":{\"exception.message\":\"Out of memory\",\"exception.type\":\"mem\",\"exception.stacktrace\":\"1/2/3\"},\"dropped_attributes_count\":2}]",
-					"links":		   `[{"trace_id":"fedcba98765432100123456789abcdef","span_id":"abcdef0123456789","attributes":{"a1":"v1","a2":"v2"},"dropped_attributes_count":24},{"trace_id":"abcdef0123456789abcdef0123456789","span_id":"fedcba9876543210","attributes":{"a3":"v2","a4":"v4"}},{"trace_id":"abcdef0123456789abcdef0123456789","span_id":"fedcba9876543210","dropped_attributes_count":2},{"trace_id":"abcdef0123456789abcdef0123456789","span_id":"fedcba9876543210"}]`,
+					"links":                   `[{"trace_id":"fedcba98765432100123456789abcdef","span_id":"abcdef0123456789","attributes":{"a1":"v1","a2":"v2"},"dropped_attributes_count":24},{"trace_id":"abcdef0123456789abcdef0123456789","span_id":"fedcba9876543210","attributes":{"a3":"v2","a4":"v4"}},{"trace_id":"abcdef0123456789abcdef0123456789","span_id":"fedcba9876543210","dropped_attributes_count":2},{"trace_id":"abcdef0123456789abcdef0123456789","span_id":"fedcba9876543210"}]`,
 					"error.msg":               "Out of memory",
 					"error.type":              "mem",
 					"error.stack":             "1/2/3",
@@ -1056,19 +1052,16 @@ func TestOTLPConvertSpan(t *testing.T) {
 						Dropped: 0,
 					},
 					{
-						TraceID: "abcdef0123456789abcdef0123456789",
-						SpanID:  "fedcba9876543210",
-						Attributes: map[string]interface{}{
-						},
-						Dropped: 2,
+						TraceID:    "abcdef0123456789abcdef0123456789",
+						SpanID:     "fedcba9876543210",
+						Attributes: map[string]interface{}{},
+						Dropped:    2,
 					},
 					{
-						TraceID: "abcdef0123456789abcdef0123456789",
-						SpanID:  "fedcba9876543210",
-						Attributes: map[string]interface{}{
-						},
-						Dropped: 0,
-						
+						TraceID:    "abcdef0123456789abcdef0123456789",
+						SpanID:     "fedcba9876543210",
+						Attributes: map[string]interface{}{},
+						Dropped:    0,
 					},
 				},
 				StatusMsg:  "Error",
@@ -1096,7 +1089,7 @@ func TestOTLPConvertSpan(t *testing.T) {
 					"version":                 "v1.2.3",
 					"otel.trace_id":           "72df520af2bde7a5240031ead750e5f3",
 					"events":                  "[{\"time_unix_nano\":123,\"name\":\"boom\",\"attributes\":{\"message\":\"Out of memory\",\"accuracy\":\"2.4\"},\"dropped_attributes_count\":2},{\"time_unix_nano\":456,\"name\":\"exception\",\"attributes\":{\"exception.message\":\"Out of memory\",\"exception.type\":\"mem\",\"exception.stacktrace\":\"1/2/3\"},\"dropped_attributes_count\":2}]",
-					"links":		   `[{"trace_id":"fedcba98765432100123456789abcdef","span_id":"abcdef0123456789","attributes":{"a1":"v1","a2":"v2"},"dropped_attributes_count":24},{"trace_id":"abcdef0123456789abcdef0123456789","span_id":"fedcba9876543210","attributes":{"a3":"v2","a4":"v4"}},{"trace_id":"abcdef0123456789abcdef0123456789","span_id":"fedcba9876543210","dropped_attributes_count":2},{"trace_id":"abcdef0123456789abcdef0123456789","span_id":"fedcba9876543210"}]`,
+					"links":                   `[{"trace_id":"fedcba98765432100123456789abcdef","span_id":"abcdef0123456789","attributes":{"a1":"v1","a2":"v2"},"dropped_attributes_count":24},{"trace_id":"abcdef0123456789abcdef0123456789","span_id":"fedcba9876543210","attributes":{"a3":"v2","a4":"v4"}},{"trace_id":"abcdef0123456789abcdef0123456789","span_id":"fedcba9876543210","dropped_attributes_count":2},{"trace_id":"abcdef0123456789abcdef0123456789","span_id":"fedcba9876543210"}]`,
 					"error.msg":               "Out of memory",
 					"error.type":              "mem",
 					"error.stack":             "1/2/3",

--- a/pkg/trace/api/otlp_test.go
+++ b/pkg/trace/api/otlp_test.go
@@ -61,6 +61,40 @@ var otlpTestSpanConfig = &testutil.OTLPSpan{
 			Dropped: 2,
 		},
 	},
+	Links: []testutil.OTLPSpanLink{
+	       {
+			TraceID: "fedcba98765432100123456789abcdef",
+			SpanID:  "abcdef0123456789",
+			Attributes: map[string]interface{}{
+				"a1": "v1",
+				"a2": "v2",
+			},
+			Dropped: 24,
+		},
+		{
+			TraceID: "abcdef0123456789abcdef0123456789",
+			SpanID:  "fedcba9876543210",
+			Attributes: map[string]interface{}{
+				"a3": "v2",
+				"a4": "v4",
+			},
+			Dropped: 0,
+		},
+		{
+			TraceID: "abcdef0123456789abcdef0123456789",
+			SpanID:  "fedcba9876543210",
+			Attributes: map[string]interface{}{
+			},
+			Dropped: 2,
+		},
+		{
+			TraceID: "abcdef0123456789abcdef0123456789",
+			SpanID:  "fedcba9876543210",
+			Attributes: map[string]interface{}{
+			},
+			Dropped: 0,
+		},
+	},
 	StatusMsg:  "Error",
 	StatusCode: ptrace.StatusCodeError,
 }
@@ -825,6 +859,7 @@ func TestOTLPConvertSpan(t *testing.T) {
 					"w3c.tracestate":          "state",
 					"version":                 "v1.2.3",
 					"events":                  `[{"time_unix_nano":123,"name":"boom","attributes":{"key":"Out of memory","accuracy":"2.4"},"dropped_attributes_count":2},{"time_unix_nano":456,"name":"exception","attributes":{"exception.message":"Out of memory","exception.type":"mem","exception.stacktrace":"1/2/3"},"dropped_attributes_count":2}]`,
+					"links":		   `[{"trace_id":"fedcba98765432100123456789abcdef","span_id":"abcdef0123456789","attributes":{"a1":"v1","a2":"v2"},"dropped_attributes_count":24},{"trace_id":"abcdef0123456789abcdef0123456789","span_id":"fedcba9876543210","attributes":{"a3":"v2","a4":"v4"}},{"trace_id":"abcdef0123456789abcdef0123456789","span_id":"fedcba9876543210","dropped_attributes_count":2},{"trace_id":"abcdef0123456789abcdef0123456789","span_id":"fedcba9876543210"}]`,
 					"error.msg":               "Out of memory",
 					"error.type":              "mem",
 					"error.stack":             "1/2/3",
@@ -881,6 +916,40 @@ func TestOTLPConvertSpan(t *testing.T) {
 						Dropped: 2,
 					},
 				},
+				Links: []testutil.OTLPSpanLink{
+					{
+						TraceID: "fedcba98765432100123456789abcdef",
+						SpanID:  "abcdef0123456789",
+						Attributes: map[string]interface{}{
+							"a1": "v1",
+							"a2": "v2",
+						},
+						Dropped: 24,
+					},
+					{
+						TraceID: "abcdef0123456789abcdef0123456789",
+						SpanID:  "fedcba9876543210",
+						Attributes: map[string]interface{}{
+							"a3": "v2",
+							"a4": "v4",
+						},
+						Dropped: 0,
+					},
+					{
+						TraceID: "abcdef0123456789abcdef0123456789",
+						SpanID:  "fedcba9876543210",
+						Attributes: map[string]interface{}{
+						},
+						Dropped: 2,
+					},
+					{
+						TraceID: "abcdef0123456789abcdef0123456789",
+						SpanID:  "fedcba9876543210",
+						Attributes: map[string]interface{}{
+						},
+						Dropped: 0,
+					},
+				},
 				StatusMsg:  "Error",
 				StatusCode: ptrace.StatusCodeError,
 			}),
@@ -907,6 +976,7 @@ func TestOTLPConvertSpan(t *testing.T) {
 					"w3c.tracestate":          "state",
 					"version":                 "v1.2.3",
 					"events":                  "[{\"time_unix_nano\":123,\"name\":\"boom\",\"attributes\":{\"message\":\"Out of memory\",\"accuracy\":\"2.4\"},\"dropped_attributes_count\":2},{\"time_unix_nano\":456,\"name\":\"exception\",\"attributes\":{\"exception.message\":\"Out of memory\",\"exception.type\":\"mem\",\"exception.stacktrace\":\"1/2/3\"},\"dropped_attributes_count\":2}]",
+					"links":		   `[{"trace_id":"fedcba98765432100123456789abcdef","span_id":"abcdef0123456789","attributes":{"a1":"v1","a2":"v2"},"dropped_attributes_count":24},{"trace_id":"abcdef0123456789abcdef0123456789","span_id":"fedcba9876543210","attributes":{"a3":"v2","a4":"v4"}},{"trace_id":"abcdef0123456789abcdef0123456789","span_id":"fedcba9876543210","dropped_attributes_count":2},{"trace_id":"abcdef0123456789abcdef0123456789","span_id":"fedcba9876543210"}]`,
 					"error.msg":               "Out of memory",
 					"error.type":              "mem",
 					"error.stack":             "1/2/3",
@@ -966,6 +1036,41 @@ func TestOTLPConvertSpan(t *testing.T) {
 						Dropped: 2,
 					},
 				},
+				Links: []testutil.OTLPSpanLink{
+					{
+						TraceID: "fedcba98765432100123456789abcdef",
+						SpanID:  "abcdef0123456789",
+						Attributes: map[string]interface{}{
+							"a1": "v1",
+							"a2": "v2",
+						},
+						Dropped: 24,
+					},
+					{
+						TraceID: "abcdef0123456789abcdef0123456789",
+						SpanID:  "fedcba9876543210",
+						Attributes: map[string]interface{}{
+							"a3": "v2",
+							"a4": "v4",
+						},
+						Dropped: 0,
+					},
+					{
+						TraceID: "abcdef0123456789abcdef0123456789",
+						SpanID:  "fedcba9876543210",
+						Attributes: map[string]interface{}{
+						},
+						Dropped: 2,
+					},
+					{
+						TraceID: "abcdef0123456789abcdef0123456789",
+						SpanID:  "fedcba9876543210",
+						Attributes: map[string]interface{}{
+						},
+						Dropped: 0,
+						
+					},
+				},
 				StatusMsg:  "Error",
 				StatusCode: ptrace.StatusCodeError,
 			}),
@@ -991,6 +1096,7 @@ func TestOTLPConvertSpan(t *testing.T) {
 					"version":                 "v1.2.3",
 					"otel.trace_id":           "72df520af2bde7a5240031ead750e5f3",
 					"events":                  "[{\"time_unix_nano\":123,\"name\":\"boom\",\"attributes\":{\"message\":\"Out of memory\",\"accuracy\":\"2.4\"},\"dropped_attributes_count\":2},{\"time_unix_nano\":456,\"name\":\"exception\",\"attributes\":{\"exception.message\":\"Out of memory\",\"exception.type\":\"mem\",\"exception.stacktrace\":\"1/2/3\"},\"dropped_attributes_count\":2}]",
+					"links":		   `[{"trace_id":"fedcba98765432100123456789abcdef","span_id":"abcdef0123456789","attributes":{"a1":"v1","a2":"v2"},"dropped_attributes_count":24},{"trace_id":"abcdef0123456789abcdef0123456789","span_id":"fedcba9876543210","attributes":{"a3":"v2","a4":"v4"}},{"trace_id":"abcdef0123456789abcdef0123456789","span_id":"fedcba9876543210","dropped_attributes_count":2},{"trace_id":"abcdef0123456789abcdef0123456789","span_id":"fedcba9876543210"}]`,
 					"error.msg":               "Out of memory",
 					"error.type":              "mem",
 					"error.stack":             "1/2/3",
@@ -1084,6 +1190,17 @@ func TestOTLPConvertSpan(t *testing.T) {
 						t.Fatalf("(%d) Error unmarshalling: %v", i, err)
 					}
 					assert.Equal(wante, gote)
+				case "links":
+					// links contain maps with no guaranteed order of
+					// traversal; best to unpack to compare
+					var gotl, wantl []testutil.OTLPSpanLink
+					if err := json.Unmarshal([]byte(v), &wantl); err != nil {
+						t.Fatalf("(%d) Error unmarshalling: %v", i, err)
+					}
+					if err := json.Unmarshal([]byte(got.Meta[k]), &gotl); err != nil {
+						t.Fatalf("(%d) Error unmarshalling: %v", i, err)
+					}
+					assert.Equal(wantl, gotl)
 				case "_dd.container_tags":
 					// order not guaranteed, so we need to unpack and sort to compare
 					gott := strings.Split(got.Meta[tagContainersTags], ",")

--- a/pkg/trace/api/otlp_test.go
+++ b/pkg/trace/api/otlp_test.go
@@ -1504,6 +1504,25 @@ func TestMarshalSpanLinks(t *testing.T) {
 					"attributes":               {"k1": "v1", "k2": "v2"},
 					"dropped_attributes_count": 57
 				}]`,
+		}, {
+
+			in: (func() ptrace.SpanLinkSlice {
+				s1 := makeSpanLinkSlice("fedcba98765432100123456789abcdef", "0123456789abcdef", "dd=asdf256,ee=jkl;128", map[string]string{"k1": "v1"}, 611187)
+				s2 := makeSpanLinkSlice("abcdef01234567899876543210fedcba", "fedcba9876543210", "", map[string]string{"k1": "v10", "k2": "v20"}, 0)
+				s2.MoveAndAppendTo(s1)
+				return s1
+			})(),
+			out: `[{
+					"trace_id":                 "fedcba98765432100123456789abcdef",
+					"span_id":                  "0123456789abcdef",
+					"trace_state":              "dd=asdf256,ee=jkl;128",
+					"attributes":               {"k1": "v1"},
+					"dropped_attributes_count": 611187
+			       }, {
+					"trace_id":                 "abcdef01234567899876543210fedcba",
+					"span_id":                  "fedcba9876543210",
+					"attributes":               {"k1": "v10", "k2": "v20"}
+			       }]`,
 		},
 	} {
 		assert.Equal(t, trimSpaces(tt.out), marshalLinks(tt.in))

--- a/pkg/trace/testutil/otlp.go
+++ b/pkg/trace/testutil/otlp.go
@@ -49,7 +49,7 @@ type OTLPSpan struct {
 	Start, End uint64
 	Attributes map[string]interface{}
 	Events     []OTLPSpanEvent
-	Links	   []OTLPSpanLink
+	Links      []OTLPSpanLink
 	StatusMsg  string
 	StatusCode ptrace.StatusCode
 }

--- a/pkg/trace/testutil/otlp.go
+++ b/pkg/trace/testutil/otlp.go
@@ -34,6 +34,7 @@ type OTLPSpanEvent struct {
 type OTLPSpanLink struct {
 	TraceID    string                 `json:"trace_id"`
 	SpanID     string                 `json:"span_id"`
+	TraceState string                 `json:"trace_state"`
 	Attributes map[string]interface{} `json:"attributes"`
 	Dropped    uint32                 `json:"dropped_attributes_count"`
 }
@@ -104,6 +105,7 @@ func setOTLPSpan(span ptrace.Span, s *OTLPSpan) {
 		li.SetTraceID(*(*pcommon.TraceID)(bytes))
 		bytes, _ = hex.DecodeString(l.SpanID)
 		li.SetSpanID(*(*pcommon.SpanID)(bytes))
+		li.TraceState().FromRaw(l.TraceState)
 		insertAttributes(li.Attributes(), l.Attributes)
 		li.SetDroppedAttributesCount(l.Dropped)
 	}

--- a/pkg/trace/testutil/otlp.go
+++ b/pkg/trace/testutil/otlp.go
@@ -98,13 +98,16 @@ func setOTLPSpan(span ptrace.Span, s *OTLPSpan) {
 		insertAttributes(ev.Attributes(), e.Attributes)
 		ev.SetDroppedAttributesCount(e.Dropped)
 	}
-	links := span.Links()
+	ls := span.Links()
 	for _, l := range s.Links {
-		li := links.AppendEmpty()
-		bytes, _ := hex.DecodeString(l.TraceID)
-		li.SetTraceID(*(*pcommon.TraceID)(bytes))
-		bytes, _ = hex.DecodeString(l.SpanID)
-		li.SetSpanID(*(*pcommon.SpanID)(bytes))
+		li := ls.AppendEmpty()
+		buf, err := hex.DecodeString(l.TraceID)
+		if err != nil {
+			panic(err)
+		}
+		li.SetTraceID(*(*pcommon.TraceID)(buf))
+		buf, _ = hex.DecodeString(l.SpanID)
+		li.SetSpanID(*(*pcommon.SpanID)(buf))
 		li.TraceState().FromRaw(l.TraceState)
 		insertAttributes(li.Attributes(), l.Attributes)
 		li.SetDroppedAttributesCount(l.Dropped)

--- a/pkg/trace/testutil/otlp.go
+++ b/pkg/trace/testutil/otlp.go
@@ -106,7 +106,10 @@ func setOTLPSpan(span ptrace.Span, s *OTLPSpan) {
 			panic(err)
 		}
 		li.SetTraceID(*(*pcommon.TraceID)(buf))
-		buf, _ = hex.DecodeString(l.SpanID)
+		buf, err = hex.DecodeString(l.SpanID)
+		if err != nil {
+			panic(err)
+		}
 		li.SetSpanID(*(*pcommon.SpanID)(buf))
 		li.TraceState().FromRaw(l.TraceState)
 		insertAttributes(li.Attributes(), l.Attributes)

--- a/releasenotes/notes/apm-span-links-support-78478b81bf08e26f.yaml
+++ b/releasenotes/notes/apm-span-links-support-78478b81bf08e26f.yaml
@@ -1,6 +1,6 @@
 ---
 enhancements:
   - |
-    Adds support for OpenTelemetry span links to the Trace Agent otlp endpoint when converting OTLP spans (span links are added as metadata to the converted span).
+    Adds support for OpenTelemetry span links to the Trace Agent OTLP endpoint when converting OTLP spans (span links are added as metadata to the converted span).
 
 

--- a/releasenotes/notes/apm-span-links-support-78478b81bf08e26f.yaml
+++ b/releasenotes/notes/apm-span-links-support-78478b81bf08e26f.yaml
@@ -1,0 +1,6 @@
+---
+enhancements:
+  - |
+    Adds support for OpenTelemetry span links to the Trace Agent otlp endpoint when converting OTLP spans (span links are added as metadata to the converted span).
+
+

--- a/releasenotes/notes/apm-span-links-support-78478b81bf08e26f.yaml
+++ b/releasenotes/notes/apm-span-links-support-78478b81bf08e26f.yaml
@@ -1,6 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
 ---
 enhancements:
   - |
     Adds support for OpenTelemetry span links to the Trace Agent OTLP endpoint when converting OTLP spans (span links are added as metadata to the converted span).
-
-


### PR DESCRIPTION
### What does this PR do?
Adds support for OpenTelemetry span links to the Trace Agent.

During the conversion from OTLP to the Datadog trace protobuf, any span with span links will have the span links added to the metadata with the key '_dd.span_links'.

### Motivation
This change is part of an ongoing effort to support OpenTelemetry Span Links at Datadog.

### Additional Notes
Span links will be JSON encoded as:
 { "trace_id":`trace_id`, "span_id":`span_id`[,"trace_state":`trace_state`]
   [,"attributes":{ (`key`:`value`)+ }] [,"dropped_attributes_count":uint64] }

where `trace_id` & `span_id` are hex-encoded unsigned ints, `trace_state` is the W3C TraceState encoding as a string,  and `key` & `value` are arbitrary strings.

Note that "trace_state", "attributes", and "dropped_attributes_count" are optional and will only be present if they contain non-empty/non-zero values.

### Possible Drawbacks / Trade-offs
This change only affects the OTel path and only for spans that contain span links so it will only impact a small percentage of spans. The main possible drawback will be the added processing overhead (converting span links to JSON) and the added metadata.

### Describe how to test/QA your changes
Send a span with span links from an OpenTelemetry service and check the resulting converted span has the links in the metadata.

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
