### PR TITLE
pkg/trace/api: Resolve dogstatsd address to be consistent

### DIFF
--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -156,7 +156,7 @@ func (r *HTTPReceiver) Start() {
 		ConnContext:  connContext,
 	}
 
-	addr := fmt.Sprintf("%s:%d", r.conf.ReceiverHost, r.conf.ReceiverPort)
+	addr := net.JoinHostPort(r.conf.ReceiverHost, strconv.Itoa(r.conf.ReceiverPort))
 	ln, err := r.listenTCP(addr)
 	if err != nil {
 		r.telemetryCollector.SendStartupError(telemetry.CantStartHttpServer, err)

--- a/pkg/trace/api/dogstatsd.go
+++ b/pkg/trace/api/dogstatsd.go
@@ -7,10 +7,10 @@ package api
 
 import (
 	"bytes"
-	"fmt"
 	"io"
 	"net"
 	"net/http"
+	"strconv"
 
 	"github.com/DataDog/datadog-agent/pkg/trace/log"
 )
@@ -25,6 +25,13 @@ func (r *HTTPReceiver) dogstatsdProxyHandler() http.Handler {
 			http.Error(w, "503 Status Unavailable", http.StatusServiceUnavailable)
 		})
 	}
+	addr, err := net.ResolveUDPAddr("udp", net.JoinHostPort(r.conf.StatsdHost, strconv.Itoa(r.conf.StatsdPort)))
+	if err != nil {
+		log.Errorf("Error resolving dogstatsd proxy addr to %s endpoint at %q: %v", "udp", addr, err)
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "503 Status Unavailable", http.StatusServiceUnavailable)
+		})
+	}
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		body, err := io.ReadAll(req.Body)
 		if err != nil {
@@ -33,15 +40,13 @@ func (r *HTTPReceiver) dogstatsdProxyHandler() http.Handler {
 		}
 		payloads := bytes.Split(body, []byte("\n"))
 
-		var network, address string
 		if r.conf.StatsdPort == 0 {
 			http.Error(w, "Agent dogstatsd UDP port not configured, but required for dogstatsd proxy.", http.StatusServiceUnavailable)
 			return
 		}
-		network, address = "udp", fmt.Sprintf("%s:%d", r.conf.StatsdHost, r.conf.StatsdPort)
-		conn, err := net.Dial(network, address)
+		conn, err := net.DialUDP("udp", nil, addr)
 		if err != nil {
-			log.Errorf("Error connecting to %s endpoint at %q: %v", network, address, err)
+			log.Errorf("Error connecting to %s endpoint at %q: %v", "udp", addr, err)
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}

--- a/pkg/trace/api/dogstatsd_test.go
+++ b/pkg/trace/api/dogstatsd_test.go
@@ -80,66 +80,72 @@ func TestDogStatsDReverseProxyEndToEndUDP(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping in short mode")
 	}
+	cfg := config.New()
 	port, err := getAvailableUDPPort()
 	if err != nil {
 		t.Skip("Couldn't find available UDP port to run test. Skipping.")
 	}
-	cfg := config.New()
-	cfg.StatsdHost = "localhost"
-	cfg.StatsdPort = port
-
-	address := fmt.Sprintf("%s:%d", cfg.StatsdHost, cfg.StatsdPort)
-	ln, err := net.ListenPacket("udp", address)
+	p, err := strconv.Atoi(port)
 	if err != nil {
-		t.Fatalf("failed to create listener on %q: %v", address, err)
+		t.Fatalf("can't convert udp port to string: %v", err)
 	}
-	defer ln.Close()
+	cfg.StatsdPort = p
+	hosts := []string{"localhost", "127.0.0.1", "::1"}
+	for _, host := range hosts {
+		t.Run(fmt.Sprintf("host=%q", host), func(t *testing.T) {
+			cfg.StatsdHost = host
+			addr, err := net.ResolveUDPAddr("udp", net.JoinHostPort(host, port))
+			if err != nil {
+				t.Fatalf("could not resolve udp addr: %s", err)
+			}
+			conn, err := net.ListenUDP("udp", addr)
+			if err != nil {
+				t.Fatalf("can't listen: %s", err)
+			}
+			defer conn.Close()
 
-	receiver := newTestReceiverFromConfig(cfg)
-	proxy := receiver.dogstatsdProxyHandler()
-	require.NotNil(t, proxy)
-	rec := httptest.NewRecorder()
+			receiver := newTestReceiverFromConfig(cfg)
+			proxy := receiver.dogstatsdProxyHandler()
+			require.NotNil(t, proxy)
+			rec := httptest.NewRecorder()
 
-	// Send two payloads separated by a newline.
-	payloads := [][]byte{[]byte("daemon:666|g|#sometag1:somevalue1,sometag2:somevalue2"), []byte("_e{21,36}:An exception occurred|Cannot parse CSV file from\\n10.0.0.17|t:warning|#err_type:bad_file")}
-	sep := []byte("\n")
-	msg := bytes.Join(payloads, sep)
-	body := io.NopCloser(bytes.NewBuffer(msg))
-	proxy.ServeHTTP(rec, httptest.NewRequest("POST", "/", body))
-	require.Equal(t, http.StatusOK, rec.Code)
+			// Send two payloads separated by a newline.
+			payloads := [][]byte{[]byte("daemon:666|g|#sometag1:somevalue1,sometag2:somevalue2"), []byte("_e{21,36}:An exception occurred|Cannot parse CSV file from\\n10.0.0.17|t:warning|#err_type:bad_file")}
+			sep := []byte("\n")
+			msg := bytes.Join(payloads, sep)
+			body := io.NopCloser(bytes.NewBuffer(msg))
+			proxy.ServeHTTP(rec, httptest.NewRequest("POST", "/", body))
+			require.Equal(t, http.StatusOK, rec.Code)
 
-	// Check that both payloads were sent over (without a newline).
-	ln.SetReadDeadline(time.Now().Add(5 * time.Second))
-	buf := make([]byte, len(msg)-len(sep))
-	n, _, err := ln.ReadFrom(buf)
-	require.NoError(t, err)
-	if got, want := buf[:n], payloads[0]; !bytes.Equal(got, want) {
-		t.Errorf("got first payload: %q\nwant first payload: %q", got, want)
-	}
-	_, _, err = ln.ReadFrom(buf[n:])
-	require.NoError(t, err)
-	if got, want := buf[n:], payloads[1]; !bytes.Equal(got, want) {
-		t.Errorf("got second payload: %q\nwant second payload: %q", got, want)
+			// Check that both payloads were sent over (without a newline).
+			conn.SetReadDeadline(time.Now().Add(10 * time.Second))
+			buf := make([]byte, len(msg)-len(sep))
+			n, _, err := conn.ReadFrom(buf)
+			require.NoError(t, err)
+			if got, want := buf[:n], payloads[0]; !bytes.Equal(got, want) {
+				t.Errorf("got first payload: %q\nwant first payload: %q", got, want)
+			}
+			_, _, err = conn.ReadFrom(buf[n:])
+			require.NoError(t, err)
+			if got, want := buf[n:], payloads[1]; !bytes.Equal(got, want) {
+				t.Errorf("got second payload: %q\nwant second payload: %q", got, want)
+			}
+		})
 	}
 }
 
 // getAvailableUDPPort requests a random port number and makes sure it is available
-func getAvailableUDPPort() (int, error) {
+func getAvailableUDPPort() (string, error) {
 	// This is based on pkg/dogstatsd/server_test.go.
 	conn, err := net.ListenPacket("udp", ":0")
 	if err != nil {
-		return -1, fmt.Errorf("can't find an available udp port: %s", err)
+		return "", fmt.Errorf("can't find an available udp port: %s", err)
 	}
 	defer conn.Close()
 
-	_, portString, err := net.SplitHostPort(conn.LocalAddr().String())
+	_, port, err := net.SplitHostPort(conn.LocalAddr().String())
 	if err != nil {
-		return -1, fmt.Errorf("can't find an available udp port: %s", err)
+		return "", fmt.Errorf("can't find an available udp port: %s", err)
 	}
-	portInt, err := strconv.Atoi(portString)
-	if err != nil {
-		return -1, fmt.Errorf("can't convert udp port: %s", err)
-	}
-
-	return portInt, nil
+	return port, nil
 }

--- a/pkg/trace/api/dogstatsd_test.go
+++ b/pkg/trace/api/dogstatsd_test.go
@@ -16,8 +16,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/trace/config"
 	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/trace/config"
 )
 
 func TestDogStatsDReverseProxy(t *testing.T) {
@@ -84,7 +85,7 @@ func TestDogStatsDReverseProxyEndToEndUDP(t *testing.T) {
 		t.Skip("Couldn't find available UDP port to run test. Skipping.")
 	}
 	cfg := config.New()
-	cfg.StatsdHost = "127.0.0.1"
+	cfg.StatsdHost = "localhost"
 	cfg.StatsdPort = port
 
 	address := fmt.Sprintf("%s:%d", cfg.StatsdHost, cfg.StatsdPort)
@@ -108,7 +109,7 @@ func TestDogStatsDReverseProxyEndToEndUDP(t *testing.T) {
 	require.Equal(t, http.StatusOK, rec.Code)
 
 	// Check that both payloads were sent over (without a newline).
-	ln.SetReadDeadline(time.Now().Add(30 * time.Second))
+	ln.SetReadDeadline(time.Now().Add(5 * time.Second))
 	buf := make([]byte, len(msg)-len(sep))
 	n, _, err := ln.ReadFrom(buf)
 	require.NoError(t, err)

--- a/pkg/trace/metrics/metrics.go
+++ b/pkg/trace/metrics/metrics.go
@@ -12,7 +12,8 @@ package metrics
 
 import (
 	"errors"
-	"fmt"
+	"net"
+	"strconv"
 
 	"github.com/DataDog/datadog-go/v5/statsd"
 
@@ -23,7 +24,7 @@ import (
 func findAddr(conf *config.AgentConfig) (string, error) {
 	if conf.StatsdPort > 0 {
 		// UDP enabled
-		return fmt.Sprintf("%s:%d", conf.StatsdHost, conf.StatsdPort), nil
+		return net.JoinHostPort(conf.StatsdHost, strconv.Itoa(conf.StatsdPort)), nil
 	}
 	if conf.StatsdPipeName != "" {
 		// Windows Pipes can be used

--- a/pkg/trace/metrics/metrics_test.go
+++ b/pkg/trace/metrics/metrics_test.go
@@ -20,13 +20,22 @@ func TestFindAddr(t *testing.T) {
 		assert.Equal(t, addr, `\\.\pipe\sock.pipe`)
 	})
 
-	t.Run("tcp", func(t *testing.T) {
+	t.Run("udp-localhost", func(t *testing.T) {
 		addr, err := findAddr(&config.AgentConfig{
 			StatsdHost: "localhost",
 			StatsdPort: 123,
 		})
 		assert.NoError(t, err)
 		assert.Equal(t, addr, `localhost:123`)
+	})
+
+	t.Run("udp-ipv6", func(t *testing.T) {
+		addr, err := findAddr(&config.AgentConfig{
+			StatsdHost: "::1",
+			StatsdPort: 123,
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, addr, `[::1]:123`) // must add the square brackets to properly connect
 	})
 
 	t.Run("socket", func(t *testing.T) {

--- a/releasenotes/notes/DogstatsdproxyFix-8d768c49b95d02b4.yaml
+++ b/releasenotes/notes/DogstatsdproxyFix-8d768c49b95d02b4.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    APM: Fix issue where dogstatsd proxy would not work when bind address was set to localhost on MacOS.

--- a/releasenotes/notes/DogstatsdproxyFix-8d768c49b95d02b4.yaml
+++ b/releasenotes/notes/DogstatsdproxyFix-8d768c49b95d02b4.yaml
@@ -9,3 +9,4 @@
 fixes:
   - |
     APM: Fix issue where dogstatsd proxy would not work when bind address was set to localhost on MacOS.
+    APM: Fix issue where setting bind_host to "::1" would break runtime metrics for the trace-agent.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
This adds address resolution for the dogstatsd proxy.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Turns out on MacOS only when dogstatsd resolves `localhost` (the agent default bind addr) it becomes `127.0.0.1` and only listens on that address. That would normally be fine, but our proxy code would resolve `localhost` to `[::1]` causing any connection to it to fail with Connection Refused. Now we just resolve the address directly using the same method as dogstatsd to ensure consistency.
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
Skip QA, we've got the unit tests for this. We've also verified this behavior manually locally on MacOS.
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
