### PR TITLE
usm: process monitor: properly exit on error

### DIFF
--- a/pkg/network/protocols/http/monitor.go
+++ b/pkg/network/protocols/http/monitor.go
@@ -235,8 +235,7 @@ func (m *Monitor) Start() error {
 	}
 
 	// Need to explicitly save the error in `err` so the defer function could save the startup error.
-	err = m.processMonitor.Initialize()
-	return err
+	return m.processMonitor.Initialize()
 }
 
 func (m *Monitor) GetUSMStats() map[string]interface{} {

--- a/pkg/network/protocols/http/shared_libraries.go
+++ b/pkg/network/protocols/http/shared_libraries.go
@@ -146,7 +146,7 @@ func (r *soRegistration) Unregister() bool {
 	}
 	if r.unregisterCB != nil {
 		if err := r.unregisterCB(r.pathID); err != nil {
-			log.Debugf("error while unregisterin %s : %s", r.pathID.String(), err)
+			log.Debugf("error while unregistering %s : %s", r.pathID.String(), err)
 		}
 	}
 	return true

--- a/pkg/process/monitor/process_monitor.go
+++ b/pkg/process/monitor/process_monitor.go
@@ -34,14 +34,14 @@ var (
 
 // ProcessMonitor will subscribe to the netlink process events like Exec, Exit
 // and call the subscribed callbacks
-// Initialize() will scan the current process and will call the subscribed callbacks
+// Initialize() will scan the current process and will call the subscribed callbacks.
 //
 // callbacks will be executed in parallel via a pool of goroutines (runtime.NumCPU())
 // callbackRunner is callbacks queue. The queue size is set by processMonitorMaxEvents
 //
 // Multiple team can use the same ProcessMonitor,
 // the callers need to guarantee calling each Initialize() Stop() one single time
-// this maintain an internal reference counter
+// this maintains an internal reference counter
 //
 // ProcessMonitor require root or CAP_NET_ADMIN capabilities
 type ProcessMonitor struct {
@@ -113,8 +113,8 @@ type ProcessCallback struct {
 //	o mon.Subscribe() will subscribe callback before or after the Initialization
 //	o mon.Initialize() will scan current processes and call subscribed callback
 //
-//	o callback{Event: EXIT, Metadata: ANY}   callback is called for all exit events, system wide
-//	o callback{Event: EXIT, Metadata: NAME}  callback will be called if we seen the process Exec event,
+//	o callback{Event: EXIT, Metadata: ANY}   callback is called for all exit events (system-wide)
+//	o callback{Event: EXIT, Metadata: NAME}  callback will be called if we have seen the process Exec event,
 //	                                         the metadata will be saved between Exec and Exit event per pid
 //	                                         then the Exit callback will evaluate the same metadata on Exit.
 //	                                         We need to save the metadata here as /proc/pid doesn't exist anymore.
@@ -141,9 +141,9 @@ func (pm *ProcessMonitor) enqueueCallback(callback *ProcessCallback, pid uint32,
 }
 
 // evalEXECCallback is a best effort and would not return errors, but report them
-func (p *ProcessMonitor) evalEXECCallback(c *ProcessCallback, pid uint32) {
+func (pm *ProcessMonitor) evalEXECCallback(c *ProcessCallback, pid uint32) {
 	if c.Metadata == ANY {
-		p.enqueueCallback(c, pid, nil)
+		pm.enqueueCallback(c, pid, nil)
 		return
 	}
 
@@ -174,29 +174,37 @@ func (p *ProcessMonitor) evalEXECCallback(c *ProcessCallback, pid uint32) {
 			return
 		}
 		if c.Regex.MatchString(pname) {
-			p.enqueueCallback(c, pid, metadataName{Name: pname})
+			pm.enqueueCallback(c, pid, metadataName{Name: pname})
 		}
 	}
 }
 
 // evalEXITCallback will evaluate the metadata saved by the Exec callback and the callback accordingly
 // please refer to GetProcessMonitor documentation
-func (p *ProcessMonitor) evalEXITCallback(c *ProcessCallback, pid uint32) {
+func (pm *ProcessMonitor) evalEXITCallback(c *ProcessCallback, pid uint32) {
 	switch c.Metadata {
 	case NAME:
-		metadata, found := p.runningPids[pid]
+		metadata, found := pm.runningPids[pid]
 		if !found {
-			// we can hit here if a process started before the Exec callback has been registred
+			// we can hit here if a process started before the Exec callback has been registered
 			// and the process Exit, so we don't find his metadata
 			return
 		}
 		pname := metadata.(metadataName).Name
 		if c.Regex.MatchString(pname) {
-			p.enqueueCallback(c, pid, metadata)
+			pm.enqueueCallback(c, pid, metadata)
 		}
 	case ANY:
-		p.enqueueCallback(c, pid, nil)
+		pm.enqueueCallback(c, pid, nil)
 	}
+}
+
+// terminateProcessMonitor is a helper function of Initialize. The goal is to make sure we properly terminate our
+// go-routine.
+func (pm *ProcessMonitor) terminateProcessMonitor() {
+	log.Info("netlink process monitor ended")
+	pm.wg.Done()
+	close(pm.callbackRunner)
 }
 
 // Initialize will scan all running processes and execute matching callbacks
@@ -235,16 +243,17 @@ func (pm *ProcessMonitor) Initialize() error {
 		}()
 	}
 
-	// This is the main async loop, where we process processes events from netlink socket
+	// This is the main async loop, where we process "processes" events from netlink socket
 	// events are dropped until
 	pm.wg.Add(1)
 	go func() {
 		logTicker := time.NewTicker(2 * time.Minute)
 
+		terminated := false
 		defer func() {
-			log.Info("netlink process monitor ended")
-			pm.wg.Done()
-			close(pm.callbackRunner)
+			if !terminated {
+				pm.terminateProcessMonitor()
+			}
 			logTicker.Stop()
 		}()
 
@@ -284,6 +293,8 @@ func (pm *ProcessMonitor) Initialize() error {
 					return
 				}
 				log.Errorf("process monitor error: %s", err)
+				pm.terminateProcessMonitor()
+				terminated = true
 				pm.Stop()
 				return
 
@@ -314,7 +325,7 @@ func (pm *ProcessMonitor) Initialize() error {
 //
 // By design : 1/ a callback object can be registered only once
 //
-//	2/ Exec callback with a Metadata (!=ANY) must be registred before the sibling Exit metadata,
+//	2/ Exec callback with a Metadata (!=ANY) must be registered before the sibling Exit metadata,
 //	   otherwise the Subscribe() will return an error as no metadata will be saved between Exec and Exit,
 //	   please refer to GetProcessMonitor()
 func (pm *ProcessMonitor) Subscribe(callback *ProcessCallback) (UnSubscribe func(), err error) {
@@ -323,7 +334,7 @@ func (pm *ProcessMonitor) Subscribe(callback *ProcessCallback) (UnSubscribe func
 
 	for _, c := range pm.procEventCallbacks[callback.Event] {
 		if c == callback {
-			return nil, errors.New("same callback can't be registred twice")
+			return nil, errors.New("same callback can't be registered twice")
 		}
 	}
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
Solving deadlock.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

We had a deadlock in the case of getting error from netlink inside our main go-routine. We called pm.Stop() which waits on pm.wg.Wait, but the main go routine called pm.wg.Done on a defered function, meaning, a deadlock.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
