### PR TITLE
[CWS] Restore security-agent log file

### DIFF
--- a/cmd/security-agent/subcommands/start/command.go
+++ b/cmd/security-agent/subcommands/start/command.go
@@ -72,7 +72,8 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 				fx.Supply(params),
 				fx.Supply(core.BundleParams{
 					ConfigParams: config.NewSecurityAgentParams(params.ConfigFilePaths),
-					LogParams:    log.LogForOneShot(command.LoggerName, "info", true)}),
+					LogParams:    log.LogForDaemon(command.LoggerName, "security_agent.log_file", pkgconfig.DefaultSecurityAgentLogFile),
+				}),
 				core.Bundle,
 			)
 		},

--- a/cmd/security-agent/subcommands/start/command_test.go
+++ b/cmd/security-agent/subcommands/start/command_test.go
@@ -27,7 +27,6 @@ func TestCommand(t *testing.T) {
 			check: func(cliParams *cliParams, params core.BundleParams) {
 				// Verify logger defaults
 				require.Equal(t, command.LoggerName, params.LoggerName(), "logger name not matching")
-				require.Equal(t, "info", params.LogLevelFn(nil), "log level not matching")
 			},
 		},
 		{
@@ -36,7 +35,6 @@ func TestCommand(t *testing.T) {
 			check: func(cliParams *cliParams, params core.BundleParams) {
 				// Verify logger defaults
 				require.Equal(t, command.LoggerName, params.LoggerName(), "logger name not matching")
-				require.Equal(t, "info", params.LogLevelFn(nil), "log level not matching")
 				require.Equal(t, "/pid/file", cliParams.pidfilePath, "PID file path not matching")
 			},
 		},

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1120,7 +1120,7 @@ func InitConfig(config Config) {
 	// Datadog security agent (common)
 	config.BindEnvAndSetDefault("security_agent.cmd_port", 5010)
 	config.BindEnvAndSetDefault("security_agent.expvar_port", 5011)
-	config.BindEnvAndSetDefault("security_agent.log_file", defaultSecurityAgentLogFile)
+	config.BindEnvAndSetDefault("security_agent.log_file", DefaultSecurityAgentLogFile)
 	config.BindEnvAndSetDefault("security_agent.remote_tagger", true)
 	config.BindEnvAndSetDefault("security_agent.remote_workloadmeta", false) // TODO: switch this to true when ready
 

--- a/pkg/config/config_darwin.go
+++ b/pkg/config/config_darwin.go
@@ -11,8 +11,8 @@ const (
 	defaultRunPath              = "/opt/datadog-agent/run"
 	defaultSyslogURI            = "unixgram:///var/run/syslog"
 	defaultGuiPort              = 5002
-	// defaultSecurityAgentLogFile points to the log file that will be used by the security-agent if not configured
-	defaultSecurityAgentLogFile = "/opt/datadog-agent/logs/security-agent.log"
+	// DefaultSecurityAgentLogFile points to the log file that will be used by the security-agent if not configured
+	DefaultSecurityAgentLogFile = "/opt/datadog-agent/logs/security-agent.log"
 	// DefaultProcessAgentLogFile is the default process-agent log file
 	DefaultProcessAgentLogFile = "/opt/datadog-agent/logs/process-agent.log"
 	// defaultSystemProbeAddress is the default unix socket path to be used for connecting to the system probe

--- a/pkg/config/config_nix.go
+++ b/pkg/config/config_nix.go
@@ -14,8 +14,8 @@ const (
 	defaultRunPath              = "/opt/datadog-agent/run"
 	defaultSyslogURI            = "unixgram:///dev/log"
 	defaultGuiPort              = -1
-	// defaultSecurityAgentLogFile points to the log file that will be used by the security-agent if not configured
-	defaultSecurityAgentLogFile = "/var/log/datadog/security-agent.log"
+	// DefaultSecurityAgentLogFile points to the log file that will be used by the security-agent if not configured
+	DefaultSecurityAgentLogFile = "/var/log/datadog/security-agent.log"
 	// DefaultProcessAgentLogFile is the default process-agent log file
 	DefaultProcessAgentLogFile = "/var/log/datadog/process-agent.log"
 

--- a/pkg/config/config_windows.go
+++ b/pkg/config/config_windows.go
@@ -18,8 +18,8 @@ var (
 	defaultAdditionalChecksPath = "c:\\programdata\\datadog\\checks.d"
 	defaultRunPath              = "c:\\programdata\\datadog\\run"
 	defaultGuiPort              = 5002
-	// defaultSecurityAgentLogFile points to the log file that will be used by the security-agent if not configured
-	defaultSecurityAgentLogFile = "c:\\programdata\\datadog\\logs\\security-agent.log"
+	// DefaultSecurityAgentLogFile points to the log file that will be used by the security-agent if not configured
+	DefaultSecurityAgentLogFile = "c:\\programdata\\datadog\\logs\\security-agent.log"
 	// DefaultProcessAgentLogFile is the default process-agent log file
 	DefaultProcessAgentLogFile = "C:\\ProgramData\\Datadog\\logs\\process-agent.log"
 
@@ -39,7 +39,7 @@ func osinit() {
 		defaultConfdPath = filepath.Join(pd, "conf.d")
 		defaultAdditionalChecksPath = filepath.Join(pd, "checks.d")
 		defaultRunPath = filepath.Join(pd, "run")
-		defaultSecurityAgentLogFile = filepath.Join(pd, "logs", "security-agent.log")
+		DefaultSecurityAgentLogFile = filepath.Join(pd, "logs", "security-agent.log")
 		defaultSystemProbeLogFilePath = filepath.Join(pd, "logs", "system-probe.log")
 		DefaultProcessAgentLogFile = filepath.Join(pd, "logs", "process-agent.log")
 	} else {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Restore the security-agent.log which stopped to be generated since 7.43

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
