### PR TITLE
[process-agent] Add common Config and SysProbeConfig component dependencies

### DIFF
--- a/cmd/process-agent/command/command.go
+++ b/cmd/process-agent/command/command.go
@@ -15,12 +15,16 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/DataDog/datadog-agent/cmd/process-agent/flags"
+	logComponent "github.com/DataDog/datadog-agent/comp/core/log"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 const LoggerName config.LoggerName = "PROCESS"
+
+// DaemonLogParams are the log params should be given to the `core.BundleParams` for when the process agent is running as a daemon
+var DaemonLogParams = logComponent.LogForDaemon(string(LoggerName), "process_config.log_file", config.DefaultProcessAgentLogFile)
 
 // GlobalParams contains the values of agent-global Cobra flags.
 //

--- a/cmd/process-agent/main_common.go
+++ b/cmd/process-agent/main_common.go
@@ -236,8 +236,9 @@ func runApp(exit chan struct{}, globalParams *command.GlobalParams, hostInfo *ch
 
 	var appInitDeps struct {
 		fx.In
+
 		Checks []types.CheckComponent `group:"check"`
-		syscfg sysprobeconfig.Component
+		Syscfg sysprobeconfig.Component
 	}
 	app := fx.New(
 		fx.Supply(
@@ -251,9 +252,8 @@ func runApp(exit chan struct{}, globalParams *command.GlobalParams, hostInfo *ch
 		// Populate dependencies required for initialization in this function.
 		fx.Populate(&appInitDeps),
 
-		// Provide process anent and core bundles so fx knows where to find components.
+		// Provide process agent bundle so fx knows where to find components.
 		process.Bundle,
-		core.Bundle,
 
 		// Allows for debug logging of fx components if the `TRACE_FX` environment variable is set
 		fxutil.FxLoggingOption(),
@@ -274,7 +274,7 @@ func runApp(exit chan struct{}, globalParams *command.GlobalParams, hostInfo *ch
 	}
 
 	// TODO: Componetize status
-	err := initStatus(hostInfo, appInitDeps.syscfg)
+	err := initStatus(hostInfo, appInitDeps.Syscfg)
 	if err != nil {
 		log.Critical("Failed to initialize status:", err)
 	}

--- a/cmd/process-agent/main_common.go
+++ b/cmd/process-agent/main_common.go
@@ -272,7 +272,7 @@ func initMisc(deps miscDeps) error {
 	expvarPort := getExpvarPort(deps.Config)
 	expvarServer := &http.Server{Addr: fmt.Sprintf("localhost:%d", expvarPort), Handler: http.DefaultServeMux}
 
-	// Initalize status
+	// Initialize status
 	err := initStatus(deps.HostInfo, deps.Syscfg)
 	if err != nil {
 		log.Critical("Failed to initialize status:", err)
@@ -309,7 +309,7 @@ func initMisc(deps miscDeps) error {
 			}
 
 			if err := expvarServer.Shutdown(ctx); err != nil {
-				log.Errorf("Error shutting down expvar server on port %v: %v", getExpvarPort, err)
+				log.Errorf("Error shutting down expvar server on port %v: %v", getExpvarPort(deps.Config), err)
 			}
 
 			return nil

--- a/cmd/process-agent/main_common.go
+++ b/cmd/process-agent/main_common.go
@@ -243,7 +243,6 @@ func initMisc(deps miscDeps) error {
 
 	// Setup workloadmeta
 	var workloadmetaCollectors workloadmeta.CollectorCatalog
-	// TODO: move these deps.Configs to after dddeps.Config.Datadog is called
 	if deps.Config.GetBool("process_config.remote_workloadmeta") {
 		workloadmetaCollectors = workloadmeta.RemoteCatalog
 	} else {
@@ -287,6 +286,10 @@ func initMisc(deps miscDeps) error {
 			if err != nil {
 				_ = log.Errorf("failed to start the tagger: %s", err)
 			}
+
+			go func() {
+				_ = expvarServer.ListenAndServe()
+			}()
 
 			// Run API server
 			err = api.StartServer()

--- a/cmd/process-agent/main_common.go
+++ b/cmd/process-agent/main_common.go
@@ -229,6 +229,7 @@ type miscDeps struct {
 }
 
 // initMisc initializes modules that cannot, or have not yet been componetized.
+// Todo: (Components) WorkloadMeta, remoteTagger, telemetry Server, expvars, api server
 func initMisc(deps miscDeps) error {
 	initRuntimeSettings()
 

--- a/comp/README.md
+++ b/comp/README.md
@@ -71,6 +71,10 @@ Package processdiscoverycheck implements a component to handle Process Discovery
 
 Package processeventscheck implements a component to handle Process Events data collection in the Process Agent.
 
+### [comp/process/profiler](https://pkg.go.dev/github.com/DataDog/dd-agent-comp-experiments/comp/process/profiler)
+
+Package profiler implements a component to handle starting and stopping the internal profiler.
+
 ### [comp/process/rtcontainercheck](https://pkg.go.dev/github.com/DataDog/dd-agent-comp-experiments/comp/process/rtcontainercheck)
 
 Package rtcontainercheck implements a component to handle realtime Container data collection in the Process Agent.

--- a/comp/README.md
+++ b/comp/README.md
@@ -55,6 +55,10 @@ Package connectionscheck implements a component to handle Connections data colle
 
 Package containercheck implements a component to handle Container data collection in the Process Agent.
 
+### [comp/process/hostinfo](https://pkg.go.dev/github.com/DataDog/dd-agent-comp-experiments/comp/process/hostinfo)
+
+Package hostinfo wraps the hostinfo inside a component. This is useful because it is relied on by other components.
+
 ### [comp/process/podcheck](https://pkg.go.dev/github.com/DataDog/dd-agent-comp-experiments/comp/process/podcheck)
 
 Package podcheck implements a component to handle Kubernetes data collection in the Process Agent.

--- a/comp/process/bundle.go
+++ b/comp/process/bundle.go
@@ -12,6 +12,7 @@
 package process
 
 import (
+	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/process/connectionscheck"
 	"github.com/DataDog/datadog-agent/comp/process/containercheck"
 	"github.com/DataDog/datadog-agent/comp/process/podcheck"
@@ -39,4 +40,7 @@ var Bundle = fxutil.Bundle(
 	processeventscheck.Module,
 	rtcontainercheck.Module,
 	processdiscoverycheck.Module,
+
+	// Config
+	core.Bundle,
 )

--- a/comp/process/bundle.go
+++ b/comp/process/bundle.go
@@ -41,6 +41,6 @@ var Bundle = fxutil.Bundle(
 	rtcontainercheck.Module,
 	processdiscoverycheck.Module,
 
-	// Config
+	// Add in the core bundle since it is used by most components
 	core.Bundle,
 )

--- a/comp/process/bundle.go
+++ b/comp/process/bundle.go
@@ -12,12 +12,10 @@
 package process
 
 import (
-	"go.uber.org/fx"
-
 	"github.com/DataDog/datadog-agent/comp/core"
-	"github.com/DataDog/datadog-agent/comp/core/log"
 	"github.com/DataDog/datadog-agent/comp/process/connectionscheck"
 	"github.com/DataDog/datadog-agent/comp/process/containercheck"
+	"github.com/DataDog/datadog-agent/comp/process/hostinfo"
 	"github.com/DataDog/datadog-agent/comp/process/podcheck"
 	"github.com/DataDog/datadog-agent/comp/process/processcheck"
 	"github.com/DataDog/datadog-agent/comp/process/processdiscoverycheck"
@@ -26,7 +24,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/process/rtcontainercheck"
 	"github.com/DataDog/datadog-agent/comp/process/runner"
 	"github.com/DataDog/datadog-agent/comp/process/submitter"
-	"github.com/DataDog/datadog-agent/pkg/process/checks"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
@@ -47,16 +44,6 @@ var Bundle = fxutil.Bundle(
 	rtcontainercheck.Module,
 	processdiscoverycheck.Module,
 
-	// Add in the core bundle since it is used by most components
+	hostinfo.Module,
 	core.Bundle,
-
-	// Provide a way to construct the HostInfo.
-	fx.Provide(func(logger log.Component) (*checks.HostInfo, error) {
-		hinfo, err := checks.CollectHostInfo()
-		if err != nil {
-			_ = logger.Critical("Error collecting host details:", err)
-			return nil, err
-		}
-		return hinfo, nil
-	}),
 )

--- a/comp/process/bundle_test.go
+++ b/comp/process/bundle_test.go
@@ -12,7 +12,8 @@ import (
 	"go.uber.org/fx"
 
 	model "github.com/DataDog/agent-payload/v5/process"
-	sysconfig "github.com/DataDog/datadog-agent/cmd/system-probe/config"
+
+	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/process/runner"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/process/checks"
@@ -31,7 +32,7 @@ func TestBundleDependencies(t *testing.T) {
 			fx.Annotate(t, fx.As(new(testing.TB))),
 
 			testHostInfo,
-			&sysconfig.Config{},
+			core.BundleParams{},
 		),
 
 		// instantiate all of the process components, since this is not done
@@ -71,7 +72,7 @@ func TestBundleOneShot(t *testing.T) {
 			fx.Annotate(t, fx.As(new(testing.TB))),
 
 			testHostInfo,
-			&sysconfig.Config{},
+			core.BundleParams{},
 		),
 
 		Bundle,

--- a/comp/process/bundle_test.go
+++ b/comp/process/bundle_test.go
@@ -35,7 +35,7 @@ func TestBundleDependencies(t *testing.T) {
 			core.BundleParams{},
 		),
 
-		// instantiate all of the process components, since this is not done
+		// instantiate all the process components, since this is not done
 		// automatically.
 		fx.Invoke(func(r runner.Component) {}),
 

--- a/comp/process/bundle_test.go
+++ b/comp/process/bundle_test.go
@@ -15,7 +15,7 @@ import (
 	configComp "github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/log"
 	"github.com/DataDog/datadog-agent/comp/process/runner"
-	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/comp/process/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
@@ -23,12 +23,6 @@ var mockCoreBundleParams = core.BundleParams{
 	ConfigParams: configComp.NewParams("", configComp.WithConfigMissingOK(true)),
 	LogParams:    log.LogForOneShot("PROCESS", "trace", false),
 }
-
-// Don't enable any features, we haven't set up a container provider so the container check will crash
-var disableContainerFeatures = fx.Invoke(func(t testing.TB, _ configComp.Component) {
-	config.SetDetectedFeatures(config.FeatureMap{})
-	t.Cleanup(func() { config.SetDetectedFeatures(nil) })
-})
 
 func TestBundleDependencies(t *testing.T) {
 	require.NoError(t, fx.ValidateApp(
@@ -38,7 +32,7 @@ func TestBundleDependencies(t *testing.T) {
 			mockCoreBundleParams,
 		),
 
-		disableContainerFeatures,
+		utils.DisableContainerFeatures,
 
 		// Start the runner
 		fx.Invoke(func(r runner.Component) {}),
@@ -48,10 +42,6 @@ func TestBundleDependencies(t *testing.T) {
 }
 
 func TestBundleOneShot(t *testing.T) {
-	// Don't enable any features, we haven't set up a container provider so the container check will crash
-	config.SetDetectedFeatures(config.FeatureMap{})
-	t.Cleanup(func() { config.SetDetectedFeatures(nil) })
-
 	runCmd := func(r runner.Component) {
 		checks := r.GetProvidedChecks()
 		require.Len(t, checks, 7)
@@ -79,7 +69,7 @@ func TestBundleOneShot(t *testing.T) {
 			mockCoreBundleParams,
 		),
 
-		disableContainerFeatures,
+		utils.DisableContainerFeatures,
 
 		Bundle,
 	)

--- a/comp/process/connectionscheck/check.go
+++ b/comp/process/connectionscheck/check.go
@@ -8,7 +8,7 @@ package connectionscheck
 import (
 	"go.uber.org/fx"
 
-	sysconfig "github.com/DataDog/datadog-agent/cmd/system-probe/config"
+	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig"
 	"github.com/DataDog/datadog-agent/comp/process/types"
 	"github.com/DataDog/datadog-agent/pkg/process/checks"
 )
@@ -22,7 +22,7 @@ type check struct {
 type dependencies struct {
 	fx.In
 
-	Sysconfig *sysconfig.Config
+	Sysconfig sysprobeconfig.Component
 }
 
 type result struct {
@@ -34,7 +34,7 @@ type result struct {
 
 func newCheck(deps dependencies) result {
 	c := &check{
-		connectionsCheck: checks.NewConnectionsCheck(deps.Sysconfig),
+		connectionsCheck: checks.NewConnectionsCheck(deps.Sysconfig.Object()),
 	}
 	return result{
 		Check: types.ProvidesCheck{

--- a/comp/process/hostinfo/component.go
+++ b/comp/process/hostinfo/component.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
 // Package hostinfo wraps the hostinfo inside a component. This is useful because it is relied on by other components.
 package hostinfo
 

--- a/comp/process/hostinfo/component.go
+++ b/comp/process/hostinfo/component.go
@@ -1,7 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2023-present Datadog, Inc.
+// Copyright 2016-present Datadog, Inc.
 
 // Package hostinfo wraps the hostinfo inside a component. This is useful because it is relied on by other components.
 package hostinfo

--- a/comp/process/hostinfo/component.go
+++ b/comp/process/hostinfo/component.go
@@ -8,6 +8,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
+// team: processes
+
 type Component interface {
 	Object() *checks.HostInfo
 }

--- a/comp/process/hostinfo/component.go
+++ b/comp/process/hostinfo/component.go
@@ -1,0 +1,17 @@
+// Package hostinfo wraps the hostinfo inside a component. This is useful because it is relied on by other components.
+package hostinfo
+
+import (
+	"go.uber.org/fx"
+
+	"github.com/DataDog/datadog-agent/pkg/process/checks"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+type Component interface {
+	Object() *checks.HostInfo
+}
+
+var Module = fxutil.Component(
+	fx.Provide(newHostInfo),
+)

--- a/comp/process/hostinfo/component.go
+++ b/comp/process/hostinfo/component.go
@@ -15,3 +15,7 @@ type Component interface {
 var Module = fxutil.Component(
 	fx.Provide(newHostInfo),
 )
+
+var MockModule = fxutil.Component(
+	fx.Provide(newMockHostInfo),
+)

--- a/comp/process/hostinfo/hostinfo.go
+++ b/comp/process/hostinfo/hostinfo.go
@@ -1,7 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2023-present Datadog, Inc.
+// Copyright 2016-present Datadog, Inc.
 
 package hostinfo
 

--- a/comp/process/hostinfo/hostinfo.go
+++ b/comp/process/hostinfo/hostinfo.go
@@ -6,6 +6,8 @@
 package hostinfo
 
 import (
+	"fmt"
+
 	"go.uber.org/fx"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
@@ -28,7 +30,7 @@ func newHostInfo(deps dependencies) (Component, error) {
 	hinfo, err := checks.CollectHostInfo()
 	if err != nil {
 		_ = deps.Logger.Critical("Error collecting host details:", err)
-		return nil, err
+		return nil, fmt.Errorf("error collecting host details: %v", err)
 	}
 	return &hostinfo{hostinfo: hinfo}, nil
 }

--- a/comp/process/hostinfo/hostinfo.go
+++ b/comp/process/hostinfo/hostinfo.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
 package hostinfo
 
 import (

--- a/comp/process/hostinfo/hostinfo.go
+++ b/comp/process/hostinfo/hostinfo.go
@@ -1,0 +1,33 @@
+package hostinfo
+
+import (
+	"go.uber.org/fx"
+
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/log"
+	"github.com/DataDog/datadog-agent/pkg/process/checks"
+)
+
+type dependencies struct {
+	fx.In
+
+	Config config.Component
+	Logger log.Component
+}
+
+type hostinfo struct {
+	hostinfo *checks.HostInfo
+}
+
+func newHostInfo(deps dependencies) (Component, error) {
+	hinfo, err := checks.CollectHostInfo()
+	if err != nil {
+		_ = deps.Logger.Critical("Error collecting host details:", err)
+		return nil, err
+	}
+	return &hostinfo{hostinfo: hinfo}, nil
+}
+
+func (h *hostinfo) Object() *checks.HostInfo {
+	return h.hostinfo
+}

--- a/comp/process/hostinfo/hostinfo.go
+++ b/comp/process/hostinfo/hostinfo.go
@@ -31,3 +31,7 @@ func newHostInfo(deps dependencies) (Component, error) {
 func (h *hostinfo) Object() *checks.HostInfo {
 	return h.hostinfo
 }
+
+func newMockHostInfo() Component {
+	return &hostinfo{hostinfo: &checks.HostInfo{}}
+}

--- a/comp/process/profiler/component.go
+++ b/comp/process/profiler/component.go
@@ -1,7 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2016-present Datadog, Inc.
+// Copyright 2023-present Datadog, Inc.
 
 // Package profiler implements a component to handle starting and stopping the internal profiler.
 package profiler

--- a/comp/process/profiler/component.go
+++ b/comp/process/profiler/component.go
@@ -1,0 +1,26 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package profiler implements a component to handle starting and stopping the internal profiler.
+package profiler
+
+import (
+	"go.uber.org/fx"
+
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+	"github.com/DataDog/datadog-agent/pkg/util/profiling"
+)
+
+// team: processes
+
+type Component interface {
+	Start(settings profiling.Settings) error
+	Stop()
+}
+
+// Module defines the fx options for this component.
+var Module = fxutil.Component(
+	fx.Provide(newProfiler),
+)

--- a/comp/process/profiler/component.go
+++ b/comp/process/profiler/component.go
@@ -1,7 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2023-present Datadog, Inc.
+// Copyright 2016-present Datadog, Inc.
 
 // Package profiler implements a component to handle starting and stopping the internal profiler.
 package profiler
@@ -10,14 +10,11 @@ import (
 	"go.uber.org/fx"
 
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
-	"github.com/DataDog/datadog-agent/pkg/util/profiling"
 )
 
 // team: processes
 
 type Component interface {
-	Start(settings profiling.Settings) error
-	Stop()
 }
 
 // Module defines the fx options for this component.

--- a/comp/process/profiler/profiler.go
+++ b/comp/process/profiler/profiler.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
 package profiler
 
 import (

--- a/comp/process/profiler/profiler.go
+++ b/comp/process/profiler/profiler.go
@@ -1,7 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2023-present Datadog, Inc.
+// Copyright 2016-present Datadog, Inc.
 
 package profiler
 
@@ -36,7 +36,7 @@ func newProfiler(deps dependencies) Component {
 	deps.Lc.Append(fx.Hook{
 		OnStart: func(context.Context) error {
 			if deps.Config.GetBool("process_config.internal_profiling.enabled") {
-				err := p.Start(settings)
+				err := profiling.Start(settings)
 				if err != nil {
 					_ = log.Warn("Failed to enable profiling:", err.Error())
 				} else {
@@ -49,19 +49,11 @@ func newProfiler(deps dependencies) Component {
 			return nil
 		},
 		OnStop: func(context.Context) error {
-			p.Stop()
+			profiling.Stop()
 			return nil
 		},
 	})
 	return p
-}
-
-func (*profiler) Start(settings profiling.Settings) error {
-	return profiling.Start(settings)
-}
-
-func (*profiler) Stop() {
-	profiling.Stop()
 }
 
 func getProfilingSettings(cfg config.Component) profiling.Settings {

--- a/comp/process/profiler/profiler.go
+++ b/comp/process/profiler/profiler.go
@@ -35,7 +35,7 @@ func newProfiler(deps dependencies) Component {
 	settings := getProfilingSettings(deps.Config)
 	deps.Lc.Append(fx.Hook{
 		OnStart: func(context.Context) error {
-			if deps.Config.GetBool("process_config.internal_profiling") {
+			if deps.Config.GetBool("process_config.internal_profiling.enabled") {
 				err := p.Start(settings)
 				if err != nil {
 					_ = log.Warn("Failed to enable profiling:", err.Error())

--- a/comp/process/profiler/profiler.go
+++ b/comp/process/profiler/profiler.go
@@ -1,0 +1,85 @@
+package profiler
+
+import (
+	"context"
+	"fmt"
+
+	"go.uber.org/fx"
+
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/util/profiling"
+	"github.com/DataDog/datadog-agent/pkg/version"
+)
+
+type dependencies struct {
+	fx.In
+	Lc fx.Lifecycle
+
+	Config config.Component
+}
+
+var _ Component = (*profiler)(nil)
+
+type profiler struct{}
+
+func newProfiler(deps dependencies) Component {
+	p := &profiler{}
+
+	settings := getProfilingSettings(deps.Config)
+	deps.Lc.Append(fx.Hook{
+		OnStart: func(context.Context) error {
+			if deps.Config.GetBool("process_config.internal_profiling") {
+				err := p.Start(settings)
+				if err != nil {
+					_ = log.Warn("Failed to enable profiling:", err.Error())
+				} else {
+					log.Info("Started process-agent profiler")
+				}
+			}
+
+			// Even if there is an error setting up the profiler, we don't want to block
+			// starting the process-agent.
+			return nil
+		},
+		OnStop: func(context.Context) error {
+			p.Stop()
+			return nil
+		},
+	})
+	return p
+}
+
+func (*profiler) Start(settings profiling.Settings) error {
+	return profiling.Start(settings)
+}
+
+func (*profiler) Stop() {
+	profiling.Stop()
+}
+
+func getProfilingSettings(cfg config.Component) profiling.Settings {
+	// allow full url override for development use
+	site := cfg.GetString("internal_profiling.profile_dd_url")
+	if site == "" {
+		s := cfg.GetString("site")
+		if s == "" {
+			s = ddconfig.DefaultSite
+		}
+		site = fmt.Sprintf(profiling.ProfilingURLTemplate, s)
+	}
+
+	v, _ := version.Agent()
+	return profiling.Settings{
+		ProfilingURL:         site,
+		Env:                  cfg.GetString("env"),
+		Service:              "process-agent",
+		Period:               cfg.GetDuration("internal_profiling.period"),
+		CPUDuration:          cfg.GetDuration("internal_profiling.cpu_duration"),
+		MutexProfileFraction: cfg.GetInt("internal_profiling.mutex_profile_fraction"),
+		BlockProfileRate:     cfg.GetInt("internal_profiling.block_profile_rate"),
+		WithGoroutineProfile: cfg.GetBool("internal_profiling.enable_goroutine_stacktraces"),
+		Tags:                 []string{fmt.Sprintf("version:%v", v)},
+	}
+}

--- a/comp/process/runner/component.go
+++ b/comp/process/runner/component.go
@@ -8,10 +8,13 @@ package runner
 
 import (
 	"context"
+	"testing"
 
 	"go.uber.org/fx"
 
+	configComp "github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/process/types"
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/process/checks"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
@@ -29,3 +32,11 @@ type Component interface {
 var Module = fxutil.Component(
 	fx.Provide(newRunner),
 )
+
+// DisableContainerFeaturesForTest is an fx option that disables all container features.
+// For some platforms, container features don't work, so in order to keep the tests from crashing we must disable container
+// features.
+var DisableContainerFeaturesForTest = fx.Invoke(func(t testing.TB, _ configComp.Component) {
+	config.SetDetectedFeatures(config.FeatureMap{})
+	t.Cleanup(func() { config.SetDetectedFeatures(nil) })
+})

--- a/comp/process/runner/component.go
+++ b/comp/process/runner/component.go
@@ -8,13 +8,10 @@ package runner
 
 import (
 	"context"
-	"testing"
 
 	"go.uber.org/fx"
 
-	configComp "github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/process/types"
-	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/process/checks"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
@@ -32,11 +29,3 @@ type Component interface {
 var Module = fxutil.Component(
 	fx.Provide(newRunner),
 )
-
-// DisableContainerFeaturesForTest is an fx option that disables all container features.
-// For some platforms, container features don't work, so in order to keep the tests from crashing we must disable container
-// features.
-var DisableContainerFeaturesForTest = fx.Invoke(func(t testing.TB, _ configComp.Component) {
-	config.SetDetectedFeatures(config.FeatureMap{})
-	t.Cleanup(func() { config.SetDetectedFeatures(nil) })
-})

--- a/comp/process/runner/runner.go
+++ b/comp/process/runner/runner.go
@@ -10,7 +10,7 @@ import (
 
 	"go.uber.org/fx"
 
-	sysconfig "github.com/DataDog/datadog-agent/cmd/system-probe/config"
+	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig"
 	"github.com/DataDog/datadog-agent/comp/process/submitter"
 	"github.com/DataDog/datadog-agent/comp/process/types"
 	"github.com/DataDog/datadog-agent/pkg/process/checks"
@@ -32,11 +32,11 @@ type dependencies struct {
 
 	Checks   []types.CheckComponent `group:"check"`
 	HostInfo *checks.HostInfo
-	SysCfg   *sysconfig.Config
+	SysCfg   sysprobeconfig.Component
 }
 
 func newRunner(deps dependencies) (Component, error) {
-	c, err := processRunner.NewRunner(deps.SysCfg, deps.HostInfo, filterEnabledChecks(deps.Checks), deps.RTNotifier)
+	c, err := processRunner.NewRunner(deps.SysCfg.Object(), deps.HostInfo, filterEnabledChecks(deps.Checks), deps.RTNotifier)
 	if err != nil {
 		return nil, err
 	}

--- a/comp/process/runner/runner.go
+++ b/comp/process/runner/runner.go
@@ -11,6 +11,7 @@ import (
 	"go.uber.org/fx"
 
 	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig"
+	"github.com/DataDog/datadog-agent/comp/process/hostinfo"
 	"github.com/DataDog/datadog-agent/comp/process/submitter"
 	"github.com/DataDog/datadog-agent/comp/process/types"
 	"github.com/DataDog/datadog-agent/pkg/process/checks"
@@ -31,12 +32,12 @@ type dependencies struct {
 	RTNotifier <-chan types.RTResponse `optional:"true"`
 
 	Checks   []types.CheckComponent `group:"check"`
-	HostInfo *checks.HostInfo
+	HostInfo hostinfo.Component
 	SysCfg   sysprobeconfig.Component
 }
 
 func newRunner(deps dependencies) (Component, error) {
-	c, err := processRunner.NewRunner(deps.SysCfg.Object(), deps.HostInfo, filterEnabledChecks(deps.Checks), deps.RTNotifier)
+	c, err := processRunner.NewRunner(deps.SysCfg.Object(), deps.HostInfo.Object(), filterEnabledChecks(deps.Checks), deps.RTNotifier)
 	if err != nil {
 		return nil, err
 	}

--- a/comp/process/runner/runner_test.go
+++ b/comp/process/runner/runner_test.go
@@ -13,6 +13,7 @@ import (
 	"go.uber.org/fx"
 
 	sysconfig "github.com/DataDog/datadog-agent/cmd/system-probe/config"
+	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/process/containercheck"
 	"github.com/DataDog/datadog-agent/comp/process/processcheck"
 	"github.com/DataDog/datadog-agent/comp/process/submitter"
@@ -59,6 +60,7 @@ func TestRunnerRealtime(t *testing.T) {
 			Module,
 			submitter.MockModule,
 			processcheck.Module,
+			core.Bundle,
 		), func(r Component) {
 			rtChan <- types.RTResponse{
 				{

--- a/comp/process/runner/runner_test.go
+++ b/comp/process/runner/runner_test.go
@@ -14,26 +14,20 @@ import (
 
 	sysconfig "github.com/DataDog/datadog-agent/cmd/system-probe/config"
 	"github.com/DataDog/datadog-agent/comp/core"
-	configComp "github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/process/containercheck"
 	"github.com/DataDog/datadog-agent/comp/process/hostinfo"
 	"github.com/DataDog/datadog-agent/comp/process/processcheck"
 	"github.com/DataDog/datadog-agent/comp/process/submitter"
 	"github.com/DataDog/datadog-agent/comp/process/types"
+	"github.com/DataDog/datadog-agent/comp/process/utils"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/process/checks"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
-// Don't enable any features, we haven't set up a container provider so the container check will crash
-var disableContainerFeatures = fx.Invoke(func(t testing.TB, _ configComp.Component) {
-	config.SetDetectedFeatures(config.FeatureMap{})
-	t.Cleanup(func() { config.SetDetectedFeatures(nil) })
-})
-
 func TestRunnerLifecycle(t *testing.T) {
 	fxutil.Test(t, fx.Options(
-		disableContainerFeatures,
+		utils.DisableContainerFeatures,
 
 		fx.Supply(core.BundleParams{}),
 
@@ -61,7 +55,7 @@ func TestRunnerRealtime(t *testing.T) {
 				func() <-chan types.RTResponse { return rtChan },
 			),
 
-			disableContainerFeatures,
+			utils.DisableContainerFeatures,
 
 			fx.Supply(core.BundleParams{}),
 
@@ -102,7 +96,7 @@ func TestRunnerRealtime(t *testing.T) {
 				func() <-chan types.RTResponse { return rtChan },
 			),
 
-			disableContainerFeatures,
+			utils.DisableContainerFeatures,
 
 			fx.Supply(core.BundleParams{}),
 

--- a/comp/process/runner/runner_test.go
+++ b/comp/process/runner/runner_test.go
@@ -15,6 +15,7 @@ import (
 	sysconfig "github.com/DataDog/datadog-agent/cmd/system-probe/config"
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/process/containercheck"
+	"github.com/DataDog/datadog-agent/comp/process/hostinfo"
 	"github.com/DataDog/datadog-agent/comp/process/processcheck"
 	"github.com/DataDog/datadog-agent/comp/process/submitter"
 	"github.com/DataDog/datadog-agent/comp/process/types"
@@ -25,14 +26,11 @@ import (
 
 func TestRunnerLifecycle(t *testing.T) {
 	fxutil.Test(t, fx.Options(
-		fx.Supply(
-			&checks.HostInfo{},
-			&sysconfig.Config{},
-		),
-
 		Module,
 		submitter.MockModule,
 		processcheck.Module,
+		hostinfo.Module,
+		core.MockBundle,
 	), func(runner Component) {
 		// Start and stop the component
 	})
@@ -46,11 +44,6 @@ func TestRunnerRealtime(t *testing.T) {
 		mockConfig.Set("process_config.disable_realtime_checks", false)
 
 		fxutil.Test(t, fx.Options(
-			fx.Supply(
-				&checks.HostInfo{},
-				&sysconfig.Config{},
-			),
-
 			fx.Provide(
 				// Cast `chan types.RTResponse` to `<-chan types.RTResponse`.
 				// We can't use `fx.As` because `<-chan types.RTResponse` is not an interface.
@@ -60,7 +53,8 @@ func TestRunnerRealtime(t *testing.T) {
 			Module,
 			submitter.MockModule,
 			processcheck.Module,
-			core.Bundle,
+			hostinfo.Module,
+			core.MockBundle,
 		), func(r Component) {
 			rtChan <- types.RTResponse{
 				{

--- a/comp/process/submitter/submitter.go
+++ b/comp/process/submitter/submitter.go
@@ -13,8 +13,8 @@ import (
 	"github.com/stretchr/testify/mock"
 	"go.uber.org/fx"
 
+	"github.com/DataDog/datadog-agent/comp/process/hostinfo"
 	"github.com/DataDog/datadog-agent/comp/process/types"
-	"github.com/DataDog/datadog-agent/pkg/process/checks"
 	processRunner "github.com/DataDog/datadog-agent/pkg/process/runner"
 	"github.com/DataDog/datadog-agent/pkg/process/runner/mocks"
 )
@@ -28,7 +28,7 @@ type dependencies struct {
 	fx.In
 	Lc fx.Lifecycle
 
-	HostInfo *checks.HostInfo
+	HostInfo hostinfo.Component
 }
 
 type result struct {
@@ -39,7 +39,7 @@ type result struct {
 }
 
 func newSubmitter(deps dependencies) (result, error) {
-	s, err := processRunner.NewSubmitter(deps.HostInfo.HostName)
+	s, err := processRunner.NewSubmitter(deps.HostInfo.Object().HostName)
 	if err != nil {
 		return result{}, err
 	}

--- a/comp/process/submitter/submitter_test.go
+++ b/comp/process/submitter/submitter_test.go
@@ -10,16 +10,15 @@ import (
 
 	"go.uber.org/fx"
 
-	"github.com/DataDog/datadog-agent/pkg/process/checks"
+	"github.com/DataDog/datadog-agent/comp/core"
+	"github.com/DataDog/datadog-agent/comp/process/hostinfo"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
 func TestSubmitterLifecycle(t *testing.T) {
 	fxutil.Test(t, fx.Options(
-		fx.Supply(
-			&checks.HostInfo{},
-		),
-
+		hostinfo.MockModule,
+		core.MockBundle,
 		Module,
 	), func(runner Component) {
 		// Start and stop the component

--- a/comp/process/utils/testing_utils.go
+++ b/comp/process/utils/testing_utils.go
@@ -1,0 +1,22 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package utils
+
+import (
+	"testing"
+
+	"go.uber.org/fx"
+
+	configComp "github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/pkg/config"
+)
+
+// DisableContainerFeatures initializes the config with an empty feature map. This prevents the container check from running
+// in tests.
+var DisableContainerFeatures = fx.Invoke(func(t testing.TB, _ configComp.Component) {
+	config.SetDetectedFeatures(config.FeatureMap{})
+	t.Cleanup(func() { config.SetDetectedFeatures(nil) })
+})


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR changes the process agent to utilize the core config and sysconfig components to initialize configs instead of manually loading it.

Additionally, since many services (such as the remote tagger, api server, workloadmeta, etc.) don't have associated components, but do rely on the config component being initalized, they have been moved to a single function `initMisc` which is invoked before startup.

Finally, this PR also adds a component for the internal profiler.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Migration to components

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

- [x] Make sure that the internal profiler is still able to be toggled on/off with `process_config.internal_profiling`
- [x] Make sure that you are able to configure the internal profiler dynamically using `process-agent  config set internal_profiling true/false`
- [x] Confirm that status still works using `process-agent status` while having a running process-agent in the background.
- [x] Make sure that no miscellaneous non-fx managed components fail to start. i.e. there are no warning or critical errors in the logs.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
