### PR TITLE
Corrects internal_profiling.profile_dd_url config registration

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -824,7 +824,7 @@ func InitConfig(config Config) {
 
 	// internal profiling
 	config.BindEnvAndSetDefault("internal_profiling.enabled", false)
-	config.BindEnv("internal_profiling.profile_dd_url", "")
+	config.BindEnv("internal_profiling.profile_dd_url")
 	config.BindEnvAndSetDefault("internal_profiling.period", 5*time.Minute)
 	config.BindEnvAndSetDefault("internal_profiling.cpu_duration", 1*time.Minute)
 	config.BindEnvAndSetDefault("internal_profiling.block_profile_rate", 0)


### PR DESCRIPTION
### What does this PR do?
Fixes the way the config option `internal_profiling.profile_dd_url` is registered with configuration.

This config option (intentionally) does not set a default value, therefore the second argument to `BindEnv` was being treated as the name of the chose environment variable for this config option. In effect, the env var for this config option was `""` (the empty string).

This makes it impossible to set this config option via environment variable.

### Motivation
Was getting error when trying to set this config option via env var: 
```
2023-03-13 18:31:13 EDT | CORE | WARN | (pkg/util/log/log.go:618 in func1) | Unknown environment variable: DD_INTERNAL_PROFILING_PROFILE_DD_URL
```

### Additional Notes


### Possible Drawbacks / Trade-offs



### Describe how to test/QA your changes
N/A

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
