### PR TITLE
system-probe: Made clang and llc optional for image build

### DIFF
--- a/tasks/process_agent.py
+++ b/tasks/process_agent.py
@@ -126,9 +126,9 @@ def build_dev_image(ctx, image=None, push=False, base_image="datadog/agent:lates
         ctx.run(f"cp pkg/ebpf/bytecode/build/co-re/*.o {docker_context}/co-re/")
         ctx.run(f"cp pkg/ebpf/bytecode/build/runtime/*.c {docker_context}")
         ctx.run(f"chmod 0444 {docker_context}/*.o {docker_context}/*.c {docker_context}/co-re/*.o")
-        ctx.run(f"cp /opt/datadog-agent/embedded/bin/clang-bpf {docker_context}")
-        ctx.run(f"cp /opt/datadog-agent/embedded/bin/llc-bpf {docker_context}")
-        ctx.run(f"cp pkg/network/java/agent-usm.jar {docker_context}")
+        ctx.run(f"cp /opt/datadog-agent/embedded/bin/clang-bpf {docker_context}", warn=True)
+        ctx.run(f"cp /opt/datadog-agent/embedded/bin/llc-bpf {docker_context}", warn=True)
+        ctx.run(f"cp pkg/network/java/agent-usm.jar {docker_context}", warn=True)
 
         with ctx.cd(docker_context):
             # --pull in the build will force docker to grab the latest base image

--- a/tools/ebpf/Dockerfiles/Dockerfile-process-agent-dev
+++ b/tools/ebpf/Dockerfiles/Dockerfile-process-agent-dev
@@ -13,8 +13,7 @@ ENV LD_LIBRARY_PATH /opt/datadog-agent/embedded/lib
 # are in the same directory
 COPY process-agent /opt/datadog-agent/embedded/bin/process-agent
 COPY system-probe /opt/datadog-agent/embedded/bin/system-probe
-COPY clang-bpf /opt/datadog-agent/embedded/bin/clang-bpf
-COPY llc-bpf /opt/datadog-agent/embedded/bin/llc-bpf
+COPY *-bpf /opt/datadog-agent/embedded/bin/
 
 # if you want to replace the base image's core agent binary, set $CORE_AGENT_DEST to
 # /opt/datadog-agent/bin/agent/agent; otherwise, set it to /dev/null


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Make clang-bpf and llc-bpf optional in the process of building a dedicate agent image

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
