### PR TITLE
[CI] Add break-glass option to disable Artifactory from SSM Parameters Store

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -179,7 +179,7 @@ variables:
   ARTIFACTORY_URL: datadog.jfrog.io
   ARTIFACTORY_GEMS_PATH: artifactory/api/gems/agent-gems
   ARTIFACTORY_PYPI_PATH: artifactory/api/pypi/agent-pypi/simple
-  USE_CACHING_PROXY_RUBY: "true"
+  USE_CACHING_PROXY_RUBY: "false"
   CLANG_LLVM_VER: 12.0.1
 
 #
@@ -287,7 +287,7 @@ workflow:
         USE_CACHING_PROXY_PYTHON: "false"
     - if: $CI_COMMIT_TAG == null
       variables:
-        USE_CACHING_PROXY_PYTHON: "true"
+        USE_CACHING_PROXY_PYTHON: "false"
 
 #
 # List of rule blocks used in the pipeline

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -175,6 +175,7 @@ variables:
   KITCHEN_INFRASTRUCTURE_FLAKES_RETRY: 2
   ARTIFACTORY_USERNAME: datadog-agent
   ARTIFACTORY_TOKEN_SSM_NAME: ci.datadog-agent.artifactory_token
+  ARTIFACTORY_BYPASS_SSM_NAME: ci.datadog-agent.artifactory_bypass
   ARTIFACTORY_URL: datadog.jfrog.io
   ARTIFACTORY_GEMS_PATH: artifactory/api/gems/agent-gems
   ARTIFACTORY_PYPI_PATH: artifactory/api/pypi/agent-pypi/simple

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -179,7 +179,7 @@ variables:
   ARTIFACTORY_URL: datadog.jfrog.io
   ARTIFACTORY_GEMS_PATH: artifactory/api/gems/agent-gems
   ARTIFACTORY_PYPI_PATH: artifactory/api/pypi/agent-pypi/simple
-  USE_CACHING_PROXY_RUBY: "false"
+  USE_CACHING_PROXY_RUBY: "true"
   CLANG_LLVM_VER: 12.0.1
 
 #
@@ -287,7 +287,7 @@ workflow:
         USE_CACHING_PROXY_PYTHON: "false"
     - if: $CI_COMMIT_TAG == null
       variables:
-        USE_CACHING_PROXY_PYTHON: "false"
+        USE_CACHING_PROXY_PYTHON: "true"
 
 #
 # List of rule blocks used in the pipeline

--- a/.gitlab/shared.yml
+++ b/.gitlab/shared.yml
@@ -20,7 +20,7 @@
 .setup_ruby_mirror_win:
   - *get_artifactory_bypass
   - *get_artifactory_token_win
-  - if ($Env:USE_CACHING_PROXY_RUBY -eq "true") && ($Env:ARTIFACTORY_BYPASS -eq "false") { $BUNDLE_MIRROR__RUBYGEMS__ORG="https://${Env:ARTIFACTORY_USERNAME}:${ARTIFACTORY_TOKEN}@${Env:ARTIFACTORY_URL}/${Env:ARTIFACTORY_GEMS_PATH}" }
+  - if (($Env:USE_CACHING_PROXY_RUBY -eq "true") -and ($Env:ARTIFACTORY_BYPASS -eq "false")) { $BUNDLE_MIRROR__RUBYGEMS__ORG="https://${Env:ARTIFACTORY_USERNAME}:${ARTIFACTORY_TOKEN}@${Env:ARTIFACTORY_URL}/${Env:ARTIFACTORY_GEMS_PATH}" }
 
 .setup_python_mirror_linux:
   - *get_artifactory_bypass
@@ -32,4 +32,4 @@
 .setup_python_mirror_win:
   - *get_artifactory_bypass
   - *get_artifactory_token_win
-  - if ($Env:USE_CACHING_PROXY_PYTHON -eq "true") && ($Env:ARTIFACTORY_BYPASS -eq "false") { $PIP_INDEX_URL="https://${Env:ARTIFACTORY_USERNAME}:${ARTIFACTORY_TOKEN}@${Env:ARTIFACTORY_URL}/${Env:ARTIFACTORY_PYPI_PATH}" }
+  - if (($Env:USE_CACHING_PROXY_PYTHON -eq "true") -and ($Env:ARTIFACTORY_BYPASS -eq "false")) { $PIP_INDEX_URL="https://${Env:ARTIFACTORY_USERNAME}:${ARTIFACTORY_TOKEN}@${Env:ARTIFACTORY_URL}/${Env:ARTIFACTORY_PYPI_PATH}" }

