### PR TITLE
[CWS] remove unneeded nolints

### DIFF
--- a/pkg/security/ebpf/kernel/kernel.go
+++ b/pkg/security/ebpf/kernel/kernel.go
@@ -29,59 +29,59 @@ var (
 	// KERNEL_VERSION(a,b,c) = (a << 16) + (b << 8) + (c)
 
 	// Kernel4_9 is the KernelVersion representation of kernel version 4.9
-	Kernel4_9 = kernel.VersionCode(4, 9, 0) //nolint:deadcode,unused
+	Kernel4_9 = kernel.VersionCode(4, 9, 0)
 	// Kernel4_10 is the KernelVersion representation of kernel version 4.10
-	Kernel4_10 = kernel.VersionCode(4, 10, 0) //nolint:deadcode,unused
+	Kernel4_10 = kernel.VersionCode(4, 10, 0)
 	// Kernel4_12 is the KernelVersion representation of kernel version 4.12
-	Kernel4_12 = kernel.VersionCode(4, 12, 0) //nolint:deadcode,unused
+	Kernel4_12 = kernel.VersionCode(4, 12, 0)
 	// Kernel4_13 is the KernelVersion representation of kernel version 4.13
-	Kernel4_13 = kernel.VersionCode(4, 13, 0) //nolint:deadcode,unused
+	Kernel4_13 = kernel.VersionCode(4, 13, 0)
 	// Kernel4_14 is the KernelVersion representation of kernel version 4.14
-	Kernel4_14 = kernel.VersionCode(4, 14, 0) //nolint:deadcode,unused
+	Kernel4_14 = kernel.VersionCode(4, 14, 0)
 	// Kernel4_15 is the KernelVersion representation of kernel version 4.15
-	Kernel4_15 = kernel.VersionCode(4, 15, 0) //nolint:deadcode,unused
+	Kernel4_15 = kernel.VersionCode(4, 15, 0)
 	// Kernel4_16 is the KernelVersion representation of kernel version 4.16
-	Kernel4_16 = kernel.VersionCode(4, 16, 0) //nolint:deadcode,unused
+	Kernel4_16 = kernel.VersionCode(4, 16, 0)
 	// Kernel4_18 is the KernelVersion representation of kernel version 4.18
-	Kernel4_18 = kernel.VersionCode(4, 18, 0) //nolint:deadcode,unused
+	Kernel4_18 = kernel.VersionCode(4, 18, 0)
 	// Kernel4_19 is the KernelVersion representation of kernel version 4.19
-	Kernel4_19 = kernel.VersionCode(4, 19, 0) //nolint:deadcode,unused
+	Kernel4_19 = kernel.VersionCode(4, 19, 0)
 	// Kernel4_20 is the KernelVersion representation of kernel version 4.20
-	Kernel4_20 = kernel.VersionCode(4, 20, 0) //nolint:deadcode,unused
+	Kernel4_20 = kernel.VersionCode(4, 20, 0)
 	// Kernel5_0 is the KernelVersion representation of kernel version 5.0
-	Kernel5_0 = kernel.VersionCode(5, 0, 0) //nolint:deadcode,unused
+	Kernel5_0 = kernel.VersionCode(5, 0, 0)
 	// Kernel5_1 is the KernelVersion representation of kernel version 5.1
-	Kernel5_1 = kernel.VersionCode(5, 1, 0) //nolint:deadcode,unused
+	Kernel5_1 = kernel.VersionCode(5, 1, 0)
 	// Kernel5_2 is the KernelVersion representation of kernel version 5.2
-	Kernel5_2 = kernel.VersionCode(5, 2, 0) //nolint:deadcode,unused
+	Kernel5_2 = kernel.VersionCode(5, 2, 0)
 	// Kernel5_3 is the KernelVersion representation of kernel version 5.3
-	Kernel5_3 = kernel.VersionCode(5, 3, 0) //nolint:deadcode,unused
+	Kernel5_3 = kernel.VersionCode(5, 3, 0)
 	// Kernel5_4 is the KernelVersion representation of kernel version 5.4
-	Kernel5_4 = kernel.VersionCode(5, 4, 0) //nolint:deadcode,unused
+	Kernel5_4 = kernel.VersionCode(5, 4, 0)
 	// Kernel5_5 is the KernelVersion representation of kernel version 5.5
-	Kernel5_5 = kernel.VersionCode(5, 5, 0) //nolint:deadcode,unused
+	Kernel5_5 = kernel.VersionCode(5, 5, 0)
 	// Kernel5_6 is the KernelVersion representation of kernel version 5.6
-	Kernel5_6 = kernel.VersionCode(5, 6, 0) //nolint:deadcode,unused
+	Kernel5_6 = kernel.VersionCode(5, 6, 0)
 	// Kernel5_7 is the KernelVersion representation of kernel version 5.7
-	Kernel5_7 = kernel.VersionCode(5, 7, 0) //nolint:deadcode,unused
+	Kernel5_7 = kernel.VersionCode(5, 7, 0)
 	// Kernel5_8 is the KernelVersion representation of kernel version 5.8
-	Kernel5_8 = kernel.VersionCode(5, 8, 0) //nolint:deadcode,unused
+	Kernel5_8 = kernel.VersionCode(5, 8, 0)
 	// Kernel5_9 is the KernelVersion representation of kernel version 5.9
-	Kernel5_9 = kernel.VersionCode(5, 9, 0) //nolint:deadcode,unused
+	Kernel5_9 = kernel.VersionCode(5, 9, 0)
 	// Kernel5_10 is the KernelVersion representation of kernel version 5.10
-	Kernel5_10 = kernel.VersionCode(5, 10, 0) //nolint:deadcode,unused
+	Kernel5_10 = kernel.VersionCode(5, 10, 0)
 	// Kernel5_11 is the KernelVersion representation of kernel version 5.11
-	Kernel5_11 = kernel.VersionCode(5, 11, 0) //nolint:deadcode,unused
+	Kernel5_11 = kernel.VersionCode(5, 11, 0)
 	// Kernel5_12 is the KernelVersion representation of kernel version 5.12
-	Kernel5_12 = kernel.VersionCode(5, 12, 0) //nolint:deadcode,unused
+	Kernel5_12 = kernel.VersionCode(5, 12, 0)
 	// Kernel5_13 is the KernelVersion representation of kernel version 5.13
-	Kernel5_13 = kernel.VersionCode(5, 13, 0) //nolint:deadcode,unused
+	Kernel5_13 = kernel.VersionCode(5, 13, 0)
 	// Kernel5_14 is the KernelVersion representation of kernel version 5.14
-	Kernel5_14 = kernel.VersionCode(5, 14, 0) //nolint:deadcode,unused
+	Kernel5_14 = kernel.VersionCode(5, 14, 0)
 	// Kernel5_15 is the KernelVersion representation of kernel version 5.15
-	Kernel5_15 = kernel.VersionCode(5, 15, 0) //nolint:deadcode,unused
+	Kernel5_15 = kernel.VersionCode(5, 15, 0)
 	// Kernel5_16 is the KernelVersion representation of kernel version 5.16
-	Kernel5_16 = kernel.VersionCode(5, 16, 0) //nolint:deadcode,unused
+	Kernel5_16 = kernel.VersionCode(5, 16, 0)
 )
 
 // Version defines a kernel version helper

