### PR TITLE
Add datadog tags to `contimage` and `sbom` payloads

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	code.cloudfoundry.org/garden v0.0.0-20210208153517-580cadd489d2
 	code.cloudfoundry.org/lager v2.0.0+incompatible
 	github.com/CycloneDX/cyclonedx-go v0.7.0
-	github.com/DataDog/agent-payload/v5 v5.0.74
+	github.com/DataDog/agent-payload/v5 v5.0.75
 	github.com/DataDog/datadog-agent/pkg/obfuscate v0.43.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.43.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/security/secl v0.43.0-rc.3

--- a/go.sum
+++ b/go.sum
@@ -128,8 +128,8 @@ github.com/BurntSushi/toml v1.2.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbi
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/CycloneDX/cyclonedx-go v0.7.0 h1:jNxp8hL7UpcvPDFXjY+Y1ibFtsW+e5zyF9QoSmhK/zg=
 github.com/CycloneDX/cyclonedx-go v0.7.0/go.mod h1:W5Z9w8pTTL+t+yG3PCiFRGlr8PUlE0pGWzKSJbsyXkg=
-github.com/DataDog/agent-payload/v5 v5.0.74 h1:QtoZKQjUQXXWV+mUnFBHyllB4a4Qd2YcNezFPYc74ts=
-github.com/DataDog/agent-payload/v5 v5.0.74/go.mod h1:oQZi1VZp1e3QvlSUX4iphZCpJaFepUxWq0hNXxihKBM=
+github.com/DataDog/agent-payload/v5 v5.0.75 h1:M7GvFvtgQPEsiFJJY69UIuawx9fn6DTbkhaq3Xtah7U=
+github.com/DataDog/agent-payload/v5 v5.0.75/go.mod h1:oQZi1VZp1e3QvlSUX4iphZCpJaFepUxWq0hNXxihKBM=
 github.com/DataDog/appsec-internal-go v0.0.0-20230215162203-5149228be86a h1:7ZiVdU4j19IYuy8rR0uUzC7I7HjWul61ZEyUgvLkZBM=
 github.com/DataDog/appsec-internal-go v0.0.0-20230215162203-5149228be86a/go.mod h1:ILSJBuOg3E0Jg8qgSnm7+g8DXa0KrfahnS7jhS1DoWs=
 github.com/DataDog/aptly v1.5.0 h1:Oy6JVRC9iDgnmpeVYa4diXwP/exU7wJ/U1kuI4Zacxg=

--- a/pkg/collector/corechecks/containerimage/processor.go
+++ b/pkg/collector/corechecks/containerimage/processor.go
@@ -10,6 +10,8 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
+	"github.com/DataDog/datadog-agent/pkg/tagger"
+	"github.com/DataDog/datadog-agent/pkg/tagger/collectors"
 	queue "github.com/DataDog/datadog-agent/pkg/util/aggregatingqueue"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
