### PR TITLE
[pkg/collector/python] Force usage of stdlib's distutils in Python

### DIFF
--- a/pkg/collector/python/init.go
+++ b/pkg/collector/python/init.go
@@ -361,7 +361,9 @@ func Initialize(paths ...string) error {
 
 	// Force the use of stdlib's distutils, to prevent loading the setuptools-vendored distutils
 	// in integrations, which causes a 10MB memory increase.
-	os.Setenv("SETUPTOOLS_USE_DISTUTILS", "stdlib")
+	if v := os.Getenv("SETUPTOOLS_USE_DISTUTILS"); v == "" {
+		os.Setenv("SETUPTOOLS_USE_DISTUTILS", "stdlib")
+	}
 
 	// Memory related RTLoader-global initialization
 	if config.Datadog.GetBool("memtrack_enabled") {

--- a/pkg/collector/python/init.go
+++ b/pkg/collector/python/init.go
@@ -361,6 +361,11 @@ func Initialize(paths ...string) error {
 
 	// Force the use of stdlib's distutils, to prevent loading the setuptools-vendored distutils
 	// in integrations, which causes a 10MB memory increase.
+	// Note: a future version of setuptools (TBD) will remove the ability to use this variable
+	// (https://github.com/pypa/setuptools/issues/3625),
+	// and Python 3.12 removes distutils from the standard library.
+	// Once we upgrade one of those, we won't have any choice but to use setuptools' distutils,
+	// which means we will get the memory increase again if integrations still use distutils.
 	if v := os.Getenv("SETUPTOOLS_USE_DISTUTILS"); v == "" {
 		os.Setenv("SETUPTOOLS_USE_DISTUTILS", "stdlib")
 	}

--- a/pkg/collector/python/init.go
+++ b/pkg/collector/python/init.go
@@ -359,6 +359,10 @@ func Initialize(paths ...string) error {
 	pythonVersion := config.Datadog.GetString("python_version")
 	allowPathHeuristicsFailure := config.Datadog.GetBool("allow_python_path_heuristics_failure")
 
+	// Force the use of stdlib's distutils, to prevent loading the setuptools-vendored distutils
+	// in integrations, which causes a 10MB memory increase.
+	os.Setenv("SETUPTOOLS_USE_DISTUTILS", "stdlib")
+
 	// Memory related RTLoader-global initialization
 	if config.Datadog.GetBool("memtrack_enabled") {
 		C.initMemoryTracker()


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Sets the `SETUPTOOLS_USE_DISTUTILS` environment variable to `stdlib` before starting the embedded Python interpreter.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Alternative fix to #15960, without removing `setuptools` from the Agent, which is causing issues when installing some integrations / dependencies in the embedded Python environment. Will be accompanied with a revert of #15960: #16025.

Using the default value (`local`) with `setuptools >= 60` present in the Python environment would cause any import of `distutils` to load `setuptools`' embedded `_distutils` (see [setuptools' changelog](https://setuptools.pypa.io/en/stable/history.html#v60-0-0)), which causes a 10MB usage increase in the Agent.
`distutils` is imported in the `network` check, which runs by default, so that 10MB usage increase would be present on all Agent deployments.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

n/a

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

n/a

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Ensure that `setuptools >= 60` is installed in the Agent's Python 3 embedded environment. Run the Agent, then restart the Agent with `SETUPTOOLS_USE_DISTUTILS=local` set in environment variables, and observe a memory usage increase.
Nothing should change for the Agent's Python 2 environment.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
