### PR TITLE
pkg/trace/api: Make forwardingTransport requests run concurrently

### DIFF
--- a/pkg/trace/api/transports.go
+++ b/pkg/trace/api/transports.go
@@ -115,8 +115,8 @@ func (m *forwardingTransport) RoundTrip(req *http.Request) (rres *http.Response,
 			if i == 0 {
 				// given the way we construct the list of targets the main endpoint
 				// will be the first one called, we return its response and error
-				rres, rerr = m.rt.RoundTrip(newreq) //nolint:bodyclose
-				// Ignoring bodyclose here because it looks like a false positive.
+				rres, rerr = m.rt.RoundTrip(newreq)
+				rres.Body.Close()
 				return
 			}
 			if resp, err := m.rt.RoundTrip(newreq); err == nil {
@@ -130,6 +130,7 @@ func (m *forwardingTransport) RoundTrip(req *http.Request) (rres *http.Response,
 		}(i, u)
 	}
 	wg.Wait()
+
 	return rres, rerr
 }
 

--- a/pkg/trace/api/transports.go
+++ b/pkg/trace/api/transports.go
@@ -119,13 +119,14 @@ func (m *forwardingTransport) RoundTrip(req *http.Request) (rres *http.Response,
 				rres.Body.Close()
 				return
 			}
-			if resp, err := m.rt.RoundTrip(newreq); err == nil {
+			resp, err := m.rt.RoundTrip(newreq)
+			if err == nil {
 				// we discard responses for all subsequent requests
 				io.Copy(io.Discard, resp.Body) //nolint:errcheck
-				resp.Body.Close()
 			} else {
 				log.Error(err)
 			}
+			resp.Body.Close()
 
 		}(i, u)
 	}

--- a/pkg/trace/api/transports.go
+++ b/pkg/trace/api/transports.go
@@ -113,9 +113,11 @@ func (m *forwardingTransport) RoundTrip(req *http.Request) (rres *http.Response,
 			newreq.Body = io.NopCloser(bytes.NewReader(slurp))
 			setTarget(newreq, u, m.keys[i])
 			if i == 0 {
-				// given the way we construct the list of targets the main endpoint
-				// will be the first one called, we return its response and error
-				rres, rerr = m.rt.RoundTrip(newreq)
+				// Given the way we construct the list of targets the main endpoint
+				// will be the first one called, we return its response and error.
+				// Ignoring bodyclose lint here because of a bug in the linter:
+				// https://github.com/timakin/bodyclose/issues/30.
+				rres, rerr = m.rt.RoundTrip(newreq) //nolint:bodyclose
 				rres.Body.Close()
 				return
 			}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Currently, requests to additional endpoints in the forwarding transport are run serially. This PR makes all request run concurrently.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

Assuming no release note is necessary because it's an implementation detail.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Configure multiple endpoints, e.g. on the debugger proxy, and verify all endpoints are hit.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
