### PR TITLE
Always recreate guesser when retrying offset guessing

### DIFF
--- a/pkg/network/ebpf/c/prebuilt/offset-guess.c
+++ b/pkg/network/ebpf/c/prebuilt/offset-guess.c
@@ -213,8 +213,8 @@ static __always_inline int guess_offsets(tracer_status_t* status, char* subject)
         break;
     case GUESS_SK_BUFF_SOCK:
         // Note that in this line we're essentially dereferencing a pointer
-        // subject initially points to a (struct socket*), and we're trying to guess the offset of
-        // (struct socket*)->sk which points to a (struct sock*) object.
+        // subject initially points to a (struct sk_buff*), and we're trying to guess the offset of
+        // (struct sk_buff*)->sk which points to a (struct sock*) object.
         new_status.offset_sk_buff_sock = aligned_offset(subject, status->offset_sk_buff_sock, SIZEOF_SK_BUFF_SOCK);
         bpf_probe_read_kernel(&subject, sizeof(subject), subject + new_status.offset_sk_buff_sock);
         bpf_probe_read_kernel(&new_status.sport_via_sk_via_sk_buf, sizeof(new_status.sport_via_sk_via_sk_buf), subject + new_status.offset_sport);
@@ -376,8 +376,7 @@ int tracepoint__net__net_dev_queue(struct net_dev_queue_ctx* ctx) {
         return 0;
     }
 
-    void* skb = (void*)ctx->skb;
-    guess_offsets(status, (char*)skb);
+    guess_offsets(status, ctx->skb);
     return 0;
 }
 

