### PR TITLE
[process-agent] Initialize command dependencies with components

### DIFF
--- a/cmd/process-agent/command/command.go
+++ b/cmd/process-agent/command/command.go
@@ -15,7 +15,10 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/DataDog/datadog-agent/cmd/process-agent/flags"
+	"github.com/DataDog/datadog-agent/comp/core"
+	configComponent "github.com/DataDog/datadog-agent/comp/core/config"
 	logComponent "github.com/DataDog/datadog-agent/comp/core/log"
+	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -25,6 +28,9 @@ const LoggerName config.LoggerName = "PROCESS"
 
 // DaemonLogParams are the log params should be given to the `core.BundleParams` for when the process agent is running as a daemon
 var DaemonLogParams = logComponent.LogForDaemon(string(LoggerName), "process_config.log_file", config.DefaultProcessAgentLogFile)
+
+// OneShotLogParams are the log params that are given to commands
+var OneShotLogParams = logComponent.LogForOneShot(string(LoggerName), "info", true)
 
 // GlobalParams contains the values of agent-global Cobra flags.
 //
@@ -193,4 +199,12 @@ func loadConfigIfExists(path string) error {
 
 	_, err := config.LoadWithoutSecret()
 	return err
+}
+
+func GetCoreBundleParamsForOneShot(globalParams *GlobalParams) core.BundleParams {
+	return core.BundleParams{
+		ConfigParams:         configComponent.NewAgentParamsWithSecrets(globalParams.ConfFilePath),
+		SysprobeConfigParams: sysprobeconfig.NewParams(sysprobeconfig.WithSysProbeConfFilePath(globalParams.SysProbeConfFilePath)),
+		LogParams:            logComponent.LogForOneShot(string(LoggerName), "info", true),
+	}
 }

--- a/cmd/process-agent/subcommands/check/check.go
+++ b/cmd/process-agent/subcommands/check/check.go
@@ -20,6 +20,12 @@ import (
 
 	"github.com/DataDog/datadog-agent/cmd/process-agent/command"
 	sysconfig "github.com/DataDog/datadog-agent/cmd/system-probe/config"
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/log"
+	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig"
+	processComponent "github.com/DataDog/datadog-agent/comp/process"
+	"github.com/DataDog/datadog-agent/comp/process/hostinfo"
+	"github.com/DataDog/datadog-agent/comp/process/types"
 	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/metadata/host"
 	"github.com/DataDog/datadog-agent/pkg/process/checks"
@@ -28,7 +34,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/tagger/local"
 	"github.com/DataDog/datadog-agent/pkg/tagger/remote"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/version"
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 )
@@ -40,6 +45,18 @@ type cliParams struct {
 	checkName       string
 	checkOutputJSON bool
 	waitInterval    time.Duration
+}
+
+type dependencies struct {
+	fx.In
+
+	CliParams *cliParams
+
+	Config   config.Component
+	Syscfg   sysprobeconfig.Component
+	Log      log.Component
+	Hostinfo hostinfo.Component
+	Checks   []types.CheckComponent `group:"check"`
 }
 
 func nextGroupID() func() int32 {
@@ -63,8 +80,18 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cliParams.checkName = args[0]
+
+			bundleParams := command.GetCoreBundleParamsForOneShot(globalParams)
+
+			// Override the log_to_console setting if `--json` is specified. This way the check command will output proper json.
+			if cliParams.checkOutputJSON {
+				bundleParams.LogParams.LogToConsole(false)
+			}
+
 			return fxutil.OneShot(runCheckCmd,
-				fx.Supply(cliParams),
+				fx.Supply(cliParams, bundleParams),
+
+				processComponent.Bundle,
 			)
 		},
 		SilenceUsage: true,
@@ -76,35 +103,18 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 	return []*cobra.Command{checkCmd}
 }
 
