### PR TITLE
Fixes for worker utilization

### DIFF
--- a/pkg/collector/worker/utilization_tracker.go
+++ b/pkg/collector/worker/utilization_tracker.go
@@ -109,6 +109,10 @@ func newUtilizationTrackerWithClock(
 		}
 
 		pollingWindowDuration := currentTime.Sub(ut.windowStart)
+		if pollingWindowDuration == 0 {
+			return 0.0
+		}
+
 		ut.windowStart = currentTime
 
 		utilization := float64(ut.busyDuration) / float64(pollingWindowDuration)

--- a/pkg/collector/worker/utilization_tracker_test.go
+++ b/pkg/collector/worker/utilization_tracker_test.go
@@ -242,15 +242,12 @@ func TestUtilizationTrackerAccuracy(t *testing.T) {
 		idleDuration := time.Duration(totalMs-runtimeMs) * time.Millisecond
 		clk.Add(idleDuration)
 
-		// Due to jitter in the aggregation of random data points, we wait a few
-		// collection intervals before comparing the values.
-		if checkIdx > 5 {
-			require.InDelta(t, getWorkerUtilizationExpvar(t, "worker"), 0.3, 0.1)
-		}
+		// We can't assume that any number of polls or expvar updates
+		// happened by now, because of asynchronous nature of the
+		// sliding window implementation. In actual test runs,
+		// sometimes even no updates happen at all.
+		require.InDelta(t, getWorkerUtilizationExpvar(t, "worker"), 0.3, 0.3)
 	}
-
-	// Assert after many data points that we're really close to 0.3
-	assert.InDelta(t, getWorkerUtilizationExpvar(t, "worker"), 0.3, 0.07)
 }
 
 func TestUtilizationTrackerLongTaskAccuracy(t *testing.T) {

--- a/pkg/collector/worker/utilization_tracker_test.go
+++ b/pkg/collector/worker/utilization_tracker_test.go
@@ -6,7 +6,6 @@
 package worker
 
 import (
-	"expvar"
 	"math/rand"
 	"testing"
 	"time"
@@ -14,43 +13,17 @@ import (
 	"github.com/benbjohnson/clock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/DataDog/datadog-agent/pkg/collector/runner/expvars"
 )
 
 // Helpers
 
-// getWorkerUtilizationExpvar returns the utilization as presented by expvars
-// for a named worker.
-func getWorkerUtilizationExpvar(t *testing.T, name string) float64 {
-	runnerMapExpvar := expvar.Get("runner")
-	require.NotNil(t, runnerMapExpvar)
-
-	workersExpvar := runnerMapExpvar.(*expvar.Map).Get("Workers")
-	require.NotNil(t, workersExpvar)
-
-	instancesExpvar := workersExpvar.(*expvar.Map).Get("Instances")
-	require.NotNil(t, instancesExpvar)
-
-	workerStatsExpvar := instancesExpvar.(*expvar.Map).Get(name)
-	require.NotNil(t, workerStatsExpvar)
-
-	workerStats := workerStatsExpvar.(*expvars.WorkerStats)
-	require.NotNil(t, workerStats)
-
-	return workerStats.Utilization
-}
-
-func newTracker(t *testing.T) (UtilizationTracker, *clock.Mock) {
+func newTracker(t *testing.T) (*UtilizationTracker, *clock.Mock) {
 	clk := clock.NewMock()
-	ut, err := newUtilizationTrackerWithClock(
+	ut := newUtilizationTrackerWithClock(
 		"worker",
-		500*time.Millisecond,
 		100*time.Millisecond,
 		clk,
 	)
-	require.Nil(t, err)
-	AssertAsyncWorkerCount(t, 0)
 
 	return ut, clk
 }
@@ -59,226 +32,125 @@ func newTracker(t *testing.T) (UtilizationTracker, *clock.Mock) {
 
 func TestUtilizationTracker(t *testing.T) {
 	ut, clk := newTracker(t)
+	defer ut.Stop()
 
-	require.NoError(t, ut.Start())
-	defer func() {
-		ut.Stop()
-		AssertAsyncWorkerCount(t, 0)
-	}()
+	old := 0.0
+	new := 0.0
 
-	AssertAsyncWorkerCount(t, 1)
-
-	// Initially and after some time without any checks running, the utilization
+	// After some time without any checks running, the utilization
 	// should be a constant zero value
-	require.Equal(t, 0.0, getWorkerUtilizationExpvar(t, "worker"))
+	clk.Add(300 * time.Millisecond)
+	ut.Tick()
+	old, new = new, <-ut.Output
+	require.Equal(t, old, new)
 
 	clk.Add(300 * time.Millisecond)
-	require.Equal(t, 0.0, getWorkerUtilizationExpvar(t, "worker"))
-
 	// Ramp up the expected utilization
-	ut.CheckStarted(false)
+	ut.CheckStarted()
+	old, new = new, <-ut.Output
+	require.Equal(t, old, new)
 
 	clk.Add(250 * time.Millisecond)
-	require.True(t, getWorkerUtilizationExpvar(t, "worker") > 0)
-	require.True(t, getWorkerUtilizationExpvar(t, "worker") < 1)
+	ut.Tick()
+	old, new = new, <-ut.Output
+	require.Greater(t, new, old)
 
 	clk.Add(550 * time.Millisecond)
-	require.Equal(t, 1.0, getWorkerUtilizationExpvar(t, "worker"))
+	ut.Tick()
+	old, new = new, <-ut.Output
+	require.Greater(t, new, old)
 
 	// Ramp down the expected utilization
 	ut.CheckFinished()
+	old, new = new, <-ut.Output
+	require.Equal(t, old, new) //no time have passed
 
 	clk.Add(250 * time.Millisecond)
-	require.True(t, getWorkerUtilizationExpvar(t, "worker") > 0)
-	require.True(t, getWorkerUtilizationExpvar(t, "worker") < 1)
+	ut.Tick()
+	old, new = new, <-ut.Output
+	require.Less(t, new, old)
 
 	clk.Add(550 * time.Millisecond)
-	require.Equal(t, 0.0, getWorkerUtilizationExpvar(t, "worker"))
-}
-
-func TestUtilizationTrackerIsRunningLongCheck(t *testing.T) {
-	ut, _ := newTracker(t)
-
-	require.NoError(t, ut.Start())
-	defer func() {
-		ut.Stop()
-		AssertAsyncWorkerCount(t, 0)
-	}()
-
-	require.False(t, ut.IsRunningLongCheck())
-
-	for idx := 0; idx < 3; idx++ {
-		ut.CheckStarted(false)
-		assert.False(t, ut.IsRunningLongCheck())
-		ut.CheckFinished()
-
-		ut.CheckStarted(true)
-		assert.True(t, ut.IsRunningLongCheck())
-		ut.CheckFinished()
-	}
-}
-
-func TestUtilizationTrackerStart(t *testing.T) {
-	ut, _ := newTracker(t)
-
-	require.NoError(t, ut.Start())
-	defer func() {
-		ut.Stop()
-		AssertAsyncWorkerCount(t, 0)
-	}()
-
-	AssertAsyncWorkerCount(t, 1)
-	require.Equal(t, 0.0, getWorkerUtilizationExpvar(t, "worker"))
-
-	// Check that on consecutive calls we don't break
-	require.Error(t, ut.Start())
-	require.Error(t, ut.Start())
-
-	AssertAsyncWorkerCount(t, 1)
-}
-
-func TestUtilizationTrackerStop(t *testing.T) {
-	ut, _ := newTracker(t)
-
-	// If we haven't started yet, stopping should throw an error
-	require.Error(t, ut.Stop())
-
-	require.NoError(t, ut.Start())
-	defer func() {
-		ut.Stop()
-		AssertAsyncWorkerCount(t, 0)
-	}()
-
-	AssertAsyncWorkerCount(t, 1)
-	require.Equal(t, 0.0, getWorkerUtilizationExpvar(t, "worker"))
-
-	require.NoError(t, ut.Stop())
-	AssertAsyncWorkerCount(t, 0)
-
-	// Check that on consecutive calls we don't break
-	require.Error(t, ut.Stop())
-	require.Error(t, ut.Stop())
-	AssertAsyncWorkerCount(t, 0)
-
-	// A stopped tracker should not be able to start again
-	require.Error(t, ut.Start())
+	ut.Tick()
+	require.Less(t, new, old)
 }
 
 func TestUtilizationTrackerCheckLifecycle(t *testing.T) {
-	windowSize := 250 * time.Millisecond
-	pollingInterval := 50 * time.Millisecond
+	ut, clk := newTracker(t)
+	defer ut.Stop()
 
-	clk := clock.NewMock()
-	ut, err := newUtilizationTrackerWithClock("worker", windowSize, pollingInterval, clk)
-	require.Nil(t, err)
-	AssertAsyncWorkerCount(t, 0)
-
-	require.NoError(t, ut.Start())
-	defer func() {
-		ut.Stop()
-		AssertAsyncWorkerCount(t, 0)
-	}()
+	var old, new float64
 
 	// No tasks should equal no utilization
-	clk.Add(windowSize)
-	AssertAsyncWorkerCount(t, 1)
-	require.InDelta(t, getWorkerUtilizationExpvar(t, "worker"), 0, 0)
+	clk.Add(250 * time.Millisecond)
+	ut.Tick()
+	old, new = new, <-ut.Output
+	assert.Equal(t, old, new)
 
 	for idx := 0; idx < 3; idx++ {
 		// Ramp up utilization
-		ut.CheckStarted(false)
+		ut.CheckStarted()
+		old, new = new, <-ut.Output
+		assert.Equal(t, old, new)
 
-		clk.Add(windowSize / 2)
-		AssertAsyncWorkerCount(t, 1)
-		assert.True(t, getWorkerUtilizationExpvar(t, "worker") > 0.1)
-		assert.True(t, getWorkerUtilizationExpvar(t, "worker") < 0.9)
+		clk.Add(250 * time.Millisecond)
+		ut.Tick()
+		old, new = new, <-ut.Output
+		assert.Greater(t, new, old)
 
-		clk.Add(windowSize)
-		AssertAsyncWorkerCount(t, 1)
-		assert.InDelta(t, getWorkerUtilizationExpvar(t, "worker"), 1, 0.05)
+		clk.Add(250 * time.Millisecond)
+		ut.Tick()
+		old, new = new, <-ut.Output
+		assert.Greater(t, new, old)
 
 		// Ramp down utilization
 		ut.CheckFinished()
+		old, new = new, <-ut.Output
+		assert.Equal(t, new, old)
 
-		clk.Add(windowSize / 2)
-		AssertAsyncWorkerCount(t, 1)
-		assert.True(t, getWorkerUtilizationExpvar(t, "worker") > 0.1)
-		assert.True(t, getWorkerUtilizationExpvar(t, "worker") < 0.9)
+		clk.Add(250 * time.Millisecond)
+		ut.Tick()
+		old, new = new, <-ut.Output
+		assert.Less(t, new, old)
 
-		clk.Add(windowSize)
-		AssertAsyncWorkerCount(t, 1)
-		assert.InDelta(t, getWorkerUtilizationExpvar(t, "worker"), 0, 0.05)
+		clk.Add(250 * time.Millisecond)
+		ut.Tick()
+		old, new = new, <-ut.Output
+		assert.Less(t, new, old)
 	}
 }
 
 func TestUtilizationTrackerAccuracy(t *testing.T) {
-	windowSize := 3000 * time.Millisecond
-	pollingInterval := 50 * time.Millisecond
+	ut, clk := newTracker(t)
 
-	clk := clock.NewMock()
-	ut, err := newUtilizationTrackerWithClock("worker", windowSize, pollingInterval, clk)
-	require.Nil(t, err)
-	AssertAsyncWorkerCount(t, 0)
+	val := 0.0
 
-	require.NoError(t, ut.Start())
-	defer func() {
-		ut.Stop()
-		AssertAsyncWorkerCount(t, 0)
-	}()
-
-	require.InDelta(t, getWorkerUtilizationExpvar(t, "worker"), 0, 0)
+	// It would be nice to figure out a way to compute bounds for the
+	// smoothed value that would work for any random sequence.
+	r := rand.New(rand.NewSource(1))
 
 	for checkIdx := 1; checkIdx <= 100; checkIdx++ {
 		// This should provide about 30% utilization
 		// Range for the full loop would be between 100-200ms
-		totalMs := rand.Int31n(100) + 100
+		totalMs := r.Int31n(100) + 100
 		runtimeMs := (totalMs * 30) / 100
 
-		ut.CheckStarted(false)
+		ut.CheckStarted()
+		<-ut.Output
+
 		runtimeDuration := time.Duration(runtimeMs) * time.Millisecond
 		clk.Add(runtimeDuration)
 
 		ut.CheckFinished()
+		val = <-ut.Output
+
 		idleDuration := time.Duration(totalMs-runtimeMs) * time.Millisecond
 		clk.Add(idleDuration)
 
-		// We can't assume that any number of polls or expvar updates
-		// happened by now, because of asynchronous nature of the
-		// sliding window implementation. In actual test runs,
-		// sometimes even no updates happen at all.
-		require.InDelta(t, getWorkerUtilizationExpvar(t, "worker"), 0.3, 0.3)
-	}
-}
-
-func TestUtilizationTrackerLongTaskAccuracy(t *testing.T) {
-	var previousUtilization, currentUtilization float64
-
-	clk := clock.NewMock()
-	ut, err := newUtilizationTrackerWithClock("worker", 1*time.Second, 25*time.Millisecond, clk)
-	require.Nil(t, err)
-	AssertAsyncWorkerCount(t, 0)
-
-	require.NoError(t, ut.Start())
-	defer func() {
-		ut.Stop()
-		AssertAsyncWorkerCount(t, 0)
-	}()
-
-	require.InDelta(t, getWorkerUtilizationExpvar(t, "worker"), 0, 0)
-
-	go ut.CheckStarted(false)
-
-	for checkIdx := 0; checkIdx < 10; checkIdx++ {
-		clk.Add(100 * time.Millisecond)
-
-		currentUtilization = getWorkerUtilizationExpvar(t, "worker")
-
-		if currentUtilization < 1 {
-			require.True(t, currentUtilization > previousUtilization)
+		if checkIdx > 30 {
+			require.InDelta(t, 0.3, val, 0.07)
 		}
-
-		previousUtilization = currentUtilization
 	}
 
-	require.InDelta(t, getWorkerUtilizationExpvar(t, "worker"), 1.0, 0.05)
+	require.InDelta(t, 0.3, val, 0.07)
 }

--- a/pkg/util/sliding_window.go
+++ b/pkg/util/sliding_window.go
@@ -222,5 +222,5 @@ func (sw *slidingWindow) average() float64 {
 		totalVal += bucketVal
 	}
 
-	return totalVal / float64(sw.numBucketsUsed)
+	return totalVal / float64(sw.numBuckets)
 }

--- a/pkg/util/sliding_window.go
+++ b/pkg/util/sliding_window.go
@@ -222,5 +222,5 @@ func (sw *slidingWindow) average() float64 {
 		totalVal += bucketVal
 	}
 
-	return totalVal / float64(sw.numBuckets)
+	return totalVal / float64(sw.numBucketsUsed)
 }


### PR DESCRIPTION
### What does this PR do?

This patch rewrites utilization tracker to operate synchronously
internally, communicating inputs and outputs via channels. Time is
sampled on the main goroutine only. The results are still
unpredictable insofar goroutine scheduling is involved, but in tests
it can be controlled by carefully placing channel reads.

It also shifts code around a bit, separating expvar and ticker
interaction from the core tracker code to make it more testable.

Finally, the smoothing method is changed from sliding window to a
exponential weighted average, for the only reason that it makes average
move more predictably towards the signal, which also helps with
testing.

### Motivation

Sliding window polling goroutine was not synchronized with the test
execution (which is advancing time on the mock clock), and, depending
on how goroutine were scheduled, could run poll zero, one or arbitrary
number of times during the test, making the results
unpredictable. Also it could poll twice in a short succession, causing
poll function to divide by zero and produce NaN utilization.

### Additional Notes

### Possible Drawbacks / Trade-offs


### Describe how to test/QA your changes

Run agent with the default checks enabled.

Check that utilization is reported, and note the value:
```
curl http://localhost:5000/debug/vars | jq .runner.Workers
```

Schedule a few instances of a long running check:

```
import time
from datadog_checks.base import AgentCheck

class SlowCheck(AgentCheck):
    def check(self, instance):
        time.sleep(10)
```

```
init_config: {}
instances:
- {service: s1}
- {service: s2}
- {service: s3}
- {service: s4}
```

Check that utilization goes up.
After ~5 minutes it should reach around 0.7 for all of 4 default workers.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
