### PR TITLE
[serverless] add http.status_code to all inferred spans as default

### DIFF
--- a/pkg/serverless/invocationlifecycle/lifecycle.go
+++ b/pkg/serverless/invocationlifecycle/lifecycle.go
@@ -229,6 +229,7 @@ func (lp *LifecycleProcessor) OnInvokeEnd(endDetails *InvocationEndDetails) {
 					lp.requestHandler.inferredSpans[1].CompleteInferredSpan(lp.ProcessTrace, lp.getInferredSpanStart(), endDetails.IsError, lp.GetExecutionInfo().TraceID, lp.GetExecutionInfo().SamplingPriority)
 					log.Debug("[lifecycle] The secondary inferred span attributes are %v", lp.requestHandler.inferredSpans[1])
 				}
+				lp.GetInferredSpan().AddTagToInferredSpan("http.status_code", statusCode)
 				lp.GetInferredSpan().CompleteInferredSpan(lp.ProcessTrace, endDetails.EndTime, endDetails.IsError, lp.GetExecutionInfo().TraceID, lp.GetExecutionInfo().SamplingPriority)
 				log.Debugf("[lifecycle] The inferred span attributes are: %v", lp.GetInferredSpan())
 			} else {

--- a/pkg/serverless/invocationlifecycle/lifecycle_test.go
+++ b/pkg/serverless/invocationlifecycle/lifecycle_test.go
@@ -253,6 +253,8 @@ func TestCompleteInferredSpanWithStartTime(t *testing.T) {
 	testProcessor.OnInvokeEnd(&endDetails)
 
 	completedInferredSpan := tracePayload.TracerPayload.Chunks[0].Spans[0]
+	httpStatusCode := testProcessor.GetInferredSpan().Span.GetMeta()["http.status_code"]
+	assert.NotNil(t, httpStatusCode)
 	assert.Equal(t, testProcessor.GetInferredSpan().Span.Start, completedInferredSpan.Start)
 }
 

--- a/pkg/serverless/trace/inferredspan/inferred_span.go
+++ b/pkg/serverless/trace/inferredspan/inferred_span.go
@@ -171,5 +171,8 @@ func IsInferredSpansEnabled() bool {
 // AddTagToInferredSpan is used to add new tags to the inferred span in
 // inferredSpan.Span.Meta[]. Should be used before completing an inferred span.
 func (inferredSpan *InferredSpan) AddTagToInferredSpan(key string, value string) {
+	if inferredSpan.Span.Meta == nil {
+		inferredSpan.Span.Meta = make(map[string]string)
+	}
 	inferredSpan.Span.Meta[key] = value
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
Sets http.status_code as a default tag on inferred spans.
<img width="1099" alt="Screen Shot 2023-03-16 at 2 08 07 PM" src="https://user-images.githubusercontent.com/49878080/225759251-c22ee622-78cd-4641-a91d-acc0e3696a81.png">


<img width="1099" alt="Screen Shot 2023-03-16 at 2 02 32 PM" src="https://user-images.githubusercontent.com/49878080/225759140-37e05b8e-da70-4d12-a42b-97a245f54b62.png">

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
[SLS-3099
](https://datadoghq.atlassian.net/browse/SLS-3099)

Which originated from [SLES-1059](https://datadoghq.atlassian.net/browse/SLES-1059) where we came to the conclusion we needed to add http.status_code as a default span tag to apigateway inferred spans. This new logic adds http.status_code to all inferred spans.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
Manually tested in sls sandbox environment, by publishing a version of the serverless agent (extension) and utilizing it as a lambda layer in the following application: API Gateway->Java AWS Lambda function. The results are captured in the screenshots above. [Dogfluence docs explaining my manual testing process](https://datadoghq.atlassian.net/wiki/spaces/SLS/pages/2723611380/Lambda+Extension#Manual-Testing)
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.


[SLES-1059]: https://datadoghq.atlassian.net/browse/SLES-1059?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