### PR TITLE
[single-machine-performance] post report to GitHub

### DIFF
--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -95,7 +95,7 @@ single-machine-performance-regression_detector:
     # Install `wheel` and some other build-related packages so `dd-package` doesn't just throw an `invalid command 'bdist_wheel'`
     # error when installing `pr-commenter`. Use more recent pip for its dependency resolver.
     - apt-get install -y python3-venv python3-pip  # `venv` and `pip` should already be installed, but don't leave it to chance
-    - python3 -m pip install pip==23.0.1 setuptools=67.0.1 wheel==0.40.0
+    - python3 -m pip install pip==23.0.1 setuptools==67.6.1 wheel==0.40.0
     - dd-package --bucket binaries.ddbuild.io --package devtools/pr-commenter
     # Post HTML report to GitHub
     - cat outputs/report.html | /usr/local/bin/pr-commenter --for-repo="$CI_PROJECT_NAME" --for-pr="$CI_COMMIT_REF_NAME"

--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -93,12 +93,14 @@ single-machine-performance-regression_detector:
     - rm dd-package.deb
     - apt-get update
     - dd-package --bucket binaries.ddbuild.io --package devtools/dd-package-dev
+    # Kludge from https://gitlab.com/gitlab-org/gitlab-runner/-/issues/4645#note_287636439 to avoid
+    # doubled output
     - echo ""
-    - echo "======================= NOTE TO MAINTAINERS ====================================="
-    - echo "| Ignore bdist_wheel build error raised when installing 'devtools/pr-commenter' |"
-    - echo "| This error is known behavior, and you should see a successful install         |"
-    - echo "| beneath the error message in the GitLab CI logs                               |"
-    - echo "================================================================================="
+    - "####################### NOTE TO MAINTAINERS #####################################"
+    - "# Ignore bdist_wheel build error raised when installing 'devtools/pr-commenter' #"
+    - "# This error is known behavior, and you should see a successful install         #"
+    - "# beneath the error message in the GitLab CI logs                               #"
+    - "#################################################################################"
     - echo ""
     - dd-package --bucket binaries.ddbuild.io --package devtools/pr-commenter
     # Post HTML report to GitHub

--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -95,7 +95,8 @@ single-machine-performance-regression_detector:
     # Install `wheel` and some other build-related packages so `dd-package` doesn't just throw an `invalid command 'bdist_wheel'`
     # error when installing `pr-commenter`. Use more recent pip for its dependency resolver.
     - apt-get install -y python3-venv python3-pip  # `venv` and `pip` should already be installed, but don't leave it to chance
-    - python3 -m pip install pip==23.0.1 setuptools==67.6.1 wheel==0.40.0
+    # - python3 -m pip install pip==23.0.1 setuptools==67.6.1 wheel==0.40.0 # This line seems useless
+    - dd-package --bucket binaries.ddbuild.io --package devtools/dd-package-dev
     - dd-package --bucket binaries.ddbuild.io --package devtools/pr-commenter
     # Post HTML report to GitHub
     - cat outputs/report.html | /usr/local/bin/pr-commenter --for-repo="$CI_PROJECT_NAME" --for-pr="$CI_COMMIT_REF_NAME"

--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -84,6 +84,15 @@ single-machine-performance-regression_detector:
     # space characters. This avoids
     # https://gitlab.com/gitlab-org/gitlab/-/issues/217231.
     - cat outputs/report.md | sed "s/^\$/$(echo -ne '\uFEFF\u00A0\u200B')/g"
+    # Add janky means of installing PR commenter borrowed from 
+    # https://github.com/DataDog/dogweb/blob/45d7fcf035d0d515ebd901919099d4c8bfa82829/docker/docker-builder/Dockerfile#L69-L77
+    - apt-get update
+    - apt-get install -y curl
+    - curl -OL https://s3.amazonaws.com/dd-package-public/dd-package.deb
+    - dpkg -i dd-package.deb
+    - rm dd-package.deb
+    - apt-get update
+    - dd-package --bucket binaries.ddbuild.io devtools/pr-commenter --distribution "20.04"
     # Post HTML report to GitHub
     - cat outputs/report.html | /usr/local/bin/pr-commenter --for-repo="$CI_PROJECT_NAME" --for-pr="$CI_COMMIT_REF_NAME"
     # Finally, exit 1 if the job signals a regression else 0.

--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -92,11 +92,14 @@ single-machine-performance-regression_detector:
     - dpkg -i dd-package.deb
     - rm dd-package.deb
     - apt-get update
-    # Install `wheel` and some other build-related packages so `dd-package` doesn't just throw an `invalid command 'bdist_wheel'`
-    # error when installing `pr-commenter`. Use more recent pip for its dependency resolver.
-    - apt-get install -y python3-venv python3-pip  # `venv` and `pip` should already be installed, but don't leave it to chance
-    # - python3 -m pip install pip==23.0.1 setuptools==67.6.1 wheel==0.40.0 # This line seems useless
     - dd-package --bucket binaries.ddbuild.io --package devtools/dd-package-dev
+    - echo ""
+    - echo "======================= NOTE TO MAINTAINERS ====================================="
+    - echo "| Ignore bdist_wheel build error raised when installing 'devtools/pr-commenter' |"
+    - echo "| This error is known behavior, and you should see a successful install         |"
+    - echo "| beneath the error message in the GitLab CI logs                               |"
+    - echo "================================================================================="
+    - echo ""
     - dd-package --bucket binaries.ddbuild.io --package devtools/pr-commenter
     # Post HTML report to GitHub
     - cat outputs/report.html | /usr/local/bin/pr-commenter --for-pr="$CI_COMMIT_REF_NAME"

--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -92,7 +92,7 @@ single-machine-performance-regression_detector:
     - dpkg -i dd-package.deb
     - rm dd-package.deb
     - apt-get update
-    - dd-package --bucket binaries.ddbuild.io devtools/pr-commenter --distribution "20.04"
+    - dd-package --bucket binaries.ddbuild.io --package devtools/pr-commenter --distribution "20.04"
     # Post HTML report to GitHub
     - cat outputs/report.html | /usr/local/bin/pr-commenter --for-repo="$CI_PROJECT_NAME" --for-pr="$CI_COMMIT_REF_NAME"
     # Finally, exit 1 if the job signals a regression else 0.

--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -99,7 +99,7 @@ single-machine-performance-regression_detector:
     - dd-package --bucket binaries.ddbuild.io --package devtools/dd-package-dev
     - dd-package --bucket binaries.ddbuild.io --package devtools/pr-commenter
     # Post HTML report to GitHub
-    - cat outputs/report.html | /usr/local/bin/pr-commenter --for-repo="$CI_PROJECT_NAME" --for-pr="$CI_COMMIT_REF_NAME"
+    - cat outputs/report.html | /usr/local/bin/pr-commenter --for-pr="$CI_COMMIT_REF_NAME"
     # Finally, exit 1 if the job signals a regression else 0.
     - RUST_LOG="${RUST_LOG}" ./smp --team-id ${SMP_AGENT_TEAM_ID} --aws-named-profile ${AWS_NAMED_PROFILE}
             job result

--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -84,6 +84,8 @@ single-machine-performance-regression_detector:
     # space characters. This avoids
     # https://gitlab.com/gitlab-org/gitlab/-/issues/217231.
     - cat outputs/report.md | sed "s/^\$/$(echo -ne '\uFEFF\u00A0\u200B')/g"
+    # Post HTML report to GitHub
+    - cat outputs/report.html | /usr/local/bin/pr-commenter --for-repo="$CI_PROJECT_NAME" --for-pr="$CI_COMMIT_REF_NAME"
     # Finally, exit 1 if the job signals a regression else 0.
     - RUST_LOG="${RUST_LOG}" ./smp --team-id ${SMP_AGENT_TEAM_ID} --aws-named-profile ${AWS_NAMED_PROFILE}
             job result

--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -92,6 +92,10 @@ single-machine-performance-regression_detector:
     - dpkg -i dd-package.deb
     - rm dd-package.deb
     - apt-get update
+    # Install `wheel` and some other build-related packages so `dd-package` doesn't just throw an `invalid command 'bdist_wheel'`
+    # error when installing `pr-commenter`. Use more recent pip for its dependency resolver.
+    - apt-get install -y python3-venv python3-pip  # `venv` and `pip` should already be installed, but don't leave it to chance
+    - python3 -m pip install pip==23.0.1 setuptools=67.0.1 wheel==0.40.0
     - dd-package --bucket binaries.ddbuild.io --package devtools/pr-commenter
     # Post HTML report to GitHub
     - cat outputs/report.html | /usr/local/bin/pr-commenter --for-repo="$CI_PROJECT_NAME" --for-pr="$CI_COMMIT_REF_NAME"

--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -92,7 +92,7 @@ single-machine-performance-regression_detector:
     - dpkg -i dd-package.deb
     - rm dd-package.deb
     - apt-get update
-    - dd-package --bucket binaries.ddbuild.io --package devtools/pr-commenter --distribution "20.04"
+    - dd-package --bucket binaries.ddbuild.io --package devtools/pr-commenter
     # Post HTML report to GitHub
     - cat outputs/report.html | /usr/local/bin/pr-commenter --for-repo="$CI_PROJECT_NAME" --for-pr="$CI_COMMIT_REF_NAME"
     # Finally, exit 1 if the job signals a regression else 0.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This pull request adds a command to the project GitLab CI configuration that emits an HTML report from the Single Machine Performance regression detector to a GitHub PR comment using the [GitHub PR Commenter
Bot](https://github.com/DataDog/devtools/tree/master/deb/pr-commenter) by analogy to other uses of the GitHub PR Commenter Bot in Agent's GitLab CI configuration.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Make Single Machine Performance regression detector results more visible via PR comment threads.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

n/a

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

Trades off increasing visibility of regression detector results for longer comment threads.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
~~Unsure.~~ Assuming the configuration change succeeds, regression detector comments should appear in GitHub PRs.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
