### PR TITLE
USM: add missing http_batch_flush()

### DIFF
--- a/pkg/network/ebpf/c/prebuilt/http.c
+++ b/pkg/network/ebpf/c/prebuilt/http.c
@@ -350,6 +350,8 @@ int uprobe__SSL_shutdown(struct pt_regs* ctx) {
     }
 
     https_finish(t);
+    http_batch_flush(ctx);
+
     bpf_map_delete_elem(&ssl_sock_by_ctx, &ssl_ctx);
     return 0;
 }
@@ -515,6 +517,7 @@ SEC("uprobe/gnutls_bye")
 int uprobe__gnutls_bye(struct pt_regs *ctx) {
     void *ssl_session = (void *)PT_REGS_PARM1(ctx);
     gnutls_goodbye(ssl_session);
+    http_batch_flush(ctx);
     return 0;
 }
 
@@ -523,6 +526,7 @@ SEC("uprobe/gnutls_deinit")
 int uprobe__gnutls_deinit(struct pt_regs *ctx) {
     void *ssl_session = (void *)PT_REGS_PARM1(ctx);
     gnutls_goodbye(ssl_session);
+    http_batch_flush(ctx);
     return 0;
 }
 

--- a/pkg/network/ebpf/c/runtime/http.c
+++ b/pkg/network/ebpf/c/runtime/http.c
@@ -639,7 +639,7 @@ int uprobe__crypto_tls_Conn_Write(struct pt_regs *ctx) {
     tls_offsets_data_t* od = get_offsets_data();
     if (od == NULL) {
         log_debug("[go-tls-write] no offsets data in map for pid %d\n", pid);
-        return 1;
+        return 0;
     }
 
     // Read the PID and goroutine ID to make the partial call key
@@ -647,7 +647,7 @@ int uprobe__crypto_tls_Conn_Write(struct pt_regs *ctx) {
     call_key.pid = pid;
     if (read_goroutine_id(ctx, &od->goroutine_id, &call_key.goroutine_id)) {
         log_debug("[go-tls-write] failed reading go routine id for pid %d\n", pid);
-        return 1;
+        return 0;
     }
 
     // Read the parameters to make the partial call data
@@ -655,17 +655,17 @@ int uprobe__crypto_tls_Conn_Write(struct pt_regs *ctx) {
     go_tls_write_args_data_t call_data = {0};
     if (read_location(ctx, &od->write_conn_pointer, sizeof(call_data.conn_pointer), &call_data.conn_pointer)) {
         log_debug("[go-tls-write] failed reading conn pointer for pid %d\n", pid);
-        return 1;
+        return 0;
     }
 
     if (read_location(ctx, &od->write_buffer.ptr, sizeof(call_data.b_data), &call_data.b_data)) {
         log_debug("[go-tls-write] failed reading buffer pointer for pid %d\n", pid);
-        return 1;
+        return 0;
     }
 
     if (read_location(ctx, &od->write_buffer.len, sizeof(call_data.b_len), &call_data.b_len)) {
         log_debug("[go-tls-write] failed reading buffer length for pid %d\n", pid);
-        return 1;
+        return 0;
     }
 
     bpf_map_update_elem(&go_tls_write_args, &call_key, &call_data, BPF_ANY);
@@ -680,7 +680,7 @@ int uprobe__crypto_tls_Conn_Write__return(struct pt_regs *ctx) {
     tls_offsets_data_t* od = get_offsets_data();
     if (od == NULL) {
         log_debug("[go-tls-write-return] no offsets data in map for pid %d\n", pid);
-        return 1;
+        return 0;
     }
 
     // Read the PID and goroutine ID to make the partial call key
@@ -690,42 +690,42 @@ int uprobe__crypto_tls_Conn_Write__return(struct pt_regs *ctx) {
     uint64_t bytes_written = 0;
     if (read_location(ctx, &od->write_return_bytes, sizeof(bytes_written), &bytes_written)) {
         log_debug("[go-tls-write-return] failed reading write return bytes location for pid %d\n", pid);
-        return 1;
+        return 0;
     }
 
     if (bytes_written <= 0) {
         log_debug("[go-tls-write-return] write returned non-positive for amount of bytes written for pid: %d\n", pid);
-        return 1;
+        return 0;
     }
 
     uint64_t err_ptr = 0;
     if (read_location(ctx, &od->write_return_error, sizeof(err_ptr), &err_ptr)) {
         log_debug("[go-tls-write-return] failed reading write return error location for pid %d\n", pid);
-        return 1;
+        return 0;
     }
 
     // check if err != nil
     if (err_ptr != 0) {
         log_debug("[go-tls-write-return] error in write for pid %d: data will be ignored\n", pid);
-        return 1;
+        return 0;
     }
 
     if (read_goroutine_id(ctx, &od->goroutine_id, &call_key.goroutine_id)) {
         log_debug("[go-tls-write-return] failed reading go routine id for pid %d\n", pid);
-        return 1;
+        return 0;
     }
 
 
-    go_tls_write_args_data_t* call_data_ptr = bpf_map_lookup_elem(&go_tls_write_args, &call_key);
+    go_tls_write_args_data_t *call_data_ptr = bpf_map_lookup_elem(&go_tls_write_args, &call_key);
     if (call_data_ptr == NULL) {
         log_debug("[go-tls-write-return] no write information in write-return for pid %d\n", pid);
-        return 1;
+        return 0;
     }
 
-    conn_tuple_t* t = conn_tup_from_tls_conn(od, (void*) call_data_ptr->conn_pointer, pid_tgid);
+    conn_tuple_t *t = conn_tup_from_tls_conn(od, (void*)call_data_ptr->conn_pointer, pid_tgid);
     if (t == NULL) {
         bpf_map_delete_elem(&go_tls_write_args, &call_key);
-        return 1;
+        return 0;
     }
 
     log_debug("[go-tls-write] processing %s\n", call_data_ptr->b_data);
@@ -744,7 +744,7 @@ int uprobe__crypto_tls_Conn_Read(struct pt_regs *ctx) {
     tls_offsets_data_t* od = get_offsets_data();
     if (od == NULL) {
         log_debug("[go-tls-read] no offsets data in map for pid %d\n", pid_tgid >> 32);
-        return 1;
+        return 0;
     }
 
     // Read the PID and goroutine ID to make the partial call key
@@ -752,7 +752,7 @@ int uprobe__crypto_tls_Conn_Read(struct pt_regs *ctx) {
     call_key.pid = pid;
     if (read_goroutine_id(ctx, &od->goroutine_id, &call_key.goroutine_id)) {
         log_debug("[go-tls-read] failed reading go routine id for pid %d\n", pid_tgid >> 32);
-        return 1;
+        return 0;
     }
 
     // Read the parameters to make the partial call data
@@ -760,11 +760,11 @@ int uprobe__crypto_tls_Conn_Read(struct pt_regs *ctx) {
     go_tls_read_args_data_t call_data = {0};
     if (read_location(ctx, &od->read_conn_pointer, sizeof(call_data.conn_pointer), &call_data.conn_pointer)) {
         log_debug("[go-tls-read] failed reading conn pointer for pid %d\n", pid_tgid >> 32);
-        return 1;
+        return 0;
     }
     if (read_location(ctx, &od->read_buffer.ptr, sizeof(call_data.b_data), &call_data.b_data)) {
         log_debug("[go-tls-read] failed reading buffer pointer for pid %d\n", pid_tgid >> 32);
-        return 1;
+        return 0;
     }
 
     bpf_map_update_elem(&go_tls_read_args, &call_key, &call_data, BPF_ANY);
@@ -779,7 +779,7 @@ int uprobe__crypto_tls_Conn_Read__return(struct pt_regs *ctx) {
     tls_offsets_data_t* od = get_offsets_data();
     if (od == NULL) {
         log_debug("[go-tls-read-return] no offsets data in map for pid %d\n", pid);
-        return 1;
+        return 0;
     }
 
     // Read the PID and goroutine ID to make the partial call key
@@ -789,12 +789,12 @@ int uprobe__crypto_tls_Conn_Read__return(struct pt_regs *ctx) {
     uint64_t bytes_read = 0;
     if (read_location(ctx, &od->read_return_bytes, sizeof(bytes_read), &bytes_read)) {
         log_debug("[go-tls-read-return] failed reading return bytes location for pid %d\n", pid);
-        return 1;
+        return 0;
     }
 
     if (bytes_read <= 0) {
         log_debug("[go-tls-read-return] read returned non-positive for amount of bytes read for pid: %d\n", pid);
-        return 1;
+        return 0;
     }
 
     // Errors like "EOF" of "unexpected EOF" can be treated as no error by the hooked program.
@@ -804,19 +804,19 @@ int uprobe__crypto_tls_Conn_Read__return(struct pt_regs *ctx) {
 
     if (read_goroutine_id(ctx, &od->goroutine_id, &call_key.goroutine_id)) {
         log_debug("[go-tls-read-return] failed reading go routine id for pid %d\n", pid);
-        return 1;
+        return 0;
     }
 
     go_tls_read_args_data_t* call_data_ptr = bpf_map_lookup_elem(&go_tls_read_args, &call_key);
     if (call_data_ptr == NULL) {
         log_debug("[go-tls-read-return] no read information in read-return for pid %d\n", pid);
-        return 1;
+        return 0;
     }
 
     conn_tuple_t* t = conn_tup_from_tls_conn(od, (void*) call_data_ptr->conn_pointer, pid_tgid);
     if (t == NULL) {
         bpf_map_delete_elem(&go_tls_read_args, &call_key);
-        return 1;
+        return 0;
     }
 
     log_debug("[go-tls-read] processing %s\n", call_data_ptr->b_data);
@@ -834,19 +834,19 @@ int uprobe__crypto_tls_Conn_Close(struct pt_regs *ctx) {
     tls_offsets_data_t* od = get_offsets_data();
     if (od == NULL) {
         log_debug("[go-tls-close] no offsets data in map for pid %d\n", pid_tgid >> 32);
-        return 1;
+        return 0;
     }
 
     void* conn_pointer = NULL;
     if (read_location(ctx, &od->close_conn_pointer, sizeof(conn_pointer), &conn_pointer)) {
         log_debug("[go-tls-close] failed reading close conn pointer for pid %d\n", pid_tgid >> 32);
-        return 1;
+        return 0;
     }
 
     conn_tuple_t* t = conn_tup_from_tls_conn(od, conn_pointer, pid_tgid);
     if (t == NULL) {
         log_debug("[go-tls-close] failed getting conn tup from tls conn for pid %d\n", pid_tgid >> 32);
-        return 1;
+        return 0;
     }
 
     https_finish(t);


### PR DESCRIPTION
### Motivation

Add missing `http_batch_flush(ctx)`

### Additional Notes

return 0 on error path to avoid to confuse the verifier

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
