### PR TITLE
[process-agent] Fix retry handling in Process Agent kitchen tests

### DIFF
--- a/test/kitchen/test/integration/container-collection-test/rspec_datadog/spec_helper.rb
+++ b/test/kitchen/test/integration/container-collection-test/rspec_datadog/spec_helper.rb
@@ -34,13 +34,13 @@ def get_with_retries(uri_or_host, path, port, max_retries=10)
   retries = 0
   begin
     return Net::HTTP.get(uri_or_host, path, port)
-  rescue Error
+  rescue Exception => e
     if retries < max_retries
       retries += 1
       sleep 1
       retry
     else
-      raise "Failed to connect to a running agent"
+      raise # if we're out of retries, raise the last exception
     end
   end
 end

--- a/test/kitchen/test/integration/process-collection-test/rspec_datadog/spec_helper.rb
+++ b/test/kitchen/test/integration/process-collection-test/rspec_datadog/spec_helper.rb
@@ -34,13 +34,13 @@ def get_with_retries(uri_or_host, path, port, max_retries=10)
   retries = 0
   begin
     return Net::HTTP.get(uri_or_host, path, port)
-  rescue Error
+  rescue Exception => e
     if retries < max_retries
       retries += 1
       sleep 1
       retry
     else
-      raise "Failed to connect to a running agent"
+      raise # if we're out of retries, raise the last exception
     end
   end
 end


### PR DESCRIPTION
### What does this PR do?
After changes made in https://github.com/DataDog/datadog-agent/pull/15906, Process Agent kitchen tests are still flaking, but with this error:
```
NameError:
              uninitialized constant Error
```

This is because the new retry handling attempts to handle exceptions using `rescue Error`, but as the base exception class in Ruby is [Exception](https://ruby-doc.org/core-2.5.1/Exception.html), we end up hitting this error at runtime when attempting to perform a retry. The net effect is that the first time we hit the underlying issue where the kitchen test is unable to connect to the agent, this error is raised and the retries never take effect.

This PR fixes this issue with retry handling added in https://github.com/DataDog/datadog-agent/pull/15906, so that retries actually occur when the test is initially unable to connect to the agent.

### Motivation
Properly implement retry handling for Process Agent kitchen tests

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
