### PR TITLE
[single-machine-performance] Update smp to 0.7.3

### DIFF
--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -10,11 +10,11 @@ single-machine-performance-regression_detector:
     paths:
       - submission_metadata
   variables:
-    SMP_VERSION: 0.7.1
+    SMP_VERSION: 0.7.3
     LADING_VERSION: 0.13.0
     TOTAL_SAMPLES: 600
     WARMUP_SECONDS: 45
-    REPLICAS: 20
+    REPLICAS: 10
     CPUS: 7
     MEMORY: "30g"
   # At present we require two artifacts to exist for the 'baseline' and the


### PR DESCRIPTION
### What does this PR do?

This release adjusts how the smp program transmits data to its associated compute cluster. There are no user-facing changes in smp's operation. 

### Additional Notes

Also, reduce the number of running replicas in half, reversing a no longer necessary experiment. #15800 

REF SMP-419
