### PR TITLE
pkg/trace/api: ensure that OTLP container tags get added to the payload

### DIFF
--- a/pkg/trace/api/otlp.go
+++ b/pkg/trace/api/otlp.go
@@ -214,6 +214,7 @@ func (o *OTLPReceiver) ReceiveResourceSpans(ctx context.Context, rspans ptrace.R
 	}
 	tracesByID := make(map[uint64]pb.Trace)
 	priorityByID := make(map[uint64]sampler.SamplingPriority)
+	ctags := make(map[string]string)
 	var spancount int64
 	for i := 0; i < rspans.ScopeSpans().Len(); i++ {
 		libspans := rspans.ScopeSpans().At(i)
@@ -225,7 +226,7 @@ func (o *OTLPReceiver) ReceiveResourceSpans(ctx context.Context, rspans ptrace.R
 			if tracesByID[traceID] == nil {
 				tracesByID[traceID] = pb.Trace{}
 			}
-			ddspan := o.convertSpan(rattr, lib, span)
+			ddspan := o.convertSpan(rattr, lib, span, ctags)
 			if !srcok {
 				// if we didn't find a hostname at the resource level
 				// try and see if the span has a hostname set
@@ -282,17 +283,19 @@ func (o *OTLPReceiver) ReceiveResourceSpans(ctx context.Context, rspans ptrace.R
 		LanguageVersion: tagstats.LangVersion,
 		TracerVersion:   tagstats.TracerVersion,
 	}
-	if ctags := getContainerTags(o.conf.ContainerTags, containerID); ctags != "" {
-		p.TracerPayload.Tags = map[string]string{
-			tagContainersTags: ctags,
-		}
+	payloadTags := flatten(ctags)
+	if tags := getContainerTags(o.conf.ContainerTags, containerID); tags != "" {
+		appendTags(payloadTags, tags)
 	} else {
 		// we couldn't obtain any container tags
 		if src.Kind == source.AWSECSFargateKind {
 			// but we have some information from the source provider that we can add
-			p.TracerPayload.Tags = map[string]string{
-				tagContainersTags: src.Tag(),
-			}
+			appendTags(payloadTags, src.Tag())
+		}
+	}
+	if payloadTags.Len() > 0 {
+		p.TracerPayload.Tags = map[string]string{
+			tagContainersTags: payloadTags.String(),
 		}
 	}
 	select {
@@ -302,6 +305,26 @@ func (o *OTLPReceiver) ReceiveResourceSpans(ctx context.Context, rspans ptrace.R
 		log.Warn("Payload in channel full. Dropped 1 payload.")
 	}
 	return src
+}
+
+func appendTags(str *strings.Builder, tags string) {
+	if str.Len() > 0 {
+		str.WriteByte(',')
+	}
+	str.WriteString(tags)
+}
+
+func flatten(m map[string]string) *strings.Builder {
+	var str strings.Builder
+	for k, v := range m {
+		if str.Len() > 0 {
+			str.WriteByte(',')
+		}
+		str.WriteString(k)
+		str.WriteString(":")
+		str.WriteString(v)
+	}
+	return &str
 }
 
 // createChunks creates a set of pb.TraceChunk's based on two maps:
@@ -475,7 +498,9 @@ func setMetricOTLP(s *pb.Span, k string, v float64) {
 
 // convertSpan converts the span in to a Datadog span, and uses the rattr resource tags and the lib instrumentation
 // library attributes to further augment it.
-func (o *OTLPReceiver) convertSpan(rattr map[string]string, lib pcommon.InstrumentationScope, in ptrace.Span) *pb.Span {
+//
+// ctags will be used to write container tags to. Existing ones are not overridden.
+func (o *OTLPReceiver) convertSpan(rattr map[string]string, lib pcommon.InstrumentationScope, in ptrace.Span, ctags map[string]string) *pb.Span {
 	traceID := [16]byte(in.TraceID())
 	span := &pb.Span{
 		TraceID:  traceIDToUint64(traceID),
@@ -521,6 +546,9 @@ func (o *OTLPReceiver) convertSpan(rattr map[string]string, lib pcommon.Instrume
 		if _, ok := span.Meta[k]; !ok {
 			// overwrite only if it does not exist
 			setMetaOTLP(span, k, v)
+		}
+		if _, ok := ctags[k]; !ok {
+			ctags[k] = v
 		}
 	}
 	if _, ok := span.Meta["env"]; !ok {

--- a/pkg/trace/api/otlp_test.go
+++ b/pkg/trace/api/otlp_test.go
@@ -297,11 +297,36 @@ func TestOTLPReceiveResourceSpans(t *testing.T) {
 				{
 					LibName:    "libname",
 					LibVersion: "1.2",
-					Attributes: map[string]interface{}{string(semconv.AttributeK8SPodUID): "1234cid"},
+					Attributes: map[string]interface{}{
+						string(semconv.AttributeK8SPodUID):  "1234cid",
+						string(semconv.AttributeK8SJobName): "kubejob",
+					},
+					Spans: []*testutil.OTLPSpan{
+						{
+							TraceID: [16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
+							Name:    "first",
+							Attributes: map[string]interface{}{
+								string(semconv.AttributeContainerImageName): "lorem-ipsum",
+							},
+						},
+						{
+							TraceID: [16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 17},
+							SpanID:  [8]byte{10, 10, 11, 12, 13, 14, 15, 16},
+							Name:    "second",
+							Attributes: map[string]interface{}{
+								string(semconv.AttributeContainerImageTag): "v2.0",
+							},
+						},
+					},
 				},
 			},
 			fn: func(out *pb.TracerPayload) {
 				require.Equal("1234cid", out.ContainerID)
+				require.Equal(map[string]string{
+					"kube_job":   "kubejob",
+					"image_name": "lorem-ipsum",
+					"image_tag":  "v2.0",
+				}, unflatten(out.Tags[tagContainersTags]))
 			},
 		},
 		{
@@ -490,6 +515,58 @@ func TestOTLPSetAttributes(t *testing.T) {
 		setMetricOTLP(s, "_sampling_priority_v1", 3)
 		require.Equal(t, float64(3), s.Metrics["_sampling_priority_v1"])
 	})
+}
+
+func unflatten(str string) map[string]string {
+	parts := strings.Split(str, ",")
+	m := make(map[string]string, len(parts))
+	if len(str) == 0 {
+		return m
+	}
+	for _, p := range parts {
+		parts2 := strings.SplitN(p, ":", 2)
+		k := parts2[0]
+		if k == "" {
+			continue
+		}
+		if len(parts2) > 1 {
+			m[k] = parts2[1]
+		} else {
+			m[k] = ""
+		}
+	}
+	return m
+}
+
+func TestUnflatten(t *testing.T) {
+	for in, out := range map[string]map[string]string{
+		"a:b": {
+			"a": "b",
+		},
+		"a:b,c:d": {
+			"a": "b",
+			"c": "d",
+		},
+		"a:b,c:d:e": {
+			"a": "b",
+			"c": "d:e",
+		},
+		"a:b,c": {
+			"a": "b",
+			"c": "",
+		},
+		"a:b,": {
+			"a": "b",
+		},
+		"bogus": {
+			"bogus": "",
+		},
+		"": {},
+	} {
+		t.Run("", func(t *testing.T) {
+			assert.Equal(t, unflatten(in), out)
+		})
+	}
 }
 
 func TestOTLPHostname(t *testing.T) {
@@ -839,6 +916,7 @@ func TestOTLPConvertSpan(t *testing.T) {
 		libver  string
 		in      ptrace.Span
 		out     *pb.Span
+		outTags map[string]string
 	}{
 		{
 			rattr: map[string]string{
@@ -1180,6 +1258,10 @@ func TestOTLPConvertSpan(t *testing.T) {
 				},
 				Type: "db",
 			},
+			outTags: map[string]string{
+				"container_id":        "cid",
+				"kube_container_name": "k8s-container",
+			},
 		},
 	} {
 		t.Run("", func(t *testing.T) {
@@ -1188,7 +1270,8 @@ func TestOTLPConvertSpan(t *testing.T) {
 			lib.SetVersion(tt.libver)
 			assert := assert.New(t)
 			want := tt.out
-			got := o.convertSpan(tt.rattr, lib, tt.in)
+			ctags := make(map[string]string)
+			got := o.convertSpan(tt.rattr, lib, tt.in, ctags)
 			if len(want.Meta) != len(got.Meta) {
 				t.Fatalf("(%d) Meta count mismatch:\n%#v", i, got.Meta)
 			}
@@ -1238,8 +1321,28 @@ func TestOTLPConvertSpan(t *testing.T) {
 			got.Meta = nil
 			got.Metrics = nil
 			assert.Equal(want, got, i)
+			if len(tt.outTags) > 0 || len(ctags) > 0 {
+				assert.Equal(ctags, tt.outTags)
+			}
 		})
 	}
+}
+
+func TestFlatten(t *testing.T) {
+	assert.Equal(t, flatten(map[string]string{"a": "b", "c": "d"}).String(), "a:b,c:d")
+	assert.Equal(t, flatten(map[string]string{"x": "y"}).String(), "x:y")
+	assert.Equal(t, flatten(map[string]string{}).String(), "")
+	assert.Equal(t, flatten(nil).String(), "")
+}
+
+func TestAppendTags(t *testing.T) {
+	var str strings.Builder
+	appendTags(&str, "a:b,c:d")
+	assert.Equal(t, str.String(), "a:b,c:d")
+	appendTags(&str, "e:f,g:h")
+	assert.Equal(t, str.String(), "a:b,c:d,e:f,g:h")
+	appendTags(&str, "i:j")
+	assert.Equal(t, str.String(), "a:b,c:d,e:f,g:h,i:j")
 }
 
 // TestResourceAttributesMap is a regression test ensuring that the resource attributes map
@@ -1248,7 +1351,8 @@ func TestResourceAttributesMap(t *testing.T) {
 	rattr := map[string]string{"key": "val"}
 	lib := pcommon.NewInstrumentationScope()
 	span := testutil.NewOTLPSpan(&testutil.OTLPSpan{})
-	NewOTLPReceiver(nil, config.New()).convertSpan(rattr, lib, span)
+	ctags := make(map[string]string)
+	NewOTLPReceiver(nil, config.New()).convertSpan(rattr, lib, span, ctags)
 	assert.Len(t, rattr, 1) // ensure "rattr" has no new entries
 	assert.Equal(t, "val", rattr["key"])
 }

--- a/releasenotes/notes/apm-otlp-container-tags-payload-1a77c0ea8e10e8ef.yaml
+++ b/releasenotes/notes/apm-otlp-container-tags-payload-1a77c0ea8e10e8ef.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    APM: OTLP: Ensure that container tags are set globally on the payload so that they can be picked up as primary tags in the app.


### PR DESCRIPTION
This change ensures that container tags are not just renamed as regular span tags, but are also set on the payload as part of the `_dd.tags.container` tag value. This approach results in them being picked up as primary tags (as expected by the backend) and having them picked up for correlation.