-func runCheckCmd(cliParams *cliParams) error {
-	// Override the log_to_console setting if `--json` is specified. This way the check command will output proper json.
-	if cliParams.checkOutputJSON {
-		ddconfig.Datadog.Set("log_to_console", false)
-	}
-
-	// Override the disable_file_logging setting so that the check command doesn't dump so much noise into the log file.
-	ddconfig.Datadog.Set("disable_file_logging", true)
-
-	if err := command.BootstrapConfig(cliParams.GlobalParams.ConfFilePath, true); err != nil {
-		return log.Criticalf("Error parsing config: %s", err)
-	}
-
-	// For system probe, there is an additional config file that is shared with the system-probe
-	syscfg, err := sysconfig.New(cliParams.SysProbeConfFilePath)
-	if err != nil {
-		return log.Critical(err)
-	}
-
+func runCheckCmd(deps dependencies) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	// Now that the logger is configured log host info
 	hostStatus := host.GetStatusInformation()
-	log.Infof("running on platform: %s", hostStatus.Platform)
+	deps.Log.Infof("running on platform: %s", hostStatus.Platform)
 	agentVersion, _ := version.Agent()
-	log.Infof("running version: %s", agentVersion.GetNumberAndPre())
+	deps.Log.Infof("running version: %s", agentVersion.GetNumberAndPre())
 
 	// Start workload metadata store before tagger (used for containerCollection)
+	// TODO: (Components) Add to dependencies once workloadmeta is migrated to components
 	var workloadmetaCollectors workloadmeta.CollectorCatalog
 	if ddconfig.Datadog.GetBool("process_config.remote_workloadmeta") {
 		workloadmetaCollectors = workloadmeta.RemoteCatalog
@@ -115,11 +125,12 @@ func runCheckCmd(cliParams *cliParams) error {
 	store.Start(ctx)
 
 	// Tagger must be initialized after agent config has been setup
+	// TODO: (Components) Add to dependencies once tagger is migrated to components
 	var t tagger.Tagger
-	if ddconfig.Datadog.GetBool("process_config.remote_tagger") {
+	if deps.Config.GetBool("process_config.remote_tagger") {
 		options, err := remote.NodeAgentOptions()
 		if err != nil {
-			log.Errorf("unable to configure the remote tagger: %s", err)
+			_ = deps.Log.Errorf("unable to configure the remote tagger: %s", err)
 		} else {
 			t = remote.NewTagger(options)
 		}
@@ -128,16 +139,11 @@ func runCheckCmd(cliParams *cliParams) error {
 	}
 
 	tagger.SetDefaultTagger(t)
-	err = tagger.Init(ctx)
+	err := tagger.Init(ctx)
 	if err != nil {
-		log.Errorf("failed to start the tagger: %s", err)
+		_ = deps.Log.Errorf("failed to start the tagger: %s", err)
 	}
 	defer tagger.Stop() //nolint:errcheck
-
-	hostInfo, err := checks.CollectHostInfo()
-	if err != nil {
-		log.Errorf("failed to collect system info: %s", err)
-	}
 
 	cleanups := make([]func(), 0)
 	defer func() {
@@ -147,35 +153,34 @@ func runCheckCmd(cliParams *cliParams) error {
 	}()
 
 	// If the sysprobe module is enabled, the process check can call out to the sysprobe for privileged stats
-	_, processModuleEnabled := syscfg.EnabledModules[sysconfig.ProcessModule]
+	_, processModuleEnabled := deps.Syscfg.Object().EnabledModules[sysconfig.ProcessModule]
 
 	if processModuleEnabled {
-		net.SetSystemProbePath(syscfg.SocketAddress)
+		net.SetSystemProbePath(deps.Syscfg.Object().SocketAddress)
 	}
 
-	// TODO: Remove dependency on syscfg once runCheckCmd is migrated to components
-	all := checks.All(syscfg)
+	all := checks.All(deps.Syscfg.Object())
 	names := make([]string, 0, len(all))
 	for _, ch := range all {
 		names = append(names, ch.Name())
 
 		cfg := &checks.SysProbeConfig{
-			MaxConnsPerMessage:   syscfg.MaxConnsPerMessage,
-			SystemProbeAddress:   syscfg.SocketAddress,
+			MaxConnsPerMessage:   deps.Syscfg.Object().MaxConnsPerMessage,
+			SystemProbeAddress:   deps.Syscfg.Object().SocketAddress,
 			ProcessModuleEnabled: processModuleEnabled,
 		}
 
-		if !matchingCheck(cliParams.checkName, ch) {
+		if !matchingCheck(deps.CliParams.checkName, ch) {
 			continue
 		}
 
-		if err = ch.Init(cfg, hostInfo); err != nil {
+		if err = ch.Init(cfg, deps.Hostinfo.Object()); err != nil {
 			return err
 		}
 		cleanups = append(cleanups, ch.Cleanup)
-		return runCheck(cliParams, ch)
+		return runCheck(deps.Log, deps.CliParams, ch)
 	}
-	return log.Errorf("invalid check '%s', choose from: %v", cliParams.checkName, names)
+	return deps.Log.Errorf("invalid check '%s', choose from: %v", deps.CliParams.checkName, names)
 }
 
 func matchingCheck(checkName string, ch checks.Check) bool {
@@ -188,7 +193,7 @@ func matchingCheck(checkName string, ch checks.Check) bool {
 	return ch.Name() == checkName
 }
 
-func runCheck(cliParams *cliParams, ch checks.Check) error {
+func runCheck(log log.Component, cliParams *cliParams, ch checks.Check) error {
 	nextGroupID := nextGroupID()
 
 	options := &checks.RunOptions{

--- a/cmd/process-agent/subcommands/check/check.go
+++ b/cmd/process-agent/subcommands/check/check.go
@@ -83,9 +83,9 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 
 			bundleParams := command.GetCoreBundleParamsForOneShot(globalParams)
 
-			// Override the log_to_console setting if `--json` is specified. This way the check command will output proper json.
+			// Disable logging if `--json` is specified. This way the check command will output proper json.
 			if cliParams.checkOutputJSON {
-				bundleParams.LogParams.LogToConsole(false)
+				bundleParams.LogParams = log.LogForOneShot(string(command.LoggerName), "off", true)
 			}
 
 			return fxutil.OneShot(runCheckCmd,
@@ -159,9 +159,10 @@ func runCheckCmd(deps dependencies) error {
 		net.SetSystemProbePath(deps.Syscfg.Object().SocketAddress)
 	}
 
-	all := checks.All(deps.Syscfg.Object())
-	names := make([]string, 0, len(all))
-	for _, ch := range all {
+	names := make([]string, 0, len(deps.Checks))
+	for _, checkComponent := range deps.Checks {
+		ch := checkComponent.Object()
+
 		names = append(names, ch.Name())
 
 		cfg := &checks.SysProbeConfig{

--- a/cmd/process-agent/subcommands/events/events.go
+++ b/cmd/process-agent/subcommands/events/events.go
@@ -18,13 +18,15 @@ import (
 	"go.uber.org/fx"
 
 	"github.com/DataDog/datadog-agent/cmd/process-agent/command"
-	sysconfig "github.com/DataDog/datadog-agent/cmd/system-probe/config"
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/log"
+	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig"
+	"github.com/DataDog/datadog-agent/comp/process"
 	"github.com/DataDog/datadog-agent/pkg/process/checks"
 	"github.com/DataDog/datadog-agent/pkg/process/events"
 	"github.com/DataDog/datadog-agent/pkg/process/events/model"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 const (
@@ -37,6 +39,16 @@ type cliParams struct {
 
 	pullInterval     time.Duration
 	eventsOutputJSON bool
+}
+
+type dependencies struct {
+	fx.In
+
+	Params *cliParams
+
+	Config         config.Component
+	SysProbeConfig sysprobeconfig.Component
+	Log            log.Component
 }
 
 // Commands returns a slice of subcommands for the `events` command in the Process Agent
@@ -58,7 +70,9 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		Short: "Open a session to listen for process lifecycle events. This feature is currently in alpha version and needs root privilege to run.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(runEventListener,
-				fx.Supply(cliParams),
+				fx.Supply(cliParams, command.GetCoreBundleParamsForOneShot(globalParams)),
+
+				process.Bundle,
 			)
 		},
 		SilenceUsage: true,
@@ -71,6 +85,8 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(runEventStore,
 				fx.Supply(cliParams),
+
+				process.Bundle,
 			)
 		},
 		SilenceUsage: true,
@@ -82,20 +98,6 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 	eventsPullCmd.Flags().DurationVarP(&cliParams.pullInterval, "tick", "t", defaultPullInterval, "The period between 2 consecutive pulls to fetch process events")
 
 	return []*cobra.Command{eventsCmd}
-}
-
-func bootstrapEventsCmd(cliParams *cliParams) error {
-	if err := command.BootstrapConfig(cliParams.GlobalParams.ConfFilePath, true); err != nil {
-		return log.Criticalf("Error parsing config: %s", err)
-	}
-
-	// Load system-probe.yaml file and merge it to the global Datadog config
-	_, err := sysconfig.New(cliParams.SysProbeConfFilePath)
-	if err != nil {
-		return log.Critical(err)
-	}
-
-	return nil
 }
 
 func printEvents(cliParams *cliParams, events ...*model.ProcessEvent) error {
@@ -126,17 +128,12 @@ func printEventsJSON(events []*model.ProcessEvent) error {
 	return nil
 }
 
-func runEventListener(cliParams *cliParams) error {
-	err := bootstrapEventsCmd(cliParams)
-	if err != nil {
-		return err
-	}
-
+func runEventListener(deps dependencies) error {
 	// Create a handler to print the collected event to stdout
 	handler := func(e *model.ProcessEvent) {
-		err = printEvents(cliParams, e)
+		err := printEvents(deps.Params, e)
 		if err != nil {
-			log.Error(err)
+			_ = deps.Log.Error(err)
 		}
 	}
 
@@ -151,17 +148,12 @@ func runEventListener(cliParams *cliParams) error {
 
 	<-exit
 	l.Stop()
-	log.Flush()
+	deps.Log.Flush()
 
 	return nil
 }
 
-func runEventStore(cliParams *cliParams) error {
-	err := bootstrapEventsCmd(cliParams)
-	if err != nil {
-		return err
-	}
-
+func runEventStore(deps dependencies) error {
 	store, err := events.NewRingStore(&statsd.NoOpClient{})
 	if err != nil {
 		return err
@@ -181,7 +173,7 @@ func runEventStore(cliParams *cliParams) error {
 	exit := make(chan struct{})
 	go util.HandleSignals(exit)
 
-	ticker := time.NewTicker(cliParams.pullInterval)
+	ticker := time.NewTicker(deps.Params.pullInterval)
 	defer ticker.Stop()
 	go func() {
 		for {
@@ -189,13 +181,13 @@ func runEventStore(cliParams *cliParams) error {
 			case <-ticker.C:
 				events, err := store.Pull(context.Background(), time.Second)
 				if err != nil {
-					log.Error(err)
+					_ = deps.Log.Error(err)
 					continue
 				}
 
-				err = printEvents(cliParams, events...)
+				err = printEvents(deps.Params, events...)
 				if err != nil {
-					log.Error(err)
+					_ = deps.Log.Error(err)
 				}
 			case <-exit:
 				return
@@ -206,7 +198,7 @@ func runEventStore(cliParams *cliParams) error {
 	<-exit
 	l.Stop()
 	store.Stop()
-	log.Flush()
+	deps.Log.Flush()
 
 	return nil
 }

--- a/cmd/process-agent/subcommands/events/events.go
+++ b/cmd/process-agent/subcommands/events/events.go
@@ -84,7 +84,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		Short: "Periodically pull process lifecycle events. This feature is currently in alpha version and needs root privilege to run.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(runEventStore,
-				fx.Supply(cliParams),
+				fx.Supply(cliParams, command.GetCoreBundleParamsForOneShot(globalParams)),
 
 				process.Bundle,
 			)

--- a/cmd/process-agent/subcommands/status/status.go
+++ b/cmd/process-agent/subcommands/status/status.go
@@ -17,13 +17,13 @@ import (
 
 	"github.com/DataDog/datadog-agent/cmd/process-agent/command"
 	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/log"
 	"github.com/DataDog/datadog-agent/comp/process"
 	apiutil "github.com/DataDog/datadog-agent/pkg/api/util"
 	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 	ddstatus "github.com/DataDog/datadog-agent/pkg/status"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 var httpClient = apiutil.GetClient(false)
@@ -58,6 +58,7 @@ type dependencies struct {
 	CliParams *cliParams
 
 	Config config.Component
+	Log    log.Component
 }
 
 // Commands returns a slice of subcommands for the `status` command in the Process Agent
@@ -83,14 +84,14 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 	return []*cobra.Command{statusCmd}
 }
 
-func writeNotRunning(w io.Writer) {
+func writeNotRunning(log log.Component, w io.Writer) {
 	_, err := fmt.Fprint(w, notRunning)
 	if err != nil {
 		_ = log.Error(err)
 	}
 }
 
-func writeError(w io.Writer, e error) {
+func writeError(log log.Component, w io.Writer, e error) {
 	tpl, err := template.New("").Funcs(ddstatus.Textfmap()).Parse(errorMessage)
 	if err != nil {
 		_ = log.Error(err)
@@ -112,14 +113,14 @@ func fetchStatus(statusURL string) ([]byte, error) {
 }
 
 // getAndWriteStatus calls the status server and writes it to `w`
-func getAndWriteStatus(statusURL string, w io.Writer, options ...util.StatusOption) {
+func getAndWriteStatus(log log.Component, statusURL string, w io.Writer, options ...util.StatusOption) {
 	body, err := fetchStatus(statusURL)
 	if err != nil {
 		switch err.(type) {
 		case util.ConnectionError:
-			writeNotRunning(w)
+			writeNotRunning(log, w)
 		default:
-			writeError(w, err)
+			writeError(log, w, err)
 		}
 		return
 	}
@@ -129,7 +130,7 @@ func getAndWriteStatus(statusURL string, w io.Writer, options ...util.StatusOpti
 		var s util.Status
 		err = json.Unmarshal(body, &s)
 		if err != nil {
-			writeError(w, err)
+			writeError(log, w, err)
 			return
 		}
 
@@ -139,14 +140,14 @@ func getAndWriteStatus(statusURL string, w io.Writer, options ...util.StatusOpti
 
 		body, err = json.Marshal(s)
 		if err != nil {
-			writeError(w, err)
+			writeError(log, w, err)
 			return
 		}
 	}
 
 	stats, err := ddstatus.FormatProcessAgentStatus(body)
 	if err != nil {
-		writeError(w, err)
+		writeError(log, w, err)
 		return
 	}
 
@@ -167,10 +168,10 @@ func getStatusURL() (string, error) {
 func runStatus(deps dependencies) error {
 	statusURL, err := getStatusURL()
 	if err != nil {
-		writeError(os.Stdout, err)
+		writeError(deps.Log, os.Stdout, err)
 		return err
 	}
 
-	getAndWriteStatus(statusURL, os.Stdout)
+	getAndWriteStatus(deps.Log, statusURL, os.Stdout)
 	return nil
 }

--- a/cmd/process-agent/subcommands/status/status_test.go
+++ b/cmd/process-agent/subcommands/status/status_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/metadata/host"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 	ddstatus "github.com/DataDog/datadog-agent/pkg/status"
+	"github.com/DataDog/datadog-agent/pkg/trace/log"
 )
 
 func fakeStatusServer(t *testing.T, stats util.Status) *httptest.Server {
@@ -60,7 +61,7 @@ func TestStatus(t *testing.T) {
 
 	// Build the actual status
 	var statusBuilder strings.Builder
-	getAndWriteStatus(server.URL, &statusBuilder, util.OverrideTime(testTime))
+	getAndWriteStatus(log.NoopLogger, server.URL, &statusBuilder, util.OverrideTime(testTime))
 
 	assert.Equal(t, expectedOutput, statusBuilder.String())
 }
@@ -75,7 +76,7 @@ func TestNotRunning(t *testing.T) {
 	statusURL := fmt.Sprintf("http://%s/agent/status", addressPort)
 
 	var b strings.Builder
-	getAndWriteStatus(statusURL, &b)
+	getAndWriteStatus(log.NoopLogger, statusURL, &b)
 
 	assert.Equal(t, notRunning, b.String())
 }
@@ -90,7 +91,7 @@ func TestError(t *testing.T) {
 	var errText, expectedErrText strings.Builder
 	url, err := getStatusURL()
 	assert.Equal(t, "", url)
-	writeError(&errText, err)
+	writeError(log.NoopLogger, &errText, err)
 
 	tpl, err := template.New("").Parse(errorMessage)
 	require.NoError(t, err)

--- a/cmd/process-agent/subcommands/workloadlist/command.go
+++ b/cmd/process-agent/subcommands/workloadlist/command.go
@@ -40,9 +40,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(workloadList,
 				fx.Supply(cliParams),
-				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewAgentParamsWithoutSecrets(globalParams.ConfFilePath),
-					LogParams:    log.LogForOneShot("PROCESS", "off", true)}),
+				fx.Supply(command.GetCoreBundleParamsForOneShot(globalParams)),
 				core.Bundle,
 			)
 		},

--- a/comp/core/log/params.go
+++ b/comp/core/log/params.go
@@ -131,6 +131,11 @@ func (params *Params) LogToFile(logFile string) {
 	params.logFileFn = func(configGetter) string { return logFile }
 }
 
+// LogToConsole modifies the parameters to toggle logging to console
+func (params *Params) LogToConsole(logToConsole bool) {
+	params.logToConsoleFn = func(configGetter) bool { return logToConsole }
+}
+
 // LoggerName is the name that appears in the logfile
 func (params Params) LoggerName() string {
 	return params.loggerName


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR uses fx to inject the components required for running each subcommand. 


### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Migration to components.


### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
Note that all tests should be run using the `TRACE_FX=true` environment variable.

- [x] Test the `process-agent check process` command. Make sure there are no errors, and that the process agent does not log to the log file.
- [x] Test the `process-agent check process --json` command. This time, make sure the logger emits no messages at all (other than the logs that are from fx).
- [x] Run the `process-agent config` subcommands. This means `config`, `config get foo`, `config set foo`.
- [x] Run `process-agent events listen` and `process-agent events pull`. Make sure that no components fail to initialize.
- [x] Run `process-agent status`. Make sure that no components fail to initialize.
- [x] Run `process-agent tagger-list`. Make sure that no components fail to initialize.
- [x] Run `process-agent workload-list`. Make sure that no components fail to initialize.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
