### PR TITLE
Use tracefs package from ebpf-manager

### DIFF
--- a/pkg/ebpf/debuglog_dumper.go
+++ b/pkg/ebpf/debuglog_dumper.go
@@ -11,13 +11,12 @@ package ebpf
 import (
 	"bufio"
 	"context"
-	"errors"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
 
-	utilkernel "github.com/DataDog/datadog-agent/pkg/util/kernel"
+	"github.com/DataDog/ebpf-manager/tracefs"
 )
 
 // DumpDebugLog is a utility to write the debug log of the running application to a given writer.
@@ -33,11 +32,7 @@ func DumpDebugLog(ctx context.Context, writer io.Writer) error {
 		maxFilenameSize = len(filename)
 	}
 
-	tracefsPath := utilkernel.GetTraceFSMountPath()
-	if tracefsPath == "" {
-		return errors.New("tracefs not available")
-	}
-	f, err := os.Open(filepath.Join(tracefsPath, "trace_pipe"))
+	f, err := tracefs.OpenFile("trace_pipe", os.O_RDONLY, 0)
 	if err != nil {
 		return err
 	}

--- a/pkg/flare/archive_linux.go
+++ b/pkg/flare/archive_linux.go
@@ -10,16 +10,16 @@ package flare
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"io"
 	"path/filepath"
 	"regexp"
 	"syscall"
 
+	"github.com/DataDog/ebpf-manager/tracefs"
+
 	flarehelpers "github.com/DataDog/datadog-agent/comp/core/flare/helpers"
 	"github.com/DataDog/datadog-agent/pkg/config"
