### PR TITLE
[CWS] improve SECL library for process data evaluation

### DIFF
--- a/pkg/security/probe/field_handlers.go
+++ b/pkg/security/probe/field_handlers.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/security/resolvers"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/args"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 )
 
@@ -188,59 +189,12 @@ func (fh *FieldHandlers) ResolveProcessArgsTruncated(ev *model.Event, process *m
 
 // ResolveProcessArgsFlags resolves the arguments flags of the event
 func (fh *FieldHandlers) ResolveProcessArgsFlags(ev *model.Event, process *model.Process) (flags []string) {
-	for _, arg := range fh.ResolveProcessArgv(ev, process) {
-		if len(arg) > 1 && arg[0] == '-' {
-			isFlag := true
-			name := arg[1:]
-			if len(name) >= 1 && name[0] == '-' {
-				name = name[1:]
-				isFlag = false
-			}
-
-			isOption := false
-			for _, r := range name {
-				isFlag = isFlag && model.IsAlphaNumeric(r)
-				isOption = isOption || r == '='
-			}
-
-			if len(name) > 0 {
-				if isFlag {
-					for _, r := range name {
-						flags = append(flags, string(r))
-					}
-				}
-				if !isOption && len(name) > 1 {
-					flags = append(flags, name)
-				}
-			}
-		}
-	}
-	return
+	return args.ParseProcessFlags(fh.ResolveProcessArgv(ev, process))
 }
 
 // ResolveProcessArgsOptions resolves the arguments options of the event
 func (fh *FieldHandlers) ResolveProcessArgsOptions(ev *model.Event, process *model.Process) (options []string) {
-	args := fh.ResolveProcessArgv(ev, process)
-	for i := 0; i < len(args); i++ {
-		arg := args[i]
-		if len(arg) > 1 && arg[0] == '-' {
-			name := arg[1:]
-			if len(name) >= 1 && name[0] == '-' {
-				name = name[1:]
-			}
-			if len(name) > 0 && model.IsAlphaNumeric(rune(name[0])) {
-				if index := strings.IndexRune(name, '='); index == -1 {
-					if i < len(args)-1 && (len(args[i+1]) == 0 || args[i+1][0] != '-') {
-						options = append(options, name+"="+args[i+1])
-						i++
-					}
-				} else {
-					options = append(options, name)
-				}
-			}
-		}
-	}
-	return
+	return args.ParseProcessOptions(fh.ResolveProcessArgv(ev, process))
 }
 
 // ResolveProcessEnvsTruncated returns whether the envs are truncated

--- a/pkg/security/secl/args/parse.go
+++ b/pkg/security/secl/args/parse.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2021-present Datadog, Inc.
+
 package args
 
 import (

--- a/pkg/security/secl/args/parse.go
+++ b/pkg/security/secl/args/parse.go
@@ -1,0 +1,63 @@
+package args
+
+import (
+	"strings"
+
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+)
+
+func ParseProcessFlags(args []string) []string {
+	flags := make([]string, 0)
+	for _, arg := range args {
+		if len(arg) > 1 && arg[0] == '-' {
+			isFlag := true
+			name := arg[1:]
+			if len(name) >= 1 && name[0] == '-' {
+				name = name[1:]
+				isFlag = false
+			}
+
+			isOption := false
+			for _, r := range name {
+				isFlag = isFlag && model.IsAlphaNumeric(r)
+				isOption = isOption || r == '='
+			}
+
+			if len(name) > 0 {
+				if isFlag {
+					for _, r := range name {
+						flags = append(flags, string(r))
+					}
+				}
+				if !isOption && len(name) > 1 {
+					flags = append(flags, name)
+				}
+			}
+		}
+	}
+	return flags
+}
+
+func ParseProcessOptions(args []string) []string {
+	options := make([]string, 0)
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if len(arg) > 1 && arg[0] == '-' {
+			name := arg[1:]
+			if len(name) >= 1 && name[0] == '-' {
+				name = name[1:]
+			}
+			if len(name) > 0 && model.IsAlphaNumeric(rune(name[0])) {
+				if index := strings.IndexRune(name, '='); index == -1 {
+					if i < len(args)-1 && (len(args[i+1]) == 0 || args[i+1][0] != '-') {
+						options = append(options, name+"="+args[i+1])
+						i++
+					}
+				} else {
+					options = append(options, name)
+				}
+			}
+		}
+	}
+	return options
+}

--- a/pkg/security/secl/rules/ruleset.go
+++ b/pkg/security/secl/rules/ruleset.go
@@ -264,6 +264,11 @@ func (rs *RuleSet) AddRules(parsingContext *ast.ParsingContext, rules []*RuleDef
 	return result
 }
 
+// ListFields returns all the fields accessed by all rules of this rule set
+func (rs *RuleSet) ListFields() []string {
+	return rs.fields
+}
+
 // GetRuleEventType return the rule EventType. Currently rules support only one eventType
 func GetRuleEventType(rule *eval.Rule) (eval.EventType, error) {
 	eventTypes, err := rule.GetEventTypes()


### PR DESCRIPTION
### What does this PR do?

This PR moves the flags/options parsing from args into the SECL package for easier external usage. This PR also implements a function allowing users of the SECL lib to list the fields accessed in a ruleset.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
