### PR TITLE
Fix structure parsing error on Server 2022

### DIFF
--- a/releasenotes/notes/fixetw2022-0acc6da346e450c1.yaml
+++ b/releasenotes/notes/fixetw2022-0acc6da346e450c1.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixes a problem with USM and IIS on Windows Server 2022 due to a change
+    in the way Microsoft reports IIS connections.


### PR DESCRIPTION
### What does this PR do?

remove length check that's not needed and causing failure.

While normally wouldn't just arbitrarily remove a length check, the check in question seems
to be triggered by a Windows bug.  Further, we're not using the buffer for which the length
check exists.  Hitting the length check (only on Server2022) was causing USM to not work on
Server 2022.

Instead, replaced with a comment describing the problem introduced in windows, and how to
navigate around the problem in the event that the data in the buffer _is_ needed.

### Motivation

### Additional Notes


### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Install on 2022 and previous version.  Ensure USM correctly reports HTTP connections on both platforms

### Reviewer's Checklist
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
