### PR TITLE
[CWS] add fallback mechanism for kernels where `veth_newlink` is not exported

### DIFF
--- a/pkg/security/ebpf/c/net_device.h
+++ b/pkg/security/ebpf/c/net_device.h
@@ -89,14 +89,18 @@ struct bpf_map_def SEC("maps/netdevice_lookup_cache") netdevice_lookup_cache = {
     .max_entries = 1024,
 };
 
-SEC("kprobe/veth_newlink")
-int kprobe_veth_newlink(struct pt_regs *ctx) {
+int __attribute__((always_inline)) start_veth_state_machine() {
     u64 id = bpf_get_current_pid_tgid();
     struct veth_state_t state = {
         .state = STATE_NEWLINK,
     };
     bpf_map_update_elem(&veth_state_machine, &id, &state, BPF_ANY);
     return 0;
+}
+
+SEC("kprobe/veth_newlink")
+int kprobe_veth_newlink(struct pt_regs *ctx) {
+    return start_veth_state_machine();
 };
 
 SEC("kprobe/rtnl_create_link")
@@ -106,16 +110,21 @@ int kprobe_rtnl_create_link(struct pt_regs *ctx) {
         return 0;
     }
 
-    if (ops->kind[0] != 'v' || ops->kind[0] != 'e' || ops->kind[0] != 't' || ops->kind[0] != 'h') {
+    char *kind_ptr;
+    if (bpf_probe_read(&kind_ptr, sizeof(char*), &ops->kind) < 0 || !kind_ptr) {
         return 0;
     }
 
-    u64 id = bpf_get_current_pid_tgid();
-    struct veth_state_t state = {
-        .state = STATE_NEWLINK,
-    };
-    bpf_map_update_elem(&veth_state_machine, &id, &state, BPF_ANY);
-    return 0;
+    char kind[5];
+    if (bpf_probe_read_str(kind, 5, kind_ptr) < 0) {
+        return 0;
+    }
+
+    if (kind[0] != 'v' || kind[1] != 'e' || kind[2] != 't' || kind[3] != 'h' || kind[4] != 0) {
+        return 0;
+    }
+
+    return start_veth_state_machine();
 }
 
 SEC("kprobe/register_netdevice")

--- a/pkg/security/ebpf/c/net_device.h
+++ b/pkg/security/ebpf/c/net_device.h
@@ -98,11 +98,6 @@ int __attribute__((always_inline)) start_veth_state_machine() {
     return 0;
 }
 
-SEC("kprobe/veth_newlink")
-int kprobe_veth_newlink(struct pt_regs *ctx) {
-    return start_veth_state_machine();
-};
-
 SEC("kprobe/rtnl_create_link")
 int kprobe_rtnl_create_link(struct pt_regs *ctx) {
     struct rtnl_link_ops *ops = (struct rtnl_link_ops*)PT_REGS_PARM4(ctx);

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -436,6 +436,7 @@ func GetSelectorsPerEventType() map[eval.EventType][]manager.ProbesSelector {
 		"dns": {
 			&manager.AllOf{Selectors: []manager.ProbesSelector{
 				&manager.AllOf{Selectors: NetworkSelectors},
+				&manager.AllOf{Selectors: NetworkVethSelectors},
 				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_security_socket_bind"}},
 			}},
 		},
@@ -444,9 +445,6 @@ func GetSelectorsPerEventType() map[eval.EventType][]manager.ProbesSelector {
 	// add probes depending on loaded modules
 	loadedModules, err := utils.FetchLoadedModules()
 	if err == nil {
-		if _, ok := loadedModules["veth"]; ok {
-			selectorsPerEventTypeStore["dns"] = append(selectorsPerEventTypeStore["dns"], NetworkVethSelectors...)
-		}
 		if _, ok := loadedModules["nf_nat"]; ok {
 			selectorsPerEventTypeStore["dns"] = append(selectorsPerEventTypeStore["dns"], NetworkNFNatSelectors...)
 		}

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -25,8 +25,9 @@ var NetworkNFNatSelectors = []manager.ProbesSelector{
 
 // NetworkVethSelectors is the list of probes that should be activated if the `veth` module is loaded
 var NetworkVethSelectors = []manager.ProbesSelector{
-	&manager.AllOf{Selectors: []manager.ProbesSelector{
+	&manager.OneOf{Selectors: []manager.ProbesSelector{
 		&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_veth_newlink"}},
+		&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_rtnl_create_link"}},
 	}},
 }
 

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -25,8 +25,7 @@ var NetworkNFNatSelectors = []manager.ProbesSelector{
 
 // NetworkVethSelectors is the list of probes that should be activated if the `veth` module is loaded
 var NetworkVethSelectors = []manager.ProbesSelector{
-	&manager.OneOf{Selectors: []manager.ProbesSelector{
-		&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_veth_newlink"}},
+	&manager.AllOf{Selectors: []manager.ProbesSelector{
 		&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_rtnl_create_link"}},
 	}},
 }

--- a/pkg/security/ebpf/probes/net_device.go
+++ b/pkg/security/ebpf/probes/net_device.go
@@ -15,12 +15,6 @@ var netDeviceProbes = []*manager.Probe{
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFFuncName: "kprobe_veth_newlink",
-		},
-	},
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
 			EBPFFuncName: "kprobe_rtnl_create_link",
 		},
 	},

--- a/pkg/security/ebpf/probes/net_device.go
+++ b/pkg/security/ebpf/probes/net_device.go
@@ -21,6 +21,12 @@ var netDeviceProbes = []*manager.Probe{
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
+			EBPFFuncName: "kprobe_rtnl_create_link",
+		},
+	},
+	{
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID:          SecurityAgentUID,
 			EBPFFuncName: "kprobe_register_netdevice",
 		},
 	},


### PR DESCRIPTION
also known as "the flatcar PR"
### What does this PR do?

This PR adds a new hook on https://elixir.bootlin.com/linux/v6.2.1/source/drivers/net/veth.c#L1750, checking the kind of the link ops is actually `veth`.
This new hookpoint is actually in the core kernel and not in a module simplifying and ensuring it's not been removed.


### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
