### PR TITLE
[workloadmeta] Fix race condition when accessing entity from store

### DIFF
--- a/pkg/workloadmeta/store.go
+++ b/pkg/workloadmeta/store.go
@@ -602,13 +602,13 @@ func (s *store) handleEvents(evs []CollectorEvent) {
 }
 
 func (s *store) getEntityByKind(kind Kind, id string) (Entity, error) {
+	s.storeMut.RLock()
+	defer s.storeMut.RUnlock()
+
 	entitiesOfKind, ok := s.store[kind]
 	if !ok {
 		return nil, errors.NewNotFound(string(kind))
 	}
-
-	s.storeMut.RLock()
-	defer s.storeMut.RUnlock()
 
 	entity, ok := entitiesOfKind[id]
 	if !ok {

--- a/pkg/workloadmeta/store_test.go
+++ b/pkg/workloadmeta/store_test.go
@@ -967,6 +967,32 @@ func TestReset(t *testing.T) {
 	}
 }
 
+func TestNoDataRace(t *testing.T) {
+	// This test ensures that no race conditions are encountered when the "--race" flag is passed
+	// to the test process and an entity is accessed in a different thread than the one handling events
+	s := newTestStore()
+
+	container := &Container{
+		EntityID: EntityID{
+			Kind: KindContainer,
+			ID:   "123",
+		},
+	}
+
+	go func() {
+		_, _ = s.GetContainer("456")
+		return
+	}()
+
+	s.handleEvents([]CollectorEvent{
+		{
+			Type:   EventTypeSet,
+			Source: fooSource,
+			Entity: container,
+		},
+	})
+}
+
 func newTestStore() *store {
 	return &store{
 		store:   make(map[Kind]map[string]*cachedEntity),

--- a/pkg/workloadmeta/testing/store.go
+++ b/pkg/workloadmeta/testing/store.go
@@ -185,13 +185,13 @@ func (s *Store) Reset(newEntities []workloadmeta.Entity, source workloadmeta.Sou
 }
 
 func (s *Store) getEntityByKind(kind workloadmeta.Kind, id string) (workloadmeta.Entity, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
 	entitiesOfKind, ok := s.store[kind]
 	if !ok {
 		return nil, errors.NewNotFound(id)
 	}
-
-	s.mu.RLock()
-	defer s.mu.RUnlock()
 
 	entity, ok := entitiesOfKind[id]
 	if !ok {


### PR DESCRIPTION
### What does this PR do?

Fixes a race condition that could occur when accessing an entity from a workloadmeta store in multiple threads

### Motivation

This bug was discovered due to a failing integration test [here](https://github.com/DataDog/datadog-agent/pull/16068) which exposed the issue

### Additional Notes

- This change adds a basic unit test which is able to simulate the behavior when it is run with the `--race` flag, which our linux unit test are currently run using (credit to @davidor)

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
