### PR TITLE
pkg/remoteconfig: add ASM product and config

### DIFF
--- a/pkg/remoteconfig/state/configs.go
+++ b/pkg/remoteconfig/state/configs.go
@@ -31,6 +31,8 @@ const (
 	ProductCWSDD = "CWS_DD"
 	// ProductCWSCustom is the cloud workload security product managed by datadog customers
 	ProductCWSCustom = "CWS_CUSTOM"
+	// ProductASM is the ASM product used by customers to issue rules configurations
+	ProductASM = "ASM"
 	// ProductASMFeatures is the ASM product used form ASM activation through remote config
 	ProductASMFeatures = "ASM_FEATURES"
 	// ProductASMDD is the application security monitoring product managed by datadog employees
@@ -56,6 +58,8 @@ func parseConfig(product string, raw []byte, metadata Metadata) (interface{}, er
 		c, err = parseConfigCWSDD(raw, metadata)
 	case ProductCWSCustom:
 		c, err = parseConfigCWSCustom(raw, metadata)
+	case ProductASM:
+		c, err = parseConfigASM(raw, metadata)
 	case ProductASMDD:
 		c, err = parseConfigASMDD(raw, metadata)
 	case ProductASMData:
@@ -161,6 +165,39 @@ func (r *Repository) CWSCustomConfigs() map[string]ConfigCWSCustom {
 		typed, ok := conf.(ConfigCWSCustom)
 		if !ok {
 			panic("unexpected config stored as CWSDD Config")
+		}
+
+		typedConfigs[path] = typed
+	}
+
+	return typedConfigs
+}
+
+// ConfigASM is a deserialized ASM configuration file along with its
+// associated remote config metadata
+type ConfigASM struct {
+	Config   []byte
+	Metadata Metadata
+}
+
+func parseConfigASM(data []byte, metadata Metadata) (ConfigASMDD, error) {
+	return ConfigASMDD{
+		Config:   data,
+		Metadata: metadata,
+	}, nil
+}
+
+// ASMConfigs returns the currently active ASM configs
+func (r *Repository) ASMConfigs() map[string]ConfigASM {
+	typedConfigs := make(map[string]ConfigASM)
+
+	configs := r.getConfigs(ProductASM)
+
+	for path, conf := range configs {
+		// We control this, so if this has gone wrong something has gone horribly wrong
+		typed, ok := conf.(ConfigASM)
+		if !ok {
+			panic("unexpected config stored as ASM Config")
 		}
 
 		typedConfigs[path] = typed


### PR DESCRIPTION
### What does this PR do?

- Add a new rc product `ProductASM`, used for customer-defined configurations.
- Add the related rc config `ConfigASM` and required utility functions.

### Motivation

The `ASM` rc product is needed for ASM to fully implement suspicious request blocking.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
