### PR TITLE
[DCA][Flare] Adds Helm user values, cluster Agent manifest, node Agent manifest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -564,7 +564,7 @@ require (
 	sigs.k8s.io/controller-runtime v0.11.2 // indirect
 	sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
-	sigs.k8s.io/yaml v1.3.0 // indirect
+	sigs.k8s.io/yaml v1.3.0
 )
 
 require github.com/aquasecurity/trivy v0.0.0-00010101000000-000000000000

--- a/pkg/flare/archive_dca.go
+++ b/pkg/flare/archive_dca.go
@@ -190,16 +190,17 @@ func getAgentDaemonSet(fb flarehelpers.FlareBuilder) error {
 
 	cl, err := apiserver.GetAPIClient()
 	if err != nil {
-		log.Errorf("Can't create client to query the API Server: %s", err)
-	} else {
-		agentDaemonsetName = os.Getenv(HELM_AGENT_DAEMONSET)
-		releaseNamespace = os.Getenv(HELM_CHART_RELEASE_NAMESPACE)
-		agentDaemonset, err = GetDaemonset(cl, agentDaemonsetName, releaseNamespace)
-		if err != nil {
-			log.Debugf("Error while collecting the Agent DaemonSet: %q", err)
-		}
+		return log.Errorf("Can't create client to query the API Server: %s", err)
 	}
-
+	agentDaemonsetName = os.Getenv(HELM_AGENT_DAEMONSET)
+	releaseNamespace = os.Getenv(HELM_CHART_RELEASE_NAMESPACE)
+	if agentDaemonsetName == "" || releaseNamespace == "" {
+		return log.Errorf("Can't collect the Agent Daemonset name or namespace from the environment variables %s and %v", HELM_AGENT_DAEMONSET, HELM_CHART_RELEASE_NAMESPACE)
+	}
+	agentDaemonset, err = GetDaemonset(cl, agentDaemonsetName, releaseNamespace)
+	if err != nil {
+		return log.Errorf("Error while collecting the Agent DaemonSet: %q", err)
+	}
 	return fb.AddFile("agent-daemonset.yaml", agentDaemonset)
 }
 
@@ -212,16 +213,17 @@ func getClusterAgentDeployment(fb flarehelpers.FlareBuilder) error {
 
 	cl, err := apiserver.GetAPIClient()
 	if err != nil {
-		log.Errorf("Can't create client to query the API Server: %s", err)
-	} else {
-		clusterAgentDeploymentName = os.Getenv(HELM_CLUSTER_AGENT_DEPLOYMENT)
-		releaseNamespace = os.Getenv(HELM_CHART_RELEASE_NAMESPACE)
-		clusterAgentDeployment, err = GetDeployment(cl, clusterAgentDeploymentName, releaseNamespace)
-		if err != nil {
-			log.Debugf("Error while collecting the Cluster Agent Deployment: %q", err)
-		}
+		return log.Errorf("Can't create client to query the API Server: %s", err)
 	}
-
+	clusterAgentDeploymentName = os.Getenv(HELM_CLUSTER_AGENT_DEPLOYMENT)
+	releaseNamespace = os.Getenv(HELM_CHART_RELEASE_NAMESPACE)
+	if clusterAgentDeploymentName == "" || releaseNamespace == "" {
+		return log.Errorf("Can't collect the Cluster Agent Deployment name or namespace from the environment variables %s and %v", HELM_CLUSTER_AGENT_DEPLOYMENT, HELM_CHART_RELEASE_NAMESPACE)
+	}
+	clusterAgentDeployment, err = GetDeployment(cl, clusterAgentDeploymentName, releaseNamespace)
+	if err != nil {
+		return log.Errorf("Error while collecting the Cluster Agent Deployment: %q", err)
+	}
 	return fb.AddFile("cluster-agent-deployment.yaml", clusterAgentDeployment)
 }
 

