### PR TITLE
env_variables_to_inject now contains quote enclosed values, to deal w…

### DIFF
--- a/.run/Build agent.run.xml
+++ b/.run/Build agent.run.xml
@@ -13,7 +13,7 @@
     <option name="EXECUTE_SCRIPT_FILE" value="true" />
     <envs>
       <env name="SCRIPT_TO_RUN" value=".run/build.sh" />
-      <env name="BUILD_COMMAND" value="&quot;invoke agent.build&quot;" />
+      <env name="BUILD_COMMAND" value="invoke agent.build" />
     </envs>
     <method v="2" />
   </configuration>

--- a/.run/Build process-agent.run.xml
+++ b/.run/Build process-agent.run.xml
@@ -12,7 +12,7 @@
     <option name="EXECUTE_IN_TERMINAL" value="true" />
     <option name="EXECUTE_SCRIPT_FILE" value="true" />
     <envs>
-      <env name="BUILD_COMMAND" value="&quot;inv process-agent.build --build-exclude=systemd&quot;" />
+      <env name="BUILD_COMMAND" value="inv process-agent.build --build-exclude=systemd" />
       <env name="SCRIPT_TO_RUN" value=".run/build.sh" />
     </envs>
     <method v="2" />

--- a/.run/Build system-probe.run.xml
+++ b/.run/Build system-probe.run.xml
@@ -13,7 +13,7 @@
     <option name="EXECUTE_SCRIPT_FILE" value="true" />
     <envs>
       <env name="SCRIPT_TO_RUN" value=".run/build.sh" />
-      <env name="BUILD_COMMAND" value="&quot;invoke system-probe.build&quot;" />
+      <env name="BUILD_COMMAND" value="invoke system-probe.build" />
     </envs>
     <method v="2" />
   </configuration>

--- a/.run/Run agent.run.xml
+++ b/.run/Run agent.run.xml
@@ -15,7 +15,7 @@
       <env name="SCRIPT_TO_RUN" value=".run/run.sh" />
       <env name="BINARY_TO_RUN" value="./bin/agent/agent" />
       <env name="DLV_PORT_TO_BIND" value="2346" />
-      <env name="BINARY_ARGUMENTS" value="run -c ./bin/agent/dist/datadog.yaml" />
+      <env name="BINARY_ARGUMENTS" value="run -c  ./dev/dist/datadog.yaml" />
     </envs>
     <method v="2" />
   </configuration>

--- a/.run/Run agent.run.xml
+++ b/.run/Run agent.run.xml
@@ -15,7 +15,7 @@
       <env name="SCRIPT_TO_RUN" value=".run/run.sh" />
       <env name="BINARY_TO_RUN" value="./bin/agent/agent" />
       <env name="DLV_PORT_TO_BIND" value="2346" />
-      <env name="BINARY_ARGUMENTS" value="&quot;run -c ./bin/agent/dist/datadog.yaml&quot;" />
+      <env name="BINARY_ARGUMENTS" value="run -c ./bin/agent/dist/datadog.yaml" />
     </envs>
     <method v="2" />
   </configuration>

--- a/.run/Run process-agent.run.xml
+++ b/.run/Run process-agent.run.xml
@@ -15,7 +15,7 @@
       <env name="SCRIPT_TO_RUN" value=".run/run.sh" />
       <env name="BINARY_TO_RUN" value="./bin/process-agent/process-agent" />
       <env name="DLV_PORT_TO_BIND" value="2347" />
-      <env name="BINARY_ARGUMENTS" value="&quot;--cfgpath ./bin/agent/dist/datadog.yaml&quot;" />
+      <env name="BINARY_ARGUMENTS" value="--cfgpath ./dev/dist/datadog.yaml" />
     </envs>
     <method v="2" />
   </configuration>

--- a/.run/Run system-probe.run.xml
+++ b/.run/Run system-probe.run.xml
@@ -15,7 +15,7 @@
       <env name="SCRIPT_TO_RUN" value=".run/run.sh" />
       <env name="BINARY_TO_RUN" value="./bin/system-probe/system-probe" />
       <env name="DLV_PORT_TO_BIND" value="2345" />
-      <env name="BINARY_ARGUMENTS" value="&quot;-c ./dev/dist/datadog.yaml&quot;" />
+      <env name="BINARY_ARGUMENTS" value="-c ./dev/dist/datadog.yaml" />
     </envs>
     <method v="2" />
   </configuration>


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Resolve the problem that arises when running a remote configuration with local environment variables that include special characters such as '=', '$', ';', etc.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

I faced an issue in which one of the local environment variables had a value of di=34:ln=35:so=32:pi=33:ex=31:bd=34;46:cd=34;43:su=37;41:sg=30;43:tw=30;42:ow=34;42:, which resulted in the bash_runner.sh script not functioning correctly.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
