### PR TITLE
[usm/npm] Fix IPv4 mapped IPv6 IPs

### DIFF
--- a/pkg/network/ebpf/c/sock.h
+++ b/pkg/network/ebpf/c/sock.h
@@ -157,17 +157,6 @@ static __always_inline int read_conn_tuple_partial(conn_tuple_t* t, struct sock*
         } else {
             t->metadata |= CONN_V6;
         }
-
-        // Check if we can map IPv6 to IPv4
-        if (is_ipv4_mapped_ipv6(t->saddr_h, t->saddr_l, t->daddr_h, t->daddr_l)) {
-            t->metadata |= CONN_V4;
-            t->saddr_h = 0;
-            t->daddr_h = 0;
-            t->saddr_l = (__u32)(t->saddr_l >> 32);
-            t->daddr_l = (__u32)(t->daddr_l >> 32);
-        } else {
-            t->metadata |= CONN_V6;
-        }
     } else {
         err = 1;
     }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Fix IPv4 mapped IPv6 IPs by removing a duplicated code section.
This regression was recently introduced in https://github.com/DataDog/datadog-agent/pull/14974

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

In the context of a IPv4 mapped IPv6 address, the result of having the following code being executed twice in a row:
```
// Check if we can map IPv6 to IPv4
if (is_ipv4_mapped_ipv6(t->saddr_h, t->saddr_l, t->daddr_h, t->daddr_l)) {
    t->metadata |= CONN_V4;
    t->saddr_h = 0;
    t->daddr_h = 0;
    t->saddr_l = (__u32)(t->saddr_l >> 32);
    t->daddr_l = (__u32)(t->daddr_l >> 32);
} else {
    t->metadata |= CONN_V6;
}
```
Resulted in the correct IPs (`saddr` and `laddr` fields), but the wrong metadata field (`CONN_V6` instead of `CONN_V4`), as `is_ipv4_mapped_ipv6` would return true in the first and false in the second time.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
