### PR TITLE
[util/docker/event_types] Add "tag" to imageEventActions

### DIFF
--- a/pkg/util/docker/event_types.go
+++ b/pkg/util/docker/event_types.go
@@ -50,7 +50,7 @@ var containerEventActions = []string{
 var imageEventActions = []string{
 	ImageEventActionPull,
 	ImageEventActionDelete,
-	ImageEventActionDelete,
+	ImageEventActionTag,
 	ImageEventActionUntag,
 }
 


### PR DESCRIPTION
### What does this PR do?

Adds "tag" to the Docker events that the agent subscribes to when image metadata collection is enabled.
These are defined in the `imageEventActions` array. "tag" was missing and "delete" was duplicated.

### Describe how to test/QA your changes

- Deploy the agent on an environment with Docker with image metadata collection enabled (`DD_CONTAINER_IMAGE_COLLECTION_METADATA_ENABLED=true`).
- Tag an existing image with `docker tag`.
- Run `agent workload-list` and check that the new tag appears in the `Repo tags` section of the image.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
