### PR TITLE
[windows] Fix flaky test caused by improper use of Once

### DIFF
--- a/pkg/util/winutil/scmmonitor_test.go
+++ b/pkg/util/winutil/scmmonitor_test.go
@@ -29,11 +29,11 @@ func (so *saveOutput) Write(p []byte) (n int, err error) {
 }
 
 var startTime windows.Filetime
+var startTimeOnce sync.Once
 
 func testGetProcessStartTimeAsNs(pid uint64) (uint64, error) {
-	var once sync.Once
 
-	once.Do(func() {
+	startTimeOnce.Do(func() {
 		windows.GetSystemTimeAsFileTime(&startTime)
 		// move the start a bit earlier to make sure it's always
 		// before current


### PR DESCRIPTION
### Additional Notes


### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
