### PR TITLE
Add Windows Event Log package

### DIFF
--- a/.github/workflows/windows-unittests.yml
+++ b/.github/workflows/windows-unittests.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   windows-unit-tests:
-    runs-on: windows-2022 # https://github.com/actions/virtual-environments/blob/main/images/win/Windows2019-Readme.md
+    runs-on: windows-2019 # https://github.com/actions/virtual-environments/blob/main/images/win/Windows2019-Readme.md
     steps:
       - name: Checkout datadog-agent repository
         uses: actions/checkout@v3

--- a/.gitlab/integration_test.yml
+++ b/.gitlab/integration_test.yml
@@ -1,40 +1,7 @@
 ---
 # integration_test stage
-# Contains jobs to run integration tests in go binaries (currently only dogstatsd)
+# Contains jobs to run integration tests in go binaries
 
-dogstatsd_x64_size_test:
-  stage: integration_test
-  rules:
-    !reference [.on_a7]
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
-  tags: ["arch:amd64"]
-  needs: ["build_dogstatsd_static-binary_x64"]
-  before_script:
-    - source /root/.bashrc
-    - mkdir -p $STATIC_BINARIES_DIR
-    - $S3_CP_CMD $S3_ARTIFACTS_URI/static/dogstatsd.amd64 $STATIC_BINARIES_DIR/dogstatsd
-  script:
-    - inv -e dogstatsd.size-test --skip-build
-
-# run benchmarks on deb
-# benchmarks-deb_x64:
-#   stage: integration_test
-#   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
-#   allow_failure: true  # FIXME: this was set to true to temporarily unblock the pipeline
-#   tags: ["runner:main"]
-#   script:
-#     - inv -e bench.aggregator
-#     # FIXME: in our docker image, non ascii characters printed by the benchmark
-#     # make invoke traceback. For now, the workaround is to call the benchmarks
-#     # manually
-#     - inv -e bench.build-dogstatsd
-
-#     - set +x # make sure we don't output the creds to the build log
-#     - DD_AGENT_API_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.dd_agent_api_key --with-decryption --query "Parameter.Value" --out text)
-
-#     # dogstatsd validation - not really benchmarking: gitlab isn't the right place to do this.
-#     - ./bin/benchmarks/dogstatsd -pps=20000 -dur 30 -ser 5 -branch $DD_REPO_BRANCH_NAME -api-key $DD_AGENT_API_KEY
-#   artifacts:
-#     expire_in: 2 weeks
-#     paths:
-#       - benchmarks
+include:
+  - /.gitlab/integration_test/dogstatsd.yml
+  - /.gitlab/integration_test/windows.yml

--- a/.gitlab/integration_test/dogstatsd.yml
+++ b/.gitlab/integration_test/dogstatsd.yml
@@ -1,0 +1,40 @@
+---
+# integration_test stage
+# Contains jobs to run integration tests in dogstatsd go binaries
+
+dogstatsd_x64_size_test:
+  stage: integration_test
+  rules:
+    !reference [.on_a7]
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
+  tags: ["arch:amd64"]
+  needs: ["build_dogstatsd_static-binary_x64"]
+  before_script:
+    - source /root/.bashrc
+    - mkdir -p $STATIC_BINARIES_DIR
+    - $S3_CP_CMD $S3_ARTIFACTS_URI/static/dogstatsd.amd64 $STATIC_BINARIES_DIR/dogstatsd
+  script:
+    - inv -e dogstatsd.size-test --skip-build
+
+# run benchmarks on deb
+# benchmarks-deb_x64:
+#   stage: integration_test
+#   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
+#   allow_failure: true  # FIXME: this was set to true to temporarily unblock the pipeline
+#   tags: ["runner:main"]
+#   script:
+#     - inv -e bench.aggregator
+#     # FIXME: in our docker image, non ascii characters printed by the benchmark
+#     # make invoke traceback. For now, the workaround is to call the benchmarks
+#     # manually
+#     - inv -e bench.build-dogstatsd
+
+#     - set +x # make sure we don't output the creds to the build log
+#     - DD_AGENT_API_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.dd_agent_api_key --with-decryption --query "Parameter.Value" --out text)
+
+#     # dogstatsd validation - not really benchmarking: gitlab isn't the right place to do this.
+#     - ./bin/benchmarks/dogstatsd -pps=20000 -dur 30 -ser 5 -branch $DD_REPO_BRANCH_NAME -api-key $DD_AGENT_API_KEY
+#   artifacts:
+#     expire_in: 2 weeks
+#     paths:
+#       - benchmarks

--- a/.gitlab/integration_test/windows.yml
+++ b/.gitlab/integration_test/windows.yml
@@ -1,0 +1,36 @@
+---
+.integration_tests_windows_base:
+  stage: source_test
+  needs: ["go_deps", "go_tools_deps", "build_vcpkg_deps"]
+  tags: ["runner:windows-docker", "windowsversion:1809"]
+  before_script:
+    - $vcpkgBlobSaSUrl = (aws ssm get-parameter --region us-east-1 --name ci.datadog-agent-buildimages.vcpkg_blob_sas_url --with-decryption --query "Parameter.Value" --out text)
+  script:
+    - $ErrorActionPreference = "Stop"
+    - '$_instance_id = (iwr  -UseBasicParsing http://169.254.169.254/latest/meta-data/instance-id).content ; Write-Host "Running on instance $($_instance_id)"'
+    # we pass in CI_JOB_URL and CI_JOB_NAME so that they can be added to additional tags
+    # inside JUNIT_TAR and then later used by datadog-ci
+    - !reference [.setup_python_mirror_win]
+    - >
+      docker run --rm
+      -m 16384M
+      -v "$(Get-Location):c:\mnt"
+      -e CI_JOB_URL="${CI_JOB_URL}"
+      -e CI_JOB_NAME="${CI_JOB_NAME}"
+      -e CI_PIPELINE_ID="${CI_PIPELINE_ID}"
+      -e CI_PROJECT_NAME="${CI_PROJECT_NAME}"
+      -e AWS_NETWORKING=true
+      -e PY_RUNTIMES="$PYTHON_RUNTIMES"
+      -e GOMODCACHE="c:\modcache"
+      -e JUNIT_TAR="c:\mnt\junit-${CI_JOB_NAME}.tgz"
+      -e VCPKG_BINARY_SOURCES="clear;x-azblob,${vcpkgBlobSaSUrl}"
+      -e PIP_INDEX_URL=${PIP_INDEX_URL}
+      486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/windows_1809_${ARCH}${Env:DATADOG_AGENT_WINBUILDIMAGES_SUFFIX}:${Env:DATADOG_AGENT_WINBUILDIMAGES}
+      c:\mnt\tasks\winbuildscripts\integrationtests.bat
+    - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
+
+integration_tests_windows-x64:
+  extends: .integration_tests_windows_base
+  variables:
+    PYTHON_RUNTIMES: 3
+    ARCH: "x64"

--- a/.gitlab/integration_test/windows.yml
+++ b/.gitlab/integration_test/windows.yml
@@ -1,6 +1,6 @@
 ---
 .integration_tests_windows_base:
-  stage: source_test
+  stage: integration_test
   needs: ["go_deps", "go_tools_deps", "build_vcpkg_deps"]
   tags: ["runner:windows-docker", "windowsversion:1809"]
   before_script:

--- a/pkg/util/winutil/eventlog/README.md
+++ b/pkg/util/winutil/eventlog/README.md
@@ -1,0 +1,29 @@
+# Windows Event Log package
+
+These package(s) interact with the [Windows Event Log API](https://learn.microsoft.com/en-us/windows/win32/wes/windows-event-log)
+
+* [evtsubscribe](subscription) - Implements a [Pull Subscription](https://learn.microsoft.com/en-us/windows/win32/wes/subscribing-to-events#pull-subscriptions)
+* [evtbookmark](bookmark) - [Bookmarking Events](https://learn.microsoft.com/en-us/windows/win32/wes/bookmarking-events)
+
+See the [example usage](example_test.go).
+
+## APIs
+
+The [evtapi.API](api) interface includes functions from both the legacy [Event Logging API](https://learn.microsoft.com/en-us/windows/win32/eventlog/event-logging) as well as the newer [Windows Event Log API](https://learn.microsoft.com/en-us/windows/win32/wes/windows-event-log).
+
+
+## Testing
+
+The [eventlog_test.APITester](test) interface provides helpers for writing tests that need to install/remove event logs/channels, sources, and generate events.
+
+Tests can be run using either the [Windows API](api/windows) or the [Fake API](api/fake), selected by the `-evtapi` argument to `go test`. By default the tests are run only with the [Fake API](api/fake) to avoid inadvertently modifying the host event logs.
+
+### Unit tests
+
+Simply run `go test ./...` to run the tests with the [Fake API](api/fake).
+
+### Integration tests
+
+The tests can be run with the [Windows API](api/windows), which will install/remove event logs on the system and fill them with events.
+
+The integration tests can be run directly `go test ./... -evtapi Windows`, or through the invoke task `inv -e integration-tests`.

--- a/pkg/util/winutil/eventlog/api/fake/fake.go
+++ b/pkg/util/winutil/eventlog/api/fake/fake.go
@@ -1,0 +1,210 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+//go:build windows
+// +build windows
+
+package fakeevtapi
+
+import (
+	"fmt"
+
+	"github.com/DataDog/datadog-agent/pkg/util/winutil/eventlog/api"
+
+	"go.uber.org/atomic"
+	"golang.org/x/sys/windows"
+)
+
+// backing datastructures for the Fake API
+
+type API struct {
+	eventLogs map[string]*eventLog
+
+	nextHandle      *atomic.Uint64
+	subscriptions   map[evtapi.EventResultSetHandle]*subscription
+	eventHandles    map[evtapi.EventRecordHandle]*eventRecord
+	sourceHandles   map[evtapi.EventSourceHandle]string
+	bookmarkHandles map[evtapi.EventBookmarkHandle]*bookmark
+}
+
+type eventLog struct {
+	name   string
+	events []*eventRecord
+
+	nextRecordID *atomic.Uint64
+
+	sources map[string]*eventSource
+
+	// For notifying of new events
+	subscriptions map[evtapi.EventResultSetHandle]*subscription
+}
+
+type eventSource struct {
+	name    string
+	logName string
+}
+
+type subscription struct {
+	channel string
+	query   string
+	handle  evtapi.EventResultSetHandle
+	// owned by caller, not closed by this lib
+	signalEventHandle evtapi.WaitEventHandle
+
+	nextEvent uint
+}
+
+type eventRecord struct {
+	handle evtapi.EventRecordHandle
+
+	// Must be exported so template can render them
+	Type     uint
+	Category uint
+	EventID  uint
+	Strings  []string
+	RawData  []uint8
+	EventLog string
+	RecordID uint
+}
+
+type bookmark struct {
+	handle        evtapi.EventBookmarkHandle
+	eventRecordID uint
+}
+
+func New() *API {
+	var api API
+
+	api.nextHandle = atomic.NewUint64(0)
+
+	api.subscriptions = make(map[evtapi.EventResultSetHandle]*subscription)
+	api.eventHandles = make(map[evtapi.EventRecordHandle]*eventRecord)
+	api.sourceHandles = make(map[evtapi.EventSourceHandle]string)
+	api.bookmarkHandles = make(map[evtapi.EventBookmarkHandle]*bookmark)
+
+	api.eventLogs = make(map[string]*eventLog)
+
+	return &api
+}
+
+func newEventLog(name string) *eventLog {
+	var e eventLog
+	e.name = name
+	e.nextRecordID = atomic.NewUint64(0)
+	e.subscriptions = make(map[evtapi.EventResultSetHandle]*subscription)
+	e.sources = make(map[string]*eventSource)
+	return &e
+}
+
+func newSubscription(channel string, query string) *subscription {
+	var s subscription
+	s.channel = channel
+	s.query = query
+	return &s
+}
+
+func newEventRecord(Type uint, category uint, eventID uint, eventLog string, strings []string, data []uint8) *eventRecord {
+	var e eventRecord
+	e.Type = Type
+	e.Category = category
+	e.EventID = eventID
+	e.Strings = strings
+	e.RawData = data
+	e.EventLog = eventLog
+	return &e
+}
+
+func (api *API) addSubscription(sub *subscription) {
+	h := api.nextHandle.Inc()
+	sub.handle = evtapi.EventResultSetHandle(h)
+	api.subscriptions[sub.handle] = sub
+}
+
+func (api *API) addEventRecord(event *eventRecord) {
+	h := api.nextHandle.Inc()
+	event.handle = evtapi.EventRecordHandle(h)
+	api.eventHandles[event.handle] = event
+}
+
+func (api *API) addBookmark(bookmark *bookmark) {
+	h := api.nextHandle.Inc()
+	bookmark.handle = evtapi.EventBookmarkHandle(h)
+	api.bookmarkHandles[bookmark.handle] = bookmark
+}
+
+func (api *API) getSubscriptionByHandle(subHandle evtapi.EventResultSetHandle) (*subscription, error) {
+	v, ok := api.subscriptions[subHandle]
+	if !ok {
+		return nil, fmt.Errorf("Subscription not found: %#x", subHandle)
+	}
+	return v, nil
+}
+
+func (api *API) getEventRecordByHandle(eventHandle evtapi.EventRecordHandle) (*eventRecord, error) {
+	v, ok := api.eventHandles[eventHandle]
+	if !ok {
+		return nil, fmt.Errorf("Event not found: %#x", eventHandle)
+	}
+	return v, nil
+}
+
+func (api *API) getBookmarkByHandle(bookmarkHandle evtapi.EventBookmarkHandle) (*bookmark, error) {
+	v, ok := api.bookmarkHandles[bookmarkHandle]
+	if !ok {
+		return nil, fmt.Errorf("Bookmark not found: %#x", bookmarkHandle)
+	}
+	return v, nil
+}
+
+func (api *API) getEventLog(name string) (*eventLog, error) {
+	v, ok := api.eventLogs[name]
+	if !ok {
+		return nil, fmt.Errorf("The Log name \"%v\" does not exist", name)
+	}
+	return v, nil
+}
+
+func (api *API) getEventSourceByHandle(sourceHandle evtapi.EventSourceHandle) (*eventLog, error) {
+	// lookup name using handle
+	v, ok := api.sourceHandles[sourceHandle]
+	if !ok {
+		return nil, fmt.Errorf("Invalid source handle: %#x", sourceHandle)
+	}
+
+	return api.getEventLog(v)
+}
+
+func (api *API) addEventLog(eventLog *eventLog) {
+	api.eventLogs[eventLog.name] = eventLog
+}
+
+func (e *eventLog) addEventRecord(event *eventRecord) {
+	event.RecordID = uint(e.nextRecordID.Inc())
+	// TODO: lock list operations
+	e.events = append(e.events, event)
+}
+
+func (e *eventLog) reportEvent(
+	api *API,
+	Type uint,
+	Category uint,
+	EventID uint,
+	Strings []string,
+	RawData []uint8) *eventRecord {
+
+	event := newEventRecord(
+		Type,
+		Category,
+		EventID,
+		e.name,
+		Strings,
+		RawData)
+	e.addEventRecord(event)
+
+	// notify subscriptions
+	for _, sub := range e.subscriptions {
+		windows.SetEvent(windows.Handle(sub.signalEventHandle))
+	}
+	return event
+}

--- a/pkg/util/winutil/eventlog/api/fake/fake.go
+++ b/pkg/util/winutil/eventlog/api/fake/fake.go
@@ -3,7 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2023-present Datadog, Inc.
 //go:build windows
-// +build windows
 
 package fakeevtapi
 

--- a/pkg/util/winutil/eventlog/api/fake/fake.go
+++ b/pkg/util/winutil/eventlog/api/fake/fake.go
@@ -62,6 +62,7 @@ type eventRecord struct {
 	Type     uint
 	Category uint
 	EventID  uint
+	UserSID  *windows.SID
 	Strings  []string
 	RawData  []uint8
 	EventLog string
@@ -104,11 +105,14 @@ func newSubscription(channel string, query string) *subscription {
 	return &s
 }
 
-func newEventRecord(Type uint, category uint, eventID uint, eventLog string, strings []string, data []uint8) *eventRecord {
+func newEventRecord(Type uint, category uint, eventID uint, userSID *windows.SID, eventLog string, strings []string, data []uint8) *eventRecord {
 	var e eventRecord
 	e.Type = Type
 	e.Category = category
 	e.EventID = eventID
+	if userSID != nil {
+		e.UserSID, _ = userSID.Copy()
+	}
 	e.Strings = strings
 	e.RawData = data
 	e.EventLog = eventLog
@@ -190,6 +194,7 @@ func (e *eventLog) reportEvent(
 	Type uint,
 	Category uint,
 	EventID uint,
+	UserSID *windows.SID,
 	Strings []string,
 	RawData []uint8) *eventRecord {
 
@@ -197,6 +202,7 @@ func (e *eventLog) reportEvent(
 		Type,
 		Category,
 		EventID,
+		UserSID,
 		e.name,
 		Strings,
 		RawData)

--- a/pkg/util/winutil/eventlog/api/fake/fake.go
+++ b/pkg/util/winutil/eventlog/api/fake/fake.go
@@ -17,6 +17,9 @@ import (
 
 // backing datastructures for the Fake API
 
+// API is a fake implementation of the Windows Event Log API intended to be used in tests.
+// It does not make any Windows Event Log API calls.
+// Event rendering is not implemented.
 type API struct {
 	eventLogs map[string]*eventLog
 
@@ -73,6 +76,7 @@ type bookmark struct {
 	eventRecordID uint
 }
 
+// New returns a new Windows Event Log API fake
 func New() *API {
 	var api API
 

--- a/pkg/util/winutil/eventlog/api/fake/test.go
+++ b/pkg/util/winutil/eventlog/api/fake/test.go
@@ -1,0 +1,88 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+//go:build windows
+// +build windows
+
+package fakeevtapi
+
+import (
+	"fmt"
+
+	"golang.org/x/sys/windows"
+)
+
+// helpers for FakeAPITester
+
+func (api *API) AddEventLog(name string) error {
+	// does it exist
+	_, err := api.getEventLog(name)
+	if err == nil {
+		return fmt.Errorf("Event log %v already exists", name)
+	}
+
+	api.addEventLog(newEventLog(name))
+	return nil
+}
+
+func (api *API) RemoveEventLog(name string) error {
+	// Get event log
+	_, err := api.getEventLog(name)
+	if err != nil {
+		return err
+	}
+	delete(api.eventLogs, name)
+	return nil
+}
+
+func (api *API) AddEventSource(channel string, source string) error {
+	// Get event log
+	log, err := api.getEventLog(channel)
+	if err != nil {
+		return err
+	}
+
+	_, exists := log.sources[source]
+	if !exists {
+		var s eventSource
+		s.name = source
+		s.logName = channel
+		log.sources[source] = &s
+	}
+
+	return nil
+}
+
+func (api *API) RemoveEventSource(channel string, name string) error {
+	// Get event log
+	log, err := api.getEventLog(channel)
+	if err != nil {
+		return err
+	}
+	delete(log.sources, name)
+	return nil
+}
+
+func (api *API) GenerateEvents(sourceName string, numEvents uint) error {
+	// find the log the source is registered to
+	var eventLog *eventLog
+	for _, log := range api.eventLogs {
+		_, ok := log.sources[sourceName]
+		if ok {
+			eventLog = log
+			break
+		}
+	}
+	if eventLog == nil {
+		return fmt.Errorf("Event source %v does not exist", sourceName)
+	}
+
+	// Add junk events
+	for i := uint(0); i < numEvents; i += 1 {
+		_ = eventLog.reportEvent(api, windows.EVENTLOG_INFORMATION_TYPE,
+			0, 1000, []string{"teststring1", "teststring2"}, []uint8("AABBCCDD"))
+	}
+
+	return nil
+}

--- a/pkg/util/winutil/eventlog/api/fake/test.go
+++ b/pkg/util/winutil/eventlog/api/fake/test.go
@@ -78,10 +78,13 @@ func (api *API) GenerateEvents(sourceName string, numEvents uint) error {
 		return fmt.Errorf("Event source %v does not exist", sourceName)
 	}
 
+	// Use LocalSystem for the SID
+	sid, _ := windows.CreateWellKnownSid(windows.WinLocalSystemSid)
+
 	// Add junk events
 	for i := uint(0); i < numEvents; i += 1 {
 		_ = eventLog.reportEvent(api, windows.EVENTLOG_INFORMATION_TYPE,
-			0, 1000, []string{"teststring1", "teststring2"}, []uint8("AABBCCDD"))
+			0, 1000, sid, []string{"teststring1", "teststring2"}, []uint8("AABBCCDD"))
 	}
 
 	return nil

--- a/pkg/util/winutil/eventlog/api/fake/test.go
+++ b/pkg/util/winutil/eventlog/api/fake/test.go
@@ -3,7 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2023-present Datadog, Inc.
 //go:build windows
-// +build windows
 
 package fakeevtapi
 

--- a/pkg/util/winutil/eventlog/api/fake/test.go
+++ b/pkg/util/winutil/eventlog/api/fake/test.go
@@ -14,6 +14,7 @@ import (
 
 // helpers for FakeAPITester
 
+// AddEventLog adds a new event log (channel) to the fake API
 func (api *API) AddEventLog(name string) error {
 	// does it exist
 	_, err := api.getEventLog(name)
@@ -25,6 +26,7 @@ func (api *API) AddEventLog(name string) error {
 	return nil
 }
 
+// RemoveEventLog removes an event log (channel) from the fake API
 func (api *API) RemoveEventLog(name string) error {
 	// Get event log
 	_, err := api.getEventLog(name)
@@ -35,6 +37,7 @@ func (api *API) RemoveEventLog(name string) error {
 	return nil
 }
 
+// AddEventSource adds a new source to an existing event log/channel
 func (api *API) AddEventSource(channel string, source string) error {
 	// Get event log
 	log, err := api.getEventLog(channel)
@@ -53,6 +56,7 @@ func (api *API) AddEventSource(channel string, source string) error {
 	return nil
 }
 
+// RemoveEventSource removes a source from a event log/channel
 func (api *API) RemoveEventSource(channel string, name string) error {
 	// Get event log
 	log, err := api.getEventLog(channel)
@@ -63,6 +67,8 @@ func (api *API) RemoveEventSource(channel string, name string) error {
 	return nil
 }
 
+// GenerateEvents writes @numEvents to the @sourceName event log source to help with
+// generating events for testing.
 func (api *API) GenerateEvents(sourceName string, numEvents uint) error {
 	// find the log the source is registered to
 	var eventLog *eventLog
@@ -81,7 +87,7 @@ func (api *API) GenerateEvents(sourceName string, numEvents uint) error {
 	sid, _ := windows.CreateWellKnownSid(windows.WinLocalSystemSid)
 
 	// Add junk events
-	for i := uint(0); i < numEvents; i += 1 {
+	for i := uint(0); i < numEvents; i++ {
 		_ = eventLog.reportEvent(api, windows.EVENTLOG_INFORMATION_TYPE,
 			0, 1000, sid, []string{"teststring1", "teststring2"}, []uint8("AABBCCDD"))
 	}

--- a/pkg/util/winutil/eventlog/api/fake/wevtapi.go
+++ b/pkg/util/winutil/eventlog/api/fake/wevtapi.go
@@ -1,0 +1,330 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+//go:build windows
+// +build windows
+
+package fakeevtapi
+
+import (
+	"bytes"
+	"encoding/hex"
+	"fmt"
+	"sort"
+	"text/template"
+
+	"github.com/DataDog/datadog-agent/pkg/util/winutil/eventlog/api"
+
+	"golang.org/x/sys/windows"
+)
+
+// Fake Windows APIs that implement evtapi.API
+
+func (api *API) EvtSubscribe(
+	SignalEvent evtapi.WaitEventHandle,
+	ChannelPath string,
+	Query string,
+	Bookmark evtapi.EventBookmarkHandle,
+	Flags uint) (evtapi.EventResultSetHandle, error) {
+
+	if Query != "" && Query != "*" {
+		return evtapi.EventResultSetHandle(0), fmt.Errorf("Fake API does not support query syntax")
+	}
+
+	// ensure channel exists
+	evtlog, err := api.getEventLog(ChannelPath)
+	if err != nil {
+		return evtapi.EventResultSetHandle(0), err
+	}
+
+	// get bookmark
+	var bookmark *bookmark
+	if Bookmark != evtapi.EventBookmarkHandle(0) {
+		bookmark, err = api.getBookmarkByHandle(Bookmark)
+		if err != nil {
+			return evtapi.EventResultSetHandle(0), err
+		}
+	}
+
+	// create sub
+	sub := newSubscription(ChannelPath, Query)
+	sub.signalEventHandle = SignalEvent
+
+	// go to bookmark
+	if bookmark != nil && (Flags&evtapi.EvtSubscribeOriginMask == evtapi.EvtSubscribeStartAfterBookmark) {
+		// binary search for event with matching RecordID, or insert location
+		i := sort.Search(len(evtlog.events), func(i int) bool {
+			e := evtlog.events[i]
+			return e.RecordID >= bookmark.eventRecordID
+		})
+		if i < len(evtlog.events) && evtlog.events[i].RecordID == bookmark.eventRecordID {
+			// start AFTER bookmark
+			sub.nextEvent = uint(i + 1)
+		} else {
+			// bookmarked event is no longer in the log
+			if Flags&evtapi.EvtSubscribeStrict == evtapi.EvtSubscribeStrict {
+				return evtapi.EventResultSetHandle(0), fmt.Errorf("bookmark not found and Strict flag set")
+			}
+			// MSDN says
+			// If you do not include the EvtSubscribeStrict flag and the bookmarked event does not exist,
+			// the subscription begins with the event that is after the event that is closest to the bookmarked event.
+			// https://learn.microsoft.com/en-us/windows/win32/api/winevt/ne-winevt-evt_subscribe_flags
+			// However, empirically, that is off by one and after clearing the event log it starts at the beginning,
+			// or "at the event that is closest to the bookmarked event".
+			sub.nextEvent = uint(i)
+			// TODO: add a test for if the event log is uninstalled and re-installed, does the RecordID start over?
+			//       if so then it's possible for the RecordID to be less than our bookmark.
+		}
+	}
+
+	// origin flags
+	if Flags&evtapi.EvtSubscribeOriginMask == evtapi.EvtSubscribeToFutureEvents {
+		sub.nextEvent = uint(len(evtlog.events))
+	}
+	if Flags&evtapi.EvtSubscribeOriginMask == evtapi.EvtSubscribeStartAtOldestRecord {
+		sub.nextEvent = 0
+	}
+
+	api.addSubscription(sub)
+	evtlog.subscriptions[sub.handle] = sub
+	return sub.handle, nil
+}
+
+func (api *API) EvtNext(
+	Session evtapi.EventResultSetHandle,
+	EventsArray []evtapi.EventRecordHandle,
+	EventsSize uint,
+	Timeout uint) ([]evtapi.EventRecordHandle, error) {
+
+	// get subscription
+	sub, err := api.getSubscriptionByHandle(Session)
+	if err != nil {
+		return nil, err
+	}
+
+	// get event log
+	eventLog, err := api.getEventLog(sub.channel)
+	if err != nil {
+		return nil, err
+	}
+
+	// is event log empty
+	if len(eventLog.events) == 0 {
+		return nil, windows.ERROR_NO_MORE_ITEMS
+	}
+	// if we are at end
+	if sub.nextEvent >= uint(len(eventLog.events)) {
+		return nil, windows.ERROR_NO_MORE_ITEMS
+	}
+
+	// get next events from log
+	end := sub.nextEvent + EventsSize
+	if end > uint(len(eventLog.events)) {
+		end = uint(len(eventLog.events))
+	}
+	events := eventLog.events[sub.nextEvent:end]
+	eventHandles := make([]evtapi.EventRecordHandle, len(events))
+	for i, e := range events {
+		api.addEventRecord(e)
+		eventHandles[i] = e.handle
+	}
+	sub.nextEvent = end
+
+	return eventHandles, nil
+}
+
+func (api *API) EvtClose(h windows.Handle) {
+	// is handle an event?
+	event, err := api.getEventRecordByHandle(evtapi.EventRecordHandle(h))
+	if err == nil {
+		delete(api.eventHandles, event.handle)
+		return
+	}
+	// TODO
+	// Is handle a subscription?
+	sub, err := api.getSubscriptionByHandle(evtapi.EventResultSetHandle(h))
+	if err == nil {
+		eventLog, err := api.getEventLog(sub.channel)
+		if err != nil {
+			return
+		}
+		delete(eventLog.subscriptions, sub.handle)
+		delete(api.subscriptions, sub.handle)
+		return
+	}
+}
+
+// EvtRenderEventXmlText renders EvtRenderEventXml
+// https://learn.microsoft.com/en-us/windows/win32/api/winevt/nf-winevt-evtrender
+func (api *API) EvtRenderEventXml(Fragment evtapi.EventRecordHandle) ([]uint16, error) {
+	// get event object
+	event, err := api.getEventRecordByHandle(Fragment)
+	if err != nil {
+		return nil, err
+	}
+
+	// Format event
+	tstr := `<Event xmlns="http://scemas.microsoft.com/win/2004/08/events/event">
+  <System>
+	<EventID>{{ .EventID }}</EventID>
+	<Channel>{{ .EventLog }}</Channel>
+	<EventRecordID>{{ .RecordID }}</EventRecordID>
+  </System>
+  <EventData>
+    {{- range $v := .Strings}}
+    <Data>{{ $v }}</Data>
+    {{- end}}
+    {{- if .RawData}}
+    <Binary>{{ hexstring .RawData }}</Binary>
+    {{- end}}
+  </EventData>
+</Event>
+`
+
+	funcMap := template.FuncMap{
+		"hexstring": hex.EncodeToString,
+	}
+
+	t, err := template.New("eventRenderXML").Funcs(funcMap).Parse(tstr)
+	if err != nil {
+		return nil, err
+	}
+
+	buf := bytes.NewBuffer(nil)
+
+	err = t.Execute(buf, event)
+	if err != nil {
+		return nil, err
+	}
+
+	// convert from utf-8 to utf-16
+	res, err := windows.UTF16FromString(buf.String())
+	if err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}
+
+// EvtRenderEventXmlText renders EvtRenderEventBookmark
+// https://learn.microsoft.com/en-us/windows/win32/api/winevt/nf-winevt-evtrender
+func (api *API) EvtRenderBookmark(Fragment evtapi.EventBookmarkHandle) ([]uint16, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (api *API) RegisterEventSource(SourceName string) (evtapi.EventSourceHandle, error) {
+	// find the log the source is registered to
+	for _, log := range api.eventLogs {
+		_, ok := log.sources[SourceName]
+		if ok {
+			// Create a handle
+			h := evtapi.EventSourceHandle(api.nextHandle.Inc())
+			api.sourceHandles[h] = log.name
+			return h, nil
+		}
+	}
+	return evtapi.EventSourceHandle(0), fmt.Errorf("Event source %s not found", SourceName)
+}
+
+func (api *API) DeregisterEventSource(sourceHandle evtapi.EventSourceHandle) error {
+	_, err := api.getEventSourceByHandle(sourceHandle)
+	if err != nil {
+		return err
+	}
+	delete(api.sourceHandles, sourceHandle)
+	return nil
+}
+
+func (api *API) ReportEvent(
+	EventLog evtapi.EventSourceHandle,
+	Type uint,
+	Category uint,
+	EventID uint,
+	Strings []string,
+	RawData []uint8) error {
+
+	// get event log
+	eventLog, err := api.getEventSourceByHandle(EventLog)
+	if err != nil {
+		return err
+	}
+
+	_ = eventLog.reportEvent(
+		api,
+		Type,
+		Category,
+		EventID,
+		Strings,
+		RawData)
+
+	return nil
+}
+
+// https://learn.microsoft.com/en-us/windows/win32/api/winevt/nf-winevt-evtclearlog
+func (api *API) EvtClearLog(ChannelPath string) error {
+	// Ensure eventlog exists
+	eventLog, err := api.getEventLog(ChannelPath)
+	if err != nil {
+		return err
+	}
+
+	// clear the log
+	eventLog.events = nil
+	// clearing the log does NOT reset the record IDs
+	return nil
+}
+
+// https://learn.microsoft.com/en-us/windows/win32/api/winevt/nf-winevt-evtcreatebookmark
+func (api *API) EvtCreateBookmark(BookmarkXml string) (evtapi.EventBookmarkHandle, error) {
+	var b bookmark
+
+	// TODO: parse Xml to get record ID
+
+	api.addBookmark(&b)
+
+	return evtapi.EventBookmarkHandle(b.handle), nil
+}
+
+// https://learn.microsoft.com/en-us/windows/win32/api/winevt/nf-winevt-evtupdatebookmark
+func (api *API) EvtUpdateBookmark(Bookmark evtapi.EventBookmarkHandle, Event evtapi.EventRecordHandle) error {
+	// Get bookmark
+	bookmark, err := api.getBookmarkByHandle(Bookmark)
+	if err != nil {
+		return err
+	}
+
+	// get event
+	event, err := api.getEventRecordByHandle(Event)
+	if err != nil {
+		return err
+	}
+
+	// Update bookmark to point to event
+	bookmark.eventRecordID = event.RecordID
+
+	return nil
+}
+
+func (api *API) EvtCreateRenderContext(ValuePaths []string, Flags uint) (evtapi.EventRenderContextHandle, error) {
+	return evtapi.EventRenderContextHandle(0), fmt.Errorf("not implemented")
+}
+
+func (api *API) EvtRenderEventValues(Context evtapi.EventRenderContextHandle, Fragment evtapi.EventRecordHandle) (evtapi.EvtVariantValues, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (api *API) EvtOpenPublisherMetadata(
+	PublisherId string,
+	LogFilePath string) (evtapi.EventPublisherMetadataHandle, error) {
+	return evtapi.EventPublisherMetadataHandle(0), fmt.Errorf("not implemented")
+}
+
+func (api *API) EvtFormatMessage(
+	PublisherMetadata evtapi.EventPublisherMetadataHandle,
+	Event evtapi.EventRecordHandle,
+	MessageId uint,
+	Values evtapi.EvtVariantValues,
+	Flags uint) (string, error) {
+	return "", fmt.Errorf("not implemented")
+}

--- a/pkg/util/winutil/eventlog/api/fake/wevtapi.go
+++ b/pkg/util/winutil/eventlog/api/fake/wevtapi.go
@@ -4,6 +4,9 @@
 // Copyright 2023-present Datadog, Inc.
 //go:build windows
 
+// Package fakeevtapi is a fake implementation of the Windows Event Log API intended to be used in tests.
+// It does not make any Windows Event Log API calls.
+// Event rendering is not implemented.
 package fakeevtapi
 
 import (
@@ -20,6 +23,8 @@ import (
 
 // Fake Windows APIs that implement evtapi.API
 
+// EvtSubscribe fake
+// https://learn.microsoft.com/en-us/windows/win32/api/winevt/nf-winevt-evtsubscribe
 func (api *API) EvtSubscribe(
 	SignalEvent evtapi.WaitEventHandle,
 	ChannelPath string,
@@ -90,6 +95,8 @@ func (api *API) EvtSubscribe(
 	return sub.handle, nil
 }
 
+// EvtNext fake
+// https://learn.microsoft.com/en-us/windows/win32/api/winevt/nf-winevt-evtnext
 func (api *API) EvtNext(
 	Session evtapi.EventResultSetHandle,
 	EventsArray []evtapi.EventRecordHandle,
@@ -133,6 +140,8 @@ func (api *API) EvtNext(
 	return eventHandles, nil
 }
 
+// EvtClose fake
+// https://learn.microsoft.com/en-us/windows/win32/api/winevt/nf-winevt-evtclose
 func (api *API) EvtClose(h windows.Handle) {
 	// is handle an event?
 	event, err := api.getEventRecordByHandle(evtapi.EventRecordHandle(h))
@@ -154,8 +163,10 @@ func (api *API) EvtClose(h windows.Handle) {
 	}
 }
 
-// EvtRenderEventXmlText renders EvtRenderEventXml
+// EvtRenderEventXml is a fake of EvtRender with EvtRenderEventXml
 // https://learn.microsoft.com/en-us/windows/win32/api/winevt/nf-winevt-evtrender
+//
+//revive:disable-next-line:var-naming Name is intended to match the Windows API name
 func (api *API) EvtRenderEventXml(Fragment evtapi.EventRecordHandle) ([]uint16, error) {
 	// get event object
 	event, err := api.getEventRecordByHandle(Fragment)
@@ -206,12 +217,15 @@ func (api *API) EvtRenderEventXml(Fragment evtapi.EventRecordHandle) ([]uint16, 
 	return res, nil
 }
 
-// EvtRenderEventXmlText renders EvtRenderEventBookmark
+// EvtRenderBookmark is a fake of EvtRender with EvtRenderEventBookmark
+// not implemented.
 // https://learn.microsoft.com/en-us/windows/win32/api/winevt/nf-winevt-evtrender
 func (api *API) EvtRenderBookmark(Fragment evtapi.EventBookmarkHandle) ([]uint16, error) {
 	return nil, fmt.Errorf("not implemented")
 }
 
+// RegisterEventSource fake
+// https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-registereventsourcew
 func (api *API) RegisterEventSource(SourceName string) (evtapi.EventSourceHandle, error) {
 	// find the log the source is registered to
 	for _, log := range api.eventLogs {
@@ -226,6 +240,8 @@ func (api *API) RegisterEventSource(SourceName string) (evtapi.EventSourceHandle
 	return evtapi.EventSourceHandle(0), fmt.Errorf("Event source %s not found", SourceName)
 }
 
+// DeregisterEventSource fake
+// https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-deregistereventsource
 func (api *API) DeregisterEventSource(sourceHandle evtapi.EventSourceHandle) error {
 	_, err := api.getEventSourceByHandle(sourceHandle)
 	if err != nil {
@@ -235,6 +251,8 @@ func (api *API) DeregisterEventSource(sourceHandle evtapi.EventSourceHandle) err
 	return nil
 }
 
+// ReportEvent fake
+// https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-reporteventw
 func (api *API) ReportEvent(
 	EventLog evtapi.EventSourceHandle,
 	Type uint,
@@ -262,6 +280,7 @@ func (api *API) ReportEvent(
 	return nil
 }
 
+// EvtClearLog fake
 // https://learn.microsoft.com/en-us/windows/win32/api/winevt/nf-winevt-evtclearlog
 func (api *API) EvtClearLog(ChannelPath string) error {
 	// Ensure eventlog exists
@@ -276,8 +295,9 @@ func (api *API) EvtClearLog(ChannelPath string) error {
 	return nil
 }
 
+// EvtCreateBookmark fake
 // https://learn.microsoft.com/en-us/windows/win32/api/winevt/nf-winevt-evtcreatebookmark
-func (api *API) EvtCreateBookmark(BookmarkXml string) (evtapi.EventBookmarkHandle, error) {
+func (api *API) EvtCreateBookmark(BookmarkXML string) (evtapi.EventBookmarkHandle, error) {
 	var b bookmark
 
 	// TODO: parse Xml to get record ID
@@ -287,6 +307,7 @@ func (api *API) EvtCreateBookmark(BookmarkXml string) (evtapi.EventBookmarkHandl
 	return evtapi.EventBookmarkHandle(b.handle), nil
 }
 
+// EvtUpdateBookmark fake
 // https://learn.microsoft.com/en-us/windows/win32/api/winevt/nf-winevt-evtupdatebookmark
 func (api *API) EvtUpdateBookmark(Bookmark evtapi.EventBookmarkHandle, Event evtapi.EventRecordHandle) error {
 	// Get bookmark
@@ -307,24 +328,35 @@ func (api *API) EvtUpdateBookmark(Bookmark evtapi.EventBookmarkHandle, Event evt
 	return nil
 }
 
+// EvtCreateRenderContext fake
+// not implemented.
+// https://learn.microsoft.com/en-us/windows/win32/api/winevt/nf-winevt-evtcreaterendercontext
 func (api *API) EvtCreateRenderContext(ValuePaths []string, Flags uint) (evtapi.EventRenderContextHandle, error) {
 	return evtapi.EventRenderContextHandle(0), fmt.Errorf("not implemented")
 }
 
+// EvtRenderEventValues is a fake of EvtRender with EvtRenderEventValues
+// https://learn.microsoft.com/en-us/windows/win32/api/winevt/nf-winevt-evtrender
 func (api *API) EvtRenderEventValues(Context evtapi.EventRenderContextHandle, Fragment evtapi.EventRecordHandle) (evtapi.EvtVariantValues, error) {
 	return nil, fmt.Errorf("not implemented")
 }
 
+// EvtOpenPublisherMetadata fake
+// not implemented.
+// https://learn.microsoft.com/en-us/windows/win32/api/winevt/nf-winevt-evtopenpublishermetadata
 func (api *API) EvtOpenPublisherMetadata(
-	PublisherId string,
+	PublisherID string,
 	LogFilePath string) (evtapi.EventPublisherMetadataHandle, error) {
 	return evtapi.EventPublisherMetadataHandle(0), fmt.Errorf("not implemented")
 }
 
+// EvtFormatMessage fake
+// not implemented.
+// https://learn.microsoft.com/en-us/windows/win32/api/winevt/nf-winevt-evtformatmessage
 func (api *API) EvtFormatMessage(
 	PublisherMetadata evtapi.EventPublisherMetadataHandle,
 	Event evtapi.EventRecordHandle,
-	MessageId uint,
+	MessageID uint,
 	Values evtapi.EvtVariantValues,
 	Flags uint) (string, error) {
 	return "", fmt.Errorf("not implemented")

--- a/pkg/util/winutil/eventlog/api/fake/wevtapi.go
+++ b/pkg/util/winutil/eventlog/api/fake/wevtapi.go
@@ -3,7 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2023-present Datadog, Inc.
 //go:build windows
-// +build windows
 
 package fakeevtapi
 

--- a/pkg/util/winutil/eventlog/api/fake/wevtapi.go
+++ b/pkg/util/winutil/eventlog/api/fake/wevtapi.go
@@ -241,6 +241,7 @@ func (api *API) ReportEvent(
 	Type uint,
 	Category uint,
 	EventID uint,
+	UserSID *windows.SID,
 	Strings []string,
 	RawData []uint8) error {
 
@@ -255,6 +256,7 @@ func (api *API) ReportEvent(
 		Type,
 		Category,
 		EventID,
+		UserSID,
 		Strings,
 		RawData)
 

--- a/pkg/util/winutil/eventlog/api/types.go
+++ b/pkg/util/winutil/eventlog/api/types.go
@@ -1,0 +1,236 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+//go:build windows
+// +build windows
+
+package evtapi
+
+import (
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+const (
+	// EVT_SUBSCRIBE_FLAGS
+	// https://learn.microsoft.com/en-us/windows/win32/api/winevt/ne-winevt-evt_subscribe_flags
+	EvtSubscribeToFutureEvents      = 1
+	EvtSubscribeStartAtOldestRecord = 2
+	EvtSubscribeStartAfterBookmark  = 3
+	EvtSubscribeOriginMask          = 3
+	EvtSubscribeTolerateQueryErrors = 0x1000
+	EvtSubscribeStrict              = 0x10000
+)
+
+const (
+	// EVT_RENDER_CONTEXT_FLAGS
+	// https://learn.microsoft.com/en-us/windows/win32/api/winevt/ne-winevt-evt_render_context_flags
+	EvtRenderContextValues = iota
+	EvtRenderContextSystem
+	EvtRenderContextUser
+)
+
+const (
+	// EVT_RENDER_FLAGS
+	// https://learn.microsoft.com/en-us/windows/win32/api/winevt/ne-winevt-evt_render_flags
+	EvtRenderEventValues = iota
+	EvtRenderEventXml
+	EvtRenderBookmark
+)
+
+const (
+	// EVT_VARIANT_TYPE
+	// https://learn.microsoft.com/en-us/windows/win32/api/winevt/ne-winevt-evt_variant_type
+	EvtVarTypeNull       = 0
+	EvtVarTypeString     = 1
+	EvtVarTypeAnsiString = 2
+	EvtVarTypeSByte      = 3
+	EvtVarTypeByte       = 4
+	EvtVarTypeInt16      = 5
+	EvtVarTypeUInt16     = 6
+	EvtVarTypeInt32      = 7
+	EvtVarTypeUInt32     = 8
+	EvtVarTypeInt64      = 9
+	EvtVarTypeUInt64     = 10
+	EvtVarTypeSingle     = 11
+	EvtVarTypeDouble     = 12
+	EvtVarTypeBoolean    = 13
+	EvtVarTypeBinary     = 14
+	EvtVarTypeGuid       = 15
+	EvtVarTypeSizeT      = 16
+	EvtVarTypeFileTime   = 17
+	EvtVarTypeSysTime    = 18
+	EvtVarTypeSid        = 19
+	EvtVarTypeHexInt32   = 20
+	EvtVarTypeHexInt64   = 21
+	EvtVarTypeEvtHandle  = 32
+	EvtVarTypeEvtXml     = 35
+)
+
+const (
+	// EVT_SYSTEM_PROPERTY_ID
+	// https://learn.microsoft.com/en-us/windows/win32/api/winevt/ne-winevt-evt_system_property_id
+	EvtSystemProviderName = iota
+	EvtSystemProviderGuid
+	EvtSystemEventID
+	EvtSystemQualifiers
+	EvtSystemLevel
+	EvtSystemTask
+	EvtSystemOpcode
+	EvtSystemKeywords
+	EvtSystemTimeCreated
+	EvtSystemEventRecordId
+	EvtSystemActivityID
+	EvtSystemRelatedActivityID
+	EvtSystemProcessID
+	EvtSystemThreadID
+	EvtSystemChannel
+	EvtSystemComputer
+	EvtSystemUserID
+	EvtSystemVersion
+	EvtSystemPropertyIdEND
+)
+
+const (
+	// EVT_FORMAT_MESSAGE_FLAGS
+	// https://learn.microsoft.com/en-us/windows/win32/api/winevt/ne-winevt-evt_format_message_flags
+	EvtFormatMessageEvent = iota + 1
+	EvtFormatMessageLevel
+	EvtFormatMessageTask
+	EvtFormatMessageOpcode
+	EvtFormatMessageKeyword
+	EvtFormatMessageChannel
+	EvtFormatMessageProvider
+	EvtFormatMessageId
+	EvtFormatMessageXml
+)
+
+// Returned from EvtQuery and EvtSubscribe
+type EventResultSetHandle windows.Handle
+
+// Returned from EvtNext
+type EventRecordHandle windows.Handle
+
+// Returned from EvtCreateBookmark
+type EventBookmarkHandle windows.Handle
+
+// Returned from EvtCreateRenderContext
+type EventRenderContextHandle windows.Handle
+
+// Returned from EvtOpenPublisherMetadata
+type EventPublisherMetadataHandle windows.Handle
+
+// Returned from RegisterEventSource
+type EventSourceHandle windows.Handle
+
+// Returned from CreateEvent
+type WaitEventHandle windows.Handle
+
+type API interface {
+	// Windows Event Log API methods
+	EvtSubscribe(
+		SignalEvent WaitEventHandle,
+		ChannelPath string,
+		Query string,
+		Bookmark EventBookmarkHandle,
+		Flags uint) (EventResultSetHandle, error)
+
+	EvtNext(
+		Session EventResultSetHandle,
+		EventsArray []EventRecordHandle,
+		EventsSize uint,
+		Timeout uint) ([]EventRecordHandle, error)
+
+	EvtClose(h windows.Handle)
+
+	EvtRenderEventXml(Fragment EventRecordHandle) ([]uint16, error)
+
+	EvtRenderBookmark(Fragment EventBookmarkHandle) ([]uint16, error)
+
+	EvtCreateRenderContext(ValuePaths []string, Flags uint) (EventRenderContextHandle, error)
+
+	// Note: Must call .Close() on the return value when done using it
+	EvtRenderEventValues(Context EventRenderContextHandle, Fragment EventRecordHandle) (EvtVariantValues, error)
+
+	EvtCreateBookmark(BookmarkXml string) (EventBookmarkHandle, error)
+
+	EvtUpdateBookmark(Bookmark EventBookmarkHandle, Event EventRecordHandle) error
+
+	EvtOpenPublisherMetadata(
+		PublisherId string,
+		LogFilePath string) (EventPublisherMetadataHandle, error)
+
+	EvtFormatMessage(
+		PublisherMetadata EventPublisherMetadataHandle,
+		Event EventRecordHandle,
+		MessageId uint,
+		Values EvtVariantValues,
+		Flags uint) (string, error)
+
+	// Windows Event Logging methods
+	RegisterEventSource(SourceName string) (EventSourceHandle, error)
+
+	DeregisterEventSource(EventLog EventSourceHandle) error
+
+	EvtClearLog(ChannelPath string) error
+
+	ReportEvent(
+		EventLog EventSourceHandle,
+		Type uint,
+		Category uint,
+		EventID uint,
+		Strings []string,
+		RawData []uint8) error
+}
+
+type EventRecord struct {
+	EventRecordHandle EventRecordHandle
+}
+
+// EvtVariantValues is returned from EvtRenderEventValues
+// https://learn.microsoft.com/en-us/windows/win32/api/winevt/ns-winevt-evt_variant
+type EvtVariantValues interface {
+	// Each type method accepts an index argument that determines which element in the
+	// array to return.
+	String(uint) (string, error)
+
+	UInt(uint) (uint64, error)
+
+	// Returns unix timestamp in seconds
+	Time(uint) (int64, error)
+
+	// Returns the EVT_VARIANT_TYPE of the element at index
+	Type(uint) (uint, error)
+
+	// Buffer to raw EVT_VARIANT buffer
+	Buffer() unsafe.Pointer
+
+	// The number of values
+	Count() uint
+
+	// Free resources
+	Close()
+}
+
+// Helpful wrappers for custom types
+func EvtCloseResultSet(api API, h EventResultSetHandle) {
+	api.EvtClose(windows.Handle(h))
+}
+
+func EvtCloseBookmark(api API, h EventBookmarkHandle) {
+	api.EvtClose(windows.Handle(h))
+}
+
+func EvtCloseRecord(api API, h EventRecordHandle) {
+	api.EvtClose(windows.Handle(h))
+}
+
+func EvtCloseRenderContext(api API, h EventRenderContextHandle) {
+	api.EvtClose(windows.Handle(h))
+}
+
+func EvtClosePublisherMetadata(api API, h EventPublisherMetadataHandle) {
+	api.EvtClose(windows.Handle(h))
+}

--- a/pkg/util/winutil/eventlog/api/types.go
+++ b/pkg/util/winutil/eventlog/api/types.go
@@ -181,6 +181,7 @@ type API interface {
 		Type uint,
 		Category uint,
 		EventID uint,
+		UserSID *windows.SID,
 		Strings []string,
 		RawData []uint8) error
 }
@@ -200,6 +201,9 @@ type EvtVariantValues interface {
 
 	// Returns unix timestamp in seconds
 	Time(uint) (int64, error)
+
+	// Returns a SID
+	SID(uint) (*windows.SID, error)
 
 	// Returns the EVT_VARIANT_TYPE of the element at index
 	Type(uint) (uint, error)

--- a/pkg/util/winutil/eventlog/api/types.go
+++ b/pkg/util/winutil/eventlog/api/types.go
@@ -3,7 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2023-present Datadog, Inc.
 //go:build windows
-// +build windows
 
 package evtapi
 

--- a/pkg/util/winutil/eventlog/api/windows/render.go
+++ b/pkg/util/winutil/eventlog/api/windows/render.go
@@ -1,0 +1,182 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+//go:build windows
+// +build windows
+
+package winevtapi
+
+import (
+	"fmt"
+	"unsafe"
+
+	"github.com/DataDog/datadog-agent/pkg/util/winutil"
+	"github.com/DataDog/datadog-agent/pkg/util/winutil/eventlog/api"
+
+	"golang.org/x/sys/windows"
+)
+
+// #define WIN32_LEAN_AND_MEAN
+// #include <windows.h>
+// #include <winevt.h>
+//
+// /* Helper to get a pointer value from the union in EVT_VARIANT without abusing
+//  * unsafe.Pointer+uintptr and triggering warnings that are not relevant because
+//  * this pointer value is in C memory not Go memory.
+//  */
+// const void *dataptr(EVT_VARIANT* v) {
+//     return v->StringVal;
+// }
+import "C"
+
+// implements EvtVariantValues
+type evtVariantValues struct {
+	// C memory, filled by the EvtRender call
+	buf unsafe.Pointer
+	// size in bytes of buf
+	bufsize uint
+	// Number of EVT_VARIANT structs contained in buf
+	count uint
+}
+
+func (v *evtVariantValues) String(index uint) (string, error) {
+	value, err := v.item(index)
+	if err != nil {
+		return "", err
+	}
+	t := C.EVT_VARIANT_TYPE_MASK & value.Type
+	if t == evtapi.EvtVarTypeString {
+		return windows.UTF16PtrToString((*uint16)(C.dataptr(value))), nil
+	}
+	return "", fmt.Errorf("invalid type %#x", t)
+}
+
+func (v *evtVariantValues) UInt(index uint) (uint64, error) {
+	value, err := v.item(index)
+	if err != nil {
+		return 0, err
+	}
+	t := C.EVT_VARIANT_TYPE_MASK & value.Type
+	if t == evtapi.EvtVarTypeByte {
+		return uint64(*(*uint8)(unsafe.Pointer(value))), nil
+	} else if t == evtapi.EvtVarTypeUInt16 {
+		return uint64(*(*uint16)(unsafe.Pointer(value))), nil
+	} else if t == evtapi.EvtVarTypeUInt64 {
+		return uint64(*(*uint64)(unsafe.Pointer(value))), nil
+	}
+	return 0, fmt.Errorf("invalid type %#x", t)
+}
+
+// Returns the number of seconds since unix epoch
+func (v *evtVariantValues) Time(index uint) (int64, error) {
+	value, err := v.item(index)
+	if err != nil {
+		return 0, err
+	}
+	t := C.EVT_VARIANT_TYPE_MASK & value.Type
+	if t == evtapi.EvtVarTypeFileTime {
+		ft := (*C.FILETIME)(unsafe.Pointer(value))
+		nsec := (uint64(ft.dwHighDateTime) << 32) | uint64(ft.dwLowDateTime)
+		return int64(winutil.FileTimeToUnix(nsec)), nil
+	}
+	return 0, fmt.Errorf("invalid type %#x", t)
+}
+
+// Get a EVT_VARIANT* to an element in the array of structs
+func (v *evtVariantValues) item(index uint) (*C.EVT_VARIANT, error) {
+	if index >= v.count {
+		return nil, fmt.Errorf("index out of bounds")
+	}
+	// Get a pointer to the structure at index, e.g. &((*EVT_VARIANT)buf)[index]
+	x := (*C.EVT_VARIANT)(unsafe.Add(v.buf, (uintptr)(index)*unsafe.Sizeof(C.EVT_VARIANT{})))
+	return x, nil
+}
+
+func (v *evtVariantValues) Type(index uint) (uint, error) {
+	value, err := v.item(index)
+	if err != nil {
+		return 0, err
+	}
+	return (uint)(value.Type), nil
+}
+
+func (v *evtVariantValues) Count() uint {
+	return v.count
+}
+
+func (v *evtVariantValues) Buffer() unsafe.Pointer {
+	return v.buf
+}
+
+func (v *evtVariantValues) Close() {
+	C.free(v.buf)
+}
+
+// EvtRenderEventValues renders EvtRenderEventValues
+// https://learn.microsoft.com/en-us/windows/win32/api/winevt/nf-winevt-evtrender
+func (api *API) EvtRenderEventValues(Context evtapi.EventRenderContextHandle, Fragment evtapi.EventRecordHandle) (evtapi.EvtVariantValues, error) {
+	rv, err := evtRenderEventValues(Context, Fragment)
+	if err != nil {
+		return nil, err
+	}
+
+	return rv, nil
+}
+
+// evtRenderEventValues renders EvtRenderEventValues
+// https://learn.microsoft.com/en-us/windows/win32/api/winevt/nf-winevt-evtrender
+func evtRenderEventValues(Context evtapi.EventRenderContextHandle, Fragment evtapi.EventRecordHandle) (*evtVariantValues, error) {
+
+	Flags := evtapi.EvtRenderEventValues
+	// Get required buffer size
+	var BufferUsed uint32
+	var PropertyCount uint32
+	r1, _, lastErr := evtRender.Call(
+		uintptr(Context),
+		uintptr(Fragment),
+		uintptr(Flags),
+		uintptr(0),
+		uintptr(0),
+		uintptr(unsafe.Pointer(&BufferUsed)),
+		uintptr(unsafe.Pointer(&PropertyCount)))
+	// EvtRenders returns C FALSE (0) on error
+	if r1 == 0 {
+		if lastErr != windows.ERROR_INSUFFICIENT_BUFFER {
+			return nil, lastErr
+		}
+	} else {
+		return nil, nil
+	}
+
+	// Allocate buffer space (BufferUsed is size in bytes)
+	//
+	// /*** MUST NOT USE GO MANAGED MEMORY ***\
+	//
+	// This buffer will contain pointers that point within the buffer itself.
+	// If Go managed memory is used then the buffer may move, which will invalidate
+	// all of the pointers inside the buffer.
+	Buffer := C.calloc(C.ulonglong(BufferUsed), 1)
+	// C.calloc will never return nil
+
+	// Fill buffer
+	r1, _, lastErr = evtRender.Call(
+		uintptr(Context),
+		uintptr(Fragment),
+		uintptr(Flags),
+		uintptr(BufferUsed),
+		// TODO: use unsafe.SliceData in go1.20
+		uintptr(Buffer),
+		uintptr(unsafe.Pointer(&BufferUsed)),
+		uintptr(unsafe.Pointer(&PropertyCount)))
+	// EvtRenders returns C FALSE (0) on error
+	if r1 == 0 {
+		return nil, lastErr
+	}
+
+	var rv evtVariantValues
+	rv.buf = Buffer
+	rv.count = (uint)(PropertyCount)
+
+	return &rv, nil
+}

--- a/pkg/util/winutil/eventlog/api/windows/render.go
+++ b/pkg/util/winutil/eventlog/api/windows/render.go
@@ -83,6 +83,24 @@ func (v *evtVariantValues) Time(index uint) (int64, error) {
 	return 0, fmt.Errorf("invalid type %#x", t)
 }
 
+// Returns a *SID
+func (v *evtVariantValues) SID(index uint) (*windows.SID, error) {
+	value, err := v.item(index)
+	if err != nil {
+		return nil, err
+	}
+	t := C.EVT_VARIANT_TYPE_MASK & value.Type
+	if t == evtapi.EvtVarTypeSid {
+		orig_sid := (*windows.SID)(C.dataptr(value))
+		s, err := orig_sid.Copy()
+		if err != nil {
+			return nil, err
+		}
+		return s, err
+	}
+	return nil, fmt.Errorf("invalid type %#x", t)
+}
+
 // Get a EVT_VARIANT* to an element in the array of structs
 func (v *evtVariantValues) item(index uint) (*C.EVT_VARIANT, error) {
 	if index >= v.count {

--- a/pkg/util/winutil/eventlog/api/windows/render.go
+++ b/pkg/util/winutil/eventlog/api/windows/render.go
@@ -90,8 +90,8 @@ func (v *evtVariantValues) SID(index uint) (*windows.SID, error) {
 	}
 	t := C.EVT_VARIANT_TYPE_MASK & value.Type
 	if t == evtapi.EvtVarTypeSid {
-		orig_sid := (*windows.SID)(C.dataptr(value))
-		s, err := orig_sid.Copy()
+		origSid := (*windows.SID)(C.dataptr(value))
+		s, err := origSid.Copy()
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/util/winutil/eventlog/api/windows/render.go
+++ b/pkg/util/winutil/eventlog/api/windows/render.go
@@ -3,7 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2023-present Datadog, Inc.
 //go:build windows
-// +build windows
 
 package winevtapi
 

--- a/pkg/util/winutil/eventlog/api/windows/wevtapi.go
+++ b/pkg/util/winutil/eventlog/api/windows/wevtapi.go
@@ -1,0 +1,419 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+//go:build windows
+// +build windows
+
+package winevtapi
+
+import (
+	"fmt"
+	"unsafe"
+
+	"github.com/DataDog/datadog-agent/pkg/util/winutil"
+	evtapi "github.com/DataDog/datadog-agent/pkg/util/winutil/eventlog/api"
+
+	"golang.org/x/sys/windows"
+)
+
+var (
+	// New Event Log API
+	// https://learn.microsoft.com/en-us/windows/win32/wes/using-windows-event-log
+	wevtapi                  = windows.NewLazySystemDLL("wevtapi.dll")
+	evtSubscribe             = wevtapi.NewProc("EvtSubscribe")
+	evtClose                 = wevtapi.NewProc("EvtClose")
+	evtNext                  = wevtapi.NewProc("EvtNext")
+	evtCreateBookmark        = wevtapi.NewProc("EvtCreateBookmark")
+	evtUpdateBookmark        = wevtapi.NewProc("EvtUpdateBookmark")
+	evtCreateRenderContext   = wevtapi.NewProc("EvtCreateRenderContext")
+	evtRender                = wevtapi.NewProc("EvtRender")
+	evtClearLog              = wevtapi.NewProc("EvtClearLog")
+	evtOpenPublisherMetadata = wevtapi.NewProc("EvtOpenPublisherMetadata")
+	evtFormatMessage         = wevtapi.NewProc("EvtFormatMessage")
+
+	// Legacy Event Logging API
+	// https://learn.microsoft.com/en-us/windows/win32/eventlog/using-event-logging
+	advapi32              = windows.NewLazySystemDLL("advapi32.dll")
+	registerEventSource   = advapi32.NewProc("RegisterEventSourceW")
+	deregisterEventSource = advapi32.NewProc("DeregisterEventSource")
+	reportEvent           = advapi32.NewProc("ReportEventW")
+)
+
+type API struct{}
+
+func New() *API {
+	var api API
+	return &api
+}
+
+// Pass returned handle to EvtClose
+// https://learn.microsoft.com/en-us/windows/win32/api/winevt/nf-winevt-evtsubscribe
+func (api *API) EvtSubscribe(
+	SignalEvent evtapi.WaitEventHandle,
+	ChannelPath string,
+	Query string,
+	Bookmark evtapi.EventBookmarkHandle,
+	Flags uint) (evtapi.EventResultSetHandle, error) {
+
+	// Convert Go string to Windows API string
+	channelPath, err := winutil.UTF16PtrOrNilFromString(ChannelPath)
+	if err != nil {
+		return evtapi.EventResultSetHandle(0), err
+	}
+	query, err := winutil.UTF16PtrOrNilFromString(Query)
+	if err != nil {
+		return evtapi.EventResultSetHandle(0), err
+	}
+
+	// Call API
+	r1, _, lastErr := evtSubscribe.Call(
+		uintptr(0), // TODO: localhost only for now
+		uintptr(SignalEvent),
+		uintptr(unsafe.Pointer(channelPath)),
+		uintptr(unsafe.Pointer(query)),
+		uintptr(Bookmark),
+		uintptr(0), // No context in pull mode
+		uintptr(0), // No callback in pull mode
+		uintptr(Flags))
+	// EvtSubscribe returns NULL on error
+	if r1 == 0 {
+		return evtapi.EventResultSetHandle(0), lastErr
+	}
+
+	return evtapi.EventResultSetHandle(r1), nil
+}
+
+// Must call EvtClose on every handle returned
+// https://learn.microsoft.com/en-us/windows/win32/api/winevt/nf-winevt-evtnext
+func (api *API) EvtNext(
+	Session evtapi.EventResultSetHandle,
+	EventsArray []evtapi.EventRecordHandle,
+	EventsSize uint,
+	Timeout uint) ([]evtapi.EventRecordHandle, error) {
+
+	var Returned uint32
+	Returned = 0
+
+	// Fill array
+	r1, _, lastErr := evtNext.Call(
+		uintptr(Session),
+		uintptr(EventsSize),
+		// TODO: use unsafe.SliceData in go1.20
+		uintptr(unsafe.Pointer(&EventsArray[:1][0])),
+		uintptr(Timeout),
+		uintptr(0), // reserved must be 0
+		uintptr(unsafe.Pointer(&Returned)))
+	// EvtNext returns C BOOL FALSE (0) on "error"
+	// "error" can mean error, ERROR_TIMEOUT, or ERROR_NO_MORE_ITEMS
+	if r1 == 0 {
+		return nil, lastErr
+	}
+
+	// Trim slice over returned # elements
+	return EventsArray[:Returned], nil
+}
+
+// https://learn.microsoft.com/en-us/windows/win32/api/winevt/nf-winevt-evtclose
+func (api *API) EvtClose(h windows.Handle) {
+	if h != windows.Handle(0) {
+		_, _, _ = evtClose.Call(uintptr(h))
+	}
+}
+
+// https://learn.microsoft.com/en-us/windows/win32/api/winevt/nf-winevt-evtcreatebookmark
+func (api *API) EvtCreateBookmark(BookmarkXml string) (evtapi.EventBookmarkHandle, error) {
+	var bookmarkXml *uint16
+
+	bookmarkXml, err := winutil.UTF16PtrOrNilFromString(BookmarkXml)
+	if err != nil {
+		return evtapi.EventBookmarkHandle(0), err
+	}
+
+	r1, _, lastErr := evtCreateBookmark.Call(uintptr(unsafe.Pointer(bookmarkXml)))
+	// EvtCreateBookmark returns NULL on error
+	if r1 == 0 {
+		return evtapi.EventBookmarkHandle(0), lastErr
+	}
+
+	return evtapi.EventBookmarkHandle(r1), nil
+}
+
+// https://learn.microsoft.com/en-us/windows/win32/api/winevt/nf-winevt-evtupdatebookmark
+func (api *API) EvtUpdateBookmark(Bookmark evtapi.EventBookmarkHandle, Event evtapi.EventRecordHandle) error {
+	r1, _, lastErr := evtUpdateBookmark.Call(uintptr(Bookmark), uintptr(Event))
+	// EvtUpdateBookmark returns C FALSE (0) on error
+	if r1 == 0 {
+		return lastErr
+	}
+
+	return nil
+}
+
+// https://learn.microsoft.com/en-us/windows/win32/api/winevt/nf-winevt-evtcreaterendercontext
+func (api *API) EvtCreateRenderContext(ValuePaths []string, Flags uint) (evtapi.EventRenderContextHandle, error) {
+	var err error
+
+	var valuePathsPtr unsafe.Pointer
+
+	if len(ValuePaths) > 0 {
+		valuePaths := make([]*uint16, len(ValuePaths))
+		for i, v := range ValuePaths {
+			valuePaths[i], err = windows.UTF16PtrFromString(v)
+			if err != nil {
+				return evtapi.EventRenderContextHandle(0), err
+			}
+		}
+		valuePathsPtr = unsafe.Pointer(&valuePaths[:1][0])
+	} else {
+		valuePathsPtr = nil
+	}
+
+	r1, _, lastErr := evtCreateRenderContext.Call(
+		uintptr(len(ValuePaths)),
+		// TODO: use unsafe.SliceData in go1.20
+		uintptr(valuePathsPtr),
+		uintptr(Flags))
+	// EvtCreateRenderContext returns NULL on error
+	if r1 == 0 {
+		return evtapi.EventRenderContextHandle(0), lastErr
+	}
+
+	return evtapi.EventRenderContextHandle(r1), nil
+}
+
+// EvtRenderText supports the EvtRenderEventXml and EvtRenderBookmark Flags
+// https://learn.microsoft.com/en-us/windows/win32/api/winevt/nf-winevt-evtrender
+func evtRenderText(
+	Fragment windows.Handle,
+	Flags uint) ([]uint16, error) {
+
+	if Flags != evtapi.EvtRenderEventXml && Flags != evtapi.EvtRenderBookmark {
+		return nil, fmt.Errorf("Invalid Flags")
+	}
+
+	// Get required buffer size
+	var BufferUsed uint32
+	var PropertyCount uint32
+	r1, _, lastErr := evtRender.Call(
+		uintptr(0),
+		uintptr(Fragment),
+		uintptr(Flags),
+		uintptr(0),
+		uintptr(0),
+		uintptr(unsafe.Pointer(&BufferUsed)),
+		uintptr(unsafe.Pointer(&PropertyCount)))
+	// EvtRenders returns C FALSE (0) on error
+	if r1 == 0 {
+		if lastErr != windows.ERROR_INSUFFICIENT_BUFFER {
+			return nil, lastErr
+		}
+	} else {
+		return nil, nil
+	}
+
+	// Allocate buffer space (BufferUsed is size in bytes)
+	Buffer := make([]uint16, BufferUsed/2)
+
+	// Fill buffer
+	r1, _, lastErr = evtRender.Call(
+		uintptr(0),
+		uintptr(Fragment),
+		uintptr(Flags),
+		uintptr(BufferUsed),
+		// TODO: use unsafe.SliceData in go1.20
+		uintptr(unsafe.Pointer(&Buffer[:1][0])),
+		uintptr(unsafe.Pointer(&BufferUsed)),
+		uintptr(unsafe.Pointer(&PropertyCount)))
+	// EvtRenders returns C FALSE (0) on error
+	if r1 == 0 {
+		return nil, lastErr
+	}
+
+	return Buffer, nil
+}
+
+// EvtRenderEventXmlText renders EvtRenderEventXml
+// https://learn.microsoft.com/en-us/windows/win32/api/winevt/nf-winevt-evtrender
+func (api *API) EvtRenderEventXml(Fragment evtapi.EventRecordHandle) ([]uint16, error) {
+	return evtRenderText(windows.Handle(Fragment), evtapi.EvtRenderEventXml)
+}
+
+// EvtRenderEventXmlText renders EvtRenderBookmark
+// https://learn.microsoft.com/en-us/windows/win32/api/winevt/nf-winevt-evtrender
+func (api *API) EvtRenderBookmark(Fragment evtapi.EventBookmarkHandle) ([]uint16, error) {
+	return evtRenderText(windows.Handle(Fragment), evtapi.EvtRenderBookmark)
+}
+
+// https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-registereventsourcew
+func (api *API) RegisterEventSource(SourceName string) (evtapi.EventSourceHandle, error) {
+	sourceName, err := winutil.UTF16PtrOrNilFromString(SourceName)
+	if err != nil {
+		return evtapi.EventSourceHandle(0), err
+	}
+
+	r1, _, lastErr := registerEventSource.Call(
+		uintptr(0), // local computer only
+		uintptr(unsafe.Pointer(sourceName)))
+	// RegisterEventSource returns NULL on error
+	if r1 == 0 {
+		return evtapi.EventSourceHandle(0), lastErr
+	}
+
+	return evtapi.EventSourceHandle(r1), nil
+}
+
+// https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-deregistereventsource
+func (api *API) DeregisterEventSource(EventLog evtapi.EventSourceHandle) error {
+	r1, _, lastErr := deregisterEventSource.Call(uintptr(EventLog))
+	// DeregisterEventSource returns C FALSE (0) on error
+	if r1 == 0 {
+		return lastErr
+	}
+
+	return nil
+}
+
+// https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-reporteventw
+func (api *API) ReportEvent(
+	EventLog evtapi.EventSourceHandle,
+	Type uint,
+	Category uint,
+	EventID uint,
+	Strings []string,
+	RawData []uint8) error {
+
+	var err error
+	strings := make([]*uint16, len(Strings))
+
+	for i, s := range Strings {
+		strings[i], err = windows.UTF16PtrFromString(s)
+		if err != nil {
+			return err
+		}
+	}
+
+	var rawData *uint8
+	if len(RawData) == 0 {
+		rawData = nil
+	} else {
+		rawData = &RawData[:1][0]
+	}
+
+	r1, _, lastErr := reportEvent.Call(
+		uintptr(EventLog),
+		uintptr(Type),
+		uintptr(Category),
+		uintptr(EventID),
+		uintptr(0), // userSid
+		uintptr(len(strings)),
+		uintptr(len(RawData)),
+		// TODO: use unsafe.SliceData in go1.20
+		uintptr(unsafe.Pointer(&strings[:1][0])),
+		// TODO: use unsafe.SliceData in go1.20
+		uintptr(unsafe.Pointer(rawData)))
+	// ReportEvent returns C FALSE (0) on error
+	if r1 == 0 {
+		return lastErr
+	}
+
+	return nil
+}
+
+// https://learn.microsoft.com/en-us/windows/win32/api/winevt/nf-winevt-evtclearlog
+func (api *API) EvtClearLog(ChannelPath string) error {
+	channelPath, err := winutil.UTF16PtrOrNilFromString(ChannelPath)
+	if err != nil {
+		return err
+	}
+
+	r1, _, lastErr := evtClearLog.Call(
+		uintptr(0), // local computer only
+		uintptr(unsafe.Pointer(channelPath)),
+		uintptr(0), // TargetFilePath not supported
+		uintptr(0)) // reserved must be 0
+	// EvtClearLog returns C FALSE (0) on error
+	if r1 == 0 {
+		return lastErr
+	}
+
+	return nil
+}
+
+func (api *API) EvtOpenPublisherMetadata(
+	PublisherId string,
+	LogFilePath string) (evtapi.EventPublisherMetadataHandle, error) {
+
+	publisherId, err := windows.UTF16PtrFromString(PublisherId)
+	if err != nil {
+		return evtapi.EventPublisherMetadataHandle(0), err
+	}
+
+	logFilePath, err := winutil.UTF16PtrOrNilFromString(LogFilePath)
+	if err != nil {
+		return evtapi.EventPublisherMetadataHandle(0), err
+	}
+
+	r1, _, lastErr := evtOpenPublisherMetadata.Call(
+		uintptr(0), // local computer only
+		uintptr(unsafe.Pointer(publisherId)),
+		uintptr(unsafe.Pointer(logFilePath)),
+		uintptr(0), // use current locale
+		uintptr(0)) // reserved must be 0
+	// EvtOpenPublisherMetadata returns NULL on error
+	if r1 == 0 {
+		return evtapi.EventPublisherMetadataHandle(0), lastErr
+	}
+
+	return evtapi.EventPublisherMetadataHandle(r1), nil
+}
+
+func (api *API) EvtFormatMessage(
+	PublisherMetadata evtapi.EventPublisherMetadataHandle,
+	Event evtapi.EventRecordHandle,
+	MessageId uint,
+	Values evtapi.EvtVariantValues,
+	Flags uint) (string, error) {
+
+	var BufferUsed uint32
+
+	r1, _, lastErr := evtFormatMessage.Call(
+		uintptr(PublisherMetadata),
+		uintptr(Event),
+		uintptr(MessageId),
+		uintptr(0),
+		uintptr(0),
+		uintptr(Flags),
+		uintptr(0),
+		uintptr(0),
+		uintptr(unsafe.Pointer(&BufferUsed)))
+	// EvtFormatMessage returns C FALSE (0) on error
+	if r1 == 0 {
+		if lastErr != windows.ERROR_INSUFFICIENT_BUFFER {
+			return "", lastErr
+		}
+	} else {
+		return "", nil
+	}
+
+	// Allocate buffer space (BufferUsed is size in characters)
+	Buffer := make([]uint16, BufferUsed)
+
+	r1, _, lastErr = evtFormatMessage.Call(
+		uintptr(PublisherMetadata),
+		uintptr(Event),
+		uintptr(MessageId),
+		uintptr(0),
+		uintptr(0),
+		uintptr(Flags),
+		uintptr(BufferUsed),
+		// TODO: use unsafe.SliceData in go1.20
+		uintptr(unsafe.Pointer(&Buffer[:1][0])),
+		uintptr(unsafe.Pointer(&BufferUsed)))
+	// EvtFormatMessage returns C FALSE (0) on error
+	if r1 == 0 {
+		return "", lastErr
+	}
+
+	return windows.UTF16ToString(Buffer), nil
+}

--- a/pkg/util/winutil/eventlog/api/windows/wevtapi.go
+++ b/pkg/util/winutil/eventlog/api/windows/wevtapi.go
@@ -3,7 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2023-present Datadog, Inc.
 //go:build windows
-// +build windows
 
 package winevtapi
 

--- a/pkg/util/winutil/eventlog/api/windows/wevtapi.go
+++ b/pkg/util/winutil/eventlog/api/windows/wevtapi.go
@@ -280,6 +280,7 @@ func (api *API) ReportEvent(
 	Type uint,
 	Category uint,
 	EventID uint,
+	UserSID *windows.SID,
 	Strings []string,
 	RawData []uint8) error {
 
@@ -305,7 +306,8 @@ func (api *API) ReportEvent(
 		uintptr(Type),
 		uintptr(Category),
 		uintptr(EventID),
-		uintptr(0), // userSid
+		// This is how Golang zsyscall_windows.go passes *windows.SID to syscalls
+		uintptr(unsafe.Pointer(UserSID)),
 		uintptr(len(strings)),
 		uintptr(len(RawData)),
 		// TODO: use unsafe.SliceData in go1.20

--- a/pkg/util/winutil/eventlog/bookmark/bookmark.go
+++ b/pkg/util/winutil/eventlog/bookmark/bookmark.go
@@ -1,0 +1,139 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+//go:build windows
+// +build windows
+
+package evtbookmark
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/DataDog/datadog-agent/pkg/util/winutil/eventlog/api"
+	"golang.org/x/sys/windows"
+)
+
+type Bookmark interface {
+	Handle() evtapi.EventBookmarkHandle
+	Update(evtapi.EventRecordHandle) error
+	Render() (string, error)
+	Close()
+}
+
+type bookmark struct {
+	// Windows API
+	eventLogAPI    evtapi.API
+	bookmarkHandle evtapi.EventBookmarkHandle
+}
+
+func New(options ...func(*bookmark) error) (*bookmark, error) {
+	var b bookmark
+
+	for _, o := range options {
+		err := o(&b)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if b.bookmarkHandle == evtapi.EventBookmarkHandle(0) {
+		if b.eventLogAPI == nil {
+			return nil, fmt.Errorf("event log API not set")
+		}
+		// Create a new empty bookmark
+		bookmarkHandle, err := b.eventLogAPI.EvtCreateBookmark("")
+		if err != nil {
+			return nil, err
+		}
+		b.bookmarkHandle = bookmarkHandle
+	}
+
+	return &b, nil
+}
+
+func WithWindowsEventLogAPI(api evtapi.API) func(*bookmark) error {
+	return func(b *bookmark) error {
+		b.eventLogAPI = api
+		return nil
+	}
+}
+
+func FromFile(bookmarkPath string) func(*bookmark) error {
+	return func(b *bookmark) error {
+		if b.eventLogAPI == nil {
+			return fmt.Errorf("event log API not set")
+		}
+		if b.bookmarkHandle != evtapi.EventBookmarkHandle(0) {
+			return fmt.Errorf("bookmark handle already initialized")
+		}
+		// Read bookmark from file
+		bookmarkXML, err := os.ReadFile(bookmarkPath)
+		if err != nil {
+			return err
+		}
+		return FromXML(string(bookmarkXML))(b)
+	}
+}
+
+func FromXML(bookmarkXML string) func(*bookmark) error {
+	return func(b *bookmark) error {
+		if b.eventLogAPI == nil {
+			return fmt.Errorf("event log API not set")
+		}
+		if b.bookmarkHandle != evtapi.EventBookmarkHandle(0) {
+			return fmt.Errorf("bookmark handle already initialized")
+		}
+		// Load bookmark XML
+		bookmarkHandle, err := b.eventLogAPI.EvtCreateBookmark(string(bookmarkXML))
+		if err != nil {
+			return err
+		}
+		b.bookmarkHandle = bookmarkHandle
+		return nil
+	}
+}
+
+func (b *bookmark) Handle() evtapi.EventBookmarkHandle {
+	return b.bookmarkHandle
+}
+
+func (b *bookmark) Update(eventHandle evtapi.EventRecordHandle) error {
+	if b.eventLogAPI == nil {
+		return fmt.Errorf("event log API not set")
+	}
+	if b.bookmarkHandle == evtapi.EventBookmarkHandle(0) {
+		return fmt.Errorf("bookmark handle is not initialized")
+	}
+	return b.eventLogAPI.EvtUpdateBookmark(b.bookmarkHandle, eventHandle)
+}
+
+func (b *bookmark) Render() (string, error) {
+	if b.eventLogAPI == nil {
+		return "", fmt.Errorf("event log API not set")
+	}
+	if b.bookmarkHandle == evtapi.EventBookmarkHandle(0) {
+		return "", fmt.Errorf("bookmark handle is not initialized")
+	}
+	// Render bookmark
+	buf, err := b.eventLogAPI.EvtRenderBookmark(b.bookmarkHandle)
+	if err != nil {
+		return "", err
+	} else if buf == nil || len(buf) == 0 {
+		return "", fmt.Errorf("Bookmark is empty")
+	}
+
+	// Convert to string
+	return windows.UTF16ToString(buf), nil
+}
+
+func (b *bookmark) Close() {
+	if b.eventLogAPI == nil {
+		return
+	}
+	if b.bookmarkHandle != evtapi.EventBookmarkHandle(0) {
+		evtapi.EvtCloseBookmark(b.eventLogAPI, b.bookmarkHandle)
+		b.bookmarkHandle = evtapi.EventBookmarkHandle(0)
+	}
+}

--- a/pkg/util/winutil/eventlog/bookmark/bookmark.go
+++ b/pkg/util/winutil/eventlog/bookmark/bookmark.go
@@ -28,7 +28,9 @@ type bookmark struct {
 	bookmarkHandle evtapi.EventBookmarkHandle
 }
 
-func New(options ...func(*bookmark) error) (*bookmark, error) {
+type Option func(*bookmark) error
+
+func New(options ...Option) (*bookmark, error) {
 	var b bookmark
 
 	for _, o := range options {
@@ -53,14 +55,14 @@ func New(options ...func(*bookmark) error) (*bookmark, error) {
 	return &b, nil
 }
 
-func WithWindowsEventLogAPI(api evtapi.API) func(*bookmark) error {
+func WithWindowsEventLogAPI(api evtapi.API) Option {
 	return func(b *bookmark) error {
 		b.eventLogAPI = api
 		return nil
 	}
 }
 
-func FromFile(bookmarkPath string) func(*bookmark) error {
+func FromFile(bookmarkPath string) Option {
 	return func(b *bookmark) error {
 		if b.eventLogAPI == nil {
 			return fmt.Errorf("event log API not set")
@@ -77,7 +79,7 @@ func FromFile(bookmarkPath string) func(*bookmark) error {
 	}
 }
 
-func FromXML(bookmarkXML string) func(*bookmark) error {
+func FromXML(bookmarkXML string) Option {
 	return func(b *bookmark) error {
 		if b.eventLogAPI == nil {
 			return fmt.Errorf("event log API not set")

--- a/pkg/util/winutil/eventlog/bookmark/bookmark.go
+++ b/pkg/util/winutil/eventlog/bookmark/bookmark.go
@@ -33,8 +33,9 @@ type bookmark struct {
 // Option type for option pattern for New bookmark constructor
 type Option func(*bookmark) error
 
-// New constructs a new Bookmark
-func New(options ...Option) (*bookmark, error) {
+// New constructs a new Bookmark.
+// Call Close() when done to release resources.
+func New(options ...Option) (Bookmark, error) {
 	var b bookmark
 
 	for _, o := range options {

--- a/pkg/util/winutil/eventlog/bookmark/bookmark.go
+++ b/pkg/util/winutil/eventlog/bookmark/bookmark.go
@@ -3,7 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2023-present Datadog, Inc.
 //go:build windows
-// +build windows
 
 package evtbookmark
 

--- a/pkg/util/winutil/eventlog/example_test.go
+++ b/pkg/util/winutil/eventlog/example_test.go
@@ -1,0 +1,231 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+//go:build windows
+// +build windows
+
+package eventlog
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/util/winutil/eventlog/api"
+	"github.com/DataDog/datadog-agent/pkg/util/winutil/eventlog/subscription"
+	"github.com/DataDog/datadog-agent/pkg/util/winutil/eventlog/test"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/windows"
+)
+
+// Example usage of the eventlog utility library to get event records from the Windows Event Log
+// while using a channel to be notified when new events are available.
+func testExampleNotifyChannel(t testing.TB, ti eventlog_test.APITester, stop chan struct{}, done chan struct{}, channelPath string, numEvents uint) {
+	defer close(done)
+
+	// Choose the Windows Event Log API implementation
+	// Windows API
+	//   "github.com/DataDog/datadog-agent/pkg/util/winutil/eventlog/api/windows"
+	//   api = winevtapi.New()
+	// Fake API
+	//   "github.com/DataDog/datadog-agent/pkg/util/winutil/eventlog/api/fake"
+	//   api = fakeevtapi.New()
+	// For this test the API implementation is selected by the test runner
+	api := ti.API()
+
+	// Create the subscription
+	sub := evtsubscribe.NewPullSubscription(
+		channelPath,
+		"*",
+		evtsubscribe.WithStartAtOldestRecord(),
+		evtsubscribe.WithNotifyEventsAvailable(),
+		evtsubscribe.WithWindowsEventLogAPI(api))
+
+	// Start the subscription
+	err := sub.Start()
+	if !assert.NoError(t, err) {
+		return
+	}
+	// Cleanup the subscription when done
+	defer sub.Stop()
+
+	// Get events until stop is set
+outerLoop:
+	for {
+		select {
+		case <-stop:
+			break outerLoop
+		case _, ok := <-sub.EventsAvailable():
+			if !ok {
+				// The channel is closed, this indicates an error or that sub.Stop() was called
+				break outerLoop
+			}
+			// Get events until there are no more events, then go back to waiting
+			for {
+				events, err := sub.GetEvents()
+				if err != nil {
+					// error
+					break outerLoop
+				}
+				if events == nil {
+					// no more events, go back to waiting for EventsAvailable()
+					continue outerLoop
+				}
+
+				// handle the events
+				for _, eventRecord := range events {
+					// do something with the event
+					// ...
+					err = printEventXML(api, eventRecord)
+					assert.NoError(t, err)
+					err = printEventValues(api, eventRecord)
+					assert.NoError(t, err)
+					// close the event when done
+					evtapi.EvtCloseRecord(api, eventRecord.EventRecordHandle)
+				}
+			}
+		}
+	}
+
+}
+
+// Example usage of the eventlog utility library to render the entire event as XML
+func printEventXML(api evtapi.API, event *evtapi.EventRecord) error {
+	xml, err := api.EvtRenderEventXml(event.EventRecordHandle)
+	if err != nil {
+		return fmt.Errorf("failed to render event XML: %v", err)
+	}
+
+	fmt.Printf("%s\n", windows.UTF16ToString(xml))
+	return nil
+}
+
+// Example usage of the eventlog utility library to render specific values from the event
+func printEventValues(api evtapi.API, event *evtapi.EventRecord) error {
+	// Create render context for the System values
+	// https://learn.microsoft.com/en-us/windows/win32/api/winevt/ne-winevt-evt_system_property_id
+	c, err := api.EvtCreateRenderContext(nil, evtapi.EvtRenderContextSystem)
+	if err != nil {
+		return fmt.Errorf("failed to create render context: %v", err)
+	}
+	defer evtapi.EvtCloseRenderContext(api, c)
+
+	// Render the values
+	vals, err := api.EvtRenderEventValues(c, event.EventRecordHandle)
+	if err != nil {
+		return fmt.Errorf("failed to render values: %v", err)
+	}
+	defer vals.Close()
+
+	// EventID
+	eventid, err := vals.UInt(evtapi.EvtSystemEventID)
+	if err != nil {
+		return fmt.Errorf("failed to get eventid value: %v", err)
+	}
+	fmt.Printf("eventid: %d\n", eventid)
+
+	// Provider
+	provider, err := vals.String(evtapi.EvtSystemProviderName)
+	if err != nil {
+		return fmt.Errorf("failed to get provider name value: %v", err)
+	}
+	fmt.Printf("provider name: %s\n", provider)
+
+	// Computer
+	computer, err := vals.String(evtapi.EvtSystemComputer)
+	if err != nil {
+		return fmt.Errorf("failed to get computer name value: %v", err)
+	}
+	fmt.Printf("computer name: %s\n", computer)
+
+	// Time Created
+	ts, err := vals.Time(evtapi.EvtSystemTimeCreated)
+	if err != nil {
+		return fmt.Errorf("failed to get time created value: %v", err)
+	}
+	fmt.Printf("time created: %d\n", ts)
+
+	// Level
+	level, err := vals.UInt(evtapi.EvtSystemLevel)
+	if err != nil {
+		return fmt.Errorf("failed to get level value: %v", err)
+	}
+	fmt.Printf("level: %d\n", level)
+
+	// Format Message
+	pm, err := api.EvtOpenPublisherMetadata(provider, "")
+	if err != nil {
+		return fmt.Errorf("failed to open provider metadata: %v", err)
+	}
+	defer evtapi.EvtClosePublisherMetadata(api, pm)
+
+	message, err := api.EvtFormatMessage(pm, event.EventRecordHandle, 0, nil, evtapi.EvtFormatMessageEvent)
+	if err != nil {
+		return fmt.Errorf("failed to format event message: %v", err)
+	}
+	fmt.Printf("message: %s\n", message)
+
+	return nil
+}
+
+// test helper function that sets up an event log for the test
+func createLog(t testing.TB, ti eventlog_test.APITester, channel string, source string) error {
+	err := ti.InstallChannel(channel)
+	if !assert.NoError(t, err) {
+		return err
+	}
+	err = ti.API().EvtClearLog(channel)
+	if !assert.NoError(t, err) {
+		return err
+	}
+	err = ti.InstallSource(channel, source)
+	if !assert.NoError(t, err) {
+		return err
+	}
+	t.Cleanup(func() {
+		ti.RemoveSource(channel, source)
+		ti.RemoveChannel(channel)
+	})
+	return nil
+}
+
+// tests our example implementation in testExampleNotifyChannel
+func TestExampleNotifyChannel(t *testing.T) {
+	testInterfaceNames := eventlog_test.GetEnabledAPITesters()
+
+	channelPath := "dd-test-channel-example"
+	eventSource := "dd-test-source-example"
+	numEvents := uint(10)
+	for _, tiName := range testInterfaceNames {
+		t.Run(fmt.Sprintf("%sAPI", tiName), func(t *testing.T) {
+			if tiName == "Fake" {
+				t.Skip("Fake API does not implement EvtRenderValues")
+			}
+			ti := eventlog_test.GetAPITesterByName(tiName, t)
+			// Create some test events
+			createLog(t, ti, channelPath, eventSource)
+			err := ti.GenerateEvents(eventSource, numEvents)
+			require.NoError(t, err)
+			// Create stop channel to use as example of an external signal to shutdown
+			stop := make(chan struct{})
+			done := make(chan struct{})
+
+			// Start our example implementation
+			go testExampleNotifyChannel(t, ti, stop, done, channelPath, numEvents)
+
+			// Create some test events while that's running
+			for i := 0; i < 3; i++ {
+				err := ti.GenerateEvents(eventSource, numEvents)
+				require.NoError(t, err)
+				// simulate some delay in event generation
+				time.Sleep(100 * time.Millisecond)
+			}
+			// Stop the event collector
+			close(stop)
+			<-done
+		})
+	}
+}

--- a/pkg/util/winutil/eventlog/example_test.go
+++ b/pkg/util/winutil/eventlog/example_test.go
@@ -88,7 +88,6 @@ outerLoop:
 			}
 		}
 	}
-
 }
 
 // Example usage of the eventlog utility library to render the entire event as XML

--- a/pkg/util/winutil/eventlog/example_test.go
+++ b/pkg/util/winutil/eventlog/example_test.go
@@ -3,7 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2023-present Datadog, Inc.
 //go:build windows
-// +build windows
 
 package eventlog
 

--- a/pkg/util/winutil/eventlog/reporter/reporter.go
+++ b/pkg/util/winutil/eventlog/reporter/reporter.go
@@ -1,0 +1,62 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+//go:build windows
+// +build windows
+
+package evtreporter
+
+import (
+	"fmt"
+
+	"github.com/DataDog/datadog-agent/pkg/util/winutil/eventlog/api"
+)
+
+type Reporter interface {
+	ReportEvent() evtapi.EventBookmarkHandle
+	Close()
+}
+
+type reporter struct {
+	eventLogAPI evtapi.API
+	logHandle   evtapi.EventSourceHandle
+}
+
+func New(channelName string, api evtapi.API) (*reporter, error) {
+	var r reporter
+
+	if api == nil {
+		return nil, fmt.Errorf("event log API is required")
+	}
+	r.eventLogAPI = api
+
+	logHandle, err := r.eventLogAPI.RegisterEventSource(channelName)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to register source %s: %v", channelName, err)
+	}
+	r.logHandle = logHandle
+
+	return &r, nil
+}
+
+func (r *reporter) ReportEvent(
+	Type uint,
+	Category uint,
+	EventID uint,
+	Strings []string,
+	RawData []uint8) error {
+	return r.eventLogAPI.ReportEvent(
+		r.logHandle,
+		Type,
+		Category,
+		EventID,
+		Strings,
+		RawData)
+}
+
+func (r *reporter) Close() {
+	if r.logHandle != evtapi.EventSourceHandle(0) {
+		_ = r.eventLogAPI.DeregisterEventSource(r.logHandle)
+	}
+}

--- a/pkg/util/winutil/eventlog/reporter/reporter.go
+++ b/pkg/util/winutil/eventlog/reporter/reporter.go
@@ -11,6 +11,8 @@ import (
 	"fmt"
 
 	"github.com/DataDog/datadog-agent/pkg/util/winutil/eventlog/api"
+
+	"golang.org/x/sys/windows"
 )
 
 type Reporter interface {
@@ -44,6 +46,7 @@ func (r *reporter) ReportEvent(
 	Type uint,
 	Category uint,
 	EventID uint,
+	UserSID *windows.SID,
 	Strings []string,
 	RawData []uint8) error {
 	return r.eventLogAPI.ReportEvent(
@@ -51,6 +54,7 @@ func (r *reporter) ReportEvent(
 		Type,
 		Category,
 		EventID,
+		UserSID,
 		Strings,
 		RawData)
 }

--- a/pkg/util/winutil/eventlog/reporter/reporter.go
+++ b/pkg/util/winutil/eventlog/reporter/reporter.go
@@ -17,7 +17,14 @@ import (
 
 // Reporter is an interface for writing an event to a Windows Event Log
 type Reporter interface {
-	ReportEvent() evtapi.EventBookmarkHandle
+	ReportEvent(
+		Type uint,
+		Category uint,
+		EventID uint,
+		UserSID *windows.SID,
+		Strings []string,
+		RawData []uint8,
+	) error
 	Close()
 }
 
@@ -26,8 +33,9 @@ type reporter struct {
 	logHandle   evtapi.EventSourceHandle
 }
 
-// New constructs a new Reporter
-func New(channelName string, api evtapi.API) (*reporter, error) {
+// New constructs a new Reporter.
+// Call Close() when done to release resources.
+func New(channelName string, api evtapi.API) (Reporter, error) {
 	var r reporter
 
 	if api == nil {

--- a/pkg/util/winutil/eventlog/reporter/reporter.go
+++ b/pkg/util/winutil/eventlog/reporter/reporter.go
@@ -4,6 +4,7 @@
 // Copyright 2023-present Datadog, Inc.
 //go:build windows
 
+// Package evtreporter provides helpers for writing events to the Windows Event Log
 package evtreporter
 
 import (
@@ -14,6 +15,7 @@ import (
 	"golang.org/x/sys/windows"
 )
 
+// Reporter is an interface for writing an event to a Windows Event Log
 type Reporter interface {
 	ReportEvent() evtapi.EventBookmarkHandle
 	Close()
@@ -24,6 +26,7 @@ type reporter struct {
 	logHandle   evtapi.EventSourceHandle
 }
 
+// New constructs a new Reporter
 func New(channelName string, api evtapi.API) (*reporter, error) {
 	var r reporter
 

--- a/pkg/util/winutil/eventlog/reporter/reporter.go
+++ b/pkg/util/winutil/eventlog/reporter/reporter.go
@@ -3,7 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2023-present Datadog, Inc.
 //go:build windows
-// +build windows
 
 package evtreporter
 

--- a/pkg/util/winutil/eventlog/subscription/helpers_test.go
+++ b/pkg/util/winutil/eventlog/subscription/helpers_test.go
@@ -1,0 +1,99 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+//go:build windows
+// +build windows
+
+package evtsubscribe
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/util/winutil/eventlog/api"
+	"github.com/DataDog/datadog-agent/pkg/util/winutil/eventlog/test"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func ReadNumEventsWithNotify(t testing.TB, ti eventlog_test.APITester, sub PullSubscription, numEvents uint) ([]*evtapi.EventRecord, error) {
+	eventRecords := make([]*evtapi.EventRecord, 0)
+
+	count := uint(0)
+eventLoop:
+	for {
+		select {
+		case _, ok := <-sub.EventsAvailable():
+			if !ok {
+				break eventLoop
+			}
+			for {
+				events, err := sub.GetEvents()
+				if !assert.NoError(t, err, "GetEvents should not return an error") {
+					return nil, fmt.Errorf("GetEvents returned error: %v", err)
+				}
+				if count == numEvents {
+					if !assert.Nil(t, events, "events should be nil when count is reached") {
+						return nil, fmt.Errorf("events should be nil when count is reached")
+					}
+				} else {
+					if !assert.NotNil(t, events, "events should not be nil if count is not reached %v/%v", count, numEvents) {
+						return nil, fmt.Errorf("events should not be nil")
+					}
+				}
+				if events != nil {
+					eventRecords = append(eventRecords, events...)
+					count += uint(len(events))
+				}
+				if count >= numEvents {
+					break eventLoop
+				}
+			}
+		}
+	}
+
+	for _, eventRecord := range eventRecords {
+		if !assert.NotEqual(t, evtapi.EventRecordHandle(0), eventRecord.EventRecordHandle, "EventRecordHandle should not be NULL") {
+			return nil, fmt.Errorf("EventRecordHandle should not be NULL")
+		}
+	}
+
+	return eventRecords, nil
+}
+
+func ReadNumEvents(t testing.TB, ti eventlog_test.APITester, sub PullSubscription, numEvents uint) ([]*evtapi.EventRecord, error) {
+	eventRecords := make([]*evtapi.EventRecord, 0)
+
+	count := uint(0)
+	for {
+		events, err := sub.GetEvents()
+		if !assert.NoError(t, err, "GetEvents should not return an error") {
+			return nil, fmt.Errorf("GetEvents returned error: %v", err)
+		}
+		if count == numEvents {
+			if !assert.Nil(t, events, "events should be nil when count is reached") {
+				return nil, fmt.Errorf("events should be nil when count is reached")
+			}
+		} else {
+			if !assert.NotNil(t, events, "events should not be nil if count is not reached %v/%v", count, numEvents) {
+				return nil, fmt.Errorf("events should not be nil")
+			}
+		}
+		if events != nil {
+			eventRecords = append(eventRecords, events...)
+			count += uint(len(events))
+		}
+		if count >= numEvents {
+			break
+		}
+	}
+
+	for _, eventRecord := range eventRecords {
+		if !assert.NotEqual(t, evtapi.EventRecordHandle(0), eventRecord.EventRecordHandle, "EventRecordHandle should not be NULL") {
+			return nil, fmt.Errorf("EventRecordHandle should not be NULL")
+		}
+	}
+
+	return eventRecords, nil
+}

--- a/pkg/util/winutil/eventlog/subscription/helpers_test.go
+++ b/pkg/util/winutil/eventlog/subscription/helpers_test.go
@@ -3,7 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2023-present Datadog, Inc.
 //go:build windows
-// +build windows
 
 package evtsubscribe
 

--- a/pkg/util/winutil/eventlog/subscription/subscription.go
+++ b/pkg/util/winutil/eventlog/subscription/subscription.go
@@ -1,0 +1,424 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+//go:build windows
+// +build windows
+
+package evtsubscribe
+
+import (
+	"fmt"
+	"sync"
+
+	// "github.com/DataDog/datadog-agent/comp/core/log"
+	pkglog "github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/util/winutil/eventlog/api"
+	"github.com/DataDog/datadog-agent/pkg/util/winutil/eventlog/bookmark"
+	"golang.org/x/sys/windows"
+)
+
+const (
+	// How many events to fetch per EvtNext call
+	DEFAULT_EVENT_BATCH_COUNT = 512
+)
+
+type PullSubscription interface {
+	// Start the event subscription
+	Start() error
+
+	// Stop the event subscription and free resources.
+	// Stop will automatically close any outstanding event record handles associated with this subscription.
+	// https://learn.microsoft.com/en-us/windows/win32/api/winevt/nf-winevt-evtclose
+	Stop()
+
+	// EventsAvailable returns a readonly channel that will contain a value to signal the user to call GetEvents().
+	// Create the subscription with the WithNotifyEventsAvailable option to enable this channel.
+	//
+	// Receiving a value from this channel does not guarantee that GetEvents() will return events.
+	EventsAvailable() <-chan struct{}
+
+	// GetEvents returns the next available events in the subscription.
+	// If no events are available returns nil,nil
+	// You must close every event record handle returned from this function.
+	GetEvents() ([]*evtapi.EventRecord, error)
+}
+
+type pullSubscription struct {
+	// Configuration
+	channelPath      string
+	query            string
+	eventBatchCount  uint
+	useNotifyChannel bool
+
+	// Notify user that event records are available
+	notifyEventsAvailable chan struct{}
+
+	// datadog components
+	//log log.Component
+
+	// Windows API
+	eventLogAPI        evtapi.API
+	subscriptionHandle evtapi.EventResultSetHandle
+	waitEventHandle    evtapi.WaitEventHandle
+	stopEventHandle    evtapi.WaitEventHandle
+	evtNextStorage     []evtapi.EventRecordHandle
+
+	// Query loop management
+	started                       bool
+	notifyEventsAvailableWaiter   sync.WaitGroup
+	notifyEventsAvailableLoopDone chan struct{}
+	notifyStop                    chan struct{}
+
+	// notifyNoMoreItems synchronizes notifyEventsAvailableLoop and GetEvents when
+	// EvtNext returns ERROR_NO_MORE_ITEMS.
+	// GetEvents writes to this channel to tell notifyEventsAvailableLoop to skip writing
+	// to the NotifyEventsAvailable channel and return to the WaitForMultipleObjects call.
+	// Without this synchronization notifyEventsAvailableLoop would block writing to the
+	// NotifyEventsAvailable channel until the user read from the channel again, at which
+	// point the user would be erroneously notified that events are available.
+	notifyNoMoreItems         chan struct{}
+	notifyNoMoreItemsComplete chan struct{}
+
+	// EvtSubscribe args
+	subscribeOriginFlag uint
+	subscribeFlags      uint
+	bookmark            evtbookmark.Bookmark
+}
+
+type PullSubscriptionOption func(*pullSubscription)
+
+func newSubscriptionWaitEvent() (evtapi.WaitEventHandle, error) {
+	// https://learn.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-createeventa
+	// Manual reset, must be initially set, Windows will not set it for old events
+	hEvent, err := windows.CreateEvent(nil, 1, 1, nil)
+	return evtapi.WaitEventHandle(hEvent), err
+}
+
+func newStopWaitEvent() (evtapi.WaitEventHandle, error) {
+	// https://learn.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-createeventa
+	// Manual reset, initially unset
+	hEvent, err := windows.CreateEvent(nil, 1, 0, nil)
+	return evtapi.WaitEventHandle(hEvent), err
+}
+
+// func NewPullSubscription(log log.Component) *pullSubscription {
+func NewPullSubscription(channelPath, query string, options ...PullSubscriptionOption) *pullSubscription {
+	var q pullSubscription
+	q.subscriptionHandle = evtapi.EventResultSetHandle(0)
+	q.waitEventHandle = evtapi.WaitEventHandle(0)
+
+	q.eventBatchCount = DEFAULT_EVENT_BATCH_COUNT
+
+	q.channelPath = channelPath
+	q.query = query
+	q.subscribeOriginFlag = evtapi.EvtSubscribeToFutureEvents
+	// q.log = log
+
+	for _, o := range options {
+		o(&q)
+	}
+
+	return &q
+}
+
+// Windows limits this to 1024
+// https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-even6/65f22d62-5f0f-4306-85c4-50fb9e77075b
+func WithEventBatchCount(count uint) PullSubscriptionOption {
+	return func(q *pullSubscription) {
+		q.eventBatchCount = count
+	}
+}
+
+func WithWindowsEventLogAPI(api evtapi.API) PullSubscriptionOption {
+	return func(q *pullSubscription) {
+		q.eventLogAPI = api
+	}
+}
+
+func WithStartAfterBookmark(bookmark evtbookmark.Bookmark) PullSubscriptionOption {
+	return func(q *pullSubscription) {
+		q.bookmark = bookmark
+		q.subscribeOriginFlag = evtapi.EvtSubscribeStartAfterBookmark
+	}
+}
+
+func WithStartAtOldestRecord() PullSubscriptionOption {
+	return func(q *pullSubscription) {
+		q.subscribeOriginFlag = evtapi.EvtSubscribeStartAtOldestRecord
+	}
+}
+
+func WithSubscribeFlags(flags uint) PullSubscriptionOption {
+	return func(q *pullSubscription) {
+		q.subscribeFlags = flags
+	}
+}
+
+func WithNotifyEventsAvailable() PullSubscriptionOption {
+	return func(q *pullSubscription) {
+		q.useNotifyChannel = true
+	}
+}
+
+func (q *pullSubscription) EventsAvailable() <-chan struct{} {
+	return q.notifyEventsAvailable
+}
+
+func (q *pullSubscription) Start() error {
+
+	if q.started {
+		return fmt.Errorf("Query subscription is already started")
+	}
+
+	var bookmarkHandle evtapi.EventBookmarkHandle
+	if q.bookmark != nil {
+		bookmarkHandle = q.bookmark.Handle()
+	}
+
+	// create subscription
+	hSubWait, err := newSubscriptionWaitEvent()
+	if err != nil {
+		return err
+	}
+	hSub, err := q.eventLogAPI.EvtSubscribe(
+		hSubWait,
+		q.channelPath,
+		q.query,
+		bookmarkHandle,
+		q.subscribeOriginFlag|q.subscribeFlags)
+	if err != nil {
+		safeCloseNullHandle(windows.Handle(hSubWait))
+		return err
+	}
+
+	// alloc reusable storage for EvtNext output
+	q.evtNextStorage = make([]evtapi.EventRecordHandle, q.eventBatchCount)
+
+	q.waitEventHandle = hSubWait
+	q.subscriptionHandle = hSub
+
+	if q.useNotifyChannel {
+		hStopWait, err := newStopWaitEvent()
+		if err != nil {
+			evtapi.EvtCloseResultSet(q.eventLogAPI, q.subscriptionHandle)
+			safeCloseNullHandle(windows.Handle(hSubWait))
+			return err
+		}
+		q.stopEventHandle = hStopWait
+
+		// Query loop management
+		q.notifyStop = make(chan struct{})
+		q.notifyNoMoreItems = make(chan struct{})
+		q.notifyNoMoreItemsComplete = make(chan struct{})
+		q.notifyEventsAvailable = make(chan struct{})
+		q.notifyEventsAvailableLoopDone = make(chan struct{})
+
+		// start goroutine to query events for channel
+		q.notifyEventsAvailableWaiter.Add(1)
+		go q.notifyEventsAvailableLoop()
+	}
+
+	q.started = true
+
+	return nil
+}
+
+func (q *pullSubscription) Stop() {
+	if !q.started {
+		return
+	}
+
+	if q.useNotifyChannel {
+		// Signal notifyEventsAvailableLoop to stop
+		windows.SetEvent(windows.Handle(q.stopEventHandle))
+		close(q.notifyStop)
+		// Wait for notifyEventsAvailableLoop to stop
+		q.notifyEventsAvailableWaiter.Wait()
+
+		close(q.notifyNoMoreItems)
+		close(q.notifyNoMoreItemsComplete)
+		safeCloseNullHandle(windows.Handle(q.stopEventHandle))
+	}
+
+	// Cleanup Windows API
+	evtapi.EvtCloseResultSet(q.eventLogAPI, q.subscriptionHandle)
+	safeCloseNullHandle(windows.Handle(q.waitEventHandle))
+
+	q.started = false
+}
+
+// notifyEventsAvailableLoop writes to the notifyEventsAvailable channel
+// when the Windows Event Log API Subscription sets the waitEventHandle.
+// On return, closes the notifyEventsAvailable channel to notify the user
+// of an error or a Stop().
+func (q *pullSubscription) notifyEventsAvailableLoop() {
+	// q.Stop() waits on this goroutine to finish, notify it that we are done
+	defer q.notifyEventsAvailableWaiter.Done()
+	// close the notify channel so the user knows this loop is dead
+	defer close(q.notifyEventsAvailable)
+	// close so internal functions know this loop is dead
+	defer close(q.notifyEventsAvailableLoopDone)
+
+	waiters := []windows.Handle{windows.Handle(q.waitEventHandle), windows.Handle(q.stopEventHandle)}
+
+	for {
+		dwWait, err := windows.WaitForMultipleObjects(waiters, false, windows.INFINITE)
+		if err != nil {
+			// WAIT_FAILED
+			pkglog.Errorf("WaitForMultipleObjects failed: %v", err)
+			return
+		}
+		if dwWait == windows.WAIT_OBJECT_0 {
+			// Event records are available, notify the user
+			pkglog.Debugf("Events are available")
+			select {
+			case <-q.notifyStop:
+				return
+			case q.notifyEventsAvailable <- struct{}{}:
+				break
+			case <-q.notifyNoMoreItems:
+				// EvtNext called, there are no more items to read, this case
+				// allows us to cancel sending notifyEventsAvailable to the user.
+				// Now we must wait for the event to be reset to ensure WaitForMultipleObjects will
+				// block until Windows sets the event again.
+				// We cannot just call ResetEvent here instead because that creates a race
+				// with the SetEvent call in GetEvents() that could create a deadlock.
+				select {
+				case <-q.notifyStop:
+					return
+				case <-q.notifyNoMoreItemsComplete:
+					break
+				}
+				break
+			}
+		} else if dwWait == (windows.WAIT_OBJECT_0 + 1) {
+			// Stop event is set
+			return
+		} else if dwWait == uint32(windows.WAIT_TIMEOUT) {
+			// timeout
+			// this shouldn't happen
+			pkglog.Errorf("WaitForMultipleObjects timed out")
+			return
+		} else {
+			// some other error occurred
+			gle := windows.GetLastError()
+			pkglog.Errorf("WaitForMultipleObjects unknown error: wait(%d,%#x) gle(%d,%#x)",
+				dwWait,
+				dwWait,
+				gle,
+				gle)
+			return
+		}
+	}
+}
+
+// synchronizeNoMoreItems is used to synchronize notifyEventsAvailableLoop when
+// EvtNext returns ERROR_NO_MORE_ITEMS.
+// Note that the Microsoft's Pull Subscription model is inherently racey. It is possible
+// for EvtNext to return ERROR_NO_MORE_ITEMS and then for Windows to call SetEvent(waitHandle)
+// before our code reaches the ResetEvent(waitHandle). If this happens we will not see those
+// events until newer events are created and Windows once again calls SetEvent(waitHandle).
+func (q *pullSubscription) synchronizeNoMoreItems() error {
+	if !q.useNotifyChannel {
+		_ = windows.ResetEvent(windows.Handle(q.waitEventHandle))
+		return nil
+	}
+
+	// If notifyEventsAvailableLoop is blocking on WaitForMultipleObjects
+	// wake it up so we can sync on notifyNoMoreItems
+	// If notifyEventsAvailableLoop is blocking on notifyNoMoreItems channel then this is a no-op
+	windows.SetEvent(windows.Handle(q.waitEventHandle))
+	// If notifyEventsAvailableLoop is blocking on sending notifyEventsAvailable
+	// then wake/cancel it so it does not erroneously send notifyEventsAvailable.
+	select {
+	case <-q.notifyStop:
+		return fmt.Errorf("stop signal")
+	case <-q.notifyEventsAvailableLoopDone:
+		return fmt.Errorf("notify loop is not running")
+	case q.notifyNoMoreItems <- struct{}{}:
+		break
+	}
+	// Reset the events ready event so notifyEventsAvailableLoop will wait again in WaitForMultipleObjects,
+	// then write to notifyNoMoreItemsComplete to tell the loop that the event has been reset and it
+	// can safely continue.
+	_ = windows.ResetEvent(windows.Handle(q.waitEventHandle))
+	select {
+	case <-q.notifyStop:
+		return fmt.Errorf("stop signal")
+	case <-q.notifyEventsAvailableLoopDone:
+		return fmt.Errorf("notify loop is not running")
+	case q.notifyNoMoreItemsComplete <- struct{}{}:
+		break
+	}
+	return nil
+}
+
+// GetEvents returns the next available events in the subscription.
+func (q *pullSubscription) GetEvents() ([]*evtapi.EventRecord, error) {
+	// Do a non-blocking check to see if the "events available" event handle is set.
+	// We should only call EvtNext when this event is set.
+	dwWait, err := windows.WaitForSingleObject(windows.Handle(q.waitEventHandle), 0)
+	if err != nil {
+		return nil, fmt.Errorf("WaitForSingleObject failed: %v", err)
+	}
+	if dwWait != windows.WAIT_OBJECT_0 {
+		// event is not set, there are no events available
+		return nil, nil
+	}
+
+	// We supply INFINITE for the Timeout parameter but if we are at the end of the log file/there are no more events EvtNext will return,
+	// it will not block forever.
+	// https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-even6/cd4c258c-5a2c-4ba8-bce3-37eefaa416e7
+	eventRecordHandles, err := q.eventLogAPI.EvtNext(q.subscriptionHandle, q.evtNextStorage, uint(len(q.evtNextStorage)), windows.INFINITE)
+	if err == nil {
+		pkglog.Debugf("EvtNext returned %v handles", len(eventRecordHandles))
+		// got events
+		eventRecords := q.parseEventRecordHandles(eventRecordHandles)
+		return eventRecords, nil
+	} else if err == windows.ERROR_TIMEOUT {
+		// no more events
+		// TODO: Should we reset the handle? MS example says no
+		pkglog.Errorf("evtnext timeout")
+		return nil, fmt.Errorf("timeout")
+	} else if err == windows.ERROR_NO_MORE_ITEMS {
+		// EvtNext returns ERROR_NO_MORE_ITEMS when there are no more items available.
+		pkglog.Debugf("EvtNext returned no more items")
+		err := q.synchronizeNoMoreItems()
+		if err != nil {
+			return nil, err
+		}
+		// not an error, there are just no more items
+		return nil, nil
+	}
+
+	pkglog.Errorf("EvtNext failed: %v", err)
+	return nil, err
+}
+
+func (q *pullSubscription) parseEventRecordHandles(eventRecordHandles []evtapi.EventRecordHandle) []*evtapi.EventRecord {
+	var err error
+
+	eventRecords := make([]*evtapi.EventRecord, len(eventRecordHandles))
+
+	for i, eventRecordHandle := range eventRecordHandles {
+		eventRecords[i], err = q.parseEventRecordHandle(eventRecordHandle)
+		if err != nil {
+			pkglog.Errorf("Failed to process event (%#x): %v", eventRecordHandle, err)
+		}
+	}
+
+	return eventRecords
+}
+
+func (q *pullSubscription) parseEventRecordHandle(eventRecordHandle evtapi.EventRecordHandle) (*evtapi.EventRecord, error) {
+	var e evtapi.EventRecord
+	e.EventRecordHandle = eventRecordHandle
+	return &e, nil
+}
+
+func safeCloseNullHandle(h windows.Handle) {
+	if h != windows.Handle(0) {
+		windows.CloseHandle(h)
+	}
+}

--- a/pkg/util/winutil/eventlog/subscription/subscription.go
+++ b/pkg/util/winutil/eventlog/subscription/subscription.go
@@ -111,8 +111,9 @@ func newStopWaitEvent() (evtapi.WaitEventHandle, error) {
 	return evtapi.WaitEventHandle(hEvent), err
 }
 
-// NewPullSubscription constructs a new PullSubscription
-func NewPullSubscription(channelPath, query string, options ...PullSubscriptionOption) *pullSubscription {
+// NewPullSubscription constructs a new PullSubscription.
+// Call Stop() when done to release resources.
+func NewPullSubscription(channelPath, query string, options ...PullSubscriptionOption) PullSubscription {
 	var q pullSubscription
 	q.subscriptionHandle = evtapi.EventResultSetHandle(0)
 	q.waitEventHandle = evtapi.WaitEventHandle(0)

--- a/pkg/util/winutil/eventlog/subscription/subscription.go
+++ b/pkg/util/winutil/eventlog/subscription/subscription.go
@@ -3,7 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2023-present Datadog, Inc.
 //go:build windows
-// +build windows
 
 package evtsubscribe
 

--- a/pkg/util/winutil/eventlog/subscription/subscription_test.go
+++ b/pkg/util/winutil/eventlog/subscription/subscription_test.go
@@ -1,0 +1,842 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+//go:build windows
+// +build windows
+
+package evtsubscribe
+
+import (
+	"flag"
+	"fmt"
+	"testing"
+	"time"
+
+	pkglog "github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/cihub/seelog"
+
+	"github.com/DataDog/datadog-agent/pkg/util/winutil/eventlog/api"
+	"github.com/DataDog/datadog-agent/pkg/util/winutil/eventlog/bookmark"
+	"github.com/DataDog/datadog-agent/pkg/util/winutil/eventlog/test"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	"golang.org/x/sys/windows"
+)
+
+var debuglogFlag = flag.Bool("debuglog", false, "Enable seelog debug logging")
+
+func optEnableDebugLogging() {
+	// Enable logger
+	if *debuglogFlag {
+		pkglog.SetupLogger(seelog.Default, "debug")
+	}
+}
+
+func TestInvalidChannel(t *testing.T) {
+	optEnableDebugLogging()
+
+	testerNames := eventlog_test.GetEnabledAPITesters()
+
+	for _, tiName := range testerNames {
+		t.Run(fmt.Sprintf("%sAPI", tiName), func(t *testing.T) {
+			ti := eventlog_test.GetAPITesterByName(tiName, t)
+			sub := NewPullSubscription(
+				"nonexistentchannel",
+				"*",
+				WithWindowsEventLogAPI(ti.API()))
+
+			err := sub.Start()
+			require.Error(t, err)
+		})
+	}
+}
+
+func createLog(t testing.TB, ti eventlog_test.APITester, channel string, source string) error {
+	err := ti.InstallChannel(channel)
+	if !assert.NoError(t, err) {
+		return err
+	}
+	err = ti.API().EvtClearLog(channel)
+	if !assert.NoError(t, err) {
+		return err
+	}
+	err = ti.InstallSource(channel, source)
+	if !assert.NoError(t, err) {
+		return err
+	}
+	t.Cleanup(func() {
+		ti.RemoveSource(channel, source)
+		ti.RemoveChannel(channel)
+	})
+	return nil
+}
+
+func startSubscription(t testing.TB, ti eventlog_test.APITester, channel string, options ...PullSubscriptionOption) (*pullSubscription, error) {
+	opts := []PullSubscriptionOption{WithWindowsEventLogAPI(ti.API())}
+	opts = append(opts, options...)
+
+	// Create sub
+	sub := NewPullSubscription(
+		channel,
+		"*",
+		opts...)
+
+	err := sub.Start()
+	if !assert.NoError(t, err) {
+		return nil, err
+	}
+
+	// run Stop() when the test finishes
+	t.Cleanup(func() { sub.Stop() })
+	return sub, nil
+}
+
+func getEventHandles(t testing.TB, ti eventlog_test.APITester, sub PullSubscription, numEvents uint) ([]*evtapi.EventRecord, error) {
+	eventRecords, err := ReadNumEventsWithNotify(t, ti, sub, numEvents)
+	if err != nil {
+		return nil, err
+	}
+	count := uint(len(eventRecords))
+	if !assert.Equal(t, numEvents, count, fmt.Sprintf("Missing events, collected %d/%d events", count, numEvents)) {
+		return eventRecords, fmt.Errorf("Missing events")
+	}
+	return eventRecords, nil
+}
+
+func assertNoMoreEvents(t testing.TB, sub PullSubscription) error {
+	events, err := sub.GetEvents()
+	if !assert.NoError(t, err, "Error should be nil when there are no more events") {
+		return fmt.Errorf("Error should be nil when there are no more events")
+	}
+	if !assert.Nil(t, events, "[]events should be nil when there are no more events") {
+		return fmt.Errorf("[]events should be nil when there are no more events")
+	}
+	return nil
+}
+
+func BenchmarkTestGetEventHandles(b *testing.B) {
+	optEnableDebugLogging()
+
+	channel := "dd-test-channel-subscription"
+	eventSource := "dd-test-source-subscription"
+	numEvents := []uint{10, 100, 1000, 10000}
+
+	testerNames := eventlog_test.GetEnabledAPITesters()
+
+	for _, tiName := range testerNames {
+		for _, v := range numEvents {
+			b.Run(fmt.Sprintf("%vAPI/%d", tiName, v), func(b *testing.B) {
+				ti := eventlog_test.GetAPITesterByName(tiName, b)
+				createLog(b, ti, channel, eventSource)
+				err := ti.GenerateEvents(eventSource, v)
+				require.NoError(b, err)
+				b.ResetTimer()
+				startTime := time.Now()
+				for i := 0; i < b.N; i++ {
+					sub, err := startSubscription(b, ti, channel,
+						WithStartAtOldestRecord(),
+						WithNotifyEventsAvailable())
+					require.NoError(b, err)
+					events, err := getEventHandles(b, ti, sub, v)
+					require.NoError(b, err)
+					err = assertNoMoreEvents(b, sub)
+					require.NoError(b, err)
+					for _, event := range events {
+						evtapi.EvtCloseRecord(ti.API(), event.EventRecordHandle)
+					}
+					sub.Stop()
+				}
+				// TODO: Use b.Elapsed in go1.20
+				elapsed := time.Since(startTime)
+				total_events := float64(v) * float64(b.N)
+				b.Logf("%.2f events/s (%.3fs)", total_events/elapsed.Seconds(), elapsed.Seconds())
+			})
+		}
+	}
+}
+
+func formatEventMessage(api evtapi.API, event *evtapi.EventRecord) (string, error) {
+	// Create render context for the System values
+	c, err := api.EvtCreateRenderContext(nil, evtapi.EvtRenderContextSystem)
+	if err != nil {
+		return "", fmt.Errorf("failed to create render context: %v", err)
+	}
+	defer evtapi.EvtCloseRenderContext(api, c)
+
+	// Render the values
+	vals, err := api.EvtRenderEventValues(c, event.EventRecordHandle)
+	if err != nil {
+		return "", fmt.Errorf("failed to render values: %v", err)
+	}
+	defer vals.Close()
+
+	// Get the provider name
+	provider, err := vals.String(evtapi.EvtSystemProviderName)
+	if err != nil {
+		return "", fmt.Errorf("failed to get provider name value: %v", err)
+	}
+
+	// Format Message
+	pm, err := api.EvtOpenPublisherMetadata(provider, "")
+	if err != nil {
+		return "", fmt.Errorf("failed to open provider metadata: %v", err)
+	}
+	defer evtapi.EvtClosePublisherMetadata(api, pm)
+
+	message, err := api.EvtFormatMessage(pm, event.EventRecordHandle, 0, nil, evtapi.EvtFormatMessageEvent)
+	if err != nil {
+		return "", fmt.Errorf("failed to format event message: %v", err)
+	}
+
+	return message, nil
+}
+
+func BenchmarkTestRenderEventXml(b *testing.B) {
+	optEnableDebugLogging()
+
+	channel := "dd-test-channel-subscription"
+	eventSource := "dd-test-source-subscription"
+	numEvents := []uint{10, 100, 1000, 10000}
+
+	testerNames := eventlog_test.GetEnabledAPITesters()
+
+	for _, tiName := range testerNames {
+		for _, v := range numEvents {
+			b.Run(fmt.Sprintf("%vAPI/%d", tiName, v), func(b *testing.B) {
+				ti := eventlog_test.GetAPITesterByName(tiName, b)
+				createLog(b, ti, channel, eventSource)
+				err := ti.GenerateEvents(eventSource, v)
+				require.NoError(b, err)
+				b.ResetTimer()
+				startTime := time.Now()
+				for i := 0; i < b.N; i++ {
+					sub, err := startSubscription(b, ti, channel,
+						WithStartAtOldestRecord(),
+						WithNotifyEventsAvailable())
+					require.NoError(b, err)
+					events, err := getEventHandles(b, ti, sub, v)
+					require.NoError(b, err)
+					for _, event := range events {
+						_, err := ti.API().EvtRenderEventXml(event.EventRecordHandle)
+						require.NoError(b, err)
+						evtapi.EvtCloseRecord(ti.API(), event.EventRecordHandle)
+					}
+					err = assertNoMoreEvents(b, sub)
+					require.NoError(b, err)
+					sub.Stop()
+				}
+				// TODO: Use b.Elapsed in go1.20
+				elapsed := time.Since(startTime)
+				total_events := float64(v) * float64(b.N)
+				b.Logf("%.2f events/s (%.3fs)", total_events/elapsed.Seconds(), elapsed.Seconds())
+			})
+		}
+	}
+}
+
+func BenchmarkTestFormatEventMessage(b *testing.B) {
+	optEnableDebugLogging()
+
+	channel := "dd-test-channel-subscription"
+	eventSource := "dd-test-source-subscription"
+	numEvents := []uint{10, 100, 1000, 10000}
+
+	testerNames := eventlog_test.GetEnabledAPITesters()
+
+	for _, tiName := range testerNames {
+		for _, v := range numEvents {
+			b.Run(fmt.Sprintf("%vAPI/%d", tiName, v), func(b *testing.B) {
+				if tiName == "Fake" {
+					b.Skip("Fake API does not implement EvtRenderValues")
+				}
+				ti := eventlog_test.GetAPITesterByName(tiName, b)
+				createLog(b, ti, channel, eventSource)
+				err := ti.GenerateEvents(eventSource, v)
+				require.NoError(b, err)
+				b.ResetTimer()
+				startTime := time.Now()
+				for i := 0; i < b.N; i++ {
+					sub, err := startSubscription(b, ti, channel,
+						WithStartAtOldestRecord(),
+						WithNotifyEventsAvailable())
+					require.NoError(b, err)
+					events, err := getEventHandles(b, ti, sub, v)
+					require.NoError(b, err)
+					for _, event := range events {
+						_, err := formatEventMessage(ti.API(), event)
+						require.NoError(b, err)
+						evtapi.EvtCloseRecord(ti.API(), event.EventRecordHandle)
+					}
+					err = assertNoMoreEvents(b, sub)
+					require.NoError(b, err)
+					sub.Stop()
+				}
+				// TODO: Use b.Elapsed in go1.20
+				elapsed := time.Since(startTime)
+				total_events := float64(v) * float64(b.N)
+				b.Logf("%.2f events/s (%.3fs)", total_events/elapsed.Seconds(), elapsed.Seconds())
+			})
+		}
+	}
+}
+
+type GetEventsTestSuite struct {
+	suite.Suite
+
+	channelPath string
+	eventSource string
+	testAPI     string
+	numEvents   uint
+
+	ti eventlog_test.APITester
+}
+
+func (s *GetEventsTestSuite) SetupSuite() {
+	//fmt.Println("SetupSuite")
+
+	optEnableDebugLogging()
+
+	s.ti = eventlog_test.GetAPITesterByName(s.testAPI, s.T())
+	err := s.ti.InstallChannel(s.channelPath)
+	require.NoError(s.T(), err)
+	err = s.ti.InstallSource(s.channelPath, s.eventSource)
+	require.NoError(s.T(), err)
+}
+
+func (s *GetEventsTestSuite) TearDownSuite() {
+	// fmt.Println("TearDownSuite")
+	s.ti.RemoveSource(s.channelPath, s.eventSource)
+	s.ti.RemoveChannel(s.channelPath)
+}
+
+func (s *GetEventsTestSuite) SetupTest() {
+	// Ensure the log is empty
+	// fmt.Println("SetupTest")
+	err := s.ti.API().EvtClearLog(s.channelPath)
+	require.NoError(s.T(), err)
+
+}
+
+func (s *GetEventsTestSuite) TearDownTest() {
+	// fmt.Println("TearDownTest")
+	err := s.ti.API().EvtClearLog(s.channelPath)
+	require.NoError(s.T(), err)
+
+}
+
+// Tests that the subscription can read old events (EvtSubscribeStartAtOldestRecord)
+func (s *GetEventsTestSuite) TestReadOldEvents() {
+	// Put events in the log
+	err := s.ti.GenerateEvents(s.eventSource, s.numEvents)
+	require.NoError(s.T(), err)
+
+	// Create sub
+	sub, err := startSubscription(s.T(), s.ti, s.channelPath,
+		WithStartAtOldestRecord(),
+		WithNotifyEventsAvailable())
+	require.NoError(s.T(), err)
+
+	// Put events in the log
+	err = s.ti.GenerateEvents(s.eventSource, s.numEvents)
+	require.NoError(s.T(), err)
+
+	// Get Events
+	_, err = getEventHandles(s.T(), s.ti, sub, 2*s.numEvents)
+	require.NoError(s.T(), err)
+	err = assertNoMoreEvents(s.T(), sub)
+	require.NoError(s.T(), err)
+}
+
+// Tests that the subscription is notified of and can read new events
+func (s *GetEventsTestSuite) TestReadNewEvents() {
+	// Create sub
+	sub, err := startSubscription(s.T(), s.ti, s.channelPath, WithNotifyEventsAvailable())
+	require.NoError(s.T(), err)
+
+	// Eat the initial state
+	err = assertNoMoreEvents(s.T(), sub)
+	require.NoError(s.T(), err)
+
+	// Put events in the log
+	err = s.ti.GenerateEvents(s.eventSource, s.numEvents)
+	require.NoError(s.T(), err)
+
+	// Get Events
+	_, err = getEventHandles(s.T(), s.ti, sub, s.numEvents)
+	require.NoError(s.T(), err)
+	err = assertNoMoreEvents(s.T(), sub)
+	require.NoError(s.T(), err)
+}
+
+// Tests that the subscription can skip over old events (EvtSubscribeToFutureEvents)
+func (s *GetEventsTestSuite) TestReadOnlyNewEvents() {
+	// Put events in the log
+	err := s.ti.GenerateEvents(s.eventSource, s.numEvents)
+	require.NoError(s.T(), err)
+
+	// Create sub
+	sub, err := startSubscription(s.T(), s.ti, s.channelPath, WithNotifyEventsAvailable())
+	require.NoError(s.T(), err)
+
+	// Put events in the log
+	err = s.ti.GenerateEvents(s.eventSource, s.numEvents)
+	require.NoError(s.T(), err)
+
+	// Get Events
+	_, err = getEventHandles(s.T(), s.ti, sub, s.numEvents)
+	require.NoError(s.T(), err)
+	err = assertNoMoreEvents(s.T(), sub)
+	require.NoError(s.T(), err)
+}
+
+// Tests that Stop() can be called when there are events available to be collected
+func (s *GetEventsTestSuite) TestStopWhileWaitingWithEventsAvailable() {
+	// Create subscription
+	sub, err := startSubscription(s.T(), s.ti, s.channelPath, WithNotifyEventsAvailable())
+	require.NoError(s.T(), err)
+
+	// Put events in the log
+	err = s.ti.GenerateEvents(s.eventSource, s.numEvents)
+	require.NoError(s.T(), err)
+
+	readyToStop := make(chan struct{})
+	stopped := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		// Read all events
+		_, err := getEventHandles(s.T(), s.ti, sub, s.numEvents)
+		close(readyToStop)
+		if !assert.NoError(s.T(), err) {
+			return
+		}
+		// Purposefully don't call EvtNext the final time when it would normally return ERROR_NO_MORE_ITEMS.
+		// This leaves the notify event set.
+		// Wait for Stop() to finish
+		<-stopped
+		_, ok := <-sub.EventsAvailable()
+		assert.False(s.T(), ok, "Notify channel should be closed after Stop()")
+	}()
+
+	<-readyToStop
+	sub.Stop()
+	close(stopped)
+	<-done
+}
+
+// Tests that Stop() can be called when the subscription is in a ERROR_NO_MORE_ITEMS state
+func (s *GetEventsTestSuite) TestStopWhileWaitingNoMoreEvents() {
+	// Create subscription
+	sub, err := startSubscription(s.T(), s.ti, s.channelPath, WithNotifyEventsAvailable())
+	require.NoError(s.T(), err)
+
+	// Put events in the log
+	err = s.ti.GenerateEvents(s.eventSource, s.numEvents)
+	require.NoError(s.T(), err)
+
+	readyToStop := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		// Read all events
+		_, err := getEventHandles(s.T(), s.ti, sub, s.numEvents)
+		if err != nil {
+			close(readyToStop)
+			close(done)
+			return
+		}
+		err = assertNoMoreEvents(s.T(), sub)
+		if err != nil {
+			close(readyToStop)
+			close(done)
+			return
+		}
+		close(readyToStop)
+		// block on events available notification
+		_, ok := <-sub.EventsAvailable()
+		assert.False(s.T(), ok, "Notify channel should be closed after Stop()")
+		close(done)
+	}()
+
+	<-readyToStop
+	sub.Stop()
+	<-done
+}
+
+// Tests that GetEvents() still works when the EventsAvailable() channel is ignored
+func (s *GetEventsTestSuite) TestUnusedNotifyChannel() {
+	// Create sub
+	sub, err := startSubscription(s.T(), s.ti, s.channelPath, WithNotifyEventsAvailable())
+	require.NoError(s.T(), err)
+
+	// Loop so we test collecting old events and then new events
+	for i := 0; i < 2; i++ {
+		// Put events in the log
+		err = s.ti.GenerateEvents(s.eventSource, s.numEvents)
+		require.NoError(s.T(), err)
+
+		// Don't wait on the channel, just get events
+		eventRecords, err := sub.GetEvents()
+		require.NoError(s.T(), err)
+		count := uint(len(eventRecords))
+		require.Equal(s.T(), s.numEvents, count, fmt.Sprintf("Missing events, collected %d/%d events", count, s.numEvents))
+		err = assertNoMoreEvents(s.T(), sub)
+		require.NoError(s.T(), err)
+	}
+}
+
+// Tests that GetEvents does not deadlock when notifyEventsAvailableLoop unexpectedly exits
+func (s *GetEventsTestSuite) TestHandleEarlyNotifyLoopExit() {
+	// Create sub
+	sub, err := startSubscription(s.T(), s.ti, s.channelPath, WithNotifyEventsAvailable())
+	require.NoError(s.T(), err)
+
+	// set stop event to trigger notify loop to exit
+	windows.SetEvent(windows.Handle(sub.stopEventHandle))
+	require.NoError(s.T(), err)
+
+	// Eat the initial state
+	err = assertNoMoreEvents(s.T(), sub)
+	require.NoError(s.T(), err)
+
+	// wait for the loop to exit
+	sub.notifyEventsAvailableWaiter.Wait()
+
+	// ensure the notify channel is closed
+	_, ok := <-sub.EventsAvailable()
+	require.False(s.T(), ok, "Notify channel should be closed when notify loop exits")
+
+	// Put events in the log
+	err = s.ti.GenerateEvents(s.eventSource, s.numEvents)
+	require.NoError(s.T(), err)
+
+	// read all the events, don't wait on the (now closed) channel, just get events
+	eventRecords, err := sub.GetEvents()
+	require.NoError(s.T(), err)
+	count := uint(len(eventRecords))
+	require.Equal(s.T(), s.numEvents, count, fmt.Sprintf("Missing events, collected %d/%d events", count, s.numEvents))
+
+	// trigger ERROR_NO_MORE_EVENTS, which triggers a sync with the (no longer running) notify loop
+	events, err := sub.GetEvents()
+	require.Nil(s.T(), events, "events should be nil on error")
+	require.Error(s.T(), err, "GetEvents should return error when notify loop is no longer running")
+
+	sub.Stop()
+
+	// success if we did not deadlock
+}
+
+// Tests that EventsAvailable() starts out set then becomes unset after calling GetEvents().
+// This ensures the Windows Event Log API follows the behavior implied by the Microsoft example.
+// https://learn.microsoft.com/en-us/windows/win32/wes/subscribing-to-events#pull-subscriptions
+func (s *GetEventsTestSuite) TestChannelInitiallyNotified() {
+	// Create sub
+	sub, err := startSubscription(s.T(), s.ti, s.channelPath, WithNotifyEventsAvailable())
+	require.NoError(s.T(), err)
+
+	select {
+	case <-sub.EventsAvailable():
+		break
+	case <-time.After(5 * time.Minute):
+		require.FailNow(s.T(), "EventsAvailable() should not block the first time")
+	}
+
+	// should return empty
+	err = assertNoMoreEvents(s.T(), sub)
+	require.NoError(s.T(), err)
+
+	// should block this time
+	select {
+	case <-sub.EventsAvailable():
+		require.FailNow(s.T(), "EventsAvailable() should block if no events available")
+	default:
+		break
+	}
+}
+
+// Tests that the subscription can start from a provided bookmark
+func (s *GetEventsTestSuite) TestStartAfterBookmark() {
+	//
+	// Add some events to the log and create a bookmark
+	//
+
+	// Put events in the log
+	err := s.ti.GenerateEvents(s.eventSource, s.numEvents)
+	require.NoError(s.T(), err)
+
+	// Create bookmark
+	bookmark, err := evtbookmark.New(evtbookmark.WithWindowsEventLogAPI(s.ti.API()))
+	require.NoError(s.T(), err)
+
+	// Create sub
+	sub, err := startSubscription(s.T(), s.ti, s.channelPath,
+		WithStartAtOldestRecord(),
+		WithNotifyEventsAvailable())
+	require.NoError(s.T(), err)
+
+	// Read the events
+	events, err := getEventHandles(s.T(), s.ti, sub, s.numEvents)
+	require.NoError(s.T(), err)
+	err = assertNoMoreEvents(s.T(), sub)
+	require.NoError(s.T(), err)
+
+	// Update bookmark to last event
+	// Must do so before closing the subscription
+	bookmark.Update(events[len(events)-1].EventRecordHandle)
+
+	// Close out this subscription
+	sub.Stop()
+
+	//
+	// Add more events and verify the log contains twice as many events
+	//
+
+	// Add some more events
+	err = s.ti.GenerateEvents(s.eventSource, s.numEvents)
+	require.NoError(s.T(), err)
+
+	// Create sub
+	sub, err = startSubscription(s.T(), s.ti, s.channelPath,
+		WithStartAtOldestRecord(),
+		WithNotifyEventsAvailable())
+	require.NoError(s.T(), err)
+
+	// Read the events
+	_, err = getEventHandles(s.T(), s.ti, sub, 2*s.numEvents)
+	require.NoError(s.T(), err)
+	err = assertNoMoreEvents(s.T(), sub)
+	require.NoError(s.T(), err)
+
+	// Close out this subscription
+	sub.Stop()
+
+	//
+	// Start subscription part way through log with bookmark
+	//
+
+	// Create a new subscription starting from the bookmark
+	sub, err = startSubscription(s.T(), s.ti, s.channelPath,
+		WithStartAfterBookmark(bookmark),
+		WithNotifyEventsAvailable())
+	require.NoError(s.T(), err)
+
+	// Get Events
+	_, err = getEventHandles(s.T(), s.ti, sub, s.numEvents)
+	require.NoError(s.T(), err)
+	// Since we started halfway through there should be no more events
+	err = assertNoMoreEvents(s.T(), sub)
+	require.NoError(s.T(), err)
+}
+
+// Tests that the subscription starts when a bookmark is not found and the EvtSubscribeStrict flag is NOT provided
+func (s *GetEventsTestSuite) TestStartAfterBookmarkNotFoundWithoutStrictFlag() {
+	//
+	// Add some events to the log and create a bookmark
+	//
+
+	// Put events in the log
+	err := s.ti.GenerateEvents(s.eventSource, s.numEvents)
+	require.NoError(s.T(), err)
+
+	// Create bookmark
+	bookmark, err := evtbookmark.New(evtbookmark.WithWindowsEventLogAPI(s.ti.API()))
+	require.NoError(s.T(), err)
+
+	// Create sub
+	sub, err := startSubscription(s.T(), s.ti, s.channelPath,
+		WithStartAtOldestRecord(),
+		WithNotifyEventsAvailable())
+	require.NoError(s.T(), err)
+
+	// Read the events
+	events, err := getEventHandles(s.T(), s.ti, sub, s.numEvents)
+	require.NoError(s.T(), err)
+	err = assertNoMoreEvents(s.T(), sub)
+	require.NoError(s.T(), err)
+
+	// Update bookmark to last event
+	// Must do so before closing the subscription
+	bookmark.Update(events[len(events)-1].EventRecordHandle)
+
+	// Close out this subscription
+	sub.Stop()
+
+	// Clear the log so the bookmark is missing
+	err = s.ti.API().EvtClearLog(s.channelPath)
+	require.NoError(s.T(), err)
+
+	//
+	// Add more events and verify the log contains only that many events
+	//
+
+	// Add some more events
+	err = s.ti.GenerateEvents(s.eventSource, s.numEvents)
+	require.NoError(s.T(), err)
+
+	// Create sub
+	sub, err = startSubscription(s.T(), s.ti, s.channelPath,
+		WithStartAtOldestRecord(),
+		WithNotifyEventsAvailable())
+	require.NoError(s.T(), err)
+
+	// Read the events
+	_, err = getEventHandles(s.T(), s.ti, sub, s.numEvents)
+	require.NoError(s.T(), err)
+	err = assertNoMoreEvents(s.T(), sub)
+	require.NoError(s.T(), err)
+
+	// Close out this subscription
+	sub.Stop()
+
+	//
+	// Bookmark is not found so subscription should start from beginning
+	//
+
+	// Create a new subscription starting from the bookmark
+	sub, err = startSubscription(s.T(), s.ti, s.channelPath,
+		WithStartAfterBookmark(bookmark),
+		WithNotifyEventsAvailable())
+	// strict flag not set so there should be no error
+	require.NoError(s.T(), err)
+
+	// Get Events
+	_, err = getEventHandles(s.T(), s.ti, sub, s.numEvents)
+	require.NoError(s.T(), err)
+	err = assertNoMoreEvents(s.T(), sub)
+	require.NoError(s.T(), err)
+}
+
+// Tests that the subscription returns an error when a bookmark is not found and the EvtSubscribeStrict flag is provided
+func (s *GetEventsTestSuite) TestStartAfterBookmarkNotFoundWithStrictFlag() {
+	//
+	// Add some events to the log and create a bookmark
+	//
+
+	// Put events in the log
+	err := s.ti.GenerateEvents(s.eventSource, s.numEvents)
+	require.NoError(s.T(), err)
+
+	// Create bookmark
+	bookmark, err := evtbookmark.New(evtbookmark.WithWindowsEventLogAPI(s.ti.API()))
+	require.NoError(s.T(), err)
+
+	// Create sub
+	sub, err := startSubscription(s.T(), s.ti, s.channelPath,
+		WithStartAtOldestRecord(),
+		WithNotifyEventsAvailable())
+	require.NoError(s.T(), err)
+
+	// Read the events
+	events, err := getEventHandles(s.T(), s.ti, sub, s.numEvents)
+	require.NoError(s.T(), err)
+	err = assertNoMoreEvents(s.T(), sub)
+	require.NoError(s.T(), err)
+
+	// Update bookmark to last event
+	// Must do so before closing the subscription
+	bookmark.Update(events[len(events)-1].EventRecordHandle)
+
+	// Close out this subscription
+	sub.Stop()
+
+	// Clear the log so the bookmark is missing
+	err = s.ti.API().EvtClearLog(s.channelPath)
+	require.NoError(s.T(), err)
+
+	//
+	// Add more events and verify the log contains only that many events
+	//
+
+	// Add some more events
+	err = s.ti.GenerateEvents(s.eventSource, s.numEvents)
+	require.NoError(s.T(), err)
+
+	// Create sub
+	sub, err = startSubscription(s.T(), s.ti, s.channelPath,
+		WithStartAtOldestRecord(),
+		WithNotifyEventsAvailable())
+	require.NoError(s.T(), err)
+
+	// Read the events
+	_, err = getEventHandles(s.T(), s.ti, sub, s.numEvents)
+	require.NoError(s.T(), err)
+	err = assertNoMoreEvents(s.T(), sub)
+	require.NoError(s.T(), err)
+
+	// Close out this subscription
+	sub.Stop()
+
+	//
+	// With bookmark not found and strict flag set subscription should fail
+	//
+
+	sub = NewPullSubscription(
+		s.channelPath,
+		"*",
+		WithWindowsEventLogAPI(s.ti.API()),
+		WithStartAfterBookmark(bookmark),
+		WithSubscribeFlags(evtapi.EvtSubscribeStrict))
+	err = sub.Start()
+	require.Error(s.T(), err, "Subscription should return error when bookmark is not found and the Strict flag is set")
+}
+
+// Tests that the subscription can call GetEvents() when there are no events
+func (s *GetEventsTestSuite) TestReadWhenNoEvents() {
+	// Create sub
+	sub, err := startSubscription(s.T(), s.ti, s.channelPath,
+		WithStartAtOldestRecord())
+	require.NoError(s.T(), err)
+
+	err = assertNoMoreEvents(s.T(), sub)
+	require.NoError(s.T(), err)
+	err = assertNoMoreEvents(s.T(), sub)
+	require.NoError(s.T(), err)
+}
+
+// Tests that the subscription can call GetEvents() when there are no more events
+func (s *GetEventsTestSuite) TestReadWhenNoMoreEvents() {
+	// Put events in the log
+	err := s.ti.GenerateEvents(s.eventSource, s.numEvents)
+	require.NoError(s.T(), err)
+
+	// Create sub
+	sub, err := startSubscription(s.T(), s.ti, s.channelPath,
+		WithStartAtOldestRecord())
+	require.NoError(s.T(), err)
+
+	// Put events in the log
+	err = s.ti.GenerateEvents(s.eventSource, s.numEvents)
+	require.NoError(s.T(), err)
+
+	// Read all the events
+	eventRecords, err := ReadNumEvents(s.T(), s.ti, sub, 2*s.numEvents)
+	require.NoError(s.T(), err)
+	count := uint(len(eventRecords))
+	if !assert.Equal(s.T(), 2*s.numEvents, count, fmt.Sprintf("Missing events, collected %d/%d events", count, 2*s.numEvents)) {
+		return
+	}
+	err = assertNoMoreEvents(s.T(), sub)
+	require.NoError(s.T(), err)
+
+	// Get no more items again
+	err = assertNoMoreEvents(s.T(), sub)
+	require.NoError(s.T(), err)
+}
+
+func TestLaunchGetEventsTestSuite(t *testing.T) {
+	testerNames := eventlog_test.GetEnabledAPITesters()
+
+	for _, tiName := range testerNames {
+		t.Run(fmt.Sprintf("%sAPI", tiName), func(t *testing.T) {
+			var s GetEventsTestSuite
+			s.channelPath = "dd-test-channel-subscription"
+			s.eventSource = "dd-test-source-subscription"
+			s.testAPI = tiName
+			s.numEvents = 10
+			suite.Run(t, &s)
+		})
+	}
+}

--- a/pkg/util/winutil/eventlog/subscription/subscription_test.go
+++ b/pkg/util/winutil/eventlog/subscription/subscription_test.go
@@ -151,8 +151,8 @@ func BenchmarkTestGetEventHandles(b *testing.B) {
 				}
 				// TODO: Use b.Elapsed in go1.20
 				elapsed := time.Since(startTime)
-				total_events := float64(v) * float64(b.N)
-				b.Logf("%.2f events/s (%.3fs)", total_events/elapsed.Seconds(), elapsed.Seconds())
+				totalEvents := float64(v) * float64(b.N)
+				b.Logf("%.2f events/s (%.3fs)", totalEvents/elapsed.Seconds(), elapsed.Seconds())
 			})
 		}
 	}
@@ -230,8 +230,8 @@ func BenchmarkTestRenderEventXml(b *testing.B) {
 				}
 				// TODO: Use b.Elapsed in go1.20
 				elapsed := time.Since(startTime)
-				total_events := float64(v) * float64(b.N)
-				b.Logf("%.2f events/s (%.3fs)", total_events/elapsed.Seconds(), elapsed.Seconds())
+				totalEvents := float64(v) * float64(b.N)
+				b.Logf("%.2f events/s (%.3fs)", totalEvents/elapsed.Seconds(), elapsed.Seconds())
 			})
 		}
 	}
@@ -276,8 +276,8 @@ func BenchmarkTestFormatEventMessage(b *testing.B) {
 				}
 				// TODO: Use b.Elapsed in go1.20
 				elapsed := time.Since(startTime)
-				total_events := float64(v) * float64(b.N)
-				b.Logf("%.2f events/s (%.3fs)", total_events/elapsed.Seconds(), elapsed.Seconds())
+				totalEvents := float64(v) * float64(b.N)
+				b.Logf("%.2f events/s (%.3fs)", totalEvents/elapsed.Seconds(), elapsed.Seconds())
 			})
 		}
 	}

--- a/pkg/util/winutil/eventlog/subscription/subscription_test.go
+++ b/pkg/util/winutil/eventlog/subscription/subscription_test.go
@@ -3,7 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2023-present Datadog, Inc.
 //go:build windows
-// +build windows
 
 package evtsubscribe
 

--- a/pkg/util/winutil/eventlog/test/fake.go
+++ b/pkg/util/winutil/eventlog/test/fake.go
@@ -1,0 +1,62 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+//go:build windows
+// +build windows
+
+package eventlog_test
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/util/winutil/eventlog/api"
+	"github.com/DataDog/datadog-agent/pkg/util/winutil/eventlog/api/fake"
+)
+
+// FakeAPITester uses a limited in-memory re-implementation of the Windows EventLog APIs
+// and provides utilities to the test framework that will simulate behavior and not make
+// any changes to the host system
+type FakeAPITester struct {
+	t           testing.TB
+	eventlogapi *fakeevtapi.API
+}
+
+func NewFakeAPITester(t testing.TB) *FakeAPITester {
+	var ti FakeAPITester
+	ti.t = t
+	ti.eventlogapi = fakeevtapi.New()
+	return &ti
+}
+
+func (ti *FakeAPITester) Name() string {
+	return "Fake"
+}
+
+func (ti *FakeAPITester) T() testing.TB {
+	return ti.t
+}
+
+func (ti *FakeAPITester) API() evtapi.API {
+	return ti.eventlogapi
+}
+
+func (ti *FakeAPITester) InstallChannel(channel string) error {
+	return ti.eventlogapi.AddEventLog(channel)
+}
+
+func (ti *FakeAPITester) RemoveChannel(channel string) error {
+	return ti.eventlogapi.RemoveEventLog(channel)
+}
+
+func (ti *FakeAPITester) InstallSource(channel string, source string) error {
+	return ti.eventlogapi.AddEventSource(channel, source)
+}
+
+func (ti *FakeAPITester) RemoveSource(channel string, source string) error {
+	return ti.eventlogapi.RemoveEventSource(channel, source)
+}
+
+func (ti *FakeAPITester) GenerateEvents(channelName string, numEvents uint) error {
+	return ti.eventlogapi.GenerateEvents(channelName, numEvents)
+}

--- a/pkg/util/winutil/eventlog/test/fake.go
+++ b/pkg/util/winutil/eventlog/test/fake.go
@@ -7,55 +7,60 @@
 package eventlog_test
 
 import (
-	"testing"
-
 	"github.com/DataDog/datadog-agent/pkg/util/winutil/eventlog/api"
 	"github.com/DataDog/datadog-agent/pkg/util/winutil/eventlog/api/fake"
+)
+
+const (
+	// FakeAPIName identifies this API in GetAPITesterByName
+	FakeAPIName = "Fake"
 )
 
 // FakeAPITester uses a limited in-memory re-implementation of the Windows EventLog APIs
 // and provides utilities to the test framework that will simulate behavior and not make
 // any changes to the host system
 type FakeAPITester struct {
-	t           testing.TB
 	eventlogapi *fakeevtapi.API
 }
 
-func NewFakeAPITester(t testing.TB) *FakeAPITester {
+// NewFakeAPITester constructs a new API tester for a fake Windows Event Log API
+func NewFakeAPITester() *FakeAPITester {
 	var ti FakeAPITester
-	ti.t = t
 	ti.eventlogapi = fakeevtapi.New()
 	return &ti
 }
 
+// Name returns the name that identifies this tester for use by GetAPITesterByName
 func (ti *FakeAPITester) Name() string {
-	return "Fake"
+	return FakeAPIName
 }
 
-func (ti *FakeAPITester) T() testing.TB {
-	return ti.t
-}
-
+// API returns the fake API
 func (ti *FakeAPITester) API() evtapi.API {
 	return ti.eventlogapi
 }
 
+// InstallChannel adds a new event log
 func (ti *FakeAPITester) InstallChannel(channel string) error {
 	return ti.eventlogapi.AddEventLog(channel)
 }
 
+// RemoveChannel removes an event log
 func (ti *FakeAPITester) RemoveChannel(channel string) error {
 	return ti.eventlogapi.RemoveEventLog(channel)
 }
 
+// InstallSource adds a new source to an event log channel
 func (ti *FakeAPITester) InstallSource(channel string, source string) error {
 	return ti.eventlogapi.AddEventSource(channel, source)
 }
 
+// RemoveSource removes a source from an event log channel
 func (ti *FakeAPITester) RemoveSource(channel string, source string) error {
 	return ti.eventlogapi.RemoveEventSource(channel, source)
 }
 
+// GenerateEvents creates numEvents new event records
 func (ti *FakeAPITester) GenerateEvents(channelName string, numEvents uint) error {
 	return ti.eventlogapi.GenerateEvents(channelName, numEvents)
 }

--- a/pkg/util/winutil/eventlog/test/fake.go
+++ b/pkg/util/winutil/eventlog/test/fake.go
@@ -3,7 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2023-present Datadog, Inc.
 //go:build windows
-// +build windows
 
 package eventlog_test
 

--- a/pkg/util/winutil/eventlog/test/test.go
+++ b/pkg/util/winutil/eventlog/test/test.go
@@ -1,0 +1,47 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+//go:build windows
+// +build windows
+
+package eventlog_test
+
+import (
+	"flag"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/util/winutil/eventlog/api"
+
+	"github.com/stretchr/testify/require"
+)
+
+var enabledAPIsFlag = flag.String("evtapi", "Fake", "Comma-separated list of Event Log APIs to run tests with")
+
+type APITester interface {
+	Name() string
+	T() testing.TB
+	API() evtapi.API
+	InstallChannel(channel string) error
+	RemoveChannel(channel string) error
+	InstallSource(channel string, source string) error
+	RemoveSource(channel string, name string) error
+	GenerateEvents(channelName string, numEvents uint) error
+}
+
+func GetEnabledAPITesters() []string {
+	return strings.Split(*enabledAPIsFlag, ",")
+}
+
+func GetAPITesterByName(name string, t testing.TB) APITester {
+	if name == "Fake" {
+		return NewFakeAPITester(t)
+	} else if name == "Windows" {
+		return NewWindowsAPITester(t)
+	}
+
+	require.FailNow(t, fmt.Sprintf("invalid test interface: %v", name))
+	return nil
+}

--- a/pkg/util/winutil/eventlog/test/test.go
+++ b/pkg/util/winutil/eventlog/test/test.go
@@ -3,7 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2023-present Datadog, Inc.
 //go:build windows
-// +build windows
 
 package eventlog_test
 

--- a/pkg/util/winutil/eventlog/test/test.go
+++ b/pkg/util/winutil/eventlog/test/test.go
@@ -4,6 +4,7 @@
 // Copyright 2023-present Datadog, Inc.
 //go:build windows
 
+// Package eventlog_test provides helpers for testing code that uses the eventlog package
 package eventlog_test
 
 import (
@@ -17,11 +18,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var enabledAPIsFlag = flag.String("evtapi", "Fake", "Comma-separated list of Event Log APIs to run tests with")
+// Add command line flag for tests to specify which APIs to use for the tests.
+// The default is just "Fake" so that the host is not modified by the tests.
+// Specify "Windows" to use the real Event Log APIs.
+var enabledAPIsFlag = flag.String("evtapi", FakeAPIName, "Comma-separated list of Event Log APIs to run tests with")
 
+// APITester defines the interface used to test Windows Event Log API implementations.
+// Notably it has helpers for adding/removing event logs and sources which would normally
+// be the work of an installer.
 type APITester interface {
 	Name() string
-	T() testing.TB
 	API() evtapi.API
 	InstallChannel(channel string) error
 	RemoveChannel(channel string) error
@@ -30,15 +36,17 @@ type APITester interface {
 	GenerateEvents(channelName string, numEvents uint) error
 }
 
+// GetEnabledAPITesters returns the APIs that are available to test as specified by enabledAPIsFlag
 func GetEnabledAPITesters() []string {
 	return strings.Split(*enabledAPIsFlag, ",")
 }
 
+// GetAPITesterByName returns a new APITester interface with the backing type identified by name.
 func GetAPITesterByName(name string, t testing.TB) APITester {
-	if name == "Fake" {
-		return NewFakeAPITester(t)
-	} else if name == "Windows" {
-		return NewWindowsAPITester(t)
+	if name == FakeAPIName {
+		return NewFakeAPITester()
+	} else if name == WindowsAPIName {
+		return NewWindowsAPITester()
 	}
 
 	require.FailNow(t, fmt.Sprintf("invalid test interface: %v", name))

--- a/pkg/util/winutil/eventlog/test/windows.go
+++ b/pkg/util/winutil/eventlog/test/windows.go
@@ -1,0 +1,157 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+//go:build windows
+// +build windows
+
+package eventlog_test
+
+import (
+	"fmt"
+	"testing"
+
+	"golang.org/x/sys/windows"
+	"golang.org/x/sys/windows/registry"
+
+	"github.com/DataDog/datadog-agent/pkg/util/winutil/eventlog/api"
+	"github.com/DataDog/datadog-agent/pkg/util/winutil/eventlog/api/windows"
+)
+
+const (
+	eventLogRootKey = `SYSTEM\CurrentControlSet\Services\EventLog`
+)
+
+// WindowsAPITester uses the real Windows EventLog APIs
+// and provides utilities to the test framework that will modify
+// the host system (e.g. install event log source, generate events).
+type WindowsAPITester struct {
+	t           testing.TB
+	eventlogapi *winevtapi.API
+}
+
+func NewWindowsAPITester(t testing.TB) *WindowsAPITester {
+	var ti WindowsAPITester
+	ti.t = t
+	ti.eventlogapi = winevtapi.New()
+	return &ti
+}
+
+func (ti *WindowsAPITester) Name() string {
+	return "Windows"
+}
+
+func (ti *WindowsAPITester) T() testing.TB {
+	return ti.t
+}
+
+func (ti *WindowsAPITester) API() evtapi.API {
+	return ti.eventlogapi
+}
+
+func (ti *WindowsAPITester) InstallChannel(channel string) error {
+	// Open EventLog registry key
+	rootKey, err := registry.OpenKey(registry.LOCAL_MACHINE, channelRootKey(), registry.CREATE_SUB_KEY)
+	if err != nil {
+		return err
+	}
+	defer rootKey.Close()
+
+	// Create the channel subkey
+	channelKey, _, err := registry.CreateKey(rootKey, channel, registry.SET_VALUE)
+	if err != nil {
+		return err
+	}
+	defer channelKey.Close()
+
+	// Increase the max size to accommodate more events
+	// The default is 20MB, we increase it to 100MB
+	err = channelKey.SetDWordValue("MaxSize", 100*1024*1024)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (ti *WindowsAPITester) InstallSource(channel string, source string) error {
+	// Open channel key
+	channelKey, err := registry.OpenKey(registry.LOCAL_MACHINE, channelRegistryKey(channel), registry.CREATE_SUB_KEY)
+	if err != nil {
+		return err
+	}
+	defer channelKey.Close()
+
+	// Create the source subkey
+	sourceKey, _, err := registry.CreateKey(channelKey, source, registry.SET_VALUE)
+	if err != nil {
+		return err
+	}
+	defer sourceKey.Close()
+
+	// eventcreate.exe is used because it has a generic message format that enabled EvtFormatMessage to succeed
+	err = sourceKey.SetExpandStringValue("EventMessageFile", `%SystemRoot%\System32\eventcreate.exe`)
+	if err != nil {
+		return err
+	}
+	err = sourceKey.SetDWordValue("TypesSupported", windows.EVENTLOG_INFORMATION_TYPE|windows.EVENTLOG_WARNING_TYPE|windows.EVENTLOG_ERROR_TYPE)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (ti *WindowsAPITester) RemoveChannel(channel string) error {
+	// Open EventLog registry key
+	rootKey, err := registry.OpenKey(registry.LOCAL_MACHINE, channelRootKey(), registry.CREATE_SUB_KEY)
+	if err != nil {
+		return err
+	}
+	defer rootKey.Close()
+
+	// Delete channel subkey
+	return registry.DeleteKey(rootKey, channel)
+}
+
+func (ti *WindowsAPITester) RemoveSource(channel string, source string) error {
+	// Open channel key
+	channelKey, err := registry.OpenKey(registry.LOCAL_MACHINE, channelRegistryKey(channel), registry.CREATE_SUB_KEY)
+	if err != nil {
+		return err
+	}
+	defer channelKey.Close()
+
+	// Delete source subkey
+	return registry.DeleteKey(channelKey, source)
+}
+
+func (ti *WindowsAPITester) GenerateEvents(channelName string, numEvents uint) error {
+
+	sourceHandle, err := ti.eventlogapi.RegisterEventSource(channelName)
+	if err != nil {
+		return err
+	}
+	//nolint:errcheck
+	defer ti.eventlogapi.DeregisterEventSource(sourceHandle)
+
+	for i := uint(0); i < numEvents; i += 1 {
+		err := ti.eventlogapi.ReportEvent(
+			sourceHandle,
+			windows.EVENTLOG_INFORMATION_TYPE,
+			0, 1000, []string{"teststring"}, nil)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func channelRootKey() string {
+	return eventLogRootKey
+}
+
+func channelRegistryKey(channel string) string {
+	return fmt.Sprintf(`%v\%v`, channelRootKey(), channel)
+}

--- a/pkg/util/winutil/eventlog/test/windows.go
+++ b/pkg/util/winutil/eventlog/test/windows.go
@@ -135,11 +135,14 @@ func (ti *WindowsAPITester) GenerateEvents(channelName string, numEvents uint) e
 	//nolint:errcheck
 	defer ti.eventlogapi.DeregisterEventSource(sourceHandle)
 
+	// Use LocalSystem for the SID
+	sid, _ := windows.CreateWellKnownSid(windows.WinLocalSystemSid)
+
 	for i := uint(0); i < numEvents; i += 1 {
 		err := ti.eventlogapi.ReportEvent(
 			sourceHandle,
 			windows.EVENTLOG_INFORMATION_TYPE,
-			0, 1000, []string{"teststring"}, nil)
+			0, 1000, sid, []string{"teststring"}, nil)
 		if err != nil {
 			return err
 		}

--- a/pkg/util/winutil/eventlog/test/windows.go
+++ b/pkg/util/winutil/eventlog/test/windows.go
@@ -3,7 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2023-present Datadog, Inc.
 //go:build windows
-// +build windows
 
 package eventlog_test
 

--- a/pkg/util/winutil/winstrings.go
+++ b/pkg/util/winutil/winstrings.go
@@ -80,3 +80,16 @@ func ExpandEnvironmentStrings(input string) (string, error) {
 	}
 	return windows.UTF16ToString(target), nil
 }
+
+// UTF16PtrOrNilFromString converts a go string into a *uint16
+// using windows.Utf16PtrFromString, but will return nil for empty strings.
+//
+// Useful for Windows APIs that take NULL or a non-zero length string.
+// Be careful to check that the Windows API does not have special behavior
+// for a zero-length string.
+func UTF16PtrOrNilFromString(s string) (*uint16, error) {
+	if s == "" {
+		return nil, nil
+	}
+	return windows.UTF16PtrFromString(s)
+}

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -459,6 +459,36 @@ def integration_tests(ctx, install_deps=False, race=False, remote_docker=False, 
     if install_deps:
         deps(ctx)
 
+    if sys.platform == 'win32':
+        return _windows_integration_tests(ctx, race=race, go_mod=go_mod, arch=arch)
+    else:
+        # TODO: See if these will function on Windows
+        return _linux_integration_tests(ctx, race=race, remote_docker=remote_docker, go_mod=go_mod, arch=arch)
+
+
+def _windows_integration_tests(ctx, race=False, go_mod="mod", arch="x64"):
+    test_args = {
+        "go_mod": go_mod,
+        "go_build_tags": " ".join(get_default_build_tags(build="test", arch=arch)),
+        "race_opt": "-race" if race else "",
+        "exec_opts": "",
+    }
+
+    go_cmd = 'go test -mod={go_mod} {race_opt} -tags "{go_build_tags}" {exec_opts}'.format(**test_args)  # noqa: FS002
+
+    tests = [
+        {
+            # Run eventlog tests with the Windows API, which depend on the EventLog service
+            'prefix': './pkg/util/winutil/eventlog/...',
+            'extra_args': '-evtapi Windows',
+        }
+    ]
+
+    for test in tests:
+        ctx.run(f"{go_cmd} {test['prefix']} {test['extra_args']}")
+
+
+def _linux_integration_tests(ctx, race=False, remote_docker=False, go_mod="mod", arch="x64"):
     test_args = {
         "go_mod": go_mod,
         "go_build_tags": " ".join(get_default_build_tags(build="test", arch=arch)),

--- a/tasks/cluster_agent.py
+++ b/tasks/cluster_agent.py
@@ -6,6 +6,7 @@ import glob
 import os
 import platform
 import shutil
+import sys
 import tempfile
 
 from invoke import task
@@ -90,6 +91,9 @@ def integration_tests(ctx, install_deps=False, race=False, remote_docker=False, 
     """
     Run integration tests for cluster-agent
     """
+    if sys.platform == 'win32':
+        raise Exit(message='cluster-agent integration tests are not supported on Windows', code=0)
+
     if install_deps:
         deps(ctx)
 

--- a/tasks/dogstatsd.py
+++ b/tasks/dogstatsd.py
@@ -253,6 +253,9 @@ def integration_tests(ctx, install_deps=False, race=False, remote_docker=False, 
     """
     Run integration tests for dogstatsd
     """
+    if sys.platform == 'win32':
+        raise Exit(message='dogstatsd integration tests are not supported on Windows', code=0)
+
     if install_deps:
         deps(ctx)
 

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -1022,10 +1022,20 @@ def integration_tests(ctx, install_deps=False, race=False, remote_docker=False):
     """
     Run all the available integration tests
     """
-    agent_integration_tests(ctx, install_deps, race, remote_docker)
-    dsd_integration_tests(ctx, install_deps, race, remote_docker)
-    dca_integration_tests(ctx, install_deps, race, remote_docker)
-    trace_integration_tests(ctx, install_deps, race)
+    tests = [
+        lambda: agent_integration_tests(ctx, install_deps, race, remote_docker),
+        lambda: dsd_integration_tests(ctx, install_deps, race, remote_docker),
+        lambda: dca_integration_tests(ctx, install_deps, race, remote_docker),
+        lambda: trace_integration_tests(ctx, install_deps, race),
+    ]
+    for t in tests:
+        try:
+            t()
+        except Exit as e:
+            if e.code != 0:
+                raise
+            else:
+                print(e.message)
 
 
 @task

--- a/tasks/trace_agent.py
+++ b/tasks/trace_agent.py
@@ -1,7 +1,7 @@
 import os
 import sys
 
-from invoke import task
+from invoke import Exit, task
 
 from .build_tags import filter_incompatible_tags, get_build_tags, get_default_build_tags
 from .flavor import AgentFlavor
@@ -78,6 +78,9 @@ def integration_tests(ctx, install_deps=False, race=False, go_mod="mod"):
     """
     Run integration tests for trace agent
     """
+    if sys.platform == 'win32':
+        raise Exit(message='trace-agent integration tests are not supported on Windows', code=0)
+
     if install_deps:
         deps(ctx)
 

--- a/tasks/winbuildscripts/integrationtests.bat
+++ b/tasks/winbuildscripts/integrationtests.bat
@@ -1,0 +1,24 @@
+if not exist c:\mnt\ goto nomntdir
+
+@echo c:\mnt found, continuing
+
+@echo PARAMS %*
+@echo PY_RUNTIMES %PY_RUNTIMES%
+
+if NOT DEFINED PY_RUNTIMES set PY_RUNTIMES=%~1
+
+set TEST_ROOT=c:\test-root
+mkdir %TEST_ROOT%\datadog-agent
+cd %TEST_ROOT%\datadog-agent
+xcopy /e/s/h/q c:\mnt\*.*
+
+call %TEST_ROOT%\datadog-agent\tasks\winbuildscripts\extract-modcache.bat %TEST_ROOT%\datadog-agent modcache
+call %TEST_ROOT%\datadog-agent\tasks\winbuildscripts\extract-modcache.bat %TEST_ROOT%\datadog-agent modcache_tools
+
+Powershell -C "%TEST_ROOT%\datadog-agent\tasks\winbuildscripts\integrationtests.ps1" || exit /b 2
+
+goto :EOF
+
+:nomntdir
+@echo directory not mounted, parameters incorrect
+exit /b 1

--- a/tasks/winbuildscripts/integrationtests.ps1
+++ b/tasks/winbuildscripts/integrationtests.ps1
@@ -1,0 +1,33 @@
+$ErrorActionPreference = "Stop"
+$Password = ConvertTo-SecureString "dummyPW_:-gch6Rejae9" -AsPlainText -Force
+New-LocalUser -Name "ddagentuser" -Description "Test user for the secrets feature on windows." -Password $Password
+
+$Env:Python2_ROOT_DIR=$Env:TEST_EMBEDDED_PY2
+$Env:Python3_ROOT_DIR=$Env:TEST_EMBEDDED_PY3
+
+if ($Env:TARGET_ARCH -eq "x64") {
+    & ridk enable
+}
+& $Env:Python3_ROOT_DIR\python.exe -m  pip install -r requirements.txt
+
+$UT_BUILD_ROOT=(Get-Location).Path
+$Env:PATH="$UT_BUILD_ROOT\dev\lib;$Env:GOPATH\bin;$Env:Python3_ROOT_DIR;$Env:Python3_ROOT_DIR\Scripts;$Env:PATH"
+
+& $Env:Python3_ROOT_DIR\python.exe -m pip install PyYAML==5.3.1
+
+$archflag = "x64"
+if ($Env:TARGET_ARCH -eq "x86") {
+    $archflag = "x86"
+}
+
+& inv -e deps
+& .\tasks\winbuildscripts\pre-go-build.ps1 -Architecture "$archflag" -PythonRuntimes "$Env:PY_RUNTIMES"
+
+& inv -e install-tools
+& inv -e integration-tests
+$err = $LASTEXITCODE
+Write-Host Test result is $err
+if($err -ne 0){
+    Write-Host -ForegroundColor Red "test failed $err"
+    [Environment]::Exit($err)
+}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Adds a package for the Windows Event Log API that will serve as the base for a log tailer and a check.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
https://datadoghq.atlassian.net/browse/WA-207

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
No changelog or QA needed because it is not used in the agent yet.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
