### PR TITLE
Add `podman_db_path` config for the rootless podman

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -631,6 +631,9 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("container_env_as_tags", map[string]string{})
 	config.BindEnvAndSetDefault("container_labels_as_tags", map[string]string{})
 
+	// Podman
+	config.BindEnvAndSetDefault("podman_db_path", "/var/lib/containers/storage/libpod/bolt_state.db")
+
 	// Kubernetes
 	config.BindEnvAndSetDefault("kubernetes_kubelet_host", "")
 	config.BindEnvAndSetDefault("kubernetes_kubelet_nodename", "")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -26,7 +26,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/secrets"
 	"github.com/DataDog/datadog-agent/pkg/util/hostname/validate"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"github.com/DataDog/datadog-agent/pkg/util/podman"
 	"github.com/DataDog/datadog-agent/pkg/version"
 
 	"gopkg.in/yaml.v2"
@@ -633,7 +632,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("container_labels_as_tags", map[string]string{})
 
 	// Podman
-	config.BindEnvAndSetDefault("podman_db_path", podman.DefaultDBPath)
+	config.BindEnvAndSetDefault("podman_db_path", "/var/lib/containers/storage/libpod/bolt_state.db")
 
 	// Kubernetes
 	config.BindEnvAndSetDefault("kubernetes_kubelet_host", "")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -26,6 +26,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/secrets"
 	"github.com/DataDog/datadog-agent/pkg/util/hostname/validate"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/util/podman"
 	"github.com/DataDog/datadog-agent/pkg/version"
 
 	"gopkg.in/yaml.v2"
@@ -632,7 +633,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("container_labels_as_tags", map[string]string{})
 
 	// Podman
-	config.BindEnvAndSetDefault("podman_db_path", "/var/lib/containers/storage/libpod/bolt_state.db")
+	config.BindEnvAndSetDefault("podman_db_path", podman.DefaultDBPath)
 
 	// Kubernetes
 	config.BindEnvAndSetDefault("kubernetes_kubelet_host", "")

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -2373,6 +2373,11 @@ api_key:
   #
   # listen_address: /var/vcap/data/garden/garden.sock
 
+## @param podman_db_path - string - optional - default: /var/lib/containers/storage/libpod/bolt_state.db
+## Settings for Podman DB that Datadog Agent collects container metrics.
+#
+# podman_db_path: /var/lib/containers/storage/libpod/bolt_state.db
+
 {{ end -}}
 {{- if .ClusterAgent }}
 

--- a/pkg/util/podman/container.go
+++ b/pkg/util/podman/container.go
@@ -3,9 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build podman
-// +build podman
-
 package podman
 
 import (

--- a/pkg/util/podman/container.go
+++ b/pkg/util/podman/container.go
@@ -3,6 +3,9 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build podman
+// +build podman
+
 package podman
 
 import (

--- a/pkg/util/podman/db_client.go
+++ b/pkg/util/podman/db_client.go
@@ -40,13 +40,11 @@ import (
 )
 
 const (
-	// DefaultDBPath is the default path of podman's state database
-	DefaultDBPath = "/var/lib/containers/storage/libpod/bolt_state.db"
-	ctrName       = "ctr"
-	allCtrsName   = "all-ctrs"
-	configName    = "config"
-	stateName     = "state"
-	openTimeout   = 30 * time.Second
+	ctrName     = "ctr"
+	allCtrsName = "all-ctrs"
+	configName  = "config"
+	stateName   = "state"
+	openTimeout = 30 * time.Second
 )
 
 var (
@@ -61,13 +59,8 @@ type DBClient struct {
 	DBPath string
 }
 
-// NewDBClient returns a DB client that uses the DB stored in dbPath. If dbPath
-// is empty, it uses the default path.
+// NewDBClient returns a DB client that uses the DB stored in dbPath. 
 func NewDBClient(dbPath string) *DBClient {
-	if dbPath == "" {
-		dbPath = DefaultDBPath
-	}
-
 	return &DBClient{
 		DBPath: dbPath,
 	}

--- a/pkg/util/podman/db_client.go
+++ b/pkg/util/podman/db_client.go
@@ -3,9 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build podman
-// +build podman
-
 package podman
 
 // The podman go package brings a lot of dependencies because it includes the

--- a/pkg/util/podman/db_client.go
+++ b/pkg/util/podman/db_client.go
@@ -3,6 +3,9 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build podman
+// +build podman
+
 package podman
 
 // The podman go package brings a lot of dependencies because it includes the

--- a/pkg/util/podman/db_client.go
+++ b/pkg/util/podman/db_client.go
@@ -59,7 +59,7 @@ type DBClient struct {
 	DBPath string
 }
 
-// NewDBClient returns a DB client that uses the DB stored in dbPath. 
+// NewDBClient returns a DB client that uses the DB stored in dbPath.
 func NewDBClient(dbPath string) *DBClient {
 	return &DBClient{
 		DBPath: dbPath,

--- a/pkg/workloadmeta/collectors/internal/podman/podman.go
+++ b/pkg/workloadmeta/collectors/internal/podman/podman.go
@@ -50,7 +50,7 @@ func (c *collector) Start(_ context.Context, store workloadmeta.Store) error {
 		return dderrors.NewDisabled(componentName, "Podman not detected")
 	}
 
-	c.client = podman.NewDBClient(podman.DefaultDBPath)
+	c.client = podman.NewDBClient(config.Datadog.GetString("podman_db_path"))
 	c.store = store
 
 	return nil

--- a/releasenotes/notes/configurable-podman-db-path-83d7039e316ea96c.yaml
+++ b/releasenotes/notes/configurable-podman-db-path-83d7039e316ea96c.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Make Podman DB path configurable for rootless environment.
+    Now we can set ``$HOME/.local/share/containers/storage/libpod/bolt_state.db``.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Now we can set the arbitrary file path to `bolt_state.db`, e.g., `$HOME/.local/share/containers/storage/libpod/bolt_state.db`

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

In the case that we install Datadog Agent on the host (not container) and use the rootless container environment with podman, setting the arbitrary file path to the podman db path would be useful.

> In rootless Podman certain fields in /etc/containers/storage.conf are ignored.
https://github.com/containers/podman/blob/main/docs/tutorials/rootless_tutorial.md#storageconf

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

The default path is still `/var/lib/containers/storage/libpod/bolt_state.db`.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

None.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

When `podman_db_path` is set to the correct path.

```shell
sudo rm /var/log/datadog/agent.log && stat /var/log/datadog/agent.log
stat: cannot statx '/var/log/datadog/agent.log': No such file or directory

sudo ~/workspace/ddbuild/opt/datadog-agent/bin/agent/agent version -c ~/workspace/ddbuild/datadog.yaml && date
Agent 7.45.0-devel - Meta: git.233.84c6825 - Commit: 84c6825 - Serialization version: v5.0.80 - Go version: go1.19.7
Tue Apr  4 04:24:22 UTC 2023

cat ~/workspace/ddbuild/datadog.yaml
api_key: xxx
podman_db_path: /home/ubuntu/bolt_state.db
log_to_console: false

sudo ln -s /var/lib/containers/storage/libpod/bolt_state.db ~/

find ~/bolt_state.db -ls
   258347      0 lrwxrwxrwx   1 root     root           48 Apr  4 04:24 /home/ubuntu/bolt_state.db -> /var/lib/containers/storage/libpod/bolt_state.db

sudo ~/workspace/ddbuild/opt/datadog-agent/bin/agent/agent run -c ~/workspace/ddbuild/datadog.yaml &
[1] 3813979

grep podman /var/log/datadog/agent.log
2023-04-04 04:24:52 UTC | CORE | INFO | (pkg/util/log/log.go:590 in func1) | 3 Features detected from environment: containerd,podman,docker
2023-04-04 04:24:52 UTC | CORE | INFO | (pkg/workloadmeta/store.go:414 in startCandidates) | workloadmeta collector "podman" started successfully
```

When `podman_db_path` is NOT set to the correct path.

```shell
sudo rm /var/log/datadog/agent.log && stat /var/log/datadog/agent.log
stat: cannot statx '/var/log/datadog/agent.log': No such file or directory

sudo ~/workspace/ddbuild/opt/datadog-agent/bin/agent/agent version -c ~/workspace/ddbuild/datadog.yaml && date
Agent 7.45.0-devel - Meta: git.233.84c6825 - Commit: 84c6825 - Serialization version: v5.0.80 - Go version: go1.19.7
Tue Apr  4 04:22:23 UTC 2023

cat ~/workspace/ddbuild/datadog.yaml
api_key: xxx
podman_db_path: /home/ubuntu/bolt_state.db
log_to_console: false

sudo ~/workspace/ddbuild/opt/datadog-agent/bin/agent/agent run -c ~/workspace/ddbuild/datadog.yaml &
[1] 3813594

grep podman /var/log/datadog/agent.log
2023-04-04 04:22:51 UTC | CORE | INFO | (pkg/util/log/log.go:590 in func1) | 3 Features detected from environment: docker,containerd,podman
2023-04-04 04:22:51 UTC | CORE | INFO | (pkg/workloadmeta/store.go:414 in startCandidates) | workloadmeta collector "podman" started successfully
2023-04-04 04:22:51 UTC | CORE | WARN | (pkg/workloadmeta/store.go:459 in func1) | error pulling from collector "podman": error opening database /home/ubuntu/bolt_state.db, err: open /home/ubuntu/bolt_state.db: no such file or directory
```

When `podman_db_path` is empty.

```bash
cat ~/workspace/datadog-agent/bin/agent/dist/datadog.yaml
api_key: xxx
log_to_console: false

sudo ~/workspace/datadog-agent/bin/agent/agent run -c ~/workspace/datadog-agent/bin/agent/dist/datadog.yaml &
[1] 3825875

sudo ~/workspace/datadog-agent/bin/agent/agent config -c ~/workspace/datadog-agent/bin/agent/dist/datadog.yaml | grep podman_db_path
podman_db_path: /var/lib/containers/storage/libpod/bolt_state.db

sudo ~/workspace/datadog-agent/bin/agent/agent version -c ~/workspace/datadog-agent/bin/agent/dist/datadog.yaml
Agent 7.45.0-devel - Meta: git.237.1a995b6 - Commit: 1a995b600e - Serialization version: v5.0.80 - Go version: go1.20.2
```

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
