### PR TITLE
Fix win-install-fail for the NG installer

### DIFF
--- a/.gitlab/kitchen_testing/windows.yml
+++ b/.gitlab/kitchen_testing/windows.yml
@@ -49,6 +49,7 @@
   script:
     - export WINDOWS_AGENT_FILE=datadog-agent-ng-$(cd ../.. && inv agent.version --url-safe --major-version $AGENT_MAJOR_VERSION)-1-x86_64
     - export LAST_STABLE_VERSION=$(cd ../.. && invoke release.get-release-json-value "last_stable::$AGENT_MAJOR_VERSION")
+    - export NG_INSTALLER=true
     - echo $WINDOWS_AGENT_FILE
     - tasks/run-test-kitchen.sh windows-install-test $AGENT_MAJOR_VERSION
   # Until the code is stabilized

--- a/test/kitchen/test-definitions/windows-install-test.yml
+++ b/test/kitchen/test-definitions/windows-install-test.yml
@@ -180,6 +180,7 @@ suites:
           WIXFAILWHENDEFERRED=1
       dd-agent-rspec:
         skip_windows_signing_test: &skip_windows_signing_test <%= ENV['SKIP_SIGNATURE_TEST'] || false %>
+        ng_installer: &ng_installer <%= ENV['NG_INSTALLER'] || false %>
 
   - name: win-alt-dir
     run_list:

--- a/test/kitchen/test/integration/common/rspec_datadog/spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec_datadog/spec_helper.rb
@@ -468,6 +468,10 @@ shared_examples_for 'Agent uninstall' do
   it_behaves_like 'an Agent that is removed'
 end
 
+def is_ng_installer()
+  parse_dna().fetch('dd-agent-rspec').fetch('ng_installer')
+end
+
 shared_examples_for "an installed Agent" do
   wait_until_service_started get_service_name("datadog-agent")
 

--- a/test/kitchen/test/integration/win-install-fail/rspec_datadog/spec_helper.rb
+++ b/test/kitchen/test/integration/win-install-fail/rspec_datadog/spec_helper.rb
@@ -1,0 +1,1 @@
+../../common/rspec_datadog/spec_helper.rb

--- a/test/kitchen/test/integration/win-install-fail/rspec_datadog/win-install-fail_spec.rb
+++ b/test/kitchen/test/integration/win-install-fail/rspec_datadog/win-install-fail_spec.rb
@@ -38,8 +38,8 @@ describe 'dd-agent-win-install-fail' do
   # The installer no longer deletes the user on uninstall and is transitioning away from managing user accounts.
   # Therefore we should instead check that it did create a ddagentuser account for now, and in the future check 
   # that it did not create a ddagentuser account.
-  it_behaves_like 'a device with a dd-agent-user' if is_ng_installer
+  it_behaves_like 'a device with a ddagentuser' if is_ng_installer
 
   # Keep the old behavior for the old installer for now.
-  it_behaves_like 'a device without a dd-agent-user' unless is_ng_installer
+  it_behaves_like 'a device without a ddagentuser' unless is_ng_installer
 end

--- a/test/kitchen/test/integration/win-install-fail/rspec_datadog/win-install-fail_spec.rb
+++ b/test/kitchen/test/integration/win-install-fail/rspec_datadog/win-install-fail_spec.rb
@@ -1,5 +1,4 @@
-
-
+require 'spec_helper'
 
 def check_user_exists(name)
   selectstatement = "powershell -command \"get-wmiobject -query \\\"Select * from Win32_UserAccount where Name='#{name}'\\\"\""
@@ -20,13 +19,27 @@ shared_examples_for 'a device with no files installed' do
   end
 end
 
-shared_examples_for 'a device with no dd-agent-user' do
+shared_examples_for 'a device with a ddagentuser' do
   is_user = check_user_exists('ddagentuser')
-  it 'has not dd-agent-user' do
+  it 'has a ddagentuser account' do
+    expect(is_user).not_to be_empty
+  end
+end
+
+shared_examples_for 'a device without a ddagentuser' do
+  is_user = check_user_exists('ddagentuser')
+  it 'doesn\'t have a ddagentuser account' do
     expect(is_user).to be_empty
   end
 end
+
 describe 'dd-agent-win-install-fail' do
   it_behaves_like 'a device with no files installed'
-  it_behaves_like 'a device with no dd-agent-user'
+  # The installer no longer deletes the user on uninstall and is transitioning away from managing user accounts.
+  # Therefore we should instead check that it did create a ddagentuser account for now, and in the future check 
+  # that it did not create a ddagentuser account.
+  it_behaves_like 'a device with a dd-agent-user' if is_ng_installer
+
+  # Keep the old behavior for the old installer for now.
+  it_behaves_like 'a device without a dd-agent-user' unless is_ng_installer
 end


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
This adds a variable to determine if the kitchen tests is running on the NG installer or not.
If it is, then the `win-install-fail` spec won't check that the `ddagentuser` is missing but instead check that it is present.
That's because the new behavior of the NG installer is to not delete the `ddagentuser` once it's created.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Passing kitchen tests.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
