### PR TITLE
[CWS] Adding verbose output back into functional tests

### DIFF
--- a/pkg/security/tests/process_test.go
+++ b/pkg/security/tests/process_test.go
@@ -2109,7 +2109,7 @@ func TestProcessFilelessExecution(t *testing.T) {
 			syscallTesterToRun:               "fileless",
 			syscallTesterScriptFilenameToRun: "script",
 			check: func(event *model.Event, rule *rules.Rule) {
-				assertFieldEqual(t, event, "process.file.name", "memfd:script", "process.file.name not matching")
+				assertFieldEqual(t, event, "process.file.name", "memfd:script"+"CI_TESTING", "process.file.name not matching")
 			},
 		},
 		{

--- a/pkg/security/tests/process_test.go
+++ b/pkg/security/tests/process_test.go
@@ -2109,7 +2109,7 @@ func TestProcessFilelessExecution(t *testing.T) {
 			syscallTesterToRun:               "fileless",
 			syscallTesterScriptFilenameToRun: "script",
 			check: func(event *model.Event, rule *rules.Rule) {
-				assertFieldEqual(t, event, "process.file.name", "memfd:script"+"CI_TESTING", "process.file.name not matching")
+				assertFieldEqual(t, event, "process.file.name", "memfd:script", "process.file.name not matching")
 			},
 		},
 		{

--- a/test/kitchen/test/integration/security-agent-test/rspec_datadog/security-agent-test_spec.rb
+++ b/test/kitchen/test/integration/security-agent-test/rspec_datadog/security-agent-test_spec.rb
@@ -14,6 +14,24 @@ platform = "#{osr["ID"]}-#{osr["VERSION_ID"]}"
 
 cws_platform = File.read('/tmp/security-agent/cws_platform').strip
 
+GOLANG_TEST_FAILURE = /FAIL:/
+
+def check_output(output, wait_thr, tag="")
+  test_failures = []
+
+  output.each_line do |line|
+    stripped_line = line.strip
+    puts KernelOut.format(stripped_line, tag)
+    test_failures << KernelOut.format(stripped_line, tag) if line =~ GOLANG_TEST_FAILURE
+  end
+
+  if test_failures.empty? && !wait_thr.value.success?
+    test_failures << KernelOut.format("Test command exited with status (#{wait_thr.value.exitstatus}) but no failures were captured.", tag)
+  end
+
+  puts test_failures.join("\n")
+end
+
 shared_examples "passes" do |bundle, env|
   after :context do
     # Combine all the /tmp/pkgjson/#{bundle}.json files into one /tmp/testjson/#{bundle}.json file, which is then used to print failed tests at the end of the functional test Gitlab job
@@ -49,18 +67,19 @@ shared_examples "passes" do |bundle, env|
       if bundle == "docker"
         cmd = gotestsum_test2json_cmd.concat(["docker", "exec", "-e", "DD_SYSTEM_PROBE_BPF_DIR=#{final_env["DD_SYSTEM_PROBE_BPF_DIR"]}",
           "docker-testsuite", testsuite_file_path, "-status-metrics", "--env", "docker", "-test.v", "-test.count=1"])
+        output_line_tag = "d"
       else
         cmd = gotestsum_test2json_cmd.concat([testsuite_file_path, "-status-metrics", "-test.v", "-test.count=1"])
+        output_line_tag = "h"
 
         if bundle == "ad"
           cmd.concat(["-test.run", "TestActivityDump"])
+          output_line_tag = "ad"
         end
       end
 
       Open3.popen2e(final_env, *cmd) do |_, output, wait_thr|
-        output.each_line do |line|
-          puts KernelOut.format(line.strip)
-        end
+        check_output(output, wait_thr, output_line_tag)
       end
 
       xmldoc = REXML::Document.new(File.read(xmlpath))

--- a/test/kitchen/test/integration/security-agent-test/rspec_datadog/security-agent-test_spec.rb
+++ b/test/kitchen/test/integration/security-agent-test/rspec_datadog/security-agent-test_spec.rb
@@ -19,16 +19,19 @@ GOLANG_TEST_FAILURE = /FAIL:/
 def check_output(output, wait_thr, tag="")
   test_failures = []
 
+  puts "Begin Test Output"
   output.each_line do |line|
     stripped_line = line.strip
     puts KernelOut.format(stripped_line, tag)
     test_failures << KernelOut.format(stripped_line, tag) if line =~ GOLANG_TEST_FAILURE
   end
+  puts "End Test Output"
 
   if test_failures.empty? && !wait_thr.value.success?
     test_failures << KernelOut.format("Test command exited with status (#{wait_thr.value.exitstatus}) but no failures were captured.", tag)
   end
 
+  puts "Test Failures"
   puts test_failures.join("\n")
 end
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Add back verbose output of CI functional tests because it's hard to debug failures like https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/232992383  without it.

Example of original CI output: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/234040553
Compare that with the CI output with this PR: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/233971339

In case the link to the original output expires, do the following:
1. `git rev-list --parents -n 1  31746e7` This gets the parents of the PR that changed the CI output (https://github.com/DataDog/datadog-agent/pull/15379). 
2. Check out the parent before the PR was merged, make a change to ensure a failure, push, and see the output of a functional test CI job.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
