### PR TITLE
[CI] Disable Codecov upload in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,10 +108,13 @@ jobs:
           name: run unit tests
           no_output_timeout: 20m
           command: inv -e test --skip-linters --rerun-fails=2 --python-runtimes 3 --coverage --race --profile --cpus 3
-      - run:
-          name: upload code coverage results
-          # Never fail on coverage upload
-          command: inv -e codecov || true
+      # Codecov upload is failing in CircleCI with a "Please upload with the Codecov repository upload token to resolve issue" error.
+      # Public repositories don't need to use a token, it's a known issue often breaking Codecov, see  https://github.com/codecov/codecov-action/issues/837
+      # Adding a token would fix it but Datadog OAuth doesn't allow us to get a token, so we're disabling it for now.
+      # - run:
+      #     name: upload code coverage results
+      #     # Never fail on coverage upload
+      #     command: inv -e codecov || true
 
   integration_tests:
     <<: *job_template


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This PR disables Codecov upload in CircleCI.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

 Codecov upload is failing in CircleCI with a ["Please upload with the Codecov repository upload token to resolve issue" error](https://app.circleci.com/pipelines/github/DataDog/datadog-agent/75063/workflows/ccddffc7-86c2-496a-b55b-196213fc9bb5/jobs/924174).
Public repositories don't need to use a token, it's a known issue often breaking Codecov, see https://github.com/codecov/feedback/issues/126
Adding a token would fix it but Datadog OAuth doesn't allow us to get a token, so we're disabling it for now.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
