### PR TITLE
[CWS] Adding rule tags to ruleset_loaded custom event

### DIFF
--- a/pkg/security/module/policy_monitor.go
+++ b/pkg/security/module/policy_monitor.go
@@ -140,11 +140,12 @@ func ReportRuleSetLoaded(sender EventSender, statsdClient statsd.ClientInterface
 // RuleLoaded defines a loaded rule
 // easyjson:json
 type RuleState struct {
-	ID         string `json:"id"`
-	Version    string `json:"version,omitempty"`
-	Expression string `json:"expression"`
-	Status     string `json:"status"`
-	Message    string `json:"message,omitempty"`
+	ID         string            `json:"id"`
+	Version    string            `json:"version,omitempty"`
+	Expression string            `json:"expression"`
+	Status     string            `json:"status"`
+	Message    string            `json:"message,omitempty"`
+	Tags       map[string]string `json:"tags,omitempty"`
 }
 
 // PolicyState is used to report policy was loaded
@@ -178,6 +179,7 @@ func RuleStateFromDefinition(def *rules.RuleDefinition, status string, message s
 		Expression: def.Expression,
 		Status:     status,
 		Message:    message,
+		Tags:       def.Tags,
 	}
 }
 

--- a/pkg/security/module/policy_monitor_easyjson.go
+++ b/pkg/security/module/policy_monitor_easyjson.go
@@ -158,6 +158,26 @@ func easyjson6151911dDecodeGithubComDataDogDatadogAgentPkgSecurityModule1(in *jl
 			out.Status = string(in.String())
 		case "message":
 			out.Message = string(in.String())
+		case "tags":
+			if in.IsNull() {
+				in.Skip()
+			} else {
+				in.Delim('{')
+				if !in.IsDelim('}') {
+					out.Tags = make(map[string]string)
+				} else {
+					out.Tags = nil
+				}
+				for !in.IsDelim('}') {
+					key := string(in.String())
+					in.WantColon()
+					var v4 string
+					v4 = string(in.String())
+					(out.Tags)[key] = v4
+					in.WantComma()
+				}
+				in.Delim('}')
+			}
 		default:
 			in.SkipRecursive()
 		}
@@ -196,6 +216,25 @@ func easyjson6151911dEncodeGithubComDataDogDatadogAgentPkgSecurityModule1(out *j
 		const prefix string = ",\"message\":"
 		out.RawString(prefix)
 		out.String(string(in.Message))
+	}
+	if len(in.Tags) != 0 {
+		const prefix string = ",\"tags\":"
+		out.RawString(prefix)
+		{
+			out.RawByte('{')
+			v5First := true
+			for v5Name, v5Value := range in.Tags {
+				if v5First {
+					v5First = false
+				} else {
+					out.RawByte(',')
+				}
+				out.String(string(v5Name))
+				out.RawByte(':')
+				out.String(string(v5Value))
+			}
+			out.RawByte('}')
+		}
 	}
 	out.RawByte('}')
 }
@@ -250,17 +289,17 @@ func easyjson6151911dDecodeGithubComDataDogDatadogAgentPkgSecurityModule2(in *jl
 					out.Rules = (out.Rules)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v4 *RuleState
+					var v6 *RuleState
 					if in.IsNull() {
 						in.Skip()
-						v4 = nil
+						v6 = nil
 					} else {
-						if v4 == nil {
-							v4 = new(RuleState)
+						if v6 == nil {
+							v6 = new(RuleState)
 						}
-						(*v4).UnmarshalEasyJSON(in)
+						(*v6).UnmarshalEasyJSON(in)
 					}
-					out.Rules = append(out.Rules, v4)
+					out.Rules = append(out.Rules, v6)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -301,14 +340,14 @@ func easyjson6151911dEncodeGithubComDataDogDatadogAgentPkgSecurityModule2(out *j
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v5, v6 := range in.Rules {
-				if v5 > 0 {
+			for v7, v8 := range in.Rules {
+				if v7 > 0 {
 					out.RawByte(',')
 				}
-				if v6 == nil {
+				if v8 == nil {
 					out.RawString("null")
 				} else {
-					(*v6).MarshalEasyJSON(out)
+					(*v8).MarshalEasyJSON(out)
 				}
 			}
 			out.RawByte(']')


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
Adds rule tags (e.g. `ruleset:threat_score`) to the ruleset_loaded security event custom event

<img width="930" alt="image" src="https://user-images.githubusercontent.com/24510443/229561602-9f58c76d-e6ab-4dee-8ad9-9d78524ef9ae.png">

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
