### PR TITLE
[Serverless] Re-enable otlp serverless integration test.

### DIFF
--- a/test/integration/serverless/run.sh
+++ b/test/integration/serverless/run.sh
@@ -148,7 +148,7 @@ trace_functions=(
     "trace-go"
     "trace-csharp"
     "trace-proxy"
-    #"otlp-python"
+    "otlp-python"
 )
 
 all_functions=("${metric_functions[@]}" "${log_functions[@]}" "${trace_functions[@]}")


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Several weeks ago we merged https://github.com/DataDog/datadog-agent/pull/15572 which added a `otlp-python` integration test. However, it was soon disabled because the [datadog-lambda-extension](https://github.com/DataDog/datadog-lambda-extension) repo was not ready to build the extension with the `otlp` build tag.

Now that we have enabled this `otlp` build tag for the serverless extension, we can re-enable this test.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Testing is good.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

Note that some of the integration tests are currently failing with `Malformed _X_AMZN_TRACE_ID` errors. These can safely be ignored as they were caused by a change in the amazon trace structure and not a change from this PR.

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
