### PR TITLE
Add the URL matching a no proxy rule to the log

### DIFF
--- a/pkg/util/http/transport.go
+++ b/pkg/util/http/transport.go
@@ -155,7 +155,7 @@ func GetProxyTransportFunc(p *config.Proxy) func(*http.Request) (*url.URL, error
 			// check no_proxy list first
 			for _, host := range p.NoProxy {
 				if r.URL.Host == host {
-					log.Debugf("URL '%s' match no_proxy list item '%s': not using any proxy", r.URL, host)
+					log.Debugf("URL '%s' matches no_proxy list item '%s': not using any proxy", r.URL, host)
 					return nil, nil
 				}
 			}

--- a/pkg/util/http/transport.go
+++ b/pkg/util/http/transport.go
@@ -155,7 +155,7 @@ func GetProxyTransportFunc(p *config.Proxy) func(*http.Request) (*url.URL, error
 			// check no_proxy list first
 			for _, host := range p.NoProxy {
 				if r.URL.Host == host {
-					log.Debugf("URL match no_proxy list item '%s': not using any proxy", host)
+					log.Debugf("URL '%s' match no_proxy list item '%s': not using any proxy", r.URL, host)
 					return nil, nil
 				}
 			}


### PR DESCRIPTION

### What does this PR do?

Add the URL matching a no proxy rule to the log to ease troubleshooting.

### Describe how to test/QA your changes

Set a "no_proxy" rule in the config and check that the URL is logged when matching the proxy rule.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
