### PR TITLE
[corechecks/containerlifecycle] Add owner info to ContainerEvent

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	code.cloudfoundry.org/garden v0.0.0-20210208153517-580cadd489d2
 	code.cloudfoundry.org/lager v2.0.0+incompatible
 	github.com/CycloneDX/cyclonedx-go v0.7.0
-	github.com/DataDog/agent-payload/v5 v5.0.78
+	github.com/DataDog/agent-payload/v5 v5.0.79
 	github.com/DataDog/appsec-internal-go v0.0.0-20230215162203-5149228be86a
 	github.com/DataDog/datadog-agent/pkg/obfuscate v0.44.0-rc.4
 	github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.44.0-rc.4

--- a/go.sum
+++ b/go.sum
@@ -128,8 +128,8 @@ github.com/BurntSushi/toml v1.2.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbi
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/CycloneDX/cyclonedx-go v0.7.0 h1:jNxp8hL7UpcvPDFXjY+Y1ibFtsW+e5zyF9QoSmhK/zg=
 github.com/CycloneDX/cyclonedx-go v0.7.0/go.mod h1:W5Z9w8pTTL+t+yG3PCiFRGlr8PUlE0pGWzKSJbsyXkg=
-github.com/DataDog/agent-payload/v5 v5.0.78 h1:reDsfIc5uVKC6M6jCbA3/+muJx/QFqNRZlMVK3xV68A=
-github.com/DataDog/agent-payload/v5 v5.0.78/go.mod h1:oQZi1VZp1e3QvlSUX4iphZCpJaFepUxWq0hNXxihKBM=
+github.com/DataDog/agent-payload/v5 v5.0.79 h1:DpoNuO+x6rpox2h26eOV52VMPgOsCmQ2oxqT0nRVGIE=
+github.com/DataDog/agent-payload/v5 v5.0.79/go.mod h1:oQZi1VZp1e3QvlSUX4iphZCpJaFepUxWq0hNXxihKBM=
 github.com/DataDog/appsec-internal-go v0.0.0-20230215162203-5149228be86a h1:7ZiVdU4j19IYuy8rR0uUzC7I7HjWul61ZEyUgvLkZBM=
 github.com/DataDog/appsec-internal-go v0.0.0-20230215162203-5149228be86a/go.mod h1:ILSJBuOg3E0Jg8qgSnm7+g8DXa0KrfahnS7jhS1DoWs=
 github.com/DataDog/aptly v1.5.0 h1:Oy6JVRC9iDgnmpeVYa4diXwP/exU7wJ/U1kuI4Zacxg=

--- a/pkg/collector/corechecks/containerlifecycle/check.go
+++ b/pkg/collector/corechecks/containerlifecycle/check.go
@@ -75,7 +75,7 @@ func (c *Check) Configure(integrationConfigDigest uint64, config, initConfig int
 		c.instance.PollInterval = defaultPollInterval
 	}
 
-	c.processor = newProcessor(sender, c.instance.ChunkSize)
+	c.processor = newProcessor(sender, c.instance.ChunkSize, c.workloadmetaStore)
 
 	return nil
 }

--- a/pkg/collector/corechecks/containerlifecycle/processor.go
+++ b/pkg/collector/corechecks/containerlifecycle/processor.go
@@ -25,13 +25,15 @@ type processor struct {
 	sender          aggregator.Sender
 	podsQueue       *queue
 	containersQueue *queue
+	store           workloadmeta.Store
 }
 
-func newProcessor(sender aggregator.Sender, chunkSize int) *processor {
+func newProcessor(sender aggregator.Sender, chunkSize int, store workloadmeta.Store) *processor {
 	return &processor{
 		sender:          sender,
 		podsQueue:       newQueue(chunkSize),
 		containersQueue: newQueue(chunkSize),
+		store:           store,
 	}
 }
 

--- a/pkg/workloadmeta/collectors/internal/kubelet/kubelet.go
+++ b/pkg/workloadmeta/collectors/internal/kubelet/kubelet.go
@@ -257,7 +257,7 @@ func (c *collector) parsePodContainers(
 				Ports:   ports,
 				Runtime: workloadmeta.ContainerRuntime(runtime),
 				State:   containerState,
-				Owner:   *parent,
+				Owner:   parent,
 			},
 		})
 	}

--- a/pkg/workloadmeta/types.go
+++ b/pkg/workloadmeta/types.go
@@ -383,7 +383,7 @@ func (o OrchestratorContainer) String(_ bool) string {
 type Container struct {
 	EntityID
 	EntityMeta
-	// EnvVars are limited to variabels included in pkg/util/containers/env_vars_filter.go
+	// EnvVars are limited to variables included in pkg/util/containers/env_vars_filter.go
 	EnvVars    map[string]string
 	Hostname   string
 	Image      ContainerImage
@@ -393,8 +393,9 @@ type Container struct {
 	Runtime    ContainerRuntime
 	State      ContainerState
 	// CollectorTags represent tags coming from the collector itself
-	// and that it would impossible to compute later on
+	// and that it would be impossible to compute later on
 	CollectorTags []string
+	Owner         EntityID
 }
 
 // GetID implements Entity#GetID.

--- a/pkg/workloadmeta/types.go
+++ b/pkg/workloadmeta/types.go
@@ -395,7 +395,7 @@ type Container struct {
 	// CollectorTags represent tags coming from the collector itself
 	// and that it would be impossible to compute later on
 	CollectorTags []string
-	Owner         EntityID
+	Owner         *EntityID
 }
 
 // GetID implements Entity#GetID.

--- a/releasenotes/notes/container-lifecycle-container-owner-info-15522ea6dd94ea23.yaml
+++ b/releasenotes/notes/container-lifecycle-container-owner-info-15522ea6dd94ea23.yaml
@@ -8,4 +8,4 @@
 ---
 enhancements:
   - |
-    Add ownership information for containers to container-lifecycle check.
+    Add ownership information for containers to the container-lifecycle check.

--- a/releasenotes/notes/container-lifecycle-container-owner-info-15522ea6dd94ea23.yaml
+++ b/releasenotes/notes/container-lifecycle-container-owner-info-15522ea6dd94ea23.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Add ownership information for containers to container-lifecycle check.


### PR DESCRIPTION
### What does this PR do?

This PR adds node orchestrator ownership information to the workloadmeta container object, and sends that information up as part of the containerlifecycle container events.

### Motivation

We would like to be able to associate containers with the pods which are running them when handling container lifecycle events.

### Additional Notes

This is only supported for Kubernetes Pods at the moment, but adding support for other node orchestrators should not require a refactor.

Because the container runtime does not know anything about the node orchestrator which is controlling the container, and because the container events on the container lifecycle side trigger when the container runtime emits the deleted event, we are not able to get the owner information in the event payload that is passed in. As a result of this, I have added a call to pull this information from the global workloadmeta store

Requires https://github.com/DataDog/agent-payload/pull/241

### Describe how to test/QA your changes

Like [this other PR](https://github.com/DataDog/datadog-agent/pull/16153), testing this is tricky, because (as far as I know) we do not have a way to inspect the payload generated by this check. I was able to validate this locally by building the agent with debug flags set, and then using delve to set breakpoints at the return statements of `toPayloadModel` and `toEventModel` in `pkg/collector/corechecks/containerlifecycle/event.go`. I was able to validate locally that the field is populated this way.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
