### PR TITLE
Don't try to stop a `UDP` tailer that failed to start

### DIFF
--- a/pkg/logs/internal/launchers/listener/udp.go
+++ b/pkg/logs/internal/launchers/listener/udp.go
@@ -58,8 +58,12 @@ func (l *UDPListener) Start() {
 
 // Stop stops the tailer.
 func (l *UDPListener) Stop() {
-	log.Infof("Stopping UDP forwarder on port: %d", l.source.Config.Port)
-	l.tailer.Stop()
+	if l.tailer != nil {
+		log.Infof("Stopping UDP forwarder on port: %d", l.source.Config.Port)
+		l.tailer.Stop()
+	} else {
+		log.Infof("Cannot stop UDP forwarder because the tailer never started")
+	}
 }
 
 // startNewTailer starts a new Tailer

--- a/pkg/logs/internal/launchers/listener/udp.go
+++ b/pkg/logs/internal/launchers/listener/udp.go
@@ -61,8 +61,6 @@ func (l *UDPListener) Stop() {
 	if l.tailer != nil {
 		log.Infof("Stopping UDP forwarder on port: %d", l.source.Config.Port)
 		l.tailer.Stop()
-	} else {
-		log.Infof("Cannot stop UDP forwarder because the tailer never started")
 	}
 }
 

--- a/pkg/logs/internal/launchers/listener/udp_test.go
+++ b/pkg/logs/internal/launchers/listener/udp_test.go
@@ -38,3 +38,10 @@ func TestUDPShouldReceiveMessage(t *testing.T) {
 
 	listener.Stop()
 }
+
+func TestUDPShouldStopWhenNotStarted(t *testing.T) {
+	pp := mock.NewMockProvider()
+	listener := NewUDPListener(pp, sources.NewLogSource("", &config.LogsConfig{Port: udpTestPort}), 9000)
+	// Don't call start, this is similar to if `startNewTailer` fails when start is called (such as if the port is already in use)
+	listener.Stop()
+}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

If a UDP tailer fails to start (such as if the port is in use), calling stop will crash the agent because the underlying `tailer` will be `nil`. This was discovered in testing where 2 agents were competing for the same port. 

### Motivation

Bug fix

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

1. start the agent with a UDP tailer
```
logs:
  - type: udp
    port: 10514
    service: "foo"
    source: "bar"
```
2. start a second agent with the same config (leaving the first agent running)
3. CTR+C the second agent after it's run for a few seconds. 
4. It should not crash. 

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
