### PR TITLE
Ci - use pr-commenter in single-machine-performance-regression_detector job

### DIFF
--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -9,6 +9,7 @@ single-machine-performance-regression_detector:
     expire_in: 1 weeks
     paths:
       - submission_metadata
+      - outputs/report.html
   variables:
     SMP_VERSION: 0.7.3
     LADING_VERSION: 0.13.0
@@ -84,28 +85,21 @@ single-machine-performance-regression_detector:
     # space characters. This avoids
     # https://gitlab.com/gitlab-org/gitlab/-/issues/217231.
     - cat outputs/report.md | sed "s/^\$/$(echo -ne '\uFEFF\u00A0\u200B')/g"
-    # Add janky means of installing PR commenter borrowed from 
-    # https://github.com/DataDog/dogweb/blob/45d7fcf035d0d515ebd901919099d4c8bfa82829/docker/docker-builder/Dockerfile#L69-L77
-    - apt-get update
-    - apt-get install -y curl
-    - curl -OL https://s3.amazonaws.com/dd-package-public/dd-package.deb
-    - dpkg -i dd-package.deb
-    - rm dd-package.deb
-    - apt-get update
-    - dd-package --bucket binaries.ddbuild.io --package devtools/dd-package-dev
-    # Kludge from https://gitlab.com/gitlab-org/gitlab-runner/-/issues/4645#note_287636439 to avoid
-    # doubled output
-    - echo ""
-    - "####################### NOTE TO MAINTAINERS #####################################"
-    - "# Ignore bdist_wheel build error raised when installing 'devtools/pr-commenter' #"
-    - "# This error is known behavior, and you should see a successful install         #"
-    - "# beneath the error message in the GitLab CI logs                               #"
-    - "#################################################################################"
-    - echo ""
-    - dd-package --bucket binaries.ddbuild.io --package devtools/pr-commenter
-    # Post HTML report to GitHub
-    - cat outputs/report.html | /usr/local/bin/pr-commenter --for-pr="$CI_COMMIT_REF_NAME"
     # Finally, exit 1 if the job signals a regression else 0.
     - RUST_LOG="${RUST_LOG}" ./smp --team-id ${SMP_AGENT_TEAM_ID} --aws-named-profile ${AWS_NAMED_PROFILE}
             job result
             --submission-metadata submission_metadata
+
+single-machine-performance-regression_detector-pr-comment:
+  stage: notify
+  needs: ["single-machine-performance-regression_detector"]
+  when: always
+  image:
+    name: registry.ddbuild.io/pr-commenter:2
+    entrypoint: [""]
+  tags: ["arch:amd64"]
+  except: ["main"]
+  script:
+    - touch outputs/report.html
+    - pr-commenter --for-pr="$CI_COMMIT_REF_NAME" -infile outputs/report.html
+  


### PR DESCRIPTION
…

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->

### What does this PR do?

CI change only, follow-up from #16500
Use `pr-commenter` docker image to post a comment with result from `single-machine-performance-regression_detector` job

### Motivation

Simplify maintenance of `single-machine-performance-regression_detector` job by decoupling functional change from installing the `pr-commenter` tool
Allow instrumenting `pr-commenter` executions without impacting `single-machine-performance-regression_detector` job

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
