### PR TITLE
[process-agent] Add retries to process agent kitchen tests

### DIFF
--- a/test/kitchen/test/integration/container-collection-test/rspec_datadog/spec_helper.rb
+++ b/test/kitchen/test/integration/container-collection-test/rspec_datadog/spec_helper.rb
@@ -39,9 +39,12 @@ def get_with_retries(uri_or_host, path, port, max_retries=10)
       retries += 1
       sleep 1
       retry
+    else
+      raise "Failed to connect to a running agent"
     end
   end
 end
+
 
 def get_runtime_config
   res = get_with_retries('localhost', '/config', 6162)

--- a/test/kitchen/test/integration/container-collection-test/rspec_datadog/spec_helper.rb
+++ b/test/kitchen/test/integration/container-collection-test/rspec_datadog/spec_helper.rb
@@ -45,7 +45,6 @@ def get_with_retries(uri_or_host, path, port, max_retries=10)
   end
 end
 
-
 def get_runtime_config
   res = get_with_retries('localhost', '/config', 6162)
   YAML.load(res)

--- a/test/kitchen/test/integration/container-collection-test/rspec_datadog/spec_helper.rb
+++ b/test/kitchen/test/integration/container-collection-test/rspec_datadog/spec_helper.rb
@@ -30,8 +30,21 @@ def os
   )
 end
 
+def get_with_retries(uri_or_host, path, port, max_retries=10)
+  retries = 0
+  begin
+    return Net::HTTP.get(uri_or_host, path, port)
+  rescue Error
+    if retries < max_retries
+      retries += 1
+      sleep 1
+      retry
+    end
+  end
+end
+
 def get_runtime_config
-  res = Net::HTTP.get('localhost', '/config', 6162)
+  res = get_with_retries('localhost', '/config', 6162)
   YAML.load(res)
 end
 
@@ -48,6 +61,6 @@ def is_process_running?(pname)
 end
 
 def check_enabled?(check_name)
-  res = Net::HTTP.get('localhost', '/debug/vars', 6062)
+  res = get_with_retries('localhost', '/debug/vars', 6062)
   JSON.parse(res)["enabled_checks"].include? check_name
 end

--- a/test/kitchen/test/integration/process-collection-test/rspec_datadog/spec_helper.rb
+++ b/test/kitchen/test/integration/process-collection-test/rspec_datadog/spec_helper.rb
@@ -44,17 +44,8 @@ def get_with_retries(uri_or_host, path, port, max_retries=10)
 end
 
 def get_runtime_config
-  retries = 0
-  begin
-    res = get_with_retries('localhost', '/config', 6162)
-    return YAML.load(res)
-  rescue Error
-    if retries < 10
-      retries += 1
-      sleep 1
-      retry
-    end
-  end
+  res = get_with_retries('localhost', '/config', 6162)
+  YAML.load(res)
 end
 
 def is_process_running?(pname)

--- a/test/kitchen/test/integration/process-collection-test/rspec_datadog/spec_helper.rb
+++ b/test/kitchen/test/integration/process-collection-test/rspec_datadog/spec_helper.rb
@@ -39,6 +39,8 @@ def get_with_retries(uri_or_host, path, port, max_retries=10)
       retries += 1
       sleep 1
       retry
+    else
+      raise "Failed to connect to a running agent"
     end
   end
 end


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR adds retries to http requests to the agent in kitchen tests. This should fix the race condition where the kitchen test tries to make a call to the api server before the agent has started up. 

The retry count is configurable via a default parameter to `get_with_retries`, however it defaults to 10 retries. There is a 1 second interval between retries. 

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
Fix flakes that happen due to the process-agent starting up after the kitchen tests make an api call

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
N/A

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
