### PR TITLE
[workloadmeta/containerd] Fix race condition in SBOM collection

### DIFF
--- a/pkg/workloadmeta/collectors/internal/containerd/containerd.go
+++ b/pkg/workloadmeta/collectors/internal/containerd/containerd.go
@@ -99,14 +99,7 @@ type collector struct {
 	handleImagesMut sync.Mutex
 
 	// SBOM Scanning
-	trivyClient  trivy.Collector // nolint: unused
-	imagesToScan chan namespacedImage
-}
-
-type namespacedImage struct {
-	namespace string
-	image     containerd.Image
-	imageID   string
+	trivyClient trivy.Collector // nolint: unused
 }
 
 func init() {
@@ -156,10 +149,6 @@ func (c *collector) Start(ctx context.Context, store workloadmeta.Store) error {
 			}
 		}()
 		defer cancelEvents()
-
-		if c.imagesToScan != nil {
-			defer close(c.imagesToScan)
-		}
 
 		c.stream(ctx)
 	}()

--- a/pkg/workloadmeta/collectors/internal/containerd/image.go
+++ b/pkg/workloadmeta/collectors/internal/containerd/image.go
@@ -342,15 +342,6 @@ func (c *collector) notifyEventForImage(ctx context.Context, namespace string, i
 		},
 	})
 
-	if existingBOM == nil && sbomCollectionIsEnabled() {
-		// Notify image scanner
-		c.imagesToScan <- namespacedImage{
-			namespace: namespace,
-			image:     img,
-			imageID:   imageID,
-		}
-	}
-
 	return nil
 }
 

--- a/pkg/workloadmeta/collectors/internal/containerd/image_sbom_stub.go
+++ b/pkg/workloadmeta/collectors/internal/containerd/image_sbom_stub.go
@@ -12,10 +12,6 @@ import (
 	"context"
 )
 
-func sbomCollectionIsEnabled() bool {
-	return false
-}
-
 func (c *collector) startSBOMCollection(context.Context) error {
 	return nil
 }

--- a/pkg/workloadmeta/collectors/internal/containerd/image_sbom_trivy.go
+++ b/pkg/workloadmeta/collectors/internal/containerd/image_sbom_trivy.go
@@ -53,7 +53,48 @@ func (c *collector) startSBOMCollection(ctx context.Context) error {
 		return fmt.Errorf("error initializing trivy client: %w", err)
 	}
 
