### PR TITLE
[Single-Machine-Performance] Increase Regression Detector replicates

### DIFF
--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -14,7 +14,7 @@ single-machine-performance-regression_detector:
     LADING_VERSION: 0.13.0
     TOTAL_SAMPLES: 600
     WARMUP_SECONDS: 45
-    REPLICAS: 10
+    REPLICAS: 20
     CPUS: 7
     MEMORY: "30g"
   # At present we require two artifacts to exist for the 'baseline' and the


### PR DESCRIPTION
### What does this PR do?

This commit doubles the number of Regression Detector replicates. 

### Motivation

We are working on a method to elide replicate runs automatically for experiments that have sufficient data but we want a higher maximum number of replicates. In the meanwhile, we believe that increasing the total number of replicates should address some of the 'wobble' we're seeing in some experiments here, that is, phantom dings.
