### PR TITLE
Fix gitlab syntax

### DIFF
--- a/.gitlab/kitchen_common/testing.yml
+++ b/.gitlab/kitchen_common/testing.yml
@@ -155,8 +155,7 @@
   variables:
     KITCHEN_EC2_REGION: us-east-1
     KITCHEN_EC2_SUBNET: subnet-c18341ed
-    KITCHEN_EC2_SG_IDS:
-    - sg-0f5617ceb3e5a6c39
+    KITCHEN_EC2_SG_IDS: sg-0f5617ceb3e5a6c39
 
 # Kitchen: Test types (test suite * agent flavor + location in each cloud provider)
 # -------------------------------

--- a/test/kitchen/drivers/ec2-driver.yml
+++ b/test/kitchen/drivers/ec2-driver.yml
@@ -32,7 +32,11 @@ driver:
   <% if ENV['KITCHEN_EC2_SSH_KEY_ID'] %>
   aws_ssh_key_id: <%= ENV['KITCHEN_EC2_SSH_KEY_ID'] %>
   <% end %>
-  security_group_ids: <%= ENV['KITCHEN_EC2_SG_IDS'] || ["sg-7fedd80a","sg-46506837"] %>
+  <% if ENV['KITCHEN_EC2_SG_IDS'] %>
+  security_group_ids: <%= [ENV['KITCHEN_EC2_SG_IDS']] %>
+  <% else %>
+  security_group_ids: [ "sg-7fedd80a","sg-46506837" ]
+  <% end %>
   region: <%= ENV['KITCHEN_EC2_REGION'] ||= "us-east-1" %>
   instance_type: <%= ENV['KITCHEN_EC2_INSTANCE_TYPE'] ||= 't3.xlarge' %>
   associate_public_ip: false

--- a/test/kitchen/tasks/kitchen.py
+++ b/test/kitchen/tasks/kitchen.py
@@ -153,8 +153,8 @@ def genconfig(
 
     if provider == "azure":
         env['TEST_IMAGE_SIZE'] = imagesize if imagesize else ""
-    elif provider == "ec2":
-        env['KITCHEN_EC2_INSTANCE_TYPE'] = imagesize if imagesize else ""
+    elif provider == "ec2" and imagesize:
+        env['KITCHEN_EC2_INSTANCE_TYPE'] = imagesize
 
     if fips:
         env['FIPS'] = 'true'


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

#15846 broke the Gitlab syntax

### Motivation

Gitlab doesn't support arrays 😢 

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