-	c.imagesToScan = make(chan namespacedImage, imagesToScanBufferSize)
+	imgEventsCh := c.store.Subscribe(
+		"SBOM collector",
+		workloadmeta.NormalPriority,
+		workloadmeta.NewFilter(
+			[]workloadmeta.Kind{workloadmeta.KindContainerImageMetadata},
+			workloadmeta.SourceAll,
+			workloadmeta.EventTypeSet,
+		),
+	)
+
+	imagesToScanCh := make(chan *workloadmeta.ContainerImageMetadata, imagesToScanBufferSize)
+
+	go func() {
+		for {
+			select {
+			// We don't want to keep scanning if image channel is not empty but context is expired
+			case <-ctx.Done():
+				close(imagesToScanCh)
+				return
+
+			case eventBundle := <-imgEventsCh:
+				close(eventBundle.Ch)
+
+				for _, event := range eventBundle.Events {
+					image := event.Entity.(*workloadmeta.ContainerImageMetadata)
+
+					if image.SBOM != nil {
+						// BOM already stored. Can happen when the same image ID
+						// is referenced with different names.
+						log.Debugf("Image: %s/%s (id %s) SBOM already available", image.Namespace, image.Name, image.ID)
+						continue
+					}
+
+					// Don't scan the image here. Enqueue it instead because we
+					// need to keep reading events from workloadmeta to avoid
+					// blocking it.
+
+					imagesToScanCh <- image
+				}
+			}
+		}
+	}()
 
 	go func() {
 		defer func() {
@@ -63,42 +104,24 @@ func (c *collector) startSBOMCollection(ctx context.Context) error {
 			}
 		}()
 
-		for {
-			select {
-			// We don't want to keep scanning if image channel is not empty but context is expired
-			case <-ctx.Done():
-				return
-
-			case image, ok := <-c.imagesToScan:
-				// Channel has been closed we should exit
-				if !ok {
-					return
-				}
-
-				scanContext, cancel := context.WithTimeout(ctx, scanningTimeout())
-				if err := c.extractBOMWithTrivy(scanContext, image); err != nil {
-					log.Warnf("Error extracting SBOM for image: namespace=%s name=%s, err: %s", image.namespace, image.image.Name(), err)
-				}
-				cancel()
+		for image := range imagesToScanCh {
+			scanContext, cancel := context.WithTimeout(ctx, scanningTimeout())
+			if err := c.extractBOMWithTrivy(scanContext, image); err != nil {
+				log.Warnf("Error extracting SBOM for image: namespace=%s name=%s, err: %s", image.Namespace, image.Name, err)
 			}
+			cancel()
+
+			time.Sleep(timeBetweenScans())
 		}
 	}()
 
 	return nil
 }
 
-func (c *collector) extractBOMWithTrivy(ctx context.Context, imageToScan namespacedImage) error {
-	storedImage, err := c.store.GetImage(imageToScan.imageID)
+func (c *collector) extractBOMWithTrivy(ctx context.Context, image *workloadmeta.ContainerImageMetadata) error {
+	containerdImage, err := c.containerdClient.Image(image.Namespace, image.Name)
 	if err != nil {
-		log.Infof("Image: %s/%s (id %s) not found in Workloadmeta, skipping scan", imageToScan.namespace, imageToScan.image.Name(), imageToScan.imageID)
-		return nil
-	}
-
-	if storedImage.SBOM != nil {
-		// BOM already stored. Can happen when the same image ID is referenced
-		// with different names.
-		log.Debugf("Image: %s/%s (id %s) SBOM already available", imageToScan.namespace, imageToScan.image.Name(), imageToScan.imageID)
-		return nil
+		return err
 	}
 
 	scanFunc := c.trivyClient.ScanContainerdImage
@@ -107,7 +130,7 @@ func (c *collector) extractBOMWithTrivy(ctx context.Context, imageToScan namespa
 	}
 
 	tStartScan := time.Now()
-	cycloneDXBOM, err := scanFunc(ctx, storedImage, imageToScan.image)
+	cycloneDXBOM, err := scanFunc(ctx, image, containerdImage)
 	if err != nil {
 		return err
 	}
@@ -122,11 +145,9 @@ func (c *collector) extractBOMWithTrivy(ctx context.Context, imageToScan namespa
 		GenerationDuration: scanDuration,
 	}
 
-	time.Sleep(timeBetweenScans())
-
 	// Updating workloadmeta entities directly is not thread-safe, that's why we
 	// generate an update event here instead.
-	return c.handleImageCreateOrUpdate(ctx, imageToScan.namespace, storedImage.Name, &sbom)
+	return c.handleImageCreateOrUpdate(ctx, image.Namespace, image.Name, &sbom)
 }
 
 func scanningTimeout() time.Duration {

--- a/releasenotes/notes/workloadmeta-sbom-scan-race-condition-ca7b274ee4faa377.yaml
+++ b/releasenotes/notes/workloadmeta-sbom-scan-race-condition-ca7b274ee4faa377.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixed a bug in the SBOM collection feature. In certain cases, some SBOMs were
+    not collected.


### PR DESCRIPTION
### What does this PR do?

Fixes a bug in the SBOM collection feature.

This PR fixes a race condition that makes the sbom extraction fail sometimes because it cannot find the image in workloadmeta. This is the error shown: https://github.com/DataDog/datadog-agent/blob/8651255b6a3b267eaeee6e2670ec8987a14cabf6/pkg/workloadmeta/collectors/internal/containerd/image_sbom_trivy.go#L92

The error happens because when we notify workloadmeta of a new image, we immediately enqueue the sbom collection job without waiting until workloadmeta had time to process the event and store the image.


### Describe how to test/QA your changes

Deploy the agent on an environment with containerd, image metadata collection enabled (`DD_CONTAINER_IMAGE_COLLECTION_METADATA_ENABLED=true`), and SBOM collection enabled (`DD_CONTAINER_IMAGE_COLLECTION_SBOM_ENABLED=true`).

Pull several images and check that the error linked above doesn't appear and that the SBOMs are stored (`agent workload-list --verbose | grep SBOM`).

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
