### PR TITLE
flare: fix trace agent debug port

### DIFF
--- a/cmd/agent/subcommands/flare/command.go
+++ b/cmd/agent/subcommands/flare/command.go
@@ -139,7 +139,7 @@ func readProfileData(cliParams *cliParams, pdata *pkgflare.ProfileData, seconds 
 
 		agentCollectors = append(agentCollectors, agentCollector{
 			name: "trace",
-			fn:   serviceProfileCollector("trace", "apm_config.receiver_port", traceCpusec),
+			fn:   serviceProfileCollector("trace", "apm_config.debug.port", traceCpusec),
 		})
 	}
 

--- a/cmd/agent/subcommands/flare/command_test.go
+++ b/cmd/agent/subcommands/flare/command_test.go
@@ -37,7 +37,7 @@ func TestReadProfileData(t *testing.T) {
 	mockConfig := config.Mock(t)
 	mockConfig.Set("expvar_port", "1001")
 	mockConfig.Set("apm_config.enabled", true)
-	mockConfig.Set("apm_config.receiver_port", "1002")
+	mockConfig.Set("apm_config.debug.port", "1002")
 	mockConfig.Set("apm_config.receiver_timeout", "10")
 	mockConfig.Set("process_config.expvar_port", "1003")
 
@@ -78,7 +78,7 @@ func TestReadProfileDataErrors(t *testing.T) {
 	mockConfig := config.Mock(t)
 	mockConfig.Set("expvar_port", "1001")
 	mockConfig.Set("apm_config.enabled", true)
-	mockConfig.Set("apm_config.receiver_port", "1002")
+	mockConfig.Set("apm_config.debug.port", "1002")
 	mockConfig.Set("apm_config.receiver_timeout", "10")
 	mockConfig.Set("process_config.expvar_port", "1003")
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Fixes the port used by `agent flare` to collect profiles from the trace agent

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Fixes the trace agent error 
```
root@70b16007dfa8:/# agent flare --profile 60
Please enter your email:
x
Getting a 60s profile snapshot from core.
Getting a 60s profile snapshot from process.
Getting a 4s profile snapshot from trace.
Getting a 60s profile snapshot from security-agent.
Could not collect performance profile data: 2 errors occurred:
	* error collecting trace agent profile: 404 page not found
```

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

Regression in https://github.com/DataDog/datadog-agent/pull/15591

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

```
docker run -d --cgroupns host --pid host --name dd-agent --network host -e DD_API_KEY=$DD_API_KEY -e DD_HOSTNAME="my.hostname" -e DD_APM_ENABLED=true -v /var/run/docker.sock:/var/run/docker.sock:ro -v /proc/:/host/proc/:ro -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro datadog/agent-dev:ahmed-fix-flare-profile-py3
```

Note: change `datadog/agent-dev:ahmed-fix-flare-profile-py3` by the RC image that contains the fix

```
docker exec -it dd-agent bash
root@docker-desktop:/# agent flare --profile 30
Please enter your email:
x
Getting a 30s profile snapshot from core.
Getting a 30s profile snapshot from process.
Getting a 4s profile snapshot from trace.
Getting a 30s profile snapshot from security-agent.
Could not collect performance profile data: 1 error occurred:
	* error collecting security-agent agent profile: Get "http://127.0.0.1:5011/debug/pprof/heap": dial tcp 127.0.0.1:5011: connect: connection refused


Asking the agent to build the flare archive.
/tmp/datadog-agent-2023-03-07T08-54-14Z-debug.zip is going to be uploaded to Datadog
Are you sure you want to upload a flare? [y/N]
N
Aborting. (You can still use /tmp/datadog-agent-2023-03-07T08-54-14Z-debug.zip)
```

Note: The security agent error is unrelated, it's bc the security agent is disabled.

```
apt update && apt install -y unzip
...
unzip /tmp/datadog-agent-2023-03-07T08-54-14Z-debug.zip
...
find my_hostname/profiles -type f -name 'trace*'
my_hostname/profiles/trace-1st-heap.pprof
my_hostname/profiles/trace-block.pprof
my_hostname/profiles/trace-cpu.pprof
my_hostname/profiles/trace-2nd-heap.pprof
my_hostname/profiles/trace-mutex.pprof
```

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