--- a/pkg/network/tracer/conntracker_test.go
+++ b/pkg/network/tracer/conntracker_test.go
@@ -91,7 +91,7 @@ func getTracerOffsets(t *testing.T, cfg *config.Config) ([]manager.ConstantEdito
 	offsetBuf, err := netebpf.ReadOffsetBPFModule(cfg.BPFDir, cfg.BPFDebug)
 	require.NoError(t, err, "could not read offset bpf module")
 	defer offsetBuf.Close()
-	return runOffsetGuessing(cfg, offsetBuf, offsetguess.NewTracerOffsetGuesser())
+	return runOffsetGuessing(cfg, offsetBuf, offsetguess.NewTracerOffsetGuesser)
 }
 
 func setupPrebuiltEBPFConntracker(t *testing.T, cfg *config.Config) (netlink.Conntracker, error) {

--- a/pkg/network/tracer/ebpf_conntracker.go
+++ b/pkg/network/tracer/ebpf_conntracker.go
@@ -506,18 +506,15 @@ func getPrebuiltConntracker(cfg *config.Config, constants []manager.ConstantEdit
 		return nil, nil, fmt.Errorf("could not read bpf module: %s", err)
 	}
 
-	guesser, err := offsetguess.NewConntrackOffsetGuesser(constants)
-	if err != nil {
-		return nil, nil, fmt.Errorf("error creating offset guesser for ebpf conntracker: %w", err)
-	}
-
 	offsetBuf, err := netebpf.ReadOffsetBPFModule(cfg.BPFDir, cfg.BPFDebug)
 	if err != nil {
 		return nil, nil, fmt.Errorf("could not load offset guessing module: %w", err)
 	}
 	defer offsetBuf.Close()
 
-	constants, err = runOffsetGuessing(cfg, offsetBuf, guesser)
+	constants, err = runOffsetGuessing(cfg, offsetBuf, func() (offsetguess.OffsetGuesser, error) {
+		return offsetguess.NewConntrackOffsetGuesser(constants)
+	})
 	if err != nil {
 		return nil, nil, fmt.Errorf("could not guess offsets for ebpf conntracker: %w", err)
 	}

--- a/pkg/network/tracer/offsetguess/conntrack.go
+++ b/pkg/network/tracer/offsetguess/conntrack.go
@@ -78,6 +78,12 @@ func (c *conntrackOffsetGuesser) Manager() *manager.Manager {
 	return c.m
 }
 
+func (c *conntrackOffsetGuesser) Close() {
+	if err := c.m.Stop(manager.CleanAll); err != nil {
+		log.Warnf("error stopping conntrack offset guesser: %s", err)
+	}
+}
+
 func (c *conntrackOffsetGuesser) Probes(cfg *config.Config) (map[probes.ProbeFuncName]struct{}, error) {
 	p := map[probes.ProbeFuncName]struct{}{}
 	enableProbe(p, probes.ConntrackHashInsert)

--- a/pkg/network/tracer/offsetguess/offsetguess.go
+++ b/pkg/network/tracer/offsetguess/offsetguess.go
@@ -79,6 +79,7 @@ type OffsetGuesser interface {
 	Manager() *manager.Manager
 	Probes(c *config.Config) (map[string]struct{}, error)
 	Guess(c *config.Config) ([]manager.ConstantEditor, error)
+	Close()
 }
 
 type fieldValues struct {

--- a/pkg/network/tracer/offsetguess/tracer.go
+++ b/pkg/network/tracer/offsetguess/tracer.go
@@ -55,7 +55,7 @@ type tracerOffsetGuesser struct {
 	status *TracerStatus
 }
 
-func NewTracerOffsetGuesser() OffsetGuesser {
+func NewTracerOffsetGuesser() (OffsetGuesser, error) {
 	return &tracerOffsetGuesser{
 		m: &manager.Manager{
 			Maps: []*manager.Map{
@@ -74,11 +74,17 @@ func NewTracerOffsetGuesser() OffsetGuesser {
 				{ProbeIdentificationPair: idPair(probes.NetDevQueue)},
 			},
 		},
-	}
+	}, nil
 }
 
 func (t *tracerOffsetGuesser) Manager() *manager.Manager {
 	return t.m
+}
+
+func (t *tracerOffsetGuesser) Close() {
+	if err := t.m.Stop(manager.CleanAll); err != nil {
+		log.Warnf("error stopping tracer offset guesser: %s", err)
+	}
 }
 
 func extractIPsAndPorts(conn net.Conn) (

--- a/pkg/network/tracer/offsetguess_test.go
+++ b/pkg/network/tracer/offsetguess_test.go
@@ -136,11 +136,11 @@ func TestOffsetGuess(t *testing.T) {
 	require.NoError(t, err, "could not read offset bpf module")
 	t.Cleanup(func() { offsetBuf.Close() })
 
-	_consts, err := runOffsetGuessing(cfg, offsetBuf, offsetguess.NewTracerOffsetGuesser())
+	_consts, err := runOffsetGuessing(cfg, offsetBuf, offsetguess.NewTracerOffsetGuesser)
 	require.NoError(t, err)
-	ctGuesser, err := offsetguess.NewConntrackOffsetGuesser(_consts)
-	require.NoError(t, err)
-	cts, err := runOffsetGuessing(cfg, offsetBuf, ctGuesser)
+	cts, err := runOffsetGuessing(cfg, offsetBuf, func() (offsetguess.OffsetGuesser, error) {
+		return offsetguess.NewConntrackOffsetGuesser(_consts)
+	})
 	require.NoError(t, err)
 	_consts = append(_consts, cts...)
 

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -154,7 +154,7 @@ func newTracer(config *config.Config) (*Tracer, error) {
 	needsOffsets := !config.EnableRuntimeCompiler || config.AllowPrecompiledFallback
 	var constantEditors []manager.ConstantEditor
 	if needsOffsets {
-		if constantEditors, err = runOffsetGuessing(config, offsetBuf, offsetguess.NewTracerOffsetGuesser()); err != nil {
+		if constantEditors, err = runOffsetGuessing(config, offsetBuf, offsetguess.NewTracerOffsetGuesser); err != nil {
 			return nil, fmt.Errorf("error guessing offsets: %s", err)
 		}
 	}
@@ -287,22 +287,26 @@ func newReverseDNS(c *config.Config) dns.ReverseDNS {
 	return rdns
 }
 
-func runOffsetGuessing(config *config.Config, buf bytecode.AssetReader, guesser offsetguess.OffsetGuesser) (editors []manager.ConstantEditor, err error) {
-	if err := offsetguess.SetupOffsetGuesser(guesser, config, buf); err != nil {
-		return nil, err
-	}
-
-	defer func() {
-		err := guesser.Manager().Stop(manager.CleanAll)
-		if err != nil {
-			log.Warnf("error stopping offset ebpf manager: %s", err)
-		}
-	}()
-
+func runOffsetGuessing(config *config.Config, buf bytecode.AssetReader, newGuesser func() (offsetguess.OffsetGuesser, error)) (editors []manager.ConstantEditor, err error) {
 	// Offset guessing has been flaky for some customers, so if it fails we'll retry it up to 5 times
+	start := time.Now()
 	for i := 0; i < 5; i++ {
-		start := time.Now()
-		if editors, err = guesser.Guess(config); err == nil {
+		err = func() error {
+			guesser, err := newGuesser()
+			if err != nil {
+				return err
+			}
+			defer guesser.Close()
+
+			if err = offsetguess.SetupOffsetGuesser(guesser, config, buf); err != nil {
+				return err
+			}
+
+			editors, err = guesser.Guess(config)
+			return err
+		}()
+
+		if err == nil {
 			log.Infof("offset guessing complete (took %v)", time.Since(start))
 			return editors, nil
 		}

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -948,7 +948,7 @@ func (t *TCPServer) Run() error {
 
 	go func() {
 		for {
-			conn, err := t.ln.Accept()
+			conn, err := ln.Accept()
 			if err != nil {
 				return
 			}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Recreates (and so resets) the offset guesser object for each offset guessing retry. This is to fix errors like these, where we don't appear to be retrying to run offsets on failure the first time around:
https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/242195105
https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/242615210
https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/242616062


### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
