### PR TITLE
Fix "length too small or too large" error

### DIFF
--- a/pkg/network/netlink/socket.go
+++ b/pkg/network/netlink/socket.go
@@ -201,56 +201,34 @@ func (s *Socket) ReceiveAndDiscard() (bool, uint32, error) {
 // ReceiveInto reads one or more netlink.Messages off the socket
 func (s *Socket) ReceiveInto(b []byte) ([]netlink.Message, uint32, error) {
 	var netns uint32
-	var ret []netlink.Message
-	for {
-		n, oobn, err := s.recvmsg()
-		if err != nil {
-			return nil, 0, os.NewSyscallError("recvmsg", err)
-		}
+	n, oobn, err := s.recvmsg()
+	if err != nil {
+		return nil, 0, os.NewSyscallError("recvmsg", err)
+	}
 
-		n = nlmsgAlign(n)
-		// If we cannot fit the date into the supplied buffer,  we allocate a slice
-		// with enough capacity. This should happen very rarely.
-		if n > len(b) {
-			b = make([]byte, n)
-		}
-		copy(b, s.recvbuf[:n])
+	n = nlmsgAlign(n)
+	// If we cannot fit the date into the supplied buffer,  we allocate a slice
+	// with enough capacity. This should happen very rarely.
+	if n > len(b) {
+		b = make([]byte, n)
+	}
+	copy(b, s.recvbuf[:n])
 
-		msgs, err := ParseNetlinkMessage(b[:n])
+	msgs, err := ParseNetlinkMessage(b[:n])
+	if err != nil {
+		return nil, 0, err
+	}
+
+	if oobn > 0 && netns == 0 {
+		scms, err := unix.ParseSocketControlMessage(s.oobbuf[:oobn])
 		if err != nil {
 			return nil, 0, err
 		}
 
-		var multi bool
-		for _, m := range msgs {
-			if err := checkMessage(m); err != nil {
-				return nil, 0, err
-			}
-
-			if m.Header.Flags&netlink.Multi == 0 {
-				continue
-			}
-
-			multi = m.Header.Type != netlink.Done
-		}
-
-		ret = append(ret, msgs...)
-
-		if oobn > 0 && netns == 0 {
-			scms, err := unix.ParseSocketControlMessage(s.oobbuf[:oobn])
-			if err != nil {
-				return nil, 0, err
-			}
-
-			netns = parseNetNS(scms)
-		}
-
-		if !multi {
-			break
-		}
+		netns = parseNetNS(scms)
 	}
 
-	return ret, netns, nil
+	return msgs, netns, nil
 }
 
 // ParseNetlinkMessage parses b as an array of netlink messages and

--- a/pkg/network/netlink/socket.go
+++ b/pkg/network/netlink/socket.go
@@ -219,7 +219,7 @@ func (s *Socket) ReceiveInto(b []byte) ([]netlink.Message, uint32, error) {
 		return nil, 0, err
 	}
 
-	if oobn > 0 && netns == 0 {
+	if oobn > 0 {
 		scms, err := unix.ParseSocketControlMessage(s.oobbuf[:oobn])
 		if err != nil {
 			return nil, 0, err

--- a/releasenotes/notes/system-probe-netlink-decode-error-ecdd2e3a2425d730.yaml
+++ b/releasenotes/notes/system-probe-netlink-decode-error-ecdd2e3a2425d730.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix partial loss of NAT info in system-probe for pre-existing connections.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Backport of https://github.com/DataDog/datadog-agent/pull/16434

Fix this error on system-probe startup:
```
2023-04-04 19:29:22 UTC | SYS-PROBE | DEBUG | (pkg/network/netlink/decoding.go:93 in DecodeAndReleaseEvent) | error decoding netlink message: invalid attribute; length too short or too large
```
This happens because we are reusing a buffer to read netlink messages in a loop. The buffer is actually pointed to by the message objects returned, so reusing it to read another batch of messages in a loop causes data corruption for the previous batches.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
