### PR TITLE
Adds dev check example with a more complex check

### DIFF
--- a/docs/dev/checks/README.md
+++ b/docs/dev/checks/README.md
@@ -158,7 +158,7 @@ The list of checks currently shipping with the Agent lives in the
 [integrations-core repo
 here](https://github.com/DataDog/integrations-core/blob/master/requirements-agent-release.txt)
 
-Scenario: You want to test the `openmetrics` check:
+Scenario: You want to test the `redisdb` check:
 
 1. Clone `integrations-core` locally. (Optionally, check out the git tag
    corresponding to the version you want to test.)
@@ -166,14 +166,22 @@ Scenario: You want to test the `openmetrics` check:
     ```
     python3 -m pip install --user './datadog_checks_base[deps]'
     ```
-3. Install the `openmetrics` check. From inside the `integrations-core`
+3. Install the `redisdb` check. From inside the `integrations-core`
    checkout:
     ```
-    python3 -m pip install --user ./openmetrics
+    python3 -m pip install --user ./redisdb
     ```
+    
+4. (Optional for some checks). Some checks have dependencies on other python modules 
+   that must be installed alongside the python check. `redisdb` is one check that _does_ have
+   dependencies, specifically on the open source `redisdb` package. In this case, we need to
+   install the `deps` explicitly.
+   ```
+   python3 -m pip install --user './redisdb[deps]'
+   ```
 
 That's it! Your local build should now have the correct packages to be able to
-run the `openmetrics` check.
+run the `redisdb` check.
 
 #### "What is this `[deps]` thing?"
 The `[deps]` at the end of the package name instructs pip to install the

--- a/docs/dev/checks/README.md
+++ b/docs/dev/checks/README.md
@@ -172,8 +172,8 @@ Scenario: You want to test the `redisdb` check:
     python3 -m pip install --user ./redisdb
     ```
     
-4. (Optional for some checks). Some checks have dependencies on other python modules 
-   that must be installed alongside the python check. `redisdb` is one check that _does_ have
+4. (Optional for some checks). Some checks have dependencies on other Python modules 
+   that must be installed alongside the Python check. `redisdb` is one check that _does_ have
    dependencies, specifically on the open source `redisdb` package. In this case, we need to
    install the `deps` explicitly.
    ```


### PR DESCRIPTION

### What does this PR do?
Adds a missing step required for check installation in a local agent build

### Motivation
Helpful docs for future developers

### Additional Notes
The `openmetrics` check does not have any external dependencies, so switching this doc to explain how to install `redisdb` check which _does_ have extra dependencies that must be installed

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
n/a

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
