### PR TITLE
[Serverless] Show dependency graph for new large serverless dependencies.

### DIFF
--- a/.github/workflows/serverless-binary-size.yml
+++ b/.github/workflows/serverless-binary-size.yml
@@ -15,6 +15,12 @@ jobs:
         with:
           path: go/src/github.com/DataDog/datadog-agent
 
+      - name: Checkout datadog-agent base branch
+        run: |
+          cd go/src/github.com/DataDog/datadog-agent
+          git fetch origin $GITHUB_BASE_REF --depth 1
+          git checkout $GITHUB_BASE_REF
+
       - name: Checkout the datadog-lambda-extension repository
         uses: actions/checkout@v3
         with:
@@ -24,25 +30,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Current binary size and dependencies
-        id: current
-        run: |
-          cd go/src/github.com/DataDog/datadog-lambda-extension
-
-          OUTPUT=$(./scripts/visualize_size.sh size)
-          echo "binary size after merging this pull request will be $OUTPUT"
-          echo "result=$OUTPUT" >> $GITHUB_OUTPUT
-
-          echo "deps<<EOF" >> $GITHUB_OUTPUT
-          ./scripts/visualize_size.sh list_symbols | awk '{print $2}' | head -n 100 >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
-
-      - name: Checkout datadog-agent main
-        run: |
-          cd go/src/github.com/DataDog/datadog-agent
-          git fetch origin $GITHUB_BASE_REF --depth 1
-          git checkout origin/$GITHUB_BASE_REF
-
       - name: Previous binary size and dependencies
         id: previous
         run: |
@@ -50,6 +37,25 @@ jobs:
 
           OUTPUT=$(./scripts/visualize_size.sh size)
           echo "binary size before merging this pull request is $OUTPUT"
+          echo "result=$OUTPUT" >> $GITHUB_OUTPUT
+
+          echo "deps<<EOF" >> $GITHUB_OUTPUT
+          ./scripts/visualize_size.sh list_symbols | awk '{print $2}' | head -n 100 >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Checkout datadog-agent pr branch
+        run: |
+          cd go/src/github.com/DataDog/datadog-agent
+          git fetch origin $GITHUB_SHA --depth 1
+          git checkout $GITHUB_SHA
+
+      - name: Current binary size and dependencies
+        id: current
+        run: |
+          cd go/src/github.com/DataDog/datadog-lambda-extension
+
+          OUTPUT=$(./scripts/visualize_size.sh size)
+          echo "binary size after merging this pull request will be $OUTPUT"
           echo "result=$OUTPUT" >> $GITHUB_OUTPUT
 
           echo "deps<<EOF" >> $GITHUB_OUTPUT
@@ -65,6 +71,17 @@ jobs:
           OUTPUT=$(( $OUTPUT / 100000 ))
           echo "coldstart=$OUTPUT" >> $GITHUB_OUTPUT
 
+      ### Steps below only run if size diff > SIZE_ALLOWANCE ###
+
+      - name: Install graphviz
+        uses: ts-graphviz/setup-graphviz@v1
+        if: steps.compare.outputs.diff > env.SIZE_ALLOWANCE
+
+      - name: Install digraph
+        if: steps.compare.outputs.diff > env.SIZE_ALLOWANCE
+        run: |
+          GOPATH=$(pwd)/go go install golang.org/x/tools/cmd/digraph@latest
+
       - name: List new dependencies
         id: deps
         if: steps.compare.outputs.diff > env.SIZE_ALLOWANCE
@@ -77,23 +94,45 @@ jobs:
           done
           echo "EOF" >> $GITHUB_OUTPUT
 
-      - name: Post comment
+      - name: Create dependency graphs
         if: steps.compare.outputs.diff > env.SIZE_ALLOWANCE
+        run: |
+          export PATH=$(pwd)/go/bin:$PATH
+          cd go/src/github.com/DataDog/datadog-lambda-extension
+          mkdir graphs
+          for dep in $(echo "${{ steps.deps.outputs.deps }}"); do
+            PACKAGE=$dep ./scripts/visualize_size.sh graph
+            mv .layers/output.svg graphs/$(echo $dep | tr '/' '-').svg
+          done
+
+      - name: Archive dependency graphs
+        uses: actions/upload-artifact@v3
+        if: steps.compare.outputs.diff > env.SIZE_ALLOWANCE
+        with:
+          name: dependency-graphs
+          path: go/src/github.com/DataDog/datadog-lambda-extension/graphs
+
+      - name: Post comment
         uses: marocchino/sticky-pull-request-comment@v2.5.0
+        if: steps.compare.outputs.diff > env.SIZE_ALLOWANCE
         with:
           hide_and_recreate: true
           hide_classify: "RESOLVED"
           message: |
             :warning::rotating_light: Warning, this pull request increases the binary size of serverless extension by ${{ steps.compare.outputs.diff }} bytes. Each MB of binary size increase means about 10ms of additional cold start time, so this pull request would increase cold start time by ${{ steps.compare.outputs.coldstart }}ms.
 
+            If you have questions, we are happy to help, come visit us in the [#serverless](https://dd.slack.com/archives/CBWDFKWV8) slack channel and provide a link to this comment.
+
             <details>
-            <summary>New dependencies added</summary>
+            <summary>Debug info</summary>
+
+            These dependencies were added to the serverless extension by this pull request:
 
             ```
             ${{ steps.deps.outputs.deps }}
             ```
-            </details>
+
+            View dependency graphs for each added dependency in the [artifacts section](https://github.com/DataDog/datadog-agent/actions/runs/${{ github.run_id }}#artifacts) of the github action.
 
             We suggest you consider adding the `!serverless` build tag to remove any new dependencies not needed in the serverless extension.
-
-            If you have questions, we are happy to help, come visit us in the [#serverless](https://dd.slack.com/archives/CBWDFKWV8) slack channel and provide a link to this comment.
+            </details>


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This pull request archives dependency graphs when the binary size of the serverless extension increases by more than 0.1MB. These graphs make it easier to track down where a new dependency was added.

<img width="830" alt="Screen Shot 2023-03-06 at 2 21 07 PM" src="https://user-images.githubusercontent.com/1383216/223257998-2453f94f-c1ce-419b-9e01-6cb351b4369c.png">

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

We want to give ourselves as much information as we need to be able to solve binary size issues.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
