### PR TITLE
Always set all properties when processing installer account

### DIFF
--- a/tools/windows/DatadogAgentInstaller/CustomActions.Tests/UserCustomActions/UserCustomActionsDomainClientTests.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions.Tests/UserCustomActions/UserCustomActionsDomainClientTests.cs
@@ -28,6 +28,7 @@ namespace CustomActions.Tests.UserCustomActions
 
             Test.Properties.Should()
                 .Contain("DDAGENTUSER_FOUND", "false").And
+                .Contain(kvp => kvp.Key == "DDAGENTUSER_SID" && string.IsNullOrEmpty(kvp.Value)).And
                 .Contain("DDAGENTUSER_PROCESSED_NAME", "ddagentuser").And
                 .Contain("DDAGENTUSER_PROCESSED_DOMAIN", Environment.MachineName).And
                 .Contain("DDAGENTUSER_PROCESSED_FQ_NAME", $"{Environment.MachineName}\\ddagentuser").And
@@ -52,6 +53,7 @@ namespace CustomActions.Tests.UserCustomActions
 
             Test.Properties.Should()
                 .Contain("DDAGENTUSER_FOUND", "true").And
+                .Contain(kvp => kvp.Key == "DDAGENTUSER_SID" && !string.IsNullOrEmpty(kvp.Value)).And
                 .Contain("DDAGENTUSER_PROCESSED_NAME", "ddagentuser").And
                 .Contain("DDAGENTUSER_PROCESSED_DOMAIN", Environment.MachineName).And
                 .Contain("DDAGENTUSER_PROCESSED_FQ_NAME", $"{Environment.MachineName}\\ddagentuser").And
@@ -79,10 +81,11 @@ namespace CustomActions.Tests.UserCustomActions
 
             Test.Properties.Should()
                 .Contain("DDAGENTUSER_FOUND", "true").And
+                .Contain(kvp => kvp.Key == "DDAGENTUSER_SID" && !string.IsNullOrEmpty(kvp.Value)).And
                 .Contain("DDAGENTUSER_PROCESSED_NAME", ddAgentUserName).And
                 .Contain("DDAGENTUSER_PROCESSED_DOMAIN", Domain).And
                 .Contain("DDAGENTUSER_PROCESSED_FQ_NAME", $"{Domain}\\{ddAgentUserName}").And
-                .NotContainKey("DDAGENTUSER_RESET_PASSWORD").And
+                .Contain(kvp => kvp.Key == "DDAGENTUSER_RESET_PASSWORD" && string.IsNullOrEmpty(kvp.Value)).And
                 .Contain(kvp => kvp.Key == "DDAGENTUSER_PROCESSED_PASSWORD" && kvp.Value == ddAgentUserPassword);
         }
 
@@ -106,7 +109,7 @@ namespace CustomActions.Tests.UserCustomActions
 
             Test.Properties.Should()
                 .OnlyContain(kvp => (kvp.Key == "DDAGENTUSER_FOUND" && kvp.Value == "true") ||
-                                    kvp.Key == "DDAGENTUSER_SID");
+                                    (kvp.Key == "DDAGENTUSER_SID" && !string.IsNullOrEmpty(kvp.Value)));
         }
 
         /// <summary>
@@ -125,7 +128,8 @@ namespace CustomActions.Tests.UserCustomActions
                 .Be(ActionResult.Failure);
 
             Test.Properties.Should()
-                .OnlyContain(kvp => kvp.Key == "DDAGENTUSER_FOUND" && kvp.Value == "false");
+                .OnlyContain(kvp => (kvp.Key == "DDAGENTUSER_FOUND" && kvp.Value == "false") ||
+                                    (kvp.Key == "DDAGENTUSER_SID" && string.IsNullOrEmpty(kvp.Value)));
         }
 
         [Theory]
@@ -144,6 +148,7 @@ namespace CustomActions.Tests.UserCustomActions
 
             Test.Properties.Should()
                 .Contain("DDAGENTUSER_FOUND", "false").And
+                .Contain(kvp => kvp.Key == "DDAGENTUSER_SID" && string.IsNullOrEmpty(kvp.Value)).And
                 .Contain("DDAGENTUSER_PROCESSED_NAME", ddAgentUserName).And
                 .Contain("DDAGENTUSER_PROCESSED_DOMAIN", Environment.MachineName).And
                 .Contain("DDAGENTUSER_PROCESSED_FQ_NAME", $"{Environment.MachineName}\\{ddAgentUserName}").And
@@ -167,6 +172,7 @@ namespace CustomActions.Tests.UserCustomActions
 
             Test.Properties.Should()
                 .Contain("DDAGENTUSER_FOUND", "false").And
+                .Contain(kvp => kvp.Key == "DDAGENTUSER_SID" && string.IsNullOrEmpty(kvp.Value)).And
                 .Contain("DDAGENTUSER_PROCESSED_NAME", ddAgentUserName).And
                 .Contain("DDAGENTUSER_PROCESSED_DOMAIN", Environment.MachineName).And
                 .Contain("DDAGENTUSER_PROCESSED_FQ_NAME", $"{Environment.MachineName}\\{ddAgentUserName}").And

--- a/tools/windows/DatadogAgentInstaller/CustomActions.Tests/UserCustomActions/UserCustomActionsDomainControllerTests.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions.Tests/UserCustomActions/UserCustomActionsDomainControllerTests.cs
@@ -22,7 +22,8 @@ namespace CustomActions.Tests.UserCustomActions
                 .Be(ActionResult.Failure);
 
             Test.Properties.Should()
-                .OnlyContain(kvp => kvp.Key == "DDAGENTUSER_FOUND" && kvp.Value == "false");
+                .OnlyContain(kvp => (kvp.Key == "DDAGENTUSER_FOUND" && kvp.Value == "false") ||
+                                    (kvp.Key == "DDAGENTUSER_SID" && string.IsNullOrEmpty(kvp.Value)));
         }
 
         [Theory]
@@ -49,7 +50,7 @@ namespace CustomActions.Tests.UserCustomActions
                 .Contain("DDAGENTUSER_PROCESSED_NAME", ddAgentUserName).And
                 .Contain("DDAGENTUSER_PROCESSED_DOMAIN", Domain).And
                 .Contain("DDAGENTUSER_PROCESSED_FQ_NAME", $"{Domain}\\{ddAgentUserName}").And
-                .NotContainKey("DDAGENTUSER_RESET_PASSWORD").And
+                .Contain(kvp => kvp.Key == "DDAGENTUSER_RESET_PASSWORD" && string.IsNullOrEmpty(kvp.Value)).And
                 .Contain(kvp => kvp.Key == "DDAGENTUSER_PROCESSED_PASSWORD" && !string.IsNullOrEmpty(kvp.Value));
         }
 
@@ -75,7 +76,7 @@ namespace CustomActions.Tests.UserCustomActions
                 .Contain("DDAGENTUSER_PROCESSED_NAME", ddAgentUserName).And
                 .Contain("DDAGENTUSER_PROCESSED_DOMAIN", Domain).And
                 .Contain("DDAGENTUSER_PROCESSED_FQ_NAME", $"{Domain}\\{ddAgentUserName}").And
-                .NotContainKey("DDAGENTUSER_RESET_PASSWORD").And
+                .Contain(kvp => kvp.Key == "DDAGENTUSER_RESET_PASSWORD" && string.IsNullOrEmpty(kvp.Value)).And
                 .Contain(kvp => kvp.Key == "DDAGENTUSER_PROCESSED_PASSWORD" &&
                                 // !! Password should be null
                                 string.IsNullOrEmpty(kvp.Value));
