### PR TITLE
Display the actual error in the test output

### DIFF
--- a/comp/core/flare/helpers/perm_info_win.go
+++ b/comp/core/flare/helpers/perm_info_win.go
@@ -230,7 +230,7 @@ func (p permissionsInfos) add(filePath string) {
 	}
 }
 
-// Commit resolves the infos of every stacked files in the map
+// commit resolves the infos of every stacked files in the map
 // and then writes the permissions.log file on the filesystem.
 func (p permissionsInfos) commit() ([]byte, error) {
 

--- a/comp/core/flare/helpers/perm_info_win_test.go
+++ b/comp/core/flare/helpers/perm_info_win_test.go
@@ -11,7 +11,6 @@ package helpers
 import (
 	"os"
 	"path/filepath"
-	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -73,10 +72,7 @@ func TestPermsFileCommit(t *testing.T) {
 	b, err := pi.commit()
 	require.NoError(t, err)
 
-	res, _ := regexp.Match("\nFile: C:\\\\.+\\\\file1\n", b)
-	assert.True(t, res)
-	res, _ = regexp.Match("\nFile: C:\\\\.+\\\\file2\n", b)
-	assert.True(t, res)
-	res, _ = regexp.Match("\ncould not stat file.+C:\\\\.+\\\\file3", b)
-	assert.True(t, res)
+	assert.Regexp(t, "\nFile: C:\\\\.+\\\\file1\n", string(b))
+	assert.Regexp(t, "\nFile: C:\\\\.+\\\\file2\n", string(b))
+	assert.Regexp(t, "\ncould not stat file.+C:\\\\.+\\\\file3", string(b))
 }


### PR DESCRIPTION
### What does this PR do?

This test is currently flaky but we don't have the actual error. First step toward a fix is getting the error in the CI.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
