### PR TITLE
[backport][CWS] call custom marshaller after rate limiter (#16517)

### DIFF
--- a/pkg/security/events/custom.go
+++ b/pkg/security/events/custom.go
@@ -47,26 +47,26 @@ func AllCustomRuleIDs() []string {
 }
 
 // NewCustomEvent returns a new custom event
-func NewCustomEvent(eventType model.EventType, marshaler easyjson.Marshaler) *CustomEvent {
+func NewCustomEvent(eventType model.EventType, marshalerCtor func() easyjson.Marshaler) *CustomEvent {
 	return &CustomEvent{
-		eventType: eventType,
-		marshaler: marshaler,
+		eventType:     eventType,
+		marshalerCtor: marshalerCtor,
 	}
 }
 
 // CustomEvent is used to send custom security events to Datadog
 type CustomEvent struct {
-	eventType model.EventType
-	tags      []string
-	marshaler easyjson.Marshaler
+	eventType     model.EventType
+	tags          []string
+	marshalerCtor func() easyjson.Marshaler
 }
 
 // Clone returns a copy of the current CustomEvent
 func (ce *CustomEvent) Clone() CustomEvent {
 	return CustomEvent{
-		eventType: ce.eventType,
-		tags:      ce.tags,
-		marshaler: ce.marshaler,
+		eventType:     ce.eventType,
+		tags:          ce.tags,
+		marshalerCtor: ce.marshalerCtor,
 	}
 }
 
@@ -86,5 +86,5 @@ func (ce *CustomEvent) GetEventType() model.EventType {
 }
 
 func (ce *CustomEvent) MarshalEasyJSON(w *jwriter.Writer) {
-	ce.marshaler.MarshalEasyJSON(w)
+	ce.marshalerCtor().MarshalEasyJSON(w)
 }

--- a/pkg/security/module/policy_monitor.go
+++ b/pkg/security/module/policy_monitor.go
@@ -14,9 +14,11 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-go/v5/statsd"
-	"github.com/hashicorp/go-multierror"
 
 	"github.com/DataDog/datadog-agent/pkg/dogstatsd"
+	"github.com/hashicorp/go-multierror"
+	easyjson "github.com/mailru/easyjson"
+
 	"github.com/DataDog/datadog-agent/pkg/security/events"
 	"github.com/DataDog/datadog-agent/pkg/security/metrics"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
@@ -222,8 +224,10 @@ func NewRuleSetLoadedEvent(rs *rules.RuleSet, err *multierror.Error) (*rules.Rul
 		policies = append(policies, policy)
 	}
 
-	return events.NewCustomRule(events.RulesetLoadedRuleID), events.NewCustomEvent(model.CustomRulesetLoadedEventType, RulesetLoadedEvent{
-		Timestamp: time.Now(),
-		Policies:  policies,
+	return events.NewCustomRule(events.RulesetLoadedRuleID), events.NewCustomEvent(model.CustomRulesetLoadedEventType, func() easyjson.Marshaler {
+		return RulesetLoadedEvent{
+			Timestamp: time.Now(),
+			Policies:  policies,
+		}
 	})
 }

--- a/pkg/security/module/self_tests.go
+++ b/pkg/security/module/self_tests.go
@@ -17,6 +17,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-go/v5/statsd"
+	easyjson "github.com/mailru/easyjson"
 )
 
 // SelfTestEvent is used to report a self test result
@@ -29,10 +30,12 @@ type SelfTestEvent struct {
 
 // NewSelfTestEvent returns the rule and the result of the self test
 func NewSelfTestEvent(success []string, fails []string) (*rules.Rule, *events.CustomEvent) {
-	return events.NewCustomRule(events.SelfTestRuleID), events.NewCustomEvent(model.CustomSelfTestEventType, SelfTestEvent{
-		Timestamp: time.Now(),
-		Success:   success,
-		Fails:     fails,
+	return events.NewCustomRule(events.SelfTestRuleID), events.NewCustomEvent(model.CustomSelfTestEventType, func() easyjson.Marshaler {
+		return SelfTestEvent{
+			Timestamp: time.Now(),
+			Success:   success,
+			Fails:     fails,
+		}
 	})
 }
 

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-multierror"
+	easyjson "github.com/mailru/easyjson"
 	"github.com/moby/sys/mountinfo"
 	"golang.org/x/exp/slices"
 	"golang.org/x/sys/unix"
@@ -384,6 +385,12 @@ func (p *Probe) zeroEvent() *model.Event {
 	*p.event = eventZero
 	p.event.FieldHandlers = p.fieldHandlers
 	return p.event
+}
+
+func (p *Probe) EventMarshallerCtor(event *model.Event) func() easyjson.Marshaler {
+	return func() easyjson.Marshaler {
+		return serializers.NewEventSerializer(event, p.resolvers)
+	}
 }
 
 func (p *Probe) unmarshalContexts(data []byte, event *model.Event) (int, error) {


### PR DESCRIPTION
(cherry picked from commit 71082409d48e3cf97b4fdf8832ae397fceded981)

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
