### PR TITLE
usm: tests: kafka: Increase timeouts and ignore topic deletion error

### DIFF
--- a/pkg/network/protocols/kafka/client.go
+++ b/pkg/network/protocols/kafka/client.go
@@ -14,6 +14,10 @@ import (
 	"github.com/twmb/franz-go/pkg/kgo"
 )
 
+const (
+	defaultTimeout = time.Second * 10
+)
+
 type Options struct {
 	ServerAddress string
 	Dialer        *net.Dialer
@@ -35,7 +39,7 @@ func NewClient(opts Options) (*Client, error) {
 		return nil, err
 	}
 
-	ctxTimeout, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	ctxTimeout, cancel := context.WithTimeout(context.Background(), defaultTimeout)
 	defer cancel()
 	if err := client.Ping(ctxTimeout); err != nil {
 		return nil, err
@@ -48,7 +52,7 @@ func NewClient(opts Options) (*Client, error) {
 
 func (c *Client) CreateTopic(topicName string) error {
 	adminClient := kadm.NewClient(c.Client)
-	ctxTimeout, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	ctxTimeout, cancel := context.WithTimeout(context.Background(), defaultTimeout)
 	defer cancel()
 	_, err := adminClient.CreateTopics(ctxTimeout, 1, 1, nil, topicName)
 	return err
@@ -56,7 +60,7 @@ func (c *Client) CreateTopic(topicName string) error {
 
 func (c *Client) DeleteTopic(topicName string) error {
 	adminClient := kadm.NewClient(c.Client)
-	ctxTimeout, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	ctxTimeout, cancel := context.WithTimeout(context.Background(), defaultTimeout)
 	defer cancel()
 	_, err := adminClient.DeleteTopics(ctxTimeout, topicName)
 	return err

--- a/pkg/network/tracer/tracer_classification_test.go
+++ b/pkg/network/tracer/tracer_classification_test.go
@@ -208,7 +208,7 @@ func testKafkaProtocolClassification(t *testing.T, tr *Tracer, clientHost, targe
 		defer client.Client.Close()
 		for k, value := range ctx.extras {
 			if strings.HasPrefix(k, "topic_name") {
-				// We're in teardown, and deleting the topic name is best effort. Thus, we can ignore, an error.
+				// We're in the teardown phase, and deleting the topic name is a best effort operation. Therefore, we can ignore any errors that may occur.
 				_ = client.DeleteTopic(value.(string))
 			}
 		}

--- a/pkg/network/tracer/tracer_classification_test.go
+++ b/pkg/network/tracer/tracer_classification_test.go
@@ -208,7 +208,8 @@ func testKafkaProtocolClassification(t *testing.T, tr *Tracer, clientHost, targe
 		defer client.Client.Close()
 		for k, value := range ctx.extras {
 			if strings.HasPrefix(k, "topic_name") {
-				require.NoError(t, client.DeleteTopic(value.(string)))
+				// We're in teardown, and deleting the topic name is best effort. Thus, we can ignore, an error.
+				_ = client.DeleteTopic(value.(string))
 			}
 		}
 	}


### PR DESCRIPTION

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
Increase timeouts and ignore topic deletion error
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Increasing the default timeout from 5 seconds to 10, as the CI is slow. Furthermore, ignoring the error (if exists) in the topic deletion during the teardown phase of the tests, as it is already best effort, and does not impact the actual test.
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
