### PR TITLE
[RCM] upgrade(remote-config): Remove noisy log on missing config entry

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -302,6 +302,7 @@ func InitConfig(config Config) {
 	config.BindEnv("remote_configuration.refresh_interval")
 	config.BindEnvAndSetDefault("remote_configuration.max_backoff_interval", 5*time.Minute)
 	config.BindEnvAndSetDefault("remote_configuration.clients.ttl_seconds", 30*time.Second)
+	config.BindEnvAndSetDefault("remote_configuration.clients.cache_bypass_limit", 5)
 	// Remote config products
 	config.BindEnvAndSetDefault("remote_configuration.apm_sampling.enabled", true)
 

--- a/pkg/config/remote/service/service.go
+++ b/pkg/config/remote/service/service.go
@@ -240,7 +240,7 @@ func (s *Service) Start(ctx context.Context) error {
 
 		err := s.refresh()
 		if err != nil {
-			log.Errorf("could not refresh remote-config: %v", err)
+			log.Errorf("Could not refresh Remote Config: %v", err)
 		}
 
 		for {
@@ -262,7 +262,7 @@ func (s *Service) Start(ctx context.Context) error {
 			}
 
 			if err != nil {
-				log.Errorf("could not refresh remote-config: %v", err)
+				log.Errorf("Could not refresh Remote Config: %v", err)
 			}
 		}
 	}()
@@ -321,7 +321,7 @@ func (s *Service) refresh() error {
 		if err == nil && ri > 0 && s.defaultRefreshInterval != ri {
 			s.defaultRefreshInterval = ri
 			s.cacheBypassClients.windowDuration = ri
-			log.Info("Overriding agent's base refresh interval to %v due to backend recommendation", ri)
+			log.Infof("Overriding agent's base refresh interval to %v due to backend recommendation", ri)
 		}
 	}
 


### PR DESCRIPTION
### What does this PR do?
Backport of https://github.com/DataDog/datadog-agent/pull/16440

### Motivation


### Additional Notes


### Possible Drawbacks / Trade-offs


### Describe how to test/QA your changes


### Reviewer's Checklist


- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
