### PR TITLE
[process-agent] Fix windows kitchen tests

### DIFF
--- a/cmd/process-agent/main_common.go
+++ b/cmd/process-agent/main_common.go
@@ -101,7 +101,7 @@ func runAgent(globalParams *command.GlobalParams, exit chan struct{}) {
 	exitCode := runApp(exit, globalParams)
 
 	// a sleep is necessary to ensure that supervisor registers this process as "STARTED"
-	// If the exit is "too quick", we enter a BACKOFF->FATAL loop even though we may have a
+	// If the exit is "too quick", we enter a BACKOFF->FATAL loop even though the exit may be expected
 	// http://supervisord.org/subprocess.html#process-states
 	if exitCode == 0 {
 		<-exitGate

--- a/cmd/process-agent/main_windows.go
+++ b/cmd/process-agent/main_windows.go
@@ -147,18 +147,8 @@ func rootCmdRun(globalParams *command.GlobalParams) {
 		}
 	}
 
-	exit := make(chan struct{})
-	exitGate := time.After(5 * time.Second)
-
 	// Invoke the Agent
-	runAgent(globalParams, exit)
-
-	// On Windows, the SCM will require that dependent services stop. This means that when running
-	// `Restart-Service datadogagent`, windows will try to stop the Process Agent, and then to be helpful it will immediately start it again.
-	// However, if Process Agent is not configured to be running it will exit immediately, which `Restart-Service` will report as an error.
-	// To avoid the error on a successful exit we ensure that we are in the RUNNING state long enough for `Restart-Service` or other tools to consider
-	// the restart successful.
-	<-exitGate
+	runAgent(globalParams, make(chan struct{}))
 }
 
 func startService() error {

--- a/cmd/process-agent/main_windows.go
+++ b/cmd/process-agent/main_windows.go
@@ -64,6 +64,15 @@ func (m *myservice) Execute(args []string, r <-chan svc.ChangeRequest, changes c
 		}
 	}()
 	elog.Info(0x40000003, ServiceName)
+
+	// On Windows, the SCM will require that dependent services stop. This means that when running
+	// `Restart-Service datadogagent`, windows will try to stop the Process Agent, and then to be helpful it will immediately start it again.
+	// However, if Process Agent is not configured to be running it will exit immediately, which `Restart-Service` will report as an error.
+	// To avoid the error on a successful exit we ensure that we are in the RUNNING state long enough for `Restart-Service` or other tools to consider
+	// the restart successful.
+	exitGate := time.After(5 * time.Second)
+	defer func() { <-exitGate }()
+
 	runAgent(m.globalParams, exit)
 
 	changes <- svc.Status{State: svc.Stopped}

--- a/cmd/process-agent/main_windows.go
+++ b/cmd/process-agent/main_windows.go
@@ -139,8 +139,17 @@ func rootCmdRun(globalParams *command.GlobalParams) {
 	}
 
 	exit := make(chan struct{})
+	exitGate := time.After(5 * time.Second)
+
 	// Invoke the Agent
 	runAgent(globalParams, exit)
+
+	// On Windows, the SCM will require that dependent services stop. This means that when running
+	// `Restart-Service datadogagent`, windows will try to stop the Process Agent, and then to be helpful it will immediately start it again.
+	// However, if Process Agent is not configured to be running it will exit immediately, which `Restart-Service` will report as an error.
+	// To avoid the error on a successful exit we ensure that we are in the RUNNING state long enough for `Restart-Service` or other tools to consider
+	// the restart successful.
+	<-exitGate
 }
 
 func startService() error {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR fixes a potential issue with https://github.com/DataDog/datadog-agent/pull/16065 where the process can go into `BACKOFF->FATAL` because we don't tell the service that the process has stopped.


### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Kitchen tests fix


### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Make sure kitchen tests pass

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
