### PR TITLE
Fix output of help command on Windows

### DIFF
--- a/cmd/agent/command/command.go
+++ b/cmd/agent/command/command.go
@@ -7,8 +7,8 @@
 package command
 
 import (
-	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
@@ -37,7 +37,12 @@ func MakeCommand(subcommandFactories []SubcommandFactory) *cobra.Command {
 
 	// AgentCmd is the root command
 	agentCmd := &cobra.Command{
-		Use:   fmt.Sprintf("%s [command]", os.Args[0]),
+		// cobra will tokenize the "Use" string by space, and take the first one so there's no need to pass anything
+		// besides the filename of the executable.
+		// Not even '[command]' is respected - try using their example "add [-F file | -D dir]... [-f format] profile"
+		// and it will still come out as "add [command]" in the help output.
+		// If the file name contains a space, this will break - but this is not the case for the Agent executable.
+		Use:   filepath.Base(os.Args[0]),
 		Short: "Datadog Agent at your service.",
 		Long: `
 The Datadog Agent faithfully collects events and metrics and brings them

--- a/releasenotes/notes/fix-agent-help-command-output-on-windows-d9f42b54bce5de86.yaml
+++ b/releasenotes/notes/fix-agent-help-command-output-on-windows-d9f42b54bce5de86.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    The help output of the Agent command now correctly displays the executable name on Windows.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
This PR fixes the output of the help command on Windows. Currently it displays this when no arguments are provided:
```
& 'C:\Program Files\Datadog\Datadog Agent\bin\agent.exe' -h                     

The Datadog Agent faithfully collects events and metrics and brings them
to Datadog on your behalf so that you can do something useful with your
monitoring and performance data.

Usage:
  C:\Program [command]
```

With this fix:
```
& 'C:\Program Files\Datadog\Datadog Agent\bin\agent.exe' -h                     

The Datadog Agent faithfully collects events and metrics and brings them
to Datadog on your behalf so that you can do something useful with your
monitoring and performance data.

Usage:
  agent.exe [command]
```

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Correct help output on Windows.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs
Previously this would display the full path to the executable in the help output, and now it doesn't. This should not be an issue since there are other means to find the full path to the executable on Linux and no-one should be parsing the help output anyway.
The `Use` field doesn't even seem to respect its own format, as using Cobra's example "add [-F file | -D dir]... [-f format] profile" produces "add [command]" in the help output.

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
On Linux & Windows, call the Agent executable without any arguments and check the help output for correctness.
Do the same for an invalid argument. Check also the help for a subcommand, like "agent run --help".
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
