### PR TITLE
Fix detection of containers missing requests & limits

### DIFF
--- a/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/pod.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/pod.go
@@ -20,6 +20,7 @@ import (
 	jsoniter "github.com/json-iterator/go"
 	"github.com/twmb/murmur3"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 const (
@@ -232,34 +233,35 @@ func convertContainerStatus(cs corev1.ContainerStatus) model.ContainerStatus {
 	return cStatus
 }
 
-// resourceRequirements calculations: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#:~:text=Resource%20units%20in%20Kubernetes&text=Limits%20and%20requests%20for%20CPU,A%20Container%20with%20spec.
-// CPU: 1/10 of a single core, would represent that as 100m.
-// Memory: Memory is measured in bytes. In addition, it may be used with SI suffices (E, P, T, G, M, K, m) or their power-of-two-equivalents (Ei, Pi, Ti, Gi, Mi, Ki).
+// convertResourceRequirements converts resource requirements to the payload
+// format. Various forms are accepted for resource quantities and this is
+// transparently abstracted by Kubernetes APIs.
+//
+// Documentation: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
 func convertResourceRequirements(rq corev1.ResourceRequirements, containerName string, resourceType model.ResourceRequirementsType) *model.ResourceRequirements {
-	requests := map[string]int64{}
-	setRequests := false
-	setLimits := false
-	limits := map[string]int64{}
+	var (
+		limits   = make(map[string]int64)
+		requests = make(map[string]int64)
+	)
 
-	for t, v := range rq.Limits {
-		if t == corev1.ResourceCPU {
-			limits[t.String()] = v.MilliValue()
-		} else {
-			limits[t.String()] = v.Value()
-		}
-		setLimits = true
-	}
-	for t, v := range rq.Requests {
-		if t == corev1.ResourceCPU {
-			requests[t.String()] = v.MilliValue()
-		} else {
-			requests[t.String()] = v.Value()
-		}
-		setRequests = true
+	// mapping between resource lists and payload structures
+	quantityHolders := map[*corev1.ResourceList]map[string]int64{
+		&rq.Limits:   limits,
+		&rq.Requests: requests,
 	}
 
-	if !setRequests && !setLimits {
-		return nil
+	// mapping between resource names and payload quantity handlers
+	quantityHandlers := map[corev1.ResourceName]func(resource.Quantity) int64{
+		corev1.ResourceCPU:    func(q resource.Quantity) int64 { return q.MilliValue() },
+		corev1.ResourceMemory: func(q resource.Quantity) int64 { return q.Value() },
+	}
+
+	for resourceName, handler := range quantityHandlers {
+		for resourceList, holder := range quantityHolders {
+			if quantity, found := (*resourceList)[resourceName]; found {
+				holder[resourceName.String()] = handler(quantity)
+			}
+		}
 	}
 
 	return &model.ResourceRequirements{

--- a/releasenotes-dca/notes/fix-k8s-resource-requirements-304442bc02ab569b.yaml
+++ b/releasenotes-dca/notes/fix-k8s-resource-requirements-304442bc02ab569b.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG-DCA.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix resource requirements detection for containers without any request and
+    limit set.

--- a/releasenotes/notes/fix-k8s-resource-requirements-26bcfbcffc5dbaf0.yaml
+++ b/releasenotes/notes/fix-k8s-resource-requirements-26bcfbcffc5dbaf0.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix resource requirements detection for containers without any request and
+    limit set.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

The case of containers with an empty resource section was not surfaced in the resource requirements extraction logic.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
