### PR TITLE
[trivy] Prevent sbom collection if disk usage is high

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1119,6 +1119,8 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("container_image_collection.sbom.cache_directory", "")
 	config.BindEnvAndSetDefault("container_image_collection.sbom.clear_cache_on_exit", false)
 	config.BindEnvAndSetDefault("container_image_collection.sbom.cache_ttl", 60*60) // Integer seconds. Only used with Badger
+	config.BindEnvAndSetDefault("container_image_collection.sbom.check_disk_usage", true)
+	config.BindEnvAndSetDefault("container_image_collection.sbom.min_available_disk", "1Gb")
 
 	// Datadog security agent (common)
 	config.BindEnvAndSetDefault("security_agent.cmd_port", 5010)

--- a/pkg/util/trivy/telemetry.go
+++ b/pkg/util/trivy/telemetry.go
@@ -1,7 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2016-present Datadog, Inc.
+// Copyright 2023-present Datadog, Inc.
 
 //go:build trivy
 // +build trivy

--- a/pkg/util/trivy/telemetry.go
+++ b/pkg/util/trivy/telemetry.go
@@ -1,0 +1,38 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build trivy
+// +build trivy
+
+package trivy
+
+import "github.com/DataDog/datadog-agent/pkg/telemetry"
+
+const (
+	subsystem        = "trivy"
+	sourceContainerd = "containerd"
+	typeDaemon       = "daemon"
+	typeFilesystem   = "filesystem"
+	reasonDiskSpace  = "disk_space"
+)
+
+var (
+	// sbomAttempts tracks sbom collection attempts.
+	sbomAttempts = telemetry.NewCounterWithOpts(
+		subsystem,
+		"sbom_attempts",
+		[]string{"source", "type"},
+		"Number of sbom failures by (source, type)",
+		telemetry.Options{NoDoubleUnderscoreSep: true},
+	)
+	// sbomFailures tracks sbom collection attempts that fail.
+	sbomFailures = telemetry.NewCounterWithOpts(
+		subsystem,
+		"sbom_errors",
+		[]string{"source", "type", "reason"},
+		"Number of sbom failures by (source, type, reason)",
+		telemetry.Options{NoDoubleUnderscoreSep: true},
+	)
+)

--- a/pkg/util/trivy/trivy.go
+++ b/pkg/util/trivy/trivy.go
@@ -90,6 +90,9 @@ func DefaultCollectorConfig(enabledAnalyzers []string, cacheLocation string) Col
 		collectorConfig.ArtifactOption.OnlyDirs = []string{"etc", "var/lib/dpkg", "var/lib/rpm", "lib/apk"}
 	}
 
+	collectorConfig.CheckDiskUsage = config.Datadog.GetBool("container_image_collection.sbom.check_disk_usage")
+	collectorConfig.MinAvailableDisk = uint64(config.Datadog.GetSizeInBytes("container_image_collection.sbom.min_available_disk"))
+
 	return collectorConfig
 }
 

--- a/pkg/workloadmeta/collectors/internal/containerd/image_sbom_trivy.go
+++ b/pkg/workloadmeta/collectors/internal/containerd/image_sbom_trivy.go
@@ -42,6 +42,8 @@ func (c *collector) startSBOMCollection(ctx context.Context) error {
 	trivyConfiguration.ContainerdAccessor = func() (cutil.ContainerdItf, error) {
 		return c.containerdClient, nil
 	}
+	trivyConfiguration.CheckDiskUsage = config.Datadog.GetBool("container_image_collection.sbom.check_disk_usage")
+	trivyConfiguration.MinAvailableDisk = uint64(config.Datadog.GetSizeInBytes("container_image_collection.sbom.min_available_disk"))
 
 	c.trivyClient, err = trivy.NewCollector(trivyConfiguration)
 	if err != nil {

--- a/pkg/workloadmeta/collectors/internal/containerd/image_sbom_trivy.go
+++ b/pkg/workloadmeta/collectors/internal/containerd/image_sbom_trivy.go
@@ -42,8 +42,6 @@ func (c *collector) startSBOMCollection(ctx context.Context) error {
 	trivyConfiguration.ContainerdAccessor = func() (cutil.ContainerdItf, error) {
 		return c.containerdClient, nil
 	}
-	trivyConfiguration.CheckDiskUsage = config.Datadog.GetBool("container_image_collection.sbom.check_disk_usage")
-	trivyConfiguration.MinAvailableDisk = uint64(config.Datadog.GetSizeInBytes("container_image_collection.sbom.min_available_disk"))
 
 	c.trivyClient, err = trivy.NewCollector(trivyConfiguration)
 	if err != nil {


### PR DESCRIPTION
### What does this PR do?

This PR adds a check for available disk space before starting SBOM collection for an image

### Motivation

The SBOM collection process writes an archive of the image to a tmp folder. When the node is running low on disk space, this check could result in the node being marked as under disk-pressure, forcing pods to be evicted. This PR aims to add a method for preventing this.

### Additional Notes

I have hard-coded the directory to check disk usage of as `/`. This is because, in my testing of both kubernetes and docker outside of kubernetes, the datadog agent is able to see the available disk space of the host volume using this directory.

### Describe how to test/QA your changes

Run the agent with the `DD_TELEMETRY_ENABLED` env var set to `true` and the `DD_CONTAINER_IMAGE_COLLECTION_SBOM_MIN_AVAILABLE_DISK` env var set to a value above your current available disk space on your machine. You should be able to see sbom failure telemetry metrics showing up.

Example:
```
# env | grep SBOM_MIN
DD_CONTAINER_IMAGE_COLLECTION_SBOM_MIN_AVAILABLE_DISK=85GB

# curl -s localhost:6000/telemetry | grep sbom
# HELP trivy_sbom_attempts Number of sbom failures by (source, type)
# TYPE trivy_sbom_attempts counter
trivy_sbom_attempts{source="containerd",type="daemon"} 60
# HELP trivy_sbom_errors Number of sbom failures by (source, type, reason)
# TYPE trivy_sbom_errors counter
trivy_sbom_errors{reason="disk_space",source="containerd",type="daemon"} 60
```

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
