### PR TITLE
feat: Honor enhanced metrics env var

### DIFF
--- a/pkg/serverless/metrics/enhanced_metrics.go
+++ b/pkg/serverless/metrics/enhanced_metrics.go
@@ -7,6 +7,7 @@ package metrics
 
 import (
 	"math"
+	"os"
 	"strings"
 	"time"
 
@@ -41,6 +42,7 @@ const (
 	// ErrorsMetric is the name of the errors enhanced Lambda metric
 	ErrorsMetric      = "aws.lambda.enhanced.errors"
 	invocationsMetric = "aws.lambda.enhanced.invocations"
+	enhancedMetricsEnvVar = "DD_ENHANCED_METRICS"
 )
 
 func getOutOfMemorySubstrings() []string {
@@ -223,6 +225,10 @@ func SendInvocationEnhancedMetric(tags []string, demux aggregator.Demultiplexer)
 
 // incrementEnhancedMetric sends an enhanced metric with a value of 1 to the metrics channel
 func incrementEnhancedMetric(name string, tags []string, timestamp float64, demux aggregator.Demultiplexer) {
+	// TODO - pass config here, instead of directly looking up var
+	if (strings.ToLower(os.Getenv(enhancedMetricsEnvVar)) == "false") {
+	    return
+	}
 	demux.AggregateSample(metrics.MetricSample{
 		Name:       name,
 		Value:      1.0,

--- a/pkg/serverless/metrics/enhanced_metrics.go
+++ b/pkg/serverless/metrics/enhanced_metrics.go
@@ -40,8 +40,8 @@ const (
 	OutOfMemoryMetric = "aws.lambda.enhanced.out_of_memory"
 	timeoutsMetric    = "aws.lambda.enhanced.timeouts"
 	// ErrorsMetric is the name of the errors enhanced Lambda metric
-	ErrorsMetric      = "aws.lambda.enhanced.errors"
-	invocationsMetric = "aws.lambda.enhanced.invocations"
+	ErrorsMetric          = "aws.lambda.enhanced.errors"
+	invocationsMetric     = "aws.lambda.enhanced.invocations"
 	enhancedMetricsEnvVar = "DD_ENHANCED_METRICS"
 )
 
@@ -226,8 +226,8 @@ func SendInvocationEnhancedMetric(tags []string, demux aggregator.Demultiplexer)
 // incrementEnhancedMetric sends an enhanced metric with a value of 1 to the metrics channel
 func incrementEnhancedMetric(name string, tags []string, timestamp float64, demux aggregator.Demultiplexer) {
 	// TODO - pass config here, instead of directly looking up var
-	if (strings.ToLower(os.Getenv(enhancedMetricsEnvVar)) == "false") {
-	    return
+	if strings.ToLower(os.Getenv(enhancedMetricsEnvVar)) == "false" {
+		return
 	}
 	demux.AggregateSample(metrics.MetricSample{
 		Name:       name,


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This PR honors the DD_ENHANCED_METRICS env var.

### Motivation

We honor this in the Lambda Layers as well as in the Lambda Forwarder, but it seems this was inadvertently removed or omitted years ago.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
