### PR TITLE
Add query/elapsed telemetry to external metrics server

### DIFF
--- a/pkg/clusteragent/externalmetrics/provider.go
+++ b/pkg/clusteragent/externalmetrics/provider.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"math"
 	"strings"
+	"time"
 
 	apierr "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -115,6 +116,7 @@ func NewDatadogMetricProvider(ctx context.Context, apiCl *apiserver.APIClient) (
 }
 
 func (p *datadogMetricProvider) GetExternalMetric(ctx context.Context, namespace string, metricSelector labels.Selector, info provider.ExternalMetricInfo) (*external_metrics.ExternalMetricValueList, error) {
+	startTime := time.Now()
 	res, err := p.getExternalMetric(namespace, metricSelector, info)
 	if err != nil {
 		convErr := apierr.NewInternalError(err)
@@ -123,6 +125,7 @@ func (p *datadogMetricProvider) GetExternalMetric(ctx context.Context, namespace
 		}
 	}
 
+	setQueryTelemtry("get", namespace, startTime, err)
 	return res, err
 }
 
@@ -160,6 +163,7 @@ func (p *datadogMetricProvider) getExternalMetric(namespace string, metricSelect
 }
 
 func (p *datadogMetricProvider) ListAllExternalMetrics() []provider.ExternalMetricInfo {
+	startTime := time.Now()
 	datadogMetrics := p.store.GetAll()
 	results := make([]provider.ExternalMetricInfo, 0, len(datadogMetrics))
 	// Unique the external metric names
@@ -184,5 +188,6 @@ func (p *datadogMetricProvider) ListAllExternalMetrics() []provider.ExternalMetr
 	}
 
 	log.Tracef("Answering list of available metrics: %v", results)
+	setQueryTelemtry("list", "", startTime, nil)
 	return results
 }


### PR DESCRIPTION
### What does this PR do?

Add query/elapsed telemetry to external metrics server

### Motivation

Better telemetry.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Check that `datadog.cluster_agent.external_metrics.api_requests` and `datadog.cluster_agent.external_metrics.api_elapsed` metrics are emitted correctly.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
