### PR TITLE
(7.44.1) [process-agent] Cache call to `user.LookupId`

### DIFF
--- a/pkg/config/process.go
+++ b/pkg/config/process.go
@@ -191,6 +191,8 @@ func setupProcesses(config Config) {
 	procBindEnvAndSetDefault(config, "process_config.event_collection.enabled", false)
 	procBindEnvAndSetDefault(config, "process_config.event_collection.interval", DefaultProcessEventsCheckInterval)
 
+	procBindEnvAndSetDefault(config, "process_config.cache_lookupid", false)
+
 	processesAddOverrideOnce.Do(func() {
 		AddOverrideFunc(loadProcessTransforms)
 	})

--- a/pkg/process/checks/process_nix.go
+++ b/pkg/process/checks/process_nix.go
@@ -37,7 +37,7 @@ func lookupIdWithCache(uid string) (*user.User, error) {
 		var err error
 		u, err := userLookupFunc(uid)
 		if err == nil {
-			formatUserCache.SetDefault(uid, result)
+			formatUserCache.SetDefault(uid, u)
 		} else {
 			formatUserCache.SetDefault(uid, err)
 		}

--- a/pkg/process/checks/process_nix.go
+++ b/pkg/process/checks/process_nix.go
@@ -11,24 +11,54 @@ package checks
 import (
 	"os/user"
 	"strconv"
+	"time"
 
 	model "github.com/DataDog/agent-payload/v5/process"
 	"github.com/DataDog/gopsutil/cpu"
 
+	"github.com/patrickmn/go-cache"
+
 	"github.com/DataDog/datadog-agent/pkg/process/procutil"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/system"
 )
 
 var (
 	// overridden in tests
 	hostCPUCount = system.HostCPUCount
+
+	formatUserCache = cache.New(time.Hour, time.Hour) // Used by lookupIdWithCache
+	userLookupFunc  = user.LookupId                   // Overridden in tests
 )
+
+func lookupIdWithCache(uid string) (*user.User, error) {
+	result, ok := formatUserCache.Get(uid)
+	if !ok {
+		var err error
+		u, err := userLookupFunc(uid)
+		if err == nil {
+			formatUserCache.SetDefault(uid, result)
+		} else {
+			formatUserCache.SetDefault(uid, err)
+		}
+		return u, err
+	}
+
+	switch v := result.(type) {
+	case *user.User:
+		return v, nil
+	case error:
+		return nil, v
+	default:
+		return nil, log.Error("Unknown value cached in formatUserCache for uid:", uid)
+	}
+}
 
 func formatUser(fp *procutil.Process) *model.ProcessUser {
 	var username string
 	var uid, gid int32
 	if len(fp.Uids) > 0 {
-		u, err := user.LookupId(strconv.Itoa(int(fp.Uids[0])))
+		u, err := lookupIdWithCache(strconv.Itoa(int(fp.Uids[0])))
 		if err == nil {
 			username = u.Username
 		}

--- a/pkg/process/checks/process_nix_test.go
+++ b/pkg/process/checks/process_nix_test.go
@@ -10,7 +10,6 @@ package checks
 
 import (
 	"fmt"
-	"os/user"
 	"regexp"
 	"sort"
 	"testing"
@@ -20,7 +19,6 @@ import (
 
 	model "github.com/DataDog/agent-payload/v5/process"
 	"github.com/DataDog/gopsutil/cpu"
-	"github.com/patrickmn/go-cache"
 
 	"github.com/DataDog/datadog-agent/pkg/process/procutil"
 )
@@ -123,7 +121,7 @@ func TestBasicProcessMessages(t *testing.T) {
 				disallowList = append(disallowList, regexp.MustCompile(s))
 			}
 
-			procs := fmtProcesses(procutil.NewDefaultDataScrubber(), disallowList, tc.processes, tc.processes, tc.pidToCid, syst2, syst1, lastRun, nil)
+			procs := fmtProcesses(procutil.NewDefaultDataScrubber(), disallowList, tc.processes, tc.processes, tc.pidToCid, syst2, syst1, lastRun, nil, nil)
 			messages, totalProcs, totalContainers := createProcCtrMessages(hostInfo, procs, tc.containers, tc.maxSize, maxBatchBytes, int32(i), "nid", 0)
 
 			assert.Equal(t, tc.expectedChunks, len(messages))
@@ -234,7 +232,7 @@ func TestContainerProcessChunking(t *testing.T) {
 			sysInfo := &model.SystemInfo{}
 			hostInfo := &HostInfo{SystemInfo: sysInfo}
 
-			processes := fmtProcesses(procutil.NewDefaultDataScrubber(), nil, procsByPid, procsByPid, pidToCid, syst2, syst1, lastRun, nil)
+			processes := fmtProcesses(procutil.NewDefaultDataScrubber(), nil, procsByPid, procsByPid, pidToCid, syst2, syst1, lastRun, nil, nil)
 			messages, totalProcs, totalContainers := createProcCtrMessages(hostInfo, processes, ctrs, tc.maxSize, maxBatchBytes, int32(i), "nid", 0)
 
 			assert.Equal(t, tc.expectedProcCount, totalProcs)
@@ -368,75 +366,6 @@ func TestFormatCPUTimes(t *testing.T) {
 			assert.Equal(t, test.expected, formatCPUTimes(
 				test.statsNow, test.statsNow.CPUTime, test.statsPrev, test.timeNow, test.timeBefore,
 			))
-		})
-	}
-}
-
-func TestLookupUserWithId(t *testing.T) {
-	for _, tc := range []struct {
-		name          string
-		expectedUser  *user.User
-		expectedError error
-		ttl           time.Duration
-	}{
-		{
-			name:         "user found",
-			expectedUser: &user.User{Name: "steve"},
-			ttl:          cache.NoExpiration,
-		},
-		{
-			name:          "user not found",
-			expectedError: user.UnknownUserIdError(0),
-			ttl:           cache.NoExpiration,
-		},
-	} {
-		const testUID = "0"
-		t.Run(tc.name, func(t *testing.T) {
-			oldUserLookupFunc := userLookupFunc
-			t.Cleanup(func() { userLookupFunc = oldUserLookupFunc })
-			t.Cleanup(func() { formatUserCache = cache.New(tc.ttl, cache.NoExpiration) })
-
-			var timesCalled int
-			userLookupFunc = func(inputUid string) (*user.User, error) {
-				// Make sure this function is called once despite the fact that we call `lookupIdWithCache`.
-				// This should simulate a cache hit vs a miss.
-				timesCalled++
-				assert.Equal(t, 1, timesCalled)
-
-				assert.Equal(t, testUID, inputUid)
-				if tc.expectedError != nil {
-					return nil, tc.expectedError
-				}
-				return tc.expectedUser, nil
-			}
-
-			checkResult := func(u *user.User, err error) {
-				t.Helper()
-
-				if tc.expectedUser != nil {
-					assert.Equal(t, tc.expectedUser.Name, u.Name)
-				} else {
-					assert.Nil(t, tc.expectedUser)
-				}
-
-				assert.ErrorIs(t, tc.expectedError, err)
-			}
-
-			checkCacheResult := func(res interface{}, ok bool) {
-				t.Helper()
-
-				assert.True(t, ok)
-				switch v := res.(type) {
-				case *user.User:
-					assert.Equal(t, tc.expectedUser.Name, v.Name)
-				case error:
-					assert.ErrorIs(t, v, tc.expectedError)
-				}
-			}
-
-			checkResult(lookupIdWithCache(testUID))
-			checkCacheResult(formatUserCache.Get(testUID))
-			checkResult(lookupIdWithCache(testUID))
 		})
 	}
 }

--- a/pkg/process/checks/process_test.go
+++ b/pkg/process/checks/process_test.go
@@ -410,8 +410,7 @@ func TestProcessWithNoCommandline(t *testing.T) {
 
 	var disallowList []*regexp.Regexp
 
-	procs := fmtProcesses(procutil.NewDefaultDataScrubber(), disallowList, procMap, procMap, nil,
-		syst2, syst1, lastRun, nil)
+	procs := fmtProcesses(procutil.NewDefaultDataScrubber(), disallowList, procMap, procMap, nil, syst2, syst1, lastRun, nil, nil)
 	assert.Len(t, procs, 1)
 
 	require.Len(t, procs[""], 1)

--- a/pkg/process/checks/process_windows.go
+++ b/pkg/process/checks/process_windows.go
@@ -23,7 +23,7 @@ var (
 	numCPU = runtime.NumCPU
 )
 
-func formatUser(fp *procutil.Process) *model.ProcessUser {
+func formatUser(fp *procutil.Process, _ *LookupIdProbe) *model.ProcessUser {
 	return &model.ProcessUser{
 		Name: fp.Username,
 	}

--- a/pkg/process/checks/user_nix.go
+++ b/pkg/process/checks/user_nix.go
@@ -1,0 +1,67 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !windows
+
+package checks
+
+import (
+	"os/user"
+	"time"
+
+	"github.com/patrickmn/go-cache"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+type LookupIdProbe struct {
+	config config.ConfigReader
+	log    *log.DatadogLogger
+
+	formatUserCache *cache.Cache
+	lookupId        func(uid string) (*user.User, error)
+}
+
+func NewLookupIdProbe(coreConfig config.ConfigReader) *LookupIdProbe {
+	return &LookupIdProbe{
+		// Inject global logger and config to make it easy to use components
+		config: coreConfig,
+		log:    log.Logger,
+
+		formatUserCache: cache.New(time.Hour, time.Hour), // Used by lookupIdWithCache
+		lookupId:        user.LookupId,
+	}
+}
+
+func (p *LookupIdProbe) lookupIdWithCache(uid string) (*user.User, error) {
+	result, ok := p.formatUserCache.Get(uid)
+	if !ok {
+		var err error
+		u, err := p.lookupId(uid)
+		if err == nil {
+			p.formatUserCache.SetDefault(uid, u)
+		} else {
+			p.formatUserCache.SetDefault(uid, err)
+		}
+		return u, err
+	}
+
+	switch v := result.(type) {
+	case *user.User:
+		return v, nil
+	case error:
+		return nil, v
+	default:
+		return nil, log.Error("Unknown value cached in formatUserCache for uid:", uid)
+	}
+}
+
+func (p *LookupIdProbe) LookupId(uid string) (*user.User, error) {
+	if p.config.GetBool("process_config.cache_lookupid") {
+		return p.lookupIdWithCache(uid)
+	}
+	return p.lookupId(uid)
+}

--- a/pkg/process/checks/user_nix.go
+++ b/pkg/process/checks/user_nix.go
@@ -19,17 +19,18 @@ import (
 
 type LookupIdProbe struct {
 	config config.ConfigReader
-	log    *log.DatadogLogger
 
 	formatUserCache *cache.Cache
 	lookupId        func(uid string) (*user.User, error)
 }
 
 func NewLookupIdProbe(coreConfig config.ConfigReader) *LookupIdProbe {
+	if coreConfig.GetBool("process_config.cache_lookupid") {
+		log.Debug("Using cached calls to `user.LookupID`")
+	}
 	return &LookupIdProbe{
 		// Inject global logger and config to make it easy to use components
 		config: coreConfig,
-		log:    log.Logger,
 
 		formatUserCache: cache.New(time.Hour, time.Hour), // Used by lookupIdWithCache
 		lookupId:        user.LookupId,

--- a/pkg/process/checks/user_nix_test.go
+++ b/pkg/process/checks/user_nix_test.go
@@ -1,0 +1,118 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !windows
+
+package checks
+
+import (
+	"os/user"
+	"testing"
+	"time"
+
+	"github.com/patrickmn/go-cache"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+)
+
+func TestLookupUserWithId(t *testing.T) {
+	cfg := config.Mock(t)
+	cfg.Set("process_config.cache_lookupid", true)
+
+	for _, tc := range []struct {
+		name          string
+		expectedUser  *user.User
+		expectedError error
+		ttl           time.Duration
+	}{
+		{
+			name:         "user found",
+			expectedUser: &user.User{Name: "steve"},
+			ttl:          cache.NoExpiration,
+		},
+		{
+			name:          "user not found",
+			expectedError: user.UnknownUserIdError(0),
+			ttl:           cache.NoExpiration,
+		},
+	} {
+		const testUID = "0"
+		t.Run(tc.name, func(t *testing.T) {
+			p := NewLookupIdProbe(cfg)
+
+			checkResult := func(u *user.User, err error) {
+				t.Helper()
+
+				if tc.expectedUser != nil {
+					assert.Equal(t, tc.expectedUser.Name, u.Name)
+				} else {
+					assert.Nil(t, tc.expectedUser)
+				}
+
+				assert.ErrorIs(t, tc.expectedError, err)
+			}
+
+			checkCacheResult := func(res interface{}, ok bool) {
+				t.Helper()
+
+				assert.True(t, ok)
+				switch v := res.(type) {
+				case *user.User:
+					assert.Equal(t, tc.expectedUser.Name, v.Name)
+				case error:
+					assert.ErrorIs(t, v, tc.expectedError)
+				}
+			}
+
+			var timesCalled int
+			p.lookupId = func(inputUid string) (*user.User, error) {
+				// Make sure this function is called once despite the fact that we call `lookupIdWithCache`.
+				// This should simulate a cache hit vs a miss.
+				timesCalled++
+				assert.Equal(t, 1, timesCalled)
+
+				assert.Equal(t, testUID, inputUid)
+				if tc.expectedError != nil {
+					return nil, tc.expectedError
+				}
+				return tc.expectedUser, nil
+			}
+
+			checkResult(p.LookupId(testUID))
+			checkCacheResult(p.formatUserCache.Get(testUID))
+			checkResult(p.LookupId(testUID))
+		})
+	}
+}
+
+func TestLookupIdConfigSetting(t *testing.T) {
+	testLookupIdFunc := func(uid string) (*user.User, error) { return &user.User{Name: "jojo"}, nil }
+
+	t.Run("enabled", func(t *testing.T) {
+		cfg := config.Mock(t)
+		cfg.Set("process_config.cache_lookupid", true)
+
+		p := NewLookupIdProbe(cfg)
+		p.lookupId = testLookupIdFunc
+
+		_, _ = p.LookupId("1234") // testLookupIdFunc should be called and "1234" added to the cache
+		u, ok := p.formatUserCache.Get("1234")
+		assert.Equal(t, "jojo", u.(*user.User).Name)
+		assert.True(t, ok)
+	})
+
+	t.Run("disabled", func(t *testing.T) {
+		cfg := config.Mock(t)
+		cfg.Set("process_config.cache_lookupid", false)
+
+		p := NewLookupIdProbe(cfg)
+		p.lookupId = testLookupIdFunc
+
+		_, _ = p.LookupId("1234")
+		_, ok := p.formatUserCache.Get("1234")
+		assert.False(t, ok)
+	})
+}

--- a/pkg/process/checks/user_nix_test.go
+++ b/pkg/process/checks/user_nix_test.go
@@ -82,7 +82,7 @@ func TestLookupUserWithId(t *testing.T) {
 			}
 
 			checkResult(p.LookupId(testUID))
-			checkCacheResult(p.formatUserCache.Get(testUID))
+			checkCacheResult(p.lookupIdCache.Get(testUID))
 			checkResult(p.LookupId(testUID))
 		})
 	}
@@ -99,7 +99,7 @@ func TestLookupIdConfigSetting(t *testing.T) {
 		p.lookupId = testLookupIdFunc
 
 		_, _ = p.LookupId("1234") // testLookupIdFunc should be called and "1234" added to the cache
-		u, ok := p.formatUserCache.Get("1234")
+		u, ok := p.lookupIdCache.Get("1234")
 		assert.Equal(t, "jojo", u.(*user.User).Name)
 		assert.True(t, ok)
 	})
@@ -112,7 +112,7 @@ func TestLookupIdConfigSetting(t *testing.T) {
 		p.lookupId = testLookupIdFunc
 
 		_, _ = p.LookupId("1234")
-		_, ok := p.formatUserCache.Get("1234")
+		_, ok := p.lookupIdCache.Get("1234")
 		assert.False(t, ok)
 	})
 }

--- a/pkg/process/checks/user_windows.go
+++ b/pkg/process/checks/user_windows.go
@@ -1,0 +1,19 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build windows
+
+package checks
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/config"
+)
+
+// On Windows the LookupIdProbe does nothing since we get the user info from the process itself.
+type LookupIdProbe struct{}
+
+func NewLookupIdProbe(config.ConfigReader) *LookupIdProbe {
+	return &LookupIdProbe{}
+}

--- a/releasenotes/notes/cache-lookupid-10d510161283a406.yaml
+++ b/releasenotes/notes/cache-lookupid-10d510161283a406.yaml
@@ -1,0 +1,22 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+upgrade:
+  - |
+    List upgrade notes here, or remove this section.
+    Upgrade notes should be rare: only list known/potential breaking changes,
+    or major behaviorial changes that require user action before the upgrade.
+    Notes here must include steps that users can follow to 1. know if they're
+    affected and 2. handle the change gracefully on their end.
+features:
+  - |
+    List new features here, or remove this section.
+enhancements:
+  - |
+    Added a new config flag `process_config.cache_lookupid`. This is an optional flag caches calls to `user.LookupId` in the process agent.
+    Some users have reported a leak here, so this flag can be used to minimize the number of calls to `user.LookupId`.

--- a/releasenotes/notes/cache-lookupid-10d510161283a406.yaml
+++ b/releasenotes/notes/cache-lookupid-10d510161283a406.yaml
@@ -1,5 +1,5 @@
 ---
 enhancements:
   - |
-    Added a new config flag `process_config.cache_lookupid`. This is an optional flag caches calls to `user.LookupId` in the process agent.
-    Some users have reported a leak here, so this flag can be used to minimize the number of calls to `user.LookupId`.
+    Added optional config flag `process_config.cache_lookupid` to cache calls to `user.LookupId` in the process Agent.
+    Use to minimize the number of calls to `user.LookupId` and avoid potential leak.

--- a/releasenotes/notes/cache-lookupid-10d510161283a406.yaml
+++ b/releasenotes/notes/cache-lookupid-10d510161283a406.yaml
@@ -1,21 +1,4 @@
-# Each section from every release note are combined when the
-# CHANGELOG.rst is rendered. So the text needs to be worded so that
-# it does not depend on any information only available in another
-# section. This may mean repeating some details, but each section
-# must be readable independently of the other.
-#
-# Each section note must be formatted as reStructuredText.
 ---
-upgrade:
-  - |
-    List upgrade notes here, or remove this section.
-    Upgrade notes should be rare: only list known/potential breaking changes,
-    or major behaviorial changes that require user action before the upgrade.
-    Notes here must include steps that users can follow to 1. know if they're
-    affected and 2. handle the change gracefully on their end.
-features:
-  - |
-    List new features here, or remove this section.
 enhancements:
   - |
     Added a new config flag `process_config.cache_lookupid`. This is an optional flag caches calls to `user.LookupId` in the process agent.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR creates a probe that caches user structs when they are requested from the operating system in `formatUser`.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

 On some machines the call to `user.LookupId` in the go standard library leaks, and we want to minimize calls to it.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
Using this config:
```yaml
log_level: debug
process_config:
  cache_lookupid: true
  process_collection:
    enabled: true
```
Look for this log line:
```
Using cached calls to `user.LookupID`
```

There is no need to test if the user struct is properly cached - this is covered by unit tests.

While testing - make sure you see none of these errors:
```Unknown value cached in formatUserCache for uid: ...```
### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
