### PR TITLE
[Serverless] Disable debug trace agent server in serverless

### DIFF
--- a/pkg/trace/api/debug_server.go
+++ b/pkg/trace/api/debug_server.go
@@ -3,6 +3,9 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2023-present Datadog, Inc.
 
+//go:build !serverless
+// +build !serverless
+
 package api
 
 import (

--- a/pkg/trace/api/debug_server_serverless.go
+++ b/pkg/trace/api/debug_server_serverless.go
@@ -1,0 +1,20 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+//go:build serverless
+// +build serverless
+
+package api
+
+import "github.com/DataDog/datadog-agent/pkg/trace/config"
+
+type DebugServer struct{}
+
+func NewDebugServer(conf *config.AgentConfig) *DebugServer {
+	return new(DebugServer)
+}
+
+func (*DebugServer) Start() {}
+func (*DebugServer) Stop()  {}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Disables the trace agent's debug server when running in serverless using a build tag. 

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

This change removes several dependences from the serverless extension, most importantly `net/http/pprof`. This reduces the binary size from 42.5MB to 42.2MB, saving roughly 0.35MB equivalent to about 3.5ms of cold start time.

Dependency graph:

<img width="1479" alt="Screen Shot 2023-02-28 at 10 31 34 AM" src="https://user-images.githubusercontent.com/1383216/221947518-0c46039a-9dfe-4432-85a9-59ba847d5ccd.png">

