### PR TITLE
[workloadmeta/docker] Add support for collecting SBOM data from docker

### DIFF
--- a/pkg/collector/corechecks/sbom/processor.go
+++ b/pkg/collector/corechecks/sbom/processor.go
@@ -50,7 +50,7 @@ type processor struct {
 }
 
 func newProcessor(workloadmetaStore workloadmeta.Store, sender aggregator.Sender, maxNbItem int, maxRetentionTime time.Duration) (*processor, error) {
-	enabledAnalyzers := ddConfig.Datadog.GetStringSlice("sbom.analyzers")
+	hostScanOpts := sbom.ScanOptionsFromConfig(ddConfig.Datadog, false)
 	sbomScanner := sbomscanner.GetGlobalScanner()
 	if sbomScanner == nil {
 		return nil, errors.New("failed to get global SBOM scanner")
@@ -76,10 +76,8 @@ func newProcessor(workloadmetaStore workloadmeta.Store, sender aggregator.Sender
 		imageRepoDigests:  make(map[string]string),
 		imageUsers:        make(map[string]map[string]struct{}),
 		sbomScanner:       sbomScanner,
-		hostScanOpts: sbom.ScanOptions{
-			Analyzers: enabledAnalyzers,
-		},
-		hostname: hostname,
+		hostScanOpts:      hostScanOpts,
+		hostname:          hostname,
 	}, nil
 }
 

--- a/pkg/sbom/collectors/docker/doc.go
+++ b/pkg/sbom/collectors/docker/doc.go
@@ -1,0 +1,6 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package docker

--- a/pkg/sbom/collectors/docker/docker.go
+++ b/pkg/sbom/collectors/docker/docker.go
@@ -1,0 +1,71 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build docker && trivy
+// +build docker,trivy
+
+package docker
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	"github.com/docker/docker/client"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/sbom"
+	"github.com/DataDog/datadog-agent/pkg/sbom/collectors"
+	"github.com/DataDog/datadog-agent/pkg/util/trivy"
+	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
+)
+
+const (
+	collectorName = "docker-collector"
+)
+
+type ScanRequest struct {
+	ImageMeta    *workloadmeta.ContainerImageMetadata
+	DockerClient client.ImageAPIClient
+}
+
+func (r *ScanRequest) Collector() string {
+	return collectorName
+}
+
+func (r *ScanRequest) Type() string {
+	return "daemon"
+}
+
+type Collector struct {
+	trivyCollector *trivy.Collector
+}
+
+func (c *Collector) Init(cfg config.Config) error {
+	trivyCollector, err := trivy.GetGlobalCollector(cfg)
+	if err != nil {
+		return err
+	}
+	c.trivyCollector = trivyCollector
+	return nil
+}
+
+func (c *Collector) Scan(ctx context.Context, request sbom.ScanRequest, opts sbom.ScanOptions) (sbom.Report, error) {
+	dockerScanRequest, ok := request.(*ScanRequest)
+	if !ok {
+		return nil, fmt.Errorf("invalid request type '%s' for collector '%s'", reflect.TypeOf(request), collectorName)
+	}
+
+	return c.trivyCollector.ScanDockerImage(
+		ctx,
+		dockerScanRequest.ImageMeta,
+		dockerScanRequest.DockerClient,
+		opts,
+	)
+}
+
+func init() {
+	collectors.RegisterCollector(collectorName, &Collector{})
+}

--- a/pkg/sbom/collectors/docker/docker.go
+++ b/pkg/sbom/collectors/docker/docker.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	collectorName = "docker-collector"
+	collectorName = "docker"
 )
 
 type ScanRequest struct {

--- a/pkg/sbom/collectors/docker/docker.go
+++ b/pkg/sbom/collectors/docker/docker.go
@@ -39,6 +39,10 @@ func (r *ScanRequest) Type() string {
 	return "daemon"
 }
 
+func (r *ScanRequest) ID() string {
+	return r.ImageMeta.ID
+}
+
 type Collector struct {
 	trivyCollector *trivy.Collector
 }

--- a/pkg/util/docker/client.go
+++ b/pkg/util/docker/client.go
@@ -13,12 +13,14 @@ import (
 	"time"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/client"
 
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
 )
 
 // Client defines the interface of our custom Docker client (e.g. DockerUtil)
 type Client interface {
+	RawClient() *client.Client
 	RawContainerList(ctx context.Context, options types.ContainerListOptions) ([]types.Container, error)
 	ResolveImageName(ctx context.Context, image string) (string, error)
 	Images(ctx context.Context, includeIntermediate bool) ([]types.ImageSummary, error)

--- a/pkg/util/docker/client_mock.go
+++ b/pkg/util/docker/client_mock.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/client"
 
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
 )
@@ -20,6 +21,7 @@ import (
 // MockClient is a mock implementation of docker.Client interface
 // Should probably be generated at some point
 type MockClient struct {
+	FakeRawClient                   *client.Client
 	FakeContainerList               []types.Container
 	FakeImageNameMapping            map[string]string
 	FakeImages                      []types.ImageSummary
@@ -29,6 +31,11 @@ type MockClient struct {
 	FakeContainerEvents             []*ContainerEvent
 	FakeLastContainerEventTimestamp time.Time
 	FakeError                       error
+}
+
+// RawClient is a mock method
+func (d *MockClient) RawClient() *client.Client {
+	return d.FakeRawClient
 }
 
 // RawContainerList is a mock method

--- a/pkg/util/docker/docker_util.go
+++ b/pkg/util/docker/docker_util.go
@@ -130,6 +130,11 @@ func (d *DockerUtil) CountVolumes(ctx context.Context) (int, int, error) {
 	return len(attachedVolumes.Volumes), len(danglingVolumes.Volumes), nil
 }
 
+// RawClient returns the underlying docker client being used by this object.
+func (d *DockerUtil) RawClient() *client.Client {
+	return d.cli
+}
+
 // RawContainerList wraps around the docker client's ContainerList method.
 // Value validation and error handling are the caller's responsibility.
 func (d *DockerUtil) RawContainerList(ctx context.Context, options types.ContainerListOptions) ([]types.Container, error) {

--- a/pkg/util/docker/event_types.go
+++ b/pkg/util/docker/event_types.go
@@ -37,6 +37,8 @@ const (
 	ImageEventActionTag = "tag"
 	// ImageEventActionUntag is the action of untagging a docker image
 	ImageEventActionUntag = "untag"
+	// ImageEventActionSbom is the action of getting SBOM information for a docker image
+	ImageEventActionSbom = "sbom"
 )
 
 var containerEventActions = []string{

--- a/pkg/util/trivy/containerd.go
+++ b/pkg/util/trivy/containerd.go
@@ -16,7 +16,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 	"github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/content"
@@ -32,6 +31,8 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/samber/lo"
 	"golang.org/x/xerrors"
+
+	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 )
 
 // Code ported from https://github.com/aquasecurity/trivy/blob/2206e008ea6e5f4e5c1aa7bc8fc77dae7041de6a/pkg/fanal/image/daemon/containerd.go

--- a/pkg/util/trivy/docker.go
+++ b/pkg/util/trivy/docker.go
@@ -1,0 +1,59 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build trivy
+// +build trivy
+
+package trivy
+
+import (
+	"context"
+	"os"
+
+	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
+
+	"github.com/aquasecurity/trivy/pkg/fanal/types"
+	"github.com/docker/docker/client"
+	"golang.org/x/xerrors"
+)
+
+// Custom code based on https://github.com/aquasecurity/trivy/blob/2206e008ea6e5f4e5c1aa7bc8fc77dae7041de6a/pkg/fanal/image/daemon/docker.go `DockerImage`
+func convertDockerImage(ctx context.Context, client client.ImageAPIClient, imgMeta *workloadmeta.ContainerImageMetadata) (types.Image, func(), error) {
+	cleanup := func() {}
+
+	// <image_name>:<tag> pattern like "alpine:3.15"
+	// or
+	// <image_name>@<digest> pattern like "alpine@sha256:21a3deaa0d32a8057914f36584b5288d2e5ecc984380bc0118285c70fa8c9300"
+	imageID := imgMeta.Name
+	inspect, _, err := client.ImageInspectWithRaw(ctx, imageID)
+	if err != nil {
+		imageID = imgMeta.ID // <image_id> pattern like `5ac716b05a9c`
+		inspect, _, err = client.ImageInspectWithRaw(ctx, imageID)
+		if err != nil {
+			return nil, cleanup, xerrors.Errorf("unable to inspect the image (%s): %w", imageID, err)
+		}
+	}
+
+	history, err := client.ImageHistory(ctx, imageID)
+	if err != nil {
+		return nil, cleanup, xerrors.Errorf("unable to get history (%s): %w", imageID, err)
+	}
+
+	f, err := os.CreateTemp("", "fanal-docker-*")
+	if err != nil {
+		return nil, cleanup, xerrors.Errorf("failed to create a temporary file")
+	}
+
+	cleanup = func() {
+		_ = f.Close()
+		_ = os.Remove(f.Name())
+	}
+
+	return &image{
+		opener:  imageOpener(ctx, imageID, f, client.ImageSave),
+		inspect: inspect,
+		history: configHistory(history),
+	}, cleanup, nil
+}

--- a/pkg/workloadmeta/collectors/internal/containerd/containerd.go
+++ b/pkg/workloadmeta/collectors/internal/containerd/containerd.go
@@ -100,8 +100,8 @@ type collector struct {
 	handleImagesMut sync.Mutex
 
 	// SBOM Scanning
-	trivyScanner *scanner.Scanner // nolint: unused
-	scanOptions  sbom.ScanOptions // nolint: unused
+	sbomScanner *scanner.Scanner // nolint: unused
+	scanOptions sbom.ScanOptions // nolint: unused
 }
 
 func init() {

--- a/pkg/workloadmeta/collectors/internal/docker/docker.go
+++ b/pkg/workloadmeta/collectors/internal/docker/docker.go
@@ -13,7 +13,11 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/sbom"
+	"github.com/DataDog/datadog-agent/pkg/sbom/scanner"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/image"
@@ -44,6 +48,17 @@ type collector struct {
 	dockerUtil        *docker.DockerUtil
 	containerEventsCh <-chan *docker.ContainerEvent
 	imageEventsCh     <-chan *docker.ImageEvent
+
+	// Images are updated from 2 goroutines: the one that handles docker
+	// events, and the one that extracts SBOMS.
+	// This mutex is used to handle images one at a time to avoid
+	// inconsistencies like trying to set an SBOM for an image that is being
+	// deleted.
+	handleImagesMut sync.Mutex
+
+	// SBOM Scanning
+	sbomScanner *scanner.Scanner // nolint: unused
+	scanOptions sbom.ScanOptions // nolint: unused
 }
 
 func init() {
@@ -62,6 +77,10 @@ func (c *collector) Start(ctx context.Context, store workloadmeta.Store) error {
 	var err error
 	c.dockerUtil, err = docker.GetDockerUtil()
 	if err != nil {
+		return err
+	}
+
+	if err = c.startSBOMCollection(ctx); err != nil {
 		return err
 	}
 
@@ -109,7 +128,7 @@ func (c *collector) stream(ctx context.Context) {
 			}
 
 		case ev := <-c.imageEventsCh:
-			err := c.handleImageEvent(ctx, ev)
+			err := c.handleImageEvent(ctx, ev, nil)
 			if err != nil {
 				log.Warnf(err.Error())
 			}
@@ -170,7 +189,7 @@ func (c *collector) generateEventsFromImageList(ctx context.Context) error {
 	events := make([]workloadmeta.CollectorEvent, 0, len(images))
 
 	for _, img := range images {
-		imgMetadata, err := c.getImageMetadata(ctx, img.ID)
+		imgMetadata, err := c.getImageMetadata(ctx, img.ID, nil)
 		if err != nil {
 			log.Warnf(err.Error())
 			continue
@@ -480,10 +499,13 @@ func extractHealth(containerHealth *types.Health) workloadmeta.ContainerHealth {
 	return workloadmeta.ContainerHealthUnknown
 }
 
-func (c *collector) handleImageEvent(ctx context.Context, event *docker.ImageEvent) error {
+func (c *collector) handleImageEvent(ctx context.Context, event *docker.ImageEvent, bom *workloadmeta.SBOM) error {
+	c.handleImagesMut.Lock()
+	defer c.handleImagesMut.Unlock()
+
 	switch event.Action {
-	case docker.ImageEventActionPull, docker.ImageEventActionTag, docker.ImageEventActionUntag:
-		imgMetadata, err := c.getImageMetadata(ctx, event.ImageID)
+	case docker.ImageEventActionPull, docker.ImageEventActionTag, docker.ImageEventActionUntag, docker.ImageEventActionSbom:
+		imgMetadata, err := c.getImageMetadata(ctx, event.ImageID, bom)
 		if err != nil {
 			return fmt.Errorf("could not get image metadata for image %q: %w", event.ImageID, err)
 		}
@@ -513,7 +535,7 @@ func (c *collector) handleImageEvent(ctx context.Context, event *docker.ImageEve
 	return nil
 }
 
-func (c *collector) getImageMetadata(ctx context.Context, imageID string) (*workloadmeta.ContainerImageMetadata, error) {
+func (c *collector) getImageMetadata(ctx context.Context, imageID string, bom *workloadmeta.SBOM) (*workloadmeta.ContainerImageMetadata, error) {
 	imgInspect, err := c.dockerUtil.ImageInspect(ctx, imageID)
 	if err != nil {
 		return nil, err
@@ -532,17 +554,43 @@ func (c *collector) getImageMetadata(ctx context.Context, imageID string) (*work
 		labels = imgInspect.Config.Labels
 	}
 
+	imageName := c.dockerUtil.GetPreferredImageName(
+		imgInspect.ID,
+		imgInspect.RepoTags,
+		imgInspect.RepoDigests,
+	)
+
+	existingBOM := bom
+	// We can get "create" events for images that already exist. That happens
+	// when the same image is referenced with different names. For example,
+	// datadog/agent:latest and datadog/agent:7 might refer to the same image.
+	// Also, in some environments (at least with Kind), pulling an image like
+	// datadog/agent:latest creates several events: in one of them the image
+	// name is a digest, in other is something with the same format as
+	// datadog/agent:7, and sometimes there's a temporary name prefixed with
+	// "import-".
+	// When that happens, give precedence to the name with repo and tag instead
+	// of the name that includes a digest. This is just to show names that are
+	// more user-friendly (the digests are already present in other attributes
+	// like ID, and repo digest).
+	existingImg, err := c.store.GetImage(imageID)
+	if err == nil {
+		if strings.Contains(imageName, "sha256:") && !strings.Contains(existingImg.Name, "sha256:") {
+			imageName = existingImg.Name
+		}
+
+		if existingBOM == nil && existingImg.SBOM != nil {
+			existingBOM = existingImg.SBOM
+		}
+	}
+
 	return &workloadmeta.ContainerImageMetadata{
 		EntityID: workloadmeta.EntityID{
 			Kind: workloadmeta.KindContainerImageMetadata,
 			ID:   imgInspect.ID,
 		},
 		EntityMeta: workloadmeta.EntityMeta{
-			Name: c.dockerUtil.GetPreferredImageName(
-				imgInspect.ID,
-				imgInspect.RepoTags,
-				imgInspect.RepoDigests,
-			),
+			Name:   imageName,
 			Labels: labels,
 		},
 		RepoTags:     imgInspect.RepoTags,
@@ -553,6 +601,7 @@ func (c *collector) getImageMetadata(ctx context.Context, imageID string) (*work
 		Architecture: imgInspect.Architecture,
 		Variant:      imgInspect.Variant,
 		Layers:       layersFromDockerHistory(imageHistory),
+		SBOM:         existingBOM,
 	}, nil
 }
 

--- a/pkg/workloadmeta/collectors/internal/docker/image_sbom_stub.go
+++ b/pkg/workloadmeta/collectors/internal/docker/image_sbom_stub.go
@@ -1,0 +1,17 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build docker && !trivy
+// +build docker,!trivy
+
+package docker
+
+import (
+	"context"
+)
+
+func (c *collector) startSBOMCollection(context.Context) error {
+	return nil
+}

--- a/pkg/workloadmeta/collectors/internal/docker/image_sbom_trivy.go
+++ b/pkg/workloadmeta/collectors/internal/docker/image_sbom_trivy.go
@@ -3,10 +3,10 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build containerd && trivy
-// +build containerd,trivy
+//go:build docker && trivy
+// +build docker,trivy
 
-package containerd
+package docker
 
 import (
 	"context"
@@ -15,11 +15,16 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/sbom"
-	"github.com/DataDog/datadog-agent/pkg/sbom/collectors/containerd"
+	"github.com/DataDog/datadog-agent/pkg/sbom/collectors/docker"
 	"github.com/DataDog/datadog-agent/pkg/sbom/scanner"
+	dutil "github.com/DataDog/datadog-agent/pkg/util/docker"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 )
+
+func imageMetadataCollectionIsEnabled() bool {
+	return config.Datadog.GetBool("container_image_collection.metadata.enabled")
+}
 
 func sbomCollectionIsEnabled() bool {
 	return imageMetadataCollectionIsEnabled() && config.Datadog.GetBool("container_image_collection.sbom.enabled")
@@ -32,19 +37,10 @@ func (c *collector) startSBOMCollection(ctx context.Context) error {
 
 	var err error
 	enabledAnalyzers := config.Datadog.GetStringSlice("container_image_collection.sbom.analyzers")
-	if len(enabledAnalyzers) == 0 {
-		enabledAnalyzers = config.Datadog.GetStringSlice("sbom.analyzers")
-	}
-
-	checkDiskUsage := config.Datadog.GetBool("container_image_collection.sbom.check_disk_usage")
-	minAvailableDisk := uint64(config.Datadog.GetSizeInBytes("container_image_collection.sbom.min_available_disk"))
-
 	c.scanOptions = sbom.ScanOptions{
-		Analyzers:        enabledAnalyzers,
-		Timeout:          scanningTimeout(),
-		WaitAfter:        timeBetweenScans(),
-		CheckDiskUsage:   checkDiskUsage,
-		MinAvailableDisk: minAvailableDisk,
+		Analyzers: enabledAnalyzers,
+		Timeout:   scanningTimeout(),
+		WaitAfter: timeBetweenScans(),
 	}
 
 	c.sbomScanner = scanner.GetGlobalScanner()
@@ -97,19 +93,13 @@ func (c *collector) startSBOMCollection(ctx context.Context) error {
 }
 
 func (c *collector) extractBOMWithTrivy(ctx context.Context, storedImage *workloadmeta.ContainerImageMetadata) error {
-	containerdImage, err := c.containerdClient.Image(storedImage.Namespace, storedImage.Name)
-	if err != nil {
-		return err
-	}
-
-	scanRequest := &containerd.ScanRequest{
-		Image:          containerdImage,
-		ImageMeta:      storedImage,
-		FromFilesystem: config.Datadog.GetBool("container_image_collection.sbom.use_mount"),
+	scanRequest := &docker.ScanRequest{
+		ImageMeta:    storedImage,
+		DockerClient: c.dockerUtil.RawClient(),
 	}
 
 	ch := make(chan sbom.ScanResult, 1)
-	if err = c.sbomScanner.Scan(scanRequest, c.scanOptions, ch); err != nil {
+	if err := c.sbomScanner.Scan(scanRequest, c.scanOptions, ch); err != nil {
 		return err
 	}
 
@@ -123,7 +113,7 @@ func (c *collector) extractBOMWithTrivy(ctx context.Context, storedImage *worklo
 				return
 			}
 
-			sbom := workloadmeta.SBOM{
+			sbom := &workloadmeta.SBOM{
 				CycloneDXBOM:       bom,
 				GenerationTime:     result.CreatedAt,
 				GenerationDuration: result.Duration,
@@ -131,7 +121,12 @@ func (c *collector) extractBOMWithTrivy(ctx context.Context, storedImage *worklo
 
 			// Updating workloadmeta entities directly is not thread-safe, that's why we
 			// generate an update event here instead.
-			if err := c.handleImageCreateOrUpdate(ctx, storedImage.Namespace, storedImage.Name, &sbom); err != nil {
+			event := &dutil.ImageEvent{
+				ImageID:   storedImage.ID,
+				Action:    dutil.ImageEventActionSbom,
+				Timestamp: time.Now(),
+			}
+			if err := c.handleImageEvent(ctx, event, sbom); err != nil {
 				log.Warnf("Error extracting SBOM for image: namespace=%s name=%s, err: %s", storedImage.Namespace, storedImage.Name, err)
 			}
 		}


### PR DESCRIPTION
### What does this PR do?

This PR adds support for collecting SBOM data from the docker runtime via trivy.

NOTE: this PR should be functionally identical to https://github.com/DataDog/datadog-agent/pull/16068, and contains the rebase of that branch onto https://github.com/DataDog/datadog-agent/pull/15686

### Motivation

At the time of authoring this PR, SBOM data is only supported by containerd. However, not every environment or configuration uses this container runtime, so this PR adds support for docker, which should allow it to be used in more environments.

### Additional Notes

- Much of the methodology behind this implementation was adapted from the implementation for containerd. Notably, some internal trivy functionality was copied over.
- Right now, this PR does not support scanning docker images from the local filesystem, unlike the containerd implementation. I am happy to add that here, I am also happy to add that in a follow-up PR.

### Describe how to test/QA your changes

Run the agent locally using docker via `docker run` with the env vars `-e DD_CONTAINER_IMAGE_COLLECTION_METADATA_ENABLED=true -e DD_CONTAINER_IMAGE_COLLECTION_SBOM_ENABLED=true` set, and verify output using `agent workload-list --verbose | grep SBOM`

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
