### PR TITLE
[pkg/otlp] Handle OTel semconv 1.17.0 in span tag conversion

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -1533,6 +1533,7 @@ core,go.opentelemetry.io/collector/receiver/otlpreceiver/internal/logs,Apache-2.
 core,go.opentelemetry.io/collector/receiver/otlpreceiver/internal/metrics,Apache-2.0,Copyright The OpenTelemetry Authors
 core,go.opentelemetry.io/collector/receiver/otlpreceiver/internal/trace,Apache-2.0,Copyright The OpenTelemetry Authors
 core,go.opentelemetry.io/collector/receiver/scrapererror,Apache-2.0,Copyright The OpenTelemetry Authors
+core,go.opentelemetry.io/collector/semconv/v1.17.0,Apache-2.0,Copyright The OpenTelemetry Authors
 core,go.opentelemetry.io/collector/semconv/v1.5.0,Apache-2.0,Copyright The OpenTelemetry Authors
 core,go.opentelemetry.io/collector/semconv/v1.6.1,Apache-2.0,Copyright The OpenTelemetry Authors
 core,go.opentelemetry.io/collector/service,Apache-2.0,Copyright The OpenTelemetry Authors

--- a/pkg/trace/api/otlp.go
+++ b/pkg/trace/api/otlp.go
@@ -33,6 +33,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.opentelemetry.io/collector/pdata/ptrace/ptraceotlp"
+	semconv117 "go.opentelemetry.io/collector/semconv/v1.17.0"
 	semconv "go.opentelemetry.io/collector/semconv/v1.6.1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
@@ -196,10 +197,7 @@ func (o *OTLPReceiver) ReceiveResourceSpans(ctx context.Context, rspans ptrace.R
 	if lang == "" {
 		lang = fastHeaderGet(httpHeader, header.Lang)
 	}
-	containerID := rattr[string(semconv.AttributeContainerID)]
-	if containerID == "" {
-		containerID = rattr[string(semconv.AttributeK8SPodUID)]
-	}
+	containerID := getFirstFromMap(rattr, semconv.AttributeContainerID, semconv.AttributeK8SPodUID)
 	if containerID == "" {
 		containerID = o.cidProvider.GetContainerID(ctx, httpHeader)
 	}
@@ -241,12 +239,7 @@ func (o *OTLPReceiver) ReceiveResourceSpans(ctx context.Context, rspans ptrace.R
 			}
 			if containerID == "" {
 				// no cid at resource level, grab what we can
-				if v := ddspan.Meta[string(semconv.AttributeK8SPodUID)]; v != "" {
-					containerID = v
-				}
-				if v := ddspan.Meta[string(semconv.AttributeContainerID)]; v != "" {
-					containerID = v
-				}
+				containerID = getFirstFromMap(ddspan.Meta, semconv.AttributeContainerID, semconv.AttributeK8SPodUID)
 			}
 			if p, ok := ddspan.Metrics["_sampling_priority_v1"]; ok {
 				priorityByID[traceID] = sampler.SamplingPriority(p)
@@ -585,25 +578,34 @@ func (o *OTLPReceiver) convertSpan(rattr map[string]string, lib pcommon.Instrume
 func resourceFromTags(meta map[string]string) string {
 	if m := meta[string(semconv.AttributeHTTPMethod)]; m != "" {
 		// use the HTTP method + route (if available)
-		if route := meta[string(semconv.AttributeHTTPRoute)]; route != "" {
-			return m + " " + route
-		} else if route := meta["grpc.path"]; route != "" {
+		if route := getFirstFromMap(meta, semconv.AttributeHTTPRoute, "grpc.path"); route != "" {
 			return m + " " + route
 		}
 		return m
 	} else if m := meta[string(semconv.AttributeMessagingOperation)]; m != "" {
 		// use the messaging operation
-		if dest := meta[string(semconv.AttributeMessagingDestination)]; dest != "" {
+		if dest := getFirstFromMap(meta, semconv.AttributeMessagingDestination, semconv117.AttributeMessagingDestinationName); dest != "" {
 			return m + " " + dest
 		}
 		return m
 	} else if m := meta[string(semconv.AttributeRPCMethod)]; m != "" {
 		// use the RPC method
 		if svc := meta[string(semconv.AttributeRPCService)]; svc != "" {
-			// ...and service if availabl
+			// ...and service if available
 			return m + " " + svc
 		}
 		return m
+	}
+	return ""
+}
+
+// getFirstFromMap checks each key in the given keys in the map and returns the first value whose
+// key matches, or an empty string if none matches.
+func getFirstFromMap(m map[string]string, keys ...string) string {
+	for _, key := range keys {
+		if val := m[key]; val != "" {
+			return val
+		}
 	}
 	return ""
 }

--- a/pkg/trace/api/otlp_test.go
+++ b/pkg/trace/api/otlp_test.go
@@ -752,6 +752,10 @@ func TestOTLPHelpers(t *testing.T) {
 				out:  "DO OP",
 			},
 			{
+				meta: map[string]string{"messaging.operation": "process", "messaging.destination.name": "Queue1", "messaging.destination": "Queue2"},
+				out:  "process Queue2",
+			},
+			{
 				meta: map[string]string{semconv.AttributeRPCService: "SVC", semconv.AttributeRPCMethod: "M"},
 				out:  "M SVC",
 			},

--- a/pkg/trace/api/otlp_test.go
+++ b/pkg/trace/api/otlp_test.go
@@ -748,6 +748,10 @@ func TestOTLPHelpers(t *testing.T) {
 				out:  "DO OP",
 			},
 			{
+				meta: map[string]string{"messaging.operation": "DO", "messaging.destination.name": "OP"},
+				out:  "DO OP",
+			},
+			{
 				meta: map[string]string{semconv.AttributeRPCService: "SVC", semconv.AttributeRPCMethod: "M"},
 				out:  "M SVC",
 			},

--- a/releasenotes/notes/otlp-semconv-1.17-88e28a30a0.yaml
+++ b/releasenotes/notes/otlp-semconv-1.17-88e28a30a0.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Support OTel semconv 1.17.0 in OTLP ingest endpoint.


### PR DESCRIPTION
### What does this PR do?

Add special handling for OTel semconv v1.17.0 in addition to v1.6.1 in OTel span ingestion. The only breaking change in v1.17.0 that impacts Agent OTLP ingestion is `messaging.destination` -> `messaging.destination.name`, all other attributes are a simply pass-through.

### Motivation

To be compatible with newer version of OTel semconv while maintaining backwards compatiibility.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Send a OTLP span with attributes `messaging.operation` and `messaging.destination.name` to Agent and check the DD span resource is set with the attribute values. E.g. a span with `messaging.operation=process` and `messaging.destination.name=my-queue` will have resource like `process my-queue`.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
