### PR TITLE
launch-gui:  follow-up #15636

### DIFF
--- a/cmd/agent/gui/views/templates/auth.tmpl
+++ b/cmd/agent/gui/views/templates/auth.tmpl
@@ -8,16 +8,8 @@
   let urlParam = location.search.substring(1).split("&");
   const authTokenPrefix = "authToken=";
   const csrfPrefix = "csrf=";
-  let authToken = "";
-  let csrf = "";
-  for (let i = 0; i < urlParam.length; i++) {
-    if (urlParam[i].includes(authTokenPrefix)) {
-      authToken = urlParam[i].substring(authTokenPrefix.length);
-    }
-    if (urlParam[i].includes("csrf=")) {
-      csrf = urlParam[i].substring(csrfPrefix.length);
-    }
-  }
+  const authToken = urlParam[0].substring(authTokenPrefix.length);
+  const csrf = urlParam[1].substring(csrfPrefix.length);
   
   if (csrf == "{{ .csrf }}") {
     // Save auth token as a cookie

--- a/comp/systray/systray/doconfigure.go
+++ b/comp/systray/systray/doconfigure.go
@@ -61,7 +61,7 @@ func doConfigure(s *systray) error {
 	}
 
 	// Open the GUI in a browser, passing the authorization tokens as parameters
-	err = open("http://127.0.0.1:" + guiPort + "/authenticate?authToken=" + string(authToken) + ";csrf=" + string(csrfToken))
+	err = open("http://127.0.0.1:" + guiPort + "/authenticate?authToken=" + string(authToken) + "&csrf=" + string(csrfToken))
 	if err != nil {
 		return fmt.Errorf("error opening GUI: " + err.Error())
 	}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

- Don't use JS `includes` function to avoid `SCRIPT438: Object doesn't support property or method 'includes'` on  Windows Server 2019 Internet Explorer
- Replace `;` with `&` for systray; it should've done in #15636

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

`launch-gui` should work for Windows Server 2019 Internet Explorer.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

https://a.cl.ly/E0uXdE56 contains steps and shows it works.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
