### PR TITLE
[CWS] use vdso for monotonic clock reading instead of real syscall

### DIFF
--- a/pkg/security/resolvers/time/resolver.go
+++ b/pkg/security/resolvers/time/resolver.go
@@ -11,6 +11,8 @@ package time
 import (
 	"time"
 
+	_ "unsafe"
+
 	"github.com/DataDog/gopsutil/host"
 )
 

--- a/pkg/security/resolvers/time/resolver.go
+++ b/pkg/security/resolvers/time/resolver.go
@@ -38,15 +38,14 @@ func NewResolver() (*Resolver, error) {
 //go:linkname nanotime runtime.nanotime
 func nanotime() int64
 
-func (tr *Resolver) getUptimeOffset() (time.Duration, error) {
-	return time.Since(tr.bootTime) - time.Duration(nanotime()), nil
+func (tr *Resolver) getUptimeOffset() time.Duration {
+	return time.Since(tr.bootTime) - time.Duration(nanotime())
 }
 
 // ResolveMonotonicTimestamp converts a kernel monotonic timestamp to an absolute time
 func (tr *Resolver) ResolveMonotonicTimestamp(timestamp uint64) time.Time {
 	if timestamp > 0 {
-		// ignore uptime resolution failure: default back to previous behavior
-		offset, _ := tr.getUptimeOffset()
+		offset := tr.getUptimeOffset()
 		return tr.bootTime.Add(time.Duration(timestamp) + offset)
 	}
 	return time.Time{}
@@ -55,8 +54,7 @@ func (tr *Resolver) ResolveMonotonicTimestamp(timestamp uint64) time.Time {
 // ApplyBootTime return the time re-aligned from the boot time
 func (tr *Resolver) ApplyBootTime(timestamp time.Time) time.Time {
 	if !timestamp.IsZero() {
-		// ignore uptime resolution failure: default back to previous behavior
-		offset, _ := tr.getUptimeOffset()
+		offset := tr.getUptimeOffset()
 		return timestamp.Add(time.Duration(tr.bootTime.UnixNano()) + offset)
 	}
 	return time.Time{}
@@ -65,8 +63,7 @@ func (tr *Resolver) ApplyBootTime(timestamp time.Time) time.Time {
 // ComputeMonotonicTimestamp converts an absolute time to a kernel monotonic timestamp
 func (tr *Resolver) ComputeMonotonicTimestamp(timestamp time.Time) int64 {
 	if !timestamp.IsZero() {
-		// ignore uptime resolution failure: default back to previous behavior
-		offset, _ := tr.getUptimeOffset()
+		offset := tr.getUptimeOffset()
 		return timestamp.Sub(tr.bootTime.Add(offset)).Nanoseconds()
 	}
 	return 0

--- a/pkg/security/resolvers/time/resolver.go
+++ b/pkg/security/resolvers/time/resolver.go
@@ -9,11 +9,9 @@
 package time
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/DataDog/gopsutil/host"
-	"golang.org/x/sys/unix"
 )
 
 // Resolver converts kernel monotonic timestamps to absolute times
@@ -34,13 +32,12 @@ func NewResolver() (*Resolver, error) {
 	return &tr, nil
 }
 
+//go:noescape
+//go:linkname nanotime runtime.nanotime
+func nanotime() int64
+
 func (tr *Resolver) getUptimeOffset() (time.Duration, error) {
-	upTime := new(unix.Timespec)
-	err := unix.ClockGettime(unix.CLOCK_MONOTONIC, upTime)
-	if err != nil {
-		return 0, fmt.Errorf("couldn't get system up time: %w", err)
-	}
-	return time.Since(tr.bootTime) - time.Duration(upTime.Nano()), nil
+	return time.Since(tr.bootTime) - time.Duration(nanotime()), nil
 }
 
 // ResolveMonotonicTimestamp converts a kernel monotonic timestamp to an absolute time


### PR DESCRIPTION
### What does this PR do?

`unix.ClockGettime(unix.CLOCK_MONOTONIC, upTime)` does an actual syscall, even when vDSO is available. This PR switches our code to use the runtime "provided" function to read the monotonic clock.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
