### PR TITLE
Add support for more username formats

### DIFF
--- a/tools/windows/DatadogAgentInstaller/CustomActions/Native/NativeMethods.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/Native/NativeMethods.cs
@@ -47,60 +47,6 @@ namespace Datadog.CustomActions.Native
             NERR_GROUP_NOT_FOUND = 2220,
         }
 
-        [DllImport("credui.dll", EntryPoint = "CredUIParseUserNameW", CharSet = CharSet.Unicode)]
-        private static extern ReturnCodes CredUIParseUserName(
-            string userName,
-            StringBuilder user,
-            int userMaxChars,
-            StringBuilder domain,
-            int domainMaxChars);
-
-        /// <summary>
-        /// Extracts the domain and user account name from a fully qualified user name.
-        /// </summary>
-        /// <param name="userName">A <see cref="string"/> that contains the user name to be parsed. The name must be in UPN or down-level format, or a certificate.</param>
-        /// <param name="user">A <see cref="string"/> that receives the user account name.</param>
-        /// <param name="domain">A <see cref="string"/> that receives the domain name. If <paramref name="userName"/> specifies a certificate, pszDomain will be <see langword="null"/>.</param>
-        /// <returns>
-        ///     <see langword="true"/> if the <paramref name="userName"/> contains a domain and a user-name; otherwise, <see langword="false"/>.
-        /// </returns>
-        public static bool ParseUserName(string userName, out string user, out string domain)
-        {
-            if (string.IsNullOrEmpty(userName))
-            {
-                throw new ArgumentNullException(nameof(userName));
-            }
-
-            StringBuilder userBuilder = new StringBuilder();
-            StringBuilder domainBuilder = new StringBuilder();
-
-            ReturnCodes returnCode = CredUIParseUserName(userName, userBuilder, int.MaxValue, domainBuilder, int.MaxValue);
-            switch (returnCode)
-            {
-                case ReturnCodes.NO_ERROR: // The username is valid.
-                    user = userBuilder.ToString();
-                    domain = domainBuilder.ToString();
-                    return true;
-
-                case ReturnCodes.ERROR_INVALID_ACCOUNT_NAME: // The username is not valid.
-                    user = userName;
-                    domain = null;
-                    return false;
-
-                // Impossible to reach this state
-                //case ReturnCodes.ERROR_INSUFFICIENT_BUFFER: // One of the buffers is too small.
-                //    throw new OutOfMemoryException();
-
-                case ReturnCodes.ERROR_INVALID_PARAMETER: // ulUserMaxChars or ulDomainMaxChars is zero OR userName, user, or domain is NULL.
-                    throw new ArgumentNullException("userName");
-
-                default:
-                    user = null;
-                    domain = null;
-                    return false;
-            }
-        }
-
         public enum NtStatus : uint
         {
             Success = 0x00000000
@@ -464,5 +410,31 @@ namespace Datadog.CustomActions.Native
             }
         }
         #endregion
+
+        public enum COMPUTER_NAME_FORMAT
+        {
+            ComputerNameNetBIOS,
+            ComputerNameDnsHostname,
+            ComputerNameDnsDomain,
+            ComputerNameDnsFullyQualified,
+            ComputerNamePhysicalNetBIOS,
+            ComputerNamePhysicalDnsHostname,
+            ComputerNamePhysicalDnsDomain,
+            ComputerNamePhysicalDnsFullyQualified
+        }
+
+        [DllImport("kernel32.dll", SetLastError=true, CharSet=CharSet.Auto)]
+        private static extern bool GetComputerNameEx(COMPUTER_NAME_FORMAT NameType,
+                           [Out] StringBuilder lpBuffer, ref uint lpnSize);
+
+        public static bool GetComputerNameEx(COMPUTER_NAME_FORMAT NameType, out string name)
+        {
+            StringBuilder nameBuilder = new StringBuilder();
+            uint nSize = 260;
+            nameBuilder.EnsureCapacity((int)nSize);
+            var result = GetComputerNameEx(NameType, nameBuilder, ref nSize);
+            name = nameBuilder.ToString();
+            return result;
+        }
     }
 }

--- a/tools/windows/DatadogAgentInstaller/CustomActions/Native/NativeMethods.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/Native/NativeMethods.cs
@@ -429,7 +429,7 @@ namespace Datadog.CustomActions.Native
 
         public static bool GetComputerNameEx(COMPUTER_NAME_FORMAT NameType, out string name)
         {
-            StringBuilder nameBuilder = new StringBuilder();
+            var nameBuilder = new StringBuilder();
             uint nSize = 260;
             nameBuilder.EnsureCapacity((int)nSize);
             var result = GetComputerNameEx(NameType, nameBuilder, ref nSize);


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Adds support for more username formats to the NG installer, for parity with OG installer
Now supports
* .\user
* hostname\user
* hostname.fqdn\user

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
On a domain client, these usernames should use/create a local account
* .\user
* netbios\user
* hostname\user
* hostname.fqdn\user

On a domain client, these usernames should use a domain account
* domain\user
* otherdomain\user

On a domain client, this username will use either a local or domain account, whichever exists. If it does not exist, it should create a local account
* user

On a DC, these usernames should use/create a domain account
* user
* .\user
* domain\user
* otherdomain\user

On a DC, these usernames should fail
* netbios\user
* hostname\user
* hostname.fqdn\user

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
