### PR TITLE
[process-agent] Migrate all usages of `config.Datadog` to use the config component

### DIFF
--- a/cmd/process-agent/api/server.go
+++ b/cmd/process-agent/api/server.go
@@ -6,19 +6,37 @@
 package api
 
 import (
-	"github.com/gorilla/mux"
+	"net/http"
 
+	"github.com/gorilla/mux"
+	"go.uber.org/fx"
+
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/log"
 	settingshttp "github.com/DataDog/datadog-agent/pkg/config/settings/http"
 )
 
-func SetupAPIServerHandlers(r *mux.Router) {
+type APIServerDeps struct {
+	fx.In
+
+	Config config.Component
+	Log    log.Component
+}
+
+func injectDeps(deps APIServerDeps, handler func(APIServerDeps, http.ResponseWriter, *http.Request)) http.HandlerFunc {
+	return func(writer http.ResponseWriter, req *http.Request) {
+		handler(deps, writer, req)
+	}
+}
+
+func SetupAPIServerHandlers(deps APIServerDeps, r *mux.Router) {
 	r.HandleFunc("/config", settingshttp.Server.GetFullDatadogConfig("process_config")).Methods("GET") // Get only settings in the process_config namespace
 	r.HandleFunc("/config/all", settingshttp.Server.GetFullDatadogConfig("")).Methods("GET")           // Get all fields from process-agent Config object
 	r.HandleFunc("/config/list-runtime", settingshttp.Server.ListConfigurable).Methods("GET")
 	r.HandleFunc("/config/{setting}", settingshttp.Server.GetValue).Methods("GET")
 	r.HandleFunc("/config/{setting}", settingshttp.Server.SetValue).Methods("POST")
-	r.HandleFunc("/agent/status", statusHandler).Methods("GET")
-	r.HandleFunc("/agent/tagger-list", getTaggerList).Methods("GET")
+	r.HandleFunc("/agent/status", injectDeps(deps, statusHandler)).Methods("GET")
+	r.HandleFunc("/agent/tagger-list", injectDeps(deps, getTaggerList)).Methods("GET")
 	r.HandleFunc("/agent/workload-list/short", getShortWorkloadList).Methods("GET")
 	r.HandleFunc("/agent/workload-list/verbose", getVerboseWorkloadList).Methods("GET")
 	r.HandleFunc("/check/{check}", checkHandler).Methods("GET")

--- a/cmd/process-agent/api/status.go
+++ b/cmd/process-agent/api/status.go
@@ -32,7 +32,7 @@ func statusHandler(deps APIServerDeps, w http.ResponseWriter, _ *http.Request) {
 	}
 	expvarEndpoint := fmt.Sprintf("http://%s:%d/debug/vars", ipcAddr, port)
 
-	agentStatus, err := util.GetStatus(expvarEndpoint)
+	agentStatus, err := util.GetStatus(deps.Config, expvarEndpoint)
 	if err != nil {
 		_ = deps.Log.Warn("failed to get status from agent:", err)
 		writeError(err, http.StatusInternalServerError, w)

--- a/cmd/process-agent/api/status.go
+++ b/cmd/process-agent/api/status.go
@@ -12,43 +12,42 @@ import (
 
 	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-func statusHandler(w http.ResponseWriter, _ *http.Request) {
-	log.Info("Got a request for the status. Making status.")
+func statusHandler(deps APIServerDeps, w http.ResponseWriter, _ *http.Request) {
+	deps.Log.Info("Got a request for the status. Making status.")
 
 	// Get expVar server address
 	ipcAddr, err := ddconfig.GetIPCAddress()
 	if err != nil {
 		writeError(err, http.StatusInternalServerError, w)
-		_ = log.Warn("config error:", err)
+		_ = deps.Log.Warn("config error:", err)
 		return
 	}
 
-	port := ddconfig.Datadog.GetInt("process_config.expvar_port")
+	port := deps.Config.GetInt("process_config.expvar_port")
 	if port <= 0 {
-		_ = log.Warnf("Invalid process_config.expvar_port -- %d, using default port %d\n", port, ddconfig.DefaultProcessExpVarPort)
+		_ = deps.Log.Warnf("Invalid process_config.expvar_port -- %d, using default port %d\n", port, ddconfig.DefaultProcessExpVarPort)
 		port = ddconfig.DefaultProcessExpVarPort
 	}
 	expvarEndpoint := fmt.Sprintf("http://%s:%d/debug/vars", ipcAddr, port)
 
 	agentStatus, err := util.GetStatus(expvarEndpoint)
 	if err != nil {
-		_ = log.Warn("failed to get status from agent:", err)
+		_ = deps.Log.Warn("failed to get status from agent:", err)
 		writeError(err, http.StatusInternalServerError, w)
 		return
 	}
 
 	b, err := json.Marshal(agentStatus)
 	if err != nil {
-		_ = log.Warn("failed to serialize status response from agent:", err)
+		_ = deps.Log.Warn("failed to serialize status response from agent:", err)
 		writeError(err, http.StatusInternalServerError, w)
 		return
 	}
 
 	_, err = w.Write(b)
 	if err != nil {
-		_ = log.Warn("received response from agent but failed write it to client:", err)
+		_ = deps.Log.Warn("received response from agent but failed write it to client:", err)
 	}
 }

--- a/cmd/process-agent/api/tagger_list.go
+++ b/cmd/process-agent/api/tagger_list.go
@@ -11,16 +11,15 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/tagger"
 	"github.com/DataDog/datadog-agent/pkg/tagger/collectors"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-func getTaggerList(w http.ResponseWriter, r *http.Request) {
+func getTaggerList(deps APIServerDeps, w http.ResponseWriter, r *http.Request) {
 	cardinality := collectors.TagCardinality(tagger.ChecksCardinality)
 	response := tagger.List(cardinality)
 
 	jsonTags, err := json.Marshal(response)
 	if err != nil {
-		setJSONError(w, log.Errorf("Unable to marshal tagger list response: %s", err), 500)
+		setJSONError(w, deps.Log.Errorf("Unable to marshal tagger list response: %s", err), 500)
 		return
 	}
 	w.Write(jsonTags)

--- a/cmd/process-agent/command/command.go
+++ b/cmd/process-agent/command/command.go
@@ -7,8 +7,6 @@
 package command
 
 import (
-	"os"
-
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 
@@ -18,7 +16,6 @@ import (
 	logComponent "github.com/DataDog/datadog-agent/comp/core/log"
 	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig"
 	"github.com/DataDog/datadog-agent/pkg/config"
-	"github.com/DataDog/datadog-agent/pkg/process/util"
 )
 
 const LoggerName config.LoggerName = "PROCESS"
@@ -111,23 +108,6 @@ func MakeCommand(subcommandFactories []SubcommandFactory, winParams bool, rootCm
 	}
 
 	return rootCmd
-}
-
-// setHostMountEnv sets HOST_PROC and HOST_SYS mounts if applicable in containerized environments
-func setHostMountEnv() {
-	// Set default values for proc/sys paths if unset.
-	// Don't set this is /host is not mounted to use context within container.
-	// Generally only applicable for container-only cases like Fargate.
-	if !config.IsContainerized() || !util.PathExists("/host") {
-		return
-	}
-
-	if v := os.Getenv("HOST_PROC"); v == "" {
-		os.Setenv("HOST_PROC", "/host/proc")
-	}
-	if v := os.Getenv("HOST_SYS"); v == "" {
-		os.Setenv("HOST_SYS", "/host/sys")
-	}
 }
 
 func GetCoreBundleParamsForOneShot(globalParams *GlobalParams) core.BundleParams {

--- a/cmd/process-agent/command/command.go
+++ b/cmd/process-agent/command/command.go
@@ -8,8 +8,6 @@ package command
 
 import (
 	"os"
-	"path/filepath"
-	"strings"
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
@@ -21,7 +19,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 const LoggerName config.LoggerName = "PROCESS"
@@ -116,49 +113,6 @@ func MakeCommand(subcommandFactories []SubcommandFactory, winParams bool, rootCm
 	return rootCmd
 }
 
-// BootstrapConfig is a helper for process-agent config initialization (until we further refactor to use components)
-func BootstrapConfig(path string, oneshotCommand bool) error {
-	setHostMountEnv()
-
-	if err := loadConfigIfExists(path); err != nil {
-		return err
-	}
-
-	// Resolve any secrets
-	if err := config.ResolveSecrets(config.Datadog, filepath.Base(path)); err != nil {
-		return err
-	}
-
-	var (
-		logFile      string
-		syslogURI    string
-		syslogRFC    = false
-		logToConsole = true
-		logAsJSON    = false
-	)
-
-	if !oneshotCommand {
-		syslogURI = config.GetSyslogURI()
-		syslogRFC = config.Datadog.GetBool("syslog_rfc")
-		logToConsole = config.Datadog.GetBool("log_to_console")
-		logAsJSON = config.Datadog.GetBool("log_format_json")
-
-		if !config.Datadog.GetBool("disable_file_logging") {
-			logFile = config.Datadog.GetString("process_config.log_file")
-		}
-	}
-
-	return config.SetupLogger(
-		LoggerName,
-		config.Datadog.GetString("log_level"),
-		logFile,
-		syslogURI,
-		syslogRFC,
-		logToConsole,
-		logAsJSON,
-	)
-}
-
 // setHostMountEnv sets HOST_PROC and HOST_SYS mounts if applicable in containerized environments
 func setHostMountEnv() {
 	// Set default values for proc/sys paths if unset.
@@ -174,27 +128,6 @@ func setHostMountEnv() {
 	if v := os.Getenv("HOST_SYS"); v == "" {
 		os.Setenv("HOST_SYS", "/host/sys")
 	}
-}
-
-// loadConfigIfExists takes a path to either a directory containing datadog.yaml or a direct path to a datadog.yaml file
-// and loads it into ddconfig.Datadog. It does this silently, and does not produce any logs.
-func loadConfigIfExists(path string) error {
-	if path == "" {
-		return nil
-	}
-
-	if !util.PathExists(path) {
-		log.Infof("No config exists at %s, ignoring...", path)
-		return nil
-	}
-
-	config.Datadog.AddConfigPath(path)
-	if strings.HasSuffix(path, ".yaml") { // If they set a config file directly, let's try to honor that
-		config.Datadog.SetConfigFile(path)
-	}
-
-	_, err := config.LoadWithoutSecret()
-	return err
 }
 
 func GetCoreBundleParamsForOneShot(globalParams *GlobalParams) core.BundleParams {

--- a/cmd/process-agent/main_common.go
+++ b/cmd/process-agent/main_common.go
@@ -120,6 +120,7 @@ func runApp(exit chan struct{}, globalParams *command.GlobalParams) error {
 
 		// Provide process agent bundle so fx knows where to find components.
 		process.Bundle,
+		core.Bundle,
 
 		// Allows for debug logging of fx components if the `TRACE_FX` environment variable is set
 		fxutil.FxLoggingOption(),

--- a/cmd/process-agent/main_common.go
+++ b/cmd/process-agent/main_common.go
@@ -120,7 +120,6 @@ func runApp(exit chan struct{}, globalParams *command.GlobalParams) error {
 
 		// Provide process agent bundle so fx knows where to find components.
 		process.Bundle,
-		core.Bundle,
 
 		// Allows for debug logging of fx components if the `TRACE_FX` environment variable is set
 		fxutil.FxLoggingOption(),

--- a/cmd/process-agent/subcommands/check/check.go
+++ b/cmd/process-agent/subcommands/check/check.go
@@ -26,7 +26,6 @@ import (
 	processComponent "github.com/DataDog/datadog-agent/comp/process"
 	"github.com/DataDog/datadog-agent/comp/process/hostinfo"
 	"github.com/DataDog/datadog-agent/comp/process/types"
-	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/metadata/host"
 	"github.com/DataDog/datadog-agent/pkg/process/checks"
 	"github.com/DataDog/datadog-agent/pkg/process/net"
@@ -116,7 +115,7 @@ func runCheckCmd(deps dependencies) error {
 	// Start workload metadata store before tagger (used for containerCollection)
 	// TODO: (Components) Add to dependencies once workloadmeta is migrated to components
 	var workloadmetaCollectors workloadmeta.CollectorCatalog
-	if ddconfig.Datadog.GetBool("process_config.remote_workloadmeta") {
+	if deps.Config.GetBool("process_config.remote_workloadmeta") {
 		workloadmetaCollectors = workloadmeta.RemoteCatalog
 	} else {
 		workloadmetaCollectors = workloadmeta.NodeAgentCatalog

--- a/cmd/process-agent/subcommands/events/events.go
+++ b/cmd/process-agent/subcommands/events/events.go
@@ -19,8 +19,8 @@ import (
 
 	"github.com/DataDog/datadog-agent/cmd/process-agent/command"
 	"github.com/DataDog/datadog-agent/comp/core/config"
-	"github.com/DataDog/datadog-agent/comp/core/log"
 	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig"
+	"github.com/DataDog/datadog-agent/comp/core/log"
 	"github.com/DataDog/datadog-agent/comp/process"
 	"github.com/DataDog/datadog-agent/pkg/process/checks"
 	"github.com/DataDog/datadog-agent/pkg/process/events"
@@ -154,7 +154,7 @@ func runEventListener(deps dependencies) error {
 }
 
 func runEventStore(deps dependencies) error {
-	store, err := events.NewRingStore(&statsd.NoOpClient{})
+	store, err := events.NewRingStore(deps.Config, &statsd.NoOpClient{})
 	if err != nil {
 		return err
 	}

--- a/cmd/process-agent/subcommands/events/events.go
+++ b/cmd/process-agent/subcommands/events/events.go
@@ -19,8 +19,8 @@ import (
 
 	"github.com/DataDog/datadog-agent/cmd/process-agent/command"
 	"github.com/DataDog/datadog-agent/comp/core/config"
-	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig"
 	"github.com/DataDog/datadog-agent/comp/core/log"
+	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig"
 	"github.com/DataDog/datadog-agent/comp/process"
 	"github.com/DataDog/datadog-agent/pkg/process/checks"
 	"github.com/DataDog/datadog-agent/pkg/process/events"

--- a/comp/process/apiserver/apiserver.go
+++ b/comp/process/apiserver/apiserver.go
@@ -32,13 +32,15 @@ type dependencies struct {
 	Lc fx.Lifecycle
 
 	Log log.Component
+
+	APIServerDeps api.APIServerDeps
 }
 
 func newApiServer(deps dependencies) Component {
 	initRuntimeSettings(deps.Log)
 
 	r := mux.NewRouter()
-	api.SetupAPIServerHandlers(r) // Set up routes
+	api.SetupAPIServerHandlers(deps.APIServerDeps, r) // Set up routes
 
 	addr, err := ddconfig.GetProcessAPIAddressPort()
 	if err != nil {

--- a/comp/process/apiserver/apiserver_test.go
+++ b/comp/process/apiserver/apiserver_test.go
@@ -13,12 +13,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/fx"
 
-	"github.com/DataDog/datadog-agent/comp/core/log"
+	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
 func TestLifecycle(t *testing.T) {
-	_ = fxutil.Test[Component](t, fx.Options(Module, log.MockModule))
+	_ = fxutil.Test[Component](t, fx.Options(Module, core.MockBundle))
 
 	assert.Eventually(t, func() bool {
 		res, err := http.Get("http://localhost:6162/config")

--- a/comp/process/connectionscheck/check.go
+++ b/comp/process/connectionscheck/check.go
@@ -8,6 +8,7 @@ package connectionscheck
 import (
 	"go.uber.org/fx"
 
+	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig"
 	"github.com/DataDog/datadog-agent/comp/process/types"
 	"github.com/DataDog/datadog-agent/pkg/process/checks"
@@ -23,6 +24,7 @@ type dependencies struct {
 	fx.In
 
 	Sysconfig sysprobeconfig.Component
+	Config    config.Component
 }
 
 type result struct {
@@ -34,7 +36,7 @@ type result struct {
 
 func newCheck(deps dependencies) result {
 	c := &check{
-		connectionsCheck: checks.NewConnectionsCheck(deps.Sysconfig.Object()),
+		connectionsCheck: checks.NewConnectionsCheck(deps.Config, deps.Sysconfig.Object()),
 	}
 	return result{
 		Check: types.ProvidesCheck{

--- a/comp/process/connectionscheck/check.go
+++ b/comp/process/connectionscheck/check.go
@@ -36,7 +36,7 @@ type result struct {
 
 func newCheck(deps dependencies) result {
 	c := &check{
-		connectionsCheck: checks.NewConnectionsCheck(deps.Config, deps.Sysconfig.Object()),
+		connectionsCheck: checks.NewConnectionsCheck(deps.Config, deps.Sysconfig, deps.Sysconfig.Object()),
 	}
 	return result{
 		Check: types.ProvidesCheck{

--- a/comp/process/containercheck/check.go
+++ b/comp/process/containercheck/check.go
@@ -8,6 +8,7 @@ package containercheck
 import (
 	"go.uber.org/fx"
 
+	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/process/types"
 	"github.com/DataDog/datadog-agent/pkg/process/checks"
 )
@@ -18,6 +19,12 @@ type check struct {
 	containerCheck *checks.ContainerCheck
 }
 
+type dependencies struct {
+	fx.In
+
+	Config config.Component
+}
+
 type result struct {
 	fx.Out
 
@@ -25,9 +32,9 @@ type result struct {
 	Component Component
 }
 
-func newCheck() result {
+func newCheck(deps dependencies) result {
 	c := &check{
-		containerCheck: checks.NewContainerCheck(),
+		containerCheck: checks.NewContainerCheck(deps.Config),
 	}
 	return result{
 		Check: types.ProvidesCheck{

--- a/comp/process/expvars/expvars.go
+++ b/comp/process/expvars/expvars.go
@@ -91,7 +91,7 @@ func initStatus(deps dependencies) error {
 
 	// If the sysprobe module is enabled, the process check can call out to the sysprobe for privileged stats
 	_, processModuleEnabled := deps.SysProbeConfig.Object().EnabledModules[sysconfig.ProcessModule]
-	eps, err := runner.GetAPIEndpoints()
+	eps, err := runner.GetAPIEndpoints(deps.Config)
 	if err != nil {
 		_ = deps.Log.Criticalf("Failed to initialize Api Endpoints: %s", err.Error())
 	}

--- a/comp/process/hostinfo/hostinfo.go
+++ b/comp/process/hostinfo/hostinfo.go
@@ -27,7 +27,7 @@ type hostinfo struct {
 }
 
 func newHostInfo(deps dependencies) (Component, error) {
-	hinfo, err := checks.CollectHostInfo()
+	hinfo, err := checks.CollectHostInfo(deps.Config)
 	if err != nil {
 		_ = deps.Logger.Critical("Error collecting host details:", err)
 		return nil, fmt.Errorf("error collecting host details: %v", err)

--- a/comp/process/processcheck/check.go
+++ b/comp/process/processcheck/check.go
@@ -8,6 +8,7 @@ package processcheck
 import (
 	"go.uber.org/fx"
 
+	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/process/types"
 	"github.com/DataDog/datadog-agent/pkg/process/checks"
 )
@@ -18,6 +19,12 @@ type check struct {
 	processCheck *checks.ProcessCheck
 }
 
+type dependencies struct {
+	fx.In
+
+	Config config.Component
+}
+
 type result struct {
 	fx.Out
 
@@ -25,9 +32,9 @@ type result struct {
 	Component Component
 }
 
-func newCheck() result {
+func newCheck(deps dependencies) result {
 	c := &check{
-		processCheck: checks.NewProcessCheck(),
+		processCheck: checks.NewProcessCheck(deps.Config),
 	}
 	return result{
 		Check: types.ProvidesCheck{

--- a/comp/process/processdiscoverycheck/check.go
+++ b/comp/process/processdiscoverycheck/check.go
@@ -8,6 +8,7 @@ package processdiscoverycheck
 import (
 	"go.uber.org/fx"
 
+	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/process/types"
 	"github.com/DataDog/datadog-agent/pkg/process/checks"
 )
@@ -18,6 +19,12 @@ type check struct {
 	processDiscoveryCheck *checks.ProcessDiscoveryCheck
 }
 
+type dependencies struct {
+	fx.In
+
+	Config config.Component
+}
+
 type result struct {
 	fx.Out
 
@@ -25,9 +32,9 @@ type result struct {
 	Component Component
 }
 
-func newCheck() result {
+func newCheck(deps dependencies) result {
 	c := &check{
-		processDiscoveryCheck: checks.NewProcessDiscoveryCheck(),
+		processDiscoveryCheck: checks.NewProcessDiscoveryCheck(deps.Config),
 	}
 	return result{
 		Check: types.ProvidesCheck{

--- a/comp/process/processeventscheck/check.go
+++ b/comp/process/processeventscheck/check.go
@@ -8,6 +8,7 @@ package processeventscheck
 import (
 	"go.uber.org/fx"
 
+	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/process/types"
 	"github.com/DataDog/datadog-agent/pkg/process/checks"
 )
@@ -18,6 +19,12 @@ type check struct {
 	processEventsCheck *checks.ProcessEventsCheck
 }
 
+type dependencies struct {
+	fx.In
+
+	Config config.Component
+}
+
 type result struct {
 	fx.Out
 
@@ -25,9 +32,9 @@ type result struct {
 	Component Component
 }
 
-func newCheck() result {
+func newCheck(deps dependencies) result {
 	c := &check{
-		processEventsCheck: checks.NewProcessEventsCheck(),
+		processEventsCheck: checks.NewProcessEventsCheck(deps.Config),
 	}
 	return result{
 		Check: types.ProvidesCheck{

--- a/comp/process/profiler/component.go
+++ b/comp/process/profiler/component.go
@@ -1,7 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2016-present Datadog, Inc.
+// Copyright 2023-present Datadog, Inc.
 
 // Package profiler implements a component to handle starting and stopping the internal profiler.
 package profiler

--- a/comp/process/profiler/component.go
+++ b/comp/process/profiler/component.go
@@ -1,7 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2023-present Datadog, Inc.
+// Copyright 2016-present Datadog, Inc.
 
 // Package profiler implements a component to handle starting and stopping the internal profiler.
 package profiler

--- a/comp/process/rtcontainercheck/check.go
+++ b/comp/process/rtcontainercheck/check.go
@@ -8,6 +8,7 @@ package rtcontainercheck
 import (
 	"go.uber.org/fx"
 
+	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/process/types"
 	"github.com/DataDog/datadog-agent/pkg/process/checks"
 )
@@ -18,6 +19,12 @@ type check struct {
 	rtContainerCheck *checks.RTContainerCheck
 }
 
+type dependencies struct {
+	fx.In
+
+	Config config.Component
+}
+
 type result struct {
 	fx.Out
 
@@ -25,9 +32,9 @@ type result struct {
 	Component Component
 }
 
-func newCheck() result {
+func newCheck(deps dependencies) result {
 	c := &check{
-		rtContainerCheck: checks.NewRTContainerCheck(),
+		rtContainerCheck: checks.NewRTContainerCheck(deps.Config),
 	}
 	return result{
 		Check: types.ProvidesCheck{

--- a/comp/process/runner/component.go
+++ b/comp/process/runner/component.go
@@ -8,10 +8,13 @@ package runner
 
 import (
 	"context"
+	"testing"
 
 	"go.uber.org/fx"
 
+	configComp "github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/process/types"
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/process/checks"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
@@ -29,3 +32,11 @@ type Component interface {
 var Module = fxutil.Component(
 	fx.Provide(newRunner),
 )
+
+// DisableContainerFeaturesForTest is an fx option that disables all container features.
+// For some platforms, container features don't work, so in order to keep the tests from crashing we must disable container
+// features.
+var DisableContainerFeaturesForTest = fx.Invoke(func(t testing.TB, _ configComp.Component) {
+	config.SetDetectedFeatures(config.FeatureMap{})
+	t.Cleanup(func() { config.SetDetectedFeatures(nil) })
+})

--- a/comp/process/runner/component.go
+++ b/comp/process/runner/component.go
@@ -8,13 +8,10 @@ package runner
 
 import (
 	"context"
-	"testing"
 
 	"go.uber.org/fx"
 
-	configComp "github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/process/types"
-	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/process/checks"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
@@ -32,11 +29,3 @@ type Component interface {
 var Module = fxutil.Component(
 	fx.Provide(newRunner),
 )
-
-// DisableContainerFeaturesForTest is an fx option that disables all container features.
-// For some platforms, container features don't work, so in order to keep the tests from crashing we must disable container
-// features.
-var DisableContainerFeaturesForTest = fx.Invoke(func(t testing.TB, _ configComp.Component) {
-	config.SetDetectedFeatures(config.FeatureMap{})
-	t.Cleanup(func() { config.SetDetectedFeatures(nil) })
-})

--- a/comp/process/runner/runner.go
+++ b/comp/process/runner/runner.go
@@ -10,6 +10,7 @@ import (
 
 	"go.uber.org/fx"
 
+	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig"
 	"github.com/DataDog/datadog-agent/comp/process/hostinfo"
 	"github.com/DataDog/datadog-agent/comp/process/submitter"
@@ -34,10 +35,11 @@ type dependencies struct {
 	Checks   []types.CheckComponent `group:"check"`
 	HostInfo hostinfo.Component
 	SysCfg   sysprobeconfig.Component
+	Config   config.Component
 }
 
 func newRunner(deps dependencies) (Component, error) {
-	c, err := processRunner.NewRunner(deps.SysCfg.Object(), deps.HostInfo.Object(), filterEnabledChecks(deps.Checks), deps.RTNotifier)
+	c, err := processRunner.NewRunner(deps.Config, deps.SysCfg.Object(), deps.HostInfo.Object(), filterEnabledChecks(deps.Checks), deps.RTNotifier)
 	if err != nil {
 		return nil, err
 	}

--- a/comp/process/runner/runner_test.go
+++ b/comp/process/runner/runner_test.go
@@ -12,8 +12,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/fx"
 
-	"github.com/DataDog/datadog-agent/comp/process/utils"
-
 	sysconfig "github.com/DataDog/datadog-agent/cmd/system-probe/config"
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/process/containercheck"

--- a/comp/process/runner/runner_test.go
+++ b/comp/process/runner/runner_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/fx"
 
+	"github.com/DataDog/datadog-agent/comp/process/utils"
+
 	sysconfig "github.com/DataDog/datadog-agent/cmd/system-probe/config"
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/process/containercheck"

--- a/comp/process/submitter/submitter.go
+++ b/comp/process/submitter/submitter.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"go.uber.org/fx"
 
+	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/process/hostinfo"
 	"github.com/DataDog/datadog-agent/comp/process/types"
 	processRunner "github.com/DataDog/datadog-agent/pkg/process/runner"
@@ -29,6 +30,7 @@ type dependencies struct {
 	Lc fx.Lifecycle
 
 	HostInfo hostinfo.Component
+	Config   config.Component
 }
 
 type result struct {
@@ -39,7 +41,7 @@ type result struct {
 }
 
 func newSubmitter(deps dependencies) (result, error) {
-	s, err := processRunner.NewSubmitter(deps.HostInfo.Object().HostName)
+	s, err := processRunner.NewSubmitter(deps.Config, deps.HostInfo.Object().HostName)
 	if err != nil {
 		return result{}, err
 	}

--- a/pkg/process/checks/checks.go
+++ b/pkg/process/checks/checks.go
@@ -7,6 +7,7 @@ package checks
 
 import (
 	model "github.com/DataDog/agent-payload/v5/process"
+
 	sysconfig "github.com/DataDog/datadog-agent/cmd/system-probe/config"
 	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -97,15 +98,15 @@ func (p CombinedRunResult) RealtimePayloads() []model.MessageBody {
 // All is a list of all runnable checks. Putting a check in here does not guarantee it will be run,
 // it just guarantees that the collector will be able to find the check.
 // If you want to add a check you MUST register it here.
-func All(syscfg *sysconfig.Config) []Check {
+func All(config ddconfig.ConfigReaderWriter, syscfg *sysconfig.Config) []Check {
 	return []Check{
-		NewProcessCheck(),
-		NewContainerCheck(),
-		NewRTContainerCheck(),
+		NewProcessCheck(config),
+		NewContainerCheck(config),
+		NewRTContainerCheck(config),
 		NewConnectionsCheck(syscfg),
 		NewPodCheck(),
-		NewProcessDiscoveryCheck(),
-		NewProcessEventsCheck(),
+		NewProcessDiscoveryCheck(config),
+		NewProcessEventsCheck(config),
 	}
 }
 
@@ -121,7 +122,7 @@ func RTName(checkName string) string {
 	}
 }
 
-func canEnableContainerChecks(config ddconfig.Config, displayFeatureWarning bool) bool {
+func canEnableContainerChecks(config ddconfig.ConfigReader, displayFeatureWarning bool) bool {
 	// The process and container checks are mutually exclusive
 	if config.GetBool("process_config.process_collection.enabled") {
 		return false
@@ -133,5 +134,5 @@ func canEnableContainerChecks(config ddconfig.Config, displayFeatureWarning bool
 		return false
 	}
 
-	return ddconfig.Datadog.GetBool("process_config.container_collection.enabled")
+	return config.GetBool("process_config.container_collection.enabled")
 }

--- a/pkg/process/checks/checks.go
+++ b/pkg/process/checks/checks.go
@@ -103,7 +103,7 @@ func All(config ddconfig.ConfigReaderWriter, syscfg *sysconfig.Config) []Check {
 		NewProcessCheck(config),
 		NewContainerCheck(config),
 		NewRTContainerCheck(config),
-		NewConnectionsCheck(syscfg),
+		NewConnectionsCheck(config, syscfg),
 		NewPodCheck(),
 		NewProcessDiscoveryCheck(config),
 		NewProcessEventsCheck(config),

--- a/pkg/process/checks/checks.go
+++ b/pkg/process/checks/checks.go
@@ -98,12 +98,12 @@ func (p CombinedRunResult) RealtimePayloads() []model.MessageBody {
 // All is a list of all runnable checks. Putting a check in here does not guarantee it will be run,
 // it just guarantees that the collector will be able to find the check.
 // If you want to add a check you MUST register it here.
-func All(config ddconfig.ConfigReaderWriter, syscfg *sysconfig.Config) []Check {
+func All(config, sysprobeYamlCfg ddconfig.ConfigReaderWriter, syscfg *sysconfig.Config) []Check {
 	return []Check{
 		NewProcessCheck(config),
 		NewContainerCheck(config),
 		NewRTContainerCheck(config),
-		NewConnectionsCheck(config, syscfg),
+		NewConnectionsCheck(config, sysprobeYamlCfg, syscfg),
 		NewPodCheck(),
 		NewProcessDiscoveryCheck(config),
 		NewProcessEventsCheck(config),

--- a/pkg/process/checks/config.go
+++ b/pkg/process/checks/config.go
@@ -11,8 +11,8 @@ import (
 )
 
 // getMaxBatchSize returns the maximum number of items (processes, containers, process_discoveries) in a check payload
-var getMaxBatchSize = func() int {
-	return ensureValidMaxBatchSize(ddconfig.Datadog.GetInt("process_config.max_per_message"))
+var getMaxBatchSize = func(config ddconfig.ConfigReader) int {
+	return ensureValidMaxBatchSize(config.GetInt("process_config.max_per_message"))
 }
 
 func ensureValidMaxBatchSize(batchSize int) int {
@@ -24,8 +24,8 @@ func ensureValidMaxBatchSize(batchSize int) int {
 }
 
 // getMaxBatchSize returns the maximum number of bytes in a check payload
-var getMaxBatchBytes = func() int {
-	return ensureValidMaxBatchBytes(ddconfig.Datadog.GetInt("process_config.max_message_bytes"))
+var getMaxBatchBytes = func(config ddconfig.ConfigReader) int {
+	return ensureValidMaxBatchBytes(config.GetInt("process_config.max_message_bytes"))
 }
 
 func ensureValidMaxBatchBytes(batchBytes int) int {

--- a/pkg/process/checks/container.go
+++ b/pkg/process/checks/container.go
@@ -24,13 +24,17 @@ const (
 )
 
 // NewContainerCheck returns an instance of the ContainerCheck.
-func NewContainerCheck() *ContainerCheck {
-	return &ContainerCheck{}
+func NewContainerCheck(config ddconfig.ConfigReader) *ContainerCheck {
+	return &ContainerCheck{
+		config: config,
+	}
 }
 
 // ContainerCheck is a check that returns container metadata and stats.
 type ContainerCheck struct {
 	sync.Mutex
+
+	config ddconfig.ConfigReader
 
 	hostInfo          *HostInfo
 	containerProvider util.ContainerProvider
@@ -54,14 +58,14 @@ func (c *ContainerCheck) Init(_ *SysProbeConfig, info *HostInfo) error {
 	c.networkID = networkID
 
 	c.containerFailedLogLimit = util.NewLogLimit(10, time.Minute*10)
-	c.maxBatchSize = getMaxBatchSize()
+	c.maxBatchSize = getMaxBatchSize(c.config)
 	return nil
 }
 
 // IsEnabled returns true if the check is enabled by configuration
 // Keep in mind that ContainerRTCheck.IsEnabled should only be enabled if the `ContainerCheck` is enabled
 func (c *ContainerCheck) IsEnabled() bool {
-	return canEnableContainerChecks(ddconfig.Datadog, true)
+	return canEnableContainerChecks(c.config, true)
 }
 
 // SupportsRunOptions returns true if the check supports RunOptions

--- a/pkg/process/checks/container_rt.go
+++ b/pkg/process/checks/container_rt.go
@@ -47,7 +47,7 @@ func (r *RTContainerCheck) Init(_ *SysProbeConfig, hostInfo *HostInfo) error {
 // IsEnabled returns true if the check is enabled by configuration
 func (r *RTContainerCheck) IsEnabled() bool {
 	rtChecksEnabled := !r.config.GetBool("process_config.disable_realtime_checks")
-	return canEnableContainerChecks(ddconfig.Datadog, false) && rtChecksEnabled
+	return canEnableContainerChecks(r.config, false) && rtChecksEnabled
 }
 
 // SupportsRunOptions returns true if the check supports RunOptions

--- a/pkg/process/checks/container_rt.go
+++ b/pkg/process/checks/container_rt.go
@@ -21,8 +21,10 @@ const (
 )
 
 // NewRTContainerCheck returns an instance of the RTContainerCheck.
-func NewRTContainerCheck() *RTContainerCheck {
-	return &RTContainerCheck{}
+func NewRTContainerCheck(config ddconfig.ConfigReader) *RTContainerCheck {
+	return &RTContainerCheck{
+		config: config,
+	}
 }
 
 // RTContainerCheck collects numeric statistics about live ctrList.
@@ -31,11 +33,12 @@ type RTContainerCheck struct {
 	hostInfo          *HostInfo
 	containerProvider util.ContainerProvider
 	lastRates         map[string]*util.ContainerRateMetrics
+	config            ddconfig.ConfigReader
 }
 
 // Init initializes a RTContainerCheck instance.
 func (r *RTContainerCheck) Init(_ *SysProbeConfig, hostInfo *HostInfo) error {
-	r.maxBatchSize = getMaxBatchSize()
+	r.maxBatchSize = getMaxBatchSize(r.config)
 	r.hostInfo = hostInfo
 	r.containerProvider = util.GetSharedContainerProvider()
 	return nil
@@ -43,7 +46,7 @@ func (r *RTContainerCheck) Init(_ *SysProbeConfig, hostInfo *HostInfo) error {
 
 // IsEnabled returns true if the check is enabled by configuration
 func (r *RTContainerCheck) IsEnabled() bool {
-	rtChecksEnabled := !ddconfig.Datadog.GetBool("process_config.disable_realtime_checks")
+	rtChecksEnabled := !r.config.GetBool("process_config.disable_realtime_checks")
 	return canEnableContainerChecks(ddconfig.Datadog, false) && rtChecksEnabled
 }
 

--- a/pkg/process/checks/enable_checks_containerized_test.go
+++ b/pkg/process/checks/enable_checks_containerized_test.go
@@ -30,7 +30,7 @@ func TestContainerCheck(t *testing.T) {
 		cfg.Set("process_config.disable_realtime_checks", false)
 		config.SetFeatures(t, config.Docker)
 
-		enabledChecks := getEnabledChecks(scfg)
+		enabledChecks := getEnabledChecks(ddconfig.Datadog, scfg)
 		assertContainsCheck(t, enabledChecks, ContainerCheckName)
 		assertContainsCheck(t, enabledChecks, RTContainerCheckName)
 		assertNotContainsCheck(t, enabledChecks, ProcessCheckName)
@@ -44,7 +44,7 @@ func TestContainerCheck(t *testing.T) {
 		cfg.Set("process_config.disable_realtime_checks", true)
 		config.SetFeatures(t, config.Docker)
 
-		enabledChecks := getEnabledChecks(scfg)
+		enabledChecks := getEnabledChecks(ddconfig.Datadog, scfg)
 		assertContainsCheck(t, enabledChecks, ContainerCheckName)
 		assertNotContainsCheck(t, enabledChecks, RTContainerCheckName)
 	})
@@ -55,7 +55,7 @@ func TestContainerCheck(t *testing.T) {
 		cfg.Set("process_config.process_collection.enabled", false)
 		cfg.Set("process_config.container_collection.enabled", true)
 
-		enabledChecks := getEnabledChecks(scfg)
+		enabledChecks := getEnabledChecks(ddconfig.Datadog, scfg)
 
 		assertNotContainsCheck(t, enabledChecks, ContainerCheckName)
 		assertNotContainsCheck(t, enabledChecks, RTContainerCheckName)
@@ -68,7 +68,7 @@ func TestContainerCheck(t *testing.T) {
 		cfg.Set("process_config.container_collection.enabled", true)
 		config.SetFeatures(t, config.Docker)
 
-		enabledChecks := getEnabledChecks(scfg)
+		enabledChecks := getEnabledChecks(ddconfig.Datadog, scfg)
 		assertContainsCheck(t, enabledChecks, ProcessCheckName)
 		assertNotContainsCheck(t, enabledChecks, ContainerCheckName)
 		assertNotContainsCheck(t, enabledChecks, RTContainerCheckName)
@@ -102,7 +102,7 @@ func TestDisableRealTime(t *testing.T) {
 			mockConfig.Set("process_config.process_discovery.enabled", false) // Not an RT check so we don't care
 			config.SetFeatures(t, config.Docker)
 
-			enabledChecks := getEnabledChecks(&sysconfig.Config{})
+			enabledChecks := getEnabledChecks(ddconfig.Datadog, &sysconfig.Config{})
 			assert.EqualValues(tc.expectedChecks, enabledChecks)
 		})
 	}

--- a/pkg/process/checks/enable_checks_containerized_test.go
+++ b/pkg/process/checks/enable_checks_containerized_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	sysconfig "github.com/DataDog/datadog-agent/cmd/system-probe/config"
 	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
@@ -20,8 +19,6 @@ import (
 // we must make sure that the build tags in this file match.
 
 func TestContainerCheck(t *testing.T) {
-	scfg := &sysconfig.Config{}
-
 	// Make sure the container check can be enabled if the process check is disabled
 	t.Run("containers enabled; rt enabled", func(t *testing.T) {
 		cfg := config.Mock(t)
@@ -30,7 +27,7 @@ func TestContainerCheck(t *testing.T) {
 		cfg.Set("process_config.disable_realtime_checks", false)
 		config.SetFeatures(t, config.Docker)
 
-		enabledChecks := getEnabledChecks(cfg, scfg)
+		enabledChecks := getEnabledChecks(t, cfg, config.MockSystemProbe(t))
 		assertContainsCheck(t, enabledChecks, ContainerCheckName)
 		assertContainsCheck(t, enabledChecks, RTContainerCheckName)
 		assertNotContainsCheck(t, enabledChecks, ProcessCheckName)
@@ -44,7 +41,7 @@ func TestContainerCheck(t *testing.T) {
 		cfg.Set("process_config.disable_realtime_checks", true)
 		config.SetFeatures(t, config.Docker)
 
-		enabledChecks := getEnabledChecks(cfg, scfg)
+		enabledChecks := getEnabledChecks(t, cfg, config.MockSystemProbe(t))
 		assertContainsCheck(t, enabledChecks, ContainerCheckName)
 		assertNotContainsCheck(t, enabledChecks, RTContainerCheckName)
 	})
@@ -55,7 +52,7 @@ func TestContainerCheck(t *testing.T) {
 		cfg.Set("process_config.process_collection.enabled", false)
 		cfg.Set("process_config.container_collection.enabled", true)
 
-		enabledChecks := getEnabledChecks(cfg, scfg)
+		enabledChecks := getEnabledChecks(t, cfg, config.MockSystemProbe(t))
 
 		assertNotContainsCheck(t, enabledChecks, ContainerCheckName)
 		assertNotContainsCheck(t, enabledChecks, RTContainerCheckName)
@@ -68,7 +65,7 @@ func TestContainerCheck(t *testing.T) {
 		cfg.Set("process_config.container_collection.enabled", true)
 		config.SetFeatures(t, config.Docker)
 
-		enabledChecks := getEnabledChecks(cfg, scfg)
+		enabledChecks := getEnabledChecks(t, cfg, config.MockSystemProbe(t))
 		assertContainsCheck(t, enabledChecks, ProcessCheckName)
 		assertNotContainsCheck(t, enabledChecks, ContainerCheckName)
 		assertNotContainsCheck(t, enabledChecks, RTContainerCheckName)
@@ -102,7 +99,7 @@ func TestDisableRealTime(t *testing.T) {
 			mockConfig.Set("process_config.process_discovery.enabled", false) // Not an RT check so we don't care
 			config.SetFeatures(t, config.Docker)
 
-			enabledChecks := getEnabledChecks(mockConfig, &sysconfig.Config{})
+			enabledChecks := getEnabledChecks(t, mockConfig, config.MockSystemProbe(t))
 			assert.EqualValues(tc.expectedChecks, enabledChecks)
 		})
 	}

--- a/pkg/process/checks/enable_checks_containerized_test.go
+++ b/pkg/process/checks/enable_checks_containerized_test.go
@@ -30,7 +30,7 @@ func TestContainerCheck(t *testing.T) {
 		cfg.Set("process_config.disable_realtime_checks", false)
 		config.SetFeatures(t, config.Docker)
 
-		enabledChecks := getEnabledChecks(ddconfig.Datadog, scfg)
+		enabledChecks := getEnabledChecks(cfg, scfg)
 		assertContainsCheck(t, enabledChecks, ContainerCheckName)
 		assertContainsCheck(t, enabledChecks, RTContainerCheckName)
 		assertNotContainsCheck(t, enabledChecks, ProcessCheckName)
@@ -44,7 +44,7 @@ func TestContainerCheck(t *testing.T) {
 		cfg.Set("process_config.disable_realtime_checks", true)
 		config.SetFeatures(t, config.Docker)
 
-		enabledChecks := getEnabledChecks(ddconfig.Datadog, scfg)
+		enabledChecks := getEnabledChecks(cfg, scfg)
 		assertContainsCheck(t, enabledChecks, ContainerCheckName)
 		assertNotContainsCheck(t, enabledChecks, RTContainerCheckName)
 	})
@@ -55,7 +55,7 @@ func TestContainerCheck(t *testing.T) {
 		cfg.Set("process_config.process_collection.enabled", false)
 		cfg.Set("process_config.container_collection.enabled", true)
 
-		enabledChecks := getEnabledChecks(ddconfig.Datadog, scfg)
+		enabledChecks := getEnabledChecks(cfg, scfg)
 
 		assertNotContainsCheck(t, enabledChecks, ContainerCheckName)
 		assertNotContainsCheck(t, enabledChecks, RTContainerCheckName)
@@ -68,7 +68,7 @@ func TestContainerCheck(t *testing.T) {
 		cfg.Set("process_config.container_collection.enabled", true)
 		config.SetFeatures(t, config.Docker)
 
-		enabledChecks := getEnabledChecks(ddconfig.Datadog, scfg)
+		enabledChecks := getEnabledChecks(cfg, scfg)
 		assertContainsCheck(t, enabledChecks, ProcessCheckName)
 		assertNotContainsCheck(t, enabledChecks, ContainerCheckName)
 		assertNotContainsCheck(t, enabledChecks, RTContainerCheckName)
@@ -102,7 +102,7 @@ func TestDisableRealTime(t *testing.T) {
 			mockConfig.Set("process_config.process_discovery.enabled", false) // Not an RT check so we don't care
 			config.SetFeatures(t, config.Docker)
 
-			enabledChecks := getEnabledChecks(ddconfig.Datadog, &sysconfig.Config{})
+			enabledChecks := getEnabledChecks(cfg, &sysconfig.Config{})
 			assert.EqualValues(tc.expectedChecks, enabledChecks)
 		})
 	}

--- a/pkg/process/checks/enable_checks_containerized_test.go
+++ b/pkg/process/checks/enable_checks_containerized_test.go
@@ -102,7 +102,7 @@ func TestDisableRealTime(t *testing.T) {
 			mockConfig.Set("process_config.process_discovery.enabled", false) // Not an RT check so we don't care
 			config.SetFeatures(t, config.Docker)
 
-			enabledChecks := getEnabledChecks(cfg, &sysconfig.Config{})
+			enabledChecks := getEnabledChecks(mockConfig, &sysconfig.Config{})
 			assert.EqualValues(tc.expectedChecks, enabledChecks)
 		})
 	}

--- a/pkg/process/checks/enabled_checks_linux_test.go
+++ b/pkg/process/checks/enabled_checks_linux_test.go
@@ -10,17 +10,14 @@ package checks
 import (
 	"testing"
 
-	sysconfig "github.com/DataDog/datadog-agent/cmd/system-probe/config"
 	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
 func TestProcessEventsCheckEnabled(t *testing.T) {
-	scfg := &sysconfig.Config{}
-
 	t.Run("default", func(t *testing.T) {
 		cfg := config.Mock(t)
 
-		enabledChecks := getEnabledChecks(cfg, scfg)
+		enabledChecks := getEnabledChecks(t, cfg, config.MockSystemProbe(t))
 		assertNotContainsCheck(t, enabledChecks, ProcessEventsCheckName)
 	})
 
@@ -28,7 +25,7 @@ func TestProcessEventsCheckEnabled(t *testing.T) {
 		cfg := config.Mock(t)
 		cfg.Set("process_config.event_collection.enabled", true)
 
-		enabledChecks := getEnabledChecks(cfg, scfg)
+		enabledChecks := getEnabledChecks(t, cfg, config.MockSystemProbe(t))
 		assertContainsCheck(t, enabledChecks, ProcessEventsCheckName)
 	})
 
@@ -36,7 +33,7 @@ func TestProcessEventsCheckEnabled(t *testing.T) {
 		cfg := config.Mock(t)
 		cfg.Set("process_config.event_collection.enabled", false)
 
-		enabledChecks := getEnabledChecks(cfg, scfg)
+		enabledChecks := getEnabledChecks(t, cfg, config.MockSystemProbe(t))
 		assertNotContainsCheck(t, enabledChecks, ProcessEventsCheckName)
 	})
 }

--- a/pkg/process/checks/enabled_checks_linux_test.go
+++ b/pkg/process/checks/enabled_checks_linux_test.go
@@ -18,9 +18,9 @@ func TestProcessEventsCheckEnabled(t *testing.T) {
 	scfg := &sysconfig.Config{}
 
 	t.Run("default", func(t *testing.T) {
-		config.Mock(t)
+		cfg := config.Mock(t)
 
-		enabledChecks := getEnabledChecks(scfg)
+		enabledChecks := getEnabledChecks(cfg, scfg)
 		assertNotContainsCheck(t, enabledChecks, ProcessEventsCheckName)
 	})
 
@@ -28,7 +28,7 @@ func TestProcessEventsCheckEnabled(t *testing.T) {
 		cfg := config.Mock(t)
 		cfg.Set("process_config.event_collection.enabled", true)
 
-		enabledChecks := getEnabledChecks(scfg)
+		enabledChecks := getEnabledChecks(cfg, scfg)
 		assertContainsCheck(t, enabledChecks, ProcessEventsCheckName)
 	})
 
@@ -36,7 +36,7 @@ func TestProcessEventsCheckEnabled(t *testing.T) {
 		cfg := config.Mock(t)
 		cfg.Set("process_config.event_collection.enabled", false)
 
-		enabledChecks := getEnabledChecks(scfg)
+		enabledChecks := getEnabledChecks(cfg, scfg)
 		assertNotContainsCheck(t, enabledChecks, ProcessEventsCheckName)
 	})
 }

--- a/pkg/process/checks/enabled_checks_pod_test.go
+++ b/pkg/process/checks/enabled_checks_pod_test.go
@@ -11,7 +11,6 @@ package checks
 import (
 	"testing"
 
-	sysconfig "github.com/DataDog/datadog-agent/cmd/system-probe/config"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/clustername"
 )
@@ -28,7 +27,7 @@ func TestPodCheck(t *testing.T) {
 		cfg.Set("orchestrator_explorer.enabled", true)
 		cfg.Set("cluster_name", "test")
 
-		enabledChecks := getEnabledChecks(cfg, &sysconfig.Config{})
+		enabledChecks := getEnabledChecks(t, cfg, config.MockSystemProbe(t))
 		assertContainsCheck(t, enabledChecks, PodCheckName)
 	})
 
@@ -39,7 +38,7 @@ func TestPodCheck(t *testing.T) {
 		cfg := config.Mock(t)
 		cfg.Set("orchestrator_explorer.enabled", false)
 
-		enabledChecks := getEnabledChecks(cfg, &sysconfig.Config{})
+		enabledChecks := getEnabledChecks(t, cfg, config.MockSystemProbe(t))
 		assertNotContainsCheck(t, enabledChecks, PodCheckName)
 	})
 }

--- a/pkg/process/checks/enabled_checks_pod_test.go
+++ b/pkg/process/checks/enabled_checks_pod_test.go
@@ -28,7 +28,7 @@ func TestPodCheck(t *testing.T) {
 		cfg.Set("orchestrator_explorer.enabled", true)
 		cfg.Set("cluster_name", "test")
 
-		enabledChecks := getEnabledChecks(&sysconfig.Config{})
+		enabledChecks := getEnabledChecks(cfg, &sysconfig.Config{})
 		assertContainsCheck(t, enabledChecks, PodCheckName)
 	})
 
@@ -39,7 +39,7 @@ func TestPodCheck(t *testing.T) {
 		cfg := config.Mock(t)
 		cfg.Set("orchestrator_explorer.enabled", false)
 
-		enabledChecks := getEnabledChecks(&sysconfig.Config{})
+		enabledChecks := getEnabledChecks(cfg, &sysconfig.Config{})
 		assertNotContainsCheck(t, enabledChecks, PodCheckName)
 	})
 }

--- a/pkg/process/checks/enabled_checks_test.go
+++ b/pkg/process/checks/enabled_checks_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	sysconfig "github.com/DataDog/datadog-agent/cmd/system-probe/config"
 	"github.com/DataDog/datadog-agent/pkg/config"
@@ -24,9 +25,12 @@ func assertNotContainsCheck(t *testing.T, checks []string, name string) {
 	assert.NotContains(t, checks, name)
 }
 
-func getEnabledChecks(config config.ConfigReaderWriter, scfg *sysconfig.Config) []string {
+func getEnabledChecks(t *testing.T, cfg, sysprobeYamlConfig config.ConfigReaderWriter) []string {
+	sysprobeConfigStruct, err := sysconfig.NewCustom("", false)
+	require.NoError(t, err)
+
 	var enabledChecks []string
-	for _, check := range All(config, scfg) {
+	for _, check := range All(cfg, sysprobeYamlConfig, sysprobeConfigStruct) {
 		if check.IsEnabled() {
 			enabledChecks = append(enabledChecks, check.Name())
 		}
@@ -35,75 +39,64 @@ func getEnabledChecks(config config.ConfigReaderWriter, scfg *sysconfig.Config) 
 }
 
 func TestProcessDiscovery(t *testing.T) {
-	scfg := &sysconfig.Config{}
-
 	// Make sure the process_discovery check can be enabled
 	t.Run("enabled", func(t *testing.T) {
-		cfg := config.Mock(t)
+		cfg, sysprobeCfg := config.Mock(t), config.MockSystemProbe(t)
 		cfg.Set("process_config.process_discovery.enabled", true)
-		enabledChecks := getEnabledChecks(cfg, scfg)
+		enabledChecks := getEnabledChecks(t, cfg, sysprobeCfg)
 		assertContainsCheck(t, enabledChecks, DiscoveryCheckName)
 	})
 
 	// Make sure the process_discovery check can be disabled
 	t.Run("disabled", func(t *testing.T) {
-		cfg := config.Mock(t)
+		cfg, scfg := config.Mock(t), config.MockSystemProbe(t)
 		cfg.Set("process_config.process_discovery.enabled", false)
-		enabledChecks := getEnabledChecks(cfg, scfg)
+		enabledChecks := getEnabledChecks(t, cfg, scfg)
 		assertNotContainsCheck(t, enabledChecks, DiscoveryCheckName)
 	})
 
 	// Make sure the process and process_discovery checks are mutually exclusive
 	t.Run("mutual exclusion", func(t *testing.T) {
-		cfg := config.Mock(t)
+		cfg, scfg := config.Mock(t), config.MockSystemProbe(t)
 		cfg.Set("process_config.process_discovery.enabled", true)
 		cfg.Set("process_config.process_collection.enabled", true)
-		enabledChecks := getEnabledChecks(cfg, scfg)
+		enabledChecks := getEnabledChecks(t, cfg, scfg)
 		assertNotContainsCheck(t, enabledChecks, DiscoveryCheckName)
 	})
 }
 
 func TestProcessCheck(t *testing.T) {
-	cfg := config.Mock(t)
-
-	scfg, err := sysconfig.New("")
-	assert.NoError(t, err)
-
 	t.Run("disabled", func(t *testing.T) {
+		cfg, scfg := config.Mock(t), config.MockSystemProbe(t)
 		cfg.Set("process_config.process_collection.enabled", false)
-		enabledChecks := getEnabledChecks(cfg, scfg)
+		enabledChecks := getEnabledChecks(t, cfg, scfg)
 		assertNotContainsCheck(t, enabledChecks, ProcessCheckName)
 	})
 
 	// Make sure the process check can be enabled
 	t.Run("enabled", func(t *testing.T) {
+		cfg, scfg := config.Mock(t), config.MockSystemProbe(t)
 		cfg.Set("process_config.process_collection.enabled", true)
-		enabledChecks := getEnabledChecks(cfg, scfg)
+		enabledChecks := getEnabledChecks(t, cfg, scfg)
 		assertContainsCheck(t, enabledChecks, ProcessCheckName)
 	})
 }
 
 func TestConnectionsCheck(t *testing.T) {
-	cfg := config.Mock(t)
-
-	syscfg := config.MockSystemProbe(t)
-	syscfg.Set("system_probe_config.enabled", true)
-
 	t.Run("enabled", func(t *testing.T) {
-		syscfg.Set("network_config.enabled", true)
-		scfg, err := sysconfig.New("")
-		assert.NoError(t, err)
+		cfg, scfg := config.Mock(t), config.MockSystemProbe(t)
+		scfg.Set("network_config.enabled", true)
+		scfg.Set("system_probe_config.enabled", true)
 
-		enabledChecks := getEnabledChecks(cfg, scfg)
+		enabledChecks := getEnabledChecks(t, cfg, scfg)
 		assertContainsCheck(t, enabledChecks, ConnectionsCheckName)
 	})
 
 	t.Run("disabled", func(t *testing.T) {
-		syscfg.Set("network_config.enabled", false)
-		scfg, err := sysconfig.New("")
-		assert.NoError(t, err)
+		cfg, scfg := config.Mock(t), config.MockSystemProbe(t)
+		scfg.Set("network_config.enabled", false)
 
-		enabledChecks := getEnabledChecks(cfg, scfg)
+		enabledChecks := getEnabledChecks(t, cfg, scfg)
 		assertNotContainsCheck(t, enabledChecks, ConnectionsCheckName)
 	})
 }

--- a/pkg/process/checks/enabled_checks_test.go
+++ b/pkg/process/checks/enabled_checks_test.go
@@ -24,9 +24,9 @@ func assertNotContainsCheck(t *testing.T, checks []string, name string) {
 	assert.NotContains(t, checks, name)
 }
 
-func getEnabledChecks(scfg *sysconfig.Config) []string {
+func getEnabledChecks(config config.ConfigReaderWriter, scfg *sysconfig.Config) []string {
 	var enabledChecks []string
-	for _, check := range All(scfg) {
+	for _, check := range All(config, scfg) {
 		if check.IsEnabled() {
 			enabledChecks = append(enabledChecks, check.Name())
 		}
@@ -41,7 +41,7 @@ func TestProcessDiscovery(t *testing.T) {
 	t.Run("enabled", func(t *testing.T) {
 		cfg := config.Mock(t)
 		cfg.Set("process_config.process_discovery.enabled", true)
-		enabledChecks := getEnabledChecks(scfg)
+		enabledChecks := getEnabledChecks(cfg, scfg)
 		assertContainsCheck(t, enabledChecks, DiscoveryCheckName)
 	})
 
@@ -49,7 +49,7 @@ func TestProcessDiscovery(t *testing.T) {
 	t.Run("disabled", func(t *testing.T) {
 		cfg := config.Mock(t)
 		cfg.Set("process_config.process_discovery.enabled", false)
-		enabledChecks := getEnabledChecks(scfg)
+		enabledChecks := getEnabledChecks(cfg, scfg)
 		assertNotContainsCheck(t, enabledChecks, DiscoveryCheckName)
 	})
 
@@ -58,7 +58,7 @@ func TestProcessDiscovery(t *testing.T) {
 		cfg := config.Mock(t)
 		cfg.Set("process_config.process_discovery.enabled", true)
 		cfg.Set("process_config.process_collection.enabled", true)
-		enabledChecks := getEnabledChecks(scfg)
+		enabledChecks := getEnabledChecks(cfg, scfg)
 		assertNotContainsCheck(t, enabledChecks, DiscoveryCheckName)
 	})
 }
@@ -71,19 +71,21 @@ func TestProcessCheck(t *testing.T) {
 
 	t.Run("disabled", func(t *testing.T) {
 		cfg.Set("process_config.process_collection.enabled", false)
-		enabledChecks := getEnabledChecks(scfg)
+		enabledChecks := getEnabledChecks(cfg, scfg)
 		assertNotContainsCheck(t, enabledChecks, ProcessCheckName)
 	})
 
 	// Make sure the process check can be enabled
 	t.Run("enabled", func(t *testing.T) {
 		cfg.Set("process_config.process_collection.enabled", true)
-		enabledChecks := getEnabledChecks(scfg)
+		enabledChecks := getEnabledChecks(cfg, scfg)
 		assertContainsCheck(t, enabledChecks, ProcessCheckName)
 	})
 }
 
 func TestConnectionsCheck(t *testing.T) {
+	cfg := config.Mock(t)
+
 	syscfg := config.MockSystemProbe(t)
 	syscfg.Set("system_probe_config.enabled", true)
 
@@ -92,7 +94,7 @@ func TestConnectionsCheck(t *testing.T) {
 		scfg, err := sysconfig.New("")
 		assert.NoError(t, err)
 
-		enabledChecks := getEnabledChecks(scfg)
+		enabledChecks := getEnabledChecks(cfg, scfg)
 		assertContainsCheck(t, enabledChecks, ConnectionsCheckName)
 	})
 
@@ -101,7 +103,7 @@ func TestConnectionsCheck(t *testing.T) {
 		scfg, err := sysconfig.New("")
 		assert.NoError(t, err)
 
-		enabledChecks := getEnabledChecks(scfg)
+		enabledChecks := getEnabledChecks(cfg, scfg)
 		assertNotContainsCheck(t, enabledChecks, ConnectionsCheckName)
 	})
 }

--- a/pkg/process/checks/host_info.go
+++ b/pkg/process/checks/host_info.go
@@ -34,13 +34,13 @@ type HostInfo struct {
 }
 
 // CollectHostInfo collects host information
-func CollectHostInfo() (*HostInfo, error) {
+func CollectHostInfo(config config.ConfigReader) (*HostInfo, error) {
 	sysInfo, err := CollectSystemInfo()
 	if err != nil {
 		return nil, err
 	}
 
-	hostName, err := resolveHostName()
+	hostName, err := resolveHostName(config)
 	if err != nil {
 		return nil, err
 	}
@@ -52,16 +52,16 @@ func CollectHostInfo() (*HostInfo, error) {
 	}, nil
 }
 
-func resolveHostName() (string, error) {
+func resolveHostName(config config.ConfigReader) (string, error) {
 	var hostName string
-	if config.Datadog.IsSet("hostname") {
-		hostName = config.Datadog.GetString("hostname")
+	if config.IsSet("hostname") {
+		hostName = config.GetString("hostname")
 	}
 
 	if err := validate.ValidHostname(hostName); err != nil {
 		// lookup hostname if there is no config override or if the override is invalid
-		agentBin := config.Datadog.GetString("process_config.dd_agent_bin")
-		connectionTimeout := config.Datadog.GetDuration("process_config.grpc_connection_timeout_secs") * time.Second
+		agentBin := config.GetString("process_config.dd_agent_bin")
+		connectionTimeout := config.GetDuration("process_config.grpc_connection_timeout_secs") * time.Second
 		var err error
 		hostName, err = getHostname(context.Background(), agentBin, connectionTimeout)
 		if err != nil {

--- a/pkg/process/checks/host_info_test.go
+++ b/pkg/process/checks/host_info_test.go
@@ -24,8 +24,9 @@ import (
 )
 
 func TestGetHostname(t *testing.T) {
+	cfg := config.Mock(t)
 	ctx := context.Background()
-	h, err := getHostname(ctx, config.Datadog.GetString("process_config.dd_agent_bin"), 0)
+	h, err := getHostname(ctx, cfg.GetString("process_config.dd_agent_bin"), 0)
 	assert.Nil(t, err)
 	// verify we fall back to getting os hostname
 	expectedHostname, _ := os.Hostname()
@@ -80,13 +81,15 @@ func TestGetHostnameFromCmd(t *testing.T) {
 }
 
 func TestInvalidHostname(t *testing.T) {
+	cfg := config.Mock(t)
+
 	// Lower the GRPC timeout, otherwise the test will time out in CI
-	config.Datadog.Set("process_config.grpc_connection_timeout_secs", 1)
-	config.Datadog.Set("hostname", "localhost")
+	cfg.Set("process_config.grpc_connection_timeout_secs", 1)
+	cfg.Set("hostname", "localhost")
 
 	expectedHostname, _ := os.Hostname()
 
-	hostName, err := resolveHostName()
+	hostName, err := resolveHostName(cfg)
 	assert.NoError(t, err)
 
 	assert.Equal(t, expectedHostname, hostName)

--- a/pkg/process/checks/interval.go
+++ b/pkg/process/checks/interval.go
@@ -62,12 +62,12 @@ func GetDefaultInterval(checkName string) time.Duration {
 }
 
 // GetInterval returns the configured check interval value
-func GetInterval(checkName string) time.Duration {
+func GetInterval(cfg config.ConfigReader, checkName string) time.Duration {
 	switch checkName {
 	case DiscoveryCheckName:
 		// We don't need to check if the key exists since we already bound it to a default in InitConfig.
 		// We use a minimum of 10 minutes for this value.
-		discoveryInterval := config.Datadog.GetDuration("process_config.process_discovery.interval")
+		discoveryInterval := cfg.GetDuration("process_config.process_discovery.interval")
 		if discoveryInterval < discoveryMinInterval {
 			discoveryInterval = discoveryMinInterval
 			_ = log.Warnf("Invalid interval for process discovery (< %s) using minimum value of %[1]s", discoveryMinInterval.String())
@@ -75,7 +75,7 @@ func GetInterval(checkName string) time.Duration {
 		return discoveryInterval
 
 	case ProcessEventsCheckName:
-		eventsInterval := config.Datadog.GetDuration("process_config.event_collection.interval")
+		eventsInterval := cfg.GetDuration("process_config.event_collection.interval")
 		if eventsInterval < config.DefaultProcessEventsMinCheckInterval {
 			eventsInterval = config.DefaultProcessEventsCheckInterval
 			_ = log.Warnf("Invalid interval for process_events check (< %s) using default value of %s",
@@ -86,11 +86,11 @@ func GetInterval(checkName string) time.Duration {
 	default:
 		defaultInterval := defaultIntervals[checkName]
 		configKey, ok := configKeys[checkName]
-		if !ok || !config.Datadog.IsSet(configKey) {
+		if !ok || !cfg.IsSet(configKey) {
 			return defaultInterval
 		}
 
-		if seconds := config.Datadog.GetInt(configKey); seconds != 0 {
+		if seconds := cfg.GetInt(configKey); seconds != 0 {
 			log.Infof("Overriding %s check interval to %ds", configKey, seconds)
 			return time.Duration(seconds) * time.Second
 		}

--- a/pkg/process/checks/interval_test.go
+++ b/pkg/process/checks/interval_test.go
@@ -52,8 +52,8 @@ func TestLegacyIntervalDefault(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			_ = config.Mock(t)
-			assert.Equal(t, tc.expectedInterval, GetInterval(tc.checkName))
+			cfg := config.Mock(t)
+			assert.Equal(t, tc.expectedInterval, GetInterval(cfg, tc.checkName))
 		})
 	}
 }
@@ -94,10 +94,9 @@ func TestLegacyIntervalOverride(t *testing.T) {
 		// Note: non-default overridden handling of pod check interval is in pkg/orhestrator/config
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			_ = config.Mock(t)
 			cfg := config.Mock(t)
 			cfg.Set(tc.setting, override)
-			assert.Equal(t, time.Duration(override)*time.Second, GetInterval(tc.checkName))
+			assert.Equal(t, time.Duration(override)*time.Second, GetInterval(cfg, tc.checkName))
 		})
 	}
 }
@@ -124,7 +123,7 @@ func TestProcessDiscoveryInterval(t *testing.T) {
 			cfg := config.Mock(t)
 			cfg.Set("process_config.process_discovery.interval", tc.interval)
 
-			assert.Equal(t, tc.expectedInterval, GetInterval(DiscoveryCheckName))
+			assert.Equal(t, tc.expectedInterval, GetInterval(cfg, DiscoveryCheckName))
 		})
 	}
 }
@@ -150,7 +149,7 @@ func TestProcessEventsInterval(t *testing.T) {
 			cfg := config.Mock(t)
 			cfg.Set("process_config.event_collection.interval", tc.interval)
 
-			assert.Equal(t, tc.expectedInterval, GetInterval(ProcessEventsCheckName))
+			assert.Equal(t, tc.expectedInterval, GetInterval(cfg, ProcessEventsCheckName))
 		})
 	}
 }

--- a/pkg/process/checks/net.go
+++ b/pkg/process/checks/net.go
@@ -14,6 +14,7 @@ import (
 	model "github.com/DataDog/agent-payload/v5/process"
 
 	sysconfig "github.com/DataDog/datadog-agent/cmd/system-probe/config"
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/metadata/host"
 	"github.com/DataDog/datadog-agent/pkg/network/dns"
@@ -38,8 +39,9 @@ var (
 )
 
 // NewConnectionsCheck returns an instance of the ConnectionsCheck.
-func NewConnectionsCheck(syscfg *sysconfig.Config) *ConnectionsCheck {
+func NewConnectionsCheck(config config.ConfigReader, syscfg *sysconfig.Config) *ConnectionsCheck {
 	return &ConnectionsCheck{
+		config: config,
 		syscfg: syscfg,
 	}
 }
@@ -59,6 +61,7 @@ type ConnectionsCheck struct {
 	processData      *ProcessData
 
 	processConnRatesTransmitter subscriptions.Transmitter[ProcessConnRates]
+	config                      config.ConfigReader
 }
 
 // ProcessConnRates describes connection rates for processes
@@ -93,7 +96,7 @@ func (c *ConnectionsCheck) Init(syscfg *SysProbeConfig, hostInfo *HostInfo) erro
 		log.Infof("no network ID detected: %s", err)
 	}
 	c.networkID = networkID
-	c.processData = NewProcessData()
+	c.processData = NewProcessData(c.config)
 	c.dockerFilter = parser.NewDockerProxy()
 	c.serviceExtractor = parser.NewServiceExtractor()
 	c.processData.Register(c.dockerFilter)

--- a/pkg/process/checks/net.go
+++ b/pkg/process/checks/net.go
@@ -39,11 +39,11 @@ var (
 )
 
 // NewConnectionsCheck returns an instance of the ConnectionsCheck.
-func NewConnectionsCheck(config, syspobeYamlConfig config.ConfigReader, syscfg *sysconfig.Config) *ConnectionsCheck {
+func NewConnectionsCheck(config, sysprobeYamlConfig config.ConfigReader, syscfg *sysconfig.Config) *ConnectionsCheck {
 	return &ConnectionsCheck{
 		config:             config,
 		syscfg:             syscfg,
-		sysprobeYamlConfig: syspobeYamlConfig,
+		sysprobeYamlConfig: sysprobeYamlConfig,
 	}
 }
 

--- a/pkg/process/checks/net.go
+++ b/pkg/process/checks/net.go
@@ -39,16 +39,19 @@ var (
 )
 
 // NewConnectionsCheck returns an instance of the ConnectionsCheck.
-func NewConnectionsCheck(config config.ConfigReader, syscfg *sysconfig.Config) *ConnectionsCheck {
+func NewConnectionsCheck(config, syspobeYamlConfig config.ConfigReader, syscfg *sysconfig.Config) *ConnectionsCheck {
 	return &ConnectionsCheck{
-		config: config,
-		syscfg: syscfg,
+		config:             config,
+		syscfg:             syscfg,
+		sysprobeYamlConfig: syspobeYamlConfig,
 	}
 }
 
 // ConnectionsCheck collects statistics about live TCP and UDP connections.
 type ConnectionsCheck struct {
-	syscfg *sysconfig.Config
+	syscfg             *sysconfig.Config
+	sysprobeYamlConfig config.ConfigReader
+	config             config.ConfigReader
 
 	hostInfo               *HostInfo
 	maxConnsPerMessage     int
@@ -61,7 +64,6 @@ type ConnectionsCheck struct {
 	processData      *ProcessData
 
 	processConnRatesTransmitter subscriptions.Transmitter[ProcessConnRates]
-	config                      config.ConfigReader
 }
 
 // ProcessConnRates describes connection rates for processes
@@ -98,7 +100,7 @@ func (c *ConnectionsCheck) Init(syscfg *SysProbeConfig, hostInfo *HostInfo) erro
 	c.networkID = networkID
 	c.processData = NewProcessData(c.config)
 	c.dockerFilter = parser.NewDockerProxy()
-	c.serviceExtractor = parser.NewServiceExtractor(config.SystemProbe)
+	c.serviceExtractor = parser.NewServiceExtractor(c.sysprobeYamlConfig)
 	c.processData.Register(c.dockerFilter)
 	c.processData.Register(c.serviceExtractor)
 

--- a/pkg/process/checks/net.go
+++ b/pkg/process/checks/net.go
@@ -98,7 +98,7 @@ func (c *ConnectionsCheck) Init(syscfg *SysProbeConfig, hostInfo *HostInfo) erro
 	c.networkID = networkID
 	c.processData = NewProcessData(c.config)
 	c.dockerFilter = parser.NewDockerProxy()
-	c.serviceExtractor = parser.NewServiceExtractor(c.config)
+	c.serviceExtractor = parser.NewServiceExtractor(config.SystemProbe)
 	c.processData.Register(c.dockerFilter)
 	c.processData.Register(c.serviceExtractor)
 

--- a/pkg/process/checks/net_test.go
+++ b/pkg/process/checks/net_test.go
@@ -55,7 +55,7 @@ func TestDNSNameEncoding(t *testing.T) {
 		"1.1.2.4": {Names: []string{"host4.domain.com"}},
 		"1.1.2.5": {Names: nil},
 	}
-	ex := parser.NewServiceExtractor()
+	ex := parser.NewServiceExtractor(ddconfig.MockSystemProbe(t))
 	maxConnsPerMessage := 10
 	chunks := batchConnections(&HostInfo{}, maxConnsPerMessage, 0, p, dns, "nid", nil, nil, model.KernelHeaderFetchResult_FetchNotAttempted, nil, nil, nil, nil, nil, nil, ex)
 	assert.Equal(t, len(chunks), 1)
@@ -121,7 +121,7 @@ func TestNetworkConnectionBatching(t *testing.T) {
 		rctm := map[string]*model.RuntimeCompilationTelemetry{}
 		khfr := model.KernelHeaderFetchResult_FetchNotAttempted
 		coretm := map[string]model.COREResult{}
-		ex := parser.NewServiceExtractor()
+		ex := parser.NewServiceExtractor(ddconfig.MockSystemProbe(t))
 		chunks := batchConnections(&HostInfo{}, tc.maxSize, 0, tc.cur, map[string]*model.DNSEntry{}, "nid", ctm, rctm, khfr, coretm, nil, nil, nil, nil, nil, ex)
 
 		assert.Len(t, chunks, tc.expectedChunks, "len %d", i)
@@ -161,7 +161,7 @@ func TestNetworkConnectionBatchingWithDNS(t *testing.T) {
 	}
 
 	maxConnsPerMessage := 1
-	ex := parser.NewServiceExtractor()
+	ex := parser.NewServiceExtractor(ddconfig.MockSystemProbe(t))
 	chunks := batchConnections(&HostInfo{}, maxConnsPerMessage, 0, p, dns, "nid", nil, nil, model.KernelHeaderFetchResult_FetchNotAttempted, nil, nil, nil, nil, nil, nil, ex)
 
 	assert.Len(t, chunks, 4)
@@ -201,7 +201,7 @@ func TestBatchSimilarConnectionsTogether(t *testing.T) {
 	p[5].Raddr.Ip = "1.3.4.5"
 
 	maxConnsPerMessage := 2
-	ex := parser.NewServiceExtractor()
+	ex := parser.NewServiceExtractor(ddconfig.MockSystemProbe(t))
 	chunks := batchConnections(&HostInfo{}, maxConnsPerMessage, 0, p, map[string]*model.DNSEntry{}, "nid", nil, nil, model.KernelHeaderFetchResult_FetchNotAttempted, nil, nil, nil, nil, nil, nil, ex)
 
 	assert.Len(t, chunks, 3)
@@ -285,7 +285,7 @@ func TestNetworkConnectionBatchingWithDomainsByQueryType(t *testing.T) {
 	dnsmap := map[string]*model.DNSEntry{}
 
 	maxConnsPerMessage := 1
-	ex := parser.NewServiceExtractor()
+	ex := parser.NewServiceExtractor(ddconfig.MockSystemProbe(t))
 	chunks := batchConnections(&HostInfo{}, maxConnsPerMessage, 0, conns, dnsmap, "nid", nil, nil, model.KernelHeaderFetchResult_FetchNotAttempted, nil, nil, domains, nil, nil, nil, ex)
 
 	assert.Len(t, chunks, 4)
@@ -403,7 +403,7 @@ func TestNetworkConnectionBatchingWithDomains(t *testing.T) {
 	dnsmap := map[string]*model.DNSEntry{}
 
 	maxConnsPerMessage := 1
-	ex := parser.NewServiceExtractor()
+	ex := parser.NewServiceExtractor(ddconfig.MockSystemProbe(t))
 	chunks := batchConnections(&HostInfo{}, maxConnsPerMessage, 0, conns, dnsmap, "nid", nil, nil, model.KernelHeaderFetchResult_FetchNotAttempted, nil, nil, domains, nil, nil, nil, ex)
 
 	assert.Len(t, chunks, 4)
@@ -512,7 +512,7 @@ func TestNetworkConnectionBatchingWithRoutes(t *testing.T) {
 	conns[7].RouteIdx = 2
 
 	maxConnsPerMessage := 4
-	ex := parser.NewServiceExtractor()
+	ex := parser.NewServiceExtractor(ddconfig.MockSystemProbe(t))
 	chunks := batchConnections(&HostInfo{}, maxConnsPerMessage, 0, conns, nil, "nid", nil, nil, model.KernelHeaderFetchResult_FetchNotAttempted, nil, nil, nil, routes, nil, nil, ex)
 
 	assert.Len(t, chunks, 2)
@@ -580,7 +580,7 @@ func TestNetworkConnectionTags(t *testing.T) {
 	foundTags := []fakeConn{}
 
 	maxConnsPerMessage := 4
-	ex := parser.NewServiceExtractor()
+	ex := parser.NewServiceExtractor(ddconfig.MockSystemProbe(t))
 	chunks := batchConnections(&HostInfo{}, maxConnsPerMessage, 0, conns, nil, "nid", nil, nil, model.KernelHeaderFetchResult_FetchNotAttempted, nil, nil, nil, nil, tags, nil, ex)
 
 	assert.Len(t, chunks, 2)
@@ -617,7 +617,7 @@ func TestNetworkConnectionTagsWithService(t *testing.T) {
 	mockConfig.Set("service_monitoring_config.process_service_inference.enabled", true)
 
 	maxConnsPerMessage := 1
-	ex := parser.NewServiceExtractor()
+	ex := parser.NewServiceExtractor(ddconfig.MockSystemProbe(t))
 	ex.Extract(procsByPid)
 
 	chunks := batchConnections(&HostInfo{}, maxConnsPerMessage, 0, conns, nil, "nid", nil, nil, model.KernelHeaderFetchResult_FetchNotAttempted, nil, nil, nil, nil, tags, nil, ex)

--- a/pkg/process/checks/process.go
+++ b/pkg/process/checks/process.go
@@ -36,8 +36,9 @@ const (
 )
 
 // NewProcessCehck returns an instance of the ProcessCheck.
-func NewProcessCheck() *ProcessCheck {
+func NewProcessCheck(config ddconfig.ConfigReader) *ProcessCheck {
 	return &ProcessCheck{
+		config:   config,
 		scrubber: procutil.NewDefaultDataScrubber(),
 	}
 }
@@ -52,6 +53,8 @@ const (
 // for live and running processes. The instance will store some state between
 // checks that will be used for rates, cpu calculations, etc.
 type ProcessCheck struct {
+	config ddconfig.ConfigReader
+
 	probe procutil.Probe
 	// scrubber is a DataScrubber to hide command line sensitive words
 	scrubber *procutil.DataScrubber
@@ -106,20 +109,19 @@ func (p *ProcessCheck) Init(syscfg *SysProbeConfig, info *HostInfo) error {
 	}
 	p.networkID = networkID
 
-	p.maxBatchSize = getMaxBatchSize()
-	p.maxBatchBytes = getMaxBatchBytes()
+	p.maxBatchSize = getMaxBatchSize(p.config)
+	p.maxBatchBytes = getMaxBatchBytes(p.config)
 
-	p.skipAmount = uint32(ddconfig.Datadog.GetInt32("process_config.process_discovery.hint_frequency"))
+	p.skipAmount = uint32(p.config.GetInt32("process_config.process_discovery.hint_frequency"))
 	if p.skipAmount == 0 {
 		log.Warnf("process_config.process_discovery.hint_frequency must be greater than 0. using default value %d",
 			ddconfig.DefaultProcessDiscoveryHintFrequency)
-		ddconfig.Datadog.Set("process_config.process_discovery.hint_frequency", ddconfig.DefaultProcessDiscoveryHintFrequency)
 		p.skipAmount = ddconfig.DefaultProcessDiscoveryHintFrequency
 	}
 
-	initScrubber(p.scrubber)
+	initScrubber(p.config, p.scrubber)
 
-	p.disallowList = initDisallowList()
+	p.disallowList = initDisallowList(p.config)
 
 	p.initConnRates()
 	return nil
@@ -154,7 +156,7 @@ func (p *ProcessCheck) getLastConnRates() ProcessConnRates {
 
 // IsEnabled returns true if the check is enabled by configuration
 func (p *ProcessCheck) IsEnabled() bool {
-	return ddconfig.Datadog.GetBool("process_config.process_collection.enabled")
+	return p.config.GetBool("process_config.process_collection.enabled")
 }
 
 // SupportsRunOptions returns true if the check supports RunOptions
@@ -587,10 +589,10 @@ func mergeProcWithSysprobeStats(pids []int32, procs map[int32]*procutil.Process,
 	}
 }
 
-func initScrubber(scrubber *procutil.DataScrubber) {
+func initScrubber(config ddconfig.ConfigReader, scrubber *procutil.DataScrubber) {
 	// Enable/Disable the DataScrubber to obfuscate process args
-	if ddconfig.Datadog.IsSet(configScrubArgs) {
-		scrubber.Enabled = ddconfig.Datadog.GetBool(configScrubArgs)
+	if config.IsSet(configScrubArgs) {
+		scrubber.Enabled = config.GetBool(configScrubArgs)
 	}
 
 	if scrubber.Enabled { // Scrubber is enabled by default when it's created
@@ -598,24 +600,24 @@ func initScrubber(scrubber *procutil.DataScrubber) {
 	}
 
 	// A custom word list to enhance the default one used by the DataScrubber
-	if ddconfig.Datadog.IsSet(configCustomSensitiveWords) {
-		words := ddconfig.Datadog.GetStringSlice(configCustomSensitiveWords)
+	if config.IsSet(configCustomSensitiveWords) {
+		words := config.GetStringSlice(configCustomSensitiveWords)
 		scrubber.AddCustomSensitiveWords(words)
 		log.Debug("Adding custom sensitives words to Scrubber:", words)
 	}
 
 	// Strips all process arguments
-	if ddconfig.Datadog.GetBool(configStripProcArgs) {
+	if config.GetBool(configStripProcArgs) {
 		log.Debug("Strip all process arguments enabled")
 		scrubber.StripAllArguments = true
 	}
 }
 
-func initDisallowList() []*regexp.Regexp {
+func initDisallowList(config ddconfig.ConfigReader) []*regexp.Regexp {
 	var disallowList []*regexp.Regexp
 	// A list of regex patterns that will exclude a process if matched.
-	if ddconfig.Datadog.IsSet(configDisallowList) {
-		for _, b := range ddconfig.Datadog.GetStringSlice(configDisallowList) {
+	if config.IsSet(configDisallowList) {
+		for _, b := range config.GetStringSlice(configDisallowList) {
 			r, err := regexp.Compile(b)
 			if err != nil {
 				log.Warnf("Ignoring invalid disallow list pattern: %s", b)

--- a/pkg/process/checks/process.go
+++ b/pkg/process/checks/process.go
@@ -98,7 +98,7 @@ type ProcessCheck struct {
 func (p *ProcessCheck) Init(syscfg *SysProbeConfig, info *HostInfo) error {
 	p.hostInfo = info
 	p.SysprobeProcessModuleEnabled = syscfg.ProcessModuleEnabled
-	p.probe = newProcessProbe(procutil.WithPermission(syscfg.ProcessModuleEnabled))
+	p.probe = newProcessProbe(p.config, procutil.WithPermission(syscfg.ProcessModuleEnabled))
 	p.containerProvider = util.GetSharedContainerProvider()
 
 	p.notInitializedLogLimit = util.NewLogLimit(1, time.Minute*10)

--- a/pkg/process/checks/process_data.go
+++ b/pkg/process/checks/process_data.go
@@ -8,6 +8,7 @@ package checks
 import (
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/process/metadata"
 	"github.com/DataDog/datadog-agent/pkg/process/procutil"
 )
@@ -20,9 +21,9 @@ type ProcessData struct {
 	extractors []metadata.Extractor
 }
 
-func NewProcessData() *ProcessData {
+func NewProcessData(cfg config.ConfigReader) *ProcessData {
 	return &ProcessData{
-		probe: newProcessProbe(),
+		probe: newProcessProbe(cfg),
 	}
 }
 

--- a/pkg/process/checks/process_data_test.go
+++ b/pkg/process/checks/process_data_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/process/procutil"
 	"github.com/DataDog/datadog-agent/pkg/process/procutil/mocks"
 )
@@ -58,7 +59,7 @@ func TestProcessDataFetch(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			p := NewProcessData()
+			p := NewProcessData(config.Mock(t))
 			p.probe = probe
 
 			for _, e := range tc.extractors {

--- a/pkg/process/checks/process_discovery_check.go
+++ b/pkg/process/checks/process_discovery_check.go
@@ -41,7 +41,7 @@ type ProcessDiscoveryCheck struct {
 func (d *ProcessDiscoveryCheck) Init(syscfg *SysProbeConfig, info *HostInfo) error {
 	d.info = info
 	d.initCalled = true
-	d.probe = newProcessProbe(procutil.WithPermission(syscfg.ProcessModuleEnabled))
+	d.probe = newProcessProbe(d.config, procutil.WithPermission(syscfg.ProcessModuleEnabled))
 
 	d.maxBatchSize = getMaxBatchSize(d.config)
 	return nil

--- a/pkg/process/checks/process_discovery_check_test.go
+++ b/pkg/process/checks/process_discovery_check_test.go
@@ -29,7 +29,7 @@ func TestProcessDiscoveryCheck(t *testing.T) {
 	maxBatchSize := 10
 	getMaxBatchSize = func(config.ConfigReader) int { return maxBatchSize }
 
-	check := &ProcessDiscoveryCheck{}
+	check := NewProcessDiscoveryCheck(config.Mock(t))
 	check.Init(
 		&SysProbeConfig{},
 		&HostInfo{

--- a/pkg/process/checks/process_discovery_check_test.go
+++ b/pkg/process/checks/process_discovery_check_test.go
@@ -10,6 +10,8 @@ import (
 
 	model "github.com/DataDog/agent-payload/v5/process"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
 func testGroupId(groupID int32) func() int32 {
@@ -25,7 +27,7 @@ func TestProcessDiscoveryCheck(t *testing.T) {
 	}()
 
 	maxBatchSize := 10
-	getMaxBatchSize = func() int { return maxBatchSize }
+	getMaxBatchSize = func(config.ConfigReader) int { return maxBatchSize }
 
 	check := &ProcessDiscoveryCheck{}
 	check.Init(

--- a/pkg/process/checks/process_events_fallback.go
+++ b/pkg/process/checks/process_events_fallback.go
@@ -10,15 +10,20 @@ package checks
 
 import (
 	"errors"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
 // NewProcessEventsCheck returns an instance of the ProcessEventsCheck.
-func NewProcessEventsCheck() *ProcessEventsCheck {
-	return &ProcessEventsCheck{}
+func NewProcessEventsCheck(config config.ConfigReader) *ProcessEventsCheck {
+	return &ProcessEventsCheck{
+		config: config,
+	}
 }
 
 // ProcessEventsCheck collects process lifecycle events such as exec and exit signals
 type ProcessEventsCheck struct {
+	config config.ConfigReader
 }
 
 // Init initializes the ProcessEventsCheck.

--- a/pkg/process/checks/process_events_linux.go
+++ b/pkg/process/checks/process_events_linux.go
@@ -57,7 +57,7 @@ func (e *ProcessEventsCheck) Init(_ *SysProbeConfig, info *HostInfo) error {
 	e.hostInfo = info
 	e.maxBatchSize = getMaxBatchSize(e.config)
 
-	store, err := events.NewRingStore(statsd.Client)
+	store, err := events.NewRingStore(e.config, statsd.Client)
 	if err != nil {
 		log.Errorf("RingStore can't be created: %v", err)
 		return err

--- a/pkg/process/checks/process_events_linux_test.go
+++ b/pkg/process/checks/process_events_linux_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/eventmonitor/proto/api"
 	"github.com/DataDog/datadog-agent/pkg/eventmonitor/proto/api/mocks"
 	"github.com/DataDog/datadog-agent/pkg/process/events"
@@ -230,7 +231,7 @@ func TestProcessEventsCheck(t *testing.T) {
 	}
 	stream.On("Recv").Return(nil, io.EOF)
 
-	store, err := events.NewRingStore(&statsd.NoOpClient{})
+	store, err := events.NewRingStore(ddconfig.Mock(t), &statsd.NoOpClient{})
 	require.NoError(t, err)
 
 	listener, err := events.NewSysProbeListener(nil, client, func(e *model.ProcessEvent) {

--- a/pkg/process/checks/process_probe.go
+++ b/pkg/process/checks/process_probe.go
@@ -9,9 +9,10 @@
 package checks
 
 import (
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/process/procutil"
 )
 
-func newProcessProbe(options ...procutil.Option) procutil.Probe {
+func newProcessProbe(config config.ConfigReader, options ...procutil.Option) procutil.Probe {
 	return procutil.NewProcessProbe(options...)
 }

--- a/pkg/process/checks/process_probe_windows.go
+++ b/pkg/process/checks/process_probe_windows.go
@@ -11,8 +11,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-func newProcessProbe(options ...procutil.Option) procutil.Probe {
-	if !config.Datadog.GetBool("process_config.windows.use_perf_counters") {
+func newProcessProbe(config config.ConfigReader, options ...procutil.Option) procutil.Probe {
+	if !config.GetBool("process_config.windows.use_perf_counters") {
 		log.Info("Using toolhelp API probe for process data collection")
 		return procutil.NewWindowsToolhelpProbe()
 	}

--- a/pkg/process/checks/process_test.go
+++ b/pkg/process/checks/process_test.go
@@ -219,12 +219,12 @@ func TestProcessCheckWithRealtime(t *testing.T) {
 }
 
 func TestOnlyEnvConfigArgsScrubbingEnabled(t *testing.T) {
-	_ = ddconfig.Mock(t)
+	cfg := ddconfig.Mock(t)
 
 	t.Setenv("DD_CUSTOM_SENSITIVE_WORDS", "*password*,consul_token,*api_key")
 
 	scrubber := procutil.NewDefaultDataScrubber()
-	initScrubber(scrubber)
+	initScrubber(cfg, scrubber)
 
 	assert.True(t, scrubber.Enabled)
 
@@ -245,13 +245,13 @@ func TestOnlyEnvConfigArgsScrubbingEnabled(t *testing.T) {
 }
 
 func TestOnlyEnvConfigArgsScrubbingDisabled(t *testing.T) {
-	_ = ddconfig.Mock(t)
+	cfg := ddconfig.Mock(t)
 
 	t.Setenv("DD_SCRUB_ARGS", "false")
 	t.Setenv("DD_CUSTOM_SENSITIVE_WORDS", "*password*,consul_token,*api_key")
 
 	scrubber := procutil.NewDefaultDataScrubber()
-	initScrubber(scrubber)
+	initScrubber(cfg, scrubber)
 
 	assert.False(t, scrubber.Enabled)
 

--- a/pkg/process/checks/process_windows_test.go
+++ b/pkg/process/checks/process_windows_test.go
@@ -23,14 +23,14 @@ func TestPerfCountersConfigSetting(t *testing.T) {
 	t.Run("use toolhelp API", func(t *testing.T) {
 		cfg := config.Mock(t)
 		cfg.Set("process_config.windows.use_perf_counters", false)
-		probe := newProcessProbe(procutil.WithPermission(false))
+		probe := newProcessProbe(cfg, procutil.WithPermission(false))
 		assert.IsType(t, procutil.NewWindowsToolhelpProbe(), probe)
 	})
 
 	t.Run("use PDH api", func(t *testing.T) {
 		cfg := config.Mock(t)
 		cfg.Set("process_config.windows.use_perf_counters", true)
-		probe := newProcessProbe(procutil.WithPermission(false))
+		probe := newProcessProbe(cfg, procutil.WithPermission(false))
 		assert.IsType(t, procutil.NewProcessProbe(), probe)
 	})
 }

--- a/pkg/process/events/store.go
+++ b/pkg/process/events/store.go
@@ -15,7 +15,7 @@ import (
 	"github.com/DataDog/datadog-go/v5/statsd"
 	"go.uber.org/atomic"
 
-	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/process/events/model"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -80,8 +80,8 @@ type RingStore struct {
 }
 
 // readPositiveInt reads a config stored in the given key and asserts that it's a positive value
-func readPositiveInt(key string) (int, error) {
-	i := ddconfig.Datadog.GetInt(key)
+func readPositiveInt(cfg config.ConfigReader, key string) (int, error) {
+	i := cfg.GetInt(key)
 	if i <= 0 {
 		return 0, fmt.Errorf("invalid setting. %s must be > 0", key)
 	}
@@ -90,23 +90,23 @@ func readPositiveInt(key string) (int, error) {
 }
 
 // NewRingStore creates a new RingStore to store process events
-func NewRingStore(client statsd.ClientInterface) (Store, error) {
-	maxItems, err := readPositiveInt("process_config.event_collection.store.max_items")
+func NewRingStore(cfg config.ConfigReader, client statsd.ClientInterface) (Store, error) {
+	maxItems, err := readPositiveInt(cfg, "process_config.event_collection.store.max_items")
 	if err != nil {
 		return nil, err
 	}
 
-	maxPushes, err := readPositiveInt("process_config.event_collection.store.max_pending_pushes")
+	maxPushes, err := readPositiveInt(cfg, "process_config.event_collection.store.max_pending_pushes")
 	if err != nil {
 		return nil, err
 	}
 
-	maxPulls, err := readPositiveInt("process_config.event_collection.store.max_pending_pulls")
+	maxPulls, err := readPositiveInt(cfg, "process_config.event_collection.store.max_pending_pulls")
 	if err != nil {
 		return nil, err
 	}
 
-	statsInterval, err := readPositiveInt("process_config.event_collection.store.stats_interval")
+	statsInterval, err := readPositiveInt(cfg, "process_config.event_collection.store.stats_interval")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/process/events/store_test.go
+++ b/pkg/process/events/store_test.go
@@ -35,7 +35,7 @@ func TestRingStoreWithoutLoop(t *testing.T) {
 
 	cfg := config.Mock(t)
 	cfg.Set("process_config.event_collection.store.max_items", 4)
-	store, err := NewRingStore(&statsd.NoOpClient{})
+	store, err := NewRingStore(cfg, &statsd.NoOpClient{})
 	require.NoError(t, err)
 
 	s, ok := store.(*RingStore)
@@ -87,7 +87,7 @@ func TestRingStoreWithLoop(t *testing.T) {
 
 	cfg := config.Mock(t)
 	cfg.Set("process_config.event_collection.store.max_items", 3)
-	store, err := NewRingStore(&statsd.NoOpClient{})
+	store, err := NewRingStore(cfg, &statsd.NoOpClient{})
 	require.NoError(t, err)
 
 	s, ok := store.(*RingStore)
@@ -140,7 +140,7 @@ func TestRingStoreWithDroppedData(t *testing.T) {
 
 	cfg := config.Mock(t)
 	cfg.Set("process_config.event_collection.store.max_items", 3)
-	store, err := NewRingStore(&statsd.NoOpClient{})
+	store, err := NewRingStore(cfg, &statsd.NoOpClient{})
 	require.NoError(t, err)
 
 	s, ok := store.(*RingStore)
@@ -199,7 +199,7 @@ func TestRingStoreAsynchronousPush(t *testing.T) {
 
 	cfg := config.Mock(t)
 	cfg.Set("process_config.event_collection.store.max_items", 3)
-	store, err := NewRingStore(&statsd.NoOpClient{})
+	store, err := NewRingStore(cfg, &statsd.NoOpClient{})
 	require.NoError(t, err)
 
 	s, ok := store.(*RingStore)
@@ -239,7 +239,7 @@ func TestRingStorePullErrors(t *testing.T) {
 	cfg := config.Mock(t)
 	maxPulls := 2
 	cfg.Set("process_config.event_collection.store.max_pending_pulls", maxPulls)
-	store, err := NewRingStore(&statsd.NoOpClient{})
+	store, err := NewRingStore(cfg, &statsd.NoOpClient{})
 	require.NoError(t, err)
 
 	s, ok := store.(*RingStore)
@@ -267,7 +267,7 @@ func TestRingStorePushErrors(t *testing.T) {
 	cfg := config.Mock(t)
 	maxPushes := 2
 	cfg.Set("process_config.event_collection.store.max_pending_pushes", 2)
-	store, err := NewRingStore(&statsd.NoOpClient{})
+	store, err := NewRingStore(cfg, &statsd.NoOpClient{})
 	require.NoError(t, err)
 
 	s, ok := store.(*RingStore)

--- a/pkg/process/metadata/parser/service.go
+++ b/pkg/process/metadata/parser/service.go
@@ -61,10 +61,10 @@ type WindowsServiceInfo struct {
 }
 
 // NewServiceExtractor instantiates a new service discovery extractor
-func NewServiceExtractor() *ServiceExtractor {
+func NewServiceExtractor(sysProbeConfig ddconfig.ConfigReader) *ServiceExtractor {
 	var (
-		enabled               = ddconfig.SystemProbe.GetBool("service_monitoring_config.process_service_inference.enabled")
-		useWindowsServiceName = ddconfig.SystemProbe.GetBool("service_monitoring_config.process_service_inference.use_windows_service_name")
+		enabled               = sysProbeConfig.GetBool("service_monitoring_config.process_service_inference.enabled")
+		useWindowsServiceName = sysProbeConfig.GetBool("service_monitoring_config.process_service_inference.use_windows_service_name")
 	)
 	return &ServiceExtractor{
 		enabled:               enabled,

--- a/pkg/process/metadata/parser/service_test.go
+++ b/pkg/process/metadata/parser/service_test.go
@@ -131,7 +131,7 @@ func TestExtractServiceMetadata(t *testing.T) {
 			}
 			procsByPid := map[int32]*procutil.Process{proc.Pid: &proc}
 
-			se := NewServiceExtractor()
+			se := NewServiceExtractor(mockConfig)
 			se.Extract(procsByPid)
 			assert.Equal(t, []string{tt.expectedServiceTag}, se.GetServiceContext(proc.Pid))
 		})
@@ -147,7 +147,7 @@ func TestExtractServiceMetadataDisabled(t *testing.T) {
 		Cmdline: []string{"/bin/bash"},
 	}
 	procsByPid := map[int32]*procutil.Process{proc.Pid: &proc}
-	se := NewServiceExtractor()
+	se := NewServiceExtractor(mockConfig)
 	se.Extract(procsByPid)
 	assert.Empty(t, se.GetServiceContext(proc.Pid))
 }

--- a/pkg/process/metadata/parser/service_windows_test.go
+++ b/pkg/process/metadata/parser/service_windows_test.go
@@ -74,8 +74,8 @@ func TestWindowsExtractServiceMetadata(t *testing.T) {
 }
 
 func TestWindowsExtractServiceWithSCMReader(t *testing.T) {
-	makeServiceExtractor := func(t *testing.T) (*ServiceExtractor, *mockSCM) {
-		se := NewServiceExtractor()
+	makeServiceExtractor := func(t *testing.T, sysprobeConfig ddconfig.ConfigReader) (*ServiceExtractor, *mockSCM) {
+		se := NewServiceExtractor(sysprobeConfig)
 		procsByPid := map[int32]*procutil.Process{1: {
 			Pid:     1,
 			Cmdline: []string{"C:\\nginx-1.23.2\\nginx.exe"},
@@ -91,7 +91,7 @@ func TestWindowsExtractServiceWithSCMReader(t *testing.T) {
 		cfg.Set("service_monitoring_config.process_service_inference.enabled", true)
 		cfg.Set("service_monitoring_config.process_service_inference.use_windows_service_name", false)
 
-		se, mockSCM := makeServiceExtractor(t)
+		se, mockSCM := makeServiceExtractor(t, cfg)
 
 		context := se.GetServiceContext(1)
 		assert.Equal(t, []string{"process_context:nginx"}, context)
@@ -103,7 +103,7 @@ func TestWindowsExtractServiceWithSCMReader(t *testing.T) {
 		cfg.Set("service_monitoring_config.process_service_inference.use_windows_service_name", true)
 		cfg.Set("service_monitoring_config.process_service_inference.enabled", true)
 
-		se, mockSCM := makeServiceExtractor(t)
+		se, mockSCM := makeServiceExtractor(t, cfg)
 		mockSCM.On("GetServiceInfo", uint64(1)).Return(&winutil.ServiceInfo{
 			ServiceName: []string{"test"},
 		}, nil)
@@ -117,7 +117,7 @@ func TestWindowsExtractServiceWithSCMReader(t *testing.T) {
 		cfg.Set("service_monitoring_config.process_service_inference.use_windows_service_name", true)
 		cfg.Set("service_monitoring_config.process_service_inference.enabled", true)
 
-		se, mockSCM := makeServiceExtractor(t)
+		se, mockSCM := makeServiceExtractor(t, cfg)
 		mockSCM.On("GetServiceInfo", uint64(1)).Return(&winutil.ServiceInfo{
 			ServiceName: []string{"test", "test2"},
 		}, nil)
@@ -131,7 +131,7 @@ func TestWindowsExtractServiceWithSCMReader(t *testing.T) {
 		cfg.Set("service_monitoring_config.process_service_inference.use_windows_service_name", true)
 		cfg.Set("service_monitoring_config.process_service_inference.enabled", true)
 
-		se, mockSCM := makeServiceExtractor(t)
+		se, mockSCM := makeServiceExtractor(t, cfg)
 		mockSCM.On("GetServiceInfo", uint64(1)).Return(nil, nil)
 		context := se.GetServiceContext(1)
 		assert.Equal(t, []string{"process_context:nginx"}, context)

--- a/pkg/process/metadata/parser/service_windows_test.go
+++ b/pkg/process/metadata/parser/service_windows_test.go
@@ -66,7 +66,7 @@ func TestWindowsExtractServiceMetadata(t *testing.T) {
 			}
 			procsByPid := map[int32]*procutil.Process{proc.Pid: &proc}
 
-			se := NewServiceExtractor()
+			se := NewServiceExtractor(mockConfig)
 			se.Extract(procsByPid)
 			assert.Equal(t, []string{tt.expectedServiceTag}, se.GetServiceContext(proc.Pid))
 		})

--- a/pkg/process/runner/collector_api_test.go
+++ b/pkg/process/runner/collector_api_test.go
@@ -80,13 +80,14 @@ func TestSendConnectionsMessage(t *testing.T) {
 		data: [][]process.MessageBody{{m}},
 	}
 
-	runCollectorTest(t, check, &endpointConfig{}, ddconfig.Mock(t), func(c *CheckRunner, ep *mockEndpoint) {
+	cfg := ddconfig.Mock(t)
+	runCollectorTest(t, check, &endpointConfig{}, cfg, func(c *CheckRunner, ep *mockEndpoint) {
 		req := <-ep.Requests
 
 		assert.Equal(t, "/api/v1/connections", req.uri)
 
 		assert.Equal(t, testHostName, req.headers.Get(headers.HostHeader))
-		apiEps, err := GetAPIEndpoints()
+		apiEps, err := GetAPIEndpoints(cfg)
 		assert.NoError(t, err)
 		assert.Equal(t, apiEps[0].APIKey, req.headers.Get("DD-Api-Key"))
 
@@ -119,13 +120,14 @@ func TestSendContainerMessage(t *testing.T) {
 		data: [][]process.MessageBody{{m}},
 	}
 
-	runCollectorTest(t, check, &endpointConfig{}, ddconfig.Mock(t), func(c *CheckRunner, ep *mockEndpoint) {
+	cfg := ddconfig.Mock(t)
+	runCollectorTest(t, check, &endpointConfig{}, cfg, func(c *CheckRunner, ep *mockEndpoint) {
 		req := <-ep.Requests
 
 		assert.Equal(t, "/api/v1/container", req.uri)
 
 		assert.Equal(t, testHostName, req.headers.Get(headers.HostHeader))
-		eps, err := GetAPIEndpoints()
+		eps, err := GetAPIEndpoints(cfg)
 		assert.NoError(t, err)
 		assert.Equal(t, eps[0].APIKey, req.headers.Get("DD-Api-Key"))
 		assert.Equal(t, "1", req.headers.Get(headers.ContainerCountHeader))
@@ -156,13 +158,14 @@ func TestSendProcMessage(t *testing.T) {
 		data: [][]process.MessageBody{{m}},
 	}
 
-	runCollectorTest(t, check, &endpointConfig{}, ddconfig.Mock(t), func(c *CheckRunner, ep *mockEndpoint) {
+	cfg := ddconfig.Mock(t)
+	runCollectorTest(t, check, &endpointConfig{}, cfg, func(c *CheckRunner, ep *mockEndpoint) {
 		req := <-ep.Requests
 
 		assert.Equal(t, "/api/v1/collector", req.uri)
 
 		assert.Equal(t, testHostName, req.headers.Get(headers.HostHeader))
-		eps, err := GetAPIEndpoints()
+		eps, err := GetAPIEndpoints(cfg)
 		assert.NoError(t, err)
 		assert.Equal(t, eps[0].APIKey, req.headers.Get("DD-Api-Key"))
 		assert.Equal(t, "1", req.headers.Get(headers.ContainerCountHeader))
@@ -196,13 +199,14 @@ func TestSendProcessDiscoveryMessage(t *testing.T) {
 		data: [][]process.MessageBody{{m}},
 	}
 
-	runCollectorTest(t, check, &endpointConfig{}, ddconfig.Mock(t), func(c *CheckRunner, ep *mockEndpoint) {
+	cfg := ddconfig.Mock(t)
+	runCollectorTest(t, check, &endpointConfig{}, cfg, func(c *CheckRunner, ep *mockEndpoint) {
 		req := <-ep.Requests
 
 		assert.Equal(t, "/api/v1/discovery", req.uri)
 
 		assert.Equal(t, testHostName, req.headers.Get(headers.HostHeader))
-		eps, err := GetAPIEndpoints()
+		eps, err := GetAPIEndpoints(cfg)
 		assert.NoError(t, err)
 		assert.Equal(t, eps[0].APIKey, req.headers.Get("DD-Api-Key"))
 		assert.Equal(t, "0", req.headers.Get(headers.ContainerCountHeader))
@@ -245,13 +249,14 @@ func TestSendProcessEventMessage(t *testing.T) {
 		data: [][]process.MessageBody{{m}},
 	}
 
-	runCollectorTest(t, check, &endpointConfig{}, ddconfig.Mock(t), func(c *CheckRunner, ep *mockEndpoint) {
+	cfg := ddconfig.Mock(t)
+	runCollectorTest(t, check, &endpointConfig{}, cfg, func(c *CheckRunner, ep *mockEndpoint) {
 		req := <-ep.Requests
 
 		assert.Equal(t, "/api/v2/proclcycle", req.uri)
 
 		assert.Equal(t, testHostName, req.headers.Get(headers.HostHeader))
-		eps, err := getEventsAPIEndpoints()
+		eps, err := getEventsAPIEndpoints(cfg)
 		assert.NoError(t, err)
 		assert.Equal(t, eps[0].APIKey, req.headers.Get("DD-Api-Key"))
 		assert.Equal(t, "0", req.headers.Get(headers.ContainerCountHeader))
@@ -289,7 +294,8 @@ func TestSendProcMessageWithRetry(t *testing.T) {
 		data: [][]process.MessageBody{{m}},
 	}
 
-	runCollectorTest(t, check, &endpointConfig{ErrorCount: 1}, ddconfig.Mock(t), func(c *CheckRunner, ep *mockEndpoint) {
+	cfg := ddconfig.Mock(t)
+	runCollectorTest(t, check, &endpointConfig{ErrorCount: 1}, cfg, func(c *CheckRunner, ep *mockEndpoint) {
 		requests := []request{
 			<-ep.Requests,
 			<-ep.Requests,
@@ -298,7 +304,7 @@ func TestSendProcMessageWithRetry(t *testing.T) {
 		timestamps := make(map[string]struct{})
 		for _, req := range requests {
 			assert.Equal(t, testHostName, req.headers.Get(headers.HostHeader))
-			eps, err := GetAPIEndpoints()
+			eps, err := GetAPIEndpoints(cfg)
 			assert.NoError(t, err)
 			assert.Equal(t, eps[0].APIKey, req.headers.Get("DD-Api-Key"))
 			assert.Equal(t, "1", req.headers.Get(headers.ContainerCountHeader))

--- a/pkg/process/runner/collector_api_test.go
+++ b/pkg/process/runner/collector_api_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/DataDog/agent-payload/v5/process"
+
 	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/process/checks"
 	apicfg "github.com/DataDog/datadog-agent/pkg/process/util/api/config"
@@ -561,11 +562,11 @@ func runCollectorTestWithAPIKeys(t *testing.T, check checks.Check, epConfig *end
 	hostInfo := &checks.HostInfo{
 		HostName: testHostName,
 	}
-	c, err := NewRunnerWithChecks([]checks.Check{check}, true, nil)
+	c, err := NewRunnerWithChecks(ddconfig.Datadog, []checks.Check{check}, true, nil)
 	check.Init(nil, hostInfo)
 	assert.NoError(t, err)
 
-	c.Submitter, err = NewSubmitter(hostInfo.HostName)
+	c.Submitter, err = NewSubmitter(ddconfig.Datadog, hostInfo.HostName)
 	require.NoError(t, err)
 
 	err = c.Submitter.Start()

--- a/pkg/process/runner/collector_api_test.go
+++ b/pkg/process/runner/collector_api_test.go
@@ -562,11 +562,11 @@ func runCollectorTestWithAPIKeys(t *testing.T, check checks.Check, epConfig *end
 	hostInfo := &checks.HostInfo{
 		HostName: testHostName,
 	}
-	c, err := NewRunnerWithChecks(ddconfig.Datadog, []checks.Check{check}, true, nil)
+	c, err := NewRunnerWithChecks(mockConfig, []checks.Check{check}, true, nil)
 	check.Init(nil, hostInfo)
 	assert.NoError(t, err)
 
-	c.Submitter, err = NewSubmitter(ddconfig.Datadog, hostInfo.HostName)
+	c.Submitter, err = NewSubmitter(mockConfig, hostInfo.HostName)
 	require.NoError(t, err)
 
 	err = c.Submitter.Start()

--- a/pkg/process/runner/endpoints.go
+++ b/pkg/process/runner/endpoints.go
@@ -13,27 +13,27 @@ import (
 	apicfg "github.com/DataDog/datadog-agent/pkg/process/util/api/config"
 )
 
-func GetAPIEndpoints() (eps []apicfg.Endpoint, err error) {
-	return getAPIEndpointsWithKeys("https://process.", "process_config.process_dd_url", "process_config.additional_endpoints")
+func GetAPIEndpoints(config ddconfig.ConfigReader) (eps []apicfg.Endpoint, err error) {
+	return getAPIEndpointsWithKeys(config, "https://process.", "process_config.process_dd_url", "process_config.additional_endpoints")
 }
 
-func getEventsAPIEndpoints() (eps []apicfg.Endpoint, err error) {
-	return getAPIEndpointsWithKeys("https://process-events.", "process_config.events_dd_url", "process_config.events_additional_endpoints")
+func getEventsAPIEndpoints(config ddconfig.ConfigReader) (eps []apicfg.Endpoint, err error) {
+	return getAPIEndpointsWithKeys(config, "https://process-events.", "process_config.events_dd_url", "process_config.events_additional_endpoints")
 }
 
-func getAPIEndpointsWithKeys(prefix, defaultEpKey, additionalEpsKey string) (eps []apicfg.Endpoint, err error) {
+func getAPIEndpointsWithKeys(config ddconfig.ConfigReader, prefix, defaultEpKey, additionalEpsKey string) (eps []apicfg.Endpoint, err error) {
 	// Setup main endpoint
 	mainEndpointURL, err := url.Parse(ddconfig.GetMainEndpoint(prefix, defaultEpKey))
 	if err != nil {
 		return nil, fmt.Errorf("error parsing %s: %s", defaultEpKey, err)
 	}
 	eps = append(eps, apicfg.Endpoint{
-		APIKey:   ddconfig.SanitizeAPIKey(ddconfig.Datadog.GetString("api_key")),
+		APIKey:   ddconfig.SanitizeAPIKey(config.GetString("api_key")),
 		Endpoint: mainEndpointURL,
 	})
 
 	// Optional additional pairs of endpoint_url => []apiKeys to submit to other locations.
-	for endpointURL, apiKeys := range ddconfig.Datadog.GetStringMapStringSlice(additionalEpsKey) {
+	for endpointURL, apiKeys := range config.GetStringMapStringSlice(additionalEpsKey) {
 		u, err := url.Parse(endpointURL)
 		if err != nil {
 			return nil, fmt.Errorf("invalid %s url '%s': %s", additionalEpsKey, endpointURL, err)

--- a/pkg/process/runner/endpoints_test.go
+++ b/pkg/process/runner/endpoints_test.go
@@ -9,9 +9,10 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/DataDog/datadog-agent/pkg/config"
 	apicfg "github.com/DataDog/datadog-agent/pkg/process/util/api/config"
-	"github.com/stretchr/testify/assert"
 )
 
 func mkurl(rawurl string) *url.URL {
@@ -92,7 +93,7 @@ func TestGetAPIEndpoints(t *testing.T) {
 				cfg.Set("process_config.additional_endpoints", tc.additionalEndpoints)
 			}
 
-			if eps, err := GetAPIEndpoints(); tc.error {
+			if eps, err := GetAPIEndpoints(cfg); tc.error {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
@@ -149,13 +150,13 @@ func TestGetAPIEndpointsSite(t *testing.T) {
 				cfg.Set("process_config.events_dd_url", tc.eventsDDURL)
 			}
 
-			eps, err := GetAPIEndpoints()
+			eps, err := GetAPIEndpoints(cfg)
 			assert.NoError(t, err)
 
 			mainEndpoint := eps[0]
 			assert.Equal(t, tc.expectedHostname, mainEndpoint.Endpoint.Hostname())
 
-			eventsEps, err := getEventsAPIEndpoints()
+			eventsEps, err := getEventsAPIEndpoints(cfg)
 			assert.NoError(t, err)
 
 			mainEventEndpoint := eventsEps[0]
@@ -297,11 +298,11 @@ func TestGetConcurrentAPIEndpoints(t *testing.T) {
 				cfg.Set("process_config.events_additional_endpoints", tc.additionalEventsEndpoints)
 			}
 
-			eps, err := GetAPIEndpoints()
+			eps, err := GetAPIEndpoints(cfg)
 			assert.NoError(t, err)
 			assert.ElementsMatch(t, tc.expectedEndpoints, eps)
 
-			eventsEps, err := getEventsAPIEndpoints()
+			eventsEps, err := getEventsAPIEndpoints(cfg)
 			assert.NoError(t, err)
 			assert.ElementsMatch(t, tc.expectedEventsEndpoints, eventsEps)
 		})

--- a/pkg/process/runner/runner.go
+++ b/pkg/process/runner/runner.go
@@ -109,7 +109,7 @@ func NewRunner(config ddconfig.ConfigReader, sysCfg *sysconfig.Config, hostInfo 
 		}
 	}
 
-	return NewRunnerWithChecks(ddconfig.Datadog, enabledChecks, runRealTime, rtNotifierChan)
+	return NewRunnerWithChecks(config, enabledChecks, runRealTime, rtNotifierChan)
 }
 
 // NewRunnerWithChecks creates a new CheckRunner

--- a/pkg/process/runner/runner.go
+++ b/pkg/process/runner/runner.go
@@ -316,8 +316,8 @@ func (l *CheckRunner) runnerForCheck(c checks.Check) (func(), error) {
 	}
 
 	rtName := checks.RTName(c.Name())
-	interval := checks.GetInterval(c.Name())
-	rtInterval := checks.GetInterval(rtName)
+	interval := checks.GetInterval(l.config, c.Name())
+	rtInterval := checks.GetInterval(l.config, rtName)
 
 	if interval < rtInterval || interval%rtInterval != 0 {
 		// Check interval must be greater or equal to realtime check interval and the intervals must be divisible
@@ -359,7 +359,7 @@ func (l *CheckRunner) basicRunner(c checks.Check) func() {
 			l.runCheck(c)
 		}
 
-		ticker := time.NewTicker(checks.GetInterval(c.Name()))
+		ticker := time.NewTicker(checks.GetInterval(l.config, c.Name()))
 		for {
 			select {
 			case <-ticker.C:

--- a/pkg/process/runner/runner_test.go
+++ b/pkg/process/runner/runner_test.go
@@ -23,8 +23,10 @@ import (
 )
 
 func TestUpdateRTStatus(t *testing.T) {
+	cfg := ddconfig.Mock(t)
+
 	assert := assert.New(t)
-	c, err := NewRunner(nil, &checks.HostInfo{}, []checks.Check{checks.NewProcessCheck()}, nil)
+	c, err := NewRunner(cfg, nil, &checks.HostInfo{}, []checks.Check{checks.NewProcessCheck(cfg)}, nil)
 	assert.NoError(err)
 	// XXX: Give the collector a big channel so it never blocks.
 	c.rtIntervalCh = make(chan time.Duration, 1000)
@@ -59,7 +61,7 @@ func TestUpdateRTStatus(t *testing.T) {
 
 func TestUpdateRTInterval(t *testing.T) {
 	assert := assert.New(t)
-	c, err := NewRunner(nil, &checks.HostInfo{}, []checks.Check{checks.NewProcessCheck()}, nil)
+	c, err := NewRunner(ddconfig.Datadog, nil, &checks.HostInfo{}, []checks.Check{checks.NewProcessCheck()}, nil)
 	assert.NoError(err)
 	// XXX: Give the collector a big channel so it never blocks.
 	c.rtIntervalCh = make(chan time.Duration, 1000)
@@ -127,7 +129,7 @@ func TestDisableRealTimeProcessCheck(t *testing.T) {
 			assert := assert.New(t)
 			expectedChecks := []checks.Check{checks.NewProcessCheck()}
 
-			c, err := NewRunner(nil, &checks.HostInfo{}, expectedChecks, nil)
+			c, err := NewRunner(ddconfig.Datadog, nil, &checks.HostInfo{}, expectedChecks, nil)
 			assert.NoError(err)
 			assert.Equal(!tc.disableRealtime, c.runRealTime)
 			assert.EqualValues(expectedChecks, c.enabledChecks)
@@ -159,7 +161,7 @@ func TestIgnoreResponseBody(t *testing.T) {
 func TestCollectorRunCheckWithRealTime(t *testing.T) {
 	check := checkmocks.NewCheck(t)
 
-	c, err := NewRunner(nil, &checks.HostInfo{}, []checks.Check{}, nil)
+	c, err := NewRunner(ddconfig.Datadog, nil, &checks.HostInfo{}, []checks.Check{}, nil)
 	assert.NoError(t, err)
 	submitter := processmocks.NewSubmitter(t)
 	c.Submitter = submitter
@@ -202,7 +204,7 @@ func TestCollectorRunCheck(t *testing.T) {
 
 	hostInfo := &checks.HostInfo{HostName: testHostName}
 
-	c, err := NewRunner(nil, hostInfo, []checks.Check{}, nil)
+	c, err := NewRunner(ddconfig.Datadog, nil, hostInfo, []checks.Check{}, nil)
 	require.NoError(t, err)
 	submitter := processmocks.NewSubmitter(t)
 	require.NoError(t, err)

--- a/pkg/process/runner/runner_test.go
+++ b/pkg/process/runner/runner_test.go
@@ -60,8 +60,9 @@ func TestUpdateRTStatus(t *testing.T) {
 }
 
 func TestUpdateRTInterval(t *testing.T) {
+	cfg := ddconfig.Mock(t)
 	assert := assert.New(t)
-	c, err := NewRunner(ddconfig.Mock(t), nil, &checks.HostInfo{}, []checks.Check{checks.NewProcessCheck()}, nil)
+	c, err := NewRunner(ddconfig.Mock(t), nil, &checks.HostInfo{}, []checks.Check{checks.NewProcessCheck(cfg)}, nil)
 	assert.NoError(err)
 	// XXX: Give the collector a big channel so it never blocks.
 	c.rtIntervalCh = make(chan time.Duration, 1000)
@@ -127,7 +128,7 @@ func TestDisableRealTimeProcessCheck(t *testing.T) {
 			mockConfig.Set("process_config.disable_realtime_checks", tc.disableRealtime)
 
 			assert := assert.New(t)
-			expectedChecks := []checks.Check{checks.NewProcessCheck()}
+			expectedChecks := []checks.Check{checks.NewProcessCheck(mockConfig)}
 
 			c, err := NewRunner(mockConfig, nil, &checks.HostInfo{}, expectedChecks, nil)
 			assert.NoError(err)

--- a/pkg/process/runner/runner_test.go
+++ b/pkg/process/runner/runner_test.go
@@ -61,7 +61,7 @@ func TestUpdateRTStatus(t *testing.T) {
 
 func TestUpdateRTInterval(t *testing.T) {
 	assert := assert.New(t)
-	c, err := NewRunner(ddconfig.Datadog, nil, &checks.HostInfo{}, []checks.Check{checks.NewProcessCheck()}, nil)
+	c, err := NewRunner(ddconfig.Mock(t), nil, &checks.HostInfo{}, []checks.Check{checks.NewProcessCheck()}, nil)
 	assert.NoError(err)
 	// XXX: Give the collector a big channel so it never blocks.
 	c.rtIntervalCh = make(chan time.Duration, 1000)
@@ -129,7 +129,7 @@ func TestDisableRealTimeProcessCheck(t *testing.T) {
 			assert := assert.New(t)
 			expectedChecks := []checks.Check{checks.NewProcessCheck()}
 
-			c, err := NewRunner(ddconfig.Datadog, nil, &checks.HostInfo{}, expectedChecks, nil)
+			c, err := NewRunner(mockConfig, nil, &checks.HostInfo{}, expectedChecks, nil)
 			assert.NoError(err)
 			assert.Equal(!tc.disableRealtime, c.runRealTime)
 			assert.EqualValues(expectedChecks, c.enabledChecks)
@@ -161,7 +161,7 @@ func TestIgnoreResponseBody(t *testing.T) {
 func TestCollectorRunCheckWithRealTime(t *testing.T) {
 	check := checkmocks.NewCheck(t)
 
-	c, err := NewRunner(ddconfig.Datadog, nil, &checks.HostInfo{}, []checks.Check{}, nil)
+	c, err := NewRunner(ddconfig.Mock(t), nil, &checks.HostInfo{}, []checks.Check{}, nil)
 	assert.NoError(t, err)
 	submitter := processmocks.NewSubmitter(t)
 	c.Submitter = submitter
@@ -204,7 +204,7 @@ func TestCollectorRunCheck(t *testing.T) {
 
 	hostInfo := &checks.HostInfo{HostName: testHostName}
 
-	c, err := NewRunner(ddconfig.Datadog, nil, hostInfo, []checks.Check{}, nil)
+	c, err := NewRunner(ddconfig.Mock(t), nil, hostInfo, []checks.Check{}, nil)
 	require.NoError(t, err)
 	submitter := processmocks.NewSubmitter(t)
 	require.NoError(t, err)

--- a/pkg/process/runner/submitter.go
+++ b/pkg/process/runner/submitter.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	model "github.com/DataDog/agent-payload/v5/process"
+
 	"github.com/DataDog/datadog-agent/comp/process/types"
 	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/config/resolver"
@@ -74,14 +75,14 @@ type CheckSubmitter struct {
 	rtNotifierChan chan types.RTResponse
 }
 
-func NewSubmitter(hostname string) (*CheckSubmitter, error) {
-	queueBytes := ddconfig.Datadog.GetInt("process_config.process_queue_bytes")
+func NewSubmitter(config ddconfig.ConfigReader, hostname string) (*CheckSubmitter, error) {
+	queueBytes := config.GetInt("process_config.process_queue_bytes")
 	if queueBytes <= 0 {
 		log.Warnf("Invalid queue bytes size: %d. Using default value: %d", queueBytes, ddconfig.DefaultProcessQueueBytes)
 		queueBytes = ddconfig.DefaultProcessQueueBytes
 	}
 
-	queueSize := ddconfig.Datadog.GetInt("process_config.queue_size")
+	queueSize := config.GetInt("process_config.queue_size")
 	if queueSize <= 0 {
 		log.Warnf("Invalid check queue size: %d. Using default value: %d", queueSize, ddconfig.DefaultProcessQueueSize)
 		queueSize = ddconfig.DefaultProcessQueueSize
@@ -89,7 +90,7 @@ func NewSubmitter(hostname string) (*CheckSubmitter, error) {
 	processResults := api.NewWeightedQueue(queueSize, int64(queueBytes))
 	log.Debugf("Creating process check queue with max_size=%d and max_weight=%d", processResults.MaxSize(), processResults.MaxWeight())
 
-	rtQueueSize := ddconfig.Datadog.GetInt("process_config.rt_queue_size")
+	rtQueueSize := config.GetInt("process_config.rt_queue_size")
 	if rtQueueSize <= 0 {
 		log.Warnf("Invalid rt check queue size: %d. Using default value: %d", rtQueueSize, ddconfig.DefaultProcessRTQueueSize)
 		rtQueueSize = ddconfig.DefaultProcessRTQueueSize
@@ -111,7 +112,7 @@ func NewSubmitter(hostname string) (*CheckSubmitter, error) {
 	eventResults := api.NewWeightedQueue(queueSize, int64(queueBytes))
 	log.Debugf("Creating event check queue with max_size=%d and max_weight=%d", eventResults.MaxSize(), eventResults.MaxWeight())
 
-	dropCheckPayloads := ddconfig.Datadog.GetStringSlice("process_config.drop_check_payloads")
+	dropCheckPayloads := config.GetStringSlice("process_config.drop_check_payloads")
 	if len(dropCheckPayloads) > 0 {
 		log.Debugf("Dropping payloads from checks: %v", dropCheckPayloads)
 	}

--- a/pkg/process/runner/submitter.go
+++ b/pkg/process/runner/submitter.go
@@ -75,14 +75,14 @@ type CheckSubmitter struct {
 	rtNotifierChan chan types.RTResponse
 }
 
-func NewSubmitter(config ddconfig.ConfigReader, hostname string) (*CheckSubmitter, error) {
-	queueBytes := config.GetInt("process_config.process_queue_bytes")
+func NewSubmitter(cfg ddconfig.ConfigReader, hostname string) (*CheckSubmitter, error) {
+	queueBytes := cfg.GetInt("process_config.process_queue_bytes")
 	if queueBytes <= 0 {
 		log.Warnf("Invalid queue bytes size: %d. Using default value: %d", queueBytes, ddconfig.DefaultProcessQueueBytes)
 		queueBytes = ddconfig.DefaultProcessQueueBytes
 	}
 
-	queueSize := config.GetInt("process_config.queue_size")
+	queueSize := cfg.GetInt("process_config.queue_size")
 	if queueSize <= 0 {
 		log.Warnf("Invalid check queue size: %d. Using default value: %d", queueSize, ddconfig.DefaultProcessQueueSize)
 		queueSize = ddconfig.DefaultProcessQueueSize
@@ -90,7 +90,7 @@ func NewSubmitter(config ddconfig.ConfigReader, hostname string) (*CheckSubmitte
 	processResults := api.NewWeightedQueue(queueSize, int64(queueBytes))
 	log.Debugf("Creating process check queue with max_size=%d and max_weight=%d", processResults.MaxSize(), processResults.MaxWeight())
 
-	rtQueueSize := config.GetInt("process_config.rt_queue_size")
+	rtQueueSize := cfg.GetInt("process_config.rt_queue_size")
 	if rtQueueSize <= 0 {
 		log.Warnf("Invalid rt check queue size: %d. Using default value: %d", rtQueueSize, ddconfig.DefaultProcessRTQueueSize)
 		rtQueueSize = ddconfig.DefaultProcessRTQueueSize
@@ -112,14 +112,14 @@ func NewSubmitter(config ddconfig.ConfigReader, hostname string) (*CheckSubmitte
 	eventResults := api.NewWeightedQueue(queueSize, int64(queueBytes))
 	log.Debugf("Creating event check queue with max_size=%d and max_weight=%d", eventResults.MaxSize(), eventResults.MaxWeight())
 
-	dropCheckPayloads := config.GetStringSlice("process_config.drop_check_payloads")
+	dropCheckPayloads := cfg.GetStringSlice("process_config.drop_check_payloads")
 	if len(dropCheckPayloads) > 0 {
 		log.Debugf("Dropping payloads from checks: %v", dropCheckPayloads)
 	}
 	status.UpdateDropCheckPayloads(dropCheckPayloads)
 
 	// Forwarder initialization
-	processAPIEndpoints, err := GetAPIEndpoints()
+	processAPIEndpoints, err := GetAPIEndpoints(cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -139,7 +139,7 @@ func NewSubmitter(config ddconfig.ConfigReader, hostname string) (*CheckSubmitte
 	podForwarderOpts.RetryQueuePayloadsTotalMaxSize = queueBytes // Allow more in-flight requests than the default
 	podForwarder := forwarder.NewDefaultForwarder(podForwarderOpts)
 
-	processEventsAPIEndpoints, err := getEventsAPIEndpoints()
+	processEventsAPIEndpoints, err := getEventsAPIEndpoints(cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/process/runner/submitter_test.go
+++ b/pkg/process/runner/submitter_test.go
@@ -282,7 +282,7 @@ func TestCollectorMessagesToCheckResult(t *testing.T) {
 }
 
 func Test_getRequestID(t *testing.T) {
-	s, err := NewSubmitter(ddconfig.Datadog, testHostName)
+	s, err := NewSubmitter(ddconfig.Mock(t), testHostName)
 	assert.NoError(t, err)
 
 	fixedDate1 := time.Date(2022, 9, 1, 0, 0, 1, 0, time.Local)

--- a/pkg/process/runner/submitter_test.go
+++ b/pkg/process/runner/submitter_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	model "github.com/DataDog/agent-payload/v5/process"
+
 	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/process/util/api/headers"
 	"github.com/DataDog/datadog-agent/pkg/version"
@@ -58,7 +59,7 @@ func TestNewCollectorQueueSize(t *testing.T) {
 				mockConfig.Set("process_config.queue_size", tc.queueSize)
 			}
 
-			c, err := NewSubmitter(testHostName)
+			c, err := NewSubmitter(ddconfig.Datadog, testHostName)
 			assert.NoError(t, err)
 			assert.Equal(t, tc.expectedQueueSize, c.processResults.MaxSize())
 			assert.Equal(t, tc.expectedQueueSize, c.podResults.MaxSize())
@@ -106,7 +107,7 @@ func TestNewCollectorRTQueueSize(t *testing.T) {
 				mockConfig.Set("process_config.rt_queue_size", tc.queueSize)
 			}
 
-			c, err := NewSubmitter(testHostName)
+			c, err := NewSubmitter(ddconfig.Datadog, testHostName)
 			assert.NoError(t, err)
 			assert.Equal(t, tc.expectedQueueSize, c.rtProcessResults.MaxSize())
 		})
@@ -153,7 +154,7 @@ func TestNewCollectorProcessQueueBytes(t *testing.T) {
 				mockConfig.Set("process_config.process_queue_bytes", tc.queueBytes)
 			}
 
-			s, err := NewSubmitter(testHostName)
+			s, err := NewSubmitter(ddconfig.Datadog, testHostName)
 			assert.NoError(t, err)
 			assert.Equal(t, int64(tc.expectedQueueSize), s.processResults.MaxWeight())
 			assert.Equal(t, int64(tc.expectedQueueSize), s.rtProcessResults.MaxWeight())
@@ -163,7 +164,7 @@ func TestNewCollectorProcessQueueBytes(t *testing.T) {
 }
 
 func TestCollectorMessagesToCheckResult(t *testing.T) {
-	submitter, err := NewSubmitter(testHostName)
+	submitter, err := NewSubmitter(ddconfig.Datadog, testHostName)
 	assert.NoError(t, err)
 
 	now := time.Now()
@@ -281,7 +282,7 @@ func TestCollectorMessagesToCheckResult(t *testing.T) {
 }
 
 func Test_getRequestID(t *testing.T) {
-	s, err := NewSubmitter(testHostName)
+	s, err := NewSubmitter(ddconfig.Datadog, testHostName)
 	assert.NoError(t, err)
 
 	fixedDate1 := time.Date(2022, 9, 1, 0, 0, 1, 0, time.Local)

--- a/pkg/process/runner/submitter_test.go
+++ b/pkg/process/runner/submitter_test.go
@@ -59,7 +59,7 @@ func TestNewCollectorQueueSize(t *testing.T) {
 				mockConfig.Set("process_config.queue_size", tc.queueSize)
 			}
 
-			c, err := NewSubmitter(ddconfig.Datadog, testHostName)
+			c, err := NewSubmitter(mockConfig, testHostName)
 			assert.NoError(t, err)
 			assert.Equal(t, tc.expectedQueueSize, c.processResults.MaxSize())
 			assert.Equal(t, tc.expectedQueueSize, c.podResults.MaxSize())
@@ -107,7 +107,7 @@ func TestNewCollectorRTQueueSize(t *testing.T) {
 				mockConfig.Set("process_config.rt_queue_size", tc.queueSize)
 			}
 
-			c, err := NewSubmitter(ddconfig.Datadog, testHostName)
+			c, err := NewSubmitter(mockConfig, testHostName)
 			assert.NoError(t, err)
 			assert.Equal(t, tc.expectedQueueSize, c.rtProcessResults.MaxSize())
 		})
@@ -154,7 +154,7 @@ func TestNewCollectorProcessQueueBytes(t *testing.T) {
 				mockConfig.Set("process_config.process_queue_bytes", tc.queueBytes)
 			}
 
-			s, err := NewSubmitter(ddconfig.Datadog, testHostName)
+			s, err := NewSubmitter(mockConfig, testHostName)
 			assert.NoError(t, err)
 			assert.Equal(t, int64(tc.expectedQueueSize), s.processResults.MaxWeight())
 			assert.Equal(t, int64(tc.expectedQueueSize), s.rtProcessResults.MaxWeight())
@@ -164,7 +164,7 @@ func TestNewCollectorProcessQueueBytes(t *testing.T) {
 }
 
 func TestCollectorMessagesToCheckResult(t *testing.T) {
-	submitter, err := NewSubmitter(ddconfig.Datadog, testHostName)
+	submitter, err := NewSubmitter(ddconfig.Mock(t), testHostName)
 	assert.NoError(t, err)
 
 	now := time.Now()

--- a/pkg/process/status/expvars.go
+++ b/pkg/process/status/expvars.go
@@ -16,10 +16,6 @@ import (
 	"sync"
 	"time"
 
-	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
-	apicfg "github.com/DataDog/datadog-agent/pkg/process/util/api/config"
-	"github.com/DataDog/datadog-agent/pkg/telemetry"
-
 	"go.uber.org/atomic"
 
 	model "github.com/DataDog/agent-payload/v5/process"

--- a/pkg/process/status/expvars.go
+++ b/pkg/process/status/expvars.go
@@ -20,7 +20,10 @@ import (
 
 	model "github.com/DataDog/agent-payload/v5/process"
 
+	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
+	apicfg "github.com/DataDog/datadog-agent/pkg/process/util/api/config"
+	"github.com/DataDog/datadog-agent/pkg/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/version"
 )
 

--- a/pkg/process/util/status.go
+++ b/pkg/process/util/status.go
@@ -121,7 +121,7 @@ func OverrideTime(t time.Time) StatusOption {
 	}
 }
 
-func getCoreStatus() (s CoreStatus) {
+func getCoreStatus(coreConfig ddconfig.ConfigReader) (s CoreStatus) {
 	hostnameData, err := hostname.GetWithProvider(context.Background())
 	var metadata *host.Payload
 	if err != nil {
@@ -136,7 +136,7 @@ func getCoreStatus() (s CoreStatus) {
 		GoVersion:    runtime.Version(),
 		Arch:         runtime.GOARCH,
 		Config: ConfigStatus{
-			LogLevel: ddconfig.Datadog.GetString("log_level"),
+			LogLevel: coreConfig.GetString("log_level"),
 		},
 		Metadata: *metadata,
 	}
@@ -154,8 +154,8 @@ func getExpvars(expVarURL string) (s ProcessExpvars, err error) {
 }
 
 // GetStatus returns a Status object with runtime information about process-agent
-func GetStatus(expVarURL string) (*Status, error) {
-	coreStatus := getCoreStatus()
+func GetStatus(coreConfig ddconfig.ConfigReader, expVarURL string) (*Status, error) {
+	coreStatus := getCoreStatus(coreConfig)
 	processExpVars, err := getExpvars(expVarURL)
 	if err != nil {
 		return nil, err

--- a/pkg/process/util/status_test.go
+++ b/pkg/process/util/status_test.go
@@ -68,7 +68,7 @@ func TestGetStatus(t *testing.T) {
 
 	// Feature detection needs to run before host methods are called. During runtime, feature detection happens
 	// when the datadog.yaml file is loaded
-	ddconfig.Mock(t)
+	cfg := ddconfig.Mock(t)
 
 	hostnameData, err := hostname.GetWithProvider(context.Background())
 	var metadata *host.Payload
@@ -85,7 +85,7 @@ func TestGetStatus(t *testing.T) {
 			GoVersion:    runtime.Version(),
 			Arch:         runtime.GOARCH,
 			Config: ConfigStatus{
-				LogLevel: ddconfig.Datadog.GetString("log_level"),
+				LogLevel: cfg.GetString("log_level"),
 			},
 			Metadata: *metadata,
 		},

--- a/pkg/process/util/status_test.go
+++ b/pkg/process/util/status_test.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2022-present Datadog, Inc.
 
+//go:build test
+
 package util
 
 import (
@@ -69,6 +71,8 @@ func TestGetStatus(t *testing.T) {
 	// Feature detection needs to run before host methods are called. During runtime, feature detection happens
 	// when the datadog.yaml file is loaded
 	cfg := ddconfig.Mock(t)
+	ddconfig.SetFeatures(t)
+	cfg.Set("hostname", "test") // Prevents panic since feature detection has not run
 
 	hostnameData, err := hostname.GetWithProvider(context.Background())
 	var metadata *host.Payload
@@ -95,7 +99,7 @@ func TestGetStatus(t *testing.T) {
 	expVarSrv := fakeExpVarServer(t, expectedExpVars)
 	defer expVarSrv.Close()
 
-	stats, err := GetStatus(expVarSrv.URL)
+	stats, err := GetStatus(cfg, expVarSrv.URL)
 	require.NoError(t, err)
 
 	OverrideTime(testTime)(stats)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR removes all usages of `config.Datadog` in the the `pkg/process/...` and `cmd/process-agent/...` directories. As part of the migration to components, the global `config.Datadog` will be removed, so to prepare for this, we should use the `config.Component` instead.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Migration to components in the process agent

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Since this PR changes many usages of the global `config.Datadog`, the best way to test this is to rely on unit tests. Ensure that no tests are failing. Additionally, you should try making some config changes. I don't think it's reasonable to ask the tester to test every config setting in the process agent (this should be covered by unit tests), so I would try changing just a couple random ones, and making sure those changes are reflected in the process agent.

Some things I recommend checking:
- Confirm that the process check still runs as intended
- Confirm that the API Server still runs as intended. Try changing settings such as `process_config.cmd_port` and confirming that that still works.
- Confirm that the `process_config.process_collection.enabled` and `process_config.container_collection.enabled` settings still work as expected.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
