### PR TITLE
[CWS] actually disable trivy when the config asks so

### DIFF
--- a/pkg/security/probe/field_handlers.go
+++ b/pkg/security/probe/field_handlers.go
@@ -423,6 +423,10 @@ func (fh *FieldHandlers) ResolvePackageName(ev *model.Event, f *model.FileEvent)
 			return ""
 		}
 
+		if fh.resolvers.SBOMResolver != nil {
+			return ""
+		}
+
 		if pkg := fh.resolvers.SBOMResolver.ResolvePackage(ev.ProcessCacheEntry.ContainerID, f); pkg != nil {
 			f.PkgName = pkg.Name
 		}
@@ -438,6 +442,10 @@ func (fh *FieldHandlers) ResolvePackageVersion(ev *model.Event, f *model.FileEve
 			return ""
 		}
 
+		if fh.resolvers.SBOMResolver != nil {
+			return ""
+		}
+
 		if pkg := fh.resolvers.SBOMResolver.ResolvePackage(ev.ProcessCacheEntry.ContainerID, f); pkg != nil {
 			f.PkgVersion = pkg.Version
 		}
@@ -450,6 +458,10 @@ func (fh *FieldHandlers) ResolvePackageSourceVersion(ev *model.Event, f *model.F
 	if f.PkgSrcVersion == "" {
 		// Force the resolution of file path to be able to map to a package provided file
 		if fh.ResolveFilePath(ev, f) == "" {
+			return ""
+		}
+
+		if fh.resolvers.SBOMResolver != nil {
 			return ""
 		}
 

--- a/pkg/security/probe/field_handlers.go
+++ b/pkg/security/probe/field_handlers.go
@@ -423,7 +423,7 @@ func (fh *FieldHandlers) ResolvePackageName(ev *model.Event, f *model.FileEvent)
 			return ""
 		}
 
-		if fh.resolvers.SBOMResolver != nil {
+		if fh.resolvers.SBOMResolver == nil {
 			return ""
 		}
 
@@ -442,7 +442,7 @@ func (fh *FieldHandlers) ResolvePackageVersion(ev *model.Event, f *model.FileEve
 			return ""
 		}
 
-		if fh.resolvers.SBOMResolver != nil {
+		if fh.resolvers.SBOMResolver == nil {
 			return ""
 		}
 
@@ -461,7 +461,7 @@ func (fh *FieldHandlers) ResolvePackageSourceVersion(ev *model.Event, f *model.F
 			return ""
 		}
 
-		if fh.resolvers.SBOMResolver != nil {
+		if fh.resolvers.SBOMResolver == nil {
 			return ""
 		}
 

--- a/pkg/security/probe/probe_monitor.go
+++ b/pkg/security/probe/probe_monitor.go
@@ -120,8 +120,10 @@ func (m *Monitor) SendStats() error {
 		if err := resolvers.MountResolver.SendStats(); err != nil {
 			return fmt.Errorf("failed to send mount_resolver stats: %w", err)
 		}
-		if err := resolvers.SBOMResolver.SendStats(); err != nil {
-			return fmt.Errorf("failed to send sbom_resolver stats: %w", err)
+		if resolvers.SBOMResolver != nil {
+			if err := resolvers.SBOMResolver.SendStats(); err != nil {
+				return fmt.Errorf("failed to send sbom_resolver stats: %w", err)
+			}
 		}
 	}
 

--- a/pkg/security/resolvers/sbom/resolver.go
+++ b/pkg/security/resolvers/sbom/resolver.go
@@ -176,10 +176,6 @@ func (r *Resolver) prepareContextTags() {
 
 // Start starts the goroutine of the SBOM resolver
 func (r *Resolver) Start(ctx context.Context) {
-	if !r.config.SBOMResolverEnabled {
-		return
-	}
-
 	go func() {
 		ctx, cancel := context.WithCancel(ctx)
 		defer cancel()

--- a/pkg/security/resolvers/sbom/resolver.go
+++ b/pkg/security/resolvers/sbom/resolver.go
@@ -313,10 +313,6 @@ func (r *Resolver) RefreshSBOM(id string, cgroup *cgroupModel.CacheEntry) error 
 // ResolvePackage returns the Package that owns the provided file. Make sure the internal fields of "file" are properly
 // resolved.
 func (r *Resolver) ResolvePackage(containerID string, file *model.FileEvent) *Package {
-	if !r.config.SBOMResolverEnabled {
-		return nil
-	}
-
 	r.sbomsLock.RLock()
 	defer r.sbomsLock.RUnlock()
 	sbom, ok := r.sboms[containerID]
@@ -387,10 +383,6 @@ func (r *Resolver) OnWorkloadSelectorResolvedEvent(sbom *cgroupModel.CacheEntry)
 
 // Retain increments the reference counter of the SBOM of a sbom
 func (r *Resolver) Retain(id string, cgroup *cgroupModel.CacheEntry) {
-	if !r.config.SBOMResolverEnabled {
-		return
-	}
-
 	r.sbomsLock.Lock()
 	defer r.sbomsLock.Unlock()
 
@@ -425,10 +417,6 @@ func (r *Resolver) OnCGroupDeletedEvent(sbom *cgroupModel.CacheEntry) {
 
 // Delete removes the SBOM of the provided cgroup
 func (r *Resolver) Delete(id string) {
-	if !r.config.SBOMResolverEnabled {
-		return
-	}
-
 	sbom := r.GetWorkload(id)
 	if sbom == nil {
 		return

--- a/pkg/security/resolvers/sbom/resolver.go
+++ b/pkg/security/resolvers/sbom/resolver.go
@@ -285,31 +285,6 @@ func (r *Resolver) analyzeWorkload(sbom *SBOM) error {
 	return nil
 }
 
-// RefreshSBOM analyzes the file system of a sbom to refresh its SBOM.
-func (r *Resolver) RefreshSBOM(id string, cgroup *cgroupModel.CacheEntry) error {
-	if !r.config.SBOMResolverEnabled {
-		return nil
-	}
-
-	r.sbomsLock.Lock()
-	defer r.sbomsLock.Unlock()
-	sbom, ok := r.sboms[id]
-	if !ok {
-		var err error
-		sbom, err = r.newWorkloadEntry(id, cgroup)
-		if err != nil {
-			return err
-		}
-	}
-
-	// push sbom to the scanner chan
-	select {
-	case r.scannerChan <- sbom:
-	default:
-	}
-	return nil
-}
-
 // ResolvePackage returns the Package that owns the provided file. Make sure the internal fields of "file" are properly
 // resolved.
 func (r *Resolver) ResolvePackage(containerID string, file *model.FileEvent) *Package {

--- a/pkg/security/resolvers/sbom/resolver.go
+++ b/pkg/security/resolvers/sbom/resolver.go
@@ -93,7 +93,6 @@ type Resolver struct {
 	sbomsCacheLock sync.RWMutex
 	sbomsCache     *simplelru.LRU[string, *SBOM]
 	scannerChan    chan *SBOM
-	config         *config.Config
 	statsdClient   statsd.ClientInterface
 	trivyScanner   trivy.Collector
 
@@ -129,7 +128,6 @@ func NewSBOMResolver(c *config.Config, tagsResolver *tags.Resolver, statsdClient
 	}
 
 	resolver := &Resolver{
-		config:                c,
 		statsdClient:          statsdClient,
 		sboms:                 make(map[string]*SBOM),
 		sbomsCache:            sbomsCache,


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This PR makes sure that when the config says `sbom.enabled = false` we ensure that trivy is not running and not trying to do some caching of something.
The issue we see in the e2e tests is that the caching operation most likely involves something that is not allowed by the seccomp profile.
The solution implemented in this PR is to not create a sbom resolver at all if `sbom.enabled` is false (which is the default).

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
