### PR TITLE
Fixes sent byte count for docker-proxy connections

### DIFF
--- a/pkg/network/conn_filter.go
+++ b/pkg/network/conn_filter.go
@@ -3,56 +3,55 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-package testutil
+package network
 
 import (
 	"net"
 	"net/netip"
 
-	"github.com/DataDog/datadog-agent/pkg/network"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 )
 
 // ConnectionFilterFunc is a function type which returns whether the provided connection matches the filter
-type ConnectionFilterFunc func(c network.ConnectionStats) bool
+type ConnectionFilterFunc func(c ConnectionStats) bool
 
 // ByTuple matches connections when both source and destination address and port match
 func ByTuple(l, r net.Addr) ConnectionFilterFunc {
-	return func(c network.ConnectionStats) bool {
+	return func(c ConnectionStats) bool {
 		return addrMatches(l, c.Source, c.SPort) && addrMatches(r, c.Dest, c.DPort)
 	}
 }
 
 // BySourceAddress matches connections with the same source address and port
 func BySourceAddress(a net.Addr) ConnectionFilterFunc {
-	return func(c network.ConnectionStats) bool {
+	return func(c ConnectionStats) bool {
 		return addrMatches(a, c.Source, c.SPort)
 	}
 }
 
 // ByDestAddress matches connections with the same destination address and port
 func ByDestAddress(a net.Addr) ConnectionFilterFunc {
-	return func(c network.ConnectionStats) bool {
+	return func(c ConnectionStats) bool {
 		return addrMatches(a, c.Dest, c.DPort)
 	}
 }
 
 // ByType matches connections with the same connection type (TCP/UDP)
-func ByType(ct network.ConnectionType) ConnectionFilterFunc {
-	return func(c network.ConnectionStats) bool {
+func ByType(ct ConnectionType) ConnectionFilterFunc {
+	return func(c ConnectionStats) bool {
 		return c.Type == ct
 	}
 }
 
 // ByFamily matches connections with the same family (IPv4 / IPv6)
-func ByFamily(f network.ConnectionFamily) ConnectionFilterFunc {
-	return func(c network.ConnectionStats) bool {
+func ByFamily(f ConnectionFamily) ConnectionFilterFunc {
+	return func(c ConnectionStats) bool {
 		return c.Family == f
 	}
 }
 
 // FirstConnection returns the first connection with matches all filters
-func FirstConnection(c *network.Connections, filters ...ConnectionFilterFunc) *network.ConnectionStats {
+func FirstConnection(c *Connections, filters ...ConnectionFilterFunc) *ConnectionStats {
 	if result := FilterConnections(c, filters...); len(result) > 0 {
 		return &result[0]
 	}
@@ -60,8 +59,8 @@ func FirstConnection(c *network.Connections, filters ...ConnectionFilterFunc) *n
 }
 
 // FilterConnections returns connections which match all filters
-func FilterConnections(c *network.Connections, filters ...ConnectionFilterFunc) []network.ConnectionStats {
-	var results []network.ConnectionStats
+func FilterConnections(c *Connections, filters ...ConnectionFilterFunc) []ConnectionStats {
+	var results []ConnectionStats
 ConnLoop:
 	for _, conn := range c.Conns {
 		for _, f := range filters {

--- a/pkg/network/ebpf/c/co-re/tracer-fentry.c
+++ b/pkg/network/ebpf/c/co-re/tracer-fentry.c
@@ -128,6 +128,48 @@ int BPF_PROG(tcp_sendmsg_exit, struct sock *sk, struct msghdr *msg, size_t size,
     return handle_message(&t, sent, 0, CONN_DIRECTION_UNKNOWN, packets_out, packets_in, PACKET_COUNT_ABSOLUTE, sk);
 }
 
+SEC("fexit/tcp_sendpage")
+int BPF_PROG(tcp_sendpage_exit, struct sock *sk, struct page *page, int offset, size_t size, int flags, int sent) {
+    if (sent < 0) {
+        log_debug("fexit/tcp_sendpage: err=%d\n", sent);
+        return 0;
+    }
+
+    u64 pid_tgid = bpf_get_current_pid_tgid();
+    log_debug("fexit/tcp_sendpage: pid_tgid: %d, sent: %d, sock: %llx\n", pid_tgid, sent, sk);
+
+    conn_tuple_t t = {};
+    if (!read_conn_tuple(&t, sk, pid_tgid, CONN_TYPE_TCP)) {
+        return 0;
+    }
+
+    handle_tcp_stats(&t, sk, 0);
+
+    __u32 packets_in = 0;
+    __u32 packets_out = 0;
+    get_tcp_segment_counts(sk, &packets_in, &packets_out);
+
+    return handle_message(&t, sent, 0, CONN_DIRECTION_UNKNOWN, packets_out, packets_in, PACKET_COUNT_ABSOLUTE, sk);
+}
+
+SEC("fexit/udp_sendpage")
+int BPF_PROG(udp_sendpage_exit, struct sock *sk, struct page *page, int offset, size_t size, int flags, int sent) {
+    if (sent < 0) {
+        log_debug("fexit/udp_sendpage: err=%d\n", sent);
+        return 0;
+    }
+
+    u64 pid_tgid = bpf_get_current_pid_tgid();
+    log_debug("fexit/udp_sendpage: pid_tgid: %d, sent: %d, sock: %llx\n", pid_tgid, sent, sk);
+
+    conn_tuple_t t = {};
+    if (!read_conn_tuple(&t, sk, pid_tgid, CONN_TYPE_UDP)) {
+        return 0;
+    }
+
+    return handle_message(&t, sent, 0, CONN_DIRECTION_UNKNOWN, 0, 0, PACKET_COUNT_NONE, sk);
+}
+
 SEC("fexit/tcp_recvmsg")
 int BPF_PROG(tcp_recvmsg_exit, struct sock *sk, struct msghdr *msg, size_t len, int nonblock, int flags, int *addr_len, int copied) {
     if (copied < 0) { // error
@@ -307,7 +349,7 @@ int BPF_PROG(tcp_retransmit_skb_exit, struct sock *sk, struct sk_buff *skb, int 
     u32 retrans_out_pre = args->retrans_out_pre;
     u32 retrans_out = BPF_CORE_READ(tcp_sk(sk), retrans_out);
     bpf_map_delete_elem(&pending_tcp_retransmit_skb, &tid);
-    
+
     if (retrans_out < 0) {
         return 0;
     }
@@ -545,33 +587,6 @@ int BPF_PROG(sockfd_lookup_light_exit, int fd, int *err, int *fput_needed, struc
     // These entries are cleaned up by tcp_close
     bpf_map_update_with_telemetry(pid_fd_by_sock, &sock, &pid_fd, BPF_ANY);
     bpf_map_update_with_telemetry(sock_by_pid_fd, &pid_fd, &sock, BPF_ANY);
-
-    return 0;
-}
-
-SEC("fexit/do_sendfile")
-int BPF_PROG(do_sendfile_exit, int out_fd, int in_fd, loff_t *ppos,
-             size_t count, loff_t max, ssize_t sent) {
-    if (sent <= 0) {
-        return 0;
-    }
-
-    u64 pid_tgid = bpf_get_current_pid_tgid();
-    pid_fd_t key = {
-        .pid = pid_tgid >> 32,
-        .fd = out_fd,
-    };
-    struct sock **sock = bpf_map_lookup_elem(&sock_by_pid_fd, &key);
-    if (sock == NULL) {
-        return 0;
-    }
-
-    conn_tuple_t t = {};
-    if (!read_conn_tuple(&t, *sock, pid_tgid, CONN_TYPE_TCP)) {
-        return 0;
-    }
-
-    handle_message(&t, sent, 0, CONN_DIRECTION_UNKNOWN, 0, 0, PACKET_COUNT_NONE, *sock);
 
     return 0;
 }

--- a/pkg/network/ebpf/c/runtime/tracer.c
+++ b/pkg/network/ebpf/c/runtime/tracer.c
@@ -115,6 +115,89 @@ int kretprobe__tcp_sendmsg(struct pt_regs *ctx) {
     return handle_message(&t, sent, 0, CONN_DIRECTION_UNKNOWN, packets_out, packets_in, PACKET_COUNT_ABSOLUTE, skp);
 }
 
+SEC("kprobe/tcp_sendpage")
+int kprobe__tcp_sendpage(struct pt_regs *ctx) {
+    u64 pid_tgid = bpf_get_current_pid_tgid();
+    log_debug("kprobe/tcp_sendpage: pid_tgid: %d\n", pid_tgid);
+    struct sock *skp = (struct sock *)PT_REGS_PARM1(ctx);
+    bpf_map_update_with_telemetry(tcp_sendpage_args, &pid_tgid, &skp, BPF_ANY);
+    return 0;
+}
+
+SEC("kretprobe/tcp_sendpage")
+int kretprobe__tcp_sendpage(struct pt_regs *ctx) {
+    u64 pid_tgid = bpf_get_current_pid_tgid();
+    struct sock **skpp = (struct sock **)bpf_map_lookup_elem(&tcp_sendpage_args, &pid_tgid);
+    if (!skpp) {
+        log_debug("kretprobe/tcp_sendpage: sock not found\n");
+        return 0;
+    }
+
+    struct sock *skp = *skpp;
+    bpf_map_delete_elem(&tcp_sendpage_args, &pid_tgid);
+
+    int sent = PT_REGS_RC(ctx);
+    if (sent < 0) {
+        return 0;
+    }
+
+    if (!skp) {
+        return 0;
+    }
+
+    log_debug("kretprobe/tcp_sendpage: pid_tgid: %d, sent: %d, sock: %x\n", pid_tgid, sent, skp);
+    conn_tuple_t t = {};
+    if (!read_conn_tuple(&t, skp, pid_tgid, CONN_TYPE_TCP)) {
+        return 0;
+    }
+
+    handle_tcp_stats(&t, skp, 0);
+
+    __u32 packets_in = 0;
+    __u32 packets_out = 0;
+    get_tcp_segment_counts(skp, &packets_in, &packets_out);
+
+    return handle_message(&t, sent, 0, CONN_DIRECTION_UNKNOWN, packets_out, packets_in, PACKET_COUNT_ABSOLUTE, skp);
+}
+
+SEC("kprobe/udp_sendpage")
+int kprobe__udp_sendpage(struct pt_regs *ctx) {
+    u64 pid_tgid = bpf_get_current_pid_tgid();
+    log_debug("kprobe/udp_sendpage: pid_tgid: %d\n", pid_tgid);
+    struct sock *skp = (struct sock *)PT_REGS_PARM1(ctx);
+    bpf_map_update_with_telemetry(udp_sendpage_args, &pid_tgid, &skp, BPF_ANY);
+    return 0;
+}
+
+SEC("kretprobe/udp_sendpage")
+int kretprobe__udp_sendpage(struct pt_regs *ctx) {
+    u64 pid_tgid = bpf_get_current_pid_tgid();
+    struct sock **skpp = (struct sock **)bpf_map_lookup_elem(&udp_sendpage_args, &pid_tgid);
+    if (!skpp) {
+        log_debug("kretprobe/udp_sendpage: sock not found\n");
+        return 0;
+    }
+
+    struct sock *skp = *skpp;
+    bpf_map_delete_elem(&udp_sendpage_args, &pid_tgid);
+
+    int sent = PT_REGS_RC(ctx);
+    if (sent < 0) {
+        return 0;
+    }
+    if (!skp) {
+        return 0;
+    }
+
+    log_debug("kretprobe/udp_sendpage: pid_tgid: %d, sent: %d, sock: %x\n", pid_tgid, sent, skp);
+    conn_tuple_t t = {};
+    if (!read_conn_tuple(&t, skp, pid_tgid, CONN_TYPE_UDP)) {
+        return 0;
+    }
+
+    return handle_message(&t, sent, 0, CONN_DIRECTION_UNKNOWN, 0, 0, PACKET_COUNT_NONE, skp);
+}
+
 SEC("kprobe/tcp_close")
 int kprobe__tcp_close(struct pt_regs *ctx) {
     struct sock *sk;
@@ -765,50 +848,6 @@ int kretprobe__sockfd_lookup_light(struct pt_regs *ctx) {
     bpf_map_update_with_telemetry(sock_by_pid_fd, &pid_fd, &sock, BPF_ANY);
 cleanup:
     bpf_map_delete_elem(&sockfd_lookup_args, &pid_tgid);
-    return 0;
-}
-
-SEC("kprobe/do_sendfile")
-int kprobe__do_sendfile(struct pt_regs *ctx) {
-    u32 fd_out = (int)PT_REGS_PARM1(ctx);
-    u64 pid_tgid = bpf_get_current_pid_tgid();
-    pid_fd_t key = {
-        .pid = pid_tgid >> 32,
-        .fd = fd_out,
-    };
-    struct sock **sock = bpf_map_lookup_elem(&sock_by_pid_fd, &key);
-    if (sock == NULL) {
-        return 0;
-    }
-
-    // bring map value to eBPF stack to satisfy Kernel 4.4 verifier
-    struct sock *skp = *sock;
-    bpf_map_update_with_telemetry(do_sendfile_args, &pid_tgid, &skp, BPF_ANY);
-    return 0;
-}
-
-SEC("kretprobe/do_sendfile")
-int kretprobe__do_sendfile(struct pt_regs *ctx) {
-    u64 pid_tgid = bpf_get_current_pid_tgid();
-    struct sock **sock = bpf_map_lookup_elem(&do_sendfile_args, &pid_tgid);
-    if (sock == NULL) {
-        return 0;
-    }
-
-    conn_tuple_t t = {};
-    if (!read_conn_tuple(&t, *sock, pid_tgid, CONN_TYPE_TCP)) {
-        goto cleanup;
-    }
-
-    ssize_t sent = (ssize_t)PT_REGS_RC(ctx);
-    if (sent > 0) {
-        __u32 packets_in = 0;
-        __u32 packets_out = 0;
-        get_tcp_segment_counts(*sock, &packets_in, &packets_out);
-        handle_message(&t, sent, 0, CONN_DIRECTION_UNKNOWN, packets_out, packets_in, PACKET_COUNT_ABSOLUTE, *sock);
-    }
-cleanup:
-    bpf_map_delete_elem(&do_sendfile_args, &pid_tgid);
     return 0;
 }
 

--- a/pkg/network/ebpf/c/tracer-maps.h
+++ b/pkg/network/ebpf/c/tracer-maps.h
@@ -37,6 +37,18 @@ BPF_HASH_MAP(conn_close_batch, __u32, batch_t, 1024)
 BPF_HASH_MAP(tcp_sendmsg_args, __u64, struct sock *, 1024)
 
 /*
+ * Map to hold struct sock parameter for tcp_sendpage calls
+ * to be used in kretprobe/tcp_sendpage
+ */
+BPF_HASH_MAP(tcp_sendpage_args, __u64, struct sock *, 1024)
+
+/*
+ * Map to hold struct sock parameter for udp_sendpage calls
+ * to be used in kretprobe/udp_sendpage
+ */
+BPF_HASH_MAP(udp_sendpage_args, __u64, struct sock *, 1024)
+
+/*
  * Map to hold struct sock parameter for tcp_recvmsg/tcp_read_sock calls
  * to be used in kretprobe/tcp_recvmsg/tcp_read_sock
  */
@@ -87,13 +99,6 @@ BPF_ARRAY_MAP(telemetry, telemetry_t, 1)
  * Values: the args of the tcp_retransmit_skb call being instrumented.
  */
 BPF_HASH_MAP(pending_tcp_retransmit_skb, __u64, tcp_retransmit_skb_args_t, 8192)
-
-// This map is used to to temporarily store function arguments (the struct sock*
-// mapped to the given fd_out) for do_sendfile function calls, so they can be
-// accessed by the corresponding kretprobe.
-// * Key is pid_tgid (u64)
-// * Value is (struct sock*)
-BPF_HASH_MAP(do_sendfile_args, __u64, struct sock *, 1024)
 
 // Used to store ip(6)_make_skb args to be used in the
 // corresponding kretprobes

--- a/pkg/network/ebpf/probes/probes.go
+++ b/pkg/network/ebpf/probes/probes.go
@@ -36,6 +36,10 @@ const (
 
 	// TCPSendMsg traces the tcp_sendmsg() system call
 	TCPSendMsg ProbeFuncName = "kprobe__tcp_sendmsg"
+	// TCPSendPage traces the tcp_sendpage() kernel function
+	TCPSendPage ProbeFuncName = "kprobe__tcp_sendpage"
+	// UDPSendPage traces the udp_sendpage() kernel function
+	UDPSendPage ProbeFuncName = "kprobe__udp_sendpage"
 
 	// TCPSendMsgPre410 traces the tcp_sendmsg() system call on kernels prior to 4.1.0. This is created because
 	// we need to load a different kprobe implementation
@@ -45,6 +49,10 @@ const (
 	// XXX: This is only used for telemetry for now to count the number of errors returned
 	// by the tcp_sendmsg func (so we can have a # of tcp sent bytes we miscounted)
 	TCPSendMsgReturn ProbeFuncName = "kretprobe__tcp_sendmsg"
+	// TCPSendPageReturn traces the return value of tcp_sendpage()
+	TCPSendPageReturn ProbeFuncName = "kretprobe__tcp_sendpage"
+	// UDPSendPageReturn traces the return value of udp_sendpage()
+	UDPSendPageReturn ProbeFuncName = "kretprobe__udp_sendpage"
 
 	// TCPGetSockOpt traces the tcp_getsockopt() kernel function
 	// This probe is used for offset guessing only
@@ -117,7 +125,7 @@ const (
 	TCPRetransmit ProbeFuncName = "kprobe__tcp_retransmit_skb"
 	// TCPRetransmitPre470 traces the params for the tcp_retransmit_skb() system call on kernel version < 4.7
 	TCPRetransmitPre470 ProbeFuncName = "kprobe__tcp_retransmit_skb_pre_4_7_0"
-	// TCPRetransmit traces the return value for the tcp_retransmit_skb() system call
+	// TCPRetransmitRet traces the return value for the tcp_retransmit_skb() system call
 	TCPRetransmitRet ProbeFuncName = "kretprobe__tcp_retransmit_skb"
 
 	// InetCskAcceptReturn traces the return value for the inet_csk_accept syscall
@@ -147,12 +155,6 @@ const (
 
 	// SockFDLookupRet is the kretprobe used for mapping socket FDs to kernel sock structs
 	SockFDLookupRet ProbeFuncName = "kretprobe__sockfd_lookup_light"
-
-	// DoSendfile is the kprobe used to trace traffic via SENDFILE(2) syscall
-	DoSendfile ProbeFuncName = "kprobe__do_sendfile"
-
-	// DoSendfileRet is the kretprobe used to trace traffic via SENDFILE(2) syscall
-	DoSendfileRet ProbeFuncName = "kretprobe__do_sendfile"
 )
 
 // BPFMapName stores the name of the BPF maps storing statistics and other info
@@ -172,10 +174,11 @@ const (
 	ConntrackMap                      BPFMapName = "conntrack"
 	ConntrackTelemetryMap             BPFMapName = "conntrack_telemetry"
 	SockFDLookupArgsMap               BPFMapName = "sockfd_lookup_args"
-	DoSendfileArgsMap                 BPFMapName = "do_sendfile_args"
 	SockByPidFDMap                    BPFMapName = "sock_by_pid_fd"
 	PidFDBySockMap                    BPFMapName = "pid_fd_by_sock"
 	TcpSendMsgArgsMap                 BPFMapName = "tcp_sendmsg_args"
+	TcpSendPageArgsMap                BPFMapName = "tcp_sendpage_args"
+	UdpSendPageArgsMap                BPFMapName = "udp_sendpage_args"
 	IpMakeSkbArgsMap                  BPFMapName = "ip_make_skb_args"
 	MapErrTelemetryMap                BPFMapName = "map_err_telemetry_map"
 	HelperErrTelemetryMap             BPFMapName = "helper_err_telemetry_map"

--- a/pkg/network/testutil/conn_filter.go
+++ b/pkg/network/testutil/conn_filter.go
@@ -1,0 +1,81 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package testutil
+
+import (
+	"net"
+	"net/netip"
+
+	"github.com/DataDog/datadog-agent/pkg/network"
+	"github.com/DataDog/datadog-agent/pkg/process/util"
+)
+
+// ConnectionFilterFunc is a function type which returns whether the provided connection matches the filter
+type ConnectionFilterFunc func(c network.ConnectionStats) bool
+
+// ByTuple matches connections when both source and destination address and port match
+func ByTuple(l, r net.Addr) ConnectionFilterFunc {
+	return func(c network.ConnectionStats) bool {
+		return addrMatches(l, c.Source, c.SPort) && addrMatches(r, c.Dest, c.DPort)
+	}
+}
+
+// BySourceAddress matches connections with the same source address and port
+func BySourceAddress(a net.Addr) ConnectionFilterFunc {
+	return func(c network.ConnectionStats) bool {
+		return addrMatches(a, c.Source, c.SPort)
+	}
+}
+
+// ByDestAddress matches connections with the same destination address and port
+func ByDestAddress(a net.Addr) ConnectionFilterFunc {
+	return func(c network.ConnectionStats) bool {
+		return addrMatches(a, c.Dest, c.DPort)
+	}
+}
+
+// ByType matches connections with the same connection type (TCP/UDP)
+func ByType(ct network.ConnectionType) ConnectionFilterFunc {
+	return func(c network.ConnectionStats) bool {
+		return c.Type == ct
+	}
+}
+
+// ByFamily matches connections with the same family (IPv4 / IPv6)
+func ByFamily(f network.ConnectionFamily) ConnectionFilterFunc {
+	return func(c network.ConnectionStats) bool {
+		return c.Family == f
+	}
+}
+
+// FirstConnection returns the first connection with matches all filters
+func FirstConnection(c *network.Connections, filters ...ConnectionFilterFunc) *network.ConnectionStats {
+	if result := FilterConnections(c, filters...); len(result) > 0 {
+		return &result[0]
+	}
+	return nil
+}
+
+// FilterConnections returns connections which match all filters
+func FilterConnections(c *network.Connections, filters ...ConnectionFilterFunc) []network.ConnectionStats {
+	var results []network.ConnectionStats
+ConnLoop:
+	for _, conn := range c.Conns {
+		for _, f := range filters {
+			if !f(conn) {
+				continue ConnLoop
+			}
+		}
+		results = append(results, conn)
+	}
+	return results
+}
+
+func addrMatches(addr net.Addr, host util.Address, port uint16) bool {
+	a := netip.MustParseAddrPort(addr.String())
+	b := netip.AddrPortFrom(host.Addr, port)
+	return a == b
+}

--- a/pkg/network/tracer/connection/dump.go
+++ b/pkg/network/tracer/connection/dump.go
@@ -15,10 +15,11 @@ import (
 	"github.com/cilium/ebpf"
 	"github.com/davecgh/go-spew/spew"
 
+	manager "github.com/DataDog/ebpf-manager"
+
 	ddebpf "github.com/DataDog/datadog-agent/pkg/network/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/network/ebpf/probes"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	manager "github.com/DataDog/ebpf-manager"
 )
 
 func dumpMapsHandler(manager *manager.Manager, mapName string, currentMap *ebpf.Map) string {
@@ -171,16 +172,6 @@ func dumpMapsHandler(manager *manager.Manager, mapName string, currentMap *ebpf.
 			log.Tracef("error retrieving the telemetry struct: %s", err)
 		}
 		output.WriteString(spew.Sdump(telemetry))
-
-	case probes.DoSendfileArgsMap: // maps/do_sendfile_args (BPF_MAP_TYPE_HASH), key C.__u64, value uintptr // C.struct sock*
-		output.WriteString("Map: '" + mapName + "', key: 'C.__u64', value: 'uintptr // C.struct sock*'\n")
-		iter := currentMap.Iterate()
-		var key uint64
-		var value uintptr // C.struct sock*
-		for iter.Next(unsafe.Pointer(&key), unsafe.Pointer(&value)) {
-			output.WriteString(spew.Sdump(key, value))
-		}
-
 	}
 
 	return output.String()

--- a/pkg/network/tracer/connection/fentry/probes.go
+++ b/pkg/network/tracer/connection/fentry/probes.go
@@ -23,7 +23,9 @@ const (
 	tcpFinishConnect = "tcp_finish_connect"
 
 	// tcpSendMsgReturn traces the return value for the tcp_sendmsg() system call
-	tcpSendMsgReturn = "tcp_sendmsg_exit"
+	tcpSendMsgReturn  = "tcp_sendmsg_exit"
+	tcpSendPageReturn = "tcp_sendpage_exit"
+	udpSendPageReturn = "udp_sendpage_exit"
 
 	// tcpSetState traces the tcp_set_state() kernel function
 	tcpSetState = "tcp_set_state"
@@ -63,18 +65,14 @@ const (
 
 	// sockFDLookupRet is the kretprobe used for mapping socket FDs to kernel sock structs
 	sockFDLookupRet = "sockfd_lookup_light_exit"
-
-	// doSendfileRet is the kretprobe used to trace traffic via SENDFILE(2) syscall
-	doSendfileRet = "do_sendfile_exit"
 )
 
 var programs = map[string]struct{}{
-	doSendfileRet:        {}, // TODO: available but sockfd_lookup_light not available on some kernels
 	inet6BindRet:         {},
 	inetBindRet:          {},
 	inetCskAcceptReturn:  {},
 	inetCskListenStop:    {},
-	sockFDLookupRet:      {}, // TODO: not available on certain kernels, will have to one or more hooks to get equivalent functionality; affects do_sendfile and HTTPS monitoring (OpenSSL/GnuTLS/GoTLS)
+	sockFDLookupRet:      {}, // TODO: not available on certain kernels, will have to one or more hooks to get equivalent functionality; affects HTTPS monitoring (OpenSSL/GnuTLS/GoTLS)
 	tcpRecvMsgReturn:     {},
 	tcpClose:             {},
 	tcpCloseReturn:       {},
@@ -83,6 +81,7 @@ var programs = map[string]struct{}{
 	tcpRetransmit:        {},
 	tcpRetransmitRet:     {},
 	tcpSendMsgReturn:     {},
+	tcpSendPageReturn:    {},
 	tcpSetState:          {},
 	udpDestroySock:       {},
 	udpDestroySockReturn: {},
@@ -105,6 +104,7 @@ func enabledPrograms(c *config.Config) (map[string]struct{}, error) {
 	enabled := make(map[string]struct{}, 0)
 	if c.CollectTCPConns {
 		enableProgram(enabled, tcpSendMsgReturn)
+		enableProgram(enabled, tcpSendPageReturn)
 		enableProgram(enabled, tcpRecvMsgReturn)
 		enableProgram(enabled, tcpClose)
 		enableProgram(enabled, tcpCloseReturn)
@@ -122,7 +122,6 @@ func enabledPrograms(c *config.Config) (map[string]struct{}, error) {
 		// missing, err := ebpf.VerifyKernelFuncs(ksymPath, []string{"sockfd_lookup_light"})
 		// if err == nil && len(missing) == 0 {
 		// 	enableProgram(enabled, sockFDLookupRet)
-		// 	enableProgram(enabled, doSendfileRet)
 		// }
 	}
 
@@ -133,6 +132,7 @@ func enabledPrograms(c *config.Config) (map[string]struct{}, error) {
 		enableProgram(enabled, udpRecvMsgReturn)
 		enableProgram(enabled, udpSendMsgReturn)
 		enableProgram(enabled, udpSendSkb)
+		enableProgram(enabled, udpSendPageReturn)
 
 		if c.CollectIPv6Conns {
 			enableProgram(enabled, inet6BindRet)

--- a/pkg/network/tracer/connection/fentry/probes.go
+++ b/pkg/network/tracer/connection/fentry/probes.go
@@ -87,6 +87,7 @@ var programs = map[string]struct{}{
 	udpDestroySockReturn: {},
 	udpRecvMsgReturn:     {},
 	udpSendMsgReturn:     {},
+	udpSendPageReturn:    {},
 	udpSendSkb:           {},
 	udpv6RecvMsgReturn:   {},
 	udpv6SendMsgReturn:   {},

--- a/pkg/network/tracer/connection/kprobe/config.go
+++ b/pkg/network/tracer/connection/kprobe/config.go
@@ -42,6 +42,8 @@ func enabledProbes(c *config.Config, runtimeTracer bool) (map[probes.ProbeFuncNa
 		}
 		enableProbe(enabled, selectVersionBasedProbe(runtimeTracer, kv, probes.TCPSendMsg, probes.TCPSendMsgPre410, kv410))
 		enableProbe(enabled, probes.TCPSendMsgReturn)
+		enableProbe(enabled, probes.TCPSendPage)
+		enableProbe(enabled, probes.TCPSendPageReturn)
 		enableProbe(enabled, selectVersionBasedProbe(runtimeTracer, kv, probes.TCPRecvMsg, probes.TCPRecvMsgPre410, kv410))
 		enableProbe(enabled, probes.TCPRecvMsgReturn)
 		enableProbe(enabled, probes.TCPReadSock)
@@ -60,8 +62,6 @@ func enabledProbes(c *config.Config, runtimeTracer bool) (map[probes.ProbeFuncNa
 		if err == nil && len(missing) == 0 {
 			enableProbe(enabled, probes.SockFDLookup)
 			enableProbe(enabled, probes.SockFDLookupRet)
-			enableProbe(enabled, probes.DoSendfile)
-			enableProbe(enabled, probes.DoSendfileRet)
 		}
 	}
 
@@ -72,6 +72,8 @@ func enabledProbes(c *config.Config, runtimeTracer bool) (map[probes.ProbeFuncNa
 		enableProbe(enabled, probes.IPMakeSkbReturn)
 		enableProbe(enabled, probes.InetBind)
 		enableProbe(enabled, probes.InetBindRet)
+		enableProbe(enabled, probes.UDPSendPage)
+		enableProbe(enabled, probes.UDPSendPageReturn)
 
 		if c.CollectIPv6Conns {
 			enableProbe(enabled, selectVersionBasedProbe(runtimeTracer, kv, probes.IP6MakeSkb, probes.IP6MakeSkbPre470, kv470))

--- a/pkg/network/tracer/connection/kprobe/manager.go
+++ b/pkg/network/tracer/connection/kprobe/manager.go
@@ -32,6 +32,8 @@ var mainProbes = []probes.ProbeFuncName{
 	probes.ProtocolClassifierDBsSocketFilter,
 	probes.TCPSendMsg,
 	probes.TCPSendMsgReturn,
+	probes.TCPSendPage,
+	probes.TCPSendPageReturn,
 	probes.TCPRecvMsg,
 	probes.TCPRecvMsgReturn,
 	probes.TCPReadSock,
@@ -61,8 +63,8 @@ var mainProbes = []probes.ProbeFuncName{
 	probes.Inet6BindRet,
 	probes.SockFDLookup,
 	probes.SockFDLookupRet,
-	probes.DoSendfile,
-	probes.DoSendfileRet,
+	probes.UDPSendPage,
+	probes.UDPSendPageReturn,
 }
 
 func initManager(mgr *manager.Manager, config *config.Config, closedHandler *ebpf.PerfHandler, runtimeTracer bool) {
@@ -80,8 +82,9 @@ func initManager(mgr *manager.Manager, config *config.Config, closedHandler *ebp
 		{Name: probes.SockByPidFDMap},
 		{Name: probes.PidFDBySockMap},
 		{Name: probes.SockFDLookupArgsMap},
-		{Name: probes.DoSendfileArgsMap},
 		{Name: probes.TcpSendMsgArgsMap},
+		{Name: probes.TcpSendPageArgsMap},
+		{Name: probes.UdpSendPageArgsMap},
 		{Name: probes.IpMakeSkbArgsMap},
 		{Name: probes.MapErrTelemetryMap},
 		{Name: probes.HelperErrTelemetryMap},

--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -212,7 +212,7 @@ func TestTCPRetransmitSharedSocket(t *testing.T) {
 
 	// Fetch all connections matching source and target address
 	allConnections := getConnections(t, tr)
-	conns := searchConnections(allConnections, byAddress(c.LocalAddr(), c.RemoteAddr()))
+	conns := testutil.FilterConnections(allConnections, testutil.ByTuple(c.LocalAddr(), c.RemoteAddr()))
 	require.Len(t, conns, numProcesses)
 
 	totalSent := 0
@@ -1387,10 +1387,10 @@ func TestSendfileRegression(t *testing.T) {
 		assert.Eventually(t, func() bool {
 			conns := getConnections(t, tr)
 			if outConn == nil {
-				outConn = firstConnection(conns, byType(connType), byFamily(family), byAddress(c.LocalAddr(), c.RemoteAddr()))
+				outConn = testutil.FirstConnection(conns, testutil.ByType(connType), testutil.ByFamily(family), testutil.ByTuple(c.LocalAddr(), c.RemoteAddr()))
 			}
 			if inConn == nil {
-				inConn = firstConnection(conns, byType(connType), byFamily(family), byAddress(c.RemoteAddr(), c.LocalAddr()))
+				inConn = testutil.FirstConnection(conns, testutil.ByType(connType), testutil.ByFamily(family), testutil.ByTuple(c.RemoteAddr(), c.LocalAddr()))
 			}
 			return outConn != nil && inConn != nil
 		}, 3*time.Second, 500*time.Millisecond, "couldn't find connections used by sendfile(2)")

--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -212,7 +212,7 @@ func TestTCPRetransmitSharedSocket(t *testing.T) {
 
 	// Fetch all connections matching source and target address
 	allConnections := getConnections(t, tr)
-	conns := testutil.FilterConnections(allConnections, testutil.ByTuple(c.LocalAddr(), c.RemoteAddr()))
+	conns := network.FilterConnections(allConnections, network.ByTuple(c.LocalAddr(), c.RemoteAddr()))
 	require.Len(t, conns, numProcesses)
 
 	totalSent := 0
@@ -1387,10 +1387,10 @@ func TestSendfileRegression(t *testing.T) {
 		assert.Eventually(t, func() bool {
 			conns := getConnections(t, tr)
 			if outConn == nil {
-				outConn = testutil.FirstConnection(conns, testutil.ByType(connType), testutil.ByFamily(family), testutil.ByTuple(c.LocalAddr(), c.RemoteAddr()))
+				outConn = network.FirstConnection(conns, network.ByType(connType), network.ByFamily(family), network.ByTuple(c.LocalAddr(), c.RemoteAddr()))
 			}
 			if inConn == nil {
-				inConn = testutil.FirstConnection(conns, testutil.ByType(connType), testutil.ByFamily(family), testutil.ByTuple(c.RemoteAddr(), c.LocalAddr()))
+				inConn = network.FirstConnection(conns, network.ByType(connType), network.ByFamily(family), network.ByTuple(c.RemoteAddr(), c.LocalAddr()))
 			}
 			return outConn != nil && inConn != nil
 		}, 3*time.Second, 500*time.Millisecond, "couldn't find connections used by sendfile(2)")

--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -18,6 +18,7 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -827,10 +828,9 @@ func TestConnectionAssured(t *testing.T) {
 		},
 	}
 
-	done := make(chan struct{})
-	err := server.Run(done, clientMessageSize)
+	err := server.Run(clientMessageSize)
 	require.NoError(t, err)
-	defer close(done)
+	t.Cleanup(server.Shutdown)
 
 	c, err := net.DialTimeout("udp", server.address, time.Second)
 	require.NoError(t, err)
@@ -869,10 +869,9 @@ func TestConnectionNotAssured(t *testing.T) {
 		},
 	}
 
-	done := make(chan struct{})
-	err := server.Run(done, clientMessageSize)
+	err := server.Run(clientMessageSize)
 	require.NoError(t, err)
-	defer close(done)
+	t.Cleanup(server.Shutdown)
 
 	c, err := net.DialTimeout("udp", server.address, time.Second)
 	require.NoError(t, err)
@@ -1174,8 +1173,8 @@ func TestUDPReusePort(t *testing.T) {
 
 func testUDPReusePort(t *testing.T, udpnet string, ip string) {
 	cfg := testConfig()
-	if !cfg.EnableRuntimeCompiler {
-		t.Skip("reuseport only supported on runtime compilation")
+	if isPrebuilt(cfg) {
+		t.Skip("reuseport not supported on prebuilt")
 	}
 
 	tr := setupTracer(t, cfg)
@@ -1203,15 +1202,15 @@ func testUDPReusePort(t *testing.T, udpnet string, ip string) {
 		}
 	}
 
-	doneChan := make(chan struct{})
-	t.Cleanup(func() { close(doneChan) })
 	s1 := createReuseServer(port)
 	s2 := createReuseServer(port)
-	err := s1.Run(doneChan, clientMessageSize)
+	err := s1.Run(clientMessageSize)
 	require.NoError(t, err)
+	t.Cleanup(s1.Shutdown)
 
-	err = s2.Run(doneChan, clientMessageSize)
+	err = s2.Run(clientMessageSize)
 	require.NoError(t, err)
+	t.Cleanup(s2.Shutdown)
 
 	// Connect to server
 	c, err := net.DialTimeout(udpnet, s1.address, 50*time.Millisecond)
@@ -1344,64 +1343,120 @@ func ipRouteGet(t *testing.T, from, dest string, iif *net.Interface) *net.Interf
 	return ifi
 }
 
+type SyscallConn interface {
+	net.Conn
+	SyscallConn() (syscall.RawConn, error)
+}
+
 func TestSendfileRegression(t *testing.T) {
 	// Start tracer
-	tr := setupTracer(t, testConfig())
-
-	if tr.ebpfTracer.Type() == connection.EBPFFentry {
-		t.Skip("sendfile not yet supported on fentry tracer/Fargate")
-	}
+	cfg := testConfig()
+	tr := setupTracer(t, cfg)
 
 	// Create temporary file
-	tmpfile, err := os.CreateTemp("", "sendfile_source")
+	tmpdir := t.TempDir()
+	tmpfilePath := filepath.Join(tmpdir, "sendfile_source")
+	tmpfile, err := os.Create(tmpfilePath)
 	require.NoError(t, err)
-	defer os.Remove(tmpfile.Name())
+
 	n, err := tmpfile.Write(genPayload(clientMessageSize))
 	require.NoError(t, err)
 	require.Equal(t, clientMessageSize, n)
-	_, err = tmpfile.Seek(0, 0)
-	require.NoError(t, err)
-
-	// Start TCP server
-	var rcvd int64
-	server := NewTCPServer(func(c net.Conn) {
-		rcvd, _ = io.Copy(io.Discard, c)
-		c.Close()
-	})
-	t.Cleanup(server.Shutdown)
-	require.NoError(t, server.Run())
-
-	// Connect to TCP server
-	c, err := net.DialTimeout("tcp", server.address, time.Second)
-	require.NoError(t, err)
 
 	// Grab file size
 	stat, err := tmpfile.Stat()
 	require.NoError(t, err)
 	fsize := int(stat.Size())
 
-	// Send file contents via SENDFILE(2)
-	n, err = sendFile(t, c, tmpfile, nil, fsize)
-	require.NoError(t, err)
-	require.Equal(t, fsize, n)
+	testSendfileServer := func(t *testing.T, c SyscallConn, connType network.ConnectionType, family network.ConnectionFamily, rcvdFunc func() int64) {
+		_, err = tmpfile.Seek(0, 0)
+		require.NoError(t, err)
 
-	// Verify that our TCP server received the contents of the file
-	c.Close()
-	require.Eventually(t, func() bool {
-		return int64(clientMessageSize) == rcvd
-	}, 3*time.Second, 500*time.Millisecond, "TCP server didn't receive data")
+		// Send file contents via SENDFILE(2)
+		n, err = sendFile(t, c, tmpfile, nil, fsize)
+		require.NoError(t, err)
+		require.Equal(t, fsize, n)
 
-	// Finally, retrieve connection and assert that the sendfile was accounted for
-	var conn *network.ConnectionStats
-	require.Eventually(t, func() bool {
-		conns := getConnections(t, tr)
-		t.Logf("%+v", conns.Conns)
-		var ok bool
-		conn, ok = findConnection(c.LocalAddr(), c.RemoteAddr(), conns)
-		return ok && conn.Monotonic.SentBytes > 0
-	}, 3*time.Second, 500*time.Millisecond, "couldn't find connection used by sendfile(2)")
+		// Verify that our server received the contents of the file
+		c.Close()
+		require.Eventually(t, func() bool {
+			return int64(clientMessageSize) == rcvdFunc()
+		}, 3*time.Second, 500*time.Millisecond, "TCP server didn't receive data")
 
-	assert.Equalf(t, int64(clientMessageSize), int64(conn.Monotonic.SentBytes), "sendfile data wasn't properly traced")
+		var outConn, inConn *network.ConnectionStats
+		assert.Eventually(t, func() bool {
+			conns := getConnections(t, tr)
+			if outConn == nil {
+				outConn = firstConnection(conns, byType(connType), byFamily(family), byAddress(c.LocalAddr(), c.RemoteAddr()))
+			}
+			if inConn == nil {
+				inConn = firstConnection(conns, byType(connType), byFamily(family), byAddress(c.RemoteAddr(), c.LocalAddr()))
+			}
+			return outConn != nil && inConn != nil
+		}, 3*time.Second, 500*time.Millisecond, "couldn't find connections used by sendfile(2)")
+
+		if assert.NotNil(t, outConn, "couldn't find outgoing connection used by sendfile(2)") {
+			assert.Equalf(t, int64(clientMessageSize), int64(outConn.Monotonic.SentBytes), "sendfile send data wasn't properly traced")
+		}
+		if assert.NotNil(t, inConn, "couldn't find incoming connection used by sendfile(2)") {
+			assert.Equalf(t, int64(clientMessageSize), int64(inConn.Monotonic.RecvBytes), "sendfile recv data wasn't properly traced")
+		}
+	}
+
+	for _, family := range []network.ConnectionFamily{network.AFINET, network.AFINET6} {
+		t.Run(family.String(), func(t *testing.T) {
+			t.Run("TCP", func(t *testing.T) {
+				// Start TCP server
+				var rcvd int64
+				server := TCPServer{
+					network: "tcp" + strings.TrimPrefix(family.String(), "v"),
+					onMessage: func(c net.Conn) {
+						rcvd, _ = io.Copy(io.Discard, c)
+						c.Close()
+					},
+				}
+				t.Cleanup(server.Shutdown)
+				require.NoError(t, server.Run())
+
+				// Connect to TCP server
+				c, err := net.DialTimeout("tcp", server.address, time.Second)
+				require.NoError(t, err)
+
+				testSendfileServer(t, c.(*net.TCPConn), network.TCP, family, func() int64 { return rcvd })
+			})
+			t.Run("UDP", func(t *testing.T) {
+				if isPrebuilt(cfg) {
+					t.Skip("UDP will fail with prebuilt tracer")
+				}
+
+				// Start TCP server
+				var rcvd int64
+				server := &UDPServer{
+					network: "udp" + strings.TrimPrefix(family.String(), "v"),
+					onMessage: func(b []byte, n int) []byte {
+						rcvd = rcvd + int64(n)
+						return nil
+					},
+				}
+				t.Cleanup(server.Shutdown)
+				require.NoError(t, server.Run(1024))
+
+				// Connect to UDP server
+				c, err := net.DialTimeout(server.network, server.address, time.Second)
+				require.NoError(t, err)
+
+				testSendfileServer(t, c.(*net.UDPConn), network.UDP, family, func() int64 { return rcvd })
+			})
+		})
+	}
+
+}
+
+func isPrebuilt(cfg *config.Config) bool {
+	if cfg.EnableRuntimeCompiler || cfg.EnableCORE {
+		return false
+	}
+	return true
 }
 
 func TestSendfileError(t *testing.T) {
@@ -1429,7 +1484,7 @@ func TestSendfileError(t *testing.T) {
 
 	// Send file contents via SENDFILE(2)
 	offset := int64(math.MaxInt64 - 1)
-	_, err = sendFile(t, c, tmpfile, &offset, 10)
+	_, err = sendFile(t, c.(*net.TCPConn), tmpfile, &offset, 10)
 	require.Error(t, err)
 
 	c.Close()
@@ -1445,9 +1500,9 @@ func TestSendfileError(t *testing.T) {
 	assert.Equalf(t, int64(0), int64(conn.Monotonic.SentBytes), "sendfile data wasn't properly traced")
 }
 
-func sendFile(t *testing.T, c net.Conn, f *os.File, offset *int64, count int) (int, error) {
+func sendFile(t *testing.T, c SyscallConn, f *os.File, offset *int64, count int) (int, error) {
 	// Send payload using SENDFILE(2) syscall
-	rawConn, err := c.(*net.TCPConn).SyscallConn()
+	rawConn, err := c.SyscallConn()
 	require.NoError(t, err)
 	var n int
 	var serr error

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -37,7 +37,6 @@ import (
 	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/network"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
-	nettestutil "github.com/DataDog/datadog-agent/pkg/network/testutil"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -762,12 +761,12 @@ func TestSkipConnectionDNS(t *testing.T) {
 }
 
 func findConnection(l, r net.Addr, c *network.Connections) (*network.ConnectionStats, bool) {
-	res := nettestutil.FirstConnection(c, nettestutil.ByTuple(l, r))
+	res := network.FirstConnection(c, network.ByTuple(l, r))
 	return res, res != nil
 }
 
 func searchConnections(c *network.Connections, predicate func(network.ConnectionStats) bool) []network.ConnectionStats {
-	return nettestutil.FilterConnections(c, predicate)
+	return network.FilterConnections(c, predicate)
 }
 
 func runBenchtests(b *testing.B, payloads []int, prefix string, f func(p int) func(*testing.B)) {

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -19,7 +19,6 @@ import (
 	"math/rand"
 	"net"
 	nethttp "net/http"
-	"net/url"
 	"os"
 	"runtime"
 	"strconv"
@@ -38,6 +37,7 @@ import (
 	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/network"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
+	nettestutil "github.com/DataDog/datadog-agent/pkg/network/testutil"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -761,69 +761,13 @@ func TestSkipConnectionDNS(t *testing.T) {
 	})
 }
 
-type connectionFilterFunc func(c network.ConnectionStats) bool
-
-func byAddress(l, r net.Addr) func(c network.ConnectionStats) bool {
-	return func(c network.ConnectionStats) bool {
-		return addrMatches(l, c.Source.String(), c.SPort) && addrMatches(r, c.Dest.String(), c.DPort)
-	}
-}
-
-func byType(ct network.ConnectionType) func(c network.ConnectionStats) bool {
-	return func(c network.ConnectionStats) bool {
-		return c.Type == ct
-	}
-}
-
-func byFamily(f network.ConnectionFamily) func(c network.ConnectionStats) bool {
-	return func(c network.ConnectionStats) bool {
-		return c.Family == f
-	}
-}
-
 func findConnection(l, r net.Addr, c *network.Connections) (*network.ConnectionStats, bool) {
-	if result := searchConnections(c, byAddress(l, r)); len(result) > 0 {
-		return &result[0], true
-	}
-
-	return nil, false
-}
-
-func firstConnection(c *network.Connections, filters ...connectionFilterFunc) *network.ConnectionStats {
-	if result := filterConnections(c, filters...); len(result) > 0 {
-		return &result[0]
-	}
-	return nil
-}
-
-func filterConnections(c *network.Connections, filters ...connectionFilterFunc) []network.ConnectionStats {
-	var results []network.ConnectionStats
-ConnLoop:
-	for _, conn := range c.Conns {
-		for _, f := range filters {
-			if !f(conn) {
-				continue ConnLoop
-			}
-		}
-		results = append(results, conn)
-	}
-	return results
+	res := nettestutil.FirstConnection(c, nettestutil.ByTuple(l, r))
+	return res, res != nil
 }
 
 func searchConnections(c *network.Connections, predicate func(network.ConnectionStats) bool) []network.ConnectionStats {
-	var results []network.ConnectionStats
-	for _, conn := range c.Conns {
-		if predicate(conn) {
-			results = append(results, conn)
-		}
-	}
-	return results
-}
-
-func addrMatches(addr net.Addr, host string, port uint16) bool {
-	addrURL := url.URL{Scheme: addr.Network(), Host: addr.String()}
-
-	return addrURL.Hostname() == host && addrURL.Port() == strconv.Itoa(int(port))
+	return nettestutil.FilterConnections(c, predicate)
 }
 
 func runBenchtests(b *testing.B, payloads []int, prefix string, f func(p int) func(*testing.B)) {

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -13,6 +13,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"math/rand"
@@ -485,10 +486,9 @@ func testUDPSendAndReceive(t *testing.T, addr string) {
 		},
 	}
 
-	doneChan := make(chan struct{})
-	err := server.Run(doneChan, clientMessageSize)
+	err := server.Run(clientMessageSize)
 	require.NoError(t, err)
-	t.Cleanup(func() { close(doneChan) })
+	t.Cleanup(server.Shutdown)
 
 	initTracerState(t, tr)
 
@@ -540,10 +540,9 @@ func TestUDPDisabled(t *testing.T) {
 		},
 	}
 
-	doneChan := make(chan struct{})
-	err := server.Run(doneChan, clientMessageSize)
+	err := server.Run(clientMessageSize)
 	require.NoError(t, err)
-	defer close(doneChan)
+	t.Cleanup(server.Shutdown)
 
 	// Connect to server
 	c, err := net.DialTimeout("udp", server.address, 50*time.Millisecond)
@@ -762,9 +761,23 @@ func TestSkipConnectionDNS(t *testing.T) {
 	})
 }
 
+type connectionFilterFunc func(c network.ConnectionStats) bool
+
 func byAddress(l, r net.Addr) func(c network.ConnectionStats) bool {
 	return func(c network.ConnectionStats) bool {
 		return addrMatches(l, c.Source.String(), c.SPort) && addrMatches(r, c.Dest.String(), c.DPort)
+	}
+}
+
+func byType(ct network.ConnectionType) func(c network.ConnectionStats) bool {
+	return func(c network.ConnectionStats) bool {
+		return c.Type == ct
+	}
+}
+
+func byFamily(f network.ConnectionFamily) func(c network.ConnectionStats) bool {
+	return func(c network.ConnectionStats) bool {
+		return c.Family == f
 	}
 }
 
@@ -774,6 +787,27 @@ func findConnection(l, r net.Addr, c *network.Connections) (*network.ConnectionS
 	}
 
 	return nil, false
+}
+
+func firstConnection(c *network.Connections, filters ...connectionFilterFunc) *network.ConnectionStats {
+	if result := filterConnections(c, filters...); len(result) > 0 {
+		return &result[0]
+	}
+	return nil
+}
+
+func filterConnections(c *network.Connections, filters ...connectionFilterFunc) []network.ConnectionStats {
+	var results []network.ConnectionStats
+ConnLoop:
+	for _, conn := range c.Conns {
+		for _, f := range filters {
+			if !f(conn) {
+				continue ConnLoop
+			}
+		}
+		results = append(results, conn)
+	}
+	return results
 }
 
 func searchConnections(c *network.Connections, predicate func(network.ConnectionStats) bool) []network.ConnectionStats {
@@ -817,11 +851,10 @@ func benchEchoUDP(size int) func(b *testing.B) {
 	}
 
 	return func(b *testing.B) {
-		end := make(chan struct{})
 		server := &UDPServer{onMessage: echoOnMessage}
-		err := server.Run(end, size)
+		err := server.Run(size)
 		require.NoError(b, err)
-		defer close(end)
+		defer server.Shutdown()
 
 		c, err := net.DialTimeout("udp", server.address, 50*time.Millisecond)
 		if err != nil {
@@ -936,6 +969,7 @@ func benchSendTCP(size int) func(b *testing.B) {
 
 type TCPServer struct {
 	address   string
+	network   string
 	onMessage func(c net.Conn)
 	ln        net.Listener
 }
@@ -952,7 +986,11 @@ func NewTCPServerOnAddress(addr string, onMessage func(c net.Conn)) *TCPServer {
 }
 
 func (t *TCPServer) Run() error {
-	ln, err := net.Listen("tcp", t.address)
+	networkType := "tcp"
+	if t.network != "" {
+		networkType = t.network
+	}
+	ln, err := net.Listen(networkType, t.address)
 	if err != nil {
 		return err
 	}
@@ -984,51 +1022,57 @@ type UDPServer struct {
 	address   string
 	lc        *net.ListenConfig
 	onMessage func(b []byte, n int) []byte
+	ln        net.PacketConn
 }
 
-func (s *UDPServer) Run(done chan struct{}, payloadSize int) error {
+func (s *UDPServer) Run(payloadSize int) error {
 	networkType := "udp"
 	if s.network != "" {
 		networkType = s.network
 	}
 	var err error
-	var ln net.PacketConn
 	if s.lc != nil {
-		ln, err = s.lc.ListenPacket(context.Background(), networkType, s.address)
+		s.ln, err = s.lc.ListenPacket(context.Background(), networkType, s.address)
 	} else {
-		ln, err = net.ListenPacket(networkType, s.address)
+		s.ln, err = net.ListenPacket(networkType, s.address)
 	}
 	if err != nil {
 		return err
 	}
 
-	s.address = ln.LocalAddr().String()
+	s.address = s.ln.LocalAddr().String()
 
 	go func() {
 		buf := make([]byte, payloadSize)
-		running := true
-		for running {
-			select {
-			case <-done:
-				running = false
-			default:
-				ln.SetReadDeadline(time.Now().Add(50 * time.Millisecond))
-				n, addr, err := ln.ReadFrom(buf)
-				if err != nil {
-					break
+		for {
+			n, addr, err := s.ln.ReadFrom(buf)
+			if err != nil {
+				if !errors.Is(err, net.ErrClosed) {
+					fmt.Printf("readfrom: %s\n", err)
 				}
-				_, err = ln.WriteTo(s.onMessage(buf, n), addr)
+				return
+			}
+			ret := s.onMessage(buf, n)
+			if ret != nil {
+				_, err = s.ln.WriteTo(ret, addr)
 				if err != nil {
-					fmt.Println(err)
-					break
+					if !errors.Is(err, net.ErrClosed) {
+						fmt.Printf("writeto: %s\n", err)
+					}
+					return
 				}
 			}
 		}
-
-		ln.Close()
 	}()
 
 	return nil
+}
+
+func (s *UDPServer) Shutdown() {
+	if s.ln != nil {
+		_ = s.ln.Close()
+		s.ln = nil
+	}
 }
 
 var letterBytes = []byte("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

- Adds support for `sendpage` kernel functions
- Extends `sendfile` tests to include UDP and v4/v6 variations
- Removes `do_sendfile` hook since it overlaps with `sendpage`
- Makes the `TestSendfileRegression` stricter by requiring it to find both sides of the connection with matching sent/recv counts.

### Motivation

`docker-proxy` connections had `0` sent byte counts, due to missing the `sendpage` calls which did not use `do_sendfile`.

### Additional Notes

UDP support on prebuilt is limited, because it cannot read the socket addresses in all cases. This causes it to fail the UDP `TestSendfileRegression` tests when using prebuilt, thus they are skipped. See https://github.com/DataDog/datadog-agent/pull/12279

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
