### PR TITLE
[CWS] fix stack trace in serialize

### DIFF
--- a/pkg/security/serializers/serializers.go
+++ b/pkg/security/serializers/serializers.go
@@ -673,9 +673,10 @@ func newProcessSerializer(ps *model.Process, e *model.Event, resolvers *resolver
 		return psSerializer
 	} else {
 		return &ProcessSerializer{
-			Pid:       ps.Pid,
-			Tid:       ps.Tid,
-			IsKworker: ps.IsKworker,
+			Pid:         ps.Pid,
+			Tid:         ps.Tid,
+			IsKworker:   ps.IsKworker,
+			Credentials: &ProcessCredentialsSerializer{},
 		}
 	}
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Fix the following stack trace

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x2f87513]

goroutine 344 [running]:
github.com/DataDog/datadog-agent/pkg/security/serializers.NewEventSerializer(0xc001eef980, 0xc000aa9960)
	/home/safchain/go-src/src/github.com/DataDog/datadog-agent/pkg/security/serializers/serializers.go:1173 +0x2373
github.com/DataDog/datadog-agent/pkg/security/probe.NewAbnormalPathEvent(0xc001eef980, 0xc001f54c00, {0x54f3fa0, 0xc001981660})
	/home/safchain/go-src/src/github.com/DataDog/datadog-agent/pkg/security/probe/custom_events.go:110 +0x150
github.com/DataDog/datadog-agent/pkg/security/probe.(*Monitor).ProcessEvent(0xc000c04f00, 0xc001eef980)
	/home/safchain/go-src/src/github.com/DataDog/datadog-agent/pkg/security/probe/probe_monitor.go:194 +0xac
github.com/DataDog/datadog-agent/pkg/security/probe.(*Probe).DispatchEvent(0xc001f54c00, 0xc001eef980)
	/home/safchain/go-src/src/github.com/DataDog/datadog-agent/pkg/security/probe/probe.go:379 +0x12b
github.com/DataDog/datadog-agent/pkg/security/probe.(*Probe).handleEvent(0xc001f54c00, 0x0?, {0xc001398ea0, 0x90, 0x120})
```

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
