### PR TITLE
Fix client-go spammy logs "Got empty response for: external.metrics.k8s.io/v1beta1" with client-go/kubectl >= 1.25

### DIFF
--- a/pkg/clusteragent/custommetrics/provider_test.go
+++ b/pkg/clusteragent/custommetrics/provider_test.go
@@ -37,9 +37,15 @@ func TestListAllExternalMetrics(t *testing.T) {
 		timestamp int64
 	}{
 		{
-			name:   "no metrics stored",
-			res:    []provider.ExternalMetricInfo{},
-			cached: nil,
+			name: "no metrics stored",
+			res: []provider.ExternalMetricInfo{
+				fakeExternalMetric,
+			},
+			cached: []externalMetric{
+				{
+					info: fakeExternalMetric,
+				},
+			},
 		},
 		{
 			name: "one nano metric stored",
@@ -48,28 +54,30 @@ func TestListAllExternalMetrics(t *testing.T) {
 					Metric: metricName,
 				},
 			},
-			cached: []externalMetric{{
-				info: provider.ExternalMetricInfo{
-					Metric: metricName,
+			cached: []externalMetric{
+				{
+					info: provider.ExternalMetricInfo{
+						Metric: metricName,
+					},
 				},
-			},
 			},
 		},
 		{
 			name: "multiple types",
-			cached: []externalMetric{{
-				info: provider.ExternalMetricInfo{
-					Metric: metricName,
+			cached: []externalMetric{
+				{
+					info: provider.ExternalMetricInfo{
+						Metric: metricName,
+					},
+				}, {
+					info: provider.ExternalMetricInfo{
+						Metric: metric2Name,
+					},
+				}, {
+					info: provider.ExternalMetricInfo{
+						Metric: metric3Name,
+					},
 				},
-			}, {
-				info: provider.ExternalMetricInfo{
-					Metric: metric2Name,
-				},
-			}, {
-				info: provider.ExternalMetricInfo{
-					Metric: metric3Name,
-				},
-			},
 			},
 			res: []provider.ExternalMetricInfo{
 				{
@@ -97,7 +105,6 @@ func TestListAllExternalMetrics(t *testing.T) {
 }
 
 func TestGetExternalMetric(t *testing.T) {
-
 	metricName := "m1"
 	goodLabel := map[string]string{
 		"foo": "bar",
@@ -120,15 +127,16 @@ func TestGetExternalMetric(t *testing.T) {
 		},
 		{
 			"one matching metric stored",
-			[]externalMetric{{
-				info: provider.ExternalMetricInfo{
-					Metric: metricName,
+			[]externalMetric{
+				{
+					info: provider.ExternalMetricInfo{
+						Metric: metricName,
+					},
+					value: external_metrics.ExternalMetricValue{
+						MetricName:   metricName,
+						MetricLabels: goodLabel,
+					},
 				},
-				value: external_metrics.ExternalMetricValue{
-					MetricName:   metricName,
-					MetricLabels: goodLabel,
-				},
-			},
 			},
 			metricCompare{
 				provider.ExternalMetricInfo{Metric: metricName},
@@ -139,19 +147,21 @@ func TestGetExternalMetric(t *testing.T) {
 				{
 					MetricName:   metricName,
 					MetricLabels: goodLabel,
-				}},
+				},
+			},
 		},
 		{
 			"one non matching metric stored",
-			[]externalMetric{{
-				info: provider.ExternalMetricInfo{
-					Metric: metricName,
+			[]externalMetric{
+				{
+					info: provider.ExternalMetricInfo{
+						Metric: metricName,
+					},
+					value: external_metrics.ExternalMetricValue{
+						MetricName:   metricName,
+						MetricLabels: goodLabel,
+					},
 				},
-				value: external_metrics.ExternalMetricValue{
-					MetricName:   metricName,
-					MetricLabels: goodLabel,
-				},
-			},
 			},
 			metricCompare{
 				provider.ExternalMetricInfo{Metric: metricName},
@@ -162,23 +172,24 @@ func TestGetExternalMetric(t *testing.T) {
 		},
 		{
 			"one matching name metrics stored",
-			[]externalMetric{{
-				info: provider.ExternalMetricInfo{
-					Metric: metricName,
+			[]externalMetric{
+				{
+					info: provider.ExternalMetricInfo{
+						Metric: metricName,
+					},
+					value: external_metrics.ExternalMetricValue{
+						MetricName:   metricName,
+						MetricLabels: goodLabel,
+					},
+				}, {
+					info: provider.ExternalMetricInfo{
+						Metric: metricName,
+					},
+					value: external_metrics.ExternalMetricValue{
+						MetricName:   metricName,
+						MetricLabels: badLabel,
+					},
 				},
-				value: external_metrics.ExternalMetricValue{
-					MetricName:   metricName,
-					MetricLabels: goodLabel,
-				},
-			}, {
-				info: provider.ExternalMetricInfo{
-					Metric: metricName,
-				},
-				value: external_metrics.ExternalMetricValue{
-					MetricName:   metricName,
-					MetricLabels: badLabel,
-				},
-			},
 			},
 			metricCompare{
 				provider.ExternalMetricInfo{Metric: metricName},
@@ -194,23 +205,24 @@ func TestGetExternalMetric(t *testing.T) {
 		},
 		{
 			"one non matching labels metrics stored",
-			[]externalMetric{{
-				info: provider.ExternalMetricInfo{
-					Metric: metricName,
+			[]externalMetric{
+				{
+					info: provider.ExternalMetricInfo{
+						Metric: metricName,
+					},
+					value: external_metrics.ExternalMetricValue{
+						MetricName:   metricName,
+						MetricLabels: goodLabel,
+					},
+				}, {
+					info: provider.ExternalMetricInfo{
+						Metric: metricName,
+					},
+					value: external_metrics.ExternalMetricValue{
+						MetricName:   metricName,
+						MetricLabels: goodLabel,
+					},
 				},
-				value: external_metrics.ExternalMetricValue{
-					MetricName:   metricName,
-					MetricLabels: goodLabel,
-				},
-			}, {
-				info: provider.ExternalMetricInfo{
-					Metric: metricName,
-				},
-				value: external_metrics.ExternalMetricValue{
-					MetricName:   metricName,
-					MetricLabels: goodLabel,
-				},
-			},
 			},
 			metricCompare{
 				provider.ExternalMetricInfo{Metric: metricName},
@@ -221,23 +233,24 @@ func TestGetExternalMetric(t *testing.T) {
 		},
 		{
 			"one matching metric with capital letter stored",
-			[]externalMetric{{
-				info: provider.ExternalMetricInfo{
-					Metric: "CapitalMetric",
+			[]externalMetric{
+				{
+					info: provider.ExternalMetricInfo{
+						Metric: "CapitalMetric",
+					},
+					value: external_metrics.ExternalMetricValue{
+						MetricName:   metricName,
+						MetricLabels: goodLabel,
+					},
+				}, {
+					info: provider.ExternalMetricInfo{
+						Metric: metricName,
+					},
+					value: external_metrics.ExternalMetricValue{
+						MetricName:   metricName,
+						MetricLabels: badLabel,
+					},
 				},
-				value: external_metrics.ExternalMetricValue{
-					MetricName:   metricName,
-					MetricLabels: goodLabel,
-				},
-			}, {
-				info: provider.ExternalMetricInfo{
-					Metric: metricName,
-				},
-				value: external_metrics.ExternalMetricValue{
-					MetricName:   metricName,
-					MetricLabels: badLabel,
-				},
-			},
 			},
 			metricCompare{
 				provider.ExternalMetricInfo{Metric: "capitalmetric"},

--- a/pkg/clusteragent/externalmetrics/provider.go
+++ b/pkg/clusteragent/externalmetrics/provider.go
@@ -31,6 +31,10 @@ const (
 	autogenExpirationPeriodHours int64 = 3
 )
 
+var fakeExternalMetric = provider.ExternalMetricInfo{
+	Metric: "noexternalmetric",
+}
+
 type datadogMetricProvider struct {
 	apiCl            *apiserver.APIClient
 	store            DatadogMetricsInternalStore
@@ -171,6 +175,12 @@ func (p *datadogMetricProvider) ListAllExternalMetrics() []provider.ExternalMetr
 
 	for metricName := range autogenMetricNames {
 		results = append(results, provider.ExternalMetricInfo{Metric: metricName})
+	}
+
+	// Workaround for https://github.com/kubernetes-sigs/custom-metrics-apiserver/issues/146
+	// In any, HPA does not use `List` endpoint
+	if len(results) == 0 {
+		results = append(results, fakeExternalMetric)
 	}
 
 	log.Tracef("Answering list of available metrics: %v", results)

--- a/pkg/clusteragent/externalmetrics/provider_test.go
+++ b/pkg/clusteragent/externalmetrics/provider_test.go
@@ -209,9 +209,11 @@ func TestListAllExternalMetrics(t *testing.T) {
 
 	fixtures := []providerFixture{
 		{
-			desc:                       "Test no metrics in store",
-			storeContent:               []ddmWithQuery{},
-			expectedExternalMetricInfo: []provider.ExternalMetricInfo{},
+			desc:         "Test no metrics in store (send fake metric back)",
+			storeContent: []ddmWithQuery{},
+			expectedExternalMetricInfo: []provider.ExternalMetricInfo{
+				fakeExternalMetric,
+			},
 		},
 		{
 			desc: "Test with metrics in store",


### PR DESCRIPTION
### What does this PR do?

Fixes spammy logs with `client-go` >= 1.25 when no `DatadogMetric` or no HPA running.
Solves https://github.com/DataDog/datadog-agent/issues/15934

### Motivation

Bugfix.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Deploy the Agent (version 7.43) on Kubernetes with external metrics, do not create any `DatadogMetric` or `HPA`, update kubectl to >= `1.25`, observe that you get this log:
```
Got empty response for: external.metrics.k8s.io/v1beta1
```

Every time a `kubectl get po` is done. Upgrade the Cluster Agent to `7.44`, observe that the log is gone.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
