### PR TITLE
[AD/Prometheus] Use the `prometheus.io/port` annotation to choose a container

### DIFF
--- a/releasenotes/notes/prometheus-ad-port-adddaa3219ee2bb0.yaml
+++ b/releasenotes/notes/prometheus-ad-port-adddaa3219ee2bb0.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    When a pod was annotated with ``prometheus.io/scrape: true``, the agent used to schedule one ``openmetrics`` check per container in the pod unless a ``datadog.prometheusScrape.additionalConfigs[].autodiscovery.kubernetes_container_names`` list was defined in order to restrict the potential container targets.
+    The agent is now able to leverage the ``prometheus.io/port`` annotation to schedule an ``openmetrics`` check only on the container of the pod that declares that port in its spec.

--- a/releasenotes/notes/prometheus-ad-port-adddaa3219ee2bb0.yaml
+++ b/releasenotes/notes/prometheus-ad-port-adddaa3219ee2bb0.yaml
@@ -8,5 +8,5 @@
 ---
 fixes:
   - |
-    When a pod was annotated with ``prometheus.io/scrape: true``, the agent used to schedule one ``openmetrics`` check per container in the pod unless a ``datadog.prometheusScrape.additionalConfigs[].autodiscovery.kubernetes_container_names`` list was defined in order to restrict the potential container targets.
-    The agent is now able to leverage the ``prometheus.io/port`` annotation to schedule an ``openmetrics`` check only on the container of the pod that declares that port in its spec.
+    When a pod was annotated with ``prometheus.io/scrape: true``, the Agent used to schedule one ``openmetrics`` check per container in the pod unless a ``datadog.prometheusScrape.additionalConfigs[].autodiscovery.kubernetes_container_names`` list was defined, which restricted the potential container targets.
+    The Agent is now able to leverage the ``prometheus.io/port`` annotation to schedule an ``openmetrics`` check only on the container of the pod that declares that port in its spec.


### PR DESCRIPTION
### What does this PR do?

When a pod annotated with `prometheus.io/scrape: true` contains several containers, the agent used to schedule one `openmetrics` check per container.
The `openmetrics_endpoint` parameter uses `%%port%%` to target the port of its targeted container.
But if the pod was annotated with `prometheus.io/port`, all the `openmetrics` check instances were targeting the same port. This was generating metrics with misleading container tags.
This PR makes the agent choose the proper container based on their port.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Create a pod with two containers and annotated with `prometheus.io/port`.
For ex.:

```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: openmetrics-generator
spec:
  replicas: 1
  selector:
    matchLabels:
      app: openmetrics-generator
  template:
    metadata:
      annotations:
        prometheus.io/port: "8080"
        prometheus.io/scrape: "true"
      labels:
        app: openmetrics-generator
      name: openmetrics-generator
    spec:
      containers:
      - args:
        - --counters
        - "5"
        - --gauges
        - "5"
        command:
        - ./prometheus-generator
        image: mfpierre/prometheus-generator
        name: openmetrics-generator
        ports:
        - containerPort: 8080
          protocol: TCP
      - args:
        - infinity
        command:
        - sleep
        image: ubuntu
        name: sleep1
```

And check the output of `agent configcheck`.
With `7.44.0`, we can find two instances of `openmetrics` check for this pod, both targets the port `8080` but they have different container tags.
With `7.45.0`, we can find only one instance of `openmetrics` check for this pod, with the correct container tags.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
