### PR TITLE
Adds 'origin's to metrics emitted by agent

### DIFF
--- a/comp/dogstatsd/server/enrich.go
+++ b/comp/dogstatsd/server/enrich.go
@@ -197,6 +197,7 @@ func enrichMetricSample(dest []metrics.MetricSample, ddSample dogstatsdMetricSam
 					OriginFromUDS:    udsOrigin,
 					OriginFromClient: clientOrigin,
 					Cardinality:      cardinality,
+					Source:           metrics.MetricSourceDogstatsd,
 				})
 		}
 		return dest
@@ -215,6 +216,7 @@ func enrichMetricSample(dest []metrics.MetricSample, ddSample dogstatsdMetricSam
 		OriginFromUDS:    udsOrigin,
 		OriginFromClient: clientOrigin,
 		Cardinality:      cardinality,
+		Source:           metrics.MetricSourceDogstatsd,
 	})
 }
 

--- a/comp/dogstatsd/server/enrich_bench_test.go
+++ b/comp/dogstatsd/server/enrich_bench_test.go
@@ -32,7 +32,7 @@ func BenchmarkExtractTagsMetadata(b *testing.B) {
 			sb.ResetTimer()
 
 			for n := 0; n < sb.N; n++ {
-				tags, _, _, _, _ = extractTagsMetadata(baseTags, "", []byte{}, conf)
+				tags, _, _, _, _, _ = extractTagsMetadata(baseTags, "", []byte{}, conf)
 			}
 		})
 	}

--- a/comp/dogstatsd/server/enrich_test.go
+++ b/comp/dogstatsd/server/enrich_test.go
@@ -1059,13 +1059,14 @@ func TestEnrichTags(t *testing.T) {
 		conf          enrichConfig
 	}
 	tests := []struct {
-		name              string
-		args              args
-		wantedTags        []string
-		wantedHost        string
-		wantedOrigin      string
-		wantedK8sOrigin   string
-		wantedCardinality string
+		name               string
+		args               args
+		wantedTags         []string
+		wantedHost         string
+		wantedOrigin       string
+		wantedK8sOrigin    string
+		wantedCardinality  string
+		wantedMetricSource metrics.MetricSource
 	}{
 		{
 			name: "empty tags, host=foo",
@@ -1076,11 +1077,12 @@ func TestEnrichTags(t *testing.T) {
 					entityIDPrecedenceEnabled: true,
 				},
 			},
-			wantedTags:        nil,
-			wantedHost:        "foo",
-			wantedOrigin:      "",
-			wantedK8sOrigin:   "",
-			wantedCardinality: "",
+			wantedTags:         nil,
+			wantedHost:         "foo",
+			wantedOrigin:       "",
+			wantedK8sOrigin:    "",
+			wantedMetricSource: metrics.MetricSourceDogstatsd,
+			wantedCardinality:  "",
 		},
 		{
 			name: "entityId not present, host=foo, should return origin tags",
@@ -1092,11 +1094,12 @@ func TestEnrichTags(t *testing.T) {
 					entityIDPrecedenceEnabled: true,
 				},
 			},
-			wantedTags:        []string{"env:prod"},
-			wantedHost:        "foo",
-			wantedOrigin:      "originID",
-			wantedK8sOrigin:   "",
-			wantedCardinality: "",
+			wantedTags:         []string{"env:prod"},
+			wantedHost:         "foo",
+			wantedOrigin:       "originID",
+			wantedK8sOrigin:    "",
+			wantedMetricSource: metrics.MetricSourceDogstatsd,
+			wantedCardinality:  "",
 		},
 		{
 			name: "entityId not present, host=foo, empty tags list, should return origin tags",
@@ -1108,11 +1111,12 @@ func TestEnrichTags(t *testing.T) {
 					entityIDPrecedenceEnabled: true,
 				},
 			},
-			wantedTags:        nil,
-			wantedHost:        "foo",
-			wantedOrigin:      "originID",
-			wantedK8sOrigin:   "",
-			wantedCardinality: "",
+			wantedTags:         nil,
+			wantedHost:         "foo",
+			wantedOrigin:       "originID",
+			wantedK8sOrigin:    "",
+			wantedMetricSource: metrics.MetricSourceDogstatsd,
+			wantedCardinality:  "",
 		},
 		{
 			name: "entityId present, host=foo, should not return origin tags",
@@ -1124,11 +1128,12 @@ func TestEnrichTags(t *testing.T) {
 					entityIDPrecedenceEnabled: true,
 				},
 			},
-			wantedTags:        []string{"env:prod"},
-			wantedHost:        "foo",
-			wantedOrigin:      "",
-			wantedK8sOrigin:   "kubernetes_pod_uid://my-id",
-			wantedCardinality: "",
+			wantedTags:         []string{"env:prod"},
+			wantedHost:         "foo",
+			wantedOrigin:       "",
+			wantedK8sOrigin:    "kubernetes_pod_uid://my-id",
+			wantedMetricSource: metrics.MetricSourceDogstatsd,
+			wantedCardinality:  "",
 		},
 		{
 			name: "entityId=none present, host=foo, should not call the originFromUDSFunc()",
@@ -1140,11 +1145,12 @@ func TestEnrichTags(t *testing.T) {
 					entityIDPrecedenceEnabled: true,
 				},
 			},
-			wantedTags:        []string{"env:prod"},
-			wantedHost:        "foo",
-			wantedOrigin:      "",
-			wantedK8sOrigin:   "",
-			wantedCardinality: "",
+			wantedTags:         []string{"env:prod"},
+			wantedHost:         "foo",
+			wantedOrigin:       "",
+			wantedK8sOrigin:    "",
+			wantedMetricSource: metrics.MetricSourceDogstatsd,
+			wantedCardinality:  "",
 		},
 		{
 			name: "entityId=42 present entityIDPrecendenceEnabled=false, host=foo, should call the originFromUDSFunc()",
@@ -1156,11 +1162,12 @@ func TestEnrichTags(t *testing.T) {
 					entityIDPrecedenceEnabled: false,
 				},
 			},
-			wantedTags:        []string{"env:prod"},
-			wantedHost:        "foo",
-			wantedOrigin:      "originID",
-			wantedK8sOrigin:   "kubernetes_pod_uid://42",
-			wantedCardinality: "",
+			wantedTags:         []string{"env:prod"},
+			wantedHost:         "foo",
+			wantedOrigin:       "originID",
+			wantedK8sOrigin:    "kubernetes_pod_uid://42",
+			wantedMetricSource: metrics.MetricSourceDogstatsd,
+			wantedCardinality:  "",
 		},
 		{
 			name: "entityId=42 cardinality=high present entityIDPrecendenceEnabled=false, host=foo, should call the originFromUDSFunc()",
@@ -1172,11 +1179,12 @@ func TestEnrichTags(t *testing.T) {
 					entityIDPrecedenceEnabled: false,
 				},
 			},
-			wantedTags:        []string{"env:prod"},
-			wantedHost:        "foo",
-			wantedOrigin:      "originID",
-			wantedK8sOrigin:   "kubernetes_pod_uid://42",
-			wantedCardinality: "high",
+			wantedTags:         []string{"env:prod"},
+			wantedHost:         "foo",
+			wantedOrigin:       "originID",
+			wantedK8sOrigin:    "kubernetes_pod_uid://42",
+			wantedMetricSource: metrics.MetricSourceDogstatsd,
+			wantedCardinality:  "high",
 		},
 		{
 			name: "entityId=42 cardinality=orchestrator present entityIDPrecendenceEnabled=false, host=foo, should call the originFromUDSFunc()",
@@ -1188,11 +1196,12 @@ func TestEnrichTags(t *testing.T) {
 					entityIDPrecedenceEnabled: false,
 				},
 			},
-			wantedTags:        []string{"env:prod"},
-			wantedHost:        "foo",
-			wantedOrigin:      "originID",
-			wantedK8sOrigin:   "kubernetes_pod_uid://42",
-			wantedCardinality: "orchestrator",
+			wantedTags:         []string{"env:prod"},
+			wantedHost:         "foo",
+			wantedOrigin:       "originID",
+			wantedK8sOrigin:    "kubernetes_pod_uid://42",
+			wantedMetricSource: metrics.MetricSourceDogstatsd,
+			wantedCardinality:  "orchestrator",
 		},
 		{
 			name: "entityId=42 cardinality=low present entityIDPrecendenceEnabled=false, host=foo, should call the originFromUDSFunc()",
@@ -1204,11 +1213,12 @@ func TestEnrichTags(t *testing.T) {
 					entityIDPrecedenceEnabled: false,
 				},
 			},
-			wantedTags:        []string{"env:prod"},
-			wantedHost:        "foo",
-			wantedOrigin:      "originID",
-			wantedK8sOrigin:   "kubernetes_pod_uid://42",
-			wantedCardinality: "low",
+			wantedTags:         []string{"env:prod"},
+			wantedHost:         "foo",
+			wantedOrigin:       "originID",
+			wantedK8sOrigin:    "kubernetes_pod_uid://42",
+			wantedMetricSource: metrics.MetricSourceDogstatsd,
+			wantedCardinality:  "low",
 		},
 		{
 			name: "entityId=42 cardinality=unknown present entityIDPrecendenceEnabled=false, host=foo, should call the originFromUDSFunc()",
@@ -1220,11 +1230,12 @@ func TestEnrichTags(t *testing.T) {
 					entityIDPrecedenceEnabled: false,
 				},
 			},
-			wantedTags:        []string{"env:prod"},
-			wantedHost:        "foo",
-			wantedOrigin:      "originID",
-			wantedK8sOrigin:   "kubernetes_pod_uid://42",
-			wantedCardinality: "unknown",
+			wantedTags:         []string{"env:prod"},
+			wantedHost:         "foo",
+			wantedOrigin:       "originID",
+			wantedK8sOrigin:    "kubernetes_pod_uid://42",
+			wantedMetricSource: metrics.MetricSourceDogstatsd,
+			wantedCardinality:  "unknown",
 		},
 		{
 			name: "entityId=42 cardinality='' present entityIDPrecendenceEnabled=false, host=foo, should call the originFromUDSFunc()",
@@ -1236,11 +1247,12 @@ func TestEnrichTags(t *testing.T) {
 					entityIDPrecedenceEnabled: false,
 				},
 			},
-			wantedTags:        []string{"env:prod"},
-			wantedHost:        "foo",
-			wantedOrigin:      "originID",
-			wantedK8sOrigin:   "kubernetes_pod_uid://42",
-			wantedCardinality: "",
+			wantedTags:         []string{"env:prod"},
+			wantedHost:         "foo",
+			wantedOrigin:       "originID",
+			wantedK8sOrigin:    "kubernetes_pod_uid://42",
+			wantedMetricSource: metrics.MetricSourceDogstatsd,
+			wantedCardinality:  "",
 		},
 		{
 			name: "entity_id=pod-uid, originFromMsg=container-id, should consider entity_id",
@@ -1252,10 +1264,11 @@ func TestEnrichTags(t *testing.T) {
 					defaultHostname: "foo",
 				},
 			},
-			wantedTags:      []string{"env:prod"},
-			wantedHost:      "foo",
-			wantedOrigin:    "originID",
-			wantedK8sOrigin: "kubernetes_pod_uid://pod-uid",
+			wantedTags:         []string{"env:prod"},
+			wantedHost:         "foo",
+			wantedOrigin:       "originID",
+			wantedK8sOrigin:    "kubernetes_pod_uid://pod-uid",
+			wantedMetricSource: metrics.MetricSourceDogstatsd,
 		},
 		{
 			name: "no entity_id, originFromMsg=container-id, should consider originFromMsg",
@@ -1267,10 +1280,11 @@ func TestEnrichTags(t *testing.T) {
 					defaultHostname: "foo",
 				},
 			},
-			wantedTags:      []string{"env:prod"},
-			wantedHost:      "foo",
-			wantedOrigin:    "originID",
-			wantedK8sOrigin: "container_id://container-id",
+			wantedTags:         []string{"env:prod"},
+			wantedHost:         "foo",
+			wantedOrigin:       "originID",
+			wantedK8sOrigin:    "container_id://container-id",
+			wantedMetricSource: metrics.MetricSourceDogstatsd,
 		},
 
 		{
@@ -1284,15 +1298,16 @@ func TestEnrichTags(t *testing.T) {
 					originOptOutEnabled: true,
 				},
 			},
-			wantedTags:      []string{"env:prod"},
-			wantedHost:      "foo",
-			wantedOrigin:    "",
-			wantedK8sOrigin: "",
+			wantedTags:         []string{"env:prod"},
+			wantedHost:         "foo",
+			wantedOrigin:       "",
+			wantedK8sOrigin:    "",
+			wantedMetricSource: metrics.MetricSourceDogstatsd,
 		},
 		{
 			name: "opt-out, entity id present, uds origin present",
 			args: args{
-				tags:          []string{"env:prod", "dd.internal.entity_id:pod-uid", "dd.internal.card:none", "host:"},
+				tags:          []string{"env:prod", "dd.internal.entity_id:pod-uid", "dd.internal.card:none", "host:", "jmx_domain:org.apache"},
 				originFromUDS: "originID",
 				originFromMsg: []byte("none"),
 				conf: enrichConfig{
@@ -1300,20 +1315,22 @@ func TestEnrichTags(t *testing.T) {
 					originOptOutEnabled: true,
 				},
 			},
-			wantedTags:      []string{"env:prod"},
-			wantedHost:      "",
-			wantedOrigin:    "",
-			wantedK8sOrigin: "",
+			wantedTags:         []string{"env:prod"},
+			wantedHost:         "",
+			wantedOrigin:       "",
+			wantedK8sOrigin:    "",
+			wantedMetricSource: metrics.MetricSourceJmx,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tags, host, origin, k8sOrigin, cardinality := extractTagsMetadata(tt.args.tags, tt.args.originFromUDS, tt.args.originFromMsg, tt.args.conf)
+			tags, host, origin, k8sOrigin, cardinality, metricSource := extractTagsMetadata(tt.args.tags, tt.args.originFromUDS, tt.args.originFromMsg, tt.args.conf)
 			assert.Equal(t, tt.wantedTags, tags)
 			assert.Equal(t, tt.wantedHost, host)
 			assert.Equal(t, tt.wantedOrigin, origin)
 			assert.Equal(t, tt.wantedK8sOrigin, k8sOrigin)
 			assert.Equal(t, tt.wantedCardinality, cardinality)
+			assert.Equal(t, tt.wantedMetricSource, metricSource)
 		})
 
 		if !tt.args.conf.originOptOutEnabled {
@@ -1321,12 +1338,13 @@ func TestEnrichTags(t *testing.T) {
 			conf := tt.args.conf
 			conf.originOptOutEnabled = true
 			t.Run(tt.name, func(t *testing.T) {
-				tags, host, origin, k8sOrigin, cardinality := extractTagsMetadata(tt.args.tags, tt.args.originFromUDS, tt.args.originFromMsg, conf)
+				tags, host, origin, k8sOrigin, cardinality, metricSource := extractTagsMetadata(tt.args.tags, tt.args.originFromUDS, tt.args.originFromMsg, conf)
 				assert.Equal(t, tt.wantedTags, tags)
 				assert.Equal(t, tt.wantedHost, host)
 				assert.Equal(t, tt.wantedOrigin, origin)
 				assert.Equal(t, tt.wantedK8sOrigin, k8sOrigin)
 				assert.Equal(t, tt.wantedCardinality, cardinality)
+				assert.Equal(t, tt.wantedMetricSource, metricSource)
 			})
 		}
 	}

--- a/pkg/aggregator/check_sampler.go
+++ b/pkg/aggregator/check_sampler.go
@@ -142,6 +142,7 @@ func (cs *CheckSampler) commitSeries(timestamp float64) {
 		serie.Tags = context.Tags()
 		serie.Host = context.Host
 		serie.NoIndex = context.noIndex
+		serie.Source = context.source
 		serie.SourceTypeName = checksSourceTypeName // this source type is required for metrics coming from the checks
 
 		cs.series = append(cs.series, serie)

--- a/pkg/aggregator/context_resolver.go
+++ b/pkg/aggregator/context_resolver.go
@@ -22,6 +22,7 @@ type Context struct {
 	taggerTags *tags.Entry
 	metricTags *tags.Entry
 	noIndex    bool
+	source     metrics.MetricSource
 }
 
 // Tags returns tags for the context.
@@ -74,6 +75,7 @@ func (cr *contextResolver) trackContext(metricSampleContext metrics.MetricSample
 			Host:       metricSampleContext.GetHost(),
 			mtype:      mtype,
 			noIndex:    metricSampleContext.IsNoIndex(),
+			source:     metricSampleContext.GetMetricSource(),
 		}
 		cr.countsByMtype[mtype]++
 	}

--- a/pkg/aggregator/sender.go
+++ b/pkg/aggregator/sender.go
@@ -236,8 +236,10 @@ func (s *checkSender) sendMetricSample(
 	flushFirstValue bool,
 	noIndex bool) {
 	tags = append(tags, s.checkTags...)
+	checkName := check.IDToCheckName(s.id)
+	source := metrics.CheckNameToMetricSource(checkName)
 
-	log.Trace(mType.String(), " sample: ", metric, ": ", value, " for hostname: ", hostname, " tags: ", tags)
+	log.Trace(mType.String(), " sample: ", metric, ": ", value, " for hostname: ", hostname, " tags: ", tags, " checkName: ", checkName, " source ", source.String())
 
 	metricSample := &metrics.MetricSample{
 		Name:            metric,
@@ -249,13 +251,7 @@ func (s *checkSender) sendMetricSample(
 		Timestamp:       timeNowNano(),
 		FlushFirstValue: flushFirstValue,
 		NoIndex:         noIndex,
-		Source:          metrics.CheckNameToMetricSource(check.IDToCheckName(s.id)),
-	}
-
-	var agentTelemetryCheckName check.ID
-	// The metricSource is only set for checks from `integrations-internal`, all others will be "Unknown"
-	if metricSample.Source == metrics.MetricSourceUnknown && s.id != agentTelemetryCheckName {
-		log.Tracef("Did not find MetricSource for metric %q emitted from check name: %q", metric, check.IDToCheckName(s.id))
+		Source:          source,
 	}
 
 	if hostname == "" && !s.defaultHostnameDisabled {

--- a/pkg/aggregator/sender.go
+++ b/pkg/aggregator/sender.go
@@ -227,24 +227,6 @@ func (s *checkSender) SendRawMetricSample(sample *metrics.MetricSample) {
 	s.itemsOut <- &senderMetricSample{s.id, sample, false}
 }
 
-func idToMetricSource(id check.ID) metrics.MetricSource {
-	checkName := check.IDToCheckName(id)
-	switch checkName {
-	case "active_directory":
-		return metrics.MetricSourceActiveDirectory
-	case "system", "io", "load", "cpu", "memory", "uptime":
-		return metrics.MetricSourceSystemCore
-	case "openmetrics":
-		return metrics.MetricSourceOpenMetrics
-	case "docker":
-		return metrics.MetricSourceDocker
-	case "ntp":
-		return metrics.MetricSourceNtp
-	}
-
-	return metrics.MetricSourceUnknown
-}
-
 func (s *checkSender) sendMetricSample(
 	metric string,
 	value float64,

--- a/pkg/aggregator/sender.go
+++ b/pkg/aggregator/sender.go
@@ -251,8 +251,11 @@ func (s *checkSender) sendMetricSample(
 		NoIndex:         noIndex,
 		Source:          metrics.CheckNameToMetricSource(check.IDToCheckName(s.id)),
 	}
-	if metricSample.Source == metrics.MetricSourceUnknown {
-		log.Warnf("Did not find MetricSource for metric %q emitted from check name: %q", metric, check.IDToCheckName(s.id))
+
+	var agentTelemetryCheckName check.ID
+	// The metricSource is only set for checks from `integrations-internal`, all others will be "Unknown"
+	if metricSample.Source == metrics.MetricSourceUnknown && s.id != agentTelemetryCheckName {
+		log.Tracef("Did not find MetricSource for metric %q emitted from check name: %q", metric, check.IDToCheckName(s.id))
 	}
 
 	if hostname == "" && !s.defaultHostnameDisabled {

--- a/pkg/aggregator/time_sampler.go
+++ b/pkg/aggregator/time_sampler.go
@@ -185,6 +185,7 @@ func (s *TimeSampler) dedupSerieBySerieSignature(
 			serie.Host = context.Host
 			serie.NoIndex = context.noIndex
 			serie.Interval = s.interval
+			serie.Source = context.source
 
 			serieBySignature[serieSignature] = serie
 		}

--- a/pkg/metrics/histogram_bucket.go
+++ b/pkg/metrics/histogram_bucket.go
@@ -18,6 +18,8 @@ type HistogramBucket struct {
 	Host            string
 	Timestamp       float64
 	FlushFirstValue bool
+	// TODO - Ensure this is set correctly
+	Source MetricSource
 }
 
 // Implement the MetricSampleContext interface
@@ -48,4 +50,9 @@ func (m *HistogramBucket) GetMetricType() MetricType {
 // IsNoIndex returns if the metric must not be indexed.
 func (m *HistogramBucket) IsNoIndex() bool {
 	return false
+}
+
+// GetMetricSource returns the source of this metric
+func (m *HistogramBucket) GetMetricSource() MetricSource {
+	return m.Source
 }

--- a/pkg/metrics/metric.go
+++ b/pkg/metrics/metric.go
@@ -55,25 +55,6 @@ func (a *APIMetricType) UnmarshalText(buf []byte) error {
 	return nil
 }
 
-// MetricSource represents how this metric made it into the Agent
-type MetricSource int
-
-// Enumeration of the existing API metric types
-const (
-	MetricSourceUnknown MetricSource = iota
-	MetricSourceDogstatsd
-)
-
-// String returns a string representation of APIMetricType
-func (ms MetricSource) String() string {
-	switch ms {
-	case MetricSourceDogstatsd:
-		return "dogstatsd"
-	default:
-		return "<unknown>"
-	}
-}
-
 // Metric is the interface of all metric types
 type Metric interface {
 	addSample(sample *MetricSample, timestamp float64)

--- a/pkg/metrics/metric.go
+++ b/pkg/metrics/metric.go
@@ -55,6 +55,25 @@ func (a *APIMetricType) UnmarshalText(buf []byte) error {
 	return nil
 }
 
+// MetricSource represents how this metric made it into the Agent
+type MetricSource int
+
+// Enumeration of the existing API metric types
+const (
+	MetricSourceUnknown MetricSource = iota
+	MetricSourceDogstatsd
+)
+
+// String returns a string representation of APIMetricType
+func (ms MetricSource) String() string {
+	switch ms {
+	case MetricSourceDogstatsd:
+		return "dogstatsd"
+	default:
+		return "<unknown>"
+	}
+}
+
 // Metric is the interface of all metric types
 type Metric interface {
 	addSample(sample *MetricSample, timestamp float64)

--- a/pkg/metrics/metric_sample.go
+++ b/pkg/metrics/metric_sample.go
@@ -96,6 +96,7 @@ type MetricSample struct {
 	OriginFromClient string
 	Cardinality      string
 	NoIndex          bool
+	Source           MetricSource
 }
 
 // Implement the MetricSampleContext interface

--- a/pkg/metrics/metric_sample.go
+++ b/pkg/metrics/metric_sample.go
@@ -79,6 +79,9 @@ type MetricSampleContext interface {
 
 	// IsNoIndex returns true if the metric must not be indexed.
 	IsNoIndex() bool
+
+	// GetMetricSource
+	GetMetricSource() MetricSource
 }
 
 // MetricSample represents a raw metric sample
@@ -134,4 +137,9 @@ func (m *MetricSample) Copy() *MetricSample {
 // IsNoIndex returns true if the metric must not be indexed.
 func (m *MetricSample) IsNoIndex() bool {
 	return m.NoIndex
+}
+
+// GetMetricSource returns the source of the given metric
+func (m *MetricSample) GetMetricSource() MetricSource {
+	return m.Source
 }

--- a/pkg/metrics/metricsource.go
+++ b/pkg/metrics/metricsource.go
@@ -1,0 +1,76 @@
+package metrics
+
+// MetricSource represents how this metric made it into the Agent
+type MetricSource int
+
+// Enumeration of the existing API metric types
+const (
+	MetricSourceUnknown MetricSource = iota
+	// TODO this conflates source and service
+	// and also gives no 'string' field for metric name
+	MetricSourceDogstatsd
+	MetricSourceActiveDirectory
+	MetricSourceSystemCore
+	MetricSourceActiveMqXml
+	MetricSourceDocker
+	MetricSourceOpenMetrics
+	MetricSourceNtp
+)
+
+func CheckNameToMetricSource(checkName string) MetricSource {
+	switch checkName {
+	case "active_directory":
+		return MetricSourceActiveDirectory
+	case "system", "io", "load", "cpu", "memory", "uptime", "file_handle":
+		return MetricSourceSystemCore
+	case "openmetrics":
+		return MetricSourceOpenMetrics
+	case "docker":
+		return MetricSourceDocker
+	case "ntp":
+		return MetricSourceNtp
+	}
+
+	return MetricSourceUnknown
+}
+
+// String returns a string representation of APIMetricType
+func (ms MetricSource) String() string {
+	switch ms {
+	case MetricSourceDogstatsd:
+		return "dogstatsd"
+	case MetricSourceSystemCore:
+		return "systemcore"
+	case MetricSourceOpenMetrics:
+		return "openmetrics"
+	default:
+		return "<unknown>"
+	}
+}
+
+func (ms MetricSource) OriginCategory() int32 {
+	// Constants from `origin.proto`
+	switch ms {
+	case MetricSourceDogstatsd:
+		return 10
+	default:
+		// integration
+		return 11
+	}
+}
+
+func (ms MetricSource) OriginService() int32 {
+	// Constants from `origin.proto`
+	switch ms {
+	case MetricSourceDogstatsd:
+		return 0 // no service
+	case MetricSourceActiveDirectory:
+		return 10
+	case MetricSourceActiveMqXml:
+		return 11
+	case MetricSourceSystemCore:
+		return 155
+	default:
+		return -1
+	}
+}

--- a/pkg/metrics/metricsource.go
+++ b/pkg/metrics/metricsource.go
@@ -10,11 +10,40 @@ const (
 	MetricSourceDogstatsd
 	MetricSourceJmx
 
-	MetricSourceContainer // TODO add this to protobuf
-	MetricSourceDocker    // TODO add this to protobuf
-	MetricSourceNtp       // TODO add this to protobuf
+	// Corechecks
+	// TODO add all these to protobuf
+	MetricSourceContainer
+	MetricSourceContainerd
+	MetricSourceCri
+	MetricSourceDocker
+	MetricSourceNtp
+	MetricSourceSystemd
+	MetricSourceHelm
+	MetricSourceKubernetesAPIServer
+	MetricSourceKubeStateMetrics
+	MetricSourceOrchestrator
+	MetricSourceWinProc
+	MetricSourceFileHandle
+	MetricSourceWinkmem
+	MetricSourceIoStats
+	MetricSourceUptime
+	MetricSourceSbom
+	MetricSourceMemory
+	MetricSourceTcpQueueLength
+	MetricSourceOomKill
+	MetricSourceContainerLifecycle
+	MetricSourceJetson
+	MetricSourceContainerImage
+	MetricSourceCpu
+	MetricSourceLoad
+	// The following are both core checks and python checks.
+	// I think this is OK as long as the check IDs are the same
+	// TODO - double check that the check names are the same
+	// MetricSourceNetwork // 'network'
+	// MetricSourceSnmp // 'snmp'
+	// MetricSourceDisk // 'disk'
 
-	// All python integrations
+	// Python integrations
 	MetricSourceActiveDirectory
 	MetricSourceActivemqXml
 	MetricSourceAerospike
@@ -474,6 +503,57 @@ func (ms MetricSource) String() string {
 	switch ms {
 	case MetricSourceDogstatsd:
 		return "dogstatsd"
+	// Corechecks
+	case MetricSourceContainer:
+		return "container"
+	case MetricSourceContainerd:
+		return "containerd"
+	case MetricSourceCri:
+		return "cri"
+	case MetricSourceDocker:
+		return "docker"
+	case MetricSourceNtp:
+		return "ntp"
+	case MetricSourceSystemd:
+		return "systemd"
+	case MetricSourceHelm:
+		return "helm"
+	case MetricSourceKubernetesAPIServer:
+		return "kubernetes_apiserver"
+	case MetricSourceKubeStateMetrics:
+		return "kubernetes_state_core"
+	case MetricSourceOrchestrator:
+		return "orchestrator"
+	case MetricSourceWinProc:
+		return "winproc"
+	case MetricSourceFileHandle:
+		return "file_handle"
+	case MetricSourceWinkmem:
+		return "winkmem"
+	case MetricSourceIoStats:
+		return "io"
+	case MetricSourceUptime:
+		return "uptime"
+	case MetricSourceSbom:
+		return "sbom"
+	case MetricSourceMemory:
+		return "memory"
+	case MetricSourceTcpQueueLength:
+		return "tcp_queue_length"
+	case MetricSourceOomKill:
+		return "oom_kill"
+	case MetricSourceContainerLifecycle:
+		return "container_lifecycle"
+	case MetricSourceJetson:
+		return "jetson"
+	case MetricSourceContainerImage:
+		return "container_image"
+	case MetricSourceCpu:
+		return "cpu"
+	case MetricSourceLoad:
+		return "load"
+
+	// Python checks
 	case MetricSourceActiveDirectory:
 		return "active_directory"
 	case MetricSourceActivemqXml:
@@ -1075,6 +1155,54 @@ func (ms MetricSource) OriginService() int32 {
 		return 177
 	case MetricSourceZk:
 		return 178
+	case MetricSourceContainer:
+		return -1 // TODO fill in appropriate protobuf value
+	case MetricSourceContainerd:
+		return -1 // TODO fill in appropriate protobuf value
+	case MetricSourceCri:
+		return -1 // TODO fill in appropriate protobuf value
+	case MetricSourceDocker:
+		return -1 // TODO fill in appropriate protobuf value
+	case MetricSourceNtp:
+		return -1 // TODO fill in appropriate protobuf value
+	case MetricSourceSystemd:
+		return -1 // TODO fill in appropriate protobuf value
+	case MetricSourceHelm:
+		return -1 // TODO fill in appropriate protobuf value
+	case MetricSourceKubernetesAPIServer:
+		return -1 // TODO fill in appropriate protobuf value
+	case MetricSourceKubeStateMetrics:
+		return -1 // TODO fill in appropriate protobuf value
+	case MetricSourceOrchestrator:
+		return -1 // TODO fill in appropriate protobuf value
+	case MetricSourceWinProc:
+		return -1 // TODO fill in appropriate protobuf value
+	case MetricSourceFileHandle:
+		return -1 // TODO fill in appropriate protobuf value
+	case MetricSourceWinkmem:
+		return -1 // TODO fill in appropriate protobuf value
+	case MetricSourceIoStats:
+		return -1 // TODO fill in appropriate protobuf value
+	case MetricSourceUptime:
+		return -1 // TODO fill in appropriate protobuf value
+	case MetricSourceSbom:
+		return -1 // TODO fill in appropriate protobuf value
+	case MetricSourceMemory:
+		return -1 // TODO fill in appropriate protobuf value
+	case MetricSourceTcpQueueLength:
+		return -1 // TODO fill in appropriate protobuf value
+	case MetricSourceOomKill:
+		return -1 // TODO fill in appropriate protobuf value
+	case MetricSourceContainerLifecycle:
+		return -1 // TODO fill in appropriate protobuf value
+	case MetricSourceJetson:
+		return -1 // TODO fill in appropriate protobuf value
+	case MetricSourceContainerImage:
+		return -1 // TODO fill in appropriate protobuf value
+	case MetricSourceCpu:
+		return -1 // TODO fill in appropriate protobuf value
+	case MetricSourceLoad:
+		return -1 // TODO fill in appropriate protobuf value
 	default:
 		return -1
 	}

--- a/pkg/metrics/metricsource.go
+++ b/pkg/metrics/metricsource.go
@@ -9,6 +9,7 @@ const (
 	// TODO this conflates source and service
 	// and also gives no 'string' field for metric name
 	MetricSourceDogstatsd
+	MetricSourceJmx
 	MetricSourceActiveDirectory
 	MetricSourceSystemCore
 	MetricSourceActiveMqXml
@@ -21,7 +22,7 @@ func CheckNameToMetricSource(checkName string) MetricSource {
 	switch checkName {
 	case "active_directory":
 		return MetricSourceActiveDirectory
-	case "system", "io", "load", "cpu", "memory", "uptime", "file_handle":
+	case "system", "io", "load", "cpu", "memory", "uptime", "file_handle", "disk":
 		return MetricSourceSystemCore
 	case "openmetrics":
 		return MetricSourceOpenMetrics
@@ -70,6 +71,8 @@ func (ms MetricSource) OriginService() int32 {
 		return 11
 	case MetricSourceSystemCore:
 		return 155
+	case MetricSourceJmx:
+		return 9
 	default:
 		return -1
 	}

--- a/pkg/metrics/metricsource.go
+++ b/pkg/metrics/metricsource.go
@@ -6,30 +6,464 @@ type MetricSource int
 // Enumeration of the existing API metric types
 const (
 	MetricSourceUnknown MetricSource = iota
-	// TODO this conflates source and service
-	// and also gives no 'string' field for metric name
+
 	MetricSourceDogstatsd
 	MetricSourceJmx
+
+	MetricSourceContainer // TODO add this to protobuf
+	MetricSourceDocker    // TODO add this to protobuf
+	MetricSourceNtp       // TODO add this to protobuf
+
+	// All python integrations
 	MetricSourceActiveDirectory
+	MetricSourceActivemqXml
+	MetricSourceAerospike
+	MetricSourceAirflow
+	MetricSourceAmazonMsk
+	MetricSourceAmbari
+	MetricSourceApache
+	MetricSourceArangodb
+	MetricSourceArgocd
+	MetricSourceAspdotnet
+	MetricSourceAviVantage
+	MetricSourceAzureIotEdge
+	MetricSourceBoundary
+	MetricSourceBtrfs
+	MetricSourceCacti
+	MetricSourceCalico
+	MetricSourceCassandraNodetool
+	MetricSourceCeph
+	MetricSourceCertManager
+	MetricSourceCilium
+	MetricSourceCiscoAci
+	MetricSourceCitrixHypervisor
+	MetricSourceClickhouse
+	MetricSourceCloudFoundryApi
+	MetricSourceCockroachdb
+	MetricSourceConsul
+	MetricSourceCoredns
+	MetricSourceCouch
+	MetricSourceCouchbase
+	MetricSourceCrio
+	MetricSourceDirectory
+	MetricSourceDisk
+	MetricSourceDnsCheck
+	MetricSourceDotnetclr
+	MetricSourceDruid
+	MetricSourceEcsFargate
+	MetricSourceEksFargate
+	MetricSourceElastic
+	MetricSourceEnvoy
+	MetricSourceEtcd
+	MetricSourceExchangeServer
+	MetricSourceExternalDns
+	MetricSourceFluentd
+	MetricSourceFoundationdb
+	MetricSourceGearmand
+	MetricSourceGitlabRunner
+	MetricSourceGitlab
+	MetricSourceGlusterfs
+	MetricSourceGoExpvar
+	MetricSourceGunicorn
+	MetricSourceHaproxy
+	MetricSourceHarbor
+	MetricSourceHdfsDatanode
+	MetricSourceHdfsNamenode
+	MetricSourceHttpCheck
+	MetricSourceHyperv
+	MetricSourceIbmAce
+	MetricSourceIbmDb
+	MetricSourceIbmI
+	MetricSourceIbmMq
+	MetricSourceIbmWas
+	MetricSourceIis
+	MetricSourceImpala
+	MetricSourceIstio
+	MetricSourceKafkaConsumer
+	MetricSourceKong
+	MetricSourceKubeApiserverMetrics
+	MetricSourceKubeControllerManager
+	MetricSourceKubeDns
+	MetricSourceKubeMetricsServer
+	MetricSourceKubeProxy
+	MetricSourceKubeScheduler
+	MetricSourceKubelet
+	MetricSourceKubernetesState
+	MetricSourceKyototycoon
+	MetricSourceLighttpd
+	MetricSourceLinkerd
+	MetricSourceLinuxProcExtras
+	MetricSourceMapr
+	MetricSourceMapreduce
+	MetricSourceMarathon
+	MetricSourceMarklogic
+	MetricSourceMcache
+	MetricSourceMesosMaster
+	MetricSourceMesosSlave
+	MetricSourceMongo
+	MetricSourceMysql
+	MetricSourceNagios
+	MetricSourceNetwork
+	MetricSourceNfsstat
+	MetricSourceNginxIngressController
+	MetricSourceNginx
+	MetricSourceOpenldap
+	MetricSourceOpenmetrics
+	MetricSourceOpenstackController
+	MetricSourceOpenstack
+	MetricSourceOracle
+	MetricSourcePdhCheck
+	MetricSourcePgbouncer
+	MetricSourcePhpFpm
+	MetricSourcePostfix
+	MetricSourcePostgres
+	MetricSourcePowerdnsRecursor
+	MetricSourceProcess
+	MetricSourcePrometheus
+	MetricSourceProxysql
+	MetricSourcePulsar
+	MetricSourceRabbitmq
+	MetricSourceRedisdb
+	MetricSourceRethinkdb
+	MetricSourceRiak
+	MetricSourceRiakcs
+	MetricSourceSapHana
+	MetricSourceScylla
+	MetricSourceSilk
+	MetricSourceSinglestore
+	MetricSourceSnmp
+	MetricSourceSnowflake
+	MetricSourceSpark
+	MetricSourceSqlserver
+	MetricSourceSquid
+	MetricSourceSshCheck
+	MetricSourceStatsd
+	MetricSourceSupervisord
 	MetricSourceSystemCore
-	MetricSourceActiveMqXml
-	MetricSourceDocker
-	MetricSourceOpenMetrics
-	MetricSourceNtp
+	MetricSourceSystemSwap
+	MetricSourceTcpCheck
+	MetricSourceTeamcity
+	MetricSourceTeradata
+	MetricSourceTls
+	MetricSourceTokumx
+	MetricSourceTrafficServer
+	MetricSourceTwemproxy
+	MetricSourceTwistlock
+	MetricSourceVarnish
+	MetricSourceVault
+	MetricSourceVertica
+	MetricSourceVoltdb
+	MetricSourceVsphere
+	MetricSourceWinEventLog
+	MetricSourceWindowsPerformanceCounters
+	MetricSourceWindowsService
+	MetricSourceWmiCheck
+	MetricSourceYarn
+	MetricSourceZk
 )
 
 func CheckNameToMetricSource(checkName string) MetricSource {
 	switch checkName {
-	case "active_directory":
-		return MetricSourceActiveDirectory
-	case "system", "io", "load", "cpu", "memory", "uptime", "file_handle", "disk":
+	// Start Manually Specified Block
+	case "system", "io", "load", "cpu", "memory", "uptime", "file_handle":
 		return MetricSourceSystemCore
-	case "openmetrics":
-		return MetricSourceOpenMetrics
 	case "docker":
 		return MetricSourceDocker
+	case "container":
+		return MetricSourceContainer
 	case "ntp":
 		return MetricSourceNtp
+	// End Manually SpecifiedBlock
+	case "active_directory":
+		return MetricSourceActiveDirectory
+	case "activemq_xml":
+		return MetricSourceActivemqXml
+	case "aerospike":
+		return MetricSourceAerospike
+	case "airflow":
+		return MetricSourceAirflow
+	case "amazon_msk":
+		return MetricSourceAmazonMsk
+	case "ambari":
+		return MetricSourceAmbari
+	case "apache":
+		return MetricSourceApache
+	case "arangodb":
+		return MetricSourceArangodb
+	case "argocd":
+		return MetricSourceArgocd
+	case "aspdotnet":
+		return MetricSourceAspdotnet
+	case "avi_vantage":
+		return MetricSourceAviVantage
+	case "azure_iot_edge":
+		return MetricSourceAzureIotEdge
+	case "boundary":
+		return MetricSourceBoundary
+	case "btrfs":
+		return MetricSourceBtrfs
+	case "cacti":
+		return MetricSourceCacti
+	case "calico":
+		return MetricSourceCalico
+	case "cassandra_nodetool":
+		return MetricSourceCassandraNodetool
+	case "ceph":
+		return MetricSourceCeph
+	case "cert_manager":
+		return MetricSourceCertManager
+	case "cilium":
+		return MetricSourceCilium
+	case "cisco_aci":
+		return MetricSourceCiscoAci
+	case "citrix_hypervisor":
+		return MetricSourceCitrixHypervisor
+	case "clickhouse":
+		return MetricSourceClickhouse
+	case "cloud_foundry_api":
+		return MetricSourceCloudFoundryApi
+	case "cockroachdb":
+		return MetricSourceCockroachdb
+	case "consul":
+		return MetricSourceConsul
+	case "coredns":
+		return MetricSourceCoredns
+	case "couch":
+		return MetricSourceCouch
+	case "couchbase":
+		return MetricSourceCouchbase
+	case "crio":
+		return MetricSourceCrio
+	case "directory":
+		return MetricSourceDirectory
+	case "disk":
+		return MetricSourceDisk
+	case "dns_check":
+		return MetricSourceDnsCheck
+	case "dotnetclr":
+		return MetricSourceDotnetclr
+	case "druid":
+		return MetricSourceDruid
+	case "ecs_fargate":
+		return MetricSourceEcsFargate
+	case "eks_fargate":
+		return MetricSourceEksFargate
+	case "elastic":
+		return MetricSourceElastic
+	case "envoy":
+		return MetricSourceEnvoy
+	case "etcd":
+		return MetricSourceEtcd
+	case "exchange_server":
+		return MetricSourceExchangeServer
+	case "external_dns":
+		return MetricSourceExternalDns
+	case "fluentd":
+		return MetricSourceFluentd
+	case "foundationdb":
+		return MetricSourceFoundationdb
+	case "gearmand":
+		return MetricSourceGearmand
+	case "gitlab_runner":
+		return MetricSourceGitlabRunner
+	case "gitlab":
+		return MetricSourceGitlab
+	case "glusterfs":
+		return MetricSourceGlusterfs
+	case "go_expvar":
+		return MetricSourceGoExpvar
+	case "gunicorn":
+		return MetricSourceGunicorn
+	case "haproxy":
+		return MetricSourceHaproxy
+	case "harbor":
+		return MetricSourceHarbor
+	case "hdfs_datanode":
+		return MetricSourceHdfsDatanode
+	case "hdfs_namenode":
+		return MetricSourceHdfsNamenode
+	case "http_check":
+		return MetricSourceHttpCheck
+	case "hyperv":
+		return MetricSourceHyperv
+	case "ibm_ace":
+		return MetricSourceIbmAce
+	case "ibm_db2":
+		return MetricSourceIbmDb
+	case "ibm_i":
+		return MetricSourceIbmI
+	case "ibm_mq":
+		return MetricSourceIbmMq
+	case "ibm_was":
+		return MetricSourceIbmWas
+	case "iis":
+		return MetricSourceIis
+	case "impala":
+		return MetricSourceImpala
+	case "istio":
+		return MetricSourceIstio
+	case "kafka_consumer":
+		return MetricSourceKafkaConsumer
+	case "kong":
+		return MetricSourceKong
+	case "kube_apiserver_metrics":
+		return MetricSourceKubeApiserverMetrics
+	case "kube_controller_manager":
+		return MetricSourceKubeControllerManager
+	case "kube_dns":
+		return MetricSourceKubeDns
+	case "kube_metrics_server":
+		return MetricSourceKubeMetricsServer
+	case "kube_proxy":
+		return MetricSourceKubeProxy
+	case "kube_scheduler":
+		return MetricSourceKubeScheduler
+	case "kubelet":
+		return MetricSourceKubelet
+	case "kubernetes_state":
+		return MetricSourceKubernetesState
+	case "kyototycoon":
+		return MetricSourceKyototycoon
+	case "lighttpd":
+		return MetricSourceLighttpd
+	case "linkerd":
+		return MetricSourceLinkerd
+	case "linux_proc_extras":
+		return MetricSourceLinuxProcExtras
+	case "mapr":
+		return MetricSourceMapr
+	case "mapreduce":
+		return MetricSourceMapreduce
+	case "marathon":
+		return MetricSourceMarathon
+	case "marklogic":
+		return MetricSourceMarklogic
+	case "mcache":
+		return MetricSourceMcache
+	case "mesos_master":
+		return MetricSourceMesosMaster
+	case "mesos_slave":
+		return MetricSourceMesosSlave
+	case "mongo":
+		return MetricSourceMongo
+	case "mysql":
+		return MetricSourceMysql
+	case "nagios":
+		return MetricSourceNagios
+	case "network":
+		return MetricSourceNetwork
+	case "nfsstat":
+		return MetricSourceNfsstat
+	case "nginx_ingress_controller":
+		return MetricSourceNginxIngressController
+	case "nginx":
+		return MetricSourceNginx
+	case "openldap":
+		return MetricSourceOpenldap
+	case "openmetrics":
+		return MetricSourceOpenmetrics
+	case "openstack_controller":
+		return MetricSourceOpenstackController
+	case "openstack":
+		return MetricSourceOpenstack
+	case "oracle":
+		return MetricSourceOracle
+	case "pdh_check":
+		return MetricSourcePdhCheck
+	case "pgbouncer":
+		return MetricSourcePgbouncer
+	case "php_fpm":
+		return MetricSourcePhpFpm
+	case "postfix":
+		return MetricSourcePostfix
+	case "postgres":
+		return MetricSourcePostgres
+	case "powerdns_recursor":
+		return MetricSourcePowerdnsRecursor
+	case "process":
+		return MetricSourceProcess
+	case "prometheus":
+		return MetricSourcePrometheus
+	case "proxysql":
+		return MetricSourceProxysql
+	case "pulsar":
+		return MetricSourcePulsar
+	case "rabbitmq":
+		return MetricSourceRabbitmq
+	case "redisdb":
+		return MetricSourceRedisdb
+	case "rethinkdb":
+		return MetricSourceRethinkdb
+	case "riak":
+		return MetricSourceRiak
+	case "riakcs":
+		return MetricSourceRiakcs
+	case "sap_hana":
+		return MetricSourceSapHana
+	case "scylla":
+		return MetricSourceScylla
+	case "silk":
+		return MetricSourceSilk
+	case "singlestore":
+		return MetricSourceSinglestore
+	case "snmp":
+		return MetricSourceSnmp
+	case "snowflake":
+		return MetricSourceSnowflake
+	case "spark":
+		return MetricSourceSpark
+	case "sqlserver":
+		return MetricSourceSqlserver
+	case "squid":
+		return MetricSourceSquid
+	case "ssh_check":
+		return MetricSourceSshCheck
+	case "statsd":
+		return MetricSourceStatsd
+	case "supervisord":
+		return MetricSourceSupervisord
+	case "system_core":
+		return MetricSourceSystemCore
+	case "system_swap":
+		return MetricSourceSystemSwap
+	case "tcp_check":
+		return MetricSourceTcpCheck
+	case "teamcity":
+		return MetricSourceTeamcity
+	case "teradata":
+		return MetricSourceTeradata
+	case "tls":
+		return MetricSourceTls
+	case "tokumx":
+		return MetricSourceTokumx
+	case "traffic_server":
+		return MetricSourceTrafficServer
+	case "twemproxy":
+		return MetricSourceTwemproxy
+	case "twistlock":
+		return MetricSourceTwistlock
+	case "varnish":
+		return MetricSourceVarnish
+	case "vault":
+		return MetricSourceVault
+	case "vertica":
+		return MetricSourceVertica
+	case "voltdb":
+		return MetricSourceVoltdb
+	case "vsphere":
+		return MetricSourceVsphere
+	case "win32_event_log":
+		return MetricSourceWinEventLog
+	case "windows_performance_counters":
+		return MetricSourceWindowsPerformanceCounters
+	case "windows_service":
+		return MetricSourceWindowsService
+	case "wmi_check":
+		return MetricSourceWmiCheck
+	case "yarn":
+		return MetricSourceYarn
+	case "zk":
+		return MetricSourceZk
 	}
 
 	return MetricSourceUnknown
@@ -40,10 +474,296 @@ func (ms MetricSource) String() string {
 	switch ms {
 	case MetricSourceDogstatsd:
 		return "dogstatsd"
-	case MetricSourceSystemCore:
-		return "systemcore"
-	case MetricSourceOpenMetrics:
+	case MetricSourceActiveDirectory:
+		return "active_directory"
+	case MetricSourceActivemqXml:
+		return "activemq_xml"
+	case MetricSourceAerospike:
+		return "aerospike"
+	case MetricSourceAirflow:
+		return "airflow"
+	case MetricSourceAmazonMsk:
+		return "amazon_msk"
+	case MetricSourceAmbari:
+		return "ambari"
+	case MetricSourceApache:
+		return "apache"
+	case MetricSourceArangodb:
+		return "arangodb"
+	case MetricSourceArgocd:
+		return "argocd"
+	case MetricSourceAspdotnet:
+		return "aspdotnet"
+	case MetricSourceAviVantage:
+		return "avi_vantage"
+	case MetricSourceAzureIotEdge:
+		return "azure_iot_edge"
+	case MetricSourceBoundary:
+		return "boundary"
+	case MetricSourceBtrfs:
+		return "btrfs"
+	case MetricSourceCacti:
+		return "cacti"
+	case MetricSourceCalico:
+		return "calico"
+	case MetricSourceCassandraNodetool:
+		return "cassandra_nodetool"
+	case MetricSourceCeph:
+		return "ceph"
+	case MetricSourceCertManager:
+		return "cert_manager"
+	case MetricSourceCilium:
+		return "cilium"
+	case MetricSourceCiscoAci:
+		return "cisco_aci"
+	case MetricSourceCitrixHypervisor:
+		return "citrix_hypervisor"
+	case MetricSourceClickhouse:
+		return "clickhouse"
+	case MetricSourceCloudFoundryApi:
+		return "cloud_foundry_api"
+	case MetricSourceCockroachdb:
+		return "cockroachdb"
+	case MetricSourceConsul:
+		return "consul"
+	case MetricSourceCoredns:
+		return "coredns"
+	case MetricSourceCouch:
+		return "couch"
+	case MetricSourceCouchbase:
+		return "couchbase"
+	case MetricSourceCrio:
+		return "crio"
+	case MetricSourceDirectory:
+		return "directory"
+	case MetricSourceDisk:
+		return "disk"
+	case MetricSourceDnsCheck:
+		return "dns_check"
+	case MetricSourceDotnetclr:
+		return "dotnetclr"
+	case MetricSourceDruid:
+		return "druid"
+	case MetricSourceEcsFargate:
+		return "ecs_fargate"
+	case MetricSourceEksFargate:
+		return "eks_fargate"
+	case MetricSourceElastic:
+		return "elastic"
+	case MetricSourceEnvoy:
+		return "envoy"
+	case MetricSourceEtcd:
+		return "etcd"
+	case MetricSourceExchangeServer:
+		return "exchange_server"
+	case MetricSourceExternalDns:
+		return "external_dns"
+	case MetricSourceFluentd:
+		return "fluentd"
+	case MetricSourceFoundationdb:
+		return "foundationdb"
+	case MetricSourceGearmand:
+		return "gearmand"
+	case MetricSourceGitlabRunner:
+		return "gitlab_runner"
+	case MetricSourceGitlab:
+		return "gitlab"
+	case MetricSourceGlusterfs:
+		return "glusterfs"
+	case MetricSourceGoExpvar:
+		return "go_expvar"
+	case MetricSourceGunicorn:
+		return "gunicorn"
+	case MetricSourceHaproxy:
+		return "haproxy"
+	case MetricSourceHarbor:
+		return "harbor"
+	case MetricSourceHdfsDatanode:
+		return "hdfs_datanode"
+	case MetricSourceHdfsNamenode:
+		return "hdfs_namenode"
+	case MetricSourceHttpCheck:
+		return "http_check"
+	case MetricSourceHyperv:
+		return "hyperv"
+	case MetricSourceIbmAce:
+		return "ibm_ace"
+	case MetricSourceIbmDb:
+		return "ibm_db2"
+	case MetricSourceIbmI:
+		return "ibm_i"
+	case MetricSourceIbmMq:
+		return "ibm_mq"
+	case MetricSourceIbmWas:
+		return "ibm_was"
+	case MetricSourceIis:
+		return "iis"
+	case MetricSourceImpala:
+		return "impala"
+	case MetricSourceIstio:
+		return "istio"
+	case MetricSourceKafkaConsumer:
+		return "kafka_consumer"
+	case MetricSourceKong:
+		return "kong"
+	case MetricSourceKubeApiserverMetrics:
+		return "kube_apiserver_metrics"
+	case MetricSourceKubeControllerManager:
+		return "kube_controller_manager"
+	case MetricSourceKubeDns:
+		return "kube_dns"
+	case MetricSourceKubeMetricsServer:
+		return "kube_metrics_server"
+	case MetricSourceKubeProxy:
+		return "kube_proxy"
+	case MetricSourceKubeScheduler:
+		return "kube_scheduler"
+	case MetricSourceKubelet:
+		return "kubelet"
+	case MetricSourceKubernetesState:
+		return "kubernetes_state"
+	case MetricSourceKyototycoon:
+		return "kyototycoon"
+	case MetricSourceLighttpd:
+		return "lighttpd"
+	case MetricSourceLinkerd:
+		return "linkerd"
+	case MetricSourceLinuxProcExtras:
+		return "linux_proc_extras"
+	case MetricSourceMapr:
+		return "mapr"
+	case MetricSourceMapreduce:
+		return "mapreduce"
+	case MetricSourceMarathon:
+		return "marathon"
+	case MetricSourceMarklogic:
+		return "marklogic"
+	case MetricSourceMcache:
+		return "mcache"
+	case MetricSourceMesosMaster:
+		return "mesos_master"
+	case MetricSourceMesosSlave:
+		return "mesos_slave"
+	case MetricSourceMongo:
+		return "mongo"
+	case MetricSourceMysql:
+		return "mysql"
+	case MetricSourceNagios:
+		return "nagios"
+	case MetricSourceNetwork:
+		return "network"
+	case MetricSourceNfsstat:
+		return "nfsstat"
+	case MetricSourceNginxIngressController:
+		return "nginx_ingress_controller"
+	case MetricSourceNginx:
+		return "nginx"
+	case MetricSourceOpenldap:
+		return "openldap"
+	case MetricSourceOpenmetrics:
 		return "openmetrics"
+	case MetricSourceOpenstackController:
+		return "openstack_controller"
+	case MetricSourceOpenstack:
+		return "openstack"
+	case MetricSourceOracle:
+		return "oracle"
+	case MetricSourcePdhCheck:
+		return "pdh_check"
+	case MetricSourcePgbouncer:
+		return "pgbouncer"
+	case MetricSourcePhpFpm:
+		return "php_fpm"
+	case MetricSourcePostfix:
+		return "postfix"
+	case MetricSourcePostgres:
+		return "postgres"
+	case MetricSourcePowerdnsRecursor:
+		return "powerdns_recursor"
+	case MetricSourceProcess:
+		return "process"
+	case MetricSourcePrometheus:
+		return "prometheus"
+	case MetricSourceProxysql:
+		return "proxysql"
+	case MetricSourcePulsar:
+		return "pulsar"
+	case MetricSourceRabbitmq:
+		return "rabbitmq"
+	case MetricSourceRedisdb:
+		return "redisdb"
+	case MetricSourceRethinkdb:
+		return "rethinkdb"
+	case MetricSourceRiak:
+		return "riak"
+	case MetricSourceRiakcs:
+		return "riakcs"
+	case MetricSourceSapHana:
+		return "sap_hana"
+	case MetricSourceScylla:
+		return "scylla"
+	case MetricSourceSilk:
+		return "silk"
+	case MetricSourceSinglestore:
+		return "singlestore"
+	case MetricSourceSnmp:
+		return "snmp"
+	case MetricSourceSnowflake:
+		return "snowflake"
+	case MetricSourceSpark:
+		return "spark"
+	case MetricSourceSqlserver:
+		return "sqlserver"
+	case MetricSourceSquid:
+		return "squid"
+	case MetricSourceSshCheck:
+		return "ssh_check"
+	case MetricSourceStatsd:
+		return "statsd"
+	case MetricSourceSupervisord:
+		return "supervisord"
+	case MetricSourceSystemCore:
+		return "system_core"
+	case MetricSourceSystemSwap:
+		return "system_swap"
+	case MetricSourceTcpCheck:
+		return "tcp_check"
+	case MetricSourceTeamcity:
+		return "teamcity"
+	case MetricSourceTeradata:
+		return "teradata"
+	case MetricSourceTls:
+		return "tls"
+	case MetricSourceTokumx:
+		return "tokumx"
+	case MetricSourceTrafficServer:
+		return "traffic_server"
+	case MetricSourceTwemproxy:
+		return "twemproxy"
+	case MetricSourceTwistlock:
+		return "twistlock"
+	case MetricSourceVarnish:
+		return "varnish"
+	case MetricSourceVault:
+		return "vault"
+	case MetricSourceVertica:
+		return "vertica"
+	case MetricSourceVoltdb:
+		return "voltdb"
+	case MetricSourceVsphere:
+		return "vsphere"
+	case MetricSourceWinEventLog:
+		return "win32_event_log"
+	case MetricSourceWindowsPerformanceCounters:
+		return "windows_performance_counters"
+	case MetricSourceWindowsService:
+		return "windows_service"
+	case MetricSourceWmiCheck:
+		return "wmi_check"
+	case MetricSourceYarn:
+		return "yarn"
+	case MetricSourceZk:
+		return "zk"
 	default:
 		return "<unknown>"
 	}
@@ -67,12 +787,294 @@ func (ms MetricSource) OriginService() int32 {
 		return 0 // no service
 	case MetricSourceActiveDirectory:
 		return 10
-	case MetricSourceActiveMqXml:
+	case MetricSourceActivemqXml:
 		return 11
+	case MetricSourceAerospike:
+		return 13
+	case MetricSourceAirflow:
+		return 14
+	case MetricSourceAmazonMsk:
+		return 15
+	case MetricSourceAmbari:
+		return 16
+	case MetricSourceApache:
+		return 17
+	case MetricSourceArangodb:
+		return 18
+	case MetricSourceArgocd:
+		return 19
+	case MetricSourceAspdotnet:
+		return 20
+	case MetricSourceAviVantage:
+		return 21
+	case MetricSourceAzureIotEdge:
+		return 22
+	case MetricSourceBoundary:
+		return 23
+	case MetricSourceBtrfs:
+		return 24
+	case MetricSourceCacti:
+		return 25
+	case MetricSourceCalico:
+		return 26
+	case MetricSourceCassandraNodetool:
+		return 27
+	case MetricSourceCeph:
+		return 29
+	case MetricSourceCertManager:
+		return 30
+	case MetricSourceCilium:
+		return 34
+	case MetricSourceCiscoAci:
+		return 35
+	case MetricSourceCitrixHypervisor:
+		return 36
+	case MetricSourceClickhouse:
+		return 37
+	case MetricSourceCloudFoundryApi:
+		return 38
+	case MetricSourceCockroachdb:
+		return 39
+	case MetricSourceConsul:
+		return 41
+	case MetricSourceCoredns:
+		return 42
+	case MetricSourceCouch:
+		return 43
+	case MetricSourceCouchbase:
+		return 44
+	case MetricSourceCrio:
+		return 45
+	case MetricSourceDirectory:
+		return 47
+	case MetricSourceDisk:
+		return 48
+	case MetricSourceDnsCheck:
+		return 49
+	case MetricSourceDotnetclr:
+		return 50
+	case MetricSourceDruid:
+		return 51
+	case MetricSourceEcsFargate:
+		return 52
+	case MetricSourceEksFargate:
+		return 53
+	case MetricSourceElastic:
+		return 54
+	case MetricSourceEnvoy:
+		return 55
+	case MetricSourceEtcd:
+		return 56
+	case MetricSourceExchangeServer:
+		return 57
+	case MetricSourceExternalDns:
+		return 58
+	case MetricSourceFluentd:
+		return 60
+	case MetricSourceFoundationdb:
+		return 61
+	case MetricSourceGearmand:
+		return 62
+	case MetricSourceGitlabRunner:
+		return 63
+	case MetricSourceGitlab:
+		return 64
+	case MetricSourceGlusterfs:
+		return 65
+	case MetricSourceGoExpvar:
+		return 66
+	case MetricSourceGunicorn:
+		return 67
+	case MetricSourceHaproxy:
+		return 68
+	case MetricSourceHarbor:
+		return 69
+	case MetricSourceHdfsDatanode:
+		return 71
+	case MetricSourceHdfsNamenode:
+		return 72
+	case MetricSourceHttpCheck:
+		return 75
+	case MetricSourceHyperv:
+		return 77
+	case MetricSourceIbmAce:
+		return 78
+	case MetricSourceIbmDb:
+		return 79
+	case MetricSourceIbmI:
+		return 80
+	case MetricSourceIbmMq:
+		return 81
+	case MetricSourceIbmWas:
+		return 82
+	case MetricSourceIis:
+		return 84
+	case MetricSourceImpala:
+		return 85
+	case MetricSourceIstio:
+		return 86
+	case MetricSourceKafkaConsumer:
+		return 89
+	case MetricSourceKong:
+		return 91
+	case MetricSourceKubeApiserverMetrics:
+		return 92
+	case MetricSourceKubeControllerManager:
+		return 93
+	case MetricSourceKubeDns:
+		return 94
+	case MetricSourceKubeMetricsServer:
+		return 95
+	case MetricSourceKubeProxy:
+		return 96
+	case MetricSourceKubeScheduler:
+		return 97
+	case MetricSourceKubelet:
+		return 98
+	case MetricSourceKubernetesState:
+		return 99
+	case MetricSourceKyototycoon:
+		return 100
+	case MetricSourceLighttpd:
+		return 101
+	case MetricSourceLinkerd:
+		return 102
+	case MetricSourceLinuxProcExtras:
+		return 103
+	case MetricSourceMapr:
+		return 104
+	case MetricSourceMapreduce:
+		return 105
+	case MetricSourceMarathon:
+		return 106
+	case MetricSourceMarklogic:
+		return 107
+	case MetricSourceMcache:
+		return 108
+	case MetricSourceMesosMaster:
+		return 109
+	case MetricSourceMesosSlave:
+		return 110
+	case MetricSourceMongo:
+		return 111
+	case MetricSourceMysql:
+		return 112
+	case MetricSourceNagios:
+		return 113
+	case MetricSourceNetwork:
+		return 114
+	case MetricSourceNfsstat:
+		return 115
+	case MetricSourceNginxIngressController:
+		return 116
+	case MetricSourceNginx:
+		return 117
+	case MetricSourceOpenldap:
+		return 118
+	case MetricSourceOpenmetrics:
+		return 119
+	case MetricSourceOpenstackController:
+		return 120
+	case MetricSourceOpenstack:
+		return 121
+	case MetricSourceOracle:
+		return 122
+	case MetricSourcePdhCheck:
+		return 124
+	case MetricSourcePgbouncer:
+		return 125
+	case MetricSourcePhpFpm:
+		return 126
+	case MetricSourcePostfix:
+		return 127
+	case MetricSourcePostgres:
+		return 128
+	case MetricSourcePowerdnsRecursor:
+		return 129
+	case MetricSourceProcess:
+		return 131
+	case MetricSourcePrometheus:
+		return 132
+	case MetricSourceProxysql:
+		return 133
+	case MetricSourcePulsar:
+		return 134
+	case MetricSourceRabbitmq:
+		return 135
+	case MetricSourceRedisdb:
+		return 136
+	case MetricSourceRethinkdb:
+		return 137
+	case MetricSourceRiak:
+		return 138
+	case MetricSourceRiakcs:
+		return 139
+	case MetricSourceSapHana:
+		return 140
+	case MetricSourceScylla:
+		return 141
+	case MetricSourceSilk:
+		return 143
+	case MetricSourceSinglestore:
+		return 144
+	case MetricSourceSnmp:
+		return 145
+	case MetricSourceSnowflake:
+		return 146
+	case MetricSourceSpark:
+		return 149
+	case MetricSourceSqlserver:
+		return 150
+	case MetricSourceSquid:
+		return 151
+	case MetricSourceSshCheck:
+		return 152
+	case MetricSourceStatsd:
+		return 153
+	case MetricSourceSupervisord:
+		return 154
 	case MetricSourceSystemCore:
 		return 155
-	case MetricSourceJmx:
-		return 9
+	case MetricSourceSystemSwap:
+		return 156
+	case MetricSourceTcpCheck:
+		return 157
+	case MetricSourceTeamcity:
+		return 158
+	case MetricSourceTeradata:
+		return 160
+	case MetricSourceTls:
+		return 161
+	case MetricSourceTokumx:
+		return 162
+	case MetricSourceTrafficServer:
+		return 164
+	case MetricSourceTwemproxy:
+		return 165
+	case MetricSourceTwistlock:
+		return 166
+	case MetricSourceVarnish:
+		return 167
+	case MetricSourceVault:
+		return 168
+	case MetricSourceVertica:
+		return 169
+	case MetricSourceVoltdb:
+		return 170
+	case MetricSourceVsphere:
+		return 171
+	case MetricSourceWinEventLog:
+		return 173
+	case MetricSourceWindowsPerformanceCounters:
+		return 174
+	case MetricSourceWindowsService:
+		return 175
+	case MetricSourceWmiCheck:
+		return 176
+	case MetricSourceYarn:
+		return 177
+	case MetricSourceZk:
+		return 178
 	default:
 		return -1
 	}

--- a/pkg/metrics/metricsource.go
+++ b/pkg/metrics/metricsource.go
@@ -11,7 +11,6 @@ const (
 	MetricSourceJmx
 
 	// Corechecks
-	// TODO add all these to protobuf
 	MetricSourceContainer
 	MetricSourceContainerd
 	MetricSourceCri
@@ -36,12 +35,6 @@ const (
 	MetricSourceContainerImage
 	MetricSourceCpu
 	MetricSourceLoad
-	// The following are both core checks and python checks.
-	// I think this is OK as long as the check IDs are the same
-	// TODO - double check that the check names are the same
-	// MetricSourceNetwork // 'network'
-	// MetricSourceSnmp // 'snmp'
-	// MetricSourceDisk // 'disk'
 
 	// Python integrations
 	MetricSourceActiveDirectory
@@ -75,7 +68,7 @@ const (
 	MetricSourceCouchbase
 	MetricSourceCrio
 	MetricSourceDirectory
-	MetricSourceDisk
+	MetricSourceDisk // Also a corecheck
 	MetricSourceDnsCheck
 	MetricSourceDotnetclr
 	MetricSourceDruid
@@ -132,7 +125,7 @@ const (
 	MetricSourceMongo
 	MetricSourceMysql
 	MetricSourceNagios
-	MetricSourceNetwork
+	MetricSourceNetwork // Also a corecheck
 	MetricSourceNfsstat
 	MetricSourceNginxIngressController
 	MetricSourceNginx
@@ -160,7 +153,7 @@ const (
 	MetricSourceScylla
 	MetricSourceSilk
 	MetricSourceSinglestore
-	MetricSourceSnmp
+	MetricSourceSnmp // Also a corecheck
 	MetricSourceSnowflake
 	MetricSourceSpark
 	MetricSourceSqlserver
@@ -193,16 +186,56 @@ const (
 
 func CheckNameToMetricSource(checkName string) MetricSource {
 	switch checkName {
-	// Start Manually Specified Block
-	case "system", "io", "load", "cpu", "memory", "uptime", "file_handle":
-		return MetricSourceSystemCore
-	case "docker":
-		return MetricSourceDocker
+	// Core Checks
 	case "container":
 		return MetricSourceContainer
+	case "containerd":
+		return MetricSourceContainerd
+	case "cri":
+		return MetricSourceCri
+	case "docker":
+		return MetricSourceDocker
+	case "systemd":
+		return MetricSourceSystemd
+	case "helm":
+		return MetricSourceHelm
+	case "kubernetes_apiserver":
+		return MetricSourceKubernetesAPIServer
+	case "kubernetes_state_core":
+		return MetricSourceKubeStateMetrics // Double check this is the correct enum value
+	case "orchestrator":
+		return MetricSourceOrchestrator
+	case "winproc":
+		return MetricSourceWinProc
+	case "file_handle":
+		return MetricSourceFileHandle
+	case "winkmem":
+		return MetricSourceWinkmem
+	case "io":
+		return MetricSourceIoStats
+	case "uptime":
+		return MetricSourceUptime
+	case "sbom":
+		return MetricSourceSbom
+	case "memory":
+		return MetricSourceMemory
+	case "tcp_queue_length":
+		return MetricSourceTcpQueueLength
+	case "oom_kill":
+		return MetricSourceOomKill
+	case "container_lifecycle":
+		return MetricSourceContainerLifecycle
+	case "jetson":
+		return MetricSourceJetson
+	case "container_image":
+		return MetricSourceContainerImage
+	case "cpu":
+		return MetricSourceCpu
+	case "load":
+		return MetricSourceLoad
 	case "ntp":
 		return MetricSourceNtp
-	// End Manually SpecifiedBlock
+	// Python Integrations
 	case "active_directory":
 		return MetricSourceActiveDirectory
 	case "activemq_xml":
@@ -852,6 +885,8 @@ func (ms MetricSource) String() string {
 func (ms MetricSource) OriginCategory() int32 {
 	// Constants from `origin.proto`
 	switch ms {
+	case MetricSourceUnknown:
+		return 0
 	case MetricSourceDogstatsd:
 		return 10
 	default:
@@ -864,7 +899,9 @@ func (ms MetricSource) OriginService() int32 {
 	// Constants from `origin.proto`
 	switch ms {
 	case MetricSourceDogstatsd:
-		return 0 // no service
+		return 0
+	case MetricSourceUnknown:
+		return 0
 	case MetricSourceActiveDirectory:
 		return 10
 	case MetricSourceActivemqXml:
@@ -1156,53 +1193,53 @@ func (ms MetricSource) OriginService() int32 {
 	case MetricSourceZk:
 		return 178
 	case MetricSourceContainer:
-		return -1 // TODO fill in appropriate protobuf value
+		return 180
 	case MetricSourceContainerd:
-		return -1 // TODO fill in appropriate protobuf value
+		return 181
 	case MetricSourceCri:
-		return -1 // TODO fill in appropriate protobuf value
+		return 182
 	case MetricSourceDocker:
-		return -1 // TODO fill in appropriate protobuf value
+		return 183
 	case MetricSourceNtp:
-		return -1 // TODO fill in appropriate protobuf value
+		return 184
 	case MetricSourceSystemd:
-		return -1 // TODO fill in appropriate protobuf value
+		return 185
 	case MetricSourceHelm:
-		return -1 // TODO fill in appropriate protobuf value
+		return 186
 	case MetricSourceKubernetesAPIServer:
-		return -1 // TODO fill in appropriate protobuf value
+		return 187
 	case MetricSourceKubeStateMetrics:
-		return -1 // TODO fill in appropriate protobuf value
+		return 188
 	case MetricSourceOrchestrator:
-		return -1 // TODO fill in appropriate protobuf value
+		return 189
 	case MetricSourceWinProc:
-		return -1 // TODO fill in appropriate protobuf value
+		return 190
 	case MetricSourceFileHandle:
-		return -1 // TODO fill in appropriate protobuf value
+		return 191
 	case MetricSourceWinkmem:
-		return -1 // TODO fill in appropriate protobuf value
+		return 192
 	case MetricSourceIoStats:
-		return -1 // TODO fill in appropriate protobuf value
+		return 193
 	case MetricSourceUptime:
-		return -1 // TODO fill in appropriate protobuf value
+		return 194
 	case MetricSourceSbom:
-		return -1 // TODO fill in appropriate protobuf value
+		return 195
 	case MetricSourceMemory:
-		return -1 // TODO fill in appropriate protobuf value
+		return 196
 	case MetricSourceTcpQueueLength:
-		return -1 // TODO fill in appropriate protobuf value
+		return 197
 	case MetricSourceOomKill:
-		return -1 // TODO fill in appropriate protobuf value
+		return 198
 	case MetricSourceContainerLifecycle:
-		return -1 // TODO fill in appropriate protobuf value
+		return 199
 	case MetricSourceJetson:
-		return -1 // TODO fill in appropriate protobuf value
+		return 200
 	case MetricSourceContainerImage:
-		return -1 // TODO fill in appropriate protobuf value
+		return 201
 	case MetricSourceCpu:
-		return -1 // TODO fill in appropriate protobuf value
+		return 202
 	case MetricSourceLoad:
-		return -1 // TODO fill in appropriate protobuf value
+		return 203
 	default:
 		return -1
 	}

--- a/pkg/metrics/series.go
+++ b/pkg/metrics/series.go
@@ -59,6 +59,7 @@ type Serie struct {
 	NameSuffix     string               `json:"-"`
 	NoIndex        bool                 `json:"-"` // This is only used by api V2
 	Resources      []Resource           `json:"-"` // This is only used by api V2
+	Source         MetricSource         `json:"-"` // This is only used by api V2
 }
 
 // SeriesAPIV2Enum returns the enumeration value for MetricPayload.MetricType in

--- a/pkg/serializer/internal/metrics/iterable_series.go
+++ b/pkg/serializer/internal/metrics/iterable_series.go
@@ -323,11 +323,16 @@ func (series *IterableSeries) MarshalSplitCompress(bufferContext *marshaler.Buff
 
 			fmt.Println("Sending a series!")
 			if serie.Source != metrics.MetricSourceUnknown {
-				// TODO - I don't see this condition getting triggered
-				// dogstatsd server -> .... -> serializer
-				//                      ^ I suspect something in here is re-creating the MetricSample and it needs
-				// to copy over the Source field as well
 				fmt.Println("Sending a series with a source! Source set to ", serie.Source)
+				/*
+
+					It works! I see this output when running and submitting dogstatsd
+
+					Sending a series!
+					Sending a series!
+					Sending a series with a source! Source set to  dogstatsd
+
+				*/
 				return ps.Embedded(serieMetadata, func(ps *molecule.ProtoStream) error {
 					return ps.Embedded(serieMetadataOrigin, func(ps *molecule.ProtoStream) error {
 						return ps.Int32(serieMetadataOriginProduct, serieMetadataProductDogstatsd)

--- a/pkg/serializer/internal/metrics/iterable_series.go
+++ b/pkg/serializer/internal/metrics/iterable_series.go
@@ -318,22 +318,33 @@ func (series *IterableSeries) MarshalSplitCompress(bufferContext *marshaler.Buff
 			}
 
 			if serie.NoIndex {
-				return ps.Embedded(serieMetadata, func(ps *molecule.ProtoStream) error {
+				err = ps.Embedded(serieMetadata, func(ps *molecule.ProtoStream) error {
 					return ps.Embedded(serieMetadataOrigin, func(ps *molecule.ProtoStream) error {
 						return ps.Int32(serieMetadataOriginMetricType, metryTypeNotIndexed)
 					})
 				})
+				if err != nil {
+					return err
+				}
 			}
 
-			if serie.Source != metrics.MetricSourceUnknown {
-				return ps.Embedded(serieMetadata, func(ps *molecule.ProtoStream) error {
-					return ps.Embedded(serieMetadataOrigin, func(ps *molecule.ProtoStream) error {
-						ps.Int32(serieMetadataOriginOriginProduct, serieMetadataOriginOriginProductAgentType)
-						ps.Int32(serieMetadataOriginOriginCategory, serie.Source.OriginCategory())
-						return ps.Int32(serieMetadataOriginOriginService, serie.Source.OriginService())
-					})
+			err = ps.Embedded(serieMetadata, func(ps *molecule.ProtoStream) error {
+				return ps.Embedded(serieMetadataOrigin, func(ps *molecule.ProtoStream) error {
+					err = ps.Int32(serieMetadataOriginOriginProduct, serieMetadataOriginOriginProductAgentType)
+					if err != nil {
+						return err
+					}
+					err = ps.Int32(serieMetadataOriginOriginCategory, serie.Source.OriginCategory())
+					if err != nil {
+						return err
+					}
+					return ps.Int32(serieMetadataOriginOriginService, serie.Source.OriginService())
 				})
+			})
+			if err != nil {
+				return err
 			}
+
 			return nil
 		})
 		if err != nil {

--- a/pkg/serializer/serializer_test.go
+++ b/pkg/serializer/serializer_test.go
@@ -10,6 +10,7 @@ package serializer
 
 import (
 	"fmt"
+	"log"
 	"net/http"
 	"reflect"
 	"strings"
@@ -207,6 +208,7 @@ func createProtoPayloadMatcher(content []byte) interface{} {
 			if payload, err := compression.Decompress(compressedPayload.GetContent()); err != nil {
 				return false
 			} else {
+				log.Printf("Content %+v Payload %+v", content, payload)
 				if reflect.DeepEqual(content, payload) {
 					return true
 				}
@@ -298,6 +300,9 @@ func TestSendV1Series(t *testing.T) {
 func TestSendSeries(t *testing.T) {
 	f := &forwarder.MockedForwarder{}
 	matcher := createProtoPayloadMatcher([]byte{0xa, 0xa, 0xa, 0x6, 0xa, 0x4, 0x68, 0x6f, 0x73, 0x74, 0x28, 0x3})
+	// TODO fix this test and validate this new payload is desired
+	//                                  Content [10 10 10 6 10 4 104 111 115 116 40 3]
+	//                                  Payload [10 16 10 6 10 4 104 111 115 116 40 3 74 4 10 2 32 10]
 	f.On("SubmitSeries", matcher, protobufExtraHeadersWithCompression).Return(nil).Times(1)
 	config.Datadog.Set("use_v2_api.series", true) // default value, but just to be sure
 


### PR DESCRIPTION
### What does this PR do?
The goal of this PR is to mark each metric series leaving the Agent with an "origin" that indicates where the metric series came from.
The basic options are "dogstatsd" or "integration", and if its an integration, we mark which specific integration originated the metric.

For now, all metrics coming from `jmxfetch` will be marked as "JMX Custom". Breaking these down by specific integration will happen as a following PR.

### Motivation
Better tracking of metric origins.

### Additional Notes

TODO list:

- [ ] Implement for sketches/histograms
- [ ] Performance testing
- [ ] Double check how python check names are determined

### Possible Drawbacks / Trade-offs
This feature inherently requires some mapping of "check" -> "metric source". There is a significant risk here where future checks may not annotate themselves properly, so this design should make it as easy as possible to add a new mapping.

### Describe how to test/QA your changes
TODO

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
