### PR TITLE
trace/agent: improve the reliability of the processing loop

### DIFF
--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -466,7 +466,7 @@ func (a *Agent) ProcessStats(in pb.ClientStatsPayload, lang, tracerVersion strin
 	a.ClientStatsAggregator.In <- a.processStats(in, lang, tracerVersion)
 }
 
-func isManualUserDrop(priority sampler.SamplingPriority, pt traceutil.ProcessedTrace) bool {
+func isManualUserDrop(priority sampler.SamplingPriority, pt *traceutil.ProcessedTrace) bool {
 	if priority != sampler.PriorityUserDrop {
 		return false
 	}
@@ -498,9 +498,7 @@ func (a *Agent) sample(now time.Time, ts *info.TagStats, pt *traceutil.Processed
 	}
 
 	sampled := a.runSamplers(now, pt, hasPriority)
-	if !sampled {
-		pt.TraceChunk.DroppedTrace = true
-	}
+	pt.TraceChunk.DroppedTrace = !sampled
 	numEvents, numExtracted := a.EventProcessor.Process(pt)
 
 	ts.EventsExtracted.Add(numExtracted)

--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -485,6 +485,8 @@ func isManualUserDrop(priority sampler.SamplingPriority, pt *traceutil.Processed
 }
 
 // sample reports the number of events found in pt and whether the chunk should be kept as a trace.
+// sample does a semi-deep copy of pt to avoid making accidental changes to which spans are in the trace.
+// But any changes made directly to the spans, such as setting tags, etc. is not allowed.
 func (a *Agent) sample(now time.Time, ts *info.TagStats, pt *traceutil.ProcessedTrace) (numEvents int64, keep bool, retPt *traceutil.ProcessedTrace) {
 	pt = pt.Clone()
 	priority, hasPriority := sampler.GetSamplingPriority(pt.TraceChunk)

--- a/pkg/trace/agent/agent_test.go
+++ b/pkg/trace/agent/agent_test.go
@@ -947,7 +947,7 @@ func TestSampling(t *testing.T) {
 }
 
 func TestSample(t *testing.T) {
-	cfg := &config.AgentConfig{TargetTPS: 5, ErrorTPS: 10, Features: make(map[string]struct{})}
+	cfg := &config.AgentConfig{TargetTPS: 5, ErrorTPS: 1000, Features: make(map[string]struct{})}
 	a := &Agent{
 		NoPrioritySampler: sampler.NewNoPrioritySampler(cfg),
 		ErrorsSampler:     sampler.NewErrorsSampler(cfg),
@@ -956,13 +956,13 @@ func TestSample(t *testing.T) {
 		EventProcessor:    newEventProcessor(cfg),
 		conf:              cfg,
 	}
-	genSpan := func(decisionMaker string, priority sampler.SamplingPriority) traceutil.ProcessedTrace {
+	genSpan := func(decisionMaker string, priority sampler.SamplingPriority, err int32) traceutil.ProcessedTrace {
 		root := &pb.Span{
 			Service:  "serv1",
 			Start:    time.Now().UnixNano(),
 			Duration: (100 * time.Millisecond).Nanoseconds(),
 			Metrics:  map[string]float64{"_top_level": 1},
-			Error:    1,
+			Error:    err, // If 1, the Error Sampler will keep the trace, if 0, it will not be sampled
 			Meta:     map[string]string{},
 		}
 		if decisionMaker != "" {
@@ -973,44 +973,70 @@ func TestSample(t *testing.T) {
 		return pt
 	}
 	tests := map[string]struct {
-		trace              traceutil.ProcessedTrace
-		sampledNoFeature   bool
-		sampledWithFeature bool
+		trace           traceutil.ProcessedTrace
+		keep            bool
+		keepWithFeature bool
+		dropped         bool // whether the trace was dropped by sampling
 	}{
 		"userdrop-error-no-dm-sampled": {
-			trace:              genSpan("", sampler.PriorityUserDrop),
-			sampledNoFeature:   false,
-			sampledWithFeature: true,
+			trace:           genSpan("", sampler.PriorityUserDrop, 1),
+			keep:            false,
+			keepWithFeature: true,
+			dropped:         false,
 		},
 		"userdrop-error-manual-dm-unsampled": {
-			trace:              genSpan("-4", sampler.PriorityUserDrop),
-			sampledNoFeature:   false,
-			sampledWithFeature: false,
+			trace:           genSpan("-4", sampler.PriorityUserDrop, 1),
+			keep:            false,
+			keepWithFeature: false,
+			dropped:         false,
 		},
 		"userdrop-error-agent-dm-sampled": {
-			trace:              genSpan("-1", sampler.PriorityUserDrop),
-			sampledNoFeature:   false,
-			sampledWithFeature: true,
+			trace:           genSpan("-1", sampler.PriorityUserDrop, 1),
+			keep:            false,
+			keepWithFeature: true,
+			dropped:         false,
 		},
 		"userkeep-error-no-dm-sampled": {
-			trace:              genSpan("", sampler.PriorityUserKeep),
-			sampledNoFeature:   true,
-			sampledWithFeature: true,
+			trace:           genSpan("", sampler.PriorityUserKeep, 1),
+			keep:            true,
+			keepWithFeature: true,
+			dropped:         false,
 		},
 		"userkeep-error-agent-dm-sampled": {
-			trace:              genSpan("-1", sampler.PriorityUserKeep),
-			sampledNoFeature:   true,
-			sampledWithFeature: true,
+			trace:           genSpan("-1", sampler.PriorityUserKeep, 1),
+			keep:            true,
+			keepWithFeature: true,
+			dropped:         false,
+		},
+		"autodrop-sampled": {
+			trace:           genSpan("", sampler.PriorityAutoDrop, 1),
+			keep:            true,
+			keepWithFeature: true,
+			dropped:         false,
+		},
+		"autodrop-not-sampled": {
+			trace:           genSpan("", sampler.PriorityAutoDrop, 0),
+			keep:            false,
+			keepWithFeature: false,
+			dropped:         true,
 		},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			_, keep, _ := a.sample(time.Now(), info.NewReceiverStats().GetTagStats(info.Tags{}), tt.trace)
-			assert.Equal(t, tt.sampledNoFeature, keep)
+			before := new(pb.TraceChunk) // make sure tt.trace.TraceChunk never changes
+			*before = *tt.trace.TraceChunk
+			chunkCopy := new(pb.TraceChunk)
+			*chunkCopy = *tt.trace.TraceChunk
+			_, keep := a.sample(time.Now(), info.NewReceiverStats().GetTagStats(info.Tags{}), chunkCopy, tt.trace)
+			assert.Equal(t, tt.keep, keep)
+			assert.Equal(t, tt.dropped, chunkCopy.DroppedTrace)
+			assert.Equal(t, before, tt.trace.TraceChunk) // make sure tt.trace.TraceChunk didn't change
 			cfg.Features["error_rare_sample_tracer_drop"] = struct{}{}
 			defer delete(cfg.Features, "error_rare_sample_tracer_drop")
-			_, keep, _ = a.sample(time.Now(), info.NewReceiverStats().GetTagStats(info.Tags{}), tt.trace)
-			assert.Equal(t, tt.sampledWithFeature, keep)
+			_, keep = a.sample(time.Now(), info.NewReceiverStats().GetTagStats(info.Tags{}), chunkCopy, tt.trace)
+			assert.Equal(t, tt.keepWithFeature, keep)
+			assert.Equal(t, before, tt.trace.TraceChunk) // make sure tt.trace.TraceChunk didn't change
+			assert.Equal(t, tt.dropped, chunkCopy.DroppedTrace)
 		})
 	}
 }
@@ -1630,11 +1656,18 @@ func TestSampleWithPriorityNone(t *testing.T) {
 	defer cancel()
 
 	span := testutil.RandomSpan()
-	numEvents, keep, _ := agnt.sample(time.Now(), info.NewReceiverStats().GetTagStats(info.Tags{}), traceutil.ProcessedTrace{
+	pt := traceutil.ProcessedTrace{
 		TraceChunk: testutil.TraceChunkWithSpan(span),
 		Root:       span,
-	})
+	}
+	before := new(pb.TraceChunk)
+	*before = *pt.TraceChunk
+	chunkCopy := new(pb.TraceChunk)
+	*chunkCopy = *pt.TraceChunk
+	numEvents, keep := agnt.sample(time.Now(), info.NewReceiverStats().GetTagStats(info.Tags{}), chunkCopy, pt)
 	assert.True(t, keep) // Score Sampler should keep the trace.
+	assert.False(t, chunkCopy.DroppedTrace)
+	assert.Equal(t, before, pt.TraceChunk)
 	assert.EqualValues(t, numEvents, 0)
 }
 

--- a/pkg/trace/event/processor.go
+++ b/pkg/trace/event/processor.go
@@ -8,6 +8,7 @@ package event
 import (
 	"github.com/DataDog/datadog-agent/pkg/trace/pb"
 	"github.com/DataDog/datadog-agent/pkg/trace/sampler"
+	"github.com/DataDog/datadog-agent/pkg/trace/traceutil"
 )
 
 // Processor is responsible for all the logic surrounding extraction and sampling of APM events from processed traces.
@@ -50,13 +51,13 @@ func (p *Processor) Stop() {
 
 // Process takes a processed trace, extracts events from it and samples them, returning a collection of
 // sampled events along with the total count of extracted events.
-func (p *Processor) Process(root *pb.Span, t *pb.TraceChunk) (numEvents, numExtracted int64) {
-	clientSampleRate := sampler.GetClientRate(root)
-	preSampleRate := sampler.GetPreSampleRate(root)
-	priority := sampler.SamplingPriority(t.Priority)
+func (p *Processor) Process(pt traceutil.ProcessedTrace) (numEvents, numExtracted int64) {
+	clientSampleRate := sampler.GetClientRate(pt.Root)
+	preSampleRate := sampler.GetPreSampleRate(pt.Root)
+	priority := sampler.SamplingPriority(pt.TraceChunk.Priority)
 	events := []*pb.Span{}
 
-	for _, span := range t.Spans {
+	for _, span := range pt.TraceChunk.Spans {
 		extractionRate, ok := p.extract(span, priority)
 		if !ok {
 			continue
@@ -77,14 +78,14 @@ func (p *Processor) Process(root *pb.Span, t *pb.TraceChunk) (numEvents, numExtr
 		sampler.SetPreSampleRate(span, preSampleRate)
 		sampler.SetEventExtractionRate(span, extractionRate)
 		sampler.SetAnalyzedSpan(span)
-		if t.DroppedTrace {
+		if pt.TraceChunk.DroppedTrace {
 			events = append(events, span)
 		}
 		numEvents++
 	}
-	if t.DroppedTrace {
+	if pt.TraceChunk.DroppedTrace {
 		// we are not keeping anything out of this trace, except the events
-		t.Spans = events
+		pt.TraceChunk.Spans = events
 	}
 	return numEvents, numExtracted
 }

--- a/pkg/trace/event/processor.go
+++ b/pkg/trace/event/processor.go
@@ -51,7 +51,7 @@ func (p *Processor) Stop() {
 
 // Process takes a processed trace, extracts events from it and samples them, returning a collection of
 // sampled events along with the total count of extracted events.
-func (p *Processor) Process(pt traceutil.ProcessedTrace) (numEvents, numExtracted int64) {
+func (p *Processor) Process(pt *traceutil.ProcessedTrace) (numEvents, numExtracted int64) {
 	clientSampleRate := sampler.GetClientRate(pt.Root)
 	preSampleRate := sampler.GetPreSampleRate(pt.Root)
 	priority := sampler.SamplingPriority(pt.TraceChunk.Priority)

--- a/pkg/trace/event/processor_test.go
+++ b/pkg/trace/event/processor_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/trace/pb"
 	"github.com/DataDog/datadog-agent/pkg/trace/sampler"
 	"github.com/DataDog/datadog-agent/pkg/trace/testutil"
+	"github.com/DataDog/datadog-agent/pkg/trace/traceutil"
 )
 
 func TestProcessor(t *testing.T) {
@@ -95,7 +96,11 @@ func TestProcessor(t *testing.T) {
 			testChunk.DroppedTrace = test.droppedTrace
 
 			p.Start()
-			numEvents, extracted := p.Process(root, testChunk)
+			pt := &traceutil.ProcessedTrace{
+				TraceChunk: testChunk,
+				Root:       root,
+			}
+			numEvents, extracted := p.Process(pt)
 			p.Stop()
 
 			expectedExtracted := float64(numSpans) * test.expectedExtractedPct

--- a/pkg/trace/traceutil/processed_trace.go
+++ b/pkg/trace/traceutil/processed_trace.go
@@ -18,3 +18,15 @@ type ProcessedTrace struct {
 	TracerHostname         string
 	ClientDroppedP0sWeight float64
 }
+
+func (p *ProcessedTrace) Clone() *ProcessedTrace {
+	pClone := new(ProcessedTrace)
+	*pClone = *p
+	c := new(pb.TraceChunk)
+	*c = *p.TraceChunk
+	pClone.TraceChunk = c
+	r := new(pb.Span)
+	*r = *p.Root
+	pClone.Root = r
+	return pClone
+}

--- a/pkg/trace/traceutil/processed_trace.go
+++ b/pkg/trace/traceutil/processed_trace.go
@@ -19,14 +19,35 @@ type ProcessedTrace struct {
 	ClientDroppedP0sWeight float64
 }
 
-func (p *ProcessedTrace) Clone() *ProcessedTrace {
-	pClone := new(ProcessedTrace)
-	*pClone = *p
-	c := new(pb.TraceChunk)
-	*c = *p.TraceChunk
-	pClone.TraceChunk = c
-	r := new(pb.Span)
-	*r = *p.Root
-	pClone.Root = r
-	return pClone
+// Clone creates a copy of ProcessedTrace, cloning p, p.TraceChunk, and p.Root. This means it is
+// safe to modify the returned ProcessedTrace's (pt's) fields along with fields in
+// pt.TraceChunk and fields in pt.Root.
+//
+// The most important consequence of this is that the TraceChunk's Spans field can be assigned,
+// *BUT* the Spans value itself should not be modified. i.e. This is ok:
+//
+//	pt2 := pt.Clone()
+//	pt2.TraceChunk.Spans = make([]*pb.Span)
+//
+// but this is NOT ok:
+//
+//	pt2 := pt.Clone()
+//	pt2.TraceChunk.Spans[0] = &pb.Span{} // This will be visible in pt.
+func (pt *ProcessedTrace) Clone() *ProcessedTrace {
+	if pt == nil {
+		return nil
+	}
+	ptClone := new(ProcessedTrace)
+	*ptClone = *pt
+	if pt.TraceChunk != nil {
+		c := new(pb.TraceChunk)
+		*c = *pt.TraceChunk
+		ptClone.TraceChunk = c
+	}
+	if pt.Root != nil {
+		r := new(pb.Span)
+		*r = *pt.Root
+		ptClone.Root = r
+	}
+	return ptClone
 }

--- a/pkg/trace/traceutil/processed_trace_test.go
+++ b/pkg/trace/traceutil/processed_trace_test.go
@@ -1,0 +1,39 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package traceutil
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/trace/pb"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClone(t *testing.T) {
+	root := &pb.Span{Name: "root"}
+	span1 := &pb.Span{Name: "span1"}
+	span2 := &pb.Span{Name: "span2"}
+	spans := []*pb.Span{root, span1, span2}
+	pt := &ProcessedTrace{
+		TraceChunk: &pb.TraceChunk{Spans: spans},
+		Root:       root,
+	}
+
+	clone := pt.Clone()
+
+	clone.TraceChunk = &pb.TraceChunk{Spans: []*pb.Span{root, span2}} // remove span1
+	assert.Len(t, clone.TraceChunk.Spans, 2)
+	assert.Len(t, pt.TraceChunk.Spans, 3) // TraceChunk in pt shouldn't change
+
+	clone.Root.Name = "root-changed"
+	assert.Equal(t, "root-changed", clone.Root.Name)
+	assert.Equal(t, "root", pt.Root.Name) // Root in pt shouldn't change
+
+	clone.TraceChunk.Spans[1].Name = "span2-changed"
+	assert.Equal(t, "span2-changed", clone.TraceChunk.Spans[1].Name)
+	assert.Equal(t, "span2-changed", pt.TraceChunk.Spans[2].Name) // span2 in pt should change as we're doing a semi-deep copy
+}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This does some refactoring to simplify the code and make it safer to change going forward. It eliminates the need of the `filteredChunk` type that floats around the main loop for a small amount of time. There should be no behavior change, but review carefully, and suggest additional testing if there are areas that you're unsure about when reviewing.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

The main loop (`Process`) is becoming unwieldy, and there are several areas of the code where we perform deep copies of the trace chunk to avoid inadvertently changing the data. Doing these refactors in small pieces is less likely to introduce bugs than doing a major rewrite all at once.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

As with any refactor, there's a risk that this changes introduces a bug by accidentally changing some unknown behavior. Reviewers should look very carefully and help identify if additional tests would be useful to increase confidence.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Additional unit tests were added to ensure that this code is covered by tests. No manual testing necessary.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
