### PR TITLE
[corechecks/ksm] Convert labels/annotations as tags to snake_case

### DIFF
--- a/releasenotes-dca/notes/fix-ksm-labels-annotations-snake-case-e761b9103c3ac71c.yaml
+++ b/releasenotes-dca/notes/fix-ksm-labels-annotations-snake-case-e761b9103c3ac71c.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    The KSM core check now correctly handles labels and annotations with
+    uppercase letters defined in the "labels_as_tags" and "annotations_as_tags"
+    config attributes.

--- a/releasenotes/notes/fix-ksm-labels-annotations-snake-case-e761b9103c3ac71c.yaml
+++ b/releasenotes/notes/fix-ksm-labels-annotations-snake-case-e761b9103c3ac71c.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    The KSM core check now correctly handles labels and annotations with
+    uppercase letters defined in the "labels_as_tags" and "annotations_as_tags"
+    config attributes.


### PR DESCRIPTION
### What does this PR do?

Fixes a bug in the `kubernetes_state_core` check.

Currently, "labels as tags" and "annotations as tags" don't work correctly when the labels or the annotations in the config contain uppercase letters. The reason is that the KSM labels that contain an annotation or a label are converted to snake_case (Ref: https://github.com/kubernetes/kube-state-metrics/blob/main/internal/store/utils.go#L133) and the KSM check does not handle that case.


### Describe how to test/QA your changes

Deploy the agent on Kubernetes. Define labels as tags and annotations as tags with uppercase letters. And deploy something that uses those labels and annotations.
Example with the helm chart:
```yaml
datadog:
  kubeStateMetricsCore:
    enabled: true
    annotationsAsTags:
      deployment:
        testAnnotation: tagfromannotation
    labelsAsTags:
      deployment:
        testLabel: tagfromlabel
```

Check that the metrics emitted by the kubernetes state core check contain the tags defined in "annotationsAsTags" and "labelsAsTags" ("tagfromannotation" and "tagfromlabel" in the example above).

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