-	utilkernel "github.com/DataDog/datadog-agent/pkg/util/kernel"
 )
 
 func addSystemProbePlatformSpecificEntries(fb flarehelpers.FlareBuilder) {
@@ -34,9 +34,9 @@ func getLinuxKernelSymbols(fb flarehelpers.FlareBuilder) error {
 }
 
 func getLinuxKprobeEvents(fb flarehelpers.FlareBuilder) error {
-	traceFSPath := utilkernel.GetTraceFSMountPath()
-	if traceFSPath == "" {
-		return errors.New("tracefs not available")
+	traceFSPath, err := tracefs.Root()
+	if err != nil {
+		return err
 	}
 	return fb.CopyFile(filepath.Join(traceFSPath, "kprobe_events"))
 }
@@ -104,17 +104,17 @@ func getLinuxDmesg(fb flarehelpers.FlareBuilder) error {
 }
 
 func getLinuxTracingAvailableEvents(fb flarehelpers.FlareBuilder) error {
-	traceFSPath := utilkernel.GetTraceFSMountPath()
-	if traceFSPath == "" {
-		return errors.New("tracefs not available")
+	traceFSPath, err := tracefs.Root()
+	if err != nil {
+		return err
 	}
 	return fb.CopyFile(filepath.Join(traceFSPath, "available_events"))
 }
 
 func getLinuxTracingAvailableFilterFunctions(fb flarehelpers.FlareBuilder) error {
-	traceFSPath := utilkernel.GetTraceFSMountPath()
-	if traceFSPath == "" {
-		return errors.New("tracefs not available")
+	traceFSPath, err := tracefs.Root()
+	if err != nil {
+		return err
 	}
 	return fb.CopyFile(filepath.Join(traceFSPath, "available_filter_functions"))
 }

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/DataDog/ebpf-manager/tracefs"
 	"github.com/cilium/ebpf"
 	"go.uber.org/atomic"
 
@@ -108,8 +109,7 @@ func NewTracer(config *config.Config) (*Tracer, error) {
 // newTracer is an internal function used by tests primarily
 // (and NewTracer above)
 func newTracer(config *config.Config) (*Tracer, error) {
-	// make sure debugfs is mounted
-	if mounted, err := kernel.IsDebugFSOrTraceFSMounted(); !mounted {
+	if _, err := tracefs.Root(); err != nil {
 		return nil, fmt.Errorf("system-probe unsupported: %s", err)
 	}
 

--- a/pkg/security/probe/probe_linux.go
+++ b/pkg/security/probe/probe_linux.go
@@ -19,6 +19,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/DataDog/ebpf-manager/tracefs"
 	"github.com/hashicorp/go-multierror"
 	easyjson "github.com/mailru/easyjson"
 	"github.com/moby/sys/mountinfo"
@@ -138,7 +139,7 @@ func (p *Probe) UseRingBuffers() bool {
 
 func (p *Probe) sanityChecks() error {
 	// make sure debugfs is mounted
-	if mounted, err := utilkernel.IsDebugFSOrTraceFSMounted(); !mounted {
+	if _, err := tracefs.Root(); err != nil {
 		return err
 	}
 

--- a/pkg/security/tests/trace_pipe.go
+++ b/pkg/security/tests/trace_pipe.go
@@ -19,15 +19,13 @@ package tests
 
 import (
 	"bufio"
-	"errors"
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
 	"regexp"
 	"strings"
 
-	utilkernel "github.com/DataDog/datadog-agent/pkg/util/kernel"
+	"github.com/DataDog/ebpf-manager/tracefs"
 )
 
 // TracePipe to read from /sys/kernel/[debug/]tracing/trace_pipe
@@ -58,11 +56,7 @@ type TraceEvent struct {
 
 // NewTracePipe instantiates a new trace pipe
 func NewTracePipe() (*TracePipe, error) {
-	traceFSPath := utilkernel.GetTraceFSMountPath()
-	if traceFSPath == "" {
-		return nil, errors.New("tracefs is not available")
-	}
-	f, err := os.Open(filepath.Join(traceFSPath, "trace_pipe"))
+	f, err := tracefs.OpenFile("trace_pipe", os.O_RDONLY, 0)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/util/kernel/fs.go
+++ b/pkg/util/kernel/fs.go
@@ -12,13 +12,10 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/moby/sys/mountinfo"
 
 	"github.com/DataDog/datadog-agent/pkg/process/util"
-	"github.com/DataDog/datadog-agent/pkg/security/seclog"
-	"github.com/DataDog/datadog-agent/pkg/util/fargate"
 )
 
 // MountInfoPidPath returns the path to the mountinfo file of a pid in /proc
@@ -35,139 +32,4 @@ func ParseMountInfoFile(pid int32) ([]*mountinfo.Info, error) {
 	defer f.Close()
 
 	return mountinfo.GetMountsFromReader(f, nil)
-}
-
-// GetMountPoint returns the mount point of the given path
-func GetMountPoint(path string) (*mountinfo.Info, error) {
-	if path == "" {
-		return nil, fmt.Errorf("empty path")
-	}
-
-	mi, err := mountinfo.GetMounts(nil)
-	if err != nil {
-		return nil, err
-	}
-
-	for {
-		for _, m := range mi {
-			if path == m.Mountpoint {
-				return m, nil
-			}
-		}
-
-		if path == "/" {
-			break
-		}
-		path = filepath.Dir(path)
-	}
-
-	return nil, fmt.Errorf("no matching mountpoint found")
-}
-
-// isDebugFSMounted would test the existence of file /sys/kernel/debug/tracing/kprobe_events to determine if debugfs (or debugfs AND tracefs) is/are mounted or not
-// returns a boolean and a possible error message
-func isDebugFSMounted() (bool, error) {
-	_, err := os.Stat("/sys/kernel/debug/tracing/kprobe_events")
-	if err != nil {
-		if os.IsPermission(err) {
-			return false, fmt.Errorf("eBPF not supported, does not have permission to access debugfs")
-		} else if os.IsNotExist(err) {
-			return false, fmt.Errorf("debugfs is not mounted and is needed for eBPF-based checks, run \"sudo mount -t debugfs none /sys/kernel/debug\" to mount debugfs")
-		} else {
-			return false, fmt.Errorf("an error occurred while accessing debugfs: %w", err)
-		}
-	}
-
-	mi, err := GetMountPoint("/sys/kernel/debug/tracing/kprobe_events")
-	if err != nil {
-		return false, fmt.Errorf("unable to detect debugfs mount point: %w", err)
-	}
-
-	if mi.FSType != "tracefs" && mi.FSType != "debugfs" {
-		return false, fmt.Errorf("kprobe_events mount point(%s): wrong fs type(%s)", mi.Mountpoint, mi.FSType)
-	}
-
-	// on fargate, kprobe_events is mounted as ro
-	if !fargate.IsFargateInstance() {
-		options := strings.Split(mi.Options, ",")
-		for _, option := range options {
-			if option == "ro" {
-				return false, fmt.Errorf("kprobe_events mount point(%s) is in read-only mode", mi.Mountpoint)
-			}
-		}
-	}
-
-	return true, nil
-}
-
-// isTraceFSMounted would test the existence of file /sys/kernel/tracing/kprobe_events to determine if tracefs is mounted (and debugfs is not)
-// returns a boolean and a possible error message
-func isTraceFSMounted() bool {
-	_, err := os.Stat("/sys/kernel/tracing/kprobe_events")
-	if err != nil {
-		if os.IsPermission(err) {
-			seclog.Infof("eBPF not supported, does not have permission to access tracefs kprobe_events (/sys/kernel/tracing/kprobe_events)")
-			return false
-		} else if os.IsNotExist(err) {
-			seclog.Infof("tracefs is not mounted in /sys/kernel/tracing/ and is needed for eBPF-based checks, run \"sudo mount -t tracefs none /sys/kernel/tracing\" to mount tracefs")
-			return false
-		} else {
-			seclog.Infof("an error occurred while accessing tracefs sysfs entry (/sys/kernel/tracing/kprobe_events): %s", err)
-			return false
-		}
-	}
-
-	mi, err := GetMountPoint("/sys/kernel/tracing/kprobe_events")
-	if err != nil {
-		seclog.Infof("unable to detect tracefs mount point (/sys/kernel/tracing/): %s", err)
-		return false
-	}
-
-	if mi.FSType != "tracefs" {
-		seclog.Infof("kprobe_events mount point(%s): wrong fs type(%s)", mi.Mountpoint, mi.FSType)
-		return false
-	}
-
-	// on fargate, kprobe_events is mounted as ro
-	if !fargate.IsFargateInstance() {
-		options := strings.Split(mi.Options, ",")
-		for _, option := range options {
-			if option == "ro" {
-				seclog.Infof("tracefs mount point(%s) is in read-only mode", mi.Mountpoint)
-				return false
-			}
-		}
-	}
-
-	return true
-}
-
-// Cf https://www.kernel.org/doc/Documentation/trace/ftrace.txt :
-//     [...] When tracefs is configured into the kernel (which selecting any ftrace
-//     option will do) the directory /sys/kernel/tracing will be created.
-//     [...] Before 4.1, all ftrace tracing control files were within the debugfs
-//     file system, which is typically located at /sys/kernel/debug/tracing.
-//     For backward compatibility, when mounting the debugfs file system,
-//     the tracefs file system will be automatically mounted at:
-//      /sys/kernel/debug/tracing
-//     All files located in the tracefs file system will be located in that
-//     debugfs file system directory as well.
-
-// IsDebugFSOrTraceFSMounted would test the existence of file /sys/kernel/tracing/kprobe_events to determine if tracefs is mounted or not
-// returns a boolean and a possible error message
-func IsDebugFSOrTraceFSMounted() (bool, error) {
-	isMounted := isTraceFSMounted()
-	if isMounted {
-		return true, nil
-	}
-	return isDebugFSMounted()
-}
-
-func GetTraceFSMountPath() string {
-	if isTraceFSMounted() {
-		return "/sys/kernel/tracing"
-	} else if isMounted, _ := isDebugFSMounted(); isMounted {
-		return "/sys/kernel/debug/tracing"
-	}
-	return ""
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Uses the `tracefs` package from `ebpf-manager` to handle debugfs/tracefs usage and detection.

### Motivation

Simpler logic and better log messages.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
