### PR TITLE
[kubelet/client] Use proxy when URL includes resolved IP

### DIFF
--- a/pkg/util/kubernetes/kubelet/kubelet_client.go
+++ b/pkg/util/kubernetes/kubelet/kubelet_client.go
@@ -264,9 +264,9 @@ func checkKubeletConnection(ctx context.Context, scheme string, port int, prefix
 	for _, ip := range hosts.ips {
 		// If `ip` is an IPv6, it must be enclosed in square brackets
 		if ipv6Re.MatchString(ip) {
-			clientConfig.baseURL = fmt.Sprintf("[%s]:%d", ip, port)
+			clientConfig.baseURL = fmt.Sprintf("[%s]:%d%s", ip, port, prefix)
 		} else {
-			clientConfig.baseURL = fmt.Sprintf("%s:%d", ip, port)
+			clientConfig.baseURL = fmt.Sprintf("%s:%d%s", ip, port, prefix)
 		}
 
 		log.Debugf("Trying to reach Kubelet at: %s", clientConfig.baseURL)


### PR DESCRIPTION
### What does this PR do?

Fixes the kubelet client to work on EKS Fargate.
The client wasn't setting the proxy prefix in the Kubelet URL when the connection info contained IPs instead of hostnames.


### Describe how to test/QA your changes

Deploy on EKS Fargate both on a IPv6 cluster and a IPv4 one.

Check that the kubelet connection works fine (`agent workload-list` should show the containers, `agent status` should report that the kubelet check is working, autodiscovery works, etc.).

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
