### PR TITLE
Make WiX User.UpdateIfExists conditional

### DIFF
--- a/tools/windows/DatadogAgentInstaller/CustomActions/Native/NativeMethods.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/Native/NativeMethods.cs
@@ -347,6 +347,67 @@ namespace Datadog.CustomActions.Native
             }
         }
 
+        /// <summary>Receives a security identifier (SID) and returns a SID representing the domain of that SID.</summary>
+        /// <param name="pSid">A pointer to the SID to examine.</param>
+        /// <param name="pDomainSid">Pointer that <b>GetWindowsAccountDomainSid</b> fills with a pointer to a SID representing the domain.</param>
+        /// <param name="cbDomainSid">A pointer to a <b>DWORD</b> that <b>GetWindowsAccountDomainSid</b> fills with the size of the domain SID, in bytes.</param>
+        /// <returns>
+        /// <para>Returns <b>TRUE</b> if successful. Otherwise, returns <b>FALSE</b>. For extended error information, call <a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a>.</para>
+        /// </returns>
+        /// <remarks>
+        /// <para><see href="https://docs.microsoft.com/windows/win32/api//securitybaseapi/nf-securitybaseapi-getwindowsaccountdomainsid">Learn more about this API from docs.microsoft.com</see>.</para>
+        /// </remarks>
+        [DllImport("ADVAPI32.dll", ExactSpelling = true, SetLastError = true)]
+        [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+        public static extern bool GetWindowsAccountDomainSid(
+            [MarshalAs(UnmanagedType.LPArray)] byte[] pSid,
+            [MarshalAs(UnmanagedType.LPArray)] byte[] pDomainSid,
+            ref uint cbDomainSid);
+
+        /// <summary>
+        /// Checks whether or not a user account belongs to a domain or is a local account.
+        /// </summary>
+        /// <param name="userSid">The SID of the user.</param>
+        /// <returns>True if the <paramref name="userSid"/> belongs to a domain, false otherwise.</returns>
+        /// <exception cref="Exception">
+        /// This method throws an exception if the second call
+        /// to <see cref="GetWindowsAccountDomainSid"/> fails.</exception>
+        public static bool IsDomainAccount(SecurityIdentifier userSid)
+        {
+            var userBinSid = new byte[userSid.BinaryLength];
+            userSid.GetBinaryForm(userBinSid, 0);
+            uint sz = 0;
+            if (!GetWindowsAccountDomainSid(userBinSid, null, ref sz) && sz == 0)
+            {
+                // This will fail if the SID is not a domain SID (i.e. a local account)
+                return false;
+            }
+            var domainBinSid = new byte[sz];
+            if (GetWindowsAccountDomainSid(userBinSid, domainBinSid, ref sz))
+            {
+                var domainSid = new SecurityIdentifier(domainBinSid, 0);
+                var machineFound = LookupAccountName(
+                    Environment.MachineName,
+                    out _,
+                    out _,
+                    out var machineSid,
+                    out _);
+                if (machineFound)
+                {
+                    // If the machineSid is different from the domainSid
+                    // that means it's a domain account.
+                    return machineSid != domainSid;
+                }
+            }
+            else
+            {
+                // That call should not fail
+                throw new Exception("Unexpected failure while checking if the account belonged to a domain.");
+            }
+
+            return false;
+        }
+
         #region Add/Remove privileges
         [DllImport("advapi32.dll", PreserveSig = true)]
         private static extern uint LsaOpenPolicy(

--- a/tools/windows/DatadogAgentInstaller/CustomActions/UserCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/UserCustomActions.cs
@@ -212,11 +212,18 @@ namespace Datadog.CustomActions
 
                 if (!isServiceAccount && string.IsNullOrEmpty(ddAgentUserPassword))
                 {
+                    session.Log($"Generating a random password");
                     ddAgentUserPassword = GetRandomPassword(128);
+                    session.Components["InstallerManagedAgentUser"].RequestState = InstallState.Local;
+                    session.Components["UserManagedAgentUser"].RequestState = InstallState.Absent;
+                } else {
+                    session.Components["InstallerManagedAgentUser"].RequestState = InstallState.Absent;
+                    session.Components["UserManagedAgentUser"].RequestState = InstallState.Local;
                 }
 
                 if (!string.IsNullOrEmpty(ddAgentUserPassword) && isServiceAccount)
                 {
+                    session.Log($"Ignoring provided password because account is a service account");
                     ddAgentUserPassword = null;
                 }
 

--- a/tools/windows/DatadogAgentInstaller/CustomActions/UserCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/UserCustomActions.cs
@@ -172,7 +172,7 @@ namespace Datadog.CustomActions
                 // do the conversion here for user's convenience.
                 if (ddAgentUserName == "LocalSystem")
                 {
-                    ddAgentUserName = "NT AUTHORIY\\SYSTEM";
+                    ddAgentUserName = "NT AUTHORITY\\SYSTEM";
                 }
 
                 if (string.IsNullOrEmpty(ddAgentUserName))

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentCustomActions.cs
@@ -224,8 +224,9 @@ namespace WixSetup.Datadog
                 UserCustomActions.ProcessDdAgentUserCredentials,
                 Return.check,
                 // Run at end of "config phase", right before the "make changes" phase.
+                // Must run before InstallValidate because it changes the User components
                 When.Before,
-                Step.InstallInitialize,
+                Step.InstallValidate,
                 // Run unless we are being uninstalled.
                 // This CA produces properties used for services, accounts, and permissions.
                 Condition.NOT(Conditions.Uninstalling)

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentCustomActionsProjectExtensions.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentCustomActionsProjectExtensions.cs
@@ -24,5 +24,61 @@ namespace WixSetup.Datadog
             );
             return project;
         }
