### PR TITLE
ebpf: cleanup header download retry mechanism

### DIFF
--- a/pkg/util/kernel/download_headers.go
+++ b/pkg/util/kernel/download_headers.go
@@ -84,7 +84,7 @@ func (h *headerDownloader) downloadHeaders(headerDownloadDir string) error {
 			return fmt.Errorf("failed to download kernel headers: %s", err)
 		}
 		return nil
-	}, retry.Attempts(2), retry.Delay(5 * time.Second), retry.OnRetry(func(_ uint, err error) {
+	}, retry.Attempts(2), retry.Delay(5*time.Second), retry.OnRetry(func(_ uint, err error) {
 		log.Infof("%s. Waiting 5 seconds and retrying kernel header download.", err)
 	}))
 }

--- a/pkg/util/kernel/find_headers.go
+++ b/pkg/util/kernel/find_headers.go
@@ -22,7 +22,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/mholt/archiver/v3"
 	"golang.org/x/exp/maps"
@@ -137,13 +136,6 @@ func GetKernelHeaders(opts KernelHeaderOptions, client statsd.ClientInterface) [
 	}
 
 	headers, result, err := HeaderProvider.getKernelHeaders(hv)
-	if result == downloadFailure {
-		// Download failures can be due to intermittent issues. To mitigate this, if a download
-		// failure occurs we will wait a moment and retry the download one time.
-		log.Infof("%s. Waiting 5 seconds and retrying kernel header download.", err)
-		time.Sleep(5 * time.Second)
-		headers, result, err = HeaderProvider.downloadHeaders(hv)
-	}
 	if client != nil {
 		submitTelemetry(result, client)
 	}


### PR DESCRIPTION
### What does this PR do?

This PR makes a small change to communicate more clearly that we retry the kernel downloading twice. This also retry only the downloading and not the backend creation, allowing for more caching opportunities in the future.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
