### PR TITLE
pkg/trace/agent: fix single span sampling stats bug

### DIFF
--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -317,14 +317,7 @@ func (a *Agent) Process(p *api.Payload) {
 			p.TracerPayload.AppVersion = traceutil.GetAppVersion(root, chunk)
 		}
 
-		pt := traceutil.ProcessedTrace{
-			TraceChunk:             chunk,
-			Root:                   root,
-			AppVersion:             p.TracerPayload.AppVersion,
-			TracerEnv:              p.TracerPayload.Env,
-			TracerHostname:         p.TracerPayload.Hostname,
-			ClientDroppedP0sWeight: float64(p.ClientDroppedP0s) / float64(len(p.Chunks())),
-		}
+		pt := p.ProcessedTrace(chunk, root)
 		if !p.ClientComputedStats {
 			statsInput.Traces = append(statsInput.Traces, pt)
 		}

--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -366,8 +366,8 @@ func (a *Agent) Process(p *api.Payload) {
 }
 
 // processedTrace creates a ProcessedTrace based on the provided chunk and root.
-// It makes a deep copy of the provided chunk to ensure that any changes to the
-// chunk will not affect the TraceChunk of the ProcessedTrace.
+// It makes a deep copy of the provided chunk to ensure that any subsequent changes
+// to the original chunk will not affect the TraceChunk of the ProcessedTrace.
 func processedTrace(p *api.Payload, chunk *pb.TraceChunk, root *pb.Span) traceutil.ProcessedTrace {
 	ptChunk := new(pb.TraceChunk)
 	*ptChunk = *chunk

--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -317,7 +317,7 @@ func (a *Agent) Process(p *api.Payload) {
 			p.TracerPayload.AppVersion = traceutil.GetAppVersion(root, chunk)
 		}
 
-		pt := p.ProcessedTrace(chunk, root)
+		pt := processedTrace(p, chunk, root)
 		if !p.ClientComputedStats {
 			statsInput.Traces = append(statsInput.Traces, pt)
 		}
@@ -362,6 +362,22 @@ func (a *Agent) Process(p *api.Payload) {
 	}
 	if len(statsInput.Traces) > 0 {
 		a.Concentrator.In <- statsInput
+	}
+}
+
+// processedTrace creates a ProcessedTrace based on the provided chunk and root.
+// It makes a deep copy of the provided chunk to ensure that any changes to the
+// chunk will not affect the TraceChunk of the ProcessedTrace.
+func processedTrace(p *api.Payload, chunk *pb.TraceChunk, root *pb.Span) traceutil.ProcessedTrace {
+	ptChunk := new(pb.TraceChunk)
+	*ptChunk = *chunk
+	return traceutil.ProcessedTrace{
+		TraceChunk:             ptChunk,
+		Root:                   root,
+		AppVersion:             p.TracerPayload.AppVersion,
+		TracerEnv:              p.TracerPayload.Env,
+		TracerHostname:         p.TracerPayload.Hostname,
+		ClientDroppedP0sWeight: float64(p.ClientDroppedP0s) / float64(len(p.Chunks())),
 	}
 }
 
@@ -491,6 +507,7 @@ func (a *Agent) sample(now time.Time, ts *info.TagStats, pt traceutil.ProcessedT
 
 	filteredChunk = pt.TraceChunk
 	if !sampled {
+		// Make a deep copy to ensure that the copy used for stats is not affected
 		filteredChunk = new(pb.TraceChunk)
 		*filteredChunk = *pt.TraceChunk
 		filteredChunk.DroppedTrace = true

--- a/pkg/trace/agent/agent_test.go
+++ b/pkg/trace/agent/agent_test.go
@@ -1933,8 +1933,9 @@ func TestSpanSampling(t *testing.T) {
 			})
 			assert.Len(t, traceAgent.TraceWriter.In, 1)
 			sampledChunks := <-traceAgent.TraceWriter.In
-			chunks := sampledChunks.TracerPayload.Chunks
-			tc.checks(t, tc.payload, chunks)
+			tc.checks(t, tc.payload, sampledChunks.TracerPayload.Chunks)
+			stats := <-traceAgent.Concentrator.In
+			assert.Equal(t, len(tc.payload.Chunks[0].Spans), len(stats.Traces[0].TraceChunk.Spans))
 		})
 	}
 }

--- a/pkg/trace/api/payload.go
+++ b/pkg/trace/api/payload.go
@@ -8,7 +8,6 @@ package api
 import (
 	"github.com/DataDog/datadog-agent/pkg/trace/info"
 	"github.com/DataDog/datadog-agent/pkg/trace/pb"
-	"github.com/DataDog/datadog-agent/pkg/trace/traceutil"
 )
 
 // Payload specifies information about a set of traces received by the API.
