### PR TITLE
[KSM] Ensure user-defined `service` tag isn’t turned into `kube_service`

### DIFF
--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
@@ -951,5 +951,11 @@ func labelsMapperOverride(metricName string) map[string]string {
 			"service_port": "kube_service_port",
 		}
 	}
+
+	if strings.HasPrefix(metricName, "kube_service") {
+		return map[string]string{
+			"service": "kube_service",
+		}
+	}
 	return nil
 }

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_defaults.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_defaults.go
@@ -100,7 +100,6 @@ func defaultLabelsMapper() map[string]string {
 		"replicaset":                          "kube_replica_set",
 		"statefulset":                         "kube_stateful_set",
 		"deployment":                          "kube_deployment",
-		"service":                             "kube_service",
 		"endpoint":                            "kube_endpoint",
 		"container":                           "kube_container_name",
 		"container_id":                        "container_id",


### PR DESCRIPTION
### What does this PR do?

Fix a tagging issue in the `kubernetes_state_core` check where, if a user sets a `labels_as_tags` option to produce a `service` tag, it was, in the end transformed in `kube_service` instead.

### Motivation

* Fix a regression introduced by #15492.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

* Configure the `kubernetes_state_core` check with:
```yaml
labels_as_tags:
  deployment:
    service: service
```

* Label a deployment with `service`,
* Check the tags on the `kubernetes_state.deployment.replicas` metric. Without this fix (and with #15492), we saw a `kube_service` tag whereas with this fix, we should properly have a `service` tag.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
