### PR TITLE
Fix the GUI metadata section where all data is displayed on a single line

### DIFF
--- a/cmd/agent/gui/views/templates/generalStatus.tmpl
+++ b/cmd/agent/gui/views/templates/generalStatus.tmpl
@@ -97,7 +97,7 @@
     <span class="stat_title">Metadata</span>
     <span class="stat_data">
     {{- range $key, $value := .agent_metadata }}
-      {{ $key }}: {{ $value }}
+      {{ $key }}: {{ $value }}<br>
     {{- end }}
     </span>
   </div>


### PR DESCRIPTION
### What does this PR do?

Line break were missing in the GUI for the metadata section.

Before:
![image](https://user-images.githubusercontent.com/311563/224970110-1e5c5701-0392-4561-9464-323bea9adc95.png)

After:
![image](https://user-images.githubusercontent.com/311563/224970460-8e535de1-8f58-4a93-850b-d25c94a51b46.png)


### Describe how to test/QA your changes

Run the Agent on Windows, go the the status page of the GUI and check that the `metadata` section is readable.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
