### PR TITLE
Fix ddtray execution by installer for non-elevated administrator users

### DIFF
--- a/cmd/systray/command/command.go
+++ b/cmd/systray/command/command.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -24,6 +25,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/DataDog/datadog-agent/pkg/util/winutil"
 	"go.uber.org/fx"
+	"golang.org/x/sys/windows"
 )
 
 const (
@@ -71,6 +73,11 @@ func MakeCommand() *cobra.Command {
 		Use:          fmt.Sprintf("%s", os.Args[0]),
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			err := ensureElevated(systrayParams, args)
+			if err != nil {
+				return err
+			}
+
 			return fxutil.Run(
 				// core
 				fx.Supply(core.BundleParams{
@@ -95,7 +102,7 @@ func MakeCommand() *cobra.Command {
 
 	cmd.PersistentFlags().BoolVar(&systrayParams.LaunchGuiFlag, "launch-gui", false, "Launch browser configuration and exit")
 
-	// launch-elev=true only means the process should have been elevated so that it will not elevate again. If the
+	// launch-elev=true only means the process should be elevated so that it will not elevate again. If the
 	// parameter is specified but the process is not elevated, some operation will fail due to access denied.
 	cmd.PersistentFlags().BoolVar(&systrayParams.LaunchElevatedFlag, "launch-elev", false, "Launch program as elevated, internal use only")
 
@@ -103,4 +110,55 @@ func MakeCommand() *cobra.Command {
 	cmd.PersistentFlags().StringVar(&systrayParams.LaunchCommand, "launch-cmd", "", "Carry out a specific command after launch")
 
 	return cmd
+}
+
+func ensureElevated(params systray.Params, args []string) error {
+	isAdmin, err := winutil.IsUserAnAdmin()
+	if err != nil {
+		return fmt.Errorf("failed to call IsUserAnAdmin %v", err)
+	}
+
+	if isAdmin {
+		// user is an admin, allow execution to continue
+		return nil
+	}
+
+	// user is not an admin
+	if params.LaunchElevatedFlag {
+		return fmt.Errorf("not running as elevated but elevated flag is set")
+	}
+
+	// attempt to launch as admin
+	err = relaunchElevated(args)
+	if err != nil {
+		return err
+	}
+
+	return fmt.Errorf("exiting to allow elevated process to start")
+}
+
+// relaunchElevated launch another instance of the current process asking it to carry out a command as admin.
+// If the function succeeds, it will quit the process, otherwise the function will return to the caller.
+func relaunchElevated(origargs []string) error {
+	verb := "runas"
+	exe, _ := os.Executable()
+	cwd, _ := os.Getwd()
+
+	// Reconstruct arguments and tell the new process it should be elevated.
+	xargs := []string{"--launch-elev=true"}
+	xargs = append(xargs, origargs...)
+	args := strings.Join(xargs, " ")
+
+	verbPtr, _ := windows.UTF16PtrFromString(verb)
+	exePtr, _ := windows.UTF16PtrFromString(exe)
+	cwdPtr, _ := windows.UTF16PtrFromString(cwd)
+	argPtr, _ := windows.UTF16PtrFromString(args)
+
+	var showCmd int32 = 1 //SW_NORMAL
+
+	err := windows.ShellExecute(0, verbPtr, exePtr, argPtr, cwdPtr, showCmd)
+	if err != nil {
+		return fmt.Errorf("Failed to launch self as elevated %v", err)
+	}
+	return nil
 }

--- a/cmd/systray/command/command.go
+++ b/cmd/systray/command/command.go
@@ -73,6 +73,8 @@ func MakeCommand() *cobra.Command {
 		Use:          fmt.Sprintf("%s", os.Args[0]),
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// Check if we are elevated and elevate if necessary. Elevation is required prior to component initialization
+			// because of restricted permissions to the agent configuration file.
 			err := ensureElevated(systrayParams, args)
 			if err != nil {
 				return err

--- a/cmd/systray/ddtray.exe.manifest
+++ b/cmd/systray/ddtray.exe.manifest
@@ -9,8 +9,15 @@
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
     <security>
       <requestedPrivileges>
+        <!-- Even though ddtray.exe requires admin privileges to function, requestedExecutionLevel must be asInvoker.
+             If set to highestAvailable or requireAdministrator, the CreateProcess call will fail with "The requested operation requires elevation"
+             for users that are a member of the Administrator group but are not currently elevated. highestAvailable does NOT allow members of the
+             Administrator group to run the application non-elevated. This causes the "run ddtray" checkbox at the end of the installer to fail to launch ddtray.
+             The ddtray entrypoint has logic to attempt to relaunch itself elevated by using ShellExecute in order to support non-admin, non-elevated admins, and
+             elevated admins running the application.
+        -->
         <requestedExecutionLevel
-          level="requireAdministrator"
+          level="asInvoker"
           uiAccess="false"/>
         </requestedPrivileges>
        </security>

--- a/cmd/systray/ddtray.exe.manifest
+++ b/cmd/systray/ddtray.exe.manifest
@@ -12,7 +12,8 @@
         <!-- Even though ddtray.exe requires admin privileges to function, requestedExecutionLevel must be asInvoker.
              If set to highestAvailable or requireAdministrator, the CreateProcess call will fail with "The requested operation requires elevation"
              for users that are a member of the Administrator group but are not currently elevated. highestAvailable does NOT allow members of the
-             Administrator group to run the application non-elevated. This causes the "run ddtray" checkbox at the end of the installer to fail to launch ddtray.
+             Administrator group to run the application non-elevated, and CreateProcess will return an error instead of triggering a UAC prompt.
+             This causes the "run ddtray" checkbox at the end of the installer to fail to launch ddtray.
              The ddtray entrypoint has logic to attempt to relaunch itself elevated by using ShellExecute in order to support non-admin, non-elevated admins, and
              elevated admins running the application.
         -->

--- a/releasenotes/notes/fix-systray-elevation-for-non-elevated-admins-07dc3da14c696fe4.yaml
+++ b/releasenotes/notes/fix-systray-elevation-for-non-elevated-admins-07dc3da14c696fe4.yaml
@@ -1,0 +1,5 @@
+fixes:
+  - |
+    Fix issue introduced in 7.43 that prevents the Datadog Agent Manager application
+    from executing from the checkbox at the end of the Datadog Agent installation when
+    the installer is run by a non-elevated administrator user.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Reverts the UAC manifest from `requireAdministrator` back to the original `asInvoker` and moves the `relaunchElevated` logic prior to the components entrypoint.  With the UAC manifest set to `asInvoker` ddtray will run as is, and will attempt to elevate itself if necessary. If elevation fails it will exit. It is important that this elevation occur prior to the components entrypoint because the agent configuration file has restricted permissions.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
Fix regression introduced by https://github.com/DataDog/datadog-agent/pull/14985

`requireAdministrator` prevents the installer from launching ddtray when the installer is run by a non-elevated admin, which is the case if you double click the installer on the desktop. Windows Installer uses the `CreateProcessAsUser` method to create the process, which returns an error instead of creating a UAC prompt.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
https://learn.microsoft.com/en-us/cpp/build/reference/manifestuac-embeds-uac-information-in-manifest?view=msvc-170#remarks
https://learn.microsoft.com/en-us/windows/security/identity-protection/user-account-control/how-user-account-control-works

When the installer is run as the `built-in` Administrator it fails to run ddtray. The `CreateProcessAsUserW` call from `msi.dll` returns `ERROR_ACCESS_DENIED`. I wasn't able to figure out why. However this also occurs in previous versions of our installer so it's not related to the regression fixed by this PR. Additionally, several Microsoft Windows utilities, such as Disk Management, also fail to run as the built-in Administrator. The solution is to [enable Admin Approval Mode for the built-in Administrator](https://learn.microsoft.com/en-us/windows/security/identity-protection/user-account-control/user-account-control-group-policy-and-registry-key-settings#user-account-control-admin-approval-mode-for-the-built-in-administrator-account), which makes that account have a split-token like other user accounts. Enabling this option also fixes the issue for our installer and ddtray runs as expected.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
#### Workstation host:
non-elevated installer
* Sign in as an administrator user account. double click the agent on the desktop, install.
* Ensure ddtray launches via the checkbox at the end of the installer.
* Ensure the web browser launches, and can be launched again via the right click menu
* ensure the Datadog Agent Manager shortcut runs ddtray

elevated installer
* Sign in as an administrator user account. run the installer from an elevated command prompt.
* Ensure ddtray launches via the checkbox at the end of the installer.
* Ensure the web browser launches, and can be launched again via the right click menu
* ensure the Datadog Agent Manager shortcut runs ddtray

#### Domain controller:
* [enable Admin Approval Mode for the built-in Administrator](https://learn.microsoft.com/en-us/windows/security/identity-protection/user-account-control/user-account-control-group-policy-and-registry-key-settings#user-account-control-admin-approval-mode-for-the-built-in-administrator-account)
* Sign in as the built-in administrator user account. double click the agent on the desktop, install.
* Ensure ddtray launches via the checkbox at the end of the installer.
* Ensure the web browser launches, and can be launched again via the right click menu
* ensure the Datadog Agent Manager shortcut runs ddtray

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
