### PR TITLE
Fix E2E tests due to mismatch on admission controller service name

### DIFF
--- a/test/e2e/argo-workflows/templates/mutate-busybox.yaml
+++ b/test/e2e/argo-workflows/templates/mutate-busybox.yaml
@@ -376,7 +376,7 @@ spec:
                 - name: namespace
                   value: "{{inputs.parameters.namespace}}"
                 - name: envValue
-                  value: datadog.{{inputs.parameters.namespace}}.svc.cluster.local
+                  value: datadog-agent.{{inputs.parameters.namespace}}.svc.cluster.local
                 - name: envKey
                   value: DD_AGENT_HOST
                 - name: target

--- a/test/e2e/scripts/setup-instance/03-ssh.sh
+++ b/test/e2e/scripts/setup-instance/03-ssh.sh
@@ -16,7 +16,9 @@ test "${COMMIT_ID}" || {
     COMMIT_ID=$(git rev-parse --verify HEAD)
 }
 
-SSH_OPTS=("-o" "ServerAliveInterval=20" "-o" "ConnectTimeout=6" "-o" "StrictHostKeyChecking=no" "-o" "UserKnownHostsFile=/dev/null" "-i" "${PWD}/id_rsa" "-o" "SendEnv=CI_* DD_API_KEY DOCKER_REGISTRY_* DATADOG_AGENT_IMAGE=${DATADOG_AGENT_IMAGE:-datadog/agent-dev:master} DATADOG_CLUSTER_AGENT_IMAGE=${DATADOG_CLUSTER_AGENT_IMAGE:-datadog/cluster-agent-dev:master} ARGO_WORKFLOW DATADOG_AGENT_SITE DATADOG_AGENT_API_KEY DATADOG_AGENT_APP_KEY")
+export DATADOG_AGENT_IMAGE=${DATADOG_AGENT_IMAGE:-datadog/agent-dev:master}
+export DATADOG_CLUSTER_AGENT_IMAGE=${DATADOG_CLUSTER_AGENT_IMAGE:-datadog/cluster-agent-dev:master}
+SSH_OPTS=("-o" "ServerAliveInterval=20" "-o" "ConnectTimeout=6" "-o" "StrictHostKeyChecking=no" "-o" "UserKnownHostsFile=/dev/null" "-i" "${PWD}/id_rsa" "-o" "SendEnv=CI_* DD_API_KEY DOCKER_REGISTRY_* DATADOG_AGENT_IMAGE DATADOG_CLUSTER_AGENT_IMAGE ARGO_WORKFLOW DATADOG_AGENT_SITE DATADOG_AGENT_API_KEY DATADOG_AGENT_APP_KEY")
 
 function _ssh() {
     ssh "${SSH_OPTS[@]}" -lcore "${MACHINE}" "$@"


### PR DESCRIPTION
### What does this PR do?

Fix E2E tests failures in admission controller

### Motivation

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
