### PR TITLE
pkg/trace/api: Allow forwarding Dynamic Instrumentation logs and snapshots to additional endpoints

### DIFF
--- a/cmd/trace-agent/config/config.go
+++ b/cmd/trace-agent/config/config.go
@@ -414,6 +414,9 @@ func applyDatadogConfig(c *config.AgentConfig) error {
 	if k := "apm_config.debugger_api_key"; coreconfig.Datadog.IsSet(k) {
 		c.DebuggerProxy.APIKey = coreconfig.Datadog.GetString(k)
 	}
+	if k := "apm_config.debugger_additional_endpoints"; coreconfig.Datadog.IsSet(k) {
+		c.DebuggerProxy.AdditionalEndpoints = coreconfig.Datadog.GetStringMapStringSlice(k)
+	}
 	if k := "evp_proxy_config.enabled"; coreconfig.Datadog.IsSet(k) {
 		c.EVPProxy.Enabled = coreconfig.Datadog.GetBool(k)
 	}

--- a/cmd/trace-agent/config/config_test.go
+++ b/cmd/trace-agent/config/config_test.go
@@ -972,6 +972,23 @@ func TestLoadEnv(t *testing.T) {
 		assert.Equal("my-key", coreconfig.Datadog.GetString("apm_config.debugger_api_key"))
 	})
 
+	env = "DD_APM_DEBUGGER_ADDITIONAL_ENDPOINTS"
+	t.Run(env, func(t *testing.T) {
+		defer cleanConfig()()
+		assert := assert.New(t)
+		t.Setenv(env, `{"url1": ["key1", "key2"], "url2": ["key3"]}`)
+		_, err := LoadConfigFile("./testdata/full.yaml")
+		assert.NoError(err)
+		expected := map[string][]string{
+			"url1": {"key1", "key2"},
+			"url2": {"key3"},
+		}
+		actual := coreconfig.Datadog.GetStringMapStringSlice(("apm_config.debugger_additional_endpoints"))
+		if !reflect.DeepEqual(actual, expected) {
+			t.Fatalf("Failed to process env var %s, expected %v and got %v", env, expected, actual)
+		}
+	})
+
 	env = "DD_APM_OBFUSCATION_CREDIT_CARDS_ENABLED"
 	t.Run(env, func(t *testing.T) {
 		defer cleanConfig()()

--- a/pkg/config/apm.go
+++ b/pkg/config/apm.go
@@ -101,6 +101,7 @@ func setupAPM(config Config) {
 	config.BindEnv("apm_config.internal_profiling.enabled", "DD_APM_INTERNAL_PROFILING_ENABLED")
 	config.BindEnv("apm_config.debugger_dd_url", "DD_APM_DEBUGGER_DD_URL")
 	config.BindEnv("apm_config.debugger_api_key", "DD_APM_DEBUGGER_API_KEY")
+	config.BindEnv("apm_config.debugger_additional_endpoints", "DD_APM_DEBUGGER_ADDITIONAL_ENDPOINTS")
 	config.BindEnvAndSetDefault("apm_config.telemetry.enabled", true, "DD_APM_TELEMETRY_ENABLED")
 	config.BindEnv("apm_config.telemetry.dd_url", "DD_APM_TELEMETRY_DD_URL")
 	config.BindEnv("apm_config.telemetry.additional_endpoints", "DD_APM_TELEMETRY_ADDITIONAL_ENDPOINTS")

--- a/pkg/trace/api/debugger.go
+++ b/pkg/trace/api/debugger.go
@@ -6,9 +6,7 @@
 package api
 
 import (
-	"bytes"
 	"fmt"
-	"io"
 	stdlog "log"
 	"net/http"
 	"net/http/httputil"
@@ -16,11 +14,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/uuid"
-
 	"github.com/DataDog/datadog-agent/pkg/trace/config"
 	"github.com/DataDog/datadog-agent/pkg/trace/log"
-	"github.com/DataDog/datadog-agent/pkg/trace/metrics"
+	"github.com/google/uuid"
 )
 
 const (
@@ -50,23 +46,9 @@ func (r *HTTPReceiver) debuggerProxyHandler() http.Handler {
 	if k := r.conf.DebuggerProxy.APIKey; k != "" {
 		apiKey = strings.TrimSpace(k)
 	}
-	targets := []*url.URL{target}
-	apiKeys := []string{apiKey}
-	additionalEndpoints := r.conf.DebuggerProxy.AdditionalEndpoints
-	if additionalEndpoints != nil {
-		for endpoint, keys := range additionalEndpoints {
-			u, err := url.Parse(endpoint)
-			if err != nil {
-				log.Errorf("Error parsing additional debugger intake URL %s: %v", endpoint, err)
-				continue
-			}
-			for _, key := range keys {
-				targets = append(targets, u)
-				apiKeys = append(apiKeys, strings.TrimSpace(key))
-			}
-		}
-	}
-	return newDebuggerProxy(r.conf, targets, apiKeys, tags)
+	transport := newMeasuringMultiTransport(
+		r.conf.NewHTTPTransport(), target, apiKey, r.conf.DebuggerProxy.AdditionalEndpoints, "datadog.trace_agent.debugger.", []string{})
+	return newDebuggerProxy(r.conf, transport, tags)
 }
 
 // debuggerErrorHandler always returns http.StatusInternalServerError with a clarifying message.
@@ -78,95 +60,32 @@ func debuggerErrorHandler(err error) http.Handler {
 }
 
 // newDebuggerProxy returns a new httputil.ReverseProxy proxying and augmenting requests with headers containing the tags.
-func newDebuggerProxy(conf *config.AgentConfig, targets []*url.URL, keys []string, tags string) *httputil.ReverseProxy {
+func newDebuggerProxy(conf *config.AgentConfig, transport http.RoundTripper, tags string) *httputil.ReverseProxy {
+	cidProvider := NewIDProvider(conf.ContainerProcRoot)
 	logger := log.NewThrottled(5, 10*time.Second) // limit to 5 messages every 10 seconds
-	director := func(req *http.Request) {
+	return &httputil.ReverseProxy{
+		Director:  getDirector(tags, cidProvider, conf.ContainerTags),
+		ErrorLog:  stdlog.New(logger, "debugger.Proxy: ", 0),
+		Transport: transport,
+	}
+}
+
+func getDirector(tags string, cidProvider IDProvider, containerTags func(string) ([]string, error)) func(*http.Request) {
+	return func(req *http.Request) {
 		req.Header.Set("DD-REQUEST-ID", uuid.New().String())
 		req.Header.Set("DD-EVP-ORIGIN", "agent-debugger")
-	}
-	return &httputil.ReverseProxy{
-		Director: director,
-		ErrorLog: stdlog.New(logger, "debugger.Proxy: ", 0),
-		Transport: &measuringDebuggerMultiTransport{
-			conf.NewHTTPTransport(),
-			targets,
-			keys,
-			tags,
-			conf,
-			NewIDProvider(conf.ContainerProcRoot),
-		},
-	}
-}
-
-// measuringDebuggerMultiTransport sends HTTP requests to a defined target url. It also sets the API keys in the headers.
-type measuringDebuggerMultiTransport struct {
-	rt          http.RoundTripper
-	targets     []*url.URL
-	keys        []string
-	tags        string
-	conf        *config.AgentConfig
-	cidProvider IDProvider
-}
-
-func (m *measuringDebuggerMultiTransport) RoundTrip(req *http.Request) (rres *http.Response, rerr error) {
-	defer func(start time.Time) {
-		var tags []string
-		metrics.Count("datadog.trace_agent.debugger.proxy_request", 1, tags, 1)
-		metrics.Timing("datadog.trace_agent.debugger.proxy_request_duration_ms", time.Since(start), tags, 1)
-		if rerr != nil {
-			tags := append(tags, fmt.Sprintf("error:%s", fmt.Sprintf("%T", rerr)))
-			metrics.Count("datadog.trace_agent.debugger.proxy_request_error", 1, tags, 1)
+		q := req.URL.Query()
+		containerID := cidProvider.GetContainerID(req.Context(), req.Header)
+		if ctags := getContainerTags(containerTags, containerID); ctags != "" {
+			tags = fmt.Sprintf("%s,%s", tags, ctags)
 		}
-	}(time.Now())
-
-	ddtags := m.tags
-	containerID := m.cidProvider.GetContainerID(req.Context(), req.Header)
-	if ct := getContainerTags(m.conf.ContainerTags, containerID); ct != "" {
-		ddtags = fmt.Sprintf("%s,%s", ddtags, ct)
-	}
-	q := req.URL.Query()
-	if qtags := q.Get("ddtags"); qtags != "" {
-		ddtags = fmt.Sprintf("%s,%s", ddtags, qtags)
-	}
-
-	if len(m.targets) == 1 {
-		m.setTarget(req, m.targets[0], m.keys[0], ddtags)
-		return m.rt.RoundTrip(req)
-	}
-
-	slurp, err := io.ReadAll(req.Body)
-	if err != nil {
-		return nil, err
-	}
-
-	for i, u := range m.targets {
-		newreq := req.Clone(req.Context())
-		newreq.Body = io.NopCloser(bytes.NewReader(slurp))
-		m.setTarget(newreq, u, m.keys[i], ddtags)
-		if i == 0 {
-			// given the way we construct the list of targets the main endpoint
-			// will be the first one called, we return its response and error
-			rres, rerr = m.rt.RoundTrip(newreq)
-			continue
+		if htags := req.Header.Get("X-Datadog-Additional-Tags"); htags != "" {
+			tags = fmt.Sprintf("%s,%s", tags, htags)
 		}
-
-		if resp, err := m.rt.RoundTrip(newreq); err == nil {
-			// we discard responses for all subsequent requests
-			io.Copy(io.Discard, resp.Body) //nolint:errcheck
-			resp.Body.Close()
-		} else {
-			log.Error(err)
+		if qtags := q.Get("ddtags"); qtags != "" {
+			tags = fmt.Sprintf("%s,%s", tags, qtags)
 		}
+		q.Set("ddtags", tags)
+		req.URL.RawQuery = q.Encode()
 	}
-	return rres, rerr
-}
-
-func (m *measuringDebuggerMultiTransport) setTarget(r *http.Request, u *url.URL, apiKey string, tags string) {
-	q := r.URL.Query()
-	q.Set("ddtags", tags)
-	newTarget := u
-	newTarget.RawQuery = q.Encode()
-	r.Host = u.Host
-	r.URL = newTarget
-	r.Header.Set("DD-API-KEY", apiKey)
 }

--- a/pkg/trace/api/debugger.go
+++ b/pkg/trace/api/debugger.go
@@ -46,7 +46,7 @@ func (r *HTTPReceiver) debuggerProxyHandler() http.Handler {
 	if k := r.conf.DebuggerProxy.APIKey; k != "" {
 		apiKey = strings.TrimSpace(k)
 	}
-	transport := newMeasuringMultiTransport(
+	transport := newMeasuringForwardingTransport(
 		r.conf.NewHTTPTransport(), target, apiKey, r.conf.DebuggerProxy.AdditionalEndpoints, "datadog.trace_agent.debugger.", []string{})
 	return newDebuggerProxy(r.conf, transport, tags)
 }

--- a/pkg/trace/api/debugger.go
+++ b/pkg/trace/api/debugger.go
@@ -47,7 +47,7 @@ func (r *HTTPReceiver) debuggerProxyHandler() http.Handler {
 		apiKey = strings.TrimSpace(k)
 	}
 	transport := newMeasuringForwardingTransport(
-		r.conf.NewHTTPTransport(), target, apiKey, r.conf.DebuggerProxy.AdditionalEndpoints, "datadog.trace_agent.debugger.", []string{})
+		r.conf.NewHTTPTransport(), target, apiKey, r.conf.DebuggerProxy.AdditionalEndpoints, "datadog.trace_agent.debugger", []string{})
 	return newDebuggerProxy(r.conf, transport, tags)
 }
 

--- a/pkg/trace/api/debugger_test.go
+++ b/pkg/trace/api/debugger_test.go
@@ -22,44 +22,28 @@ import (
 func TestDebuggerProxy(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		slurp, err := io.ReadAll(req.Body)
-		_ = req.Body.Close()
-		if err != nil {
-			t.Fatal(err)
-		}
-		if body := string(slurp); body != "body" {
-			t.Fatalf("invalid request body: %q", body)
-		}
-		if v := req.Header.Get("DD-API-KEY"); v != "123" {
-			t.Fatalf("got invalid API key: %q", v)
-		}
-		if query := req.URL.RawQuery; query != "ddtags=key%3Aval" {
-			t.Fatalf("got invalid query params: %q", query)
-		}
+		assert.NoError(t, err)
+		err = req.Body.Close()
+		assert.NoError(t, err)
+		body := string(slurp)
+		assert.Equal(t, "body", string(slurp), "invalid request body: %q", body)
+		assert.Equal(t, "123", req.Header.Get("DD-API-KEY"), "got invalid API key: %q", req.Header.Get("DD-API-KEY"))
+		assert.Equal(t, "ddtags=key%3Aval", req.URL.RawQuery, "got invalid query params: %q", req.URL.Query())
 		_, err = w.Write([]byte("OK"))
-		if err != nil {
-			t.Fatal(err)
-		}
+		assert.NoError(t, err)
 	}))
 	u, err := url.Parse(srv.URL)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(t, err)
 	req, err := http.NewRequest("POST", "dummy.com/path", strings.NewReader("body"))
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(t, err)
 	rec := httptest.NewRecorder()
 	c := &traceconfig.AgentConfig{}
 	newDebuggerProxy(c, []*url.URL{u}, []string{"123"}, "key:val").ServeHTTP(rec, req)
 	result := rec.Result()
 	slurp, err := io.ReadAll(result.Body)
 	result.Body.Close()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(slurp) != "OK" {
-		t.Fatal("did not proxy")
-	}
+	assert.NoError(t, err)
+	assert.Equal(t, "OK", string(slurp), "did not proxy")
 }
 
 func TestDebuggerProxyHandler(t *testing.T) {
@@ -67,76 +51,54 @@ func TestDebuggerProxyHandler(t *testing.T) {
 		var called bool
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 			ddtags := req.URL.Query().Get("ddtags")
-			if strings.Contains(ddtags, "orchestrator") {
-				t.Fatalf("ddtags should not contain orchestrator: %v", ddtags)
-			}
+			assert.False(t, strings.Contains(ddtags, "orchestrator"), "ddtags should not contain orchestrator: %v", ddtags)
 			for _, tag := range []string{"host", "default_env", "agent_version"} {
-				if !strings.Contains(ddtags, tag) {
-					t.Fatalf("ddtags should contain %s", tag)
-				}
+				assert.True(t, strings.Contains(ddtags, tag), "ddtags should contain %s", tag)
 			}
 			called = true
 		}))
 		req, err := http.NewRequest("POST", "/some/path", nil)
-		if err != nil {
-			t.Fatal(err)
-		}
+		assert.NoError(t, err)
 		conf := getConf()
 		conf.Hostname = "myhost"
 		conf.DebuggerProxy.DDURL = srv.URL
 		receiver := newTestReceiverFromConfig(conf)
 		receiver.debuggerProxyHandler().ServeHTTP(httptest.NewRecorder(), req)
-		if !called {
-			t.Fatal("request not proxied")
-		}
+		assert.True(t, called, "request not proxied")
 	})
 
 	t.Run("ok_fargate", func(t *testing.T) {
 		var called bool
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 			ddtags := req.URL.Query().Get("ddtags")
-			if !strings.Contains(ddtags, "orchestrator:fargate_orchestrator") {
-				t.Fatalf("invalid ddtags, fargate env should contain '%s' tag: %q", "orchestrator", ddtags)
-			}
+			assert.True(t, strings.Contains(ddtags, "orchestrator"), "ddtags must contain orchestrator: %v", ddtags)
 			called = true
 		}))
 		req, err := http.NewRequest("POST", "/some/path", nil)
-		if err != nil {
-			t.Fatal(err)
-		}
+		assert.NoError(t, err)
 		conf := newTestReceiverConfig()
 		conf.Hostname = "myhost"
 		conf.FargateOrchestrator = "orchestrator"
 		conf.DebuggerProxy.DDURL = srv.URL
 		receiver := newTestReceiverFromConfig(conf)
 		receiver.debuggerProxyHandler().ServeHTTP(httptest.NewRecorder(), req)
-		if !called {
-			t.Fatal("request not proxied")
-		}
+		assert.True(t, called, "request not proxied")
 	})
 
 	t.Run("error", func(t *testing.T) {
 		req, err := http.NewRequest("POST", "/some/path", nil)
-		if err != nil {
-			t.Fatal(err)
-		}
+		assert.NoError(t, err)
 		rec := httptest.NewRecorder()
 		conf := newTestReceiverConfig()
 		conf.Site = "asd:\r\n"
 		r := newTestReceiverFromConfig(conf)
 		r.debuggerProxyHandler().ServeHTTP(rec, req)
 		res := rec.Result()
-		if res.StatusCode != http.StatusInternalServerError {
-			t.Fatalf("invalid response: %s", res.Status)
-		}
+		assert.Equal(t, http.StatusInternalServerError, res.StatusCode, "invalid response: %s", res.Status)
 		slurp, err := io.ReadAll(res.Body)
 		res.Body.Close()
-		if err != nil {
-			t.Fatal(err)
-		}
-		if !strings.Contains(string(slurp), "error parsing debugger intake URL") {
-			t.Fatalf("invalid message: %q", slurp)
-		}
+		assert.NoError(t, err)
+		assert.Contains(t, string(slurp), "error parsing debugger intake URL", "invalid message: %q", string(slurp))
 	})
 
 	t.Run("ok_additional_endpoints", func(t *testing.T) {
@@ -145,12 +107,7 @@ func TestDebuggerProxyHandler(t *testing.T) {
 		conf := getConf()
 		for i := 0; i < numEndpoints; i++ {
 			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-				ddtags := req.URL.Query().Get("ddtags")
-				for _, tag := range []string{"host", "default_env", "agent_version"} {
-					if !strings.Contains(ddtags, tag) {
-						t.Fatalf("ddtags should contain %s", tag)
-					}
-				}
+				assert.Equal(t, "ddtags=host%3Amyhost%2Cdefault_env%3Atest%2Cagent_version%3Av1", req.URL.RawQuery, "got invalid query params: %q", req.URL.Query())
 				numCalls.Add(1)
 			}))
 			if i == 0 {
@@ -160,16 +117,12 @@ func TestDebuggerProxyHandler(t *testing.T) {
 			conf.DebuggerProxy.AdditionalEndpoints[srv.URL] = []string{"foo"}
 		}
 		req, err := http.NewRequest("POST", "/some/path", strings.NewReader("body"))
-		if err != nil {
-			t.Fatal(err)
-		}
+		assert.NoError(t, err)
 		receiver := newTestReceiverFromConfig(conf)
 		receiver.debuggerProxyHandler().ServeHTTP(httptest.NewRecorder(), req)
 		var expected atomic.Int32
 		expected.Store(int32(numEndpoints))
-		if numCalls != expected {
-			t.Fatalf("requests not proxied, expected %d calls, got %d", numEndpoints, numCalls)
-		}
+		assert.Equal(t, expected, numCalls, "requests not proxied, expected %d calls, got %d", numEndpoints, numCalls)
 	})
 
 	t.Run("error_additional_endpoints_main_endpoint_error", func(t *testing.T) {
@@ -192,9 +145,7 @@ func TestDebuggerProxyHandler(t *testing.T) {
 			conf.DebuggerProxy.AdditionalEndpoints[srv.URL] = []string{"foo"}
 		}
 		req, err := http.NewRequest("POST", "/some/path", strings.NewReader("body"))
-		if err != nil {
-			t.Fatal(err)
-		}
+		assert.NoError(t, err)
 		receiver := newTestReceiverFromConfig(conf)
 		recorder := httptest.NewRecorder()
 		receiver.debuggerProxyHandler().ServeHTTP(recorder, req)
@@ -223,9 +174,7 @@ func TestDebuggerProxyHandler(t *testing.T) {
 			conf.DebuggerProxy.AdditionalEndpoints[srv.URL] = []string{"foo"}
 		}
 		req, err := http.NewRequest("POST", "/some/path", strings.NewReader("body"))
-		if err != nil {
-			t.Fatal(err)
-		}
+		assert.NoError(t, err)
 		receiver := newTestReceiverFromConfig(conf)
 		recorder := httptest.NewRecorder()
 		receiver.debuggerProxyHandler().ServeHTTP(recorder, req)

--- a/pkg/trace/api/debugger_test.go
+++ b/pkg/trace/api/debugger_test.go
@@ -70,9 +70,6 @@ func TestDebuggerProxyHandler(t *testing.T) {
 			if strings.Contains(ddtags, "orchestrator") {
 				t.Fatalf("ddtags should not contain orchestrator: %v", ddtags)
 			}
-			if strings.Contains(ddtags, "orchestrator") {
-				t.Fatalf("ddtags should not contain orchestrator: %v", ddtags)
-			}
 			for _, tag := range []string{"host", "default_env", "agent_version"} {
 				if !strings.Contains(ddtags, tag) {
 					t.Fatalf("ddtags should contain %s", tag)

--- a/pkg/trace/api/transports.go
+++ b/pkg/trace/api/transports.go
@@ -1,0 +1,139 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package api
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/trace/log"
+	"github.com/DataDog/datadog-agent/pkg/trace/metrics"
+)
+
+// measuringTransport is a transport that emits count and timing metrics
+// prefixed with a prefix and decorated with tags.
+type measuringTransport struct {
+	rt     http.RoundTripper
+	prefix string
+	tags   []string
+}
+
+// newMeasuringTransport creates a measuringTransport wrapping another round
+// tripper emitting metrics.
+func newMeasuringTransport(rt http.RoundTripper, prefix string, tags []string) *measuringTransport {
+	return &measuringTransport{rt, prefix, tags}
+}
+
+// RoundTrip makes an HTTP round trip measuring request count and timing.
+func (m *measuringTransport) RoundTrip(req *http.Request) (rres *http.Response, rerr error) {
+	defer func(start time.Time) {
+		metrics.Count(fmt.Sprintf("%s.proxy_request", m.prefix), 1, m.tags, 1)
+		metrics.Timing(fmt.Sprintf("%s.proxy_request_duration_ms", m.prefix), time.Since(start), m.tags, 1)
+		if rerr != nil {
+			tags := append(m.tags, fmt.Sprintf("error:%s", fmt.Sprintf("%T", rerr)))
+			metrics.Count(fmt.Sprintf("%s.proxy_request_error", m.prefix), 1, tags, 1)
+		}
+	}(time.Now())
+	return m.rt.RoundTrip(req)
+}
+
+// forwardingTransport is an HTTP transport wraps another transport that
+// forwards a request to multiple endpoints. The first target in the targets
+// slice is considered the main endpoint. Only the main endpoints response will
+// be returned to the client. Responses of additional endpoints in the targets
+// slice are dropped. Errors on additional endpoints will be logged.
+type forwardingTransport struct {
+	rt      http.RoundTripper
+	targets []*url.URL
+	keys    []string
+}
+
+// newForwardingTransport creates a new forwardingTransport, wrapping another
+// round tripper with a main endpoint and additional endpoints to forwards the
+// request to.
+func newForwardingTransport(
+	rt http.RoundTripper,
+	mainEndpoint *url.URL,
+	mainEndpointKey string,
+	additionalEndpoints map[string][]string,
+) *forwardingTransport {
+	targets := []*url.URL{mainEndpoint}
+	apiKeys := []string{mainEndpointKey}
+	if additionalEndpoints != nil {
+		for endpoint, keys := range additionalEndpoints {
+			u, err := url.Parse(endpoint)
+			if err != nil {
+				log.Errorf("Error parsing additional intake URL %s: %v", endpoint, err)
+				continue
+			}
+			for _, key := range keys {
+				targets = append(targets, u)
+				apiKeys = append(apiKeys, strings.TrimSpace(key))
+			}
+		}
+	}
+	return &forwardingTransport{rt, targets, apiKeys}
+}
+
+// RoundTrip makes an HTTP round trip forwarding one request to multiple
+// additional endpoints.
+func (m *forwardingTransport) RoundTrip(req *http.Request) (rres *http.Response, rerr error) {
+	setTarget := func(r *http.Request, u *url.URL, apiKey string) {
+		q := r.URL.Query()
+		u.RawQuery = q.Encode()
+		r.Host = u.Host
+		r.URL = u
+		r.Header.Set("DD-API-KEY", apiKey)
+	}
+	if len(m.targets) == 1 {
+		setTarget(req, m.targets[0], m.keys[0])
+		return m.rt.RoundTrip(req)
+	}
+
+	slurp, err := io.ReadAll(req.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	for i, u := range m.targets {
+		newreq := req.Clone(req.Context())
+		newreq.Body = io.NopCloser(bytes.NewReader(slurp))
+		setTarget(newreq, u, m.keys[i])
+		if i == 0 {
+			// given the way we construct the list of targets the main endpoint
+			// will be the first one called, we return its response and error
+			rres, rerr = m.rt.RoundTrip(newreq)
+			continue
+		}
+
+		if resp, err := m.rt.RoundTrip(newreq); err == nil {
+			// we discard responses for all subsequent requests
+			io.Copy(io.Discard, resp.Body) //nolint:errcheck
+			resp.Body.Close()
+		} else {
+			log.Error(err)
+		}
+	}
+	return rres, rerr
+}
+
+// newMeasuringMultiTransport creates a MultiTransport wrapped in a MeasuringTransport.
+func newMeasuringMultiTransport(
+	rt http.RoundTripper,
+	mainEndpoint *url.URL,
+	mainEndpointKey string,
+	additionalEndpoints map[string][]string,
+	metricPrefix string,
+	metricTags []string,
+) http.RoundTripper {
+	forwardingTransport := newForwardingTransport(rt, mainEndpoint, mainEndpointKey, additionalEndpoints)
+	return newMeasuringTransport(forwardingTransport, metricPrefix, metricTags)
+}

--- a/pkg/trace/api/transports.go
+++ b/pkg/trace/api/transports.go
@@ -125,8 +125,8 @@ func (m *forwardingTransport) RoundTrip(req *http.Request) (rres *http.Response,
 	return rres, rerr
 }
 
-// newMeasuringMultiTransport creates a MultiTransport wrapped in a MeasuringTransport.
-func newMeasuringMultiTransport(
+// newMeasuringForwardingTransport creates a forwardingTransport wrapped in a measuringTransport.
+func newMeasuringForwardingTransport(
 	rt http.RoundTripper,
 	mainEndpoint *url.URL,
 	mainEndpointKey string,

--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -283,6 +283,8 @@ type DebuggerProxyConfig struct {
 	DDURL string
 	// APIKey ...
 	APIKey string `json:"-"` // Never marshal this field
+	// AdditionalEndpoints is a map of additional Datadog sites to API keys.
+	AdditionalEndpoints map[string][]string `json:"-"` // Never marshal this field
 }
 
 // AgentConfig handles the interpretation of the configuration (with default

--- a/releasenotes/notes/apm-dynamic-instrumentation-dual-publishing-d6633db34b49d16d.yaml
+++ b/releasenotes/notes/apm-dynamic-instrumentation-dual-publishing-d6633db34b49d16d.yaml
@@ -8,4 +8,4 @@
 ---
 enhancements:
   - |
-    APM: Dynamic instrumentation logs and snapshots can now be shipped to multiple datadog logs intakes.
+    APM: Dynamic instrumentation logs and snapshots can now be shipped to multiple Datadog logs intakes.

--- a/releasenotes/notes/apm-dynamic-instrumentation-dual-publishing-d6633db34b49d16d.yaml
+++ b/releasenotes/notes/apm-dynamic-instrumentation-dual-publishing-d6633db34b49d16d.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    APM: Dynamic instrumentation logs and snapshots can now be shipped to multiple datadog logs intakes.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Updates the Dynamic Instrumentation (DI) reverse proxy api endpoint to allow forwarding payloads to additional endpoints.


### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
Currently the Dynamic Instrumentation reverse proxy does not support forwarding to additional endpoints as many other products do. This leads to extra configuration being necessary to accommodate DI. This PR tries to homogenize the behavior of the DI endpoint with other products.
### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
At the moment the `forwardingTransport` that forwards the single input request to multiple additional endpoints firing all requests in sequence. While not required at this time, there is room for future optimization by making this concurrent and optionally not waiting for the response of the additional endpoints because their responses are not returned to the client anyway.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Tested this by running trace-agent locally and verifying that it works
1. Without any custom `*_DEBUGGER_*` config
2. With single custom endpoint
3. With additional endpoints

Once this is merged and a 7.45 RC is deployed to staging clusters, I will verify it there as well.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
