### PR TITLE
Handle the return value of `Close()` for writable files and forces writes to disks in `pkg/forwarder`

### DIFF
--- a/pkg/forwarder/internal/retry/on_disk_retry_queue.go
+++ b/pkg/forwarder/internal/retry/on_disk_retry_queue.go
@@ -95,14 +95,12 @@ func (s *onDiskRetryQueue) Store(transactions []transaction.Transaction) error {
 		_ = os.Remove(file.Name())
 		return err
 	}
-	defer file.Close()
-
 	s.currentSizeInBytes += bufferSize
 	s.filenames = append(s.filenames, file.Name())
 	s.telemetry.setFileSize(bufferSize)
 	s.telemetry.setCurrentSizeInBytes(s.GetDiskSpaceUsed())
 	s.telemetry.setFilesCount(s.getFilesCount())
-	return nil
+	return file.Close()
 }
 
 // ExtractLast extracts the last transactions stored.

--- a/pkg/forwarder/internal/retry/on_disk_retry_queue.go
+++ b/pkg/forwarder/internal/retry/on_disk_retry_queue.go
@@ -100,7 +100,11 @@ func (s *onDiskRetryQueue) Store(transactions []transaction.Transaction) error {
 	s.telemetry.setFileSize(bufferSize)
 	s.telemetry.setCurrentSizeInBytes(s.GetDiskSpaceUsed())
 	s.telemetry.setFilesCount(s.getFilesCount())
-	return file.Close()
+	err = file.Close()
+	if err != nil {
+		return fmt.Errorf("could not close file [%s]: %w", file.Name(), err)
+	}
+	return nil
 }
 
 // ExtractLast extracts the last transactions stored.

--- a/pkg/forwarder/internal/retry/on_disk_retry_queue.go
+++ b/pkg/forwarder/internal/retry/on_disk_retry_queue.go
@@ -95,15 +95,15 @@ func (s *onDiskRetryQueue) Store(transactions []transaction.Transaction) error {
 		_ = os.Remove(file.Name())
 		return err
 	}
+	err = file.Close()
+	if err != nil {
+		return err
+	}
 	s.currentSizeInBytes += bufferSize
 	s.filenames = append(s.filenames, file.Name())
 	s.telemetry.setFileSize(bufferSize)
 	s.telemetry.setCurrentSizeInBytes(s.GetDiskSpaceUsed())
 	s.telemetry.setFilesCount(s.getFilesCount())
-	err = file.Close()
-	if err != nil {
-		return fmt.Errorf("could not close file [%s]: %w", file.Name(), err)
-	}
 	return nil
 }
 

--- a/pkg/forwarder/internal/retry/on_disk_retry_queue.go
+++ b/pkg/forwarder/internal/retry/on_disk_retry_queue.go
@@ -97,6 +97,7 @@ func (s *onDiskRetryQueue) Store(transactions []transaction.Transaction) error {
 	}
 	err = file.Close()
 	if err != nil {
+		_ = os.Remove(file.Name())
 		return err
 	}
 	s.currentSizeInBytes += bufferSize

--- a/releasenotes/notes/handle-deferred-close-forwarder.yaml
+++ b/releasenotes/notes/handle-deferred-close-forwarder.yaml
@@ -1,0 +1,5 @@
+---
+security:
+  - |
+    Fixes cwe 703. Handle the return value of Close() for writtable files and forces writes to disks
+    in `pkg/forwarder`

--- a/releasenotes/notes/handle-deferred-close-forwarder.yaml
+++ b/releasenotes/notes/handle-deferred-close-forwarder.yaml
@@ -1,5 +1,4 @@
 ---
 security:
   - |
-    Handle the return value of Close() for writtable files and forces writes to disks
-    in `pkg/forwarder`
+    Handle the return value of Close() for writable files in `pkg/forwarder`

--- a/releasenotes/notes/handle-deferred-close-forwarder.yaml
+++ b/releasenotes/notes/handle-deferred-close-forwarder.yaml
@@ -1,5 +1,5 @@
 ---
 security:
   - |
-    Fixes cwe 703. Handle the return value of Close() for writtable files and forces writes to disks
+    Handle the return value of Close() for writtable files and forces writes to disks
     in `pkg/forwarder`

--- a/releasenotes/notes/handle-deferred-close-forwarder.yaml
+++ b/releasenotes/notes/handle-deferred-close-forwarder.yaml
@@ -1,4 +1,4 @@
 ---
 security:
   - |
-    Handle the return value of Close() for writable files in `pkg/forwarder`
+    Handle the return value of Close() for writable files in ``pkg/forwarder``


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
Fixes cwe 703. Handle the return value of Close() for writable files and forces writes to disks in `pkg/forwarder`.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
There are many places in the Datadog Agent codebase that defer a file close operation after writing to the file and so do not check the close operation error result. This may introduce undefined behavior when a write failure is not detected, but the code continues as if it did, causing other issues.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
See [reference](https://www.joeshaw.org/dont-defer-close-on-writable-files/).

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs
N/A
<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
