### PR TITLE
Fix the DCA admission controller in socket mode for pods with an init container

### DIFF
--- a/pkg/clusteragent/admission/mutate/common.go
+++ b/pkg/clusteragent/admission/mutate/common.go
@@ -116,8 +116,14 @@ func injectVolume(pod *corev1.Pod, volume corev1.Volume, volumeMount corev1.Volu
 		pod.Spec.Containers[i].VolumeMounts = append(pod.Spec.Containers[i].VolumeMounts, volumeMount)
 		shouldInject = true
 	}
-	for i := range pod.Spec.InitContainers {
+	for i, container := range pod.Spec.InitContainers {
+		if containsVolumeMount(container.VolumeMounts, volumeMount) {
+			// Ensure volume mount name and path uniqueness
+			log.Debugf("Ignoring init container %q in pod %q: a volume mount with name %q or path %q already exists", container.Name, podStr, volumeMount.Name, volumeMount.MountPath)
+			continue
+		}
 		pod.Spec.InitContainers[i].VolumeMounts = append(pod.Spec.InitContainers[i].VolumeMounts, volumeMount)
+		shouldInject = true
 	}
 
 	if shouldInject {

--- a/releasenotes-dca/notes/fix-agent-pod-mutation-in-socket-mode-c610a4dfd7a63a09.yaml
+++ b/releasenotes-dca/notes/fix-agent-pod-mutation-in-socket-mode-c610a4dfd7a63a09.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix the admission controller in socket mode for pods with init containers.


### PR DESCRIPTION
### What does this PR do?

Fixes a bug in the cluster agent admission controller in socket mode.

When a pod needs to be mutated (either annotated with `admission.datadoghq.com/enabled: true` and `admission.datadoghq.com/config.mode: socket` or because the cluster-agent is configured with:
```yaml
admission_controller:
  enabled: true
  inject_config:
    enabled: true
    endpoint: /injectconfig
    local_service_name: datadog
    mode: socket
    socket_path: /var/run/datadog
    trace_agent_socket: unix:///var/run/datadog/apm.socket
  mutate_unlabelled: true
```

The pods will be mutated at admission time to inject a `datadog` `hostPath` volume for `/var/run/datadog` and the corresponding volumeMounts for all the init and regular containers.
If a container already has a volumeMount for that path, the injection of the `datadog` one is skipped.
If the injection of the `datadog` container is skipped for all the containers, the injection of the volume was skipped.
So, if there are some init containers, a volume mount was injected in the init container, but the corresponding volume wasn’t injected, leading to invalid pods.

### Motivation

This bug prevents the deployment of the datadog agent itself with the latest version of the Helm chart.
The issue is triggered by default since the Helm chart version `3.22.0` because DataDog/helm-charts#944 changed the default admission controller mode to `socket`.

### Additional Notes

* Fixes #16402 
* Fixes DataDog/helm-charts#986

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Deploy the agent and the cluster agent with the latest version of the Helm chart and the following `values.yaml` file:
```yaml
clusterAgent:
  admissionController:
    enabled: true
    mutateUnlabelled: true
```

Once the cluster agent is up and running, try to delete all the agent pods.

Without this fix, agent pods are re-created and a `kubectl describe ds/datadog` shows the following events:
```
Error creating: Pod "datadog-5wxwt" is invalid: [spec.initContainers[0].volumeMounts[2].name: Not found: "datadog", spec.initContainers[1].volumeMounts[5].name: Not found: "datadog"]
```
With this fix, agent pods are starting.

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
