### PR TITLE
[trivy] Add option to clear cache on exit

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1116,6 +1116,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("container_image_collection.sbom.scan_timeout", 10*60) // Integer seconds
 	config.BindEnvAndSetDefault("container_image_collection.sbom.analyzers", []string{"os"})
 	config.BindEnvAndSetDefault("container_image_collection.sbom.cache_directory", "")
+	config.BindEnvAndSetDefault("container_image_collection.sbom.clear_cache_on_exit", true)
 
 	// Datadog security agent (common)
 	config.BindEnvAndSetDefault("security_agent.cmd_port", 5010)

--- a/pkg/util/trivy/trivy.go
+++ b/pkg/util/trivy/trivy.go
@@ -137,15 +137,11 @@ func NewCollector(collectorConfig CollectorConfig) (Collector, error) {
 }
 
 func (c *collector) Close() error {
-	if err := c.cache.Close(); err != nil {
-		return err
+	if c.config.ClearCacheOnClose {
+		return c.cache.Clear()
 	}
 
-	if err := c.cache.Clear(); err != nil {
-		return err
-	}
-
-	return nil
+	return c.cache.Close()
 }
 
 func (c *collector) ScanContainerdImage(ctx context.Context, imgMeta *workloadmeta.ContainerImageMetadata, img containerd.Image) (*cyclonedxgo.BOM, error) {

--- a/pkg/workloadmeta/collectors/internal/containerd/image_sbom_trivy.go
+++ b/pkg/workloadmeta/collectors/internal/containerd/image_sbom_trivy.go
@@ -40,6 +40,7 @@ func (c *collector) startSBOMCollection(ctx context.Context) error {
 	var err error
 	enabledAnalyzers := config.Datadog.GetStringSlice("container_image_collection.sbom.analyzers")
 	trivyConfiguration := trivy.DefaultCollectorConfig(enabledAnalyzers)
+	trivyConfiguration.ClearCacheOnClose = config.Datadog.GetBool("container_image_collection.sbom.clear_cache_on_exit")
 	trivyConfiguration.ContainerdAccessor = func() (cutil.ContainerdItf, error) {
 		return c.containerdClient, nil
 	}


### PR DESCRIPTION
### What does this PR do?

Adds a config option (`container_image_collection.sbom.clear_cache_on_exit`) to remove the cache used by the SBOM collection feature when the agent stops. The option is enabled by default.

We want to make this configurable because keeping the cache between executions is useful to avoid scanning multiple times the same images. On the other hand, when using boltdb as cache, there's no cleanup mechanism implemented for now. So if disk space is a concern, the cache needs to be deleted on exit.

Notice that sometimes the cache will not be deleted even when the option is set to true. That's because currently when the agent stops we don't wait for the workloadmeta to handle the main context cancellation. This should probably be addressed on a separate PR.


### Describe how to test/QA your changes

It's not straightforward due to the problem that I mentioned above. I needed to add a sleep in this line https://github.com/DataDog/datadog-agent/blob/main/cmd/agent/subcommands/run/command.go#L552 to make sure that workloadmeta has time to process the context cancellation.

Run the agent on containerd with image metadata collection enabled (`DD_CONTAINER_IMAGE_COLLECTION_METADATA_ENABLED=true`), SBOM collection enabled (`DD_CONTAINER_IMAGE_COLLECTION_SBOM_ENABLED=true`), mount the cache dir and set it in `DD_CONTAINER_IMAGE_COLLECTION_SBOM_CACHE_DIRECTORY`, and try with `DD_CONTAINER_IMAGE_COLLECTION_SBOM_CLEAR_CACHE_ON_EXIT` both set to true and false.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
