### PR TITLE
Removed max entries from perf map

### DIFF
--- a/pkg/ebpf/c/map-defs.h
+++ b/pkg/ebpf/c/map-defs.h
@@ -16,9 +16,9 @@
     BPF_MAP(name, BPF_MAP_TYPE_PERF_EVENT_ARRAY, u32, value_type, \
         max_entries, 1)
 
-#define BPF_PERF_EVENT_ARRAY_MAP(name, value_type, max_entries)   \
+#define BPF_PERF_EVENT_ARRAY_MAP(name, value_type)   \
     BPF_MAP(name, BPF_MAP_TYPE_PERF_EVENT_ARRAY, u32, value_type, \
-        max_entries, 0)
+        0, 0)
 
 #define BPF_ARRAY_MAP(name, value_type, max_entries) \
     BPF_MAP(name, BPF_MAP_TYPE_ARRAY, u32, value_type, max_entries, 0)

--- a/pkg/network/ebpf/c/protocols/events.h
+++ b/pkg/network/ebpf/c/protocols/events.h
@@ -16,7 +16,7 @@
                    _STR(name)" batch is too large");                                    \
                                                                                         \
     BPF_PERCPU_ARRAY_MAP(name##_batch_state, __u32, batch_state_t, 1)                   \
-    BPF_PERF_EVENT_ARRAY_MAP(name##_batch_events, __u32, 0)                             \
+    BPF_PERF_EVENT_ARRAY_MAP(name##_batch_events, __u32)                                \
     BPF_HASH_MAP(name##_batches, batch_key_t, batch_data_t, 1)                          \
                                                                                         \
     static __always_inline bool name##_batch_full(batch_data_t *batch) {                \

--- a/pkg/network/ebpf/c/protocols/http/maps.h
+++ b/pkg/network/ebpf/c/protocols/http/maps.h
@@ -51,6 +51,6 @@ BPF_HASH_MAP(conn_tup_by_go_tls_conn, __u32, conn_tuple_t, 1)
 BPF_LRU_MAP(java_tls_connections, conn_tuple_t, bool, 1)
 
 /* This map used for notifying userspace of a shared library being loaded */
-BPF_PERF_EVENT_ARRAY_MAP(shared_libraries, __u32, 0)
+BPF_PERF_EVENT_ARRAY_MAP(shared_libraries, __u32)
 
 #endif

--- a/pkg/network/ebpf/c/tracer-maps.h
+++ b/pkg/network/ebpf/c/tracer-maps.h
@@ -21,7 +21,7 @@ BPF_HASH_MAP(tcp_ongoing_connect_pid, struct sock *, __u64, 1024)
 /* Will hold the tcp/udp close events
  * The keys are the cpu number and the values a perf file descriptor for a perf event
  */
-BPF_PERF_EVENT_ARRAY_MAP(conn_close_event, __u32, 0)
+BPF_PERF_EVENT_ARRAY_MAP(conn_close_event, __u32)
 
 /* We use this map as a container for batching closed tcp/udp connections
  * The key represents the CPU core. Ideally we should use a BPF_MAP_TYPE_PERCPU_HASH map


### PR DESCRIPTION

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
removes max entries option from perf event map


<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

perf map is a per-cpu array, and thus we should be able to modify the size of it, otherwise we can result in not consuming events from some cpus
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
