### PR TITLE
{tagger,ksm,admission} add rc rev and id as tags

### DIFF
--- a/pkg/clusteragent/admission/common/const.go
+++ b/pkg/clusteragent/admission/common/const.go
@@ -20,10 +20,4 @@ const (
 
 	// LibConfigV1AnnotKeyFormat is the format of the library config annotation
 	LibConfigV1AnnotKeyFormat = "admission.datadoghq.com/%s-lib.config.v1"
-
-	// RcIDAnnotKey is the key of the RC ID annotation
-	RcIDAnnotKey = "admission.datadoghq.com/rc.id"
-
-	// RcRevisionAnnotKey is the key of the RC revision annotation
-	RcRevisionAnnotKey = "admission.datadoghq.com/rc.rev"
 )

--- a/pkg/clusteragent/admission/patch/patcher.go
+++ b/pkg/clusteragent/admission/patch/patcher.go
@@ -90,6 +90,8 @@ func (p *patcher) patchDeployment(req PatchRequest) error {
 	}
 	deploy.Annotations[k8sutil.RcIDAnnotKey] = req.ID
 	deploy.Annotations[k8sutil.RcRevisionAnnotKey] = revision
+	deploy.Spec.Template.Annotations[k8sutil.RcIDAnnotKey] = req.ID
+	deploy.Spec.Template.Annotations[k8sutil.RcRevisionAnnotKey] = fmt.Sprint(req.Revision)
 	newObj, err := json.Marshal(deploy)
 	if err != nil {
 		return fmt.Errorf("failed to encode object: %v", err)
@@ -122,8 +124,6 @@ func enableConfig(deploy *corev1.Deployment, req PatchRequest) error {
 	}
 	configAnnotKey := fmt.Sprintf(common.LibConfigV1AnnotKeyFormat, req.LibConfig.Language)
 	deploy.Spec.Template.Annotations[configAnnotKey] = string(conf)
-	deploy.Spec.Template.Annotations[k8sutil.RcIDAnnotKey] = req.ID
-	deploy.Spec.Template.Annotations[k8sutil.RcRevisionAnnotKey] = fmt.Sprint(req.Revision)
 	return nil
 }
 
@@ -139,6 +139,4 @@ func disableConfig(deploy *corev1.Deployment, req PatchRequest) {
 	delete(deploy.Spec.Template.Annotations, versionAnnotKey)
 	configAnnotKey := fmt.Sprintf(common.LibConfigV1AnnotKeyFormat, req.LibConfig.Language)
 	delete(deploy.Spec.Template.Annotations, configAnnotKey)
-	delete(deploy.Spec.Template.Annotations, k8sutil.RcIDAnnotKey)
-	delete(deploy.Spec.Template.Annotations, k8sutil.RcRevisionAnnotKey)
 }

