### PR TITLE
[ksm-core][CI] add build flag to customresources to fix the CI

### DIFF
--- a/pkg/collector/corechecks/cluster/ksm/customresources/crd.go
+++ b/pkg/collector/corechecks/cluster/ksm/customresources/crd.go
@@ -3,6 +3,9 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build kubeapiserver
+// +build kubeapiserver
+
 package customresources
 
 import (

--- a/pkg/collector/corechecks/cluster/ksm/customresources/cronjob.go
+++ b/pkg/collector/corechecks/cluster/ksm/customresources/cronjob.go
@@ -3,6 +3,9 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build kubeapiserver
+// +build kubeapiserver
+
 package customresources
 
 // This file has most of its logic copied from the KSM cronjob metric family

--- a/pkg/collector/corechecks/cluster/ksm/customresources/hpa.go
+++ b/pkg/collector/corechecks/cluster/ksm/customresources/hpa.go
@@ -3,6 +3,9 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build kubeapiserver
+// +build kubeapiserver
+
 package customresources
 
 // This file has most of its logic copied from the KSM hpa metric family

--- a/pkg/collector/corechecks/cluster/ksm/customresources/job.go
+++ b/pkg/collector/corechecks/cluster/ksm/customresources/job.go
@@ -3,6 +3,9 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build kubeapiserver
+// +build kubeapiserver
+
 package customresources
 
 import (

--- a/pkg/collector/corechecks/cluster/ksm/customresources/node.go
+++ b/pkg/collector/corechecks/cluster/ksm/customresources/node.go
@@ -3,6 +3,9 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build kubeapiserver
+// +build kubeapiserver
+
 package customresources
 
 import (

--- a/pkg/collector/corechecks/cluster/ksm/customresources/pdb.go
+++ b/pkg/collector/corechecks/cluster/ksm/customresources/pdb.go
@@ -3,6 +3,9 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build kubeapiserver
+// +build kubeapiserver
+
 package customresources
 
 // This file has most of its logic copied from the KSM pdb metric family

--- a/pkg/collector/corechecks/cluster/ksm/customresources/pod.go
+++ b/pkg/collector/corechecks/cluster/ksm/customresources/pod.go
@@ -3,6 +3,9 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build kubeapiserver
+// +build kubeapiserver
+
 package customresources
 
 import (

--- a/pkg/collector/corechecks/cluster/ksm/customresources/utils.go
+++ b/pkg/collector/corechecks/cluster/ksm/customresources/utils.go
@@ -1,3 +1,6 @@
+//go:build kubeapiserver
+// +build kubeapiserver
+
 /*
 Copyright 2018 The Kubernetes Authors All rights reserved.
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
Fix CI jobs `tests_flavor_iot_deb-x64` and `tests_flavor_dogstatsd_deb-x64`
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Tests are broken because of the missing build flag:
```
pkg/collector/corechecks/cluster/ksm/customresources/crd.go:39:18: client.CRDClient undefined (type *apiserver.APIClient has no field or method CRDClient)
```
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs
N/A
<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
CI jobs must pass
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
