### PR TITLE
[process-agent] Fix process CPU usage percentages being reported as negative values

### DIFF
--- a/pkg/process/checks/process_common_test.go
+++ b/pkg/process/checks/process_common_test.go
@@ -120,7 +120,7 @@ func TestPercentCalculation(t *testing.T) {
 		assert.True(t, floatEquals(calculatePct(1.09, 8.08, 8), 107.920792))
 	} else {
 		// on Windows, CPU utilization is not multiplied by number of cores
-		assert.True(t, floatEquals(calculatePct(100, 200, 2), 500))
+		assert.True(t, floatEquals(calculatePct(100, 200, 2), 50))
 		assert.True(t, floatEquals(calculatePct(0.04, 8.08, 8), 0.4950495))
 		assert.True(t, floatEquals(calculatePct(1.09, 8.08, 8), 13.490099))
 	}

--- a/pkg/process/checks/process_common_test.go
+++ b/pkg/process/checks/process_common_test.go
@@ -108,6 +108,10 @@ func TestPercentCalculation(t *testing.T) {
 	// Zero deltaTime case
 	assert.True(t, floatEquals(calculatePct(100, 0, 8), 0.0))
 
+	// Negative CPU values should be sanitized to 0
+	assert.True(t, floatEquals(calculatePct(100, -200, 1), 0.0))
+	assert.True(t, floatEquals(calculatePct(-100, 200, 1), 0.0))
+
 	assert.True(t, floatEquals(calculatePct(0, 8.08, 8), 0.0))
 	if runtime.GOOS != "windows" {
 		// on *nix systems, CPU utilization is multiplied by number of cores to emulate top

--- a/pkg/process/checks/process_common_test.go
+++ b/pkg/process/checks/process_common_test.go
@@ -120,7 +120,7 @@ func TestPercentCalculation(t *testing.T) {
 		assert.True(t, floatEquals(calculatePct(1.09, 8.08, 8), 107.920792))
 	} else {
 		// on Windows, CPU utilization is not multiplied by number of cores
-		assert.True(t, floatEquals(calculatePct(100, 200, 2), 50))
+		assert.True(t, floatEquals(calculatePct(100, 200, 2), 500))
 		assert.True(t, floatEquals(calculatePct(0.04, 8.08, 8), 0.4950495))
 		assert.True(t, floatEquals(calculatePct(1.09, 8.08, 8), 13.490099))
 	}

--- a/pkg/process/checks/process_common_test.go
+++ b/pkg/process/checks/process_common_test.go
@@ -110,9 +110,15 @@ func TestPercentCalculation(t *testing.T) {
 
 	assert.True(t, floatEquals(calculatePct(0, 8.08, 8), 0.0))
 	if runtime.GOOS != "windows" {
+		// on *nix systems, CPU utilization is multiplied by number of cores to emulate top
 		assert.True(t, floatEquals(calculatePct(100, 200, 2), 100))
 		assert.True(t, floatEquals(calculatePct(0.04, 8.08, 8), 3.960396))
 		assert.True(t, floatEquals(calculatePct(1.09, 8.08, 8), 107.920792))
+	} else {
+		// on Windows, CPU utilization is not multiplied by number of cores
+		assert.True(t, floatEquals(calculatePct(100, 200, 2), 50))
+		assert.True(t, floatEquals(calculatePct(0.04, 8.08, 8), 0.4950495))
+		assert.True(t, floatEquals(calculatePct(1.09, 8.08, 8), 13.490099))
 	}
 }
 

--- a/pkg/process/checks/process_nix.go
+++ b/pkg/process/checks/process_nix.go
@@ -9,6 +9,7 @@
 package checks
 
 import (
+	"math"
 	"os/user"
 	"strconv"
 
@@ -76,5 +77,9 @@ func calculatePct(deltaProc, deltaTime, numCPU float64) float32 {
 	}
 
 	// In order to emulate top we multiply utilization by # of CPUs so a busy loop would be 100%.
-	return float32(overalPct * numCPU)
+	pct := overalPct * numCPU
+
+	// Clamp to 0 below if we get a negative value
+	pct = math.Max(pct, 0.0)
+	return float32(pct)
 }

--- a/pkg/process/checks/process_nix.go
+++ b/pkg/process/checks/process_nix.go
@@ -80,6 +80,8 @@ func calculatePct(deltaProc, deltaTime, numCPU float64) float32 {
 	pct := overalPct * numCPU
 
 	// Clamp to 0 below if we get a negative value
+	// CPU time counters in /proc/ used to determine process execution time may potentially be decremented, leading to a negative deltaProc
+	// Avoid reporting negative CPU percentages when this occurs
 	pct = math.Max(pct, 0.0)
 	return float32(pct)
 }

--- a/pkg/process/checks/process_windows.go
+++ b/pkg/process/checks/process_windows.go
@@ -63,6 +63,8 @@ func calculatePct(deltaProc, deltaTime, numCPU float64) float32 {
 	}
 
 	// Clamp to 0 below if we get a negative value
+	// deltaTime is approximated using the system time on Windows, and can turn negative when NTP clock synchronization occurs or the system time is manually reset
+	// Avoid reporting negative CPU percentages when this occurs
 	overalPct = math.Max(overalPct, 0.0)
 	return float32(overalPct)
 }

--- a/pkg/process/checks/process_windows.go
+++ b/pkg/process/checks/process_windows.go
@@ -9,6 +9,7 @@
 package checks
 
 import (
+	"math"
 	"runtime"
 
 	"github.com/DataDog/gopsutil/cpu"
@@ -60,5 +61,8 @@ func calculatePct(deltaProc, deltaTime, numCPU float64) float32 {
 	if overalPct > (numCPU * 100) {
 		overalPct = numCPU * 100
 	}
+
+	// Clamp to 0 below if we get a negative value
+	overalPct = math.Max(overalPct, 0.0)
 	return float32(overalPct)
 }

--- a/releasenotes/notes/process-agent-negative-cpu-process-fix-2f2d22446cd7d89f.yaml
+++ b/releasenotes/notes/process-agent-negative-cpu-process-fix-2f2d22446cd7d89f.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixes an issue in the process agent where in rare scenarios, negative CPU usage percentages would be reported for processes.


### PR DESCRIPTION
### What does this PR do?

Prevents the process agent from reporting negative CPU usage percentage value for processes.

### Motivation

Broadly speaking, CPU usage percentages on both *nix and Windows systems is computed by dividing the amount of time the process has spent executing by the total CPU execution time, and in rare scenarios, the operating system may report negative values for these quantities, resulting in negative CPU usage percentage values being computed. 

For Linux systems, CPU time counters used to determine process execution time may potentially be decremented as described in https://0xstubs.org/debugging-a-flaky-cpu-steal-time-counter-on-a-paravirtualized-xen-guest/,  and hence lead to the process agent collecting negative process execution times. On Windows systems, the process agent approximates the total CPU execution time using the elapsed system time, which can become negative if the system time is manually reset, and thus cause negative CPU usage percentage values.

This patch adds a check to the process agent's CPU percentage computation logic in the process check on both *nix and Windows systems to handle cases where negative values are reported, and return a CPU percentage value of 0 instead. A similar check in the CPU percentage computation logic already exists for the container check.

### Additional Notes





### Possible Drawbacks / Trade-offs



### Describe how to test/QA your changes

- Set up the core agent and process agent on a Windows machine and verify that process metrics are being reported correctly for the host in Live Processes.
- **With the process agent running**, go to the Windows date and time settings (accessible by clicking on the date and time in the lower right -> Date and time settings) and disable automatic clock synchronization ("Set time automatically").
- Reset the system time to 2 minutes in the past.
- Monitor process CPU usage metrics being reported in Live Processes and ensure that negative CPU usage values are not reported for the host.
- Optionally, do some basic testing on a Linux machine and verify that CPU usage values look correct for the host in Live Processes

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
