### PR TITLE
backmerge 16342 https orphan connections

### DIFF
--- a/pkg/network/encoding/encoding.go
+++ b/pkg/network/encoding/encoding.go
@@ -84,7 +84,7 @@ func modelConnections(conns *network.Connections) *model.Connections {
 
 	if httpEncoder != nil && httpEncoder.orphanEntries > 0 {
 		log.Debugf(
-			"detected orphan http aggreggations. this can be either caused by conntrack sampling or missed tcp close events. count=%d",
+			"detected orphan http aggregations. this may be caused by conntrack sampling or missed tcp close events. count=%d",
 			httpEncoder.orphanEntries,
 		)
 
@@ -94,6 +94,34 @@ func modelConnections(conns *network.Connections) *model.Connections {
 			telemetry.OptExpvar,
 			telemetry.OptStatsd,
 		).Add(int64(httpEncoder.orphanEntries))
+	}
+
+	if http2Encoder != nil && http2Encoder.orphanEntries > 0 {
+		log.Debugf(
+			"detected orphan http2 aggregations. this may be caused by conntrack sampling or missed tcp close events. count=%d",
+			http2Encoder.orphanEntries,
+		)
+
+		telemetry.NewMetric(
+			"usm.http2.orphan_aggregations",
+			telemetry.OptMonotonic,
+			telemetry.OptExpvar,
+			telemetry.OptStatsd,
+		).Add(int64(http2Encoder.orphanEntries))
+	}
+
+	if kafkaEncoder != nil && kafkaEncoder.orphanEntries > 0 {
+		log.Debugf(
+			"detected orphan kafka aggregations. this may be caused by conntrack sampling or missed tcp close events. count=%d",
+			kafkaEncoder.orphanEntries,
+		)
+
+		telemetry.NewMetric(
+			"usm.kafka.orphan_aggregations",
+			telemetry.OptMonotonic,
+			telemetry.OptExpvar,
+			telemetry.OptStatsd,
+		).Add(int64(kafkaEncoder.orphanEntries))
 	}
 
 	routes := make([]*model.Route, len(routeIndex))

--- a/pkg/network/encoding/encoding.go
+++ b/pkg/network/encoding/encoding.go
@@ -96,34 +96,6 @@ func modelConnections(conns *network.Connections) *model.Connections {
 		).Add(int64(httpEncoder.orphanEntries))
 	}
 
-	if http2Encoder != nil && http2Encoder.orphanEntries > 0 {
-		log.Debugf(
-			"detected orphan http2 aggregations. this may be caused by conntrack sampling or missed tcp close events. count=%d",
-			http2Encoder.orphanEntries,
-		)
-
-		telemetry.NewMetric(
-			"usm.http2.orphan_aggregations",
-			telemetry.OptMonotonic,
-			telemetry.OptExpvar,
-			telemetry.OptStatsd,
-		).Add(int64(http2Encoder.orphanEntries))
-	}
-
-	if kafkaEncoder != nil && kafkaEncoder.orphanEntries > 0 {
-		log.Debugf(
-			"detected orphan kafka aggregations. this may be caused by conntrack sampling or missed tcp close events. count=%d",
-			kafkaEncoder.orphanEntries,
-		)
-
-		telemetry.NewMetric(
-			"usm.kafka.orphan_aggregations",
-			telemetry.OptMonotonic,
-			telemetry.OptExpvar,
-			telemetry.OptStatsd,
-		).Add(int64(kafkaEncoder.orphanEntries))
-	}
-
 	routes := make([]*model.Route, len(routeIndex))
 	for _, v := range routeIndex {
 		routes[v.Idx] = &v.Route

--- a/pkg/network/encoding/http.go
+++ b/pkg/network/encoding/http.go
@@ -85,7 +85,6 @@ func newHTTPEncoder(payload *network.Connections) *httpEncoder {
 	// this allows us to skip encoding orphan HTTP objects that can't be matched to a connection
 	for _, conn := range payload.Conns {
 		for _, key := range network.HTTPKeyTuplesFromConn(conn) {
-			log.Tracef("Payload has a connection %v and was converted to http key %v", conn, key)
 			encoder.aggregations[key] = nil
 		}
 	}

--- a/pkg/network/encoding/http.go
+++ b/pkg/network/encoding/http.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/network"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/http"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 type httpEncoder struct {
@@ -84,6 +85,7 @@ func newHTTPEncoder(payload *network.Connections) *httpEncoder {
 	// this allows us to skip encoding orphan HTTP objects that can't be matched to a connection
 	for _, conn := range payload.Conns {
 		for _, key := range network.HTTPKeyTuplesFromConn(conn) {
+			log.Tracef("Payload has a connection %v and was converted to http key %v", conn, key)
 			encoder.aggregations[key] = nil
 		}
 	}
@@ -116,6 +118,7 @@ func (e *httpEncoder) buildAggregations(payload *network.Connections) {
 		aggregation, ok := e.aggregations[key.KeyTuple]
 		if !ok {
 			// if there is no matching connection don't even bother to serialize HTTP data
+			log.Tracef("Found http orphan connection %v", key.KeyTuple)
 			e.orphanEntries++
 			continue
 		}

--- a/pkg/network/encoding/http2.go
+++ b/pkg/network/encoding/http2.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/network"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/http"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 type http2Encoder struct {
@@ -95,9 +96,10 @@ func newHTTP2Encoder(payload *network.Connections) *http2Encoder {
 	}
 
 	// pre-populate aggregation map with keys for all existent connections
-	// this allows us to skip encoding orphan HTTP objects that can't be matched to a connection
+	// this allows us to skip encoding orphan HTTP2 objects that can't be matched to a connection
 	for _, conn := range payload.Conns {
 		for _, key := range network.HTTPKeyTuplesFromConn(conn) {
+			log.Tracef("Payload has a connection %v and was converted to http2 key %v", conn, key)
 			encoder.aggregations[key] = nil
 		}
 	}
@@ -116,6 +118,7 @@ func (e *http2Encoder) buildAggregations(payload *network.Connections) {
 		aggregation, ok := e.aggregations[key.KeyTuple]
 		if !ok {
 			// if there is no matching connection don't even bother to serialize HTTP2 data
+			log.Tracef("Found http2 orphan connection %v", key.KeyTuple)
 			e.orphanEntries++
 			continue
 		}

--- a/pkg/network/encoding/http2.go
+++ b/pkg/network/encoding/http2.go
@@ -99,7 +99,6 @@ func newHTTP2Encoder(payload *network.Connections) *http2Encoder {
 	// this allows us to skip encoding orphan HTTP2 objects that can't be matched to a connection
 	for _, conn := range payload.Conns {
 		for _, key := range network.HTTPKeyTuplesFromConn(conn) {
-			log.Tracef("Payload has a connection %v and was converted to http2 key %v", conn, key)
 			encoder.aggregations[key] = nil
 		}
 	}

--- a/pkg/network/encoding/kafka.go
+++ b/pkg/network/encoding/kafka.go
@@ -78,7 +78,6 @@ func newKafkaEncoder(payload *network.Connections) *kafkaEncoder {
 	// this allows us to skip encoding orphan Kafka objects that can't be matched to a connection
 	for _, conn := range payload.Conns {
 		for _, key := range network.KafkaKeyTuplesFromConn(conn) {
-			log.Tracef("Payload has a connection %v and was converted to kafka key %v", conn, key)
 			encoder.aggregations[key] = nil
 		}
 	}

--- a/pkg/network/encoding/kafka.go
+++ b/pkg/network/encoding/kafka.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/network"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/kafka"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 type kafkaEncoder struct {
@@ -77,6 +78,7 @@ func newKafkaEncoder(payload *network.Connections) *kafkaEncoder {
 	// this allows us to skip encoding orphan Kafka objects that can't be matched to a connection
 	for _, conn := range payload.Conns {
 		for _, key := range network.KafkaKeyTuplesFromConn(conn) {
+			log.Tracef("Payload has a connection %v and was converted to kafka key %v", conn, key)
 			encoder.aggregations[key] = nil
 		}
 	}
@@ -109,6 +111,7 @@ func (e *kafkaEncoder) buildAggregations(payload *network.Connections) {
 		aggregation, ok := e.aggregations[key.KeyTuple]
 		if !ok {
 			// if there is no matching connection don't even bother to serialize Kafka data
+			log.Tracef("Found kafka orphan connection %v", key.KeyTuple)
 			e.orphanEntries++
 			continue
 		}

--- a/pkg/network/event_common.go
+++ b/pkg/network/event_common.go
@@ -407,34 +407,56 @@ func printAddress(address util.Address, names []dns.Hostname) string {
 	return b.String()
 }
 
-// HTTPKeyTuplesFromConn build the key for the http map based on whether the local or remote side is http.
-func HTTPKeyTuplesFromConn(c ConnectionStats) [2]http.KeyTuple {
-	// Retrieve translated addresses
-	laddr, lport := GetNATLocalAddress(c)
-	raddr, rport := GetNATRemoteAddress(c)
+// HTTPKeyTuplesFromConn constructs HTTP key tuples using the underlying raw connection stats object, which is produced by the tracer.
+// Each ConnectionStats object contains both the source and destination addresses, as well as an IPTranslation object that stores the original addresses in the event that the connection is NAT'd.
+// This function generates all relevant combinations of connection keys: [(source, dest), (dest, source), (NAT'd source, NAT'd dest), (NAT'd dest, NAT'd source)].
+// This is necessary to handle all possible scenarios for connections originating from the USM HTTP module (i.e., whether they are NAT'd or not, and whether they use TLS or plain HTTP).
+func HTTPKeyTuplesFromConn(connectionStats ConnectionStats) []http.KeyTuple {
 
 	// HTTP data is always indexed as (client, server), but we don't know which is the remote
 	// and which is the local address. To account for this, we'll construct 2 possible
 	// http keys and check for both of them in our http aggregations map.
-	return [2]http.KeyTuple{
-		http.NewKeyTuple(laddr, raddr, lport, rport),
-		http.NewKeyTuple(raddr, laddr, rport, lport),
+	httpKeyTuples := []http.KeyTuple{
+		http.NewKeyTuple(connectionStats.Source, connectionStats.Dest, connectionStats.SPort, connectionStats.DPort),
+		http.NewKeyTuple(connectionStats.Dest, connectionStats.Source, connectionStats.DPort, connectionStats.SPort),
 	}
+
+	// if IPTranslation is not nil, at least one of the sides has a translation, thus we need to add translated addresses.
+	if connectionStats.IPTranslation != nil {
+		localAddress, localPort := GetNATLocalAddress(connectionStats)
+		remoteAddress, remotePort := GetNATRemoteAddress(connectionStats)
+		httpKeyTuples = append(httpKeyTuples,
+			http.NewKeyTuple(localAddress, remoteAddress, localPort, remotePort),
+			http.NewKeyTuple(remoteAddress, localAddress, remotePort, localPort))
+	}
+
+	return httpKeyTuples
 }
 
-// KafkaKeyTuplesFromConn build the key for the kafka map based on whether the local or remote side is kafka.
-func KafkaKeyTuplesFromConn(c ConnectionStats) [2]kafka.KeyTuple {
-	// Retrieve translated addresses
-	laddr, lport := GetNATLocalAddress(c)
-	raddr, rport := GetNATRemoteAddress(c)
+// KafkaKeyTuplesFromConn constructs Kafka key tuples using the underlying raw connection stats object, which is produced by the tracer.
+// Each ConnectionStats object contains both the source and destination addresses, as well as an IPTranslation object that stores the original addresses in the event that the connection is NAT'd.
+// This function generates all relevant combinations of connection keys: [(source, dest), (dest, source), (NAT'd source, NAT'd dest), (NAT'd dest, NAT'd source)].
+// This is necessary to handle all possible scenarios for connections originating from the Kafka module (i.e., whether they are NAT'd or not, and whether they use TLS or plain Kafka).
+func KafkaKeyTuplesFromConn(connectionStats ConnectionStats) []kafka.KeyTuple {
 
 	// Kafka data is always indexed as (client, server), but we don't know which is the remote
 	// and which is the local address. To account for this, we'll construct 2 possible
 	// kafka keys and check for both of them in our kafka aggregations map.
-	return [2]kafka.KeyTuple{
-		kafka.NewKeyTuple(laddr, raddr, lport, rport),
-		kafka.NewKeyTuple(raddr, laddr, rport, lport),
+	kafkaKeyTuples := []kafka.KeyTuple{
+		kafka.NewKeyTuple(connectionStats.Source, connectionStats.Dest, connectionStats.SPort, connectionStats.DPort),
+		kafka.NewKeyTuple(connectionStats.Dest, connectionStats.Source, connectionStats.DPort, connectionStats.SPort),
 	}
+
+	// if IPTranslation is not nil, at least one of the sides has a translation, thus we need to add translated addresses.
+	if connectionStats.IPTranslation != nil {
+		localAddress, localPort := GetNATLocalAddress(connectionStats)
+		remoteAddress, remotePort := GetNATRemoteAddress(connectionStats)
+		kafkaKeyTuples = append(kafkaKeyTuples,
+			kafka.NewKeyTuple(localAddress, remoteAddress, localPort, remotePort),
+			kafka.NewKeyTuple(remoteAddress, localAddress, remotePort, localPort))
+	}
+
+	return kafkaKeyTuples
 }
 
 func generateConnectionKey(c ConnectionStats, buf []byte, useNAT bool) []byte {

--- a/pkg/network/event_common.go
+++ b/pkg/network/event_common.go
@@ -448,7 +448,7 @@ func KafkaKeyTuplesFromConn(connectionStats ConnectionStats) []kafka.KeyTuple {
 	}
 	connectionKeys := make([]kafka.KeyTuple, connectionKeysCount)
 
-	// kafka data is always indexed as (client, server), but we don't know which is the remote
+	// Kafka data is always indexed as (client, server), but we don't know which is the remote
 	// and which is the local address. To account for this, we'll construct 2 possible
 	// kafka keys and check for both of them in our kafka aggregations map.
 	connectionKeys[0] = kafka.NewKeyTuple(connectionStats.Source, connectionStats.Dest, connectionStats.SPort, connectionStats.DPort)

--- a/pkg/network/event_test.go
+++ b/pkg/network/event_test.go
@@ -11,6 +11,9 @@ import (
 	"runtime"
 	"testing"
 
+	"golang.org/x/exp/slices"
+
+	"github.com/DataDog/datadog-agent/pkg/network/protocols/http"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 
 	"github.com/stretchr/testify/assert"
@@ -120,6 +123,7 @@ func TestConnStatsByteKey(t *testing.T) {
 		assert.NotEqual(t, keyA, keyB)
 	}
 }
+
 func TestByteKeyNAT(t *testing.T) {
 	buf := make([]byte, ConnectionByteKeyMaxLen)
 	for _, test := range []struct {
@@ -239,6 +243,96 @@ func TestIsExpired(t *testing.T) {
 	} {
 		assert.Equal(t, tc.expected, tc.stats.IsExpired(tc.latestTime, timeout))
 	}
+}
+
+func TestKeyTuplesFromConn(t *testing.T) {
+	sourceAddress := util.AddressFromString("1.2.3.4")
+	sourcePort := uint16(1234)
+	destinationAddress := util.AddressFromString("5.6.7.8")
+	destinationPort := uint16(5678)
+
+	connectionStats := ConnectionStats{
+		Source: sourceAddress,
+		SPort:  sourcePort,
+		Dest:   destinationAddress,
+		DPort:  destinationPort,
+	}
+	keyTuples := HTTPKeyTuplesFromConn(connectionStats)
+
+	assert.Len(t, keyTuples, 2, "Expected different number of key tuples")
+	assert.True(t, slices.ContainsFunc(keyTuples, func(keyTuple http.KeyTuple) bool {
+		sourceAddressLow, sourceAddressHigh := util.ToLowHigh(sourceAddress)
+		destinationAddressLow, destinationAddressHigh := util.ToLowHigh(destinationAddress)
+		return (keyTuple.SrcIPLow == sourceAddressLow) && (keyTuple.SrcIPHigh == sourceAddressHigh) &&
+			(keyTuple.DstIPLow == destinationAddressLow) && (keyTuple.DstIPHigh == destinationAddressHigh) &&
+			(keyTuple.SrcPort == sourcePort) && (keyTuple.DstPort == destinationPort)
+	}), "Missing original connection")
+	assert.True(t, slices.ContainsFunc(keyTuples, func(keyTuple http.KeyTuple) bool {
+		sourceAddressLow, sourceAddressHigh := util.ToLowHigh(sourceAddress)
+		destinationAddressLow, destinationAddressHigh := util.ToLowHigh(destinationAddress)
+		return (keyTuple.SrcIPLow == destinationAddressLow) && (keyTuple.SrcIPHigh == destinationAddressHigh) &&
+			(keyTuple.DstIPLow == sourceAddressLow) && (keyTuple.DstIPHigh == sourceAddressHigh) &&
+			(keyTuple.SrcPort == destinationPort) && (keyTuple.DstPort == sourcePort)
+	}), "Missing flipped connection")
+}
+
+func TestKeyTuplesFromConnNAT(t *testing.T) {
+	sourceAddress := util.AddressFromString("1.2.3.4")
+	sourcePort := uint16(1234)
+	destinationAddress := util.AddressFromString("5.6.7.8")
+	destinationPort := uint16(5678)
+
+	natSourceAddress := util.AddressFromString("10.20.30.40")
+	natSourcePort := uint16(4321)
+	natDestinationAddress := util.AddressFromString("50.60.70.80")
+	natDestinationPort := uint16(8765)
+
+	connectionStats := ConnectionStats{
+		Source: sourceAddress,
+		Dest:   destinationAddress,
+		SPort:  sourcePort,
+		DPort:  destinationPort,
+		IPTranslation: &IPTranslation{
+			ReplSrcIP:   natSourceAddress,
+			ReplDstIP:   natDestinationAddress,
+			ReplSrcPort: natSourcePort,
+			ReplDstPort: natDestinationPort,
+		},
+	}
+	keyTuples := HTTPKeyTuplesFromConn(connectionStats)
+
+	// Expecting 2 non NAT'd keys and 2 NAT'd keys
+	assert.Len(t, keyTuples, 4, "Expected different number of key tuples")
+
+	assert.True(t, slices.ContainsFunc(keyTuples, func(keyTuple http.KeyTuple) bool {
+		sourceAddressLow, sourceAddressHigh := util.ToLowHigh(sourceAddress)
+		destinationAddressLow, destinationAddressHigh := util.ToLowHigh(destinationAddress)
+		return (keyTuple.SrcIPLow == sourceAddressLow) && (keyTuple.SrcIPHigh == sourceAddressHigh) &&
+			(keyTuple.DstIPLow == destinationAddressLow) && (keyTuple.DstIPHigh == destinationAddressHigh) &&
+			(keyTuple.SrcPort == sourcePort) && (keyTuple.DstPort == destinationPort)
+	}), "Missing original connection")
+	assert.True(t, slices.ContainsFunc(keyTuples, func(keyTuple http.KeyTuple) bool {
+		sourceAddressLow, sourceAddressHigh := util.ToLowHigh(sourceAddress)
+		destinationAddressLow, destinationAddressHigh := util.ToLowHigh(destinationAddress)
+		return (keyTuple.SrcIPLow == destinationAddressLow) && (keyTuple.SrcIPHigh == destinationAddressHigh) &&
+			(keyTuple.DstIPLow == sourceAddressLow) && (keyTuple.DstIPHigh == sourceAddressHigh) &&
+			(keyTuple.SrcPort == destinationPort) && (keyTuple.DstPort == sourcePort)
+	}), "Missing flipped connection")
+
+	assert.True(t, slices.ContainsFunc(keyTuples, func(keyTuple http.KeyTuple) bool {
+		sourceAddressLow, sourceAddressHigh := util.ToLowHigh(natSourceAddress)
+		destinationAddressLow, destinationAddressHigh := util.ToLowHigh(natDestinationAddress)
+		return (keyTuple.SrcIPLow == sourceAddressLow) && (keyTuple.SrcIPHigh == sourceAddressHigh) &&
+			(keyTuple.DstIPLow == destinationAddressLow) && (keyTuple.DstIPHigh == destinationAddressHigh) &&
+			(keyTuple.SrcPort == natSourcePort) && (keyTuple.DstPort == natDestinationPort)
+	}), "Missing NAT'd connection")
+	assert.True(t, slices.ContainsFunc(keyTuples, func(keyTuple http.KeyTuple) bool {
+		sourceAddressLow, sourceAddressHigh := util.ToLowHigh(natSourceAddress)
+		destinationAddressLow, destinationAddressHigh := util.ToLowHigh(natDestinationAddress)
+		return (keyTuple.SrcIPLow == destinationAddressLow) && (keyTuple.SrcIPHigh == destinationAddressHigh) &&
+			(keyTuple.DstIPLow == sourceAddressLow) && (keyTuple.DstIPHigh == sourceAddressHigh) &&
+			(keyTuple.SrcPort == natDestinationPort) && (keyTuple.DstPort == natSourcePort)
+	}), "Missing flipped NAT'd connection")
 }
 
 func BenchmarkByteKey(b *testing.B) {


### PR DESCRIPTION

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Introduced a fix for HTTPKeyTuplesFromConn and some other minor fixes

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Backmerge #16342 
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
