### PR TITLE
[backport] Fix ddtray execution by installer for non-elevated administrator users

### DIFF
--- a/cmd/systray/ddtray.exe.manifest
+++ b/cmd/systray/ddtray.exe.manifest
@@ -9,8 +9,16 @@
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
     <security>
       <requestedPrivileges>
+        <!-- Even though ddtray.exe requires admin privileges to function, requestedExecutionLevel must be asInvoker.
+             If set to highestAvailable or requireAdministrator, the CreateProcess call will fail with "The requested operation requires elevation"
+             for users that are a member of the Administrator group but are not currently elevated. highestAvailable does NOT allow members of the
+             Administrator group to run the application non-elevated, and CreateProcess will return an error instead of triggering a UAC prompt.
+             This causes the "run ddtray" checkbox at the end of the installer to fail to launch ddtray.
+             The ddtray entrypoint has logic to attempt to relaunch itself elevated by using ShellExecute in order to support non-admin, non-elevated admins, and
+             elevated admins running the application.
+        -->
         <requestedExecutionLevel
-          level="requireAdministrator"
+          level="asInvoker"
           uiAccess="false"/>
         </requestedPrivileges>
        </security>

--- a/releasenotes/notes/fix-systray-elevation-for-non-elevated-admins-07dc3da14c696fe4.yaml
+++ b/releasenotes/notes/fix-systray-elevation-for-non-elevated-admins-07dc3da14c696fe4.yaml
@@ -1,0 +1,5 @@
+fixes:
+  - |
+    Fix issue introduced in 7.43 that prevents the Datadog Agent Manager application
+    from executing from the checkbox at the end of the Datadog Agent installation when
+    the installer is run by a non-elevated administrator user.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
backport of https://github.com/DataDog/datadog-agent/pull/16218

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
#### Workstation host:
non-elevated installer
* Sign in as an administrator user account. double click the agent on the desktop, install.
* Ensure ddtray launches via the checkbox at the end of the installer.
* Ensure the web browser launches, and can be launched again via the right click menu
* ensure the Datadog Agent Manager shortcut runs ddtray

elevated installer
* Sign in as an administrator user account. run the installer from an elevated command prompt.
* Ensure ddtray launches via the checkbox at the end of the installer.
* Ensure the web browser launches, and can be launched again via the right click menu
* ensure the Datadog Agent Manager shortcut runs ddtray

#### Domain controller:
* [enable Admin Approval Mode for the built-in Administrator](https://learn.microsoft.com/en-us/windows/security/identity-protection/user-account-control/user-account-control-group-policy-and-registry-key-settings#user-account-control-admin-approval-mode-for-the-built-in-administrator-account)
* Sign in as the built-in administrator user account. double click the agent on the desktop, install.
* Ensure ddtray launches via the checkbox at the end of the installer.
* Ensure the web browser launches, and can be launched again via the right click menu
* ensure the Datadog Agent Manager shortcut runs ddtray

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
