### PR TITLE
[corechecks/snmp] Rename speed_source tag value from `snmp` to `device`

### DIFF
--- a/pkg/collector/corechecks/snmp/internal/report/report_bandwidth_usage.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_bandwidth_usage.go
@@ -135,7 +135,7 @@ func (ms *MetricSender) sendIfSpeedMetric(symbolName string, customSpeed uint64,
 	speedSource := "custom"
 	if customSpeed == 0 {
 		ifSpeed = ifHighSpeed
-		speedSource = "snmp"
+		speedSource = "device"
 	}
 	if ifSpeed == 0 {
 		return

--- a/pkg/collector/corechecks/snmp/internal/report/report_bandwidth_usage_test.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_bandwidth_usage_test.go
@@ -466,7 +466,7 @@ func Test_metricSender_sendIfSpeedMetrics(t *testing.T) {
 			},
 			expectedMetric: []Metric{
 				{"snmp.ifInSpeed", 160_000_000, []string{"interface:eth0", "speed_source:custom"}},
-				{"snmp.ifOutSpeed", 80_000_000, []string{"interface:eth0", "speed_source:snmp"}},
+				{"snmp.ifOutSpeed", 80_000_000, []string{"interface:eth0", "speed_source:device"}},
 			},
 		},
 		{
@@ -490,8 +490,8 @@ func Test_metricSender_sendIfSpeedMetrics(t *testing.T) {
 				},
 			},
 			expectedMetric: []Metric{
-				{"snmp.ifInSpeed", 80_000_000, []string{"speed_source:snmp"}},
-				{"snmp.ifOutSpeed", 80_000_000, []string{"speed_source:snmp"}},
+				{"snmp.ifInSpeed", 80_000_000, []string{"speed_source:device"}},
+				{"snmp.ifOutSpeed", 80_000_000, []string{"speed_source:device"}},
 			},
 		},
 		{
@@ -510,8 +510,8 @@ func Test_metricSender_sendIfSpeedMetrics(t *testing.T) {
 				},
 			},
 			expectedMetric: []Metric{
-				{"snmp.ifInSpeed", 80_000_000, []string{"speed_source:snmp"}},
-				{"snmp.ifOutSpeed", 80_000_000, []string{"speed_source:snmp"}},
+				{"snmp.ifInSpeed", 80_000_000, []string{"speed_source:device"}},
+				{"snmp.ifOutSpeed", 80_000_000, []string{"speed_source:device"}},
 			},
 		},
 		{


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

[corechecks/snmp] Rename speed_source snmp to device

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

I think it makes more sense to use `device` since the value is from the device, snmp is just the protocol for fetching the data, not the "source" of the value.

This change should not affect users since the original features is for 7.44 and it's not released yet.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
