### PR TITLE
[CSPM] Make telemetry registration safe for concurrent usage

### DIFF
--- a/pkg/compliance/metrics/rego.go
+++ b/pkg/compliance/metrics/rego.go
@@ -15,6 +15,12 @@ import (
 	"github.com/spf13/cast"
 )
 
+var (
+	registrationMu       sync.Mutex
+	registeredHistograms map[string]telemetry.Histogram
+	registeredCounters   map[string]telemetry.Counter
+)
+
 func NewRegoTelemetry() *regoTelemetry {
 	return &regoTelemetry{
 		inner:      opametrics.New(),
@@ -24,9 +30,10 @@ func NewRegoTelemetry() *regoTelemetry {
 	}
 }
 
-var registeredHistograms map[string]telemetry.Histogram
-
 func registerHistogram(name string) telemetry.Histogram {
+	registrationMu.Lock()
+	defer registrationMu.Unlock()
+
 	if registeredHistograms == nil {
 		registeredHistograms = make(map[string]telemetry.Histogram)
 	}
@@ -45,9 +52,10 @@ func registerHistogram(name string) telemetry.Histogram {
 	return histogram
 }
 
-var registeredCounters map[string]telemetry.Counter
-
 func registerCounter(name string) telemetry.Counter {
+	registrationMu.Lock()
+	defer registrationMu.Unlock()
+
 	if registeredCounters == nil {
 		registeredCounters = make(map[string]telemetry.Counter)
 	}


### PR DESCRIPTION

### What does this PR do?

Fix possible race condition when registering global metrics, histograms and gauges for telemetry of our rego evaluation in `pkg/compliance/metrics`.

### Motivation

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
