### PR TITLE
[Pipeline/Tooling] Report arm64 package and binary size metrics

### DIFF
--- a/.gitlab/pkg_metrics.yml
+++ b/.gitlab/pkg_metrics.yml
@@ -35,7 +35,7 @@
 send_pkg_size-a6:
   allow_failure: true
   rules:
-    !reference [.on_deploy_a6]
+    !reference [.on_a6]
   stage: pkg_metrics
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
   tags: ["runner:main"]
@@ -70,7 +70,7 @@ send_pkg_size-a6:
     - cd /tmp/rpm/agent && rpm2cpio $OMNIBUS_PACKAGE_DIR/datadog-agent-6.*.x86_64.rpm | cpio -idm > /dev/null
     - RPM_AGENT_SIZE=$(du -sB1 /tmp/rpm/agent | sed 's/\([0-9]\+\).\+/\1/')
     # centos arm64
-    - cd /tmp/rpm/agent && rpm2cpio $OMNIBUS_PACKAGE_DIR/datadog-agent-6.*.aarch64.rpm | cpio -idm > /dev/null
+    - cd /tmp/rpm/arm-agent && rpm2cpio $OMNIBUS_PACKAGE_DIR/datadog-agent-6.*.aarch64.rpm | cpio -idm > /dev/null
     - ARM_RPM_AGENT_SIZE=$(du -sB1 /tmp/rpm/arm-agent | sed 's/\([0-9]\+\).\+/\1/')
 
     # suse

--- a/.gitlab/pkg_metrics.yml
+++ b/.gitlab/pkg_metrics.yml
@@ -52,41 +52,41 @@ send_pkg_size-a6:
     - ls -l $OMNIBUS_PACKAGE_DIR_SUSE
   script:
     - source /root/.bashrc && conda activate ddpy3
-    - mkdir -p /tmp/deb/agent
-    - mkdir -p /tmp/deb/arm-agent
-    - mkdir -p /tmp/rpm/agent
-    - mkdir -p /tmp/rpm/arm-agent
-    - mkdir -p /tmp/suse/agent
+    - mkdir -p /tmp/deb/amd64-agent
+    - mkdir -p /tmp/deb/arm64-agent
+    - mkdir -p /tmp/rpm/amd64-agent
+    - mkdir -p /tmp/rpm/arm64-agent
+    - mkdir -p /tmp/suse/amd64-agent
 
     # we silence dpkg and cpio output so we don't exceed gitlab log limit
 
     # debian
-    - dpkg -x $OMNIBUS_PACKAGE_DIR/datadog-agent_6*_amd64.deb /tmp/deb/agent > /dev/null
-    - DEB_AGENT_SIZE=$(du -sB1 /tmp/deb/agent | sed 's/\([0-9]\+\).\+/\1/')
+    - dpkg -x $OMNIBUS_PACKAGE_DIR/datadog-agent_6*_amd64.deb /tmp/deb/amd64-agent > /dev/null
+    - AMD64_DEB_AGENT_SIZE=$(du -sB1 /tmp/deb/amd64-agent | sed 's/\([0-9]\+\).\+/\1/')
     # debian arm64
-    - dpkg -x $OMNIBUS_PACKAGE_DIR/datadog-agent_6*_arm64.deb /tmp/deb/arm-agent > /dev/null
-    - ARM_DEB_AGENT_SIZE=$(du -sB1 /tmp/deb/arm-agent | sed 's/\([0-9]\+\).\+/\1/')
+    - dpkg -x $OMNIBUS_PACKAGE_DIR/datadog-agent_6*_arm64.deb /tmp/deb/arm64-agent > /dev/null
+    - ARM64_DEB_AGENT_SIZE=$(du -sB1 /tmp/deb/arm64-agent | sed 's/\([0-9]\+\).\+/\1/')
     # centos
-    - cd /tmp/rpm/agent && rpm2cpio $OMNIBUS_PACKAGE_DIR/datadog-agent-6.*.x86_64.rpm | cpio -idm > /dev/null
-    - RPM_AGENT_SIZE=$(du -sB1 /tmp/rpm/agent | sed 's/\([0-9]\+\).\+/\1/')
+    - cd /tmp/rpm/amd64-agent && rpm2cpio $OMNIBUS_PACKAGE_DIR/datadog-agent-6.*.x86_64.rpm | cpio -idm > /dev/null
+    - AMD64_RPM_AGENT_SIZE=$(du -sB1 /tmp/rpm/amd64-agent | sed 's/\([0-9]\+\).\+/\1/')
     # centos arm64
-    - cd /tmp/rpm/arm-agent && rpm2cpio $OMNIBUS_PACKAGE_DIR/datadog-agent-6.*.aarch64.rpm | cpio -idm > /dev/null
-    - ARM_RPM_AGENT_SIZE=$(du -sB1 /tmp/rpm/arm-agent | sed 's/\([0-9]\+\).\+/\1/')
+    - cd /tmp/rpm/arm64-agent && rpm2cpio $OMNIBUS_PACKAGE_DIR/datadog-agent-6.*.aarch64.rpm | cpio -idm > /dev/null
+    - ARM64_RPM_AGENT_SIZE=$(du -sB1 /tmp/rpm/arm64-agent | sed 's/\([0-9]\+\).\+/\1/')
 
     # suse
-    - cd /tmp/suse/agent && rpm2cpio $OMNIBUS_PACKAGE_DIR_SUSE/datadog-agent-6.*.x86_64.rpm | cpio -idm > /dev/null
-    - SUSE_AGENT_SIZE=$(du -sB1 /tmp/suse/agent | sed 's/\([0-9]\+\).\+/\1/')
+    - cd /tmp/suse/amd64-agent && rpm2cpio $OMNIBUS_PACKAGE_DIR_SUSE/datadog-agent-6.*.x86_64.rpm | cpio -idm > /dev/null
+    - AMD64_SUSE_AGENT_SIZE=$(du -sB1 /tmp/suse/amd64-agent | sed 's/\([0-9]\+\).\+/\1/')
 
     - currenttime=$(date +%s)
     - DD_API_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.datadog_api_key --with-decryption --query "Parameter.Value" --out text)
     - |
       curl --fail -X POST -H "Content-type: application/json" \
       -d "{\"series\":[
