### PR TITLE
Adds optional environment file for SystemD service

### DIFF
--- a/omnibus/config/templates/datadog-agent/systemd.service.erb
+++ b/omnibus/config/templates/datadog-agent/systemd.service.erb
@@ -8,6 +8,7 @@ Type=simple
 PIDFile=<%= install_dir %>/run/agent.pid
 User=dd-agent
 Restart=on-failure
+EnvironmentFile=-<%= etc_dir %>/environment
 ExecStart=<%= install_dir %>/bin/agent/agent run -p <%= install_dir %>/run/agent.pid
 # Since systemd 229, should be in [Unit] but in order to support systemd <229,
 # it is also supported to have it here.

--- a/releasenotes/notes/SystemD-service-EnvironmentFile-2d28ba3eee4b50bc.yaml
+++ b/releasenotes/notes/SystemD-service-EnvironmentFile-2d28ba3eee4b50bc.yaml
@@ -1,0 +1,6 @@
+enhancements:
+  - |
+    Datadog Agent running as a systemd service can optionally read
+    environment variables from a text file `/etc/datadog-agent/environment`
+    containing newline-separated variable assignments.
+    See https://www.freedesktop.org/software/systemd/man/systemd.exec.html#Environment


### PR DESCRIPTION
### What does this PR do?

Provides an easier way to define environment variables for the Agent service running on SystemD.
The target file itself is optional and doesn't need to exist. The absence of the file should not prevent the Datadog Agent service from starting. 
Users can simply 
 - create `/etc/datadog-agent/environment` with any needed env vars (example below)
```
FOO=BAR
GODEBUG=x509ignoreCN=0,x509sha1=1
GOTRACEBACK=crash
``` 
 - or create a symlink to `/etc/environment` if system-wide environment variables are desired
    -  `/etc/datadog-agent/environment -> /etc/environment`
 - restart the Agent
 
Previous to this, we needed users to perform SystemD specific steps
- find the systemd unit file with `systemctl status` -  which can be different depending on os
- create an override directory and file `/path/to/datadog-agent.service.d/override.conf`
   ```
   [Service]
   EnvironmentFile=-/path/to/env
   ```
- run `systemctl daemon-reload`

Problem with that is that the user needs to be familiar with SystemD and it may not persist on uninstall-reinstall scenarios.


### Motivation

We often get questions why defined global environment variables (e.g. `/etc/environment`) are not being detected by the Agent - usually with their custom checks or secrets backend command that pulls information from environment variables.

- AGENT-9291
- AGENT-9180
- AGENT-6550
- AGENT-8565

### Additional Notes

This will probably need a public facing doc to let users know this is possible.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

#### verify systemd unit
- Install DD Agent in any Linux distro that uses SystemD.
- Verify that the `EnvironmentFile` is set: `grep EnvironmentFile /lib/systemd/system/datadog-agent.service`

#### Service should read the file if present and load the defined environment variable/s
- Create the text file
  ```
  cat <<-EOF > /etc/datadog-agent/environment
  DD_LOG_LEVEL=debug
  EOF
  ```
- Restart the Agent: `systemctl restart datadog-agent`
- Check if the service picked up the variable by checking if logging is in debug: `tail /var/log/datadog/agent.log`

#### Absence of the file should not impact the service.
- Delete the file: `rm /etc/datadog-agent/environment`
- Restart the Agent: `systemctl restart datadog-agent`
- Check if logging is back to default: `tail /var/log/datadog/agent.log`

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
