### PR TITLE
Fix NG installer `dd-agent-win-install-fail` kitchen tests

### DIFF
--- a/tools/windows/DatadogAgentInstaller/CustomActions/CleanUpFilesCustomAction.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/CleanUpFilesCustomAction.cs
@@ -8,57 +8,41 @@ namespace Datadog.CustomActions
 {
     public class CleanUpFilesCustomAction
     {
-        private static void RemovePythonDistributions(string projectLocation, ISession session)
-        {
-            var embeddedFolders = new List<string>
-            {
-                Path.Combine(projectLocation, "embedded2"),
-                Path.Combine(projectLocation, "embedded3")
-            };
-            try
-            {
-                foreach (var embeddedDist in embeddedFolders)
-                {
-                    if (Directory.Exists(embeddedDist))
-                    {
-                        session.Log($"{embeddedDist} found, deleting.");
-                        Directory.Delete(embeddedDist, true);
-                    }
-                    else
-                    {
-                        session.Log($"{embeddedDist} not found, skip deletion.");
-                    }
-                }
-            }
-            catch (Exception e)
-            {
-                session.Log($"Error while deleting embedded distribution: {e}");
-            }
-        }
-
         private static ActionResult CleanupFiles(ISession session)
         {
             var projectLocation = session.Property("PROJECTLOCATION");
             var applicationDataLocation = session.Property("APPLICATIONDATADIRECTORY");
-            RemovePythonDistributions(projectLocation, session);
-            try
+            var toDelete = new[]
             {
-                var authToken = Path.Combine(applicationDataLocation, "auth_token");
-
-                if (File.Exists(authToken))
-                {
-                    session.Log($"{authToken} found, deleting.");
-                    File.Delete(authToken);
-                }
-                else
-                {
-                    session.Log($"{authToken} not found exists, skip deletion.");
-                }
-            }
-            catch (Exception e)
+                Path.Combine(projectLocation, "embedded2"),
+                Path.Combine(projectLocation, "embedded3"),
+                Path.Combine(projectLocation, "install_info"),
+                Path.Combine(applicationDataLocation, "auth_token")
+            };
+            foreach (var path in toDelete)
             {
-                session.Log($"Error while deleting file: {e}");
-                return ActionResult.Failure;
+                try
+                {
+                    if (Directory.Exists(path))
+                    {
+                        session.Log($"Deleting directory \"{path}\"");
+                        Directory.Delete(path, true);
+                    }
+                    else if (File.Exists(path))
+                    {
+                        session.Log($"Deleting file \"{path}\"");
+                        File.Delete(path);
+                    }
+                    else
+                    {
+                        session.Log($"{path} not found, skip deletion.");
+                    }
+                }
+                catch (Exception e)
+                {
+                    session.Log($"Error while deleting file: {e}");
+                    return ActionResult.Failure;
+                }
             }
 
             return ActionResult.Success;

--- a/tools/windows/DatadogAgentInstaller/CustomActions/CleanUpFilesCustomAction.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/CleanUpFilesCustomAction.cs
@@ -41,7 +41,8 @@ namespace Datadog.CustomActions
                 catch (Exception e)
                 {
                     session.Log($"Error while deleting file: {e}");
-                    return ActionResult.Failure;
+                    // Don't fail in cleanup/rollback actions otherwise
+                    // we may brick the installation.
                 }
             }
 

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentInstaller.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentInstaller.cs
@@ -161,8 +161,12 @@ namespace WixSetup.Datadog
                 new Dir("logs")
             );
 
-            // enable the ability to repair the installation even when the original MSI is no longer available.
-            project.EnableResilientPackage();
+            // Enable the ability to repair the installation even when the original MSI is no longer available.
+            // This adds a symlink in %PROGRAMFILES%\Datadog\Datadog Agent which remains even when uninstalled
+            // and makes the kitchen test fail.
+            // Furthermore this symbolic link points to the locally cached MSI package (%WINDIR%\Installer)
+            // and won't help if the customer removed it from there.
+            //project.EnableResilientPackage();
 
             project.MajorUpgrade = MajorUpgrade.Default;
             // When set to yes, WiX sets the msidbUpgradeAttributesVersionMaxInclusive attribute,


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
This PR fixes the `dd-agent-win-install-fail` by disabling the resilient package feature because it was leaving a symbolic link behind.
Also refactors the `CleanupFiles` to make it easier to add files/directories to cleanup.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Kitchen tests should pass.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
