### PR TITLE
[Serverless] Fix panic when running the extension without appsec enabled.

### DIFF
--- a/cmd/serverless/main.go
+++ b/cmd/serverless/main.go
@@ -276,15 +276,20 @@ func runAgent(stopCh chan struct{}) (serverlessDaemon *daemon.Daemon, err error)
 
 	// start appsec
 	var (
-		appsecSubProcessor   *httpsec.InvocationSubProcessor
+		appsecSubProcessor   invocationlifecycle.InvocationSubProcessor
 		appsecProxyProcessor *httpsec.ProxyLifecycleProcessor
 	)
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		appsecSubProcessor, appsecProxyProcessor, err = appsec.New()
+		subProcessor, proxySubProcessor, err := appsec.New()
 		if err != nil {
 			log.Error("appsec: could not start: ", err)
+		}
+		if subProcessor != nil {
+			appsecSubProcessor = subProcessor
+		} else if proxySubProcessor != nil {
+			appsecProxyProcessor = proxySubProcessor
 		}
 	}()
 

--- a/pkg/serverless/appsec/httpsec/http.go
+++ b/pkg/serverless/appsec/httpsec/http.go
@@ -45,9 +45,19 @@ func NewInvocationSubProcessor(appsec Monitorer) *InvocationSubProcessor {
 
 func (p *InvocationSubProcessor) OnInvokeStart(_ *invocationlifecycle.InvocationStartDetails, _ *invocationlifecycle.RequestHandler) {
 	// In monitoring-only mode - without blocking - we can wait until the request's end to monitor it
+
+	// XXX: Because this *InvocationSubProcessor is referenced as an interface,
+	// a nil check like (*myInterface)(nil) != nil will return true.
+	// See https://go.dev/tour/methods/12
+	if p == nil {
+		return
+	}
 }
 
 func (p *InvocationSubProcessor) OnInvokeEnd(endDetails *invocationlifecycle.InvocationEndDetails, invocCtx *invocationlifecycle.RequestHandler) {
+	if p == nil {
+		return
+	}
 	span := invocCtx
 	// Set the span tags that are always expected to be there when appsec is enabled
 	setAppSecEnabledTags(span)

--- a/pkg/serverless/appsec/httpsec/http_test.go
+++ b/pkg/serverless/appsec/httpsec/http_test.go
@@ -8,6 +8,7 @@ package httpsec_test
 import (
 	"bytes"
 	"os"
+	"strconv"
 	"testing"
 	"time"
 
@@ -21,54 +22,73 @@ import (
 )
 
 func TestLifecycleSubProcessor(t *testing.T) {
-	t.Setenv("DD_SERVERLESS_APPSEC_ENABLED", "true")
-	asm, _, err := appsec.New()
-	if err != nil {
-		t.Skipf("appsec disabled: %v", err)
+	test := func(t *testing.T, appsecEnabled bool) {
+		t.Setenv("DD_SERVERLESS_APPSEC_ENABLED", strconv.FormatBool(appsecEnabled))
+		asm, _, err := appsec.New()
+		require.NoError(t, err)
+
+		var sp invocationlifecycle.InvocationSubProcessor
+		if appsecEnabled {
+			require.NotNil(t, asm)
+			sp = asm
+		} else {
+			require.Nil(t, asm)
+		}
+
+		var tracedPayload *api.Payload
+		testProcessor := &invocationlifecycle.LifecycleProcessor{
+			DetectLambdaLibrary: func() bool { return false },
+			ProcessTrace: func(payload *api.Payload) {
+				tracedPayload = payload
+			},
+			SubProcessor: sp,
+		}
+
+		t.Run("api-gateway", func(t *testing.T) {
+			// First invocation without any attack
+			testProcessor.OnInvokeStart(&invocationlifecycle.InvocationStartDetails{
+				InvokeEventRawPayload: getEventFromFile("api-gateway.json"),
+				InvokedFunctionARN:    "arn:aws:lambda:us-east-1:123456789012:function:my-function",
+			})
+			testProcessor.OnInvokeEnd(&invocationlifecycle.InvocationEndDetails{
+				EndTime: time.Now(),
+				IsError: false,
+			})
+			tags := testProcessor.GetTags()
+			require.Equal(t, "api-gateway", tags["function_trigger.event_source"])
+			require.Equal(t, "arn:aws:apigateway:us-east-1::/restapis/1234567890/stages/prod", tags["function_trigger.event_source_arn"])
+			require.Equal(t, "POST", tags["http.method"])
+			require.Equal(t, "70ixmpl4fl.execute-api.us-east-2.amazonaws.com", tags["http.url"])
+
+			// Second invocation containing attacks
+			testProcessor.OnInvokeStart(&invocationlifecycle.InvocationStartDetails{
+				InvokeEventRawPayload: getEventFromFile("api-gateway-appsec.json"),
+				InvokedFunctionARN:    "arn:aws:lambda:us-east-1:123456789012:function:my-function",
+			})
+			testProcessor.OnInvokeEnd(&invocationlifecycle.InvocationEndDetails{
+				EndTime: time.Now(),
+				IsError: false,
+			})
+			tags = testProcessor.GetTags()
+			require.Equal(t, "api-gateway", tags["function_trigger.event_source"])
+			require.Equal(t, "arn:aws:apigateway:us-east-1::/restapis/1234567890/stages/prod", tags["function_trigger.event_source_arn"])
+			require.Equal(t, "POST", tags["http.method"])
+			require.Equal(t, "70ixmpl4fl.execute-api.us-east-2.amazonaws.com", tags["http.url"])
+
+			if appsecEnabled {
+				require.Contains(t, tags, "_dd.appsec.json")
+				require.Equal(t, int32(sampler.PriorityUserKeep), tracedPayload.TracerPayload.Chunks[0].Priority)
+				require.Equal(t, 1.0, tracedPayload.TracerPayload.Chunks[0].Spans[0].Metrics["_dd.appsec.enabled"])
+			}
+		})
 	}
 
-	var tracedPayload *api.Payload
-	testProcessor := &invocationlifecycle.LifecycleProcessor{
-		DetectLambdaLibrary: func() bool { return false },
-		ProcessTrace: func(payload *api.Payload) {
-			tracedPayload = payload
-		},
-		SubProcessor: asm,
-	}
+	t.Run("appsec-enabled", func(t *testing.T) {
+		test(t, true)
+	})
 
-	t.Run("api-gateway", func(t *testing.T) {
-		// First invocation without any attack
-		testProcessor.OnInvokeStart(&invocationlifecycle.InvocationStartDetails{
-			InvokeEventRawPayload: getEventFromFile("api-gateway.json"),
-			InvokedFunctionARN:    "arn:aws:lambda:us-east-1:123456789012:function:my-function",
-		})
-		testProcessor.OnInvokeEnd(&invocationlifecycle.InvocationEndDetails{
-			EndTime: time.Now(),
-			IsError: false,
-		})
-		tags := testProcessor.GetTags()
-		require.Equal(t, "api-gateway", tags["function_trigger.event_source"])
-		require.Equal(t, "arn:aws:apigateway:us-east-1::/restapis/1234567890/stages/prod", tags["function_trigger.event_source_arn"])
-		require.Equal(t, "POST", tags["http.method"])
-		require.Equal(t, "70ixmpl4fl.execute-api.us-east-2.amazonaws.com", tags["http.url"])
-
-		// Second invocation containing attacks
-		testProcessor.OnInvokeStart(&invocationlifecycle.InvocationStartDetails{
-			InvokeEventRawPayload: getEventFromFile("api-gateway-appsec.json"),
-			InvokedFunctionARN:    "arn:aws:lambda:us-east-1:123456789012:function:my-function",
-		})
-		testProcessor.OnInvokeEnd(&invocationlifecycle.InvocationEndDetails{
-			EndTime: time.Now(),
-			IsError: false,
-		})
-		tags = testProcessor.GetTags()
-		require.Equal(t, "api-gateway", tags["function_trigger.event_source"])
-		require.Equal(t, "arn:aws:apigateway:us-east-1::/restapis/1234567890/stages/prod", tags["function_trigger.event_source_arn"])
-		require.Equal(t, "POST", tags["http.method"])
-		require.Equal(t, "70ixmpl4fl.execute-api.us-east-2.amazonaws.com", tags["http.url"])
-		require.Contains(t, tags, "_dd.appsec.json")
-		require.Equal(t, int32(sampler.PriorityUserKeep), tracedPayload.TracerPayload.Chunks[0].Priority)
-		require.Equal(t, 1.0, tracedPayload.TracerPayload.Chunks[0].Spans[0].Metrics["_dd.appsec.enabled"])
+	t.Run("appsec-disabled", func(t *testing.T) {
+		test(t, false)
 	})
 }
 

--- a/pkg/serverless/appsec/httpsec/http_test.go
+++ b/pkg/serverless/appsec/httpsec/http_test.go
@@ -25,7 +25,9 @@ func TestLifecycleSubProcessor(t *testing.T) {
 	test := func(t *testing.T, appsecEnabled bool) {
 		t.Setenv("DD_SERVERLESS_APPSEC_ENABLED", strconv.FormatBool(appsecEnabled))
 		asm, _, err := appsec.New()
-		require.NoError(t, err)
+		if err != nil {
+			t.Skipf("appsec disabled: %v", err)
+		}
 
 		var sp invocationlifecycle.InvocationSubProcessor
 		if appsecEnabled {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This pull request fixes a bug when running a java function in aws lambda without appsec enabled.

The problem stems from the fact that when a go interface can be implemented by a nil pointer, the interface itself is considered not nil. In the example below, the interface `io.Reader` is implemented in three ways, but only the first of which is considered `nil`. This is despite the second implementation be a nil pointer, as is the case which triggered the panic this PR addresses.

```go
func main() {
	var r io.Reader
	fmt.Println(r == nil)    // true

	r = (*bytes.Buffer)(nil)
	fmt.Println(r == nil)    // false
	
	r = &bytes.Buffer{}
	fmt.Println(r == nil)    // false
}
```

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
