### PR TITLE
pkg/obfuscate: 35 is a valid CC IIN

### DIFF
--- a/pkg/obfuscate/credit_cards.go
+++ b/pkg/obfuscate/credit_cards.go
@@ -154,9 +154,9 @@ func validCardPrefix(n int) (maybe, yes bool) {
 			// 34-39, 51-55, 62, 65 are valid IIN
 			return false, true
 		}
-		if n == 30 || n == 63 || n == 64 || n == 35 || n == 50 || n == 60 ||
+		if n == 30 || n == 63 || n == 64 || n == 50 || n == 60 ||
 			(n >= 22 && n <= 27) || (n >= 56 && n <= 58) || (n >= 60 && n <= 69) {
-			// 30, 63, 64, 35, 50, 60, 22-27, 56-58, 60-69 may end up as valid IIN
+			// 30, 63, 64, 50, 60, 22-27, 56-58, 60-69 may end up as valid IIN
 			return true, false
 		}
 	}


### PR DESCRIPTION
### What does this PR do?
Remove an unnecessary / incorrect check in CC detection. This doesn't change the existing behavior it just cleans the code up (note that in the `if` above my change that `35` is already included).
And this is correct according to the [link](https://www.regular-expressions.info/creditcard.html) in the code, some JCB credit cards have an IIN of `35`. 

### Motivation
I was porting this code to rust for this pr (https://github.com/DataDog/libdatadog/pull/117) And thanks to rust match clause checking it helpfully pointed out that the previous `if` here already includes `35` as a valid Issuer Identification Number(IIN).

### Describe how to test/QA your changes
Already well covered by unit tests :) 


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