--- a/pkg/flare/archive_dca.go
+++ b/pkg/flare/archive_dca.go
@@ -3,6 +3,9 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build kubeapiserver
+// +build kubeapiserver
+
 package flare
 
 import (

--- a/pkg/flare/archive_dca.go
+++ b/pkg/flare/archive_dca.go
@@ -195,7 +195,7 @@ func getAgentDaemonSet(fb flarehelpers.FlareBuilder) error {
 	agentDaemonsetName = os.Getenv(HELM_AGENT_DAEMONSET)
 	releaseNamespace = os.Getenv(HELM_CHART_RELEASE_NAMESPACE)
 	if agentDaemonsetName == "" || releaseNamespace == "" {
-		return log.Errorf("Can't collect the Agent Daemonset name or namespace from the environment variables %s and %v", HELM_AGENT_DAEMONSET, HELM_CHART_RELEASE_NAMESPACE)
+		return log.Errorf("Can't collect the Agent Daemonset name and/or namespace from the environment variables %s and %v", HELM_AGENT_DAEMONSET, HELM_CHART_RELEASE_NAMESPACE)
 	}
 	agentDaemonset, err = GetDaemonset(cl, agentDaemonsetName, releaseNamespace)
 	if err != nil {
@@ -218,7 +218,7 @@ func getClusterAgentDeployment(fb flarehelpers.FlareBuilder) error {
 	clusterAgentDeploymentName = os.Getenv(HELM_CLUSTER_AGENT_DEPLOYMENT)
 	releaseNamespace = os.Getenv(HELM_CHART_RELEASE_NAMESPACE)
 	if clusterAgentDeploymentName == "" || releaseNamespace == "" {
-		return log.Errorf("Can't collect the Cluster Agent Deployment name or namespace from the environment variables %s and %v", HELM_CLUSTER_AGENT_DEPLOYMENT, HELM_CHART_RELEASE_NAMESPACE)
+		return log.Errorf("Can't collect the Cluster Agent Deployment name and/or namespace from the environment variables %s and %v", HELM_CLUSTER_AGENT_DEPLOYMENT, HELM_CHART_RELEASE_NAMESPACE)
 	}
 	clusterAgentDeployment, err = GetDeployment(cl, clusterAgentDeploymentName, releaseNamespace)
 	if err != nil {

--- a/pkg/flare/archive_dca.go
+++ b/pkg/flare/archive_dca.go
@@ -240,7 +240,7 @@ func getHelmValues(fb flarehelpers.FlareBuilder) error {
 	releaseName = os.Getenv(HELM_CHART_RELEASE_NAME)
 	releaseNamespace = os.Getenv(HELM_CHART_RELEASE_NAMESPACE)
 	if releaseName == "" || releaseNamespace == "" {
-		return log.Errorf("Can't collect the Datadog Helm chart release name and/or namespace from the environment variables %s and %v", HELM_CLUSTER_AGENT_DEPLOYMENT, HELM_CHART_RELEASE_NAMESPACE)
+		return log.Errorf("Can't collect the Datadog Helm chart release name and/or namespace from the environment variables %s and %v", HELM_CHART_RELEASE_NAME, HELM_CHART_RELEASE_NAMESPACE)
 	}
 	helmUserValues, err = GetDatadogHelmUserValues(cl, releaseName, releaseNamespace, "secret")
 	if err != nil {

--- a/pkg/flare/archive_dca.go
+++ b/pkg/flare/archive_dca.go
@@ -239,6 +239,9 @@ func getHelmValues(fb flarehelpers.FlareBuilder) error {
 	}
 	releaseName = os.Getenv(HELM_CHART_RELEASE_NAME)
 	releaseNamespace = os.Getenv(HELM_CHART_RELEASE_NAMESPACE)
+	if releaseName == "" || releaseNamespace == "" {
+		return log.Errorf("Can't collect the Datadog Helm chart release name and/or namespace from the environment variables %s and %v", HELM_CLUSTER_AGENT_DEPLOYMENT, HELM_CHART_RELEASE_NAMESPACE)
+	}
 	helmUserValues, err = GetDatadogHelmUserValues(cl, releaseName, releaseNamespace, "secret")
 	if err != nil {
 		log.Warnf("Error while collecting the Helm chart values from secret: %v", err)

--- a/pkg/flare/archive_dca.go
+++ b/pkg/flare/archive_dca.go
@@ -261,5 +261,4 @@ func getHelmValues(fb flarehelpers.FlareBuilder) error {
 	}
 
 	return nil
-
 }

--- a/pkg/flare/envvars.go
+++ b/pkg/flare/envvars.go
@@ -87,6 +87,11 @@ var allowedEnvvarNames = []string{
 
 	// CI
 	"DD_INSIDE_CI",
+
+	// Cluster agent
+	"DD_CHART_RELEASE_NAME",
+	"DD_AGENT_DAEMONSET",
+	"DD_CLUSTER_AGENT_DEPLOYMENT",
 }
 
 func getAllowedEnvvars() []string {

--- a/pkg/flare/envvars.go
+++ b/pkg/flare/envvars.go
@@ -89,9 +89,9 @@ var allowedEnvvarNames = []string{
 	"DD_INSIDE_CI",
 
 	// Cluster agent
-	HELM_CHART_RELEASE_NAME,
-	HELM_AGENT_DAEMONSET,
-	HELM_CLUSTER_AGENT_DEPLOYMENT,
+	"CHART_RELEASE_NAME",
+	"AGENT_DAEMONSET",
+	"CLUSTER_AGENT_DEPLOYMENT",
 }
 
 func getAllowedEnvvars() []string {

--- a/pkg/flare/envvars.go
+++ b/pkg/flare/envvars.go
@@ -89,9 +89,9 @@ var allowedEnvvarNames = []string{
 	"DD_INSIDE_CI",
 
 	// Cluster agent
-	"DD_CHART_RELEASE_NAME",
-	"DD_AGENT_DAEMONSET",
-	"DD_CLUSTER_AGENT_DEPLOYMENT",
+	HELM_CHART_RELEASE_NAME,
+	HELM_AGENT_DAEMONSET,
+	HELM_CLUSTER_AGENT_DEPLOYMENT,
 }
 
 func getAllowedEnvvars() []string {

--- a/pkg/flare/manifests.go
+++ b/pkg/flare/manifests.go
@@ -3,6 +3,9 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build kubeapiserver
+// +build kubeapiserver
+
 package flare
 
 import (

--- a/pkg/flare/manifests.go
+++ b/pkg/flare/manifests.go
@@ -73,7 +73,7 @@ func GetDeployment(cl *apiserver.APIClient, name string, namespace string) ([]by
 }
 
 // getDeployedHelmConfigmap returns the configmap for a given release.
-// Only a single release for a given name can deployed at one time.
+// Only a single release for a given name can be deployed at one time.
 func getDeployedHelmConfigmap(cl *apiserver.APIClient, name string, namespace string) (*v1.ConfigMap, error) {
 	var selector string
 
@@ -93,7 +93,7 @@ func getDeployedHelmConfigmap(cl *apiserver.APIClient, name string, namespace st
 }
 
 // getDeployedHelmSecret returns the secret for a given release.
-// Only a single release for a given name can deployed at one time.
+// Only a single release for a given name can be deployed at one time.
 func getDeployedHelmSecret(cl *apiserver.APIClient, name string, namespace string) (*v1.Secret, error) {
 	var selector string
 

--- a/pkg/flare/manifests.go
+++ b/pkg/flare/manifests.go
@@ -87,7 +87,7 @@ func getDeployedHelmConfigmap(cl *apiserver.APIClient, name string, namespace st
 		return nil, err
 	}
 	if len(configmapList.Items) != 1 {
-		return nil, log.Errorf("%s configmaps found, but expected 1", fmt.Sprint((configmapList.Items)))
+		return nil, log.Errorf("%s configmaps found, but expected 1", fmt.Sprint(len(configmapList.Items)))
 	}
 	return &configmapList.Items[0], nil
 }
@@ -110,30 +110,6 @@ func getDeployedHelmSecret(cl *apiserver.APIClient, name string, namespace strin
 		return nil, log.Errorf("%s secrets found, but expected 1", fmt.Sprint(len(secretList.Items)))
 	}
 	return &secretList.Items[0], nil
-}
-
-// Retrieve Helm chart user values from the API server for a given name and namespace looking through Secrets or Configmaps
-func GetDatadogHelmUserValues(cl *apiserver.APIClient, name string, namespace string, storage string) ([]byte, error) {
-	var dataString string
-
-	switch storage {
-	case "secret":
-		secret, err := getDeployedHelmSecret(cl, name, namespace)
-		if err != nil {
-			return nil, err
-		}
-		// Contrary to the Configmap, the secret data is a byte array, so the string function is necessary
-		dataString = string(secret.Data["release"])
-	case "configmap":
-		configmap, err := getDeployedHelmConfigmap(cl, name, namespace)
-		if err != nil {
-			return nil, err
-		}
-		dataString = configmap.Data["release"]
-	default:
-		return nil, log.Errorf("The requested storage %s is not supported", storage)
-	}
-	return decodeChartValuesFromRelease(dataString)
 }
 
 // decodeRelease decodes the bytes of data into a readable byte array.

--- a/pkg/flare/manifests.go
+++ b/pkg/flare/manifests.go
@@ -1,0 +1,206 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package flare
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"sigs.k8s.io/yaml"
+
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+var (
+	b64       = base64.StdEncoding
+	magicGzip = []byte{0x1f, 0x8b, 0x08}
+)
+
+const (
+	HELM_CHART_RELEASE_NAME       = "CHART_RELEASE_NAME"
+	HELM_CHART_RELEASE_NAMESPACE  = "DD_KUBE_RESOURCES_NAMESPACE"
+	HELM_AGENT_DAEMONSET          = "AGENT_DAEMONSET"
+	HELM_CLUSTER_AGENT_DEPLOYMENT = "CLUSTER_AGENT_DEPLOYMENT"
+)
+
+// chartUserValues is defined to unmarshall JSON data decoded from a Helm cart release into accessible fields
+type chartUserValues struct {
+	// user-defined values overriding the chart defaults
+	Config map[string]interface{} `json:"config,omitempty"`
+}
+
+// Retrieve a DaemonSet YAML from the API server for a given name and namespace, and returns the associated YAML manifest into a a byte array.
+// Its purpose is to retrieve the Datadog Agent DaemonSet manifest when building a Cluster Agent flare.
+func GetDaemonset(cl *apiserver.APIClient, name string, namespace string) ([]byte, error) {
+	var b bytes.Buffer
+
+	ds, err := cl.Cl.AppsV1().DaemonSets(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		log.Debugf("Can't retrieve DaemonSet %v from the API server: %s", name, err.Error())
+		return nil, err
+	}
+
+	dsjson, err := json.Marshal(ds)
+	ddyaml, err := yaml.JSONToYAML(dsjson)
+	fmt.Fprintln(&b, string(ddyaml))
+	return b.Bytes(), nil
+}
+
+// Retrieve a Deployment YAML from the API server for a given name and namespace, and returns the associated YAML manifest into a a byte array.
+// Its purpose is to retrieve the Datadog Cluster Agent Deployment manifest when building a Cluster Agent flare.
+func GetDeployment(cl *apiserver.APIClient, name string, namespace string) ([]byte, error) {
+	var b bytes.Buffer
+
+	deploy, err := cl.Cl.AppsV1().Deployments(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		log.Debugf("Can't retrieve Deployment %v from the API server: %s", name, err.Error())
+		return nil, err
+	}
+
+	deployjson, err := json.Marshal(deploy)
+	deployyaml, err := yaml.JSONToYAML(deployjson)
+	fmt.Fprintln(&b, string(deployyaml))
+	return b.Bytes(), nil
+}
+
+// getDeployedHelmConfigmap returns the configmap for a given release.
+// Only a single release for a given name can deployed at one time.
+func getDeployedHelmConfigmap(cl *apiserver.APIClient, name string, namespace string) (*v1.ConfigMap, error) {
+	var selector string
+
+	selector = labels.Set{
+		"owner":  "helm",
+		"status": "deployed",
+		"name":   name,
+	}.AsSelector().String()
+	configmapList, err := cl.Cl.CoreV1().ConfigMaps(namespace).List(context.TODO(), metav1.ListOptions{LabelSelector: selector})
+	if err != nil {
+		return nil, err
+	}
+	if len(configmapList.Items) != 1 {
+		return nil, log.Errorf("%s configmaps found, but expected 1", fmt.Sprint((configmapList.Items)))
+	}
+	return &configmapList.Items[0], nil
+}
+
+// getDeployedHelmSecret returns the secret for a given release.
+// Only a single release for a given name can deployed at one time.
+func getDeployedHelmSecret(cl *apiserver.APIClient, name string, namespace string) (*v1.Secret, error) {
+	var selector string
+
+	selector = labels.Set{
+		"owner":  "helm",
+		"status": "deployed",
+		"name":   name,
+	}.AsSelector().String()
+	secretList, err := cl.Cl.CoreV1().Secrets(namespace).List(context.TODO(), metav1.ListOptions{LabelSelector: selector})
+	if err != nil {
+		return nil, err
+	}
+	if len(secretList.Items) != 1 {
+		return nil, log.Errorf("%s secrets found, but expected 1", fmt.Sprint(len(secretList.Items)))
+	}
+	return &secretList.Items[0], nil
+}
+
+// Retrieve Helm chart user values from the API server for a given name and namespace looking through Secrets or Configmaps
+func GetDatadogHelmUserValues(cl *apiserver.APIClient, name string, namespace string, storage string) ([]byte, error) {
+	switch storage {
+	case "secret":
+		secret, err := getDeployedHelmSecret(cl, name, namespace)
+		if err != nil {
+			return nil, err
+		}
+		b64EncodedGzipRelease := secret.Data["release"]
+		// Contrary to the Configmap, the secret data is a byte array, so the string function is necessary
+		b, err := decodeChartValuesFromRelease(string(b64EncodedGzipRelease))
+		if err != nil {
+			return nil, err
+		}
+		return b, nil
+	case "configmap":
+		configmap, err := getDeployedHelmConfigmap(cl, name, namespace)
+		if err != nil {
+			return nil, err
+		}
+		b64EncodedGzipRelease := configmap.Data["release"]
+		b, err := decodeChartValuesFromRelease(b64EncodedGzipRelease)
+		if err != nil {
+			return nil, err
+		}
+		return b, nil
+	default:
+		return nil, log.Errorf("The requested storage %s is not supported", storage)
+	}
+}
+
+// decodeRelease decodes the bytes of data into a readable byte array.
+// Data must contain a base64 encoded gzipped string of a valid release, otherwise nil is returned.
+func decodeRelease(data string) ([]byte, error) {
+	// base64 decode string
+	b, err := b64.DecodeString(data)
+	if err != nil {
+		return nil, err
+	}
+
+	// For backwards compatibility with releases that were stored before
+	// compression was introduced we skip decompression if the
+	// gzip magic header is not found
+	if len(b) < 4 {
+		// Avoid panic if b[0:3] cannot be accessed
+		return nil, log.Errorf("The byte array is too short (expected at least 4 characters, got %s instead): it cannot contain a Helm release", fmt.Sprint(len(b)))
+	}
+	if bytes.Equal(b[0:3], magicGzip) {
+		r, err := gzip.NewReader(bytes.NewReader(b))
+		if err != nil {
+			return nil, err
+		}
+		defer r.Close()
+		b2, err := io.ReadAll(r)
+		if err != nil {
+			return nil, err
+		}
+		b = b2
+	}
+	return b, nil
+}
+
+// decodeChartValuesFromRelease returns a byte array with the user values from an encoded Helm chart release
+func decodeChartValuesFromRelease(encodedRelease string) ([]byte, error) {
+	var b bytes.Buffer
+	var userConfig chartUserValues
+
+	decodedrelease, err := decodeRelease(encodedRelease)
+	if err != nil {
+		return nil, err
+	}
+	err = json.Unmarshal(decodedrelease, &userConfig)
+	if err != nil {
+		log.Debugf("Unable to retrieve the config data: %s", err.Error())
+		return nil, err
+	}
+	configjson, err := json.Marshal(userConfig)
+	if err != nil {
+		log.Debugf("Can't marshall user values into a proper JSON: %s", err.Error())
+		return nil, err
+	}
+	configyaml, err := yaml.JSONToYAML(configjson)
+	if err != nil {
+		log.Debugf("Can't convert user values to YAML: %s", err.Error())
+		return nil, err
+	}
+	fmt.Fprintln(&b, string(configyaml))
+	return b.Bytes(), nil
+}

--- a/pkg/util/kubernetes/apiserver/apiserver.go
+++ b/pkg/util/kubernetes/apiserver/apiserver.go
@@ -694,7 +694,6 @@ func (c *APIClient) GetARandomNodeName(ctx context.Context) (string, error) {
 // Retrieve a DaemonSet YAML from the API server for a given name and namespace, and returns the associated YAML manifest into a a byte array.
 // Its purpose is to retrieve the Datadog Agent DaemonSet manifest when building a Cluster Agent flare.
 func GetDs(cl *APIClient, name string, namespace string) ([]byte, error) {
-
 	var b bytes.Buffer
 
 	ds, err := cl.Cl.AppsV1().DaemonSets(namespace).Get(context.TODO(), name, metav1.GetOptions{})
@@ -713,7 +712,6 @@ func GetDs(cl *APIClient, name string, namespace string) ([]byte, error) {
 // Retrieve a Deployment YAML from the API server for a given name and namespace, and returns the associated YAML manifest into a a byte array.
 // Its purpose is to retrieve the Datadog Cluster Agent Deployment manifest when building a Cluster Agent flare.
 func GetDeploy(cl *APIClient, name string, namespace string) ([]byte, error) {
-
 	var b bytes.Buffer
 
 	deploy, err := cl.Cl.AppsV1().Deployments(namespace).Get(context.TODO(), name, metav1.GetOptions{})
@@ -770,7 +768,7 @@ func getConfigmapList(cl *APIClient, namespace string) ([]v1.ConfigMap, error) {
 func getSecretList(cl *APIClient, namespace string) ([]v1.Secret, error) {
 	secrets, err := cl.Cl.CoreV1().Secrets(namespace).List(context.TODO(), metav1.ListOptions{TimeoutSeconds: &cl.timeoutSeconds})
 	if err != nil {
-		log.Errorf("Can't list configmaps from the API server: %s", err.Error())
+		log.Errorf("Can't list secrets from the API server: %s", err.Error())
 		return nil, err
 	}
 	return secrets.Items, nil

--- a/pkg/util/kubernetes/apiserver/apiserver.go
+++ b/pkg/util/kubernetes/apiserver/apiserver.go
@@ -9,26 +9,18 @@
 package apiserver
 
 import (
-	"bytes"
-	"compress/gzip"
 	"context"
-	"encoding/base64"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"sync"
 	"time"
-
-	"sigs.k8s.io/yaml"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	vpa "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned"
 	vpai "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/informers/externalversions"
@@ -54,8 +46,6 @@ var (
 	ErrNotFound         = errors.New("entity not found") //nolint:revive
 	ErrIsEmpty          = errors.New("entity is empty")  //nolint:revive
 	ErrNotLeader        = errors.New("not Leader")       //nolint:revive
-	b64                 = base64.StdEncoding
-	magicGzip           = []byte{0x1f, 0x8b, 0x08}
 )
 
 const (
@@ -117,12 +107,6 @@ type APIClient struct {
 
 	// timeoutSeconds defines the kubernetes client timeout
 	timeoutSeconds int64
-}
-
-// chartUserValues is defined to unmarshall JSON data decoded from a Helm cart release into accessible fields
-type chartUserValues struct {
-	// user-defined values overriding the chart defaults
-	Config map[string]interface{} `json:"config,omitempty"`
 }
 
 func initAPIClient() {
@@ -689,182 +673,4 @@ func (c *APIClient) GetARandomNodeName(ctx context.Context) (string, error) {
 	}
 
 	return nodeList.Items[0].Name, nil
-}
-
-// Retrieve a DaemonSet YAML from the API server for a given name and namespace, and returns the associated YAML manifest into a a byte array.
-// Its purpose is to retrieve the Datadog Agent DaemonSet manifest when building a Cluster Agent flare.
-func GetDs(cl *APIClient, name string, namespace string) ([]byte, error) {
-	var b bytes.Buffer
-
-	ds, err := cl.Cl.AppsV1().DaemonSets(namespace).Get(context.TODO(), name, metav1.GetOptions{})
-	if err != nil {
-		log.Debugf("Can't retrieve DaemonSet %v from the API server: %s", name, err.Error())
-		return nil, err
-	}
-
-	dsjson, err := json.Marshal(ds)
-	ddyaml, err := yaml.JSONToYAML(dsjson)
-	fmt.Fprintln(&b, string(ddyaml))
-
-	return b.Bytes(), nil
-}
-
-// Retrieve a Deployment YAML from the API server for a given name and namespace, and returns the associated YAML manifest into a a byte array.
-// Its purpose is to retrieve the Datadog Cluster Agent Deployment manifest when building a Cluster Agent flare.
-func GetDeploy(cl *APIClient, name string, namespace string) ([]byte, error) {
-	var b bytes.Buffer
-
-	deploy, err := cl.Cl.AppsV1().Deployments(namespace).Get(context.TODO(), name, metav1.GetOptions{})
-	if err != nil {
-		log.Debugf("Can't retrieve Deployment %v from the API server: %s", name, err.Error())
-		return nil, err
-	}
-
-	deployjson, err := json.Marshal(deploy)
-	deployyaml, err := yaml.JSONToYAML(deployjson)
-	fmt.Fprintln(&b, string(deployyaml))
-
-	return b.Bytes(), nil
-}
-
-// decodeRelease decodes the bytes of data into a readable byte array.
-// Data must contain a base64 encoded gzipped string of a valid release, otherwise nil is returned.
-func decodeRelease(data string) []byte {
-	// base64 decode string
-	b, err := b64.DecodeString(data)
-	if err != nil {
-		return nil
-	}
-
-	// For backwards compatibility with releases that were stored before
-	// compression was introduced we skip decompression if the
-	// gzip magic header is not found
-	if bytes.Equal(b[0:3], magicGzip) {
-		r, err := gzip.NewReader(bytes.NewReader(b))
-		if err != nil {
-			return nil
-		}
-		defer r.Close()
-		b2, err := io.ReadAll(r)
-		if err != nil {
-			return nil
-		}
-		b = b2
-	}
-	return b
-}
-
-// getConfigmapList retrieves a list of configmaps for a given namespace
-func getConfigmapList(cl *APIClient, namespace string) ([]v1.ConfigMap, error) {
-	configmaps, err := cl.Cl.CoreV1().ConfigMaps(namespace).List(context.TODO(), metav1.ListOptions{TimeoutSeconds: &cl.timeoutSeconds})
-	if err != nil {
-		log.Errorf("Can't list configmaps from the API server: %s", err.Error())
-		return nil, err
-	}
-	return configmaps.Items, nil
-}
-
-// getSecretList retrieves a list of secrets for a given namespace
-func getSecretList(cl *APIClient, namespace string) ([]v1.Secret, error) {
-	secrets, err := cl.Cl.CoreV1().Secrets(namespace).List(context.TODO(), metav1.ListOptions{TimeoutSeconds: &cl.timeoutSeconds})
-	if err != nil {
-		log.Errorf("Can't list secrets from the API server: %s", err.Error())
-		return nil, err
-	}
-	return secrets.Items, nil
-}
-
-// Retrieve Helm chart user values from the API server for a given name and namespace looking through Configmaps
-func GetDatadogHelmUserValuesFromConfigmap(cl *APIClient, name string, namespace string) ([]byte, error) {
-	var b bytes.Buffer
-	var userConfig chartUserValues
-	var selector labels.Selector
-	var helmConfigmap *v1.ConfigMap
-
-	// Only a single release for a given name can be deployed at one time.
-	// Other releases present a different status.
-	selector = labels.Set{
-		"owner":  "helm",
-		"status": "deployed",
-		"name":   name,
-	}.AsSelector()
-
-	configmaps, err := getConfigmapList(cl, namespace)
-	if err != nil {
-		log.Errorf("Can't list configmaps from the API server: %s", err.Error())
-	}
-
-	for _, cm := range configmaps {
-		if selector.Matches(labels.Set(cm.ObjectMeta.Labels)) {
-			helmConfigmap = &cm
-			// Chart data is stored in a gzipped base 64 encoded string
-			b64EncodedGzipRelease := helmConfigmap.Data["release"]
-			decodedrelease := decodeRelease(b64EncodedGzipRelease)
-			err := json.Unmarshal(decodedrelease, &userConfig)
-			if err != nil {
-				log.Debugf("Unable to retrieve the config data: %s", err.Error())
-			}
-			configjson, err := json.Marshal(userConfig)
-			if err != nil {
-				log.Debugf("Can't marshall user values into a proper JSON: %s", err.Error())
-			}
-			configyaml, err := yaml.JSONToYAML(configjson)
-			if err != nil {
-				log.Debugf("Can't convert user values to YAML: %s", err.Error())
-			}
-			fmt.Fprintln(&b, string(configyaml))
-			return b.Bytes(), nil
-		}
-	}
-
-	// If we exit the loop and reach this point, a matching configmap couldn't be found
-	return nil, log.Error("No matching configmap found")
-}
-
-// Retrieve Helm chart user values from the API server for a given name and namespace looking through secrets
-func GetDatadogHelmUserValuesFromSecret(cl *APIClient, name string, namespace string) ([]byte, error) {
-	var b bytes.Buffer
-	var userConfig chartUserValues
-	var selector labels.Selector
-	var helmSecret *v1.Secret
-
-	// Only a single release for a given name can be deployed at one time.
-	// Other releases present a different status.
-	selector = labels.Set{
-		"owner":  "helm",
-		"status": "deployed",
-		"name":   name,
-	}.AsSelector()
-
-	secrets, err := getSecretList(cl, namespace)
-	if err != nil {
-		log.Errorf("Can't list secrets from the API server: %s", err.Error())
-	}
-
-	for _, secret := range secrets {
-		if selector.Matches(labels.Set(secret.ObjectMeta.Labels)) {
-			helmSecret = &secret
-			// Contrary to the configmap, the chart data is encoded twice in base64 (native Kubernetes secret base64 + Helm).
-			// The K8s Go client decodes the native Kubernetes encoding, so we do not have to do it ourselves and can use the same logic, as the ConfigMap
-			b64EncodedGzipRelease := helmSecret.Data["release"]
-			decodedrelease := decodeRelease(string(b64EncodedGzipRelease))
-			err = json.Unmarshal(decodedrelease, &userConfig)
-			if err != nil {
-				log.Debugf("Unable to retrieve the config data: %s", err.Error())
-			}
-			configjson, err := json.Marshal(userConfig)
-			if err != nil {
-				log.Debugf("Can't marshall user values into a proper JSON: %s", err.Error())
-			}
-			configyaml, err := yaml.JSONToYAML(configjson)
-			if err != nil {
-				log.Debugf("Can't convert user values to YAML: %s", err.Error())
-			}
-			fmt.Fprintln(&b, string(configyaml))
-			return b.Bytes(), nil
-		}
-	}
-
-	// If we exit the loop and reach this point, a matching secret couldn't be found
-	return nil, log.Error("No matching secret found")
 }

--- a/releasenotes/notes/DCA-flare-manifests-and-helm-values-0e7056fe726f45d6.yaml
+++ b/releasenotes/notes/DCA-flare-manifests-and-helm-values-0e7056fe726f45d6.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Cluster Agent: User config, cluster Agent deployment and node Agent daemonset manifests are now added to the flare archive, when the Cluster Agent is deployed with Helm (version 3.20.4+).

--- a/releasenotes/notes/DCA-flare-manifests-and-helm-values-0e7056fe726f45d6.yaml
+++ b/releasenotes/notes/DCA-flare-manifests-and-helm-values-0e7056fe726f45d6.yaml
@@ -8,4 +8,4 @@
 ---
 enhancements:
   - |
-    Cluster Agent: User config, cluster Agent deployment and node Agent daemonset manifests are now added to the flare archive, when the Cluster Agent is deployed with Helm (version 3.20.4+).
+    Cluster Agent: User config, cluster Agent deployment and node Agent daemonset manifests are now added to the flare archive, when the Cluster Agent is deployed with Helm (version 3.23.0+).


### PR DESCRIPTION
### What does this PR do?

* Adds redacted (using the flare redaction system) Helm user values, cluster Agent deployment manifest, node Agent daemonset manifest to the cluster Agent flare by retrieving them from the API server

### Motivation

* https://datadoghq.atlassian.net/browse/CONT-3734 : 
    * As containers support team, I would like to get all the info needed directly from the flare. We usually ask customer to provide the helm value files and the daemonset|deployment manifests
    * As customer, I would like that my support ticket require the least possible roundtrip iterations to speedup the resolution.

### Additional Notes

* This requires adding additional environment variables to the cluster Agent deployment : 
    * The chart release name
    * The cluster Agent deployment name
    * The node Agent daemonset name
        * These env vars will be added in a Helm chart update
* Since Helm v3, the default backend to store the release information is `secrets`, so the Cluster Agent needs the associated RBAC to access secrets in its namespaces. Even if the storage driver is `configmap`, by default, the DCA does not have necessarily the RBAC unless the Helm check is enabled, so it requires a Helm chart change to add RBAC for it and disable it if not desired (on top of the required env vars)

### Possible Drawbacks / Trade-offs

* Requires the cluster Agent to access secrets/configmaps in its own namespace, which will require a Helm chart change to enable it by default (and add an option to disable it)
* Requires the flare redaction utility to adequately handles these objects

### Describe how to test/QA your changes

3 scenarios to test : 
- [ ] Default Helm v3 configuration (using `HELM_DRIVER=secret`)
- [ ] "Legacy" Helm configuration (using `HELM_DRIVER=configmap`)
- [ ] Not using Helm to deploy

1. Use a local Helm chart build (https://github.com/DataDog/helm-charts/pull/965) or in your Helm chart, add the necessary environment variables : 
```
    env:
    - name: CHART_RELEASE_NAME
      value: <YOUR RELEASE NAME>
    - name: AGENT_DAEMONSET
      value: <GENERATED DAEMONSET NAME>
    - name: CLUSTER_AGENT_DEPLOYMENT
      value: <GENERATED DEPLOYMENT NAME>
```
2. Deploy the cluster Agent and run the `agent flare` command.
3. Check the built flare to establish the presence of : 
    * `agent-daemonset.yaml`
    * `cluster-agent-deployment.yaml`
    * `helm-values.yaml`
<img width="855" alt="Image 2023-03-22 at 9 45 48 AM" src="https://user-images.githubusercontent.com/97530782/226848587-a6954abb-689f-4b91-91fe-9ba8b76f881f.png">
4. Ensure potential sensitive values are redacted, such as API keys 

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
