### PR TITLE
Fix autodiscovery in K8s - Correctly restore `container.go` and tests.

### DIFF
--- a/pkg/autodiscovery/providers/container.go
+++ b/pkg/autodiscovery/providers/container.go
@@ -10,198 +10,308 @@ package providers
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"sync"
-	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/common/utils"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/providers/names"
 	"github.com/DataDog/datadog-agent/pkg/config"
-	"github.com/DataDog/datadog-agent/pkg/status/health"
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 )
 
-const (
-	delayDuration = 5 * time.Second
-)
-
-// ContainerConfigProvider implements the ConfigProvider interface for container labels.
+// ContainerConfigProvider implements the ConfigProvider interface for both pods and containers
 type ContainerConfigProvider struct {
-	sync.RWMutex
 	workloadmetaStore workloadmeta.Store
-	upToDate          bool
-	streaming         bool
-	containerCache    map[string]*workloadmeta.Container
-	containerFilter   *containers.Filter
-	once              sync.Once
+	configErrors      map[string]ErrorMsgSet                   // map[entity name]ErrorMsgSet
+	configCache       map[string]map[string]integration.Config // map[entity name]map[config digest]integration.Config
+	mu                sync.RWMutex
 }
 
-// NewContainerConfigProvider creates a new ContainerConfigProvider
+// NewContainerConfigProvider returns a new ConfigProvider subscribed to both container
+// and pods
 func NewContainerConfigProvider(*config.ConfigurationProviders) (ConfigProvider, error) {
-	containerFilter, err := containers.NewAutodiscoveryFilter(containers.GlobalFilter)
-	if err != nil {
-		log.Warnf("Can't get container include/exclude filter, no filtering will be applied: %v", err)
-	}
-
 	return &ContainerConfigProvider{
 		workloadmetaStore: workloadmeta.GetGlobalStore(),
-		containerCache:    make(map[string]*workloadmeta.Container),
-		containerFilter:   containerFilter,
+		configCache:       make(map[string]map[string]integration.Config),
+		configErrors:      make(map[string]ErrorMsgSet),
 	}, nil
 }
 
 // String returns a string representation of the ContainerConfigProvider
-func (d *ContainerConfigProvider) String() string {
-	return names.Container
+func (k *ContainerConfigProvider) String() string {
+	return names.KubeContainer
 }
 
-// Collect retrieves all running containers and extract AD templates from their labels.
-func (d *ContainerConfigProvider) Collect(ctx context.Context) ([]integration.Config, error) {
-	d.once.Do(func() {
-		ch := make(chan struct{})
-		go d.listen(ch)
-		<-ch
-	})
+// Stream starts listening to workloadmeta to generate configs as they come
+// instead of relying on a periodic call to Collect.
+func (k *ContainerConfigProvider) Stream(ctx context.Context) <-chan integration.ConfigChanges {
+	const name = "ad-kubecontainerprovider"
 
-	d.Lock()
-	d.upToDate = true
-	d.Unlock()
+	// outCh must be unbuffered. processing of workloadmeta events must not
+	// proceed until the config is processed by autodiscovery, as configs
+	// need to be generated before any associated services.
+	outCh := make(chan integration.ConfigChanges)
 
-	d.RLock()
-	defer d.RUnlock()
-	return d.generateConfigs()
-}
-
-// listen, closing the given channel after the initial set of events are received
-func (d *ContainerConfigProvider) listen(ch chan struct{}) {
-	d.Lock()
-	d.streaming = true
-	health := health.RegisterLiveness("ad-containerprovider")
-	defer func() {
-		err := health.Deregister()
-		if err != nil {
-			log.Warnf("error de-registering health check: %s", err)
-		}
-	}()
-	d.Unlock()
-
-	var ranOnce bool
-
-	workloadmetaEventsChannel := d.workloadmetaStore.Subscribe("ad-containerprovider", workloadmeta.NormalPriority, workloadmeta.NewFilter(
-		[]workloadmeta.Kind{workloadmeta.KindContainer},
-		workloadmeta.SourceRuntime,
+	inCh := k.workloadmetaStore.Subscribe(name, workloadmeta.ConfigProviderPriority, workloadmeta.NewFilter(
+		[]workloadmeta.Kind{workloadmeta.KindKubernetesPod, workloadmeta.KindContainer},
+		workloadmeta.SourceAll,
 		workloadmeta.EventTypeAll,
 	))
 
-	for {
-		select {
-		case evBundle, ok := <-workloadmetaEventsChannel:
-			if !ok {
-				return
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				k.workloadmetaStore.Unsubscribe(inCh)
+
+			case evBundle, ok := <-inCh:
+				if !ok {
+					return
+				}
+
+				// send changes even when they're empty, as we
+				// need to signal that an event has been
+				// received, for flow control reasons
+				outCh <- k.processEvents(evBundle)
+
+				close(evBundle.Ch)
 			}
-
-			d.processEvents(evBundle)
-
-			if !ranOnce {
-				close(ch)
-				ranOnce = true
-			}
-
-		case <-health.C:
-
 		}
-	}
+	}()
+
+	return outCh
 }
 
-func (d *ContainerConfigProvider) processEvents(eventBundle workloadmeta.EventBundle) {
-	close(eventBundle.Ch)
+func (k *ContainerConfigProvider) processEvents(evBundle workloadmeta.EventBundle) integration.ConfigChanges {
+	k.mu.Lock()
+	defer k.mu.Unlock()
 
-	for _, event := range eventBundle.Events {
-		containerID := event.Entity.GetID().ID
+	changes := integration.ConfigChanges{}
+
+	for _, event := range evBundle.Events {
+		entityName := buildEntityName(event.Entity)
 
 		switch event.Type {
 		case workloadmeta.EventTypeSet:
-			container := event.Entity.(*workloadmeta.Container)
+			configs, err := k.generateConfig(event.Entity)
 
-			d.RLock()
-			_, containerSeen := d.containerCache[container.ID]
-			d.RUnlock()
-			if containerSeen {
-				// Container restarted with the same ID within 5 seconds.
-				// This delay is needed because of the delay introduced in the
-				// EventTypeUnset case.
-				time.AfterFunc(delayDuration, func() {
-					d.addContainer(containerID, container)
-				})
+			if err != nil {
+				k.configErrors[entityName] = err
 			} else {
-				d.addContainer(containerID, container)
+				delete(k.configErrors, entityName)
+			}
+
+			configCache, ok := k.configCache[entityName]
+			if !ok {
+				configCache = make(map[string]integration.Config)
+				k.configCache[entityName] = configCache
+			}
+
+			configsToUnschedule := make(map[string]integration.Config)
+			for digest, config := range configCache {
+				configsToUnschedule[digest] = config
+			}
+
+			for _, config := range configs {
+				digest := config.Digest()
+				if _, ok := configCache[digest]; ok {
+					delete(configsToUnschedule, digest)
+				} else {
+					configCache[digest] = config
+					changes.ScheduleConfig(config)
+				}
+			}
+
+			for oldDigest, oldConfig := range configsToUnschedule {
+				delete(configCache, oldDigest)
+				changes.UnscheduleConfig(oldConfig)
 			}
 
 		case workloadmeta.EventTypeUnset:
-			// delay for short-lived detection
-			time.AfterFunc(delayDuration, func() {
-				d.deleteContainer(containerID)
-			})
+			oldConfigs, found := k.configCache[entityName]
+			if !found {
+				log.Debugf("entity %q removed from workloadmeta store but not found in cache. skipping", entityName)
+				continue
+			}
+
+			for _, oldConfig := range oldConfigs {
+				changes.UnscheduleConfig(oldConfig)
+			}
+
+			delete(k.configCache, entityName)
+			delete(k.configErrors, entityName)
 
 		default:
 			log.Errorf("cannot handle event of type %d", event.Type)
 		}
 	}
 
+	return changes
 }
 
-// IsUpToDate checks whether we have new containers to parse, based on events
-// received by the listen goroutine. If listening fails, we fallback to
-// collecting everytime.
-func (d *ContainerConfigProvider) IsUpToDate(ctx context.Context) (bool, error) {
-	d.RLock()
-	defer d.RUnlock()
-	return d.streaming && d.upToDate, nil
-}
+func (k *ContainerConfigProvider) generateConfig(e workloadmeta.Entity) ([]integration.Config, ErrorMsgSet) {
+	var (
+		errMsgSet ErrorMsgSet
+		errs      []error
+		configs   []integration.Config
+	)
 
-// addLabels updates the cache for a given container
-func (d *ContainerConfigProvider) addContainer(containerID string, container *workloadmeta.Container) {
-	d.Lock()
-	defer d.Unlock()
-	d.containerCache[containerID] = container
-	d.upToDate = false
-}
+	switch entity := e.(type) {
+	case *workloadmeta.Container:
+		// kubernetes containers need to be handled together with their
+		// pod, so they generate a single []integration.Config.
+		// otherwise, it's possible for a container that belongs to an
+		// AD-annotated pod to briefly be scheduled without its
+		// annotations.
+		if !findKubernetesInLabels(entity.Labels) {
+			configs, errs = k.generateContainerConfig(entity)
 
-func (d *ContainerConfigProvider) deleteContainer(containerID string) {
-	d.Lock()
-	defer d.Unlock()
-	delete(d.containerCache, containerID)
-	d.upToDate = false
-}
+			containerID := entity.ID
+			containerEntityName := containers.BuildEntityName(string(entity.Runtime), containerID)
+			configs = utils.AddContainerCollectAllConfigs(configs, containerEntityName)
 
-func (d *ContainerConfigProvider) generateConfigs() ([]integration.Config, error) {
-	var configs []integration.Config
-	for containerID, container := range d.containerCache {
-		containerEntityName := containers.BuildEntityName(string(container.Runtime), containerID)
-		c, errors := utils.ExtractTemplatesFromContainerLabels(containerEntityName, container.Labels)
-
-		for _, err := range errors {
-			log.Errorf("Can't parse template for container %s: %s", containerID, err)
+			for idx := range configs {
+				configs[idx].Source = names.Container + ":" + containerEntityName
+			}
 		}
 
-		c = utils.AddContainerCollectAllConfigs(c, containerEntityName)
+	case *workloadmeta.KubernetesPod:
+		containerIdentifiers := map[string]struct{}{}
+		containerNames := map[string]struct{}{}
+		for _, podContainer := range entity.Containers {
+			container, err := k.workloadmetaStore.GetContainer(podContainer.ID)
+			if err != nil {
+				log.Debugf("Pod %q has reference to non-existing container %q", entity.Name, podContainer.ID)
+				continue
+			}
 
-		for idx := range c {
-			c[idx].Source = names.Container + ":" + containerEntityName
+			var (
+				c      []integration.Config
+				errors []error
+			)
+
+			c, errors = k.generateContainerConfig(container)
+			configs = append(configs, c...)
+			errs = append(errs, errors...)
+
+			adIdentifier := podContainer.Name
+			if customADID, found := utils.ExtractCheckIDFromPodAnnotations(entity.Annotations, podContainer.Name); found {
+				adIdentifier = customADID
+			}
+
+			containerEntity := containers.BuildEntityName(string(container.Runtime), container.ID)
+			c, errors = utils.ExtractTemplatesFromPodAnnotations(
+				containerEntity,
+				entity.Annotations,
+				adIdentifier,
+			)
+
+			// container_collect_all configs must be added after
+			// configs generated from annotations, since services
+			// are reconciled against configs one-by-one instead of
+			// as a set, so if a container_collect_all config
+			// appears before an annotation one, it'll cause a logs
+			// config to be scheduled as container_collect_all,
+			// unscheduled, and then re-scheduled correctly.
+			c = utils.AddContainerCollectAllConfigs(c, containerEntity)
+
+			if len(errors) > 0 {
+				errs = append(errs, errors...)
+				if len(c) == 0 {
+					// Only got errors, no valid configs so
+					// let's move on to the next container.
+					continue
+				}
+			}
+
+			containerIdentifiers[adIdentifier] = struct{}{}
+			containerNames[podContainer.Name] = struct{}{}
+
+			for idx := range c {
+				c[idx].Source = names.Container + ":" + containerEntity
+			}
+
+			configs = append(configs, c...)
 		}
 
-		configs = append(configs, c...)
+		errs = append(errs, utils.ValidateAnnotationsMatching(
+			entity.Annotations,
+			containerIdentifiers,
+			containerNames)...)
+
+	default:
+		log.Errorf("cannot handle entity of kind %s", e.GetID().Kind)
 	}
-	return configs, nil
+
+	if len(errs) > 0 {
+		errMsgSet = make(ErrorMsgSet)
+		for _, err := range errs {
+			errMsgSet[err.Error()] = struct{}{}
+		}
+	}
+
+	return configs, errMsgSet
+}
+
+func (k *ContainerConfigProvider) generateContainerConfig(container *workloadmeta.Container) ([]integration.Config, []error) {
+	var (
+		errs    []error
+		configs []integration.Config
+	)
+
+	containerID := container.ID
+	containerEntityName := containers.BuildEntityName(string(container.Runtime), containerID)
+	configs, errs = utils.ExtractTemplatesFromContainerLabels(containerEntityName, container.Labels)
+
+	return configs, errs
+}
+
+// GetConfigErrors returns a map of configuration errors for each namespace/pod
+func (k *ContainerConfigProvider) GetConfigErrors() map[string]ErrorMsgSet {
+	k.mu.RLock()
+	defer k.mu.RUnlock()
+
+	errors := make(map[string]ErrorMsgSet, len(k.configErrors))
+
+	for entity, errset := range k.configErrors {
+		errors[entity] = errset
+	}
+
+	return errors
+}
+
+// buildEntityName is also used as display key in `agent status` "Configuration Errors" display.
+// (for instance, incorrect annotation syntax or unknown container name).
+// That's why it does not simply use Kind + ID.
+// It needs to be unique over time.
+// (for instance, namespace+name is not unique for a POD as it can be deleted/created with a different UID, see STS rollout)
+func buildEntityName(e workloadmeta.Entity) string {
+	entityID := e.GetID()
+	switch entity := e.(type) {
+	case *workloadmeta.KubernetesPod:
+		return fmt.Sprintf("%s/%s (%s)", entity.Namespace, entity.Name, entity.ID)
+	case *workloadmeta.Container:
+		return containers.BuildEntityName(string(entity.Runtime), entityID.ID)
+	default:
+		return fmt.Sprintf("%s://%s", entityID.Kind, entityID.ID)
+	}
+}
+
+// findKubernetesInLabels traverses a map of container labels and
+// returns true if a kubernetes label is detected
+func findKubernetesInLabels(labels map[string]string) bool {
+	for name := range labels {
+		if strings.HasPrefix(name, "io.kubernetes.") {
+			return true
+		}
+	}
+	return false
 }
 
 func init() {
-	RegisterProvider(names.Container, NewContainerConfigProvider)
-}
-
-// GetConfigErrors is not implemented for the ContainerConfigProvider
-func (d *ContainerConfigProvider) GetConfigErrors() map[string]ErrorMsgSet {
-	return make(map[string]ErrorMsgSet)
+	RegisterProvider(names.KubeContainer, NewContainerConfigProvider)
 }

--- a/pkg/autodiscovery/providers/container_test.go
+++ b/pkg/autodiscovery/providers/container_test.go
@@ -13,46 +13,446 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
+	workloadmetatesting "github.com/DataDog/datadog-agent/pkg/workloadmeta/testing"
 )
 
-// Only testing generateConfigs, lifecycle should be tested in end-to-end test
+func TestProcessEvents(t *testing.T) {
+	store := workloadmetatesting.NewStore()
 
-func TestGenerateConfigs_Container(t *testing.T) {
-	configProvider := ContainerConfigProvider{
-		containerCache: map[string]*workloadmeta.Container{
-			"nolabels": {
-				Runtime: workloadmeta.ContainerRuntimeContainerd,
-			},
-			"3b8efe0c50e8": {
-				EntityMeta: workloadmeta.EntityMeta{
-					Labels: map[string]string{
-						"com.datadoghq.ad.check_names":  "[\"apache\",\"http_check\"]",
-						"com.datadoghq.ad.init_configs": "[{}, {}]",
-						"com.datadoghq.ad.instances":    "[{\"apache_status_url\": \"http://%%host%%/server-status?auto\"},{\"name\": \"My service\", \"url\": \"http://%%host%%\", \"timeout\": 1}]",
-					},
+	cp := &ContainerConfigProvider{
+		workloadmetaStore: store,
+		configCache:       make(map[string]map[string]integration.Config),
+		configErrors:      make(map[string]ErrorMsgSet),
+	}
+
+	tests := []struct {
+		name    string
+		events  []workloadmeta.Event
+		changes integration.ConfigChanges
+	}{
+		{
+			name: "create config",
+			events: []workloadmeta.Event{
+				{
+					Type:   workloadmeta.EventTypeSet,
+					Entity: basicDockerContainer(),
 				},
-				Runtime: workloadmeta.ContainerRuntimeDocker,
+			},
+			changes: integration.ConfigChanges{
+				Schedule: basicDockerConfigs(),
+			},
+		},
+		{
+			name: "replace config",
+			events: []workloadmeta.Event{
+				{
+					Type:   workloadmeta.EventTypeSet,
+					Entity: basicDockerContainerSingleCheck(),
+				},
+			},
+			changes: integration.ConfigChanges{
+				Unschedule: []integration.Config{
+					basicDockerConfigs()[1],
+				},
+			},
+		},
+		{
+			name: "delete config",
+			events: []workloadmeta.Event{
+				{
+					Type:   workloadmeta.EventTypeUnset,
+					Entity: basicDockerContainer(),
+				},
+			},
+			changes: integration.ConfigChanges{
+				Unschedule: []integration.Config{
+					basicDockerConfigs()[0],
+				},
 			},
 		},
 	}
 
-	checks, err := configProvider.generateConfigs()
-	assert.Nil(t, err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			changes := cp.processEvents(workloadmeta.EventBundle{
+				Events: tt.events,
+			})
 
-	assert.Len(t, checks, 2)
+			assert.Equal(t, tt.changes.Schedule, changes.Schedule)
+			assert.Equal(t, tt.changes.Unschedule, changes.Unschedule)
+		})
+	}
+}
 
-	assert.Equal(t, []string{"docker://3b8efe0c50e8"}, checks[0].ADIdentifiers)
-	assert.Equal(t, "{}", string(checks[0].InitConfig))
-	assert.Equal(t, "container:docker://3b8efe0c50e8", checks[0].Source)
-	assert.Len(t, checks[0].Instances, 1)
-	assert.Equal(t, "{\"apache_status_url\":\"http://%%host%%/server-status?auto\"}", string(checks[0].Instances[0]))
-	assert.Equal(t, "apache", checks[0].Name)
+func TestGenerateConfig(t *testing.T) {
+	tests := []struct {
+		name                string
+		entity              workloadmeta.Entity
+		expectedConfigs     []integration.Config
+		expectedErr         ErrorMsgSet
+		containerCollectAll bool
+	}{
+		{
+			name:            "container check",
+			entity:          basicDockerContainer(),
+			expectedConfigs: basicDockerConfigs(),
+		},
+		{
+			name: "No annotations",
+			entity: &workloadmeta.KubernetesPod{
+				Containers: []workloadmeta.OrchestratorContainer{
+					{
+						Name: "testName",
+						ID:   "testID",
+					},
+				},
+			},
+		},
+		{
+			name: "v2 annotations",
+			entity: &workloadmeta.KubernetesPod{
+				EntityMeta: workloadmeta.EntityMeta{
+					Annotations: map[string]string{
+						"ad.datadoghq.com/apache.checks": `{
+							"http_check": {
+								"instances": [
+									{
+										"name": "My service",
+										"url": "http://%%host%%",
+										"timeout": 1
+									}
+								]
+							}
+						}`,
+						"ad.datadoghq.com/apache.check_names":  "[\"invalid\"]",
+						"ad.datadoghq.com/apache.init_configs": "[{}]",
+						"ad.datadoghq.com/apache.instances":    "[{}]",
+					},
+				},
+				Containers: []workloadmeta.OrchestratorContainer{
+					{
+						Name: "apache",
+						ID:   "3b8efe0c50e8",
+					},
+				},
+			},
+			expectedConfigs: []integration.Config{
+				{
+					Name:          "http_check",
+					ADIdentifiers: []string{"docker://3b8efe0c50e8"},
+					InitConfig:    integration.Data("{}"),
+					Instances:     []integration.Data{integration.Data("{\"name\":\"My service\",\"timeout\":1,\"url\":\"http://%%host%%\"}")},
+					Source:        "container:docker://3b8efe0c50e8",
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			name: "New + old, new takes over",
+			entity: &workloadmeta.KubernetesPod{
+				EntityMeta: workloadmeta.EntityMeta{
+					Annotations: map[string]string{
+						"ad.datadoghq.com/apache.check_names":                 "[\"http_check\"]",
+						"ad.datadoghq.com/apache.init_configs":                "[{}]",
+						"ad.datadoghq.com/apache.instances":                   "[{\"name\": \"My service\", \"url\": \"http://%%host%%\", \"timeout\": 1}]",
+						"service-discovery.datadoghq.com/apache.check_names":  "[\"invalid\"]",
+						"service-discovery.datadoghq.com/apache.init_configs": "[{}]",
+						"service-discovery.datadoghq.com/apache.instances":    "[{}]",
+					},
+				},
+				Containers: []workloadmeta.OrchestratorContainer{
+					{
+						Name: "apache",
+						ID:   "3b8efe0c50e8",
+					},
+				},
+			},
+			expectedConfigs: []integration.Config{
+				{
+					Name:          "http_check",
+					ADIdentifiers: []string{"docker://3b8efe0c50e8"},
+					InitConfig:    integration.Data("{}"),
+					Instances:     []integration.Data{integration.Data("{\"name\":\"My service\",\"timeout\":1,\"url\":\"http://%%host%%\"}")},
+					Source:        "container:docker://3b8efe0c50e8",
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			name: "New annotation prefix, two templates",
+			entity: &workloadmeta.KubernetesPod{
+				EntityMeta: workloadmeta.EntityMeta{
+					Annotations: map[string]string{
+						"ad.datadoghq.com/apache.check_names":  "[\"http_check\"]",
+						"ad.datadoghq.com/apache.init_configs": "[{}]",
+						"ad.datadoghq.com/apache.instances":    "[{\"name\": \"My service\", \"url\": \"http://%%host%%\", \"timeout\": 1}]",
+						"ad.datadoghq.com/nginx.check_names":   "[\"http_check\"]",
+						"ad.datadoghq.com/nginx.init_configs":  "[{}]",
+						"ad.datadoghq.com/nginx.instances":     "[{\"name\": \"Other service\", \"url\": \"http://%%host_external%%\", \"timeout\": 1}]",
+					},
+				},
+				Containers: []workloadmeta.OrchestratorContainer{
+					{
+						Name: "apache",
+						ID:   "3b8efe0c50e8",
+					},
+					{
+						Name: "nginx",
+						ID:   "4ac8352d70bf1",
+					},
+				},
+			},
+			expectedConfigs: []integration.Config{
+				{
+					Name:          "http_check",
+					ADIdentifiers: []string{"docker://3b8efe0c50e8"},
+					InitConfig:    integration.Data("{}"),
+					Instances:     []integration.Data{integration.Data("{\"name\":\"My service\",\"timeout\":1,\"url\":\"http://%%host%%\"}")},
+					Source:        "container:docker://3b8efe0c50e8",
+				},
+				{
+					Name:          "http_check",
+					ADIdentifiers: []string{"docker://4ac8352d70bf1"},
+					InitConfig:    integration.Data("{}"),
+					Instances:     []integration.Data{integration.Data("{\"name\":\"Other service\",\"timeout\":1,\"url\":\"http://%%host_external%%\"}")},
+					Source:        "container:docker://4ac8352d70bf1",
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			name: "Legacy annotation prefix, two checks in one template",
+			entity: &workloadmeta.KubernetesPod{
+				EntityMeta: workloadmeta.EntityMeta{
+					Annotations: map[string]string{
+						"service-discovery.datadoghq.com/apache.check_names":  "[\"apache\",\"http_check\"]",
+						"service-discovery.datadoghq.com/apache.init_configs": "[{},{}]",
+						"service-discovery.datadoghq.com/apache.instances":    "[{\"apache_status_url\": \"http://%%host%%/server-status?auto\"},{\"name\": \"My service\", \"url\": \"http://%%host%%\", \"timeout\": 1}]",
+					},
+				},
+				Containers: []workloadmeta.OrchestratorContainer{
+					{
+						Name: "apache",
+						ID:   "3b8efe0c50e8",
+					},
+				},
+			},
+			expectedConfigs: []integration.Config{
+				{
+					Name:          "apache",
+					ADIdentifiers: []string{"docker://3b8efe0c50e8"},
+					InitConfig:    integration.Data("{}"),
+					Instances:     []integration.Data{integration.Data("{\"apache_status_url\":\"http://%%host%%/server-status?auto\"}")},
+					Source:        "container:docker://3b8efe0c50e8",
+				},
+				{
+					Name:          "http_check",
+					ADIdentifiers: []string{"docker://3b8efe0c50e8"},
+					InitConfig:    integration.Data("{}"),
+					Instances:     []integration.Data{integration.Data("{\"name\":\"My service\",\"timeout\":1,\"url\":\"http://%%host%%\"}")},
+					Source:        "container:docker://3b8efe0c50e8",
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			name: "Custom check ID",
+			entity: &workloadmeta.KubernetesPod{
+				EntityMeta: workloadmeta.EntityMeta{
+					Annotations: map[string]string{
+						"ad.datadoghq.com/nginx.check.id":            "nginx-custom",
+						"ad.datadoghq.com/nginx-custom.check_names":  "[\"http_check\"]",
+						"ad.datadoghq.com/nginx-custom.init_configs": "[{}]",
+						"ad.datadoghq.com/nginx-custom.instances":    "[{\"name\": \"Other service\", \"url\": \"http://%%host_external%%\", \"timeout\": 1}]",
+					},
+				},
+				Containers: []workloadmeta.OrchestratorContainer{
+					{
+						Name: "nginx",
+						ID:   "4ac8352d70bf1",
+					},
+				},
+			},
+			expectedConfigs: []integration.Config{
+				{
+					Name:          "http_check",
+					ADIdentifiers: []string{"docker://4ac8352d70bf1"},
+					InitConfig:    integration.Data("{}"),
+					Instances:     []integration.Data{integration.Data("{\"name\":\"Other service\",\"timeout\":1,\"url\":\"http://%%host_external%%\"}")},
+					Source:        "container:docker://4ac8352d70bf1",
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			name: "Non-duplicate errors",
+			entity: &workloadmeta.KubernetesPod{
+				EntityMeta: workloadmeta.EntityMeta{
+					Name:      "nginx-1752f8c774-wtjql",
+					Namespace: "testNamespace",
+					Annotations: map[string]string{
+						"ad.datadoghq.com/nonmatching.check_names":  "[\"http_check\"]",
+						"ad.datadoghq.com/nonmatching.init_configs": "[{}]",
+						"ad.datadoghq.com/nonmatching.instances":    "[{\"name\": \"Other service\", \"url\": \"http://%%host_external%%\", \"timeout\": 1}]",
+					},
+				},
+				Containers: []workloadmeta.OrchestratorContainer{
+					{
+						Name: "nginx",
+						ID:   "4ac8352d70bf1",
+					},
+					{
+						Name: "apache",
+						ID:   "3b8efe0c50e8",
+					},
+				},
+			},
+			expectedErr: ErrorMsgSet{
+				"annotation ad.datadoghq.com/nonmatching.check_names is invalid: nonmatching doesn't match a container identifier [apache nginx]":  {},
+				"annotation ad.datadoghq.com/nonmatching.init_configs is invalid: nonmatching doesn't match a container identifier [apache nginx]": {},
+				"annotation ad.datadoghq.com/nonmatching.instances is invalid: nonmatching doesn't match a container identifier [apache nginx]":    {},
+			},
+		},
+		{
+			name: "One invalid config, one valid config",
+			entity: &workloadmeta.KubernetesPod{
+				EntityMeta: workloadmeta.EntityMeta{
+					Annotations: map[string]string{
+						"ad.datadoghq.com/nginx.check_names":  "[\"http_check\"]",
+						"ad.datadoghq.com/nginx.init_configs": "[{}]",
+						"ad.datadoghq.com/nginx.instances":    "[{\"name\": \"nginx\", \"url\": \"http://%%host%%\", \"timeout\": 1}]",
+						"ad.datadoghq.com/nginx.logs":         "[{\"source\": \"nginx\" \"service\": \"nginx\"}]", // invalid json
+					},
+				},
+				Containers: []workloadmeta.OrchestratorContainer{
+					{
+						Name: "nginx",
+						ID:   "4ac8352d70bf1",
+					},
+				},
+			},
+			expectedConfigs: []integration.Config{
+				{
+					Name:          "http_check",
+					ADIdentifiers: []string{"docker://4ac8352d70bf1"},
+					InitConfig:    integration.Data("{}"),
+					Instances:     []integration.Data{integration.Data("{\"name\":\"nginx\",\"timeout\":1,\"url\":\"http://%%host%%\"}")},
+					Source:        "container:docker://4ac8352d70bf1",
+				},
+			},
+			expectedErr: ErrorMsgSet{
+				"could not extract logs config: in logs: invalid character '\"' after object key:value pair": {},
+			},
+		},
+		{
+			name: "bare container, container collect all",
+			entity: &workloadmeta.Container{
+				EntityID: workloadmeta.EntityID{
+					ID: "3b8efe0c50e8",
+				},
+				Runtime: workloadmeta.ContainerRuntimeDocker,
+			},
+			expectedConfigs: []integration.Config{
+				{
+					Name:          "container_collect_all",
+					Source:        "container:docker://3b8efe0c50e8",
+					LogsConfig:    integration.Data("[{}]"),
+					ADIdentifiers: []string{"docker://3b8efe0c50e8"},
+				},
+			},
+			containerCollectAll: true,
+		},
+	}
 
-	assert.Equal(t, []string{"docker://3b8efe0c50e8"}, checks[1].ADIdentifiers)
-	assert.Equal(t, "{}", string(checks[1].InitConfig))
-	assert.Equal(t, "container:docker://3b8efe0c50e8", checks[1].Source)
-	assert.Len(t, checks[1].Instances, 1)
-	assert.Equal(t, "{\"name\":\"My service\",\"timeout\":1,\"url\":\"http://%%host%%\"}", string(checks[1].Instances[0]))
-	assert.Equal(t, "http_check", checks[1].Name)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config.Datadog.Set("logs_config.container_collect_all", tt.containerCollectAll)
+			defer config.Datadog.Set("logs_config.container_collect_all", false)
+
+			store := workloadmetatesting.NewStore()
+
+			if pod, ok := tt.entity.(*workloadmeta.KubernetesPod); ok {
+				for _, c := range pod.Containers {
+					store.Set(&workloadmeta.Container{
+						EntityID: workloadmeta.EntityID{
+							Kind: workloadmeta.KindContainer,
+							ID:   c.ID,
+						},
+						Runtime: workloadmeta.ContainerRuntimeDocker,
+					})
+				}
+			}
+
+			cp := &ContainerConfigProvider{
+				workloadmetaStore: store,
+				configCache:       make(map[string]map[string]integration.Config),
+				configErrors:      make(map[string]ErrorMsgSet),
+			}
+
+			configs, err := cp.generateConfig(tt.entity)
+
+			assert.Equal(t, tt.expectedConfigs, configs)
+			assert.Equal(t, tt.expectedErr, err)
+		})
+	}
+}
+
+func basicDockerContainer() *workloadmeta.Container {
+	return &workloadmeta.Container{
+		EntityID: workloadmeta.EntityID{
+			ID:   "3b8efe0c50e8",
+			Kind: workloadmeta.KindContainer,
+		},
+		EntityMeta: workloadmeta.EntityMeta{
+			Labels: map[string]string{
+				"com.datadoghq.ad.check_names":  "[\"apache\",\"http_check\"]",
+				"com.datadoghq.ad.init_configs": "[{}, {}]",
+				"com.datadoghq.ad.instances":    "[{\"apache_status_url\": \"http://%%host%%/server-status?auto\"},{\"name\": \"My service\", \"url\": \"http://%%host%%\", \"timeout\": 1}]",
+			},
+		},
+		Runtime: workloadmeta.ContainerRuntimeDocker,
+	}
+}
+
+func basicDockerContainerSingleCheck() *workloadmeta.Container {
+	return &workloadmeta.Container{
+		EntityID: workloadmeta.EntityID{
+			ID:   "3b8efe0c50e8",
+			Kind: workloadmeta.KindContainer,
+		},
+		EntityMeta: workloadmeta.EntityMeta{
+			Labels: map[string]string{
+				"com.datadoghq.ad.check_names":  "[\"apache\"]",
+				"com.datadoghq.ad.init_configs": "[{}]",
+				"com.datadoghq.ad.instances":    "[{\"apache_status_url\": \"http://%%host%%/server-status?auto\"}]",
+			},
+		},
+		Runtime: workloadmeta.ContainerRuntimeDocker,
+	}
+}
+
+func basicDockerConfigs() []integration.Config {
+	return []integration.Config{
+		{
+			Name:          "apache",
+			ADIdentifiers: []string{"docker://3b8efe0c50e8"},
+			InitConfig:    integration.Data("{}"),
+			Source:        "container:docker://3b8efe0c50e8",
+			Instances: []integration.Data{
+				integration.Data("{\"apache_status_url\":\"http://%%host%%/server-status?auto\"}"),
+			},
+		},
+		{
+			Name:          "http_check",
+			ADIdentifiers: []string{"docker://3b8efe0c50e8"},
+			InitConfig:    integration.Data("{}"),
+			Source:        "container:docker://3b8efe0c50e8",
+			Instances: []integration.Data{
+				integration.Data("{\"name\":\"My service\",\"timeout\":1,\"url\":\"http://%%host%%\"}"),
+			},
+		},
+	}
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

These files were incorrectly merged when bringing the branch for https://github.com/DataDog/datadog-agent/pull/15738 in sync with main. 

This PR puts them back to their correct state from https://github.com/DataDog/datadog-agent/pull/14955
The specific comment tracking why this was done can be found here: https://github.com/DataDog/datadog-agent/pull/14955#discussion_r1063487572

### Motivation

Autodiscovery broken in 7.44 RC1


### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Check that the agent works in K8s. Internal deployments of the RC build should be good enough. 

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
