### PR TITLE
Use the proper timeout when using AWS sdk

### DIFF
--- a/pkg/util/ec2/ec2_tags.go
+++ b/pkg/util/ec2/ec2_tags.go
@@ -130,7 +130,7 @@ func getTagsWithCreds(ctx context.Context, instanceIdentity *ec2Identity, awsCre
 	connection := ec2.New(awsSess)
 
 	// We want to use 'ec2_metadata_timeout' here instead of current context. 'ctx' comes from the agent main and will
-	// only be canceled if the agent is stopped. The default timeout for the AWS SQK is 1 minutes (20s timeout with
+	// only be canceled if the agent is stopped. The default timeout for the AWS SDK is 1 minutes (20s timeout with
 	// 3 retries). Since we call getTagsWithCreds twice in a row, it can be a 2 minutes latency.
 	ctx, cancel := context.WithTimeout(ctx, config.Datadog.GetDuration("ec2_metadata_timeout")*time.Millisecond)
 	defer cancel()

--- a/pkg/util/ec2/ec2_tags.go
+++ b/pkg/util/ec2/ec2_tags.go
@@ -13,6 +13,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -127,6 +128,13 @@ func getTagsWithCreds(ctx context.Context, instanceIdentity *ec2Identity, awsCre
 	}
 
 	connection := ec2.New(awsSess)
+
+	// We want to use 'ec2_metadata_timeout' here instead of current context. 'ctx' comes from the agent main and will
+	// only be canceled if the agent is stopped. The default timeout for the AWS SQK is 1 minutes (20s timeout with
+	// 3 retries). Since we call getTagsWithCreds twice in a row, it can be a 2 minutes latency.
+	ctx, cancel := context.WithTimeout(ctx, config.Datadog.GetDuration("ec2_metadata_timeout")*time.Millisecond)
+	defer cancel()
+
 	ec2Tags, err := connection.DescribeTagsWithContext(ctx,
 		&ec2.DescribeTagsInput{
 			Filters: []*ec2.Filter{{

--- a/releasenotes/notes/fix-aws-sdk-timeout-7eeeef375e8d92d4.yaml
+++ b/releasenotes/notes/fix-aws-sdk-timeout-7eeeef375e8d92d4.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    The agent now use `ec2_metadata_timeout` value when fetching EC2 instance tags with AWS SDK. The agent fetch
+    instance tags when `collect_ec2_tags` is set to `true`.

--- a/releasenotes/notes/fix-aws-sdk-timeout-7eeeef375e8d92d4.yaml
+++ b/releasenotes/notes/fix-aws-sdk-timeout-7eeeef375e8d92d4.yaml
@@ -1,5 +1,5 @@
 ---
 enhancements:
   - |
-    The agent now use `ec2_metadata_timeout` value when fetching EC2 instance tags with AWS SDK. The agent fetch
+    The Agent now uses the `ec2_metadata_timeout` value when fetching EC2 instance tags with AWS SDK. The Agent fetches
     instance tags when `collect_ec2_tags` is set to `true`.


### PR DESCRIPTION
### What does this PR do?

The default `ec2_metadata_timeout` is now also used when fetching instance tags with the AWS SDK.

### Describe how to test/QA your changes

Check that the agent can still correctly fetch EC2 tags when `collect_ec2_tags` is enabled (we should test Windows and Linux).

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
