### PR TITLE
admission/patch: support stage action

### DIFF
--- a/pkg/clusteragent/admission/patch/patch_request.go
+++ b/pkg/clusteragent/admission/patch/patch_request.go
@@ -27,6 +27,8 @@ const (
 type Action string
 
 const (
+	// StageConfig instructs the patcher to process the configuration without triggering a rolling update
+	StageConfig Action = "stage"
 	// EnableConfig instructs the patcher to apply the patch request
 	EnableConfig Action = "enable"
 	// DisableConfig instructs the patcher to disable library injection

--- a/pkg/clusteragent/admission/patch/patcher.go
+++ b/pkg/clusteragent/admission/patch/patcher.go
@@ -77,8 +77,11 @@ func (p *patcher) patchDeployment(req PatchRequest) error {
 		log.Infof("Remote Config ID %q with revision %q has already been applied to object %s, skipping", req.ID, revision, req.K8sTarget)
 		return nil
 	}
-	log.Infof("Applying Remote Config ID %q with revision %q to object %s", req.ID, revision, req.K8sTarget)
+	log.Infof("Applying Remote Config ID %q with revision %q and action %q to object %s", req.ID, revision, req.Action, req.K8sTarget)
 	switch req.Action {
+	case StageConfig:
+		// Consume the config without triggering a rolling update.
+		log.Debugf("Remote Config ID %q with revision %q has a \"stage\" action. The pod template won't be patched, only the deployment annotations", req.ID, revision)
 	case EnableConfig:
 		if err := enableConfig(deploy, req); err != nil {
 			return err
@@ -90,8 +93,6 @@ func (p *patcher) patchDeployment(req PatchRequest) error {
 	}
 	deploy.Annotations[k8sutil.RcIDAnnotKey] = req.ID
 	deploy.Annotations[k8sutil.RcRevisionAnnotKey] = revision
-	deploy.Spec.Template.Annotations[k8sutil.RcIDAnnotKey] = req.ID
-	deploy.Spec.Template.Annotations[k8sutil.RcRevisionAnnotKey] = fmt.Sprint(req.Revision)
 	newObj, err := json.Marshal(deploy)
 	if err != nil {
 		return fmt.Errorf("failed to encode object: %v", err)
@@ -124,6 +125,8 @@ func enableConfig(deploy *corev1.Deployment, req PatchRequest) error {
 	}
 	configAnnotKey := fmt.Sprintf(common.LibConfigV1AnnotKeyFormat, req.LibConfig.Language)
 	deploy.Spec.Template.Annotations[configAnnotKey] = string(conf)
+	deploy.Spec.Template.Annotations[k8sutil.RcIDAnnotKey] = req.ID
+	deploy.Spec.Template.Annotations[k8sutil.RcRevisionAnnotKey] = fmt.Sprint(req.Revision)
 	return nil
 }
 
@@ -139,4 +142,6 @@ func disableConfig(deploy *corev1.Deployment, req PatchRequest) {
 	delete(deploy.Spec.Template.Annotations, versionAnnotKey)
 	configAnnotKey := fmt.Sprintf(common.LibConfigV1AnnotKeyFormat, req.LibConfig.Language)
 	delete(deploy.Spec.Template.Annotations, configAnnotKey)
+	deploy.Spec.Template.Annotations[k8sutil.RcIDAnnotKey] = req.ID
+	deploy.Spec.Template.Annotations[k8sutil.RcRevisionAnnotKey] = fmt.Sprint(req.Revision)
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Support a new action "stage" to allow consuming configs from RC without triggering rolling updates (i.e adds a dry-run mode).

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Better UX: users can create configs without applying them directly in the cluster

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

The RC ID and Revision annotations will still be applied at the deployment level, but not in the pod template.

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Depends on BE and FE work, can only be tested e2e when all the pieces are ready to support the new "stage" action.

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
