### PR TITLE
[Serverless] Decrease binary size when building serverless extension.

### DIFF
--- a/pkg/forwarder/telemetry.go
+++ b/pkg/forwarder/telemetry.go
@@ -8,18 +8,12 @@ package forwarder
 import (
 	"expvar"
 
-	model "github.com/DataDog/agent-payload/v5/process"
-
 	"github.com/DataDog/datadog-agent/pkg/forwarder/endpoints"
 	"github.com/DataDog/datadog-agent/pkg/forwarder/transaction"
-	"github.com/DataDog/datadog-agent/pkg/orchestrator"
 	"github.com/DataDog/datadog-agent/pkg/telemetry"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 var (
-	transactionsIntakeOrchestrator = map[model.K8SResource]*expvar.Int{}
-
 	highPriorityQueueFull            = expvar.Int{}
 	transactionsInputBytesByEndpoint = expvar.Map{}
 	transactionsInputCountByEndpoint = expvar.Map{}
@@ -74,23 +68,6 @@ func initEndpointExpvars() {
 	for _, endpoint := range endpoints {
 		transaction.TransactionsSuccessByEndpoint.Set(endpoint.Name, expvar.NewInt(endpoint.Name))
 	}
-}
-
-func initOrchestratorExpVars() {
-	for _, nodeType := range orchestrator.NodeTypes() {
-		transactionsIntakeOrchestrator[nodeType] = &expvar.Int{}
-		transaction.TransactionsExpvars.Set(nodeType.String(), transactionsIntakeOrchestrator[nodeType])
-	}
-	transaction.TransactionsExpvars.Set("OrchestratorManifest", &transactionsOrchestratorManifest)
-}
-
-func bumpOrchestratorPayload(nodeType int) {
-	e, ok := transactionsIntakeOrchestrator[model.K8SResource(nodeType)]
-	if !ok {
-		log.Errorf("Unknown NodeType %v, cannot bump expvar", nodeType)
-		return
-	}
-	e.Add(1)
 }
 
 func initTransactionsExpvars() {

--- a/pkg/forwarder/telemetry_not_serverless.go
+++ b/pkg/forwarder/telemetry_not_serverless.go
@@ -1,0 +1,37 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !serverless
+// +build !serverless
+
+package forwarder
+
+import (
+	"expvar"
+
+	model "github.com/DataDog/agent-payload/v5/process"
+	"github.com/DataDog/datadog-agent/pkg/forwarder/transaction"
+	"github.com/DataDog/datadog-agent/pkg/orchestrator"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+var transactionsIntakeOrchestrator = map[model.K8SResource]*expvar.Int{}
+
+func initOrchestratorExpVars() {
+	for _, nodeType := range orchestrator.NodeTypes() {
+		transactionsIntakeOrchestrator[nodeType] = &expvar.Int{}
+		transaction.TransactionsExpvars.Set(nodeType.String(), transactionsIntakeOrchestrator[nodeType])
+	}
+	transaction.TransactionsExpvars.Set("OrchestratorManifest", &transactionsOrchestratorManifest)
+}
+
+func bumpOrchestratorPayload(nodeType int) {
+	e, ok := transactionsIntakeOrchestrator[model.K8SResource(nodeType)]
+	if !ok {
+		log.Errorf("Unknown NodeType %v, cannot bump expvar", nodeType)
+		return
+	}
+	e.Add(1)
+}

--- a/pkg/forwarder/telemetry_serverless.go
+++ b/pkg/forwarder/telemetry_serverless.go
@@ -1,0 +1,13 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build serverless
+// +build serverless
+
+package forwarder
+
+func initOrchestratorExpVars() {}
+
+func bumpOrchestratorPayload(nodeType int) {}

--- a/pkg/logs/agent_not_serverless.go
+++ b/pkg/logs/agent_not_serverless.go
@@ -1,0 +1,125 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !serverless
+// +build !serverless
+
+package logs
+
+import (
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery"
+	coreConfig "github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/logs/auditor"
+	"github.com/DataDog/datadog-agent/pkg/logs/client"
+	"github.com/DataDog/datadog-agent/pkg/logs/client/http"
+	"github.com/DataDog/datadog-agent/pkg/logs/config"
+	"github.com/DataDog/datadog-agent/pkg/logs/diagnostic"
+	"github.com/DataDog/datadog-agent/pkg/logs/internal/launchers"
+	"github.com/DataDog/datadog-agent/pkg/logs/internal/launchers/container"
+	"github.com/DataDog/datadog-agent/pkg/logs/internal/launchers/docker"
+	filelauncher "github.com/DataDog/datadog-agent/pkg/logs/internal/launchers/file"
+	"github.com/DataDog/datadog-agent/pkg/logs/internal/launchers/journald"
+	"github.com/DataDog/datadog-agent/pkg/logs/internal/launchers/kubernetes"
+	"github.com/DataDog/datadog-agent/pkg/logs/internal/launchers/listener"
+	"github.com/DataDog/datadog-agent/pkg/logs/internal/launchers/windowsevent"
+	"github.com/DataDog/datadog-agent/pkg/logs/internal/util/containersorpods"
+	"github.com/DataDog/datadog-agent/pkg/logs/pipeline"
+	"github.com/DataDog/datadog-agent/pkg/logs/schedulers"
+	adScheduler "github.com/DataDog/datadog-agent/pkg/logs/schedulers/ad"
+	ccaScheduler "github.com/DataDog/datadog-agent/pkg/logs/schedulers/cca"
+	"github.com/DataDog/datadog-agent/pkg/logs/service"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
+	"github.com/DataDog/datadog-agent/pkg/status/health"
+	"github.com/DataDog/datadog-agent/pkg/util"
+	ddUtil "github.com/DataDog/datadog-agent/pkg/util"
+)
+
+// NewAgent returns a new Logs Agent
+func NewAgent(sources *sources.LogSources, services *service.Services, processingRules []*config.ProcessingRule, endpoints *config.Endpoints) *Agent {
+	health := health.RegisterLiveness("logs-agent")
+
+	// setup the auditor
+	// We pass the health handle to the auditor because it's the end of the pipeline and the most
+	// critical part. Arguably it could also be plugged to the destination.
+	auditorTTL := time.Duration(coreConfig.Datadog.GetInt("logs_config.auditor_ttl")) * time.Hour
+	auditor := auditor.New(coreConfig.Datadog.GetString("logs_config.run_path"), auditor.DefaultRegistryFilename, auditorTTL, health)
+	destinationsCtx := client.NewDestinationsContext()
+	diagnosticMessageReceiver := diagnostic.NewBufferedMessageReceiver()
+
+	// setup the pipeline provider that provides pairs of processor and sender
+	pipelineProvider := pipeline.NewProvider(config.NumberOfPipelines, auditor, diagnosticMessageReceiver, processingRules, endpoints, destinationsCtx)
+
+	cop := containersorpods.NewChooser()
+
+	// setup the launchers
+	lnchrs := launchers.NewLaunchers(sources, pipelineProvider, auditor)
+	lnchrs.AddLauncher(filelauncher.NewLauncher(
+		coreConfig.Datadog.GetInt("logs_config.open_files_limit"),
+		filelauncher.DefaultSleepDuration,
+		coreConfig.Datadog.GetBool("logs_config.validate_pod_container_id"),
+		time.Duration(coreConfig.Datadog.GetFloat64("logs_config.file_scan_period")*float64(time.Second)),
+		coreConfig.Datadog.GetString("logs_config.file_wildcard_selection_mode")))
+	lnchrs.AddLauncher(listener.NewLauncher(coreConfig.Datadog.GetInt("logs_config.frame_size")))
+	lnchrs.AddLauncher(journald.NewLauncher())
+	lnchrs.AddLauncher(windowsevent.NewLauncher())
+	if !util.CcaInAD() {
+		lnchrs.AddLauncher(docker.NewLauncher(
+			time.Duration(coreConfig.Datadog.GetInt("logs_config.docker_client_read_timeout"))*time.Second,
+			sources,
+			services,
+			cop,
+			coreConfig.Datadog.GetBool("logs_config.docker_container_use_file"),
+			coreConfig.Datadog.GetBool("logs_config.docker_container_force_use_file")))
+		lnchrs.AddLauncher(kubernetes.NewLauncher(
+			sources,
+			services,
+			cop,
+			coreConfig.Datadog.GetBool("logs_config.container_collect_all")))
+	} else {
+		lnchrs.AddLauncher(container.NewLauncher(sources))
+	}
+
+	return &Agent{
+		sources:                   sources,
+		services:                  services,
+		schedulers:                schedulers.NewSchedulers(sources, services),
+		auditor:                   auditor,
+		destinationsCtx:           destinationsCtx,
+		pipelineProvider:          pipelineProvider,
+		launchers:                 lnchrs,
+		health:                    health,
+		diagnosticMessageReceiver: diagnosticMessageReceiver,
+	}
+}
+
+// Start starts logs-agent
+// getAC is a func returning the prepared AutoConfig. It is nil until
+// the AutoConfig is ready, please consider using BlockUntilAutoConfigRanOnce
+// instead of directly using it.
+func Start(ac *autodiscovery.AutoConfig) (*Agent, error) {
+	agent, err := start()
+	if err != nil {
+		return nil, err
+	}
+	if ac == nil {
+		panic("AutoConfig must be initialized before logs-agent")
+	}
+	agent.AddScheduler(adScheduler.New(ac))
+	if !ddUtil.CcaInAD() {
+		agent.AddScheduler(ccaScheduler.New(ac))
+	}
+	return agent, nil
+}
+
+// buildEndpoints builds endpoints for the logs agent
+func buildEndpoints() (*config.Endpoints, error) {
+	httpConnectivity := config.HTTPConnectivityFailure
+	if endpoints, err := config.BuildHTTPEndpointsWithVectorOverride(intakeTrackType, AgentJSONIntakeProtocol, config.DefaultIntakeOrigin); err == nil {
+		httpConnectivity = http.CheckConnectivity(endpoints.Main)
+	}
+	return config.BuildEndpointsWithVectorOverride(httpConnectivity, intakeTrackType, AgentJSONIntakeProtocol, config.DefaultIntakeOrigin)
+}

--- a/pkg/logs/agent_serverless.go
+++ b/pkg/logs/agent_serverless.go
@@ -1,0 +1,64 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build serverless
+// +build serverless
+
+package logs
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/logs/auditor"
+	"github.com/DataDog/datadog-agent/pkg/logs/client"
+	"github.com/DataDog/datadog-agent/pkg/logs/config"
+	"github.com/DataDog/datadog-agent/pkg/logs/diagnostic"
+	"github.com/DataDog/datadog-agent/pkg/logs/internal/launchers"
+	"github.com/DataDog/datadog-agent/pkg/logs/internal/launchers/channel"
+	"github.com/DataDog/datadog-agent/pkg/logs/pipeline"
+	"github.com/DataDog/datadog-agent/pkg/logs/schedulers"
+	"github.com/DataDog/datadog-agent/pkg/logs/service"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
+	"github.com/DataDog/datadog-agent/pkg/status/health"
+)
+
+// Note: Building the logs-agent for serverless separately removes the
+// dependency on autodiscovery, file launchers, and some schedulers
+// thereby decreasing the binary size.
+
+// NewAgent returns a Logs Agent instance to run in a serverless environment.
+// The Serverless Logs Agent has only one input being the channel to receive the logs to process.
+// It is using a NullAuditor because we've nothing to do after having sent the logs to the intake.
+func NewAgent(sources *sources.LogSources, services *service.Services, processingRules []*config.ProcessingRule, endpoints *config.Endpoints) *Agent {
+	health := health.RegisterLiveness("logs-agent")
+
+	diagnosticMessageReceiver := diagnostic.NewBufferedMessageReceiver()
+
+	// setup the a null auditor, not tracking data in any registry
+	auditor := auditor.NewNullAuditor()
+	destinationsCtx := client.NewDestinationsContext()
+
+	// setup the pipeline provider that provides pairs of processor and sender
+	pipelineProvider := pipeline.NewServerlessProvider(config.NumberOfPipelines, auditor, processingRules, endpoints, destinationsCtx)
+
+	// setup the sole launcher for this agent
+	lnchrs := launchers.NewLaunchers(sources, pipelineProvider, auditor)
+	lnchrs.AddLauncher(channel.NewLauncher())
+
+	return &Agent{
+		sources:                   sources,
+		services:                  services,
+		schedulers:                schedulers.NewSchedulers(sources, services),
+		auditor:                   auditor,
+		destinationsCtx:           destinationsCtx,
+		pipelineProvider:          pipelineProvider,
+		launchers:                 lnchrs,
+		health:                    health,
+		diagnosticMessageReceiver: diagnosticMessageReceiver,
+	}
+}
+
+// buildEndpoints builds endpoints for the logs agent
+func buildEndpoints() (*config.Endpoints, error) {
+	return config.BuildServerlessEndpoints(intakeTrackType, config.DefaultIntakeProtocol)
+}

--- a/pkg/logs/agent_test.go
+++ b/pkg/logs/agent_test.go
@@ -3,6 +3,9 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build !serverless
+// +build !serverless
+
 package logs
 
 import (

--- a/pkg/logs/logs_not_serverless_test.go
+++ b/pkg/logs/logs_not_serverless_test.go
@@ -3,6 +3,9 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build !serverless
+// +build !serverless
+
 package logs
 
 import (
@@ -11,15 +14,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestBuildServerlessEndpoints(t *testing.T) {
-	endpoints, err := buildEndpoints(true)
-	assert.Nil(t, err)
-	assert.Equal(t, "http-intake.logs.datadoghq.com", endpoints.Main.Host)
-	assert.Equal(t, "lambda-extension", string(endpoints.Main.Origin))
-}
-
 func TestBuildEndpoints(t *testing.T) {
-	endpoints, err := buildEndpoints(false)
+	endpoints, err := buildEndpoints()
 	assert.Nil(t, err)
 	assert.Equal(t, "agent-intake.logs.datadoghq.com", endpoints.Main.Host)
 }

--- a/pkg/logs/logs_serverless_test.go
+++ b/pkg/logs/logs_serverless_test.go
@@ -1,0 +1,22 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build serverless
+// +build serverless
+
+package logs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildServerlessEndpoints(t *testing.T) {
+	endpoints, err := buildEndpoints()
+	assert.Nil(t, err)
+	assert.Equal(t, "http-intake.logs.datadoghq.com", endpoints.Main.Host)
+	assert.Equal(t, "lambda-extension", string(endpoints.Main.Origin))
+}

--- a/pkg/serializer/types_sbom.go
+++ b/pkg/serializer/types_sbom.go
@@ -3,6 +3,9 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2022-present Datadog, Inc.
 
+//go:build !serverless
+// +build !serverless
+
 package serializer
 
 import (

--- a/pkg/serializer/types_sbom_serverless.go
+++ b/pkg/serializer/types_sbom_serverless.go
@@ -1,0 +1,25 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
+//go:build serverless
+// +build serverless
+
+package serializer
+
+import "google.golang.org/protobuf/reflect/protoreflect"
+
+// SBOMMessage is a type alias for SBOM proto payload and is not needed in
+// serverless mode
+type SBOMMessage struct {
+	Version  int
+	Host     string
+	Source   *string
+	Entities []interface{}
+}
+
+var _ protoreflect.ProtoMessage = (*SBOMMessage)(nil)
+
+// ProtoReflect allows SBOMMessage to implement protoreflect.ProtoMessage
+func (s *SBOMMessage) ProtoReflect() protoreflect.Message { return nil }

--- a/pkg/trace/api/debug_server.go
+++ b/pkg/trace/api/debug_server.go
@@ -3,6 +3,9 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2023-present Datadog, Inc.
 
+//go:build !serverless
+// +build !serverless
+
 package api
 
 import (

--- a/pkg/trace/api/debug_server_serverless.go
+++ b/pkg/trace/api/debug_server_serverless.go
@@ -1,0 +1,20 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+//go:build serverless
+// +build serverless
+
+package api
+
+import "github.com/DataDog/datadog-agent/pkg/trace/config"
+
+type DebugServer struct{}
+
+func NewDebugServer(conf *config.AgentConfig) *DebugServer {
+	return new(DebugServer)
+}
+
+func (*DebugServer) Start() {}
+func (*DebugServer) Stop()  {}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This pull request uses build tags to reduce the size of the serverless extension. Specifically, it removes the dependency on `golang.org/x/text/encoding` and reduces binary size from 42433176 to 41930304, or a total savings of 502872. (note I am only 80% certain these numbers are in bytes)



<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Increases in binary size directly correlate to increases in cold start time.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

Dependency graph before this change:

![golang org_x_text_encoding](https://user-images.githubusercontent.com/1383216/221256300-75949ab3-3837-40b6-99e6-7a57db7cfc4f.svg)

The `golang.org/x/text/encoding` package was being used for reading log files directly from the filesystem. However, we do not support this in serverless and the code was inaccessible anyway. This PR just changes how we load the code, from using a `bool` in a method signature to using a build tag.

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
