### PR TITLE
[POC][aggregator] Move EventPlatform events to another loop

### DIFF
--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -774,7 +774,7 @@ func (agg *BufferedAggregator) runEventPlatformBlocking() {
 			if err != nil {
 				state = stateError
 				aggregatorEventPlatformEventsErrors.Add(event.eventType, 1)
-				log.Errorf("error submitting event platform event: %s", err)
+				log.Errorf("Failed to process some event platform events. error='%s' eventCounts=%s errorCounts=%s", err, aggregatorEventPlatformEvents.String(), aggregatorEventPlatformEventsErrors.String())
 			}
 			tlmFlush.Add(1, event.eventType, state)
 		}

--- a/pkg/aggregator/demultiplexer_agent.go
+++ b/pkg/aggregator/demultiplexer_agent.go
@@ -318,7 +318,7 @@ func (d *AgentDemultiplexer) Run() {
 		go w.run()
 	}
 
-	go d.aggregator.run()
+	d.aggregator.run()
 
 	if d.noAggStreamWorker != nil {
 		go d.noAggStreamWorker.run()

--- a/pkg/aggregator/demultiplexer_test.go
+++ b/pkg/aggregator/demultiplexer_test.go
@@ -186,7 +186,7 @@ func TestDemuxFlushAggregatorToSerializer(t *testing.T) {
 		time.Sleep(250 * time.Millisecond)
 		demux.aggregator.stopChan <- struct{}{}
 	}()
-	demux.aggregator.run()
+	demux.aggregator.runOther()
 
 	series, sketches := demux.aggregator.checkSamplers[defaultCheckID].flush()
 	require.Len(series, 3)

--- a/pkg/aggregator/sender_test.go
+++ b/pkg/aggregator/sender_test.go
@@ -67,7 +67,7 @@ func TestGetDefaultSenderReturnsSameSender(t *testing.T) {
 
 	demux := testDemux()
 	aggregatorInstance := demux.Aggregator()
-	go aggregatorInstance.run()
+	aggregatorInstance.run()
 	defer aggregatorInstance.Stop()
 
 	s, err := demux.GetDefaultSender()
@@ -87,7 +87,7 @@ func TestGetSenderWithDifferentIDsReturnsDifferentCheckSamplers(t *testing.T) {
 
 	demux := testDemux()
 	aggregatorInstance := demux.Aggregator()
-	go aggregatorInstance.run()
+	aggregatorInstance.run()
 	defer aggregatorInstance.Stop()
 
 	s, err := demux.GetSender(checkID1)
@@ -115,7 +115,7 @@ func TestGetSenderWithSameIDsReturnsSameSender(t *testing.T) {
 
 	demux := testDemux()
 	aggregatorInstance := demux.Aggregator()
-	go aggregatorInstance.run()
+	aggregatorInstance.run()
 	defer aggregatorInstance.Stop()
 
 	sender1, err := demux.GetSender(checkID1)
@@ -137,7 +137,7 @@ func TestDestroySender(t *testing.T) {
 
 	demux := testDemux()
 	aggregatorInstance := demux.Aggregator()
-	go aggregatorInstance.run()
+	aggregatorInstance.run()
 	defer aggregatorInstance.Stop()
 
 	_, err := demux.GetSender(checkID1)
@@ -188,7 +188,7 @@ func TestGetSenderDefaultHostname(t *testing.T) {
 
 	demux := testDemux()
 	aggregatorInstance := demux.Aggregator()
-	go aggregatorInstance.run()
+	aggregatorInstance.run()
 
 	sender, err := demux.GetSender(checkID1)
 	require.NoError(t, err)

--- a/pkg/epforwarder/epforwarder.go
+++ b/pkg/epforwarder/epforwarder.go
@@ -177,12 +177,8 @@ func (s *defaultEventPlatformForwarder) SendEventPlatformEvent(e *message.Messag
 	if !ok {
 		return fmt.Errorf("unknown eventType=%s", eventType)
 	}
-	select {
-	case p.in <- e:
-		return nil
-	default:
-		return fmt.Errorf("event platform forwarder pipeline channel is full for eventType=%s. Channel capacity is %d. consider increasing batch_max_concurrent_send", eventType, cap(p.in))
-	}
+	p.in <- e
+	return nil
 }
 
 func purgeChan(in chan *message.Message) (result []*message.Message) {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
