### PR TITLE
pkg/trace/api: Add support for 128-Bit TraceIds in OpenTelemetry integration.

### DIFF
--- a/pkg/trace/api/otlp.go
+++ b/pkg/trace/api/otlp.go
@@ -315,8 +315,9 @@ func (o *OTLPReceiver) ReceiveResourceSpans(ctx context.Context, rspans ptrace.R
 	return src
 }
 
-// createChunks creates a set of pb.TraceChunk's based on two maps:
+// createChunks creates a set of pb.TraceChunk's based on three maps:
 // - a map from trace ID to the spans sharing that trace ID
+// - a map from trace ID to the hex-encoding of the higher-order 64 bits of the original 128-bit OpenTelemetry trace ID.
 // - a map of user-set sampling priorities by trace ID, if set
 func (o *OTLPReceiver) createChunks(tracesByID map[uint64]pb.Trace, tidByID map[uint64]string, prioritiesByID map[uint64]sampler.SamplingPriority) []*pb.TraceChunk {
 	traceChunks := make([]*pb.TraceChunk, 0, len(tracesByID))

--- a/releasenotes/notes/apm-128-bit-traceid-support-e615c1e168a375f8.yaml
+++ b/releasenotes/notes/apm-128-bit-traceid-support-e615c1e168a375f8.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Adds support for 128-bit TraceIds to the Trace Agent OTLP endpoint when converting OTLP traces to trace data.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.
-->

### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Updates the translation from OTLP to Datadog trace data in the trace agent to support the full 128-bits of the TraceId by hex-encoding the higher-order 64 bits and adding it as the `_dd.p.tid` tag to the first span of the trace chunk, as defined in the "Supporting 128-Bit TraceIds - Integrations" RFC.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
This change is being made as part of the ongoing effort to support 128-bit TraceIds throughout the organization.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->
This change will add 1 tag with a 16 character value to each span chunk coming from OpenTelemetry services, the overall impact should be minor (note that the Datadog tracer libraries are adding the same tag).

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
Send a trace from an OpenTelemetry service to the trace agent's OTLP endpoint and verify that the higher-order 64 bits of the TraceId is encoded in the `_dd.p.tid` tag of the first span of the trace chunk for that trace.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
