### PR TITLE
Use a single tracer for TestProtocolClassification

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -1106,7 +1106,7 @@ core,github.com/open-policy-agent/opa/internal/compiler/wasm/opa,Apache-2.0,Copy
 core,github.com/open-policy-agent/opa/internal/debug,Apache-2.0,Copyright 2016 The OPA Authors.  All rights reserved.
 core,github.com/open-policy-agent/opa/internal/deepcopy,Apache-2.0,Copyright 2016 The OPA Authors.  All rights reserved.
 core,github.com/open-policy-agent/opa/internal/edittree,Apache-2.0,Copyright 2016 The OPA Authors.  All rights reserved.
-core,github.com/open-policy-agent/opa/internal/edittree/bitvector,BSD-3-Clause,"Copyright (c) 2014 Dropbox, Inc | Copyright 2016 The OPA Authors.  All rights reserved."
+core,github.com/open-policy-agent/opa/internal/edittree/bitvector,BSD-3-Clause,Copyright 2016 The OPA Authors.  All rights reserved.
 core,github.com/open-policy-agent/opa/internal/file/archive,Apache-2.0,Copyright 2016 The OPA Authors.  All rights reserved.
 core,github.com/open-policy-agent/opa/internal/file/url,Apache-2.0,Copyright 2016 The OPA Authors.  All rights reserved.
 core,github.com/open-policy-agent/opa/internal/future,Apache-2.0,Copyright 2016 The OPA Authors.  All rights reserved.

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -65,6 +65,7 @@ core,github.com/DataDog/datadog-operator/apis/utils,Apache-2.0,"Copyright 2016-2
 core,github.com/DataDog/datadog-operator/pkg/defaulting,Apache-2.0,"Copyright 2016-2020 Datadog, Inc"
 core,github.com/DataDog/datadog-operator/pkg/utils,Apache-2.0,"Copyright 2016-2020 Datadog, Inc"
 core,github.com/DataDog/ebpf-manager,MIT,Copyright (c) 2021 Authors of Datadog
+core,github.com/DataDog/ebpf-manager/tracefs,MIT,Copyright (c) 2021 Authors of Datadog
 core,github.com/DataDog/extendeddaemonset/api/v1alpha1,Apache-2.0,"Copyright 2016-2020 Datadog, Inc"
 core,github.com/DataDog/go-libddwaf,Apache-2.0,"Copyright 2016-present Datadog, Inc"
 core,github.com/DataDog/go-libddwaf/include,Apache-2.0,"Copyright 2016-present Datadog, Inc"
@@ -1105,7 +1106,7 @@ core,github.com/open-policy-agent/opa/internal/compiler/wasm/opa,Apache-2.0,Copy
 core,github.com/open-policy-agent/opa/internal/debug,Apache-2.0,Copyright 2016 The OPA Authors.  All rights reserved.
 core,github.com/open-policy-agent/opa/internal/deepcopy,Apache-2.0,Copyright 2016 The OPA Authors.  All rights reserved.
 core,github.com/open-policy-agent/opa/internal/edittree,Apache-2.0,Copyright 2016 The OPA Authors.  All rights reserved.
-core,github.com/open-policy-agent/opa/internal/edittree/bitvector,BSD-3-Clause,Copyright 2016 The OPA Authors.  All rights reserved.
+core,github.com/open-policy-agent/opa/internal/edittree/bitvector,BSD-3-Clause,"Copyright (c) 2014 Dropbox, Inc | Copyright 2016 The OPA Authors.  All rights reserved."
 core,github.com/open-policy-agent/opa/internal/file/archive,Apache-2.0,Copyright 2016 The OPA Authors.  All rights reserved.
 core,github.com/open-policy-agent/opa/internal/file/url,Apache-2.0,Copyright 2016 The OPA Authors.  All rights reserved.
 core,github.com/open-policy-agent/opa/internal/future,Apache-2.0,Copyright 2016 The OPA Authors.  All rights reserved.

--- a/go.mod
+++ b/go.mod
@@ -52,7 +52,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.44.0-rc.4
 	github.com/DataDog/datadog-go/v5 v5.1.1
 	github.com/DataDog/datadog-operator v0.7.1-0.20230215125730-2ba58ce29d56
-	github.com/DataDog/ebpf-manager v0.2.4
+	github.com/DataDog/ebpf-manager v0.2.5
 	github.com/DataDog/go-libddwaf v0.0.0-20221118110754-0372d7c76b8a
 	github.com/DataDog/go-tuf v0.3.0--fix-localmeta-fork
 	github.com/DataDog/gohai v0.0.0-20221116153829-5d479901d2e9

--- a/go.mod
+++ b/go.mod
@@ -52,7 +52,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.44.0-rc.4
 	github.com/DataDog/datadog-go/v5 v5.1.1
 	github.com/DataDog/datadog-operator v0.7.1-0.20230215125730-2ba58ce29d56
-	github.com/DataDog/ebpf-manager v0.2.3
+	github.com/DataDog/ebpf-manager v0.2.4
 	github.com/DataDog/go-libddwaf v0.0.0-20221118110754-0372d7c76b8a
 	github.com/DataDog/go-tuf v0.3.0--fix-localmeta-fork
 	github.com/DataDog/gohai v0.0.0-20221116153829-5d479901d2e9

--- a/go.sum
+++ b/go.sum
@@ -142,8 +142,8 @@ github.com/DataDog/datadog-go/v5 v5.1.1 h1:JLZ6s2K1pG2h9GkvEvMdEGqMDyVLEAccdX5Tl
 github.com/DataDog/datadog-go/v5 v5.1.1/go.mod h1:KhiYb2Badlv9/rofz+OznKoEF5XKTonWyhx5K83AP8E=
 github.com/DataDog/datadog-operator v0.7.1-0.20230215125730-2ba58ce29d56 h1:uj+2t8VpFSgnRucSTr3fG3atc1I6j6fgSw8+nCxnwOs=
 github.com/DataDog/datadog-operator v0.7.1-0.20230215125730-2ba58ce29d56/go.mod h1:3XBfwfK0wBBcs7L+10JI79pg6vYdbOwY3oj+O4Omi6c=
-github.com/DataDog/ebpf-manager v0.2.3 h1:xzPnk1JoLU1zei0BsUXKiBeG5HJ5zOTL747cyU9R2RY=
-github.com/DataDog/ebpf-manager v0.2.3/go.mod h1:QNbbXqQdl1RDRDna/vSHzhpTNXTnqxxJRVXdeANgCUA=
+github.com/DataDog/ebpf-manager v0.2.4 h1:WEbs2u/vGrZ/FaoNcoJpt8684+/IEDjKfKvvaQUII1I=
+github.com/DataDog/ebpf-manager v0.2.4/go.mod h1:QNbbXqQdl1RDRDna/vSHzhpTNXTnqxxJRVXdeANgCUA=
 github.com/DataDog/extendeddaemonset v0.9.0-rc.2 h1:uTE/QEU0oYtHnebKSMbxap7XMG5603WQxNP/UX63E7k=
 github.com/DataDog/extendeddaemonset v0.9.0-rc.2/go.mod h1:JgKVGTsjdTdtJjNyxRZjcs81/rng6LJ3XX/0D7Y12Gc=
 github.com/DataDog/go-grpc-bidirectional-streaming-example v0.0.0-20221024060302-b9cf785c02fe h1:RO40ywnX/vZLi4Pb4jRuFGgQQBYGIIoQ6u+P2MIgFOA=

--- a/go.sum
+++ b/go.sum
@@ -142,8 +142,8 @@ github.com/DataDog/datadog-go/v5 v5.1.1 h1:JLZ6s2K1pG2h9GkvEvMdEGqMDyVLEAccdX5Tl
 github.com/DataDog/datadog-go/v5 v5.1.1/go.mod h1:KhiYb2Badlv9/rofz+OznKoEF5XKTonWyhx5K83AP8E=
 github.com/DataDog/datadog-operator v0.7.1-0.20230215125730-2ba58ce29d56 h1:uj+2t8VpFSgnRucSTr3fG3atc1I6j6fgSw8+nCxnwOs=
 github.com/DataDog/datadog-operator v0.7.1-0.20230215125730-2ba58ce29d56/go.mod h1:3XBfwfK0wBBcs7L+10JI79pg6vYdbOwY3oj+O4Omi6c=
-github.com/DataDog/ebpf-manager v0.2.4 h1:WEbs2u/vGrZ/FaoNcoJpt8684+/IEDjKfKvvaQUII1I=
-github.com/DataDog/ebpf-manager v0.2.4/go.mod h1:QNbbXqQdl1RDRDna/vSHzhpTNXTnqxxJRVXdeANgCUA=
+github.com/DataDog/ebpf-manager v0.2.5 h1:hWpMPL/ysxV9FBNjH+zLXcV8y7EtkuIJbk0V2PDmv2A=
+github.com/DataDog/ebpf-manager v0.2.5/go.mod h1:QNbbXqQdl1RDRDna/vSHzhpTNXTnqxxJRVXdeANgCUA=
 github.com/DataDog/extendeddaemonset v0.9.0-rc.2 h1:uTE/QEU0oYtHnebKSMbxap7XMG5603WQxNP/UX63E7k=
 github.com/DataDog/extendeddaemonset v0.9.0-rc.2/go.mod h1:JgKVGTsjdTdtJjNyxRZjcs81/rng6LJ3XX/0D7Y12Gc=
 github.com/DataDog/go-grpc-bidirectional-streaming-example v0.0.0-20221024060302-b9cf785c02fe h1:RO40ywnX/vZLi4Pb4jRuFGgQQBYGIIoQ6u+P2MIgFOA=

--- a/pkg/network/tracer/connection/tracer.go
+++ b/pkg/network/tracer/connection/tracer.go
@@ -64,6 +64,9 @@ type Tracer interface {
 	DumpMaps(maps ...string) (string, error)
 	// Type returns the type of the underlying ebpf tracer that is currently loaded
 	Type() TracerType
+
+	Pause() error
+	Resume() error
 }
 
 const (
@@ -222,6 +225,14 @@ func (t *tracer) Start(callback func([]network.ConnectionStats)) (err error) {
 
 	t.closeConsumer.Start(callback)
 	return nil
+}
+
+func (t *tracer) Pause() error {
+	return t.m.Pause()
+}
+
+func (t *tracer) Resume() error {
+	return t.m.Resume()
 }
 
 func (t *tracer) FlushPending() {

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -20,6 +20,8 @@ import (
 	"go.uber.org/atomic"
 	"golang.org/x/sys/unix"
 
+	manager "github.com/DataDog/ebpf-manager"
+
 	ddebpf "github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/ebpf/bytecode"
 	"github.com/DataDog/datadog-agent/pkg/ebpf/bytecode/runtime"
@@ -40,7 +42,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/atomicstats"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	manager "github.com/DataDog/ebpf-manager"
 )
 
 const defaultUDPConnTimeoutNanoSeconds = uint64(time.Duration(120) * time.Second)
@@ -476,6 +477,10 @@ func (t *Tracer) GetActiveConnections(clientID string) (*network.Connections, er
 func (t *Tracer) RegisterClient(clientID string) error {
 	t.state.RegisterClient(clientID)
 	return nil
+}
+
+func (t *Tracer) removeClient(clientID string) {
+	t.state.RemoveClient(clientID)
 }
 
 func (t *Tracer) getConnTelemetry(mapSize int) map[network.ConnTelemetryType]int64 {

--- a/pkg/network/tracer/tracer_classification_linux_test.go
+++ b/pkg/network/tracer/tracer_classification_linux_test.go
@@ -1,0 +1,46 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+// +build linux_bpf
+
+package tracer
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func testProtocolClassificationInner(t *testing.T, params protocolClassificationAttributes, tr *Tracer) {
+	if params.skipCallback != nil {
+		params.skipCallback(t, params.context)
+	}
+	t.Cleanup(func() { tr.removeClient(clientID) })
+	t.Cleanup(func() { tr.ebpfTracer.Pause() })
+
+	if params.teardown != nil {
+		t.Cleanup(func() {
+			params.teardown(t, params.context)
+		})
+	}
+
+	require.NoError(t, tr.ebpfTracer.Pause(), "disable probes - before pre tracer")
+	if params.preTracerSetup != nil {
+		params.preTracerSetup(t, params.context)
+	}
+	initTracerState(t, tr)
+	t.Cleanup(func() { tr.removeClient(clientID) })
+
+	initTracerState(t, tr)
+	require.NoError(t, tr.ebpfTracer.Resume(), "enable probes - before post tracer")
+	// give a small amount of time for socket filter to re-engage
+	time.Sleep(1 * time.Millisecond)
+	params.postTracerSetup(t, params.context)
+	require.NoError(t, tr.ebpfTracer.Pause(), "disable probes - after post tracer")
+
+	params.validation(t, params.context, tr)
+}

--- a/pkg/network/tracer/tracer_classification_linux_test.go
+++ b/pkg/network/tracer/tracer_classification_linux_test.go
@@ -10,7 +10,6 @@ package tracer
 
 import (
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -37,8 +36,6 @@ func testProtocolClassificationInner(t *testing.T, params protocolClassification
 
 	initTracerState(t, tr)
 	require.NoError(t, tr.ebpfTracer.Resume(), "enable probes - before post tracer")
-	// give a small amount of time for socket filter to re-engage
-	time.Sleep(1 * time.Millisecond)
 	params.postTracerSetup(t, params.context)
 	require.NoError(t, tr.ebpfTracer.Pause(), "disable probes - after post tracer")
 

--- a/pkg/network/tracer/tracer_classification_linux_test.go
+++ b/pkg/network/tracer/tracer_classification_linux_test.go
@@ -31,9 +31,8 @@ func testProtocolClassificationInner(t *testing.T, params protocolClassification
 	if params.preTracerSetup != nil {
 		params.preTracerSetup(t, params.context)
 	}
-	initTracerState(t, tr)
-	t.Cleanup(func() { tr.removeClient(clientID) })
 
+	tr.removeClient(clientID)
 	initTracerState(t, tr)
 	require.NoError(t, tr.ebpfTracer.Resume(), "enable probes - before post tracer")
 	params.postTracerSetup(t, params.context)

--- a/pkg/network/tracer/tracer_classification_test.go
+++ b/pkg/network/tracer/tracer_classification_test.go
@@ -1647,6 +1647,8 @@ func testProtocolClassificationInner(t *testing.T, params protocolClassification
 
 	initTracerState(t, tr)
 	require.NoError(t, tr.ebpfTracer.Resume(), "enable probes - before post tracer")
+	// give a small amount of time for socket filter to re-engage
+	time.Sleep(1 * time.Millisecond)
 	params.postTracerSetup(t, params.context)
 	require.NoError(t, tr.ebpfTracer.Pause(), "disable probes - after post tracer")
 

--- a/pkg/network/tracer/tracer_classification_test.go
+++ b/pkg/network/tracer/tracer_classification_test.go
@@ -407,8 +407,6 @@ func testKafkaProtocolClassification(t *testing.T, tr *Tracer, clientHost, targe
 				records := fetches.Records()
 				require.Len(t, records, 1)
 				require.Equal(t, ctx.extras["topic_name"].(string), records[0].Topic)
-				// unclear why it is needs this extra time but it fails without it
-				time.Sleep(1 * time.Millisecond)
 			},
 			validation: validateProtocolConnection(expectedProtocol),
 			teardown:   kafkaTeardown,

--- a/pkg/network/tracer/tracer_classification_test.go
+++ b/pkg/network/tracer/tracer_classification_test.go
@@ -1625,36 +1625,6 @@ func testEdgeCasesProtocolClassification(t *testing.T, tr *Tracer, clientHost, t
 	}
 }
 
-func testProtocolClassificationInner(t *testing.T, params protocolClassificationAttributes, tr *Tracer) {
-	if params.skipCallback != nil {
-		params.skipCallback(t, params.context)
-	}
-	t.Cleanup(func() { tr.removeClient(clientID) })
-	t.Cleanup(func() { tr.ebpfTracer.Pause() })
-
-	if params.teardown != nil {
-		t.Cleanup(func() {
-			params.teardown(t, params.context)
-		})
-	}
-
-	require.NoError(t, tr.ebpfTracer.Pause(), "disable probes - before pre tracer")
-	if params.preTracerSetup != nil {
-		params.preTracerSetup(t, params.context)
-	}
-	initTracerState(t, tr)
-	t.Cleanup(func() { tr.removeClient(clientID) })
-
-	initTracerState(t, tr)
-	require.NoError(t, tr.ebpfTracer.Resume(), "enable probes - before post tracer")
-	// give a small amount of time for socket filter to re-engage
-	time.Sleep(1 * time.Millisecond)
-	params.postTracerSetup(t, params.context)
-	require.NoError(t, tr.ebpfTracer.Pause(), "disable probes - after post tracer")
-
-	params.validation(t, params.context, tr)
-}
-
 func waitForConnectionsWithProtocol(t *testing.T, tr *Tracer, targetAddr, serverAddr string, expectedProtocol network.ProtocolType) {
 	var incomingConns, outgoingConns []network.ConnectionStats
 

--- a/pkg/network/tracer/tracer_classification_windows_test.go
+++ b/pkg/network/tracer/tracer_classification_windows_test.go
@@ -35,6 +35,7 @@ func testProtocolClassificationInner(t *testing.T, params protocolClassification
 	if params.preTracerSetup != nil {
 		params.preTracerSetup(t, params.context)
 	}
+	cfg := testConfig()
 	tr := setupTracer(t, cfg)
 	params.postTracerSetup(t, params.context)
 	params.validation(t, params.context, tr)

--- a/pkg/network/tracer/tracer_classification_windows_test.go
+++ b/pkg/network/tracer/tracer_classification_windows_test.go
@@ -8,7 +8,9 @@
 
 package tracer
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestProtocolClassification(t *testing.T) {
 	cfg := testConfig()
@@ -16,6 +18,24 @@ func TestProtocolClassification(t *testing.T) {
 		t.Skip("Classification is not supported")
 	}
 	t.Run("without nat", func(t *testing.T) {
-		testProtocolClassification(t, cfg, "localhost", "127.0.0.1", "127.0.0.1")
+		testProtocolClassification(t, nil, "localhost", "127.0.0.1", "127.0.0.1")
 	})
+}
+
+func testProtocolClassificationInner(t *testing.T, params protocolClassificationAttributes, _ *Tracer) {
+	if params.skipCallback != nil {
+		params.skipCallback(t, params.context)
+	}
+
+	if params.teardown != nil {
+		t.Cleanup(func() {
+			params.teardown(t, params.context)
+		})
+	}
+	if params.preTracerSetup != nil {
+		params.preTracerSetup(t, params.context)
+	}
+	tr := setupTracer(t, cfg)
+	params.postTracerSetup(t, params.context)
+	params.validation(t, params.context, tr)
 }

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -1037,14 +1037,16 @@ func addrPort(addr string) int {
 	return p
 }
 
+const clientID = "1"
+
 func initTracerState(t testing.TB, tr *Tracer) {
-	err := tr.RegisterClient("1")
+	err := tr.RegisterClient(clientID)
 	require.NoError(t, err)
 }
 
 func getConnections(t *testing.T, tr *Tracer) *network.Connections {
 	// Iterate through active connections until we find connection created above, and confirm send + recv counts
-	connections, err := tr.GetActiveConnections("1")
+	connections, err := tr.GetActiveConnections(clientID)
 	require.NoError(t, err)
 	return connections
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Uses a single tracer for all tests within `TestProtocolClassification`. It also:
- resets the tracer client state between tests
- pauses tracepoints/kprobes/socket filters except within the `postTracerSetup` step

### Motivation

~75% of the previous time was spent attaching/detaching kprobes. 

### Additional Notes

This should be reviewed for possible side-effects between tests. We can always reset even more state within the tracer.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
