### PR TITLE
Add Windows FILETIME helpers

### DIFF
--- a/pkg/network/protocols/http/etw_http_service.go
+++ b/pkg/network/protocols/http/etw_http_service.go
@@ -313,7 +313,7 @@ func completeReqRespTracking(eventInfo *etw.DDEtwEventInfo, httpConnLink *HttpCo
 	}
 
 	// Time
-	httpConnLink.http.Txn.ResponseLastSeen = winutil.FileTimeToUnixTimeNs(uint64(eventInfo.Event.TimeStamp))
+	httpConnLink.http.Txn.ResponseLastSeen = winutil.FileTimeToUnixNano(uint64(eventInfo.Event.TimeStamp))
 
 	// Clean it up related containers
 	cleanupActivityIdViaConnOpen(connOpen, eventInfo.Event.ActivityId)
@@ -490,7 +490,7 @@ func httpCallbackOnHTTPConnectionTraceTaskConnConn(eventInfo *etw.DDEtwEventInfo
 	}
 
 	// Time
-	connOpen.conn.connected = winutil.FileTimeToUnixTimeNs(uint64(eventInfo.Event.TimeStamp))
+	connOpen.conn.connected = winutil.FileTimeToUnixNano(uint64(eventInfo.Event.TimeStamp))
 
 	// Http back links (to cleanup on closure)
 	connOpen.httpPendingBackLinks = make(map[etw.DDGUID]struct{}, 10)
@@ -525,7 +525,7 @@ func httpCallbackOnHTTPConnectionTraceTaskConnClose(eventInfo *etw.DDEtwEventInf
 		completedRequestCount++
 
 		// move it to close connection
-		connOpen.conn.disconnected = winutil.FileTimeToUnixTimeNs(uint64(eventInfo.Event.TimeStamp))
+		connOpen.conn.disconnected = winutil.FileTimeToUnixNano(uint64(eventInfo.Event.TimeStamp))
 
 		// Clean pending http2openConn
 		for httpReqRespActivityId := range connOpen.httpPendingBackLinks {
@@ -595,7 +595,7 @@ func httpCallbackOnHTTPRequestTraceTaskRecvReq(eventInfo *etw.DDEtwEventInfo) {
 	reqRespAndLink := &HttpConnLink{}
 	reqRespAndLink.connActivityId = eventInfo.Event.ActivityId
 	reqRespAndLink.http.Txn.Tup = connOpen.conn.tup
-	reqRespAndLink.http.Txn.RequestStarted = winutil.FileTimeToUnixTimeNs(uint64(eventInfo.Event.TimeStamp))
+	reqRespAndLink.http.Txn.RequestStarted = winutil.FileTimeToUnixNano(uint64(eventInfo.Event.TimeStamp))
 
 	// Save Req/Resp Conn Link and back reference to it
 	http2openConn[*eventInfo.RelatedActivityId] = reqRespAndLink

--- a/pkg/network/protocols/http/etw_http_service.go
+++ b/pkg/network/protocols/http/etw_http_service.go
@@ -313,7 +313,7 @@ func completeReqRespTracking(eventInfo *etw.DDEtwEventInfo, httpConnLink *HttpCo
 	}
 
 	// Time
-	httpConnLink.http.Txn.ResponseLastSeen = etw.FileTimeToUnixTime(uint64(eventInfo.Event.TimeStamp))
+	httpConnLink.http.Txn.ResponseLastSeen = winutil.FileTimeToUnixTimeNs(uint64(eventInfo.Event.TimeStamp))
 
 	// Clean it up related containers
 	cleanupActivityIdViaConnOpen(connOpen, eventInfo.Event.ActivityId)
@@ -490,7 +490,7 @@ func httpCallbackOnHTTPConnectionTraceTaskConnConn(eventInfo *etw.DDEtwEventInfo
 	}
 
 	// Time
-	connOpen.conn.connected = etw.FileTimeToUnixTime(uint64(eventInfo.Event.TimeStamp))
+	connOpen.conn.connected = winutil.FileTimeToUnixTimeNs(uint64(eventInfo.Event.TimeStamp))
 
 	// Http back links (to cleanup on closure)
 	connOpen.httpPendingBackLinks = make(map[etw.DDGUID]struct{}, 10)
@@ -525,7 +525,7 @@ func httpCallbackOnHTTPConnectionTraceTaskConnClose(eventInfo *etw.DDEtwEventInf
 		completedRequestCount++
 
 		// move it to close connection
-		connOpen.conn.disconnected = etw.FileTimeToUnixTime(uint64(eventInfo.Event.TimeStamp))
+		connOpen.conn.disconnected = winutil.FileTimeToUnixTimeNs(uint64(eventInfo.Event.TimeStamp))
 
 		// Clean pending http2openConn
 		for httpReqRespActivityId := range connOpen.httpPendingBackLinks {
@@ -595,7 +595,7 @@ func httpCallbackOnHTTPRequestTraceTaskRecvReq(eventInfo *etw.DDEtwEventInfo) {
 	reqRespAndLink := &HttpConnLink{}
 	reqRespAndLink.connActivityId = eventInfo.Event.ActivityId
 	reqRespAndLink.http.Txn.Tup = connOpen.conn.tup
-	reqRespAndLink.http.Txn.RequestStarted = etw.FileTimeToUnixTime(uint64(eventInfo.Event.TimeStamp))
+	reqRespAndLink.http.Txn.RequestStarted = winutil.FileTimeToUnixTimeNs(uint64(eventInfo.Event.TimeStamp))
 
 	// Save Req/Resp Conn Link and back reference to it
 	http2openConn[*eventInfo.RelatedActivityId] = reqRespAndLink

--- a/pkg/util/winutil/etw/etw-utils.go
+++ b/pkg/util/winutil/etw/etw-utils.go
@@ -27,11 +27,6 @@ import (
 */
 import "C"
 
-// From GetUnixTimestamp() datadog-windows-filter\ddfilter\http\http_callbacks.c
-// difference between windows and unix epochs in 100ns intervals
-// 11644473600s * 1000ms/s * 1000us/ms * 10 intervals/us
-const EPOCH_DIFFERENCE_SECS uint64 = 116444736000000000
-
 // Copied from github.com\DataDog\datadog-agent\pkg\network\http\http_stats.go
 // Note: cannot refer to it due to package circularity
 //
@@ -248,15 +243,6 @@ func FormatUInt(num uint64) string {
 	}
 
 	return output
-}
-
-// stampToTime translates FileTime to a golang time. Same as in standard packages.
-// // From GetUnixTimestamp() datadog-windows-filter\ddfilter\http\http_callbacks.c
-// returns timestamp in ns since unix epoch
-
-// FilteTimeToUnixTime converts a windows Filetime to unix time
-func FileTimeToUnixTime(ft uint64) uint64 {
-	return (ft - EPOCH_DIFFERENCE_SECS) * 100
 }
 
 // FormatUnixTime takes a unix timestamp and returns a human readable string

--- a/pkg/util/winutil/time.go
+++ b/pkg/util/winutil/time.go
@@ -13,14 +13,12 @@ package winutil
 // 11644473600s * 1000ms/s * 1000us/ms * 10 intervals/us
 const EPOCH_DIFFERENCE_SECS uint64 = 116444736000000000
 
-// FileTimeToUnixTime translates FileTime to a golang time. Same as in standard packages.
-// // From GetUnixTimestamp() datadog-windows-filter\ddfilter\http\http_callbacks.c
-// returns timestamp in ns since unix epoch
-func FileTimeToUnixTimeNs(ft uint64) uint64 {
+// FileTimeToUnixNano translates Windows FileTime to nanoseconds since Unix epoch
+func FileTimeToUnixNano(ft uint64) uint64 {
 	return (ft - EPOCH_DIFFERENCE_SECS) * 100
 }
 
-// returns time in seconds since unix epoch
-func FileTimeToUnixTimeS(ft uint64) uint64 {
+// FileTimeToUnix translates Windows FileTime to seconds since Unix epoch
+func FileTimeToUnix(ft uint64) uint64 {
 	return (ft - EPOCH_DIFFERENCE_SECS) / 10000000
 }

--- a/pkg/util/winutil/time.go
+++ b/pkg/util/winutil/time.go
@@ -1,0 +1,26 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+//go:build windows
+// +build windows
+
+package winutil
+
+// From GetUnixTimestamp() datadog-windows-filter\ddfilter\http\http_callbacks.c
+// difference between windows and unix epochs in 100ns intervals
+// 11644473600s * 1000ms/s * 1000us/ms * 10 intervals/us
+const EPOCH_DIFFERENCE_SECS uint64 = 116444736000000000
+
+// FileTimeToUnixTime translates FileTime to a golang time. Same as in standard packages.
+// // From GetUnixTimestamp() datadog-windows-filter\ddfilter\http\http_callbacks.c
+// returns timestamp in ns since unix epoch
+func FileTimeToUnixTimeNs(ft uint64) uint64 {
+	return (ft - EPOCH_DIFFERENCE_SECS) * 100
+}
+
+// returns time in seconds since unix epoch
+func FileTimeToUnixTimeS(ft uint64) uint64 {
+	return (ft - EPOCH_DIFFERENCE_SECS) / 10000000
+}

--- a/pkg/util/winutil/time_test.go
+++ b/pkg/util/winutil/time_test.go
@@ -1,0 +1,36 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+//go:build windows
+// +build windows
+
+package winutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFileTimeToUnix(t *testing.T) {
+
+	testcases := []struct {
+		filetime uint64
+		seconds  uint64
+		nano     uint64
+	}{
+		// 1970/01/01 00:00:00
+		{116444736000000000, 0, 0},
+		// 2023/04/06 19:34:17
+		{133252832570000000, 1680809657, 1680809657000000000},
+		// 2023/04/06 19:28:16
+		{133252828968413292, 1680809296, 1680809296841329200},
+	}
+
+	for _, tc := range testcases {
+		assert.Equal(t, tc.nano, FileTimeToUnixNano(tc.filetime), "Should correctly convert filetime %d to nanoseconds", tc.filetime)
+		assert.Equal(t, tc.seconds, FileTimeToUnix(tc.filetime), "Should correctly convert filetime %d to seconds", tc.filetime)
+	}
+}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Move `FileTimeToUnix` helpers into winutil so they can be reused

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
function names based on `time.Unix` and `time.UnixNano`

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
no QA needed, moving existing function without change. added unit tests.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