--- a/pkg/security/probe/erpc/erpc.go
+++ b/pkg/security/probe/erpc/erpc.go
@@ -33,7 +33,7 @@ const (
 	// ResolveParentOp resolves the parent of the provide path key
 	ResolveParentOp
 	// RegisterSpanTLSOP is used for span TLS registration
-	RegisterSpanTLSOP //nolint:deadcode,unused
+	RegisterSpanTLSOP
 	// ExpireInodeDiscarderOp is used to expire an inode discarder
 	ExpireInodeDiscarderOp
 	// ExpirePidDiscarderOp is used to expire a pid discarder

--- a/pkg/security/probe/perf_buffer_monitor.go
+++ b/pkg/security/probe/perf_buffer_monitor.go
@@ -53,8 +53,6 @@ func (s *PerfMapStats) UnmarshalBinary(data []byte) error {
 }
 
 // PerfBufferMonitor holds statistics about the number of lost and received events
-//
-//nolint:structcheck,unused
 type PerfBufferMonitor struct {
 	// probe is a pointer to the Probe
 	probe        *Probe

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -1207,7 +1207,9 @@ func (p *Probe) setupNewTCClassifier(device model.NetDevice) error {
 	netns := p.resolvers.NamespaceResolver.ResolveNetworkNamespace(device.NetNS)
 	if netns != nil {
 		handle, err = netns.GetNamespaceHandleDup()
-		defer handle.Close() // nolint:errcheck,staticcheck
+	}
+	if err != nil {
+		defer handle.Close()
 	}
 	if netns == nil || err != nil || handle == nil {
 		// queue network device so that a TC classifier can be added later

--- a/pkg/security/secl/model/events.go
+++ b/pkg/security/secl/model/events.go
@@ -222,8 +222,6 @@ func (t EventType) String() string {
 
 // ParseEvalEventType convert a eval.EventType (string) to its uint64 representation
 // the current algorithm is not efficient but allows us to reduce the number of conversion functions
-//
-//nolint:deadcode,unused
 func ParseEvalEventType(eventType eval.EventType) EventType {
 	for i := uint64(0); i != uint64(MaxAllEventType); i++ {
 		if EventType(i).String() == eventType {

--- a/pkg/security/tests/syscalls_amd64.go
+++ b/pkg/security/tests/syscalls_amd64.go
@@ -10,7 +10,6 @@ package tests
 
 import "syscall"
 
-//nolint:unused
 var supportedSyscalls = map[string]uintptr{
 	"SYS_CHMOD":  syscall.SYS_CHMOD,
 	"SYS_CHOWN":  syscall.SYS_CHOWN,

--- a/pkg/security/tests/syscalls_arm64.go
+++ b/pkg/security/tests/syscalls_arm64.go
@@ -8,5 +8,4 @@
 
 package tests
 
-//nolint:unused
 var supportedSyscalls = map[string]uintptr{}


### PR DESCRIPTION
### What does this PR do?

This PR removes some unneeded annotations

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
