### PR TITLE
pkg/clusteragent/admission: configure init resources

### DIFF
--- a/pkg/clusteragent/admission/mutate/auto_instrumentation.go
+++ b/pkg/clusteragent/admission/mutate/auto_instrumentation.go
@@ -21,6 +21,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/client-go/dynamic"
 )
 
@@ -251,11 +252,17 @@ func injectAutoInstruConfig(pod *corev1.Pod, libsToInject []libInfo) error {
 	}
 
 	for lang, image := range initContainerToInject {
-		injectLibInitContainer(pod, image, lang)
-		err := injectLibConfig(pod, lang)
+		err := injectLibInitContainer(pod, image, lang)
 		if err != nil {
 			metrics.LibInjectionErrors.Inc(string(lang))
 			lastError = err
+			log.Errorf("Cannot inject init container into pod %s: %s", podString(pod), err)
+		}
+		err = injectLibConfig(pod, lang)
+		if err != nil {
+			metrics.LibInjectionErrors.Inc(string(lang))
+			lastError = err
+			log.Errorf("Cannot inject library configuration into pod %s: %s", podString(pod), err)
 		}
 	}
 
@@ -264,22 +271,67 @@ func injectAutoInstruConfig(pod *corev1.Pod, libsToInject []libInfo) error {
 	return lastError
 }
 
-func injectLibInitContainer(pod *corev1.Pod, image string, lang language) {
+func injectLibInitContainer(pod *corev1.Pod, image string, lang language) error {
 	initCtrName := initContainerName(lang)
 	log.Debugf("Injecting init container named %q with image %q into pod %s", initCtrName, image, podString(pod))
-	pod.Spec.InitContainers = append([]corev1.Container{
-		{
-			Name:    initCtrName,
-			Image:   image,
-			Command: []string{"sh", "copy-lib.sh", mountPath},
-			VolumeMounts: []corev1.VolumeMount{
-				{
-					Name:      volumeName,
-					MountPath: mountPath,
-				},
+	initContainer := corev1.Container{
+		Name:    initCtrName,
+		Image:   image,
+		Command: []string{"sh", "copy-lib.sh", mountPath},
+		VolumeMounts: []corev1.VolumeMount{
+			{
+				Name:      volumeName,
+				MountPath: mountPath,
 			},
 		},
-	}, pod.Spec.InitContainers...)
+	}
+	resources, hasResources, err := initResources()
+	if err != nil {
+		return err
+	}
+	if hasResources {
+		initContainer.Resources = resources
+	}
+	pod.Spec.InitContainers = append([]corev1.Container{initContainer}, pod.Spec.InitContainers...)
+	return nil
+}
+
+func initResources() (corev1.ResourceRequirements, bool, error) {
+	hasResources := false
+	var resources = corev1.ResourceRequirements{Limits: corev1.ResourceList{}, Requests: corev1.ResourceList{}}
+	if config.Datadog.IsSet("admission_controller.auto_instrumentation.init_resources.cpu.request") {
+		quantity, err := resource.ParseQuantity(config.Datadog.GetString("admission_controller.auto_instrumentation.init_resources.cpu.request"))
+		if err != nil {
+			return resources, hasResources, err
+		}
+		resources.Requests[corev1.ResourceCPU] = quantity
+		hasResources = true
+	}
+	if config.Datadog.IsSet("admission_controller.auto_instrumentation.init_resources.cpu.limit") {
+		quantity, err := resource.ParseQuantity(config.Datadog.GetString("admission_controller.auto_instrumentation.init_resources.cpu.limit"))
+		if err != nil {
+			return resources, hasResources, err
+		}
+		resources.Limits[corev1.ResourceCPU] = quantity
+		hasResources = true
+	}
+	if config.Datadog.IsSet("admission_controller.auto_instrumentation.init_resources.memory.request") {
+		quantity, err := resource.ParseQuantity(config.Datadog.GetString("admission_controller.auto_instrumentation.init_resources.memory.request"))
+		if err != nil {
+			return resources, hasResources, err
+		}
+		resources.Requests[corev1.ResourceMemory] = quantity
+		hasResources = true
+	}
+	if config.Datadog.IsSet("admission_controller.auto_instrumentation.init_resources.memory.limit") {
+		quantity, err := resource.ParseQuantity(config.Datadog.GetString("admission_controller.auto_instrumentation.init_resources.memory.limit"))
+		if err != nil {
+			return resources, hasResources, err
+		}
+		resources.Limits[corev1.ResourceMemory] = quantity
+		hasResources = true
+	}
+	return resources, hasResources, nil
 }
 
 // injectLibRequirements injects the minimal config requirements to enable instrumentation

--- a/pkg/clusteragent/admission/mutate/auto_instrumentation.go
+++ b/pkg/clusteragent/admission/mutate/auto_instrumentation.go
@@ -299,35 +299,21 @@ func injectLibInitContainer(pod *corev1.Pod, image string, lang language) error 
 func initResources() (corev1.ResourceRequirements, bool, error) {
 	hasResources := false
 	var resources = corev1.ResourceRequirements{Limits: corev1.ResourceList{}, Requests: corev1.ResourceList{}}
-	if config.Datadog.IsSet("admission_controller.auto_instrumentation.init_resources.cpu.request") {
-		quantity, err := resource.ParseQuantity(config.Datadog.GetString("admission_controller.auto_instrumentation.init_resources.cpu.request"))
+	if config.Datadog.IsSet("admission_controller.auto_instrumentation.init_resources.cpu") {
+		quantity, err := resource.ParseQuantity(config.Datadog.GetString("admission_controller.auto_instrumentation.init_resources.cpu"))
 		if err != nil {
 			return resources, hasResources, err
 		}
 		resources.Requests[corev1.ResourceCPU] = quantity
-		hasResources = true
-	}
-	if config.Datadog.IsSet("admission_controller.auto_instrumentation.init_resources.cpu.limit") {
-		quantity, err := resource.ParseQuantity(config.Datadog.GetString("admission_controller.auto_instrumentation.init_resources.cpu.limit"))
-		if err != nil {
-			return resources, hasResources, err
-		}
 		resources.Limits[corev1.ResourceCPU] = quantity
 		hasResources = true
 	}
-	if config.Datadog.IsSet("admission_controller.auto_instrumentation.init_resources.memory.request") {
-		quantity, err := resource.ParseQuantity(config.Datadog.GetString("admission_controller.auto_instrumentation.init_resources.memory.request"))
+	if config.Datadog.IsSet("admission_controller.auto_instrumentation.init_resources.memory") {
+		quantity, err := resource.ParseQuantity(config.Datadog.GetString("admission_controller.auto_instrumentation.init_resources.memory"))
 		if err != nil {
 			return resources, hasResources, err
 		}
 		resources.Requests[corev1.ResourceMemory] = quantity
-		hasResources = true
-	}
-	if config.Datadog.IsSet("admission_controller.auto_instrumentation.init_resources.memory.limit") {
-		quantity, err := resource.ParseQuantity(config.Datadog.GetString("admission_controller.auto_instrumentation.init_resources.memory.limit"))
-		if err != nil {
-			return resources, hasResources, err
-		}
 		resources.Limits[corev1.ResourceMemory] = quantity
 		hasResources = true
 	}

--- a/pkg/clusteragent/admission/mutate/auto_instrumentation_test.go
+++ b/pkg/clusteragent/admission/mutate/auto_instrumentation_test.go
@@ -492,9 +492,16 @@ func TestInjectLibInitContainer(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:    "with partial resources",
+			name:    "cpu only",
 			pod:     fakePod("java-pod"),
 			cpu:     "200m",
+			image:   "gcr.io/datadoghq/dd-lib-java-init:v1",
+			lang:    java,
+			wantErr: false,
+		},
+		{
+			name:    "memory only",
+			pod:     fakePod("java-pod"),
 			mem:     "512Mi",
 			image:   "gcr.io/datadoghq/dd-lib-java-init:v1",
 			lang:    java,

--- a/pkg/clusteragent/admission/mutate/auto_instrumentation_test.go
+++ b/pkg/clusteragent/admission/mutate/auto_instrumentation_test.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -460,6 +461,97 @@ func TestInjectLibConfig(t *testing.T) {
 				}
 			}
 			require.Equal(t, len(tt.expectedEnvs), envCount)
+		})
+	}
+}
+
+func TestInjectLibInitContainer(t *testing.T) {
+	tests := []struct {
+		name     string
+		cpuLimit string
+		cpuReq   string
+		memLimit string
+		memReq   string
+		pod      *corev1.Pod
+		image    string
+		lang     language
+		wantErr  bool
+	}{
+		{
+			name:    "no resources",
+			pod:     fakePod("java-pod"),
+			image:   "gcr.io/datadoghq/dd-lib-java-init:v1",
+			lang:    java,
+			wantErr: false,
+		},
+		{
+			name:     "with resources",
+			pod:      fakePod("java-pod"),
+			cpuLimit: "100m",
+			cpuReq:   "50",
+			memLimit: "1Gi",
+			memReq:   "500",
+			image:    "gcr.io/datadoghq/dd-lib-java-init:v1",
+			lang:     java,
+			wantErr:  false,
+		},
+		{
+			name:     "with partial resources",
+			pod:      fakePod("java-pod"),
+			cpuLimit: "200m",
+			memLimit: "512Mi",
+			image:    "gcr.io/datadoghq/dd-lib-java-init:v1",
+			lang:     java,
+			wantErr:  false,
+		},
+		{
+			name:     "with invalid resources",
+			pod:      fakePod("java-pod"),
+			cpuLimit: "foo",
+			image:    "gcr.io/datadoghq/dd-lib-java-init:v1",
+			lang:     java,
+			wantErr:  true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conf := config.Mock(t)
+			if tt.cpuLimit != "" {
+				conf.Set("admission_controller.auto_instrumentation.init_resources.cpu.limit", tt.cpuLimit)
+			}
+			if tt.cpuReq != "" {
+				conf.Set("admission_controller.auto_instrumentation.init_resources.cpu.request", tt.cpuReq)
+			}
+			if tt.memLimit != "" {
+				conf.Set("admission_controller.auto_instrumentation.init_resources.memory.limit", tt.memLimit)
+			}
+			if tt.memReq != "" {
+				conf.Set("admission_controller.auto_instrumentation.init_resources.memory.request", tt.memReq)
+			}
+			err := injectLibInitContainer(tt.pod, tt.image, tt.lang)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("injectLibInitContainer() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if err != nil {
+				return
+			}
+			require.Len(t, tt.pod.Spec.InitContainers, 1)
+			if tt.cpuLimit != "" {
+				quantity := tt.pod.Spec.InitContainers[0].Resources.Limits[corev1.ResourceCPU]
+				require.Equal(t, tt.cpuLimit, quantity.String())
+			}
+			if tt.cpuReq != "" {
+				quantity := tt.pod.Spec.InitContainers[0].Resources.Requests[corev1.ResourceCPU]
+				require.Equal(t, tt.cpuReq, quantity.String())
+			}
+			if tt.memLimit != "" {
+				quantity := tt.pod.Spec.InitContainers[0].Resources.Limits[corev1.ResourceMemory]
+				require.Equal(t, tt.memLimit, quantity.String())
+			}
+			if tt.memReq != "" {
+				quantity := tt.pod.Spec.InitContainers[0].Resources.Requests[corev1.ResourceMemory]
+				require.Equal(t, tt.memReq, quantity.String())
+			}
 		})
 	}
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1029,10 +1029,8 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("admission_controller.auto_instrumentation.patcher.enabled", false)
 	config.BindEnvAndSetDefault("admission_controller.auto_instrumentation.patcher.fallback_to_file_provider", false)                                // to be enabled only in e2e tests
 	config.BindEnvAndSetDefault("admission_controller.auto_instrumentation.patcher.file_provider_path", "/etc/datadog-agent/patch/auto-instru.json") // to be used only in e2e tests
-	config.BindEnv("admission_controller.auto_instrumentation.init_resources.cpu.request")
-	config.BindEnv("admission_controller.auto_instrumentation.init_resources.cpu.limit")
-	config.BindEnv("admission_controller.auto_instrumentation.init_resources.memory.request")
-	config.BindEnv("admission_controller.auto_instrumentation.init_resources.memory.limit")
+	config.BindEnv("admission_controller.auto_instrumentation.init_resources.cpu")
+	config.BindEnv("admission_controller.auto_instrumentation.init_resources.memory")
 
 	// Telemetry
 	// Enable telemetry metrics on the internals of the Agent.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1029,6 +1029,10 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("admission_controller.auto_instrumentation.patcher.enabled", false)
 	config.BindEnvAndSetDefault("admission_controller.auto_instrumentation.patcher.fallback_to_file_provider", false)                                // to be enabled only in e2e tests
 	config.BindEnvAndSetDefault("admission_controller.auto_instrumentation.patcher.file_provider_path", "/etc/datadog-agent/patch/auto-instru.json") // to be used only in e2e tests
+	config.BindEnv("admission_controller.auto_instrumentation.init_resources.cpu.request")
+	config.BindEnv("admission_controller.auto_instrumentation.init_resources.cpu.limit")
+	config.BindEnv("admission_controller.auto_instrumentation.init_resources.memory.request")
+	config.BindEnv("admission_controller.auto_instrumentation.init_resources.memory.limit")
 
 	// Telemetry
 	// Enable telemetry metrics on the internals of the Agent.

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -2641,6 +2641,28 @@ api_key:
   ## See https://docs.microsoft.com/en-us/azure/aks/faq#can-i-use-admission-controller-webhooks-on-aks
   #
   # add_aks_selectors: false
+
+  ## @param auto_instrumentation - custom object - optional
+  ## Library injection parameters.
+  #
+  # auto_instrumentation:
+
+    ## @param init_resources - custom object - optional
+    ## CPU and Memory resources of the init containers.
+    #
+    # init_resources:
+
+      ## @param cpu - string - optional
+      ## @env DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_INIT_RESOURCES_CPU - string - optional
+      ## Configures the CPU request and limit for the init containers.
+      #
+      # cpu:
+
+      ## @param memory - string - optional
+      ## @env DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_INIT_RESOURCES_MEMORY - string - optional
+      ## Configures the memory request and limit for the init containers.
+      #
+      # memory:
 {{ end -}}
 {{- if .DockerTagging }}
 

--- a/releasenotes-dca/notes/lib-injection-res-f74efd52aec32385.yaml
+++ b/releasenotes-dca/notes/lib-injection-res-f74efd52aec32385.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Library injection via Admission Controller: Allow configuring the CPU and Memory requests/limits for library init containers.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Library injection via Admission Controller: Allow configuring the CPU and Memory requests/limits for library init containers.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

FR

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Configure `admission_controller.auto_instrumentation.init_resources.cpu|memory` and ensures it gets applied to the init container.

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
