### PR TITLE
Include allocs pprof in flare

### DIFF
--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -81,6 +81,11 @@ func CreatePerformanceProfile(prefix, debugURL string, cpusec int, target *Profi
 			URL:  debugURL + "/heap",
 		},
 		{
+			// A sampling of all past memory allocations
+			Name: prefix + "-allocs.pprof",
+			URL:  debugURL + "/allocs",
+		},
+		{
 			// mutex profile
 			Name: prefix + "-mutex.pprof",
 			URL:  debugURL + "/mutex",


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Include allocs pprof in flare.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Useful for troubleshooting.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

```bash
python3 -m invoke agent.build --build-exclude=systemd,python

git rev-parse HEAD
d3715cdb8297b3870e4b700139ee345e0c138588

bin/agent/agent version
Agent 7.45.0-devel - Meta: git.208.d3715cd - Commit: d3715cdb82 - Serialization version: v5.0.80 - Go version: go1.20.2
nN

sudo bin/agent/agent flare -c ~/.datadog-agent/datadog.yaml --profile 30
Please enter your email:
test
Getting a 30s profile snapshot from core.
Getting a 30s profile snapshot from process.
Getting a 30s profile snapshot from security-agent.
Could not collect performance profile data: 1 error occurred:
	* error collecting security-agent agent profile: Get "http://127.0.0.1:5011/debug/pprof/heap": dial tcp 127.0.0.1:5011: connect: connection refused


Asking the agent to build the flare archive.
/var/folders/fb/h4py8c1n5hx6wnrmdxvrx64c0000gn/T/datadog-agent-2023-03-30T21-42-31Z-debug.zip is going to be uploaded to Datadog
Are you sure you want to upload a flare? [y/N]
N
Aborting. (You can still use /var/folders/fb/h4py8c1n5hx6wnrmdxvrx64c0000gn/T/datadog-agent-2023-03-30T21-42-31Z-debug.zip)
unzip  /var/folders/fb/h4py8c1n5hx6wnrmdxvrx64c0000gn/T/datadog-agent-2023-03-30T21-42-31Z-debug.zip -d ~/Downloads/

ls -la ~/Downloads/COMP-C02GJ019ML87/profiles/
total 496
drwxr-xr-x@ 14 keisukeumegaki  staff    448 Mar 31 06:42 .
drwxr-xr-x@ 27 keisukeumegaki  staff    864 Mar 31 06:42 ..
-rwxr-xr-x@  1 keisukeumegaki  staff  57163 Mar 31 06:42 core-1st-heap.pprof
-rwxr-xr-x@  1 keisukeumegaki  staff  57563 Mar 31 06:42 core-2nd-heap.pprof
-rwxr-xr-x@  1 keisukeumegaki  staff  57549 Mar 31 06:42 core-allocs.pprof
-rwxr-xr-x@  1 keisukeumegaki  staff    104 Mar 31 06:42 core-block.pprof
-rwxr-xr-x@  1 keisukeumegaki  staff   3574 Mar 31 06:42 core-cpu.pprof
-rwxr-xr-x@  1 keisukeumegaki  staff    104 Mar 31 06:42 core-mutex.pprof
-rwxr-xr-x@  1 keisukeumegaki  staff  14983 Mar 31 06:42 process-1st-heap.pprof
-rwxr-xr-x@  1 keisukeumegaki  staff  15063 Mar 31 06:42 process-2nd-heap.pprof
-rwxr-xr-x@  1 keisukeumegaki  staff  15064 Mar 31 06:42 process-allocs.pprof
-rwxr-xr-x@  1 keisukeumegaki  staff    104 Mar 31 06:42 process-block.pprof
-rwxr-xr-x@  1 keisukeumegaki  staff   1622 Mar 31 06:42 process-cpu.pprof
-rwxr-xr-x@  1 keisukeumegaki  staff    104 Mar 31 06:42 process-mutex.pprof
```

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
