### PR TITLE
[CWS] add opt for pathname resolution

### DIFF
--- a/cmd/system-probe/modules/eventmonitor.go
+++ b/cmd/system-probe/modules/eventmonitor.go
@@ -33,7 +33,14 @@ var EventMonitor = module.Factory{
 			return nil, module.ErrNotEnabled
 		}
 
-		evm, err := eventmonitor.NewEventMonitor(emconfig, secconfig, eventmonitor.Opts{})
+		opts := eventmonitor.Opts{}
+
+		// adapt options
+		if secconfig.RuntimeSecurity.IsRuntimeEnabled() {
+			secmodule.UpdateEventMonitorOpts(&opts)
+		}
+
+		evm, err := eventmonitor.NewEventMonitor(emconfig, secconfig, opts)
 		if err != nil {
 			log.Infof("error initializing event monitoring module: %v", err)
 			return nil, module.ErrNotEnabled

--- a/pkg/security/ebpf/c/include/maps.h
+++ b/pkg/security/ebpf/c/include/maps.h
@@ -53,7 +53,7 @@ BPF_LRU_MAP(netns_cache, u32, u32, 40960)
 BPF_LRU_MAP(span_tls, u32, struct span_tls_t, 4096)
 BPF_LRU_MAP(inode_discarders, struct inode_discarder_t, struct inode_discarder_params_t, 4096)
 BPF_LRU_MAP(pid_discarders, u32, struct pid_discarder_params_t, 512)
-BPF_LRU_MAP(pathnames, struct path_key_t, struct path_leaf_t, 64000)
+BPF_LRU_MAP(pathnames, struct path_key_t, struct path_leaf_t, 1) // edited
 BPF_LRU_MAP(flow_pid, struct pid_route_t, u32, 10240)
 BPF_LRU_MAP(conntrack, struct namespaced_flow_t, struct namespaced_flow_t, 4096)
 BPF_LRU_MAP(io_uring_ctx_pid, void*, u64, 2048)

--- a/pkg/security/ebpf/probes/all.go
+++ b/pkg/security/ebpf/probes/all.go
@@ -145,8 +145,18 @@ func getMaxEntries(numCPU int, min int, max int) uint32 {
 	return uint32(maxEntries)
 }
 
+// MapSpecEditorOpts defines some options of the map spec editor
+type MapSpecEditorOpts struct {
+	TracedCgroupSize        int
+	UseMmapableMaps         bool
+	UseRingBuffers          bool
+	RingBufferSize          uint32
+	PathResolutionEnabled   bool
+	SecurityProfileMaxCount int
+}
+
 // AllMapSpecEditors returns the list of map editors
-func AllMapSpecEditors(numCPU int, tracedCgroupSize int, supportMmapableMaps, useRingBuffers bool, ringBufferSize uint32, securityProfileMaxCount int) map[string]manager.MapSpecEditor {
+func AllMapSpecEditors(numCPU int, opts MapSpecEditorOpts) map[string]manager.MapSpecEditor {
 	editors := map[string]manager.MapSpecEditor{
 		"proc_cache": {
 			MaxEntries: getMaxEntries(numCPU, minProcEntries, maxProcEntries),
@@ -156,10 +166,7 @@ func AllMapSpecEditors(numCPU int, tracedCgroupSize int, supportMmapableMaps, us
 			MaxEntries: getMaxEntries(numCPU, minProcEntries, maxProcEntries),
 			EditorFlag: manager.EditMaxEntries,
 		},
-		"pathnames": {
-			MaxEntries: getMaxEntries(numCPU, minPathnamesEntries, maxPathnamesEntries),
-			EditorFlag: manager.EditMaxEntries,
-		},
+
 		"activity_dumps_config": {
 			MaxEntries: model.MaxTracedCgroupsCount,
 			EditorFlag: manager.EditMaxEntries,
@@ -173,34 +180,41 @@ func AllMapSpecEditors(numCPU int, tracedCgroupSize int, supportMmapableMaps, us
 			EditorFlag: manager.EditMaxEntries,
 		},
 		"security_profiles": {
-			MaxEntries: uint32(securityProfileMaxCount),
+			MaxEntries: uint32(opts.SecurityProfileMaxCount),
 			EditorFlag: manager.EditMaxEntries,
 		},
 		"secprofs_syscalls": {
-			MaxEntries: uint32(securityProfileMaxCount),
+			MaxEntries: uint32(opts.SecurityProfileMaxCount),
 			EditorFlag: manager.EditMaxEntries,
 		},
 	}
 
-	if tracedCgroupSize > 0 {
-		editors["traced_cgroups"] = manager.MapSpecEditor{
-			MaxEntries: uint32(tracedCgroupSize),
+	if opts.PathResolutionEnabled {
+		editors["pathnames"] = manager.MapSpecEditor{
+			MaxEntries: getMaxEntries(numCPU, minPathnamesEntries, maxPathnamesEntries),
 			EditorFlag: manager.EditMaxEntries,
 		}
 	}
 
-	if supportMmapableMaps {
+	if opts.TracedCgroupSize > 0 {
+		editors["traced_cgroups"] = manager.MapSpecEditor{
+			MaxEntries: uint32(opts.TracedCgroupSize),
+			EditorFlag: manager.EditMaxEntries,
+		}
+	}
+
+	if opts.UseMmapableMaps {
 		editors["dr_erpc_buffer"] = manager.MapSpecEditor{
 			Flags:      unix.BPF_F_MMAPABLE,
 			EditorFlag: manager.EditFlags,
 		}
 	}
-	if useRingBuffers {
-		if ringBufferSize == 0 {
-			ringBufferSize = computeDefaultEventsRingBufferSize()
+	if opts.UseRingBuffers {
+		if opts.RingBufferSize == 0 {
+			opts.RingBufferSize = computeDefaultEventsRingBufferSize()
 		}
 		editors["events"] = manager.MapSpecEditor{
-			MaxEntries: ringBufferSize,
+			MaxEntries: opts.RingBufferSize,
 			Type:       ebpf.RingBuf,
 			EditorFlag: manager.EditMaxEntries | manager.EditType | manager.EditKeyValue,
 		}

--- a/pkg/security/module/cws.go
+++ b/pkg/security/module/cws.go
@@ -591,3 +591,8 @@ func logLoadingErrors(msg string, m *multierror.Error) {
 		seclog.Warnf(msg, m.Error())
 	}
 }
+
+// UpdateEventMonitorOpts adapt the event monitor options
+func UpdateEventMonitorOpts(opts *eventmonitor.Opts) {
+	opts.ProbeOpts.PathResolutionEnabled = true
+}

--- a/pkg/security/module/cws_unsupported.go
+++ b/pkg/security/module/cws_unsupported.go
@@ -30,3 +30,6 @@ func (c *CWSConsumer) Start() error {
 }
 
 func (c *CWSConsumer) Stop() {}
+
+// UpdateEventMonitorOpts adapt the event monitor options
+func UpdateEventMonitorOpts(opts *eventmonitor.Opts) {}

--- a/pkg/security/probe/model_test.go
+++ b/pkg/security/probe/model_test.go
@@ -31,7 +31,7 @@ func TestProcessArgsFlags(t *testing.T) {
 	}
 
 	resolver, _ := process.NewResolver(&manager.Manager{}, &config.Config{}, &statsd.NoOpClient{},
-		&procutil.DataScrubber{}, nil, nil, nil, nil, nil, nil, process.NewResolverOpts(nil))
+		&procutil.DataScrubber{}, nil, nil, nil, nil, nil, nil, process.NewResolverOpts())
 
 	e := model.Event{
 		Exec: model.ExecEvent{
@@ -92,7 +92,7 @@ func TestProcessArgsOptions(t *testing.T) {
 	}
 
 	resolver, _ := process.NewResolver(&manager.Manager{}, &config.Config{}, &statsd.NoOpClient{},
-		&procutil.DataScrubber{}, nil, nil, nil, nil, nil, nil, process.NewResolverOpts(nil))
+		&procutil.DataScrubber{}, nil, nil, nil, nil, nil, nil, process.NewResolverOpts())
 
 	e := model.Event{
 		Exec: model.ExecEvent{

--- a/pkg/security/probe/opts_linux.go
+++ b/pkg/security/probe/opts_linux.go
@@ -18,6 +18,8 @@ type Opts struct {
 	DontDiscardRuntime bool
 	// StatsdClient to be used for probe stats
 	StatsdClient statsd.ClientInterface
+	// PathResolutionEnabled defines if the path resolution is enabled
+	PathResolutionEnabled bool
 }
 
 func (o *Opts) normalize() {

--- a/pkg/security/probe/probe_linux.go
+++ b/pkg/security/probe/probe_linux.go
@@ -1375,14 +1375,15 @@ func NewProbe(config *config.Config, opts Opts) (*Probe, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse CPU count: %w", err)
 	}
-	p.managerOptions.MapSpecEditors = probes.AllMapSpecEditors(
-		numCPU,
-		config.RuntimeSecurity.ActivityDumpTracedCgroupsCount,
-		useMmapableMaps,
-		useRingBuffers,
-		uint32(p.Config.Probe.EventStreamBufferSize),
-		p.Config.RuntimeSecurity.SecurityProfileMaxCount,
-	)
+
+	p.managerOptions.MapSpecEditors = probes.AllMapSpecEditors(numCPU, probes.MapSpecEditorOpts{
+		TracedCgroupSize:        p.Config.RuntimeSecurity.ActivityDumpTracedCgroupsCount,
+		UseRingBuffers:          useRingBuffers,
+		UseMmapableMaps:         useMmapableMaps,
+		RingBufferSize:          uint32(p.Config.Probe.EventStreamBufferSize),
+		PathResolutionEnabled:   p.Opts.PathResolutionEnabled,
+		SecurityProfileMaxCount: p.Config.RuntimeSecurity.SecurityProfileMaxCount,
+	})
 
 	if config.RuntimeSecurity.ActivityDumpEnabled {
 		for _, e := range config.RuntimeSecurity.ActivityDumpTracedEventTypes {
@@ -1533,13 +1534,15 @@ func NewProbe(config *config.Config, opts Opts) (*Probe, error) {
 	p.scrubber = procutil.NewDefaultDataScrubber()
 	p.scrubber.AddCustomSensitiveWords(config.Probe.CustomSensitiveWords)
 
-	resolvers, err := resolvers.NewResolvers(config, p.Manager, p.StatsdClient, p.scrubber, p.Erpc)
+	resolversOpts := resolvers.ResolversOpts{
+		PathResolutionEnabled: opts.PathResolutionEnabled,
+	}
+	p.resolvers, err = resolvers.NewResolvers(config, p.Manager, p.StatsdClient, p.scrubber, p.Erpc, resolversOpts)
 	if err != nil {
 		return nil, err
 	}
-	p.resolvers = resolvers
 
-	p.fieldHandlers = &FieldHandlers{resolvers: resolvers}
+	p.fieldHandlers = &FieldHandlers{resolvers: p.resolvers}
 
 	// be sure to zero the probe event before everything else
 	p.zeroEvent()

--- a/pkg/security/resolvers/path/resolver.go
+++ b/pkg/security/resolvers/path/resolver.go
@@ -18,6 +18,49 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 )
 
+type ResolverInterface interface {
+	ResolveBasename(e *model.FileFields) string
+	ResolveFileFieldsPath(e *model.FileFields, pidCtx *model.PIDContext, ctrCtx *model.ContainerContext) (string, error)
+	SetMountRoot(ev *model.Event, e *model.Mount) error
+	ResolveMountRoot(ev *model.Event, e *model.Mount) (string, error)
+	SetMountPoint(ev *model.Event, e *model.Mount) error
+	ResolveMountPoint(ev *model.Event, e *model.Mount) (string, error)
+}
+
+// NoResolver returns an empty resolver
+type NoResolver struct {
+}
+
+// ResolveBasename resolves an inode/mount ID pair to a file basename
+func (n *NoResolver) ResolveBasename(e *model.FileFields) string {
+	return ""
+}
+
+// ResolveFileFieldsPath resolves an inode/mount ID pair to a full path
+func (n *NoResolver) ResolveFileFieldsPath(e *model.FileFields, pidCtx *model.PIDContext, ctrCtx *model.ContainerContext) (string, error) {
+	return "", nil
+}
+
+// SetMountRoot set the mount point information
+func (n *NoResolver) SetMountRoot(ev *model.Event, e *model.Mount) error {
+	return nil
+}
+
+// ResolveMountRoot resolves the mountpoint to a full path
+func (n *NoResolver) ResolveMountRoot(ev *model.Event, e *model.Mount) (string, error) {
+	return "", nil
+}
+
+// SetMountPoint set the mount point information
+func (n *NoResolver) SetMountPoint(ev *model.Event, e *model.Mount) error {
+	return nil
+}
+
+// ResolveMountPoint resolves the mountpoint to a full path
+func (n *NoResolver) ResolveMountPoint(ev *model.Event, e *model.Mount) (string, error) {
+	return "", nil
+}
+
 // Resolver describes a resolvers for path and file names
 type Resolver struct {
 	dentryResolver *dentry.Resolver

--- a/pkg/security/resolvers/process/resolver_test.go
+++ b/pkg/security/resolvers/process/resolver_test.go
@@ -34,7 +34,7 @@ func testCacheSize(t *testing.T, resolver *Resolver) {
 }
 
 func TestFork1st(t *testing.T) {
-	resolver, err := NewResolver(nil, nil, &statsd.NoOpClient{}, nil, nil, nil, nil, nil, nil, nil, NewResolverOpts(nil))
+	resolver, err := NewResolver(nil, nil, &statsd.NoOpClient{}, nil, nil, nil, nil, nil, nil, nil, NewResolverOpts())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -73,7 +73,7 @@ func TestFork1st(t *testing.T) {
 }
 
 func TestFork2nd(t *testing.T) {
-	resolver, err := NewResolver(nil, nil, &statsd.NoOpClient{}, nil, nil, nil, nil, nil, nil, nil, NewResolverOpts(nil))
+	resolver, err := NewResolver(nil, nil, &statsd.NoOpClient{}, nil, nil, nil, nil, nil, nil, nil, NewResolverOpts())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -114,7 +114,7 @@ func TestFork2nd(t *testing.T) {
 }
 
 func TestForkExec(t *testing.T) {
-	resolver, err := NewResolver(nil, nil, &statsd.NoOpClient{}, nil, nil, nil, nil, nil, nil, nil, NewResolverOpts(nil))
+	resolver, err := NewResolver(nil, nil, &statsd.NoOpClient{}, nil, nil, nil, nil, nil, nil, nil, NewResolverOpts())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -169,7 +169,7 @@ func TestForkExec(t *testing.T) {
 }
 
 func TestOrphanExec(t *testing.T) {
-	resolver, err := NewResolver(nil, nil, &statsd.NoOpClient{}, nil, nil, nil, nil, nil, nil, nil, NewResolverOpts(nil))
+	resolver, err := NewResolver(nil, nil, &statsd.NoOpClient{}, nil, nil, nil, nil, nil, nil, nil, NewResolverOpts())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -224,7 +224,7 @@ func TestOrphanExec(t *testing.T) {
 }
 
 func TestForkExecExec(t *testing.T) {
-	resolver, err := NewResolver(nil, nil, &statsd.NoOpClient{}, nil, nil, nil, nil, nil, nil, nil, NewResolverOpts(nil))
+	resolver, err := NewResolver(nil, nil, &statsd.NoOpClient{}, nil, nil, nil, nil, nil, nil, nil, NewResolverOpts())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -293,7 +293,7 @@ func TestForkExecExec(t *testing.T) {
 }
 
 func TestForkReuse(t *testing.T) {
-	resolver, err := NewResolver(nil, nil, &statsd.NoOpClient{}, nil, nil, nil, nil, nil, nil, nil, NewResolverOpts(nil))
+	resolver, err := NewResolver(nil, nil, &statsd.NoOpClient{}, nil, nil, nil, nil, nil, nil, nil, NewResolverOpts())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -387,7 +387,7 @@ func TestForkReuse(t *testing.T) {
 }
 
 func TestForkForkExec(t *testing.T) {
-	resolver, err := NewResolver(nil, nil, &statsd.NoOpClient{}, nil, nil, nil, nil, nil, nil, nil, NewResolverOpts(nil))
+	resolver, err := NewResolver(nil, nil, &statsd.NoOpClient{}, nil, nil, nil, nil, nil, nil, nil, NewResolverOpts())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -866,8 +866,9 @@ func newTestModule(t testing.TB, macroDefs []*rules.MacroDefinition, ruleDefs []
 	emopts := eventmonitor.Opts{
 		StatsdClient: statsdClient,
 		ProbeOpts: probe.Opts{
-			StatsdClient:       statsdClient,
-			DontDiscardRuntime: true,
+			StatsdClient:          statsdClient,
+			DontDiscardRuntime:    true,
+			PathResolutionEnabled: true,
 		},
 	}
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This PR add an option to enable/disable pathname resolution which reduce the in-kernel memory usage if the option is disabled. The kernel map size is reduce to 1 entry is that case. 

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
