### PR TITLE
Add Impersonate=no to deferred and rollback custom actions

### DIFF
--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentCustomActions.cs
@@ -94,7 +94,8 @@ namespace WixSetup.Datadog
                 Conditions.Upgrading
             )
             {
-                Execute = Execute.deferred
+                Execute = Execute.deferred,
+                Impersonate = false
             };
 
             ReportInstallFailure = new CustomAction<Telemetry>(
@@ -105,7 +106,8 @@ namespace WixSetup.Datadog
                 Step.StartServices
             )
             {
-                Execute = Execute.rollback
+                Execute = Execute.rollback,
+                Impersonate = false
             }
             .SetProperties("APIKEY=[APIKEY], SITE=[SITE]")
             .HideTarget(true); ;
@@ -119,7 +121,8 @@ namespace WixSetup.Datadog
                 Conditions.FirstInstall | Conditions.Upgrading | Conditions.Maintenance
             )
                 {
-                Execute = Execute.deferred
+                Execute = Execute.deferred,
+                Impersonate = false
             }
             .SetProperties("ADDLOCAL=[ADDLOCAL]");
 
@@ -132,7 +135,8 @@ namespace WixSetup.Datadog
                 Conditions.FirstInstall
             )
             {
-                Execute = Execute.deferred
+                Execute = Execute.deferred,
+                Impersonate = false
             }
             .SetProperties(
                 "APPLICATIONDATADIRECTORY=[APPLICATIONDATADIRECTORY], " +
@@ -175,7 +179,8 @@ namespace WixSetup.Datadog
                 Conditions.FirstInstall
             )
             {
-                Execute = Execute.rollback
+                Execute = Execute.rollback,
+                Impersonate = false
             }
             .SetProperties("PROJECTLOCATION=[PROJECTLOCATION], APPLICATIONDATADIRECTORY=[APPLICATIONDATADIRECTORY]");
 
@@ -188,7 +193,8 @@ namespace WixSetup.Datadog
                 Conditions.FirstInstall | Conditions.Upgrading
             )
             {
-                Execute = Execute.deferred
+                Execute = Execute.deferred,
+                Impersonate = false
             }
             .SetProperties("PROJECTLOCATION=[PROJECTLOCATION], embedded2_SIZE=[embedded2_SIZE], embedded3_SIZE=[embedded3_SIZE]");
 
@@ -215,7 +221,8 @@ namespace WixSetup.Datadog
                 Conditions.Uninstalling
             )
             {
-                Execute = Execute.deferred
+                Execute = Execute.deferred,
+                Impersonate = false
             }
             .SetProperties("PROJECTLOCATION=[PROJECTLOCATION], APPLICATIONDATADIRECTORY=[APPLICATIONDATADIRECTORY]");
 
@@ -228,7 +235,8 @@ namespace WixSetup.Datadog
                 Condition.NOT(Conditions.Uninstalling)
             )
             {
-                Execute = Execute.deferred
+                Execute = Execute.deferred,
+                Impersonate = false
             }
             .SetProperties("APPLICATIONDATADIRECTORY=[APPLICATIONDATADIRECTORY], " +
                            "PROJECTLOCATION=[PROJECTLOCATION], " +
@@ -277,7 +285,8 @@ namespace WixSetup.Datadog
                 Conditions.FirstInstall | Conditions.Upgrading
             )
             {
-                Execute = Execute.deferred
+                Execute = Execute.deferred,
+                Impersonate = false
             }
             .SetProperties("APPLICATIONDATADIRECTORY=[APPLICATIONDATADIRECTORY]," +
                            "OVERRIDE_INSTALLATION_METHOD=[OVERRIDE_INSTALLATION_METHOD]");


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Add `Impersonate=no` to our deferred and rollback custom actions. This makes them run in the context of the installer service (SYSTEM) instead of impersonating to the user running the installer, which may not be elevated. For example if an admin double clicks the installer on the desktop, the installer will not be run elevated.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
https://datadoghq.atlassian.net/browse/WA-269

### Additional Notes
Corresponding actions in [OG installer
](https://github.com/DataDog/datadog-agent/blob/7f004efcd0ec1d4bc741c4b282cd08e4abec7d20/omnibus/resources/agent/msi/source.wxs.erb#L717-L721)
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
With default UAC settings (enabled), double click the installer on the desktop to install and then to uninstall.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
