### PR TITLE
[apiserver] Add debug logs to output k8s timeout settings when a timeout occurs

### DIFF
--- a/pkg/util/kubernetes/apiserver/apiserver.go
+++ b/pkg/util/kubernetes/apiserver/apiserver.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"sync"
 	"time"
 
@@ -191,6 +192,9 @@ func getClientConfig(timeout time.Duration) (*rest.Config, error) {
 	}
 
 	clientConfig.Timeout = timeout
+	clientConfig.Wrap(func(rt http.RoundTripper) http.RoundTripper {
+		return NewCustomRoundTripper(rt)
+	})
 
 	return clientConfig, nil
 }

--- a/pkg/util/kubernetes/apiserver/roundtrip.go
+++ b/pkg/util/kubernetes/apiserver/roundtrip.go
@@ -41,7 +41,8 @@ func (rt *CustomRoundTripper) RoundTrip(request *http.Request) (*http.Response, 
 
 	response, err := rt.rt.RoundTrip(request)
 	if err, ok := err.(net.Error); ok && err.Timeout() || errors.Is(err, context.DeadlineExceeded) {
-		log.Debugf("timeout trying to make the request in %v (kubernetes_apiserver_client_timeout: %v)", time.Now().Sub(start), rt.timeout)
+		clientTimeouts.Inc()
+		log.Warnf("timeout trying to make the request in %v (kubernetes_apiserver_client_timeout: %v)", time.Now().Sub(start), rt.timeout)
 	}
 
 	return response, err

--- a/pkg/util/kubernetes/apiserver/roundtrip.go
+++ b/pkg/util/kubernetes/apiserver/roundtrip.go
@@ -1,0 +1,51 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+// +build kubeapiserver
+
+package apiserver
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// CustomRoundTripper serves as a wrapper around the default http.RoundTripper, allowing us greater flexibility regarding
+// the logging of request errors.
+type CustomRoundTripper struct {
+	rt      http.RoundTripper
+	timeout int64
+}
+
+// NewCustomRoundTripper creates a new CustomRoundTripper with the apiserver timeout value already populated from the
+// agent config, wrapping an existing http.RoundTripper.
+func NewCustomRoundTripper(rt http.RoundTripper) *CustomRoundTripper {
+	return &CustomRoundTripper{
+		rt:      rt,
+		timeout: config.Datadog.GetInt64("kubernetes_apiserver_client_timeout"),
+	}
+}
+
+// RoundTrip implements http.RoundTripper. It adds logging on request timeouts with more context.
+func (rt *CustomRoundTripper) RoundTrip(request *http.Request) (*http.Response, error) {
+	start := time.Now()
+
+	response, err := rt.rt.RoundTrip(request)
+	if err, ok := err.(net.Error); ok && err.Timeout() || errors.Is(err, context.DeadlineExceeded) {
+		log.Debugf("timeout trying to make the request in %v (kubernetes_apiserver_client_timeout: %v)", time.Now().Sub(start), rt.timeout)
+	}
+
+	return response, err
+}
+
+// WrappedRoundTripper implements http.RoundTripperWrapper.
+func (rt *CustomRoundTripper) WrappedRoundTripper() http.RoundTripper { return rt.rt }

--- a/pkg/util/kubernetes/apiserver/telemetry.go
+++ b/pkg/util/kubernetes/apiserver/telemetry.go
@@ -1,0 +1,32 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+// +build kubeapiserver
+
+package apiserver
+
+import "github.com/DataDog/datadog-agent/pkg/telemetry"
+
+const subsystem = "apiserver"
+
+var (
+	// apiServerTimeouts tracks timeouts to kubernetes apiserver done by the Agent.
+	clientTimeouts = telemetry.NewCounterWithOpts(
+		subsystem,
+		"client_timeouts",
+		[]string{},
+		"Count of requests to the apiserver which have timed out. Consider increasing the kubernetes_apiserver_client_timeout setting.",
+		telemetry.Options{NoDoubleUnderscoreSep: true},
+	)
+	// kube_cache_sync_timeouts tracks timeouts to kubernetes apiserver done by the Agent.
+	cacheSyncTimeouts = telemetry.NewCounterWithOpts(
+		subsystem,
+		"cache_sync_timeouts",
+		[]string{},
+		"Count of kubernetes cache requests which have timed out. Consider increasing the kube_cache_sync_timeout_seconds setting.",
+		telemetry.Options{NoDoubleUnderscoreSep: true},
+	)
+)

--- a/pkg/util/kubernetes/apiserver/util.go
+++ b/pkg/util/kubernetes/apiserver/util.go
@@ -41,7 +41,8 @@ func SyncInformers(informers map[InformerName]cache.SharedInformer, extraWait ti
 			start := time.Now()
 			if !cache.WaitForCacheSync(ctx.Done(), informers[name].HasSynced) {
 				end := time.Now()
-				log.Debugf("couldn't sync informer %s in %v (kube_cache_sync_timeout_seconds: %v)", name, end.Sub(start), timeoutConfig)
+				cacheSyncTimeouts.Inc()
+				log.Warnf("couldn't sync informer %s in %v (kube_cache_sync_timeout_seconds: %v)", name, end.Sub(start), timeoutConfig)
 				return fmt.Errorf("couldn't sync informer %s in %v", name, end.Sub(start))
 			}
 			log.Debugf("Sync done for informer %s in %v, last resource version: %s", name, time.Now().Sub(start), informers[name].LastSyncResourceVersion())

--- a/pkg/util/kubernetes/apiserver/util.go
+++ b/pkg/util/kubernetes/apiserver/util.go
@@ -29,9 +29,10 @@ import (
 // An extra timeout duration can be provided depending on the informer
 func SyncInformers(informers map[InformerName]cache.SharedInformer, extraWait time.Duration) error {
 	var g errgroup.Group
+	timeoutConfig := config.Datadog.GetDuration("kube_cache_sync_timeout_seconds") * time.Second
 	// syncTimeout can be used to wait for the kubernetes client-go cache to sync.
 	// It cannot be retrieved at the package-level due to the package being imported before configs are loaded.
-	syncTimeout := config.Datadog.GetDuration("kube_cache_sync_timeout_seconds")*time.Second + extraWait
+	syncTimeout := timeoutConfig + extraWait
 	for name := range informers {
 		name := name // https://golang.org/doc/faq#closures_and_goroutines
 		g.Go(func() error {
@@ -39,7 +40,9 @@ func SyncInformers(informers map[InformerName]cache.SharedInformer, extraWait ti
 			defer cancel()
 			start := time.Now()
 			if !cache.WaitForCacheSync(ctx.Done(), informers[name].HasSynced) {
-				return fmt.Errorf("couldn't sync informer %s in %v", name, time.Now().Sub(start))
+				end := time.Now()
+				log.Debugf("couldn't sync informer %s in %v (kube_cache_sync_timeout_seconds: %v)", name, end.Sub(start), timeoutConfig)
+				return fmt.Errorf("couldn't sync informer %s in %v", name, end.Sub(start))
 			}
 			log.Debugf("Sync done for informer %s in %v, last resource version: %s", name, time.Now().Sub(start), informers[name].LastSyncResourceVersion())
 			return nil


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

- This PR adds a couple of warn level logs to log the amount of time a request took, as well as the configured timeout settings affecting the request for the config values `kubernetes_apiserver_client_timeout` and `kube_cache_sync_timeout_seconds`
- To accurately catch apiserver timeouts, this PR adds a custom RoundTripperWrapper which wraps the default apiserver RoundTripper and logs on request error.
- This PR also adds telemetry metrics surrounding the number of timeouts caused by the two codepaths in question

### Motivation

The goal here is to aid in debugging apiserver timeouts, which (among other things) result in kubernetes_state metrics disappearing intermittently on clusters with a large number of pods. The solution in these cases are usually to increase these timeout configs, but finding that information can be time consuming. The hope here is that this will help speed up that discovery.

### Additional Notes

I have tested this manually on a minikube cluster, but hacking away at the timeout configs to make them millisecond values instead of second values, and throwing a bunch of load at the api server.

### Possible Drawbacks / Trade-offs

~I chose to make the logs debug level, to prevent log spam in the instance where the api server is having problems. I am happy to change the logging level to info / warn / error if others feel strongly about this information showing up by default.~
Changed to warn based on feedback

### Describe how to test/QA your changes

N/A

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
