### PR TITLE
Do not try to get Kubernetes cluster name outside of Kubernetes

### DIFF
--- a/pkg/clusteragent/clusterchecks/dispatcher_test.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_test.go
@@ -431,6 +431,9 @@ func TestReset(t *testing.T) {
 }
 
 func TestPatchConfiguration(t *testing.T) {
+	config.SetFeature(config.Kubernetes)
+	defer config.ClearFeatures()
+
 	checkConfig := integration.Config{
 		Name:          "test",
 		ADIdentifiers: []string{"redis"},
@@ -467,6 +470,9 @@ func TestPatchConfiguration(t *testing.T) {
 }
 
 func TestPatchEndpointsConfiguration(t *testing.T) {
+	config.SetFeature(config.Kubernetes)
+	defer config.ClearFeatures()
+
 	checkConfig := integration.Config{
 		Name:          "test",
 		ADIdentifiers: []string{"redis"},
@@ -498,6 +504,9 @@ func TestPatchEndpointsConfiguration(t *testing.T) {
 }
 
 func TestExtraTags(t *testing.T) {
+	config.SetFeature(config.Kubernetes)
+	defer config.ClearFeatures()
+
 	for _, tc := range []struct {
 		extraTagsConfig   []string
 		clusterNameConfig string

--- a/pkg/config/environment_testing.go
+++ b/pkg/config/environment_testing.go
@@ -3,9 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build test
-// +build test
-
 package config
 
 // Setting a default list of features with what is widely used in unit tests.

--- a/pkg/util/kubernetes/clustername/clustername_test.go
+++ b/pkg/util/kubernetes/clustername/clustername_test.go
@@ -17,27 +17,29 @@ import (
 func TestGetClusterName(t *testing.T) {
 	ctx := context.Background()
 	mockConfig := config.Mock(t)
+	config.SetFeature(config.Kubernetes)
+	defer config.ClearFeatures()
 	data := newClusterNameData()
 
-	var testClusterName = "laika"
+	testClusterName := "laika"
 	mockConfig.Set("cluster_name", testClusterName)
 	defer mockConfig.Set("cluster_name", nil)
 
 	assert.Equal(t, testClusterName, getClusterName(ctx, data, "hostname"))
 
 	// Test caching and reset
-	var newClusterName = "youri"
+	newClusterName := "youri"
 	mockConfig.Set("cluster_name", newClusterName)
 	assert.Equal(t, testClusterName, getClusterName(ctx, data, "hostname"))
 	freshData := newClusterNameData()
 	assert.Equal(t, newClusterName, getClusterName(ctx, freshData, "hostname"))
 
-	var dotClusterName = "aclusternamewitha.dot"
+	dotClusterName := "aclusternamewitha.dot"
 	mockConfig.Set("cluster_name", dotClusterName)
 	data = newClusterNameData()
 	assert.Equal(t, dotClusterName, getClusterName(ctx, data, "hostname"))
 
-	var dotsClusterName = "a.cluster.name.with.dots"
+	dotsClusterName := "a.cluster.name.with.dots"
 	mockConfig.Set("cluster_name", dotsClusterName)
 	data = newClusterNameData()
 	assert.Equal(t, dotsClusterName, getClusterName(ctx, data, "hostname"))

--- a/test/integration/util/kube_apiserver/apiserver_test.go
+++ b/test/integration/util/kube_apiserver/apiserver_test.go
@@ -44,7 +44,7 @@ func TestSuiteKube(t *testing.T) {
 	s := &testSuite{}
 
 	// Env detection
-	config.DetectFeatures()
+	config.SetFeature(config.Kubernetes)
 
 	// Start compose stack
 	compose, err := initAPIServerCompose()
@@ -193,7 +193,7 @@ func (suite *testSuite) TestHostnameProvider() {
 	assert.Equal(suite.T(), "target.host", foundHost)
 
 	// Testing hostname when a cluster name is set
-	var testClusterName = "laika"
+	testClusterName := "laika"
 	mockConfig.Set("cluster_name", testClusterName)
 	clustername.ResetClusterName()
 	defer mockConfig.Set("cluster_name", "")


### PR DESCRIPTION
### What does this PR do?

Always return empty string when trying to get Kubernetes cluster name when Kubernetes feature is not enabled.

### Motivation

Avoid useless cloud provider calls to retrieve cluster name.

### Additional Notes

EC2 Metadata is called due to host tags retrieving cluster name.

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Deploy the Agent on EC2 (not in Kubernetes) with `DEBUG` logs, verify that you don't get any log like:
```
Trying to auto discover the cluster name from the ec2 API
```

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
