### PR TITLE
Fix Prometheus scrape + service_endpoints missed updates leading to checks not being scheduled

### DIFF
--- a/releasenotes/notes/prometheus-endpoints-no-update-0faad43bda24b26a.yaml
+++ b/releasenotes/notes/prometheus-endpoints-no-update-0faad43bda24b26a.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixing an issue with Prometheus scrape feature when `service_endpoints` option is used where endpoint updates were missed by the Agent, causing checks to not be scheduled on endpoints created after Agent start.


### PR DESCRIPTION
### What does this PR do?

Fix Prometheus scrape + service_endpoints missed updates leading to checks not being scheduled

### Motivation

Bugfix.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Create a service backed by PODs with `prometheus.io/scrape: "true"` annotation.
Deploy the agent with `prometheus_scrape.service_endpoints` set to `true`.
Scale the `Deployment` behind your service from 1 -> 3, observe that all checks have correctly been created (`agent clusterchecks`), scale down from 3 -> 1, observe the checks have correctly been removed.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
