### PR TITLE
Fix NPM installation in the NG installer

### DIFF
--- a/tools/windows/DatadogAgentInstaller/CustomActions.Tests/Telemetry/TelemetryUnitTests.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions.Tests/Telemetry/TelemetryUnitTests.cs
@@ -14,7 +14,6 @@ namespace CustomActions.Tests.Telemetry
         [Theory]
         [InlineAutoData("aaaa", "", "agent.installation.success")]
         [InlineAutoData("aaaa", "datadoghq.eu", "agent.installation.failure")]
-        [InlineAutoData("", "", "aaaaaaa")]
         public void ReportTelemetry_Should_Post_Telemetry(
             string apiKey,
             string site,
@@ -53,6 +52,29 @@ namespace CustomActions.Tests.Telemetry
                     { "Content-Type", "application/json" },
                 }
             ));
+        }
+
+        [Theory]
+        [InlineAutoData("", "")]
+        [InlineAutoData("", "datadoghq.eu")]
+        public void ReportTelemetry_Should_Not_Post_Telemetry(
+            string apiKey,
+            string site,
+            string eventName,
+            Mock<IInstallerHttpClient> httpClientMock,
+            Mock<ISession> sessionMock
+        )
+        {
+            if (site == string.Empty)
+            {
+                site = "datadoghq.com";
+            }
+            sessionMock.Setup(session => session["SITE"]).Returns(site);
+            sessionMock.Setup(session => session["APIKEY"]).Returns(apiKey);
+
+            var sut = new Datadog.CustomActions.Telemetry(httpClientMock.Object, sessionMock.Object);
+            sut.ReportTelemetry(eventName);
+            httpClientMock.VerifyNoOtherCalls();
         }
     }
 }

--- a/tools/windows/DatadogAgentInstaller/CustomActions/CleanUpFilesCustomAction.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/CleanUpFilesCustomAction.cs
@@ -1,6 +1,5 @@
 using Datadog.CustomActions.Extensions;
 using Microsoft.Deployment.WindowsInstaller;
-using System.Collections.Generic;
 using System.IO;
 using System;
 
@@ -16,7 +15,7 @@ namespace Datadog.CustomActions
             {
                 Path.Combine(projectLocation, "embedded2"),
                 Path.Combine(projectLocation, "embedded3"),
-                Path.Combine(projectLocation, "install_info"),
+                Path.Combine(applicationDataLocation, "install_info"),
                 Path.Combine(applicationDataLocation, "auth_token")
             };
             foreach (var path in toDelete)

--- a/tools/windows/DatadogAgentInstaller/CustomActions/CustomActions.csproj
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/CustomActions.csproj
@@ -62,6 +62,7 @@
     <Compile Include="IInstallerHttpClient.cs" />
     <Compile Include="InstallerWebClient.cs" />
     <Compile Include="InstallInfoCustomActions.cs" />
+    <Compile Include="NpmCustomAction.cs" />
     <Compile Include="PatchInstallerCustomAction.cs" />
     <Compile Include="PythonDistributionCustomAction.cs" />
     <Compile Include="Extensions\SessionExtensions.cs" />

