### PR TITLE
[Serverless] Action to monitor serverless binary size.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -33,6 +33,7 @@
 /.github/CODEOWNERS                                 # do not notify anyone
 /.github/*_TEMPLATE.md                              @DataDog/agent-all
 /.github/dependabot.yaml                            @DataDog/agent-platform
+/.github/workflows/serverless-binary-size.yml       @DataDog/serverless
 /.github/workflows/serverless-integration.yml       @DataDog/serverless
 /.github/workflows/cws-btfhub-sync.yml              @DataDog/agent-security
 

--- a/.github/workflows/serverless-binary-size.yml
+++ b/.github/workflows/serverless-binary-size.yml
@@ -1,0 +1,100 @@
+name: "Serverless Binary Size"
+
+on:
+  pull_request:
+
+env:
+  SIZE_ALLOWANCE: 100000  # 0.1 MB
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout datadog-agent repository
+        uses: actions/checkout@v3
+        with:
+          path: go/src/github.com/DataDog/datadog-agent
+
+      - name: Checkout the datadog-lambda-extension repository
+        uses: actions/checkout@v3
+        with:
+          repository: DataDog/datadog-lambda-extension
+          path: go/src/github.com/DataDog/datadog-lambda-extension
+          ref: rey.abolofia/viz-tools
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Current binary size and dependencies
+        id: current
+        run: |
+          cd go/src/github.com/DataDog/datadog-lambda-extension
+
+          OUTPUT=$(./scripts/visualize_size.sh size)
+          echo "binary size after merging this pull request will be $OUTPUT"
+          echo "result=$OUTPUT" >> $GITHUB_OUTPUT
+
+          echo "deps<<EOF" >> $GITHUB_OUTPUT
+          ./scripts/visualize_size.sh list_symbols | awk '{print $2}' | head -n 100 >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Checkout datadog-agent main
+        run: |
+          cd go/src/github.com/DataDog/datadog-agent
+          git fetch origin $GITHUB_BASE_REF --depth 1
+          git checkout origin/$GITHUB_BASE_REF
+
+      - name: Previous binary size and dependencies
+        id: previous
+        run: |
+          cd go/src/github.com/DataDog/datadog-lambda-extension
+
+          OUTPUT=$(./scripts/visualize_size.sh size)
+          echo "binary size before merging this pull request is $OUTPUT"
+          echo "result=$OUTPUT" >> $GITHUB_OUTPUT
+
+          echo "deps<<EOF" >> $GITHUB_OUTPUT
+          ./scripts/visualize_size.sh list_symbols | awk '{print $2}' | head -n 100 >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Compare sizes
+        id: compare
+        run: |
+          OUTPUT=$(( ${{ steps.current.outputs.result }} - ${{ steps.previous.outputs.result }} ))
+          echo "diff=$OUTPUT" >> $GITHUB_OUTPUT
+
+          OUTPUT=$(( $OUTPUT / 100000 ))
+          echo "coldstart=$OUTPUT" >> $GITHUB_OUTPUT
+
+      - name: List new dependencies
+        id: deps
+        if: steps.compare.outputs.diff > env.SIZE_ALLOWANCE
+        run: |
+          echo "deps<<EOF" >> $GITHUB_OUTPUT
+          for dep in $(echo "${{ steps.current.outputs.deps }}"); do
+            if ! echo "${{ steps.previous.outputs.deps }}" | grep -w -q "$dep"; then
+              echo "$dep" >> $GITHUB_OUTPUT
+            fi
+          done
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Post comment
+        if: steps.compare.outputs.diff > env.SIZE_ALLOWANCE
+        uses: marocchino/sticky-pull-request-comment@v2.5.0
+        with:
+          hide_and_recreate: true
+          hide_classify: "RESOLVED"
+          message: |
+            :warning::rotating_light: Warning, this pull request increases the binary size of serverless extension by ${{ steps.compare.outputs.diff }} bytes. Each MB of binary size increase means about 10ms of additional cold start time, so this pull request would increase cold start time by ${{ steps.compare.outputs.coldstart }}ms.
+
+            <details>
+            <summary>New dependencies added</summary>
+
+            ```
+            ${{ steps.deps.outputs.deps }}
+            ```
+            </details>
+
+            We suggest you consider adding the `!serverless` build tag to remove any new dependencies not needed in the serverless extension.
+
+            If you have questions, we are happy to help, come visit us in the [#serverless](https://dd.slack.com/archives/CBWDFKWV8) slack channel and provide a link to this comment.

--- a/.github/workflows/serverless-binary-size.yml
+++ b/.github/workflows/serverless-binary-size.yml
@@ -20,7 +20,6 @@ jobs:
         with:
           repository: DataDog/datadog-lambda-extension
           path: go/src/github.com/DataDog/datadog-lambda-extension
-          ref: rey.abolofia/viz-tools
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2

--- a/.github/workflows/serverless-binary-size.yml
+++ b/.github/workflows/serverless-binary-size.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
 
 env:
-  SIZE_ALLOWANCE: 100000  # 0.1 MB
+  SIZE_ALLOWANCE: 1000000  # 1 MB
 
 jobs:
   comment:

--- a/.gitlab/binary_build/serverless.yml
+++ b/.gitlab/binary_build/serverless.yml
@@ -5,17 +5,7 @@
     - !reference [.retrieve_linux_go_deps]
   script:
     - inv check-go-version
-    - cd cmd/serverless && go build -ldflags="-w -s" -a -v -tags serverless -o $BINARY_NAME
-
-.check_size_common:
-  stage: binary_build
-  script:
-    - cd cmd/serverless && go build -ldflags="-w -s" -a -v -tags serverless -o $BINARY_NAME
-    - if [[ ! -f "$BINARY_NAME" ]]; then echo "Could not find $BINARY_NAME please investigate/reach the serverless slack channel" && exit 1; fi
-    - export CURRENT_SIZE_IN_BYTES=$(ls -l "$BINARY_NAME" | awk '{print $5}')
-    - echo "Current extension size $CURRENT_SIZE_IN_BYTES bytes"
-    - export DELTA=$(($CURRENT_SIZE_IN_BYTES-$BASELINE_SIZE_IN_BYTES))
-    - if [[ "$DELTA" -gt 0 ]]; then echo "Extension binary size is too big for $BINARY_NAME, please investigate/reach the serverless slack channel" && exit 1; else exit 0; fi
+    - cd cmd/serverless && go build -ldflags="-w -s" -a -v -tags "serverless otlp" -o $BINARY_NAME
 
 build_serverless-deb_x64:
   extends: .build_serverless_common
@@ -33,30 +23,6 @@ build_serverless-deb_arm64:
   extends: .build_serverless_common
   variables:
     BINARY_NAME: datadog-agent-arm64
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
-  tags: ["runner:docker-arm", "platform:arm64"]
-  needs: ["go_deps"]
-
-check_serverless_size_x64:
-  extends: .check_size_common
-  allow_failure: true
-  tags: ["runner:main"]
-  variables:
-    BINARY_NAME: datadog-agent-x64
-    # this baseline is the current binary size + 3%
-    BASELINE_SIZE_IN_BYTES: 30562465
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
-  tags: ["runner:main"]
-  needs: ["go_deps"]
-
-
-check_serverless_size_arm64:
-  extends: .check_size_common
-  allow_failure: true
-  variables:
-    BINARY_NAME: datadog-agent-arm64
-    # this baseline is the current binary size + 3%
-    BASELINE_SIZE_IN_BYTES: 30562465
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["runner:docker-arm", "platform:arm64"]
   needs: ["go_deps"]


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This pull request adds a new github action to check the serverless binary size. It will post a comment with some helpful debug info if the pull request causes the binary to increase by more than 0.1MB.

<img width="924" alt="Screen Shot 2023-03-03 at 11 24 07 AM" src="https://user-images.githubusercontent.com/1383216/222808877-2f30f3a2-2812-483e-9f47-64be48eb1db7.png">

It's preferable to add a comment rather than fail a test because it is not always the case that we would want to block a merge due to a size increase. A comment allows us to be more helpful and specific with the information we give the developer.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

We never know which PRs have what impact on binary size in the extension. This will make sure everyone has access to important details while coding.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
