### PR TITLE
Revert "filter syscall events in kernel space (#15863)"

### DIFF
--- a/pkg/security/ebpf/c/raw_syscalls.h
+++ b/pkg/security/ebpf/c/raw_syscalls.h
@@ -75,18 +75,6 @@ int sys_enter(struct _tracepoint_raw_syscalls_sys_enter *args) {
     u64 pid_tgid = bpf_get_current_pid_tgid();
     u32 pid = pid_tgid >> 32;
 
-    // check if we are monitoring the syscalls of the current process
-    u64 now = bpf_ktime_get_ns();
-    struct syscall_monitor_event_t event = {};
-    struct proc_cache_t *proc_cache_entry = fill_process_context(&event.process);
-    fill_container_context(proc_cache_entry, &event.container);
-    char comm[TASK_COMM_LEN];
-    bpf_get_current_comm(&comm, TASK_COMM_LEN);
-    if (!should_trace_new_process(args, now, pid, event.container.container_id, comm)) {
-        // we're not tracing this process, ignore
-        return 0;
-    }
-
     struct syscall_monitor_entry_t *entry = bpf_map_lookup_elem(&syscall_monitor, &pid);
     if (entry == NULL) {
         bpf_map_update_elem(&syscall_monitor, &pid, &zero, BPF_NOEXIST);
@@ -109,6 +97,7 @@ int sys_enter(struct _tracepoint_raw_syscalls_sys_enter *args) {
     }
 
     // check if an event should be sent
+    u64 now = bpf_ktime_get_ns();
     u8 should_send = 0;
     struct syscall_table_key_t key = {
         .id = args->id,
@@ -136,8 +125,12 @@ shoud_send_event:
     if (should_send) {
 
         // send an event now
-        event.syscalls = *entry;
-        event.event.flags = EVENT_FLAGS_ACTIVITY_DUMP_SAMPLE; // syscall events are used only by activity dumps
+        struct syscall_monitor_event_t event = {
+            .syscalls = *entry,
+            .event.flags = EVENT_FLAGS_ACTIVITY_DUMP_SAMPLE, // syscall events are used only by activity dumps
+        };
+        struct proc_cache_t *proc_cache_entry = fill_process_context(&event.process);
+        fill_container_context(proc_cache_entry, &event.container);
 
         // regardless if we successfully send the event, update the "last_sent" field to avoid spamming the perf map
         entry->last_sent = now;


### PR DESCRIPTION
This reverts commit e40c1e64b0605fd76f462ed1ae3a7acffe7fc8b0.

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
