### PR TITLE
Introduce generic usage of GOMEMLIMIT in all Agents with logic suited for pure Go and Go/Python Agents.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -85,8 +85,6 @@ linters-settings:
         files:
           - $all
         deny:
-          - pkg: "sync/atomic"
-            desc: "Use go.uber.org/atomic instead; see docs/dev/atomics.md"
           - pkg: "io/ioutil"
             desc: "Deprecated since Go 1.16. Use package io or os instead."
           - pkg: "github.com/golang/glog"

--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -51,6 +51,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config/remote/data"
 	rcservice "github.com/DataDog/datadog-agent/pkg/config/remote/service"
 	commonsettings "github.com/DataDog/datadog-agent/pkg/config/settings"
+	"github.com/DataDog/datadog-agent/pkg/runtime"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
 	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
@@ -129,6 +130,14 @@ func start(log log.Component, config config.Component, telemetry telemetry.Compo
 
 	// Starting Cluster Agent sequence
 	// Initialization order is important for multiple reasons, see comments
+
+	// Set memory limit
+	go func() {
+		err := runtime.RunMemoryLimiterFromConfig(mainCtx, "")
+		if err != nil {
+			log.Infof("Running memory limiter failed with: %v", err)
+		}
+	}()
 
 	if err := util.SetupCoreDump(config); err != nil {
 		pkglog.Warnf("Can't setup core dumps: %v, core dumps might not be available after a crash", err)

--- a/cmd/process-agent/main_common.go
+++ b/cmd/process-agent/main_common.go
@@ -42,6 +42,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/process/metadata/workloadmeta/collector"
 	"github.com/DataDog/datadog-agent/pkg/process/statsd"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
+	"github.com/DataDog/datadog-agent/pkg/runtime"
 	"github.com/DataDog/datadog-agent/pkg/tagger"
 	"github.com/DataDog/datadog-agent/pkg/tagger/local"
 	"github.com/DataDog/datadog-agent/pkg/tagger/remote"
@@ -281,8 +282,12 @@ func initMisc(deps miscDeps) error {
 	appCtx, stopApp := context.WithCancel(context.Background())
 	deps.Lc.Append(fx.Hook{
 		OnStart: func(startCtx context.Context) error {
+			err := runtime.RunMemoryLimiterFromConfig(appCtx, "process_config")
+			if err != nil {
+				log.Infof("Running memory limiter failed with: %v", err)
+			}
 
-			err := tagger.Init(startCtx)
+			err = tagger.Init(startCtx)
 			if err != nil {
 				log.Errorf("failed to start the tagger: %s", err)
 			}

--- a/cmd/system-probe/subcommands/run/command.go
+++ b/cmd/system-probe/subcommands/run/command.go
@@ -43,7 +43,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/pidfile"
 	processstatsd "github.com/DataDog/datadog-agent/pkg/process/statsd"
-	ddruntime "github.com/DataDog/datadog-agent/pkg/runtime"
 	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	pkglog "github.com/DataDog/datadog-agent/pkg/util/log"
@@ -98,9 +97,6 @@ func run(log log.Component, _ config.Component, statsd compstatsd.Component, tel
 	defer func() {
 		stopSystemProbe(cliParams)
 	}()
-
-	// prepare go runtime
-	ddruntime.SetMaxProcs()
 
 	// Setup a channel to catch OS signals
 	signalCh := make(chan os.Signal, 1)
@@ -231,6 +227,9 @@ func startSystemProbe(cliParams *cliParams, log log.Component, statsd compstatsd
 	var ctx context.Context
 	ctx, common.MainCtxCancel = context.WithCancel(context.Background())
 	cfg := sysprobeconfig.SysProbeObject()
+
+	// prepare go runtime
+	setupRuntime(ctx)
 
 	log.Infof("starting system-probe v%v", version.AgentVersion)
 

--- a/cmd/system-probe/subcommands/run/command_linux.go
+++ b/cmd/system-probe/subcommands/run/command_linux.go
@@ -1,0 +1,42 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+package run
+
+import (
+	"context"
+	"time"
+
+	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/runtime"
+	"github.com/DataDog/datadog-agent/pkg/util/cgroups"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+func setupRuntime(ctx context.Context) {
+	runtime.SetMaxProcs()
+	go func() {
+		limiter, err := runtime.NewDynamicMemoryLimiter(1*time.Second, ddconfig.IsContainerized(), 0.20, func(ms cgroups.MemoryStats) uint64 {
+			var nonGoMemory uint64
+			if ms.KernelMemory != nil {
+				nonGoMemory += *ms.KernelMemory
+			}
+			if ms.MappedFile != nil {
+				nonGoMemory += *ms.MappedFile
+			}
+			return nonGoMemory
+		})
+		if err != nil {
+			log.Infof("Creating memory limiter failed with: %v", err)
+		}
+
+		err = limiter.Run(ctx)
+		if err != nil {
+			log.Infof("Running memory limiter failed with: %v", err)
+		}
+	}()
+}

--- a/cmd/system-probe/subcommands/run/command_others.go
+++ b/cmd/system-probe/subcommands/run/command_others.go
@@ -1,0 +1,18 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !linux
+
+package run
+
+import (
+	"context"
+
+	"github.com/DataDog/datadog-agent/pkg/runtime"
+)
+
+func setupRuntime(ctx context.Context) {
+	runtime.SetMaxProcs()
+}

--- a/comp/trace/config/setup.go
+++ b/comp/trace/config/setup.go
@@ -559,6 +559,10 @@ func applyDatadogConfig(c *config.AgentConfig, core corecompcfg.Component) error
 		c.DDAgentBin = core.GetString("apm_config.dd_agent_bin")
 	}
 
+	if core.IsSet("apm_config.go_memlimit_pct") {
+		c.GoMemLimitPct = core.GetFloat64("apm_config.go_memlimit_pct")
+	}
+
 	if err := loadDeprecatedValues(c); err != nil {
 		return err
 	}

--- a/pkg/collector/python/init.go
+++ b/pkg/collector/python/init.go
@@ -20,7 +20,9 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
+	ddruntime "github.com/DataDog/datadog-agent/pkg/runtime"
 	"github.com/DataDog/datadog-agent/pkg/tagset"
 	"github.com/DataDog/datadog-agent/pkg/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util/cache"
@@ -421,7 +423,7 @@ func Initialize(paths ...string) error {
 		return err
 	}
 
-	if config.Datadog.GetBool("telemetry.enabled") && config.Datadog.GetBool("telemetry.python_memory") {
+	if setup.IsPythonMemoryMonitoringEnabled() {
 		initPymemTelemetry()
 	}
 
@@ -495,6 +497,7 @@ func initPymemTelemetry() {
 			var s C.pymem_stats_t
 			C.get_pymem_stats(rtloader, &s)
 			inuse.Set(float64(s.inuse))
+			ddruntime.SetPythonMemoryInUse(uint64(s.inuse))
 			alloc.Add(float64(s.alloc - prevAlloc))
 			prevAlloc = s.alloc
 		}

--- a/pkg/config/setup/apm.go
+++ b/pkg/config/setup/apm.go
@@ -93,9 +93,10 @@ func setupAPM(config pkgconfigmodel.Config) {
 	config.BindEnv("apm_config.max_traces_per_second", "DD_APM_MAX_TPS", "DD_MAX_TPS")
 	config.BindEnv("apm_config.errors_per_second", "DD_APM_ERROR_TPS")
 	config.BindEnv("apm_config.enable_rare_sampler", "DD_APM_ENABLE_RARE_SAMPLER")
-	config.BindEnv("apm_config.disable_rare_sampler", "DD_APM_DISABLE_RARE_SAMPLER") //Deprecated
+	config.BindEnv("apm_config.disable_rare_sampler", "DD_APM_DISABLE_RARE_SAMPLER") // Deprecated
 	config.BindEnv("apm_config.max_remote_traces_per_second", "DD_APM_MAX_REMOTE_TPS")
 
+	config.BindEnv("apm_config.go_memlimit_pct", "DD_APM_GO_MEMLIMIT_PCT")
 	config.BindEnv("apm_config.max_memory", "DD_APM_MAX_MEMORY")
 	config.BindEnv("apm_config.max_cpu_percent", "DD_APM_MAX_CPU_PERCENT")
 	config.BindEnv("apm_config.env", "DD_APM_ENV")

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -201,6 +201,14 @@ func init() {
 	InitSystemProbeConfig(SystemProbe)
 }
 
+func NSKey(namespace, key string) string {
+	if namespace == "" {
+		return key
+	}
+
+	return namespace + "." + key
+}
+
 // InitConfig initializes the config defaults on a config
 func InitConfig(config pkgconfigmodel.Config) {
 	// Agent
@@ -261,6 +269,8 @@ func InitConfig(config pkgconfigmodel.Config) {
 	config.BindEnvAndSetDefault("allow_arbitrary_tags", false)
 	config.BindEnvAndSetDefault("use_proxy_for_cloud_metadata", false)
 	config.BindEnvAndSetDefault("remote_tagger_timeout_seconds", 30)
+	config.BindEnvAndSetDefault("go_memlimit_pct", 0.95)
+	config.BindEnvAndSetDefault("go_dynamic_memlimit_interval_seconds", 1)
 
 	// Fips
 	config.BindEnvAndSetDefault("fips.enabled", false)
@@ -1166,6 +1176,7 @@ func InitConfig(config pkgconfigmodel.Config) {
 	config.BindEnvAndSetDefault("security_agent.log_file", DefaultSecurityAgentLogFile)
 	config.BindEnvAndSetDefault("security_agent.remote_tagger", true)
 	config.BindEnvAndSetDefault("security_agent.remote_workloadmeta", false) // TODO: switch this to true when ready
+	config.BindEnvAndSetDefault("security_agent.go_memlimit_pct", 0.95)
 
 	config.BindEnvAndSetDefault("security_agent.internal_profiling.enabled", false, "DD_SECURITY_AGENT_INTERNAL_PROFILING_ENABLED")
 	config.BindEnvAndSetDefault("security_agent.internal_profiling.site", DefaultSite, "DD_SECURITY_AGENT_INTERNAL_PROFILING_SITE", "DD_SITE")
@@ -2056,4 +2067,9 @@ func GetRemoteConfigurationAllowedIntegrations(cfg pkgconfigmodel.Reader) map[st
 	}
 
 	return allowMap
+}
+
+// IsPythonMemoryMonitoringEnabled returns if python memory monitoring is enabled
+func IsPythonMemoryMonitoringEnabled() bool {
+	return Datadog.GetBool("telemetry.enabled") && Datadog.GetBool("telemetry.python_memory")
 }

--- a/pkg/config/setup/process.go
+++ b/pkg/config/setup/process.go
@@ -122,6 +122,7 @@ func setupProcesses(config pkgconfigmodel.Config) {
 	})
 	procBindEnvAndSetDefault(config, "process_config.container_collection.enabled", true)
 	procBindEnvAndSetDefault(config, "process_config.process_collection.enabled", false)
+	procBindEnvAndSetDefault(config, "process_config.go_memlimit_pct", 0.95)
 
 	config.BindEnv("process_config.process_dd_url",
 		"DD_PROCESS_CONFIG_PROCESS_DD_URL",

--- a/pkg/runtime/gomemlimit.go
+++ b/pkg/runtime/gomemlimit.go
@@ -3,15 +3,24 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build !linux || !go1.19
-
 package runtime
 
 import (
-	"errors"
+	"context"
+	"time"
 )
 
-// SetGoMemLimit configures Go memory limit based on cgroups. Only supported on Linux.
-func SetGoMemLimit(isContainerized bool) (int64, error) { //nolint:revive // TODO fix revive unused-parameter
-	return 0, errors.New("unsupported")
+// MemoryLimiter allows to set GOMEMLIMIT based on different scenarios
+type MemoryLimiter interface {
+	Run(ctx context.Context) error
+}
+
+// MemoryLimiterArgs are the arguments to create a MemoryLimiter
+type MemoryLimiterArgs struct {
+	// LimitPct is the percentage of the memory limit (or MaxMemory) to set as GOMEMLIMIT (0.0 - 1.0)
+	LimitPct float64
+	// MaxMemory allows to provide a custom memory limit without relying cgroups (bytes)
+	MaxMemory uint64
+	// Interval is the interval at which the memory limiter will check the memory usage (only for dynamic memory limiter)
+	Interval time.Duration
 }

--- a/pkg/runtime/gomemlimit_linux.go
+++ b/pkg/runtime/gomemlimit_linux.go
@@ -3,49 +3,155 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build linux && go1.19
+//go:build linux
 
 package runtime
 
 import (
+	"context"
 	"errors"
-	"os"
+	"math"
 	"runtime/debug"
+	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util/cgroups"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-// SetGoMemLimit configures Go memory soft limit based on cgroups.
-// The soft limit is set to 90% of the cgroup memory hard limit.
-// The function is noop if
-//   - GOMEMLIMIT is set already
-//   - There is no cgroup limit
-//
-// Read more about Go memory limit in https://tip.golang.org/doc/gc-guide#Memory_limit
-func SetGoMemLimit(isContainerized bool) (int64, error) {
-	if _, ok := os.LookupEnv("GOMEMLIMIT"); ok {
+var memoryLimitTelemetry = telemetry.NewGauge("limiter", "mem_limit", nil, "The current value of GOMEMLIMIT")
+
+type staticMemoryLimiter struct {
+	customLimit     uint64
+	limitPct        float64
+	isContainerized bool
+}
+
+// NewStaticMemoryLimiter return a memory limit that sets memory limit once based on cgroup limit
+func NewStaticMemoryLimiter(limitPct float64, customLimit uint64, isContainerized bool) MemoryLimiter {
+	return staticMemoryLimiter{
+		customLimit:     customLimit,
+		limitPct:        limitPct,
+		isContainerized: isContainerized,
+	}
+}
+
+// Run runs the memory limit logic
+func (s staticMemoryLimiter) Run(context.Context) error {
+	// SetMemoryLimit with negative values returns current value
+	if debug.SetMemoryLimit(-1) != math.MaxInt64 {
 		log.Debug("GOMEMLIMIT is set already, doing nothing")
-		return 0, nil
+		return nil
 	}
-	selfReader, err := cgroups.NewSelfReader("/proc", isContainerized)
+
+	if s.customLimit > 0 {
+		s.setMemoryLimit(s.customLimit)
+	}
+
+	selfCgroup, err := getSelfCgroup(s.isContainerized)
 	if err != nil {
-		return 0, err
-	}
-	cgroup := selfReader.GetCgroup(cgroups.SelfCgroupIdentifier)
-	if cgroup == nil {
-		return 0, errors.New("cannot get cgroup")
+		return err
 	}
 	var stats cgroups.MemoryStats
-	if err := cgroup.GetMemoryStats(&stats); err != nil {
-		return 0, err
+	if err := selfCgroup.GetMemoryStats(&stats); err != nil {
+		return err
 	}
 	if stats.Limit == nil {
-		log.Info("Cgroup memory limit not found, doing nothing")
-		return 0, nil
+		return nil
 	}
-	softLimit := int64(0.9 * float64(*stats.Limit))
-	log.Infof("Cgroup memory limit is %d, setting gomemlimit to %d", *stats.Limit, softLimit)
-	debug.SetMemoryLimit(softLimit)
-	return softLimit, nil
+
+	s.setMemoryLimit(*stats.Limit)
+	return nil
+}
+
+func (s staticMemoryLimiter) setMemoryLimit(cgroupLimit uint64) {
+	memLimit := int64(s.limitPct * float64(cgroupLimit))
+	log.Infof("Cgroup memory limit is %d, setting gomemlimit to %d", cgroupLimit, memLimit)
+	memoryLimitTelemetry.Set(float64(memLimit))
+	debug.SetMemoryLimit(memLimit)
+}
+
+type dynamicMemoryLimiter struct {
+	ticker               *time.Ticker
+	selfCgroup           cgroups.Cgroup
+	minLimitPct          float64
+	externalMemoryReader func(cgroups.MemoryStats) uint64
+}
+
+// NewDynamicMemoryLimiter creates a memory limiter that adapts limit continuously based on Cgroup limit
+// plus memory consumed outside of the Go space.
+// It will set GOMEMLIMT to max(cgroupLimit * minLimitPct, cgroupLimit-externalMemory)
+// It will override existing value of GOMEMLIMIT
+func NewDynamicMemoryLimiter(interval time.Duration, isContainerized bool, minLimitPct float64, externalMemoryReader func(cgroups.MemoryStats) uint64) (MemoryLimiter, error) {
+	if externalMemoryReader == nil {
+		return nil, errors.New("unable to create dynamicMemoryLimiter, externalMemoryReader function is missing")
+	}
+
+	if debug.SetMemoryLimit(-1) != math.MaxInt64 {
+		return nil, errors.New(("GOMEMLIMIT is set already, doing nothing"))
+	}
+
+	selfCgroup, err := getSelfCgroup(isContainerized)
+	if err != nil {
+		return nil, err
+	}
+
+	return dynamicMemoryLimiter{
+		ticker:               time.NewTicker(interval),
+		selfCgroup:           selfCgroup,
+		externalMemoryReader: externalMemoryReader,
+	}, nil
+}
+
+// Run runs the memory limit logic
+func (d dynamicMemoryLimiter) Run(c context.Context) error {
+	log.Info("Starting dynamic memory limiter")
+
+	for {
+		select {
+		case <-c.Done():
+			return nil
+
+		case <-d.ticker.C:
+			d.computeSetLimit()
+		}
+	}
+}
+
+func (d dynamicMemoryLimiter) computeSetLimit() {
+	var cgroupMemStats cgroups.MemoryStats
+	if err := d.selfCgroup.GetMemoryStats(&cgroupMemStats); err != nil {
+		log.Warnf("Unable to get self memory stats, dynamic memory limiter unavailable, err: %v", err)
+		return
+	}
+
+	// If no limit is set, we'll let the system OOM do its job in case of system-wide memory shortage.
+	if cgroupMemStats.Limit == nil {
+		return
+	}
+
+	externalMemory := d.externalMemoryReader(cgroupMemStats)
+	goMemorySpace := *cgroupMemStats.Limit - externalMemory
+	minGoMemorySpace := uint64(float64(*cgroupMemStats.Limit) * d.minLimitPct)
+	if goMemorySpace < minGoMemorySpace {
+		goMemorySpace = minGoMemorySpace
+	}
+
+	log.Tracef("Setting Go memory limit to: %d, external memory: %d", goMemorySpace, externalMemory)
+	memoryLimitTelemetry.Set(float64(goMemorySpace))
+	debug.SetMemoryLimit(int64(goMemorySpace))
+}
+
+func getSelfCgroup(isContainerized bool) (cgroups.Cgroup, error) {
+	cgroupReader, err := cgroups.NewSelfReader("/proc", isContainerized)
+	if err != nil {
+		return nil, err
+	}
+
+	selfCgroup := cgroupReader.GetCgroup(cgroups.SelfCgroupIdentifier)
+	if selfCgroup == nil {
+		return nil, errors.New("cannot get self cgroup")
+	}
+
+	return selfCgroup, nil
 }

--- a/pkg/runtime/gomemlimit_linux_nopython.go
+++ b/pkg/runtime/gomemlimit_linux_nopython.go
@@ -1,0 +1,28 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux && !python
+
+package runtime
+
+import (
+	"context"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/config/env"
+	"github.com/DataDog/datadog-agent/pkg/config/setup"
+)
+
+// RunMemoryLimiterFromConfig runs the memory limiter, filling args from the config
+func RunMemoryLimiterFromConfig(c context.Context, configNS string) error {
+	return RunMemoryLimiter(c, MemoryLimiterArgs{
+		LimitPct: config.Datadog.GetFloat64(setup.NSKey(configNS, "go_memlimit_pct")),
+	})
+}
+
+// RunMemoryLimiter runs the memory limiter
+func RunMemoryLimiter(c context.Context, args MemoryLimiterArgs) error {
+	return NewStaticMemoryLimiter(args.LimitPct, args.MaxMemory, env.IsContainerized()).Run(c)
+}

--- a/pkg/runtime/gomemlimit_linux_python.go
+++ b/pkg/runtime/gomemlimit_linux_python.go
@@ -1,0 +1,47 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux && python
+
+package runtime
+
+import (
+	"context"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/config/setup"
+	"github.com/DataDog/datadog-agent/pkg/util/cgroups"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+const minMemLimtPct = 0.20
+
+func RunMemoryLimiterFromConfig(c context.Context, configNS string) error {
+	return RunMemoryLimiter(c, MemoryLimiterArgs{
+		Interval: time.Duration(config.Datadog.GetFloat64(setup.NSKey(configNS, "go_dynamic_memlimit_interval_seconds"))) * time.Second,
+	})
+}
+
+// RunMemoryLimiter runs the memory limiter
+func RunMemoryLimiter(c context.Context, args MemoryLimiterArgs) error {
+	if !setup.IsPythonMemoryMonitoringEnabled() {
+		log.Infof("Memory limiter not running as Python memory monitoring is disabled")
+		return nil
+	}
+
+	limiter, err := NewDynamicMemoryLimiter(
+		args.Interval,
+		config.IsContainerized(),
+		minMemLimtPct,
+		func(cgroups.MemoryStats) uint64 {
+			return pythonMemoryInuse.Load()
+		})
+	if err != nil {
+		return nil
+	}
+
+	return limiter.Run(c)
+}

--- a/pkg/runtime/gomemlimit_linux_test.go
+++ b/pkg/runtime/gomemlimit_linux_test.go
@@ -1,0 +1,77 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+package runtime
+
+import (
+	"context"
+	"runtime/debug"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/util/cgroups"
+	"github.com/DataDog/datadog-agent/pkg/util/pointer"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStaticMemoryLimiter(t *testing.T) {
+	currentLimit := debug.SetMemoryLimit(-1)
+	t.Cleanup(func() {
+		debug.SetMemoryLimit(currentLimit)
+	})
+
+	limiter := staticMemoryLimiter{
+		limitPct: 0.42,
+	}
+
+	// Test no action if already set
+	debug.SetMemoryLimit(42 * 1024 * 1024)
+	err := limiter.Run(context.Background())
+	assert.NoError(t, err)
+	assert.EqualValues(t, 42*1024*1024, debug.SetMemoryLimit(-1))
+
+	// Test memory limit is set to 42% of provided limit
+	limiter.setMemoryLimit(33 * 1024 * 1024)
+	assert.EqualValues(t, 0.42*33*1024*1024, debug.SetMemoryLimit(-1))
+}
+
+func TestDynamicMemoryLimiter(t *testing.T) {
+	currentLimit := debug.SetMemoryLimit(-1)
+	t.Cleanup(func() {
+		debug.SetMemoryLimit(currentLimit)
+	})
+
+	memoryLimit := 42 * 1024 * 1024
+	mockCgroup := &cgroups.MockCgroup{
+		Memory: &cgroups.MemoryStats{
+			Limit: pointer.Ptr(uint64(memoryLimit)),
+		},
+	}
+
+	externalMemoryValue := uint64(1024 * 1024)
+
+	limiter := dynamicMemoryLimiter{
+		selfCgroup:  mockCgroup,
+		minLimitPct: 0.20,
+		externalMemoryReader: func(cgroups.MemoryStats) uint64 {
+			return externalMemoryValue
+		},
+	}
+
+	// Testing limiter takes externalMemoryReader
+	limiter.computeSetLimit()
+	assert.EqualValues(t, 41*1024*1024, debug.SetMemoryLimit(-1))
+
+	// Test that previously set limit does not impact calculation
+	externalMemoryValue = uint64(2 * 1024 * 1024)
+	limiter.computeSetLimit()
+	assert.EqualValues(t, 40*1024*1024, debug.SetMemoryLimit(-1))
+
+	// Test that we can't go below minLimitPct
+	externalMemoryValue = uint64(42 * 1024 * 1024)
+	limiter.computeSetLimit()
+	assert.EqualValues(t, limiter.minLimitPct*float64(memoryLimit), debug.SetMemoryLimit(-1))
+}

--- a/pkg/runtime/gomemlimit_others.go
+++ b/pkg/runtime/gomemlimit_others.go
@@ -1,0 +1,15 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !linux
+
+package runtime
+
+import "context"
+
+// RunMemoryLimiter runs the memory limiter
+func RunMemoryLimiter(string, context.Context) error {
+	return nil
+}

--- a/pkg/runtime/gomemlimit_python.go
+++ b/pkg/runtime/gomemlimit_python.go
@@ -1,0 +1,19 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build python
+
+package runtime
+
+import (
+	"sync/atomic"
+)
+
+var pythonMemoryInuse atomic.Uint64
+
+// SetPythonMemoryInUse sets the current memory in use by Python
+func SetPythonMemoryInUse(inuse uint64) {
+	pythonMemoryInuse.Store(inuse)
+}

--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -350,6 +350,7 @@ type AgentConfig struct {
 	MaxMemory        float64       // MaxMemory is the threshold (bytes allocated) above which program panics and exits, to be restarted
 	MaxCPU           float64       // MaxCPU is the max UserAvg CPU the program should consume
 	WatchdogInterval time.Duration // WatchdogInterval is the delay between 2 watchdog checks
+	GoMemLimitPct    float64       // GoMemLimitPct is the % of container memory limit used to set GOMEMLIMIT
 
 	// http/s proxying
 	ProxyURL          *url.URL
@@ -498,6 +499,7 @@ func New() *AgentConfig {
 		MaxMemory:        5e8, // 500 Mb, should rarely go above 50 Mb
 		MaxCPU:           0.5, // 50%, well behaving agents keep below 5%
 		WatchdogInterval: 10 * time.Second,
+		GoMemLimitPct:    0.90,
 
 		Ignore:                      make(map[string][]string),
 		AnalyzedRateByServiceLegacy: make(map[string]float64),


### PR DESCRIPTION
### What does this PR do?

Introduce a memory limiter that is selected based on build tags and:
- For pure Go Agents, it uses a static limiter, setting `GOMEMLIMIT` once based on a percentage set with `go_memlimit_pct`, default to `95%` of cgroup limit.
- Fore Go+Python Agent, it uses a dynamic limiter setting `GOMEMLIMIT` continuously (every `go_dynamic_memlimit_interval_seconds`) based on Python consumption. `go_memlimit_pct` is not applied in this case. This is only activated if Python telemetry is activated. It does NOT fallback to static limiter as it's not suited to mixed workload.

### Motivation

Improve Agent operability.

### Additional Notes

Replaced existing mechanism for `trace-agent` and `system-probe`. It will behave the same except that the percentage has been increased to 98% as 10% of "lost" memory seem a bit high, we can review the default value if it does not work properly internally.

### Possible Drawbacks / Trade-offs

Currently I put a hook in `pkg/collector/python/init.go` to set a variable with Python memory usage. It's probably not the cleanest way. I've seen we already have a (more expensive?) `GetPythonInterpreterMemoryUsage` in `pkg/collector/python/helpers.go`.
Waiting on @DataDog/agent-shared-components feedback on the best way to get this information.

### Describe how to test/QA your changes

No QA card created for that as we're going to test that internally.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
