### PR TITLE
Send device as a resource and not a tag

### DIFF
--- a/pkg/serializer/internal/metrics/iterable_series.go
+++ b/pkg/serializer/internal/metrics/iterable_series.go
@@ -200,6 +200,7 @@ func (series *IterableSeries) MarshalSplitCompress(bufferContext *marshaler.Buff
 	// the serie.NoIndex field.
 	for series.source.MoveNext() {
 		serie = series.source.Current()
+		serie.PopulateDeviceField()
 		serie.PopulateResources()
 
 		buf.Reset()

--- a/pkg/serializer/internal/metrics/series_test.go
+++ b/pkg/serializer/internal/metrics/series_test.go
@@ -365,8 +365,7 @@ func makeSeries(numItems, numPoints int) *IterableSeries {
 			Name:     "test.metrics",
 			Interval: 15,
 			Host:     "localHost",
-			Device:   "SomeDevice",
-			Tags:     tagset.CompositeTagsFromSlice([]string{"tag1", "tag2:yes", "dd.internal.resource:device:some_other_device", "dd.internal.resource:database_instance:some_instance", "dd.internal.resource:aws_rds_instance:some_endpoint"}),
+			Tags:     tagset.CompositeTagsFromSlice([]string{"tag1", "tag2:yes", "device:SomeDevice", "dd.internal.resource:device:some_other_device", "dd.internal.resource:database_instance:some_instance", "dd.internal.resource:aws_rds_instance:some_endpoint"}),
 		})
 	}
 	return CreateIterableSeries(CreateSerieSource(series))

--- a/releasenotes/notes/device-620eb9d825e0a1ea.yaml
+++ b/releasenotes/notes/device-620eb9d825e0a1ea.yaml
@@ -1,3 +1,3 @@
 fixes:
   - |
-    Fix missing case-sensitive version of the ``device`` tag on the `system.disk` group of metrics.
+    Fix missing case-sensitive version of the ``device`` tag on the ``system.disk`` group of metrics.

--- a/releasenotes/notes/device-620eb9d825e0a1ea.yaml
+++ b/releasenotes/notes/device-620eb9d825e0a1ea.yaml
@@ -1,3 +1,3 @@
 fixes:
   - |
-    Fix missing case-sensitive version of the ``device`` tag on `system.disk` group of metrics.
+    Fix missing case-sensitive version of the ``device`` tag on the `system.disk` group of metrics.

--- a/releasenotes/notes/device-620eb9d825e0a1ea.yaml
+++ b/releasenotes/notes/device-620eb9d825e0a1ea.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    Fix missing case-sensitive version of the ``device`` tag on `system.disk` group of metrics.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Add a missing call to pull `device` out of tags into the resources section.

This fixes a capitalization issue when device tag was not available in upper-case when sending metrics via v2 API (a special case compared to other tags).


<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Create a device with an uppercase name and mount it:
```
dd if=/dev/zero of=image
sudo losetup /dev/loop0 image
sudo ln /dev/loop0 /dev/CASE
mke2fs /dev/CASE
mount /dev/CASE /mnt
```

Run the agent with the disk check enabled (usually enabled by default).

Check that `system.disk.free` and other `system.disk` metrics have two `device` tags: one lowercased, one as is.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
