### PR TITLE
[windows] fix http counting & tagging of loopback connections (#15404)

### DIFF
--- a/pkg/network/protocols/http/http_stats.go
+++ b/pkg/network/protocols/http/http_stats.go
@@ -260,6 +260,13 @@ func (r *RequestStats) HalfAllCounts() {
 	for _, stats := range r.Data {
 		if stats != nil {
 			stats.Count = stats.Count / 2
+			// temporary fix until we can remove this altogether.
+			// blindly halving all counts doesn't take into account we might not have
+			// both ends, either because (a) it's https via etw or (b) the request
+			// might come in between the kernel flush & etw flush.
+			if stats.Count == 0 {
+				stats.Count = 1
+			}
 		}
 	}
 }


### PR DESCRIPTION
Implements a temporary fix on counting/tagging of loopback connections until a better/permanent fix can be added.

### What does this PR do?

Applies change that was made to 7.43 (for the same reason) but wasn't applied back to main.

Otherwise, behavior will regress from 7.43 to 7.44

(Previous PR #15404)

### Motivation
### Additional Notes


### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Take a previous build. Install IIS.
Make a connection via loopback interface.
use the debug endpoint, dump the output of the http transactions>
Note that the port is off.
Note two transactions, some with correct tags and some not>

Test again with fix; above should be remedied.
### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
