### PR TITLE
Ensure agent open files and os file limit display in decimal notation

### DIFF
--- a/pkg/logs/internal/launchers/file/launcher.go
+++ b/pkg/logs/internal/launchers/file/launcher.go
@@ -8,6 +8,7 @@ package file
 import (
 	"regexp"
 	"time"
+	"strconv"
 
 	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -342,10 +343,12 @@ func (s *Launcher) createRotatedTailer(t *tailer.Tailer, file *tailer.File, patt
 }
 
 func CheckProcessTelemetry(stats *util.ProcessFileStats) {
+	AgentOpenFilesStr := strconv.FormatFloat(stats.AgentOpenFiles,'f',0,64)
+	OsFileLimitStr := strconv.FormatFloat(stats.OsFileLimit,'f',0,64)
 	if stats.AgentOpenFiles/stats.OsFileLimit > 0.9 {
-		log.Warnf("Agent process is close to OS file limit of %v. Agent process currently has %v files open.", stats.OsFileLimit, stats.AgentOpenFiles)
+		log.Warnf("Agent process is close to OS file limit of %v. Agent process currently has %v files open.", OsFileLimitStr, AgentOpenFilesStr)
 	} else if stats.AgentOpenFiles/stats.OsFileLimit >= 1 {
-		log.Errorf("Agent process has reached the OS open file limit: %v. This may be preventing log files from being tailed by the Agent and could interfere with the basic functionality of the Agent. OS file limit must be increased.", stats.OsFileLimit)
+		log.Errorf("Agent process has reached the OS open file limit: %v. This may be preventing log files from being tailed by the Agent and could interfere with the basic functionality of the Agent. OS file limit must be increased.", OsFileLimitStr)
 	}
-	log.Debugf("Agent process currently has %v files open. OS file limit is currently set to %v.", stats.AgentOpenFiles, stats.OsFileLimit)
+	log.Debugf("Agent process currently has %v files open. OS file limit is currently set to %v.", AgentOpenFilesStr, OsFileLimitStr)
 }

--- a/pkg/logs/internal/launchers/file/launcher.go
+++ b/pkg/logs/internal/launchers/file/launcher.go
@@ -342,7 +342,7 @@ func (s *Launcher) createRotatedTailer(t *tailer.Tailer, file *tailer.File, patt
 }
 
 func CheckProcessTelemetry(stats *util.ProcessFileStats) {
-	if float64(stats.AgentOpenFiles/stats.OsFileLimit) > 0.9 {
+	if float64(stats.AgentOpenFiles)/float64(stats.OsFileLimit) > 0.9 {
 		log.Warnf("Agent process is close to OS file limit of %v. Agent process currently has %v files open.", stats.OsFileLimit, stats.AgentOpenFiles)
 	} else if stats.AgentOpenFiles/stats.OsFileLimit >= 1 {
 		log.Errorf("Agent process has reached the OS open file limit: %v. This may be preventing log files from being tailed by the Agent and could interfere with the basic functionality of the Agent. OS file limit must be increased.", stats.OsFileLimit)

--- a/pkg/logs/internal/launchers/file/launcher.go
+++ b/pkg/logs/internal/launchers/file/launcher.go
@@ -8,7 +8,6 @@ package file
 import (
 	"regexp"
 	"time"
-	"strconv"
 
 	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -343,12 +342,10 @@ func (s *Launcher) createRotatedTailer(t *tailer.Tailer, file *tailer.File, patt
 }
 
 func CheckProcessTelemetry(stats *util.ProcessFileStats) {
-	AgentOpenFilesStr := strconv.FormatFloat(stats.AgentOpenFiles,'f',0,64)
-	OsFileLimitStr := strconv.FormatFloat(stats.OsFileLimit,'f',0,64)
-	if stats.AgentOpenFiles/stats.OsFileLimit > 0.9 {
-		log.Warnf("Agent process is close to OS file limit of %v. Agent process currently has %v files open.", OsFileLimitStr, AgentOpenFilesStr)
+	if float64(stats.AgentOpenFiles/stats.OsFileLimit) > 0.9 {
+		log.Warnf("Agent process is close to OS file limit of %v. Agent process currently has %v files open.", stats.OsFileLimit, stats.AgentOpenFiles)
 	} else if stats.AgentOpenFiles/stats.OsFileLimit >= 1 {
-		log.Errorf("Agent process has reached the OS open file limit: %v. This may be preventing log files from being tailed by the Agent and could interfere with the basic functionality of the Agent. OS file limit must be increased.", OsFileLimitStr)
+		log.Errorf("Agent process has reached the OS open file limit: %v. This may be preventing log files from being tailed by the Agent and could interfere with the basic functionality of the Agent. OS file limit must be increased.", stats.OsFileLimit)
 	}
-	log.Debugf("Agent process currently has %v files open. OS file limit is currently set to %v.", AgentOpenFilesStr, OsFileLimitStr)
+	log.Debugf("Agent process currently has %v files open. OS file limit is currently set to %v.", stats.AgentOpenFiles, stats.OsFileLimit)
 }

--- a/pkg/logs/status/builder.go
+++ b/pkg/logs/status/builder.go
@@ -8,6 +8,7 @@ package status
 import (
 	"expvar"
 	"strings"
+	"strconv"
 
 	"go.uber.org/atomic"
 
@@ -177,14 +178,14 @@ func (b *Builder) getMetricsStatus() map[string]int64 {
 	return metrics
 }
 
-func (b *Builder) getProcessFileStats() map[string]float64 {
-	stats := make(map[string]float64)
+func (b *Builder) getProcessFileStats() map[string]string {
+	stats := make(map[string]string)
 	fs, err := util.GetProcessFileStats()
 	if err != nil {
 		return stats
 	}
 
-	stats["CoreAgentProcessOpenFiles"] = fs.AgentOpenFiles
-	stats["OSFileLimit"] = fs.OsFileLimit
+	stats["CoreAgentProcessOpenFiles"] = strconv.FormatFloat(fs.AgentOpenFiles,'f',0,64)
+	stats["OSFileLimit"] = strconv.FormatFloat(fs.OsFileLimit,'f',0,64)
 	return stats
 }

--- a/pkg/logs/status/builder.go
+++ b/pkg/logs/status/builder.go
@@ -8,7 +8,6 @@ package status
 import (
 	"expvar"
 	"strings"
-	"strconv"
 
 	"go.uber.org/atomic"
 
@@ -178,14 +177,14 @@ func (b *Builder) getMetricsStatus() map[string]int64 {
 	return metrics
 }
 
-func (b *Builder) getProcessFileStats() map[string]string {
-	stats := make(map[string]string)
+func (b *Builder) getProcessFileStats() map[string]uint64 {
+	stats := make(map[string]uint64)
 	fs, err := util.GetProcessFileStats()
 	if err != nil {
 		return stats
 	}
 
-	stats["CoreAgentProcessOpenFiles"] = strconv.FormatFloat(fs.AgentOpenFiles,'f',0,64)
-	stats["OSFileLimit"] = strconv.FormatFloat(fs.OsFileLimit,'f',0,64)
+	stats["CoreAgentProcessOpenFiles"] = fs.AgentOpenFiles
+	stats["OSFileLimit"] = fs.OsFileLimit
 	return stats
 }

--- a/pkg/logs/status/status.go
+++ b/pkg/logs/status/status.go
@@ -53,14 +53,14 @@ type Integration struct {
 
 // Status provides some information about logs-agent.
 type Status struct {
-	IsRunning        bool               `json:"is_running"`
-	Endpoints        []string           `json:"endpoints"`
-	StatusMetrics    map[string]int64   `json:"metrics"`
-	ProcessFileStats map[string]float64 `json:"process_file_stats"`
-	Integrations     []Integration      `json:"integrations"`
-	Errors           []string           `json:"errors"`
-	Warnings         []string           `json:"warnings"`
-	UseHTTP          bool               `json:"use_http"`
+	IsRunning        bool              `json:"is_running"`
+	Endpoints        []string          `json:"endpoints"`
+	StatusMetrics    map[string]int64  `json:"metrics"`
+	ProcessFileStats map[string]string `json:"process_file_stats"`
+	Integrations     []Integration     `json:"integrations"`
+	Errors           []string          `json:"errors"`
+	Warnings         []string          `json:"warnings"`
+	UseHTTP          bool              `json:"use_http"`
 }
 
 // Init instantiates the builder that builds the status on the fly.

--- a/pkg/logs/status/status.go
+++ b/pkg/logs/status/status.go
@@ -56,7 +56,7 @@ type Status struct {
 	IsRunning        bool              `json:"is_running"`
 	Endpoints        []string          `json:"endpoints"`
 	StatusMetrics    map[string]int64  `json:"metrics"`
-	ProcessFileStats map[string]string `json:"process_file_stats"`
+	ProcessFileStats map[string]uint64 `json:"process_file_stats"`
 	Integrations     []Integration     `json:"integrations"`
 	Errors           []string          `json:"errors"`
 	Warnings         []string          `json:"warnings"`

--- a/pkg/status/templates/logsagent.tmpl
+++ b/pkg/status/templates/logsagent.tmpl
@@ -32,7 +32,7 @@ Logs Agent
 
 {{- if .process_file_stats }}
   {{- range $metric_name, $metric_value := .process_file_stats }}
-    {{$metric_name}}: {{$metric_value}}
+    {{$metric_name}}: {{printf "%.0f" $metric_value}}
   {{- end}}
 {{- end}}
 

--- a/pkg/util/process_file_stats.go
+++ b/pkg/util/process_file_stats.go
@@ -7,6 +7,6 @@ package util
 
 // ProcessFileStats is used to retrieve stats from gopsutil/v3/process -- these stats are used for troubleshooting purposes
 type ProcessFileStats struct {
-	AgentOpenFiles float64 `json:"agent_open_files"`
-	OsFileLimit    float64 `json:"os_file_limit"`
+	AgentOpenFiles uint64 `json:"agent_open_files"`
+	OsFileLimit    uint64 `json:"os_file_limit"`
 }

--- a/pkg/util/process_file_stats_linux.go
+++ b/pkg/util/process_file_stats_linux.go
@@ -34,8 +34,8 @@ func GetProcessFileStats() (*ProcessFileStats, error) {
 	}
 
 	// Retrieving how many file handles the Core Agent process has open and the file limit set on the OS level
-	stats.AgentOpenFiles = float64(rs[process.RLIMIT_NOFILE].Used)
-	stats.OsFileLimit = float64(rs[process.RLIMIT_NOFILE].Soft)
+	stats.AgentOpenFiles = rs[process.RLIMIT_NOFILE].Used
+	stats.OsFileLimit = rs[process.RLIMIT_NOFILE].Soft
 
 	return &stats, nil
 }


### PR DESCRIPTION
### What does this PR do?
This PR ensures that the Agent Open Files and OS File Limit metrics in the Logs Agent section of the agent status command and the agent.log lines that get generated always displays in decimal notation instead of scientific notation. 

### Motivation
While testing large OS file limits, we noticed that the file limit would display in scientific notation. For example:

`2023-03-06 15:37:37 UTC | CORE | DEBUG | (pkg/logs/internal/launchers/file/launcher.go:350 in CheckProcessTelemetry) | Agent process currently has 22 files open. OS file limit is currently set to 1.048576e+06.`

With this PR, it will display as:

`2023-03-06 15:37:37 UTC | CORE | DEBUG | (pkg/logs/internal/launchers/file/launcher.go:350 in CheckProcessTelemetry) | Agent process currently has 22 files open. OS file limit is currently set to 1048576.`

in regular notation, the file limit is easier to read.

### Describe how to test/QA your changes
- Change the soft file limit to a large value. This can be done with command `ulimit -n <new limit>`.
- In the datadog.yaml, set log_level to debug and logs_enabled to true. 
- Allow the Agent to run and look for the debug line from above.
- Run the status command and look in the Logs Agent section. 
- Redo the steps with a new file limit to test WARN and ERROR logs. 

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
