### PR TITLE
Fix cluster Agent image build on x86_64 machines

### DIFF
--- a/tasks/cluster_agent.py
+++ b/tasks/cluster_agent.py
@@ -19,7 +19,7 @@ from .utils import load_release_versions
 BIN_PATH = os.path.join(".", "bin", "datadog-cluster-agent")
 AGENT_TAG = "datadog/cluster_agent:master"
 POLICIES_REPO = "https://github.com/DataDog/security-agent-policies.git"
-CONTAINER_PLATFORM_MAPPING = {"aarch64": "arm64", "amd64": "amd64"}
+CONTAINER_PLATFORM_MAPPING = {"aarch64": "arm64", "amd64": "amd64", "x86_64": "amd64"}
 
 
 @task


### PR DESCRIPTION
### What does this PR do?

* Adds an entry to `CONTAINER_PLATFORM_MAPPING` mapping `x86_64` to `amd64` architecture

### Motivation

* Fix local build : `platform.machine` depends on the output of `uname -m` on Unix systems. There are multiple OS where `uname -m` returns `x86_64` (https://en.wikipedia.org/wiki/Uname), thus preventing the cluster Agent build task from functioning on such systems, for instance on Intel macbooks.
* Alternative fix would be to default to `amd64` as previously `arch = CONTAINER_PLATFORM_MAPPING.get(platform.machine().lower(), "amd64")` but previous PR comment mentions this is not desired : https://github.com/DataDog/datadog-agent/pull/15945#discussion_r1124267620

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