-            {\"metric\":\"datadog.agent.package.size\",\"points\":[[$currenttime, $DEB_AGENT_SIZE]], \"tags\":[\"os:debian\", \"package:agent\", \"agent:6\", \"bucket_branch:$BUCKET_BRANCH\", \"arch:amd64\"]},
-            {\"metric\":\"datadog.agent.package.size\",\"points\":[[$currenttime, $RPM_AGENT_SIZE]], \"tags\":[\"os:centos\", \"package:agent\", \"agent:6\", \"bucket_branch:$BUCKET_BRANCH\", \"arch:amd64\"]},
-            {\"metric\":\"datadog.agent.package.size\",\"points\":[[$currenttime, $SUSE_AGENT_SIZE]], \"tags\":[\"os:suse\", \"package:agent\", \"agent:6\", \"bucket_branch:$BUCKET_BRANCH\", \"arch:amd64\"]},
-            {\"metric\":\"datadog.agent.package.size\",\"points\":[[$currenttime, $ARM_DEB_AGENT_SIZE]], \"tags\":[\"os:debian\", \"package:agent\", \"agent:6\", \"bucket_branch:$BUCKET_BRANCH\", \"arch:arm64\"]},
-            {\"metric\":\"datadog.agent.package.size\",\"points\":[[$currenttime, $ARM_RPM_AGENT_SIZE]], \"tags\":[\"os:centos\", \"package:agent\", \"agent:6\", \"bucket_branch:$BUCKET_BRANCH\", \"arch:arm64\"]}
+            {\"metric\":\"datadog.agent.package.size\",\"points\":[[$currenttime, $AMD64_DEB_AGENT_SIZE]], \"tags\":[\"os:debian\", \"package:agent\", \"agent:6\", \"bucket_branch:$BUCKET_BRANCH\", \"arch:amd64\"]},
+            {\"metric\":\"datadog.agent.package.size\",\"points\":[[$currenttime, $AMD64_RPM_AGENT_SIZE]], \"tags\":[\"os:centos\", \"package:agent\", \"agent:6\", \"bucket_branch:$BUCKET_BRANCH\", \"arch:amd64\"]},
+            {\"metric\":\"datadog.agent.package.size\",\"points\":[[$currenttime, $AMD64_SUSE_AGENT_SIZE]], \"tags\":[\"os:suse\", \"package:agent\", \"agent:6\", \"bucket_branch:$BUCKET_BRANCH\", \"arch:amd64\"]},
+            {\"metric\":\"datadog.agent.package.size\",\"points\":[[$currenttime, $ARM64_DEB_AGENT_SIZE]], \"tags\":[\"os:debian\", \"package:agent\", \"agent:6\", \"bucket_branch:$BUCKET_BRANCH\", \"arch:arm64\"]},
+            {\"metric\":\"datadog.agent.package.size\",\"points\":[[$currenttime, $ARM64_RPM_AGENT_SIZE]], \"tags\":[\"os:centos\", \"package:agent\", \"agent:6\", \"bucket_branch:$BUCKET_BRANCH\", \"arch:arm64\"]}
           ]}" \
       "https://api.datadoghq.com/api/v1/series?api_key=$DD_API_KEY"
 
@@ -122,11 +122,11 @@ send_pkg_size-a7:
     - !reference [.add_metric_func, script]
 
     - source /root/.bashrc && conda activate ddpy3
-    - mkdir -p /tmp/deb/agent /tmp/deb/dogstatsd /tmp/deb/iot-agent /tmp/deb/heroku-agent
-    - mkdir -p /tmp/arm-deb/agent /tmp/arm-deb/dogstatsd /tmp/arm-deb/iot-agent
-    - mkdir -p /tmp/rpm/agent /tmp/rpm/dogstatsd /tmp/rpm/iot-agent
-    - mkdir -p /tmp/arm-rpm/agent /tmp/arm-rpm/iot-agent
-    - mkdir -p /tmp/suse/agent /tmp/suse/dogstatsd /tmp/suse/iot-agent
+    - mkdir -p /tmp/amd64-deb/agent /tmp/amd64-deb/dogstatsd /tmp/amd64-deb/iot-agent /tmp/amd64-deb/heroku-agent
+    - mkdir -p /tmp/arm64-deb/agent /tmp/arm64-deb/dogstatsd /tmp/arm64-deb/iot-agent
+    - mkdir -p /tmp/amd64-rpm/agent /tmp/amd64-rpm/dogstatsd /tmp/amd64-rpm/iot-agent
+    - mkdir -p /tmp/arm64-rpm/agent /tmp/arm64-rpm/iot-agent
+    - mkdir -p /tmp/amd64-suse/agent /tmp/amd64-suse/dogstatsd /tmp/amd64-suse/iot-agent
 
     - |
         add_metrics() {
@@ -153,34 +153,34 @@ send_pkg_size-a7:
     # We silence dpkg and cpio output so we don't exceed gitlab log limit
 
     # debian
-    - dpkg -x $OMNIBUS_PACKAGE_DIR/datadog-agent_7*_amd64.deb /tmp/deb/agent > /dev/null
-    - dpkg -x $OMNIBUS_PACKAGE_DIR/datadog-iot-agent_7*_amd64.deb /tmp/deb/iot-agent > /dev/null
-    - dpkg -x $OMNIBUS_PACKAGE_DIR/datadog-dogstatsd_7*_amd64.deb /tmp/deb/dogstatsd > /dev/null
-    - dpkg -x $OMNIBUS_PACKAGE_DIR/datadog-heroku-agent_7*_amd64.deb /tmp/deb/heroku-agent > /dev/null
-    - add_metrics /tmp/deb debian amd64
+    - dpkg -x $OMNIBUS_PACKAGE_DIR/datadog-agent_7*_amd64.deb /tmp/amd64-deb/agent > /dev/null
+    - dpkg -x $OMNIBUS_PACKAGE_DIR/datadog-iot-agent_7*_amd64.deb /tmp/amd64-deb/iot-agent > /dev/null
+    - dpkg -x $OMNIBUS_PACKAGE_DIR/datadog-dogstatsd_7*_amd64.deb /tmp/amd64-deb/dogstatsd > /dev/null
+    - dpkg -x $OMNIBUS_PACKAGE_DIR/datadog-heroku-agent_7*_amd64.deb /tmp/amd64-deb/heroku-agent > /dev/null
+    - add_metrics /tmp/amd64-deb debian amd64
 
     # debian arm64
-    - dpkg -x $OMNIBUS_PACKAGE_DIR/datadog-agent_7*_arm64.deb /tmp/arm-deb/agent > /dev/null
-    - dpkg -x $OMNIBUS_PACKAGE_DIR/datadog-iot-agent_7*_arm64.deb /tmp/arm-deb/iot-agent > /dev/null
-    - dpkg -x $OMNIBUS_PACKAGE_DIR/datadog-dogstatsd_7*_arm64.deb /tmp/arm-deb/dogstatsd > /dev/null
-    - add_metrics /tmp/arm-deb debian arm64
+    - dpkg -x $OMNIBUS_PACKAGE_DIR/datadog-agent_7*_arm64.deb /tmp/arm64-deb/agent > /dev/null
+    - dpkg -x $OMNIBUS_PACKAGE_DIR/datadog-iot-agent_7*_arm64.deb /tmp/arm64-deb/iot-agent > /dev/null
+    - dpkg -x $OMNIBUS_PACKAGE_DIR/datadog-dogstatsd_7*_arm64.deb /tmp/arm64-deb/dogstatsd > /dev/null
+    - add_metrics /tmp/arm64-deb debian arm64
 
     # centos
-    - cd /tmp/rpm/agent && rpm2cpio $OMNIBUS_PACKAGE_DIR/datadog-agent-7.*.x86_64.rpm | cpio -idm > /dev/null
-    - cd /tmp/rpm/dogstatsd && rpm2cpio $OMNIBUS_PACKAGE_DIR/datadog-dogstatsd-7.*.x86_64.rpm | cpio -idm > /dev/null
-    - cd /tmp/rpm/iot-agent && rpm2cpio $OMNIBUS_PACKAGE_DIR/datadog-iot-agent-7.*.x86_64.rpm | cpio -idm > /dev/null
-    - add_metrics /tmp/rpm centos amd64
+    - cd /tmp/amd64-rpm/agent && rpm2cpio $OMNIBUS_PACKAGE_DIR/datadog-agent-7.*.x86_64.rpm | cpio -idm > /dev/null
+    - cd /tmp/amd64-rpm/dogstatsd && rpm2cpio $OMNIBUS_PACKAGE_DIR/datadog-dogstatsd-7.*.x86_64.rpm | cpio -idm > /dev/null
+    - cd /tmp/amd64-rpm/iot-agent && rpm2cpio $OMNIBUS_PACKAGE_DIR/datadog-iot-agent-7.*.x86_64.rpm | cpio -idm > /dev/null
+    - add_metrics /tmp/amd64-rpm centos amd64
 
     # centos arm64
-    - cd /tmp/arm-rpm/agent && rpm2cpio $OMNIBUS_PACKAGE_DIR/datadog-agent-7.*.aarch64.rpm | cpio -idm > /dev/null
-    - cd /tmp/arm-rpm/iot-agent && rpm2cpio $OMNIBUS_PACKAGE_DIR/datadog-iot-agent-7.*.aarch64.rpm | cpio -idm > /dev/null
-    - add_metrics /tmp/arm-rpm centos arm64
+    - cd /tmp/arm64-rpm/agent && rpm2cpio $OMNIBUS_PACKAGE_DIR/datadog-agent-7.*.aarch64.rpm | cpio -idm > /dev/null
+    - cd /tmp/arm64-rpm/iot-agent && rpm2cpio $OMNIBUS_PACKAGE_DIR/datadog-iot-agent-7.*.aarch64.rpm | cpio -idm > /dev/null
+    - add_metrics /tmp/arm64-rpm centos arm64
 
     # suse
-    - cd /tmp/suse/agent && rpm2cpio $OMNIBUS_PACKAGE_DIR_SUSE/datadog-agent-7.*.x86_64.rpm | cpio -idm > /dev/null
-    - cd /tmp/suse/dogstatsd && rpm2cpio $OMNIBUS_PACKAGE_DIR_SUSE/datadog-dogstatsd-7.*.x86_64.rpm | cpio -idm > /dev/null
-    - cd /tmp/suse/iot-agent && rpm2cpio $OMNIBUS_PACKAGE_DIR_SUSE/datadog-iot-agent-7.*.x86_64.rpm | cpio -idm > /dev/null
-    - add_metrics /tmp/suse suse amd64
+    - cd /tmp/amd64-suse/agent && rpm2cpio $OMNIBUS_PACKAGE_DIR_SUSE/datadog-agent-7.*.x86_64.rpm | cpio -idm > /dev/null
+    - cd /tmp/amd64-suse/dogstatsd && rpm2cpio $OMNIBUS_PACKAGE_DIR_SUSE/datadog-dogstatsd-7.*.x86_64.rpm | cpio -idm > /dev/null
+    - cd /tmp/amd64-suse/iot-agent && rpm2cpio $OMNIBUS_PACKAGE_DIR_SUSE/datadog-iot-agent-7.*.x86_64.rpm | cpio -idm > /dev/null
+    - add_metrics /tmp/amd64-suse suse amd64
 
     # Send package and binary size metrics
     - !reference [.send_metrics, script]
@@ -202,28 +202,36 @@ send_pkg_size-a7:
     # We want to run all package size comparisons before failing, so we set +e while doing the comparisons
     # to get the error codes without exiting the shell.
     - |
+        if [[ "${ARCH}" == "amd64" ]]; then ARCH_RPM_EXT="x86_64"; else ARCH_RPM_EXT="aarch64"; fi
         for flavor in ${FLAVORS}; do
-            mkdir -p "/tmp/stable/${flavor}" "/tmp/stable/${flavor}/suse"
+            
+            if [[ "${ARCH}" == "amd64" && "$flavor" != "datadog-heroku-agent" ]]; then
+              mkdir -p "/tmp/stable/${flavor}/suse"
+              curl -sSL "https://s3.amazonaws.com/yum.datadoghq.com/suse/stable/${MAJOR_VERSION}/${ARCH_RPM_EXT}/${flavor}-${last_stable}-1.${ARCH_RPM_EXT}.rpm" -o "/tmp/stable/${flavor}/suse/${flavor}-${last_stable}-1.${ARCH_RPM_EXT}.rpm"
+              add_metric datadog.agent.compressed_package.size $(du -sB1 ${OMNIBUS_PACKAGE_DIR_SUSE}/${flavor}-${MAJOR_VERSION}.*.${ARCH_RPM_EXT}.rpm | cut -f -1) os:suse package:${flavor} agent:${MAJOR_VERSION} git_ref:${CI_COMMIT_REF_SLUG} bucket_branch:${BUCKET_BRANCH} arch:${ARCH}
+              set +e
+              inv package.compare-size --package-type "${flavor} suse rpm" --last-stable "${last_stable}" --threshold "${max_sizes[${flavor}]}" --new-package "$OMNIBUS_PACKAGE_DIR_SUSE/${flavor}-${MAJOR_VERSION}.*.${ARCH_RPM_EXT}.rpm" --stable-package "/tmp/stable/${flavor}/suse/${flavor}-${last_stable}-1.${ARCH_RPM_EXT}.rpm"
+              failures=$((${failures}+$?))
+              set -e
+            fi
 
-            curl -sSL "https://s3.amazonaws.com/apt.datadoghq.com/pool/d/da/${flavor}_${last_stable}-1_amd64.deb" -o "/tmp/stable/${flavor}/${flavor}_${last_stable}-1_amd64.deb"
+            mkdir -p "/tmp/stable/${flavor}" 
 
-            add_metric datadog.agent.compressed_package.size $(du -sB1 ${OMNIBUS_PACKAGE_DIR}/${flavor}_${MAJOR_VERSION}*_amd64.deb | cut -f -1) os:debian package:${flavor} agent:${MAJOR_VERSION} git_ref:${CI_COMMIT_REF_SLUG} bucket_branch:${BUCKET_BRANCH} arch:amd64
+            curl -sSL "https://s3.amazonaws.com/apt.datadoghq.com/pool/d/da/${flavor}_${last_stable}-1_${ARCH}.deb" -o "/tmp/stable/${flavor}/${flavor}_${last_stable}-1_${ARCH}.deb"
+
+            add_metric datadog.agent.compressed_package.size $(du -sB1 ${OMNIBUS_PACKAGE_DIR}/${flavor}_${MAJOR_VERSION}*_${ARCH}.deb | cut -f -1) os:debian package:${flavor} agent:${MAJOR_VERSION} git_ref:${CI_COMMIT_REF_SLUG} bucket_branch:${BUCKET_BRANCH} arch:${ARCH}
 
             set +e
-            inv package.compare-size --package-type "${flavor} deb" --last-stable "${last_stable}" --threshold "${max_sizes[${flavor}]}" --new-package "$OMNIBUS_PACKAGE_DIR/${flavor}_${MAJOR_VERSION}*_amd64.deb" --stable-package "/tmp/stable/${flavor}/${flavor}_${last_stable}-1_amd64.deb"
+            inv package.compare-size --package-type "${flavor} deb" --last-stable "${last_stable}" --threshold "${max_sizes[${flavor}]}" --new-package "$OMNIBUS_PACKAGE_DIR/${flavor}_${MAJOR_VERSION}*_${ARCH}.deb" --stable-package "/tmp/stable/${flavor}/${flavor}_${last_stable}-1_${ARCH}.deb"
             failures=$((${failures}+$?))
             set -e
 
-            if [[ "$flavor" != "datadog-heroku-agent" ]]; then
+            if [[ "$flavor" != "datadog-heroku-agent" && ( "${ARCH}" == "amd64" || "$flavor" != "datadog-dogstatsd") ]]; then
               # We don't build RPM packages for the heroku flavor
-              curl -sSL "https://s3.amazonaws.com/yum.datadoghq.com/stable/${MAJOR_VERSION}/x86_64/${flavor}-${last_stable}-1.x86_64.rpm" -o "/tmp/stable/${flavor}/${flavor}-${last_stable}-1.x86_64.rpm"
-              curl -sSL "https://s3.amazonaws.com/yum.datadoghq.com/suse/stable/${MAJOR_VERSION}/x86_64/${flavor}-${last_stable}-1.x86_64.rpm" -o "/tmp/stable/${flavor}/suse/${flavor}-${last_stable}-1.x86_64.rpm"
-              add_metric datadog.agent.compressed_package.size $(du -sB1 ${OMNIBUS_PACKAGE_DIR}/${flavor}-${MAJOR_VERSION}.*.x86_64.rpm | cut -f -1) os:centos package:${flavor} agent:${MAJOR_VERSION} git_ref:${CI_COMMIT_REF_SLUG} bucket_branch:${BUCKET_BRANCH} arch:amd64
-              add_metric datadog.agent.compressed_package.size $(du -sB1 ${OMNIBUS_PACKAGE_DIR_SUSE}/${flavor}-${MAJOR_VERSION}.*.x86_64.rpm | cut -f -1) os:suse package:${flavor} agent:${MAJOR_VERSION} git_ref:${CI_COMMIT_REF_SLUG} bucket_branch:${BUCKET_BRANCH} arch:amd64
+              curl -sSL "https://s3.amazonaws.com/yum.datadoghq.com/stable/${MAJOR_VERSION}/${ARCH_RPM_EXT}/${flavor}-${last_stable}-1.${ARCH_RPM_EXT}.rpm" -o "/tmp/stable/${flavor}/${flavor}-${last_stable}-1.${ARCH_RPM_EXT}.rpm"
+              add_metric datadog.agent.compressed_package.size $(du -sB1 ${OMNIBUS_PACKAGE_DIR}/${flavor}-${MAJOR_VERSION}.*.${ARCH_RPM_EXT}.rpm | cut -f -1) os:centos package:${flavor} agent:${MAJOR_VERSION} git_ref:${CI_COMMIT_REF_SLUG} bucket_branch:${BUCKET_BRANCH} arch:${ARCH}
               set +e
-              inv package.compare-size --package-type "${flavor} rpm" --last-stable "${last_stable}" --threshold "${max_sizes[${flavor}]}" --new-package "$OMNIBUS_PACKAGE_DIR/${flavor}-${MAJOR_VERSION}.*.x86_64.rpm" --stable-package "/tmp/stable/${flavor}/${flavor}-${last_stable}-1.x86_64.rpm"
-              failures=$((${failures}+$?))
-              inv package.compare-size --package-type "${flavor} suse rpm" --last-stable "${last_stable}" --threshold "${max_sizes[${flavor}]}" --new-package "$OMNIBUS_PACKAGE_DIR_SUSE/${flavor}-${MAJOR_VERSION}.*.x86_64.rpm" --stable-package "/tmp/stable/${flavor}/suse/${flavor}-${last_stable}-1.x86_64.rpm"
+              inv package.compare-size --package-type "${flavor} rpm" --last-stable "${last_stable}" --threshold "${max_sizes[${flavor}]}" --new-package "$OMNIBUS_PACKAGE_DIR/${flavor}-${MAJOR_VERSION}.*.${ARCH_RPM_EXT}.rpm" --stable-package "/tmp/stable/${flavor}/${flavor}-${last_stable}-1.${ARCH_RPM_EXT}.rpm"
               failures=$((${failures}+$?))
               set -e
             fi
@@ -235,51 +243,7 @@ send_pkg_size-a7:
     # Make the job fail if at least one package is above threshold
     - if [ "${failures}" -ne "0" ]; then false; fi
 
-.check_arm64_pkg_size:
-  stage: pkg_metrics
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
-  tags: ["runner:main"]
-  script:
-    - !reference [.add_metric_func, script]
-
-    - ls -l $OMNIBUS_PACKAGE_DIR
-    - source /root/.bashrc && conda activate ddpy3
-    - export failures=0
-    - export last_stable=$(inv release.get-release-json-value "last_stable::${MAJOR_VERSION}")
-    # Get stable packages from S3 buckets, send new package sizes & compare stable and new package sizes
-    # The loop assumes that all flavors start with "da", which is currently the case
-    # We want to run all package size comparisons before failing, so we set +e while doing the comparisons
-    # to get the error codes without exiting the shell.
-    - |
-        for flavor in ${FLAVORS}; do
-            mkdir -p "/tmp/stable/${flavor}"
-
-            curl -sSL "https://s3.amazonaws.com/apt.datadoghq.com/pool/d/da/${flavor}_${last_stable}-1_arm64.deb" -o "/tmp/stable/${flavor}/${flavor}_${last_stable}-1_arm64.deb"
-
-            add_metric datadog.agent.compressed_package.size $(du -sB1 ${OMNIBUS_PACKAGE_DIR}/${flavor}_${MAJOR_VERSION}*_arm64.deb | cut -f -1) os:debian package:${flavor} agent:${MAJOR_VERSION} git_ref:${CI_COMMIT_REF_SLUG} bucket_branch:${BUCKET_BRANCH} arch:arm64
-
-            set +e
-            inv package.compare-size --package-type "${flavor} deb" --last-stable "${last_stable}" --threshold "${max_sizes[${flavor}]}" --new-package "$OMNIBUS_PACKAGE_DIR/${flavor}_${MAJOR_VERSION}*_arm64.deb" --stable-package "/tmp/stable/${flavor}/${flavor}_${last_stable}-1_arm64.deb"
-            failures=$((${failures}+$?))
-            set -e
-
-            if [[ "$flavor" != "datadog-dogstatsd" ]]; then 
-              curl -sSL "https://s3.amazonaws.com/yum.datadoghq.com/stable/${MAJOR_VERSION}/aarch64/${flavor}-${last_stable}-1.aarch64.rpm" -o "/tmp/stable/${flavor}/${flavor}-${last_stable}-1.aarch64.rpm"
-              add_metric datadog.agent.compressed_package.size $(du -sB1 ${OMNIBUS_PACKAGE_DIR}/${flavor}-${MAJOR_VERSION}.*.aarch64.rpm | cut -f -1) os:centos package:${flavor} agent:${MAJOR_VERSION} git_ref:${CI_COMMIT_REF_SLUG} bucket_branch:${BUCKET_BRANCH} arch:arm64
-              set +e
-              inv package.compare-size --package-type "${flavor} rpm" --last-stable "${last_stable}" --threshold "${max_sizes[${flavor}]}" --new-package "$OMNIBUS_PACKAGE_DIR/${flavor}-${MAJOR_VERSION}.*.aarch64.rpm" --stable-package "/tmp/stable/${flavor}/${flavor}-${last_stable}-1.aarch64.rpm"
-              failures=$((${failures}+$?))
-              set -e
-            fi
-        done
-
-    # Send package size metrics
-    - !reference [.send_metrics, script]
-
-    # Make the job fail if at least one package is above threshold
-    - if [ "${failures}" -ne "0" ]; then false; fi
-
-check_pkg_size-a6:
+check_pkg_size-amd64-a6:
   extends: .check_pkg_size
   rules:
     !reference [.on_a6]
@@ -290,6 +254,7 @@ check_pkg_size-a6:
   variables:
     MAJOR_VERSION: 6
     FLAVORS: "datadog-agent"
+    ARCH: "amd64"
   before_script:
     # FIXME: ["datadog-agent"]="25000000" should be replaced by "15000000"
     # "25000000" is needed as of now because of a large bump in size in system-probe in 7.35
@@ -299,7 +264,7 @@ check_pkg_size-a6:
         )
 
 check_pkg_size-arm64-a6:
-  extends: .check_arm64_pkg_size
+  extends: .check_pkg_size
   rules:
     !reference [.on_all_builds_a6]
   needs:
@@ -308,6 +273,7 @@ check_pkg_size-arm64-a6:
   variables:
     MAJOR_VERSION: 6
     FLAVORS: "datadog-agent"
+    ARCH: "arm64"
   before_script:
     # FIXME: ["datadog-agent"]="25000000" should be replaced by "15000000"
     # "25000000" is needed as of now because of a large bump in size in system-probe in 7.35
@@ -316,7 +282,7 @@ check_pkg_size-arm64-a6:
             ["datadog-agent"]="25000000"
         )
 
-check_pkg_size-a7:
+check_pkg_size-amd64-a7:
   extends: .check_pkg_size
   rules:
     !reference [.on_a7]
@@ -334,6 +300,7 @@ check_pkg_size-a7:
   variables:
     MAJOR_VERSION: 7
     FLAVORS: "datadog-agent datadog-iot-agent datadog-dogstatsd datadog-heroku-agent"
+    ARCH: "amd64"
   before_script:
     # FIXME: ["datadog-agent"]="25000000" and ["datadog-heroku-agent"]="25000000" should
     # be replaced by "15000000"
@@ -348,7 +315,7 @@ check_pkg_size-a7:
         )
 
 check_pkg_size-arm64-a7:
-  extends: .check_arm64_pkg_size
+  extends: .check_pkg_size
   rules:
     !reference [.on_all_builds_a7]
   needs:
@@ -360,6 +327,7 @@ check_pkg_size-arm64-a7:
   variables:
     MAJOR_VERSION: 7
     FLAVORS: "datadog-agent datadog-iot-agent datadog-dogstatsd"
+    ARCH: "arm64"
   before_script:
     # FIXME: ["datadog-agent"]="25000000" and ["datadog-heroku-agent"]="25000000" should
     # be replaced by "15000000"

--- a/.gitlab/pkg_metrics.yml
+++ b/.gitlab/pkg_metrics.yml
@@ -287,8 +287,6 @@ check_pkg_size-a6:
     - agent_deb-x64-a6
     - agent_rpm-x64-a6
     - agent_suse-x64-a6
-    - agent_deb-arm64-a6
-    - agent_rpm-arm64-a6
   variables:
     MAJOR_VERSION: 6
     FLAVORS: "datadog-agent"
@@ -324,16 +322,11 @@ check_pkg_size-a7:
     !reference [.on_a7]
   needs:
     - agent_deb-x64-a7
-    - agent_deb-arm64-a7
     - iot_agent_deb-x64
-    - iot_agent_deb-arm64
     - dogstatsd_deb-x64
-    - dogstatsd_deb-arm64
     - agent_heroku_deb-x64-a7
     - agent_rpm-x64-a7
-    - agent_rpm-arm64-a7
     - iot_agent_rpm-x64
-    - iot_agent_rpm-arm64
     - dogstatsd_rpm-x64
     - agent_suse-x64-a7
     - dogstatsd_suse-x64

--- a/.gitlab/pkg_metrics.yml
+++ b/.gitlab/pkg_metrics.yml
@@ -43,6 +43,8 @@ send_pkg_size-a6:
     - agent_deb-x64-a6
     - agent_rpm-x64-a6
     - agent_suse-x64-a6
+    - agent_deb-arm64-a6
+    - agent_rpm-arm64-a6
   before_script:
     # FIXME: tmp while we uppdate the base image
     - apt-get install -y wget rpm2cpio cpio
@@ -51,7 +53,9 @@ send_pkg_size-a6:
   script:
     - source /root/.bashrc && conda activate ddpy3
     - mkdir -p /tmp/deb/agent
+    - mkdir -p /tmp/deb/arm-agent
     - mkdir -p /tmp/rpm/agent
+    - mkdir -p /tmp/rpm/arm-agent
     - mkdir -p /tmp/suse/agent
 
     # we silence dpkg and cpio output so we don't exceed gitlab log limit
@@ -59,9 +63,16 @@ send_pkg_size-a6:
     # debian
     - dpkg -x $OMNIBUS_PACKAGE_DIR/datadog-agent_6*_amd64.deb /tmp/deb/agent > /dev/null
     - DEB_AGENT_SIZE=$(du -sB1 /tmp/deb/agent | sed 's/\([0-9]\+\).\+/\1/')
+    # debian arm64
+    - dpkg -x $OMNIBUS_PACKAGE_DIR/datadog-agent_6*_arm64.deb /tmp/deb/arm-agent > /dev/null
+    - ARM_DEB_AGENT_SIZE=$(du -sB1 /tmp/deb/arm-agent | sed 's/\([0-9]\+\).\+/\1/')
     # centos
     - cd /tmp/rpm/agent && rpm2cpio $OMNIBUS_PACKAGE_DIR/datadog-agent-6.*.x86_64.rpm | cpio -idm > /dev/null
     - RPM_AGENT_SIZE=$(du -sB1 /tmp/rpm/agent | sed 's/\([0-9]\+\).\+/\1/')
+    # centos arm64
+    - cd /tmp/rpm/agent && rpm2cpio $OMNIBUS_PACKAGE_DIR/datadog-agent-6.*.aarch64.rpm | cpio -idm > /dev/null
+    - ARM_RPM_AGENT_SIZE=$(du -sB1 /tmp/rpm/arm-agent | sed 's/\([0-9]\+\).\+/\1/')
+
     # suse
     - cd /tmp/suse/agent && rpm2cpio $OMNIBUS_PACKAGE_DIR_SUSE/datadog-agent-6.*.x86_64.rpm | cpio -idm > /dev/null
     - SUSE_AGENT_SIZE=$(du -sB1 /tmp/suse/agent | sed 's/\([0-9]\+\).\+/\1/')
@@ -71,9 +82,11 @@ send_pkg_size-a6:
     - |
       curl --fail -X POST -H "Content-type: application/json" \
       -d "{\"series\":[
-            {\"metric\":\"datadog.agent.package.size\",\"points\":[[$currenttime, $DEB_AGENT_SIZE]], \"tags\":[\"os:debian\", \"package:agent\", \"agent:6\", \"bucket_branch:$BUCKET_BRANCH\"]},
-            {\"metric\":\"datadog.agent.package.size\",\"points\":[[$currenttime, $RPM_AGENT_SIZE]], \"tags\":[\"os:centos\", \"package:agent\", \"agent:6\", \"bucket_branch:$BUCKET_BRANCH\"]},
-            {\"metric\":\"datadog.agent.package.size\",\"points\":[[$currenttime, $SUSE_AGENT_SIZE]], \"tags\":[\"os:suse\", \"package:agent\", \"agent:6\", \"bucket_branch:$BUCKET_BRANCH\"]}
+            {\"metric\":\"datadog.agent.package.size\",\"points\":[[$currenttime, $DEB_AGENT_SIZE]], \"tags\":[\"os:debian\", \"package:agent\", \"agent:6\", \"bucket_branch:$BUCKET_BRANCH\", \"arch:amd64\"]},
+            {\"metric\":\"datadog.agent.package.size\",\"points\":[[$currenttime, $RPM_AGENT_SIZE]], \"tags\":[\"os:centos\", \"package:agent\", \"agent:6\", \"bucket_branch:$BUCKET_BRANCH\", \"arch:amd64\"]},
+            {\"metric\":\"datadog.agent.package.size\",\"points\":[[$currenttime, $SUSE_AGENT_SIZE]], \"tags\":[\"os:suse\", \"package:agent\", \"agent:6\", \"bucket_branch:$BUCKET_BRANCH\", \"arch:amd64\"]},
+            {\"metric\":\"datadog.agent.package.size\",\"points\":[[$currenttime, $ARM_DEB_AGENT_SIZE]], \"tags\":[\"os:debian\", \"package:agent\", \"agent:6\", \"bucket_branch:$BUCKET_BRANCH\", \"arch:arm64\"]},
+            {\"metric\":\"datadog.agent.package.size\",\"points\":[[$currenttime, $ARM_RPM_AGENT_SIZE]], \"tags\":[\"os:centos\", \"package:agent\", \"agent:6\", \"bucket_branch:$BUCKET_BRANCH\", \"arch:arm64\"]}
           ]}" \
       "https://api.datadoghq.com/api/v1/series?api_key=$DD_API_KEY"
 

--- a/.gitlab/pkg_metrics.yml
+++ b/.gitlab/pkg_metrics.yml
@@ -39,7 +39,7 @@ send_pkg_size-a6:
   stage: pkg_metrics
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
   tags: ["runner:main"]
-  dependencies:
+  needs:
     - agent_deb-x64-a6
     - agent_rpm-x64-a6
     - agent_suse-x64-a6
@@ -93,17 +93,22 @@ send_pkg_size-a6:
 send_pkg_size-a7:
   allow_failure: true
   rules:
-    !reference [.on_deploy_a7]
+    !reference [.on_all_builds_a7]
   stage: pkg_metrics
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
   tags: ["runner:main"]
-  dependencies:
+  needs:
     - agent_deb-x64-a7
+    - agent_deb-arm64-a7
     - iot_agent_deb-x64
+    - iot_agent_deb-arm64
     - dogstatsd_deb-x64
+    - dogstatsd_deb-arm64
     - agent_heroku_deb-x64-a7
+    - agent_rpm-arm64-a7
     - agent_rpm-x64-a7
     - iot_agent_rpm-x64
+    - iot_agent_rpm-arm64
     - dogstatsd_rpm-x64
     - agent_suse-x64-a7
     - dogstatsd_suse-x64
@@ -118,28 +123,31 @@ send_pkg_size-a7:
 
     - source /root/.bashrc && conda activate ddpy3
     - mkdir -p /tmp/deb/agent /tmp/deb/dogstatsd /tmp/deb/iot-agent /tmp/deb/heroku-agent
+    - mkdir -p /tmp/arm-deb/agent /tmp/arm-deb/dogstatsd /tmp/arm-deb/iot-agent
     - mkdir -p /tmp/rpm/agent /tmp/rpm/dogstatsd /tmp/rpm/iot-agent
+    - mkdir -p /tmp/arm-rpm/agent /tmp/arm-rpm/iot-agent
     - mkdir -p /tmp/suse/agent /tmp/suse/dogstatsd /tmp/suse/iot-agent
 
     - |
         add_metrics() {
             local base="${1}"
             local os="${2}"
+            local arch="${3}"
 
             # record the total uncompressed size of each package
-            add_metric datadog.agent.package.size $(du -sB1 ${base}/agent | sed 's/\([0-9]\+\).\+/\1/') os:${os} package:agent agent:7 bucket_branch:$BUCKET_BRANCH
-            add_metric datadog.agent.package.size $(du -sB1 ${base}/dogstatsd | sed 's/\([0-9]\+\).\+/\1/') os:${os} package:dogstatsd agent:7 bucket_branch:$BUCKET_BRANCH
-            add_metric datadog.agent.package.size $(du -sB1 ${base}/iot-agent | sed 's/\([0-9]\+\).\+/\1/') os:${os} package:iot-agent agent:7 bucket_branch:$BUCKET_BRANCH
-            if [[ "$os" == "debian" ]]; then add_metric datadog.agent.package.size $(du -sB1 ${base}/heroku-agent | sed 's/\([0-9]\+\).\+/\1/') os:${os} package:heroku-agent agent:7 bucket_branch:$BUCKET_BRANCH; fi
+            add_metric datadog.agent.package.size $(du -sB1 ${base}/agent | sed 's/\([0-9]\+\).\+/\1/') os:${os} package:agent agent:7 bucket_branch:$BUCKET_BRANCH arch:${arch}
+            if [[ "$arch" == "amd64" || "$os" == "debian" ]]; then add_metric datadog.agent.package.size $(du -sB1 ${base}/dogstatsd | sed 's/\([0-9]\+\).\+/\1/') os:${os} package:dogstatsd agent:7 bucket_branch:$BUCKET_BRANCH arch:${arch}; fi
+            add_metric datadog.agent.package.size $(du -sB1 ${base}/iot-agent | sed 's/\([0-9]\+\).\+/\1/') os:${os} package:iot-agent agent:7 bucket_branch:$BUCKET_BRANCH arch:${arch}
+            if [[ "$os" == "debian" && "$arch" == "amd64" ]]; then add_metric datadog.agent.package.size $(du -sB1 ${base}/heroku-agent | sed 's/\([0-9]\+\).\+/\1/') os:${os} package:heroku-agent agent:7 bucket_branch:$BUCKET_BRANCH arch:amd64; fi
 
             # record the size of each of the important binaries in each package
-            add_metric datadog.agent.binary.size $(du -sB1 ${base}/agent/opt/datadog-agent/bin/agent/agent | sed 's/\([0-9]\+\).\+/\1/') bin:agent os:${os} package:agent agent:7 bucket_branch:$BUCKET_BRANCH
-            add_metric datadog.agent.binary.size $(du -sB1 ${base}/agent/opt/datadog-agent/embedded/bin/trace-agent | sed 's/\([0-9]\+\).\+/\1/') bin:trace-agent os:${os} package:agent agent:7 bucket_branch:$BUCKET_BRANCH
-            add_metric datadog.agent.binary.size $(du -sB1 ${base}/agent/opt/datadog-agent/embedded/bin/security-agent | sed 's/\([0-9]\+\).\+/\1/') bin:security-agent os:${os} package:agent agent:7 bucket_branch:$BUCKET_BRANCH
-            add_metric datadog.agent.binary.size $(du -sB1 ${base}/agent/opt/datadog-agent/embedded/bin/process-agent | sed 's/\([0-9]\+\).\+/\1/') bin:process-agent os:${os} package:agent agent:7 bucket_branch:$BUCKET_BRANCH
-            add_metric datadog.agent.binary.size $(du -sB1 ${base}/agent/opt/datadog-agent/embedded/bin/system-probe | sed 's/\([0-9]\+\).\+/\1/') bin:system-probe os:${os} package:agent agent:7 bucket_branch:$BUCKET_BRANCH
-            add_metric datadog.agent.binary.size $(du -sB1 ${base}/dogstatsd/opt/datadog-dogstatsd/bin/dogstatsd | sed 's/\([0-9]\+\).\+/\1/') bin:dogstatsd os:${os} package:dogstatsd agent:7 bucket_branch:$BUCKET_BRANCH
-            add_metric datadog.agent.binary.size $(du -sB1 ${base}/iot-agent/opt/datadog-agent/bin/agent/agent | sed 's/\([0-9]\+\).\+/\1/') bin:agent os:${os} package:iot-agent agent:7 bucket_branch:$BUCKET_BRANCH
+            add_metric datadog.agent.binary.size $(du -sB1 ${base}/agent/opt/datadog-agent/bin/agent/agent | sed 's/\([0-9]\+\).\+/\1/') bin:agent os:${os} package:agent agent:7 bucket_branch:$BUCKET_BRANCH arch:${arch}
+            add_metric datadog.agent.binary.size $(du -sB1 ${base}/agent/opt/datadog-agent/embedded/bin/trace-agent | sed 's/\([0-9]\+\).\+/\1/') bin:trace-agent os:${os} package:agent agent:7 bucket_branch:$BUCKET_BRANCH arch:${arch}
+            add_metric datadog.agent.binary.size $(du -sB1 ${base}/agent/opt/datadog-agent/embedded/bin/security-agent | sed 's/\([0-9]\+\).\+/\1/') bin:security-agent os:${os} package:agent agent:7 bucket_branch:$BUCKET_BRANCH arch:${arch}
+            add_metric datadog.agent.binary.size $(du -sB1 ${base}/agent/opt/datadog-agent/embedded/bin/process-agent | sed 's/\([0-9]\+\).\+/\1/') bin:process-agent os:${os} package:agent agent:7 bucket_branch:$BUCKET_BRANCH arch:${arch}
+            add_metric datadog.agent.binary.size $(du -sB1 ${base}/agent/opt/datadog-agent/embedded/bin/system-probe | sed 's/\([0-9]\+\).\+/\1/') bin:system-probe os:${os} package:agent agent:7 bucket_branch:$BUCKET_BRANCH arch:${arch}
+            if [[ "$arch" == "amd64" || "$os" == "debian" ]]; then add_metric datadog.agent.binary.size $(du -sB1 ${base}/dogstatsd/opt/datadog-dogstatsd/bin/dogstatsd | sed 's/\([0-9]\+\).\+/\1/') bin:dogstatsd os:${os} package:dogstatsd agent:7 bucket_branch:$BUCKET_BRANCH arch:${arch}; fi 
+            add_metric datadog.agent.binary.size $(du -sB1 ${base}/iot-agent/opt/datadog-agent/bin/agent/agent | sed 's/\([0-9]\+\).\+/\1/') bin:agent os:${os} package:iot-agent agent:7 bucket_branch:$BUCKET_BRANCH arch:${arch}
         }
 
     # We silence dpkg and cpio output so we don't exceed gitlab log limit
@@ -149,19 +157,30 @@ send_pkg_size-a7:
     - dpkg -x $OMNIBUS_PACKAGE_DIR/datadog-iot-agent_7*_amd64.deb /tmp/deb/iot-agent > /dev/null
     - dpkg -x $OMNIBUS_PACKAGE_DIR/datadog-dogstatsd_7*_amd64.deb /tmp/deb/dogstatsd > /dev/null
     - dpkg -x $OMNIBUS_PACKAGE_DIR/datadog-heroku-agent_7*_amd64.deb /tmp/deb/heroku-agent > /dev/null
-    - add_metrics /tmp/deb debian
+    - add_metrics /tmp/deb debian amd64
+
+    # debian arm64
+    - dpkg -x $OMNIBUS_PACKAGE_DIR/datadog-agent_7*_arm64.deb /tmp/arm-deb/agent > /dev/null
+    - dpkg -x $OMNIBUS_PACKAGE_DIR/datadog-iot-agent_7*_arm64.deb /tmp/arm-deb/iot-agent > /dev/null
+    - dpkg -x $OMNIBUS_PACKAGE_DIR/datadog-dogstatsd_7*_arm64.deb /tmp/arm-deb/dogstatsd > /dev/null
+    - add_metrics /tmp/arm-deb debian arm64
 
     # centos
     - cd /tmp/rpm/agent && rpm2cpio $OMNIBUS_PACKAGE_DIR/datadog-agent-7.*.x86_64.rpm | cpio -idm > /dev/null
     - cd /tmp/rpm/dogstatsd && rpm2cpio $OMNIBUS_PACKAGE_DIR/datadog-dogstatsd-7.*.x86_64.rpm | cpio -idm > /dev/null
     - cd /tmp/rpm/iot-agent && rpm2cpio $OMNIBUS_PACKAGE_DIR/datadog-iot-agent-7.*.x86_64.rpm | cpio -idm > /dev/null
-    - add_metrics /tmp/rpm centos
+    - add_metrics /tmp/rpm centos amd64
+
+    # centos arm64
+    - cd /tmp/arm-rpm/agent && rpm2cpio $OMNIBUS_PACKAGE_DIR/datadog-agent-7.*.aarch64.rpm | cpio -idm > /dev/null
+    - cd /tmp/arm-rpm/iot-agent && rpm2cpio $OMNIBUS_PACKAGE_DIR/datadog-iot-agent-7.*.aarch64.rpm | cpio -idm > /dev/null
+    - add_metrics /tmp/arm-rpm centos arm64
 
     # suse
     - cd /tmp/suse/agent && rpm2cpio $OMNIBUS_PACKAGE_DIR_SUSE/datadog-agent-7.*.x86_64.rpm | cpio -idm > /dev/null
     - cd /tmp/suse/dogstatsd && rpm2cpio $OMNIBUS_PACKAGE_DIR_SUSE/datadog-dogstatsd-7.*.x86_64.rpm | cpio -idm > /dev/null
     - cd /tmp/suse/iot-agent && rpm2cpio $OMNIBUS_PACKAGE_DIR_SUSE/datadog-iot-agent-7.*.x86_64.rpm | cpio -idm > /dev/null
-    - add_metrics /tmp/suse suse
+    - add_metrics /tmp/suse suse amd64
 
     # Send package and binary size metrics
     - !reference [.send_metrics, script]

--- a/.gitlab/pkg_metrics.yml
+++ b/.gitlab/pkg_metrics.yml
@@ -35,11 +35,11 @@
 send_pkg_size-a6:
   allow_failure: true
   rules:
-    !reference [.on_all_builds_a6]
+    !reference [.on_deploy_a6]
   stage: pkg_metrics
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
   tags: ["runner:main"]
-  needs:
+  dependencies:
     - agent_deb-x64-a6
     - agent_rpm-x64-a6
     - agent_suse-x64-a6
@@ -93,11 +93,11 @@ send_pkg_size-a6:
 send_pkg_size-a7:
   allow_failure: true
   rules:
-    !reference [.on_all_builds_a7]
+    !reference [.on_deploy_a7]
   stage: pkg_metrics
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
   tags: ["runner:main"]
-  needs:
+  dependencies:
     - agent_deb-x64-a7
     - agent_deb-arm64-a7
     - iot_agent_deb-x64
@@ -207,10 +207,16 @@ send_pkg_size-a7:
 
             curl -sSL "https://s3.amazonaws.com/apt.datadoghq.com/pool/d/da/${flavor}_${last_stable}-1_amd64.deb" -o "/tmp/stable/${flavor}/${flavor}_${last_stable}-1_amd64.deb"
 
-            add_metric datadog.agent.compressed_package.size $(du -sB1 ${OMNIBUS_PACKAGE_DIR}/${flavor}_${MAJOR_VERSION}*_amd64.deb | cut -f -1) os:debian package:${flavor} agent:${MAJOR_VERSION} git_ref:${CI_COMMIT_REF_SLUG} bucket_branch:${BUCKET_BRANCH}
+            curl -sSL "https://s3.amazonaws.com/apt.datadoghq.com/pool/d/da/${flavor}_${last_stable}-1_arm64.deb" -o "/tmp/stable/${flavor}/${flavor}_${last_stable}-1_arm64.deb"
+
+            add_metric datadog.agent.compressed_package.size $(du -sB1 ${OMNIBUS_PACKAGE_DIR}/${flavor}_${MAJOR_VERSION}*_amd64.deb | cut -f -1) os:debian package:${flavor} agent:${MAJOR_VERSION} git_ref:${CI_COMMIT_REF_SLUG} bucket_branch:${BUCKET_BRANCH} arch:amd64
+
+            add_metric datadog.agent.compressed_package.size $(du -sB1 ${OMNIBUS_PACKAGE_DIR}/${flavor}_${MAJOR_VERSION}*_arm64.deb | cut -f -1) os:debian package:${flavor} agent:${MAJOR_VERSION} git_ref:${CI_COMMIT_REF_SLUG} bucket_branch:${BUCKET_BRANCH} arch:arm64
 
             set +e
             inv package.compare-size --package-type "${flavor} deb" --last-stable "${last_stable}" --threshold "${max_sizes[${flavor}]}" --new-package "$OMNIBUS_PACKAGE_DIR/${flavor}_${MAJOR_VERSION}*_amd64.deb" --stable-package "/tmp/stable/${flavor}/${flavor}_${last_stable}-1_amd64.deb"
+            failures=$((${failures}+$?))
+            inv package.compare-size --package-type "${flavor} deb" --last-stable "${last_stable}" --threshold "${max_sizes[${flavor}]}" --new-package "$OMNIBUS_PACKAGE_DIR/${flavor}_${MAJOR_VERSION}*_arm64.deb" --stable-package "/tmp/stable/${flavor}/${flavor}_${last_stable}-1_arm64.deb"
             failures=$((${failures}+$?))
             set -e
 
@@ -219,9 +225,17 @@ send_pkg_size-a7:
               curl -sSL "https://s3.amazonaws.com/yum.datadoghq.com/stable/${MAJOR_VERSION}/x86_64/${flavor}-${last_stable}-1.x86_64.rpm" -o "/tmp/stable/${flavor}/${flavor}-${last_stable}-1.x86_64.rpm"
               curl -sSL "https://s3.amazonaws.com/yum.datadoghq.com/suse/stable/${MAJOR_VERSION}/x86_64/${flavor}-${last_stable}-1.x86_64.rpm" -o "/tmp/stable/${flavor}/suse/${flavor}-${last_stable}-1.x86_64.rpm"
 
-              add_metric datadog.agent.compressed_package.size $(du -sB1 ${OMNIBUS_PACKAGE_DIR}/${flavor}-${MAJOR_VERSION}.*.x86_64.rpm | cut -f -1) os:centos package:${flavor} agent:${MAJOR_VERSION} git_ref:${CI_COMMIT_REF_SLUG} bucket_branch:${BUCKET_BRANCH}
-              add_metric datadog.agent.compressed_package.size $(du -sB1 ${OMNIBUS_PACKAGE_DIR_SUSE}/${flavor}-${MAJOR_VERSION}.*.x86_64.rpm | cut -f -1) os:suse package:${flavor} agent:${MAJOR_VERSION} git_ref:${CI_COMMIT_REF_SLUG} bucket_branch:${BUCKET_BRANCH}
+              curl -sSL "https://s3.amazonaws.com/yum.datadoghq.com/stable/${MAJOR_VERSION}/aarch64/${flavor}-${last_stable}-1.aarch64.rpm" -o "/tmp/stable/${flavor}/${flavor}-${last_stable}-1.aarch64.rpm"
 
+              add_metric datadog.agent.compressed_package.size $(du -sB1 ${OMNIBUS_PACKAGE_DIR}/${flavor}-${MAJOR_VERSION}.*.x86_64.rpm | cut -f -1) os:centos package:${flavor} agent:${MAJOR_VERSION} git_ref:${CI_COMMIT_REF_SLUG} bucket_branch:${BUCKET_BRANCH} arch:amd64
+              add_metric datadog.agent.compressed_package.size $(du -sB1 ${OMNIBUS_PACKAGE_DIR_SUSE}/${flavor}-${MAJOR_VERSION}.*.x86_64.rpm | cut -f -1) os:suse package:${flavor} agent:${MAJOR_VERSION} git_ref:${CI_COMMIT_REF_SLUG} bucket_branch:${BUCKET_BRANCH} arch:amd64
+              if [[ "$flavor" != "datadog-dogstatsd" ]]; then
+                add_metric datadog.agent.compressed_package.size $(du -sB1 ${OMNIBUS_PACKAGE_DIR}/${flavor}-${MAJOR_VERSION}.*.aarch64.rpm | cut -f -1) os:centos package:${flavor} agent:${MAJOR_VERSION} git_ref:${CI_COMMIT_REF_SLUG} bucket_branch:${BUCKET_BRANCH} arch:arm64
+                set +e
+                inv package.compare-size --package-type "${flavor} rpm" --last-stable "${last_stable}" --threshold "${max_sizes[${flavor}]}" --new-package "$OMNIBUS_PACKAGE_DIR/${flavor}-${MAJOR_VERSION}.*.aarch64.rpm" --stable-package "/tmp/stable/${flavor}/${flavor}-${last_stable}-1.aarch64.rpm"
+                failures=$((${failures}+$?))
+                set -e
+              fi
               set +e
               inv package.compare-size --package-type "${flavor} rpm" --last-stable "${last_stable}" --threshold "${max_sizes[${flavor}]}" --new-package "$OMNIBUS_PACKAGE_DIR/${flavor}-${MAJOR_VERSION}.*.x86_64.rpm" --stable-package "/tmp/stable/${flavor}/${flavor}-${last_stable}-1.x86_64.rpm"
               failures=$((${failures}+$?))

--- a/.gitlab/pkg_metrics.yml
+++ b/.gitlab/pkg_metrics.yml
@@ -243,7 +243,6 @@ send_pkg_size-a7:
     - !reference [.add_metric_func, script]
 
     - ls -l $OMNIBUS_PACKAGE_DIR
-    - ls -l $OMNIBUS_PACKAGE_DIR_SUSE
     - source /root/.bashrc && conda activate ddpy3
     - export failures=0
     - export last_stable=$(inv release.get-release-json-value "last_stable::${MAJOR_VERSION}")

--- a/.gitlab/pkg_metrics.yml
+++ b/.gitlab/pkg_metrics.yml
@@ -193,7 +193,7 @@ send_pkg_size-a7:
     - !reference [.add_metric_func, script]
 
     - ls -l $OMNIBUS_PACKAGE_DIR
-    - ls -l $OMNIBUS_PACKAGE_DIR_SUSE
+    - if [[ "${ARCH}" == "amd64" ]]; then ls -l $OMNIBUS_PACKAGE_DIR_SUSE; fi
     - source /root/.bashrc && conda activate ddpy3
     - export failures=0
     - export last_stable=$(inv release.get-release-json-value "last_stable::${MAJOR_VERSION}")

--- a/.gitlab/pkg_metrics.yml
+++ b/.gitlab/pkg_metrics.yml
@@ -207,16 +207,10 @@ send_pkg_size-a7:
 
             curl -sSL "https://s3.amazonaws.com/apt.datadoghq.com/pool/d/da/${flavor}_${last_stable}-1_amd64.deb" -o "/tmp/stable/${flavor}/${flavor}_${last_stable}-1_amd64.deb"
 
-            curl -sSL "https://s3.amazonaws.com/apt.datadoghq.com/pool/d/da/${flavor}_${last_stable}-1_arm64.deb" -o "/tmp/stable/${flavor}/${flavor}_${last_stable}-1_arm64.deb"
-
             add_metric datadog.agent.compressed_package.size $(du -sB1 ${OMNIBUS_PACKAGE_DIR}/${flavor}_${MAJOR_VERSION}*_amd64.deb | cut -f -1) os:debian package:${flavor} agent:${MAJOR_VERSION} git_ref:${CI_COMMIT_REF_SLUG} bucket_branch:${BUCKET_BRANCH} arch:amd64
-
-            add_metric datadog.agent.compressed_package.size $(du -sB1 ${OMNIBUS_PACKAGE_DIR}/${flavor}_${MAJOR_VERSION}*_arm64.deb | cut -f -1) os:debian package:${flavor} agent:${MAJOR_VERSION} git_ref:${CI_COMMIT_REF_SLUG} bucket_branch:${BUCKET_BRANCH} arch:arm64
 
             set +e
             inv package.compare-size --package-type "${flavor} deb" --last-stable "${last_stable}" --threshold "${max_sizes[${flavor}]}" --new-package "$OMNIBUS_PACKAGE_DIR/${flavor}_${MAJOR_VERSION}*_amd64.deb" --stable-package "/tmp/stable/${flavor}/${flavor}_${last_stable}-1_amd64.deb"
-            failures=$((${failures}+$?))
-            inv package.compare-size --package-type "${flavor} deb" --last-stable "${last_stable}" --threshold "${max_sizes[${flavor}]}" --new-package "$OMNIBUS_PACKAGE_DIR/${flavor}_${MAJOR_VERSION}*_arm64.deb" --stable-package "/tmp/stable/${flavor}/${flavor}_${last_stable}-1_arm64.deb"
             failures=$((${failures}+$?))
             set -e
 
@@ -224,22 +218,57 @@ send_pkg_size-a7:
               # We don't build RPM packages for the heroku flavor
               curl -sSL "https://s3.amazonaws.com/yum.datadoghq.com/stable/${MAJOR_VERSION}/x86_64/${flavor}-${last_stable}-1.x86_64.rpm" -o "/tmp/stable/${flavor}/${flavor}-${last_stable}-1.x86_64.rpm"
               curl -sSL "https://s3.amazonaws.com/yum.datadoghq.com/suse/stable/${MAJOR_VERSION}/x86_64/${flavor}-${last_stable}-1.x86_64.rpm" -o "/tmp/stable/${flavor}/suse/${flavor}-${last_stable}-1.x86_64.rpm"
-
-              curl -sSL "https://s3.amazonaws.com/yum.datadoghq.com/stable/${MAJOR_VERSION}/aarch64/${flavor}-${last_stable}-1.aarch64.rpm" -o "/tmp/stable/${flavor}/${flavor}-${last_stable}-1.aarch64.rpm"
-
               add_metric datadog.agent.compressed_package.size $(du -sB1 ${OMNIBUS_PACKAGE_DIR}/${flavor}-${MAJOR_VERSION}.*.x86_64.rpm | cut -f -1) os:centos package:${flavor} agent:${MAJOR_VERSION} git_ref:${CI_COMMIT_REF_SLUG} bucket_branch:${BUCKET_BRANCH} arch:amd64
               add_metric datadog.agent.compressed_package.size $(du -sB1 ${OMNIBUS_PACKAGE_DIR_SUSE}/${flavor}-${MAJOR_VERSION}.*.x86_64.rpm | cut -f -1) os:suse package:${flavor} agent:${MAJOR_VERSION} git_ref:${CI_COMMIT_REF_SLUG} bucket_branch:${BUCKET_BRANCH} arch:amd64
-              if [[ "$flavor" != "datadog-dogstatsd" ]]; then
-                add_metric datadog.agent.compressed_package.size $(du -sB1 ${OMNIBUS_PACKAGE_DIR}/${flavor}-${MAJOR_VERSION}.*.aarch64.rpm | cut -f -1) os:centos package:${flavor} agent:${MAJOR_VERSION} git_ref:${CI_COMMIT_REF_SLUG} bucket_branch:${BUCKET_BRANCH} arch:arm64
-                set +e
-                inv package.compare-size --package-type "${flavor} rpm" --last-stable "${last_stable}" --threshold "${max_sizes[${flavor}]}" --new-package "$OMNIBUS_PACKAGE_DIR/${flavor}-${MAJOR_VERSION}.*.aarch64.rpm" --stable-package "/tmp/stable/${flavor}/${flavor}-${last_stable}-1.aarch64.rpm"
-                failures=$((${failures}+$?))
-                set -e
-              fi
               set +e
               inv package.compare-size --package-type "${flavor} rpm" --last-stable "${last_stable}" --threshold "${max_sizes[${flavor}]}" --new-package "$OMNIBUS_PACKAGE_DIR/${flavor}-${MAJOR_VERSION}.*.x86_64.rpm" --stable-package "/tmp/stable/${flavor}/${flavor}-${last_stable}-1.x86_64.rpm"
               failures=$((${failures}+$?))
               inv package.compare-size --package-type "${flavor} suse rpm" --last-stable "${last_stable}" --threshold "${max_sizes[${flavor}]}" --new-package "$OMNIBUS_PACKAGE_DIR_SUSE/${flavor}-${MAJOR_VERSION}.*.x86_64.rpm" --stable-package "/tmp/stable/${flavor}/suse/${flavor}-${last_stable}-1.x86_64.rpm"
+              failures=$((${failures}+$?))
+              set -e
+            fi
+        done
+
+    # Send package size metrics
+    - !reference [.send_metrics, script]
+
+    # Make the job fail if at least one package is above threshold
+    - if [ "${failures}" -ne "0" ]; then false; fi
+
+.check_arm64_pkg_size:
+  stage: pkg_metrics
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
+  tags: ["runner:main"]
+  script:
+    - !reference [.add_metric_func, script]
+
+    - ls -l $OMNIBUS_PACKAGE_DIR
+    - ls -l $OMNIBUS_PACKAGE_DIR_SUSE
+    - source /root/.bashrc && conda activate ddpy3
+    - export failures=0
+    - export last_stable=$(inv release.get-release-json-value "last_stable::${MAJOR_VERSION}")
+    # Get stable packages from S3 buckets, send new package sizes & compare stable and new package sizes
+    # The loop assumes that all flavors start with "da", which is currently the case
+    # We want to run all package size comparisons before failing, so we set +e while doing the comparisons
+    # to get the error codes without exiting the shell.
+    - |
+        for flavor in ${FLAVORS}; do
+            mkdir -p "/tmp/stable/${flavor}"
+
+            curl -sSL "https://s3.amazonaws.com/apt.datadoghq.com/pool/d/da/${flavor}_${last_stable}-1_arm64.deb" -o "/tmp/stable/${flavor}/${flavor}_${last_stable}-1_arm64.deb"
+
+            add_metric datadog.agent.compressed_package.size $(du -sB1 ${OMNIBUS_PACKAGE_DIR}/${flavor}_${MAJOR_VERSION}*_arm64.deb | cut -f -1) os:debian package:${flavor} agent:${MAJOR_VERSION} git_ref:${CI_COMMIT_REF_SLUG} bucket_branch:${BUCKET_BRANCH} arch:arm64
+
+            set +e
+            inv package.compare-size --package-type "${flavor} deb" --last-stable "${last_stable}" --threshold "${max_sizes[${flavor}]}" --new-package "$OMNIBUS_PACKAGE_DIR/${flavor}_${MAJOR_VERSION}*_arm64.deb" --stable-package "/tmp/stable/${flavor}/${flavor}_${last_stable}-1_arm64.deb"
+            failures=$((${failures}+$?))
+            set -e
+
+            if [[ "$flavor" != "datadog-dogstatsd" ]]; then 
+              curl -sSL "https://s3.amazonaws.com/yum.datadoghq.com/stable/${MAJOR_VERSION}/aarch64/${flavor}-${last_stable}-1.aarch64.rpm" -o "/tmp/stable/${flavor}/${flavor}-${last_stable}-1.aarch64.rpm"
+              add_metric datadog.agent.compressed_package.size $(du -sB1 ${OMNIBUS_PACKAGE_DIR}/${flavor}-${MAJOR_VERSION}.*.aarch64.rpm | cut -f -1) os:centos package:${flavor} agent:${MAJOR_VERSION} git_ref:${CI_COMMIT_REF_SLUG} bucket_branch:${BUCKET_BRANCH} arch:arm64
+              set +e
+              inv package.compare-size --package-type "${flavor} rpm" --last-stable "${last_stable}" --threshold "${max_sizes[${flavor}]}" --new-package "$OMNIBUS_PACKAGE_DIR/${flavor}-${MAJOR_VERSION}.*.aarch64.rpm" --stable-package "/tmp/stable/${flavor}/${flavor}-${last_stable}-1.aarch64.rpm"
               failures=$((${failures}+$?))
               set -e
             fi
@@ -259,6 +288,26 @@ check_pkg_size-a6:
     - agent_deb-x64-a6
     - agent_rpm-x64-a6
     - agent_suse-x64-a6
+    - agent_deb-arm64-a6
+    - agent_rpm-arm64-a6
+  variables:
+    MAJOR_VERSION: 6
+    FLAVORS: "datadog-agent"
+  before_script:
+    # FIXME: ["datadog-agent"]="25000000" should be replaced by "15000000"
+    # "25000000" is needed as of now because of a large bump in size in system-probe in 7.35
+    - |
+        declare -Ar max_sizes=(
+            ["datadog-agent"]="25000000"
+        )
+
+check_pkg_size-arm64-a6:
+  extends: .check_arm64_pkg_size
+  rules:
+    !reference [.on_all_builds_a6]
+  needs:
+    - agent_deb-arm64-a6
+    - agent_rpm-arm64-a6
   variables:
     MAJOR_VERSION: 6
     FLAVORS: "datadog-agent"
@@ -276,11 +325,16 @@ check_pkg_size-a7:
     !reference [.on_a7]
   needs:
     - agent_deb-x64-a7
+    - agent_deb-arm64-a7
     - iot_agent_deb-x64
+    - iot_agent_deb-arm64
     - dogstatsd_deb-x64
+    - dogstatsd_deb-arm64
     - agent_heroku_deb-x64-a7
     - agent_rpm-x64-a7
+    - agent_rpm-arm64-a7
     - iot_agent_rpm-x64
+    - iot_agent_rpm-arm64
     - dogstatsd_rpm-x64
     - agent_suse-x64-a7
     - dogstatsd_suse-x64
@@ -299,4 +353,29 @@ check_pkg_size-a7:
             ["datadog-iot-agent"]="10000000"
             ["datadog-dogstatsd"]="10000000"
             ["datadog-heroku-agent"]="25000000"
+        )
+
+check_pkg_size-arm64-a7:
+  extends: .check_arm64_pkg_size
+  rules:
+    !reference [.on_all_builds_a7]
+  needs:
+    - agent_deb-arm64-a7
+    - iot_agent_deb-arm64
+    - dogstatsd_deb-arm64
+    - agent_rpm-arm64-a7
+    - iot_agent_rpm-arm64
+  variables:
+    MAJOR_VERSION: 7
+    FLAVORS: "datadog-agent datadog-iot-agent datadog-dogstatsd"
+  before_script:
+    # FIXME: ["datadog-agent"]="25000000" and ["datadog-heroku-agent"]="25000000" should
+    # be replaced by "15000000"
+    # "25000000" is needed as of now because of a large bump in size in system-probe in 7.35
+    # If this happens often we could exclude system-probe from the heroku build, it's not used.
+    - |
+        declare -Ar max_sizes=(
+            ["datadog-agent"]="25000000"
+            ["datadog-iot-agent"]="10000000"
+            ["datadog-dogstatsd"]="10000000"
         )

--- a/.gitlab/pkg_metrics.yml
+++ b/.gitlab/pkg_metrics.yml
@@ -35,7 +35,7 @@
 send_pkg_size-a6:
   allow_failure: true
   rules:
-    !reference [.on_a6]
+    !reference [.on_all_builds_a6]
   stage: pkg_metrics
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
   tags: ["runner:main"]


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Allows the datadog-agent pipeline to report the size of arm64 Linux packages & binaries. The tag `arch:arm64` or `arch:amd64` is used to differentiate reports.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
