### PR TITLE
Fix panic on capture/replay shutdown because of failed start

### DIFF
--- a/comp/dogstatsd/replay/capture.go
+++ b/comp/dogstatsd/replay/capture.go
@@ -99,6 +99,9 @@ func (tc *trafficCapture) Start(p string, d time.Duration, compressed bool) (str
 func (tc *trafficCapture) Stop() {
 	tc.Lock()
 	defer tc.Unlock()
+	if tc.writer == nil {
+		return
+	}
 
 	tc.writer.StopCapture()
 }

--- a/comp/dogstatsd/server/server.go
+++ b/comp/dogstatsd/server/server.go
@@ -403,6 +403,9 @@ func (s *server) Start(demultiplexer aggregator.Demultiplexer) error {
 }
 
 func (s *server) Stop() {
+	if !s.IsRunning() {
+		return
+	}
 	close(s.stopChan)
 	for _, l := range s.listeners {
 		l.Stop()


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

If 2 agents are running and competing for port (api server, dogstatsd, etc) the second agent will fail to start. During shutdown, it attempted to stop the capture/replay component even though it was never started. 

[This check fixes the panic](https://github.com/DataDog/datadog-agent/pull/16415/files#diff-8f03a0673456a958337442b14761fa9846a7fafda02da48d0469f5130e652697R102)

[This check is for good measure ](https://github.com/DataDog/datadog-agent/pull/16415/files#diff-3dcb0167bd80d5725682c1bf4cd0a237b1bf633f7a6c3580f11ce22102634f9dR406)(would have also prevented the panic) - but we should not try to stop a component that is not running. 


<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

FIx edge case bug.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

1. Start the agent
2. While the agent is running, start another agent 
3. When it shuts down immediately due to port conflicts, it should not panic. 

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
