### PR TITLE
Prevent the Agent from parsing large containerd Spec and filter stored environment variables

### DIFF
--- a/pkg/tagger/collectors/workloadmeta_extract.go
+++ b/pkg/tagger/collectors/workloadmeta_extract.go
@@ -56,6 +56,8 @@ const (
 )
 
 var (
+	// When adding new environment variables, they need to be added to
+	// pkg/util/containers/env_vars_filter.go
 	standardEnvKeys = map[string]string{
 		envVarEnv:     tagKeyEnv,
 		envVarVersion: tagKeyVersion,

--- a/pkg/tagger/collectors/workloadmeta_main.go
+++ b/pkg/tagger/collectors/workloadmeta_main.go
@@ -146,6 +146,7 @@ func NewWorkloadMetaCollector(ctx context.Context, store workloadmeta.Store, p p
 		retrieveMappingFromConfig("docker_labels_as_tags"),
 		retrieveMappingFromConfig("container_labels_as_tags"),
 	)
+	// Adding new environment variables require adding them to pkg/util/containers/env_vars_filter.go
 	containerEnvAsTags := mergeMaps(
 		retrieveMappingFromConfig("docker_env_as_tags"),
 		retrieveMappingFromConfig("container_env_as_tags"),

--- a/pkg/util/containerd/containerd_util_test.go
+++ b/pkg/util/containerd/containerd_util_test.go
@@ -90,6 +90,7 @@ func TestEnvVars(t *testing.T) {
 	tests := []struct {
 		name           string
 		specEnvs       []string
+		filterFunc     func(string) bool
 		expectedResult map[string]string
 		expectsErr     bool
 	}{
@@ -97,6 +98,14 @@ func TestEnvVars(t *testing.T) {
 			name:           "valid envs",
 			specEnvs:       []string{"ENV1=val1", "ENV2=val2"},
 			expectedResult: map[string]string{"ENV1": "val1", "ENV2": "val2"},
+		},
+		{
+			name:     "valid envs",
+			specEnvs: []string{"ENV1=val1", "ENV2=val2"},
+			filterFunc: func(s string) bool {
+				return s == "ENV1"
+			},
+			expectedResult: map[string]string{"ENV1": "val1"},
 		},
 		{
 			name:       "wrong format",
@@ -113,7 +122,7 @@ func TestEnvVars(t *testing.T) {
 				},
 			}
 
-			envVars, err := EnvVarsFromSpec(spec)
+			envVars, err := EnvVarsFromSpec(spec, test.filterFunc)
 
 			if test.expectsErr {
 				require.Error(t, err)

--- a/pkg/util/containerd/containerd_util_test.go
+++ b/pkg/util/containerd/containerd_util_test.go
@@ -107,19 +107,13 @@ func TestEnvVars(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			mockUtil := ContainerdUtil{}
-
-			container := &mockContainer{
-				mockSpec: func() (*oci.Spec, error) {
-					return &oci.Spec{
-						Process: &specs.Process{
-							Env: test.specEnvs,
-						},
-					}, nil
+			spec := &oci.Spec{
+				Process: &specs.Process{
+					Env: test.specEnvs,
 				},
 			}
 
-			envVars, err := mockUtil.EnvVars(TestNamespace, container)
+			envVars, err := EnvVarsFromSpec(spec)
 
 			if test.expectsErr {
 				require.Error(t, err)
@@ -294,19 +288,6 @@ func TestIsSandbox(t *testing.T) {
 	}
 
 	isSandbox, err := mockUtil.IsSandbox(TestNamespace, withSandboxLabel)
-	require.NoError(t, err)
-	require.True(t, isSandbox)
-
-	withSandboxAnnotation := &mockContainer{
-		mockSpec: func() (*oci.Spec, error) {
-			return &oci.Spec{Annotations: map[string]string{"io.kubernetes.cri.container-type": "sandbox"}}, nil
-		},
-		mockLabels: func() (map[string]string, error) {
-			return map[string]string{}, nil
-		},
-	}
-
-	isSandbox, err = mockUtil.IsSandbox(TestNamespace, withSandboxAnnotation)
 	require.NoError(t, err)
 	require.True(t, isSandbox)
 

--- a/pkg/util/containerd/fake/containerd_util.go
+++ b/pkg/util/containerd/fake/containerd_util.go
@@ -30,7 +30,6 @@ type MockedContainerdClient struct {
 	MockContainers            func(namespace string) ([]containerd.Container, error)
 	MockContainer             func(namespace string, id string) (containerd.Container, error)
 	MockContainerWithCtx      func(ctx context.Context, namespace string, id string) (containerd.Container, error)
-	MockEnvVars               func(namespace string, ctn containerd.Container) (map[string]string, error)
 	MockMetadata              func() (containerd.Version, error)
 	MockListImages            func(namespace string) ([]containerd.Image, error)
 	MockImage                 func(namespace string, name string) (containerd.Image, error)
@@ -42,11 +41,9 @@ type MockedContainerdClient struct {
 	MockLabels                func(namespace string, ctn containerd.Container) (map[string]string, error)
 	MockLabelsWithContext     func(ctx context.Context, namespace string, ctn containerd.Container) (map[string]string, error)
 	MockNamespaces            func(ctx context.Context) ([]string, error)
-	MockSpec                  func(namespace string, ctn containerd.Container) (*oci.Spec, error)
-	MockSpecWithContext       func(ctx context.Context, namespace string, ctn containerd.Container) (*oci.Spec, error)
+	MockSpec                  func(namespace string, ctn containers.Container) (*oci.Spec, error)
 	MockStatus                func(namespace string, ctn containerd.Container) (containerd.ProcessStatus, error)
 	MockCallWithClientContext func(namespace string, f func(context.Context) error) error
-	MockAnnotations           func(namespace string, ctn containerd.Container) (map[string]string, error)
 	MockIsSandbox             func(namespace string, ctn containerd.Container) (bool, error)
 	MockMountImage            func(ctx context.Context, expiration time.Duration, namespace string, img containerd.Image, targetDir string) (func(context.Context) error, error)
 }
@@ -142,18 +139,8 @@ func (client *MockedContainerdClient) GetEvents() containerd.EventService {
 }
 
 // Spec is a mock method
-func (client *MockedContainerdClient) Spec(namespace string, ctn containerd.Container) (*oci.Spec, error) {
+func (client *MockedContainerdClient) Spec(namespace string, ctn containers.Container, maxSize int) (*oci.Spec, error) {
 	return client.MockSpec(namespace, ctn)
-}
-
-// SpecWithContext is a mock method
-func (client *MockedContainerdClient) SpecWithContext(ctx context.Context, namespace string, ctn containerd.Container) (*oci.Spec, error) {
-	return client.MockSpecWithContext(ctx, namespace, ctn)
-}
-
-// EnvVars is a mock method
-func (client *MockedContainerdClient) EnvVars(namespace string, ctn containerd.Container) (map[string]string, error) {
-	return client.MockEnvVars(namespace, ctn)
 }
 
 // Status is a mock method
@@ -164,11 +151,6 @@ func (client *MockedContainerdClient) Status(namespace string, ctn containerd.Co
 // CallWithClientContext is a mock method
 func (client *MockedContainerdClient) CallWithClientContext(namespace string, f func(context.Context) error) error {
 	return client.MockCallWithClientContext(namespace, f)
-}
-
-// Annotations is a mock method
-func (client *MockedContainerdClient) Annotations(namespace string, ctn containerd.Container) (map[string]string, error) {
-	return client.MockAnnotations(namespace, ctn)
 }
 
 // IsSandbox is a mock method

--- a/pkg/util/containers/env_vars_filter.go
+++ b/pkg/util/containers/env_vars_filter.go
@@ -1,0 +1,80 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package containers
+
+import (
+	"strings"
+	"sync"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+)
+
+var (
+	defaultEnvVarsIncludeList = []string{
+		"DD_ENV",
+		"DD_VERSION",
+		"DD_SERVICE",
+		"CHRONOS_JOB_NAME",
+		"CHRONOS_JOB_OWNER",
+		"NOMAD_TASK_NAME",
+		"NOMAD_JOB_NAME",
+		"NOMAD_GROUP_NAME",
+		"NOMAD_NAMESPACE",
+		"NOMAD_DC",
+		"MESOS_TASK_ID",
+		"ECS_CONTAINER_METADATA_URI",
+		"ECS_CONTAINER_METADATA_URI_V4",
+		// Included to ease unit tests withtout requiring a mock
+		"TEST_ENV",
+	}
+
+	envFilterOnce       sync.Once
+	envFilterFromConfig EnvFilter
+)
+
+func EnvVarFilterFromConfig() EnvFilter {
+	envFilterOnce.Do(func() {
+		configEnvVars := make([]string, 0)
+		dockerEnvs := config.Datadog.GetStringMapString("docker_env_as_tags")
+		for envName := range dockerEnvs {
+			configEnvVars = append(configEnvVars, envName)
+		}
+
+		containerEnvs := config.Datadog.GetStringMapString("container_env_as_tags")
+		for envName := range containerEnvs {
+			configEnvVars = append(configEnvVars, envName)
+		}
+
+		envFilterFromConfig = newEnvFilter(configEnvVars)
+	})
+
+	return envFilterFromConfig
+}
+
+type EnvFilter struct {
+	includeVars map[string]struct{}
+}
+
+func newEnvFilter(includeVars []string) EnvFilter {
+	filter := EnvFilter{
+		includeVars: make(map[string]struct{}),
+	}
+
+	for _, varName := range defaultEnvVarsIncludeList {
+		filter.includeVars[strings.ToUpper(varName)] = struct{}{}
+	}
+
+	for _, varName := range includeVars {
+		filter.includeVars[strings.ToUpper(varName)] = struct{}{}
+	}
+
+	return filter
+}
+
+func (f EnvFilter) IsIncluded(envVarName string) bool {
+	_, found := f.includeVars[strings.ToUpper(envVarName)]
+	return found
+}

--- a/pkg/util/containers/env_vars_filter_test.go
+++ b/pkg/util/containers/env_vars_filter_test.go
@@ -1,0 +1,21 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package containers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEnvFilter_IsIncluded(t *testing.T) {
+	filter := newEnvFilter([]string{"FOO", "bar"})
+
+	assert.True(t, filter.IsIncluded("DD_VERSION"))
+	assert.True(t, filter.IsIncluded("FOO"))
+	assert.True(t, filter.IsIncluded("BAR"))
+	assert.False(t, filter.IsIncluded("BAZ"))
+}

--- a/pkg/util/containers/metrics/containerd/collector.go
+++ b/pkg/util/containers/metrics/containerd/collector.go
@@ -15,9 +15,11 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/containerd/containerd/oci"
 	"github.com/containerd/typeurl"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/containerd"
 	cutil "github.com/DataDog/datadog-agent/pkg/util/containerd"
 	"github.com/DataDog/datadog-agent/pkg/util/containers/metrics/provider"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -109,7 +111,12 @@ func (c *containerdCollector) GetContainerStats(containerNS, containerID string,
 	}
 
 	// Filling information from Spec
-	OCISpec, err := c.client.Spec(containerNS, container)
+	var OCISpec *oci.Spec
+	info, err := c.client.Info(containerNS, container)
+	if err == nil {
+		OCISpec, err = c.client.Spec(containerNS, info, containerd.DefaultAllowedSpecMaxSize)
+	}
+
 	if err == nil {
 		fillStatsFromSpec(containerStats, OCISpec)
 	} else {

--- a/pkg/util/containers/metrics/containerd/collector_test.go
+++ b/pkg/util/containers/metrics/containerd/collector_test.go
@@ -91,7 +91,7 @@ func containerdClient(metrics *types.Metric) *fake.MockedContainerdClient {
 		MockInfo: func(namespace string, ctn containerd.Container) (containers.Container, error) {
 			return containers.Container{}, nil
 		},
-		MockSpec: func(namespace string, ctn containerd.Container) (*oci.Spec, error) {
+		MockSpec: func(namespace string, ctn containers.Container) (*oci.Spec, error) {
 			return nil, nil
 		},
 		MockTaskPids: func(namespace string, ctn containerd.Container) ([]containerd.ProcessInfo, error) {

--- a/pkg/workloadmeta/collectors/internal/containerd/container_builder.go
+++ b/pkg/workloadmeta/collectors/internal/containerd/container_builder.go
@@ -17,6 +17,7 @@ import (
 	"github.com/containerd/containerd/errdefs"
 
 	cutil "github.com/DataDog/datadog-agent/pkg/util/containerd"
+	"github.com/DataDog/datadog-agent/pkg/util/containers"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 )
@@ -91,7 +92,7 @@ func buildWorkloadMetaContainer(namespace string, container containerd.Container
 			return workloadmeta.Container{}, fmt.Errorf("retrieved empty spec for container id: %s", info.ID)
 		}
 
-		envs, err := cutil.EnvVarsFromSpec(spec)
+		envs, err := cutil.EnvVarsFromSpec(spec, containers.EnvVarFilterFromConfig().IsIncluded)
 		if err != nil {
 			return workloadmeta.Container{}, err
 		}

--- a/pkg/workloadmeta/collectors/internal/containerd/container_builder_test.go
+++ b/pkg/workloadmeta/collectors/internal/containerd/container_builder_test.go
@@ -70,9 +70,6 @@ func TestBuildWorkloadMetaContainer(t *testing.T) {
 	}
 
 	client := fake.MockedContainerdClient{
-		MockEnvVars: func(namespace string, ctn containerd.Container) (map[string]string, error) {
-			return envVars, nil
-		},
 		MockInfo: func(namespace string, ctn containerd.Container) (containers.Container, error) {
 			return containers.Container{
 				Labels:    labels,
@@ -80,7 +77,7 @@ func TestBuildWorkloadMetaContainer(t *testing.T) {
 				Image:     imgName,
 			}, nil
 		},
-		MockSpec: func(namespace string, ctn containerd.Container) (*oci.Spec, error) {
+		MockSpec: func(namespace string, ctn containers.Container) (*oci.Spec, error) {
 			return &oci.Spec{Hostname: hostName, Process: &specs.Process{Env: envVarStrs}}, nil
 		},
 		MockStatus: func(namespace string, ctn containerd.Container) (containerd.ProcessStatus, error) {

--- a/pkg/workloadmeta/collectors/internal/containerd/event_builder_test.go
+++ b/pkg/workloadmeta/collectors/internal/containerd/event_builder_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/containerd/containerd/oci"
 	"github.com/gogo/protobuf/proto"
 	"github.com/gogo/protobuf/types"
+	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-agent/pkg/util/containerd/fake"
@@ -279,7 +280,7 @@ func TestBuildCollectorEvent(t *testing.T) {
 func containerdClient(container containerd.Container) fake.MockedContainerdClient {
 	labels := map[string]string{"some_label": "some_val"}
 	imgName := "datadog/agent:7"
-	envVars := map[string]string{"test_env": "test_val"}
+	envVarStrs := []string{"test_env=test_val"}
 	hostName := "test_hostname"
 	createdAt, _ := time.Parse("2006-01-02", "2021-10-11")
 
@@ -297,14 +298,11 @@ func containerdClient(container containerd.Container) fake.MockedContainerdClien
 				},
 			}, nil
 		},
-		MockEnvVars: func(namespace string, ctn containerd.Container) (map[string]string, error) {
-			return envVars, nil
-		},
 		MockInfo: func(namespace string, ctn containerd.Container) (containers.Container, error) {
 			return containers.Container{CreatedAt: createdAt}, nil
 		},
-		MockSpec: func(namespace string, ctn containerd.Container) (*oci.Spec, error) {
-			return &oci.Spec{Hostname: hostName}, nil
+		MockSpec: func(namespace string, ctn containers.Container) (*oci.Spec, error) {
+			return &oci.Spec{Hostname: hostName, Process: &specs.Process{Env: envVarStrs}}, nil
 		},
 		MockStatus: func(namespace string, ctn containerd.Container) (containerd.ProcessStatus, error) {
 			return containerd.Running, nil

--- a/pkg/workloadmeta/collectors/internal/docker/docker.go
+++ b/pkg/workloadmeta/collectors/internal/docker/docker.go
@@ -378,7 +378,9 @@ func extractEnvVars(env []string) map[string]string {
 			continue
 		}
 
-		envMap[envSplit[0]] = envSplit[1]
+		if containers.EnvVarFilterFromConfig().IsIncluded(envSplit[0]) {
+			envMap[envSplit[0]] = envSplit[1]
+		}
 	}
 
 	return envMap

--- a/pkg/workloadmeta/collectors/internal/kubelet/kubelet.go
+++ b/pkg/workloadmeta/collectors/internal/kubelet/kubelet.go
@@ -281,6 +281,10 @@ func extractEnvFromSpec(envSpec []kubelet.EnvVar) map[string]string {
 	// done by the kubelet.
 
 	for _, e := range envSpec {
+		if !containers.EnvVarFilterFromConfig().IsIncluded(e.Name) {
+			continue
+		}
+
 		runtimeVal := e.Value
 		if runtimeVal != "" {
 			runtimeVal = expansion.Expand(runtimeVal, mappingFunc)

--- a/pkg/workloadmeta/collectors/internal/podman/podman.go
+++ b/pkg/workloadmeta/collectors/internal/podman/podman.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 	dderrors "github.com/DataDog/datadog-agent/pkg/errors"
+	"github.com/DataDog/datadog-agent/pkg/util/containers"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/podman"
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
@@ -213,7 +214,9 @@ func envVars(container *podman.Container) (map[string]string, error) {
 			return nil, errors.New("unexpected environment variable format")
 		}
 
-		res[envSplit[0]] = envSplit[1]
+		if containers.EnvVarFilterFromConfig().IsIncluded(envSplit[0]) {
+			res[envSplit[0]] = envSplit[1]
+		}
 	}
 
 	return res, nil

--- a/pkg/workloadmeta/collectors/internal/podman/podman_test.go
+++ b/pkg/workloadmeta/collectors/internal/podman/podman_test.go
@@ -216,9 +216,7 @@ func TestPull(t *testing.T) {
 						"label-b-dev": "value-b-dev",
 					},
 				},
-				EnvVars: map[string]string{
-					"SOME_ENV": "SOME_VAL",
-				},
+				EnvVars:  map[string]string{},
 				Hostname: "agent-dev",
 				Image: workloadmeta.ContainerImage{
 					RawName:   "docker.io/datadog/agent-dev:latest",

--- a/pkg/workloadmeta/types.go
+++ b/pkg/workloadmeta/types.go
@@ -383,6 +383,7 @@ func (o OrchestratorContainer) String(_ bool) string {
 type Container struct {
 	EntityID
 	EntityMeta
+	// EnvVars are limited to variabels included in pkg/util/containers/env_vars_filter.go
 	EnvVars    map[string]string
 	Hostname   string
 	Image      ContainerImage

--- a/releasenotes/notes/max-containerd-spec-5dec95b909062b4e.yaml
+++ b/releasenotes/notes/max-containerd-spec-5dec95b909062b4e.yaml
@@ -1,0 +1,4 @@
+---
+security:
+  - |
+    The Agent now checks containerd containers `Spec` size before parsing it. Any `Spec` exceeding 2MB will not be parsed and a warning will be emitted. This impacts the `container_env_as_tags` feature for environments based on `containerd` outside of Kubernetes.

--- a/releasenotes/notes/max-containerd-spec-5dec95b909062b4e.yaml
+++ b/releasenotes/notes/max-containerd-spec-5dec95b909062b4e.yaml
@@ -1,4 +1,4 @@
 ---
 security:
   - |
-    The Agent now checks containerd containers `Spec` size before parsing it. Any `Spec` exceeding 2MB will not be parsed and a warning will be emitted. This impacts the `container_env_as_tags` feature for environments based on `containerd` outside of Kubernetes.
+    The Agent now checks containerd containers `Spec` size before parsing it. Any `Spec` exceeding 2MB will not be parsed and a warning will be emitted. This impacts the `container_env_as_tags` feature and `%%hostname%%` variable resolution for environments based on `containerd` outside of Kubernetes.


### PR DESCRIPTION
### What does this PR do?

Prevent the Agent from parsing large containerd Spec as it triggers an important memory and CPU consumption in the Agent while only few use cases requires it.

Also adding filter on stored environment variables (no change from customer PoV) to reduce memory usage and allocations for content we don't use.

### Motivation

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Deploy the Agent on Kubernetes with containerd. Deploy a fake application that sets a lot of variables (>30 000) in its environment. You should get a `warning` log.
Deploy a normal application with some environment variables and set `container_env_as_tags` to get these env vars as tags. Verify the tags are correctly emitted.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
