### PR TITLE
[Admission][e2e] Use the official .NET lib image

### DIFF
--- a/test/e2e/argo-workflows/templates/mutate-busybox.yaml
+++ b/test/e2e/argo-workflows/templates/mutate-busybox.yaml
@@ -146,7 +146,7 @@ spec:
               "app": "busybox"
               "admission.datadoghq.com/enabled": "true"
             annotations:
-              admission.datadoghq.com/dotnet-lib.custom-image: "ghcr.io/datadog/dd-trace-dotnet/dd-lib-dotnet-init:a43a0170de4c469864385fa2cc38cad48fb91bad" # TODO: Use the default repo when ready
+              admission.datadoghq.com/dotnet-lib.version: "latest"
           spec:
             containers:
               - command:


### PR DESCRIPTION
### What does this PR do?
Use the official .NET lib image in the auto-instrumentation e2e tests

### Motivation

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes


### Reviewer's Checklist
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
