### PR TITLE
Make the agent detect ECS EC2 environment even with host install

### DIFF
--- a/pkg/config/environment.go
+++ b/pkg/config/environment.go
@@ -53,9 +53,17 @@ func IsECS() bool {
 		return false
 	}
 
-	return os.Getenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI") != "" ||
+	if os.Getenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI") != "" ||
 		os.Getenv("ECS_CONTAINER_METADATA_URI") != "" ||
-		os.Getenv("ECS_CONTAINER_METADATA_URI_V4") != ""
+		os.Getenv("ECS_CONTAINER_METADATA_URI_V4") != "" {
+		return true
+	}
+
+	if _, err := os.Stat("/etc/ecs/ecs.config"); err == nil {
+		return true
+	}
+
+	return false
 }
 
 // IsECSFargate returns whether the Agent is running in ECS Fargate

--- a/releasenotes/notes/detect-ecs-ec2-on-host-install-531f216c04516546.yaml
+++ b/releasenotes/notes/detect-ecs-ec2-on-host-install-531f216c04516546.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Make the agent able to detect it is running on ECS EC2, even with a host install, i.e. when the agent isn’t deployed as an ECS task.


### PR DESCRIPTION
### What does this PR do?

Since #14978, the agent detects whether it is running on ECS EC2 or not to decide to start the ECS EC2 workload meta collector.
However, the current detection mechanism works only if the agent itself is running as an ECS task.
So, if the agent is deployed on ECS EC2 nodes with the host install method, the ECS EC2 environment wasn’t detected and the ECS tags wouldn’t show up unless the environment is explicitly configured with
```yaml
autoconfig_include_features:
  - ecsec2
```

This PR adds logic to try to detect ECS EC2 hosts from the host.

### Motivation

Have the ECS tags even when the agent is deployed as host install without requiring any additional parameters.

### Additional Notes

This will work only on “classic Linux” hosts (like Amazon Linux 2 for ex.) and not on BottleRocket ones. But anyway, ECS BottleRocket isn’t the default.

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Deploy the agent on ECS EC2 nodes with host installation method and not as an ECS task.
Prior to this fix, ECS tags would be missing. With this fix, they should be present.

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
