### PR TITLE
[RCM-832] upgrade(inventories): Add RC enablement to the list of metadata sent by the agent

### DIFF
--- a/pkg/metadata/inventories/README.md
+++ b/pkg/metadata/inventories/README.md
@@ -93,7 +93,7 @@ The payload is a JSON dict with the following fields
     `network_config.enabled` config option in `system-probe.yaml`).
   - `feature_networks_http_enabled` - **bool**: True if HTTP monitoring is enabled for Network Performance Monitoring (see: `network_config.enable_http_monitoring` config option in `system-probe.yaml`).
   - `feature_networks_https_enabled` - **bool**: True if HTTPS monitoring is enabled for Network Performance Monitoring (see: `network_config.enable_https_monitoring` config option in `system-probe.yaml`).
-  - `feature_remote_configuration_enabled` - **bool**: True if the Cloud Workload Security is enabled (see: `remote_configuration.enabled` config option).
+  - `feature_remote_configuration_enabled` - **bool**: True if Remote Configuration is enabled (see: `remote_configuration.enabled` config option).
   - `feature_usm_http2_enabled` - **bool**: True if HTTP2 monitoring is enabled for Universal Service Monitoring (see: `service_monitoring_config.enable_http2_monitoring` config option in `system-probe.yaml`).
   - `feature_usm_kafka_enabled` - **bool**: True is Kafka monitoring is enabled for Universal Service Monitoring (see: `data_streams_config.enabled` config option in `system-probe.yaml`)
   - `feature_usm_java_tls_enabled` - **bool**: True if HTTPS monitoring through java TLS is enabled for Universal Service Monitoring (see: `service_monitoring_config.enable_java_tls_support` config option in `system-probe.yaml`).

--- a/pkg/metadata/inventories/README.md
+++ b/pkg/metadata/inventories/README.md
@@ -93,6 +93,7 @@ The payload is a JSON dict with the following fields
     `network_config.enabled` config option in `system-probe.yaml`).
   - `feature_networks_http_enabled` - **bool**: True if HTTP monitoring is enabled for Network Performance Monitoring (see: `network_config.enable_http_monitoring` config option in `system-probe.yaml`).
   - `feature_networks_https_enabled` - **bool**: True if HTTPS monitoring is enabled for Network Performance Monitoring (see: `network_config.enable_https_monitoring` config option in `system-probe.yaml`).
+  - `feature_remote_configuration_enabled` - **bool**: True if the Cloud Workload Security is enabled (see: `remote_configuration.enabled` config option).
   - `feature_usm_http2_enabled` - **bool**: True if HTTP2 monitoring is enabled for Universal Service Monitoring (see: `service_monitoring_config.enable_http2_monitoring` config option in `system-probe.yaml`).
   - `feature_usm_kafka_enabled` - **bool**: True is Kafka monitoring is enabled for Universal Service Monitoring (see: `data_streams_config.enabled` config option in `system-probe.yaml`)
   - `feature_usm_java_tls_enabled` - **bool**: True if HTTPS monitoring through java TLS is enabled for Universal Service Monitoring (see: `service_monitoring_config.enable_java_tls_support` config option in `system-probe.yaml`).
@@ -177,6 +178,7 @@ Here an example of an inventory payload:
         "feature_logs_enabled": true,
         "feature_networks_enabled": false,
         "feature_process_enabled": false,
+        "feature_remote_configuration_enabled": false,
         "flavor": "agent",
         "hostname_source": "os",
         "install_method_installer_version": "",

--- a/pkg/metadata/inventories/inventories.go
+++ b/pkg/metadata/inventories/inventories.go
@@ -91,6 +91,7 @@ const (
 	AgentNetworksEnabled                AgentMetadataName = "feature_networks_enabled"
 	AgentNetworksHTTPEnabled            AgentMetadataName = "feature_networks_http_enabled"
 	AgentNetworksHTTPSEnabled           AgentMetadataName = "feature_networks_https_enabled"
+	AgentRemoteConfigEnabled            AgentMetadataName = "feature_remote_configuration_enabled"
 	AgentUSMKafkaEnabled                AgentMetadataName = "feature_usm_kafka_enabled"
 	AgentUSMJavaTLSEnabled              AgentMetadataName = "feature_usm_java_tls_enabled"
 	AgentUSMHTTP2Enabled                AgentMetadataName = "feature_usm_http2_enabled"
@@ -419,6 +420,7 @@ func initializeConfig(cfg config.Config) {
 	SetAgentMetadata(AgentNetworksHTTPEnabled, config.SystemProbe.GetBool("network_config.enable_http_monitoring"))
 	SetAgentMetadata(AgentNetworksHTTPSEnabled, config.SystemProbe.GetBool("network_config.enable_https_monitoring"))
 	SetAgentMetadata(AgentUSMKafkaEnabled, config.Datadog.GetBool("data_streams_config.enabled"))
+	SetAgentMetadata(AgentRemoteConfigEnabled, config.Datadog.GetBool("remote_configuration.enabled"))
 	SetAgentMetadata(AgentUSMJavaTLSEnabled, config.SystemProbe.GetBool("service_monitoring_config.enable_java_tls_support"))
 	SetAgentMetadata(AgentUSMHTTP2Enabled, config.SystemProbe.GetBool("service_monitoring_config.enable_http2_monitoring"))
 	SetAgentMetadata(AgentUSMEnableHTTPStatsByStatusCode, config.SystemProbe.GetBool("service_monitoring_config.enable_http_stats_by_status_code"))


### PR DESCRIPTION
### What does this PR do?
Add remote_configuration.enabled to the list of metadata sent by the agent

### Motivation
We'd like to provide information on the configuration of agents related to Remote Configuration, and figured that this was the best way to send the information.

### Additional Notes
N/A

### Possible Drawbacks / Trade-offs
I guess an ever so slightly heavier inventories request.

### Describe how to test/QA your changes
Enable / disable RC on your host, and check on inventories SQL that the value for your host in the datadog_agent table changes. 
`SELECT feature_remote_configuration_enabled FROM datadog_agent JOIN host USING(datadog_agent_key) WHERE hostname='<MY_HOSTNAME>'`

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