@@ -105,7 +106,7 @@ namespace CustomActions.Tests.UserCustomActions
                 .Contain("DDAGENTUSER_PROCESSED_NAME", ddAgentUserName).And
                 .Contain("DDAGENTUSER_PROCESSED_DOMAIN", Domain).And
                 .Contain("DDAGENTUSER_PROCESSED_FQ_NAME", $"{Domain}\\{ddAgentUserName}").And
-                .NotContainKey("DDAGENTUSER_RESET_PASSWORD").And
+                .Contain(kvp => kvp.Key == "DDAGENTUSER_RESET_PASSWORD" && string.IsNullOrEmpty(kvp.Value)).And
                 .Contain(kvp => kvp.Key == "DDAGENTUSER_PROCESSED_PASSWORD" &&
                                 // !! Password should be null
                                 string.IsNullOrEmpty(kvp.Value));
@@ -134,7 +135,7 @@ namespace CustomActions.Tests.UserCustomActions
                 .Contain("DDAGENTUSER_PROCESSED_NAME", ddAgentUserName).And
                 .Contain("DDAGENTUSER_PROCESSED_DOMAIN", Domain).And
                 .Contain("DDAGENTUSER_PROCESSED_FQ_NAME", $"{Domain}\\{ddAgentUserName}").And
-                .NotContainKey("DDAGENTUSER_RESET_PASSWORD").And
+                .Contain(kvp => kvp.Key == "DDAGENTUSER_RESET_PASSWORD" && string.IsNullOrEmpty(kvp.Value)).And
                 .Contain(kvp => kvp.Key == "DDAGENTUSER_PROCESSED_PASSWORD" &&
                                 // !! Password should be null
                                 string.IsNullOrEmpty(kvp.Value));
@@ -160,7 +161,7 @@ namespace CustomActions.Tests.UserCustomActions
             // The install will proceed with the default `ddagentuser` in the machine domain
             Test.Properties.Should()
                 .OnlyContain(kvp => (kvp.Key == "DDAGENTUSER_FOUND" && kvp.Value == "true") ||
-                                     kvp.Key == "DDAGENTUSER_SID");
+                                    (kvp.Key == "DDAGENTUSER_SID" && !string.IsNullOrEmpty(kvp.Value)));
         }
 
         [Theory]
@@ -181,7 +182,8 @@ namespace CustomActions.Tests.UserCustomActions
 
             // The install will proceed with the default `ddagentuser` in the machine domain
             Test.Properties.Should()
-                .OnlyContain(kvp => kvp.Key == "DDAGENTUSER_FOUND" && kvp.Value == "false");
+                .OnlyContain(kvp => (kvp.Key == "DDAGENTUSER_FOUND" && kvp.Value == "false") ||
+                                    (kvp.Key == "DDAGENTUSER_SID" && string.IsNullOrEmpty(kvp.Value)));
         }
 
         [Theory]
@@ -200,7 +202,8 @@ namespace CustomActions.Tests.UserCustomActions
                 .Be(ActionResult.Failure);
 
             Test.Properties.Should()
-                .OnlyContain(kvp => kvp.Key == "DDAGENTUSER_FOUND" && kvp.Value == "false");
+                .OnlyContain(kvp => (kvp.Key == "DDAGENTUSER_FOUND" && kvp.Value == "false") ||
+                                    (kvp.Key == "DDAGENTUSER_SID" && string.IsNullOrEmpty(kvp.Value)));
         }
     }
 }

--- a/tools/windows/DatadogAgentInstaller/CustomActions.Tests/UserCustomActions/UserCustomActionsTests.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions.Tests/UserCustomActions/UserCustomActionsTests.cs
@@ -28,6 +28,7 @@ namespace CustomActions.Tests.UserCustomActions
 
             Test.Properties.Should()
                 .Contain("DDAGENTUSER_FOUND", "false").And