--- a/.gitlab/shared.yml
+++ b/.gitlab/shared.yml
@@ -6,30 +6,34 @@
 .get_artifactory_token_win: &get_artifactory_token_win
   - $ARTIFACTORY_TOKEN=$(aws ssm get-parameter --region us-east-1 --name $ARTIFACTORY_TOKEN_SSM_NAME --with-decryption --query "Parameter.Value" --out text)
 
-.get_artifactory_bypass: &get_artifactory_bypass
+.get_artifactory_bypass_linux: &get_artifactory_bypass_linux
   - ARTIFACTORY_BYPASS=$(aws ssm get-parameter --region us-east-1 --name $ARTIFACTORY_BYPASS_SSM_NAME --with-decryption --query "Parameter.Value" --out text)
   - if [ "${ARTIFACTORY_BYPASS}" = "true" ]; then echo "Bypassing Artifactory"; fi
 
+.get_artifactory_bypass_win: &get_artifactory_bypass_win
+  - $ARTIFACTORY_BYPASS=$(aws ssm get-parameter --region us-east-1 --name $ARTIFACTORY_BYPASS_SSM_NAME --with-decryption --query "Parameter.Value" --out text)
+  - if ($Env:ARTIFACTORY_BYPASS -eq "true") { Write-Host "Bypassing Artifactory" }
+
 .setup_ruby_mirror_linux:
-  - *get_artifactory_bypass
+  - *get_artifactory_bypass_linux
   - set +x
   - *get_artifactory_token_linux
   - if [ "${USE_CACHING_PROXY_RUBY}" = "true" ] && [ "${ARTIFACTORY_BYPASS}" = "false" ]; then export BUNDLE_MIRROR__RUBYGEMS__ORG=https://${ARTIFACTORY_USERNAME}:${ARTIFACTORY_TOKEN}@${ARTIFACTORY_URL}/${ARTIFACTORY_GEMS_PATH}; fi
   - set -x
 
 .setup_ruby_mirror_win:
-  - *get_artifactory_bypass
+  - *get_artifactory_bypass_win
   - *get_artifactory_token_win
   - if (($Env:USE_CACHING_PROXY_RUBY -eq "true") -and ($Env:ARTIFACTORY_BYPASS -eq "false")) { $BUNDLE_MIRROR__RUBYGEMS__ORG="https://${Env:ARTIFACTORY_USERNAME}:${ARTIFACTORY_TOKEN}@${Env:ARTIFACTORY_URL}/${Env:ARTIFACTORY_GEMS_PATH}" }
 
 .setup_python_mirror_linux:
-  - *get_artifactory_bypass
+  - *get_artifactory_bypass_linux
   - set +x
   - *get_artifactory_token_linux
   - if [ "${USE_CACHING_PROXY_PYTHON}" = "true" ] && [ "${ARTIFACTORY_BYPASS}" = "false" ]; then export PIP_INDEX_URL=https://${ARTIFACTORY_USERNAME}:${ARTIFACTORY_TOKEN}@${ARTIFACTORY_URL}/${ARTIFACTORY_PYPI_PATH}; fi
   - set -x
 
 .setup_python_mirror_win:
-  - *get_artifactory_bypass
+  - *get_artifactory_bypass_win
   - *get_artifactory_token_win
   - if (($Env:USE_CACHING_PROXY_PYTHON -eq "true") -and ($Env:ARTIFACTORY_BYPASS -eq "false")) { $PIP_INDEX_URL="https://${Env:ARTIFACTORY_USERNAME}:${ARTIFACTORY_TOKEN}@${Env:ARTIFACTORY_URL}/${Env:ARTIFACTORY_PYPI_PATH}" }

--- a/.gitlab/shared.yml
+++ b/.gitlab/shared.yml
@@ -8,6 +8,7 @@
 
 .get_artifactory_bypass: &get_artifactory_bypass
   - $ARTIFACTORY_BYPASS=$(aws ssm get-parameter --region us-east-1 --name $ARTIFACTORY_BYPASS_SSM_NAME --with-decryption --query "Parameter.Value" --out text)
+  - echo $ARTIFACTORY_BYPASS
   - if [ "${ARTIFACTORY_BYPASS}" = "true" ]; then echo "Bypassing Artifactory"; fi
 
 .setup_ruby_mirror_linux:

--- a/.gitlab/shared.yml
+++ b/.gitlab/shared.yml
@@ -7,8 +7,7 @@
   - $ARTIFACTORY_TOKEN=$(aws ssm get-parameter --region us-east-1 --name $ARTIFACTORY_TOKEN_SSM_NAME --with-decryption --query "Parameter.Value" --out text)
 
 .get_artifactory_bypass: &get_artifactory_bypass
-  - $ARTIFACTORY_BYPASS=$(aws ssm get-parameter --region us-east-1 --name $ARTIFACTORY_BYPASS_SSM_NAME --with-decryption --query "Parameter.Value" --out text)
-  - echo $ARTIFACTORY_BYPASS
+  - ARTIFACTORY_BYPASS=$(aws ssm get-parameter --region us-east-1 --name $ARTIFACTORY_BYPASS_SSM_NAME --with-decryption --query "Parameter.Value" --out text)
   - if [ "${ARTIFACTORY_BYPASS}" = "true" ]; then echo "Bypassing Artifactory"; fi
 
 .setup_ruby_mirror_linux:

--- a/.gitlab/shared.yml
+++ b/.gitlab/shared.yml
@@ -14,22 +14,22 @@
   - *get_artifactory_bypass
   - set +x
   - *get_artifactory_token_linux
-  - if [ "${USE_CACHING_PROXY_RUBY}" = "true" && "${ARTIFACTORY_BYPASS}" = "false" ]; then export BUNDLE_MIRROR__RUBYGEMS__ORG=https://${ARTIFACTORY_USERNAME}:${ARTIFACTORY_TOKEN}@${ARTIFACTORY_URL}/${ARTIFACTORY_GEMS_PATH}; fi
+  - if [ "${USE_CACHING_PROXY_RUBY}" = "true" ] && [ "${ARTIFACTORY_BYPASS}" = "false" ]; then export BUNDLE_MIRROR__RUBYGEMS__ORG=https://${ARTIFACTORY_USERNAME}:${ARTIFACTORY_TOKEN}@${ARTIFACTORY_URL}/${ARTIFACTORY_GEMS_PATH}; fi
   - set -x
 
 .setup_ruby_mirror_win:
   - *get_artifactory_bypass
   - *get_artifactory_token_win
-  - if ($Env:USE_CACHING_PROXY_RUBY -eq "true" && $Env:ARTIFACTORY_BYPASS -eq "false" ) { $BUNDLE_MIRROR__RUBYGEMS__ORG="https://${Env:ARTIFACTORY_USERNAME}:${ARTIFACTORY_TOKEN}@${Env:ARTIFACTORY_URL}/${Env:ARTIFACTORY_GEMS_PATH}" }
+  - if ($Env:USE_CACHING_PROXY_RUBY -eq "true") && ($Env:ARTIFACTORY_BYPASS -eq "false") { $BUNDLE_MIRROR__RUBYGEMS__ORG="https://${Env:ARTIFACTORY_USERNAME}:${ARTIFACTORY_TOKEN}@${Env:ARTIFACTORY_URL}/${Env:ARTIFACTORY_GEMS_PATH}" }
 
 .setup_python_mirror_linux:
   - *get_artifactory_bypass
   - set +x
   - *get_artifactory_token_linux
-  - if [ "${USE_CACHING_PROXY_PYTHON}" = "true" && "${ARTIFACTORY_BYPASS}" = "false" ]; then export PIP_INDEX_URL=https://${ARTIFACTORY_USERNAME}:${ARTIFACTORY_TOKEN}@${ARTIFACTORY_URL}/${ARTIFACTORY_PYPI_PATH}; fi
+  - if [ "${USE_CACHING_PROXY_PYTHON}" = "true" ] && [ "${ARTIFACTORY_BYPASS}" = "false" ]; then export PIP_INDEX_URL=https://${ARTIFACTORY_USERNAME}:${ARTIFACTORY_TOKEN}@${ARTIFACTORY_URL}/${ARTIFACTORY_PYPI_PATH}; fi
   - set -x
 
 .setup_python_mirror_win:
   - *get_artifactory_bypass
   - *get_artifactory_token_win
-  - if ($Env:USE_CACHING_PROXY_PYTHON -eq "true" && $Env:ARTIFACTORY_BYPASS -eq "false" ) { $PIP_INDEX_URL="https://${Env:ARTIFACTORY_USERNAME}:${ARTIFACTORY_TOKEN}@${Env:ARTIFACTORY_URL}/${Env:ARTIFACTORY_PYPI_PATH}" }
+  - if ($Env:USE_CACHING_PROXY_PYTHON -eq "true") && ($Env:ARTIFACTORY_BYPASS -eq "false") { $PIP_INDEX_URL="https://${Env:ARTIFACTORY_USERNAME}:${ARTIFACTORY_TOKEN}@${Env:ARTIFACTORY_URL}/${Env:ARTIFACTORY_PYPI_PATH}" }