@@ -50,20 +49,4 @@ func (p *Payload) RemoveChunk(i int) {
 // ReplaceChunk replaces a chunk in TracerPayload at a given index
 func (p *Payload) ReplaceChunk(i int, chunk *pb.TraceChunk) {
 	p.TracerPayload.Chunks[i] = chunk
-}
-
-// ProcessedTrace creates a ProcessedTrace based on the provided chunk and root.
-// It makes a deep copy of the provided chunk to ensure that any changes to the
-// chunk will not affect the TraceChunk of the ProcessedTrace.
-func (p *Payload) ProcessedTrace(chunk *pb.TraceChunk, root *pb.Span) traceutil.ProcessedTrace {
-	ptChunk := new(pb.TraceChunk)
-	*ptChunk = *chunk
-	return traceutil.ProcessedTrace{
-		TraceChunk:             ptChunk,
-		Root:                   root,
-		AppVersion:             p.TracerPayload.AppVersion,
-		TracerEnv:              p.TracerPayload.Env,
-		TracerHostname:         p.TracerPayload.Hostname,
-		ClientDroppedP0sWeight: float64(p.ClientDroppedP0s) / float64(len(p.Chunks())),
-	}
 }

--- a/pkg/trace/api/payload.go
+++ b/pkg/trace/api/payload.go
@@ -8,6 +8,7 @@ package api
 import (
 	"github.com/DataDog/datadog-agent/pkg/trace/info"
 	"github.com/DataDog/datadog-agent/pkg/trace/pb"
+	"github.com/DataDog/datadog-agent/pkg/trace/traceutil"
 )
 
 // Payload specifies information about a set of traces received by the API.
@@ -49,4 +50,20 @@ func (p *Payload) RemoveChunk(i int) {
 // ReplaceChunk replaces a chunk in TracerPayload at a given index
 func (p *Payload) ReplaceChunk(i int, chunk *pb.TraceChunk) {
 	p.TracerPayload.Chunks[i] = chunk
+}
+
+// ProcessedTrace creates a ProcessedTrace based on the provided chunk and root.
+// It makes a deep copy of the provided chunk to ensure that any changes to the
+// chunk will not affect the TraceChunk of the ProcessedTrace.
+func (p *Payload) ProcessedTrace(chunk *pb.TraceChunk, root *pb.Span) traceutil.ProcessedTrace {
+	ptChunk := new(pb.TraceChunk)
+	*ptChunk = *chunk
+	return traceutil.ProcessedTrace{
+		TraceChunk:             ptChunk,
+		Root:                   root,
+		AppVersion:             p.TracerPayload.AppVersion,
+		TracerEnv:              p.TracerPayload.Env,
+		TracerHostname:         p.TracerPayload.Hostname,
+		ClientDroppedP0sWeight: float64(p.ClientDroppedP0s) / float64(len(p.Chunks())),
+	}
 }

--- a/releasenotes/notes/apm-single-span-stats-8f4b7b6319e500b5.yaml
+++ b/releasenotes/notes/apm-single-span-stats-8f4b7b6319e500b5.yaml
@@ -8,5 +8,5 @@
 ---
 fixes:
   - |
-    Fixes a bug with how stats are calculated when using single span sampling
+    APM: Fixes a bug with how stats are calculated when using single span sampling
     along with other sampling configurations.

--- a/releasenotes/notes/apm-single-span-stats-8f4b7b6319e500b5.yaml
+++ b/releasenotes/notes/apm-single-span-stats-8f4b7b6319e500b5.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixes bug with how stats are calculated when using single span sampling
+    along with other sampling configurations.

--- a/releasenotes/notes/apm-single-span-stats-8f4b7b6319e500b5.yaml
+++ b/releasenotes/notes/apm-single-span-stats-8f4b7b6319e500b5.yaml
@@ -8,5 +8,5 @@
 ---
 fixes:
   - |
-    Fixes bug with how stats are calculated when using single span sampling
+    Fixes a bug with how stats are calculated when using single span sampling
     along with other sampling configurations.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Use a deep copy of the chunk when creating a `ProcessedTrace` for stats calculation
This changes [some code](https://github.com/DataDog/datadog-agent/pull/13461) that fixed a different single span sampling bug.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Fixes a bug with stats calculation when using single span sampling.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

This is *now* covered by unit tests, and has already been tested locally.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
