### PR TITLE
Fix pre-InstallValidate custom action conditions

### DIFF
--- a/tools/windows/DatadogAgentInstaller/CustomActions/ConfigCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/ConfigCustomActions.cs
@@ -27,19 +27,19 @@ namespace Datadog.CustomActions
 
         private static ActionResult ReadConfig(ISession session)
         {
-            var configFolder = session.Property("APPLICATIONDATADIRECTORY");
-            var configFilePath = Path.Combine(configFolder, "datadog.yaml");
-            if (!File.Exists(configFilePath))
-            {
-                session.Log($"No user config found in {configFilePath}, continuing.");
-                session["DATADOGYAMLEXISTS"] = "no";
-                return ActionResult.Success;
-            }
-
-            session["DATADOGYAMLEXISTS"] = "yes";
-
             try
             {
+                var configFolder = session.Property("APPLICATIONDATADIRECTORY");
+                var configFilePath = Path.Combine(configFolder, "datadog.yaml");
+                if (!File.Exists(configFilePath))
+                {
+                    session.Log($"No user config found in {configFilePath}, continuing.");
+                    session["DATADOGYAMLEXISTS"] = "no";
+                    return ActionResult.Success;
+                }
+
+                session["DATADOGYAMLEXISTS"] = "yes";
+
                 using var input = new StreamReader(configFilePath);
                 var deserializer = new DeserializerBuilder()
                     .IgnoreUnmatchedProperties()

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentCustomActions.cs
@@ -56,7 +56,9 @@ namespace WixSetup.Datadog
                 // It is executed on the Welcome screen of the installer.
                 When.After,
                 Step.AppSearch,
-                Condition.NOT_BeingRemoved,
+                // Not needed during uninstall, but since it runs before InstallValidate the recommended
+                // REMOVE=ALL condition does not work, so always run it.
+                Condition.Always,
                 // Run in either sequence so our CA is also run in non-UI installs
                 Sequence.InstallExecuteSequence | Sequence.InstallUISequence
             )
@@ -75,7 +77,9 @@ namespace WixSetup.Datadog
                 // Must execute after CostFinalize since we depend
                 // on APPLICATIONDATADIRECTORY being set.
                 Step.CostFinalize,
-                Condition.NOT_BeingRemoved,
+                // Not needed during uninstall, but since it runs before InstallValidate the recommended
+                // REMOVE=ALL condition does not work, so always run it.
+                Condition.Always,
                 // Run in either sequence so our CA is also run in non-UI installs
                 Sequence.InstallExecuteSequence | Sequence.InstallUISequence
             )


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Changes the conditions of our custom actions that are sequenced before `InstallValidate`. Since these custom actions are safe to always run, they are now configured to always run.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
According to [Microsoft documentation](https://learn.microsoft.com/en-us/windows/win32/msi/sequencing-custom-actions), the `REMOVE` property may not be set to `ALL` before the `InstallValidate` action. We have custom actions that are sequenced before `InstallValidate` but were checking for this condition.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
Partial fix for https://datadoghq.atlassian.net/browse/WA-261 / https://github.com/DataDog/datadog-agent/pull/16014

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
Verify that installation and uninstallation works with NG installer

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
