### PR TITLE
Add proxy support from env

### DIFF
--- a/cmd/agent/subcommands/integrations/command.go
+++ b/cmd/agent/subcommands/integrations/command.go
@@ -545,7 +545,7 @@ func downloadWheel(cliParams *cliParams, integration, version, rootLayoutType st
 	downloaderCmd.Env = environ
 
 	// Proxy support
-	proxies := pkgconfig.GetProxies()
+	proxies := pkgconfig.Datadog.GetProxies()
 	if proxies != nil {
 		downloaderCmd.Env = append(downloaderCmd.Env,
 			fmt.Sprintf("HTTP_PROXY=%s", proxies.HTTP),

--- a/cmd/trace-agent/config/config.go
+++ b/cmd/trace-agent/config/config.go
@@ -80,7 +80,7 @@ func prepareConfig(path string) (*config.AgentConfig, error) {
 	}
 	orch := fargate.GetOrchestrator() // Needs to be after loading config, because it relies on feature auto-detection
 	cfg.FargateOrchestrator = config.FargateOrchestratorName(orch)
-	if p := coreconfig.GetProxies(); p != nil {
+	if p := coreconfig.Datadog.GetProxies(); p != nil {
 		cfg.Proxy = httputils.GetProxyTransportFunc(p)
 	}
 	cfg.ConfigPath = path

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1282,25 +1282,29 @@ func LoadProxyFromEnv(config Config) {
 		p.NoProxy = strings.Split(noProxy, ",") // comma-separated list, consistent with other tools that use the NO_PROXY env var
 	}
 
+	if !config.GetBool("use_proxy_for_cloud_metadata") {
+		log.Debugf("'use_proxy_for_cloud_metadata' is enabled: adding cloud provider URL to the no_proxy list")
+		isSet = true
+		p.NoProxy = append(p.NoProxy,
+			"169.254.169.254", // Azure, EC2, GCE
+			"100.100.100.200", // Alibaba
+		)
+	}
+
 	// We have to set each value individually so both config.Get("proxy")
 	// and config.Get("proxy.http") work
 	if isSet {
 		config.Set("proxy.http", p.HTTP)
 		config.Set("proxy.https", p.HTTPS)
-		if len(p.NoProxy) > 0 {
-			config.Set("proxy.no_proxy", p.NoProxy)
-		} else {
-			// If this is set to an empty []string, viper will have a type conflict when merging
-			// this config during secrets resolution. It unmarshals empty yaml lists to type
-			// []interface{}, which will then conflict with type []string and fail to merge.
-			config.Set("proxy.no_proxy", []interface{}{})
-		}
-		proxies = p
-	}
 
-	if !config.GetBool("use_proxy_for_cloud_metadata") {
-		p.NoProxy = append(p.NoProxy, "169.254.169.254") // Azure, EC2, GCE
-		p.NoProxy = append(p.NoProxy, "100.100.100.200") // Alibaba
+		// If this is set to an empty []string, viper will have a type conflict when merging
+		// this config during secrets resolution. It unmarshals empty yaml lists to type
+		// []interface{}, which will then conflict with type []string and fail to merge.
+		noProxy := make([]interface{}, len(p.NoProxy))
+		for idx := range p.NoProxy {
+			noProxy[idx] = p.NoProxy[idx]
+		}
+		config.Set("proxy.no_proxy", noProxy)
 	}
 }
 
@@ -1492,7 +1496,6 @@ func LoadDatadogCustomWithKnownEnvVars(config Config, origin string, loadSecret 
 		AddOverride("python_version", DefaultPython)
 	}
 
-	LoadProxyFromEnv(config)
 	SanitizeAPIKeyConfig(config, "api_key")
 	// setTracemallocEnabled *must* be called before setNumWorkers
 	warnings.TraceMallocEnabledWithPy2 = setTracemallocEnabled(config)
@@ -1528,6 +1531,9 @@ func LoadCustom(config Config, origin string, loadSecret bool, additionalKnownEn
 	for _, warningMsg := range findUnexpectedUnicode(config) {
 		log.Warnf(warningMsg)
 	}
+
+	// We resolve proxy setting before secrets. This allows setting secrets through DD_PROXY_* env variables
+	LoadProxyFromEnv(config)
 
 	if loadSecret {
 		if err := ResolveSecrets(config, origin); err != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -104,7 +104,6 @@ const (
 var (
 	Datadog       Config
 	SystemProbe   Config
-	proxies       *Proxy
 	overrideFuncs = make([]func(Config), 0)
 )
 
@@ -173,13 +172,6 @@ func (l *Listeners) IsProviderEnabled(provider string) bool {
 	_, found := l.EnabledProviders[provider]
 
 	return found
-}
-
-// Proxy represents the configuration for proxies in the agent
-type Proxy struct {
-	HTTP    string   `mapstructure:"http"`
-	HTTPS   string   `mapstructure:"https"`
-	NoProxy []string `mapstructure:"no_proxy"`
 }
 
 // MappingProfile represent a group of mappings
@@ -1222,11 +1214,6 @@ func InitConfig(config Config) {
 // ddURLRegexp determines if an URL belongs to Datadog or not. If the URL belongs to Datadog it's prefixed with the Agent
 // version (see AddAgentVersionToDomain).
 var ddURLRegexp = regexp.MustCompile(`^app(\.[a-z]{2}\d)?\.(datad(oghq|0g)\.(com|eu)|ddog-gov\.com)$`)
-
-// GetProxies returns the proxy settings from the configuration
-func GetProxies() *Proxy {
-	return proxies
-}
 
 // LoadProxyFromEnv overrides the proxy settings with environment variables
 func LoadProxyFromEnv(config Config) {

--- a/pkg/config/config_secret_test.go
+++ b/pkg/config/config_secret_test.go
@@ -1,0 +1,126 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build secrets
+// +build secrets
+
+package config
+
+import (
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/secrets"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProxyWithSecret(t *testing.T) {
+	type testCase struct {
+		name  string
+		setup func(t *testing.T, config Config)
+		tests func(t *testing.T, config Config)
+	}
+
+	cases := []testCase{
+		{
+			name: "secrets fron configuration for proxy",
+			setup: func(t *testing.T, config Config) {
+				secrets.InjectSecrets(t, "http_handle", "http_url")
+				secrets.InjectSecrets(t, "https_handle", "https_url")
+				secrets.InjectSecrets(t, "no_proxy_1_handle", "no_proxy_1")
+				secrets.InjectSecrets(t, "no_proxy_2_handle", "no_proxy_2")
+
+				config.Set("secret_backend_command", "some_command")
+				config.Set("proxy.http", "ENC[http_handle]")
+				config.Set("proxy.https", "ENC[https_handle]")
+				config.Set("proxy.no_proxy", []string{"ENC[no_proxy_1_handle]", "ENC[no_proxy_2_handle]"})
+			},
+			tests: func(t *testing.T, config Config) {
+				assert.Equal(t,
+					&Proxy{
+						HTTP:    "http_url",
+						HTTPS:   "https_url",
+						NoProxy: []string{"no_proxy_1", "no_proxy_2"},
+					},
+					config.GetProxies())
+			},
+		},
+		{
+			name: "secrets fron DD env vars for proxy",
+			setup: func(t *testing.T, config Config) {
+				secrets.InjectSecrets(t, "http_handle", "http_url")
+				secrets.InjectSecrets(t, "https_handle", "https_url")
+				secrets.InjectSecrets(t, "no_proxy_1_handle", "no_proxy_1")
+				secrets.InjectSecrets(t, "no_proxy_2_handle", "no_proxy_2")
+
+				config.Set("secret_backend_command", "some_command")
+				t.Setenv("DD_PROXY_HTTP", "ENC[http_handle]")
+				t.Setenv("DD_PROXY_HTTPS", "ENC[https_handle]")
+				t.Setenv("DD_PROXY_NO_PROXY", "ENC[no_proxy_1_handle] ENC[no_proxy_2_handle]")
+			},
+			tests: func(t *testing.T, config Config) {
+				assert.Equal(t,
+					&Proxy{
+						HTTP:    "http_url",
+						HTTPS:   "https_url",
+						NoProxy: []string{"no_proxy_1", "no_proxy_2"},
+					},
+					config.GetProxies())
+			},
+		},
+		{
+			name: "secrets fron UNIX env vars for proxy",
+			setup: func(t *testing.T, config Config) {
+				secrets.InjectSecrets(t, "http_handle", "http_url")
+				secrets.InjectSecrets(t, "https_handle", "https_url")
+				secrets.InjectSecrets(t, "no_proxy_1_handle", "no_proxy_1")
+				secrets.InjectSecrets(t, "no_proxy_2_handle", "no_proxy_2")
+
+				config.Set("secret_backend_command", "some_command")
+				t.Setenv("HTTP_PROXY", "ENC[http_handle]")
+				t.Setenv("HTTPS_PROXY", "ENC[https_handle]")
+				t.Setenv("NO_PROXY", "ENC[no_proxy_1_handle],ENC[no_proxy_2_handle]")
+			},
+			tests: func(t *testing.T, config Config) {
+				assert.Equal(t,
+					&Proxy{
+						HTTP:    "http_url",
+						HTTPS:   "https_url",
+						NoProxy: []string{"no_proxy_1", "no_proxy_2"},
+					},
+					config.GetProxies())
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+
+			// CircleCI sets NO_PROXY, so unset it for this test
+			unsetEnvForTest(t, "NO_PROXY")
+
+			config := setupConf()
+			config.Set("use_proxy_for_cloud_metadata", true)
+
+			// Viper.MergeConfigOverride, which is used when secrets is enabled, will silently fail if a
+			// config file is never set.
+			path := t.TempDir()
+			configPath := filepath.Join(path, "empty_conf.yaml")
+			ioutil.WriteFile(configPath, nil, 0600)
+			config.SetConfigFile(configPath)
+
+			if c.setup != nil {
+				c.setup(t, config)
+			}
+
+			_, err := LoadCustom(config, "unit_test", true, nil)
+			require.NoError(t, err)
+
+			c.tests(t, config)
+		})
+	}
+}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1195,9 +1195,7 @@ proxy:
 	assert.Equal(t, false, testConfig.GetBool("logs_config.logs_no_ssl"))
 	assert.Equal(t, false, testConfig.GetBool("runtime_security_config.endpoints.use_http"))
 	assert.Equal(t, false, testConfig.GetBool("runtime_security_config.endpoints.logs_no_ssl"))
-	assert.NotNil(t, GetProxies())
-	// reseting proxies
-	proxies = nil
+	assert.NotNil(t, testConfig.GetProxies())
 
 	datadogYamlFips := datadogYaml + `
 fips:
@@ -1219,7 +1217,7 @@ fips:
 	assert.Equal(t, true, testConfig.GetBool("logs_config.logs_no_ssl"))
 	assert.Equal(t, true, testConfig.GetBool("runtime_security_config.endpoints.use_http"))
 	assert.Equal(t, true, testConfig.GetBool("runtime_security_config.endpoints.logs_no_ssl"))
-	assert.Nil(t, GetProxies())
+	assert.Nil(t, testConfig.GetProxies())
 
 	datadogYamlFips = datadogYaml + `
 fips:
@@ -1243,7 +1241,7 @@ fips:
 	assert.Equal(t, true, testConfig.GetBool("runtime_security_config.endpoints.use_http"))
 	assert.Equal(t, false, testConfig.GetBool("runtime_security_config.endpoints.logs_no_ssl"))
 	assert.Equal(t, true, testConfig.GetBool("skip_ssl_validation"))
-	assert.Nil(t, GetProxies())
+	assert.Nil(t, testConfig.GetProxies())
 
 	testConfig.Set("skip_ssl_validation", true) // should be overridden by fips.tls_verify
 	testConfig.Set("fips.tls_verify", true)
@@ -1252,7 +1250,7 @@ fips:
 	require.NoError(t, err)
 
 	assert.Equal(t, false, testConfig.GetBool("skip_ssl_validation"))
-	assert.Nil(t, GetProxies())
+	assert.Nil(t, testConfig.GetProxies())
 }
 
 func assertFipsProxyExpectedConfig(t *testing.T, expectedBaseHTTPURL, expectedBaseURL string, rng bool, c Config) {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -82,7 +82,7 @@ api_key: fakeapikey
 		},
 	}
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.EqualValues(t, expectedMultipleEndpoints, multipleEndpoints)
 	assert.Equal(t, "https://external-agent.datadoghq.com", externalAgentURL)
 }
@@ -103,7 +103,7 @@ api_key: fakeapikey
 		},
 	}
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.EqualValues(t, expectedMultipleEndpoints, multipleEndpoints)
 	assert.Equal(t, "https://external-agent.datadoghq.eu", externalAgentURL)
 }
@@ -226,7 +226,7 @@ func TestSiteEnvVar(t *testing.T) {
 		},
 	}
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.EqualValues(t, expectedMultipleEndpoints, multipleEndpoints)
 	assert.Equal(t, "https://external-agent.datadoghq.eu", externalAgentURL)
 }
