### PR TITLE
[serverless] Default DD_TRACE_MANAGED_SERVICES to true

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1157,7 +1157,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("enhanced_metrics", true)
 	config.BindEnvAndSetDefault("capture_lambda_payload", false)
 	config.BindEnvAndSetDefault("serverless.trace_enabled", false, "DD_TRACE_ENABLED")
-	config.BindEnvAndSetDefault("serverless.trace_managed_services", false, "DD_TRACE_MANAGED_SERVICES")
+	config.BindEnvAndSetDefault("serverless.trace_managed_services", true, "DD_TRACE_MANAGED_SERVICES")
 
 	// trace-agent's evp_proxy
 	config.BindEnv("evp_proxy_config.enabled")

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -231,6 +231,17 @@ func TestSiteEnvVar(t *testing.T) {
 	assert.Equal(t, "https://external-agent.datadoghq.eu", externalAgentURL)
 }
 
+func TestDefaultTraceManagedServicesEnvVarValue(t *testing.T) {
+	testConfig := setupConfFromYAML("")
+	assert.Equal(t, true, testConfig.Get("serverless.trace_managed_services"))
+}
+
+func TestExplicitFalseTraceManagedServicesEnvVar(t *testing.T) {
+	t.Setenv("DD_TRACE_MANAGED_SERVICES", "false")
+	testConfig := setupConfFromYAML("")
+	assert.Equal(t, false, testConfig.Get("serverless.trace_managed_services"))
+}
+
 func TestDDHostnameFileEnvVar(t *testing.T) {
 	t.Setenv("DD_API_KEY", "fakeapikey")
 	t.Setenv("DD_HOSTNAME_FILE", "somefile")


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
Defaults `serverless.trace_managed_services` to true unless DD_TRACE_MANAGED_SERVICES is explicitly set to false
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Conform to logic in JS and Python
https://github.com/DataDog/datadog-lambda-js/blob/8cca684c3e80da7169da6f6a251cf14d92924367/src/index.ts#L27

https://github.com/DataDog/datadog-lambda-python/blob/3e09ff472f0e23fa28af21f86070456945c34318/datadog_lambda/wrapper.py#L126

By default we will trace managed services via the extension. Therefore runtimes that require the extension to trace managed services such as Java will be able to create inferred spans.
ex. API Gateway -> Java AWS Lambda Function
By default:
<img width="1120" alt="Screen Shot 2023-03-17 at 2 53 50 PM" src="https://user-images.githubusercontent.com/49878080/226059935-e5450279-3ef8-412d-a63b-2ff908dbcaee.png">


If `DD_TRACE_MANAGED_SERVICES` is explicitly set to false then we get:
<img width="1120" alt="Screen Shot 2023-03-17 at 2 53 57 PM" src="https://user-images.githubusercontent.com/49878080/226059946-b9f41971-9dbe-4829-bad0-b30714a987c7.png">


<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
Manually tested in sls sandbox environment, by publishing a version of the serverless agent (extension) and utilizing it as a lambda layer in the following application: API Gateway->Java AWS Lambda function. The results are captured in the screenshots above. [Dogfluence docs explaining my manual testing process](https://datadoghq.atlassian.net/wiki/spaces/SLS/pages/2723611380/Lambda+Extension#Manual-Testing)
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
