### PR TITLE
Quick check on array length to avoid panic in edge cases

### DIFF
--- a/pkg/collector/corechecks/cluster/helm/release.go
+++ b/pkg/collector/corechecks/cluster/helm/release.go
@@ -80,7 +80,10 @@ func decodeRelease(data string) (*release, error) {
 	if err != nil {
 		return nil, err
 	}
-
+	if len(b) < 4 {
+		// Avoid panic if b[0:3] cannot be accessed
+		return nil, fmt.Errorf("The byte array is too short (expected at least 4 characters, got %s instead): it cannot contain a Helm release", fmt.Sprint(len(b)))
+	}
 	// For backwards compatibility with releases that were stored before
 	// compression was introduced we skip decompression if the
 	// gzip magic header is not found


### PR DESCRIPTION
### What does this PR do?
* Introduces a safety check on the length of the byte array to decode to avoid panic in edge cases when the Helm check is enabled

### Motivation
* A secret with label `owner=helm` that is not an actual Helm release will be considered in the release store, and the Helm check would attempt to decode it, creating a panic : 
```
panic: runtime error: slice bounds out of range [:3] with capacity 0 [recovered]
	panic: runtime error: slice bounds out of range [:3] with capacity 0

goroutine 1072 [running]:
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x0, 0x0, 0x4f34a0?})
	/go/pkg/mod/k8s.io/apimachinery@v0.23.15/pkg/util/runtime/runtime.go:55 +0xd7
panic({0x30f7a00, 0xc000121d88})
	/goroot/src/runtime/panic.go:884 +0x212
github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/helm.decodeRelease({0x0?, 0x0?})
	/go/src/github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/helm/release.go:87 +0x305
github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/helm.(*HelmCheck).addRelease(0xc000c00000, {0x0?, 0x32e5ac5?}, {{0x7?, 0x44b396?, 0x54cfb60?}}, {0x32e344f, 0x6})
```
* Checking the length of the array before attempting to access the first 3 bytes prevents the panic

### Describe how to test/QA your changes

* Deploy Cluster Agent with Helm check enabled (`datadog.helmCheck.enabled=true`)
* Create a fake "Helm" secret by adding `owner=helm` label : 
    *  `k create secret generic fakehelmsecret --from-literal=username=admin --from-literal=password=test`
    * ` k label secret fakehelmsecret owner=helm`
* The Cluster Agent should not panic and simply disregard the fake secret (and prints a `DEBUG` log : `Error while decoding Helm release ...` from https://github.com/DataDog/datadog-agent/blob/main/pkg/collector/corechecks/cluster/helm/helm.go#L399)

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
