### PR TITLE
downgrade 2 logs from ERROR to DEBUG, lower log thresholds for func CheckProcessTelemetry

### DIFF
--- a/pkg/logs/internal/launchers/file/launcher.go
+++ b/pkg/logs/internal/launchers/file/launcher.go
@@ -342,10 +342,20 @@ func (s *Launcher) createRotatedTailer(t *tailer.Tailer, file *tailer.File, patt
 }
 
 func CheckProcessTelemetry(stats *util.ProcessFileStats) {
-	if float64(stats.AgentOpenFiles)/float64(stats.OsFileLimit) > 0.9 {
-		log.Warnf("Agent process is close to OS file limit of %v. Agent process currently has %v files open.", stats.OsFileLimit, stats.AgentOpenFiles)
-	} else if stats.AgentOpenFiles/stats.OsFileLimit >= 1 {
-		log.Errorf("Agent process has reached the OS open file limit: %v. This may be preventing log files from being tailed by the Agent and could interfere with the basic functionality of the Agent. OS file limit must be increased.", stats.OsFileLimit)
+	ratio := float64(stats.AgentOpenFiles) / float64(stats.OsFileLimit)
+	if ratio > 0.7 {
+		log.Warnf("Agent process has %v files open (%0.f%%), which is over 70%% of OS open file limit (%v). Consider increasing OS file limit.",
+			stats.AgentOpenFiles,
+			ratio*100,
+			stats.OsFileLimit)
+	} else if ratio > 0.9 {
+		log.Errorf("Agent process has %v files open (%0.f%%), which is over 90%% of OS open file limit (%v). This may be preventing log files from being tailed by the Agent and could interfere with the basic functionality of the Agent. OS file limit must be increased.",
+			stats.AgentOpenFiles,
+			ratio*100,
+			stats.OsFileLimit)
 	}
-	log.Debugf("Agent process currently has %v files open. OS file limit is currently set to %v.", stats.AgentOpenFiles, stats.OsFileLimit)
+	log.Debugf("Agent process has %v files open or %0.f%% of the OS file limit. OS file limit is currently set to %v.",
+		stats.AgentOpenFiles,
+		ratio*100,
+		stats.OsFileLimit)
 }

--- a/pkg/logs/internal/launchers/file/launcher.go
+++ b/pkg/logs/internal/launchers/file/launcher.go
@@ -343,18 +343,18 @@ func (s *Launcher) createRotatedTailer(t *tailer.Tailer, file *tailer.File, patt
 
 func CheckProcessTelemetry(stats *util.ProcessFileStats) {
 	ratio := float64(stats.AgentOpenFiles) / float64(stats.OsFileLimit)
-	if ratio > 0.7 {
-		log.Warnf("Agent process has %v files open (%0.f%%), which is over 70%% of OS open file limit (%v). Consider increasing OS file limit.",
+	if ratio > 0.9 {
+		log.Errorf("Agent process has %v files open which is %0.f%% of the OS open file limit (%v). This is over 90%% utilization. This may be preventing log files from being tailed by the Agent and could interfere with the basic functionality of the Agent. OS file limit must be increased.",
 			stats.AgentOpenFiles,
 			ratio*100,
 			stats.OsFileLimit)
-	} else if ratio > 0.9 {
-		log.Errorf("Agent process has %v files open (%0.f%%), which is over 90%% of OS open file limit (%v). This may be preventing log files from being tailed by the Agent and could interfere with the basic functionality of the Agent. OS file limit must be increased.",
+	} else if ratio > 0.7 {
+		log.Warnf("Agent process has %v files open which is %0.f%% of the OS open file limit (%v). This is over 70%% utilization; consider increasing the OS open file limit.",
 			stats.AgentOpenFiles,
 			ratio*100,
 			stats.OsFileLimit)
 	}
-	log.Debugf("Agent process has %v files open or %0.f%% of the OS file limit. OS file limit is currently set to %v.",
+	log.Debugf("Agent process has %v files open which is %0.f%% of the OS open file limit (%v).",
 		stats.AgentOpenFiles,
 		ratio*100,
 		stats.OsFileLimit)

--- a/pkg/util/process_file_stats_linux.go
+++ b/pkg/util/process_file_stats_linux.go
@@ -22,14 +22,14 @@ func GetProcessFileStats() (*ProcessFileStats, error) {
 	// Creating a new process.Process type based on Agent PID
 	p, err := process.NewProcess(int32(os.Getpid()))
 	if err != nil {
-		log.Errorf("Failed to retrieve agent process: %s. Process ID: %v", err, int32(os.Getpid()))
+		log.Debugf("Failed to retrieve agent process: %s. Process ID: %v", err, int32(os.Getpid()))
 		return &stats, err
 	}
 
 	// Retrieving type []RlimitStat from struct process.Process p
 	rs, err := p.RlimitUsage(true)
 	if err != nil {
-		log.Errorf("Failed to retrieve type RlimitStat: %s", err)
+		log.Debugf("Failed to retrieve type RlimitStat: %s", err)
 		return &stats, err
 	}
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This PR does two things:

1. Downgrade two ERROR logs in process_file_stats_linux.go to DEBUG because there are cases where this error would be unactionable (i.e. Fargate).
2. Reduce the thresholds for WARN and ERROR logs from 90% to 70% and 100% to 90% respectively. This is because the Agent is already failing to function properly at 100%, and will fail to generate these lines by the time the OS file limit is hit.

### Motivation

These two changes were prompted by testing done by the AML and process agent teams.

**AML:**


**Process Agent:**


### Describe how to test/QA your changes

Regarding 1), this can be tested by running the Agent in ECS Fargate with `logs_enabled` set to `true` and `log_level` set to `'debug'` in the `datadog.yaml`. See Process Agent Slack conversation screenshot for details.

Regarding 2), this can be tested by having the Agent tail ~70 Docker containers by file and setting the OS file limit to something lower, i.e. 100. See AML Slack conversation screenshot for details.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
