### PR TITLE
Add an option and an annotation to not attach `kube_service` tag

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -650,6 +650,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("kubernetes_apiserver_client_timeout", 10)
 	config.BindEnvAndSetDefault("kubernetes_map_services_on_ip", false) // temporary opt-out of the new mapping logic
 	config.BindEnvAndSetDefault("kubernetes_apiserver_use_protobuf", false)
+	config.BindEnvAndSetDefault("kubernetes_ad_tags_disabled", []string{})
 
 	config.BindEnvAndSetDefault("prometheus_scrape.enabled", false)           // Enables the prometheus config provider
 	config.BindEnvAndSetDefault("prometheus_scrape.service_endpoints", false) // Enables Service Endpoints checks in the prometheus config provider

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1225,7 +1225,7 @@ api_key:
   ## @param features - list of strings - optional
   ## @env DD_APM_FEATURES - comma separated list of strings - optional
   ## Configure additional beta APM features.
-  ## The list of items available under apm_config.features is not guaranteed to persist across versions; 
+  ## The list of items available under apm_config.features is not guaranteed to persist across versions;
   ## a feature may eventually be promoted to its own configuration option on the agent, or dropped entirely.
   #
   # features: ["error_rare_sample_tracer_drop","table_names","component2name","sql_cache"]
@@ -3108,6 +3108,14 @@ api_key:
 ## regardless of the value of this parameter.
 #
 # disable_cluster_name_tag_key: false
+
+## @param kubernetes_ad_tags_disabled -- list of strings - optional
+## @env DD_KUBERNETES_AD_TAGS_DISABLED -- list of strings - optional
+## Can only be set to a single valid value: [ "kube_service" ]
+## in order to not attach the kube_service tag on ready pods
+#
+# kubernetes_ad_tags_disabled:
+#   - kube_service
 
 {{ end -}}
 {{- if .PrometheusScrape }}

--- a/pkg/tagger/collectors/workloadmeta_test.go
+++ b/pkg/tagger/collectors/workloadmeta_test.go
@@ -393,6 +393,35 @@ func TestHandleKubePod(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "disable kube_service",
+			pod: workloadmeta.KubernetesPod{
+				EntityID: podEntityID,
+				EntityMeta: workloadmeta.EntityMeta{
+					Name:      podName,
+					Namespace: podNamespace,
+					Annotations: map[string]string{
+						"tags.datadoghq.com/disable": "kube_service",
+					},
+				},
+				// kube_service tags
+				KubeServices: []string{"service1", "service2"},
+			},
+			expected: []*TagInfo{
+				{
+					Source:       podSource,
+					Entity:       podTaggerEntityID,
+					HighCardTags: []string{},
+					OrchestratorCardTags: []string{
+						fmt.Sprintf("pod_name:%s", podName),
+					},
+					LowCardTags: []string{
+						fmt.Sprintf("kube_namespace:%s", podNamespace),
+					},
+					StandardTags: []string{},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/releasenotes/notes/option_ignore_kube_service-e3d7864fbe726e3a.yaml
+++ b/releasenotes/notes/option_ignore_kube_service-e3d7864fbe726e3a.yaml
@@ -1,0 +1,25 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Add an option and an annotation to skip ``kube_service`` tags on Kubernetes pods.
+
+    When the selector of a service matches a pod and that pod is ready, its metrics are decorated with a ``kube_service`` tag.
+
+    When the readiness of pod flips, so does the ``kube_service`` tag. This could create visual artifacts (spikes when the tag flips) on dashboards where the queries are missing ``.fill(null)``.
+
+    If many services target a pod, the total number of tags attached to its metrics might exceed a limit that make the whole metric being discarded.
+
+    In order to mitigate those two issues, it’s now possible to set ``kubernetes_ad_tags_disabled`` parameter to ``kube_config`` to globally remove the ``kube_service`` tags on all pods::
+      kubernetes_ad_tags_disabled
+        - kube_service
+
+    It’s also possible to add a ``tags.datadoghq.com/disable: kube_service`` annotation on only the pods for which we want to remove the ``kube_service`` tag.
+
+    Note that ``kube_service`` is the only tag that can be removed via this parameter and this annotation.

--- a/releasenotes/notes/option_ignore_kube_service-e3d7864fbe726e3a.yaml
+++ b/releasenotes/notes/option_ignore_kube_service-e3d7864fbe726e3a.yaml
@@ -12,11 +12,11 @@ enhancements:
 
     When the selector of a service matches a pod and that pod is ready, its metrics are decorated with a ``kube_service`` tag.
 
-    When the readiness of pod flips, so does the ``kube_service`` tag. This could create visual artifacts (spikes when the tag flips) on dashboards where the queries are missing ``.fill(null)``.
+    When the readiness of a pod flips, so does the ``kube_service`` tag. This could create visual artifacts (spikes when the tag flips) on dashboards where the queries are missing ``.fill(null)``.
 
-    If many services target a pod, the total number of tags attached to its metrics might exceed a limit that make the whole metric being discarded.
+    If many services target a pod, the total number of tags attached to its metrics might exceed a limit that causes the whole metric to be discarded.
 
-    In order to mitigate those two issues, it’s now possible to set ``kubernetes_ad_tags_disabled`` parameter to ``kube_config`` to globally remove the ``kube_service`` tags on all pods::
+    In order to mitigate these two issues, it’s now possible to set the ``kubernetes_ad_tags_disabled`` parameter to ``kube_config`` to globally remove the ``kube_service`` tags on all pods::
       kubernetes_ad_tags_disabled
         - kube_service
 


### PR DESCRIPTION
### What does this PR do?

Add an option (`kubernetes_ad_tags_disabled`) and an annotation (`tags.datadoghq.com/disable`) to *not* attach the `kube_service` tag to the metrics, logs, events generated by Kubernetes pods.

### Motivation

When the selector of a service matches a pod and that pod is ready, its metrics are decorated with a ``kube_service`` tag.

When the readiness of pod flips, so does the `kube_service` tag. This could create visual artifacts (spikes when the tag flips) on dashboards where the queries are missing `.fill(null)`.

If many services target a pod, the total number of tags attached to its metrics might exceed a limit that make the whole metric being discarded.

In order to mitigate those two issues, it’s now possible to set `kubernetes_ad_tags_disabled` parameter to `kube_config` to globally remove the `kube_service` tags on all pods:
```yaml
kubernetes_ad_tags_disabled:
  - kube_service
```

It’s also possible to add a `tags.datadoghq.com/disable: kube_service` annotation on only the pods for which we want to remove the `kube_service` tag.

### Additional Notes

Although the syntax of the the option and the annotation look generic, `kube_service` is the only value supported.

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Deploy a `Deployment` and a `Service` that selects the pods of the former.
Check that the metrics and logs of the pods have the proper `kube_service` tag when they are ready.
Add this environment variable to the `datadog-agent` pods:
```yaml
        - name: DD_KUBERNETES_AD_TAGS_DISABLED
          value: '["kube_service"]'
```
and check that the `kube_service` tag isn’t attached to any pod anymore.
Remove the environment variable and annotate the pods with:
```yaml
        tags.datadoghq.com/disable: kube_service
```
and check that the `kube_service` tag disappears only for the annotated pod.

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
