### PR TITLE
[fakeintake] add stats endpoint

### DIFF
--- a/test/fakeintake/api/api.go
+++ b/test/fakeintake/api/api.go
@@ -8,3 +8,12 @@ package api
 type APIFakeIntakePayloadsGETResponse struct {
 	Payloads [][]byte `json:"payloads"`
 }
+
+type RouteStat struct {
+	ID    string `json:"id"`
+	Count int    `json:"count"`
+}
+
+type APIFakeIntakeRouteStatsGETResponse struct {
+	Routes []RouteStat `json:"routes"`
+}

--- a/test/fakeintake/api/api.go
+++ b/test/fakeintake/api/api.go
@@ -15,5 +15,5 @@ type RouteStat struct {
 }
 
 type APIFakeIntakeRouteStatsGETResponse struct {
-	Routes []RouteStat `json:"routes"`
+	Routes map[string]RouteStat `json:"routes"`
 }

--- a/test/fakeintake/server/server.go
+++ b/test/fakeintake/server/server.go
@@ -201,10 +201,10 @@ func (fi *Server) getRouteStats(w http.ResponseWriter, req *http.Request) {
 	routes := fi.safeGetRouteStats()
 	// build response
 	resp := api.APIFakeIntakeRouteStatsGETResponse{
-		Routes: []api.RouteStat{},
+		Routes: map[string]api.RouteStat{},
 	}
 	for route, count := range routes {
-		resp.Routes = append(resp.Routes, api.RouteStat{ID: route, Count: count})
+		resp.Routes[route] = api.RouteStat{ID: route, Count: count}
 	}
 	jsonResp, err := json.Marshal(resp)
 	if err != nil {

--- a/test/fakeintake/server/server.go
+++ b/test/fakeintake/server/server.go
@@ -41,6 +41,7 @@ func NewServer(port int) *Server {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", fi.handleDatadogRequest)
 	mux.HandleFunc("/fakeintake/payloads/", fi.getPayloads)
+	mux.HandleFunc("/fakeintake/routestats/", fi.getRouteStats)
 
 	fi.server = http.Server{
 		Addr:    fmt.Sprintf(":%d", port),
@@ -193,4 +194,42 @@ func (fi *Server) safeGetPayloads(route string) [][]byte {
 		payloads = append(payloads, p.data)
 	}
 	return payloads
+}
+
+func (fi *Server) getRouteStats(w http.ResponseWriter, req *http.Request) {
+	log.Print("Handling getRouteStats request")
+	routes := fi.safeGetRouteStats()
+	// build response
+	resp := api.APIFakeIntakeRouteStatsGETResponse{
+		Routes: []api.RouteStat{},
+	}
+	for route, count := range routes {
+		resp.Routes = append(resp.Routes, api.RouteStat{ID: route, Count: count})
+	}
+	jsonResp, err := json.Marshal(resp)
+	if err != nil {
+		writeHttpResponse(w, httpResponse{
+			contentType: "text/plain",
+			statusCode:  http.StatusInternalServerError,
+			body:        []byte(err.Error()),
+		})
+		return
+	}
+
+	// send response
+	writeHttpResponse(w, httpResponse{
+		contentType: "application/json",
+		statusCode:  http.StatusOK,
+		body:        jsonResp,
+	})
+}
+
+func (fi *Server) safeGetRouteStats() map[string]int {
+	routes := map[string]int{}
+	fi.mu.Lock()
+	defer fi.mu.Unlock()
+	for route, payloads := range fi.payloadStore {
+		routes[route] = len(payloads)
+	}
+	return routes
 }

--- a/test/fakeintake/server/server_test.go
+++ b/test/fakeintake/server/server_test.go
@@ -128,12 +128,12 @@ func TestServer(t *testing.T) {
 		assert.Equal(t, http.StatusOK, getResponse.Code)
 
 		expectedGETResponse := api.APIFakeIntakeRouteStatsGETResponse{
-			Routes: []api.RouteStat{
-				{
+			Routes: map[string]api.RouteStat{
+				"/api/v2/series": {
 					ID:    "/api/v2/series",
 					Count: 2,
 				},
-				{
+				"/api/v2/logs": {
 					ID:    "/api/v2/logs",
 					Count: 1,
 				},

--- a/test/fakeintake/server/server_test.go
+++ b/test/fakeintake/server/server_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/test/fakeintake/api"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const testFakeIntakePort = 8081
@@ -88,22 +89,9 @@ func TestServer(t *testing.T) {
 		fi := NewServer(testFakeIntakePort)
 		defer fi.server.Close()
 
-		request, err := http.NewRequest(http.MethodPost, "/api/v2/series", strings.NewReader("totoro|5|tag:valid,owner:pducolin"))
-		assert.NoError(t, err, "Error creating POST request")
-		postResponse := httptest.NewRecorder()
-		fi.handleDatadogRequest(postResponse, request)
+		postSomePayloads(t, fi)
 
-		request, err = http.NewRequest(http.MethodPost, "/api/v2/series", strings.NewReader("totoro|7|tag:valid,owner:pducolin"))
-		assert.NoError(t, err, "Error creating POST request")
-		postResponse = httptest.NewRecorder()
-		fi.handleDatadogRequest(postResponse, request)
-
-		request, err = http.NewRequest(http.MethodPost, "/api/v2/logs", strings.NewReader("I am just a poor log"))
-		assert.NoError(t, err, "Error creating POST request")
-		postResponse = httptest.NewRecorder()
-		fi.handleDatadogRequest(postResponse, request)
-
-		request, err = http.NewRequest(http.MethodGet, "/fakeintake/payloads?endpoint=/api/v2/series", nil)
+		request, err := http.NewRequest(http.MethodGet, "/fakeintake/payloads?endpoint=/api/v2/series", nil)
 		assert.NoError(t, err, "Error creating GET request")
 		getResponse := httptest.NewRecorder()
 
@@ -124,4 +112,55 @@ func TestServer(t *testing.T) {
 
 		assert.Equal(t, expectedGETResponse, actualGETResponse, "unexpected GET response")
 	})
+
+	t.Run("should store multiple payloads on any route and return the list of routes", func(t *testing.T) {
+		fi := NewServer(testFakeIntakePort)
+		defer fi.server.Close()
+
+		postSomePayloads(t, fi)
+
+		request, err := http.NewRequest(http.MethodGet, "/fakeintake/routestats", nil)
+		assert.NoError(t, err, "Error creating GET request")
+		getResponse := httptest.NewRecorder()
+
+		fi.getRouteStats(getResponse, request)
+
+		assert.Equal(t, http.StatusOK, getResponse.Code)
+
+		expectedGETResponse := api.APIFakeIntakeRouteStatsGETResponse{
+			Routes: []api.RouteStat{
+				{
+					ID:    "/api/v2/series",
+					Count: 2,
+				},
+				{
+					ID:    "/api/v2/logs",
+					Count: 1,
+				},
+			},
+		}
+		actualGETResponse := api.APIFakeIntakeRouteStatsGETResponse{}
+		body, err := io.ReadAll(getResponse.Body)
+		assert.NoError(t, err, "Error reading GET response")
+		json.Unmarshal(body, &actualGETResponse)
+
+		assert.Equal(t, expectedGETResponse, actualGETResponse, "unexpected GET response")
+	})
+}
+
+func postSomePayloads(t *testing.T, fi *Server) {
+	request, err := http.NewRequest(http.MethodPost, "/api/v2/series", strings.NewReader("totoro|5|tag:valid,owner:pducolin"))
+	require.NoError(t, err, "Error creating POST request")
+	postResponse := httptest.NewRecorder()
+	fi.handleDatadogRequest(postResponse, request)
+
+	request, err = http.NewRequest(http.MethodPost, "/api/v2/series", strings.NewReader("totoro|7|tag:valid,owner:pducolin"))
+	require.NoError(t, err, "Error creating POST request")
+	postResponse = httptest.NewRecorder()
+	fi.handleDatadogRequest(postResponse, request)
+
+	request, err = http.NewRequest(http.MethodPost, "/api/v2/logs", strings.NewReader("I am just a poor log"))
+	require.NoError(t, err, "Error creating POST request")
+	postResponse = httptest.NewRecorder()
+	fi.handleDatadogRequest(postResponse, request)
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This endpoint returns the number of payloads received on any endpoint in the following format

```text
{
  routes: []{
      id: string,
      count: number,    
    }
}
```

Example:

```json
{
  "routes": [
    {
      "id": "/api/v2/metrics",
      "count": 42,    
    },
    {
      "id": "/api/v2/logs",
      "count": 20,    
    }
  ]
}
```


### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Useful during test and while adding new aggregators to the client.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
