### PR TITLE
Fix Cluster Agent image build invoke task to use current arch by default instead of hardcoded amd64

### DIFF
--- a/tasks/cluster_agent.py
+++ b/tasks/cluster_agent.py
@@ -4,8 +4,8 @@ Cluster Agent tasks
 
 import glob
 import os
-import shutil
 import platform
+import shutil
 
 from invoke import task
 from invoke.exceptions import Exit

--- a/tasks/cluster_agent.py
+++ b/tasks/cluster_agent.py
@@ -5,6 +5,7 @@ Cluster Agent tasks
 import glob
 import os
 import shutil
+import platform
 
 from invoke import task
 from invoke.exceptions import Exit
@@ -18,6 +19,10 @@ from .utils import load_release_versions
 BIN_PATH = os.path.join(".", "bin", "datadog-cluster-agent")
 AGENT_TAG = "datadog/cluster_agent:master"
 POLICIES_REPO = "https://github.com/DataDog/security-agent-policies.git"
+CONTAINER_PLATFORM_MAPPING = {
+    "aarch64": "arm64",
+    "amd64": "amd64"
+}
 
 
 @task
@@ -116,10 +121,16 @@ def integration_tests(ctx, install_deps=False, race=False, remote_docker=False, 
 
 
 @task
-def image_build(ctx, arch='amd64', tag=AGENT_TAG, push=False):
+def image_build(ctx, arch=None, tag=AGENT_TAG, push=False):
     """
     Build the docker image
     """
+    if arch is None:
+        arch = CONTAINER_PLATFORM_MAPPING.get(platform.machine().lower())
+
+    if arch is None:
+        print("Unable to determine architecture to build, please set `arch` parameter")
+        raise Exit(code=1)
 
     dca_binary = glob.glob(os.path.join(BIN_PATH, "datadog-cluster-agent"))
     # get the last debian package built

--- a/tasks/cluster_agent.py
+++ b/tasks/cluster_agent.py
@@ -19,10 +19,7 @@ from .utils import load_release_versions
 BIN_PATH = os.path.join(".", "bin", "datadog-cluster-agent")
 AGENT_TAG = "datadog/cluster_agent:master"
 POLICIES_REPO = "https://github.com/DataDog/security-agent-policies.git"
-CONTAINER_PLATFORM_MAPPING = {
-    "aarch64": "arm64",
-    "amd64": "amd64"
-}
+CONTAINER_PLATFORM_MAPPING = {"aarch64": "arm64", "amd64": "amd64"}
 
 
 @task


### PR DESCRIPTION
### What does this PR do?

Fix Cluster Agent image build invoke task to use current arch by default instead of hardcoded amd64

### Motivation

Fix local build

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
