### PR TITLE
[RCM] Add a Stop method to Service to allow for clean-up in tests

### DIFF
--- a/pkg/config/remote/service/service_test.go
+++ b/pkg/config/remote/service/service_test.go
@@ -110,6 +110,7 @@ func newTestService(t *testing.T, api *mockAPI, uptane *mockUptane, clock clock.
 	serializedKey, _ := testRCKey.MarshalMsg(nil)
 	config.Datadog.Set("remote_configuration.key", base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString(serializedKey))
 	service, err := NewService()
+	t.Cleanup(func() { service.Stop() })
 	assert.NoError(t, err)
 	service.api = api
 	service.clock = clock
@@ -123,7 +124,6 @@ func TestServiceBackoffFailure(t *testing.T) {
 	uptaneClient := &mockUptane{}
 	clock := clock.NewMock()
 	service := newTestService(t, api, uptaneClient, clock)
-	defer service.Stop()
 
 	lastConfigResponse := &pbgo.LatestConfigsResponse{
 		TargetFiles: []*pbgo.File{{Path: "test"}},
@@ -202,7 +202,6 @@ func TestServiceBackoffFailureRecovery(t *testing.T) {
 	uptaneClient := &mockUptane{}
 	clock := clock.NewMock()
 	service := newTestService(t, api, uptaneClient, clock)
-	defer service.Stop()
 
 	lastConfigResponse := &pbgo.LatestConfigsResponse{
 		TargetFiles: []*pbgo.File{{Path: "test"}},
@@ -268,7 +267,6 @@ func TestClientGetConfigsRequestMissingFields(t *testing.T) {
 	uptaneClient := &mockUptane{}
 	clock := clock.NewMock()
 	service := newTestService(t, api, uptaneClient, clock)
-	defer service.Stop()
 
 	uptaneClient.On("TUFVersionState").Return(uptane.TUFVersions{}, nil)
 
@@ -334,7 +332,6 @@ func TestService(t *testing.T) {
 	uptaneClient := &mockUptane{}
 	clock := clock.NewMock()
 	service := newTestService(t, api, uptaneClient, clock)
-	defer service.Stop()
 
 	lastConfigResponse := &pbgo.LatestConfigsResponse{
 		TargetFiles: []*pbgo.File{{Path: "test"}},
@@ -476,7 +473,6 @@ func TestServiceClientPredicates(t *testing.T) {
 	api := &mockAPI{}
 
 	service := newTestService(t, api, uptaneClient, clock)
-	defer service.Stop()
 
 	client := &pbgo.Client{
 		Id: clientID,
@@ -567,7 +563,6 @@ func TestServiceGetRefreshIntervalNone(t *testing.T) {
 	uptaneClient := &mockUptane{}
 	clock := clock.NewMock()
 	service := newTestService(t, api, uptaneClient, clock)
-	defer service.Stop()
 
 	// For this test we'll just send an empty update to save us some work mocking everything.
 	// What matters is the data reported by the uptane module for the top targets custom
@@ -605,7 +600,6 @@ func TestServiceGetRefreshIntervalValid(t *testing.T) {
 	uptaneClient := &mockUptane{}
 	clock := clock.NewMock()
 	service := newTestService(t, api, uptaneClient, clock)
-	defer service.Stop()
 
 	// For this test we'll just send an empty update to save us some work mocking everything.
 	// What matters is the data reported by the uptane module for the top targets custom
@@ -643,7 +637,6 @@ func TestServiceGetRefreshIntervalTooSmall(t *testing.T) {
 	uptaneClient := &mockUptane{}
 	clock := clock.NewMock()
 	service := newTestService(t, api, uptaneClient, clock)
-	defer service.Stop()
 
 	// For this test we'll just send an empty update to save us some work mocking everything.
 	// What matters is the data reported by the uptane module for the top targets custom
@@ -681,7 +674,6 @@ func TestServiceGetRefreshIntervalTooBig(t *testing.T) {
 	uptaneClient := &mockUptane{}
 	clock := clock.NewMock()
 	service := newTestService(t, api, uptaneClient, clock)
-	defer service.Stop()
 
 	// For this test we'll just send an empty update to save us some work mocking everything.
 	// What matters is the data reported by the uptane module for the top targets custom
@@ -719,7 +711,6 @@ func TestServiceGetRefreshIntervalNoOverrideAllowed(t *testing.T) {
 	uptaneClient := &mockUptane{}
 	clock := clock.NewMock()
 	service := newTestService(t, api, uptaneClient, clock)
-	defer service.Stop()
 
 	// Mock that customers set the value, making overrides not allowed
 	service.refreshIntervalOverrideAllowed = false
@@ -770,7 +761,6 @@ func TestConfigExpiration(t *testing.T) {
 	api := &mockAPI{}
 
 	service := newTestService(t, api, uptaneClient, clock)
-	defer service.Stop()
 
 	client := &pbgo.Client{
 		Id: clientID,

--- a/pkg/config/remote/service/service_test.go
+++ b/pkg/config/remote/service/service_test.go
@@ -123,6 +123,7 @@ func TestServiceBackoffFailure(t *testing.T) {
 	uptaneClient := &mockUptane{}
 	clock := clock.NewMock()
 	service := newTestService(t, api, uptaneClient, clock)
+	defer service.Stop()
 
 	lastConfigResponse := &pbgo.LatestConfigsResponse{
 		TargetFiles: []*pbgo.File{{Path: "test"}},
@@ -201,6 +202,7 @@ func TestServiceBackoffFailureRecovery(t *testing.T) {
 	uptaneClient := &mockUptane{}
 	clock := clock.NewMock()
 	service := newTestService(t, api, uptaneClient, clock)
+	defer service.Stop()
 
 	lastConfigResponse := &pbgo.LatestConfigsResponse{
 		TargetFiles: []*pbgo.File{{Path: "test"}},
@@ -266,6 +268,7 @@ func TestClientGetConfigsRequestMissingFields(t *testing.T) {
 	uptaneClient := &mockUptane{}
 	clock := clock.NewMock()
 	service := newTestService(t, api, uptaneClient, clock)
+	defer service.Stop()
 
 	uptaneClient.On("TUFVersionState").Return(uptane.TUFVersions{}, nil)
 
@@ -331,6 +334,7 @@ func TestService(t *testing.T) {
 	uptaneClient := &mockUptane{}
 	clock := clock.NewMock()
 	service := newTestService(t, api, uptaneClient, clock)
+	defer service.Stop()
 
 	lastConfigResponse := &pbgo.LatestConfigsResponse{
 		TargetFiles: []*pbgo.File{{Path: "test"}},
@@ -472,6 +476,7 @@ func TestServiceClientPredicates(t *testing.T) {
 	api := &mockAPI{}
 
 	service := newTestService(t, api, uptaneClient, clock)
+	defer service.Stop()
 
 	client := &pbgo.Client{
 		Id: clientID,
@@ -562,6 +567,7 @@ func TestServiceGetRefreshIntervalNone(t *testing.T) {
 	uptaneClient := &mockUptane{}
 	clock := clock.NewMock()
 	service := newTestService(t, api, uptaneClient, clock)
+	defer service.Stop()
 
 	// For this test we'll just send an empty update to save us some work mocking everything.
 	// What matters is the data reported by the uptane module for the top targets custom
@@ -599,6 +605,7 @@ func TestServiceGetRefreshIntervalValid(t *testing.T) {
 	uptaneClient := &mockUptane{}
 	clock := clock.NewMock()
 	service := newTestService(t, api, uptaneClient, clock)
+	defer service.Stop()
 
 	// For this test we'll just send an empty update to save us some work mocking everything.
 	// What matters is the data reported by the uptane module for the top targets custom
@@ -636,6 +643,7 @@ func TestServiceGetRefreshIntervalTooSmall(t *testing.T) {
 	uptaneClient := &mockUptane{}
 	clock := clock.NewMock()
 	service := newTestService(t, api, uptaneClient, clock)
+	defer service.Stop()
 
 	// For this test we'll just send an empty update to save us some work mocking everything.
 	// What matters is the data reported by the uptane module for the top targets custom
@@ -673,6 +681,7 @@ func TestServiceGetRefreshIntervalTooBig(t *testing.T) {
 	uptaneClient := &mockUptane{}
 	clock := clock.NewMock()
 	service := newTestService(t, api, uptaneClient, clock)
+	defer service.Stop()
 
 	// For this test we'll just send an empty update to save us some work mocking everything.
 	// What matters is the data reported by the uptane module for the top targets custom
@@ -710,6 +719,7 @@ func TestServiceGetRefreshIntervalNoOverrideAllowed(t *testing.T) {
 	uptaneClient := &mockUptane{}
 	clock := clock.NewMock()
 	service := newTestService(t, api, uptaneClient, clock)
+	defer service.Stop()
 
 	// Mock that customers set the value, making overrides not allowed
 	service.refreshIntervalOverrideAllowed = false
@@ -760,6 +770,7 @@ func TestConfigExpiration(t *testing.T) {
 	api := &mockAPI{}
 
 	service := newTestService(t, api, uptaneClient, clock)
+	defer service.Stop()
 
 	client := &pbgo.Client{
 		Id: clientID,


### PR DESCRIPTION
The bolt DB is designed to be persistent for the RC service, but we don't want it persisting between test runs. A PR made to attempt to clean up the DB file creating during tests was failing as there was no way to delete the DB due to the fact the instantiated test Service instance still had a handle to it. In order to allow the test code to clean up the test bolt DB, we need a way to shut down the Service and tell it to close the DB. The new Stop method leverages the context.CancelFunc we create when starting the main goroutine to both stop the main goroutine and then shutdown the bolt DB to allow test cleanup to proceed.

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
