### PR TITLE
Calling cloud providers in parallel to detect host aliases

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -7,6 +7,7 @@ package config
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -2058,8 +2059,8 @@ func getBindHost(cfg Config) string {
 
 // GetValidHostAliases validates host aliases set in `host_aliases` variable and returns
 // only valid ones.
-func GetValidHostAliases() []string {
-	return getValidHostAliasesWithConfig(Datadog)
+func GetValidHostAliases(_ context.Context) ([]string, error) {
+	return getValidHostAliasesWithConfig(Datadog), nil
 }
 
 func getValidHostAliasesWithConfig(config Config) []string {

--- a/pkg/util/cloudproviders/cloudproviders_test.go
+++ b/pkg/util/cloudproviders/cloudproviders_test.go
@@ -1,0 +1,55 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package cloudproviders
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCloudProviderAliases(t *testing.T) {
+	origDetectors := hostAliasesDetectors
+	defer func() { hostAliasesDetectors = origDetectors }()
+
+	detector1Called := false
+	detector2Called := false
+	detector3Called := false
+
+	hostAliasesDetectors = []cloudProviderAliasesDetector{
+		{
+			name: "detector1",
+			callback: func(_ context.Context) ([]string, error) {
+				detector1Called = true
+				return []string{"alias2"}, nil
+			},
+		},
+		{
+			name: "detector2",
+			callback: func(_ context.Context) ([]string, error) {
+				detector2Called = true
+				return nil, fmt.Errorf("error from detector2")
+			},
+		},
+		{
+			name: "detector3",
+			callback: func(_ context.Context) ([]string, error) {
+				detector3Called = true
+				return []string{"alias1", "alias2"}, nil
+			},
+		},
+	}
+
+	aliases := GetHostAliases(context.TODO())
+	assert.True(t, detector1Called, "host alias callback for 'detector1' was not called")
+	assert.True(t, detector2Called, "host alias callback for 'detector2' was not called")
+	assert.True(t, detector3Called, "host alias callback for 'detector3' was not called")
+
+	assert.Equal(t, []string{"alias1", "alias2"}, aliases)
+
+}


### PR DESCRIPTION
### What does this PR do?

As we add more cloud provider the host aliases detection now take up 10 to 15s in the worst case. This blocks the agent startup and is particularly visible on Windows when using the GUI (since the GUI wait 10 to 15s to get the status page).

Calling each cloud providers in parallel should reduce the delay to the slowest provider.

### Describe how to test/QA your changes

Check that host aliases from the cloud providers still works (I don't think we need to test all of them, EC2, GCP and Azure should be enough).

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
