### PR TITLE
Add source to Agent images to ease work for scanning/dep tools

### DIFF
--- a/Dockerfiles/agent/Dockerfile
+++ b/Dockerfiles/agent/Dockerfile
@@ -1,6 +1,8 @@
 FROM ubuntu:22.04 AS baseimage
 LABEL baseimage.os "ubuntu jammy LTS"
 LABEL baseimage.name "ubuntu:22.04"
+# Can be used by Dependabot
+LABEL org.opencontainers.image.source "https://github.com/DataDog/datadog-agent"
 
 ARG CIBUILD
 # NOTE about APT mirrorlists:

--- a/Dockerfiles/cluster-agent/Dockerfile
+++ b/Dockerfiles/cluster-agent/Dockerfile
@@ -6,6 +6,8 @@ FROM ubuntu:22.04 as builder
 ARG TARGETARCH
 LABEL baseimage.os "ubuntu jammy LTS"
 LABEL baseimage.name "ubuntu:22.04"
+# Can be used by Dependabot
+LABEL org.opencontainers.image.source "https://github.com/DataDog/datadog-agent"
 
 WORKDIR /output
 

--- a/Dockerfiles/dogstatsd/alpine/Dockerfile
+++ b/Dockerfiles/dogstatsd/alpine/Dockerfile
@@ -4,6 +4,8 @@ ARG TARGETARCH
 LABEL baseimage.os "alpine"
 LABEL baseimage.name "alpine:3.17"
 LABEL maintainer "Datadog <package@datadoghq.com>"
+# Can be used by Dependabot
+LABEL org.opencontainers.image.source "https://github.com/DataDog/datadog-agent"
 
 ENV DOCKER_DD_AGENT=true
 


### PR DESCRIPTION
### What does this PR do?

Add source to Agent images to ease work for scanning/dep tools

### Motivation

Requested.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
