### PR TITLE
[corechecks/snmp] Add support to format bytes into ip_address

### DIFF
--- a/pkg/collector/corechecks/snmp/internal/report/report_format.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_format.go
@@ -8,6 +8,7 @@ package report
 import (
 	"encoding/hex"
 	"fmt"
+	"net"
 	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/internal/valuestore"
@@ -21,6 +22,12 @@ func formatValue(value valuestore.ResultValue, format string) (valuestore.Result
 		case "mac_address":
 			// Format mac address from OctetString to IEEE 802.1a canonical format e.g. `82:a5:6e:a5:c8:01`
 			value.Value = formatColonSepBytes(val)
+		case "ip_address":
+			if len(val) == 0 {
+				value.Value = ""
+			} else {
+				value.Value = net.IP(val).String()
+			}
 		default:
 			return valuestore.ResultValue{}, fmt.Errorf("unknown format `%s` (value type `%T`)", format, value.Value)
 		}

--- a/pkg/collector/corechecks/snmp/internal/report/report_format_test.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_format_test.go
@@ -34,11 +34,11 @@ func Test_formatValue(t *testing.T) {
 		{
 			name: "ip_address: format IPv4 address",
 			value: valuestore.ResultValue{
-				Value: []byte{0x64, 0x43, 0x00, 0x07},
+				Value: []byte{0x0a, 0x43, 0x00, 0x07},
 			},
 			format: "ip_address",
 			expectedValue: valuestore.ResultValue{
-				Value: "100.67.0.7",
+				Value: "10.67.0.7",
 			},
 		},
 		{

--- a/pkg/collector/corechecks/snmp/internal/report/report_format_test.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_format_test.go
@@ -22,13 +22,53 @@ func Test_formatValue(t *testing.T) {
 		expectedError string
 	}{
 		{
-			name: "format mac address",
+			name: "mac_address: format mac_address",
 			value: valuestore.ResultValue{
 				Value: []byte{0x82, 0xa5, 0x6e, 0xa5, 0xc8, 0x01},
 			},
 			format: "mac_address",
 			expectedValue: valuestore.ResultValue{
 				Value: "82:a5:6e:a5:c8:01",
+			},
+		},
+		{
+			name: "ip_address: format IPv4 address",
+			value: valuestore.ResultValue{
+				Value: []byte{0x64, 0x43, 0x00, 0x07},
+			},
+			format: "ip_address",
+			expectedValue: valuestore.ResultValue{
+				Value: "100.67.0.7",
+			},
+		},
+		{
+			name: "ip_address: format IPv6 address",
+			value: valuestore.ResultValue{
+				Value: []byte{0x20, 0x01, 0x48, 0x60, 0, 0, 0x20, 0x01, 0, 0, 0, 0, 0, 0, 0x00, 0x68},
+			},
+			format: "ip_address",
+			expectedValue: valuestore.ResultValue{
+				Value: "2001:4860:0:2001::68",
+			},
+		},
+		{
+			name: "ip_address: invalid ip_address",
+			value: valuestore.ResultValue{
+				Value: []byte{0x64, 0x43}, // only 2 bytes instead of 4 bytes (IPv4)
+			},
+			format: "ip_address",
+			expectedValue: valuestore.ResultValue{
+				Value: "?6443", // net.IP(...).String() will return `?` followed by hex when input is not IPv4 or IPv6
+			},
+		},
+		{
+			name: "ip_address: empty raw bytes",
+			value: valuestore.ResultValue{
+				Value: []byte{},
+			},
+			format: "ip_address",
+			expectedValue: valuestore.ResultValue{
+				Value: "",
 			},
 		},
 		{

--- a/releasenotes/notes/snmp_format_ip_address-4fbc4711ff09844b.yaml
+++ b/releasenotes/notes/snmp_format_ip_address-4fbc4711ff09844b.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    [corechecks/snmp] Add support to format bytes into ip_address


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

[corechecks/snmp] format ip_address

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

user request

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
