### PR TITLE
[invoke] Add unit test tags to system-probe unit tests

### DIFF
--- a/.gitlab/source_test/ebpf.yml
+++ b/.gitlab/source_test/ebpf.yml
@@ -40,7 +40,7 @@
   script:
     - inv -e install-tools
     - inv -e system-probe.object-files
-    - invoke -e golangci-lint --build system-probe --concurrency 4 ./pkg
+    - invoke -e golangci-lint --build system-probe-unit-tests --concurrency 4 ./pkg
     - invoke -e security-agent.run-ebpf-unit-tests --verbose
     - invoke -e golangci-lint --targets=./pkg/security/tests --concurrency 4 --build-tags="functionaltests stresstests trivy containerd linux_bpf ebpf_bindata" --arch=$TASK_ARCH
 

--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -165,6 +165,7 @@ build_tags = {
         "process-agent": PROCESS_AGENT_TAGS,
         "security-agent": SECURITY_AGENT_TAGS,
         "system-probe": SYSTEM_PROBE_TAGS,
+        "system-probe-unit-tests": SYSTEM_PROBE_TAGS.union(UNIT_TEST_TAGS),
         "trace-agent": TRACE_AGENT_TAGS,
         # Test setups
         "test": AGENT_TEST_TAGS,

--- a/tasks/winbuildscripts/sysprobe.ps1
+++ b/tasks/winbuildscripts/sysprobe.ps1
@@ -30,7 +30,7 @@ if($err -ne 0){
     [Environment]::Exit($err)
 }
 
-& inv -e golangci-lint --build system-probe .\pkg
+& inv -e golangci-lint --build system-probe-unit-tests .\pkg
 $err = $LASTEXITCODE
 if ($err -ne 0) {
     Write-Host -ForegroundColor Red "golangci-lint failed $err"


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Follow-up of #16437, adding the `test` build tag to the system-probe linting steps, to make sure we cover test files as well.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Linters may fail when test files (ending in `_test.go`) require non-test files with the `test` build tag, like in this PR: https://github.com/DataDog/datadog-agent/pull/16426

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

n/a

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

n/a

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

n/a

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
