### PR TITLE
[process-agent] Fix `ServiceExtractor` using the wrong config

### DIFF
--- a/pkg/process/checks/net_test.go
+++ b/pkg/process/checks/net_test.go
@@ -613,7 +613,7 @@ func TestNetworkConnectionTagsWithService(t *testing.T) {
 			Cmdline: []string{"./my-server.sh"},
 		},
 	}
-	mockConfig := ddconfig.Mock(t)
+	mockConfig := ddconfig.MockSystemProbe(t)
 	mockConfig.Set("service_monitoring_config.process_service_inference.enabled", true)
 
 	maxConnsPerMessage := 1

--- a/pkg/process/metadata/parser/service.go
+++ b/pkg/process/metadata/parser/service.go
@@ -63,8 +63,8 @@ type WindowsServiceInfo struct {
 // NewServiceExtractor instantiates a new service discovery extractor
 func NewServiceExtractor() *ServiceExtractor {
 	var (
-		enabled               = ddconfig.Datadog.GetBool("service_monitoring_config.process_service_inference.enabled")
-		useWindowsServiceName = ddconfig.Datadog.GetBool("service_monitoring_config.process_service_inference.use_windows_service_name")
+		enabled               = ddconfig.SystemProbe.GetBool("service_monitoring_config.process_service_inference.enabled")
+		useWindowsServiceName = ddconfig.SystemProbe.GetBool("service_monitoring_config.process_service_inference.use_windows_service_name")
 	)
 	return &ServiceExtractor{
 		enabled:               enabled,

--- a/pkg/process/metadata/parser/service_test.go
+++ b/pkg/process/metadata/parser/service_test.go
@@ -121,7 +121,7 @@ func TestExtractServiceMetadata(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mockConfig := ddconfig.Mock(t)
+			mockConfig := ddconfig.MockSystemProbe(t)
 			mockConfig.Set("service_monitoring_config.process_service_inference.enabled", true)
 			mockConfig.Set("service_monitoring_config.process_service_inference.use_windows_service_name", true)
 

--- a/pkg/process/metadata/parser/service_windows_test.go
+++ b/pkg/process/metadata/parser/service_windows_test.go
@@ -57,7 +57,7 @@ func TestWindowsExtractServiceMetadata(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mockConfig := ddconfig.Mock(t)
+			mockConfig := ddconfig.MockSystemProbe(t)
 			mockConfig.Set("service_monitoring_config.process_service_inference.enabled", true)
 
 			proc := procutil.Process{
@@ -87,7 +87,7 @@ func TestWindowsExtractServiceWithSCMReader(t *testing.T) {
 	}
 
 	t.Run("disabled", func(t *testing.T) {
-		cfg := ddconfig.Mock(t)
+		cfg := ddconfig.MockSystemProbe(t)
 		cfg.Set("service_monitoring_config.process_service_inference.enabled", true)
 		cfg.Set("service_monitoring_config.process_service_inference.use_windows_service_name", false)
 
@@ -99,7 +99,7 @@ func TestWindowsExtractServiceWithSCMReader(t *testing.T) {
 	})
 
 	t.Run("enabled", func(t *testing.T) {
-		cfg := ddconfig.Mock(t)
+		cfg := ddconfig.MockSystemProbe(t)
 		cfg.Set("service_monitoring_config.process_service_inference.use_windows_service_name", true)
 		cfg.Set("service_monitoring_config.process_service_inference.enabled", true)
 
@@ -113,7 +113,7 @@ func TestWindowsExtractServiceWithSCMReader(t *testing.T) {
 	})
 
 	t.Run("enabled, multiple results", func(t *testing.T) {
-		cfg := ddconfig.Mock(t)
+		cfg := ddconfig.MockSystemProbe(t)
 		cfg.Set("service_monitoring_config.process_service_inference.use_windows_service_name", true)
 		cfg.Set("service_monitoring_config.process_service_inference.enabled", true)
 
@@ -127,7 +127,7 @@ func TestWindowsExtractServiceWithSCMReader(t *testing.T) {
 	})
 
 	t.Run("fallback_to_parsing", func(t *testing.T) {
-		cfg := ddconfig.Mock(t)
+		cfg := ddconfig.MockSystemProbe(t)
 		cfg.Set("service_monitoring_config.process_service_inference.use_windows_service_name", true)
 		cfg.Set("service_monitoring_config.process_service_inference.enabled", true)
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR fixes the `ServiceExtractor` using the wrong config as a result of the core config and sysprobe config separation introduced in https://github.com/DataDog/datadog-agent/pull/14024.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Fix https://github.com/DataDog/datadog-agent/pull/15615

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

On a windows machine, use this config in the `system_probe.yaml`:
```yaml
service_monitoring_config:
  enabled: true
  process_service_inference:
    enabled: true
```
**Make sure it is not set in the `datadog.yaml` config file**. Then, repeat the testing instructions for https://github.com/DataDog/datadog-agent/pull/15615 to make sure that the the `ServiceExtractor` is reading feature flags from the `system_probe.yaml` and not the `datadog.yaml`. One service tag is enough - we just want to test that the `ServiceExtractor` is being enabled.


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
