### PR TITLE
Retrieve container image ID

### DIFF
--- a/pkg/util/podman/container.go
+++ b/pkg/util/podman/container.go
@@ -188,12 +188,23 @@ type ContainerConfig struct {
 	Dependencies []string
 
 	// embedded sub-configs
-	//ContainerRootFSConfig
+	ContainerRootFSConfig
 	ContainerSecurityConfig
 	ContainerNameSpaceConfig
 	ContainerNetworkConfig
 	ContainerImageConfig
 	ContainerMiscConfig
+}
+
+// ContainerRootFSConfig is an embedded sub-config providing config info about the container's root fs.
+// We use it to get the container's imageID
+type ContainerRootFSConfig struct {
+	// RootfsImageID is the ID of the image used to create the container.
+	// If the container was created from a Rootfs, this will be empty.
+	// If non-empty, Podman will create a root filesystem for the container
+	// based on an image with this ID.
+	// This conflicts with Rootfs.
+	RootfsImageID string `json:"rootfsImageID,omitempty"`
 }
 
 // ContainerSecurityConfig is an embedded sub-config providing security configuration

--- a/pkg/workloadmeta/collectors/internal/containerd/container_builder.go
+++ b/pkg/workloadmeta/collectors/internal/containerd/container_builder.go
@@ -41,12 +41,10 @@ func buildWorkloadMetaContainer(namespace string, container containerd.Container
 
 	// Get image id from container's image config
 	var imageID string
-	img, err := container.Image(ctx)
-	if err != nil {
+	if img, err := container.Image(ctx); err != nil {
 		log.Warnf("cannot get container %s's image: %v", container.ID(), err)
 	} else {
-		imgConfig, err := img.Config(ctx)
-		if err != nil {
+		if imgConfig, err := img.Config(ctx); err != nil
 			log.Warnf("cannot get container %s's image's config: %v", container.ID(), err)
 		} else {
 			imageID = imgConfig.Digest.String()

--- a/pkg/workloadmeta/collectors/internal/containerd/container_builder.go
+++ b/pkg/workloadmeta/collectors/internal/containerd/container_builder.go
@@ -48,15 +48,16 @@ func buildWorkloadMetaContainer(namespace string, container containerd.Container
 	img, err := container.Image(ctx)
 	if err != nil {
 		log.Debugf("cannot get container's image: %s", err)
+	} else {
+		imgConfig, err := img.Config(ctx)
+		if err != nil {
+			log.Debugf("cannot get image's config: %s", err)
+		} else {
+			imageID := imgConfig.Digest.String()
+			// Add imageID
+			image.ID = imageID
+		}
 	}
-	imgConfig, err := img.Config(ctx)
-	if err != nil {
-		log.Debugf("cannot get image's config: %s", err)
-	}
-	imageID := imgConfig.Digest.String()
-
-	// Add imageID
-	image.ID = imageID
 
 	status, err := containerdClient.Status(namespace, container)
 	if err != nil {

--- a/pkg/workloadmeta/collectors/internal/containerd/container_builder.go
+++ b/pkg/workloadmeta/collectors/internal/containerd/container_builder.go
@@ -47,15 +47,13 @@ func buildWorkloadMetaContainer(namespace string, container containerd.Container
 	// Get image id from container's image config
 	img, err := container.Image(ctx)
 	if err != nil {
-		log.Debugf("cannot get container's image: %s", err)
+		log.Debugf("cannot get container %s's image: %v", container.ID(), err)
 	} else {
 		imgConfig, err := img.Config(ctx)
 		if err != nil {
-			log.Debugf("cannot get image's config: %s", err)
+			log.Debugf("cannot get container %s's image's config: %v", container.ID(), err)
 		} else {
-			imageID := imgConfig.Digest.String()
-			// Add imageID
-			image.ID = imageID
+			image.ID = imgConfig.Digest.String()
 		}
 	}
 

--- a/pkg/workloadmeta/collectors/internal/containerd/container_builder.go
+++ b/pkg/workloadmeta/collectors/internal/containerd/container_builder.go
@@ -44,7 +44,7 @@ func buildWorkloadMetaContainer(namespace string, container containerd.Container
 	if img, err := container.Image(ctx); err != nil {
 		log.Warnf("cannot get container %s's image: %v", container.ID(), err)
 	} else {
-		if imgConfig, err := img.Config(ctx); err != nil
+		if imgConfig, err := img.Config(ctx); err != nil {
 			log.Warnf("cannot get container %s's image's config: %v", container.ID(), err)
 		} else {
 			imageID = imgConfig.Digest.String()

--- a/pkg/workloadmeta/collectors/internal/containerd/container_builder_test.go
+++ b/pkg/workloadmeta/collectors/internal/containerd/container_builder_test.go
@@ -9,6 +9,7 @@
 package containerd
 
 import (
+	"context"
 	"strings"
 	"testing"
 	"time"
@@ -16,6 +17,7 @@ import (
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/containers"
 	"github.com/containerd/containerd/oci"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/assert"
 
@@ -25,20 +27,27 @@ import (
 
 type mockedContainer struct {
 	containerd.Container
-	mockID func() string
+	mockID    func() string
+	mockImage func() (containerd.Image, error)
 }
 
 func (m *mockedContainer) ID() string {
 	return m.mockID()
 }
 
-type mockedImage struct {
-	containerd.Image
-	mockName func() string
+// Image is from the containerd.Container interface
+func (m *mockedContainer) Image(context.Context) (containerd.Image, error) {
+	return m.mockImage()
 }
 
-func (m *mockedImage) Name() string {
-	return m.mockName()
+type mockedImage struct {
+	containerd.Image
+	mockName   func() string
+	mockConfig func() (ocispec.Descriptor, error)
+}
+
+func (m *mockedImage) Config(ctx context.Context) (ocispec.Descriptor, error) {
+	return m.mockConfig()
 }
 
 func TestBuildWorkloadMetaContainer(t *testing.T) {
@@ -63,10 +72,17 @@ func TestBuildWorkloadMetaContainer(t *testing.T) {
 	createdAt, err := time.Parse("2006-01-02", "2021-10-11")
 	assert.NoError(t, err)
 
+	image := &mockedImage{
+		mockConfig: func() (ocispec.Descriptor, error) {
+			return ocispec.Descriptor{Digest: "my_image_id"}, nil
+		},
+	}
 	container := mockedContainer{
-		fake.mockedContainer,
 		mockID: func() string {
 			return containerID
+		},
+		mockImage: func() (containerd.Image, error) {
+			return image, nil
 		},
 	}
 
@@ -106,6 +122,7 @@ func TestBuildWorkloadMetaContainer(t *testing.T) {
 			Name:      "datadog/agent",
 			ShortName: "agent",
 			Tag:       "7",
+			ID:        "my_image_id",
 		},
 		EnvVars: envVars,
 		Ports:   nil, // Not available

--- a/pkg/workloadmeta/collectors/internal/containerd/container_builder_test.go
+++ b/pkg/workloadmeta/collectors/internal/containerd/container_builder_test.go
@@ -64,7 +64,7 @@ func TestBuildWorkloadMetaContainer(t *testing.T) {
 	assert.NoError(t, err)
 
 	container := mockedContainer{
-		fake.mockedContainer
+		fake.mockedContainer,
 		mockID: func() string {
 			return containerID
 		},

--- a/pkg/workloadmeta/collectors/internal/containerd/container_builder_test.go
+++ b/pkg/workloadmeta/collectors/internal/containerd/container_builder_test.go
@@ -64,6 +64,7 @@ func TestBuildWorkloadMetaContainer(t *testing.T) {
 	assert.NoError(t, err)
 
 	container := mockedContainer{
+		fake.mockedContainer
 		mockID: func() string {
 			return containerID
 		},

--- a/pkg/workloadmeta/collectors/internal/containerd/event_builder_test.go
+++ b/pkg/workloadmeta/collectors/internal/containerd/event_builder_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/containerd/containerd/oci"
 	"github.com/gogo/protobuf/proto"
 	"github.com/gogo/protobuf/types"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/assert"
 
@@ -31,9 +32,18 @@ func TestBuildCollectorEvent(t *testing.T) {
 	containerID := "10"
 	namespace := "test_namespace"
 
+	image := &mockedImage{
+		mockConfig: func() (ocispec.Descriptor, error) {
+			return ocispec.Descriptor{Digest: "my_image_id"}, nil
+		},
+	}
+
 	container := mockedContainer{
 		mockID: func() string {
 			return containerID
+		},
+		mockImage: func() (containerd.Image, error) {
+			return image, nil
 		},
 	}
 

--- a/pkg/workloadmeta/collectors/internal/docker/docker.go
+++ b/pkg/workloadmeta/collectors/internal/docker/docker.go
@@ -37,6 +37,7 @@ const (
 )
 
 type resolveHook func(ctx context.Context, co types.ContainerJSON) (string, error)
+type resolveContainerListWithFilter func(ctx context.Context, options types.ContainerListOptions, filter *containers.Filter) ([]types.Container, error)
 
 type collector struct {
 	store workloadmeta.Store
@@ -258,7 +259,7 @@ func (c *collector) buildCollectorEvent(ctx context.Context, ev *docker.Containe
 				Name:   strings.TrimPrefix(container.Name, "/"),
 				Labels: container.Config.Labels,
 			},
-			Image:   extractImage(ctx, container, c.dockerUtil.ResolveImageNameFromContainer),
+			Image:   extractImage(ctx, container, c.dockerUtil.ResolveImageNameFromContainer, c.dockerUtil.RawContainerListWithFilter),
 			EnvVars: extractEnvVars(container.Config.Env),
 			Ports:   extractPorts(container),
 			Runtime: workloadmeta.ContainerRuntimeDocker,
@@ -303,7 +304,7 @@ func (c *collector) buildCollectorEvent(ctx context.Context, ev *docker.Containe
 	return event, nil
 }
 
-func extractImage(ctx context.Context, container types.ContainerJSON, resolve resolveHook) workloadmeta.ContainerImage {
+func extractImage(ctx context.Context, container types.ContainerJSON, resolve resolveHook, resolveContainersList resolveContainerListWithFilter) workloadmeta.ContainerImage {
 	imageSpec := container.Config.Image
 	image := workloadmeta.ContainerImage{
 		RawName: imageSpec,
@@ -353,6 +354,25 @@ func extractImage(ctx context.Context, container types.ContainerJSON, resolve re
 	image.Registry = registry
 	image.ShortName = shortName
 	image.Tag = tag
+
+	// Get imageID from running container with mathing ID
+	var imageID string
+	filter, err := containers.GetPauseContainerFilter()
+	if err != nil {
+		log.Warnf("Can't get pause container filter, no filtering will be applied: %v", err)
+	}
+	running_containers, err := resolveContainersList(ctx, types.ContainerListOptions{}, filter)
+	if err != nil {
+		log.Debugf("cannot get running containers: %v", err)
+	}
+
+	for _, c := range running_containers {
+		if c.ID == container.ContainerJSONBase.ID {
+			imageID = c.ImageID
+		}
+	}
+	// Add imageID to image
+	image.ID = imageID
 
 	return image
 }

--- a/pkg/workloadmeta/collectors/internal/docker/docker.go
+++ b/pkg/workloadmeta/collectors/internal/docker/docker.go
@@ -354,26 +354,7 @@ func extractImage(ctx context.Context, container types.ContainerJSON, resolve re
 	image.Registry = registry
 	image.ShortName = shortName
 	image.Tag = tag
-
-	// Get imageID from running container with mathing ID
-	var imageID string
-	filter, err := containers.GetPauseContainerFilter()
-	if err != nil {
-		log.Warnf("Can't get pause container filter, no filtering will be applied: %v", err)
-	}
-	running_containers, err := resolveContainersList(ctx, types.ContainerListOptions{}, filter)
-	if err != nil {
-		log.Debugf("cannot get running containers: %v", err)
-	}
-
-	for _, c := range running_containers {
-		if c.ID == container.ContainerJSONBase.ID {
-			imageID = c.ImageID
-		}
-	}
-	// Add imageID to image
-	image.ID = imageID
-
+	image.ID = container.Image
 	return image
 }
 

--- a/pkg/workloadmeta/collectors/internal/docker/docker.go
+++ b/pkg/workloadmeta/collectors/internal/docker/docker.go
@@ -37,7 +37,6 @@ const (
 )
 
 type resolveHook func(ctx context.Context, co types.ContainerJSON) (string, error)
-type resolveContainerListWithFilter func(ctx context.Context, options types.ContainerListOptions, filter *containers.Filter) ([]types.Container, error)
 
 type collector struct {
 	store workloadmeta.Store
@@ -259,7 +258,7 @@ func (c *collector) buildCollectorEvent(ctx context.Context, ev *docker.Containe
 				Name:   strings.TrimPrefix(container.Name, "/"),
 				Labels: container.Config.Labels,
 			},
-			Image:   extractImage(ctx, container, c.dockerUtil.ResolveImageNameFromContainer, c.dockerUtil.RawContainerListWithFilter),
+			Image:   extractImage(ctx, container, c.dockerUtil.ResolveImageNameFromContainer),
 			EnvVars: extractEnvVars(container.Config.Env),
 			Ports:   extractPorts(container),
 			Runtime: workloadmeta.ContainerRuntimeDocker,
@@ -304,7 +303,7 @@ func (c *collector) buildCollectorEvent(ctx context.Context, ev *docker.Containe
 	return event, nil
 }
 
-func extractImage(ctx context.Context, container types.ContainerJSON, resolve resolveHook, resolveContainersList resolveContainerListWithFilter) workloadmeta.ContainerImage {
+func extractImage(ctx context.Context, container types.ContainerJSON, resolve resolveHook) workloadmeta.ContainerImage {
 	imageSpec := container.Config.Image
 	image := workloadmeta.ContainerImage{
 		RawName: imageSpec,

--- a/pkg/workloadmeta/collectors/internal/ecsfargate/ecsfargate.go
+++ b/pkg/workloadmeta/collectors/internal/ecsfargate/ecsfargate.go
@@ -159,6 +159,10 @@ func (c *collector) parseTaskContainers(
 		seen[entityID] = struct{}{}
 
 		image, err := workloadmeta.NewContainerImage(container.Image)
+
+		// Add imageID to image
+		image.ID = container.ImageID
+
 		if err != nil {
 			log.Debugf("cannot split image name %q: %s", container.Image, err)
 		}

--- a/pkg/workloadmeta/collectors/internal/ecsfargate/ecsfargate.go
+++ b/pkg/workloadmeta/collectors/internal/ecsfargate/ecsfargate.go
@@ -158,10 +158,7 @@ func (c *collector) parseTaskContainers(
 
 		seen[entityID] = struct{}{}
 
-		image, err := workloadmeta.NewContainerImage(container.Image)
-
-		// Add imageID to image
-		image.ID = container.ImageID
+		image, err := workloadmeta.NewContainerImage(container.ImageID, container.Image)
 
 		if err != nil {
 			log.Debugf("cannot split image name %q: %s", container.Image, err)

--- a/pkg/workloadmeta/collectors/internal/kubelet/kubelet.go
+++ b/pkg/workloadmeta/collectors/internal/kubelet/kubelet.go
@@ -178,21 +178,19 @@ func (c *collector) parsePodContainers(
 		var env map[string]string
 		var ports []workloadmeta.ContainerPort
 
-		image, err := workloadmeta.NewContainerImage(container.Image)
+		image, err := workloadmeta.NewContainerImage(container.ImageID, container.Image)
 		if err != nil {
 			if err == containers.ErrImageIsSha256 {
 				// try the resolved image ID if the image name in the container
 				// status is a SHA256. this seems to happen sometimes when
 				// pinning the image to a SHA256
-				image, err = workloadmeta.NewContainerImage(container.ImageID)
+				image, err = workloadmeta.NewContainerImage(container.ImageID, container.ImageID)
 			}
 
 			if err != nil {
 				log.Debugf("cannot split image name %q nor %q: %s", container.Image, container.ImageID, err)
 			}
 		}
-
-		image.ID = container.ImageID
 
 		runtime, containerID := containers.SplitEntityName(container.ID)
 		podContainer := workloadmeta.OrchestratorContainer{
@@ -204,12 +202,10 @@ func (c *collector) parsePodContainers(
 		if containerSpec != nil {
 			env = extractEnvFromSpec(containerSpec.Env)
 
-			podContainer.Image, err = workloadmeta.NewContainerImage(containerSpec.Image)
+			podContainer.Image, err = workloadmeta.NewContainerImage(container.ImageID, containerSpec.Image)
 			if err != nil {
 				log.Debugf("cannot split image name %q: %s", containerSpec.Image, err)
 			}
-
-			podContainer.Image.ID = container.ImageID
 
 			ports = make([]workloadmeta.ContainerPort, 0, len(containerSpec.Ports))
 			for _, port := range containerSpec.Ports {

--- a/pkg/workloadmeta/collectors/internal/podman/podman.go
+++ b/pkg/workloadmeta/collectors/internal/podman/podman.go
@@ -110,6 +110,13 @@ func convertToEvent(container *podman.Container) workloadmeta.CollectorEvent {
 		log.Warnf("Could not get image for container %s", containerID)
 	}
 
+	// Add imageID to image
+	imageID := container.Config.ContainerRootFSConfig.RootfsImageID
+	if !strings.HasPrefix(imageID, "sha256:") {
+		imageID = "sha256:" + imageID
+	}
+	image.ID = imageID
+
 	var ports []workloadmeta.ContainerPort
 	for _, portMapping := range container.Config.PortMappings {
 		ports = append(ports, workloadmeta.ContainerPort{

--- a/pkg/workloadmeta/collectors/internal/podman/podman.go
+++ b/pkg/workloadmeta/collectors/internal/podman/podman.go
@@ -112,9 +112,6 @@ func convertToEvent(container *podman.Container) workloadmeta.CollectorEvent {
 
 	// Add imageID to image
 	imageID := container.Config.ContainerRootFSConfig.RootfsImageID
-	if !strings.HasPrefix(imageID, "sha256:") {
-		imageID = "sha256:" + imageID
-	}
 	image.ID = imageID
 
 	var ports []workloadmeta.ContainerPort

--- a/pkg/workloadmeta/collectors/internal/podman/podman.go
+++ b/pkg/workloadmeta/collectors/internal/podman/podman.go
@@ -105,13 +105,10 @@ func convertToEvent(container *podman.Container) workloadmeta.CollectorEvent {
 		log.Warnf("Could not get env vars for container %s", containerID)
 	}
 
-	image, err := workloadmeta.NewContainerImage(container.Config.RawImageName)
+	image, err := workloadmeta.NewContainerImage(container.Config.ContainerRootFSConfig.RootfsImageID, container.Config.RawImageName)
 	if err != nil {
 		log.Warnf("Could not get image for container %s", containerID)
 	}
-
-	// Add imageID to image
-	image.ID = container.Config.ContainerRootFSConfig.RootfsImageID
 
 	var ports []workloadmeta.ContainerPort
 	for _, portMapping := range container.Config.PortMappings {

--- a/pkg/workloadmeta/collectors/internal/podman/podman.go
+++ b/pkg/workloadmeta/collectors/internal/podman/podman.go
@@ -111,8 +111,7 @@ func convertToEvent(container *podman.Container) workloadmeta.CollectorEvent {
 	}
 
 	// Add imageID to image
-	imageID := container.Config.ContainerRootFSConfig.RootfsImageID
-	image.ID = imageID
+	image.ID = container.Config.ContainerRootFSConfig.RootfsImageID
 
 	var ports []workloadmeta.ContainerPort
 	for _, portMapping := range container.Config.PortMappings {

--- a/pkg/workloadmeta/collectors/internal/podman/podman_test.go
+++ b/pkg/workloadmeta/collectors/internal/podman/podman_test.go
@@ -75,6 +75,9 @@ func TestPull(t *testing.T) {
 						"label-b": "value-b",
 					},
 				},
+				ContainerRootFSConfig: podman.ContainerRootFSConfig{
+					RootfsImageID: "my_image_id_1",
+				},
 			},
 			State: &podman.ContainerState{
 				State:       podman.ContainerStateRunning,
@@ -123,6 +126,9 @@ func TestPull(t *testing.T) {
 						"label-a-dev": "value-a-dev",
 						"label-b-dev": "value-b-dev",
 					},
+				},
+				ContainerRootFSConfig: podman.ContainerRootFSConfig{
+					RootfsImageID: "my_image_id_2",
 				},
 			},
 			State: &podman.ContainerState{
@@ -176,6 +182,7 @@ func TestPull(t *testing.T) {
 					Registry:  "docker.io",
 					ShortName: "agent",
 					Tag:       "latest",
+					ID:        "my_image_id_1",
 				},
 				NetworkIPs: map[string]string{
 					"podman": "10.88.0.13",
@@ -224,6 +231,7 @@ func TestPull(t *testing.T) {
 					Registry:  "docker.io",
 					ShortName: "agent-dev",
 					Tag:       "latest",
+					ID:        "my_image_id_2",
 				},
 				NetworkIPs: map[string]string{
 					"podman": "10.88.0.14",

--- a/pkg/workloadmeta/types.go
+++ b/pkg/workloadmeta/types.go
@@ -277,9 +277,10 @@ type ContainerImage struct {
 	Tag       string
 }
 
-// NewContainerImage builds a ContainerImage from an image name
-func NewContainerImage(imageName string) (ContainerImage, error) {
+// NewContainerImage builds a ContainerImage from an image name and its id
+func NewContainerImage(imageID string, imageName string) (ContainerImage, error) {
 	image := ContainerImage{
+		ID:      imageID,
 		RawName: imageName,
 		Name:    imageName,
 	}

--- a/pkg/workloadmeta/types_test.go
+++ b/pkg/workloadmeta/types_test.go
@@ -6,6 +6,7 @@
 package workloadmeta
 
 import (
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -26,6 +27,7 @@ func TestNewContainerImage(t *testing.T) {
 				Name:      "datadog/agent",
 				ShortName: "agent",
 				Tag:       "7",
+				ID:        "0",
 			},
 		}, {
 			name:      "image without tag",
@@ -35,13 +37,14 @@ func TestNewContainerImage(t *testing.T) {
 				Name:      "datadog/agent",
 				ShortName: "agent",
 				Tag:       "latest", // Default to latest when there's no tag
+				ID:        "1",
 			},
 		},
 	}
 
-	for _, test := range tests {
+	for i, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			image, err := NewContainerImage(test.imageName)
+			image, err := NewContainerImage(strconv.Itoa(i), test.imageName)
 			assert.NoError(t, err)
 			assert.Equal(t, test.expectedWorkloadmetaImage, image)
 		})


### PR DESCRIPTION
This PR aims to retrieve a container's imageID. Currently, when a container is directly on a host (not using kubernetes...), the ID field is always empty for a given Container's Image.

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
