### PR TITLE
Fixed path resolution for gotls hooking

### DIFF
--- a/pkg/network/protocols/http/ebpf_gotls.go
+++ b/pkg/network/protocols/http/ebpf_gotls.go
@@ -283,6 +283,8 @@ func (p *GoTLSProgram) handleProcessStart(pid pid) {
 		// there are not much we can do and we don't want to flood the logs
 		return
 	}
+	// Getting the full path in the process' namespace.
+	binPath = filepath.Join(p.procRoot, strconv.FormatUint(uint64(pid), 10), "root", binPath)
 
 	var stat syscall.Stat_t
 	if err = syscall.Stat(binPath, &stat); err != nil {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Backmerges https://github.com/DataDog/datadog-agent/pull/15816 specific change to allow hooking go applications running in a container.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

1. Run the agent with gotls enabled
```yaml
service_monitoring_config:
  enabled: true
  enable_go_tls_support: true
```
2. run `docker run -it --rm -p 8444:8080 public.ecr.aws/b1o7r7e0/usm-team/go-httpbin:https`
3. download the client
```go
package main

import (
    "crypto/tls"
    "fmt"
    "io"
    "net/http"
    "os"
)

func main() {
    htClone := http.DefaultTransport.(*http.Transport).Clone()
    htClone.ForceAttemptHTTP2 = false
    htClone.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
    htClone.TLSClientConfig.NextProtos = []string{"http/1.1"}

    client := &http.Client{Transport: htClone}
    resp, err := client.Get(os.Args[1])
    if err != nil {
        fmt.Println(err)
        return
    }
    defer resp.Body.Close()

    body, err := io.ReadAll(resp.Body)
    if err != nil {
        fmt.Println(err)
        return
    }
    fmt.Println(string(body))
}
```
4. build the client without symbols `go build -o client -ldflags="-s -w" main.go`
5. run `./client https://localhost:8444/anything/status/ip`
6. run `sudo curl --unix /opt/datadog-agent/run/sysprobe.sock http://unix/network_tracer/debug/http_monitoring | jq`
7. expect to see the endpoint
8. repeat the test above, when replacing steps 1 and 2, meaning, running the server before running the agent
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
