### PR TITLE
[USM] reduce process exit events cpu pressure in callbacks

### DIFF
--- a/pkg/network/usm/ebpf_gotls.go
+++ b/pkg/network/usm/ebpf_gotls.go
@@ -396,13 +396,15 @@ func (p *GoTLSProgram) registerProcess(binID binaryID, pid pid, mTime syscall.Ti
 }
 
 func (p *GoTLSProgram) unregisterProcess(pid pid) {
-	p.lock.Lock()
-	defer p.lock.Unlock()
-
+	p.lock.RLock()
 	binID, found := p.processes[pid]
+	p.lock.RUnlock()
 	if !found {
 		return
 	}
+
+	p.lock.Lock()
+	defer p.lock.Unlock()
 	delete(p.processes, pid)
 
 	bin, found := p.binaries[binID]

--- a/pkg/network/usm/ebpf_gotls.go
+++ b/pkg/network/usm/ebpf_gotls.go
@@ -397,7 +397,7 @@ func (p *GoTLSProgram) registerProcess(binID binaryID, pid pid, mTime syscall.Ti
 
 func (p *GoTLSProgram) unregisterProcess(pid pid) {
 	p.lock.RLock()
-	binID, found := p.processes[pid]
+	_, found := p.processes[pid]
 	p.lock.RUnlock()
 	if !found {
 		return
@@ -405,6 +405,10 @@ func (p *GoTLSProgram) unregisterProcess(pid pid) {
 
 	p.lock.Lock()
 	defer p.lock.Unlock()
+	binID, found := p.processes[pid]
+	if !found {
+		return
+	}
 	delete(p.processes, pid)
 
 	bin, found := p.binaries[binID]

--- a/pkg/network/usm/shared_libraries.go
+++ b/pkg/network/usm/shared_libraries.go
@@ -105,7 +105,7 @@ type soWatcher struct {
 type pathIdentifierSet = map[pathIdentifier]struct{}
 
 type soRegistry struct {
-	m     sync.Mutex
+	m     sync.RWMutex
 	byID  map[pathIdentifier]*soRegistration
 	byPID map[uint32]pathIdentifierSet
 
@@ -264,13 +264,15 @@ func (r *soRegistry) cleanup() {
 
 // unregister a pid if exists, unregisterCB will be called if his uniqueProcessesCount == 0
 func (r *soRegistry) unregister(pid uint32) {
-	r.m.Lock()
-	defer r.m.Unlock()
-
+	r.m.RLock()
 	paths, found := r.byPID[pid]
+	r.m.RUnlock()
 	if !found {
 		return
 	}
+
+	r.m.Lock()
+	defer r.m.Unlock()
 	for pathID := range paths {
 		reg, found := r.byID[pathID]
 		if !found {

--- a/pkg/network/usm/shared_libraries.go
+++ b/pkg/network/usm/shared_libraries.go
@@ -265,7 +265,7 @@ func (r *soRegistry) cleanup() {
 // unregister a pid if exists, unregisterCB will be called if his uniqueProcessesCount == 0
 func (r *soRegistry) unregister(pid uint32) {
 	r.m.RLock()
-	paths, found := r.byPID[pid]
+	_, found := r.byPID[pid]
 	r.m.RUnlock()
 	if !found {
 		return
@@ -273,6 +273,10 @@ func (r *soRegistry) unregister(pid uint32) {
 
 	r.m.Lock()
 	defer r.m.Unlock()
+	paths, found := r.byPID[pid]
+	if !found {
+		return
+	}
 	for pathID := range paths {
 		reg, found := r.byID[pathID]
 		if !found {


### PR DESCRIPTION
### What does this PR do?

As we are running in callback spawned by process monitor
reduce the lock pressure as multiple callback can call the same code path
and likely(!found) as pid exit event are not related to ssl or gotls

### Motivation

Avoid mutex/cpu pressure

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