@@ -266,7 +266,7 @@ func TestDDURLEnvVar(t *testing.T) {
 		},
 	}
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.EqualValues(t, expectedMultipleEndpoints, multipleEndpoints)
 	assert.Equal(t, "https://custom.external-agent.datadoghq.com", externalAgentURL)
 }
@@ -287,7 +287,7 @@ func TestDDDDURLEnvVar(t *testing.T) {
 		},
 	}
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.EqualValues(t, expectedMultipleEndpoints, multipleEndpoints)
 	assert.Equal(t, "https://custom.external-agent.datadoghq.com", externalAgentURL)
 }
@@ -312,7 +312,7 @@ func TestDDURLAndDDDDURLEnvVar(t *testing.T) {
 		},
 	}
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.EqualValues(t, expectedMultipleEndpoints, multipleEndpoints)
 	assert.Equal(t, "https://custom.external-agent.datadoghq.com", externalAgentURL)
 }
@@ -337,7 +337,7 @@ external_config:
 		},
 	}
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.EqualValues(t, expectedMultipleEndpoints, multipleEndpoints)
 	assert.Equal(t, "https://external-agent.datadoghq.com", externalAgentURL)
 }
@@ -361,7 +361,7 @@ external_config:
 		},
 	}
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.EqualValues(t, expectedMultipleEndpoints, multipleEndpoints)
 	assert.Equal(t, "https://custom.external-agent.datadoghq.eu", externalAgentURL)
 }
@@ -393,7 +393,7 @@ additional_endpoints:
 		},
 	}
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.EqualValues(t, expectedMultipleEndpoints, multipleEndpoints)
 }
 
@@ -414,7 +414,7 @@ func TestGetMultipleEndpointsEnvVar(t *testing.T) {
 		},
 	}
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.EqualValues(t, expectedMultipleEndpoints, multipleEndpoints)
 }
 
@@ -448,7 +448,7 @@ additional_endpoints:
 		},
 	}
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.EqualValues(t, expectedMultipleEndpoints, multipleEndpoints)
 }
 
@@ -480,7 +480,7 @@ additional_endpoints:
 		},
 	}
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.EqualValues(t, expectedMultipleEndpoints, multipleEndpoints)
 }
 
@@ -500,7 +500,7 @@ api_key: fakeapikey
 		},
 	}
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.EqualValues(t, expectedMultipleEndpoints, multipleEndpoints)
 }
 
@@ -532,7 +532,7 @@ additional_endpoints:
 		},
 	}
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.EqualValues(t, expectedMultipleEndpoints, multipleEndpoints)
 }
 
@@ -566,7 +566,7 @@ additional_endpoints:
 		},
 	}
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.EqualValues(t, expectedMultipleEndpoints, multipleEndpoints)
 }
 
@@ -1047,7 +1047,7 @@ dogstatsd_mapper_profiles:
 		},
 	}
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.EqualValues(t, expectedProfiles, profiles)
 }
 
@@ -1061,7 +1061,7 @@ dogstatsd_mapper_profiles:
 
 	var expectedProfiles []MappingProfile
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.EqualValues(t, expectedProfiles, profiles)
 }
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -8,8 +8,10 @@ package config
 import (
 	"bytes"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -36,17 +38,17 @@ func setupConfFromYAML(yamlConfig string) Config {
 	return conf
 }
 
-func unsetEnvForTest(env string) (reset func()) {
+func unsetEnvForTest(t *testing.T, env string) {
 	oldValue, ok := os.LookupEnv(env)
 	os.Unsetenv(env)
 
-	return func() {
+	t.Cleanup(func() {
 		if !ok {
 			os.Unsetenv(env)
 		} else {
 			os.Setenv(env, oldValue)
 		}
-	}
+	})
 }
 
 func TestDefaults(t *testing.T) {
@@ -688,207 +690,225 @@ func TestEnvNestedConfig(t *testing.T) {
 	assert.Equal(t, "baz", config.GetString("foo.bar.nested"))
 }
 
-func TestLoadProxyFromStdEnvNoValue(t *testing.T) {
-	config := setupConf()
+func TestProxy(t *testing.T) {
+	type testCase struct {
+		name                  string
+		setup                 func(t *testing.T, config Config)
+		tests                 func(t *testing.T, config Config)
+		proxyForCloudMetadata bool
+	}
 
-	resetEnv := unsetEnvForTest("NO_PROXY") // CircleCI sets NO_PROXY, so unset it for this test
-	defer resetEnv()
+	expectedProxy := &Proxy{
+		HTTP:    "http_url",
+		HTTPS:   "https_url",
+		NoProxy: []string{"a", "b", "c"}}
 
-	LoadProxyFromEnv(config)
-	assert.Nil(t, config.Get("proxy"))
-
-	proxies := GetProxies()
-	require.Nil(t, proxies)
-}
-
-func TestLoadProxyConfOnly(t *testing.T) {
-	config := setupConf()
-
-	// check value loaded before aren't overwrite when no env variables are set
-	p := &Proxy{HTTP: "test", HTTPS: "test2", NoProxy: []string{"a", "b", "c"}}
-	config.Set("proxy", p)
-	// Don't include cloud metadata URL's in no_proxy
-	config.Set("use_proxy_for_cloud_metadata", true)
-
-	resetEnv := unsetEnvForTest("NO_PROXY") // CircleCI sets NO_PROXY, so unset it for this test
-	defer resetEnv()
-
-	LoadProxyFromEnv(config)
-	proxies := GetProxies()
-	assert.Equal(t, p, proxies)
-}
-
-func TestLoadProxyStdEnvOnly(t *testing.T) {
-	config := setupConf()
-
-	// Don't include cloud metadata URL's in no_proxy
-	config.Set("use_proxy_for_cloud_metadata", true)
-
-	// uppercase
-	t.Setenv("HTTP_PROXY", "http_url")
-	t.Setenv("HTTPS_PROXY", "https_url")
-	t.Setenv("NO_PROXY", "a,b,c") // comma-separated list
-
-	LoadProxyFromEnv(config)
-
-	proxies := GetProxies()
-	assert.Equal(t,
-		&Proxy{
-			HTTP:    "http_url",
-			HTTPS:   "https_url",
-			NoProxy: []string{"a", "b", "c"}},
-		proxies)
-
-	os.Unsetenv("NO_PROXY")
-	os.Unsetenv("HTTPS_PROXY")
-	os.Unsetenv("HTTP_PROXY")
-	config.Set("proxy", nil)
-
-	// lowercase
-	t.Setenv("http_proxy", "http_url2")
-	t.Setenv("https_proxy", "https_url2")
-	t.Setenv("no_proxy", "1,2,3") // comma-separated list
-
-	LoadProxyFromEnv(config)
-	proxies = GetProxies()
-	assert.Equal(t,
-		&Proxy{
-			HTTP:    "http_url2",
-			HTTPS:   "https_url2",
-			NoProxy: []string{"1", "2", "3"}},
-		proxies)
-}
-
-func TestLoadProxyDDSpecificEnvOnly(t *testing.T) {
-	config := setupConf()
-	// Don't include cloud metadata URL's in no_proxy
-	config.Set("use_proxy_for_cloud_metadata", true)
-
-	t.Setenv("DD_PROXY_HTTP", "http_url")
-	t.Setenv("DD_PROXY_HTTPS", "https_url")
-	t.Setenv("DD_PROXY_NO_PROXY", "a b c") // space-separated list
-
-	LoadProxyFromEnv(config)
-
-	proxies := GetProxies()
-	assert.Equal(t,
-		&Proxy{
-			HTTP:    "http_url",
-			HTTPS:   "https_url",
-			NoProxy: []string{"a", "b", "c"}},
-		proxies)
-}
-
-func TestLoadProxyDDSpecificEnvPrecedenceOverStdEnv(t *testing.T) {
-	config := setupConf()
-	// Don't include cloud metadata URL's in no_proxy
-	config.Set("use_proxy_for_cloud_metadata", true)
-
-	t.Setenv("DD_PROXY_HTTP", "dd_http_url")
-	t.Setenv("DD_PROXY_HTTPS", "dd_https_url")
-	t.Setenv("DD_PROXY_NO_PROXY", "a b c")
-	t.Setenv("HTTP_PROXY", "env_http_url")
-	t.Setenv("HTTPS_PROXY", "env_https_url")
-	t.Setenv("NO_PROXY", "d,e,f")
-
-	LoadProxyFromEnv(config)
-
-	proxies := GetProxies()
-	assert.Equal(t,
-		&Proxy{
-			HTTP:    "dd_http_url",
-			HTTPS:   "dd_https_url",
-			NoProxy: []string{"a", "b", "c"}},
-		proxies)
-}
-
-func TestLoadProxyStdEnvAndConf(t *testing.T) {
-	config := setupConf()
-	// Don't include cloud metadata URL's in no_proxy
-	config.Set("use_proxy_for_cloud_metadata", true)
-
-	t.Setenv("HTTP_PROXY", "http_env")
-	resetNoProxy := unsetEnvForTest("NO_PROXY") // CircleCI sets NO_PROXY, so unset it for this test
-	config.Set("proxy.no_proxy", []string{"d", "e", "f"})
-	config.Set("proxy.http", "http_conf")
-	defer resetNoProxy()
-
-	LoadProxyFromEnv(config)
-	proxies := GetProxies()
-	assert.Equal(t,
-		&Proxy{
-			HTTP:    "http_env",
-			HTTPS:   "",
-			NoProxy: []string{"d", "e", "f"}},
-		proxies)
-}
-
-func TestLoadProxyDDSpecificEnvAndConf(t *testing.T) {
-	config := setupConf()
-	// Don't include cloud metadata URL's in no_proxy
-	config.Set("use_proxy_for_cloud_metadata", true)
-
-	t.Setenv("DD_PROXY_HTTP", "http_env")
-	resetNoProxy := unsetEnvForTest("NO_PROXY") // CircleCI sets NO_PROXY, so unset it for this test
-	config.Set("proxy.no_proxy", []string{"d", "e", "f"})
-	config.Set("proxy.http", "http_conf")
-	defer resetNoProxy()
-
-	LoadProxyFromEnv(config)
-	proxies := GetProxies()
-	assert.Equal(t,
-		&Proxy{
-			HTTP:    "http_env",
-			HTTPS:   "",
-			NoProxy: []string{"d", "e", "f"}},
-		proxies)
-}
-
-func TestLoadProxyEmptyValuePrecedence(t *testing.T) {
-	config := setupConf()
-	// Don't include cloud metadata URL's in no_proxy
-	config.Set("use_proxy_for_cloud_metadata", true)
-
-	t.Setenv("DD_PROXY_HTTP", "")
-	t.Setenv("DD_PROXY_NO_PROXY", "a b c")
-	t.Setenv("HTTP_PROXY", "env_http_url")
-	t.Setenv("HTTPS_PROXY", "")
-	t.Setenv("NO_PROXY", "")
-	config.Set("proxy.https", "https_conf")
-
-	LoadProxyFromEnv(config)
-
-	proxies := GetProxies()
-	assert.Equal(t,
-		&Proxy{
-			HTTP:    "",
-			HTTPS:   "",
-			NoProxy: []string{"a", "b", "c"}},
-		proxies)
-}
-
-func TestLoadProxyWithoutNoProxy(t *testing.T) {
-	config := setupConf()
-
-	// Don't include cloud metadata URL's in no_proxy
-	config.Set("use_proxy_for_cloud_metadata", true)
-
-	t.Setenv("DD_PROXY_HTTP", "http_url")
-	t.Setenv("DD_PROXY_HTTPS", "https_url")
-	resetNoProxy := unsetEnvForTest("NO_PROXY") // CircleCI sets NO_PROXY, so unset it for this test
-	defer resetNoProxy()
-
-	LoadProxyFromEnv(config)
-
-	proxies := GetProxies()
-	assert.Equal(t,
-		&Proxy{
-			HTTP:  "http_url",
-			HTTPS: "https_url",
+	cases := []testCase{
+		{
+			name: "no values",
+			tests: func(t *testing.T, config Config) {
+				assert.Nil(t, config.Get("proxy"))
+				assert.Nil(t, config.GetProxies())
+			},
+			proxyForCloudMetadata: true,
 		},
-		proxies)
+		{
+			name: "from configuration",
+			setup: func(t *testing.T, config Config) {
+				config.Set("proxy", expectedProxy)
+			},
+			tests: func(t *testing.T, config Config) {
+				assert.Equal(t, expectedProxy, config.GetProxies())
+			},
+			proxyForCloudMetadata: true,
+		},
+		{
+			name: "from UNIX env only upper case",
+			setup: func(t *testing.T, config Config) {
+				t.Setenv("HTTP_PROXY", "http_url")
+				t.Setenv("HTTPS_PROXY", "https_url")
+				t.Setenv("NO_PROXY", "a,b,c") // comma-separated list
+			},
+			tests: func(t *testing.T, config Config) {
+				assert.Equal(t, expectedProxy, config.GetProxies())
+			},
+			proxyForCloudMetadata: true,
+		},
+		{
+			name: "from env only lower case",
+			setup: func(t *testing.T, config Config) {
+				t.Setenv("http_proxy", "http_url")
+				t.Setenv("https_proxy", "https_url")
+				t.Setenv("no_proxy", "a,b,c") // comma-separated list
+			},
+			tests: func(t *testing.T, config Config) {
+				assert.Equal(t, expectedProxy, config.GetProxies())
+			},
+			proxyForCloudMetadata: true,
+		},
+		{
+			name: "from DD env vars only",
+			setup: func(t *testing.T, config Config) {
+				t.Setenv("DD_PROXY_HTTP", "http_url")
+				t.Setenv("DD_PROXY_HTTPS", "https_url")
+				t.Setenv("DD_PROXY_NO_PROXY", "a b c") // space-separated list
+			},
+			tests: func(t *testing.T, config Config) {
+				assert.Equal(t, expectedProxy, config.GetProxies())
+			},
+			proxyForCloudMetadata: true,
+		},
+		{
+			name: "from DD env vars precedence over UNIX env vars",
+			setup: func(t *testing.T, config Config) {
+				t.Setenv("DD_PROXY_HTTP", "dd_http_url")
+				t.Setenv("DD_PROXY_HTTPS", "dd_https_url")
+				t.Setenv("DD_PROXY_NO_PROXY", "a b c")
+				t.Setenv("HTTP_PROXY", "env_http_url")
+				t.Setenv("HTTPS_PROXY", "env_https_url")
+				t.Setenv("NO_PROXY", "d,e,f")
+			},
+			tests: func(t *testing.T, config Config) {
+				assert.Equal(t,
+					&Proxy{
+						HTTP:    "dd_http_url",
+						HTTPS:   "dd_https_url",
+						NoProxy: []string{"a", "b", "c"}},
+					config.GetProxies())
+			},
+			proxyForCloudMetadata: true,
+		},
+		{
+			name: "from UNIX env vars and conf",
+			setup: func(t *testing.T, config Config) {
+				t.Setenv("HTTP_PROXY", "http_env")
+				config.Set("proxy.no_proxy", []string{"d", "e", "f"})
+				config.Set("proxy.http", "http_conf")
+			},
+			tests: func(t *testing.T, config Config) {
+				assert.Equal(t,
+					&Proxy{
+						HTTP:    "http_env",
+						HTTPS:   "",
+						NoProxy: []string{"d", "e", "f"}},
+					config.GetProxies())
+			},
+			proxyForCloudMetadata: true,
+		},
+		{
+			name: "from DD env vars and conf",
+			setup: func(t *testing.T, config Config) {
+				t.Setenv("DD_PROXY_HTTP", "http_env")
+				config.Set("proxy.no_proxy", []string{"d", "e", "f"})
+				config.Set("proxy.http", "http_conf")
+			},
+			tests: func(t *testing.T, config Config) {
+				assert.Equal(t,
+					&Proxy{
+						HTTP:    "http_env",
+						HTTPS:   "",
+						NoProxy: []string{"d", "e", "f"}},
+					config.GetProxies())
+			},
+			proxyForCloudMetadata: true,
+		},
+		{
+			name: "empty values precedence",
+			setup: func(t *testing.T, config Config) {
+				t.Setenv("DD_PROXY_HTTP", "")
+				t.Setenv("DD_PROXY_NO_PROXY", "a b c")
+				t.Setenv("HTTP_PROXY", "env_http_url")
+				t.Setenv("HTTPS_PROXY", "")
+				t.Setenv("NO_PROXY", "")
+				config.Set("proxy.https", "https_conf")
+			},
+			tests: func(t *testing.T, config Config) {
+				assert.Equal(t,
+					&Proxy{
+						HTTP:    "",
+						HTTPS:   "",
+						NoProxy: []string{"a", "b", "c"}},
+					config.GetProxies())
+			},
+			proxyForCloudMetadata: true,
+		},
+		{
+			name: "proxy withou no_proxy",
+			setup: func(t *testing.T, config Config) {
+				t.Setenv("DD_PROXY_HTTP", "http_url")
+				t.Setenv("DD_PROXY_HTTPS", "https_url")
+			},
+			tests: func(t *testing.T, config Config) {
+				assert.Equal(t,
+					&Proxy{
+						HTTP:  "http_url",
+						HTTPS: "https_url",
+					},
+					config.GetProxies())
+				assert.Equal(t, []interface{}{}, config.Get("proxy.no_proxy"))
+			},
+			proxyForCloudMetadata: true,
+		},
+		{
+			name:  "empty config with use_proxy_for_cloud_metadata",
+			setup: func(t *testing.T, config Config) {},
+			tests: func(t *testing.T, config Config) {
+				assert.Equal(t,
+					&Proxy{
+						HTTP:    "",
+						HTTPS:   "",
+						NoProxy: []string{"169.254.169.254", "100.100.100.200"},
+					},
+					config.GetProxies())
+			},
+			proxyForCloudMetadata: false,
+		},
+		{
+			name: "use proxy for cloud metadata",
+			setup: func(t *testing.T, config Config) {
+				t.Setenv("DD_PROXY_HTTP", "http_url")
+				t.Setenv("DD_PROXY_HTTPS", "https_url")
+				t.Setenv("DD_PROXY_NO_PROXY", "a b c")
+			},
+			tests: func(t *testing.T, config Config) {
+				assert.Equal(t,
+					&Proxy{
+						HTTP:    "http_url",
+						HTTPS:   "https_url",
+						NoProxy: []string{"a", "b", "c", "169.254.169.254", "100.100.100.200"},
+					},
+					config.GetProxies())
+			},
+			proxyForCloudMetadata: false,
+		},
+	}
 
-	assert.Equal(t, []interface{}{}, config.Get("proxy.no_proxy"))
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+
+			// CircleCI sets NO_PROXY, so unset it for this test
+			unsetEnvForTest(t, "NO_PROXY")
+
+			config := setupConf()
+			config.Set("use_proxy_for_cloud_metadata", c.proxyForCloudMetadata)
+
+			// Viper.MergeConfigOverride, which is used when secrets is enabled, will silently fail if a
+			// config file is never set.
+			path := t.TempDir()
+			configPath := filepath.Join(path, "empty_conf.yaml")
+			ioutil.WriteFile(configPath, nil, 0600)
+			config.SetConfigFile(configPath)
+
+			if c.setup != nil {
+				c.setup(t, config)
+			}
+
+			_, err := LoadCustom(config, "unit_test", true, nil)
+			require.NoError(t, err)
+
+			c.tests(t, config)
+		})
+	}
 }
 
 func TestSanitizeAPIKeyConfig(t *testing.T) {

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -15,6 +15,13 @@ import (
 	"github.com/spf13/pflag"
 )
 
+// Proxy represents the configuration for proxies in the agent
+type Proxy struct {
+	HTTP    string   `mapstructure:"http"`
+	HTTPS   string   `mapstructure:"https"`
+	NoProxy []string `mapstructure:"no_proxy"`
+}
+
 // ConfigReader is a subset of Config that only allows reading of configuration
 type ConfigReader interface {
 	Get(key string) interface{}
@@ -32,6 +39,7 @@ type ConfigReader interface {
 	GetStringMapString(key string) map[string]string
 	GetStringMapStringSlice(key string) map[string][]string
 	GetSizeInBytes(key string) uint
+	GetProxies() *Proxy
 
 	ConfigFileUsed() string
 

--- a/pkg/secrets/secrets_mock.go
+++ b/pkg/secrets/secrets_mock.go
@@ -1,0 +1,21 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build secrets && test
+// +build secrets,test
+
+package secrets
+
+import (
+	"testing"
+)
+
+// InjectSecrets inject a value for an handle into the secrets cache. This allows to use secrets in tests.
+func InjectSecrets(t *testing.T, handle string, value string) {
+	secretCache[handle] = value
+	t.Cleanup(func() {
+		delete(secretCache, handle)
+	})
+}

--- a/pkg/util/http/transport.go
+++ b/pkg/util/http/transport.go
@@ -127,7 +127,7 @@ func CreateHTTPTransport() *http.Transport {
 		ExpectContinueTimeout: 1 * time.Second,
 	}
 
-	if proxies := config.GetProxies(); proxies != nil {
+	if proxies := config.Datadog.GetProxies(); proxies != nil {
 		transport.Proxy = GetProxyTransportFunc(proxies)
 	}
 

--- a/releasenotes/notes/resolve-secret-proxy-env-c9caebbf78ce1add.yaml
+++ b/releasenotes/notes/resolve-secret-proxy-env-c9caebbf78ce1add.yaml
@@ -1,0 +1,6 @@
+---
+enhancements:
+  - |
+    Secrets with `ENC[]` notation are now supported for proxy setting from environment variables. For more information
+    you can refer to our [Secrets Management](https://docs.datadoghq.com/agent/guide/secrets-management/)
+    and [Agent Proxy Configuration](https://docs.datadoghq.com/agent/proxy/) documentations.


### PR DESCRIPTION
### What does this PR do?

This PR allows secrets in proxy configuration from env vars. We now compute the proxy configuration before replacing secrets. This allows user to use `ENC[]` notation in env variables.

It also moves the `GetProxies` method to the config object instead of using the global state. Since we can load multiple configs, the latest loaded will overwrite the proxy settings. We also can't guarantee that a configuration was loaded before call 'GetProxies'. Moving the method to the 'Config' level solves both issues and allows better logic to support proxy settings,

### Describe how to test/QA your changes

Tests that proxy configuration still works as expected:
- Setting proxy through the configuration file with and without secrets.
- Setting proxy through `DD_PROXY_HTTPS`/`DD_PROXY_HTTP`/`DD_PROXY_NO_PROXY` env varts with and without secrets.
- Setting proxy through `HTTPS_PROXY`/`HTTP_PROXY`/`NO_PROXY` env varts with and without secrets.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
