### PR TITLE
[CWS] simplify creation of lazy `NewCustomEvent`

### DIFF
--- a/pkg/security/events/custom.go
+++ b/pkg/security/events/custom.go
@@ -65,11 +65,17 @@ func AllCustomRuleIDs() []string {
 }
 
 // NewCustomEvent returns a new custom event
-func NewCustomEvent(eventType model.EventType, marshalerCtor func() easyjson.Marshaler) *CustomEvent {
+func NewCustomEventLazy(eventType model.EventType, marshalerCtor func() easyjson.Marshaler) *CustomEvent {
 	return &CustomEvent{
 		eventType:     eventType,
 		marshalerCtor: marshalerCtor,
 	}
+}
+
+func NewCustomEvent(eventType model.EventType, marshaler easyjson.Marshaler) *CustomEvent {
+	return NewCustomEventLazy(eventType, func() easyjson.Marshaler {
+		return marshaler
+	})
 }
 
 // CustomEvent is used to send custom security events to Datadog

--- a/pkg/security/module/policy_monitor.go
+++ b/pkg/security/module/policy_monitor.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-multierror"
-	easyjson "github.com/mailru/easyjson"
 
 	dogstatsdServer "github.com/DataDog/datadog-agent/comp/dogstatsd/server"
 	"github.com/DataDog/datadog-agent/pkg/security/events"
@@ -231,5 +230,5 @@ func NewRuleSetLoadedEvent(rs *rules.RuleSet, err *multierror.Error) (*rules.Rul
 	evt.FillCustomEventCommonFields()
 
 	return events.NewCustomRule(events.RulesetLoadedRuleID),
-		events.NewCustomEvent(model.CustomRulesetLoadedEventType, func() easyjson.Marshaler { return evt })
+		events.NewCustomEvent(model.CustomRulesetLoadedEventType, evt)
 }

--- a/pkg/security/module/self_tests.go
+++ b/pkg/security/module/self_tests.go
@@ -16,7 +16,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-go/v5/statsd"
-	easyjson "github.com/mailru/easyjson"
 )
 
 // SelfTestEvent is used to report a self test result
@@ -36,7 +35,7 @@ func NewSelfTestEvent(success []string, fails []string) (*rules.Rule, *events.Cu
 	evt.FillCustomEventCommonFields()
 
 	return events.NewCustomRule(events.SelfTestRuleID),
-		events.NewCustomEvent(model.CustomSelfTestEventType, func() easyjson.Marshaler { return evt })
+		events.NewCustomEvent(model.CustomSelfTestEventType, evt)
 }
 
 // ReportSelfTest reports to Datadog that a self test was performed

--- a/pkg/security/probe/custom_events.go
+++ b/pkg/security/probe/custom_events.go
@@ -37,7 +37,7 @@ func NewEventLostReadEvent(mapName string, lost float64) (*rules.Rule, *events.C
 	}
 	evt.FillCustomEventCommonFields()
 
-	return events.NewCustomRule(events.LostEventsRuleID), events.NewCustomEvent(model.CustomLostReadEventType, func() easyjson.Marshaler { return evt })
+	return events.NewCustomRule(events.LostEventsRuleID), events.NewCustomEvent(model.CustomLostReadEventType, evt)
 }
 
 // EventLostWrite is the event used to report lost events detected from kernel space
@@ -56,7 +56,7 @@ func NewEventLostWriteEvent(mapName string, perEventPerCPU map[string]uint64) (*
 	}
 	evt.FillCustomEventCommonFields()
 
-	return events.NewCustomRule(events.LostEventsRuleID), events.NewCustomEvent(model.CustomLostWriteEventType, func() easyjson.Marshaler { return evt })
+	return events.NewCustomRule(events.LostEventsRuleID), events.NewCustomEvent(model.CustomLostWriteEventType, evt)
 }
 
 // NoisyProcessEvent is used to report that a noisy process was temporarily discarded
@@ -92,7 +92,7 @@ func NewNoisyProcessEvent(count uint64,
 	// Overwrite common timestamp
 	evt.Timestamp = timestamp
 
-	return events.NewCustomRule(events.NoisyProcessRuleID), events.NewCustomEvent(model.CustomNoisyProcessEventType, func() easyjson.Marshaler { return evt })
+	return events.NewCustomRule(events.NoisyProcessRuleID), events.NewCustomEvent(model.CustomNoisyProcessEventType, evt)
 }
 
 func resolutionErrorToEventType(err error) model.EventType {
@@ -126,5 +126,5 @@ func NewAbnormalPathEvent(event *model.Event, probe *Probe, pathResolutionError 
 		return evt
 	}
 
-	return events.NewCustomRule(events.AbnormalPathRuleID), events.NewCustomEvent(resolutionErrorToEventType(event.PathResolutionError), marshalerCtor)
+	return events.NewCustomRule(events.AbnormalPathRuleID), events.NewCustomEventLazy(resolutionErrorToEventType(event.PathResolutionError), marshalerCtor)
 }

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -886,7 +886,7 @@ func (p *Probe) handleEvent(CPU int, data []byte) {
 
 		p.DispatchCustomEvent(
 			events.NewCustomRule(events.AnomalyDetectionRuleID),
-			events.NewCustomEvent(event.GetEventType(), p.EventMarshallerCtor(event)),
+			events.NewCustomEventLazy(event.GetEventType(), p.EventMarshallerCtor(event)),
 		)
 	}
 


### PR DESCRIPTION
### What does this PR do?

Clean up a bit the code introduced by 71082409d48e3cf97b4fdf8832ae397fceded981

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
