### PR TITLE
Migrate the `containerlifecycle` message to Google protobuf generator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	code.cloudfoundry.org/garden v0.0.0-20210208153517-580cadd489d2
 	code.cloudfoundry.org/lager v2.0.0+incompatible
 	github.com/CycloneDX/cyclonedx-go v0.7.0
-	github.com/DataDog/agent-payload/v5 v5.0.76
+	github.com/DataDog/agent-payload/v5 v5.0.77
 	github.com/DataDog/appsec-internal-go v0.0.0-20230215162203-5149228be86a
 	github.com/DataDog/datadog-agent/pkg/obfuscate v0.44.0-rc.4
 	github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.44.0-rc.4

--- a/go.sum
+++ b/go.sum
@@ -128,8 +128,8 @@ github.com/BurntSushi/toml v1.2.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbi
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/CycloneDX/cyclonedx-go v0.7.0 h1:jNxp8hL7UpcvPDFXjY+Y1ibFtsW+e5zyF9QoSmhK/zg=
 github.com/CycloneDX/cyclonedx-go v0.7.0/go.mod h1:W5Z9w8pTTL+t+yG3PCiFRGlr8PUlE0pGWzKSJbsyXkg=
-github.com/DataDog/agent-payload/v5 v5.0.76 h1:ulvh3tU2qCAMydnZWWXDdUJKtuByQlBTbw7yJxgMoic=
-github.com/DataDog/agent-payload/v5 v5.0.76/go.mod h1:oQZi1VZp1e3QvlSUX4iphZCpJaFepUxWq0hNXxihKBM=
+github.com/DataDog/agent-payload/v5 v5.0.77 h1:mcN87AgcY7LQX//wUJXVP8+PxknxkqEauRnV2EIuj0Q=
+github.com/DataDog/agent-payload/v5 v5.0.77/go.mod h1:oQZi1VZp1e3QvlSUX4iphZCpJaFepUxWq0hNXxihKBM=
 github.com/DataDog/appsec-internal-go v0.0.0-20230215162203-5149228be86a h1:7ZiVdU4j19IYuy8rR0uUzC7I7HjWul61ZEyUgvLkZBM=
 github.com/DataDog/appsec-internal-go v0.0.0-20230215162203-5149228be86a/go.mod h1:ILSJBuOg3E0Jg8qgSnm7+g8DXa0KrfahnS7jhS1DoWs=
 github.com/DataDog/aptly v1.5.0 h1:Oy6JVRC9iDgnmpeVYa4diXwP/exU7wJ/U1kuI4Zacxg=

--- a/pkg/collector/corechecks/containerlifecycle/check.go
+++ b/pkg/collector/corechecks/containerlifecycle/check.go
@@ -7,7 +7,6 @@ package containerlifecycle
 
 import (
 	"context"
-	"errors"
 	"time"
 
 	yaml "gopkg.in/yaml.v2"
@@ -15,7 +14,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
-	ddConfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 )
@@ -52,10 +50,6 @@ type Check struct {
 
 // Configure parses the check configuration and initializes the container_lifecycle check
 func (c *Check) Configure(integrationConfigDigest uint64, config, initConfig integration.Data, source string) error {
-	if !ddConfig.Datadog.GetBool("container_lifecycle.enabled") {
-		return errors.New("collection of container lifecycle events is disabled")
-	}
-
 	var err error
 
 	err = c.CommonConfigure(integrationConfigDigest, initConfig, config, source)

--- a/pkg/collector/corechecks/containerlifecycle/event.go
+++ b/pkg/collector/corechecks/containerlifecycle/event.go
@@ -20,12 +20,11 @@ type event interface {
 	withSource(string)
 	withContainerExitCode(*int32)
 	withContainerExitTimestamp(*int64)
-	toPayloadModel() (model.EventsPayload, error)
+	toPayloadModel() (*model.EventsPayload, error)
 	toEventModel() (*model.Event, error)
 }
 
 type eventTransformer struct {
-	tpl          model.EventsPayload
 	objectKind   string
 	objectID     string
 	eventType    string
@@ -35,9 +34,7 @@ type eventTransformer struct {
 }
 
 func newEvent() event {
-	return &eventTransformer{
-		tpl: model.EventsPayload{Version: types.PayloadV1},
-	}
+	return &eventTransformer{}
 }
 
 func (e *eventTransformer) withObjectKind(kind string) {
@@ -64,18 +61,18 @@ func (e *eventTransformer) withContainerExitTimestamp(exitTS *int64) {
 	e.contExitTS = exitTS
 }
 
-func (e *eventTransformer) toPayloadModel() (model.EventsPayload, error) {
-	payload := e.tpl
+func (e *eventTransformer) toPayloadModel() (*model.EventsPayload, error) {
+	payload := &model.EventsPayload{Version: types.PayloadV1}
 	kind, err := e.kind()
 	if err != nil {
-		return model.EventsPayload{}, err
+		return nil, err
 	}
 
 	payload.ObjectKind = kind
 
 	event, err := e.toEventModel()
 	if err != nil {
-		return model.EventsPayload{}, err
+		return nil, err
 	}
 
 	payload.Events = []*model.Event{event}

--- a/pkg/collector/corechecks/containerlifecycle/processor.go
+++ b/pkg/collector/corechecks/containerlifecycle/processor.go
@@ -18,7 +18,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 
-	"github.com/gogo/protobuf/proto"
+	"google.golang.org/protobuf/proto"
 )
 
 type processor struct {
@@ -154,9 +154,9 @@ func (p *processor) flushPods() {
 	}
 }
 
-func (p *processor) containerLifecycleEvent(msgs []contlcycle.EventsPayload) {
+func (p *processor) containerLifecycleEvent(msgs []*contlcycle.EventsPayload) {
 	for _, msg := range msgs {
-		encoded, err := proto.Marshal(&msg)
+		encoded, err := proto.Marshal(msg)
 		if err != nil {
 			log.Errorf("Unable to encode message: %+v", err)
 			continue
@@ -166,7 +166,7 @@ func (p *processor) containerLifecycleEvent(msgs []contlcycle.EventsPayload) {
 	}
 }
 
-func eventCountByType(eventPayloads []contlcycle.EventsPayload) map[string]int {
+func eventCountByType(eventPayloads []*contlcycle.EventsPayload) map[string]int {
 	res := make(map[string]int)
 
 	for _, payload := range eventPayloads {

--- a/pkg/collector/corechecks/containerlifecycle/processor_test.go
+++ b/pkg/collector/corechecks/containerlifecycle/processor_test.go
@@ -33,7 +33,7 @@ func TestProcessQueues(t *testing.T) {
 		},
 		{
 			name: "one container",
-			containersQueue: &queue{data: []model.EventsPayload{
+			containersQueue: &queue{data: []*model.EventsPayload{
 				{Version: "v1", Events: modelEvents("cont1")},
 			}},
 			podsQueue: &queue{},
@@ -43,11 +43,11 @@ func TestProcessQueues(t *testing.T) {
 		},
 		{
 			name: "multiple chunks per types",
-			containersQueue: &queue{data: []model.EventsPayload{
+			containersQueue: &queue{data: []*model.EventsPayload{
 				{Version: "v1", Events: modelEvents("cont1", "cont2")},
 				{Version: "v1", Events: modelEvents("cont3")},
 			}},
-			podsQueue: &queue{data: []model.EventsPayload{
+			podsQueue: &queue{data: []*model.EventsPayload{
 				{Version: "v1", Events: modelEvents("pod1", "pod2")},
 				{Version: "v1", Events: modelEvents("pod3")},
 			}},

--- a/pkg/collector/corechecks/containerlifecycle/queue.go
+++ b/pkg/collector/corechecks/containerlifecycle/queue.go
@@ -14,7 +14,7 @@ import (
 
 type queue struct {
 	chunkSize int
-	data      []model.EventsPayload
+	data      []*model.EventsPayload
 	sync.RWMutex
 }
 
@@ -22,13 +22,13 @@ type queue struct {
 func newQueue(chunkSize int) *queue {
 	return &queue{
 		chunkSize: chunkSize,
-		data:      []model.EventsPayload{},
+		data:      []*model.EventsPayload{},
 	}
 }
 
 // flush returns and resets the queue content. Returns nil if the queue is empty.
 // flush is thread-safe.
-func (q *queue) flush() []model.EventsPayload {
+func (q *queue) flush() []*model.EventsPayload {
 	q.Lock()
 	defer q.Unlock()
 
@@ -39,7 +39,7 @@ func (q *queue) flush() []model.EventsPayload {
 	data := q.data
 
 	// Reset the data in the queue.
-	q.data = []model.EventsPayload{}
+	q.data = []*model.EventsPayload{}
 
 	return data
 }
@@ -98,9 +98,9 @@ func (q *queue) isEmpty() bool {
 
 // lastPayload returns the last payload entry in the queue.
 // lastPayload is not thread-safe, the caller must lock the queue.
-func (q *queue) lastPayload() (model.EventsPayload, error) {
+func (q *queue) lastPayload() (*model.EventsPayload, error) {
 	if q.isEmpty() {
-		return model.EventsPayload{}, errors.New("empty queue")
+		return nil, errors.New("empty queue")
 	}
 
 	return q.data[len(q.data)-1], nil

--- a/pkg/collector/corechecks/containerlifecycle/queue_test.go
+++ b/pkg/collector/corechecks/containerlifecycle/queue_test.go
@@ -36,27 +36,27 @@ func TestSingleQueueAdd(t *testing.T) {
 
 	tests := []struct {
 		name string
-		data []model.EventsPayload
+		data []*model.EventsPayload
 		ev   event
-		want []model.EventsPayload
+		want []*model.EventsPayload
 	}{
 		{
 			name: "empty queue",
-			data: []model.EventsPayload{},
+			data: []*model.EventsPayload{},
 			ev:   fakeContainerEvent("obj1"),
-			want: []model.EventsPayload{{Version: "v1", Events: modelEvents("obj1")}},
+			want: []*model.EventsPayload{{Version: "v1", Events: modelEvents("obj1")}},
 		},
 		{
 			name: "last payload not full",
-			data: []model.EventsPayload{{Version: "v1", Events: modelEvents("obj1")}},
+			data: []*model.EventsPayload{{Version: "v1", Events: modelEvents("obj1")}},
 			ev:   fakeContainerEvent("obj2"),
-			want: []model.EventsPayload{{Version: "v1", Events: modelEvents("obj1", "obj2")}},
+			want: []*model.EventsPayload{{Version: "v1", Events: modelEvents("obj1", "obj2")}},
 		},
 		{
 			name: "last payload full",
-			data: []model.EventsPayload{{Version: "v1", Events: modelEvents("obj1", "obj2")}},
+			data: []*model.EventsPayload{{Version: "v1", Events: modelEvents("obj1", "obj2")}},
 			ev:   fakeContainerEvent("obj3"),
-			want: []model.EventsPayload{
+			want: []*model.EventsPayload{
 				{Version: "v1", Events: modelEvents("obj1", "obj2")},
 				{Version: "v1", Events: modelEvents("obj3")},
 			},


### PR DESCRIPTION
### What does this PR do?

Migrate the `containerlifecycle` message from the deprecated [`gogo` ProtocolBuffer implementation](https://github.com/gogo/protobuf) to the officially maintained Google one.

### Motivation

[`gogo` is deprecated and not maintained anymore](https://github.com/gogo/protobuf#readme).

### Additional Notes

This needs DataDog/agent-payload#239.

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Validate that container lifecycle events are still properly sent.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
