### PR TITLE
system-probe kitchen: Homogenize os.platform tag

### DIFF
--- a/test/kitchen/test/integration/system-probe-test/rspec_datadog/system-probe-test_spec.rb
+++ b/test/kitchen/test/integration/system-probe-test/rspec_datadog/system-probe-test_spec.rb
@@ -57,7 +57,8 @@ print KernelOut.format(`uname -a`)
 arch = `uname -m`.strip
 release = `uname -r`.strip
 osr = Hash[*CSV.read("/etc/os-release", col_sep: "=").flatten(1)]
-platform = "#{osr["ID"]}-#{osr["VERSION_ID"]}"
+platform = Gem::Platform.local.os
+osname = "#{osr["ID"]}-#{osr["VERSION_ID"]}"
 
 ##
 ## The main chef recipe (test\kitchen\site-cookbooks\dd-system-probe-check\recipes\default.rb)
@@ -111,6 +112,7 @@ shared_examples "passes" do |bundle, env, filter, filter_inclusive|
         REXML::XPath.each(xmldoc, "//testsuites/testsuite/properties") do |props|
           props.add_element("property", { "name" => "dd_tags[test.bundle]", "value" => bundle })
           props.add_element("property", { "name" => "dd_tags[os.platform]", "value" => platform })
+          props.add_element("property", { "name" => "dd_tags[os.name]", "value" => osname })
           props.add_element("property", { "name" => "dd_tags[os.architecture]", "value" => arch })
           props.add_element("property", { "name" => "dd_tags[os.version]", "value" => release })
         end


### PR DESCRIPTION
### What does this PR do?

Changes the `os.platform` tag in the JuniXML file that is generated from the system-probe kitchen tests and then uploaded to Datadog's CI Visibility. 

This tag usually stores the OS family instead of the specific distro name, this PR follows that and makes it become just "linux".

To not lose info, I'm creating a `os.name` tag with the contents of the old `os.platform` tag.

### Additional Notes

If this breaks dashboards/monitors that you don't want to break, feel free to close the PR. While it would be nice to homogenize this tag across all tests, it's not critical.
