### PR TITLE
Add a checkbox to launch the tray in the NG installer

### DIFF
--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentBinaries.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentBinaries.cs
@@ -1,3 +1,5 @@
+using WixSharp;
+
 namespace WixSetup.Datadog
 {
     public class AgentBinaries
@@ -5,6 +7,7 @@ namespace WixSetup.Datadog
         private readonly string _binSource;
         public string Agent => $@"{_binSource}\agent\agent.exe";
         public string Tray => $@"{_binSource}\agent\ddtray.exe";
+        public Id TrayId => new ("ddtray");
         public string ProcessAgent => $@"{_binSource}\agent\process-agent.exe";
         public string SystemProbe => $@"{_binSource}\agent\system-probe.exe";
         public string TraceAgent => $@"{_binSource}\agent\trace-agent.exe";

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentInstaller.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentInstaller.cs
@@ -84,6 +84,12 @@ namespace WixSetup.Datadog
                 {
                     AttributesDefinition = "Secure=yes",
                 },
+                // Add a checkbox at the end of the setup to launch the Datadog Agent Manager
+                new LaunchCustomApplicationFromExitDialog(
+                    _agentBinaries.TrayId,
+                    "!(loc.LaunchAgentManager)",
+                    "AGENT",
+                    "\"[AGENT]ddtray.exe\" \"--launch-gui\""),
                 new CloseApplication(new Id("CloseTrayApp"),
                     Path.GetFileName(_agentBinaries.Tray),
                     closeMessage: true,
@@ -208,13 +214,14 @@ namespace WixSetup.Datadog
                 document
                     .Select("Wix/Product/InstallExecuteSequence")
                     .AddElement("DeleteServices", value: "(Installed AND (REMOVE=\"ALL\") AND NOT (WIX_UPGRADE_DETECTED OR UPGRADINGPRODUCTCODE))");
+
+                // We don't use the Wix "Merge" MSM feature because it seems to be a no-op...
                 document
                     .FindAll("Directory")
                     .First(x => x.HasAttribute("Id", value => value == "AGENT"))
                     .AddElement("Directory", "Id=DRIVER; Name=driver")
                     .AddElement("Merge",
                         $"Id=ddnpminstall; SourceFile={BinSource}\\agent\\DDNPM.msm; DiskId=1; Language=1033");
-                // We don't use the Wix "Merge" MSM feature because it seems to be a no-op...
                 document
                     .FindAll("Feature")
                     .First(x => x.HasAttribute("Id", value => value == "NPM"))
@@ -398,7 +405,7 @@ namespace WixSetup.Datadog
                     new Dir("dist",
                         new Files($@"{InstallerSource}\bin\agent\dist\*")
                     ),
-                    new WixSharp.File(_agentBinaries.Tray),
+                    new WixSharp.File(_agentBinaries.TrayId, _agentBinaries.Tray),
                     new WixSharp.File(_agentBinaries.ProcessAgent, processAgentService),
                     new EventSource
                     {

--- a/tools/windows/DatadogAgentInstaller/WixSetup/LaunchCustomApplicationFromExitDialog.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/LaunchCustomApplicationFromExitDialog.cs
@@ -1,0 +1,42 @@
+using System.Linq;
+using WixSharp;
+
+namespace WixSetup;
+
+public class LaunchCustomApplicationFromExitDialog : WixEntity, IGenericEntity
+{
+    private readonly LaunchApplicationFromExitDialog _launchApplicationFromExitDialog;
+
+    /// <summary>
+    /// CheckBox text. <br />
+    /// Default value is <value>"Launch"</value>.
+    /// </summary>
+    public string Description
+    {
+        get => _launchApplicationFromExitDialog.Description;
+        set => _launchApplicationFromExitDialog.Description = value;
+    }
+
+    /// <summary>Exe ID.</summary>
+    public string ExeId => _launchApplicationFromExitDialog.ExeId;
+
+    public string ExeCommand { get; }
+    public string Directory { get; }
+
+    public LaunchCustomApplicationFromExitDialog(string exeId, string description, string directory, string exeCommand)
+    {
+        _launchApplicationFromExitDialog = new LaunchApplicationFromExitDialog(exeId, description);
+        ExeCommand = exeCommand;
+        Directory = directory;
+    }
+
+    public void Process(ProcessingContext context)
+    {
+        _launchApplicationFromExitDialog.Process(context);
+        var customAction = context.XParent
+            .FindAll("CustomAction")
+            .First(x => x.HasAttribute("Id", value => value == "LaunchApplication"));
+        customAction.RemoveAttributes();
+        customAction.SetAttributes($"Id=LaunchApplication;Directory={Directory};Execute=immediate;Return=asyncNoWait;ExeCommand={ExeCommand}");
+    }
+}

--- a/tools/windows/DatadogAgentInstaller/WixSetup/LaunchCustomApplicationFromExitDialog.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/LaunchCustomApplicationFromExitDialog.cs
@@ -1,42 +1,43 @@
 using System.Linq;
 using WixSharp;
 
-namespace WixSetup;
-
-public class LaunchCustomApplicationFromExitDialog : WixEntity, IGenericEntity
+namespace WixSetup
 {
-    private readonly LaunchApplicationFromExitDialog _launchApplicationFromExitDialog;
-
-    /// <summary>
-    /// CheckBox text. <br />
-    /// Default value is <value>"Launch"</value>.
-    /// </summary>
-    public string Description
+    public class LaunchCustomApplicationFromExitDialog : WixEntity, IGenericEntity
     {
-        get => _launchApplicationFromExitDialog.Description;
-        set => _launchApplicationFromExitDialog.Description = value;
-    }
+        private readonly LaunchApplicationFromExitDialog _launchApplicationFromExitDialog;
 
-    /// <summary>Exe ID.</summary>
-    public string ExeId => _launchApplicationFromExitDialog.ExeId;
+        /// <summary>
+        /// CheckBox text. <br />
+        /// Default value is <value>"Launch"</value>.
+        /// </summary>
+        public string Description
+        {
+            get => _launchApplicationFromExitDialog.Description;
+            set => _launchApplicationFromExitDialog.Description = value;
+        }
 
-    public string ExeCommand { get; }
-    public string Directory { get; }
+        /// <summary>Exe ID.</summary>
+        public string ExeId => _launchApplicationFromExitDialog.ExeId;
 
-    public LaunchCustomApplicationFromExitDialog(string exeId, string description, string directory, string exeCommand)
-    {
-        _launchApplicationFromExitDialog = new LaunchApplicationFromExitDialog(exeId, description);
-        ExeCommand = exeCommand;
-        Directory = directory;
-    }
+        public string ExeCommand { get; }
+        public string Directory { get; }
 
-    public void Process(ProcessingContext context)
-    {
-        _launchApplicationFromExitDialog.Process(context);
-        var customAction = context.XParent
-            .FindAll("CustomAction")
-            .First(x => x.HasAttribute("Id", value => value == "LaunchApplication"));
-        customAction.RemoveAttributes();
-        customAction.SetAttributes($"Id=LaunchApplication;Directory={Directory};Execute=immediate;Return=asyncNoWait;ExeCommand={ExeCommand}");
+        public LaunchCustomApplicationFromExitDialog(string exeId, string description, string directory, string exeCommand)
+        {
+            _launchApplicationFromExitDialog = new LaunchApplicationFromExitDialog(exeId, description);
+            ExeCommand = exeCommand;
+            Directory = directory;
+        }
+
+        public void Process(ProcessingContext context)
+        {
+            _launchApplicationFromExitDialog.Process(context);
+            var customAction = context.XParent
+                .FindAll("CustomAction")
+                .First(x => x.HasAttribute("Id", value => value == "LaunchApplication"));
+            customAction.RemoveAttributes();
+            customAction.SetAttributes($"Id=LaunchApplication;Directory={Directory};Execute=immediate;Return=asyncNoWait;ExeCommand={ExeCommand}");
+        }
     }
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
This PR adds a checkbox at the end of a successful NG installation to launch the Datadog Agent Manager.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Easily launch the Datadog Agent Manager from the installation.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
Run the installer with the UI to completion, check that there is a checkbox at the end which says "Launch Datadog Agent Manager".
If the checkbox is checked, make sure that when pressing "Finish" it launches the Datadog Agent Manager.
If the checkbox is not checked, it should not launch it.

Run the installer in quiet mode, it should succeed (no errors related to the Datadog Agent Manager).

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
