### PR TITLE
Fix some failures in dogstatsd TestUDPReceive

### DIFF
--- a/pkg/aggregator/demultiplexer_agent.go
+++ b/pkg/aggregator/demultiplexer_agent.go
@@ -30,6 +30,7 @@ type DemultiplexerWithAggregator interface {
 	// AggregateCheckSample adds check sample sent by a check from one of the collectors into a check sampler pipeline.
 	AggregateCheckSample(sample metrics.MetricSample)
 	Options() AgentDemultiplexerOptions
+	GetEventsAndServiceChecksChannels() (chan []*metrics.Event, chan []*metrics.ServiceCheck)
 }
 
 // AgentDemultiplexer is the demultiplexer implementation for the main Agent.

--- a/pkg/aggregator/demultiplexer_mock.go
+++ b/pkg/aggregator/demultiplexer_mock.go
@@ -22,6 +22,9 @@ type TestAgentDemultiplexer struct {
 	aggregatedSamples []metrics.MetricSample
 	noAggSamples      []metrics.MetricSample
 	sync.Mutex
+
+	events        chan []*metrics.Event
+	serviceChecks chan []*metrics.ServiceCheck
 }
 
 // AggregateSamples implements a noop timesampler, appending the samples in an internal slice.
@@ -40,7 +43,7 @@ func (a *TestAgentDemultiplexer) AggregateSample(sample metrics.MetricSample) {
 
 // GetEventsAndServiceChecksChannels returneds underlying events and service checks channels.
 func (a *TestAgentDemultiplexer) GetEventsAndServiceChecksChannels() (chan []*metrics.Event, chan []*metrics.ServiceCheck) {
-	return a.aggregator.GetBufferedChannels()
+	return a.events, a.serviceChecks
 }
 
 // SendSamplesWithoutAggregation implements a fake no aggregation pipeline ingestion part,
@@ -150,6 +153,8 @@ func InitTestAgentDemultiplexerWithOpts(opts AgentDemultiplexerOptions) *TestAge
 	demux := InitAndStartAgentDemultiplexer(opts, "hostname")
 	testAgent := TestAgentDemultiplexer{
 		AgentDemultiplexer: demux,
+		events:             make(chan []*metrics.Event),
+		serviceChecks:      make(chan []*metrics.ServiceCheck),
 	}
 	return &testAgent
 }

