### PR TITLE
Add Windows 10 detection to NG installer

### DIFF
--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/MinimumSupportedWindowsVersion.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/MinimumSupportedWindowsVersion.cs
@@ -50,6 +50,10 @@ namespace WixSetup.Datadog
 
         public static MinimumSupportedWindowsVersion Windows8            = new("Windows 8",              602,  9200, Client);
         public static MinimumSupportedWindowsVersion Windows8_1          = new("Windows 8.1",            603,  9600, Client);
+        // Windows 10 RTM (1507) shipped with 10240, so it's safe to assume anything above 10000 is Windows 10.
+        public static MinimumSupportedWindowsVersion Windows10           = new("Windows 10",             603, 10000, Client);
+        // Official first publicly available preview of Windows 11 bore the build number 22000.51, so assume anything
+        // above 22000 is Windows 11.
         public static MinimumSupportedWindowsVersion Windows11           = new("Windows 11",             603, 22000, Client);
 
         public void Process(ProcessingContext context)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
Add support for detecting Windows 10 in the NG installer.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Prepare for future OS deprecation.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
`skip-qa` since this is going to be tested at a later date when we decide that the minimum supported version of a client Windows will be Windows 10.

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