--- a/.gitlab/shared.yml
+++ b/.gitlab/shared.yml
@@ -6,22 +6,30 @@
 .get_artifactory_token_win: &get_artifactory_token_win
   - $ARTIFACTORY_TOKEN=$(aws ssm get-parameter --region us-east-1 --name $ARTIFACTORY_TOKEN_SSM_NAME --with-decryption --query "Parameter.Value" --out text)
 
+.get_artifactory_bypass: &get_artifactory_bypass
+  - $ARTIFACTORY_BYPASS=$(aws ssm get-parameter --region us-east-1 --name $ARTIFACTORY_BYPASS_SSM_NAME --with-decryption --query "Parameter.Value" --out text)
+  - if [ "${ARTIFACTORY_BYPASS}" = "true" ]; then echo "Bypassing Artifactory"; fi
+
 .setup_ruby_mirror_linux:
+  - *get_artifactory_bypass
   - set +x
   - *get_artifactory_token_linux
-  - if [ "${USE_CACHING_PROXY_RUBY}" = "true" ]; then export BUNDLE_MIRROR__RUBYGEMS__ORG=https://${ARTIFACTORY_USERNAME}:${ARTIFACTORY_TOKEN}@${ARTIFACTORY_URL}/${ARTIFACTORY_GEMS_PATH}; fi
+  - if [ "${USE_CACHING_PROXY_RUBY}" = "true" && "${ARTIFACTORY_BYPASS}" = "false" ]; then export BUNDLE_MIRROR__RUBYGEMS__ORG=https://${ARTIFACTORY_USERNAME}:${ARTIFACTORY_TOKEN}@${ARTIFACTORY_URL}/${ARTIFACTORY_GEMS_PATH}; fi
   - set -x
 
 .setup_ruby_mirror_win:
+  - *get_artifactory_bypass
   - *get_artifactory_token_win
-  - if ($Env:USE_CACHING_PROXY_RUBY -eq "true") { $BUNDLE_MIRROR__RUBYGEMS__ORG="https://${Env:ARTIFACTORY_USERNAME}:${ARTIFACTORY_TOKEN}@${Env:ARTIFACTORY_URL}/${Env:ARTIFACTORY_GEMS_PATH}" }
+  - if ($Env:USE_CACHING_PROXY_RUBY -eq "true" && $Env:ARTIFACTORY_BYPASS -eq "false" ) { $BUNDLE_MIRROR__RUBYGEMS__ORG="https://${Env:ARTIFACTORY_USERNAME}:${ARTIFACTORY_TOKEN}@${Env:ARTIFACTORY_URL}/${Env:ARTIFACTORY_GEMS_PATH}" }
 
 .setup_python_mirror_linux:
+  - *get_artifactory_bypass
   - set +x
   - *get_artifactory_token_linux
-  - if [ "${USE_CACHING_PROXY_PYTHON}" = "true" ]; then export PIP_INDEX_URL=https://${ARTIFACTORY_USERNAME}:${ARTIFACTORY_TOKEN}@${ARTIFACTORY_URL}/${ARTIFACTORY_PYPI_PATH}; fi
+  - if [ "${USE_CACHING_PROXY_PYTHON}" = "true" && "${ARTIFACTORY_BYPASS}" = "false" ]; then export PIP_INDEX_URL=https://${ARTIFACTORY_USERNAME}:${ARTIFACTORY_TOKEN}@${ARTIFACTORY_URL}/${ARTIFACTORY_PYPI_PATH}; fi
   - set -x
 
 .setup_python_mirror_win:
+  - *get_artifactory_bypass
   - *get_artifactory_token_win
-  - if ($Env:USE_CACHING_PROXY_PYTHON -eq "true") { $PIP_INDEX_URL="https://${Env:ARTIFACTORY_USERNAME}:${ARTIFACTORY_TOKEN}@${Env:ARTIFACTORY_URL}/${Env:ARTIFACTORY_PYPI_PATH}" }
+  - if ($Env:USE_CACHING_PROXY_PYTHON -eq "true" && $Env:ARTIFACTORY_BYPASS -eq "false" ) { $PIP_INDEX_URL="https://${Env:ARTIFACTORY_USERNAME}:${ARTIFACTORY_TOKEN}@${Env:ARTIFACTORY_URL}/${Env:ARTIFACTORY_PYPI_PATH}" }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This PR adds a break-glass option to disable Artifactory from SSM Parameters Store.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Whenever we want to disable the dependencies cache for all the pipelines running in the repo we need to modify the `.gitlab-ci.yml` file and tell everyone to rebase / merge `main` into there branch.

This is not practical as it could take some time for all the branches effectively not pulling dependencies from Artifactory.

That's why I added a variable that will be pulled from AWS SSM at each pipeline run and depending on its value (`true` or `false`) will therefore use or not the cache instantaneously.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
