### PR TITLE
Only load system-probe secrets within system-probe

### DIFF
--- a/cmd/system-probe/config/config.go
+++ b/cmd/system-probe/config/config.go
@@ -70,6 +70,15 @@ type Config struct {
 
 // New creates a config object for system-probe. It assumes no configuration has been loaded as this point.
 func New(configPath string) (*Config, error) {
+	return newSysprobeConfig(configPath, true)
+}
+
+// NewCustom creates a config object for system-probe. It assumes no configuration has been loaded as this point.
+func NewCustom(configPath string, loadSecrets bool) (*Config, error) {
+	return newSysprobeConfig(configPath, loadSecrets)
+}
+
+func newSysprobeConfig(configPath string, loadSecrets bool) (*Config, error) {
 	aconfig.SystemProbe.SetConfigName("system-probe")
 	// set the paths where a config file is expected
 	if len(configPath) != 0 {
@@ -85,7 +94,7 @@ func New(configPath string) (*Config, error) {
 		aconfig.SystemProbe.AddConfigPath(defaultConfigDir)
 	}
 	// load the configuration
-	_, err := aconfig.LoadCustom(aconfig.SystemProbe, "system-probe", true, aconfig.Datadog.GetEnvVars())
+	_, err := aconfig.LoadCustom(aconfig.SystemProbe, "system-probe", loadSecrets, aconfig.Datadog.GetEnvVars())
 	if err != nil {
 		var e viper.ConfigFileNotFoundError
 		if errors.As(err, &e) || errors.Is(err, os.ErrNotExist) {

--- a/cmd/system-probe/subcommands/config/command.go
+++ b/cmd/system-probe/subcommands/config/command.go
@@ -45,7 +45,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
 					ConfigParams:         config.NewAgentParamsWithoutSecrets("", config.WithConfigMissingOK(true)),
-					SysprobeConfigParams: sysprobeconfig.NewParams(sysprobeconfig.WithSysProbeConfFilePath(globalParams.ConfFilePath)),
+					SysprobeConfigParams: sysprobeconfig.NewParams(sysprobeconfig.WithSysProbeConfFilePath(globalParams.ConfFilePath), sysprobeconfig.WithConfigLoadSecrets(true)),
 					LogParams:            log.LogForOneShot("SYS-PROBE", "off", true),
 				}),
 				// no need to provide sysprobe logger since LogForOneShot ignores config values

--- a/cmd/system-probe/subcommands/debug/command.go
+++ b/cmd/system-probe/subcommands/debug/command.go
@@ -47,7 +47,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
 					ConfigParams:         config.NewAgentParamsWithoutSecrets("", config.WithConfigMissingOK(true)),
-					SysprobeConfigParams: sysprobeconfig.NewParams(sysprobeconfig.WithSysProbeConfFilePath(globalParams.ConfFilePath)),
+					SysprobeConfigParams: sysprobeconfig.NewParams(sysprobeconfig.WithSysProbeConfFilePath(globalParams.ConfFilePath), sysprobeconfig.WithConfigLoadSecrets(true)),
 					LogParams:            log.LogForOneShot("SYS-PROBE", "off", false),
 				}),
 				// no need to provide sysprobe logger since LogForOneShot ignores config values

--- a/cmd/system-probe/subcommands/modrestart/command.go
+++ b/cmd/system-probe/subcommands/modrestart/command.go
@@ -45,7 +45,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
 					ConfigParams:         config.NewAgentParamsWithoutSecrets("", config.WithConfigMissingOK(true)),
-					SysprobeConfigParams: sysprobeconfig.NewParams(sysprobeconfig.WithSysProbeConfFilePath(globalParams.ConfFilePath)),
+					SysprobeConfigParams: sysprobeconfig.NewParams(sysprobeconfig.WithSysProbeConfFilePath(globalParams.ConfFilePath), sysprobeconfig.WithConfigLoadSecrets(true)),
 					LogParams:            log.LogForOneShot("SYS-PROBE", "off", false),
 				}),
 				// no need to provide sysprobe logger since LogForOneShot ignores config values

--- a/cmd/system-probe/subcommands/run/command.go
+++ b/cmd/system-probe/subcommands/run/command.go
@@ -64,7 +64,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 			return fxutil.OneShot(run,
 				fx.Supply(cliParams),
 				fx.Supply(config.NewAgentParamsWithoutSecrets("", config.WithConfigMissingOK(true))),
-				fx.Supply(sysprobeconfig.NewParams(sysprobeconfig.WithSysProbeConfFilePath(globalParams.ConfFilePath))),
+				fx.Supply(sysprobeconfig.NewParams(sysprobeconfig.WithSysProbeConfFilePath(globalParams.ConfFilePath), sysprobeconfig.WithConfigLoadSecrets(true))),
 				fx.Supply(log.LogForDaemon("SYS-PROBE", "log_file", common.DefaultLogFile)),
 				config.Module,
 				sysprobeconfig.Module,
@@ -147,7 +147,7 @@ func StartSystemProbeWithDefaults() error {
 		},
 		// no config file path specification in this situation
 		fx.Supply(config.NewAgentParamsWithoutSecrets("", config.WithConfigMissingOK(true))),
-		fx.Supply(sysprobeconfig.NewParams(sysprobeconfig.WithSysProbeConfFilePath(""))),
+		fx.Supply(sysprobeconfig.NewParams(sysprobeconfig.WithSysProbeConfFilePath(""), sysprobeconfig.WithConfigLoadSecrets(true))),
 		fx.Supply(log.LogForDaemon("SYS-PROBE", "log_file", common.DefaultLogFile)),
 		config.Module,
 		sysprobeconfig.Module,

--- a/comp/core/sysprobeconfig/params.go
+++ b/comp/core/sysprobeconfig/params.go
@@ -10,6 +10,10 @@ type Params struct {
 	// sysProbeConfFilePath is the path at which to look for configuration, usually
 	// given by the --sysprobecfgpath command-line flag.
 	sysProbeConfFilePath string
+
+	// configLoadSecrets determines whether secrets in the configuration file
+	// should be evaluated.
+	configLoadSecrets bool
 }
 
 // NewParams creates a new instance of Params
@@ -24,5 +28,11 @@ func NewParams(options ...func(*Params)) Params {
 func WithSysProbeConfFilePath(confFilePath string) func(*Params) {
 	return func(b *Params) {
 		b.sysProbeConfFilePath = confFilePath
+	}
+}
+
+func WithConfigLoadSecrets(configLoadSecrets bool) func(*Params) {
+	return func(b *Params) {
+		b.configLoadSecrets = configLoadSecrets
 	}
 }

--- a/comp/core/sysprobeconfig/setup.go
+++ b/comp/core/sysprobeconfig/setup.go
@@ -11,5 +11,5 @@ import (
 
 func setupConfig(deps dependencies) (*sysconfig.Config, error) {
 	confFilePath := deps.Params.sysProbeConfFilePath
-	return sysconfig.New(confFilePath)
+	return sysconfig.NewCustom(confFilePath, deps.Params.configLoadSecrets)
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Disables loading of secrets from `system-probe.yaml` unless from within `system-probe` itself.

### Motivation

The `secrets` functionality has some global variables. Attempting to use it multiple times with different arguments causes the last-provided values to be used for everyone. This causes issues in the `agent` process when it tries to load secrets in autodiscovery configurations, which happens after the initial `datadog.yaml` load.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
