### PR TITLE
Adding `test` tag to all testing jobs

### DIFF
--- a/pkg/aggregator/aggregator_test.go
+++ b/pkg/aggregator/aggregator_test.go
@@ -36,7 +36,6 @@ var checkID1 check.ID = "1"
 var checkID2 check.ID = "2"
 
 const defaultHostname = "hostname"
-const altDefaultHostname = "althostname"
 
 func init() {
 	initF()

--- a/pkg/aggregator/context_resolver_test.go
+++ b/pkg/aggregator/context_resolver_test.go
@@ -265,15 +265,15 @@ func (s *mockSink) Append(ms *metrics.Serie) {
 }
 
 type mockSample struct {
-	name string
+	name       string
 	taggerTags []string
 	metricTags []string
 }
 
-func (s *mockSample) GetName() string { return s.name }
-func (s *mockSample) GetHost() string { return "noop" }
+func (s *mockSample) GetName() string                   { return s.name }
+func (s *mockSample) GetHost() string                   { return "noop" }
 func (s *mockSample) GetMetricType() metrics.MetricType { return metrics.GaugeType }
-func (s *mockSample) IsNoIndex() bool { return false }
+func (s *mockSample) IsNoIndex() bool                   { return false }
 func (s *mockSample) GetTags(tb, mb tagset.TagsAccumulator) {
 	tb.Append(s.taggerTags...)
 	mb.Append(s.metricTags...)
@@ -291,22 +291,22 @@ func TestOriginTelemetry(t *testing.T) {
 	r.sendOriginTelemetry(ts, &sink, "test", []string{"test"})
 
 	assert.ElementsMatch(t, sink, []*metrics.Serie{{
-		Name: "datadog.agent.aggregator.dogstatsd_contexts_by_origin",
-		Host: "test",
-		Tags: tagset.NewCompositeTags([]string{"test"}, []string{"foo"}),
-		MType: metrics.APIGaugeType,
-		Points: []metrics.Point{{Ts: ts, Value: 2.0 }},
+		Name:   "datadog.agent.aggregator.dogstatsd_contexts_by_origin",
+		Host:   "test",
+		Tags:   tagset.NewCompositeTags([]string{"test"}, []string{"foo"}),
+		MType:  metrics.APIGaugeType,
+		Points: []metrics.Point{{Ts: ts, Value: 2.0}},
 	}, {
-		Name: "datadog.agent.aggregator.dogstatsd_contexts_by_origin",
-		Host: "test",
-		Tags: tagset.NewCompositeTags([]string{"test"}, []string{"bar"}),
-		MType: metrics.APIGaugeType,
-		Points: []metrics.Point{{Ts: ts, Value: 2.0 }},
+		Name:   "datadog.agent.aggregator.dogstatsd_contexts_by_origin",
+		Host:   "test",
+		Tags:   tagset.NewCompositeTags([]string{"test"}, []string{"bar"}),
+		MType:  metrics.APIGaugeType,
+		Points: []metrics.Point{{Ts: ts, Value: 2.0}},
 	}, {
-		Name: "datadog.agent.aggregator.dogstatsd_contexts_by_origin",
-		Host: "test",
-		Tags: tagset.NewCompositeTags([]string{"test"}, []string{"baz"}),
-		MType: metrics.APIGaugeType,
-		Points: []metrics.Point{{Ts: ts, Value: 1.0 }},
+		Name:   "datadog.agent.aggregator.dogstatsd_contexts_by_origin",
+		Host:   "test",
+		Tags:   tagset.NewCompositeTags([]string{"test"}, []string{"baz"}),
+		MType:  metrics.APIGaugeType,
+		Points: []metrics.Point{{Ts: ts, Value: 1.0}},
 	}})
 }

--- a/pkg/collector/collector_demux_test.go
+++ b/pkg/collector/collector_demux_test.go
@@ -148,7 +148,7 @@ func (suite *CollectorDemuxTestSuite) TestRescheduledCheckReusesSampler() {
 	}, time.Second, 10*time.Millisecond)
 
 	//create new sender and try registering sampler before flush
-	sender, err = aggregator.GetSender(ch.ID())
+	_, err = aggregator.GetSender(ch.ID())
 	assert.NoError(suite.T(), err)
 
 	// flush

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -1207,7 +1207,7 @@ func (p *Probe) setupNewTCClassifier(device model.NetDevice) error {
 	netns := p.resolvers.NamespaceResolver.ResolveNetworkNamespace(device.NetNS)
 	if netns != nil {
 		handle, err = netns.GetNamespaceHandleDup()
-		defer handle.Close() // nolint:errcheck
+		defer handle.Close() // nolint:errcheck,staticcheck
 	}
 	if netns == nil || err != nil || handle == nil {
 		// queue network device so that a TC classifier can be added later

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -1207,7 +1207,7 @@ func (p *Probe) setupNewTCClassifier(device model.NetDevice) error {
 	netns := p.resolvers.NamespaceResolver.ResolveNetworkNamespace(device.NetNS)
 	if netns != nil {
 		handle, err = netns.GetNamespaceHandleDup()
-		defer handle.Close()
+		defer handle.Close() // nolint:errcheck
 	}
 	if netns == nil || err != nil || handle == nil {
 		// queue network device so that a TC classifier can be added later

--- a/pkg/serializer/internal/metrics/series_test.go
+++ b/pkg/serializer/internal/metrics/series_test.go
@@ -73,7 +73,7 @@ func TestPopulateResources(t *testing.T) {
 		{
 			[]string{"some:tag", "dd.internal.resource:aws_rds_instance:some_instance_endpoint"},
 			[]string{"some:tag"},
-			[]metrics.Resource{metrics.Resource{
+			[]metrics.Resource{{
 				Type: "aws_rds_instance",
 				Name: "some_instance_endpoint",
 			}},
@@ -82,11 +82,11 @@ func TestPopulateResources(t *testing.T) {
 			[]string{"some:tag", "dd.internal.resource:database_instance:some_db_host", "dd.internal.resource:aws_rds_instance:some_instance_endpoint", "some_other:tag"},
 			[]string{"some:tag", "some_other:tag"},
 			[]metrics.Resource{
-				metrics.Resource{
+				{
 					Type: "database_instance",
 					Name: "some_db_host",
 				},
-				metrics.Resource{
+				{
 					Type: "aws_rds_instance",
 					Name: "some_instance_endpoint",
 				}},
@@ -95,7 +95,7 @@ func TestPopulateResources(t *testing.T) {
 			[]string{"some:tag", "dd.internal.resource:database_instance:some_db_host", "resource:some_resource_value", "some_other:tag"},
 			[]string{"some:tag", "resource:some_resource_value", "some_other:tag"},
 			[]metrics.Resource{
-				metrics.Resource{
+				{
 					Type: "database_instance",
 					Name: "some_db_host",
 				},

--- a/pkg/serializer/serializer_test.go
+++ b/pkg/serializer/serializer_test.go
@@ -230,13 +230,6 @@ func TestSendV1Events(t *testing.T) {
 	f.AssertExpectations(t)
 }
 
-type testPayloadMutipleValues struct {
-	testPayload
-	count int
-}
-
-func (p *testPayloadMutipleValues) Len() int { return p.count }
-
 func TestSendV1EventsCreateMarshalersBySourceType(t *testing.T) {
 	config.Datadog.Set("enable_events_stream_payload_serialization", true)
 	defer config.Datadog.Set("enable_events_stream_payload_serialization", nil)

--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -168,25 +168,25 @@ build_tags = {
         "trace-agent": TRACE_AGENT_TAGS,
         # Test setups
         "test": AGENT_TEST_TAGS,
-        "lint": AGENT_TEST_TAGS.union(PROCESS_AGENT_TAGS),
+        "lint": AGENT_TEST_TAGS.union(PROCESS_AGENT_TAGS).union(UNIT_TEST_TAGS),
         "unit-tests": AGENT_TEST_TAGS.union(PROCESS_AGENT_TAGS).union(UNIT_TEST_TAGS),
     },
     AgentFlavor.heroku: {
         "agent": AGENT_HEROKU_TAGS,
         "process-agent": PROCESS_AGENT_HEROKU_TAGS,
         "trace-agent": TRACE_AGENT_HEROKU_TAGS,
-        "lint": AGENT_HEROKU_TAGS,
+        "lint": AGENT_HEROKU_TAGS.union(UNIT_TEST_TAGS),
         "unit-tests": AGENT_HEROKU_TAGS.union(UNIT_TEST_TAGS),
     },
     AgentFlavor.iot: {
         "agent": IOT_AGENT_TAGS,
-        "lint": IOT_AGENT_TAGS,
+        "lint": IOT_AGENT_TAGS.union(UNIT_TEST_TAGS),
         "unit-tests": IOT_AGENT_TAGS.union(UNIT_TEST_TAGS),
     },
     AgentFlavor.dogstatsd: {
         "dogstatsd": DOGSTATSD_TAGS,
         "system-tests": AGENT_TAGS,
-        "lint": DOGSTATSD_TAGS,
+        "lint": DOGSTATSD_TAGS.union(UNIT_TEST_TAGS),
         "unit-tests": DOGSTATSD_TAGS.union(UNIT_TEST_TAGS),
     },
 }


### PR DESCRIPTION
### What does this PR do?

Most mock/testing helpers are behind a `test` build tag. We need to add this tag to every linting/testing jobs in the CI to be able to use it everywhere.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
