### PR TITLE
[single-machine-performance] Update lading to 0.14.0

### DIFF
--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -11,7 +11,7 @@ single-machine-performance-regression_detector:
       - submission_metadata
   variables:
     SMP_VERSION: 0.7.3
-    LADING_VERSION: 0.13.0
+    LADING_VERSION: 0.14.0
     TOTAL_SAMPLES: 600
     WARMUP_SECONDS: 45
     REPLICAS: 10
@@ -84,7 +84,7 @@ single-machine-performance-regression_detector:
     # space characters. This avoids
     # https://gitlab.com/gitlab-org/gitlab/-/issues/217231.
     - cat outputs/report.md | sed "s/^\$/$(echo -ne '\uFEFF\u00A0\u200B')/g"
-    # Add janky means of installing PR commenter borrowed from 
+    # Add janky means of installing PR commenter borrowed from
     # https://github.com/DataDog/dogweb/blob/45d7fcf035d0d515ebd901919099d4c8bfa82829/docker/docker-builder/Dockerfile#L69-L77
     - apt-get update
     - apt-get install -y curl

--- a/test/regression/cases/uds_dogstatsd_to_api/lading/lading.yaml
+++ b/test/regression/cases/uds_dogstatsd_to_api/lading/lading.yaml
@@ -3,7 +3,12 @@ generator:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
              59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
       path: "/tmp/dsd.socket"
-      variant: "dogstatsd"
+      variant:
+        dogstatsd:
+          metric_names_minimum: 32
+          metric_names_maximum: 128
+          tag_keys_minimum: 0
+          tag_keys_maximum: 512
       bytes_per_second: "100 Mb"
       block_sizes: ["256b", "512b", "1Kb", "2Kb", "3Kb", "4Kb", "5Kb", "6Kb"]
       maximum_prebuild_cache_size_bytes: "500 Mb"


### PR DESCRIPTION
### What does this PR do?

This commit updates the lading preferred by Agent CI to 0.14.0, release notes [here](https://github.com/DataDog/lading/releases/tag/v0.14.0).

REF SMP-456
REF SMP-458