@@ -17,6 +19,10 @@ import (
 	model "github.com/DataDog/agent-payload/v5/contimage"
 
 	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+var /* const */ (
+	sourceAgent = "agent"
 )
 
 type processor struct {
@@ -29,6 +35,7 @@ func newProcessor(sender aggregator.Sender, maxNbItem int, maxRetentionTime time
 			sender.ContainerImage([]model.ContainerImagePayload{
 				{
 					Version: "v1",
+					Source:  &sourceAgent,
 					Images:  images,
 				},
 			})
@@ -54,6 +61,11 @@ func (p *processor) processRefresh(allImages []*workloadmeta.ContainerImageMetad
 }
 
 func (p *processor) processImage(img *workloadmeta.ContainerImageMetadata) {
+	ddTags, err := tagger.Tag("container_image_metadata://"+img.ID, collectors.HighCardinality)
+	if err != nil {
+		log.Errorf("Could not retrieve tags for container image %s: %v", img.ID, err)
+	}
+
 	var lastCreated *timestamppb.Timestamp = nil
 	layers := make([]*model.ContainerImage_ContainerImageLayer, 0, len(img.Layers))
 	for _, layer := range img.Layers {
@@ -101,10 +113,10 @@ func (p *processor) processImage(img *workloadmeta.ContainerImageMetadata) {
 
 		id := repo + "@" + img.ID
 
-		tags := make([]string, 0, len(img.RepoTags))
+		repoTags := make([]string, 0, len(img.RepoTags))
 		for _, repoTag := range img.RepoTags {
 			if strings.HasPrefix(repoTag, repo+":") {
-				tags = append(tags, strings.SplitN(repoTag, ":", 2)[1])
+				repoTags = append(repoTags, strings.SplitN(repoTag, ":", 2)[1])
 			}
 		}
 
@@ -115,12 +127,31 @@ func (p *processor) processImage(img *workloadmeta.ContainerImageMetadata) {
 			}
 		}
 
+		// Because we split a single image entity into different payloads if it has several repo digests,
+		// me must re-compute `image_name`, `short_image` and `image_tag` tags.
+		ddTags2 := make([]string, 0, len(ddTags))
+		for _, ddTag := range ddTags {
+			if !strings.HasPrefix(ddTag, "image_name:") &&
+				!strings.HasPrefix(ddTag, "short_image:") &&
+				!strings.HasPrefix(ddTag, "image_tag:") {
+				ddTags2 = append(ddTags2, ddTag)
+			}
+		}
+
+		ddTags2 = append(ddTags2,
+			"image_name:"+repo,
+			"short_image:"+shortName)
+		for _, t := range repoTags {
+			ddTags2 = append(ddTags2, "image_tag:"+t)
+		}
+
 		p.queue <- &model.ContainerImage{
 			Id:          id,
+			DdTags:      ddTags2,
 			Name:        repo,
 			Registry:    registry,
 			ShortName:   shortName,
-			Tags:        tags,
+			RepoTags:    repoTags,
 			Digest:      img.ID,
 			Size:        img.SizeBytes,
 			RepoDigests: repoDigests,

--- a/pkg/collector/corechecks/containerimage/processor.go
+++ b/pkg/collector/corechecks/containerimage/processor.go
@@ -128,10 +128,11 @@ func (p *processor) processImage(img *workloadmeta.ContainerImageMetadata) {
 		}
 
 		// Because we split a single image entity into different payloads if it has several repo digests,
-		// me must re-compute `image_name`, `short_image` and `image_tag` tags.
+		// me must re-compute `image_id`, `image_name`, `short_image` and `image_tag` tags.
 		ddTags2 := make([]string, 0, len(ddTags))
 		for _, ddTag := range ddTags {
-			if !strings.HasPrefix(ddTag, "image_name:") &&
+			if !strings.HasPrefix(ddTag, "image_id:") &&
+				!strings.HasPrefix(ddTag, "image_name:") &&
 				!strings.HasPrefix(ddTag, "short_image:") &&
 				!strings.HasPrefix(ddTag, "image_tag:") {
 				ddTags2 = append(ddTags2, ddTag)
@@ -139,6 +140,7 @@ func (p *processor) processImage(img *workloadmeta.ContainerImageMetadata) {
 		}
 
 		ddTags2 = append(ddTags2,
+			"image_id:"+id,
 			"image_name:"+repo,
 			"short_image:"+shortName)
 		for _, t := range repoTags {

--- a/pkg/collector/corechecks/containerimage/processor_test.go
+++ b/pkg/collector/corechecks/containerimage/processor_test.go
@@ -79,11 +79,17 @@ func TestProcessEvents(t *testing.T) {
 			},
 			expectedImages: []*model.ContainerImage{
 				{
-					Id:        "datadog/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
+					Id: "datadog/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
+					DdTags: []string{
+						"image_name:datadog/agent",
+						"short_image:agent",
+						"image_tag:7-rc",
+						"image_tag:7.41.1-rc.1",
+					},
 					Name:      "datadog/agent",
 					Registry:  "",
 					ShortName: "agent",
-					Tags: []string{
+					RepoTags: []string{
 						"7-rc",
 						"7.41.1-rc.1",
 					},
@@ -127,11 +133,17 @@ func TestProcessEvents(t *testing.T) {
 					},
 				},
 				{
-					Id:        "gcr.io/datadoghq/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
+					Id: "gcr.io/datadoghq/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
+					DdTags: []string{
+						"image_name:gcr.io/datadoghq/agent",
+						"short_image:agent",
+						"image_tag:7-rc",
+						"image_tag:7.41.1-rc.1",
+					},
 					Name:      "gcr.io/datadoghq/agent",
 					Registry:  "gcr.io",
 					ShortName: "agent",
-					Tags: []string{
+					RepoTags: []string{
 						"7-rc",
 						"7.41.1-rc.1",
 					},
@@ -175,11 +187,17 @@ func TestProcessEvents(t *testing.T) {
 					},
 				},
 				{
-					Id:        "public.ecr.aws/datadog/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
+					Id: "public.ecr.aws/datadog/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
+					DdTags: []string{
+						"image_name:public.ecr.aws/datadog/agent",
+						"short_image:agent",
+						"image_tag:7-rc",
+						"image_tag:7.41.1-rc.1",
+					},
 					Name:      "public.ecr.aws/datadog/agent",
 					Registry:  "public.ecr.aws",
 					ShortName: "agent",
-					Tags: []string{
+					RepoTags: []string{
 						"7-rc",
 						"7.41.1-rc.1",
 					},
@@ -277,11 +295,16 @@ func TestProcessEvents(t *testing.T) {
 			},
 			expectedImages: []*model.ContainerImage{
 				{
-					Id:        "public.ecr.aws/datadog/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
+					Id: "public.ecr.aws/datadog/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
+					DdTags: []string{
+						"image_name:public.ecr.aws/datadog/agent",
+						"short_image:agent",
+						"image_tag:7-rc",
+					},
 					Name:      "public.ecr.aws/datadog/agent",
 					Registry:  "public.ecr.aws",
 					ShortName: "agent",
-					Tags: []string{
+					RepoTags: []string{
 						"7-rc",
 					},
 					Digest:      "sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
@@ -324,11 +347,16 @@ func TestProcessEvents(t *testing.T) {
 					},
 				},
 				{
-					Id:        "gcr.io/datadoghq/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
+					Id: "gcr.io/datadoghq/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
+					DdTags: []string{
+						"image_name:gcr.io/datadoghq/agent",
+						"short_image:agent",
+						"image_tag:7-rc",
+					},
 					Name:      "gcr.io/datadoghq/agent",
 					Registry:  "gcr.io",
 					ShortName: "agent",
-					Tags: []string{
+					RepoTags: []string{
 						"7-rc",
 					},
 					Digest:      "sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
@@ -404,6 +432,7 @@ func TestProcessEvents(t *testing.T) {
 				sender.AssertContainerImage(t, []model.ContainerImagePayload{
 					{
 						Version: "v1",
+						Source:  &sourceAgent,
 						Images:  []*model.ContainerImage{expectedImage},
 					},
 				})

--- a/pkg/collector/corechecks/containerimage/processor_test.go
+++ b/pkg/collector/corechecks/containerimage/processor_test.go
@@ -81,6 +81,7 @@ func TestProcessEvents(t *testing.T) {
 				{
 					Id: "datadog/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
 					DdTags: []string{
+						"image_id:datadog/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
 						"image_name:datadog/agent",
 						"short_image:agent",
 						"image_tag:7-rc",
@@ -135,6 +136,7 @@ func TestProcessEvents(t *testing.T) {
 				{
 					Id: "gcr.io/datadoghq/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
 					DdTags: []string{
+						"image_id:gcr.io/datadoghq/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
 						"image_name:gcr.io/datadoghq/agent",
 						"short_image:agent",
 						"image_tag:7-rc",
@@ -189,6 +191,7 @@ func TestProcessEvents(t *testing.T) {
 				{
 					Id: "public.ecr.aws/datadog/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
 					DdTags: []string{
+						"image_id:public.ecr.aws/datadog/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
 						"image_name:public.ecr.aws/datadog/agent",
 						"short_image:agent",
 						"image_tag:7-rc",
@@ -297,6 +300,7 @@ func TestProcessEvents(t *testing.T) {
 				{
 					Id: "public.ecr.aws/datadog/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
 					DdTags: []string{
+						"image_id:public.ecr.aws/datadog/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
 						"image_name:public.ecr.aws/datadog/agent",
 						"short_image:agent",
 						"image_tag:7-rc",
@@ -349,6 +353,7 @@ func TestProcessEvents(t *testing.T) {
 				{
 					Id: "gcr.io/datadoghq/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
 					DdTags: []string{
+						"image_id:gcr.io/datadoghq/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
 						"image_name:gcr.io/datadoghq/agent",
 						"short_image:agent",
 						"image_tag:7-rc",

--- a/pkg/collector/corechecks/sbom/processor.go
+++ b/pkg/collector/corechecks/sbom/processor.go
@@ -180,10 +180,11 @@ func (p *processor) processSBOM(img *workloadmeta.ContainerImageMetadata) {
 		}
 
 		// Because we split a single image entity into different payloads if it has several repo digests,
-		// me must re-compute `image_name`, `short_image` and `image_tag` tags.
+		// me must re-compute `image_id`, `image_name`, `short_image` and `image_tag` tags.
 		ddTags2 := make([]string, 0, len(ddTags))
 		for _, ddTag := range ddTags {
-			if !strings.HasPrefix(ddTag, "image_name:") &&
+			if !strings.HasPrefix(ddTag, "image_id:") &&
+				!strings.HasPrefix(ddTag, "image_name:") &&
 				!strings.HasPrefix(ddTag, "short_image:") &&
 				!strings.HasPrefix(ddTag, "image_tag:") {
 				ddTags2 = append(ddTags2, ddTag)
@@ -191,6 +192,7 @@ func (p *processor) processSBOM(img *workloadmeta.ContainerImageMetadata) {
 		}
 
 		ddTags2 = append(ddTags2,
+			"image_id:"+id,
 			"image_name:"+repo,
 			"short_image:"+shortName)
 		for _, t := range repoTags {

--- a/pkg/collector/corechecks/sbom/processor_test.go
+++ b/pkg/collector/corechecks/sbom/processor_test.go
@@ -81,7 +81,13 @@ func TestProcessEvents(t *testing.T) {
 				{
 					Type: model.SBOMSourceType_CONTAINER_IMAGE_LAYERS,
 					Id:   "datadog/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
-					Tags: []string{
+					DdTags: []string{
+						"image_name:datadog/agent",
+						"short_image:agent",
+						"image_tag:7-rc",
+						"image_tag:7.41.1-rc.1",
+					},
+					RepoTags: []string{
 						"7-rc",
 						"7.41.1-rc.1",
 					},
@@ -109,7 +115,13 @@ func TestProcessEvents(t *testing.T) {
 				{
 					Type: model.SBOMSourceType_CONTAINER_IMAGE_LAYERS,
 					Id:   "gcr.io/datadoghq/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
-					Tags: []string{
+					DdTags: []string{
+						"image_name:gcr.io/datadoghq/agent",
+						"short_image:agent",
+						"image_tag:7-rc",
+						"image_tag:7.41.1-rc.1",
+					},
+					RepoTags: []string{
 						"7-rc",
 						"7.41.1-rc.1",
 					},
@@ -137,7 +149,13 @@ func TestProcessEvents(t *testing.T) {
 				{
 					Type: model.SBOMSourceType_CONTAINER_IMAGE_LAYERS,
 					Id:   "public.ecr.aws/datadog/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
-					Tags: []string{
+					DdTags: []string{
+						"image_name:public.ecr.aws/datadog/agent",
+						"short_image:agent",
+						"image_tag:7-rc",
+						"image_tag:7.41.1-rc.1",
+					},
+					RepoTags: []string{
 						"7-rc",
 						"7.41.1-rc.1",
 					},
@@ -214,7 +232,12 @@ func TestProcessEvents(t *testing.T) {
 				{
 					Type: model.SBOMSourceType_CONTAINER_IMAGE_LAYERS,
 					Id:   "public.ecr.aws/datadog/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
-					Tags: []string{
+					DdTags: []string{
+						"image_name:public.ecr.aws/datadog/agent",
+						"short_image:agent",
+						"image_tag:7-rc",
+					},
+					RepoTags: []string{
 						"7-rc",
 					},
 					InUse:              false,
@@ -241,7 +264,12 @@ func TestProcessEvents(t *testing.T) {
 				{
 					Type: model.SBOMSourceType_CONTAINER_IMAGE_LAYERS,
 					Id:   "gcr.io/datadoghq/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
-					Tags: []string{
+					DdTags: []string{
+						"image_name:gcr.io/datadoghq/agent",
+						"short_image:agent",
+						"image_tag:7-rc",
+					},
+					RepoTags: []string{
 						"7-rc",
 					},
 					InUse:              false,
@@ -309,7 +337,12 @@ func TestProcessEvents(t *testing.T) {
 				{
 					Type: model.SBOMSourceType_CONTAINER_IMAGE_LAYERS,
 					Id:   "datadog/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
-					Tags: []string{
+					DdTags: []string{
+						"image_name:datadog/agent",
+						"short_image:agent",
+						"image_tag:7-rc",
+					},
+					RepoTags: []string{
 						"7-rc",
 					},
 					InUse:              false,
@@ -325,7 +358,12 @@ func TestProcessEvents(t *testing.T) {
 				{
 					Type: model.SBOMSourceType_CONTAINER_IMAGE_LAYERS,
 					Id:   "datadog/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
-					Tags: []string{
+					DdTags: []string{
+						"image_name:datadog/agent",
+						"short_image:agent",
+						"image_tag:7-rc",
+					},
+					RepoTags: []string{
 						"7-rc",
 					},
 					InUse:              true,

--- a/pkg/collector/corechecks/sbom/processor_test.go
+++ b/pkg/collector/corechecks/sbom/processor_test.go
@@ -82,6 +82,7 @@ func TestProcessEvents(t *testing.T) {
 					Type: model.SBOMSourceType_CONTAINER_IMAGE_LAYERS,
 					Id:   "datadog/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
 					DdTags: []string{
+						"image_id:datadog/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
 						"image_name:datadog/agent",
 						"short_image:agent",
 						"image_tag:7-rc",
@@ -116,6 +117,7 @@ func TestProcessEvents(t *testing.T) {
 					Type: model.SBOMSourceType_CONTAINER_IMAGE_LAYERS,
 					Id:   "gcr.io/datadoghq/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
 					DdTags: []string{
+						"image_id:gcr.io/datadoghq/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
 						"image_name:gcr.io/datadoghq/agent",
 						"short_image:agent",
 						"image_tag:7-rc",
@@ -150,6 +152,7 @@ func TestProcessEvents(t *testing.T) {
 					Type: model.SBOMSourceType_CONTAINER_IMAGE_LAYERS,
 					Id:   "public.ecr.aws/datadog/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
 					DdTags: []string{
+						"image_id:public.ecr.aws/datadog/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
 						"image_name:public.ecr.aws/datadog/agent",
 						"short_image:agent",
 						"image_tag:7-rc",
@@ -233,6 +236,7 @@ func TestProcessEvents(t *testing.T) {
 					Type: model.SBOMSourceType_CONTAINER_IMAGE_LAYERS,
 					Id:   "public.ecr.aws/datadog/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
 					DdTags: []string{
+						"image_id:public.ecr.aws/datadog/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
 						"image_name:public.ecr.aws/datadog/agent",
 						"short_image:agent",
 						"image_tag:7-rc",
@@ -265,6 +269,7 @@ func TestProcessEvents(t *testing.T) {
 					Type: model.SBOMSourceType_CONTAINER_IMAGE_LAYERS,
 					Id:   "gcr.io/datadoghq/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
 					DdTags: []string{
+						"image_id:gcr.io/datadoghq/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
 						"image_name:gcr.io/datadoghq/agent",
 						"short_image:agent",
 						"image_tag:7-rc",
@@ -338,6 +343,7 @@ func TestProcessEvents(t *testing.T) {
 					Type: model.SBOMSourceType_CONTAINER_IMAGE_LAYERS,
 					Id:   "datadog/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
 					DdTags: []string{
+						"image_id:datadog/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
 						"image_name:datadog/agent",
 						"short_image:agent",
 						"image_tag:7-rc",
@@ -359,6 +365,7 @@ func TestProcessEvents(t *testing.T) {
 					Type: model.SBOMSourceType_CONTAINER_IMAGE_LAYERS,
 					Id:   "datadog/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
 					DdTags: []string{
+						"image_id:datadog/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
 						"image_name:datadog/agent",
 						"short_image:agent",
 						"image_tag:7-rc",

--- a/pkg/tagger/README.md
+++ b/pkg/tagger/README.md
@@ -62,17 +62,18 @@ cache. Cache invalidation is triggered by the collectors (or source) by either:
 Tagger entities are identified by a string-typed ID, with one of the following forms:
 
 <!-- NOTE: a similar table appears in pkg/autodiscovery/README.md; please keep both in sync -->
-| *Service*                         | *Tagger Entity*                                                    |
-|-----------------------------------|--------------------------------------------------------------------|
-| workloadmeta.KindContainer        | `container_id://<sha>`                                             |
-| workloadmeta.KindGardenContainer  | `container_id://<sha>`                                             |
-| workloadmeta.KindKubernetesPod    | `kubernetes_pod_uid://<uid>`                                       |
-| workloadmeta.KindECSTask          | `ecs_task://<task-id>`                                             |
-| CloudFoundry LRP                  | `<processGuid>/<svcName>/<instanceGuid>`  or `<appGuid>/<svcName>` |
-| Container runtime or orchestrator | (none)                                                             |
-| Kubernetes Endpoint               | `kube_endpoint_uid://<namespace>/<name>/<ip>`                      |
-| Kubernetes Service                | `kube_service://<namespace>/<name>`                                |
-| SNMP Config                       | config hash                                                        |
+| *Service*                               | *Tagger Entity*                                                    |
+|-----------------------------------------|--------------------------------------------------------------------|
+| workloadmeta.KindContainer              | `container_id://<sha>`                                             |
+| workloadmeta.KindContainerImageMetadata | `container_image_metadata://<sha>                                  |
+| workloadmeta.KindGardenContainer        | `container_id://<sha>`                                             |
+| workloadmeta.KindKubernetesPod          | `kubernetes_pod_uid://<uid>`                                       |
+| workloadmeta.KindECSTask                | `ecs_task://<task-id>`                                             |
+| CloudFoundry LRP                        | `<processGuid>/<svcName>/<instanceGuid>`  or `<appGuid>/<svcName>` |
+| Container runtime or orchestrator       | (none)                                                             |
+| Kubernetes Endpoint                     | `kube_endpoint_uid://<namespace>/<name>/<ip>`                      |
+| Kubernetes Service                      | `kube_service://<namespace>/<name>`                                |
+| SNMP Config                             | config hash                                                        |
 
 ## Tagger
 

--- a/pkg/tagger/collectors/workloadmeta_extract.go
+++ b/pkg/tagger/collectors/workloadmeta_extract.go
@@ -136,7 +136,7 @@ func (c *WorkloadMetaCollector) processEvents(evBundle workloadmeta.EventBundle)
 			case workloadmeta.KindECSTask:
 				tagInfos = append(tagInfos, c.handleECSTask(ev)...)
 			case workloadmeta.KindContainerImageMetadata:
-				// No tags for now
+				tagInfos = append(tagInfos, c.handleContainerImage(ev)...)
 			default:
 				log.Errorf("cannot handle event for entity %q with kind %q", entityID.ID, entityID.Kind)
 			}
@@ -194,25 +194,7 @@ func (c *WorkloadMetaCollector) handleContainer(ev workloadmeta.Event) []*TagInf
 		}
 	}
 
-	// standard tags from labels
-	c.extractFromMapWithFn(container.Labels, standardDockerLabels, tags.AddStandard)
-
-	// container labels as tags
-	for labelName, labelValue := range container.Labels {
-		utils.AddMetadataAsTags(labelName, labelValue, c.containerLabelsAsTags, c.globContainerLabels, tags)
-	}
-
-	// orchestrator tags from labels
-	c.extractFromMapWithFn(container.Labels, lowCardOrchestratorLabels, tags.AddLow)
-	c.extractFromMapWithFn(container.Labels, highCardOrchestratorLabels, tags.AddHigh)
-
-	// extract labels as tags
-	c.extractFromMapNormalizedWithFn(container.Labels, c.containerLabelsAsTags, tags.AddAuto)
-
-	// custom tags from label
-	if lbl, ok := container.Labels[autodiscoveryLabelTagsKey]; ok {
-		parseContainerADTagsLabels(tags, lbl)
-	}
+	c.labelsToTags(container.Labels, tags)
 
 	// standard tags from environment
 	c.extractFromMapWithFn(container.EnvVars, standardEnvKeys, tags.AddStandard)
@@ -241,6 +223,78 @@ func (c *WorkloadMetaCollector) handleContainer(ev workloadmeta.Event) []*TagInf
 			LowCardTags:          low,
 			StandardTags:         standard,
 		},
+	}
+}
+
+func (c *WorkloadMetaCollector) handleContainerImage(ev workloadmeta.Event) []*TagInfo {
+	image := ev.Entity.(*workloadmeta.ContainerImageMetadata)
+
+	tags := utils.NewTagList()
+	tags.AddLow("image_name", image.Name)
+
+	// In containerd some images are created without a repo digest, and it's
+	// also possible to remove repo digests manually.
+	// This means that the set of repos that we need to handle is the union of
+	// the repos present in the repo digests and the ones present in the repo
+	// tags.
+	repos := make(map[string]struct{})
+	for _, repoDigest := range image.RepoDigests {
+		repos[strings.SplitN(repoDigest, "@sha256:", 2)[0]] = struct{}{}
+	}
+	for _, repoTag := range image.RepoTags {
+		repos[strings.SplitN(repoTag, ":", 2)[0]] = struct{}{}
+	}
+	for repo := range repos {
+		repoSplitted := strings.Split(repo, "/")
+		shortName := repoSplitted[len(repoSplitted)-1]
+		tags.AddLow("short_image", shortName)
+	}
+
+	for _, repoTag := range image.RepoTags {
+		repoTagSplitted := strings.SplitN(repoTag, ":", 2)
+		if len(repoTagSplitted) == 2 {
+			tags.AddLow("image_tag", repoTagSplitted[1])
+		}
+	}
+
+	tags.AddLow("os_name", image.OS)
+	tags.AddLow("os_version", image.OSVersion)
+	tags.AddLow("architecture", image.Architecture)
+
+	c.labelsToTags(image.Labels, tags)
+
+	low, orch, high, standard := tags.Compute()
+	return []*TagInfo{
+		{
+			Source:               containerImageSource,
+			Entity:               buildTaggerEntityID(image.EntityID),
+			HighCardTags:         high,
+			OrchestratorCardTags: orch,
+			LowCardTags:          low,
+			StandardTags:         standard,
+		},
+	}
+}
+
+func (c *WorkloadMetaCollector) labelsToTags(labels map[string]string, tags *utils.TagList) {
+	// standard tags from labels
+	c.extractFromMapWithFn(labels, standardDockerLabels, tags.AddStandard)
+
+	// container labels as tags
+	for labelName, labelValue := range labels {
+		utils.AddMetadataAsTags(labelName, labelValue, c.containerLabelsAsTags, c.globContainerLabels, tags)
+	}
+
+	// orchestrator tags from labels
+	c.extractFromMapWithFn(labels, lowCardOrchestratorLabels, tags.AddLow)
+	c.extractFromMapWithFn(labels, highCardOrchestratorLabels, tags.AddHigh)
+
+	// extract labels as tags
+	c.extractFromMapNormalizedWithFn(labels, c.containerLabelsAsTags, tags.AddAuto)
+
+	// custom tags from label
+	if lbl, ok := labels[autodiscoveryLabelTagsKey]; ok {
+		parseContainerADTagsLabels(tags, lbl)
 	}
 }
 

--- a/pkg/tagger/collectors/workloadmeta_main.go
+++ b/pkg/tagger/collectors/workloadmeta_main.go
@@ -22,10 +22,11 @@ import (
 const (
 	workloadmetaCollectorName = "workloadmeta"
 
-	staticSource    = workloadmetaCollectorName + "-static"
-	podSource       = workloadmetaCollectorName + "-" + string(workloadmeta.KindKubernetesPod)
-	taskSource      = workloadmetaCollectorName + "-" + string(workloadmeta.KindECSTask)
-	containerSource = workloadmetaCollectorName + "-" + string(workloadmeta.KindContainer)
+	staticSource         = workloadmetaCollectorName + "-static"
+	podSource            = workloadmetaCollectorName + "-" + string(workloadmeta.KindKubernetesPod)
+	taskSource           = workloadmetaCollectorName + "-" + string(workloadmeta.KindECSTask)
+	containerSource      = workloadmetaCollectorName + "-" + string(workloadmeta.KindContainer)
+	containerImageSource = workloadmetaCollectorName + "+" + string(workloadmeta.KindContainerImageMetadata)
 )
 
 // CollectorPriorities holds collector priorities
@@ -188,4 +189,5 @@ func init() {
 	CollectorPriorities[podSource] = NodeOrchestrator
 	CollectorPriorities[taskSource] = NodeOrchestrator
 	CollectorPriorities[containerSource] = NodeRuntime
+	CollectorPriorities[containerImageSource] = NodeRuntime
 }


### PR DESCRIPTION
### What does this PR do?

Attach datadog tags to `contimage` and `sbom` payloads.

### Motivation

Enrich the data we send alongside container images in the `contimage` and the `sbom` checks.

### Additional Notes

Requires DataDog/agent-payload#232

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Enable container image metadata collection by adding this in the Helm chart:
```yaml
datadog:
  env:
    - name: DD_CONTAINER_IMAGE_COLLECTION_METADATA_ENABLED
      value: "true"
```

And then, check the output of `agent tagger-list` for `container_image_metadata://…` entities.

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
