### PR TITLE
[NDM] Add Admin and Oper status tags to interface metric

### DIFF
--- a/pkg/collector/corechecks/snmp/common/contants.go
+++ b/pkg/collector/corechecks/snmp/common/contants.go
@@ -22,6 +22,20 @@ const (
 	AdminStatus_Testing IfAdminStatus = 3
 )
 
+var adminStatus_StringMap map[IfAdminStatus]string = map[IfAdminStatus]string{
+	AdminStatus_Up:      "up",
+	AdminStatus_Down:    "down",
+	AdminStatus_Testing: "testing",
+}
+
+func (i IfAdminStatus) AsString() string {
+	status, ok := adminStatus_StringMap[i]
+	if !ok {
+		return "unknown"
+	}
+	return status
+}
+
 type IfOperStatus int
 
 const (
@@ -33,6 +47,24 @@ const (
 	OperStatus_NotPresent     IfOperStatus = 6
 	OperStatus_LowerLayerDown IfOperStatus = 7
 )
+
+var operStatus_StringMap map[IfOperStatus]string = map[IfOperStatus]string{
+	OperStatus_Up:             "up",
+	OperStatus_Down:           "down",
+	OperStatus_Testing:        "testing",
+	OperStatus_Unknown:        "unknown",
+	OperStatus_Dormant:        "dormant",
+	OperStatus_NotPresent:     "not_present",
+	OperStatus_LowerLayerDown: "lower_layer_down",
+}
+
+func (i IfOperStatus) AsString() string {
+	status, ok := operStatus_StringMap[i]
+	if !ok {
+		return "unknown"
+	}
+	return status
+}
 
 type InterfaceStatus string
 

--- a/pkg/collector/corechecks/snmp/internal/report/report_device_metadata.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_device_metadata.go
@@ -54,7 +54,7 @@ func (ms *MetricSender) ReportNetworkDeviceMetadata(config *checkconfig.CheckCon
 	// Telemetry
 	for _, interfaceStatus := range interfaces {
 		status := string(computeInterfaceStatus(interfaceStatus.AdminStatus, interfaceStatus.OperStatus))
-		interfaceTags := []string{"status:" + status, "interface_index:" + strconv.Itoa(int(interfaceStatus.Index))}
+		interfaceTags := []string{"status:" + status, "admin_status:" + interfaceStatus.AdminStatus.AsString(), "oper_status:" + interfaceStatus.OperStatus.AsString(), "interface_index:" + strconv.Itoa(int(interfaceStatus.Index))}
 		if interfaceStatus.Name != "" {
 			interfaceTags = append(interfaceTags, "interface:"+interfaceStatus.Name)
 		}

--- a/pkg/collector/corechecks/snmp/internal/report/report_device_metadata.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_device_metadata.go
@@ -54,7 +54,12 @@ func (ms *MetricSender) ReportNetworkDeviceMetadata(config *checkconfig.CheckCon
 	// Telemetry
 	for _, interfaceStatus := range interfaces {
 		status := string(computeInterfaceStatus(interfaceStatus.AdminStatus, interfaceStatus.OperStatus))
-		interfaceTags := []string{"status:" + status, "admin_status:" + interfaceStatus.AdminStatus.AsString(), "oper_status:" + interfaceStatus.OperStatus.AsString(), "interface_index:" + strconv.Itoa(int(interfaceStatus.Index))}
+		interfaceTags := []string{
+			"status:" + status, 
+			"admin_status:" + interfaceStatus.AdminStatus.AsString(), 
+			"oper_status:" + interfaceStatus.OperStatus.AsString(), 
+			"interface_index:" + strconv.Itoa(int(interfaceStatus.Index)),
+		}
 		if interfaceStatus.Name != "" {
 			interfaceTags = append(interfaceTags, "interface:"+interfaceStatus.Name)
 		}

--- a/pkg/collector/corechecks/snmp/internal/report/report_device_metadata.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_device_metadata.go
@@ -55,9 +55,9 @@ func (ms *MetricSender) ReportNetworkDeviceMetadata(config *checkconfig.CheckCon
 	for _, interfaceStatus := range interfaces {
 		status := string(computeInterfaceStatus(interfaceStatus.AdminStatus, interfaceStatus.OperStatus))
 		interfaceTags := []string{
-			"status:" + status, 
-			"admin_status:" + interfaceStatus.AdminStatus.AsString(), 
-			"oper_status:" + interfaceStatus.OperStatus.AsString(), 
+			"status:" + status,
+			"admin_status:" + interfaceStatus.AdminStatus.AsString(),
+			"oper_status:" + interfaceStatus.OperStatus.AsString(),
 			"interface_index:" + strconv.Itoa(int(interfaceStatus.Index)),
 		}
 		if interfaceStatus.Name != "" {

--- a/pkg/collector/corechecks/snmp/internal/report/report_device_metadata_test.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_device_metadata_test.go
@@ -237,6 +237,14 @@ func Test_metricSender_reportNetworkDeviceMetadata_withInterfaces(t *testing.T) 
 				"1": valuestore.ResultValue{Value: float64(21)},
 				"2": valuestore.ResultValue{Value: float64(22)},
 			},
+			"1.3.6.1.2.1.2.2.1.7": {
+				"1": valuestore.ResultValue{Value: float64(2)},
+				"2": valuestore.ResultValue{Value: float64(2)},
+			},
+			"1.3.6.1.2.1.2.2.1.8": {
+				"1": valuestore.ResultValue{Value: float64(1)},
+				"2": valuestore.ResultValue{Value: float64(2)},
+			},
 			"1.3.6.1.2.1.31.1.1.1.18": {
 				"1": valuestore.ResultValue{Value: "ifAlias1"},
 				"2": valuestore.ResultValue{Value: ""},
@@ -271,6 +279,18 @@ func Test_metricSender_reportNetworkDeviceMetadata_withInterfaces(t *testing.T) 
 							Name: "ifAlias",
 						},
 					},
+					"admin_status": {
+						Symbol: checkconfig.SymbolConfig{
+							OID:  "1.3.6.1.2.1.2.2.1.7",
+							Name: "ifAdminStatus",
+						},
+					},
+					"oper_status": {
+						Symbol: checkconfig.SymbolConfig{
+							OID:  "1.3.6.1.2.1.2.2.1.8",
+							Name: "ifOperStatus",
+						},
+					},
 				},
 				IDTags: checkconfig.MetricTagConfigList{
 					checkconfig.MetricTagConfig{
@@ -291,8 +311,8 @@ func Test_metricSender_reportNetworkDeviceMetadata_withInterfaces(t *testing.T) 
 	assert.NoError(t, err)
 	ms.ReportNetworkDeviceMetadata(config, storeWithIfName, []string{"tag1", "tag2"}, collectTime, metadata.DeviceStatusReachable)
 
-	ifTags1 := []string{"tag1", "tag2", "status:down", "interface:21", "interface_alias:ifAlias1", "interface_index:1"}
-	ifTags2 := []string{"tag1", "tag2", "status:down", "interface:22", "interface_index:2"}
+	ifTags1 := []string{"tag1", "tag2", "status:down", "interface:21", "interface_alias:ifAlias1", "interface_index:1", "oper_status:up", "admin_status:down"}
+	ifTags2 := []string{"tag1", "tag2", "status:off", "interface:22", "interface_index:2", "oper_status:down", "admin_status:down"}
 
 	sender.AssertMetric(t, "Gauge", interfaceStatusMetric, 1., "", ifTags1)
 	sender.AssertMetric(t, "Gauge", interfaceStatusMetric, 1., "", ifTags2)
@@ -324,7 +344,9 @@ func Test_metricSender_reportNetworkDeviceMetadata_withInterfaces(t *testing.T) 
             ],
             "index": 1,
 			"name": "21",
-			"alias": "ifAlias1"
+			"alias": "ifAlias1",
+			"admin_status": 2,
+			"oper_status": 1
         },
         {
             "device_id": "1234",
@@ -332,7 +354,9 @@ func Test_metricSender_reportNetworkDeviceMetadata_withInterfaces(t *testing.T) 
                 "interface:22"
             ],
             "index": 2,
-            "name": "22"
+            "name": "22",
+			"admin_status": 2,
+			"oper_status": 2
         }
     ],
     "collect_timestamp":1415792726


### PR DESCRIPTION
Additionally tag the metric snmp.interface.status with admin_status and oper_status tags
