### PR TITLE
[CWS][SEC-7288] Introduce syscall hardening based on Security Profiles

### DIFF
--- a/docs/cloud-workload-security/backend.md
+++ b/docs/cloud-workload-security/backend.md
@@ -18,6 +18,20 @@ CWS logs have the following JSON schema:
 {
     "$id": "https://github.com/DataDog/datadog-agent/pkg/security/serializers/event",
     "$defs": {
+        "AnomalyDetectionSyscallEvent": {
+            "properties": {
+                "syscall": {
+                    "type": "string",
+                    "description": "Name of the syscall that triggered the anomaly detection event"
+                }
+            },
+            "additionalProperties": false,
+            "type": "object",
+            "required": [
+                "syscall"
+            ],
+            "description": "AnomalyDetectionSyscallEventSerializer serializes an anomaly detection for a syscall event"
+        },
         "BPFEvent": {
             "properties": {
                 "cmd": {
@@ -1078,6 +1092,38 @@ CWS logs have the following JSON schema:
             "type": "object",
             "description": "SELinuxEventSerializer serializes a SELinux context to JSON"
         },
+        "SecurityProfileContext": {
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Name of the security profile"
+                },
+                "status": {
+                    "type": "string",
+                    "description": "Status defines in which state the security profile was when the event was triggered"
+                },
+                "version": {
+                    "type": "string",
+                    "description": "Version of the profile in use"
+                },
+                "tags": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array",
+                    "description": "List of tags associated to this profile"
+                }
+            },
+            "additionalProperties": false,
+            "type": "object",
+            "required": [
+                "name",
+                "status",
+                "version",
+                "tags"
+            ],
+            "description": "SecurityProfileContextSerializer serializes the security profile context in an event"
+        },
         "SignalEvent": {
             "properties": {
                 "type": {
@@ -1182,6 +1228,9 @@ CWS logs have the following JSON schema:
         "mount": {
             "$ref": "#/$defs/MountEvent"
         },
+        "anomaly_detection_syscall": {
+            "$ref": "#/$defs/AnomalyDetectionSyscallEvent"
+        },
         "usr": {
             "$ref": "#/$defs/UserContext"
         },
@@ -1193,6 +1242,9 @@ CWS logs have the following JSON schema:
         },
         "container": {
             "$ref": "#/$defs/ContainerContext"
+        },
+        "security_profile": {
+            "$ref": "#/$defs/SecurityProfileContext"
         },
         "date": {
             "type": "string",
@@ -1223,11 +1275,39 @@ CWS logs have the following JSON schema:
 | `bind` | $ref | Please see [BindEvent](#bindevent) |
 | `exit` | $ref | Please see [ExitEvent](#exitevent) |
 | `mount` | $ref | Please see [MountEvent](#mountevent) |
+| `anomaly_detection_syscall` | $ref | Please see [AnomalyDetectionSyscallEvent](#anomalydetectionsyscallevent) |
 | `usr` | $ref | Please see [UserContext](#usercontext) |
 | `process` | $ref | Please see [ProcessContext](#processcontext) |
 | `dd` | $ref | Please see [DDContext](#ddcontext) |
 | `container` | $ref | Please see [ContainerContext](#containercontext) |
+| `security_profile` | $ref | Please see [SecurityProfileContext](#securityprofilecontext) |
 | `date` | string |  |
+
+## `AnomalyDetectionSyscallEvent`
+
+
+{{< code-block lang="json" collapsible="true" >}}
+{
+    "properties": {
+        "syscall": {
+            "type": "string",
+            "description": "Name of the syscall that triggered the anomaly detection event"
+        }
+    },
+    "additionalProperties": false,
+    "type": "object",
+    "required": [
+        "syscall"
+    ],
+    "description": "AnomalyDetectionSyscallEventSerializer serializes an anomaly detection for a syscall event"
+}
+
+{{< /code-block >}}
+
+| Field | Description |
+| ----- | ----------- |
+| `syscall` | Name of the syscall that triggered the anomaly detection event |
+
 
 ## `BPFEvent`
 
@@ -2810,6 +2890,53 @@ CWS logs have the following JSON schema:
 | [SELinuxBoolChange](#selinuxboolchange) |
 | [SELinuxEnforceStatus](#selinuxenforcestatus) |
 | [SELinuxBoolCommit](#selinuxboolcommit) |
+
+## `SecurityProfileContext`
+
+
+{{< code-block lang="json" collapsible="true" >}}
+{
+    "properties": {
+        "name": {
+            "type": "string",
+            "description": "Name of the security profile"
+        },
+        "status": {
+            "type": "string",
+            "description": "Status defines in which state the security profile was when the event was triggered"
+        },
+        "version": {
+            "type": "string",
+            "description": "Version of the profile in use"
+        },
+        "tags": {
+            "items": {
+                "type": "string"
+            },
+            "type": "array",
+            "description": "List of tags associated to this profile"
+        }
+    },
+    "additionalProperties": false,
+    "type": "object",
+    "required": [
+        "name",
+        "status",
+        "version",
+        "tags"
+    ],
+    "description": "SecurityProfileContextSerializer serializes the security profile context in an event"
+}
+
+{{< /code-block >}}
+
+| Field | Description |
+| ----- | ----------- |
+| `name` | Name of the security profile |
+| `status` | Status defines in which state the security profile was when the event was triggered |
+| `version` | Version of the profile in use |
+| `tags` | List of tags associated to this profile |
+
 
 ## `SignalEvent`
 

--- a/docs/cloud-workload-security/backend.schema.json
+++ b/docs/cloud-workload-security/backend.schema.json
@@ -2,6 +2,20 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/DataDog/datadog-agent/pkg/security/serializers/event",
   "$defs": {
+    "AnomalyDetectionSyscallEvent": {
+      "properties": {
+        "syscall": {
+          "type": "string",
+          "description": "Name of the syscall that triggered the anomaly detection event"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "syscall"
+      ],
+      "description": "AnomalyDetectionSyscallEventSerializer serializes an anomaly detection for a syscall event"
+    },
     "BPFEvent": {
       "properties": {
         "cmd": {
@@ -1062,6 +1076,38 @@
       "type": "object",
       "description": "SELinuxEventSerializer serializes a SELinux context to JSON"
     },
+    "SecurityProfileContext": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the security profile"
+        },
+        "status": {
+          "type": "string",
+          "description": "Status defines in which state the security profile was when the event was triggered"
+        },
+        "version": {
+          "type": "string",
+          "description": "Version of the profile in use"
+        },
+        "tags": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "List of tags associated to this profile"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "status",
+        "version",
+        "tags"
+      ],
+      "description": "SecurityProfileContextSerializer serializes the security profile context in an event"
+    },
     "SignalEvent": {
       "properties": {
         "type": {
@@ -1166,6 +1212,9 @@
     "mount": {
       "$ref": "#/$defs/MountEvent"
     },
+    "anomaly_detection_syscall": {
+      "$ref": "#/$defs/AnomalyDetectionSyscallEvent"
+    },
     "usr": {
       "$ref": "#/$defs/UserContext"
     },
@@ -1177,6 +1226,9 @@
     },
     "container": {
       "$ref": "#/$defs/ContainerContext"
+    },
+    "security_profile": {
+      "$ref": "#/$defs/SecurityProfileContext"
     },
     "date": {
       "type": "string",

--- a/pkg/config/system_probe.go
+++ b/pkg/config/system_probe.go
@@ -297,6 +297,7 @@ func InitSystemProbeConfig(cfg Config) {
 	cfg.BindEnvAndSetDefault("runtime_security_config.security_profile.dir", DefaultSecurityProfilesDir)
 	cfg.BindEnvAndSetDefault("runtime_security_config.security_profile.watch_dir", false)
 	cfg.BindEnvAndSetDefault("runtime_security_config.security_profile.cache_size", 10)
+	cfg.BindEnvAndSetDefault("runtime_security_config.security_profile.max_count", 400)
 }
 
 func join(pieces ...string) string {

--- a/pkg/security/config/config.go
+++ b/pkg/security/config/config.go
@@ -124,6 +124,8 @@ type RuntimeSecurityConfig struct {
 	SecurityProfileWatchDir bool
 	// SecurityProfileCacheSize defines the count of Security Profiles held in cache
 	SecurityProfileCacheSize int
+	// SecurityProfileMaxCount defines the maximum number of Security Profiles that may be evaluated concurrently
+	SecurityProfileMaxCount int
 
 	// SBOMResolverEnabled defines if the SBOM resolver should be enabled
 	SBOMResolverEnabled bool
@@ -220,6 +222,7 @@ func NewRuntimeSecurityConfig() (*RuntimeSecurityConfig, error) {
 		SecurityProfileDir:       coreconfig.SystemProbe.GetString("runtime_security_config.security_profile.dir"),
 		SecurityProfileWatchDir:  coreconfig.SystemProbe.GetBool("runtime_security_config.security_profile.watch_dir"),
 		SecurityProfileCacheSize: coreconfig.SystemProbe.GetInt("runtime_security_config.security_profile.cache_size"),
+		SecurityProfileMaxCount:  coreconfig.SystemProbe.GetInt("runtime_security_config.security_profile.max_count"),
 	}
 
 	if err := rsConfig.sanitize(); err != nil {

--- a/pkg/security/ebpf/c/include/constants/custom.h
+++ b/pkg/security/ebpf/c/include/constants/custom.h
@@ -151,4 +151,10 @@ static __attribute__((always_inline)) u64 get_syscall_monitor_event_period() {
     return syscall_monitor_event_period;
 }
 
+static __attribute__((always_inline)) u64 is_send_signal_available() {
+    u64 send_signal;
+    LOAD_CONSTANT("send_signal", send_signal);
+    return send_signal;
+};
+
 #endif

--- a/pkg/security/ebpf/c/include/constants/enums.h
+++ b/pkg/security/ebpf/c/include/constants/enums.h
@@ -44,6 +44,7 @@ enum event_type {
     EVENT_BIND,
     EVENT_UNSHARE_MNTNS,
     EVENT_SYSCALLS,
+    EVENT_ANOMALY_DETECTION_SYSCALL,
     EVENT_MAX, // has to be the last one
 
     EVENT_ALL = 0xffffffff // used as a mask for all the events
@@ -180,6 +181,12 @@ enum selinux_event_kind_t {
     SELINUX_BOOL_CHANGE_EVENT_KIND,
     SELINUX_STATUS_CHANGE_EVENT_KIND,
     SELINUX_BOOL_COMMIT_EVENT_KIND,
+};
+
+enum security_profile_state {
+    SECURITY_PROFILE_UNKNOWN,
+    SECURITY_PROFILE_ALERT,
+    SECURITY_PROFILE_KILL,
 };
 
 #endif

--- a/pkg/security/ebpf/c/include/events_definition.h
+++ b/pkg/security/ebpf/c/include/events_definition.h
@@ -285,7 +285,10 @@ struct syscall_monitor_event_t {
     struct span_context_t span;
     struct container_context_t container;
 
-    struct syscall_monitor_entry_t syscalls;
+    union {
+        struct syscall_monitor_entry_t syscalls;
+        long syscall_id;
+    } syscall_data;
 };
 
 struct rename_event_t {

--- a/pkg/security/ebpf/c/include/helpers/all.h
+++ b/pkg/security/ebpf/c/include/helpers/all.h
@@ -17,6 +17,7 @@
 #include "network.h"
 #include "process.h"
 #include "raw_syscalls.h"
+#include "security_profile.h"
 #include "selinux.h"
 #include "span.h"
 #include "syscall_macro.h"

--- a/pkg/security/ebpf/c/include/helpers/security_profile.h
+++ b/pkg/security/ebpf/c/include/helpers/security_profile.h
@@ -1,0 +1,47 @@
+#ifndef _HELPERS_SECURITY_PROFILE_H_
+#define _HELPERS_SECURITY_PROFILE_H_
+
+#include "constants/custom.h"
+#include "maps.h"
+#include "perf_ring.h"
+
+__attribute__((always_inline)) void evaluate_security_profile_syscalls(void *args, struct syscall_monitor_event_t *event, long syscall_id) {
+    // lookup security profile
+    struct security_profile_t *profile = bpf_map_lookup_elem(&security_profiles, &event->container);
+    if (profile == NULL) {
+        // this workload doesn't have a profile, ignore
+        return;
+    }
+
+    // lookup the syscalls in this profile
+    struct security_profile_syscalls_t *syscalls = bpf_map_lookup_elem(&security_profile_syscalls, &profile->cookie);
+    if (syscalls == NULL) {
+        // should never happen, ignore
+        return;
+    }
+
+    // compute the offset of the current syscall
+    u16 index = ((unsigned long) syscall_id) / 8;
+    u8 bit = 1 << (((unsigned long) syscall_id) % 8);
+    if ((syscalls->syscalls[index & (SYSCALL_ENCODING_TABLE_SIZE - 1)] & bit) == bit) {
+        // all good
+        return;
+    }
+
+    // this syscall isn't allowed
+    event->syscall_data.syscall_id = syscall_id;
+
+    // remove last_sent and dirty from the event size, we don't care about these fields
+    send_event_with_size_ptr(args, EVENT_ANOMALY_DETECTION_SYSCALL, event, offsetof(struct syscall_monitor_event_t, syscall_data) + sizeof(event->syscall_data.syscall_id));
+
+    // reset syscall id in case we're also dumping this workload
+    event->syscall_data.syscall_id = 0;
+
+    if (profile->state == SECURITY_PROFILE_KILL) {
+        if (is_send_signal_available()) {
+            bpf_send_signal(9); // SIGKILL
+        }
+    }
+}
+
+#endif

--- a/pkg/security/ebpf/c/include/helpers/security_profile.h
+++ b/pkg/security/ebpf/c/include/helpers/security_profile.h
@@ -14,7 +14,8 @@ __attribute__((always_inline)) void evaluate_security_profile_syscalls(void *arg
     }
 
     // lookup the syscalls in this profile
-    struct security_profile_syscalls_t *syscalls = bpf_map_lookup_elem(&security_profile_syscalls, &profile->cookie);
+    u64 cookie = profile->cookie;
+    struct security_profile_syscalls_t *syscalls = bpf_map_lookup_elem(&security_profile_syscalls, &cookie);
     if (syscalls == NULL) {
         // should never happen, ignore
         return;

--- a/pkg/security/ebpf/c/include/maps.h
+++ b/pkg/security/ebpf/c/include/maps.h
@@ -63,6 +63,9 @@ BPF_LRU_MAP(veth_device_name_to_ifindex, struct device_name_t, struct device_ifi
 BPF_LRU_MAP(exec_file_cache, u64, struct file_t, 4096)
 BPF_LRU_MAP(syscall_monitor, u32, struct syscall_monitor_entry_t, 2048)
 BPF_LRU_MAP(syscall_table, struct syscall_table_key_t, u8, 50)
+BPF_LRU_MAP(security_profiles, struct container_context_t, struct security_profile_t, 1) // max entries will be overriden at runtime
+BPF_LRU_MAP(security_profile_syscalls, u64, struct security_profile_syscalls_t, 1) // max entries will be overriden at runtime
+
 BPF_LRU_MAP_FLAGS(tasks_in_coredump, u64, u8, 64, BPF_F_NO_COMMON_LRU)
 
 BPF_PERCPU_ARRAY_MAP(cgroup_tracing_event_gen, u32, struct cgroup_tracing_event_t, 1)

--- a/pkg/security/ebpf/c/include/structs/all.h
+++ b/pkg/security/ebpf/c/include/structs/all.h
@@ -12,6 +12,7 @@
 #include "network.h"
 #include "open.h"
 #include "process.h"
+#include "security_profile.h"
 #include "selinux.h"
 #include "syscalls.h"
 #include "tracepoints.h"

--- a/pkg/security/ebpf/c/include/structs/security_profile.h
+++ b/pkg/security/ebpf/c/include/structs/security_profile.h
@@ -1,0 +1,15 @@
+#ifndef _STRUCTS_SECURITY_PROFILE_H_
+#define _STRUCTS_SECURITY_PROFILE_H_
+
+#include "constants/custom.h"
+
+struct security_profile_t {
+    u64 cookie;
+    u32 state;
+};
+
+struct security_profile_syscalls_t {
+    char syscalls[SYSCALL_ENCODING_TABLE_SIZE];
+};
+
+#endif

--- a/pkg/security/ebpf/probes/all.go
+++ b/pkg/security/ebpf/probes/all.go
@@ -146,7 +146,7 @@ func getMaxEntries(numCPU int, min int, max int) uint32 {
 }
 
 // AllMapSpecEditors returns the list of map editors
-func AllMapSpecEditors(numCPU int, tracedCgroupSize int, supportMmapableMaps, useRingBuffers bool, ringBufferSize uint32) map[string]manager.MapSpecEditor {
+func AllMapSpecEditors(numCPU int, tracedCgroupSize int, supportMmapableMaps, useRingBuffers bool, ringBufferSize uint32, securityProfileMaxCount int) map[string]manager.MapSpecEditor {
 	editors := map[string]manager.MapSpecEditor{
 		"proc_cache": {
 			MaxEntries: getMaxEntries(numCPU, minProcEntries, maxProcEntries),
@@ -170,6 +170,14 @@ func AllMapSpecEditors(numCPU int, tracedCgroupSize int, supportMmapableMaps, us
 		},
 		"cgroup_wait_list": {
 			MaxEntries: model.MaxTracedCgroupsCount,
+			EditorFlag: manager.EditMaxEntries,
+		},
+		"security_profiles": {
+			MaxEntries: uint32(securityProfileMaxCount),
+			EditorFlag: manager.EditMaxEntries,
+		},
+		"security_profile_syscalls": {
+			MaxEntries: uint32(securityProfileMaxCount),
 			EditorFlag: manager.EditMaxEntries,
 		},
 	}

--- a/pkg/security/events/custom.go
+++ b/pkg/security/events/custom.go
@@ -29,6 +29,8 @@ const (
 	AbnormalPathRuleID = "abnormal_path"
 	// SelfTestRuleID is the rule ID for the self_test events
 	SelfTestRuleID = "self_test"
+	// AnomalyDetectionRuleID is the rule ID for anomaly_detection events
+	AnomalyDetectionRuleID = "anomaly_detection"
 )
 
 type CustomEventCommonFields struct {
@@ -57,6 +59,7 @@ func AllCustomRuleIDs() []string {
 		NoisyProcessRuleID,
 		AbnormalPathRuleID,
 		SelfTestRuleID,
+		AnomalyDetectionRuleID,
 	}
 }
 

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -847,6 +847,10 @@ func (p *Probe) handleEvent(CPU int, data []byte) {
 			seclog.Errorf("failed to decode syscalls event: %s (offset %d, len %d)", err, offset, len(data))
 			return
 		}
+	case model.AnomalyDetectionSyscallEventType:
+		if _, err = event.AnomalyDetectionSyscallEvent.UnmarshalBinary(data[offset:]); err != nil {
+			seclog.Errorf("failed to decode anomaly detection for syscall event: %s (offset %d, len %d)", err)
+		}
 	default:
 		seclog.Errorf("unsupported event type %d", eventType)
 		return
@@ -867,6 +871,16 @@ func (p *Probe) handleEvent(CPU int, data []byte) {
 	}
 
 	p.DispatchEvent(event)
+
+	// anomaly detection events
+	if model.IsAnomalyDetectionEvent(event.GetType()) {
+		p.monitor.securityProfileManager.FillProfileContextFromContainerID(event.ProcessContext.ContainerID, &event.SecurityProfileContext)
+
+		p.DispatchCustomEvent(
+			events.NewCustomRule(events.AnomalyDetectionRuleID),
+			events.NewCustomEvent(event.GetEventType(), serializers.NewEventSerializer(event, p.resolvers)),
+		)
+	}
 
 	// flush exited process
 	p.resolvers.ProcessResolver.DequeueExited()
@@ -1375,6 +1389,7 @@ func NewProbe(config *config.Config, opts Opts) (*Probe, error) {
 		useMmapableMaps,
 		useRingBuffers,
 		uint32(p.Config.Probe.EventStreamBufferSize),
+		p.Config.RuntimeSecurity.SecurityProfileMaxCount,
 	)
 
 	if config.RuntimeSecurity.ActivityDumpEnabled {
@@ -1458,6 +1473,10 @@ func NewProbe(config *config.Config, opts Opts) (*Probe, error) {
 		manager.ConstantEditor{
 			Name:  "syscall_monitor_event_period",
 			Value: uint64(config.RuntimeSecurity.ActivityDumpSyscallMonitorPeriod.Nanoseconds()),
+		},
+		manager.ConstantEditor{
+			Name:  "send_signal",
+			Value: isBPFSendSignalHelperAvailable(p.kernelVersion),
 		},
 	)
 
@@ -1579,6 +1598,14 @@ func getDoForkInput(kernelVersion *kernel.Version) uint64 {
 		return doForkStructInput
 	}
 	return doForkListInput
+}
+
+// isBPFSendSignalHelperAvailable returns true if the bpf_send_signal helper is available in the current kernel
+func isBPFSendSignalHelperAvailable(kernelVersion *kernel.Version) uint64 {
+	if kernelVersion.Code != 0 && kernelVersion.Code >= kernel.Kernel5_3 {
+		return uint64(1)
+	}
+	return uint64(0)
 }
 
 // getCGroupWriteConstants returns the value of the constant used to determine how cgroups should be captured in kernel

--- a/pkg/security/probe/probe_monitor.go
+++ b/pkg/security/probe/probe_monitor.go
@@ -67,7 +67,7 @@ func (m *Monitor) Init() error {
 	}
 
 	if p.Config.RuntimeSecurity.SecurityProfileEnabled {
-		m.securityProfileManager, err = profile.NewSecurityProfileManager(p.Config, p.StatsdClient, p.resolvers.CGroupResolver)
+		m.securityProfileManager, err = profile.NewSecurityProfileManager(p.Config, p.StatsdClient, p.resolvers.CGroupResolver, p.Manager)
 		if err != nil {
 			return fmt.Errorf("couldn't create the security profile manager: %w", err)
 		}

--- a/pkg/security/secl/model/category.go
+++ b/pkg/security/secl/model/category.go
@@ -5,7 +5,11 @@
 
 package model
 
-import "github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
+import (
+	"golang.org/x/exp/slices"
+
+	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
+)
 
 // EventCategory category type
 type EventCategory = string
@@ -35,7 +39,7 @@ func GetAllCategories() []EventCategory {
 // GetEventTypeCategory returns the category for the given event type
 func GetEventTypeCategory(eventType eval.EventType) EventCategory {
 	switch eventType {
-	case "exec", "signal", "exit", "fork":
+	case "exec", "signal", "exit", "fork", "anomaly_detection_syscall":
 		return ProcessCategory
 	case "bpf", "selinux", "mmap", "mprotect", "ptrace", "load_module", "unload_module", "bind":
 		// TODO(will): "bind" is in this category because answering "NetworkCategory" would insert a network section in the serializer.
@@ -67,4 +71,11 @@ func GetEventTypePerCategory() map[EventCategory][]eval.EventType {
 	}
 
 	return categories
+}
+
+// IsAnomalyDetectionEvent returns true for the event types that have a security profile context
+func IsAnomalyDetectionEvent(eventyType eval.EventType) bool {
+	return slices.Contains([]eval.EventType{
+		"anomaly_detection_syscall",
+	}, eventyType)
 }

--- a/pkg/security/secl/model/events.go
+++ b/pkg/security/secl/model/events.go
@@ -89,6 +89,8 @@ const (
 	UnshareMountNsEventType
 	// SyscallsEventType Syscalls event
 	SyscallsEventType
+	// AnomalyDetectionSyscallEventType Anomaly Detection Syscall event
+	AnomalyDetectionSyscallEventType
 	// MaxKernelEventType is used internally to get the maximum number of kernel events.
 	MaxKernelEventType
 
@@ -200,6 +202,8 @@ func (t EventType) String() string {
 		return "unshare_mntns"
 	case SyscallsEventType:
 		return "syscalls"
+	case AnomalyDetectionSyscallEventType:
+		return "anomaly_detection_syscall"
 
 	case CustomLostReadEventType:
 		return "lost_events_read"

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -150,6 +150,14 @@ type ContainerContext struct {
 	Tags      []string `field:"tags,handler:ResolveContainerTags,opts:skip_ad,weight:9999"` // SECLDoc[tags] Definition:`Tags of the container`
 }
 
+// SecurityProfileContext holds the security context of the profile
+type SecurityProfileContext struct {
+	Name    string   `field:"name"`    // SECLDoc[name] Definition:`Name of the security profile`
+	Status  string   `field:"status"`  // SECLDoc[status] Definition:`Status of the security profile`
+	Version string   `field:"version"` // SECLDoc[version] Definition:`Version of the security profile`
+	Tags    []string `field:"tags"`    // SECLDoc[tags] Definition:`Tags of the security profile`
+}
+
 // Event represents an event sent from the kernel
 // genaccessors
 type Event struct {
@@ -162,12 +170,13 @@ type Event struct {
 	Rules        []*MatchedRule `field:"-"`
 
 	// context shared with all events
-	ProcessCacheEntry *ProcessCacheEntry `field:"-" json:"-"`
-	PIDContext        PIDContext         `field:"-" json:"-"`
-	SpanContext       SpanContext        `field:"-" json:"-"`
-	ProcessContext    *ProcessContext    `field:"process" event:"*"`
-	ContainerContext  ContainerContext   `field:"container"`
-	NetworkContext    NetworkContext     `field:"network"`
+	ProcessCacheEntry      *ProcessCacheEntry     `field:"-" json:"-"`
+	PIDContext             PIDContext             `field:"-" json:"-"`
+	SpanContext            SpanContext            `field:"-" json:"-"`
+	ProcessContext         *ProcessContext        `field:"process" event:"*"`
+	ContainerContext       ContainerContext       `field:"container"`
+	NetworkContext         NetworkContext         `field:"network"`
+	SecurityProfileContext SecurityProfileContext `field:"-"`
 
 	// fim events
 	Chmod       ChmodEvent    `field:"chmod" event:"chmod"`             // [7.27] [File] A file’s permissions were changed
@@ -192,6 +201,9 @@ type Event struct {
 	Signal   SignalEvent   `field:"signal" event:"signal"` // [7.35] [Process] A signal was sent
 	Exit     ExitEvent     `field:"exit" event:"exit"`     // [7.38] [Process] A process was terminated
 	Syscalls SyscallsEvent `field:"-"`
+
+	// anomaly detection related events
+	AnomalyDetectionSyscallEvent AnomalyDetectionSyscallEvent `field:"-"`
 
 	// kernel events
 	SELinux      SELinuxEvent      `field:"selinux" event:"selinux"`             // [7.30] [Kernel] An SELinux operation was run
@@ -1042,6 +1054,11 @@ type SyscallsEvent struct {
 }
 
 const PathKeySize = 16
+
+// AnomalyDetectionSyscallEvent represents an anomaly detection for a syscall event
+type AnomalyDetectionSyscallEvent struct {
+	SyscallID Syscall
+}
 
 // PathKey identifies an entry in the dentry cache
 type PathKey struct {

--- a/pkg/security/secl/model/unmarshallers.go
+++ b/pkg/security/secl/model/unmarshallers.go
@@ -1063,3 +1063,13 @@ func (e *SyscallsEvent) UnmarshalBinary(data []byte) (int, error) {
 	}
 	return 64, nil
 }
+
+// UnmarshalBinary unmarshalls a binary representation of itself
+func (e *AnomalyDetectionSyscallEvent) UnmarshalBinary(data []byte) (int, error) {
+	if len(data) < 8 {
+		return 0, ErrNotEnoughData
+	}
+
+	e.SyscallID = Syscall(ByteOrder.Uint64(data[0:8]))
+	return 8, nil
+}

--- a/pkg/security/security_profile/dump/activity_dump_profile_proto_enc_v1.go
+++ b/pkg/security/security_profile/dump/activity_dump_profile_proto_enc_v1.go
@@ -19,7 +19,7 @@ func ActivityDumpToSecurityProfileProto(input *ActivityDump) *proto.SecurityProf
 	}
 
 	output := proto.SecurityProfile{
-		Status:   1,
+		Status:   2,
 		Version:  "1",
 		Metadata: adMetadataToProto(&input.Metadata),
 		Syscalls: input.computeSyscallsList(),

--- a/pkg/security/security_profile/profile/profile.go
+++ b/pkg/security/security_profile/profile/profile.go
@@ -12,20 +12,45 @@ import (
 	"sync"
 
 	cgroupModel "github.com/DataDog/datadog-agent/pkg/security/resolvers/cgroup/model"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/security_profile/dump"
+	"github.com/DataDog/datadog-agent/pkg/security/utils"
 )
+
+// Status is the status of a security profile
+type Status uint32
+
+const (
+	UnknownStatus Status = iota
+	// Alert anomaly detections will trigger an alert
+	Alert
+	// Kill anomaly detections will kill the process that triggered them
+	Kill
+)
+
+func (s Status) String() string {
+	switch s {
+	case Alert:
+		return "alert"
+	case Kill:
+		return "kill"
+	default:
+		return "unknown"
+	}
+}
 
 // SecurityProfile defines a security profile
 type SecurityProfile struct {
 	sync.Mutex
 	loadedInKernel bool
 	selector       cgroupModel.WorkloadSelector
+	profileCookie  uint64
 
 	// Instances is the list of workload instances to witch the profile should apply
 	Instances []*cgroupModel.CacheEntry
 
 	// Status is the status of the profile
-	Status uint32
+	Status Status
 
 	// Version is the version of a Security Profile
 	Version string
@@ -43,15 +68,39 @@ type SecurityProfile struct {
 	ProcessActivityTree []*dump.ProcessActivityNode
 }
 
+// NewSecurityProfile creates a new instance of Security Profile
+func NewSecurityProfile(selector cgroupModel.WorkloadSelector) *SecurityProfile {
+	return &SecurityProfile{
+		selector: selector,
+	}
+}
+
 // reset empties all internal fields so that this profile can be used again in the future
 func (p *SecurityProfile) reset() {
 	p.loadedInKernel = false
 	p.Instances = nil
 }
 
-// NewSecurityProfile creates a new instance of Security Profile
-func NewSecurityProfile(selector cgroupModel.WorkloadSelector) *SecurityProfile {
-	return &SecurityProfile{
-		selector: selector,
+// generateCookies computes random cookies for all the entries in the profile that require one
+func (p *SecurityProfile) generateCookies() {
+	p.profileCookie = utils.RandNonZeroUint64()
+
+	// TODO: generate cookies for all the nodes in the activity tree
+}
+
+func (p *SecurityProfile) generateSyscallsFilters() [64]byte {
+	var output [64]byte
+	for _, syscall := range p.Syscalls {
+		if syscall/8 < 64 && (1<<(syscall%8) < 256) {
+			output[syscall/8] |= 1 << (syscall % 8)
+		}
 	}
+	return output
+}
+
+func (p *SecurityProfile) generateKernelSecurityProfileDefinition() [16]byte {
+	var output [16]byte
+	model.ByteOrder.PutUint64(output[0:8], p.profileCookie)
+	model.ByteOrder.PutUint32(output[8:12], uint32(p.Status))
+	return output
 }

--- a/pkg/security/security_profile/profile/profile_dir.go
+++ b/pkg/security/security_profile/profile/profile_dir.go
@@ -233,7 +233,7 @@ func (dp *DirectoryProvider) loadProfile(profilePath string) error {
 	// update profile mapping
 	if existingProfile, ok := dp.profileMapping[workloadSelector]; ok {
 		if existingProfile.version >= profile.Version {
-			seclog.Warnf("ignoring %s (version %v): a more recent version of this profile already exists (existing version is %v)", profilePath, profile.Version, existingProfile.version)
+			seclog.Warnf("ignoring %s (version: %v status: %s): a more recent version of this profile already exists (existing version is %v)", profilePath, profile.Version, Status(profile.Status), existingProfile.version)
 			return nil
 		}
 	}
@@ -242,7 +242,7 @@ func (dp *DirectoryProvider) loadProfile(profilePath string) error {
 		version: profile.Version,
 	}
 
-	seclog.Debugf("security profile %s (version %s) loaded from file system", workloadSelector, profile.Version)
+	seclog.Debugf("security profile %s (version: %s status: %s) loaded from file system", workloadSelector, profile.Version, Status(profile.Status))
 
 	if dp.onNewProfileCallback == nil {
 		return nil

--- a/pkg/security/security_profile/profile/profile_proto_dec_v1.go
+++ b/pkg/security/security_profile/profile/profile_proto_dec_v1.go
@@ -18,11 +18,11 @@ func protoToSecurityProfile(output *SecurityProfile, input *proto.SecurityProfil
 		return
 	}
 
-	output.Status = input.Status
+	output.Status = Status(input.Status)
 	output.Version = input.Version
 	output.Metadata = dump.ProtoMetadataToMetadata(input.Metadata)
 
-	output.Tags = make([]string, len(output.Tags))
+	output.Tags = make([]string, len(input.Tags))
 	copy(output.Tags, input.Tags)
 
 	output.Syscalls = make([]uint32, len(input.Syscalls))

--- a/pkg/security/serializers/serializers.go
+++ b/pkg/security/serializers/serializers.go
@@ -18,12 +18,13 @@ import (
 
 	"golang.org/x/sys/unix"
 
+	jwriter "github.com/mailru/easyjson/jwriter"
+
 	"github.com/DataDog/datadog-agent/pkg/security/events"
 	"github.com/DataDog/datadog-agent/pkg/security/resolvers"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
-	jwriter "github.com/mailru/easyjson/jwriter"
 )
 
 // FileSerializer serializes a file to JSON
@@ -520,29 +521,66 @@ type MountEventSerializer struct {
 	MountSourcePathResolutionError string          `json:"source.path_error,omitempty"`     // Mount source path error
 }
 
+// AnomalyDetectionSyscallEventSerializer serializes an anomaly detection for a syscall event
+type AnomalyDetectionSyscallEventSerializer struct {
+	// Name of the syscall that triggered the anomaly detection event
+	Syscall string `json:"syscall"`
+}
+
+// SecurityProfileContextSerializer serializes the security profile context in an event
+type SecurityProfileContextSerializer struct {
+	// Name of the security profile
+	Name string `json:"name"`
+	// Status defines in which state the security profile was when the event was triggered
+	Status string `json:"status"`
+	// Version of the profile in use
+	Version string `json:"version"`
+	// List of tags associated to this profile
+	Tags []string `json:"tags"`
+}
+
 // EventSerializer serializes an event to JSON
 // easyjson:json
 type EventSerializer struct {
-	EventContextSerializer      `json:"evt,omitempty"`
-	*FileEventSerializer        `json:"file,omitempty"`
-	*SELinuxEventSerializer     `json:"selinux,omitempty"`
-	*BPFEventSerializer         `json:"bpf,omitempty"`
-	*MMapEventSerializer        `json:"mmap,omitempty"`
-	*MProtectEventSerializer    `json:"mprotect,omitempty"`
-	*PTraceEventSerializer      `json:"ptrace,omitempty"`
-	*ModuleEventSerializer      `json:"module,omitempty"`
-	*SignalEventSerializer      `json:"signal,omitempty"`
-	*SpliceEventSerializer      `json:"splice,omitempty"`
-	*DNSEventSerializer         `json:"dns,omitempty"`
-	*NetworkContextSerializer   `json:"network,omitempty"`
-	*BindEventSerializer        `json:"bind,omitempty"`
-	*ExitEventSerializer        `json:"exit,omitempty"`
-	*MountEventSerializer       `json:"mount,omitempty"`
-	*UserContextSerializer      `json:"usr,omitempty"`
-	*ProcessContextSerializer   `json:"process,omitempty"`
-	*DDContextSerializer        `json:"dd,omitempty"`
-	*ContainerContextSerializer `json:"container,omitempty"`
-	Date                        utils.EasyjsonTime `json:"date,omitempty"`
+	EventContextSerializer                  `json:"evt,omitempty"`
+	*FileEventSerializer                    `json:"file,omitempty"`
+	*SELinuxEventSerializer                 `json:"selinux,omitempty"`
+	*BPFEventSerializer                     `json:"bpf,omitempty"`
+	*MMapEventSerializer                    `json:"mmap,omitempty"`
+	*MProtectEventSerializer                `json:"mprotect,omitempty"`
+	*PTraceEventSerializer                  `json:"ptrace,omitempty"`
+	*ModuleEventSerializer                  `json:"module,omitempty"`
+	*SignalEventSerializer                  `json:"signal,omitempty"`
+	*SpliceEventSerializer                  `json:"splice,omitempty"`
+	*DNSEventSerializer                     `json:"dns,omitempty"`
+	*NetworkContextSerializer               `json:"network,omitempty"`
+	*BindEventSerializer                    `json:"bind,omitempty"`
+	*ExitEventSerializer                    `json:"exit,omitempty"`
+	*MountEventSerializer                   `json:"mount,omitempty"`
+	*AnomalyDetectionSyscallEventSerializer `json:"anomaly_detection_syscall,omitempty"`
+	*UserContextSerializer                  `json:"usr,omitempty"`
+	*ProcessContextSerializer               `json:"process,omitempty"`
+	*DDContextSerializer                    `json:"dd,omitempty"`
+	*ContainerContextSerializer             `json:"container,omitempty"`
+	*SecurityProfileContextSerializer       `json:"security_profile,omitempty"`
+	Date                                    utils.EasyjsonTime `json:"date,omitempty"`
+}
+
+func newSecurityProfileContextSerializer(e *model.SecurityProfileContext) *SecurityProfileContextSerializer {
+	tags := make([]string, len(e.Tags))
+	copy(tags, e.Tags)
+	return &SecurityProfileContextSerializer{
+		Name:    e.Name,
+		Version: e.Version,
+		Status:  e.Status,
+		Tags:    tags,
+	}
+}
+
+func newAnomalyDetectionSyscallEventSerializer(e *model.AnomalyDetectionSyscallEvent) *AnomalyDetectionSyscallEventSerializer {
+	return &AnomalyDetectionSyscallEventSerializer{
+		Syscall: e.SyscallID.String(),
+	}
 }
 
 func getInUpperLayer(f *model.FileFields) *bool {
@@ -1063,6 +1101,10 @@ func NewEventSerializer(event *model.Event, resolvers *resolvers.Resolvers) *Eve
 		s.NetworkContextSerializer = newNetworkContextSerializer(event)
 	}
 
+	if model.IsAnomalyDetectionEvent(eventType.String()) {
+		s.SecurityProfileContextSerializer = newSecurityProfileContextSerializer(&event.SecurityProfileContext)
+	}
+
 	switch eventType {
 	case model.FileChmodEventType:
 		s.FileEventSerializer = &FileEventSerializer{
@@ -1252,6 +1294,8 @@ func NewEventSerializer(event *model.Event, resolvers *resolvers.Resolvers) *Eve
 	case model.BindEventType:
 		s.EventContextSerializer.Outcome = serializeSyscallRetval(event.Bind.Retval)
 		s.BindEventSerializer = newBindEventSerializer(event)
+	case model.AnomalyDetectionSyscallEventType:
+		s.AnomalyDetectionSyscallEventSerializer = newAnomalyDetectionSyscallEventSerializer(&event.AnomalyDetectionSyscallEvent)
 	}
 
 	return s

--- a/pkg/security/serializers/serializers_easyjson.go
+++ b/pkg/security/serializers/serializers_easyjson.go
@@ -3243,10 +3243,12 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecuritySerializers24(
 	out.BindEventSerializer = new(BindEventSerializer)
 	out.ExitEventSerializer = new(ExitEventSerializer)
 	out.MountEventSerializer = new(MountEventSerializer)
+	out.AnomalyDetectionSyscallEventSerializer = new(AnomalyDetectionSyscallEventSerializer)
 	out.UserContextSerializer = new(UserContextSerializer)
 	out.ProcessContextSerializer = new(ProcessContextSerializer)
 	out.DDContextSerializer = new(DDContextSerializer)
 	out.ContainerContextSerializer = new(ContainerContextSerializer)
+	out.SecurityProfileContextSerializer = new(SecurityProfileContextSerializer)
 	in.Delim('{')
 	for !in.IsDelim('}') {
 		key := in.UnsafeFieldName(false)
@@ -3399,6 +3401,16 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecuritySerializers24(
 				}
 				(*out.MountEventSerializer).UnmarshalEasyJSON(in)
 			}
+		case "anomaly_detection_syscall":
+			if in.IsNull() {
+				in.Skip()
+				out.AnomalyDetectionSyscallEventSerializer = nil
+			} else {
+				if out.AnomalyDetectionSyscallEventSerializer == nil {
+					out.AnomalyDetectionSyscallEventSerializer = new(AnomalyDetectionSyscallEventSerializer)
+				}
+				easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecuritySerializers25(in, out.AnomalyDetectionSyscallEventSerializer)
+			}
 		case "usr":
 			if in.IsNull() {
 				in.Skip()
@@ -3438,6 +3450,16 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecuritySerializers24(
 					out.ContainerContextSerializer = new(ContainerContextSerializer)
 				}
 				(*out.ContainerContextSerializer).UnmarshalEasyJSON(in)
+			}
+		case "security_profile":
+			if in.IsNull() {
+				in.Skip()
+				out.SecurityProfileContextSerializer = nil
+			} else {
+				if out.SecurityProfileContextSerializer == nil {
+					out.SecurityProfileContextSerializer = new(SecurityProfileContextSerializer)
+				}
+				easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecuritySerializers26(in, out.SecurityProfileContextSerializer)
 			}
 		case "date":
 			if data := in.Raw(); in.Ok() {
@@ -3603,6 +3625,16 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecuritySerializers24(
 		}
 		(*in.MountEventSerializer).MarshalEasyJSON(out)
 	}
+	if in.AnomalyDetectionSyscallEventSerializer != nil {
+		const prefix string = ",\"anomaly_detection_syscall\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecuritySerializers25(out, *in.AnomalyDetectionSyscallEventSerializer)
+	}
 	if in.UserContextSerializer != nil {
 		const prefix string = ",\"usr\":"
 		if first {
@@ -3643,6 +3675,16 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecuritySerializers24(
 		}
 		(*in.ContainerContextSerializer).MarshalEasyJSON(out)
 	}
+	if in.SecurityProfileContextSerializer != nil {
+		const prefix string = ",\"security_profile\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecuritySerializers26(out, *in.SecurityProfileContextSerializer)
+	}
 	if true {
 		const prefix string = ",\"date\":"
 		if first {
@@ -3665,7 +3707,144 @@ func (v EventSerializer) MarshalEasyJSON(w *jwriter.Writer) {
 func (v *EventSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
 	easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecuritySerializers24(l, v)
 }
-func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecuritySerializers25(in *jlexer.Lexer, out *EventContextSerializer) {
+func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecuritySerializers26(in *jlexer.Lexer, out *SecurityProfileContextSerializer) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		if isTopLevel {
+			in.Consumed()
+		}
+		in.Skip()
+		return
+	}
+	in.Delim('{')
+	for !in.IsDelim('}') {
+		key := in.UnsafeFieldName(false)
+		in.WantColon()
+		if in.IsNull() {
+			in.Skip()
+			in.WantComma()
+			continue
+		}
+		switch key {
+		case "name":
+			out.Name = string(in.String())
+		case "status":
+			out.Status = string(in.String())
+		case "version":
+			out.Version = string(in.String())
+		case "tags":
+			if in.IsNull() {
+				in.Skip()
+				out.Tags = nil
+			} else {
+				in.Delim('[')
+				if out.Tags == nil {
+					if !in.IsDelim(']') {
+						out.Tags = make([]string, 0, 4)
+					} else {
+						out.Tags = []string{}
+					}
+				} else {
+					out.Tags = (out.Tags)[:0]
+				}
+				for !in.IsDelim(']') {
+					var v28 string
+					v28 = string(in.String())
+					out.Tags = append(out.Tags, v28)
+					in.WantComma()
+				}
+				in.Delim(']')
+			}
+		default:
+			in.SkipRecursive()
+		}
+		in.WantComma()
+	}
+	in.Delim('}')
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecuritySerializers26(out *jwriter.Writer, in SecurityProfileContextSerializer) {
+	out.RawByte('{')
+	first := true
+	_ = first
+	{
+		const prefix string = ",\"name\":"
+		out.RawString(prefix[1:])
+		out.String(string(in.Name))
+	}
+	{
+		const prefix string = ",\"status\":"
+		out.RawString(prefix)
+		out.String(string(in.Status))
+	}
+	{
+		const prefix string = ",\"version\":"
+		out.RawString(prefix)
+		out.String(string(in.Version))
+	}
+	{
+		const prefix string = ",\"tags\":"
+		out.RawString(prefix)
+		if in.Tags == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+			out.RawString("null")
+		} else {
+			out.RawByte('[')
+			for v29, v30 := range in.Tags {
+				if v29 > 0 {
+					out.RawByte(',')
+				}
+				out.String(string(v30))
+			}
+			out.RawByte(']')
+		}
+	}
+	out.RawByte('}')
+}
+func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecuritySerializers25(in *jlexer.Lexer, out *AnomalyDetectionSyscallEventSerializer) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		if isTopLevel {
+			in.Consumed()
+		}
+		in.Skip()
+		return
+	}
+	in.Delim('{')
+	for !in.IsDelim('}') {
+		key := in.UnsafeFieldName(false)
+		in.WantColon()
+		if in.IsNull() {
+			in.Skip()
+			in.WantComma()
+			continue
+		}
+		switch key {
+		case "syscall":
+			out.Syscall = string(in.String())
+		default:
+			in.SkipRecursive()
+		}
+		in.WantComma()
+	}
+	in.Delim('}')
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecuritySerializers25(out *jwriter.Writer, in AnomalyDetectionSyscallEventSerializer) {
+	out.RawByte('{')
+	first := true
+	_ = first
+	{
+		const prefix string = ",\"syscall\":"
+		out.RawString(prefix[1:])
+		out.String(string(in.Syscall))
+	}
+	out.RawByte('}')
+}
+func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecuritySerializers27(in *jlexer.Lexer, out *EventContextSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -3702,7 +3881,7 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecuritySerializers25(
 		in.Consumed()
 	}
 }
-func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecuritySerializers25(out *jwriter.Writer, in EventContextSerializer) {
+func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecuritySerializers27(out *jwriter.Writer, in EventContextSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -3747,14 +3926,14 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecuritySerializers25(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v EventContextSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecuritySerializers25(w, v)
+	easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecuritySerializers27(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *EventContextSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecuritySerializers25(l, v)
+	easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecuritySerializers27(l, v)
 }
-func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecuritySerializers26(in *jlexer.Lexer, out *DNSQuestionSerializer) {
+func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecuritySerializers28(in *jlexer.Lexer, out *DNSQuestionSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -3793,7 +3972,7 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecuritySerializers26(
 		in.Consumed()
 	}
 }
-func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecuritySerializers26(out *jwriter.Writer, in DNSQuestionSerializer) {
+func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecuritySerializers28(out *jwriter.Writer, in DNSQuestionSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -3827,14 +4006,14 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecuritySerializers26(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v DNSQuestionSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecuritySerializers26(w, v)
+	easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecuritySerializers28(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *DNSQuestionSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecuritySerializers26(l, v)
+	easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecuritySerializers28(l, v)
 }
-func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecuritySerializers27(in *jlexer.Lexer, out *DNSEventSerializer) {
+func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecuritySerializers29(in *jlexer.Lexer, out *DNSEventSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -3875,7 +4054,7 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecuritySerializers27(
 		in.Consumed()
 	}
 }
-func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecuritySerializers27(out *jwriter.Writer, in DNSEventSerializer) {
+func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecuritySerializers29(out *jwriter.Writer, in DNSEventSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -3894,14 +4073,14 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecuritySerializers27(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v DNSEventSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecuritySerializers27(w, v)
+	easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecuritySerializers29(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *DNSEventSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecuritySerializers27(l, v)
+	easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecuritySerializers29(l, v)
 }
-func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecuritySerializers28(in *jlexer.Lexer, out *DDContextSerializer) {
+func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecuritySerializers30(in *jlexer.Lexer, out *DDContextSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -3934,7 +4113,7 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecuritySerializers28(
 		in.Consumed()
 	}
 }
-func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecuritySerializers28(out *jwriter.Writer, in DDContextSerializer) {
+func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecuritySerializers30(out *jwriter.Writer, in DDContextSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -3959,14 +4138,14 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecuritySerializers28(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v DDContextSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecuritySerializers28(w, v)
+	easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecuritySerializers30(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *DDContextSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecuritySerializers28(l, v)
+	easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecuritySerializers30(l, v)
 }
-func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecuritySerializers29(in *jlexer.Lexer, out *CredentialsSerializer) {
+func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecuritySerializers31(in *jlexer.Lexer, out *CredentialsSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -4025,9 +4204,9 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecuritySerializers29(
 					out.CapEffective = (out.CapEffective)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v28 string
-					v28 = string(in.String())
-					out.CapEffective = append(out.CapEffective, v28)
+					var v31 string
+					v31 = string(in.String())
+					out.CapEffective = append(out.CapEffective, v31)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -4048,9 +4227,9 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecuritySerializers29(
 					out.CapPermitted = (out.CapPermitted)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v29 string
-					v29 = string(in.String())
-					out.CapPermitted = append(out.CapPermitted, v29)
+					var v32 string
+					v32 = string(in.String())
+					out.CapPermitted = append(out.CapPermitted, v32)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -4065,7 +4244,7 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecuritySerializers29(
 		in.Consumed()
 	}
 }
-func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecuritySerializers29(out *jwriter.Writer, in CredentialsSerializer) {
+func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecuritySerializers31(out *jwriter.Writer, in CredentialsSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -4136,11 +4315,11 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecuritySerializers29(
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v30, v31 := range in.CapEffective {
-				if v30 > 0 {
+			for v33, v34 := range in.CapEffective {
+				if v33 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v31))
+				out.String(string(v34))
 			}
 			out.RawByte(']')
 		}
@@ -4152,11 +4331,11 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecuritySerializers29(
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v32, v33 := range in.CapPermitted {
-				if v32 > 0 {
+			for v35, v36 := range in.CapPermitted {
+				if v35 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v33))
+				out.String(string(v36))
 			}
 			out.RawByte(']')
 		}
@@ -4166,14 +4345,14 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecuritySerializers29(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v CredentialsSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecuritySerializers29(w, v)
+	easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecuritySerializers31(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *CredentialsSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecuritySerializers29(l, v)
+	easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecuritySerializers31(l, v)
 }
-func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecuritySerializers30(in *jlexer.Lexer, out *ContainerContextSerializer) {
+func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecuritySerializers32(in *jlexer.Lexer, out *ContainerContextSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -4216,7 +4395,7 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecuritySerializers30(
 		in.Consumed()
 	}
 }
-func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecuritySerializers30(out *jwriter.Writer, in ContainerContextSerializer) {
+func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecuritySerializers32(out *jwriter.Writer, in ContainerContextSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -4241,14 +4420,14 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecuritySerializers30(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v ContainerContextSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecuritySerializers30(w, v)
+	easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecuritySerializers32(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *ContainerContextSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecuritySerializers30(l, v)
+	easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecuritySerializers32(l, v)
 }
-func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecuritySerializers31(in *jlexer.Lexer, out *CapsetSerializer) {
+func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecuritySerializers33(in *jlexer.Lexer, out *CapsetSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -4283,9 +4462,9 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecuritySerializers31(
 					out.CapEffective = (out.CapEffective)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v34 string
-					v34 = string(in.String())
-					out.CapEffective = append(out.CapEffective, v34)
+					var v37 string
+					v37 = string(in.String())
+					out.CapEffective = append(out.CapEffective, v37)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -4306,9 +4485,9 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecuritySerializers31(
 					out.CapPermitted = (out.CapPermitted)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v35 string
-					v35 = string(in.String())
-					out.CapPermitted = append(out.CapPermitted, v35)
+					var v38 string
+					v38 = string(in.String())
+					out.CapPermitted = append(out.CapPermitted, v38)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -4323,7 +4502,7 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecuritySerializers31(
 		in.Consumed()
 	}
 }
-func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecuritySerializers31(out *jwriter.Writer, in CapsetSerializer) {
+func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecuritySerializers33(out *jwriter.Writer, in CapsetSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -4334,11 +4513,11 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecuritySerializers31(
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v36, v37 := range in.CapEffective {
-				if v36 > 0 {
+			for v39, v40 := range in.CapEffective {
+				if v39 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v37))
+				out.String(string(v40))
 			}
 			out.RawByte(']')
 		}
@@ -4350,11 +4529,11 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecuritySerializers31(
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v38, v39 := range in.CapPermitted {
-				if v38 > 0 {
+			for v41, v42 := range in.CapPermitted {
+				if v41 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v39))
+				out.String(string(v42))
 			}
 			out.RawByte(']')
 		}
@@ -4364,14 +4543,14 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecuritySerializers31(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v CapsetSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecuritySerializers31(w, v)
+	easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecuritySerializers33(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *CapsetSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecuritySerializers31(l, v)
+	easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecuritySerializers33(l, v)
 }
-func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecuritySerializers32(in *jlexer.Lexer, out *BindEventSerializer) {
+func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecuritySerializers34(in *jlexer.Lexer, out *BindEventSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -4410,7 +4589,7 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecuritySerializers32(
 		in.Consumed()
 	}
 }
-func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecuritySerializers32(out *jwriter.Writer, in BindEventSerializer) {
+func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecuritySerializers34(out *jwriter.Writer, in BindEventSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -4428,14 +4607,14 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecuritySerializers32(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v BindEventSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecuritySerializers32(w, v)
+	easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecuritySerializers34(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *BindEventSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecuritySerializers32(l, v)
+	easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecuritySerializers34(l, v)
 }
-func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecuritySerializers33(in *jlexer.Lexer, out *BPFProgramSerializer) {
+func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecuritySerializers35(in *jlexer.Lexer, out *BPFProgramSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -4478,9 +4657,9 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecuritySerializers33(
 					out.Helpers = (out.Helpers)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v40 string
-					v40 = string(in.String())
-					out.Helpers = append(out.Helpers, v40)
+					var v43 string
+					v43 = string(in.String())
+					out.Helpers = append(out.Helpers, v43)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -4495,7 +4674,7 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecuritySerializers33(
 		in.Consumed()
 	}
 }
-func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecuritySerializers33(out *jwriter.Writer, in BPFProgramSerializer) {
+func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecuritySerializers35(out *jwriter.Writer, in BPFProgramSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -4545,11 +4724,11 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecuritySerializers33(
 		}
 		{
 			out.RawByte('[')
-			for v41, v42 := range in.Helpers {
-				if v41 > 0 {
+			for v44, v45 := range in.Helpers {
+				if v44 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v42))
+				out.String(string(v45))
 			}
 			out.RawByte(']')
 		}
@@ -4559,14 +4738,14 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecuritySerializers33(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v BPFProgramSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecuritySerializers33(w, v)
+	easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecuritySerializers35(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *BPFProgramSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecuritySerializers33(l, v)
+	easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecuritySerializers35(l, v)
 }
-func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecuritySerializers34(in *jlexer.Lexer, out *BPFMapSerializer) {
+func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecuritySerializers36(in *jlexer.Lexer, out *BPFMapSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -4599,7 +4778,7 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecuritySerializers34(
 		in.Consumed()
 	}
 }
-func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecuritySerializers34(out *jwriter.Writer, in BPFMapSerializer) {
+func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecuritySerializers36(out *jwriter.Writer, in BPFMapSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -4624,14 +4803,14 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecuritySerializers34(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v BPFMapSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecuritySerializers34(w, v)
+	easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecuritySerializers36(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *BPFMapSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecuritySerializers34(l, v)
+	easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecuritySerializers36(l, v)
 }
-func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecuritySerializers35(in *jlexer.Lexer, out *BPFEventSerializer) {
+func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecuritySerializers37(in *jlexer.Lexer, out *BPFEventSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -4682,7 +4861,7 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecuritySerializers35(
 		in.Consumed()
 	}
 }
-func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecuritySerializers35(out *jwriter.Writer, in BPFEventSerializer) {
+func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecuritySerializers37(out *jwriter.Writer, in BPFEventSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -4706,10 +4885,10 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecuritySerializers35(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v BPFEventSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecuritySerializers35(w, v)
+	easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecuritySerializers37(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *BPFEventSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecuritySerializers35(l, v)
+	easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecuritySerializers37(l, v)
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR introduces syscall hardening based on Security Profiles. The goal of this PR is to introduce the ability to define the list of syscalls that a workload should be allowed to execute. Depending on the status of the Security Profile that applies to a given workload (and the version of the kernel on which the agent is running), our eBPF program will issue a `bpf_send_signal(9)` (= SIGKILL) to the thread that performed a syscall outside of the allowed list. Regardless of the enforcement setting, a custom `anomaly_detection` event will be sent to notify when an unusual syscall is detected.

In ordre to support this effort, a new configuration parameter was introduced:
- `runtime_security_config.security_profile.max_count` : defines the maximum number of profiles that can be pushed to kernel space at runtime.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

This PR is meant to provide a first kernel space use case for Security Profiles.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Here is what you need to do to QA this PR:
- configure system-probe to encode activity dumps in the `profile` format locally with the following config:
```yaml
runtime_security_config:
  activity_dump:
    enabled: true
    local_storage:
      formats:
        - profile
```
- start a container (like a ubuntu container for example) and make sure a dump is being created for this container (use `security-agent runtime activity-dump list` command and make sure your container is present)
- generate some activity
- stop the dump and move the generate profile in `/etc/datadog-agent/runtime-security.d/profiles/` (a log line should appear to indicate that a new profile was loaded)
- start a container from the same Docker image (a log line should appear to indicate that a profile was applied to the new workload)
- generate a new activity / make a syscall you didn't do before: your process should be killed and an `anomaly_detection` alert should be generated

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
