### PR TITLE
[process] add new fastpath to `DataScrubber`

### DIFF
--- a/pkg/process/procutil/data_scrubber.go
+++ b/pkg/process/procutil/data_scrubber.go
@@ -205,6 +205,10 @@ func (ds *DataScrubber) AddCustomSensitiveWords(words []string) {
 	ds.SensitivePatterns = append(ds.SensitivePatterns, newPatterns...)
 }
 
+// wordToFastChecker returns a string that can be used to do a first fast lookup before doing the full
+// regex search
+// for example `wordToFastChecker("*aa*bbb*") = "bbb"`
+// if no string is found, it returns ""
 func wordToFastChecker(word string) string {
 	bestLen := 0
 	best := ""

--- a/pkg/process/procutil/data_scrubber_test.go
+++ b/pkg/process/procutil/data_scrubber_test.go
@@ -420,6 +420,51 @@ func TestScrubWithCache(t *testing.T) {
 	assert.Equal(t, sensible, len(scrubber.scrubbedCmdlines))
 }
 
+func TestWordToFastChecker(t *testing.T) {
+	testEntries := []struct{ in, out string }{
+		{
+			in:  "",
+			out: "",
+		},
+		{
+			in:  "*aa*bbbb*",
+			out: "bbbb",
+		},
+		{
+			in:  "*",
+			out: "",
+		},
+		{
+			in:  "***",
+			out: "",
+		},
+		{
+			in:  "*aa**bbbb*",
+			out: "bbbb",
+		},
+		{
+			in:  "*a",
+			out: "a",
+		},
+		{
+			in:  "a*",
+			out: "a",
+		},
+		{
+			in:  "a",
+			out: "a",
+		},
+		{
+			in:  "*aa**bbbb*cc",
+			out: "bbbb",
+		},
+	}
+
+	for _, entry := range testEntries {
+		assert.Equal(t, wordToFastChecker(entry.in), entry.out)
+	}
+}
+
 func BenchmarkRegexMatching1(b *testing.B)    { benchmarkRegexMatching(1, b) }
 func BenchmarkRegexMatching10(b *testing.B)   { benchmarkRegexMatching(10, b) }
 func BenchmarkRegexMatching100(b *testing.B)  { benchmarkRegexMatching(100, b) }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

On the CWS side we use the `procutil.DataScrubber` to scrub process arguments coming from our eBPF hooks. It was identified that this code path represents a huge chunk of our CPU time (especially on linux laptop from fellow developers) and this PR is a tentative improvement to the scrubber.

The main idea is to add a fast path to the regex matching looking for a raw string pattern in the command line. This allows to skip the costly regexp matching in most cases.

This improvement will mostly affected uncached usage (i.e. more CWS than processes).

Benchmarks:
```
>>> go test -benchmem -run=^$ -tags kubeapiserver,linux_bpf,kubelet,containerd,podman,docker,test -bench ^BenchmarkCache$ github.com/DataDog/datadog-agent/pkg/process/procutil -count=10 -cache=false
goos: darwin
goarch: arm64
pkg: github.com/DataDog/datadog-agent/pkg/process/procutil
         │ dev/dist/bench/old.txt │       dev/dist/bench/new.txt        │
         │         sec/op         │   sec/op     vs base                │
Cache-10             22.477m ± 0%   2.882m ± 2%  -87.18% (p=0.000 n=10)

         │ dev/dist/bench/old.txt │       dev/dist/bench/new.txt        │
         │          B/op          │     B/op      vs base               │
Cache-10             252.5Ki ± 0%   256.8Ki ± 0%  +1.69% (p=0.000 n=10)

         │ dev/dist/bench/old.txt │       dev/dist/bench/new.txt       │
         │       allocs/op        │  allocs/op   vs base               │
Cache-10              6.788k ± 0%   6.914k ± 0%  +1.86% (p=0.000 n=10)
```

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

- ensure that process-agent scrub feature still works with OOTB patterns
- ensure that process-agent scrub feature still works with custom pattern.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
