### PR TITLE
Better invoke unit tests architecture 

### DIFF
--- a/.gitlab/source_test/linux.yml
+++ b/.gitlab/source_test/linux.yml
@@ -18,8 +18,7 @@
   script:
     - !reference [.retrieve_linux_go_tools_deps]
     - inv -e install-tools
-    - python3 -m tasks.release_tests
-    - python3 -m tasks.libs.version_tests
+    - inv -e invoke-unit-tests
     - inv -e test $FLAVORS --race --profile --rerun-fails=2 --python-runtimes "$PYTHON_RUNTIMES" --cpus 4 $EXTRA_OPTS --save-result-json test_output.json --junit-tar "junit-${CI_JOB_NAME}.tgz"
   artifacts:
     expire_in: 2 weeks

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -51,6 +51,7 @@ from .test import (
     install_shellcheck,
     install_tools,
     integration_tests,
+    invoke_unit_tests,
     junit_macos_repack,
     junit_upload,
     lint_copyrights,
@@ -90,6 +91,7 @@ ns.add_task(e2e_tests)
 ns.add_task(install_shellcheck)
 ns.add_task(download_tools)
 ns.add_task(install_tools)
+ns.add_task(invoke_unit_tests)
 ns.add_task(check_mod_tidy)
 ns.add_task(tidy_all)
 ns.add_task(check_go_version)

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -127,7 +127,7 @@ def install_tools(ctx):
 @task
 def invoke_unit_tests(ctx):
     """
-    Start unit testsuite of tasks
+    Run the unit tests on the invoke tasks
     """
     for _, _, files in os.walk("tasks/unit-tests/", topdown=False):
         for file in files:

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -36,6 +36,7 @@ PROFILE_COV = "profile.cov"
 GO_TEST_RESULT_TMP_JSON = 'module_test_output.json'
 UNIT_TEST_FILE_FORMAT = re.compile(r'[^a-zA-Z0-9]')
 
+
 class TestProfiler:
     times = []
     parser = re.compile(r"^ok\s+github.com\/DataDog\/datadog-agent\/(\S+)\s+([0-9\.]+)s", re.MULTILINE)
@@ -132,6 +133,7 @@ def invoke_unit_tests(ctx):
         for file in files:
             if file[-3:] == ".py" and file != "__init__.py" and not bool(UNIT_TEST_FILE_FORMAT.search(file[:-3])):
                 ctx.run(f"python3 -m tasks.unit-tests.{file[:-3]}")
+
 
 def test_core(
     modules: List[GoModule],

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -35,7 +35,7 @@ from .utils import DEFAULT_BRANCH, get_build_flags
 
 PROFILE_COV = "profile.cov"
 GO_TEST_RESULT_TMP_JSON = 'module_test_output.json'
-
+UNIT_TEST_FILE_FORMAT = re.compile(r'[^a-zA-Z0-9]')
 
 class TestProfiler:
     times = []
@@ -131,7 +131,7 @@ def invoke_unit_tests(ctx):
     """
     for _, _, files in os.walk("tasks/unit-tests/", topdown=False):
         for file in files:
-            if file[-3:] == ".py" and file != "__init__.py":
+            if file[-3:] == ".py" and file != "__init__.py" and not bool(UNIT_TEST_FILE_FORMAT.search(file[:-3])):
                 ctx.run(f"python3 -m tasks.unit-tests.{file[:-3]}")
 
 def test_core(

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -6,6 +6,7 @@ High level testing tasks
 # so we only need to check that we don't run this code with old Python versions.
 
 import abc
+import glob
 import json
 import operator
 import os
@@ -122,6 +123,16 @@ def install_tools(ctx):
                 for tool in tools:
                     ctx.run(f"go install {tool}")
 
+
+@task
+def invoke_unit_tests(ctx):
+    """
+    Start unit testsuite of tasks
+    """
+    for _, _, files in os.walk("tasks/unit-tests/", topdown=False):
+        for file in files:
+            if file[-3:] == ".py" and file != "__init__.py":
+                ctx.run(f"python3 -m tasks.unit-tests.{file[:-3]}")
 
 def test_core(
     modules: List[GoModule],

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -6,7 +6,6 @@ High level testing tasks
 # so we only need to check that we don't run this code with old Python versions.
 
 import abc
-import glob
 import json
 import operator
 import os
@@ -129,7 +128,7 @@ def invoke_unit_tests(ctx):
     """
     Start unit testsuite of tasks
     """
-    for _, _, files in os.walk("tasks/unit-tests/", topdown=False):
+    for _, _, files in os.walk("tasks/unit-tests/"):
         for file in files:
             if file[-3:] == ".py" and file != "__init__.py" and not bool(UNIT_TEST_FILE_FORMAT.search(file[:-3])):
                 ctx.run(f"python3 -m tasks.unit-tests.{file[:-3]}")

--- a/tasks/unit-tests/release_tests.py
+++ b/tasks/unit-tests/release_tests.py
@@ -5,8 +5,8 @@ from unittest import mock
 
 from invoke.exceptions import Exit
 
-from . import release
-from .libs.version import Version
+from .. import release
+from ..libs.version import Version
 
 
 def mocked_github_requests_get(*args, **_kwargs):

--- a/tasks/unit-tests/version_tests.py
+++ b/tasks/unit-tests/version_tests.py
@@ -1,7 +1,7 @@
 import random
 import unittest
 
-from .version import Version
+from ..libs.version import Version
 
 
 class TestVersionComparison(unittest.TestCase):

--- a/tasks/winbuildscripts/unittests.ps1
+++ b/tasks/winbuildscripts/unittests.ps1
@@ -15,7 +15,7 @@ $Env:PATH="$Env:BUILD_ROOT\dev\lib;$Env:GOPATH\bin;$Env:Python3_ROOT_DIR;$Env:Py
 
 & $Env:Python3_ROOT_DIR\python.exe -m pip install PyYAML==5.3.1
 
-inv -e invoke-unit-tests
+& inv -e invoke-unit-tests
 
 $archflag = "x64"
 if ($Env:TARGET_ARCH -eq "x86") {

--- a/tasks/winbuildscripts/unittests.ps1
+++ b/tasks/winbuildscripts/unittests.ps1
@@ -10,14 +10,12 @@ if ($Env:TARGET_ARCH -eq "x64") {
 }
 & $Env:Python3_ROOT_DIR\python.exe -m  pip install -r requirements.txt
 
-# Run invoke tasks unit tests
-& $Env:Python3_ROOT_DIR\python.exe -m tasks.release_tests
-& $Env:Python3_ROOT_DIR\python.exe -m tasks.libs.version_tests
-
 $Env:BUILD_ROOT=(Get-Location).Path
 $Env:PATH="$Env:BUILD_ROOT\dev\lib;$Env:GOPATH\bin;$Env:Python3_ROOT_DIR;$Env:Python3_ROOT_DIR\Scripts;$Env:PATH"
 
 & $Env:Python3_ROOT_DIR\python.exe -m pip install PyYAML==5.3.1
+
+inv -e invoke-unit-tests
 
 $archflag = "x64"
 if ($Env:TARGET_ARCH -eq "x86") {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Move ``release_tests.py`` and ``version_tests.py`` inside of ``unit-tests`` folder.
Created a task ``invoke-unit-tests`` that run every module inside of the newly created ``unit-tests`` folder

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

PR #16288 needs some tests to assure proper functionality and prevent regression.
Since these tests existed but were spread inside the ``task`` folder, it seemed better to group them up. Allowing us to simply create a task starting every task's unit tests all at once.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