--- a/pkg/dogstatsd/batch.go
+++ b/pkg/dogstatsd/batch.go
@@ -76,7 +76,7 @@ func newBatcher(demux aggregator.DemultiplexerWithAggregator) *batcher {
 
 	// the Serverless Agent doesn't have to support service checks nor events so
 	// it doesn't run an Aggregator.
-	e, sc = demux.Aggregator().GetBufferedChannels()
+	e, sc = demux.GetEventsAndServiceChecksChannels()
 
 	// prepare on-time samples buffers
 	samples := make([]metrics.MetricSampleBatch, pipelineCount)

--- a/pkg/dogstatsd/server_test.go
+++ b/pkg/dogstatsd/server_test.go
@@ -200,7 +200,7 @@ func TestUDPReceive(t *testing.T) {
 
 	// multi-metric packet
 	conn.Write([]byte("daemon1:666|c\ndaemon2:1000|c"))
-	samples, timedSamples = demux.WaitForNumberOfSamples(2, 0, time.Second * 2)
+	samples, timedSamples = demux.WaitForNumberOfSamples(2, 0, time.Second*2)
 	require.Len(t, samples, 2)
 	require.Len(t, timedSamples, 0)
 	sample1 := samples[0]
@@ -217,7 +217,7 @@ func TestUDPReceive(t *testing.T) {
 
 	// multi-value packet
 	conn.Write([]byte("daemon1:666:123|c\ndaemon2:1000|c"))
-	samples, timedSamples = demux.WaitForNumberOfSamples(3, 0, time.Second * 2)
+	samples, timedSamples = demux.WaitForNumberOfSamples(3, 0, time.Second*2)
 	require.Len(t, samples, 3)
 	require.Len(t, timedSamples, 0)
 	sample1 = samples[0]
@@ -239,7 +239,7 @@ func TestUDPReceive(t *testing.T) {
 
 	// multi-value packet with skip empty
 	conn.Write([]byte("daemon1::666::123::::|c\ndaemon2:1000|c"))
-	samples, timedSamples = demux.WaitForNumberOfSamples(3, 0, time.Second * 2)
+	samples, timedSamples = demux.WaitForNumberOfSamples(3, 0, time.Second*2)
 	require.Len(t, samples, 3)
 	require.Len(t, timedSamples, 0)
 	sample1 = samples[0]
@@ -261,7 +261,7 @@ func TestUDPReceive(t *testing.T) {
 
 	//	// slightly malformed multi-metric packet, should still be parsed in whole
 	conn.Write([]byte("daemon1:666|c\n\ndaemon2:1000|c\n"))
-	samples, timedSamples = demux.WaitForNumberOfSamples(2, 0, time.Second * 2)
+	samples, timedSamples = demux.WaitForNumberOfSamples(2, 0, time.Second*2)
 	require.Len(t, samples, 2)
 	require.Len(t, timedSamples, 0)
 	sample1 = samples[0]
@@ -322,7 +322,7 @@ func TestUDPReceive(t *testing.T) {
 
 	// Late metric and a normal one
 	conn.Write([]byte("daemon:666|g|#sometag1:somevalue1,sometag2:somevalue2|T1658328888\ndaemon2:666|c"))
-	samples, timedSamples = demux.WaitForNumberOfSamples(1, 1, time.Second * 2)
+	samples, timedSamples = demux.WaitForNumberOfSamples(1, 1, time.Second*2)
 	require.Len(t, samples, 1)
 	require.Len(t, timedSamples, 1)
 	sample = timedSamples[0]

--- a/pkg/dogstatsd/server_test.go
+++ b/pkg/dogstatsd/server_test.go
@@ -200,7 +200,7 @@ func TestUDPReceive(t *testing.T) {
 
 	// multi-metric packet
 	conn.Write([]byte("daemon1:666|c\ndaemon2:1000|c"))
-	samples, timedSamples = demux.WaitForSamples(time.Second * 2)
+	samples, timedSamples = demux.WaitForNumberOfSamples(2, 0, time.Second * 2)
 	require.Len(t, samples, 2)
 	require.Len(t, timedSamples, 0)
 	sample1 := samples[0]
@@ -217,7 +217,7 @@ func TestUDPReceive(t *testing.T) {
 
 	// multi-value packet
 	conn.Write([]byte("daemon1:666:123|c\ndaemon2:1000|c"))
-	samples, timedSamples = demux.WaitForSamples(time.Second * 2)
+	samples, timedSamples = demux.WaitForNumberOfSamples(3, 0, time.Second * 2)
 	require.Len(t, samples, 3)
 	require.Len(t, timedSamples, 0)
 	sample1 = samples[0]
@@ -239,7 +239,7 @@ func TestUDPReceive(t *testing.T) {
 
 	// multi-value packet with skip empty
 	conn.Write([]byte("daemon1::666::123::::|c\ndaemon2:1000|c"))
-	samples, timedSamples = demux.WaitForSamples(time.Second * 2)
+	samples, timedSamples = demux.WaitForNumberOfSamples(3, 0, time.Second * 2)
 	require.Len(t, samples, 3)
 	require.Len(t, timedSamples, 0)
 	sample1 = samples[0]
@@ -261,7 +261,7 @@ func TestUDPReceive(t *testing.T) {
 
 	//	// slightly malformed multi-metric packet, should still be parsed in whole
 	conn.Write([]byte("daemon1:666|c\n\ndaemon2:1000|c\n"))
-	samples, timedSamples = demux.WaitForSamples(time.Second * 2)
+	samples, timedSamples = demux.WaitForNumberOfSamples(2, 0, time.Second * 2)
 	require.Len(t, samples, 2)
 	require.Len(t, timedSamples, 0)
 	sample1 = samples[0]
@@ -322,7 +322,7 @@ func TestUDPReceive(t *testing.T) {
 
 	// Late metric and a normal one
 	conn.Write([]byte("daemon:666|g|#sometag1:somevalue1,sometag2:somevalue2|T1658328888\ndaemon2:666|c"))
-	samples, timedSamples = demux.WaitForSamples(time.Second * 2)
+	samples, timedSamples = demux.WaitForNumberOfSamples(1, 1, time.Second * 2)
 	require.Len(t, samples, 1)
 	require.Len(t, timedSamples, 1)
 	sample = timedSamples[0]


### PR DESCRIPTION
### What does this PR do?

- Avoid a race between the test code and a running aggregator instance to read service checks. 
- Avoid a race when waiting for multiple samples in the test body.

### Motivation

Fix a flaky test.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