--- a/tools/windows/DatadogAgentInstaller/CustomActions/NpmCustomAction.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/NpmCustomAction.cs
@@ -16,7 +16,7 @@ public class NpmCustomAction
             using var systemProbeDef = Registry.LocalMachine.OpenSubKey(@"SYSTEM\CurrentControlSet\Services\datadog-system-probe", true);
             if (systemProbeDef != null)
             {
-                if (string.IsNullOrEmpty(addLocal) )
+                if (string.IsNullOrEmpty(addLocal))
                 {
                     systemProbeDef.SetValue("DependOnService", new[]
                     {

--- a/tools/windows/DatadogAgentInstaller/CustomActions/NpmCustomAction.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/NpmCustomAction.cs
@@ -1,0 +1,53 @@
+using System;
+using Datadog.CustomActions.Extensions;
+using Microsoft.Deployment.WindowsInstaller;
+using Microsoft.Win32;
+
+namespace Datadog.CustomActions;
+
+public class NpmCustomAction
+{
+    private static ActionResult EnsureNpmServiceDepdendency(ISession session)
+    {
+        try
+        {
+            var addLocal = session.Property("ADDLOCAL");
+            session.Log($"ADDLOCAL={addLocal}");
+            using var systemProbeDef = Registry.LocalMachine.OpenSubKey(@"SYSTEM\CurrentControlSet\Services\datadog-system-probe", true);
+            if (systemProbeDef != null)
+            {
+                if (string.IsNullOrEmpty(addLocal) )
+                {
+                    systemProbeDef.SetValue("DependOnService", new[]
+                    {
+                        "datadogagent"
+                    }, RegistryValueKind.MultiString);
+
+                }
+                else if (addLocal.Contains("NPM"))
+                {
+                    systemProbeDef.SetValue("DependOnService", new[]
+                    {
+                        "datadogagent",
+                        "ddnpm"
+                    }, RegistryValueKind.MultiString);
+                }
+            }
+            else
+            {
+                session.Log("Registry key does not exist");
+            }
+        }
+        catch (Exception e)
+        {
+            session.Log($"Could not update system probe dependent service: {e.Message}");
+        }
+        return ActionResult.Success;
+    }
+
+    [CustomAction]
+    public static ActionResult EnsureNpmServiceDependency(Session session)
+    {
+        return EnsureNpmServiceDepdendency(new SessionWrapper(session));
+    }
+}

--- a/tools/windows/DatadogAgentInstaller/CustomActions/NpmCustomAction.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/NpmCustomAction.cs
@@ -11,7 +11,7 @@ namespace Datadog.CustomActions
         {
             try
             {
-                var addLocal = session.Property("ADDLOCAL");
+                var addLocal = session.Property("ADDLOCAL").ToUpper();
                 session.Log($"ADDLOCAL={addLocal}");
                 using var systemProbeDef = Registry.LocalMachine.OpenSubKey(@"SYSTEM\CurrentControlSet\Services\datadog-system-probe", true);
                 if (systemProbeDef != null)

--- a/tools/windows/DatadogAgentInstaller/CustomActions/Telemetry.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/Telemetry.cs
@@ -29,6 +29,11 @@ namespace Datadog.CustomActions
         public void ReportTelemetry(string eventName)
         {
             var apikey = _session.Property("APIKEY");
+            if (string.IsNullOrEmpty(apikey))
+            {
+                _session.Log("API key empty, not reporting telemetry");
+                return;
+            }
             var site = _session.Property("SITE");
             if (string.IsNullOrEmpty(site))
             {
@@ -68,7 +73,8 @@ namespace Datadog.CustomActions
             }
             catch (Exception e)
             {
-                session.Log($"Error sending telemetry: {e}");
+                // No need for full stack trace here.
+                session.Log($"Error sending telemetry: {e.Message}");
                 return ActionResult.Failure;
             }
             return ActionResult.Success;

--- a/tools/windows/DatadogAgentInstaller/CustomActions/UserCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/UserCustomActions.cs
@@ -162,8 +162,8 @@ namespace Datadog.CustomActions
             {
                 if (!string.IsNullOrEmpty(session["DDAGENTUSER_PROCESSED_FQ_NAME"]))
                 {
-                  // This function has already executed successfully
-                  return ActionResult.Success;
+                    // This function has already executed successfully
+                    return ActionResult.Success;
                 }
 
                 var ddAgentUserName = session["DDAGENTUSER_NAME"];

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentCustomActions.cs
@@ -42,6 +42,8 @@ namespace WixSetup.Datadog
 
         public ManagedAction ReportInstallSuccess { get; }
 
+        public ManagedAction EnsureNpmServiceDepdendency { get; }
+
         public AgentCustomActions()
         {
             ReadRegistryProperties = new CustomAction<UserCustomActions>(
@@ -94,12 +96,13 @@ namespace WixSetup.Datadog
             {
                 Execute = Execute.deferred
             };
+
             ReportInstallFailure = new CustomAction<Telemetry>(
-                    new Id(nameof(ReportInstallFailure)),
-                    Telemetry.ReportFailure,
-                    Return.ignore,
-                    When.Before,
-                    Step.StartServices
+                new Id(nameof(ReportInstallFailure)),
+                Telemetry.ReportFailure,
+                Return.ignore,
+                When.Before,
+                Step.StartServices
             )
             {
                 Execute = Execute.rollback
@@ -107,12 +110,25 @@ namespace WixSetup.Datadog
             .SetProperties("APIKEY=[APIKEY], SITE=[SITE]")
             .HideTarget(true); ;
 
+            EnsureNpmServiceDepdendency = new CustomAction<NpmCustomAction>(
+                new Id(nameof(EnsureNpmServiceDepdendency)),
+                NpmCustomAction.EnsureNpmServiceDependency,
+                Return.check,
+                When.After,
+                new Step(ReportInstallFailure.Id),
+                Conditions.FirstInstall | Conditions.Upgrading | Conditions.Maintenance
+            )
+                {
+                Execute = Execute.deferred
+            }
+            .SetProperties("ADDLOCAL=[ADDLOCAL]");
+
             WriteConfig = new CustomAction<ConfigCustomActions>(
                 new Id(nameof(WriteConfig)),
                 ConfigCustomActions.WriteConfig,
                 Return.check,
                 When.After,
-                new Step(ReportInstallFailure.Id),
+                new Step(EnsureNpmServiceDepdendency.Id),
                 Conditions.FirstInstall
             )
             {

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentFeatures.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentFeatures.cs
@@ -13,7 +13,7 @@ namespace WixSetup.Datadog
 
         public AgentFeatures()
         {
-            Npm = new Feature(NpmFeatureName, description: string.Empty, isEnabled: true, allowChange: false, configurableDir: "PROJECTLOCATION")
+            Npm = new Feature(NpmFeatureName, description: string.Empty, isEnabled: false, allowChange: true, configurableDir: "PROJECTLOCATION")
             {
                 Id = new Id("NPM")
             };

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentFeatures.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentFeatures.cs
@@ -13,7 +13,7 @@ namespace WixSetup.Datadog
 
         public AgentFeatures()
         {
-            Npm = new Feature(NpmFeatureName, description: string.Empty, isEnabled: false, allowChange: true, configurableDir: "PROJECTLOCATION")
+            Npm = new Feature(NpmFeatureName, description: string.Empty, isEnabled: true, allowChange: false, configurableDir: "PROJECTLOCATION")
             {
                 Id = new Id("NPM")
             };

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentInstaller.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentInstaller.cs
@@ -387,15 +387,6 @@ namespace WixSetup.Datadog
                     new Dir("dist",
                         new Files($@"{InstallerSource}\bin\agent\dist\*")
                     ),
-                    // This doesn't work.
-                    //new Dir(new Id("DRIVER"), "driver"
-                    //, new Merge
-                        //{
-                        //    Id = "ddnpminstall",
-                        //    Feature = _agentFeatures.Npm,
-                        //    SourceFile = $@"{BinSource}\agent\DDNPM.msm"
-                        //}
-                    //),
                     new WixSharp.File(_agentBinaries.Tray),
                     new WixSharp.File(_agentBinaries.ProcessAgent, processAgentService),
                     new EventSource

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentInstaller.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentInstaller.cs
@@ -13,7 +13,7 @@ namespace WixSetup.Datadog
     public class AgentInstaller : IWixProjectEvents
     {
         // Company
-        private const string CompanyFullName = "Datadog, inc.";
+        private const string CompanyFullName = "Datadog, Inc.";
 
         // Product
         private const string ProductFullName = "Datadog Agent";

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentInstaller.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentInstaller.cs
@@ -229,6 +229,7 @@ namespace WixSetup.Datadog
                     .AddElement("Directory", "Id=DRIVER; Name=driver")
                     .AddElement("Merge",
                         $"Id=ddnpminstall; SourceFile={BinSource}\\agent\\DDNPM.msm; DiskId=1; Language=1033");
+                // We don't use the Wix "Merge" MSM feature because it seems to be a no-op...
                 document
                     .FindAll("Feature")
                     .First(x => x.HasAttribute("Id", value => value == "NPM"))

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentInstaller.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentInstaller.cs
@@ -372,7 +372,7 @@ namespace WixSetup.Datadog
             var processAgentService = GenerateDependentServiceInstaller(new Id("ddagentprocessservice"), "datadog-process-agent", "Datadog Process Agent", "Send process metrics to Datadog", "LocalSystem");
             var traceAgentService = GenerateDependentServiceInstaller(new Id("ddagenttraceservice"), "datadog-trace-agent", "Datadog Trace Agent", "Send tracing metrics to Datadog", "[DDAGENTUSER_PROCESSED_FQ_NAME]", "[DDAGENTUSER_PROCESSED_PASSWORD]");
             var systemProbeService = GenerateDependentServiceInstaller(new Id("ddagentsysprobeservice"), "datadog-system-probe", "Datadog System Probe", "Send network metrics to Datadog", "LocalSystem");
-
+            systemProbeService.DependsOn = systemProbeService.DependsOn.Combine(new ServiceDependency("ddnpm"));
             var targetBinFolder = new Dir(new Id("BIN"), "bin",
                 new WixSharp.File(_agentBinaries.Agent, agentService),
                 new EventSource

--- a/tools/windows/DatadogAgentInstaller/WixSetup/WixSetup.csproj
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/WixSetup.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>WinExe</OutputType>
+    <OutputType>Exe</OutputType>
     <TargetFramework>net472</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <RootNamespace>$(MSBuildProjectName.Replace(" ", "_").Replace("-", "_"))</RootNamespace>


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
This PR fixes the NPM installation in the NG installer by always writing the NPM driver to disk and having the `system-probe` dependency correctly setup.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Working NPM in NG installer

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
