### PR TITLE
Fix rollback on upgrade from previous installer

### DIFF
--- a/tools/windows/DatadogAgentInstaller/CustomActions/CustomActions.csproj
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/CustomActions.csproj
@@ -62,6 +62,7 @@
     <Compile Include="IInstallerHttpClient.cs" />
     <Compile Include="InstallerWebClient.cs" />
     <Compile Include="InstallInfoCustomActions.cs" />
+    <Compile Include="PatchInstallerCustomAction.cs" />
     <Compile Include="PythonDistributionCustomAction.cs" />
     <Compile Include="Extensions\SessionExtensions.cs" />
     <Compile Include="ISession.cs" />

--- a/tools/windows/DatadogAgentInstaller/CustomActions/PatchInstallerCustomAction.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/PatchInstallerCustomAction.cs
@@ -6,33 +6,13 @@ namespace Datadog.CustomActions
 {
     public class PatchInstallerCustomAction
     {
-        private static void RenameSubKey(string path, string keyName, string newKeyName)
-        {
-            if (Environment.Is64BitOperatingSystem && !Environment.Is64BitProcess)
-            {
-                var rk64 = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry64)
-                    .OpenSubKey(path, RegistryKeyPermissionCheck.ReadWriteSubTree);
-
-                var objValue = rk64.GetValue(keyName);
-                var valKind = rk64.GetValueKind(keyName);
-
-                rk64.SetValue(newKeyName, objValue, valKind);
-                rk64.DeleteValue(keyName);
-            }
-
-            using var rk = Registry.LocalMachine.OpenSubKey(path, RegistryKeyPermissionCheck.ReadWriteSubTree);
-            {
-                var objValue = rk.GetValue(keyName);
-                var valKind = rk.GetValueKind(keyName);
-
-                rk.SetValue(newKeyName, objValue, valKind);
-                rk.DeleteValue(keyName);
-            }
-        }
-
         /// <summary>
         /// Patch the previous install to make the upgrade work.
         /// </summary>
+        /// <remarks>
+        /// This function is used to make any changes necessary
+        /// to the system during an upgrade to ensure it goes smoothly.
+        /// </remarks>
         /// <param name="s">The session object.</param>
         /// <returns><see cref="ActionResult.Success"/></returns>
         [CustomAction]
@@ -41,43 +21,15 @@ namespace Datadog.CustomActions
             ISession session = new SessionWrapper(s);
             try
             {
-                // Prevent the previous installer from deleting the services on rollback
-                RenameSubKey(@"Software\Datadog\Datadog Agent\installRollback\", "Installed Services",
-                    "_Installed Services");
-
-                // Prevent the previous installer from deleting the ddagentuser on rollback
-                RenameSubKey(@"Software\Datadog\Datadog Agent\installRollback\", "CreatedDDUser", "_CreatedDDUser");
+                // The previous installer left this key around
+                // which causes both the services and the user to be deleted on rollback.
+                // So delete it now to ensure rollbacks work smoothly.
+                Registry.LocalMachine.DeleteSubKey(@"Software\Datadog\Datadog Agent\installRollback");
             }
             catch (Exception e)
             {
                 // Don't need full stack trace
                 session.Log($"Cannot patch previous installation: {e.Message}");
-            }
-
-            return ActionResult.Success;
-        }
-
-        /// <summary>
-        /// Undo the patch done in the <see cref="Patch"/> function.
-        /// </summary>
-        /// Ideally we would schedule this as a rollback for the `<see cref="Patch"/> function
-        /// and it would run as the last rollback, unfortunately the previous installer
-        /// rollback runs after this one no matter which order we put the custom action in.
-        /// <param name="s">The session object.</param>
-        /// <returns><see cref="ActionResult.Success"/></returns>
-        public static ActionResult Unpatch(Session s)
-        {
-            ISession session = new SessionWrapper(s);
-            try
-            {
-                RenameSubKey(@"Software\Datadog\Datadog Agent\installRollback", "_Installed Services",
-                    "Installed Services");
-                RenameSubKey(@"Software\Datadog\Datadog Agent\installRollback", "_CreatedDDUser", "CreatedDDUser");
-            }
-            catch (Exception e)
-            {
-                // Don't need full stack trace
-                session.Log($"Cannot unpatch previous installation: {e.Message}");
             }
 
             return ActionResult.Success;

--- a/tools/windows/DatadogAgentInstaller/CustomActions/PatchInstallerCustomAction.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/PatchInstallerCustomAction.cs
@@ -1,0 +1,82 @@
+using System;
+using Microsoft.Deployment.WindowsInstaller;
+using Microsoft.Win32;
+
+namespace Datadog.CustomActions;
+
+public class PatchInstallerCustomAction
+{
+    private static void RenameSubKey(string path, string keyName, string newKeyName)
+    {
+        if (Environment.Is64BitOperatingSystem && !Environment.Is64BitProcess)
+        {
+            var rk64 = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry64).OpenSubKey(path, RegistryKeyPermissionCheck.ReadWriteSubTree);
+
+            var objValue = rk64.GetValue(keyName);
+            var valKind = rk64.GetValueKind(keyName);
+
+            rk64.SetValue(newKeyName, objValue, valKind);
+            rk64.DeleteValue(keyName);
+        }
+
+        using var rk = Registry.LocalMachine.OpenSubKey(path, RegistryKeyPermissionCheck.ReadWriteSubTree);
+        {
+            var objValue = rk.GetValue(keyName);
+            var valKind = rk.GetValueKind(keyName);
+
+            rk.SetValue(newKeyName, objValue, valKind);
+            rk.DeleteValue(keyName);
+        }
+    }
+
+    /// <summary>
+    /// Patch the previous install to make the upgrade work.
+    /// </summary>
+    /// <param name="s">The session object.</param>
+    /// <returns><see cref="ActionResult.Success"/></returns>
+    [CustomAction]
+    public static ActionResult Patch(Session s)
+    {
+        ISession session = new SessionWrapper(s);
+        try
+        {
+            // Prevent the previous installer from deleting the services on rollback
+            RenameSubKey(@"Software\Datadog\Datadog Agent\installRollback\", "Installed Services", "_Installed Services");
+
+            // Prevent the previous installer from deleting the ddagentuser on rollback
+            RenameSubKey(@"Software\Datadog\Datadog Agent\installRollback\", "CreatedDDUser", "_CreatedDDUser"); 
+        }
+        catch (Exception e)
+        {
+            // Don't need full stack trace
+            session.Log($"Cannot patch previous installation: {e.Message}");
+        }
+
+        return ActionResult.Success;
+    }
+
+    /// <summary>
+    /// Undo the patch done in the <see cref="Patch"/> function.
+    /// </summary>
+    /// Ideally we would schedule this as a rollback for the `<see cref="Patch"/> function
+    /// and it would run as the last rollback, unfortunately the previous installer
+    /// rollback runs after this one no matter which order we put the custom action in.
+    /// <param name="s">The session object.</param>
+    /// <returns><see cref="ActionResult.Success"/></returns>
+    public static ActionResult Unpatch(Session s)
+    {
+        ISession session = new SessionWrapper(s);
+        try
+        {
+            RenameSubKey(@"Software\Datadog\Datadog Agent\installRollback", "_Installed Services", "Installed Services");
+            RenameSubKey(@"Software\Datadog\Datadog Agent\installRollback", "_CreatedDDUser", "CreatedDDUser");
+        }
+        catch (Exception e)
+        {
+            // Don't need full stack trace
+            session.Log($"Cannot unpatch previous installation: {e.Message}");
+        }
+
+        return ActionResult.Success;
+    }
+}

--- a/tools/windows/DatadogAgentInstaller/CustomActions/PatchInstallerCustomAction.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/PatchInstallerCustomAction.cs
@@ -2,81 +2,85 @@ using System;
 using Microsoft.Deployment.WindowsInstaller;
 using Microsoft.Win32;
 
-namespace Datadog.CustomActions;
-
-public class PatchInstallerCustomAction
+namespace Datadog.CustomActions
 {
-    private static void RenameSubKey(string path, string keyName, string newKeyName)
+    public class PatchInstallerCustomAction
     {
-        if (Environment.Is64BitOperatingSystem && !Environment.Is64BitProcess)
+        private static void RenameSubKey(string path, string keyName, string newKeyName)
         {
-            var rk64 = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry64).OpenSubKey(path, RegistryKeyPermissionCheck.ReadWriteSubTree);
+            if (Environment.Is64BitOperatingSystem && !Environment.Is64BitProcess)
+            {
+                var rk64 = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry64)
+                    .OpenSubKey(path, RegistryKeyPermissionCheck.ReadWriteSubTree);
 
-            var objValue = rk64.GetValue(keyName);
-            var valKind = rk64.GetValueKind(keyName);
+                var objValue = rk64.GetValue(keyName);
+                var valKind = rk64.GetValueKind(keyName);
 
-            rk64.SetValue(newKeyName, objValue, valKind);
-            rk64.DeleteValue(keyName);
+                rk64.SetValue(newKeyName, objValue, valKind);
+                rk64.DeleteValue(keyName);
+            }
+
+            using var rk = Registry.LocalMachine.OpenSubKey(path, RegistryKeyPermissionCheck.ReadWriteSubTree);
+            {
+                var objValue = rk.GetValue(keyName);
+                var valKind = rk.GetValueKind(keyName);
+
+                rk.SetValue(newKeyName, objValue, valKind);
+                rk.DeleteValue(keyName);
+            }
         }
 
-        using var rk = Registry.LocalMachine.OpenSubKey(path, RegistryKeyPermissionCheck.ReadWriteSubTree);
+        /// <summary>
+        /// Patch the previous install to make the upgrade work.
+        /// </summary>
+        /// <param name="s">The session object.</param>
+        /// <returns><see cref="ActionResult.Success"/></returns>
+        [CustomAction]
+        public static ActionResult Patch(Session s)
         {
-            var objValue = rk.GetValue(keyName);
-            var valKind = rk.GetValueKind(keyName);
+            ISession session = new SessionWrapper(s);
+            try
+            {
+                // Prevent the previous installer from deleting the services on rollback
+                RenameSubKey(@"Software\Datadog\Datadog Agent\installRollback\", "Installed Services",
+                    "_Installed Services");
 
-            rk.SetValue(newKeyName, objValue, valKind);
-            rk.DeleteValue(keyName);
-        }
-    }
+                // Prevent the previous installer from deleting the ddagentuser on rollback
+                RenameSubKey(@"Software\Datadog\Datadog Agent\installRollback\", "CreatedDDUser", "_CreatedDDUser");
+            }
+            catch (Exception e)
+            {
+                // Don't need full stack trace
+                session.Log($"Cannot patch previous installation: {e.Message}");
+            }
 
-    /// <summary>
-    /// Patch the previous install to make the upgrade work.
-    /// </summary>
-    /// <param name="s">The session object.</param>
-    /// <returns><see cref="ActionResult.Success"/></returns>
-    [CustomAction]
-    public static ActionResult Patch(Session s)
-    {
-        ISession session = new SessionWrapper(s);
-        try
-        {
-            // Prevent the previous installer from deleting the services on rollback
-            RenameSubKey(@"Software\Datadog\Datadog Agent\installRollback\", "Installed Services", "_Installed Services");
-
-            // Prevent the previous installer from deleting the ddagentuser on rollback
-            RenameSubKey(@"Software\Datadog\Datadog Agent\installRollback\", "CreatedDDUser", "_CreatedDDUser"); 
-        }
-        catch (Exception e)
-        {
-            // Don't need full stack trace
-            session.Log($"Cannot patch previous installation: {e.Message}");
+            return ActionResult.Success;
         }
 
-        return ActionResult.Success;
-    }
-
-    /// <summary>
-    /// Undo the patch done in the <see cref="Patch"/> function.
-    /// </summary>
-    /// Ideally we would schedule this as a rollback for the `<see cref="Patch"/> function
-    /// and it would run as the last rollback, unfortunately the previous installer
-    /// rollback runs after this one no matter which order we put the custom action in.
-    /// <param name="s">The session object.</param>
-    /// <returns><see cref="ActionResult.Success"/></returns>
-    public static ActionResult Unpatch(Session s)
-    {
-        ISession session = new SessionWrapper(s);
-        try
+        /// <summary>
+        /// Undo the patch done in the <see cref="Patch"/> function.
+        /// </summary>
+        /// Ideally we would schedule this as a rollback for the `<see cref="Patch"/> function
+        /// and it would run as the last rollback, unfortunately the previous installer
+        /// rollback runs after this one no matter which order we put the custom action in.
+        /// <param name="s">The session object.</param>
+        /// <returns><see cref="ActionResult.Success"/></returns>
+        public static ActionResult Unpatch(Session s)
         {
-            RenameSubKey(@"Software\Datadog\Datadog Agent\installRollback", "_Installed Services", "Installed Services");
-            RenameSubKey(@"Software\Datadog\Datadog Agent\installRollback", "_CreatedDDUser", "CreatedDDUser");
-        }
-        catch (Exception e)
-        {
-            // Don't need full stack trace
-            session.Log($"Cannot unpatch previous installation: {e.Message}");
-        }
+            ISession session = new SessionWrapper(s);
+            try
+            {
+                RenameSubKey(@"Software\Datadog\Datadog Agent\installRollback", "_Installed Services",
+                    "Installed Services");
+                RenameSubKey(@"Software\Datadog\Datadog Agent\installRollback", "_CreatedDDUser", "CreatedDDUser");
+            }
+            catch (Exception e)
+            {
+                // Don't need full stack trace
+                session.Log($"Cannot unpatch previous installation: {e.Message}");
+            }
 
-        return ActionResult.Success;
+            return ActionResult.Success;
+        }
     }
 }

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentCustomActions.cs
@@ -14,6 +14,8 @@ namespace WixSetup.Datadog
 
         public ManagedAction ReadConfig { get; }
 
+        public ManagedAction PatchInstaller { get; set; }
+
         public ManagedAction WriteConfig { get; }
 
         public ManagedAction ReadRegistryProperties { get; }
@@ -81,6 +83,16 @@ namespace WixSetup.Datadog
             }
             .SetProperties("APPLICATIONDATADIRECTORY=[APPLICATIONDATADIRECTORY]");
 
+            PatchInstaller = new CustomAction<PatchInstallerCustomAction>(
+                new Id(nameof(PatchInstaller)),
+                PatchInstallerCustomAction.Patch,
+                Return.ignore,
+                When.After,
+                Step.InstallFiles,
+                Conditions.Upgrading)
+            {
+                Execute = Execute.deferred
+            };
             ReportInstallFailure = new CustomAction<Telemetry>(
                     new Id(nameof(ReportInstallFailure)),
                     Telemetry.ReportFailure,

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentCustomActions.cs
@@ -89,7 +89,8 @@ namespace WixSetup.Datadog
                 Return.ignore,
                 When.After,
                 Step.InstallFiles,
-                Conditions.Upgrading)
+                Conditions.Upgrading
+            )
             {
                 Execute = Execute.deferred
             };


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
This PR addresses the issue of rollback on upgrade from an OG installer to the NG installer, where the OG installer would delete the services and user on rollback.
There are 2 registry keys that control the deletion behavior, one on `uninstall` and one on `rollback`, it's safe to delete the `rollback` keys since the rollback on upgrade should never delete the services/user in the first place.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Working rollback on upgrade.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
