### PR TITLE
Sles 1096 google cloud run attribution of dd tags to forwarded logs

### DIFF
--- a/cmd/serverless-init/main.go
+++ b/cmd/serverless-init/main.go
@@ -42,7 +42,7 @@ func setup() (cloudservice.CloudService, *log.Config, *trace.ServerlessTraceAgen
 	setupProxy()
 
 	cloudService := cloudservice.GetCloudServiceType()
-	tags := tag.MergeTags(cloudService.GetTags(), config.GetGlobalConfiguredTags(false))
+	tags := tag.MergeWithOverwrite(tag.ArrayTagToMap(config.GetGlobalConfiguredTags(false)), cloudService.GetTags())
 	origin := cloudService.GetOrigin()
 	prefix := cloudService.GetPrefix()
 

--- a/cmd/serverless-init/main.go
+++ b/cmd/serverless-init/main.go
@@ -9,6 +9,7 @@
 package main
 
 import (
+	"github.com/DataDog/datadog-agent/pkg/serverless/tags"
 	"os"
 	"time"
 
@@ -42,7 +43,7 @@ func setup() (cloudservice.CloudService, *log.Config, *trace.ServerlessTraceAgen
 	setupProxy()
 
 	cloudService := cloudservice.GetCloudServiceType()
-	tags := tag.MergeWithOverwrite(tag.ArrayTagToMap(config.GetGlobalConfiguredTags(false)), cloudService.GetTags())
+	tags := tag.MergeWithOverwrite(tags.ArrayToMap(config.GetGlobalConfiguredTags(false)), cloudService.GetTags())
 	origin := cloudService.GetOrigin()
 	prefix := cloudService.GetPrefix()
 

--- a/cmd/serverless-init/main.go
+++ b/cmd/serverless-init/main.go
@@ -32,10 +32,10 @@ const (
 func main() {
 	if len(os.Args) < 2 {
 		panic("[datadog init process] invalid argument count, did you forget to set CMD ?")
+	} else {
+		cloudService, logConfig, traceAgent, metricAgent := setup()
+		initcontainer.Run(cloudService, logConfig, metricAgent, traceAgent, os.Args[1:])
 	}
-
-	cloudService, logConfig, traceAgent, metricAgent := setup()
-	initcontainer.Run(cloudService, logConfig, metricAgent, traceAgent, os.Args[1:])
 }
 
 func setup() (cloudservice.CloudService, *log.Config, *trace.ServerlessTraceAgent, *metrics.ServerlessMetricAgent) {

--- a/cmd/serverless-init/main.go
+++ b/cmd/serverless-init/main.go
@@ -37,7 +37,7 @@ func main() {
 	setupProxy()
 
 	cloudService := cloudservice.GetCloudServiceType()
-	tags := cloudService.GetTags()
+	tags := tag.MergeTags(cloudService.GetTags(), config.GetConfiguredTags(config.Datadog, false))
 	origin := cloudService.GetOrigin()
 	prefix := cloudService.GetPrefix()
 

--- a/cmd/serverless-init/main.go
+++ b/cmd/serverless-init/main.go
@@ -43,7 +43,7 @@ func setup() (cloudservice.CloudService, *log.Config, *trace.ServerlessTraceAgen
 	setupProxy()
 
 	cloudService := cloudservice.GetCloudServiceType()
-	tags := tag.MergeWithOverwrite(tags.ArrayToMap(config.GetGlobalConfiguredTags(false)), cloudService.GetTags())
+	tags := tags.MergeWithOverwrite(tags.ArrayToMap(config.GetGlobalConfiguredTags(false)), cloudService.GetTags())
 	origin := cloudService.GetOrigin()
 	prefix := cloudService.GetPrefix()
 

--- a/cmd/serverless-init/main_test.go
+++ b/cmd/serverless-init/main_test.go
@@ -42,10 +42,13 @@ func TestProxyLoaded(t *testing.T) {
 
 func TestTagsSetup(t *testing.T) {
 	t.Setenv("DD_TAGS", "key1:value1 key2:value2 key3:value3")
+	t.Setenv("DD_EXTRA_TAGS", "key22:value22 key23:value23")
 	tags := map[string]string{
-		"key1": "value1",
-		"key2": "value2",
-		"key3": "value3",
+		"key1":  "value1",
+		"key2":  "value2",
+		"key3":  "value3",
+		"key22": "value22",
+		"key23": "value23",
 	}
 	_, _, _, metricAgent := setup()
 	assert.True(t, tagArrayContainsTags(metricAgent.GetExtraTags(), tags))

--- a/cmd/serverless-init/main_test.go
+++ b/cmd/serverless-init/main_test.go
@@ -11,7 +11,9 @@ package main
 import (
 	"github.com/DataDog/datadog-agent/cmd/serverless-init/tag"
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/serverless/logs"
 	"github.com/stretchr/testify/assert"
+
 	"testing"
 )
 
@@ -46,12 +48,14 @@ func TestTagsSetup(t *testing.T) {
 		"key3": "value3",
 	}
 	_, _, _, metricAgent := setup()
-	assert.True(t, mapContains(tag.MergeTags(map[string]string{}, metricAgent.GetExtraTags()), tags))
+	assert.True(t, tagArrayContainsTags(metricAgent.GetExtraTags(), tags))
+	assert.True(t, tagArrayContainsTags(logs.GetLogsTags(), tags))
 }
 
-func mapContains(subject map[string]string, valuesToContain map[string]string) bool {
+func tagArrayContainsTags(subject []string, valuesToContain map[string]string) bool {
+	sub := tag.ArrayTagToMap(subject)
 	for k, v := range valuesToContain {
-		if subject[k] != v {
+		if sub[k] != v {
 			return false
 		}
 	}

--- a/cmd/serverless-init/main_test.go
+++ b/cmd/serverless-init/main_test.go
@@ -9,8 +9,9 @@
 package main
 
 import (
+	"github.com/DataDog/datadog-agent/cmd/serverless-init/tag"
 	"github.com/DataDog/datadog-agent/pkg/config"
-	"gotest.tools/assert"
+	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
@@ -35,4 +36,24 @@ func TestProxyLoaded(t *testing.T) {
 	proxyHttpsConfig := config.Datadog.GetString("proxy.https")
 	assert.Equal(t, proxyHttp, proxyHttpConfig)
 	assert.Equal(t, proxyHttps, proxyHttpsConfig)
+}
+
+func TestTagsSetup(t *testing.T) {
+	t.Setenv("DD_TAGS", "key1:value1 key2:value2 key3:value3")
+	tags := map[string]string{
+		"key1": "value1",
+		"key2": "value2",
+		"key3": "value3",
+	}
+	_, _, _, metricAgent := setup()
+	assert.True(t, mapContains(tag.MergeTags(map[string]string{}, metricAgent.GetExtraTags()), tags))
+}
+
+func mapContains(subject map[string]string, valuesToContain map[string]string) bool {
+	for k, v := range valuesToContain {
+		if subject[k] != v {
+			return false
+		}
+	}
+	return true
 }

--- a/cmd/serverless-init/main_test.go
+++ b/cmd/serverless-init/main_test.go
@@ -13,8 +13,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/serverless/logs"
 	"github.com/spf13/cast"
 	"github.com/stretchr/testify/assert"
-	"strings"
-
 	"testing"
 )
 
@@ -44,19 +42,14 @@ func TestProxyLoaded(t *testing.T) {
 func TestTagsSetup(t *testing.T) {
 	ddTagsEnv := "key1:value1 key2:value2 key3:value3:4"
 	ddExtraTagsEnv := "key22:value22 key23:value23"
-	tags := cast.ToStringSlice(ddTagsEnv)
 	t.Setenv("DD_TAGS", ddTagsEnv)
 	t.Setenv("DD_EXTRA_TAGS", ddExtraTagsEnv)
-	var allEnvTags []string
+	ddTags := cast.ToStringSlice(ddTagsEnv)
+	ddExtraTags := cast.ToStringSlice(ddExtraTagsEnv)
 
-	for _, tag := range strings.Split(ddTagsEnv, " ") {
-		allEnvTags = append(allEnvTags, tag)
-	}
-	for _, tag := range strings.Split(ddExtraTagsEnv, " ") {
-		allEnvTags = append(allEnvTags, tag)
-	}
+	allTags := append(ddTags, ddExtraTags...)
 
 	_, _, _, metricAgent := setup()
-	assert.Subset(t, metricAgent.GetExtraTags(), tags)
-	assert.Subset(t, logs.GetLogsTags(), tags)
+	assert.Subset(t, metricAgent.GetExtraTags(), allTags)
+	assert.Subset(t, logs.GetLogsTags(), allTags)
 }

--- a/cmd/serverless-init/tag/tag.go
+++ b/cmd/serverless-init/tag/tag.go
@@ -6,7 +6,6 @@
 package tag
 
 import (
-	"fmt"
 	"os"
 	"strings"
 
@@ -62,9 +61,5 @@ func GetBaseTagsMapWithMetadata(metadata map[string]string) map[string]string {
 // GetBaseTagsArrayWithMetadataTags see GetBaseTagsMapWithMetadata (as array)
 func GetBaseTagsArrayWithMetadataTags(metadata map[string]string) []string {
 	tagsMap := GetBaseTagsMapWithMetadata(metadata)
-	tagsArray := make([]string, 0, len(tagsMap))
-	for key, value := range tagsMap {
-		tagsArray = append(tagsArray, fmt.Sprintf("%s:%s", key, value))
-	}
-	return tagsArray
+	return tags.MapToArray(tagsMap)
 }

--- a/cmd/serverless-init/tag/tag.go
+++ b/cmd/serverless-init/tag/tag.go
@@ -72,7 +72,7 @@ func GetBaseTagsArrayWithMetadataTags(metadata map[string]string) []string {
 func ArrayTagToMap(tagArray []string) map[string]string {
 	toMap := make(map[string]string)
 	for _, v := range tagArray {
-		keyVal := strings.Split(v, ":")
+		keyVal := strings.SplitN(v, ":", 2)
 		toMap[keyVal[0]] = keyVal[1]
 	}
 	return toMap

--- a/cmd/serverless-init/tag/tag.go
+++ b/cmd/serverless-init/tag/tag.go
@@ -68,3 +68,15 @@ func GetBaseTagsArrayWithMetadataTags(metadata map[string]string) []string {
 	}
 	return tagsArray
 }
+
+func MergeTags(tags map[string]string, configuredTags []string) map[string]string {
+	merged := make(map[string]string)
+	for _, v := range configuredTags {
+		keyVal := strings.Split(v, ":")
+		merged[keyVal[0]] = keyVal[1]
+	}
+	for k, v := range tags {
+		merged[k] = v
+	}
+	return merged
+}

--- a/cmd/serverless-init/tag/tag.go
+++ b/cmd/serverless-init/tag/tag.go
@@ -69,15 +69,6 @@ func GetBaseTagsArrayWithMetadataTags(metadata map[string]string) []string {
 	return tagsArray
 }
 
-func ArrayTagToMap(tagArray []string) map[string]string {
-	toMap := make(map[string]string)
-	for _, v := range tagArray {
-		keyVal := strings.SplitN(v, ":", 2)
-		toMap[keyVal[0]] = keyVal[1]
-	}
-	return toMap
-}
-
 func MergeWithOverwrite(tags map[string]string, overwritingTags map[string]string) map[string]string {
 	merged := make(map[string]string)
 	for k, v := range tags {

--- a/cmd/serverless-init/tag/tag.go
+++ b/cmd/serverless-init/tag/tag.go
@@ -68,14 +68,3 @@ func GetBaseTagsArrayWithMetadataTags(metadata map[string]string) []string {
 	}
 	return tagsArray
 }
-
-func MergeWithOverwrite(tags map[string]string, overwritingTags map[string]string) map[string]string {
-	merged := make(map[string]string)
-	for k, v := range tags {
-		merged[k] = v
-	}
-	for k, v := range overwritingTags {
-		merged[k] = v
-	}
-	return merged
-}

--- a/cmd/serverless-init/tag/tag.go
+++ b/cmd/serverless-init/tag/tag.go
@@ -69,13 +69,21 @@ func GetBaseTagsArrayWithMetadataTags(metadata map[string]string) []string {
 	return tagsArray
 }
 
-func MergeTags(tags map[string]string, configuredTags []string) map[string]string {
-	merged := make(map[string]string)
-	for _, v := range configuredTags {
+func ArrayTagToMap(tagArray []string) map[string]string {
+	toMap := make(map[string]string)
+	for _, v := range tagArray {
 		keyVal := strings.Split(v, ":")
-		merged[keyVal[0]] = keyVal[1]
+		toMap[keyVal[0]] = keyVal[1]
 	}
+	return toMap
+}
+
+func MergeWithOverwrite(tags map[string]string, overwritingTags map[string]string) map[string]string {
+	merged := make(map[string]string)
 	for k, v := range tags {
+		merged[k] = v
+	}
+	for k, v := range overwritingTags {
 		merged[k] = v
 	}
 	return merged

--- a/cmd/serverless-init/tag/tag_test.go
+++ b/cmd/serverless-init/tag/tag_test.go
@@ -88,11 +88,11 @@ func TestGetBaseTagsArrayWithMetadataTags(t *testing.T) {
 
 func TestDdTags(t *testing.T) {
 	t.Setenv("DD_TAGS", "originalKey:shouldNotOverride key2:value2 key3:value3")
-	originalTags := map[string]string{
-		"originalKey": "originalValue",
+	overwritingTags := map[string]string{
+		"originalKey": "overWrittenValue",
 	}
-	mergedTags := MergeWithOverwrite(originalTags, ArrayTagToMap(config.GetGlobalConfiguredTags(false)))
-	assert.Equal(t, "originalValue", mergedTags["originalKey"])
+	mergedTags := MergeWithOverwrite(ArrayTagToMap(config.GetGlobalConfiguredTags(false)), overwritingTags)
+	assert.Equal(t, "overWrittenValue", mergedTags["originalKey"])
 	assert.Equal(t, "value2", mergedTags["key2"])
 	assert.Equal(t, "value3", mergedTags["key3"])
 }

--- a/cmd/serverless-init/tag/tag_test.go
+++ b/cmd/serverless-init/tag/tag_test.go
@@ -91,7 +91,7 @@ func TestDdTags(t *testing.T) {
 	originalTags := map[string]string{
 		"originalKey": "originalValue",
 	}
-	mergedTags := MergeTags(originalTags, config.GetGlobalConfiguredTags(false))
+	mergedTags := MergeWithOverwrite(originalTags, ArrayTagToMap(config.GetGlobalConfiguredTags(false)))
 	assert.Equal(t, "originalValue", mergedTags["originalKey"])
 	assert.Equal(t, "value2", mergedTags["key2"])
 	assert.Equal(t, "value3", mergedTags["key3"])

--- a/cmd/serverless-init/tag/tag_test.go
+++ b/cmd/serverless-init/tag/tag_test.go
@@ -6,6 +6,7 @@
 package tag
 
 import (
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"sort"
 	"testing"
 
@@ -83,4 +84,15 @@ func TestGetBaseTagsArrayWithMetadataTags(t *testing.T) {
 	assert.Contains(t, tags[0], "datadog_init_version")
 	assert.Equal(t, "location:mysuperlocation", tags[1])
 	assert.Equal(t, "othermetadata:mysuperothermetadatavalue", tags[2])
+}
+
+func TestDdTags(t *testing.T) {
+	t.Setenv("DD_TAGS", "originalKey:shouldNotOverride key2:value2 key3:value3")
+	originalTags := map[string]string{
+		"originalKey": "originalValue",
+	}
+	mergedTags := MergeTags(originalTags, config.GetGlobalConfiguredTags(false))
+	assert.Equal(t, "originalValue", mergedTags["originalKey"])
+	assert.Equal(t, "value2", mergedTags["key2"])
+	assert.Equal(t, "value3", mergedTags["key3"])
 }

--- a/cmd/serverless-init/tag/tag_test.go
+++ b/cmd/serverless-init/tag/tag_test.go
@@ -88,6 +88,7 @@ func TestGetBaseTagsArrayWithMetadataTags(t *testing.T) {
 
 func TestDdTags(t *testing.T) {
 	t.Setenv("DD_TAGS", "originalKey:shouldNotOverride key2:value2 key3:value3")
+	t.Setenv("DD_EXTRA_TAGS", "key5:value5 key6:value6")
 	overwritingTags := map[string]string{
 		"originalKey": "overWrittenValue",
 	}
@@ -95,4 +96,6 @@ func TestDdTags(t *testing.T) {
 	assert.Equal(t, "overWrittenValue", mergedTags["originalKey"])
 	assert.Equal(t, "value2", mergedTags["key2"])
 	assert.Equal(t, "value3", mergedTags["key3"])
+	assert.Equal(t, "value5", mergedTags["key5"])
+	assert.Equal(t, "value6", mergedTags["key6"])
 }

--- a/cmd/serverless-init/tag/tag_test.go
+++ b/cmd/serverless-init/tag/tag_test.go
@@ -93,7 +93,7 @@ func TestDdTags(t *testing.T) {
 	overwritingTags := map[string]string{
 		"originalKey": "overWrittenValue",
 	}
-	mergedTags := MergeWithOverwrite(tags.ArrayToMap(config.GetGlobalConfiguredTags(false)), overwritingTags)
+	mergedTags := tags.MergeWithOverwrite(tags.ArrayToMap(config.GetGlobalConfiguredTags(false)), overwritingTags)
 	assert.Equal(t, "overWrittenValue", mergedTags["originalKey"])
 	assert.Equal(t, "value2", mergedTags["key2"])
 	assert.Equal(t, "value3", mergedTags["key3"])

--- a/cmd/serverless-init/tag/tag_test.go
+++ b/cmd/serverless-init/tag/tag_test.go
@@ -7,6 +7,7 @@ package tag
 
 import (
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/serverless/tags"
 	"sort"
 	"testing"
 
@@ -92,7 +93,7 @@ func TestDdTags(t *testing.T) {
 	overwritingTags := map[string]string{
 		"originalKey": "overWrittenValue",
 	}
-	mergedTags := MergeWithOverwrite(ArrayTagToMap(config.GetGlobalConfiguredTags(false)), overwritingTags)
+	mergedTags := MergeWithOverwrite(tags.ArrayToMap(config.GetGlobalConfiguredTags(false)), overwritingTags)
 	assert.Equal(t, "overWrittenValue", mergedTags["originalKey"])
 	assert.Equal(t, "value2", mergedTags["key2"])
 	assert.Equal(t, "value3", mergedTags["key3"])

--- a/pkg/logs/schedulers/channel/scheduler.go
+++ b/pkg/logs/schedulers/channel/scheduler.go
@@ -27,9 +27,6 @@ type Scheduler struct {
 	// logsChan is the channel carrying messages to be sent to the pipeline
 	logsChan chan *config.ChannelMessage
 
-	// extraTags are the tags attached to each log message.
-	extraTags []string
-
 	// logSource is the source currently managed by the scheduler
 	logSource *sources.LogSource
 
@@ -40,12 +37,11 @@ type Scheduler struct {
 var _ schedulers.Scheduler = &Scheduler{}
 
 // NewScheduler creates a new Scheduler.
-func NewScheduler(sourceName, source string, logsChan chan *config.ChannelMessage, extraTags []string) *Scheduler {
+func NewScheduler(sourceName, source string, logsChan chan *config.ChannelMessage) *Scheduler {
 	return &Scheduler{
 		sourceName: sourceName,
 		source:     source,
 		logsChan:   logsChan,
-		extraTags:  extraTags,
 	}
 }
 
@@ -67,10 +63,9 @@ func (s *Scheduler) setSource() {
 	}
 
 	s.logSource = sources.NewLogSource(s.sourceName, &config.LogsConfig{
-		Type:        config.StringChannelType,
-		Source:      s.source,
-		ChannelTags: s.extraTags,
-		Channel:     s.logsChan,
+		Type:    config.StringChannelType,
+		Source:  s.source,
+		Channel: s.logsChan,
 	})
 	s.sourceMgr.AddSource(s.logSource)
 }

--- a/pkg/logs/schedulers/channel/scheduler.go
+++ b/pkg/logs/schedulers/channel/scheduler.go
@@ -87,3 +87,12 @@ func (s *Scheduler) SetLogsTags(tags []string) {
 	defer s.logSource.Config.ChannelTagsMutex.Unlock()
 	s.logSource.Config.ChannelTags = tags
 }
+
+// GetLogsTags returns a defensive copy of the used tags
+func (s *Scheduler) GetLogsTags() []string {
+	s.logSource.Config.ChannelTagsMutex.Lock()
+	defer s.logSource.Config.ChannelTagsMutex.Unlock()
+	defensiveCopy := make([]string, len(s.logSource.Config.ChannelTags))
+	copy(defensiveCopy, s.logSource.Config.ChannelTags)
+	return defensiveCopy
+}

--- a/pkg/logs/schedulers/channel/scheduler_test.go
+++ b/pkg/logs/schedulers/channel/scheduler_test.go
@@ -17,7 +17,7 @@ import (
 
 func setup() (scheduler *Scheduler, spy *schedulers.MockSourceManager) {
 	ch := make(chan *config.ChannelMessage)
-	scheduler = NewScheduler("test source", "testy", ch, nil)
+	scheduler = NewScheduler("test source", "testy", ch)
 	spy = &schedulers.MockSourceManager{}
 	scheduler.Start(spy)
 	return

--- a/pkg/serverless/logs/scheduler.go
+++ b/pkg/serverless/logs/scheduler.go
@@ -24,7 +24,7 @@ func SetupLogAgent(logChannel chan *config.ChannelMessage, sourceName string, so
 		return
 	}
 
-	logsScheduler = channel.NewScheduler(sourceName, source, logChannel, nil)
+	logsScheduler = channel.NewScheduler(sourceName, source, logChannel)
 	agent.AddScheduler(logsScheduler)
 }
 

--- a/pkg/serverless/logs/scheduler.go
+++ b/pkg/serverless/logs/scheduler.go
@@ -37,3 +37,10 @@ func SetLogsTags(tags []string) {
 		logsScheduler.SetLogsTags(tags)
 	}
 }
+
+func GetLogsTags() []string {
+	if logsScheduler != nil {
+		return logsScheduler.GetLogsTags()
+	}
+	return nil
+}

--- a/pkg/serverless/tags/tags.go
+++ b/pkg/serverless/tags/tags.go
@@ -91,11 +91,8 @@ func BuildTagMap(arn string, configTags []string) map[string]string {
 	tags = setIfNotEmpty(tags, VersionKey, os.Getenv(versionEnvVar))
 	tags = setIfNotEmpty(tags, ServiceKey, os.Getenv(serviceEnvVar))
 
-	for _, tag := range configTags {
-		splitTags := strings.Split(tag, ",")
-		for _, singleTag := range splitTags {
-			tags = addTag(tags, singleTag)
-		}
+	for tagName, tagValue := range ArrayToMap(configTags) {
+		tags[tagName] = tagValue
 	}
 
 	tags = setIfNotEmpty(tags, traceOriginMetadataKey, traceOriginMetadataValue)
@@ -123,6 +120,17 @@ func BuildTagMap(arn string, configTags []string) map[string]string {
 	}
 
 	return tags
+}
+
+func ArrayToMap(tagArray []string) map[string]string {
+	tagMap := make(map[string]string)
+	for _, tag := range tagArray {
+		splitTags := strings.Split(tag, ",")
+		for _, singleTag := range splitTags {
+			tagMap = addTag(tagMap, singleTag)
+		}
+	}
+	return tagMap
 }
 
 // BuildTagsFromMap builds an array of tag based on map of tags
@@ -183,9 +191,11 @@ func setIfNotEmpty(tagMap map[string]string, key string, value string) map[strin
 }
 
 func addTag(tagMap map[string]string, tag string) map[string]string {
-	extract := strings.Split(tag, ":")
+	extract := strings.SplitN(tag, ":", 2)
 	if len(extract) == 2 {
 		tagMap[strings.ToLower(extract[0])] = strings.ToLower(extract[1])
+	} else {
+		log.Debug("Tag" + tag + " has not expected format")
 	}
 	return tagMap
 }

--- a/pkg/serverless/tags/tags.go
+++ b/pkg/serverless/tags/tags.go
@@ -131,6 +131,14 @@ func ArrayToMap(tagArray []string) map[string]string {
 	return tagMap
 }
 
+func MapToArray(tagsMap map[string]string) []string {
+	tagsArray := make([]string, 0, len(tagsMap))
+	for key, value := range tagsMap {
+		tagsArray = append(tagsArray, fmt.Sprintf("%s:%s", key, value))
+	}
+	return tagsArray
+}
+
 func MergeWithOverwrite(tags map[string]string, overwritingTags map[string]string) map[string]string {
 	merged := make(map[string]string)
 	for k, v := range tags {
@@ -144,29 +152,21 @@ func MergeWithOverwrite(tags map[string]string, overwritingTags map[string]strin
 
 // BuildTagsFromMap builds an array of tag based on map of tags
 func BuildTagsFromMap(tags map[string]string) []string {
-	tagsMap := make(map[string]string)
-	tagBlackList := []string{traceOriginMetadataKey, computeStatsKey}
-	for k, v := range tags {
-		tagsMap[k] = v
-	}
-	for _, blackListKey := range tagBlackList {
-		delete(tagsMap, blackListKey)
-	}
-	tagsArray := make([]string, 0, len(tagsMap))
-	for key, value := range tagsMap {
-		tagsArray = append(tagsArray, fmt.Sprintf("%s:%s", key, value))
-	}
-	return tagsArray
+	tagsMap := buildTags(tags, []string{traceOriginMetadataKey, computeStatsKey})
+	return MapToArray(tagsMap)
 }
 
 // BuildTracerTags builds a map of tag from an existing map of tag removing useless tags for traces
 func BuildTracerTags(tags map[string]string) map[string]string {
+	return buildTags(tags, []string{resourceKey})
+}
+
+func buildTags(tags map[string]string, tagsToSkip []string) map[string]string {
 	tagsMap := make(map[string]string)
-	tagBlackList := []string{resourceKey}
 	for k, v := range tags {
 		tagsMap[k] = v
 	}
-	for _, blackListKey := range tagBlackList {
+	for _, blackListKey := range tagsToSkip {
 		delete(tagsMap, blackListKey)
 	}
 	return tagsMap

--- a/pkg/serverless/tags/tags.go
+++ b/pkg/serverless/tags/tags.go
@@ -91,9 +91,7 @@ func BuildTagMap(arn string, configTags []string) map[string]string {
 	tags = setIfNotEmpty(tags, VersionKey, os.Getenv(versionEnvVar))
 	tags = setIfNotEmpty(tags, ServiceKey, os.Getenv(serviceEnvVar))
 
-	for tagName, tagValue := range ArrayToMap(configTags) {
-		tags[tagName] = tagValue
-	}
+	tags = MergeWithOverwrite(tags, ArrayToMap(configTags))
 
 	tags = setIfNotEmpty(tags, traceOriginMetadataKey, traceOriginMetadataValue)
 	tags = setIfNotEmpty(tags, computeStatsKey, computeStatsValue)
@@ -131,6 +129,17 @@ func ArrayToMap(tagArray []string) map[string]string {
 		}
 	}
 	return tagMap
+}
+
+func MergeWithOverwrite(tags map[string]string, overwritingTags map[string]string) map[string]string {
+	merged := make(map[string]string)
+	for k, v := range tags {
+		merged[k] = v
+	}
+	for k, v := range overwritingTags {
+		merged[k] = v
+	}
+	return merged
 }
 
 // BuildTagsFromMap builds an array of tag based on map of tags

--- a/pkg/serverless/tags/tags.go
+++ b/pkg/serverless/tags/tags.go
@@ -204,7 +204,7 @@ func addTag(tagMap map[string]string, tag string) map[string]string {
 	if len(extract) == 2 {
 		tagMap[strings.ToLower(extract[0])] = strings.ToLower(extract[1])
 	} else {
-		log.Debug("Tag" + tag + " has not expected format")
+		log.Warn("Tag" + tag + " has not expected format")
 	}
 	return tagMap
 }

--- a/pkg/serverless/tags/tags_test.go
+++ b/pkg/serverless/tags/tags_test.go
@@ -212,16 +212,6 @@ func TestAddTagInvalid(t *testing.T) {
 	assert.Equal(t, "value_b", tagMap["key_b"])
 }
 
-func TestAddTagInvalid2(t *testing.T) {
-	tagMap := map[string]string{
-		"key_a": "value_a",
-		"key_b": "value_b",
-	}
-	addTag(tagMap, "invalidTag:invalid:invalid")
-	assert.Equal(t, 2, len(tagMap))
-	assert.Equal(t, "value_a", tagMap["key_a"])
-	assert.Equal(t, "value_b", tagMap["key_b"])
-}
 func TestAddTagInvalid3(t *testing.T) {
 	tagMap := map[string]string{
 		"key_a": "value_a",
@@ -243,6 +233,18 @@ func TestAddTag(t *testing.T) {
 	assert.Equal(t, "value_a", tagMap["key_a"])
 	assert.Equal(t, "value_b", tagMap["key_b"])
 	assert.Equal(t, "tag", tagMap["valid"])
+}
+
+func TestAddTagWithColumnInValue(t *testing.T) {
+	tagMap := map[string]string{
+		"key_a": "value_a",
+		"key_b": "value_b",
+	}
+	addTag(tagMap, "VaLiD:TaG:Val")
+	assert.Equal(t, 3, len(tagMap))
+	assert.Equal(t, "value_a", tagMap["key_a"])
+	assert.Equal(t, "value_b", tagMap["key_b"])
+	assert.Equal(t, "tag:val", tagMap["valid"])
 }
 
 func TestAddColdStartTagWithoutColdStart(t *testing.T) {

--- a/pkg/serverless/tags/tags_test.go
+++ b/pkg/serverless/tags/tags_test.go
@@ -201,7 +201,7 @@ func TestBuildTagMapFromArnCompleteWithVersionNumber(t *testing.T) {
 	assert.True(t, tagMap["runtime"] == "unknown" || tagMap["runtime"] == "provided.al2")
 }
 
-func TestAddTagInvalid(t *testing.T) {
+func TestAddTagInvalidNoValue(t *testing.T) {
 	tagMap := map[string]string{
 		"key_a": "value_a",
 		"key_b": "value_b",
@@ -212,7 +212,7 @@ func TestAddTagInvalid(t *testing.T) {
 	assert.Equal(t, "value_b", tagMap["key_b"])
 }
 
-func TestAddTagInvalid3(t *testing.T) {
+func TestAddTagInvalidEmpty(t *testing.T) {
 	tagMap := map[string]string{
 		"key_a": "value_a",
 		"key_b": "value_b",
@@ -223,7 +223,7 @@ func TestAddTagInvalid3(t *testing.T) {
 	assert.Equal(t, "value_b", tagMap["key_b"])
 }
 
-func TestAddTag(t *testing.T) {
+func TestAddTagValid(t *testing.T) {
 	tagMap := map[string]string{
 		"key_a": "value_a",
 		"key_b": "value_b",
@@ -235,7 +235,7 @@ func TestAddTag(t *testing.T) {
 	assert.Equal(t, "tag", tagMap["valid"])
 }
 
-func TestAddTagWithColumnInValue(t *testing.T) {
+func TestAddTagValidWithColumnInValue(t *testing.T) {
 	tagMap := map[string]string{
 		"key_a": "value_a",
 		"key_b": "value_b",


### PR DESCRIPTION
# What does this PR do?
- Fix a bug where `DD_TAG` and `DD_EXTRA_TAG` are ignored in the log agent in serverless-init
- `DD_TAG` and `DD_EXTRA_TAG` env tags are overwritten by Cloud provider default tags
- remove nil/unused `extraTags` attribute
- moved some logic to `pkg/serverless/tags` and removed some duplicates
- this also support tags with column in value, for both `serverless-init` and `serverless`