### PR TITLE
[CWS] add parameter to enable/disable anomaly for syscall

### DIFF
--- a/pkg/config/system_probe.go
+++ b/pkg/config/system_probe.go
@@ -298,6 +298,9 @@ func InitSystemProbeConfig(cfg Config) {
 	cfg.BindEnvAndSetDefault("runtime_security_config.security_profile.watch_dir", false)
 	cfg.BindEnvAndSetDefault("runtime_security_config.security_profile.cache_size", 10)
 	cfg.BindEnvAndSetDefault("runtime_security_config.security_profile.max_count", 400)
+
+	// CWS - Anomaly detection
+	cfg.BindEnvAndSetDefault("runtime_security_config.security_profile.anomaly_detection.syscalls", true)
 }
 
 func join(pieces ...string) string {

--- a/pkg/security/config/config.go
+++ b/pkg/security/config/config.go
@@ -127,6 +127,9 @@ type RuntimeSecurityConfig struct {
 	// SecurityProfileMaxCount defines the maximum number of Security Profiles that may be evaluated concurrently
 	SecurityProfileMaxCount int
 
+	// AnomalyDetectionSyscallsEnabled enable anomaly detection for syscalls
+	AnomalyDetectionSyscallsEnabled bool
+
 	// SBOMResolverEnabled defines if the SBOM resolver should be enabled
 	SBOMResolverEnabled bool
 	// SBOMResolverWorkloadsCacheSize defines the count of SBOMs to keep in memory in order to prevent re-computing
@@ -223,6 +226,9 @@ func NewRuntimeSecurityConfig() (*RuntimeSecurityConfig, error) {
 		SecurityProfileWatchDir:  coreconfig.SystemProbe.GetBool("runtime_security_config.security_profile.watch_dir"),
 		SecurityProfileCacheSize: coreconfig.SystemProbe.GetInt("runtime_security_config.security_profile.cache_size"),
 		SecurityProfileMaxCount:  coreconfig.SystemProbe.GetInt("runtime_security_config.security_profile.max_count"),
+
+		// anomaly detection
+		AnomalyDetectionSyscallsEnabled: coreconfig.SystemProbe.GetBool("runtime_security_config.security_profile.anomaly_detection.syscalls.enabled"),
 	}
 
 	if err := rsConfig.sanitize(); err != nil {

--- a/pkg/security/ebpf/c/include/constants/custom.h
+++ b/pkg/security/ebpf/c/include/constants/custom.h
@@ -157,4 +157,10 @@ static __attribute__((always_inline)) u64 is_send_signal_available() {
     return send_signal;
 };
 
+static __attribute__((always_inline)) u64 is_anomaly_syscalls_enabled() {
+    u64 anomaly;
+    LOAD_CONSTANT("anomaly_syscalls", anomaly);
+    return anomaly;
+};
+
 #endif

--- a/pkg/security/ebpf/c/include/hooks/raw_syscalls.h
+++ b/pkg/security/ebpf/c/include/hooks/raw_syscalls.h
@@ -18,7 +18,9 @@ int sys_enter(struct _tracepoint_raw_syscalls_sys_enter *args) {
     fill_container_context(proc_cache_entry, &event.container);
 
     // check if this workload has a security profile
-    evaluate_security_profile_syscalls(args, &event, args->id);
+    if (is_anomaly_syscalls_enabled()) {
+        evaluate_security_profile_syscalls(args, &event, args->id);
+    }
 
     // check if we are monitoring the syscalls of the current process
     char comm[TASK_COMM_LEN];

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -1488,6 +1488,10 @@ func NewProbe(config *config.Config, opts Opts) (*Probe, error) {
 			Name:  "send_signal",
 			Value: isBPFSendSignalHelperAvailable(p.kernelVersion),
 		},
+		manager.ConstantEditor{
+			Name:  "anomaly_syscalls",
+			Value: utils.BoolTouint64(p.Config.RuntimeSecurity.AnomalyDetectionSyscallsEnabled),
+		},
 	)
 
 	p.managerOptions.ConstantEditors = append(p.managerOptions.ConstantEditors, DiscarderConstants...)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Add a config parameter to enable/disable the anomaly detection for syscalls

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
