### PR TITLE
Enable `ec2_prefer_imdsv2` by default

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -739,7 +739,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("ec2_use_windows_prefix_detection", false)
 	config.BindEnvAndSetDefault("ec2_metadata_timeout", 300)          // value in milliseconds
 	config.BindEnvAndSetDefault("ec2_metadata_token_lifetime", 21600) // value in seconds
-	config.BindEnvAndSetDefault("ec2_prefer_imdsv2", false)
+	config.BindEnvAndSetDefault("ec2_prefer_imdsv2", true)
 	config.BindEnvAndSetDefault("ec2_prioritize_instance_id_as_hostname", false) // used to bypass the hostname detection logic and force the EC2 instance ID as a hostname.
 	config.BindEnvAndSetDefault("ec2_use_dmi", true)                             // should the agent leverage DMI information to know if it's running on EC2 or not. Enabling this will add the instance ID from DMI to the host alias list.
 	config.BindEnvAndSetDefault("collect_ec2_tags", false)

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -394,16 +394,18 @@ api_key:
 #
 # ec2_metadata_timeout: 300
 
-## @param ec2_prefer_imdsv2 - boolean - optional - default: false
-## @env DD_EC2_PREFER_IMDSV2 - boolean - optional - default: false
+## @param ec2_prefer_imdsv2 - boolean - optional - default: true
+## @env DD_EC2_PREFER_IMDSV2 - boolean - optional - default: true
 ## If this flag is true then the agent will request EC2 metadata using IMDS v2,
 ## which offers additional security for accessing metadata. However, in some
 ## situations (such as a containerized agent on a plain EC2 instance) it may
 ## require additional configuration on the AWS side. See the AWS guidelines
 ## for further details:
 ## https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html#instance-metadata-transition-to-version-2
+##
+## When the agent fails to fetch a IMDSv2 token it falls back on IMDSv1.
 #
-# ec2_prefer_imdsv2: false
+# ec2_prefer_imdsv2: true
 
 ## @param collect_gce_tags - boolean - optional - default: true
 ## @env DD_COLLECT_GCE_TAGS - boolean - optional - default: true

--- a/pkg/util/ec2/imds_helpers.go
+++ b/pkg/util/ec2/imds_helpers.go
@@ -61,7 +61,7 @@ func doHTTPRequest(ctx context.Context, url string) (string, error) {
 	if config.Datadog.GetBool("ec2_prefer_imdsv2") {
 		tokenValue, err := token.Get(ctx)
 		if err != nil {
-			log.Warnf("ec2_prefer_imdsv2 is set to true in the configuration but the agent was unable to proceed: %s", err)
+			log.Warnf("'ec2_prefer_imdsv2' is set to true in but the agent could not fetch a IMDSv2 token, falling back on IMDSv1: %s", err)
 		} else {
 			headers["X-aws-ec2-metadata-token"] = tokenValue
 			source = metadataSourceIMDSv2

--- a/releasenotes/notes/enable-imdsv2-default-7be51aed461356e0.yaml
+++ b/releasenotes/notes/enable-imdsv2-default-7be51aed461356e0.yaml
@@ -5,8 +5,8 @@ upgrade:
     try to fetch a token from the IMDSv2 API by default to request EC2
     metadata. When IMDSv2 is not available, the Agent still automatically falls
     back on IMDSv1.
-    Upon upgrading, this will change the hostname used by the Agent in case
-    where IMDSv2 was enforced on AWS side but `ec2_prefer_imdsv2` was left to
+    Upon upgrading, this will change the hostname used by the Agent in cases
+    where IMDSv2 was enforced on the AWS side but `ec2_prefer_imdsv2` was left to
     `false` (the Agent used to fail fetching the instance ID from IMDSv1 and
     would fall back on the system hostname). This can break monitors or
     dashboards using the old hostname.

--- a/releasenotes/notes/enable-imdsv2-default-7be51aed461356e0.yaml
+++ b/releasenotes/notes/enable-imdsv2-default-7be51aed461356e0.yaml
@@ -10,5 +10,5 @@ upgrade:
     `false` (the Agent used to fail fetching the instance ID from IMDSv1 and
     would fall back on the system hostname). This can break monitors or
     dashboards using the old hostname.
-    To keep the old behavior, set `ec2_prefer_imdsv2` to false in the Agent
+    To keep the old behavior, set `ec2_prefer_imdsv2` to `false` in the Agent
     configuration.

--- a/releasenotes/notes/enable-imdsv2-default-7be51aed461356e0.yaml
+++ b/releasenotes/notes/enable-imdsv2-default-7be51aed461356e0.yaml
@@ -3,7 +3,7 @@ upgrade:
   - |
     The setting 'ec2_prefer_imdsv2' now defaults to `true`. The Agent will now
     try to fetch a token from the IMDSv2 API by default to request EC2
-    metadata. When IMDSv2 is not available, the agent still automatically falls
+    metadata. When IMDSv2 is not available, the Agent still automatically falls
     back on IMDSv1.
     Upon upgrading, this will change the hostname used by the Agent in case
     where IMDSv2 was enforced on AWS side but `ec2_prefer_imdsv2` was left to

--- a/releasenotes/notes/enable-imdsv2-default-7be51aed461356e0.yaml
+++ b/releasenotes/notes/enable-imdsv2-default-7be51aed461356e0.yaml
@@ -1,0 +1,14 @@
+---
+upgrade:
+  - |
+    The setting 'ec2_prefer_imdsv2' now defaults to `true`. The Agent will now
+    try to fetch a token from the IMDSv2 API by default to request EC2
+    metadata. When IMDSv2 is not available, the agent still automatically falls
+    back on IMDSv1.
+    Upon upgrading, this will change the hostname used by the Agent in case
+    where IMDSv2 was enforced on AWS side but `ec2_prefer_imdsv2` was left to
+    `false` (the Agent used to fail fetching the instance ID from IMDSv1 and
+    would fall back on the system hostname). This can break monitors or
+    dashboards using the old hostname.
+    To keep the old behavior, set `ec2_prefer_imdsv2` to false in the Agent
+    configuration.


### PR DESCRIPTION
### What does this PR do?

Enable `ec2_prefer_imdsv2` by default. As IMDSv2 becomes the default this avoid manual configuration from users to correctly fetch instance ID on EC2.

### Describe how to test/QA your changes

On EC2 test:
- enforce IMDSv2 `aws ec2 modify-instance-metadata-options --region eu-west-3 --instance-id XXX --http-tokens required` and check that the instance ID is correctly used as the hostname by default. Then disable `ec2_prefer_imdsv2` and check that the instance ID is not pulled but a warning is added to the logs.
- Set IMDSv2 as optional `aws ec2 modify-instance-metadata-options --region eu-west-3 --instance-id XXX --http-tokens optional` and check that the instance ID is correctly used with `ec2_prefer_imdsv2` enabled AND disabled
- Disable the IMDS endpoint `aws ec2 modify-instance-metadata-options --instance-id XXX --http-endpoint disabled`. Check that a warning is correctly logged with `ec2_prefer_imdsv2` enabled (we shouldn't log anything when it's disabled).

In all cases the agent should still start without any issues.

For all tests, also check that the `cloud_provider_source` metadata in the inventory payload is correctly set to `IMDSv1` or `IMDSv2` (using `datadog-agent diagnose show-metadata inventory`).

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
