### PR TITLE
create only AF_PACKET socket for headless socket filter

### DIFF
--- a/pkg/network/filter/socket_filter.go
+++ b/pkg/network/filter/socket_filter.go
@@ -9,37 +9,61 @@
 package filter
 
 import (
-	"github.com/vishvananda/netns"
+	"encoding/binary"
+	"runtime"
+
+	"golang.org/x/sys/unix"
 
 	manager "github.com/DataDog/ebpf-manager"
 
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
+	"github.com/DataDog/datadog-agent/pkg/util/native"
 )
+
+type headlessSocketFilter struct {
+	fd int
+}
+
+func (h *headlessSocketFilter) Close() {
+	if h.fd == -1 {
+		return
+	}
+	unix.Close(h.fd)
+	h.fd = -1
+	runtime.SetFinalizer(h, nil)
+}
 
 // HeadlessSocketFilter creates a raw socket attached to the given socket filter.
 // The underlying raw socket isn't polled and the filter is not meant to accept any packets.
 // The purpose is to use this for pure eBPF packet inspection.
 // TODO: After the proof-of-concept we might want to replace the SOCKET_FILTER program by a TC classifier
 func HeadlessSocketFilter(cfg *config.Config, filter *manager.Probe) (closeFn func(), err error) {
-	var (
-		packetSrc *AFPacketSource
-		srcErr    error
-		ns        netns.NsHandle
-	)
-
-	if ns, err = cfg.GetRootNetNs(); err != nil {
+	hsf := &headlessSocketFilter{}
+	ns, err := cfg.GetRootNetNs()
+	if err != nil {
 		return nil, err
 	}
 	defer ns.Close()
 
 	err = util.WithNS(ns, func() error {
-		packetSrc, srcErr = NewPacketSource(filter, nil)
-		return srcErr
+		hsf.fd, err = unix.Socket(unix.AF_PACKET, unix.SOCK_RAW, int(htons(unix.ETH_P_ALL)))
+		if err != nil {
+			return err
+		}
+		filter.SocketFD = hsf.fd
+		runtime.SetFinalizer(hsf, (*headlessSocketFilter).Close)
+		return nil
 	})
 	if err != nil {
 		return nil, err
 	}
 
-	return func() { packetSrc.Close() }, nil
+	return func() { hsf.Close() }, nil
+}
+
+func htons(a uint16) uint16 {
+	var arr [2]byte
+	native.Endian.PutUint16(arr[:], a)
+	return binary.BigEndian.Uint16(arr[:])
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Creates just the `AF_PACKET` socket for headless socket filters.

### Motivation

We don't need the ring buffers and other overhead if we never intend to read packets from userspace.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
