### PR TITLE
[single-machine-performance] Introduce trace-agent experiments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -204,6 +204,3 @@ test/fakeintake/build/*
 
 # dev container
 .devcontainer/
-
-# Allow Regression Detector material to ignore excludes
-!test/regression/**

--- a/.gitignore
+++ b/.gitignore
@@ -204,3 +204,6 @@ test/fakeintake/build/*
 
 # dev container
 .devcontainer/
+
+# Allow Regression Detector material to ignore excludes
+!test/regression/**

--- a/test/regression/cases/trace_agent_json/datadog-agent/datadog.yaml
+++ b/test/regression/cases/trace_agent_json/datadog-agent/datadog.yaml
@@ -1,0 +1,21 @@
+api_key: 00000000000000000000000000000000
+auth_token_file_path: /tmp/agent-auth-token
+hostname: smp-regression
+
+dd_url: http://127.0.0.1:9092
+
+confd_path: /etc/datadog-agent/conf.d
+
+# Disable cloud detection. This stops the Agent from poking around the
+# execution environment & network. This is particularly important if the target
+# has network access.
+cloud_provider_metadata: []
+
+apm_config:
+  enabled: true
+  apm_dd_url: http://127.0.0.1:9091
+
+  # disable ingest sampling
+  max_traces_per_second: 0
+  errors_per_second: 0
+  max_events_per_second: 0

--- a/test/regression/cases/trace_agent_json/experiment.yaml
+++ b/test/regression/cases/trace_agent_json/experiment.yaml
@@ -1,0 +1,2 @@
+optimization_goal: ingress_throughput
+erratic: false

--- a/test/regression/cases/trace_agent_json/lading/lading.yaml
+++ b/test/regression/cases/trace_agent_json/lading/lading.yaml
@@ -1,0 +1,19 @@
+generator:
+  - http:
+      seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
+        59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
+      headers: {}
+      target_uri: "http://localhost:9091/"
+      bytes_per_second: "256 Mb"
+      parallel_connections: 8
+      method:
+        post:
+          maximum_prebuild_cache_size_bytes: "512 Mb"
+          variant:
+            trace_agent: json
+
+blackhole:
+  - http:
+      binding_addr: "127.0.0.1:9091"
+  - http:
+      binding_addr: "127.0.0.1:9092"

--- a/test/regression/cases/trace_agent_msgpack/datadog-agent/datadog.yaml
+++ b/test/regression/cases/trace_agent_msgpack/datadog-agent/datadog.yaml
@@ -1,0 +1,21 @@
+api_key: 00000000000000000000000000000000
+auth_token_file_path: /tmp/agent-auth-token
+hostname: smp-regression
+
+dd_url: http://127.0.0.1:9092
+
+confd_path: /etc/datadog-agent/conf.d
+
+# Disable cloud detection. This stops the Agent from poking around the
+# execution environment & network. This is particularly important if the target
+# has network access.
+cloud_provider_metadata: []
+
+apm_config:
+  enabled: true
+  apm_dd_url: http://127.0.0.1:9091
+
+  # disable ingest sampling
+  max_traces_per_second: 0
+  errors_per_second: 0
+  max_events_per_second: 0

--- a/test/regression/cases/trace_agent_msgpack/experiment.yaml
+++ b/test/regression/cases/trace_agent_msgpack/experiment.yaml
@@ -1,0 +1,2 @@
+optimization_goal: ingress_throughput
+erratic: false

--- a/test/regression/cases/trace_agent_msgpack/lading/lading.yaml
+++ b/test/regression/cases/trace_agent_msgpack/lading/lading.yaml
@@ -1,0 +1,19 @@
+generator:
+  - http:
+      seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
+        59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
+      headers: {}
+      target_uri: "http://localhost:9091/"
+      bytes_per_second: "256 Mb"
+      parallel_connections: 8
+      method:
+        post:
+          maximum_prebuild_cache_size_bytes: "512 Mb"
+          variant:
+            trace_agent: msgpack
+
+blackhole:
+  - http:
+      binding_addr: "127.0.0.1:9091"
+  - http:
+      binding_addr: "127.0.0.1:9092"


### PR DESCRIPTION
### What does this PR do?

This commit introduces experiments for the trace agent, payloads in both msgpack and json. 

REF SMP-410