--- a/pkg/clusteragent/admission/patch/patcher_test.go
+++ b/pkg/clusteragent/admission/patch/patcher_test.go
@@ -55,6 +55,8 @@ func TestPatchDeployment(t *testing.T) {
 	require.Equal(t, got.Spec.Template.Labels["admission.datadoghq.com/enabled"], "true")
 	require.Equal(t, got.Spec.Template.Annotations["admission.datadoghq.com/java-lib.version"], "latest")
 	require.Equal(t, got.Spec.Template.Annotations["admission.datadoghq.com/java-lib.config.v1"], `{"library_language":"java","library_version":"latest"}`)
+	require.Equal(t, got.Spec.Template.Annotations["admission.datadoghq.com/rc.id"], "id")
+	require.Equal(t, got.Spec.Template.Annotations["admission.datadoghq.com/rc.rev"], "123")
 	require.Equal(t, got.Annotations["admission.datadoghq.com/rc.id"], "id")
 	require.Equal(t, got.Annotations["admission.datadoghq.com/rc.rev"], "123")
 
@@ -84,6 +86,8 @@ func TestPatchDeployment(t *testing.T) {
 	require.Equal(t, got.Spec.Template.Labels["admission.datadoghq.com/enabled"], "true")
 	require.Equal(t, got.Spec.Template.Annotations["admission.datadoghq.com/java-lib.version"], "latest")
 	require.Equal(t, got.Spec.Template.Annotations["admission.datadoghq.com/java-lib.config.v1"], `{"library_language":"java","library_version":"latest","tracing_tags":["k1:v1","k2:v2"]}`)
+	require.Equal(t, got.Spec.Template.Annotations["admission.datadoghq.com/rc.id"], "id")
+	require.Equal(t, got.Spec.Template.Annotations["admission.datadoghq.com/rc.rev"], "12345")
 	require.Equal(t, got.Annotations["admission.datadoghq.com/rc.id"], "id")
 	require.Equal(t, got.Annotations["admission.datadoghq.com/rc.rev"], "12345")
 }

--- a/pkg/clusteragent/admission/patch/patcher_test.go
+++ b/pkg/clusteragent/admission/patch/patcher_test.go
@@ -71,6 +71,8 @@ func TestPatchDeployment(t *testing.T) {
 	require.Equal(t, got.Spec.Template.Labels["admission.datadoghq.com/enabled"], "false")
 	require.NotContains(t, got.Spec.Template.Annotations, "admission.datadoghq.com/java-lib.version")
 	require.NotContains(t, got.Spec.Template.Annotations, "admission.datadoghq.com/java-lib.config.v1")
+	require.Equal(t, got.Spec.Template.Annotations["admission.datadoghq.com/rc.id"], "id")
+	require.Equal(t, got.Spec.Template.Annotations["admission.datadoghq.com/rc.rev"], "1234")
 	require.Equal(t, got.Annotations["admission.datadoghq.com/rc.id"], "id")
 	require.Equal(t, got.Annotations["admission.datadoghq.com/rc.rev"], "1234")
 

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
@@ -215,6 +215,8 @@ func (k *KSMCheck) Configure(integrationConfigDigest uint64, config, initConfig 
 
 	k.processLabelJoins()
 	k.processLabelsAsTags()
+
+	k.mergeAnnotationsAsTags(defaultAnnotationsAsTags())
 	k.processAnnotationsAsTags()
 
 	// Prepare labels mapper
@@ -650,6 +652,23 @@ func (k *KSMCheck) mergeLabelJoins(extra map[string]*JoinsConfigWithoutLabelsMap
 	for key, value := range extra {
 		if _, found := k.instance.LabelJoins[key]; !found {
 			k.instance.LabelJoins[key] = value
+		}
+	}
+}
+
+// mergeAnnotationsAsTags adds extra annotations as tags to the configured mapping.
+// User-defined annotations as tags are prioritized.
+func (k *KSMCheck) mergeAnnotationsAsTags(extra map[string]map[string]string) {
+	for resource, mapping := range extra {
+		_, found := k.instance.AnnotationsAsTags[resource]
+		if !found {
+			k.instance.AnnotationsAsTags[resource] = mapping
+			continue
+		}
+		for key, value := range mapping {
+			if _, found := k.instance.AnnotationsAsTags[resource][key]; !found {
+				k.instance.AnnotationsAsTags[resource][key] = value
+			}
 		}
 	}
 }

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
@@ -659,9 +659,13 @@ func (k *KSMCheck) mergeLabelJoins(extra map[string]*JoinsConfigWithoutLabelsMap
 // mergeAnnotationsAsTags adds extra annotations as tags to the configured mapping.
 // User-defined annotations as tags are prioritized.
 func (k *KSMCheck) mergeAnnotationsAsTags(extra map[string]map[string]string) {
+	if k.instance.AnnotationsAsTags == nil {
+		k.instance.AnnotationsAsTags = make(map[string]map[string]string)
+	}
 	for resource, mapping := range extra {
 		_, found := k.instance.AnnotationsAsTags[resource]
 		if !found {
+			k.instance.AnnotationsAsTags[resource] = make(map[string]string)
 			k.instance.AnnotationsAsTags[resource] = mapping
 			continue
 		}

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_defaults.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_defaults.go
@@ -8,6 +8,8 @@
 
 package ksm
 
+import "github.com/DataDog/datadog-agent/pkg/util/kubernetes"
+
 // ksmMetricPrefix defines the KSM metrics namespace
 const ksmMetricPrefix = "kubernetes_state."
 
@@ -225,5 +227,12 @@ func getLabelToMatchForKind(kind string) []string {
 		return []string{"persistentvolume"}
 	default:
 		return []string{kind, "namespace"}
+	}
+}
+
+func defaultAnnotationsAsTags() map[string]map[string]string {
+	return map[string]map[string]string{
+		"pod":        {kubernetes.RcIDAnnotKey: kubernetes.RcIDTagName, kubernetes.RcRevisionAnnotKey: kubernetes.RcRevisionTagName},
+		"deployment": {kubernetes.RcIDAnnotKey: kubernetes.RcIDTagName, kubernetes.RcRevisionAnnotKey: kubernetes.RcRevisionTagName},
 	}
 }

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_test.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_test.go
@@ -1215,6 +1215,53 @@ func TestKSMCheck_mergeLabelsMapper(t *testing.T) {
 	}
 }
 
+func TestKSMCheck_mergeAnnotationsAsTags(t *testing.T) {
+	tests := []struct {
+		name     string
+		conf     map[string]map[string]string
+		extra    map[string]map[string]string
+		expected map[string]map[string]string
+	}{
+		{
+			name:     "nominal",
+			conf:     make(map[string]map[string]string),
+			extra:    defaultAnnotationsAsTags(),
+			expected: defaultAnnotationsAsTags(),
+		},
+		{
+			name:     "nil conf",
+			conf:     nil,
+			extra:    defaultAnnotationsAsTags(),
+			expected: defaultAnnotationsAsTags(),
+		},
+		{
+			name:     "collision",
+			conf:     map[string]map[string]string{"pod": {"common_key": "in_val"}},
+			extra:    map[string]map[string]string{"pod": {"common_key": "extra_val", "foo": "bar"}},
+			expected: map[string]map[string]string{"pod": {"common_key": "in_val", "foo": "bar"}},
+		},
+		{
+			name:     "no collision",
+			conf:     map[string]map[string]string{"pod": {"common_key": "in_val"}},
+			extra:    map[string]map[string]string{"deployment": {"common_key": "extra_val", "foo": "bar"}},
+			expected: map[string]map[string]string{"pod": {"common_key": "in_val"}, "deployment": {"common_key": "extra_val", "foo": "bar"}},
+		},
+		{
+			name:     "nil extra",
+			conf:     map[string]map[string]string{"pod": {"common_key": "in_val"}},
+			extra:    nil,
+			expected: map[string]map[string]string{"pod": {"common_key": "in_val"}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			k := &KSMCheck{instance: &KSMConfig{AnnotationsAsTags: tt.conf}}
+			k.mergeAnnotationsAsTags(tt.extra)
+			assert.True(t, reflect.DeepEqual(tt.expected, k.instance.AnnotationsAsTags))
+		})
+	}
+}
+
 var metadataMetrics = []string{
 	"kube_cronjob_info",
 	"kube_job_info",

--- a/pkg/tagger/collectors/workloadmeta_extract.go
+++ b/pkg/tagger/collectors/workloadmeta_extract.go
@@ -276,6 +276,14 @@ func (c *WorkloadMetaCollector) handleKubePod(ev workloadmeta.Event) []*TagInfo 
 		tags.AddOrchestrator("oshift_deployment", deployName)
 	}
 
+	// Admission + Remote Config correlation tags
+	if rcID, found := pod.Annotations[kubernetes.RcIDAnnotKey]; found {
+		tags.AddLow(kubernetes.RcIDTagName, rcID)
+	}
+	if rcRev, found := pod.Annotations[kubernetes.RcRevisionAnnotKey]; found {
+		tags.AddLow(kubernetes.RcRevisionTagName, rcRev)
+	}
+
 	for _, owner := range pod.Owners {
 		tags.AddLow(kubernetes.OwnerRefKindTagName, strings.ToLower(owner.Kind))
 		tags.AddOrchestrator(kubernetes.OwnerRefNameTagName, owner.Name)

--- a/pkg/tagger/collectors/workloadmeta_test.go
+++ b/pkg/tagger/collectors/workloadmeta_test.go
@@ -336,6 +336,36 @@ func TestHandleKubePod(t *testing.T) {
 			},
 		},
 		{
+			name: "pod with admission + remote config annotations",
+			pod: workloadmeta.KubernetesPod{
+				EntityID: podEntityID,
+				EntityMeta: workloadmeta.EntityMeta{
+					Name:      podName,
+					Namespace: podNamespace,
+					Annotations: map[string]string{
+						"admission.datadoghq.com/rc.id":  "id",
+						"admission.datadoghq.com/rc.rev": "123",
+					},
+				},
+			},
+			expected: []*TagInfo{
+				{
+					Source:       podSource,
+					Entity:       podTaggerEntityID,
+					HighCardTags: []string{},
+					OrchestratorCardTags: []string{
+						fmt.Sprintf("pod_name:%s", podName),
+					},
+					LowCardTags: []string{
+						fmt.Sprintf("kube_namespace:%s", podNamespace),
+						"admission_rc_id:id",
+						"admission_rc_rev:123",
+					},
+					StandardTags: []string{},
+				},
+			},
+		},
+		{
 			name: "static tags",
 			staticTags: map[string]string{
 				"eks_fargate_node": "foobar",

--- a/pkg/tagger/collectors/workloadmeta_test.go
+++ b/pkg/tagger/collectors/workloadmeta_test.go
@@ -358,8 +358,8 @@ func TestHandleKubePod(t *testing.T) {
 					},
 					LowCardTags: []string{
 						fmt.Sprintf("kube_namespace:%s", podNamespace),
-						"admission_rc_id:id",
-						"admission_rc_rev:123",
+						"dd_remote_config_id:id",
+						"dd_remote_config_rev:123",
 					},
 					StandardTags: []string{},
 				},

--- a/pkg/util/kubernetes/const.go
+++ b/pkg/util/kubernetes/const.go
@@ -30,13 +30,13 @@ const (
 	RcIDAnnotKey = "admission.datadoghq.com/rc.id"
 
 	// RcIDTagName is the key of the RC ID tag
-	RcIDTagName = "admission_rc_id"
+	RcIDTagName = "dd_remote_config_id"
 
 	// RcRevisionAnnotKey is the key of the RC revision annotation
 	RcRevisionAnnotKey = "admission.datadoghq.com/rc.rev"
 
 	// RcRevisionTagName is the key of the RC revision tag
-	RcRevisionTagName = "admission_rc_rev"
+	RcRevisionTagName = "dd_remote_config_rev"
 
 	// EnvTagEnvVar is the environment variable of the env standard tag
 	EnvTagEnvVar = "DD_ENV"

--- a/pkg/util/kubernetes/const.go
+++ b/pkg/util/kubernetes/const.go
@@ -26,6 +26,18 @@ const (
 	// KubeAppManagedByLabelKey is the label key of the tool being used to manage the operation of an application
 	KubeAppManagedByLabelKey = "app.kubernetes.io/managed-by"
 
+	// RcIDAnnotKey is the key of the RC ID annotation
+	RcIDAnnotKey = "admission.datadoghq.com/rc.id"
+
+	// RcIDTagName is the key of the RC ID tag
+	RcIDTagName = "admission_rc_id"
+
+	// RcRevisionAnnotKey is the key of the RC revision annotation
+	RcRevisionAnnotKey = "admission.datadoghq.com/rc.rev"
+
+	// RcRevisionTagName is the key of the RC revision tag
+	RcRevisionTagName = "admission_rc_rev"
+
 	// EnvTagEnvVar is the environment variable of the env standard tag
 	EnvTagEnvVar = "DD_ENV"
 	// ServiceTagEnvVar is the environment variable of the service standard tag


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

- Add RC rev and ID annotations at the pod level
- Add the `dd_remote_config_id` and `dd_remote_config_rev` tags in the tagger
- Add the `dd_remote_config_id` and `dd_remote_config_rev` tags in the KSM core check via a default annotations as tags config

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Tag `kubernetes.*` and `kubernetes_state.*` (and other ootb) metrics (deployment and pod metrics) with RC metadata to allow correlation.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

No release note bc the feature is not GA.

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Auto-instrument a library via remote config, ensure `kubernetes.*` and `kubernetes_state.*` metrics are tagged with `dd_remote_config_id` and `dd_remote_config_rev`. (the tag names in the screenshot are outdated)

![image](https://user-images.githubusercontent.com/38987709/221882114-f607edf3-35fc-4033-ac79-ff9c313733bd.png)

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
