### PR TITLE
validate orchestration config

### DIFF
--- a/pkg/collector/corechecks/cluster/orchestrator/collector_bundle.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collector_bundle.go
@@ -38,7 +38,7 @@ type CollectorBundle struct {
 	stopCh              chan struct{}
 	runCfg              *collectors.CollectorRunConfig
 	manifestBuffer      *ManifestBuffer
-	crdDiscovery        *discovery.DiscoveryCollector
+	collectorDiscovery  *discovery.DiscoveryCollector
 	activatedCollectors map[string]struct{}
 }
 
@@ -65,7 +65,7 @@ func NewCollectorBundle(chk *OrchestratorCheck) *CollectorBundle {
 		},
 		stopCh:              make(chan struct{}),
 		manifestBuffer:      NewManifestBuffer(chk),
-		crdDiscovery:        discovery.NewDiscoveryCollectorForInventory(),
+		collectorDiscovery:  discovery.NewDiscoveryCollectorForInventory(),
 		activatedCollectors: map[string]struct{}{},
 	}
 
@@ -144,13 +144,13 @@ func (cb *CollectorBundle) addCollectorFromConfig(collectorName string, isCRD bo
 
 			return
 		}
-		collector, err = cb.crdDiscovery.VerifyForInventory(resource, groupVersion)
+		collector, err = cb.collectorDiscovery.VerifyForCRDInventory(resource, groupVersion)
 	} else if idx := strings.LastIndex(collectorName, "/"); idx != -1 {
 		groupVersion := collectorName[:idx]
 		name := collectorName[idx+1:]
-		collector, err = cb.inventory.CollectorForVersion(name, groupVersion)
+		collector, err = cb.collectorDiscovery.VerifyForInventory(name, groupVersion, cb.inventory)
 	} else {
-		collector, err = cb.inventory.CollectorForDefaultVersion(collectorName)
+		collector, err = cb.collectorDiscovery.VerifyForInventory(collectorName, "", cb.inventory)
 	}
 
 	if err != nil {

--- a/pkg/collector/corechecks/cluster/orchestrator/discovery/collector_discovery_crd.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/discovery/collector_discovery_crd.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/collectors"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/collectors/inventory"
 	k8sCollectors "github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -33,29 +34,22 @@ type DiscoveryCollector struct {
 }
 
 func NewDiscoveryCollectorForInventory() *DiscoveryCollector {
-	return &DiscoveryCollector{
+	dc := &DiscoveryCollector{
 		cache: discoveryCache{collectorForVersion: map[collectorVersion]struct{}{}},
 	}
+	dc.fillCache()
+	return dc
 }
-
-func (d *DiscoveryCollector) VerifyForInventory(resource string, groupVersion string) (collectors.Collector, error) {
-	collector, err := d.DiscoverCRDResource(resource, groupVersion)
-	if err != nil {
-		return nil, err
-	}
-	return collector, nil
-}
-
-func (d *DiscoveryCollector) DiscoverCRDResource(resource string, groupVersion string) (*k8sCollectors.CRCollector, error) {
+func (d *DiscoveryCollector) fillCache() error {
 	if !d.cache.filled {
 		var err error
 		d.cache.groups, d.cache.resources, err = GetServerGroupsAndResources()
 		if err != nil {
-			return nil, err
+			return err
 		}
 
 		if len(d.cache.resources) == 0 {
-			return nil, fmt.Errorf("failed to discover resources from API groups")
+			return fmt.Errorf("failed to discover resources from API groups")
 		}
 		for _, list := range d.cache.resources {
 			for _, resource := range list.APIResources {
@@ -68,16 +62,56 @@ func (d *DiscoveryCollector) DiscoverCRDResource(resource string, groupVersion s
 		}
 		d.cache.filled = true
 	}
+	return nil
+}
 
+func (d *DiscoveryCollector) VerifyForCRDInventory(resource string, groupVersion string) (collectors.Collector, error) {
+	collector, err := d.DiscoverCRDResource(resource, groupVersion)
+	if err != nil {
+		return nil, err
+	}
+	return collector, nil
+}
+
+func (d *DiscoveryCollector) VerifyForInventory(resource string, groupVersion string, collectorInventory *inventory.CollectorInventory) (collectors.Collector, error) {
+	collector, err := d.DiscoverRegularResource(resource, groupVersion, collectorInventory)
+	if err != nil {
+		return nil, err
+	}
+	return collector, nil
+}
+
+func (d *DiscoveryCollector) DiscoverCRDResource(resource string, groupVersion string) (collectors.Collector, error) {
 	collector, err := k8sCollectors.NewCRCollectorVersion(resource, groupVersion)
 	if err != nil {
 		return nil, err
 	}
+
+	return d.isSupportCollector(collector)
+}
+
+func (d *DiscoveryCollector) DiscoverRegularResource(resource string, groupVersion string, collectorInventory *inventory.CollectorInventory) (collectors.Collector, error) {
+	var collector collectors.Collector
+	var err error
+
+	if groupVersion == "" {
+		collector, err = collectorInventory.CollectorForDefaultVersion(resource)
+	} else {
+		collector, err = collectorInventory.CollectorForVersion(resource, groupVersion)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return d.isSupportCollector(collector)
+}
+
+func (d *DiscoveryCollector) isSupportCollector(collector collectors.Collector) (collectors.Collector, error) {
 	if _, ok := d.cache.collectorForVersion[collectorVersion{
 		version: collector.Metadata().Version,
 		name:    collector.Metadata().Name,
 	}]; ok {
 		return collector, nil
 	}
-	return nil, fmt.Errorf("failed to discover resource %s", resource)
+	return nil, fmt.Errorf("failed to discover resource %s", collector.Metadata().Name)
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/discovery/collector_discovery_crd.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/discovery/collector_discovery_crd.go
@@ -14,6 +14,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/collectors"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/collectors/inventory"
 	k8sCollectors "github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -37,7 +38,10 @@ func NewDiscoveryCollectorForInventory() *DiscoveryCollector {
 	dc := &DiscoveryCollector{
 		cache: discoveryCache{collectorForVersion: map[collectorVersion]struct{}{}},
 	}
-	dc.fillCache()
+	err := dc.fillCache()
+	if err != nil {
+		log.Error("Fail to init discovery collector", err)
+	}
 	return dc
 }
 func (d *DiscoveryCollector) fillCache() error {

--- a/releasenotes-dca/notes/validate-config-b6bd131de42c023e.yaml
+++ b/releasenotes-dca/notes/validate-config-b6bd131de42c023e.yaml
@@ -1,4 +1,4 @@
 ---
 enhancements:
   - |
-    validate the orchestration config provided by user
+    Validate the orchestration config provided by the user.

--- a/releasenotes-dca/notes/validate-config-b6bd131de42c023e.yaml
+++ b/releasenotes-dca/notes/validate-config-b6bd131de42c023e.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    validate the orchestration config provided by user


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
Validate the orchestration config provided by user
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

A deployment in one of our internal clusters led to cluster workers entering CLB because a collector was activated while the resource type was not available in that cluster.
When a resource is not available in a cluster, the informer initial synchronization call blocks until the context timeout is hit which leads to CLB because the liveness probe fails due to the configpoller being blocked as well.


<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
For example, run cluster agent on a cluster not supporting verticalpodautoscalers, then you should be able to see warning 
```
Unsupported collector: verticalpodautoscalers
```

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
