### PR TITLE
[CI] Disable `codecov` in the CI because its Python package disappeared from Pypi

### DIFF
--- a/.circleci/requirements.txt
+++ b/.circleci/requirements.txt
@@ -1,5 +1,5 @@
 black==22.10.0
-# Codecov was deprecated on Feb 1, 2022 and disappeared from PyPi on Apr 12, 2023.
+# The Codecov Python uploader was deprecated on Feb 1, 2022 and disappeared from PyPi on Apr 12, 2023.
 # codecov==2.1.12
 flake8-bugbear==22.10.27
 flake8-comprehensions==3.10.1

--- a/.circleci/requirements.txt
+++ b/.circleci/requirements.txt
@@ -1,5 +1,6 @@
 black==22.10.0
-codecov==2.1.12
+# Codecov was deprecated on Feb 1, 2022 and disappeared from PyPi on Apr 12, 2023.
+# codecov==2.1.12
 flake8-bugbear==22.10.27
 flake8-comprehensions==3.10.1
 flake8-unused-arguments==0.0.12

--- a/.github/workflows/windows-lint-go.yml
+++ b/.github/workflows/windows-lint-go.yml
@@ -34,7 +34,9 @@ jobs:
         run: |
           $ErrorActionPreference = 'Stop';
           # install dependencies
-          python -m pip install codecov -r requirements.txt
+          # Codecov was deprecated on Feb 1, 2022 and disappeared from PyPi on Apr 12, 2023.
+          # python -m pip install codecov
+          python -m pip install -r requirements.txt
           If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
           inv -e install-tools
           If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }

--- a/.github/workflows/windows-lint-go.yml
+++ b/.github/workflows/windows-lint-go.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           $ErrorActionPreference = 'Stop';
           # install dependencies
-          # Codecov was deprecated on Feb 1, 2022 and disappeared from PyPi on Apr 12, 2023.
+          # The Codecov Python uploader was deprecated on Feb 1, 2022 and disappeared from PyPi on Apr 12, 2023.
           # python -m pip install codecov
           python -m pip install -r requirements.txt
           If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }

--- a/.github/workflows/windows-unittests.yml
+++ b/.github/workflows/windows-unittests.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           $ErrorActionPreference = 'Stop';
           # install dependencies
-          # Codecov was deprecated on Feb 1, 2022 and disappeared from PyPi on Apr 12, 2023.
+          # The Codecov Python uploader was deprecated on Feb 1, 2022 and disappeared from PyPi on Apr 12, 2023.
           # python -m pip install codecov
           python -m pip install -r requirements.txt
           If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }

--- a/.github/workflows/windows-unittests.yml
+++ b/.github/workflows/windows-unittests.yml
@@ -34,7 +34,9 @@ jobs:
         run: |
           $ErrorActionPreference = 'Stop';
           # install dependencies
-          python -m pip install codecov -r requirements.txt
+          # Codecov was deprecated on Feb 1, 2022 and disappeared from PyPi on Apr 12, 2023.
+          # python -m pip install codecov
+          python -m pip install -r requirements.txt
           If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
           inv -e install-tools
           If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
@@ -55,4 +57,5 @@ jobs:
           # FIXME: skipping rtloader tests because they fail with a DLL-not-found error
           # inv -e rtloader.test
           inv -e test --skip-linters --rerun-fails=2 --python-runtimes 3 --coverage --profile --python-home-3=$pythonLocation
-          inv -e codecov
+          # Codecov was deprecated on Feb 1, 2022 and disappeared from PyPi on Apr 12, 2023.
+          # inv -e codecov

--- a/.github/workflows/windows-unittests.yml
+++ b/.github/workflows/windows-unittests.yml
@@ -57,5 +57,5 @@ jobs:
           # FIXME: skipping rtloader tests because they fail with a DLL-not-found error
           # inv -e rtloader.test
           inv -e test --skip-linters --rerun-fails=2 --python-runtimes 3 --coverage --profile --python-home-3=$pythonLocation
-          # Codecov was deprecated on Feb 1, 2022 and disappeared from PyPi on Apr 12, 2023.
+          # The Codecov Python uploader was deprecated on Feb 1, 2022 and disappeared from PyPi on Apr 12, 2023.
           # inv -e codecov


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This PR stops using `codecov` in the Github Actions CI.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

The python Codecov uploader [was deprecated on Feb 1, 2022](https://github.com/codecov/codecov-python) and [completely disappeared from Pypi on Apr 12, 2023](https://pypi.org/project/codecov/).

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
