### PR TITLE
Fix custom metrics query window

### DIFF
--- a/pkg/util/kubernetes/autoscalers/processor.go
+++ b/pkg/util/kubernetes/autoscalers/processor.go
@@ -147,8 +147,8 @@ func (p *Processor) UpdateExternalMetrics(emList map[string]custommetrics.Extern
 		}
 	}
 
-	// In non-DatadogMetric path, we don't have any custom maxAge possible, passing 0 as custom time window to QueryExternalMetric
-	metrics, err := p.QueryExternalMetric(batch, 0)
+	// In non-DatadogMetric path, we don't have any custom maxAge possible, always use default time window
+	metrics, err := p.QueryExternalMetric(batch, GetDefaultTimeWindow())
 	if len(metrics) == 0 && err != nil {
 		log.Errorf("Error getting metrics from Datadog: %v", err.Error())
 		// If no metrics can be retrieved from Datadog in a given list, we need to invalidate them


### PR DESCRIPTION
### What does this PR do?

Fix bug introduced in https://github.com/DataDog/datadog-agent/pull/15624.
When legacy external metrics implementation is used, time window was always set to `0`.

### Motivation

Bugfix

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Deploy the Cluster Agent with external metrics but WITHOUT DatadogMetrics, verify that the autoscaling works.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