+
+        /// <summary>
+        /// Adds WiX User elements to the <see cref="Project"/> for the Agent user account.
+        /// </summary>
+        ///
+        /// <remarks>
+        /// The User Element handles creation of the user account, and setting of the password and USER_INFO flags
+        /// such as UF_DONT_EXPIRE_PASSWD.
+        /// See <a href="https://github.com/wixtoolset/wix3/blob/c02e48ec301a60eba88a3b519d47e88eeaa4c978/src/ext/ca/serverca/scaexec/scaexec.cpp#L1722-L1725">WIX CreateUser custom action</a> and <a href="https://wixtoolset.org/docs/v3/xsd/util/user/">WiX User Element</a>.
+        /// Other account settings such as group membership and user rights assignment are handled in our own custom actions
+        /// and are not affected by this element.
+        ///
+        /// Two User elements are used because WiX does not allow YesNoType to be configurable with Properties.
+        /// Only one is ever enabled at a time and are selected by our custom actions.
+        /// </remarks>
+        /// <param name="project">The project to add the WiX User elements to.</param>
+        /// <returns>The project, for chaining.</returns>
+        public static Project AddAgentUser(this Project project)
+        {
+            project.GenericItems = project.GenericItems.Combine(
+                // This User element is used when the user account is a regular account and the DDAGENTUSER_PASSWORD field is blank.
+                // The installer will create the account if needed and also change an existing account's password and USER_FLAGS.
+                //
+                // Use case: The customer expects the installer to manage its own user account on the local machine.
+                new User(new Id("InstallerManagedAgentUser"), "")
+                {
+                    // CreateUser fails with ERROR_BAD_USERNAME if Name is a fully qualified user name
+                    Name = "[DDAGENTUSER_PROCESSED_NAME]",
+                    Domain = "[DDAGENTUSER_PROCESSED_DOMAIN]",
+                    Password = "[DDAGENTUSER_PROCESSED_PASSWORD]",
+                    PasswordNeverExpires = true,
+                    RemoveOnUninstall = false,
+                    FailIfExists = false,
+                    CreateUser = true,
+                    UpdateIfExists = true,
+                },
+                // This User element is used when a regular account with a DDAGENTUSER_PASSWORD or a service account is provided.
+                // Regular accounts will be created if they do not exist and the USER_INFO flags will be set.
+                // If the account already exists then it will not be modified.
+                //
+                // Use case: The customer manages and provides the user account for the Agent to use.
+                new User(new Id("UserManagedAgentUser"), "")
+                {
+                    // CreateUser fails with ERROR_BAD_USERNAME if Name is a fully qualified user name
+                    Name = "[DDAGENTUSER_PROCESSED_NAME]",
+                    Domain = "[DDAGENTUSER_PROCESSED_DOMAIN]",
+                    Password = "[DDAGENTUSER_PROCESSED_PASSWORD]",
+                    PasswordNeverExpires = true,
+                    RemoveOnUninstall = false,
+                    FailIfExists = false,
+                    CreateUser = true,
+                    UpdateIfExists = false,
+                }
+            );
+            return project;
+        }
     }
 }

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentInstaller.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentInstaller.cs
@@ -61,18 +61,6 @@ namespace WixSetup.Datadog
         public Project ConfigureProject()
         {
             var project = new ManagedProject("Datadog Agent",
-                new User
-                {
-                    // CreateUser fails with ERROR_BAD_USERNAME if Name is a fully qualified user name
-                    Name = "[DDAGENTUSER_PROCESSED_NAME]",
-                    Domain = "[DDAGENTUSER_PROCESSED_DOMAIN]",
-                    Password = "[DDAGENTUSER_PROCESSED_PASSWORD]",
-                    PasswordNeverExpires = true,
-                    RemoveOnUninstall = false,
-                    FailIfExists = false,
-                    UpdateIfExists = true,
-                    CreateUser = true
-                },
                 new Property("MsiLogging", "iwearucmop!"),
                 new Property("APIKEY")
                 {
@@ -120,6 +108,7 @@ namespace WixSetup.Datadog
                 new RemoveRegistryKey(_agentFeatures.MainApplication, @"Software\Datadog\Datadog Agent")
             );
             project
+            .AddAgentUser()
             .SetCustomActions(_agentCustomActions)
             .SetProjectInfo(
                 upgradeCode: ProductUpgradeCode,
@@ -185,7 +174,7 @@ namespace WixSetup.Datadog
             project.MajorUpgrade.DowngradeErrorMessage =
                 "Automatic downgrades are not supported.  Uninstall the current version, and then reinstall the desired version.";
             project.ReinstallMode = "amus";
-            
+
             project.Platform = Platform.x64;
             // MSI 5.0 was shipped in Windows Server 2012 R2.
             // https://learn.microsoft.com/en-us/windows/win32/msi/released-versions-of-windows-installer


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Makes the WiX `User.UpdateIfExists` option conditional on the installer parameters. If the user does not provide `DDAGENTUSER_PASSWORD` the installer will generate a random password and try to update the account (`UpdateIfExists=true`). If the user provides `DDAGENTUSER_PASSWORD` the installer will try to create the account, but will not update existing accounts (`UpdateIfExists=false`).

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
https://datadoghq.atlassian.net/browse/WA-261
`UpdateIfExists: true` causes the install to fail on domain clients, which do not have permission to update the account.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
See Windows Installer QA wiki

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
