### PR TITLE
Adding `secret_backend_remove_trailing_line_break` option

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -381,6 +381,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("secret_backend_timeout", 30)
 	config.BindEnvAndSetDefault("secret_backend_command_allow_group_exec_perm", false)
 	config.BindEnvAndSetDefault("secret_backend_skip_checks", false)
+	config.BindEnvAndSetDefault("secret_backend_remove_trailing_line_break", false)
 
 	// Use to output logs in JSON format
 	config.BindEnvAndSetDefault("log_format_json", false)
@@ -1666,6 +1667,7 @@ func ResolveSecrets(config Config, origin string) error {
 		config.GetInt("secret_backend_timeout"),
 		config.GetInt("secret_backend_output_max_size"),
 		config.GetBool("secret_backend_command_allow_group_exec_perm"),
+		config.GetBool("secret_backend_remove_trailing_line_break"),
 	)
 
 	if config.GetString("secret_backend_command") != "" {

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -710,6 +710,14 @@ api_key:
 ## Disable fetching secrets for check configurations
 #
 # secret_backend_skip_checks: false
+#
+
+## @param secret_backend_remove_trailing_line_break - boolean - optional - default: false
+## @env DD_SECRET_BACKEND_REMOVE_TRAILING_LINE_BREAK - boolean - optional - default: false
+## Remove trailing line breaks from secrets returned by the secret_backend_command. Some secret management tools automatically
+## add a line break when exporting secrets through files.
+#
+# secret_backend_remove_trailing_line_break: false
 
 ## @param snmp_listener - custom object - optional
 ## Creates and schedules a listener to automatically discover your SNMP devices.

--- a/pkg/secrets/fetch_secret.go
+++ b/pkg/secrets/fetch_secret.go
@@ -148,6 +148,11 @@ func fetchSecret(secretsHandle []string) (map[string]string, error) {
 		if v.ErrorMsg != "" {
 			return nil, fmt.Errorf("an error occurred while decrypting '%s': %s", sec, v.ErrorMsg)
 		}
+
+		if removeTrailingLinebreak {
+			v.Value = strings.TrimRight(v.Value, "\r\n")
+		}
+
 		if v.Value == "" {
 			return nil, fmt.Errorf("decrypted secret for '%s' is empty", sec)
 		}

--- a/pkg/secrets/no_secrets.go
+++ b/pkg/secrets/no_secrets.go
@@ -19,7 +19,8 @@ import (
 var SecretBackendOutputMaxSize = 1024 * 1024
 
 // Init placeholder when compiled without the 'secrets' build tag
-func Init(command string, arguments []string, timeout int, maxSize int, groupExecPerm bool) {}
+func Init(command string, arguments []string, timeout int, maxSize int, groupExecPerm bool, removeTrailingLineBreak bool) {
+}
 
 // Decrypt encrypted secrets are not available on windows
 func Decrypt(data []byte, origin string) ([]byte, error) {

--- a/pkg/secrets/secrets.go
+++ b/pkg/secrets/secrets.go
@@ -37,6 +37,7 @@ var (
 	secretBackendArguments             []string
 	secretBackendTimeout               = 5
 	secretBackendCommandAllowGroupExec bool
+	removeTrailingLinebreak            bool
 
 	// SecretBackendOutputMaxSize defines max size of the JSON output from a secrets reader backend
 	SecretBackendOutputMaxSize = 1024 * 1024
@@ -83,12 +84,13 @@ func registerSecretOrigin(handle string, origin string, yamlPath []string) {
 // Init initializes the command and other options of the secrets package. Since
 // this package is used by the 'config' package to decrypt itself we can't
 // directly use it.
-func Init(command string, arguments []string, timeout int, maxSize int, groupExecPerm bool) {
+func Init(command string, arguments []string, timeout int, maxSize int, groupExecPerm bool, removeLinebreak bool) {
 	secretBackendCommand = command
 	secretBackendArguments = arguments
 	secretBackendTimeout = timeout
 	SecretBackendOutputMaxSize = maxSize
 	secretBackendCommandAllowGroupExec = groupExecPerm
+	removeTrailingLinebreak = removeLinebreak
 	if secretBackendCommandAllowGroupExec {
 		log.Warnf("Agent configuration relax permissions constraint on the secret backend cmd, Group can read and exec")
 	}

--- a/pkg/secrets/secrets_test.go
+++ b/pkg/secrets/secrets_test.go
@@ -142,6 +142,7 @@ func resetPackageVars() {
 	secretFetcher = fetchSecret
 	secretBackendTimeout = 0
 	scrubberAddReplacer = scrubber.AddStrippedKeys
+	removeTrailingLinebreak = false
 }
 
 func TestIsEnc(t *testing.T) {

--- a/releasenotes/notes/secret-remove-line-break-0060501dec2ddf0f.yaml
+++ b/releasenotes/notes/secret-remove-line-break-0060501dec2ddf0f.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Adding a new option `secret_backend_remove_trailing_line_break` to remove trailing line breaks from secrets returned
+    by `secret_backend_command`. This makes it easier to use secret management tools that automatically add a line break when
+    exporting secrets through files.


### PR DESCRIPTION
### What does this PR do?

This new option all users to remove trailing line breaks from secrets returned by `secret_backend_command`. This is needed because some secret management tools automatically add a line break when exporting secrets through files.

### Describe how to test/QA your changes

Configure the secret management tool to read secrets from file ([using the `secret-helper` command for example](https://docs.datadoghq.com/agent/guide/secrets-management/?tab=linux#helper-scripts-for-autodiscovery)). Check that line break are kept by default. Then enable `secret_backend_remove_trailing_line_break` and check that trailing line break are remove (an only trailing line break).

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
