### PR TITLE
[CWS] remove unused code around process scoping of variables

### DIFF
--- a/pkg/security/resolvers/process/resolver.go
+++ b/pkg/security/resolvers/process/resolver.go
@@ -37,9 +37,7 @@ import (
 	spath "github.com/DataDog/datadog-agent/pkg/security/resolvers/path"
 	stime "github.com/DataDog/datadog-agent/pkg/security/resolvers/time"
 	"github.com/DataDog/datadog-agent/pkg/security/resolvers/usergroup"
-	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
-	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
 	"github.com/DataDog/datadog-agent/pkg/security/seclog"
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
 )
@@ -1232,18 +1230,6 @@ func (p *Resolver) Walk(callback func(entry *model.ProcessCacheEntry)) {
 	for _, entry := range p.entryCache {
 		callback(entry)
 	}
-}
-
-// NewProcessVariables returns a provider for variables attached to a process cache entry
-func (p *Resolver) NewProcessVariables(scoper func(ctx *eval.Context) *model.ProcessCacheEntry) rules.VariableProvider {
-	var variables *eval.ScopedVariables[*model.ProcessCacheEntry]
-	variables = eval.NewScopedVariables(scoper, func(key *model.ProcessCacheEntry) {
-		key.SetReleaseCallback(func() {
-			variables.ReleaseVariable(key)
-		})
-	})
-
-	return variables
 }
 
 // NewResolver returns a new process resolver

--- a/pkg/security/secl/compiler/eval/variables.go
+++ b/pkg/security/secl/compiler/eval/variables.go
@@ -537,11 +537,6 @@ func (v *ScopedVariables[T]) GetVariable(name string, value interface{}) (Variab
 	}
 }
 
-// ReleaseVariable releases a scoped variable
-func (v *ScopedVariables[T]) ReleaseVariable(key T) {
-	delete(v.vars, key)
-}
-
 // NewScopedVariables returns a new set of scope variables
 func NewScopedVariables[T comparable](scoper Scoper[T], onNewVariables func(T)) *ScopedVariables[T] {
 	return &ScopedVariables[T]{

--- a/pkg/security/secl/compiler/eval/variables.go
+++ b/pkg/security/secl/compiler/eval/variables.go
@@ -484,9 +484,10 @@ func (v *ScopedVariables[T]) GetVariable(name string, value interface{}) (Variab
 		key := v.scoper(ctx)
 		vars := v.vars[key]
 		if vars == nil {
-			v.vars[key] = &Variables{}
+			vars = &Variables{}
+			v.vars[key] = vars
 		}
-		v.vars[key].Set(name, value)
+		vars.Set(name, value)
 		return nil
 	}
 

--- a/pkg/security/secl/compiler/eval/variables.go
+++ b/pkg/security/secl/compiler/eval/variables.go
@@ -470,9 +470,8 @@ func (v *Variables) Set(name string, value interface{}) bool {
 
 // ScopedVariables holds a set of scoped variables
 type ScopedVariables[T comparable] struct {
-	scoper         Scoper[T]
-	onNewVariables func(T)
-	vars           map[T]*Variables
+	scoper Scoper[T]
+	vars   map[T]*Variables
 }
 
 // GetVariable returns new variable of the type of the specified value
@@ -485,13 +484,9 @@ func (v *ScopedVariables[T]) GetVariable(name string, value interface{}) (Variab
 		key := v.scoper(ctx)
 		vars := v.vars[key]
 		if vars == nil {
-			vars = &Variables{}
-			v.vars[key] = vars
-			if v.onNewVariables != nil {
-				v.onNewVariables(key)
-			}
+			v.vars[key] = &Variables{}
 		}
-		vars.Set(name, value)
+		v.vars[key].Set(name, value)
 		return nil
 	}
 
@@ -538,10 +533,9 @@ func (v *ScopedVariables[T]) GetVariable(name string, value interface{}) (Variab
 }
 
 // NewScopedVariables returns a new set of scope variables
-func NewScopedVariables[T comparable](scoper Scoper[T], onNewVariables func(T)) *ScopedVariables[T] {
+func NewScopedVariables[T comparable](scoper Scoper[T]) *ScopedVariables[T] {
 	return &ScopedVariables[T]{
-		scoper:         scoper,
-		onNewVariables: onNewVariables,
-		vars:           make(map[T]*Variables),
+		scoper: scoper,
+		vars:   make(map[T]*Variables),
 	}
 }

--- a/pkg/security/secl/rules/opts.go
+++ b/pkg/security/secl/rules/opts.go
@@ -67,7 +67,7 @@ func NewEvalOpts(eventTypeEnabled map[eval.EventType]bool) (*Opts, *eval.Opts) {
 			"process": func() VariableProvider {
 				return eval.NewScopedVariables(func(ctx *eval.Context) *model.ProcessContext {
 					return ctx.Event.(*model.Event).ProcessContext
-				}, nil)
+				})
 			},
 		})
 


### PR DESCRIPTION
### What does this PR do?

This code is unused, this PR removes it

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
