### PR TITLE
[autodiscovery] Add container filtering based on pod annotation

### DIFF
--- a/pkg/autodiscovery/listeners/container.go
+++ b/pkg/autodiscovery/listeners/container.go
@@ -113,6 +113,10 @@ func (l *ContainerListener) createContainerService(entity workloadmeta.Entity) {
 	if findKubernetesInLabels(container.Labels) {
 		pod, err := l.Store().GetKubernetesPodForContainer(container.ID)
 		if err == nil {
+			if containers.IsExcludedByAnnotation(containers.GlobalFilter, pod.Annotations, container.Name) {
+				log.Debugf("container %s filtered out: name %q image %q", container.ID, container.Name, containerImg.RawName)
+				return
+			}
 			svc.hosts = map[string]string{"pod": pod.IP}
 			svc.ready = pod.Ready
 		} else {

--- a/pkg/autodiscovery/listeners/container.go
+++ b/pkg/autodiscovery/listeners/container.go
@@ -119,6 +119,19 @@ func (l *ContainerListener) createContainerService(entity workloadmeta.Entity) {
 			}
 			svc.hosts = map[string]string{"pod": pod.IP}
 			svc.ready = pod.Ready
+
+			svc.metricsExcluded = l.IsExcluded(
+				containers.MetricsFilter,
+				container.Name,
+				containerImg.RawName,
+				"",
+			) || containers.IsExcludedByAnnotation(containers.MetricsFilter, pod.Annotations, container.Name)
+			svc.logsExcluded = l.IsExcluded(
+				containers.LogsFilter,
+				container.Name,
+				containerImg.RawName,
+				"",
+			) || containers.IsExcludedByAnnotation(containers.LogsFilter, pod.Annotations, container.Name)
 		} else {
 			log.Debugf("container %q belongs to a pod but was not found: %s", container.ID, err)
 		}

--- a/pkg/autodiscovery/listeners/container_test.go
+++ b/pkg/autodiscovery/listeners/container_test.go
@@ -9,12 +9,14 @@
 package listeners
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
+	workloadmetatesting "github.com/DataDog/datadog-agent/pkg/workloadmeta/testing"
 )
 
 func TestCreateContainerService(t *testing.T) {
@@ -79,9 +81,81 @@ func TestCreateContainerService(t *testing.T) {
 		Runtime: workloadmeta.ContainerRuntimeDocker,
 	}
 
+	kubernetesContainer := &workloadmeta.Container{
+		EntityID: workloadmeta.EntityID{
+			Kind: workloadmeta.KindContainer,
+			ID:   "foo",
+		},
+		EntityMeta: workloadmeta.EntityMeta{
+			Name: "foobar",
+			Labels: map[string]string{
+				"io.kubernetes.foo": "bar",
+			},
+		},
+		Image: workloadmeta.ContainerImage{
+			RawName:   "gcr.io/foobar:latest",
+			ShortName: "foobar",
+		},
+		State: workloadmeta.ContainerState{
+			Running: true,
+		},
+		Runtime: workloadmeta.ContainerRuntimeDocker,
+	}
+
+	kubernetesExcludedContainer := &workloadmeta.Container{
+		EntityID: workloadmeta.EntityID{
+			Kind: workloadmeta.KindContainer,
+			ID:   "bar",
+		},
+		EntityMeta: workloadmeta.EntityMeta{
+			Name: "barfoo",
+			Labels: map[string]string{
+				"io.kubernetes.foo": "bar",
+			},
+		},
+		Image: workloadmeta.ContainerImage{
+			RawName:   "gcr.io/foobar:latest",
+			ShortName: "foobar",
+		},
+		State: workloadmeta.ContainerState{
+			Running: true,
+		},
+		Runtime: workloadmeta.ContainerRuntimeDocker,
+	}
+
+	pod := &workloadmeta.KubernetesPod{
+		EntityID: workloadmeta.EntityID{
+			Kind: workloadmeta.KindKubernetesPod,
+			ID:   podID,
+		},
+		EntityMeta: workloadmeta.EntityMeta{
+			Name:      podName,
+			Namespace: podNamespace,
+			Annotations: map[string]string{
+				fmt.Sprintf("ad.datadoghq.com/%s.exclude", kubernetesContainer.Name):         `false`,
+				fmt.Sprintf("ad.datadoghq.com/%s.exclude", kubernetesExcludedContainer.Name): `true`,
+			},
+		},
+		Containers: []workloadmeta.OrchestratorContainer{
+			{
+				ID:    kubernetesContainer.ID,
+				Name:  kubernetesContainer.Name,
+				Image: kubernetesContainer.Image,
+			},
+			{
+				ID:    kubernetesExcludedContainer.ID,
+				Name:  kubernetesExcludedContainer.Name,
+				Image: kubernetesExcludedContainer.Image,
+			},
+		},
+		IP:    "127.0.0.1",
+		Ready: false,
+	}
+
 	tests := []struct {
 		name             string
 		container        *workloadmeta.Container
+		pod              *workloadmeta.KubernetesPod
 		expectedServices map[string]wlmListenerSvc
 	}{
 		{
@@ -166,11 +240,40 @@ func TestCreateContainerService(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:      "running in k8s",
+			container: kubernetesContainer,
+			pod:       pod,
+			expectedServices: map[string]wlmListenerSvc{
+				"container://foo": {
+					service: &service{
+						entity: kubernetesContainer,
+						adIdentifiers: []string{
+							"docker://foo",
+							"gcr.io/foobar",
+							"foobar",
+						},
+						hosts: map[string]string{"pod": pod.IP},
+						ports: []ContainerPort{},
+						ready: pod.Ready,
+					},
+				},
+			},
+		},
+		{
+			name:             "running in k8s has excluded annotation is excluded",
+			container:        kubernetesExcludedContainer,
+			pod:              pod,
+			expectedServices: map[string]wlmListenerSvc{},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			listener, wlm := newContainerListener(t)
+			if tt.pod != nil {
+				listener.Store().(*workloadmetatesting.Store).Set(tt.pod)
+			}
 
 			listener.createContainerService(tt.container)
 

--- a/pkg/autodiscovery/listeners/kubelet.go
+++ b/pkg/autodiscovery/listeners/kubelet.go
@@ -117,7 +117,7 @@ func (l *KubeletListener) createContainerService(
 		containerName,
 		containerImg.RawName,
 		pod.Namespace,
-	) {
+	) || containers.IsExcludedByAnnotation(containers.GlobalFilter, pod.Annotations, containerName) {
 		log.Debugf("container %s filtered out: name %q image %q namespace %q", container.ID, containerName, containerImg.RawName, pod.Namespace)
 		return
 	}
@@ -166,13 +166,13 @@ func (l *KubeletListener) createContainerService(
 			containerName,
 			containerImg.RawName,
 			pod.Namespace,
-		) || !container.State.Running,
+		) || !container.State.Running || containers.IsExcludedByAnnotation(containers.MetricsFilter, pod.Annotations, containerName),
 		logsExcluded: l.IsExcluded(
 			containers.LogsFilter,
 			containerName,
 			containerImg.RawName,
 			pod.Namespace,
-		),
+		) || containers.IsExcludedByAnnotation(containers.LogsFilter, pod.Annotations, containerName),
 	}
 
 	adIdentifier := containerName

--- a/pkg/collector/corechecks/containers/generic/filters.go
+++ b/pkg/collector/corechecks/containers/generic/filters.go
@@ -51,7 +51,7 @@ func (f LegacyContainerFilter) IsExcluded(container *workloadmeta.Container) boo
 		return false
 	}
 
-	if container.Owner != nil && container.Owner.Kind == workloadmeta.KindKubernetesPod {
+	if container.IsOwnedByPod() {
 		pod, _ := workloadmeta.GetGlobalStore().GetKubernetesPod(container.Owner.ID)
 		if containers.IsExcludedByAnnotation(containers.GlobalFilter, pod.Annotations, container.Name) {
 			return true

--- a/pkg/collector/corechecks/containers/generic/filters.go
+++ b/pkg/collector/corechecks/containers/generic/filters.go
@@ -51,6 +51,13 @@ func (f LegacyContainerFilter) IsExcluded(container *workloadmeta.Container) boo
 		return false
 	}
 
+	if container.Owner != nil && container.Owner.Kind == workloadmeta.KindKubernetesPod {
+		pod, _ := workloadmeta.GetGlobalStore().GetKubernetesPod(container.Owner.ID)
+		if containers.IsExcludedByAnnotation(containers.GlobalFilter, pod.Annotations, container.Name) {
+			return true
+		}
+	}
+
 	return f.OldFilter.IsExcluded(container.Name, container.Image.Name, container.Labels[kubernetes.CriContainerNamespaceLabel])
 }
 

--- a/pkg/process/util/containers.go
+++ b/pkg/process/util/containers.go
@@ -106,7 +106,7 @@ func (p *containerProvider) GetContainers(cacheValidity time.Duration, previousC
 			continue
 		}
 
-		if container.Owner != nil && container.Owner.Kind == workloadmeta.KindKubernetesPod {
+		if container.IsOwnedByPod() {
 			if pod, err := p.metadataStore.GetKubernetesPod(container.Owner.ID); err == nil && containers.IsExcludedByAnnotation(containers.GlobalFilter, pod.Annotations, container.Name) {
 				continue
 			}

--- a/pkg/process/util/containers.go
+++ b/pkg/process/util/containers.go
@@ -106,6 +106,12 @@ func (p *containerProvider) GetContainers(cacheValidity time.Duration, previousC
 			continue
 		}
 
+		if container.Owner != nil && container.Owner.Kind == workloadmeta.KindKubernetesPod {
+			if pod, err := p.metadataStore.GetKubernetesPod(container.Owner.ID); err == nil && containers.IsExcludedByAnnotation(containers.GlobalFilter, pod.Annotations, container.Name) {
+				continue
+			}
+		}
+
 		if container.Runtime == workloadmeta.ContainerRuntimeGarden && len(container.CollectorTags) == 0 {
 			log.Debugf("No tags found for garden container: %s, skipping", container.ID)
 			continue

--- a/pkg/process/util/containers_test.go
+++ b/pkg/process/util/containers_test.go
@@ -52,6 +52,7 @@ func TestGetContainers(t *testing.T) {
 	// cID4 missing tags
 	// cID5 garden container full stats
 	// cID6 garden container missing tags
+	// cID7 container from pod with exclude annotation
 
 	// cID1 full stats
 	cID1Metrics := mock.GetFullSampleContainerEntry()
@@ -227,6 +228,64 @@ func TestGetContainers(t *testing.T) {
 			StartedAt: testTime,
 		},
 	})
+
+	// cID7 container from pod with exclude annotation
+	cID7Metrics := mock.GetFullSampleContainerEntry()
+	cID7Metrics.ContainerStats.Timestamp = testTime
+	cID7Metrics.NetworkStats.Timestamp = testTime
+	cID7Metrics.ContainerStats.PID.PIDs = []int{1, 2, 3}
+	metricsCollector.SetContainerEntry("cID7", cID7Metrics)
+	metadataProvider.SetEntity(&workloadmeta.KubernetesPod{
+		EntityID: workloadmeta.EntityID{
+			Kind: workloadmeta.KindKubernetesPod,
+			ID:   "pod7",
+		},
+		EntityMeta: workloadmeta.EntityMeta{
+			Name:      "foobar-pod7",
+			Namespace: "default",
+			Annotations: map[string]string{
+				fmt.Sprintf("ad.datadoghq.com/container7.exclude"): `true`,
+			},
+		},
+		IP: "127.0.0.1",
+	})
+	metadataProvider.SetEntity(&workloadmeta.Container{
+		EntityID: workloadmeta.EntityID{
+			Kind: workloadmeta.KindContainer,
+			ID:   "cID7",
+		},
+		EntityMeta: workloadmeta.EntityMeta{
+			Name:      "container7",
+			Namespace: "foo",
+		},
+		NetworkIPs: map[string]string{
+			"net1": "10.0.0.1",
+			"net2": "192.168.0.1",
+		},
+		Ports: []workloadmeta.ContainerPort{
+			{
+				Port:     420,
+				Protocol: "tcp",
+			},
+		},
+		Image: workloadmeta.ContainerImage{
+			ID:   "somesha",
+			Name: "myapp/foo",
+		},
+		Runtime: workloadmeta.ContainerRuntimeContainerd,
+		State: workloadmeta.ContainerState{
+			Running:   true,
+			Status:    workloadmeta.ContainerStatusRunning,
+			Health:    workloadmeta.ContainerHealthHealthy,
+			CreatedAt: testTime.Add(-10 * time.Minute),
+			StartedAt: testTime,
+		},
+		Owner: &workloadmeta.EntityID{
+			Kind: workloadmeta.KindKubernetesPod,
+			ID:   "pod7",
+		},
+	})
+	fakeTagger.SetTags(containers.BuildTaggerEntityName("cID7"), "fake", []string{"low:common"}, []string{"orch:orch7"}, []string{"id:container7"}, nil)
 
 	//
 	// Running and checking

--- a/pkg/util/containers/filter_test.go
+++ b/pkg/util/containers/filter_test.go
@@ -344,6 +344,34 @@ func TestFilter(t *testing.T) {
 	}
 }
 
+func TestIsExcludedByAnnotation(t *testing.T) {
+	containerExcludeName := "foo"
+	containerIncludeName := "bar"
+	containerNoMentionName := "other"
+	annotations := map[string]string{
+		fmt.Sprintf("ad.datadoghq.com/%s.exclude", containerExcludeName):         `true`,
+		fmt.Sprintf("ad.datadoghq.com/%s.metrics_exclude", containerExcludeName): `true`,
+		fmt.Sprintf("ad.datadoghq.com/%s.logs_exclude", containerExcludeName):    `true`,
+		fmt.Sprintf("ad.datadoghq.com/%s.exclude", containerIncludeName):         `false`,
+		fmt.Sprintf("ad.datadoghq.com/%s.metrics_exclude", containerIncludeName): `false`,
+		fmt.Sprintf("ad.datadoghq.com/%s.logs_exclude", containerIncludeName):    `false`,
+	}
+
+	assert.True(t, IsExcludedByAnnotation(GlobalFilter, annotations, containerExcludeName))
+	assert.True(t, IsExcludedByAnnotation(MetricsFilter, annotations, containerExcludeName))
+	assert.True(t, IsExcludedByAnnotation(LogsFilter, annotations, containerExcludeName))
+
+	assert.False(t, IsExcludedByAnnotation(GlobalFilter, annotations, containerIncludeName))
+	assert.False(t, IsExcludedByAnnotation(MetricsFilter, annotations, containerIncludeName))
+	assert.False(t, IsExcludedByAnnotation(LogsFilter, annotations, containerIncludeName))
+
+	assert.False(t, IsExcludedByAnnotation(GlobalFilter, annotations, containerNoMentionName))
+	assert.False(t, IsExcludedByAnnotation(MetricsFilter, annotations, containerNoMentionName))
+	assert.False(t, IsExcludedByAnnotation(LogsFilter, annotations, containerNoMentionName))
+
+	assert.False(t, IsExcludedByAnnotation(GlobalFilter, nil, containerExcludeName))
+}
+
 func TestNewMetricFilterFromConfig(t *testing.T) {
 	config.Datadog.SetDefault("exclude_pause_container", true)
 	config.Datadog.SetDefault("ac_include", []string{"image:apache.*"})

--- a/pkg/util/containers/filter_test.go
+++ b/pkg/util/containers/filter_test.go
@@ -357,6 +357,13 @@ func TestIsExcludedByAnnotation(t *testing.T) {
 		fmt.Sprintf("ad.datadoghq.com/%s.logs_exclude", containerIncludeName):    `false`,
 	}
 
+	containerlessAnnotations := map[string]string{
+		"ad.datadoghq.com/exclude":         `true`,
+		"ad.datadoghq.com/metrics_exclude": `true`,
+		"ad.datadoghq.com/logs_exclude":    `true`,
+	}
+
+	// Container-specific annotations
 	assert.True(t, IsExcludedByAnnotation(GlobalFilter, annotations, containerExcludeName))
 	assert.True(t, IsExcludedByAnnotation(MetricsFilter, annotations, containerExcludeName))
 	assert.True(t, IsExcludedByAnnotation(LogsFilter, annotations, containerExcludeName))
@@ -368,6 +375,19 @@ func TestIsExcludedByAnnotation(t *testing.T) {
 	assert.False(t, IsExcludedByAnnotation(GlobalFilter, annotations, containerNoMentionName))
 	assert.False(t, IsExcludedByAnnotation(MetricsFilter, annotations, containerNoMentionName))
 	assert.False(t, IsExcludedByAnnotation(LogsFilter, annotations, containerNoMentionName))
+
+	// Container-less annotations
+	assert.True(t, IsExcludedByAnnotation(GlobalFilter, containerlessAnnotations, containerExcludeName))
+	assert.True(t, IsExcludedByAnnotation(MetricsFilter, containerlessAnnotations, containerExcludeName))
+	assert.True(t, IsExcludedByAnnotation(LogsFilter, containerlessAnnotations, containerExcludeName))
+
+	assert.True(t, IsExcludedByAnnotation(GlobalFilter, containerlessAnnotations, containerIncludeName))
+	assert.True(t, IsExcludedByAnnotation(MetricsFilter, containerlessAnnotations, containerIncludeName))
+	assert.True(t, IsExcludedByAnnotation(LogsFilter, containerlessAnnotations, containerIncludeName))
+
+	assert.True(t, IsExcludedByAnnotation(GlobalFilter, containerlessAnnotations, containerNoMentionName))
+	assert.True(t, IsExcludedByAnnotation(MetricsFilter, containerlessAnnotations, containerNoMentionName))
+	assert.True(t, IsExcludedByAnnotation(LogsFilter, containerlessAnnotations, containerNoMentionName))
 
 	assert.False(t, IsExcludedByAnnotation(GlobalFilter, nil, containerExcludeName))
 }

--- a/pkg/workloadmeta/types.go
+++ b/pkg/workloadmeta/types.go
@@ -453,6 +453,11 @@ func (c Container) String(verbose bool) string {
 	return sb.String()
 }
 
+// IsOwnedByPod checks if a container's Owner is a KindKubernetesPod
+func (c *Container) IsOwnedByPod() bool {
+	return c.Owner != nil && c.Owner.Kind == KindKubernetesPod
+}
+
 var _ Entity = &Container{}
 
 // ContainerFilterFunc is a function used to filter containers.

--- a/releasenotes/notes/ad-exclude-annotations-0cce55729c053b9d.yaml
+++ b/releasenotes/notes/ad-exclude-annotations-0cce55729c053b9d.yaml
@@ -1,0 +1,14 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Add ability to filter kubernetes containers based on autodiscovery annotation. Containers in a pod
+    can now be omitted by setting `ad.datadoghq.com/<container_name>.exclude` as an annotation on the
+    pod. Logs can now be ommitted by setting `ad.datadoghq.com/<container_name>.logs_exclude` as an
+    annotation on the pod.


### PR DESCRIPTION
### What does this PR do?

This PR adds container filtering based on pod annotations. It adds support for the following annotations:
- `ad.datadoghq.com/<container_name>.exclude`
- `ad.datadoghq.com/<container_name>.logs_exclude`
- `ad.datadoghq.com/<container_name>.metrics_exclude`
- `ad.datadoghq.com/exclude`
- `ad.datadoghq.com/logs_exclude`
- `ad.datadoghq.com/metrics_exclude`

### Motivation

Before this change, we supported excluding containers from collection based on environment variables set on the agent itself. This became problematic when needing to add new containers to exclude, because it required the user to redeploy the agent stack in order for the changes to take affect.

### Additional Notes

Right now, only kubernetes pod annotations are supported. If the desire is there to build this out further, we can do that later.

### Possible Drawbacks / Trade-offs

I really, really wanted this change to be part of containers.Filter.IsExcluded(). The fact that there are now two filter check functions seems less than ideal to me, in a way that makes it come across as very hacky.

The reason I went with this implementation was because of the container listener in the autodiscovery package. The containers do not have knowledge of kubernetes pod annotations, so we would need to determine what pod the container belongs to, which is costly and we do not want to do it if the container is excluded already based on config. But the filter IsExcluded check has the potential to also be costly, because it is doing a bunch of regex matches.

Please let me know if I am overthinking this, or if I missed something here, or if you have any concerns as a result of this drawback.

### Describe how to test/QA your changes

1. Deploy a pod to a kubernetes environment with 2 containers. Decide which container you want to filter. 
2. Add the `ad.datadoghq.com/<container_name>.exclude: "true"` annotation to the pod, and now no data should be coming in for live containers or for logs. 
3. Now, set that annotation to false and add `ad.datadoghq.com/<container_name>.logs_exclude: "true"` as an annotation to the pod, and now there should be data in the live containers view but no logs. 

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
