### PR TITLE
[system-probe] Fix flaky test

### DIFF
--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -1673,7 +1673,6 @@ func TestTCPDirectionWithPreexistingConnection(t *testing.T) {
 	server := NewTCPServer(func(c net.Conn) {
 		t.Logf("received connection from %s", c.RemoteAddr())
 		_, err := bufio.NewReader(c).ReadBytes('\n')
-		c.Close()
 		if err == nil {
 			wg.Done()
 		}
@@ -1685,7 +1684,7 @@ func TestTCPDirectionWithPreexistingConnection(t *testing.T) {
 	// create an initial client connection to the server
 	c, err := net.DialTimeout("tcp", server.address, 5*time.Second)
 	require.NoError(t, err)
-	defer c.Close()
+	t.Cleanup(func() { c.Close() })
 
 	// start tracer so it dumps port bindings
 	cfg := testConfig()
@@ -1708,13 +1707,18 @@ func TestTCPDirectionWithPreexistingConnection(t *testing.T) {
 	require.NoError(t, err)
 	wg.Wait()
 
+	var origConn []network.ConnectionStats
 	// the original connection should still be incoming for the server
-	conns := getConnections(t, tr)
-	origConn := searchConnections(conns, func(cs network.ConnectionStats) bool {
-		return fmt.Sprintf("%s:%d", cs.Source, cs.SPort) == server.address &&
-			fmt.Sprintf("%s:%d", cs.Dest, cs.DPort) == c.LocalAddr().String()
-	})
-	require.Len(t, origConn, 1)
+	require.Eventually(t, func() bool {
+		conns := getConnections(t, tr)
+		origConn = searchConnections(conns, func(cs network.ConnectionStats) bool {
+			return fmt.Sprintf("%s:%d", cs.Source, cs.SPort) == server.address &&
+				fmt.Sprintf("%s:%d", cs.Dest, cs.DPort) == c.LocalAddr().String()
+		})
+
+		return len(origConn) == 1
+	}, 3*time.Second, 500*time.Millisecond, "timed out waiting for original conneection")
+
 	require.Equal(t, network.INCOMING, origConn[0].Direction, "original server<->client connection should have incoming direction")
 }
 

--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -1717,7 +1717,7 @@ func TestTCPDirectionWithPreexistingConnection(t *testing.T) {
 		})
 
 		return len(origConn) == 1
-	}, 3*time.Second, 500*time.Millisecond, "timed out waiting for original conneection")
+	}, 3*time.Second, 500*time.Millisecond, "timed out waiting for original connection")
 
 	require.Equal(t, network.INCOMING, origConn[0].Direction, "original server<->client connection should have incoming direction")
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Fixes `TestTCPDirectionWithPreexistingConnection` after failure seen in CI.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
