### PR TITLE
backmerge 16291 run process monitor in root ns

### DIFF
--- a/pkg/process/monitor/process_monitor.go
+++ b/pkg/process/monitor/process_monitor.go
@@ -60,6 +60,11 @@ type ProcessMonitor struct {
 	procEventCallbacks map[ProcessEventType][]*ProcessCallback
 	runningPids        map[uint32]interface{}
 	callbackRunner     chan func()
+
+	// monitor stats
+	eventCount int
+	execCount  int
+	exitCount  int
 }
 
 type ProcessEventType int
@@ -209,7 +214,11 @@ func (pm *ProcessMonitor) Initialize() error {
 	pm.done = make(chan struct{})
 	pm.errors = make(chan error, 10)
 
-	if err := netlink.ProcEventMonitor(pm.events, pm.done, pm.errors); err != nil {
+	hostProc := util.HostProc()
+	if err := util.WithRootNS(hostProc, func() error {
+		return netlink.ProcEventMonitor(pm.events, pm.done, pm.errors)
+
+	}); err != nil {
 		return fmt.Errorf("couldn't initialize process monitor: %s", err)
 	}
 
@@ -230,11 +239,15 @@ func (pm *ProcessMonitor) Initialize() error {
 	// events are dropped until
 	pm.wg.Add(1)
 	go func() {
+		logTicker := time.NewTicker(2 * time.Minute)
+
 		defer func() {
 			log.Info("netlink process monitor ended")
 			pm.wg.Done()
 			close(pm.callbackRunner)
+			logTicker.Stop()
 		}()
+
 		for {
 			select {
 			case <-pm.done:
@@ -249,13 +262,17 @@ func (pm *ProcessMonitor) Initialize() error {
 					continue
 				}
 
+				pm.eventCount += 1
+
 				switch ev := event.Msg.(type) {
 				case *netlink.ExecProcEvent:
 					for _, c := range pm.procEventCallbacks[EXEC] {
+						pm.execCount += 1
 						pm.evalEXECCallback(c, ev.ProcessPid)
 					}
 				case *netlink.ExitProcEvent:
 					for _, c := range pm.procEventCallbacks[EXIT] {
+						pm.exitCount += 1
 						pm.evalEXITCallback(c, ev.ProcessPid)
 					}
 					delete(pm.runningPids, ev.ProcessPid)
@@ -269,6 +286,9 @@ func (pm *ProcessMonitor) Initialize() error {
 				log.Errorf("process monitor error: %s", err)
 				pm.Stop()
 				return
+
+			case <-logTicker.C:
+				pm.logStats()
 			}
 		}
 	}()
@@ -358,4 +378,12 @@ func (pm *ProcessMonitor) Stop() {
 	pm.m.Unlock()
 	close(pm.done)
 	pm.wg.Wait()
+}
+
+func (pm *ProcessMonitor) logStats() {
+	log.Debugf("process monitor stats - total events: %v; exec events: %v; exit events: %v", pm.eventCount, pm.execCount, pm.exitCount)
+
+	pm.eventCount = 0
+	pm.execCount = 0
+	pm.exitCount = 0
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This fixes a bug where system-probe's netlink-based process monitor would not see process events when started from a non-root network namespace (i.e in a containerised environment). This is due to netlink being affected by network namespaces.

### Motivation

This commit fixes it by ensuring we start the process monitor from the root network namespace.
Backmerge #16291 

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

1. Run agent on k8s
2. Run go-https service
3. See that we're hooking the new process

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
