### PR TITLE
usm: kafka: Using topic name size in user mode

### DIFF
--- a/pkg/ebpf/cgo/genpost.go
+++ b/pkg/ebpf/cgo/genpost.go
@@ -22,15 +22,10 @@ func main() {
 
 	b = removeAbsolutePath(b, runtime.GOOS)
 
-	// Convert [160]int8 to [160]byte in http_transaction_t members to simplify
+	// Convert []int8 to []byte in multiple generated fields from the kernel, to simplify
 	// conversion to string; see golang.org/issue/20753
-	convertHTTPTransactionRegex := regexp.MustCompile(`(Request_fragment|Topic_name)(\s+)\[(\d+)\]u?int8`)
-	b = convertHTTPTransactionRegex.ReplaceAll(b, []byte("$1$2[$3]byte"))
-
-	// Convert [120]int8 to [120]byte in lib_path_t members to simplify
-	// conversion to string; see golang.org/issue/20753
-	convertLibraryRegex := regexp.MustCompile(`(Buf)(\s+)\[(\d+)\]u?int8`)
-	b = convertLibraryRegex.ReplaceAll(b, []byte("$1$2[$3]byte"))
+	convertInt8ArrayToByteArrayRegex := regexp.MustCompile(`(Request_fragment|Topic_name|Buf)(\s+)\[(\d+)\]u?int8`)
+	b = convertInt8ArrayToByteArrayRegex.ReplaceAll(b, []byte("$1$2[$3]byte"))
 
 	b, err = format.Source(b)
 	if err != nil {

--- a/pkg/ebpf/cgo/genpost.go
+++ b/pkg/ebpf/cgo/genpost.go
@@ -24,7 +24,7 @@ func main() {
 
 	// Convert [160]int8 to [160]byte in http_transaction_t members to simplify
 	// conversion to string; see golang.org/issue/20753
-	convertHTTPTransactionRegex := regexp.MustCompile(`(Request_fragment)(\s+)\[(\d+)\]u?int8`)
+	convertHTTPTransactionRegex := regexp.MustCompile(`(Request_fragment|Topic_name)(\s+)\[(\d+)\]u?int8`)
 	b = convertHTTPTransactionRegex.ReplaceAll(b, []byte("$1$2[$3]byte"))
 
 	// Convert [120]int8 to [120]byte in lib_path_t members to simplify

--- a/pkg/network/ebpf/c/protocols/kafka/kafka-parsing.h
+++ b/pkg/network/ebpf/c/protocols/kafka/kafka-parsing.h
@@ -175,6 +175,7 @@ static __always_inline bool kafka_process(kafka_transaction_t *kafka_transaction
     bpf_memset(kafka_transaction->base.topic_name, 0, TOPIC_NAME_MAX_STRING_SIZE);
     parser_read_into_buffer_topic_name((char *)kafka_transaction->base.topic_name, skb, offset);
     offset += topic_name_size;
+    kafka_transaction->base.topic_name_size = topic_name_size;
 
     CHECK_STRING_COMPOSED_OF_ASCII_FOR_PARSING(TOPIC_NAME_MAX_STRING_SIZE_TO_VALIDATE, topic_name_size, kafka_transaction->base.topic_name);
 

--- a/pkg/network/ebpf/c/protocols/kafka/types.h
+++ b/pkg/network/ebpf/c/protocols/kafka/types.h
@@ -23,6 +23,7 @@ typedef struct {
     __u16 request_api_key;
     __u16 request_api_version;
     char topic_name[TOPIC_NAME_MAX_STRING_SIZE];
+    __u16 topic_name_size;
 } kafka_transaction_batch_entry_t;
 
 // Kafka transaction information associated to a certain socket (tuple_t)

--- a/pkg/network/protocols/kafka/kafka_types_linux.go
+++ b/pkg/network/protocols/kafka/kafka_types_linux.go
@@ -19,6 +19,7 @@ type EbpfKafkaTx struct {
 	Tup                 kafkaConnTuple
 	Request_api_key     uint16
 	Request_api_version uint16
-	Topic_name          [80]int8
-	Pad_cgo_0           [4]byte
+	Topic_name          [80]byte
+	Topic_name_size     uint16
+	Pad_cgo_0           [2]byte
 }

--- a/pkg/network/protocols/kafka/model_linux.go
+++ b/pkg/network/protocols/kafka/model_linux.go
@@ -22,14 +22,7 @@ func (tx *EbpfKafkaTx) ConnTuple() types.ConnectionKey {
 }
 
 func (tx *EbpfKafkaTx) TopicName() string {
-	topicNameAsByteArray := make([]byte, 0, len(tx.Topic_name))
-	for _, integer := range tx.Topic_name {
-		if integer == 0 {
-			break
-		}
-		topicNameAsByteArray = append(topicNameAsByteArray, byte(integer))
-	}
-	return string(topicNameAsByteArray)
+	return string(tx.Topic_name[:tx.Topic_name_size])
 }
 
 func (tx *EbpfKafkaTx) APIKey() uint16 {


### PR DESCRIPTION
### What does this PR do?

We're now sending to the user mode the topic name size as well, as we cannot assume we have null terminator in the original array. Furthermore, made a change to the structs creation script, so the Topic_name field will be generated as [80]byte instead of [80]int8 and improve the conversion to string

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Found a bug.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
