### PR TITLE
[RCM-802] upgrade(RC): Make logs more descriptive in the event of a 401

### DIFF
--- a/pkg/config/remote/api/http.go
+++ b/pkg/config/remote/api/http.go
@@ -27,6 +27,12 @@ const (
 	orgDataEndpoint = "/api/v0.1/org"
 )
 
+var (
+	// errUnauthorized is the error that will be logged for the customer to see in case of a 401. We make it as
+	// descriptive as possible (while not leaking data) to make RC onboarding easier
+	errUnauthorized = fmt.Errorf("unauthorized. Please make sure your API key is valid and has the Remote Config scope")
+)
+
 // API is the interface to implement for a configuration fetcher
 type API interface {
 	Fetch(context.Context, *pbgo.LatestConfigsRequest) (*pbgo.LatestConfigsResponse, error)
@@ -105,7 +111,7 @@ func (c *HTTPClient) Fetch(ctx context.Context, request *pbgo.LatestConfigsReque
 	// we want to be descriptive about what can be done
 	// to fix this as the error is pretty common
 	if resp.StatusCode == 401 {
-		return nil, fmt.Errorf("unauthorized. Please make sure your API key is valid and has the Remote Config scope")
+		return nil, errUnauthorized
 	}
 
 	// Any other error will have a generic message
@@ -154,7 +160,7 @@ func (c *HTTPClient) FetchOrgData(ctx context.Context) (*pbgo.OrgDataResponse, e
 	// we want to be descriptive about what can be done
 	// to fix this as the error is pretty common
 	if resp.StatusCode == 401 {
-		return nil, fmt.Errorf("unauthorized. Please make sure your API key is valid and has the Remote Config scope")
+		return nil, errUnauthorized
 	}
 
 	// Any other error will have a generic message

--- a/pkg/config/remote/api/http.go
+++ b/pkg/config/remote/api/http.go
@@ -101,12 +101,20 @@ func (c *HTTPClient) Fetch(ctx context.Context, request *pbgo.LatestConfigsReque
 	}
 	defer resp.Body.Close()
 
+	// Specific case: authentication method is wrong
+	// we want to be descriptive about what can be done
+	// to fix this as the error is pretty common
+	if resp.StatusCode == 401 {
+		return nil, fmt.Errorf("unauthorized. Please make sure your API key is valid and has the Remote Config scope")
+	}
+
+	// Any other error will have a generic message
 	if resp.StatusCode != 200 {
 		body, err = io.ReadAll(resp.Body)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read response: %w", err)
 		}
-		log.Debugf("Non-200 response. Response body: %s", string(body))
+		log.Debugf("Got a %d response code. Response body: %s", resp.StatusCode, string(body))
 		return nil, fmt.Errorf("non-200 response code: %d", resp.StatusCode)
 	}
 
@@ -142,6 +150,14 @@ func (c *HTTPClient) FetchOrgData(ctx context.Context) (*pbgo.OrgDataResponse, e
 	defer resp.Body.Close()
 
 	var body []byte
+	// Specific case: authentication method is wrong
+	// we want to be descriptive about what can be done
+	// to fix this as the error is pretty common
+	if resp.StatusCode == 401 {
+		return nil, fmt.Errorf("unauthorized. Please make sure your API key is valid and has the Remote Config scope")
+	}
+
+	// Any other error will have a generic message
 	if resp.StatusCode != 200 {
 		return nil, fmt.Errorf("non-200 response code: %d", resp.StatusCode)
 	}

--- a/pkg/config/remote/service/service.go
+++ b/pkg/config/remote/service/service.go
@@ -240,7 +240,7 @@ func (s *Service) Start(ctx context.Context) error {
 
 		err := s.refresh()
 		if err != nil {
-			log.Errorf("could not refresh remote-config: %v", err)
+			log.Errorf("Could not refresh Remote Config: %v", err)
 		}
 
 		for {
@@ -262,7 +262,7 @@ func (s *Service) Start(ctx context.Context) error {
 			}
 
 			if err != nil {
-				log.Errorf("could not refresh remote-config: %v", err)
+				log.Errorf("Could not refresh Remote Config: %v", err)
 			}
 		}
 	}()


### PR DESCRIPTION
### What does this PR do?
Make Remote Config logs a bit more verbose in case of a 401 error

### Motivation
As this is on the onboarding hot path, having a descriptive log for that common error will remove friction on the onboarding process for Remote Config.

### Additional Notes
[RCM-802]

### Possible Drawbacks / Trade-offs
Note that using an API key with the wrong format will result in a 403 that we won't catch with a nice log like we do for 401s as it's not as common

### Describe how to test/QA your changes
As it is just a log change, this doesn't require QA. If needed, check that the error message is clear enough when using an API key that isn't scoped.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.


[RCM-802]: https://datadoghq.atlassian.net/browse/RCM-802?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