+                .Contain(kvp => kvp.Key == "DDAGENTUSER_SID" && string.IsNullOrEmpty(kvp.Value)).And
                 .Contain("DDAGENTUSER_PROCESSED_NAME", "ddagentuser").And
                 .Contain("DDAGENTUSER_PROCESSED_DOMAIN", Environment.MachineName).And
                 .Contain("DDAGENTUSER_PROCESSED_FQ_NAME", $"{Environment.MachineName}\\ddagentuser").And
@@ -49,6 +50,7 @@ namespace CustomActions.Tests.UserCustomActions
 
             Test.Properties.Should()
                 .Contain("DDAGENTUSER_FOUND", "false").And
+                .Contain(kvp => kvp.Key == "DDAGENTUSER_SID" && string.IsNullOrEmpty(kvp.Value)).And
                 .Contain("DDAGENTUSER_PROCESSED_NAME", "ddagentuser").And
                 .Contain("DDAGENTUSER_PROCESSED_DOMAIN", Environment.MachineName).And
                 .Contain("DDAGENTUSER_PROCESSED_FQ_NAME", $"{Environment.MachineName}\\ddagentuser").And
@@ -96,10 +98,8 @@ namespace CustomActions.Tests.UserCustomActions
                 .Contain("DDAGENTUSER_PROCESSED_NAME", "SYSTEM").And
                 .Contain("DDAGENTUSER_PROCESSED_DOMAIN", "NT AUTHORITY").And
                 .Contain("DDAGENTUSER_PROCESSED_FQ_NAME", "NT AUTHORITY\\SYSTEM").And
-                .NotContainKey("DDAGENTUSER_RESET_PASSWORD").And
-                .Contain(kvp => kvp.Key == "DDAGENTUSER_PROCESSED_PASSWORD" &&
-                                // !! The password should be null
-                                string.IsNullOrEmpty(kvp.Value));
+                .Contain(kvp => kvp.Key == "DDAGENTUSER_RESET_PASSWORD" && string.IsNullOrEmpty(kvp.Value)).And
+                .Contain(kvp => kvp.Key == "DDAGENTUSER_PROCESSED_PASSWORD" && string.IsNullOrEmpty(kvp.Value));
         }
 
         [Theory]

--- a/tools/windows/DatadogAgentInstaller/CustomActions/UserCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/UserCustomActions.cs
@@ -316,6 +316,7 @@ namespace Datadog.CustomActions
                 else
                 {
                     _session["DDAGENTUSER_FOUND"] = "false";
+                    _session["DDAGENTUSER_SID"] = null;
                     _session.Log($"User {ddAgentUserName} doesn't exist.");
 
                     if (isDomainController)
@@ -357,6 +358,7 @@ namespace Datadog.CustomActions
                 _session["DDAGENTUSER_PROCESSED_DOMAIN"] = domain;
                 _session["DDAGENTUSER_PROCESSED_FQ_NAME"] = $"{domain}\\{userName}";
 
+                _session["DDAGENTUSER_RESET_PASSWORD"] = null;
                 if (!isServiceAccount &&
                     !isDomainAccount  &&
                     string.IsNullOrEmpty(ddAgentUserPassword))


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Ensures all of the properties set by the `ProcessDDAgentUserCredentials` custom action are set to an appropriate value when the function is successful.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
Some properties (`DDAGENTUSER_SID` and `DDAGENTUSER_RESET_PASSWORD`) were only set in some cases. This meant that one run of the method could set these properties, and another run would change other properties but leave these two unset/unchanged, leading to erroneous behavior in future custom actions.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
NG installer not released yet so changelog is not necessary

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
On a non-domain controller host
* Install the datadog agent with default parameters, it will create a `ddagentuser` account.
* Run the installer to upgrade or change. The user selection dialog should be pre-populated with `ddagentuser`, click next to go to the verify screen, but then go back and change the user to a non-existing local user account
* Ensure the install is successful and the account is created

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
