### PR TITLE
Always open podman DB as read only

### DIFF
--- a/pkg/util/podman/db_client.go
+++ b/pkg/util/podman/db_client.go
@@ -31,6 +31,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
+	"time"
 
 	bolt "go.etcd.io/bbolt"
 
@@ -44,6 +46,7 @@ const (
 	allCtrsName   = "all-ctrs"
 	configName    = "config"
 	stateName     = "state"
+	openTimeout   = 30 * time.Second
 )
 
 var (
@@ -139,10 +142,21 @@ func (client *DBClient) GetAllContainers() ([]Container, error) {
 	return res, nil
 }
 
+// Note: original function comes from https://github.com/containers/podman/blob/v3.4.1/libpod/boltdb_state_internal.go
+// It was adapted as we don't need to write any information to the DB.
 func (client *DBClient) getDBCon() (*bolt.DB, error) {
-	db, err := bolt.Open(client.DBPath, 0600, nil)
+	dbOptions := bolt.DefaultOptions
+	dbOptions.ReadOnly = true
+	dbOptions.Timeout = openTimeout
+
+	// Using a custom `OpenFile` to remove the O_CREATE option as we never want to create a file
+	dbOptions.OpenFile = func(name string, flag int, perm os.FileMode) (*os.File, error) {
+		return os.OpenFile(name, flag&^os.O_CREATE, perm)
+	}
+
+	db, err := bolt.Open(client.DBPath, 0o0, dbOptions)
 	if err != nil {
-		return nil, fmt.Errorf("error opening database %s", client.DBPath)
+		return nil, fmt.Errorf("error opening database %s, err: %w", client.DBPath, err)
 	}
 
 	return db, nil


### PR DESCRIPTION
### What does this PR do?

Superseed https://github.com/DataDog/datadog-agent/pull/15946

### Motivation

Improvement.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Test the Agent on `podman`, and verifies that there are no regression

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
