### PR TITLE
Fix a race in the dogstatsd capture writer

### DIFF
--- a/comp/dogstatsd/server/server.go
+++ b/comp/dogstatsd/server/server.go
@@ -47,20 +47,7 @@ func (s *server) IsRunning() bool {
 }
 
 func (s *server) Capture(p string, d time.Duration, compressed bool) (string, error) {
-
-	err := s.server.Capture(p, d, compressed)
-	if err != nil {
-		return "", err
-	}
-
-	// wait for the capture to start
-	for !s.server.TCapture.IsOngoing() {
-		time.Sleep(500 * time.Millisecond)
-	}
-
-	path, err := s.server.TCapture.Path()
-
-	return path, err
+	return s.server.Capture(p, d, compressed)
 }
 
 func (s *server) GetJSONDebugStats() ([]byte, error) {

--- a/pkg/dogstatsd/replay/writer.go
+++ b/pkg/dogstatsd/replay/writer.go
@@ -213,11 +213,16 @@ func (tc *TrafficCaptureWriter) Capture(target io.WriteCloser, d time.Duration, 
 	}
 	tc.Unlock()
 
+	done := make(chan struct{})
+	defer close(done)
 	go func() {
 		log.Debugf("Capture will be stopped after %v", d)
 
-		<-time.After(d)
-		tc.StopCapture()
+		select {
+		case <-time.After(d):
+			tc.StopCapture()
+		case <-done:
+		}
 	}()
 
 process:

--- a/pkg/dogstatsd/server.go
+++ b/pkg/dogstatsd/server.go
@@ -469,7 +469,7 @@ func (s *Server) handleMessages() {
 
 // Capture starts a traffic capture at the specified path and with the specified duration,
 // an empty path will default to the default location. Returns an error if any.
-func (s *Server) Capture(p string, d time.Duration, compressed bool) error {
+func (s *Server) Capture(p string, d time.Duration, compressed bool) (string, error) {
 	return s.TCapture.Start(p, d, compressed)
 }
 


### PR DESCRIPTION
### What does this PR do?

Refactor dogstatsd capture writer to avoid a race condition.

### Motivation

Fix a flaky test.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Run the agent.
Send some metrics.
Run a dogstatsd capture.
Check that the metrics are included in the capture: `zstdcat $capture | grep metric.name`

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
