### PR TITLE
Handle prerelease versions passed via DD_AGENT_MINOR_VERSION

### DIFF
--- a/cmd/agent/install_mac_os.sh
+++ b/cmd/agent/install_mac_os.sh
@@ -165,7 +165,7 @@ if [ -z "$dmg_version" ]; then
     if [ "$agent_minor_version" = "$clean_agent_minor_version" ];then
         dmg_version="${agent_major_version}.${agent_minor_version_without_patch}.${agent_patch_version}-1"
     else
-        dmg_version="${agent_minor_version}-1"
+        dmg_version="${agent_major_version}.${agent_minor_version}-1"
     fi
 fi
 dmg_url="$dmg_base_url/datadog-agent-${dmg_version}.dmg"

--- a/cmd/agent/install_mac_os.sh
+++ b/cmd/agent/install_mac_os.sh
@@ -14,6 +14,10 @@ run_dir=/opt/datadog-agent/run
 service_name="com.datadoghq.agent"
 systemwide_servicefile_name="/Library/LaunchDaemons/${service_name}.plist"
 
+if [ -n "$DD_REPO_URL" ]; then
+    dmg_base_url=$DD_REPO_URL
+fi
+
 upgrade=
 if [ -n "$DD_UPGRADE" ]; then
     upgrade=$DD_UPGRADE

--- a/cmd/agent/install_mac_os.sh
+++ b/cmd/agent/install_mac_os.sh
@@ -41,7 +41,8 @@ if [ -n "$DD_AGENT_MINOR_VERSION" ]; then
   #  - 20   = defaults to highest patch version x.20.2
   #  - 20.0 = sets explicit patch version x.20.0
   # Note: Specifying an invalid minor version will terminate the script.
-  agent_minor_version=$DD_AGENT_MINOR_VERSION
+  # Handle pre-release versions like "35.0~rc.5" -> "35.0" or "27.1~viper~conflict~fix" -> "27.1"
+  agent_minor_version=$(echo "${DD_AGENT_MINOR_VERSION}" | sed -E 's/~.*//g')
   # remove the patch version if the minor version includes it (eg: 33.1 -> 33)
   agent_minor_version_without_patch="${agent_minor_version%.*}"
   if [ "$agent_minor_version" != "$agent_minor_version_without_patch" ]; then


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Mirror of [PR#29](https://github.com/DataDog/agent-linux-install-script/pull/29) for the linux install script

Changes :
  - agent_minor_version now parse pre_release suffix correctly ( e.g: 35.0~rc.5 -> 35.0)
  - Allow the install script to use the environment variable ``DD_REPO_URL`` to specify the repo to fetch agent from (allowing users to install pre-release on macOS)

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
