### PR TITLE
pkg/clusteragent/admission: allow injecting all libs

### DIFF
--- a/pkg/clusteragent/admission/mutate/auto_instrumentation_test.go
+++ b/pkg/clusteragent/admission/mutate/auto_instrumentation_test.go
@@ -548,3 +548,51 @@ func TestInjectLibInitContainer(t *testing.T) {
 		})
 	}
 }
+
+func TestInjectAll(t *testing.T) {
+	wantAll := []libInfo{
+		{lang: java, image: "gcr.io/datadoghq/dd-lib-java-init:latest"},
+		{lang: js, image: "gcr.io/datadoghq/dd-lib-js-init:latest"},
+		{lang: python, image: "gcr.io/datadoghq/dd-lib-python-init:latest"},
+		{lang: dotnet, image: "gcr.io/datadoghq/dd-lib-dotnet-init:latest"},
+		{lang: ruby, image: "gcr.io/datadoghq/dd-lib-ruby-init:latest"},
+	}
+	tests := []struct {
+		name             string
+		ns               string
+		targetNamespaces []string
+		want             []libInfo
+	}{
+		{
+			name:             "nominal",
+			ns:               "targeted",
+			targetNamespaces: []string{"targeted"},
+			want:             wantAll,
+		},
+		{
+			name:             "many",
+			ns:               "targeted",
+			targetNamespaces: []string{"targeted", "foo", "bar"},
+			want:             wantAll,
+		},
+		{
+			name:             "no match",
+			ns:               "not-targeted",
+			targetNamespaces: []string{"foo", "bar"},
+			want:             []libInfo{},
+		},
+		{
+			name:             "empty target",
+			ns:               "targeted",
+			targetNamespaces: []string{},
+			want:             []libInfo{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			targetNamespaces = tt.targetNamespaces
+			got := injectAll(tt.ns, "gcr.io/datadoghq")
+			require.EqualValues(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1035,6 +1035,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("admission_controller.auto_instrumentation.patcher.file_provider_path", "/etc/datadog-agent/patch/auto-instru.json") // to be used only in e2e tests
 	config.BindEnv("admission_controller.auto_instrumentation.init_resources.cpu")
 	config.BindEnv("admission_controller.auto_instrumentation.init_resources.memory")
+	config.BindEnvAndSetDefault("admission_controller.auto_instrumentation.inject_all.namespaces", []string{})
 
 	// Telemetry
 	// Enable telemetry metrics on the internals of the Agent.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Add the option to inject all libraries into all pods in given namespaces

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Easier instrumentation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

- This will be in beta. The new config parameter is not documented on purpose, as the naming might be changed before GA.
- We will eventually support regex in namespace names.

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Set `DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_INJECT_ALL_NAMESPACES` to space separated list of namespaces, add the label `admission.datadoghq.com/enabled: "true"` on your target pod or enable `mutateUnlabelled` in the admission controller. Ensure the five supported languages get injected.

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
