### PR TITLE
[CWS] decouple AD from probe monitor

### DIFF
--- a/cmd/security-agent/subcommands/runtime/activity_dump.go
+++ b/cmd/security-agent/subcommands/runtime/activity_dump.go
@@ -343,7 +343,7 @@ func generateEncodingFromActivityDump(log log.Component, config config.Component
 			return fmt.Errorf("couldn't load configuration: %w", err)
 
 		}
-		storage, err := dump.NewActivityDumpStorageManager(cfg, nil, nil)
+		storage, err := dump.NewActivityDumpStorageManager(cfg.RuntimeSecurity, nil, nil)
 		if err != nil {
 			return fmt.Errorf("couldn't instantiate storage manager: %w", err)
 		}

--- a/pkg/security/config/config.go
+++ b/pkg/security/config/config.go
@@ -237,6 +237,16 @@ func (c *RuntimeSecurityConfig) IsRuntimeEnabled() bool {
 	return c.RuntimeEnabled || c.FIMEnabled
 }
 
+// IsActivityDumpEnabled returns true if AD is enabled
+func (c *RuntimeSecurityConfig) IsActivityDumpEnabled() bool {
+	return c.ActivityDumpEnabled
+}
+
+// IsActivityDumpTagRulesEnabled returns true is AD with rules tags is enabled
+func (c *RuntimeSecurityConfig) IsActivityDumpTagRulesEnabled() bool {
+	return c.ActivityDumpTagRulesEnabled
+}
+
 // sanitize ensures that the configuration is properly setup
 func (c *RuntimeSecurityConfig) sanitize() error {
 	// if runtime is enabled then we force fim

--- a/pkg/security/module/cws.go
+++ b/pkg/security/module/cws.go
@@ -119,7 +119,9 @@ func NewCWSConsumer(evm *eventmonitor.EventMonitor, config *config.RuntimeSecuri
 	}
 
 	// Activity dumps related
-	evm.Probe.AddActivityDumpHandler(c)
+	if adm := evm.Probe.GetProfileHandler().GetActivityDumpManager(); adm != nil {
+		adm.AddActivityDumpHandler(c)
+	}
 
 	// policy loader
 	c.policyLoader = rules.NewPolicyLoader()

--- a/pkg/security/module/server.go
+++ b/pkg/security/module/server.go
@@ -165,8 +165,8 @@ func (a *APIServer) DumpProcessCache(ctx context.Context, params *api.DumpProces
 
 // DumpActivity handle an activity dump request
 func (a *APIServer) DumpActivity(ctx context.Context, params *api.ActivityDumpParams) (*api.ActivityDumpMessage, error) {
-	if monitor := a.probe.GetMonitor(); monitor != nil {
-		msg, err := monitor.DumpActivity(params)
+	if handler := a.probe.GetProfileHandler(); handler != nil {
+		msg, err := handler.DumpActivity(params)
 		if err != nil {
 			seclog.Errorf(err.Error())
 		}
@@ -178,8 +178,8 @@ func (a *APIServer) DumpActivity(ctx context.Context, params *api.ActivityDumpPa
 
 // ListActivityDumps returns the list of active dumps
 func (a *APIServer) ListActivityDumps(ctx context.Context, params *api.ActivityDumpListParams) (*api.ActivityDumpListMessage, error) {
-	if monitor := a.probe.GetMonitor(); monitor != nil {
-		msg, err := monitor.ListActivityDumps(params)
+	if handler := a.probe.GetProfileHandler(); handler != nil {
+		msg, err := handler.ListActivityDumps(params)
 		if err != nil {
 			seclog.Errorf(err.Error())
 		}
@@ -191,8 +191,8 @@ func (a *APIServer) ListActivityDumps(ctx context.Context, params *api.ActivityD
 
 // StopActivityDump stops an active activity dump if it exists
 func (a *APIServer) StopActivityDump(ctx context.Context, params *api.ActivityDumpStopParams) (*api.ActivityDumpStopMessage, error) {
-	if monitor := a.probe.GetMonitor(); monitor != nil {
-		msg, err := monitor.StopActivityDump(params)
+	if handler := a.probe.GetProfileHandler(); handler != nil {
+		msg, err := handler.StopActivityDump(params)
 		if err != nil {
 			seclog.Errorf(err.Error())
 		}
@@ -204,8 +204,8 @@ func (a *APIServer) StopActivityDump(ctx context.Context, params *api.ActivityDu
 
 // TranscodingRequest encodes an activity dump following the requested parameters
 func (a *APIServer) TranscodingRequest(ctx context.Context, params *api.TranscodingRequestParams) (*api.TranscodingRequestMessage, error) {
-	if monitor := a.probe.GetMonitor(); monitor != nil {
-		msg, err := monitor.GenerateTranscoding(params)
+	if handler := a.probe.GetProfileHandler(); handler != nil {
+		msg, err := handler.GenerateTranscoding(params)
 		if err != nil {
 			seclog.Errorf(err.Error())
 		}
@@ -364,7 +364,7 @@ func (a *APIServer) GetConfig(ctx context.Context, params *api.GetConfigParams) 
 		return &api.SecurityConfigMessage{
 			FIMEnabled:          a.cfg.FIMEnabled,
 			RuntimeEnabled:      a.cfg.RuntimeEnabled,
-			ActivityDumpEnabled: a.probe.IsActivityDumpEnabled(),
+			ActivityDumpEnabled: a.cfg.IsActivityDumpEnabled(),
 		}, nil
 	}
 	return &api.SecurityConfigMessage{}, nil

--- a/pkg/security/security_profile/dump/activity_dump.go
+++ b/pkg/security/security_profile/dump/activity_dump.go
@@ -195,20 +195,20 @@ func NewActivityDump(adm *ActivityDumpManager, options ...WithDumpOption) *Activ
 		Name:              fmt.Sprintf("activity-dump-%s", utils.RandString(10)),
 		ProtobufVersion:   ProtobufVersion,
 		Start:             now,
-		End:               now.Add(adm.config.RuntimeSecurity.ActivityDumpCgroupDumpTimeout),
+		End:               now.Add(adm.config.ActivityDumpCgroupDumpTimeout),
 		Arch:              probes.RuntimeArch,
 	}
 	ad.Host = adm.hostname
 	ad.Source = ActivityDumpSource
 	ad.adm = adm
-	ad.shouldMergePaths = adm.config.RuntimeSecurity.ActivityDumpPathMergeEnabled
+	ad.shouldMergePaths = adm.config.ActivityDumpPathMergeEnabled
 
 	// set load configuration to initial defaults
 	ad.LoadConfig = NewActivityDumpLoadConfig(
-		adm.config.RuntimeSecurity.ActivityDumpTracedEventTypes,
-		adm.config.RuntimeSecurity.ActivityDumpCgroupDumpTimeout,
-		adm.config.RuntimeSecurity.ActivityDumpCgroupWaitListTimeout,
-		adm.config.RuntimeSecurity.ActivityDumpRateLimiter,
+		adm.config.ActivityDumpTracedEventTypes,
+		adm.config.ActivityDumpCgroupDumpTimeout,
+		adm.config.ActivityDumpCgroupWaitListTimeout,
+		adm.config.ActivityDumpRateLimiter,
 		now,
 		adm.timeResolver,
 	)
@@ -339,7 +339,7 @@ func (ad *ActivityDump) AddStorageRequest(request config.StorageRequest) {
 }
 
 func (ad *ActivityDump) checkInMemorySize() {
-	if ad.computeInMemorySize() < int64(ad.adm.config.RuntimeSecurity.ActivityDumpMaxDumpSize()) {
+	if ad.computeInMemorySize() < int64(ad.adm.config.ActivityDumpMaxDumpSize()) {
 		return
 	}
 

--- a/pkg/security/security_profile/dump/load_controller.go
+++ b/pkg/security/security_profile/dump/load_controller.go
@@ -55,14 +55,14 @@ func NewActivityDumpLoadController(adm *ActivityDumpManager) (*ActivityDumpLoadC
 func (lc *ActivityDumpLoadController) PushCurrentConfig() error {
 	// push default load config values
 	defaults := NewActivityDumpLoadConfig(
-		lc.adm.config.RuntimeSecurity.ActivityDumpTracedEventTypes,
-		lc.adm.config.RuntimeSecurity.ActivityDumpCgroupDumpTimeout,
+		lc.adm.config.ActivityDumpTracedEventTypes,
+		lc.adm.config.ActivityDumpCgroupDumpTimeout,
 		0,
-		lc.adm.config.RuntimeSecurity.ActivityDumpRateLimiter,
+		lc.adm.config.ActivityDumpRateLimiter,
 		time.Now(),
 		lc.adm.timeResolver,
 	)
-	defaults.WaitListTimestampRaw = uint64(lc.adm.config.RuntimeSecurity.ActivityDumpCgroupWaitListTimeout)
+	defaults.WaitListTimestampRaw = uint64(lc.adm.config.ActivityDumpCgroupWaitListTimeout)
 	if err := lc.activityDumpConfigDefaults.Put(uint32(0), defaults); err != nil {
 		return fmt.Errorf("couldn't update default activity dump load config: %w", err)
 	}

--- a/pkg/security/security_profile/dump/local_storage.go
+++ b/pkg/security/security_profile/dump/local_storage.go
@@ -62,8 +62,8 @@ type ActivityDumpLocalStorage struct {
 }
 
 // NewActivityDumpLocalStorage creates a new ActivityDumpLocalStorage instance
-func NewActivityDumpLocalStorage(cfg *config.Config) (ActivityDumpStorage, error) {
-	lru, err := simplelru.NewLRU(cfg.RuntimeSecurity.ActivityDumpLocalStorageMaxDumpsCount, func(name string, files []string) {
+func NewActivityDumpLocalStorage(cfg *config.RuntimeSecurityConfig) (ActivityDumpStorage, error) {
+	lru, err := simplelru.NewLRU(cfg.ActivityDumpLocalStorageMaxDumpsCount, func(name string, files []string) {
 		if len(files) == 0 {
 			return
 		}
@@ -77,13 +77,13 @@ func NewActivityDumpLocalStorage(cfg *config.Config) (ActivityDumpStorage, error
 	}
 
 	// snapshot the dumps in the default output directory
-	if len(cfg.RuntimeSecurity.ActivityDumpLocalStorageDirectory) > 0 {
+	if len(cfg.ActivityDumpLocalStorageDirectory) > 0 {
 		// list all the files in the activity dump output directory
-		files, err := os.ReadDir(cfg.RuntimeSecurity.ActivityDumpLocalStorageDirectory)
+		files, err := os.ReadDir(cfg.ActivityDumpLocalStorageDirectory)
 		if err != nil {
 			if os.IsNotExist(err) {
 				files = make([]os.DirEntry, 0)
-				if err = os.MkdirAll(cfg.RuntimeSecurity.ActivityDumpLocalStorageDirectory, 0400); err != nil {
+				if err = os.MkdirAll(cfg.ActivityDumpLocalStorageDirectory, 0400); err != nil {
 					return nil, fmt.Errorf("couldn't create output directory for cgroup activity dumps: %w", err)
 				}
 			} else {

--- a/pkg/security/security_profile/dump/manager.go
+++ b/pkg/security/security_profile/dump/manager.go
@@ -45,7 +45,7 @@ type ActivityDumpHandler interface {
 // ActivityDumpManager is used to manage ActivityDumps
 type ActivityDumpManager struct {
 	sync.RWMutex
-	config             *config.Config
+	config             *config.RuntimeSecurityConfig
 	statsdClient       statsd.ClientInterface
 	emptyDropped       *atomic.Uint64
 	dropMaxDumpReached *atomic.Uint64
@@ -81,13 +81,13 @@ func (adm *ActivityDumpManager) Start(ctx context.Context, wg *sync.WaitGroup) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	ticker := time.NewTicker(adm.config.RuntimeSecurity.ActivityDumpCleanupPeriod)
+	ticker := time.NewTicker(adm.config.ActivityDumpCleanupPeriod)
 	defer ticker.Stop()
 
-	tagsTicker := time.NewTicker(adm.config.RuntimeSecurity.ActivityDumpTagsResolutionPeriod)
+	tagsTicker := time.NewTicker(adm.config.ActivityDumpTagsResolutionPeriod)
 	defer tagsTicker.Stop()
 
-	loadControlTicker := time.NewTicker(adm.config.RuntimeSecurity.ActivityDumpLoadControlPeriod)
+	loadControlTicker := time.NewTicker(adm.config.ActivityDumpLoadControlPeriod)
 	defer loadControlTicker.Stop()
 
 	for {
@@ -196,7 +196,7 @@ func (adm *ActivityDumpManager) resolveTags() {
 				adm.dumpLimiter.Add(limiterKey, counter)
 			}
 
-			if counter.Load() >= uint64(ad.adm.config.RuntimeSecurity.ActivityDumpMaxDumpCountPerWorkload) {
+			if counter.Load() >= uint64(ad.adm.config.ActivityDumpMaxDumpCountPerWorkload) {
 				ad.Finalize(true)
 				adm.RemoveDump(ad)
 				adm.dropMaxDumpReached.Inc()
@@ -221,7 +221,7 @@ func (adm *ActivityDumpManager) HandleActivityDump(dump *api.ActivityDumpStreamM
 }
 
 // NewActivityDumpManager returns a new ActivityDumpManager instance
-func NewActivityDumpManager(config *config.Config, statsdClient statsd.ClientInterface, newEvent func() *model.Event, processResolver *process.Resolver, timeResolver *stime.Resolver,
+func NewActivityDumpManager(config *config.RuntimeSecurityConfig, statsdClient statsd.ClientInterface, newEvent func() *model.Event, processResolver *process.Resolver, timeResolver *stime.Resolver,
 	tagsResolver *tags.Resolver, kernelVersion *kernel.Version, scrubber *procutil.DataScrubber, manager *manager.Manager) (*ActivityDumpManager, error) {
 	tracedPIDs, err := managerhelper.Map(manager, "traced_pids")
 	if err != nil {
@@ -374,17 +374,17 @@ func (adm *ActivityDumpManager) HandleCgroupTracingEvent(event *model.CgroupTrac
 
 	newDump := NewActivityDump(adm, func(ad *ActivityDump) {
 		ad.Metadata.ContainerID = event.ContainerContext.ID
-		ad.Metadata.DifferentiateArgs = adm.config.RuntimeSecurity.ActivityDumpCgroupDifferentiateArgs
+		ad.Metadata.DifferentiateArgs = adm.config.ActivityDumpCgroupDifferentiateArgs
 		ad.SetLoadConfig(event.ConfigCookie, event.Config)
 	})
 
 	// add local storage requests
-	for _, format := range adm.config.RuntimeSecurity.ActivityDumpLocalStorageFormats {
+	for _, format := range adm.config.ActivityDumpLocalStorageFormats {
 		newDump.AddStorageRequest(config.NewStorageRequest(
 			config.LocalStorage,
 			format,
-			adm.config.RuntimeSecurity.ActivityDumpLocalStorageCompression,
-			adm.config.RuntimeSecurity.ActivityDumpLocalStorageDirectory,
+			adm.config.ActivityDumpLocalStorageCompression,
+			adm.config.ActivityDumpLocalStorageDirectory,
 		))
 	}
 
@@ -723,7 +723,7 @@ func (adm *ActivityDumpManager) getOverweightDumps() []*ActivityDump {
 			seclog.Errorf("couldn't send %s metric: %v", metrics.MetricActivityDumpActiveDumpSizeInMemory, err)
 		}
 
-		if dumpSize >= int64(adm.config.RuntimeSecurity.ActivityDumpMaxDumpSize()) {
+		if dumpSize >= int64(adm.config.ActivityDumpMaxDumpSize()) {
 			toDelete = append([]int{i}, toDelete...)
 			dumps = append(dumps, ad)
 			adm.ignoreFromSnapshot[ad.Metadata.ContainerID] = true

--- a/pkg/security/security_profile/dump/manager_test.go
+++ b/pkg/security/security_profile/dump/manager_test.go
@@ -350,11 +350,9 @@ func TestActivityDumpManager_getOverweightDumps(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			adm := &ActivityDumpManager{
 				activeDumps: tt.fields.activeDumps,
-				config: &config.Config{
-					RuntimeSecurity: &config.RuntimeSecurityConfig{
-						ActivityDumpMaxDumpSize: func() int {
-							return 2048
-						},
+				config: &config.RuntimeSecurityConfig{
+					ActivityDumpMaxDumpSize: func() int {
+						return 2048
 					},
 				},
 				statsdClient:       &statsd.NoOpClient{},

--- a/pkg/security/security_profile/dump/storage_manager.go
+++ b/pkg/security/security_profile/dump/storage_manager.go
@@ -61,7 +61,7 @@ func NewSecurityAgentStorageManager() (*ActivityDumpStorageManager, error) {
 }
 
 // NewActivityDumpStorageManager returns a new instance of ActivityDumpStorageManager
-func NewActivityDumpStorageManager(cfg *config.Config, statsdClient statsd.ClientInterface, handler ActivityDumpHandler) (*ActivityDumpStorageManager, error) {
+func NewActivityDumpStorageManager(cfg *config.RuntimeSecurityConfig, statsdClient statsd.ClientInterface, handler ActivityDumpHandler) (*ActivityDumpStorageManager, error) {
 	manager := &ActivityDumpStorageManager{
 		storages:     make(map[config.StorageType]ActivityDumpStorage),
 		statsdClient: statsdClient,

--- a/pkg/security/security_profile/profile/manager.go
+++ b/pkg/security/security_profile/profile/manager.go
@@ -48,19 +48,19 @@ type SecurityProfileManager struct {
 }
 
 // NewSecurityProfileManager returns a new instance of SecurityProfileManager
-func NewSecurityProfileManager(config *config.Config, statsdClient statsd.ClientInterface, cgroupResolver *cgroup.Resolver, manager *manager.Manager) (*SecurityProfileManager, error) {
+func NewSecurityProfileManager(config *config.RuntimeSecurityConfig, statsdClient statsd.ClientInterface, cgroupResolver *cgroup.Resolver, manager *manager.Manager) (*SecurityProfileManager, error) {
 	var providers []Provider
 
 	// instantiate directory provider
-	if len(config.RuntimeSecurity.SecurityProfileDir) != 0 {
-		dirProvider, err := NewDirectoryProvider(config.RuntimeSecurity.SecurityProfileDir, config.RuntimeSecurity.SecurityProfileWatchDir)
+	if len(config.SecurityProfileDir) != 0 {
+		dirProvider, err := NewDirectoryProvider(config.SecurityProfileDir, config.SecurityProfileWatchDir)
 		if err != nil {
 			return nil, fmt.Errorf("couldn't instantiate a new security profile directory provider: %w", err)
 		}
 		providers = append(providers, dirProvider)
 	}
 
-	profileCache, err := simplelru.NewLRU[cgroupModel.WorkloadSelector, *SecurityProfile](config.RuntimeSecurity.SecurityProfileCacheSize, nil)
+	profileCache, err := simplelru.NewLRU[cgroupModel.WorkloadSelector, *SecurityProfile](config.SecurityProfileCacheSize, nil)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't create security profile cache: %w", err)
 	}

--- a/pkg/security/security_profile/security_profile.go
+++ b/pkg/security/security_profile/security_profile.go
@@ -1,0 +1,186 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+// +build linux
+
+package security_profile
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/DataDog/datadog-go/v5/statsd"
+	manager "github.com/DataDog/ebpf-manager"
+
+	"github.com/DataDog/datadog-agent/pkg/process/procutil"
+	"github.com/DataDog/datadog-agent/pkg/security/config"
+	"github.com/DataDog/datadog-agent/pkg/security/ebpf/kernel"
+	"github.com/DataDog/datadog-agent/pkg/security/proto/api"
+	"github.com/DataDog/datadog-agent/pkg/security/resolvers"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+	"github.com/DataDog/datadog-agent/pkg/security/security_profile/dump"
+	"github.com/DataDog/datadog-agent/pkg/security/security_profile/profile"
+)
+
+// ProfileHandler of the activity dumps and security profiles
+type ProfileHandler struct {
+	Config       *config.RuntimeSecurityConfig
+	StatsdClient statsd.ClientInterface
+
+	activityDumpManager    *dump.ActivityDumpManager
+	securityProfileManager *profile.SecurityProfileManager
+}
+
+// NewProfileHandler returns a new instance of a ProfileHandler
+func NewProfileHandler(cfg *config.RuntimeSecurityConfig, statsdClient statsd.ClientInterface) *ProfileHandler {
+	return &ProfileHandler{
+		Config:       cfg,
+		StatsdClient: statsdClient,
+	}
+}
+
+// Init initializes the event handler
+func (e *ProfileHandler) Init(manager *manager.Manager, resolvers *resolvers.Resolvers, kernelVersion *kernel.Version, scrubber *procutil.DataScrubber, eventCtor func() *model.Event) error {
+	var err error
+
+	if e.Config.IsActivityDumpEnabled() {
+		e.activityDumpManager, err = dump.NewActivityDumpManager(e.Config, e.StatsdClient, eventCtor, resolvers.ProcessResolver, resolvers.TimeResolver, resolvers.TagsResolver, kernelVersion, scrubber, manager)
+		if err != nil {
+			return fmt.Errorf("couldn't create the activity dump manager: %w", err)
+		}
+	}
+
+	if e.Config.SecurityProfileEnabled {
+		e.securityProfileManager, err = profile.NewSecurityProfileManager(e.Config, e.StatsdClient, resolvers.CGroupResolver, manager)
+		if err != nil {
+			return fmt.Errorf("couldn't create the security profile manager: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// GetActivityDumpManager returns the activity dump manager
+func (e *ProfileHandler) GetActivityDumpManager() *dump.ActivityDumpManager {
+	return e.activityDumpManager
+}
+
+// Start triggers the goroutine of all the underlying handlers
+func (e *ProfileHandler) Start(ctx context.Context, wg *sync.WaitGroup) error {
+	if e.activityDumpManager != nil {
+		wg.Add(1)
+		go e.activityDumpManager.Start(ctx, wg)
+	}
+
+	if e.securityProfileManager != nil {
+		go e.securityProfileManager.Start(ctx)
+	}
+
+	return nil
+}
+
+// SendStats sends statistics
+func (e *ProfileHandler) SendStats() error {
+	if e.activityDumpManager != nil {
+		if err := e.activityDumpManager.SendStats(); err != nil {
+			return fmt.Errorf("failed to send activity dump manager stats: %w", err)
+		}
+	}
+
+	if e.securityProfileManager != nil {
+		if err := e.securityProfileManager.SendStats(); err != nil {
+			return fmt.Errorf("failed to send security profile manager stats: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// ProcessEvent processes an event
+func (e *ProfileHandler) ProcessEvent(event *model.Event) {
+	if e.activityDumpManager != nil && event.PathResolutionError == nil {
+		e.activityDumpManager.ProcessEvent(event)
+	}
+}
+
+// ErrActivityDumpManagerDisabled is returned when the activity dump manager is disabled
+var ErrActivityDumpManagerDisabled = errors.New("ActivityDumpManager is disabled")
+
+// DumpActivity handles an activity dump request
+func (e *ProfileHandler) DumpActivity(params *api.ActivityDumpParams) (*api.ActivityDumpMessage, error) {
+	if !e.Config.IsActivityDumpEnabled() {
+		return &api.ActivityDumpMessage{
+			Error: ErrActivityDumpManagerDisabled.Error(),
+		}, ErrActivityDumpManagerDisabled
+	}
+	return e.activityDumpManager.DumpActivity(params)
+}
+
+// ListActivityDumps returns the list of active dumps
+func (e *ProfileHandler) ListActivityDumps(params *api.ActivityDumpListParams) (*api.ActivityDumpListMessage, error) {
+	if !e.Config.IsActivityDumpEnabled() {
+		return &api.ActivityDumpListMessage{
+			Error: ErrActivityDumpManagerDisabled.Error(),
+		}, ErrActivityDumpManagerDisabled
+	}
+	return e.activityDumpManager.ListActivityDumps(params)
+}
+
+// StopActivityDump stops an active activity dump
+func (e *ProfileHandler) StopActivityDump(params *api.ActivityDumpStopParams) (*api.ActivityDumpStopMessage, error) {
+	if !e.Config.IsActivityDumpEnabled() {
+		return &api.ActivityDumpStopMessage{
+			Error: ErrActivityDumpManagerDisabled.Error(),
+		}, ErrActivityDumpManagerDisabled
+	}
+	return e.activityDumpManager.StopActivityDump(params)
+}
+
+// GenerateTranscoding encodes an activity dump following the input parameters
+func (e *ProfileHandler) GenerateTranscoding(params *api.TranscodingRequestParams) (*api.TranscodingRequestMessage, error) {
+	if !e.Config.IsActivityDumpEnabled() {
+		return &api.TranscodingRequestMessage{
+			Error: ErrActivityDumpManagerDisabled.Error(),
+		}, ErrActivityDumpManagerDisabled
+	}
+	return e.activityDumpManager.TranscodingRequest(params)
+}
+
+func (e *ProfileHandler) GetActivityDumpTracedEventTypes() []model.EventType {
+	return e.Config.ActivityDumpTracedEventTypes
+}
+
+// IsNeededForActivityDump returns if the event will be handled by AD
+func (e *ProfileHandler) IsNeededForActivityDump(eventType eval.EventType) bool {
+	if e.Config.IsActivityDumpEnabled() {
+		for _, e := range e.GetActivityDumpTracedEventTypes() {
+			if e.String() == eventType {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// IsSyscallEventTypeEnabled returns if the syscall capture is enabled
+func (e *ProfileHandler) IsSyscallEventTypeEnabled() bool {
+	if e.Config.IsActivityDumpEnabled() {
+		for _, e := range e.GetActivityDumpTracedEventTypes() {
+			if e == model.SyscallsEventType {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// FillProfileContextFromContainerID returns the profile of a container ID
+func (e *ProfileHandler) FillProfileContextFromContainerID(id string, ctx *model.SecurityProfileContext) *profile.SecurityProfile {
+	return e.securityProfileManager.FillProfileContextFromContainerID(id, ctx)
+}

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -1650,8 +1650,8 @@ func checkKernelCompatibility(tb testing.TB, why string, skipCheck func(kv *kern
 }
 
 func (tm *testModule) StartActivityDumpComm(comm string, outputDir string, formats []string) ([]string, error) {
-	monitor := tm.probe.GetMonitor()
-	if monitor == nil {
+	handler := tm.probe.GetProfileHandler()
+	if handler == nil {
 		return nil, errors.New("No monitor")
 	}
 	p := &api.ActivityDumpParams{
@@ -1666,7 +1666,7 @@ func (tm *testModule) StartActivityDumpComm(comm string, outputDir string, forma
 			RemoteStorageCompression: false,
 		},
 	}
-	mess, err := monitor.DumpActivity(p)
+	mess, err := handler.DumpActivity(p)
 	if err != nil || mess == nil || len(mess.Storage) < 1 {
 		return nil, errors.New("failed to start activity dump")
 	}
@@ -1679,8 +1679,8 @@ func (tm *testModule) StartActivityDumpComm(comm string, outputDir string, forma
 }
 
 func (tm *testModule) StopActivityDump(name, containerID, comm string) error {
-	monitor := tm.probe.GetMonitor()
-	if monitor == nil {
+	handler := tm.probe.GetProfileHandler()
+	if handler == nil {
 		return errors.New("No monitor")
 	}
 	p := &api.ActivityDumpStopParams{
@@ -1688,7 +1688,7 @@ func (tm *testModule) StopActivityDump(name, containerID, comm string) error {
 		ContainerID: containerID,
 		Comm:        comm,
 	}
-	_, err := monitor.StopActivityDump(p)
+	_, err := handler.StopActivityDump(p)
 	if err != nil {
 		return err
 	}
@@ -1703,12 +1703,12 @@ type activityDumpIdentifier struct {
 }
 
 func (tm *testModule) ListActivityDumps() ([]*activityDumpIdentifier, error) {
-	monitor := tm.probe.GetMonitor()
-	if monitor == nil {
+	handler := tm.probe.GetProfileHandler()
+	if handler == nil {
 		return nil, errors.New("No monitor")
 	}
 	p := &api.ActivityDumpListParams{}
-	mess, err := monitor.ListActivityDumps(p)
+	mess, err := handler.ListActivityDumps(p)
 	if err != nil || mess == nil {
 		return nil, err
 	}
@@ -1736,12 +1736,12 @@ func (tm *testModule) ListActivityDumps() ([]*activityDumpIdentifier, error) {
 }
 
 func (tm *testModule) DecodeActivityDump(path string) (*dump.ActivityDump, error) {
-	monitor := tm.probe.GetMonitor()
-	if monitor == nil {
+	handler := tm.probe.GetProfileHandler()
+	if handler == nil {
 		return nil, errors.New("No monitor")
 	}
 
-	adm := monitor.GetActivityDumpManager()
+	adm := handler.GetActivityDumpManager()
 	if adm == nil {
 		return nil, errors.New("No activity dump manager")
 	}
@@ -1856,11 +1856,11 @@ func (tm *testModule) addAllEventTypesOnDump(dockerInstance *dockerCmdWrapper, i
 
 //nolint:deadcode,unused
 func (tm *testModule) triggerLoadControlerReducer(dockerInstance *dockerCmdWrapper, id *activityDumpIdentifier) {
-	monitor := tm.probe.GetMonitor()
-	if monitor == nil {
+	handler := tm.probe.GetProfileHandler()
+	if handler == nil {
 		return
 	}
-	adm := monitor.GetActivityDumpManager()
+	adm := handler.GetActivityDumpManager()
 	if adm == nil {
 		return
 	}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This decouple secprof and secdump from the probe monitor

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
