### PR TITLE
Adding an option to the secret-helper command to remove trailing linebreak

### DIFF
--- a/cmd/secrethelper/secret_helper.go
+++ b/cmd/secrethelper/secret_helper.go
@@ -83,7 +83,7 @@ func Commands() []*cobra.Command {
 		},
 	}
 	cmd.PersistentFlags().BoolVarP(&cliParams.usePrefixes, providerPrefixesFlag, "", false, "Use prefixes to select the secrets provider (file, k8s_secret)")
-	cmd.PersistentFlags().BoolVarP(&cliParams.removeTrailingLineBreak, removeTrailingLineBreak, "", false, "Remove the last trailing linebreaks from the file if any")
+	cmd.PersistentFlags().BoolVarP(&cliParams.removeTrailingLineBreak, removeTrailingLineBreak, "", false, "Remove the trailing newline characters (if any) from the fetched secrets")
 
 	secretHelperCmd := &cobra.Command{
 		Use:   "secret-helper",

--- a/cmd/secrethelper/testdata/read-secrets/secret7
+++ b/cmd/secrethelper/testdata/read-secrets/secret7
@@ -1,0 +1,1 @@
+some secret data

--- a/releasenotes/notes/secret-help-add-line-break-trailing-68eab7f9895cc8e9.yaml
+++ b/releasenotes/notes/secret-help-add-line-break-trailing-68eab7f9895cc8e9.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    The `secret-helper` command has a new option `--remove-trailing-linebreaks` to remove any trailing linebreaks from
+    secrets read. This can be helpful when your secrets management tool automatically add an extra line break to the
+    file created.

--- a/releasenotes/notes/secret-help-add-line-break-trailing-68eab7f9895cc8e9.yaml
+++ b/releasenotes/notes/secret-help-add-line-break-trailing-68eab7f9895cc8e9.yaml
@@ -1,6 +1,6 @@
 ---
 features:
   - |
-    The `secret-helper` command has a new option `--remove-trailing-linebreaks` to remove any trailing linebreaks from
-    secrets read. This can be helpful when your secrets management tool automatically add an extra line break to the
+    The `secret-helper` command has a new option `--remove-trailing-linebreaks` to remove trailing linebreaks from
+    secrets read. This can be helpful when your secrets management tool automatically adds an extra line break to the
     file created.


### PR DESCRIPTION
### What does this PR do?

This PR add the option to remove any line break at the end of a secret file.

Example:
```
$> cat -e secret1
some secret data$
$> echo '{"version": "1.0", "secrets": ["secret1"]}' | datadog-agent secret-helper read .
{"secret1":{"value":"some secret data\n"}}
$>  echo '{"version": "1.0", "secrets": ["secret1"]}' | datadog-agent read --remove-trailing-linebreaks .
{"secret7":{"value":"some secret data"}}
```

### Motivation

Some secret management tool can add an extra line break automatically.

### Describe how to test/QA your changes

Setup a secret through a file with a line break and test that the helper trim the line break.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
