### PR TITLE
Fix pod condition tag

### DIFF
--- a/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/pod.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/pod.go
@@ -293,7 +293,7 @@ func extractPodConditions(p *corev1.Pod) (conditions []*model.PodCondition, cond
 
 		conditions = append(conditions, c)
 
-		conditionTag := fmt.Sprintf("pod_condition_%s:%s", strings.ToLower(string(condition.Type)), strings.ToLower(string(condition.Status)))
+		conditionTag := fmt.Sprintf("kube_condition_%s:%s", strings.ToLower(string(condition.Type)), strings.ToLower(string(condition.Status)))
 		conditionTags = append(conditionTags, conditionTag)
 	}
 

--- a/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/pod_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/pod_test.go
@@ -218,7 +218,7 @@ func TestExtractPod(t *testing.T) {
 						LastTransitionTime: timestamp.Unix(),
 					},
 				},
-				Tags: []string{"pod_condition_ready:true", "pod_condition_podscheduled:true"},
+				Tags: []string{"kube_condition_ready:true", "kube_condition_podscheduled:true"},
 			},
 		},
 		"empty pod": {input: v1.Pod{}, expected: model.Pod{Metadata: &model.Metadata{}}},
@@ -299,7 +299,7 @@ func TestExtractPod(t *testing.T) {
 						Status: "True",
 					},
 				},
-				Tags: []string{"pod_condition_ready:true"},
+				Tags: []string{"kube_condition_ready:true"},
 			},
 		},
 		"partial pod with init container": {
@@ -397,7 +397,7 @@ func TestExtractPod(t *testing.T) {
 						Status: "True",
 					},
 				},
-				Tags:     []string{"pod_condition_ready:true"},
+				Tags:     []string{"kube_condition_ready:true"},
 				QOSClass: "BestEffort",
 			},
 		},
@@ -480,7 +480,7 @@ func TestExtractPod(t *testing.T) {
 						Status: "True",
 					},
 				},
-				Tags: []string{"pod_condition_ready:true"},
+				Tags: []string{"kube_condition_ready:true"},
 			},
 		},
 	}
@@ -730,10 +730,10 @@ func TestExtractPodConditions(t *testing.T) {
 		},
 	}
 	expectedTags := []string{
-		"pod_condition_initialized:true",
-		"pod_condition_podscheduled:true",
-		"pod_condition_containersready:false",
-		"pod_condition_ready:unknown",
+		"kube_condition_initialized:true",
+		"kube_condition_podscheduled:true",
+		"kube_condition_containersready:false",
+		"kube_condition_ready:unknown",
 	}
 
 	conditions, conditionTags := extractPodConditions(p)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Fix the tag format used for pod conditions: `kube_condition_<condition_name>:<condition_value>` instead of `pod_condition_<condition_name>:<condition_value>`.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
