### PR TITLE
[Serverless] Implement serverless `SBOMMessage` to avoid agent-payload dependency.

### DIFF
--- a/pkg/serializer/types_sbom.go
+++ b/pkg/serializer/types_sbom.go
@@ -3,6 +3,9 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2022-present Datadog, Inc.
 
+//go:build !serverless
+// +build !serverless
+
 package serializer
 
 import (

--- a/pkg/serializer/types_sbom_serverless.go
+++ b/pkg/serializer/types_sbom_serverless.go
@@ -1,0 +1,25 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
+//go:build serverless
+// +build serverless
+
+package serializer
+
+import "google.golang.org/protobuf/reflect/protoreflect"
+
+// SBOMMessage is a type alias for SBOM proto payload and is not needed in
+// serverless mode
+type SBOMMessage struct {
+	Version  int
+	Host     string
+	Source   *string
+	Entities []interface{}
+}
+
+var _ protoreflect.ProtoMessage = (*SBOMMessage)(nil)
+
+// ProtoReflect allows SBOMMessage to implement protoreflect.ProtoMessage
+func (s *SBOMMessage) ProtoReflect() protoreflect.Message { return nil }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Use a build tag to create a dummy version of an `SBOMMessage` when running in serverless. These payloads are ignored in serverless and not used or sent.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
This change removes several dependences from the serverless extension, most importantly `github.com/DataDog/agent-payload/v5/sbom` and `github.com/DataDog/agent-payload/v5/cyclonedx_v1_4`. This reduces the binary size from 42.5MB to 42.3MB, saving roughly 0.262MB equivalent to about 2.62ms of cold start time.

Dependency graph:

<img width="1341" alt="Screen Shot 2023-02-28 at 10 49 53 AM" src="https://user-images.githubusercontent.com/1383216/221950679-a15975d1-fadc-43bb-baf8-2d9ccd190ef8.png">


<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
