### PR TITLE
remoteconfig: guard against empty updates causing repository errors

### DIFF
--- a/pkg/remoteconfig/state/repository.go
+++ b/pkg/remoteconfig/state/repository.go
@@ -62,6 +62,11 @@ type Update struct {
 	ClientConfigs []string
 }
 
+// isEmpty returns whether or not all the fields of `Update` are empty
+func (u *Update) isEmpty() bool {
+	return len(u.TUFRoots) == 0 && len(u.TUFTargets) == 0 && (u.TargetFiles == nil || len(u.TargetFiles) == 0) && len(u.ClientConfigs) == 0
+}
+
 // Repository is a remote config client used in a downstream process to retrieve
 // remote config updates from an Agent.
 type Repository struct {
@@ -131,6 +136,11 @@ func (r *Repository) Update(update Update) ([]string, error) {
 	var err error
 	var updatedTargets *data.Targets
 	var tmpRootClient *tufRootsClient
+
+	// If there's literally nothing in the update, it's not an error.
+	if update.isEmpty() {
+		return []string{}, nil
+	}
 
 	// TUF: Update the roots and verify the TUF Targets file (optional)
 	//

--- a/pkg/remoteconfig/state/repository_test.go
+++ b/pkg/remoteconfig/state/repository_test.go
@@ -32,7 +32,9 @@ func TestNewUnverifiedRepository(t *testing.T) {
 	assert.Nil(t, err, "Creating an unverified repository should always succeed with no error")
 }
 
-func TestEmptyUpdate(t *testing.T) {
+// TestEmptyUpdateZeroTypes makes sure that a properly initialized, but otherwise empty,
+// `Update` won't cause an error, crash the Update process, and also results in unchanged state.
+func TestEmptyUpdateZeroTypes(t *testing.T) {
 	ta := newTestArtifacts()
 
 	emptyUpdate := Update{
@@ -45,7 +47,7 @@ func TestEmptyUpdate(t *testing.T) {
 	r := ta.repository
 
 	updatedProducts, err := r.Update(emptyUpdate)
-	assert.NotNil(t, err)
+	assert.Nil(t, err)
 	assert.Equal(t, 0, len(updatedProducts), "An empty update shouldn't indicate any updated products")
 	assert.Equal(t, 0, len(r.APMConfigs()), "An empty update shoudldn't add any APM configs")
 	assert.Equal(t, 0, len(r.CWSDDConfigs()), "An empty update shouldn't add any CWSDD configs")
@@ -62,7 +64,53 @@ func TestEmptyUpdate(t *testing.T) {
 	r = ta.unverifiedRepository
 
 	updatedProducts, err = r.Update(emptyUpdate)
-	assert.NotNil(t, err)
+	assert.Nil(t, err)
+	assert.Equal(t, 0, len(updatedProducts), "An empty update shouldn't indicate any updated products")
+	assert.Equal(t, 0, len(r.APMConfigs()), "An empty update shoudldn't add any APM configs")
+	assert.Equal(t, 0, len(r.CWSDDConfigs()), "An empty update shouldn't add any CWSDD configs")
+
+	state, err = r.CurrentState()
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(state.Configs))
+	assert.Equal(t, 0, len(state.CachedFiles))
+	assert.EqualValues(t, 0, state.TargetsVersion)
+	assert.EqualValues(t, 1, state.RootsVersion)
+	assert.Nil(t, state.OpaqueBackendState)
+}
+
+// TestEmptyUpdateNilTypes makes sure that a completely uninitialized `Update` field won't
+// cause an error, crash the Update process, and also results in unchanged state.
+func TestEmptyUpdateNilTypes(t *testing.T) {
+	ta := newTestArtifacts()
+
+	emptyUpdate := Update{
+		TUFRoots:      nil,
+		TUFTargets:    nil,
+		TargetFiles:   nil,
+		ClientConfigs: nil,
+	}
+
+	r := ta.repository
+
+	updatedProducts, err := r.Update(emptyUpdate)
+	assert.Nil(t, err)
+	assert.Equal(t, 0, len(updatedProducts), "An empty update shouldn't indicate any updated products")
+	assert.Equal(t, 0, len(r.APMConfigs()), "An empty update shoudldn't add any APM configs")
+	assert.Equal(t, 0, len(r.CWSDDConfigs()), "An empty update shouldn't add any CWSDD configs")
+
+	state, err := r.CurrentState()
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(state.Configs))
+	assert.Equal(t, 0, len(state.CachedFiles))
+	assert.EqualValues(t, 0, state.TargetsVersion)
+	assert.EqualValues(t, 1, state.RootsVersion)
+	assert.Nil(t, state.OpaqueBackendState)
+
+	// Do the same with the unverified repository, there should be no functional difference.
+	r = ta.unverifiedRepository
+
+	updatedProducts, err = r.Update(emptyUpdate)
+	assert.Nil(t, err)
 	assert.Equal(t, 0, len(updatedProducts), "An empty update shouldn't indicate any updated products")
 	assert.Equal(t, 0, len(r.APMConfigs()), "An empty update shoudldn't add any APM configs")
 	assert.Equal(t, 0, len(r.CWSDDConfigs()), "An empty update shouldn't add any CWSDD configs")


### PR DESCRIPTION
This is primarily a defensive change for any upstream clients using the `Repository` structure in `pkg/remoteconfig`. Because the agent sends an `{}` payload to tracers when there isn't an update, if a client directly tries to serilaize this into an `Update` field it could result in the client calling Update with an empty payload. This previously caused a JSON parsing error, which registers as a client update error and is reported to the backend despite this being a perfectly normal situation.

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
