### PR TITLE
Add prebuilt ebpf asset telemetry

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	code.cloudfoundry.org/garden v0.0.0-20210208153517-580cadd489d2
 	code.cloudfoundry.org/lager v2.0.0+incompatible
 	github.com/CycloneDX/cyclonedx-go v0.7.0
-	github.com/DataDog/agent-payload/v5 v5.0.75
+	github.com/DataDog/agent-payload/v5 v5.0.76-0.20230303204218-881d992cf5dc
 	github.com/DataDog/appsec-internal-go v0.0.0-20230215162203-5149228be86a
 	github.com/DataDog/datadog-agent/pkg/obfuscate v0.43.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.43.0-rc.3

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	code.cloudfoundry.org/garden v0.0.0-20210208153517-580cadd489d2
 	code.cloudfoundry.org/lager v2.0.0+incompatible
 	github.com/CycloneDX/cyclonedx-go v0.7.0
-	github.com/DataDog/agent-payload/v5 v5.0.76-0.20230303204218-881d992cf5dc
+	github.com/DataDog/agent-payload/v5 v5.0.76
 	github.com/DataDog/appsec-internal-go v0.0.0-20230215162203-5149228be86a
 	github.com/DataDog/datadog-agent/pkg/obfuscate v0.43.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.43.0-rc.3

--- a/go.sum
+++ b/go.sum
@@ -128,8 +128,8 @@ github.com/BurntSushi/toml v1.2.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbi
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/CycloneDX/cyclonedx-go v0.7.0 h1:jNxp8hL7UpcvPDFXjY+Y1ibFtsW+e5zyF9QoSmhK/zg=
 github.com/CycloneDX/cyclonedx-go v0.7.0/go.mod h1:W5Z9w8pTTL+t+yG3PCiFRGlr8PUlE0pGWzKSJbsyXkg=
-github.com/DataDog/agent-payload/v5 v5.0.75 h1:M7GvFvtgQPEsiFJJY69UIuawx9fn6DTbkhaq3Xtah7U=
-github.com/DataDog/agent-payload/v5 v5.0.75/go.mod h1:oQZi1VZp1e3QvlSUX4iphZCpJaFepUxWq0hNXxihKBM=
+github.com/DataDog/agent-payload/v5 v5.0.76-0.20230303204218-881d992cf5dc h1:MGQfLgtqbabYm2YIC7B3uKHXL2C0aBcDJZSq/UQo920=
+github.com/DataDog/agent-payload/v5 v5.0.76-0.20230303204218-881d992cf5dc/go.mod h1:oQZi1VZp1e3QvlSUX4iphZCpJaFepUxWq0hNXxihKBM=
 github.com/DataDog/appsec-internal-go v0.0.0-20230215162203-5149228be86a h1:7ZiVdU4j19IYuy8rR0uUzC7I7HjWul61ZEyUgvLkZBM=
 github.com/DataDog/appsec-internal-go v0.0.0-20230215162203-5149228be86a/go.mod h1:ILSJBuOg3E0Jg8qgSnm7+g8DXa0KrfahnS7jhS1DoWs=
 github.com/DataDog/aptly v1.5.0 h1:Oy6JVRC9iDgnmpeVYa4diXwP/exU7wJ/U1kuI4Zacxg=

--- a/go.sum
+++ b/go.sum
@@ -128,8 +128,8 @@ github.com/BurntSushi/toml v1.2.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbi
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/CycloneDX/cyclonedx-go v0.7.0 h1:jNxp8hL7UpcvPDFXjY+Y1ibFtsW+e5zyF9QoSmhK/zg=
 github.com/CycloneDX/cyclonedx-go v0.7.0/go.mod h1:W5Z9w8pTTL+t+yG3PCiFRGlr8PUlE0pGWzKSJbsyXkg=
-github.com/DataDog/agent-payload/v5 v5.0.76-0.20230303204218-881d992cf5dc h1:MGQfLgtqbabYm2YIC7B3uKHXL2C0aBcDJZSq/UQo920=
-github.com/DataDog/agent-payload/v5 v5.0.76-0.20230303204218-881d992cf5dc/go.mod h1:oQZi1VZp1e3QvlSUX4iphZCpJaFepUxWq0hNXxihKBM=
+github.com/DataDog/agent-payload/v5 v5.0.76 h1:ulvh3tU2qCAMydnZWWXDdUJKtuByQlBTbw7yJxgMoic=
+github.com/DataDog/agent-payload/v5 v5.0.76/go.mod h1:oQZi1VZp1e3QvlSUX4iphZCpJaFepUxWq0hNXxihKBM=
 github.com/DataDog/appsec-internal-go v0.0.0-20230215162203-5149228be86a h1:7ZiVdU4j19IYuy8rR0uUzC7I7HjWul61ZEyUgvLkZBM=
 github.com/DataDog/appsec-internal-go v0.0.0-20230215162203-5149228be86a/go.mod h1:ILSJBuOg3E0Jg8qgSnm7+g8DXa0KrfahnS7jhS1DoWs=
 github.com/DataDog/aptly v1.5.0 h1:Oy6JVRC9iDgnmpeVYa4diXwP/exU7wJ/U1kuI4Zacxg=

--- a/pkg/network/ebpf/bpf_module.go
+++ b/pkg/network/ebpf/bpf_module.go
@@ -10,9 +10,15 @@ package ebpf
 
 import (
 	"fmt"
+	"sync"
 
 	"github.com/DataDog/datadog-agent/pkg/ebpf/bytecode"
 )
+
+// prebuiltModulesInUse is a global object which is responsible for keeping a list of all the prebuilt ebpf assets in use.
+// This is used to report ebpf asset telemetry
+var prebuiltModulesInUse = []string{}
+var telemetrymu sync.Mutex
 
 func readModule(bpfDir, moduleName string, debug bool) (bytecode.AssetReader, error) {
 	var file string
@@ -26,6 +32,10 @@ func readModule(bpfDir, moduleName string, debug bool) (bytecode.AssetReader, er
 	if err != nil {
 		return nil, fmt.Errorf("couldn't find asset: %s", err)
 	}
+
+	telemetrymu.Lock()
+	defer telemetrymu.Unlock()
+	prebuiltModulesInUse = append(prebuiltModulesInUse, moduleName)
 
 	return ebpfReader, nil
 }
@@ -52,4 +62,13 @@ func ReadOffsetBPFModule(bpfDir string, debug bool) (bytecode.AssetReader, error
 
 func ReadFentryTracerModule(bpfDir string, debug bool) (bytecode.AssetReader, error) {
 	return readModule(bpfDir, "tracer-fentry", debug)
+}
+
+func GetModulesInUse() []string {
+	telemetrymu.Lock()
+	defer telemetrymu.Unlock()
+
+	result := make([]string, len(prebuiltModulesInUse))
+	copy(result, prebuiltModulesInUse)
+	return result
 }

--- a/pkg/network/encoding/encoding.go
+++ b/pkg/network/encoding/encoding.go
@@ -110,6 +110,7 @@ func modelConnections(conns *network.Connections) *model.Connections {
 	payload.CompilationTelemetryByAsset = FormatCompilationTelemetry(conns.CompilationTelemetryByAsset)
 	payload.KernelHeaderFetchResult = model.KernelHeaderFetchResult(conns.KernelHeaderFetchResult)
 	payload.CORETelemetryByAsset = FormatCORETelemetry(conns.CORETelemetryByAsset)
+	payload.PrebuiltEBPFAssets = conns.PrebuiltAssets
 	payload.Routes = routes
 	payload.Tags = tagsSet.GetStrings()
 

--- a/pkg/network/encoding/encoding_test.go
+++ b/pkg/network/encoding/encoding_test.go
@@ -279,6 +279,7 @@ func testSerialization(t *testing.T, aggregateByStatusCode bool) {
 			result.Conns[1].Tags = nil
 			result.Tags = nil
 		}
+		result.PrebuiltEBPFAssets = nil
 		assert.Equal(out, result)
 	})
 	t.Run("requesting application/json serialization (with query types)", func(t *testing.T) {
@@ -303,6 +304,7 @@ func testSerialization(t *testing.T, aggregateByStatusCode bool) {
 			result.Conns[1].Tags = nil
 			result.Tags = nil
 		}
+		result.PrebuiltEBPFAssets = nil
 		assert.Equal(out, result)
 	})
 
@@ -328,6 +330,7 @@ func testSerialization(t *testing.T, aggregateByStatusCode bool) {
 			result.Conns[1].Tags = nil
 			result.Tags = nil
 		}
+		result.PrebuiltEBPFAssets = nil
 		assert.Equal(out, result)
 	})
 
@@ -355,6 +358,7 @@ func testSerialization(t *testing.T, aggregateByStatusCode bool) {
 			result.Conns[1].Tags = nil
 			result.Tags = nil
 		}
+		result.PrebuiltEBPFAssets = nil
 		assert.Equal(out, result)
 	})
 

--- a/pkg/network/event_common.go
+++ b/pkg/network/event_common.go
@@ -131,6 +131,7 @@ type Connections struct {
 	CompilationTelemetryByAsset map[string]RuntimeCompilationTelemetry
 	KernelHeaderFetchResult     int32
 	CORETelemetryByAsset        map[string]int32
+	PrebuiltAssets              []string
 	HTTP                        map[http.Key]*http.RequestStats
 	HTTP2                       map[http.Key]*http.RequestStats
 	Kafka                       map[kafka.Key]*kafka.RequestStat

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -454,6 +454,7 @@ func (t *Tracer) GetActiveConnections(clientID string) (*network.Connections, er
 	rctm := t.getRuntimeCompilationTelemetry()
 	khfr := int32(kernel.HeaderProvider.GetResult())
 	coretm := ddebpf.GetCORETelemetryByAsset()
+	pbassets := netebpf.GetModulesInUse()
 	t.lastCheck.Store(time.Now().Unix())
 
 	return &network.Connections{
@@ -467,6 +468,7 @@ func (t *Tracer) GetActiveConnections(clientID string) (*network.Connections, er
 		KernelHeaderFetchResult:     khfr,
 		CompilationTelemetryByAsset: rctm,
 		CORETelemetryByAsset:        coretm,
+		PrebuiltAssets:              pbassets,
 	}, nil
 }
 

--- a/pkg/process/checks/net.go
+++ b/pkg/process/checks/net.go
@@ -154,7 +154,7 @@ func (c *ConnectionsCheck) Run(nextGroupID func() int32, _ *RunOptions) (RunResu
 	log.Debugf("collected connections in %s", time.Since(start))
 
 	groupID := nextGroupID()
-	messages := batchConnections(c.hostInfo, c.maxConnsPerMessage, groupID, conns.Conns, conns.Dns, c.networkID, conns.ConnTelemetryMap, conns.CompilationTelemetryByAsset, conns.KernelHeaderFetchResult, conns.CORETelemetryByAsset, conns.Domains, conns.Routes, conns.Tags, conns.AgentConfiguration, c.serviceExtractor)
+	messages := batchConnections(c.hostInfo, c.maxConnsPerMessage, groupID, conns.Conns, conns.Dns, c.networkID, conns.ConnTelemetryMap, conns.CompilationTelemetryByAsset, conns.KernelHeaderFetchResult, conns.CORETelemetryByAsset, conns.PrebuiltEBPFAssets, conns.Domains, conns.Routes, conns.Tags, conns.AgentConfiguration, c.serviceExtractor)
 	return StandardRunResult(messages), nil
 }
 
@@ -292,6 +292,7 @@ func batchConnections(
 	compilationTelemetry map[string]*model.RuntimeCompilationTelemetry,
 	kernelHeaderFetchResult model.KernelHeaderFetchResult,
 	coreTelemetry map[string]model.COREResult,
+	prebuiltAssets []string,
 	domains []string,
 	routes []*model.Route,
 	tags []string,
@@ -429,6 +430,7 @@ func batchConnections(
 			cc.CompilationTelemetryByAsset = compilationTelemetry
 			cc.KernelHeaderFetchResult = kernelHeaderFetchResult
 			cc.CORETelemetryByAsset = coreTelemetry
+			cc.PrebuiltEBPFAssets = prebuiltAssets
 		}
 		batches = append(batches, cc)
 

--- a/pkg/process/checks/net_test.go
+++ b/pkg/process/checks/net_test.go
@@ -57,7 +57,7 @@ func TestDNSNameEncoding(t *testing.T) {
 	}
 	ex := parser.NewServiceExtractor()
 	maxConnsPerMessage := 10
-	chunks := batchConnections(&HostInfo{}, maxConnsPerMessage, 0, p, dns, "nid", nil, nil, model.KernelHeaderFetchResult_FetchNotAttempted, nil, nil, nil, nil, nil, ex)
+	chunks := batchConnections(&HostInfo{}, maxConnsPerMessage, 0, p, dns, "nid", nil, nil, model.KernelHeaderFetchResult_FetchNotAttempted, nil, nil, nil, nil, nil, nil, ex)
 	assert.Equal(t, len(chunks), 1)
 
 	chunk := chunks[0]
@@ -122,7 +122,7 @@ func TestNetworkConnectionBatching(t *testing.T) {
 		khfr := model.KernelHeaderFetchResult_FetchNotAttempted
 		coretm := map[string]model.COREResult{}
 		ex := parser.NewServiceExtractor()
-		chunks := batchConnections(&HostInfo{}, tc.maxSize, 0, tc.cur, map[string]*model.DNSEntry{}, "nid", ctm, rctm, khfr, coretm, nil, nil, nil, nil, ex)
+		chunks := batchConnections(&HostInfo{}, tc.maxSize, 0, tc.cur, map[string]*model.DNSEntry{}, "nid", ctm, rctm, khfr, coretm, nil, nil, nil, nil, nil, ex)
 
 		assert.Len(t, chunks, tc.expectedChunks, "len %d", i)
 		total := 0
@@ -162,7 +162,7 @@ func TestNetworkConnectionBatchingWithDNS(t *testing.T) {
 
 	maxConnsPerMessage := 1
 	ex := parser.NewServiceExtractor()
-	chunks := batchConnections(&HostInfo{}, maxConnsPerMessage, 0, p, dns, "nid", nil, nil, model.KernelHeaderFetchResult_FetchNotAttempted, nil, nil, nil, nil, nil, ex)
+	chunks := batchConnections(&HostInfo{}, maxConnsPerMessage, 0, p, dns, "nid", nil, nil, model.KernelHeaderFetchResult_FetchNotAttempted, nil, nil, nil, nil, nil, nil, ex)
 
 	assert.Len(t, chunks, 4)
 	total := 0
@@ -202,7 +202,7 @@ func TestBatchSimilarConnectionsTogether(t *testing.T) {
 
 	maxConnsPerMessage := 2
 	ex := parser.NewServiceExtractor()
-	chunks := batchConnections(&HostInfo{}, maxConnsPerMessage, 0, p, map[string]*model.DNSEntry{}, "nid", nil, nil, model.KernelHeaderFetchResult_FetchNotAttempted, nil, nil, nil, nil, nil, ex)
+	chunks := batchConnections(&HostInfo{}, maxConnsPerMessage, 0, p, map[string]*model.DNSEntry{}, "nid", nil, nil, model.KernelHeaderFetchResult_FetchNotAttempted, nil, nil, nil, nil, nil, nil, ex)
 
 	assert.Len(t, chunks, 3)
 	total := 0
@@ -286,7 +286,7 @@ func TestNetworkConnectionBatchingWithDomainsByQueryType(t *testing.T) {
 
 	maxConnsPerMessage := 1
 	ex := parser.NewServiceExtractor()
-	chunks := batchConnections(&HostInfo{}, maxConnsPerMessage, 0, conns, dnsmap, "nid", nil, nil, model.KernelHeaderFetchResult_FetchNotAttempted, nil, domains, nil, nil, nil, ex)
+	chunks := batchConnections(&HostInfo{}, maxConnsPerMessage, 0, conns, dnsmap, "nid", nil, nil, model.KernelHeaderFetchResult_FetchNotAttempted, nil, nil, domains, nil, nil, nil, ex)
 
 	assert.Len(t, chunks, 4)
 	total := 0
@@ -404,7 +404,7 @@ func TestNetworkConnectionBatchingWithDomains(t *testing.T) {
 
 	maxConnsPerMessage := 1
 	ex := parser.NewServiceExtractor()
-	chunks := batchConnections(&HostInfo{}, maxConnsPerMessage, 0, conns, dnsmap, "nid", nil, nil, model.KernelHeaderFetchResult_FetchNotAttempted, nil, domains, nil, nil, nil, ex)
+	chunks := batchConnections(&HostInfo{}, maxConnsPerMessage, 0, conns, dnsmap, "nid", nil, nil, model.KernelHeaderFetchResult_FetchNotAttempted, nil, nil, domains, nil, nil, nil, ex)
 
 	assert.Len(t, chunks, 4)
 	total := 0
@@ -513,7 +513,7 @@ func TestNetworkConnectionBatchingWithRoutes(t *testing.T) {
 
 	maxConnsPerMessage := 4
 	ex := parser.NewServiceExtractor()
-	chunks := batchConnections(&HostInfo{}, maxConnsPerMessage, 0, conns, nil, "nid", nil, nil, model.KernelHeaderFetchResult_FetchNotAttempted, nil, nil, routes, nil, nil, ex)
+	chunks := batchConnections(&HostInfo{}, maxConnsPerMessage, 0, conns, nil, "nid", nil, nil, model.KernelHeaderFetchResult_FetchNotAttempted, nil, nil, nil, routes, nil, nil, ex)
 
 	assert.Len(t, chunks, 2)
 	total := 0
@@ -581,7 +581,7 @@ func TestNetworkConnectionTags(t *testing.T) {
 
 	maxConnsPerMessage := 4
 	ex := parser.NewServiceExtractor()
-	chunks := batchConnections(&HostInfo{}, maxConnsPerMessage, 0, conns, nil, "nid", nil, nil, model.KernelHeaderFetchResult_FetchNotAttempted, nil, nil, nil, tags, nil, ex)
+	chunks := batchConnections(&HostInfo{}, maxConnsPerMessage, 0, conns, nil, "nid", nil, nil, model.KernelHeaderFetchResult_FetchNotAttempted, nil, nil, nil, nil, tags, nil, ex)
 
 	assert.Len(t, chunks, 2)
 	total := 0
@@ -620,7 +620,7 @@ func TestNetworkConnectionTagsWithService(t *testing.T) {
 	ex := parser.NewServiceExtractor()
 	ex.Extract(procsByPid)
 
-	chunks := batchConnections(&HostInfo{}, maxConnsPerMessage, 0, conns, nil, "nid", nil, nil, model.KernelHeaderFetchResult_FetchNotAttempted, nil, nil, nil, tags, nil, ex)
+	chunks := batchConnections(&HostInfo{}, maxConnsPerMessage, 0, conns, nil, "nid", nil, nil, model.KernelHeaderFetchResult_FetchNotAttempted, nil, nil, nil, nil, tags, nil, ex)
 
 	assert.Len(t, chunks, 1)
 	connections := chunks[0].(*model.CollectorConnections)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Adds some telemetry for tracking when prebuilt ebpf assets are used.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

We'd like to know how many users are using runtime compilation vs CO-RE vs prebuilt.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

1) Configure some ebpf assets to be loaded using prebuilt assets, ie.
```
system_probe_config:
  enable_co_re: false
  enable_runtime_compiler: false
network_config:
  enabled: true
service_monitoring_config:
  enabled: true
```
2) Run the system-probe and query the connections endpoint:
```
sudo curl -s --unix-socket /opt/datadog-agent/run/sysprobe.sock http://unix/network_tracer/connections?client_id=1 | jq .
```
3) Verify that the `PrebuiltEBPFAssets` field lists the prebuilt assets.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
