### PR TITLE
[CWS][Innovation week] Add an action on kill to collect intel about sys and the killed prosses

### DIFF
--- a/pkg/security/module/module.go
+++ b/pkg/security/module/module.go
@@ -767,10 +767,7 @@ func InvestigateKill(pid int) error {
 	utils.CopyFile(filepath.Join("/proc", sPid, "status"), filepath.Join(invDir, "status"))
 
 	// fetch who, history, last
-	cmd = exec.Command("history")
-	if history, err := cmd.CombinedOutput(); err == nil {
-		os.WriteFile(filepath.Join(invDir, "history"), history, 0640)
-	}
+	utils.CopyFile("/root/.bash_history", filepath.Join(invDir, "history"))
 	cmd = exec.Command("who", "-a")
 	if who, err := cmd.CombinedOutput(); err == nil {
 		os.WriteFile(filepath.Join(invDir, "who"), who, 0640)

--- a/pkg/security/secl/rules/ruleset.go
+++ b/pkg/security/secl/rules/ruleset.go
@@ -163,7 +163,8 @@ type SetDefinition struct {
 
 // KillDefinition describes the 'kill' section of a rule action
 type KillDefinition struct {
-	Signal string `yaml:"signal"`
+	Signal      string `yaml:"signal"`
+	Investigate bool   `yaml:"investigate"`
 }
 
 // Rule describes a rule of a ruleset

--- a/pkg/security/utils/utils.go
+++ b/pkg/security/utils/utils.go
@@ -6,6 +6,9 @@
 package utils
 
 import (
+	"io"
+	"os"
+
 	"github.com/Masterminds/semver/v3"
 
 	"github.com/DataDog/datadog-agent/pkg/version"
@@ -27,4 +30,31 @@ func BoolTouint64(value bool) uint64 {
 		return 1
 	}
 	return 0
+}
+
+func CopyFile(src, dst string) error {
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	_, err = io.Copy(out, in)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func MoveFile(src, dst string) error {
+	err := CopyFile(src, dst)
+	if err != nil {
+		return nil
+	}
+	return os.Remove(src)
 }


### PR DESCRIPTION

### What does this PR do?

Add a new kill paremmeter to collect a bunch of intel about the sys and killed proc.

Rule ex:
```
rules:
  - id: OPEN_FOO
    expression: open.file.path == "/tmp/foo"
    actions:
      - kill:
          signal: SIGSTOP
          investigate: true
```

This will create a `/tmp/kill_investigation_pid.tgz` tarball that will contains:
* information about the process that is about to be killed:
  * its open file descriptors (`/proc/pid/fd` && `/proc/pid/fdinfo/`)
  * its stack trace
  * a coredump with memory
  * process status (`/proc/pid/status`)
* and some intel about the system:
  * the output of `history`
  * the output of `who -a`
  * and the output of `last -F`

The size of the tarball will mainly depend of the amount of process memory to be coredumped


<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
