### PR TITLE
[Serverless] Use build tags to determine how to start logs agent.

### DIFF
--- a/pkg/logs/agent_not_serverless.go
+++ b/pkg/logs/agent_not_serverless.go
@@ -1,0 +1,125 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !serverless
+// +build !serverless
+
+package logs
+
+import (
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery"
+	coreConfig "github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/logs/auditor"
+	"github.com/DataDog/datadog-agent/pkg/logs/client"
+	"github.com/DataDog/datadog-agent/pkg/logs/client/http"
+	"github.com/DataDog/datadog-agent/pkg/logs/config"
+	"github.com/DataDog/datadog-agent/pkg/logs/diagnostic"
+	"github.com/DataDog/datadog-agent/pkg/logs/internal/launchers"
+	"github.com/DataDog/datadog-agent/pkg/logs/internal/launchers/container"
+	"github.com/DataDog/datadog-agent/pkg/logs/internal/launchers/docker"
+	filelauncher "github.com/DataDog/datadog-agent/pkg/logs/internal/launchers/file"
+	"github.com/DataDog/datadog-agent/pkg/logs/internal/launchers/journald"
+	"github.com/DataDog/datadog-agent/pkg/logs/internal/launchers/kubernetes"
+	"github.com/DataDog/datadog-agent/pkg/logs/internal/launchers/listener"
+	"github.com/DataDog/datadog-agent/pkg/logs/internal/launchers/windowsevent"
+	"github.com/DataDog/datadog-agent/pkg/logs/internal/util/containersorpods"
+	"github.com/DataDog/datadog-agent/pkg/logs/pipeline"
+	"github.com/DataDog/datadog-agent/pkg/logs/schedulers"
+	adScheduler "github.com/DataDog/datadog-agent/pkg/logs/schedulers/ad"
+	ccaScheduler "github.com/DataDog/datadog-agent/pkg/logs/schedulers/cca"
+	"github.com/DataDog/datadog-agent/pkg/logs/service"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
+	"github.com/DataDog/datadog-agent/pkg/status/health"
+	"github.com/DataDog/datadog-agent/pkg/util"
+	ddUtil "github.com/DataDog/datadog-agent/pkg/util"
+)
+
+// NewAgent returns a new Logs Agent
+func NewAgent(sources *sources.LogSources, services *service.Services, processingRules []*config.ProcessingRule, endpoints *config.Endpoints) *Agent {
+	health := health.RegisterLiveness("logs-agent")
+
+	// setup the auditor
+	// We pass the health handle to the auditor because it's the end of the pipeline and the most
+	// critical part. Arguably it could also be plugged to the destination.
+	auditorTTL := time.Duration(coreConfig.Datadog.GetInt("logs_config.auditor_ttl")) * time.Hour
+	auditor := auditor.New(coreConfig.Datadog.GetString("logs_config.run_path"), auditor.DefaultRegistryFilename, auditorTTL, health)
+	destinationsCtx := client.NewDestinationsContext()
+	diagnosticMessageReceiver := diagnostic.NewBufferedMessageReceiver()
+
+	// setup the pipeline provider that provides pairs of processor and sender
+	pipelineProvider := pipeline.NewProvider(config.NumberOfPipelines, auditor, diagnosticMessageReceiver, processingRules, endpoints, destinationsCtx)
+
+	cop := containersorpods.NewChooser()
+
+	// setup the launchers
+	lnchrs := launchers.NewLaunchers(sources, pipelineProvider, auditor)
+	lnchrs.AddLauncher(filelauncher.NewLauncher(
+		coreConfig.Datadog.GetInt("logs_config.open_files_limit"),
+		filelauncher.DefaultSleepDuration,
+		coreConfig.Datadog.GetBool("logs_config.validate_pod_container_id"),
+		time.Duration(coreConfig.Datadog.GetFloat64("logs_config.file_scan_period")*float64(time.Second)),
+		coreConfig.Datadog.GetString("logs_config.file_wildcard_selection_mode")))
+	lnchrs.AddLauncher(listener.NewLauncher(coreConfig.Datadog.GetInt("logs_config.frame_size")))
+	lnchrs.AddLauncher(journald.NewLauncher())
+	lnchrs.AddLauncher(windowsevent.NewLauncher())
+	if !util.CcaInAD() {
+		lnchrs.AddLauncher(docker.NewLauncher(
+			time.Duration(coreConfig.Datadog.GetInt("logs_config.docker_client_read_timeout"))*time.Second,
+			sources,
+			services,
+			cop,
+			coreConfig.Datadog.GetBool("logs_config.docker_container_use_file"),
+			coreConfig.Datadog.GetBool("logs_config.docker_container_force_use_file")))
+		lnchrs.AddLauncher(kubernetes.NewLauncher(
+			sources,
+			services,
+			cop,
+			coreConfig.Datadog.GetBool("logs_config.container_collect_all")))
+	} else {
+		lnchrs.AddLauncher(container.NewLauncher(sources))
+	}
+
+	return &Agent{
+		sources:                   sources,
+		services:                  services,
+		schedulers:                schedulers.NewSchedulers(sources, services),
+		auditor:                   auditor,
+		destinationsCtx:           destinationsCtx,
+		pipelineProvider:          pipelineProvider,
+		launchers:                 lnchrs,
+		health:                    health,
+		diagnosticMessageReceiver: diagnosticMessageReceiver,
+	}
+}
+
+// Start starts logs-agent
+// getAC is a func returning the prepared AutoConfig. It is nil until
+// the AutoConfig is ready, please consider using BlockUntilAutoConfigRanOnce
+// instead of directly using it.
+func Start(ac *autodiscovery.AutoConfig) (*Agent, error) {
+	agent, err := start()
+	if err != nil {
+		return nil, err
+	}
+	if ac == nil {
+		panic("AutoConfig must be initialized before logs-agent")
+	}
+	agent.AddScheduler(adScheduler.New(ac))
+	if !ddUtil.CcaInAD() {
+		agent.AddScheduler(ccaScheduler.New(ac))
+	}
+	return agent, nil
+}
+
+// buildEndpoints builds endpoints for the logs agent
+func buildEndpoints() (*config.Endpoints, error) {
+	httpConnectivity := config.HTTPConnectivityFailure
+	if endpoints, err := config.BuildHTTPEndpointsWithVectorOverride(intakeTrackType, AgentJSONIntakeProtocol, config.DefaultIntakeOrigin); err == nil {
+		httpConnectivity = http.CheckConnectivity(endpoints.Main)
+	}
+	return config.BuildEndpointsWithVectorOverride(httpConnectivity, intakeTrackType, AgentJSONIntakeProtocol, config.DefaultIntakeOrigin)
+}

--- a/pkg/logs/agent_serverless.go
+++ b/pkg/logs/agent_serverless.go
@@ -1,0 +1,64 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build serverless
+// +build serverless
+
+package logs
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/logs/auditor"
+	"github.com/DataDog/datadog-agent/pkg/logs/client"
+	"github.com/DataDog/datadog-agent/pkg/logs/config"
+	"github.com/DataDog/datadog-agent/pkg/logs/diagnostic"
+	"github.com/DataDog/datadog-agent/pkg/logs/internal/launchers"
+	"github.com/DataDog/datadog-agent/pkg/logs/internal/launchers/channel"
+	"github.com/DataDog/datadog-agent/pkg/logs/pipeline"
+	"github.com/DataDog/datadog-agent/pkg/logs/schedulers"
+	"github.com/DataDog/datadog-agent/pkg/logs/service"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
+	"github.com/DataDog/datadog-agent/pkg/status/health"
+)
+
+// Note: Building the logs-agent for serverless separately removes the
+// dependency on autodiscovery, file launchers, and some schedulers
+// thereby decreasing the binary size.
+
+// NewAgent returns a Logs Agent instance to run in a serverless environment.
+// The Serverless Logs Agent has only one input being the channel to receive the logs to process.
+// It is using a NullAuditor because we've nothing to do after having sent the logs to the intake.
+func NewAgent(sources *sources.LogSources, services *service.Services, processingRules []*config.ProcessingRule, endpoints *config.Endpoints) *Agent {
+	health := health.RegisterLiveness("logs-agent")
+
+	diagnosticMessageReceiver := diagnostic.NewBufferedMessageReceiver()
+
+	// setup the a null auditor, not tracking data in any registry
+	auditor := auditor.NewNullAuditor()
+	destinationsCtx := client.NewDestinationsContext()
+
+	// setup the pipeline provider that provides pairs of processor and sender
+	pipelineProvider := pipeline.NewServerlessProvider(config.NumberOfPipelines, auditor, processingRules, endpoints, destinationsCtx)
+
+	// setup the sole launcher for this agent
+	lnchrs := launchers.NewLaunchers(sources, pipelineProvider, auditor)
+	lnchrs.AddLauncher(channel.NewLauncher())
+
+	return &Agent{
+		sources:                   sources,
+		services:                  services,
+		schedulers:                schedulers.NewSchedulers(sources, services),
+		auditor:                   auditor,
+		destinationsCtx:           destinationsCtx,
+		pipelineProvider:          pipelineProvider,
+		launchers:                 lnchrs,
+		health:                    health,
+		diagnosticMessageReceiver: diagnosticMessageReceiver,
+	}
+}
+
+// buildEndpoints builds endpoints for the logs agent
+func buildEndpoints() (*config.Endpoints, error) {
+	return config.BuildServerlessEndpoints(intakeTrackType, config.DefaultIntakeProtocol)
+}

--- a/pkg/logs/agent_test.go
+++ b/pkg/logs/agent_test.go
@@ -3,6 +3,9 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build !serverless
+// +build !serverless
+
 package logs
 
 import (

--- a/pkg/logs/logs_not_serverless_test.go
+++ b/pkg/logs/logs_not_serverless_test.go
@@ -3,6 +3,9 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build !serverless
+// +build !serverless
+
 package logs
 
 import (
@@ -11,15 +14,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestBuildServerlessEndpoints(t *testing.T) {
-	endpoints, err := buildEndpoints(true)
-	assert.Nil(t, err)
-	assert.Equal(t, "http-intake.logs.datadoghq.com", endpoints.Main.Host)
-	assert.Equal(t, "lambda-extension", string(endpoints.Main.Origin))
-}
-
 func TestBuildEndpoints(t *testing.T) {
-	endpoints, err := buildEndpoints(false)
+	endpoints, err := buildEndpoints()
 	assert.Nil(t, err)
 	assert.Equal(t, "agent-intake.logs.datadoghq.com", endpoints.Main.Host)
 }

--- a/pkg/logs/logs_serverless_test.go
+++ b/pkg/logs/logs_serverless_test.go
@@ -1,0 +1,22 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build serverless
+// +build serverless
+
+package logs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildServerlessEndpoints(t *testing.T) {
+	endpoints, err := buildEndpoints()
+	assert.Nil(t, err)
+	assert.Equal(t, "http-intake.logs.datadoghq.com", endpoints.Main.Host)
+	assert.Equal(t, "lambda-extension", string(endpoints.Main.Origin))
+}


### PR DESCRIPTION

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Instead of passing a `bool` to `Start` which specifies if its running in serverless, use a build tag.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

This change removes several dependences from the serverless extension, most importantly `golang.org/x/text/encoding`. This reduces the binary size from 42.5MB to 41.8MB, saving roughly 0.78MB equivalent to about 7.8ms of cold start time.

Dependency graph:
<img width="1092" alt="Screen Shot 2023-02-28 at 10 24 29 AM" src="https://user-images.githubusercontent.com/1383216/221945213-2fba420b-1069-44c9-85a4-c4e8ed6b67f7.png">

