### PR TITLE
pkg/otlp: Fix trace data dropping in OTLP ingest

### DIFF
--- a/pkg/otlp/map_provider.go
+++ b/pkg/otlp/map_provider.go
@@ -31,6 +31,9 @@ const defaultTracesConfig string = `
 receivers:
   otlp:
 
+processors:
+  batch:
+
 exporters:
   otlp:
     tls:

--- a/pkg/otlp/map_provider.go
+++ b/pkg/otlp/map_provider.go
@@ -33,6 +33,7 @@ receivers:
 
 processors:
   batch:
+    timeout: 10s
 
 exporters:
   otlp:

--- a/pkg/otlp/map_provider.go
+++ b/pkg/otlp/map_provider.go
@@ -47,6 +47,7 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
+      processors: [batch]
       exporters: [otlp]
 `
 

--- a/pkg/otlp/map_provider_test.go
+++ b/pkg/otlp/map_provider_test.go
@@ -55,12 +55,18 @@ func TestNewMap(t *testing.T) {
 						"endpoint":    "localhost:5003",
 					},
 				},
+				"processors": map[string]interface{}{
+					"batch": map[string]interface{}{
+						"timeout": "10s",
+					},
+				},
 				"service": map[string]interface{}{
 					"telemetry": map[string]interface{}{"metrics": map[string]interface{}{"level": "none"}},
 					"pipelines": map[string]interface{}{
 						"traces": map[string]interface{}{
-							"receivers": []interface{}{"otlp"},
-							"exporters": []interface{}{"otlp"},
+							"receivers":  []interface{}{"otlp"},
+							"processors": []interface{}{"batch"},
+							"exporters":  []interface{}{"otlp"},
 						},
 					},
 				},
@@ -127,8 +133,9 @@ func TestNewMap(t *testing.T) {
 					"telemetry": map[string]interface{}{"metrics": map[string]interface{}{"level": "none"}},
 					"pipelines": map[string]interface{}{
 						"traces": map[string]interface{}{
-							"receivers": []interface{}{"otlp"},
-							"exporters": []interface{}{"otlp"},
+							"receivers":  []interface{}{"otlp"},
+							"processors": []interface{}{"batch"},
+							"exporters":  []interface{}{"otlp"},
 						},
 						"metrics": map[string]interface{}{
 							"receivers":  []interface{}{"otlp"},
@@ -200,8 +207,9 @@ func TestNewMap(t *testing.T) {
 					"telemetry": map[string]interface{}{"metrics": map[string]interface{}{"level": "none"}},
 					"pipelines": map[string]interface{}{
 						"traces": map[string]interface{}{
-							"receivers": []interface{}{"otlp"},
-							"exporters": []interface{}{"otlp"},
+							"receivers":  []interface{}{"otlp"},
+							"processors": []interface{}{"batch"},
+							"exporters":  []interface{}{"otlp"},
 						},
 						"metrics": map[string]interface{}{
 							"receivers":  []interface{}{"otlp"},
@@ -235,6 +243,11 @@ func TestNewMap(t *testing.T) {
 						},
 					},
 				},
+				"processors": map[string]interface{}{
+					"batch": map[string]interface{}{
+						"timeout": "10s",
+					},
+				},
 				"exporters": map[string]interface{}{
 					"otlp": map[string]interface{}{
 						"tls": map[string]interface{}{
@@ -248,8 +261,9 @@ func TestNewMap(t *testing.T) {
 					"telemetry": map[string]interface{}{"metrics": map[string]interface{}{"level": "none"}},
 					"pipelines": map[string]interface{}{
 						"traces": map[string]interface{}{
-							"receivers": []interface{}{"otlp"},
-							"exporters": []interface{}{"otlp"},
+							"receivers":  []interface{}{"otlp"},
+							"processors": []interface{}{"batch"},
+							"exporters":  []interface{}{"otlp"},
 						},
 					},
 				},
@@ -336,6 +350,11 @@ func TestNewMap(t *testing.T) {
 						},
 					},
 				},
+				"processors": map[string]interface{}{
+					"batch": map[string]interface{}{
+						"timeout": "10s",
+					},
+				},
 				"exporters": map[string]interface{}{
 					"otlp": map[string]interface{}{
 						"tls": map[string]interface{}{
@@ -352,8 +371,9 @@ func TestNewMap(t *testing.T) {
 					"telemetry": map[string]interface{}{"metrics": map[string]interface{}{"level": "none"}},
 					"pipelines": map[string]interface{}{
 						"traces": map[string]interface{}{
-							"receivers": []interface{}{"otlp"},
-							"exporters": []interface{}{"otlp", "logging"},
+							"receivers":  []interface{}{"otlp"},
+							"processors": []interface{}{"batch"},
+							"exporters":  []interface{}{"otlp", "logging"},
 						},
 					},
 				},
@@ -483,8 +503,9 @@ func TestNewMap(t *testing.T) {
 					"telemetry": map[string]interface{}{"metrics": map[string]interface{}{"level": "none"}},
 					"pipelines": map[string]interface{}{
 						"traces": map[string]interface{}{
-							"receivers": []interface{}{"otlp"},
-							"exporters": []interface{}{"otlp", "logging"},
+							"receivers":  []interface{}{"otlp"},
+							"processors": []interface{}{"batch"},
+							"exporters":  []interface{}{"otlp", "logging"},
 						},
 						"metrics": map[string]interface{}{
 							"receivers":  []interface{}{"otlp"},

--- a/pkg/trace/api/otlp.go
+++ b/pkg/trace/api/otlp.go
@@ -69,7 +69,7 @@ func (o *OTLPReceiver) Start() {
 		if err != nil {
 			log.Criticalf("Error starting OpenTelemetry gRPC server: %v", err)
 		} else {
-			o.grpcsrv = grpc.NewServer(grpc.MaxRecvMsgSize(5 * 1024 * 1024))
+			o.grpcsrv = grpc.NewServer(grpc.MaxRecvMsgSize(10 * 1024 * 1024))
 			ptraceotlp.RegisterGRPCServer(o.grpcsrv, o)
 			o.wg.Add(1)
 			go func() {

--- a/pkg/trace/api/otlp.go
+++ b/pkg/trace/api/otlp.go
@@ -69,7 +69,7 @@ func (o *OTLPReceiver) Start() {
 		if err != nil {
 			log.Criticalf("Error starting OpenTelemetry gRPC server: %v", err)
 		} else {
-			o.grpcsrv = grpc.NewServer()
+			o.grpcsrv = grpc.NewServer(grpc.MaxRecvMsgSize(5 * 1024 * 1024))
 			ptraceotlp.RegisterGRPCServer(o.grpcsrv, o)
 			o.wg.Add(1)
 			go func() {

--- a/releasenotes/notes/fix-trace-data-dropping-otlp-ingest-843200ffdc2a8196.yaml
+++ b/releasenotes/notes/fix-trace-data-dropping-otlp-ingest-843200ffdc2a8196.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixes issue where trace data drops in OTLP ingest by adding batch processor for traces, and increases the grpc message limit


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
- Adds batch processing in traces like we do in metrics with max size set
- Increases the grpc message limit 

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Fixes bug potentially affecting multiple support cases: https://datadoghq.atlassian.net/browse/OTEL-384

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
Send varying amounts of trace data with default Agent OTLP config and verify that data doesn't get dropped and batch processor is working as intended.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
