### PR TITLE
[CWS] Fix activity dump flaky tests

### DIFF
--- a/pkg/security/tests/activity_dumps_test.go
+++ b/pkg/security/tests/activity_dumps_test.go
@@ -29,7 +29,7 @@ const dedicatedADNodeForTestsEnv = "DEDICATED_ACTIVITY_DUMP_NODE"
 
 var expectedFormats = []string{"json", "protobuf"}
 
-const testActivityDumpRateLimiter = 20
+const testActivityDumpRateLimiter = 200
 const testActivityDumpTracedCgroupsCount = 3
 const testActivityDumpCgroupDumpTimeout = 11 // probe.MinDumpTimeout(10) + 5
 var testActivityDumpTracedEventTypes = []string{"exec", "open", "syscalls", "dns", "bind"}
@@ -74,6 +74,7 @@ func TestActivityDumps(t *testing.T) {
 		}
 		defer dockerInstance.stop()
 
+		time.Sleep(time.Second * 1) // to ensure we did not get ratelimited
 		cmd := dockerInstance.Command(syscallTester, []string{"sleep", "1"}, []string{})
 		_, err = cmd.CombinedOutput()
 		if err != nil {
@@ -153,6 +154,7 @@ func TestActivityDumps(t *testing.T) {
 		}
 		defer dockerInstance.stop()
 
+		time.Sleep(time.Second * 1) // to ensure we did not get ratelimited
 		cmd := dockerInstance.Command(syscallTester, []string{"bind", "AF_INET", "any", "tcp"}, []string{})
 		_, err = cmd.CombinedOutput()
 		if err != nil {
@@ -197,6 +199,7 @@ func TestActivityDumps(t *testing.T) {
 		}
 		defer dockerInstance.stop()
 
+		time.Sleep(time.Second * 1) // to ensure we did not get ratelimited
 		cmd := dockerInstance.Command("nslookup", []string{"foo.bar"}, []string{})
 		_, err = cmd.CombinedOutput()
 		if err != nil {
@@ -235,6 +238,7 @@ func TestActivityDumps(t *testing.T) {
 		temp, _ := os.CreateTemp(test.st.Root(), "ad-test-create")
 		os.Remove(temp.Name()) // next touch command have to create the file
 
+		time.Sleep(time.Second * 1) // to ensure we did not get ratelimited
 		cmd := dockerInstance.Command("touch", []string{temp.Name()}, []string{})
 		_, err = cmd.CombinedOutput()
 		if err != nil {
@@ -277,6 +281,7 @@ func TestActivityDumps(t *testing.T) {
 		}
 		defer dockerInstance.stop()
 
+		time.Sleep(time.Second * 1) // to ensure we did not get ratelimited
 		cmd := dockerInstance.Command(syscallTester, []string{"bind", "AF_INET", "any", "tcp"}, []string{})
 		_, err = cmd.CombinedOutput()
 		if err != nil {
@@ -332,6 +337,7 @@ func TestActivityDumps(t *testing.T) {
 		}
 		args := []string{"sleep", "2", ";", "open"}
 		args = append(args, files...)
+		time.Sleep(time.Second * 1) // to ensure we did not get ratelimited before starting
 		cmd := dockerInstance.Command(syscallTester, args, []string{})
 		_, err = cmd.CombinedOutput()
 		if err != nil {
@@ -502,6 +508,7 @@ func TestActivityDumpsThreatScore(t *testing.T) {
 		defer dockerInstance.stop()
 
 		filePath := filepath.Join(test.st.Root(), "tag-open")
+		time.Sleep(time.Second * 1) // to ensure we did not get ratelimited
 		cmd := dockerInstance.Command("touch", []string{filePath}, []string{})
 		_, err = cmd.CombinedOutput()
 		if err != nil {
@@ -551,6 +558,7 @@ func TestActivityDumpsThreatScore(t *testing.T) {
 		}
 		defer dockerInstance.stop()
 
+		time.Sleep(time.Second * 1) // to ensure we did not get ratelimited
 		cmd := dockerInstance.Command("nslookup", []string{"foo.bar"}, []string{})
 		_, err = cmd.CombinedOutput()
 		if err != nil {
@@ -591,6 +599,7 @@ func TestActivityDumpsThreatScore(t *testing.T) {
 		}
 		defer dockerInstance.stop()
 
+		time.Sleep(time.Second * 1) // to ensure we did not get ratelimited
 		cmd := dockerInstance.Command(syscallTester, []string{"bind", "AF_INET", "any", "tcp"}, []string{})
 		_, err = cmd.CombinedOutput()
 		if err != nil {
@@ -636,6 +645,7 @@ func TestActivityDumpsThreatScore(t *testing.T) {
 		}
 		defer dockerInstance.stop()
 
+		time.Sleep(time.Second * 1) // to ensure we did not get ratelimited
 		cmd := dockerInstance.Command(syscallTester, []string{"sleep", "1"}, []string{})
 		_, err = cmd.CombinedOutput()
 		if err != nil {


### PR DESCRIPTION


<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Fix activity dump tests by raising the ratelimiter value and adding sleeps before container event we want to validate

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
