### PR TITLE
Improve debug logging related to hostname detection

### DIFF
--- a/pkg/util/hostname/common.go
+++ b/pkg/util/hostname/common.go
@@ -129,7 +129,7 @@ func fromEC2(ctx context.Context, currentHostname string) (string, error) {
 
 	prioritizeEC2Hostname := config.Datadog.GetBool("ec2_prioritize_instance_id_as_hostname")
 
-	log.Debugf("detected default EC2 hostname: %v", ec2.IsDefaultHostname(currentHostname))
+	log.Debugf("Detected a default EC2 hostname: %v", ec2.IsDefaultHostname(currentHostname))
 	log.Debugf("ec2_prioritize_instance_id_as_hostname is set to %v", prioritizeEC2Hostname)
 
 	// We use the instance id if we're on an ECS cluster or we're on EC2 and the hostname is one of the default ones

--- a/pkg/util/hostname/common.go
+++ b/pkg/util/hostname/common.go
@@ -129,11 +129,16 @@ func fromEC2(ctx context.Context, currentHostname string) (string, error) {
 
 	prioritizeEC2Hostname := config.Datadog.GetBool("ec2_prioritize_instance_id_as_hostname")
 
+	log.Debugf("detected default EC2 hostname: %v", ec2.IsDefaultHostname(currentHostname))
+	log.Debugf("ec2_prioritize_instance_id_as_hostname is set to %v", prioritizeEC2Hostname)
+
 	// We use the instance id if we're on an ECS cluster or we're on EC2 and the hostname is one of the default ones
 	// or ec2_prioritize_instance_id_as_hostname is set to true
 	if config.IsFeaturePresent(config.ECSEC2) || ec2.IsDefaultHostname(currentHostname) || prioritizeEC2Hostname {
+		log.Debugf("Trying to fetch hostname from EC2 metadata")
 		return getValidEC2Hostname(ctx)
 	} else if ec2.IsWindowsDefaultHostname(currentHostname) {
+		log.Debugf("Default EC2 Windows hostname detected")
 		// Display a message when enabling `ec2_use_windows_prefix_detection` would make the hostname resolution change.
 
 		// As we are in the else clause `ec2.IsDefaultHostname(currentHostname)` is false. If

--- a/pkg/util/kubelet/host_alias.go
+++ b/pkg/util/kubelet/host_alias.go
@@ -18,10 +18,13 @@ import (
 // GetHostAliases uses the "kubelet" hostname provider to fetch the kubernetes alias
 func GetHostAliases(ctx context.Context) ([]string, error) {
 	name, err := GetHostname(ctx)
-	if err == nil && validate.ValidHostname(name) == nil {
-		return []string{name}, nil
+	if err != nil {
+		return nil, fmt.Errorf("couldn't extract a host alias from the kubelet: %w", err)
 	}
-	return nil, fmt.Errorf("couldn't extract a host alias from the kubelet: %s", err)
+	if err := validate.ValidHostname(name); err != nil {
+		return nil, fmt.Errorf("host alias from kubelet is not valid: %w", err)
+	}
+	return []string{name}, nil
 }
 
 // GetMetaClusterNameText returns the clusterName text for the agent status output. Returns "" if the feature kubernetes is not activated


### PR DESCRIPTION
### What does this PR do?

This commit ease troubleshooting issue related to hostname detection. When the agent is in debug, flare will contains more granular error on why a hostname was used or not.

### Describe how to test/QA your changes

Test that host alias detection on k8s still works.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
