### PR TITLE
npm: tracer: Better cleanup during error

### DIFF
--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -588,6 +588,7 @@ func TestGatewayLookupEnabled(t *testing.T) {
 	tr, err := newTracer(cfg)
 	require.NoError(t, err)
 	require.NotNil(t, tr)
+	t.Cleanup(tr.Stop)
 	require.NotNil(t, tr.gwLookup)
 
 	tr.gwLookup.subnetForHwAddrFunc = func(hwAddr net.HardwareAddr) (network.Subnet, error) {
@@ -602,7 +603,6 @@ func TestGatewayLookupEnabled(t *testing.T) {
 	}
 
 	require.NoError(t, tr.start(), "could not start tracer")
-	defer tr.Stop()
 
 	initTracerState(t, tr)
 
@@ -636,6 +636,7 @@ func TestGatewayLookupSubnetLookupError(t *testing.T) {
 	tr, err := newTracer(cfg)
 	require.NoError(t, err)
 	require.NotNil(t, tr)
+	t.Cleanup(tr.Stop)
 	require.NotNil(t, tr.gwLookup)
 
 	ifi := ipRouteGet(t, "", "8.8.8.8", nil)
@@ -649,7 +650,6 @@ func TestGatewayLookupSubnetLookupError(t *testing.T) {
 
 	tr.gwLookup.purge()
 	require.NoError(t, tr.start(), "failed to start tracer")
-	defer tr.Stop()
 
 	initTracerState(t, tr)
 
@@ -690,6 +690,7 @@ func TestGatewayLookupCrossNamespace(t *testing.T) {
 	tr, err := newTracer(cfg)
 	require.NoError(t, err)
 	require.NotNil(t, tr)
+	t.Cleanup(tr.Stop)
 	require.NotNil(t, tr.gwLookup)
 
 	// setup two network namespaces
@@ -745,7 +746,6 @@ func TestGatewayLookupCrossNamespace(t *testing.T) {
 	}
 
 	require.NoError(t, tr.start(), "could not start tracer")
-	defer tr.Stop()
 
 	test1Ns, err := vnetns.GetFromName("test1")
 	require.NoError(t, err)

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -71,9 +71,7 @@ func TestMain(m *testing.M) {
 func setupTracer(t testing.TB, cfg *config.Config) *Tracer {
 	tr, err := NewTracer(cfg)
 	require.NoError(t, err)
-	t.Cleanup(func() {
-		tr.Stop()
-	})
+	t.Cleanup(tr.Stop)
 
 	initTracerState(t, tr)
 	return tr

--- a/pkg/network/tracer/tracer_usm_linux_test.go
+++ b/pkg/network/tracer/tracer_usm_linux_test.go
@@ -479,9 +479,7 @@ func TestProtocolClassification(t *testing.T) {
 
 	tr, err := NewTracer(cfg)
 	require.NoError(t, err)
-	t.Cleanup(func() {
-		tr.Stop()
-	})
+	t.Cleanup(tr.Stop)
 
 	t.Run("with dnat", func(t *testing.T) {
 		// SetupDNAT sets up a NAT translation from 2.2.2.2 to 1.1.1.1


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Better closing tracer, to avoid leaking probes.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
