### PR TITLE
clusteragent: fix timeWindow print format

### DIFF
--- a/pkg/util/kubernetes/autoscalers/datadogexternal.go
+++ b/pkg/util/kubernetes/autoscalers/datadogexternal.go
@@ -11,6 +11,7 @@ package autoscalers
 import (
 	"errors"
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 	"time"

--- a/pkg/util/kubernetes/autoscalers/datadogexternal.go
+++ b/pkg/util/kubernetes/autoscalers/datadogexternal.go
@@ -146,7 +146,7 @@ func (p *Processor) queryDatadogExternal(ddQueries []string, timeWindow time.Dur
 		if _, found := processedMetrics[ddQuery]; !found {
 			processedMetrics[ddQuery] = Point{
 				Timestamp: time.Now().Unix(),
-				Error:     fmt.Errorf("no serie returned for this query, check data is available in the last %f seconds", timeWindow.Seconds()),
+				Error:     fmt.Errorf("no serie returned for this query, check data is available in the last %.0f seconds", math.Ceil(timeWindow.Seconds())),
 			}
 		}
 	}

--- a/pkg/util/kubernetes/autoscalers/datadogexternal.go
+++ b/pkg/util/kubernetes/autoscalers/datadogexternal.go
@@ -146,7 +146,7 @@ func (p *Processor) queryDatadogExternal(ddQueries []string, timeWindow time.Dur
 		if _, found := processedMetrics[ddQuery]; !found {
 			processedMetrics[ddQuery] = Point{
 				Timestamp: time.Now().Unix(),
-				Error:     fmt.Errorf("no serie returned for this query, check data is available in the last %d seconds", timeWindow),
+				Error:     fmt.Errorf("no serie returned for this query, check data is available in the last %f seconds", timeWindow.Seconds()),
 			}
 		}
 	}


### PR DESCRIPTION
Correctly display seconds instead of nanoseconds