### PR TITLE
usm: gotls: Fixed capturing issues

### DIFF
--- a/pkg/network/ebpf/c/protocols/http/maps.h
+++ b/pkg/network/ebpf/c/protocols/http/maps.h
@@ -34,11 +34,11 @@ BPF_HASH_MAP(offsets_data, go_tls_offsets_data_key_t, tls_offsets_data_t, 1024)
 
 /* go_tls_read_args is used to get the read function info when running in the read-return uprobe.
    The key contains the go routine id and the pid. */
-BPF_HASH_MAP(go_tls_read_args, go_tls_function_args_key_t, go_tls_read_args_data_t, 1024)
+BPF_LRU_MAP(go_tls_read_args, go_tls_function_args_key_t, go_tls_read_args_data_t, 2048)
 
 /* go_tls_write_args is used to get the read function info when running in the write-return uprobe.
    The key contains the go routine id and the pid. */
-BPF_HASH_MAP(go_tls_write_args, go_tls_function_args_key_t, go_tls_write_args_data_t, 1024)
+BPF_LRU_MAP(go_tls_write_args, go_tls_function_args_key_t, go_tls_write_args_data_t, 2048)
 
 /* This map associates crypto/tls.(*Conn) values to the corresponding conn_tuple_t* value.
    It is used to implement a simplified version of tup_from_ssl_ctx from http.c

--- a/pkg/network/ebpf/c/runtime/http.c
+++ b/pkg/network/ebpf/c/runtime/http.c
@@ -679,37 +679,41 @@ int uprobe__crypto_tls_Conn_Write__return(struct pt_regs *ctx) {
     go_tls_function_args_key_t call_key = {0};
     call_key.pid = pid;
 
+    if (read_goroutine_id(ctx, &od->goroutine_id, &call_key.goroutine_id)) {
+        log_debug("[go-tls-write-return] failed reading go routine id for pid %d\n", pid);
+        return 0;
+    }
+
     uint64_t bytes_written = 0;
     if (read_location(ctx, &od->write_return_bytes, sizeof(bytes_written), &bytes_written)) {
+        bpf_map_delete_elem(&go_tls_write_args, &call_key);
         log_debug("[go-tls-write-return] failed reading write return bytes location for pid %d\n", pid);
         return 0;
     }
 
     if (bytes_written <= 0) {
+        bpf_map_delete_elem(&go_tls_write_args, &call_key);
         log_debug("[go-tls-write-return] write returned non-positive for amount of bytes written for pid: %d\n", pid);
         return 0;
     }
 
     uint64_t err_ptr = 0;
     if (read_location(ctx, &od->write_return_error, sizeof(err_ptr), &err_ptr)) {
+        bpf_map_delete_elem(&go_tls_write_args, &call_key);
         log_debug("[go-tls-write-return] failed reading write return error location for pid %d\n", pid);
         return 0;
     }
 
     // check if err != nil
     if (err_ptr != 0) {
+        bpf_map_delete_elem(&go_tls_write_args, &call_key);
         log_debug("[go-tls-write-return] error in write for pid %d: data will be ignored\n", pid);
         return 0;
     }
 
-    if (read_goroutine_id(ctx, &od->goroutine_id, &call_key.goroutine_id)) {
-        log_debug("[go-tls-write-return] failed reading go routine id for pid %d\n", pid);
-        return 0;
-    }
-
-
     go_tls_write_args_data_t *call_data_ptr = bpf_map_lookup_elem(&go_tls_write_args, &call_key);
     if (call_data_ptr == NULL) {
+        bpf_map_delete_elem(&go_tls_write_args, &call_key);
         log_debug("[go-tls-write-return] no write information in write-return for pid %d\n", pid);
         return 0;
     }
@@ -795,16 +799,15 @@ int uprobe__crypto_tls_Conn_Read__return(struct pt_regs *ctx) {
         return 0;
     }
 
+    // Errors like "EOF" of "unexpected EOF" can be treated as no error by the hooked program.
+    // Therefore, if we choose to ignore data if read had returned these errors we may have accuracy issues.
+    // For now for success validation we chose to check only the amount of bytes read
+    // and make sure it's greater than zero.
     if (bytes_read <= 0) {
         log_debug("[go-tls-read-return] read returned non-positive for amount of bytes read for pid: %d\n", pid);
         bpf_map_delete_elem(&go_tls_read_args, &call_key);
         return 0;
     }
-
-    // Errors like "EOF" of "unexpected EOF" can be treated as no error by the hooked program.
-    // Therefore, if we choose to ignore data if read had returned these errors we may have accuracy issues.
-    // For now for success validation we chose to check only the amount of bytes read
-    // and make sure it's greater than zero.
 
     conn_tuple_t* t = conn_tup_from_tls_conn(od, (void*) call_data_ptr->conn_pointer, pid_tgid);
     if (t == NULL) {

--- a/pkg/network/ebpf/c/runtime/http.c
+++ b/pkg/network/ebpf/c/runtime/http.c
@@ -777,23 +777,6 @@ int uprobe__crypto_tls_Conn_Read__return(struct pt_regs *ctx) {
     // Read the PID and goroutine ID to make the partial call key
     go_tls_function_args_key_t call_key = {0};
     call_key.pid = pid;
-
-    uint64_t bytes_read = 0;
-    if (read_location(ctx, &od->read_return_bytes, sizeof(bytes_read), &bytes_read)) {
-        log_debug("[go-tls-read-return] failed reading return bytes location for pid %d\n", pid);
-        return 0;
-    }
-
-    if (bytes_read <= 0) {
-        log_debug("[go-tls-read-return] read returned non-positive for amount of bytes read for pid: %d\n", pid);
-        return 0;
-    }
-
-    // Errors like "EOF" of "unexpected EOF" can be treated as no error by the hooked program.
-    // Therefore, if we choose to ignore data if read had returned these errors we may have accuracy issues.
-    // For now for success validation we chose to check only the amount of bytes read
-    // and make sure it's greater than zero.
-
     if (read_goroutine_id(ctx, &od->goroutine_id, &call_key.goroutine_id)) {
         log_debug("[go-tls-read-return] failed reading go routine id for pid %d\n", pid);
         return 0;
@@ -804,6 +787,24 @@ int uprobe__crypto_tls_Conn_Read__return(struct pt_regs *ctx) {
         log_debug("[go-tls-read-return] no read information in read-return for pid %d\n", pid);
         return 0;
     }
+
+    uint64_t bytes_read = 0;
+    if (read_location(ctx, &od->read_return_bytes, sizeof(bytes_read), &bytes_read)) {
+        log_debug("[go-tls-read-return] failed reading return bytes location for pid %d\n", pid);
+        bpf_map_delete_elem(&go_tls_read_args, &call_key);
+        return 0;
+    }
+
+    if (bytes_read <= 0) {
+        log_debug("[go-tls-read-return] read returned non-positive for amount of bytes read for pid: %d\n", pid);
+        bpf_map_delete_elem(&go_tls_read_args, &call_key);
+        return 0;
+    }
+
+    // Errors like "EOF" of "unexpected EOF" can be treated as no error by the hooked program.
+    // Therefore, if we choose to ignore data if read had returned these errors we may have accuracy issues.
+    // For now for success validation we chose to check only the amount of bytes read
+    // and make sure it's greater than zero.
 
     conn_tuple_t* t = conn_tup_from_tls_conn(od, (void*) call_data_ptr->conn_pointer, pid_tgid);
     if (t == NULL) {
@@ -827,6 +828,14 @@ int uprobe__crypto_tls_Conn_Close(struct pt_regs *ctx) {
     if (od == NULL) {
         log_debug("[go-tls-close] no offsets data in map for pid %d\n", pid_tgid >> 32);
         return 0;
+    }
+
+    // Read the PID and goroutine ID to make the partial call key
+    go_tls_function_args_key_t call_key = {0};
+    call_key.pid = pid_tgid >> 32;
+    if (read_goroutine_id(ctx, &od->goroutine_id, &call_key.goroutine_id) == 0) {
+        bpf_map_delete_elem(&go_tls_read_args, &call_key);
+        bpf_map_delete_elem(&go_tls_write_args, &call_key);
     }
 
     void* conn_pointer = NULL;

--- a/pkg/network/go/asmscan/scan.go
+++ b/pkg/network/go/asmscan/scan.go
@@ -19,7 +19,7 @@ import (
 // The callback should return a slice of indices into the buffer
 // that point to positions within the larger binary.
 // These positions will then be adjusted based on the offset of the text section
-// to provide the same positiions as PC positions,
+// to provide the same positions as PC positions,
 // which will be returned from the outer function.
 //
 // lowPC, highPC forms an interval that contains all machine code bytes


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

1. Fixed leaked entries in bpf maps
2. increases the default size of the bpf maps to 2048, as by default we capture datadog's own processes tls connections, and they hold around 270 entries in the maps. So increasing our capacity for other connections.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

During the Read-Return hook, we cleaned resources only during happy flow. Now cleanning the resources on every exit of the hook

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
