### PR TITLE
Speed up tests by caching kernel function and helper detection

### DIFF
--- a/cmd/system-probe/modules/network_tracer.go
+++ b/cmd/system-probe/modules/network_tracer.go
@@ -49,8 +49,8 @@ var NetworkTracer = module.Factory{
 		ncfg := networkconfig.New()
 
 		// Checking whether the current OS + kernel version is supported by the tracer
-		if supported, msg := tracer.IsTracerSupportedByOS(ncfg.ExcludedBPFLinuxVersions); !supported {
-			return nil, fmt.Errorf("%w: %s", ErrSysprobeUnsupported, msg)
+		if supported, err := tracer.IsTracerSupportedByOS(ncfg.ExcludedBPFLinuxVersions); !supported {
+			return nil, fmt.Errorf("%w: %s", ErrSysprobeUnsupported, err)
 		}
 
 		if ncfg.NPMEnabled {

--- a/pkg/ebpf/ksyms.go
+++ b/pkg/ebpf/ksyms.go
@@ -7,38 +7,83 @@ package ebpf
 
 import (
 	"bufio"
+	"bytes"
 	"fmt"
 	"os"
 	"sort"
+	"sync"
 
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 )
 
+type existCache struct {
+	mtx  sync.Mutex
+	path string
+	c    map[string]bool
+}
+
+func newExistCache(path string) *existCache {
+	return &existCache{
+		path: path,
+		c:    make(map[string]bool),
+	}
+}
+
+var funcCache = newExistCache("/proc/kallsyms")
+
 // VerifyKernelFuncs ensures all kernel functions exist in ksyms located at provided path.
-func VerifyKernelFuncs(path string, requiredKernelFuncs []string) (map[string]struct{}, error) {
-	missing := make(util.SSBytes, len(requiredKernelFuncs))
-	for i, f := range requiredKernelFuncs {
-		missing[i] = []byte(f)
-	}
-	sort.Sort(missing)
+func VerifyKernelFuncs(requiredKernelFuncs ...string) (map[string]struct{}, error) {
+	return funcCache.verifyKernelFuncs(requiredKernelFuncs)
+}
 
-	f, err := os.Open(path)
-	if err != nil {
-		return nil, fmt.Errorf("error reading kallsyms file from: %s: %w", path, err)
-	}
-	defer f.Close()
+func (ec *existCache) verifyKernelFuncs(requiredKernelFuncs []string) (map[string]struct{}, error) {
+	ec.mtx.Lock()
+	defer ec.mtx.Unlock()
 
-	scanner := bufio.NewScanner(f)
-	scanner.Split(bufio.ScanWords)
-	for scanner.Scan() && len(missing) > 0 {
-		if i := missing.Search(scanner.Bytes()); i < len(missing) {
-			missing = append(missing[:i], missing[i+1:]...)
+	var check util.SSBytes
+	for _, rf := range requiredKernelFuncs {
+		if _, ok := ec.c[rf]; !ok {
+			// only check for functions we don't know about yet
+			check = append(check, []byte(rf))
 		}
 	}
 
-	missingStrs := make(map[string]struct{}, len(missing))
-	for i := range missing {
-		missingStrs[string(missing[i])] = struct{}{}
+	if len(check) != 0 {
+		sort.Sort(check)
+
+		f, err := os.Open(ec.path)
+		if err != nil {
+			return nil, fmt.Errorf("error reading kallsyms file from: %s: %w", ec.path, err)
+		}
+		defer f.Close()
+
+		scanner := bufio.NewScanner(f)
+		scanner.Split(bufio.ScanLines)
+		for scanner.Scan() {
+			fields := bytes.Fields(scanner.Bytes())
+			if len(fields) >= 3 {
+				if idx := check.Search(fields[2]); idx >= 0 {
+					// found it in kallsyms, cache result
+					ec.c[string(check[idx])] = true
+					check = append(check[:idx], check[idx+1:]...)
+				}
+			}
+		}
+		if err := scanner.Err(); err != nil {
+			return nil, err
+		}
+		// anything left in check is missing
+		for _, rf := range check {
+			ec.c[string(rf)] = false
+		}
+	}
+
+	// only return missing funcs at this point
+	missingStrs := make(map[string]struct{})
+	for _, rf := range requiredKernelFuncs {
+		if v, ok := ec.c[rf]; !ok || !v {
+			missingStrs[rf] = struct{}{}
+		}
 	}
 	return missingStrs, nil
 }

--- a/pkg/ebpf/ksyms_test.go
+++ b/pkg/ebpf/ksyms_test.go
@@ -23,18 +23,22 @@ var requiredKernelFuncs = []string{
 }
 
 func TestVerifyKernelFuncs(t *testing.T) {
-	missing, err := VerifyKernelFuncs("./testdata/kallsyms.supported", requiredKernelFuncs)
+	fc := newExistCache("./testdata/kallsyms.supported")
+	missing, err := fc.verifyKernelFuncs(requiredKernelFuncs)
 	assert.Empty(t, missing)
 	assert.Empty(t, err)
 
-	missing, err = VerifyKernelFuncs("./testdata/kallsyms.unsupported", requiredKernelFuncs)
-	assert.NotEmpty(t, missing)
+	fc = newExistCache("./testdata/kallsyms.unsupported")
+	missing, err = fc.verifyKernelFuncs(requiredKernelFuncs)
+	assert.Len(t, missing, len(requiredKernelFuncs))
 	assert.Empty(t, err)
 
-	missing, err = VerifyKernelFuncs("./testdata/kallsyms.empty", requiredKernelFuncs)
-	assert.NotEmpty(t, missing)
+	fc = newExistCache("./testdata/kallsyms.empty")
+	missing, err = fc.verifyKernelFuncs(requiredKernelFuncs)
+	assert.Len(t, missing, len(requiredKernelFuncs))
 	assert.Empty(t, err)
 
-	_, err = VerifyKernelFuncs("./testdata/kallsyms.d_o_n_o_t_e_x_i_s_t", requiredKernelFuncs)
+	fc = newExistCache("./testdata/kallsyms.d_o_n_o_t_e_x_i_s_t")
+	_, err = fc.verifyKernelFuncs(requiredKernelFuncs)
 	assert.NotEmpty(t, err)
 }

--- a/pkg/network/nettop/main.go
+++ b/pkg/network/nettop/main.go
@@ -18,8 +18,8 @@ import (
 )
 
 func main() {
-	if supported, msg := tracer.IsTracerSupportedByOS(nil); !supported {
-		fmt.Fprintf(os.Stderr, "system-probe is not supported: %s\n", msg)
+	if supported, err := tracer.IsTracerSupportedByOS(nil); !supported {
+		fmt.Fprintf(os.Stderr, "system-probe is not supported: %s\n", err)
 		os.Exit(1)
 	}
 

--- a/pkg/network/protocols/http/kernel_requirements.go
+++ b/pkg/network/protocols/http/kernel_requirements.go
@@ -9,7 +9,6 @@
 package http
 
 import (
-	"path/filepath"
 	"runtime"
 	"strings"
 
@@ -71,8 +70,7 @@ func HTTP2Supported() bool {
 }
 
 func sysOpenAt2Supported(c *config.Config) bool {
-	ksymPath := filepath.Join(c.ProcRoot, "kallsyms")
-	missing, err := ddebpf.VerifyKernelFuncs(ksymPath, []string{doSysOpenAt2.section})
+	missing, err := ddebpf.VerifyKernelFuncs(doSysOpenAt2.section)
 	if err == nil && len(missing) == 0 {
 		return true
 	}

--- a/pkg/network/tracer/connection/kprobe/config.go
+++ b/pkg/network/tracer/connection/kprobe/config.go
@@ -10,7 +10,6 @@ package kprobe
 
 import (
 	"fmt"
-	"path/filepath"
 
 	"github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
@@ -26,7 +25,6 @@ func enableProbe(enabled map[probes.ProbeFuncName]struct{}, name probes.ProbeFun
 // This map does not include the probes used exclusively in the offset guessing process.
 func enabledProbes(c *config.Config, runtimeTracer bool) (map[probes.ProbeFuncName]struct{}, error) {
 	enabled := make(map[probes.ProbeFuncName]struct{}, 0)
-	ksymPath := filepath.Join(c.ProcRoot, "kallsyms")
 
 	kv410 := kernel.VersionCode(4, 1, 0)
 	kv470 := kernel.VersionCode(4, 7, 0)
@@ -58,7 +56,7 @@ func enabledProbes(c *config.Config, runtimeTracer bool) (map[probes.ProbeFuncNa
 		enableProbe(enabled, selectVersionBasedProbe(runtimeTracer, kv, probes.TCPRetransmit, probes.TCPRetransmitPre470, kv470))
 		enableProbe(enabled, probes.TCPRetransmitRet)
 
-		missing, err := ebpf.VerifyKernelFuncs(ksymPath, []string{"sockfd_lookup_light"})
+		missing, err := ebpf.VerifyKernelFuncs("sockfd_lookup_light")
 		if err == nil && len(missing) == 0 {
 			enableProbe(enabled, probes.SockFDLookup)
 			enableProbe(enabled, probes.SockFDLookupRet)
@@ -83,7 +81,7 @@ func enabledProbes(c *config.Config, runtimeTracer bool) (map[probes.ProbeFuncNa
 		}
 
 		if runtimeTracer {
-			missing, err := ebpf.VerifyKernelFuncs(ksymPath, []string{"skb_consume_udp", "__skb_free_datagram_locked", "skb_free_datagram_locked"})
+			missing, err := ebpf.VerifyKernelFuncs("skb_consume_udp", "__skb_free_datagram_locked", "skb_free_datagram_locked")
 			if err != nil {
 				return nil, fmt.Errorf("error verifying kernel function presence: %s", err)
 			}

--- a/pkg/network/tracer/utils_linux.go
+++ b/pkg/network/tracer/utils_linux.go
@@ -9,35 +9,25 @@
 package tracer
 
 import (
+	"errors"
 	"fmt"
-	"path"
 	"strings"
 
-	ddebpf "github.com/DataDog/datadog-agent/pkg/ebpf"
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/asm"
+	"github.com/cilium/ebpf/features"
+
 	"github.com/DataDog/datadog-agent/pkg/metadata/host"
-	"github.com/DataDog/datadog-agent/pkg/process/util"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-// Feature versions sourced from: https://github.com/iovisor/bcc/blob/master/docs/kernel-versions.md
-var requiredKernelFuncs = []string{
-	// Maps (3.18)
-	"bpf_map_lookup_elem",
-	"bpf_map_update_elem",
-	"bpf_map_delete_elem",
-	// bpf_probe_read intentionally omitted since it was renamed in kernel 5.5
-	// Perf events (4.4)
-	"bpf_perf_event_output",
-	"bpf_perf_event_read",
-}
-
 // IsTracerSupportedByOS returns whether or not the current kernel version supports tracer functionality
 // along with some context on why it's not supported
-func IsTracerSupportedByOS(exclusionList []string) (bool, string) {
+func IsTracerSupportedByOS(exclusionList []string) (bool, error) {
 	currentKernelCode, err := kernel.HostVersion()
 	if err != nil {
-		return false, fmt.Sprintf("could not get kernel version: %s", err)
+		return false, fmt.Errorf("could not get kernel version: %s", err)
 	}
 
 	hostInfo := host.GetStatusInformation()
@@ -45,10 +35,10 @@ func IsTracerSupportedByOS(exclusionList []string) (bool, string) {
 	return verifyOSVersion(currentKernelCode, hostInfo.Platform, exclusionList)
 }
 
-func verifyOSVersion(kernelCode kernel.Version, platform string, exclusionList []string) (bool, string) {
+func verifyOSVersion(kernelCode kernel.Version, platform string, exclusionList []string) (bool, error) {
 	for _, version := range exclusionList {
 		if code := kernel.ParseVersion(version); code == kernelCode {
-			return false, fmt.Sprintf(
+			return false, fmt.Errorf(
 				"current kernel version (%s) is in the exclusion list: %s (list: %+v)",
 				kernelCode,
 				version,
@@ -60,29 +50,35 @@ func verifyOSVersion(kernelCode kernel.Version, platform string, exclusionList [
 	// Hardcoded exclusion list
 	if platform == "" {
 		// If we can't retrieve the platform just return true to avoid blocking the tracer from running
-		return true, ""
+		return true, nil
 	}
 
 	// using eBPF causes kernel panic for linux kernel version 4.4.114 ~ 4.4.127
 	if platform == "ubuntu" && kernelCode >= kernel.VersionCode(4, 4, 114) && kernelCode <= kernel.VersionCode(4, 4, 127) {
-		return false, fmt.Sprintf("Known bug for kernel %s on platform %s, see: \n- https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1763454", kernelCode, platform)
+		return false, fmt.Errorf("Known bug for kernel %s on platform %s, see: \n- https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1763454", kernelCode, platform)
 	}
 
-	missing, err := ddebpf.VerifyKernelFuncs(path.Join(util.GetProcRoot(), "kallsyms"), requiredKernelFuncs)
-	if err != nil {
-		log.Warnf("error reading /proc/kallsyms file: %s (check your kernel version, current is: %s)", err, kernelCode)
-		// If we can't read the /proc/kallsyms file let's just return true to avoid blocking the tracer from running
-		return true, ""
+	var requiredFuncs = []asm.BuiltinFunc{
+		asm.FnMapLookupElem,
+		asm.FnMapUpdateElem,
+		asm.FnMapDeleteElem,
+		asm.FnPerfEventOutput,
+		asm.FnPerfEventRead,
 	}
-	if len(missing) == 0 {
-		return true, ""
+	var missingFuncs []string
+	for _, rf := range requiredFuncs {
+		if err := features.HaveProgramHelper(ebpf.Kprobe, rf); err != nil {
+			if errors.Is(err, ebpf.ErrNotSupported) {
+				missingFuncs = append(missingFuncs, rf.String())
+			} else {
+				return false, fmt.Errorf("error checking for ebpf helper %s support: %w", rf.String(), err)
+			}
+		}
+	}
+	if len(missingFuncs) == 0 {
+		return true, nil
 	}
 	errMsg := fmt.Sprintf("Kernel unsupported (%s) - ", kernelCode)
-
-	var missingFuncs []string
-	for f := range missing {
-		missingFuncs = append(missingFuncs, f)
-	}
 	errMsg += fmt.Sprintf("required functions missing: %s", strings.Join(missingFuncs, ", "))
-	return false, errMsg
+	return false, fmt.Errorf(errMsg)
 }

--- a/pkg/process/util/ss_bytes.go
+++ b/pkg/process/util/ss_bytes.go
@@ -27,7 +27,7 @@ func (ss SSBytes) Swap(i, j int) {
 	ss[i], ss[j] = ss[j], ss[i]
 }
 
-// Search returns the index of element x if found or the length of the SSBytes otherwise.
+// Search returns the index of element x if found or -1 otherwise.
 // SSBytes is expected to be sorted.
 func (ss SSBytes) Search(x []byte) int {
 	i := sort.Search(len(ss), func(i int) bool {
@@ -38,5 +38,5 @@ func (ss SSBytes) Search(x []byte) int {
 		return i
 	}
 
-	return len(ss)
+	return -1
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

- Uses `cilium/ebpf/features` to check for eBPF program helper functions, which caches the results internally.
- Caches the results of checking `/proc/kallsyms` for kernel functions
- Removes the need to pass a `path` to `VerifyKernelFuncs` since `/proc/kallsyms` is not masked within a container.

### Motivation

I profiled a test run of just `TestProtocolClassification` and >20% of the cpu time was spent in `VerifyKernelFuncs`:
![Screenshot 2023-03-03 at 1 34 10 PM](https://user-images.githubusercontent.com/1010430/222833765-7fb1ba20-03fd-4a80-820a-aaf672db2bb1.png)

After this change, the function doesn't even appear in the profile, meaning it was insignificant.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.


-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
