### PR TITLE
USM : rename http_flush_batch() to http_batch_flush()

### DIFF
--- a/pkg/network/ebpf/c/protocols/tls/java-tls-erpc.h
+++ b/pkg/network/ebpf/c/protocols/tls/java-tls-erpc.h
@@ -39,7 +39,7 @@ static int __always_inline handle_request(struct pt_regs *ctx, conn_tuple_t* con
     bpf_map_update_with_telemetry(java_tls_connections, connection, &val, BPF_ANY);
     log_debug("[java-tls-handle_request] handling tls request of size: %d\n", bytes_read);
     https_process(connection, data+sizeof(bytes_read), bytes_read, JAVA_TLS);
-    http_flush_batch(ctx);
+    http_batch_flush(ctx);
     return 0;
 }
 


### PR DESCRIPTION
### What does this PR do?

Fixing last PR merge due to the refactoring meged on Friday #15609 55b470de0c93aa0ed5fe00f7d3f7163921318f42

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
