### PR TITLE
pkg/trace/api: Forward data streams data to mutiple endpoints

### DIFF
--- a/pkg/trace/api/pipeline_stats.go
+++ b/pkg/trace/api/pipeline_stats.go
@@ -6,8 +6,10 @@
 package api
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	stdlog "log"
 	"net/http"
 	"net/http/httputil"
@@ -25,21 +27,25 @@ const (
 )
 
 // pipelineStatsEndpoint returns the pipeline intake url and the corresponding API key.
-func pipelineStatsEndpoint(cfg *config.AgentConfig) (*url.URL, string, error) {
+func pipelineStatsEndpoints(cfg *config.AgentConfig) (urls []*url.URL, apiKeys []string, err error) {
 	if e := cfg.Endpoints; len(e) == 0 || e[0].Host == "" || e[0].APIKey == "" {
-		return nil, "", errors.New("config was not properly validated")
+		return nil, nil, errors.New("config was not properly validated")
 	}
-	urlStr := cfg.Endpoints[0].Host + pipelineStatsURLSuffix
-	url, err := url.Parse(urlStr)
-	if err != nil {
-		return nil, "", fmt.Errorf("error parsing pipeline stats intake URL %q: %v", urlStr, err)
+	for _, e := range cfg.Endpoints {
+		urlStr := e.Host + pipelineStatsURLSuffix
+		url, err := url.Parse(urlStr)
+		if err != nil {
+			return nil, nil, fmt.Errorf("error parsing pipeline stats intake URL %q: %v", urlStr, err)
+		}
+		urls = append(urls, url)
+		apiKeys = append(apiKeys, e.APIKey)
 	}
-	return url, cfg.Endpoints[0].APIKey, nil
+	return urls, apiKeys, nil
 }
 
 // pipelineStatsProxyHandler returns a new HTTP handler which will proxy requests to the pipeline stats intake.
 func (r *HTTPReceiver) pipelineStatsProxyHandler() http.Handler {
-	target, key, err := pipelineStatsEndpoint(r.conf)
+	urls, apiKeys, err := pipelineStatsEndpoints(r.conf)
 	if err != nil {
 		log.Errorf("Failed to start pipeline stats proxy handler: %v", err)
 		return pipelineStatsErrorHandler(err)
@@ -49,7 +55,7 @@ func (r *HTTPReceiver) pipelineStatsProxyHandler() http.Handler {
 		tag := fmt.Sprintf("orchestrator:fargate_%s", strings.ToLower(string(orch)))
 		tags = tags + "," + tag
 	}
-	return newPipelineStatsProxy(r.conf, target, key, tags)
+	return newPipelineStatsProxy(r.conf, urls, apiKeys, tags)
 }
 
 func pipelineStatsErrorHandler(err error) http.Handler {
@@ -61,7 +67,7 @@ func pipelineStatsErrorHandler(err error) http.Handler {
 
 // newPipelineStatsProxy creates an http.ReverseProxy which forwards requests to the pipeline stats intake.
 // The tags will be added as a header to all proxied requests.
-func newPipelineStatsProxy(conf *config.AgentConfig, target *url.URL, key string, tags string) *httputil.ReverseProxy {
+func newPipelineStatsProxy(conf *config.AgentConfig, urls []*url.URL, apiKeys []string, tags string) *httputil.ReverseProxy {
 	cidProvider := NewIDProvider(conf.ContainerProcRoot)
 	director := func(req *http.Request) {
 		req.Header.Set("Via", fmt.Sprintf("trace-agent %s", conf.AgentVersion))
@@ -77,14 +83,59 @@ func newPipelineStatsProxy(conf *config.AgentConfig, target *url.URL, key string
 		}
 		req.Header.Set("X-Datadog-Additional-Tags", tags)
 		metrics.Count("datadog.trace_agent.pipelines_stats", 1, nil, 1)
-		req.Host = target.Host
-		req.URL = target
-		req.Header.Set("DD-API-KEY", key)
 	}
 	logger := log.NewThrottled(5, 10*time.Second) // limit to 5 messages every 10 seconds
 	return &httputil.ReverseProxy{
 		Director:  director,
 		ErrorLog:  stdlog.New(logger, "pipeline_stats.Proxy: ", 0),
-		Transport: conf.NewHTTPTransport(),
+		Transport: &multiDataStreamsTransport{rt: conf.NewHTTPTransport(), targets: urls, keys: apiKeys},
 	}
+}
+
+// multiDataStreamsTransport sends HTTP requests to multiple targets using an
+// underlying http.RoundTripper. API keys are set separately for each target.
+// When multiple endpoints are in use the response from the main endpoint
+// is proxied back to the client, while for all additional endpoints the
+// response is discarded. There is no de-duplication done between endpoint
+// hosts or api keys.
+type multiDataStreamsTransport struct {
+	rt      http.RoundTripper
+	targets []*url.URL
+	keys    []string
+}
+
+func (m *multiDataStreamsTransport) RoundTrip(req *http.Request) (rresp *http.Response, rerr error) {
+	setTarget := func(r *http.Request, u *url.URL, apiKey string) {
+		r.Host = u.Host
+		r.URL = u
+		r.Header.Set("DD-API-KEY", apiKey)
+	}
+	if len(m.targets) == 1 {
+		setTarget(req, m.targets[0], m.keys[0])
+		return m.rt.RoundTrip(req)
+	}
+	slurp, err := io.ReadAll(req.Body)
+	if err != nil {
+		return nil, err
+	}
+	for i, u := range m.targets {
+		newreq := req.Clone(req.Context())
+		newreq.Body = io.NopCloser(bytes.NewReader(slurp))
+		setTarget(newreq, u, m.keys[i])
+		if i == 0 {
+			// given the way we construct the list of targets the main endpoint
+			// will be the first one called, we return its response and error
+			rresp, rerr = m.rt.RoundTrip(newreq)
+			continue
+		}
+
+		if resp, err := m.rt.RoundTrip(newreq); err == nil {
+			// we discard responses for all subsequent requests
+			io.Copy(io.Discard, resp.Body) //nolint:errcheck
+			resp.Body.Close()
+		} else {
+			log.Error(err)
+		}
+	}
+	return rresp, rerr
 }

--- a/releasenotes/notes/data-streams-multiple-endpoints-b7802e06d24769e5.yaml
+++ b/releasenotes/notes/data-streams-multiple-endpoints-b7802e06d24769e5.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Support the config additional_endpoints for data-streams monitoring.

--- a/releasenotes/notes/data-streams-multiple-endpoints-b7802e06d24769e5.yaml
+++ b/releasenotes/notes/data-streams-multiple-endpoints-b7802e06d24769e5.yaml
@@ -1,4 +1,4 @@
 ---
 features:
   - |
-    Support the config additional_endpoints for data-streams monitoring.
+    Support the config `additional_endpoints` for Data Streams monitoring.


### PR DESCRIPTION
### What does this PR do?

Updates the reverse proxy in data streams code to support forwarding to more than 1 endpoint.

### Motivation

Data streams data gets only sent to the main configured endpoint right now. This PR adds support for `additional_endpoints` for data streams.


### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

I ran the agent locally with additional endpoints, and checked that the multiple datadog environments have been populated.
```
api_key: <>

apm_config:
  enabled: true
  env: "dev"
  apm_dd_url: "https://trace.agent.datadoghq.com"
  additional_endpoints:
    "https://trace.agent.datadoghq.eu":
      - <>
```

Once the agent is released on staging, I will verify that data is sent to both organizations that monitor our staging environment.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
