### PR TITLE
Collect RFC1123 compliant cluster name for pods

### DIFF
--- a/pkg/orchestrator/config/config.go
+++ b/pkg/orchestrator/config/config.go
@@ -203,7 +203,7 @@ func IsOrchestratorEnabled() (bool, string) {
 	if enabled {
 		// Set clustername
 		hname, _ := hostname.Get(context.TODO())
-		clusterName = clustername.GetClusterName(context.TODO(), hname)
+		clusterName = clustername.GetRFC1123CompliantClusterName(context.TODO(), hname)
 	}
 	return enabled, clusterName
 }

--- a/releasenotes/notes/compliant-pod-cluster-name-9b674213adfe4fef.yaml
+++ b/releasenotes/notes/compliant-pod-cluster-name-9b674213adfe4fef.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fix an issue on the pod collection where the cluster name would not
+    be consistently RFC1123 compliant

--- a/releasenotes/notes/compliant-pod-cluster-name-9b674213adfe4fef.yaml
+++ b/releasenotes/notes/compliant-pod-cluster-name-9b674213adfe4fef.yaml
@@ -2,4 +2,4 @@
 fixes:
   - |
     Fix an issue on the pod collection where the cluster name would not
-    be consistently RFC1123 compliant
+    be consistently RFC1123 compliant.


### PR DESCRIPTION
### What does this PR do?

Collect RFC1123 compliant cluster name for pods

### Motivation

Fix consistency on the cluster name tag

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
