### PR TITLE
Fix flaky test

### DIFF
--- a/comp/core/flare/helpers/perm_info_win_test.go
+++ b/comp/core/flare/helpers/perm_info_win_test.go
@@ -72,7 +72,15 @@ func TestPermsFileCommit(t *testing.T) {
 	b, err := pi.commit()
 	require.NoError(t, err)
 
-	assert.Regexp(t, "\nFile: C:\\\\.+\\\\file1\n", string(b))
-	assert.Regexp(t, "\nFile: C:\\\\.+\\\\file2\n", string(b))
-	assert.Regexp(t, "\ncould not stat file.+C:\\\\.+\\\\file3", string(b))
+	// file1 and file2 header
+	assert.Regexp(t, "(?ms)^File: C:\\\\.+\\\\file1$", string(b))
+	assert.Regexp(t, "(?ms)^File: C:\\\\.+\\\\file2$", string(b))
+	assert.Regexp(t, "(?ms)^File: C:\\\\.+\\\\file3$", string(b))
+
+	// check no error was raised for file21 and file2
+	assert.NotRegexp(t, "(?ms)^could not stat file: C:\\\\.+\\\\file1", string(b))
+	assert.NotRegexp(t, "(?ms)^could not stat file: C:\\\\.+\\\\file2", string(b))
+
+	// check that an error was raised for file3
+	assert.Regexp(t, "(?ms)^could not stat file.+C:\\\\.+\\\\file3", string(b))
 }


### PR DESCRIPTION
### What does this PR do?

Using line break in the regexp make the test flaky. Depending on the file order, the first line break will not match since the first line of the output doesn't start by one.
