### PR TITLE
[CWS][SEC-7824] Add image_id field to activity dump tags

### DIFF
--- a/cmd/system-probe/subcommands/run/command.go
+++ b/cmd/system-probe/subcommands/run/command.go
@@ -205,7 +205,7 @@ func startSystemProbe(cliParams *cliParams, log log.Component, sysprobeconfig sy
 
 	// Init workload metastore collectors
 	workloadmetaCollectors := workloadmeta.NodeAgentCatalog
-	if sysprobeconfig.GetBool("system_probe.remote_workloadmeta") {
+	if sysprobeconfig.GetBool("runtime_security_config.remote_workloadmeta") {
 		workloadmetaCollectors = workloadmeta.RemoteCatalog
 	}
 

--- a/cmd/system-probe/subcommands/run/command.go
+++ b/cmd/system-probe/subcommands/run/command.go
@@ -205,7 +205,7 @@ func startSystemProbe(cliParams *cliParams, log log.Component, sysprobeconfig sy
 
 	// Init workload metastore collectors
 	workloadmetaCollectors := workloadmeta.NodeAgentCatalog
-	if sysprobeconfig.GetBool("runtime_security_config.remote_workloadmeta") {
+	if sysprobeconfig.GetBool("runtime_security_config.remote_workloadmeta.enabled") {
 		workloadmetaCollectors = workloadmeta.RemoteCatalog
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1155,6 +1155,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("runtime_security_config.socket", "/opt/datadog-agent/run/runtime-security.sock")
 	config.BindEnvAndSetDefault("runtime_security_config.run_path", defaultRunPath)
 	config.BindEnvAndSetDefault("runtime_security_config.log_profiled_workloads", false)
+	config.BindEnvAndSetDefault("runtime_security_config.remote_workloadmeta", false) // TODO: switch this to true when ready
 	bindEnvAndSetLogsConfigKeys(config, "runtime_security_config.endpoints.")
 	bindEnvAndSetLogsConfigKeys(config, "runtime_security_config.activity_dump.remote_storage.endpoints.")
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1155,7 +1155,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("runtime_security_config.socket", "/opt/datadog-agent/run/runtime-security.sock")
 	config.BindEnvAndSetDefault("runtime_security_config.run_path", defaultRunPath)
 	config.BindEnvAndSetDefault("runtime_security_config.log_profiled_workloads", false)
-	config.BindEnvAndSetDefault("runtime_security_config.remote_workloadmeta", false) // TODO: switch this to true when ready
+	config.BindEnvAndSetDefault("runtime_security_config.remote_workloadmeta.enabled", false) // TODO: switch this to true when ready
 	bindEnvAndSetLogsConfigKeys(config, "runtime_security_config.endpoints.")
 	bindEnvAndSetLogsConfigKeys(config, "runtime_security_config.activity_dump.remote_storage.endpoints.")
 

--- a/pkg/security/resolvers/tags/resolver.go
+++ b/pkg/security/resolvers/tags/resolver.go
@@ -116,20 +116,22 @@ func (t *Resolver) ImageIDResolver(containerID string) string {
 
 	// Build new imageId (repo + @sha256:XXX)
 	// To get repo, check repoDigests first,
-	// If empty check repoTags
-	imageMetadata, _ := m.GetImage(imageID)
-	repoDigests := imageMetadata.RepoDigests
-	repoTags := imageMetadata.RepoTags
-	if len(repoDigests) != 0 {
-		repo := strings.SplitN(repoDigests[0], "@sha256:", 2)[0]
-		return repo + "@" + imageID
+	// If empty, check repoTags
+	imageMetadata, err := m.GetImage(imageID)
+	if err != nil {
+		log.Errorf("unable get image metadata for %s: %s", imageID, err)
+	} else {
+		repoDigests := imageMetadata.RepoDigests
+		repoTags := imageMetadata.RepoTags
+		if len(repoDigests) != 0 {
+			repo := strings.SplitN(repoDigests[0], "@sha256:", 2)[0]
+			return repo + "@" + imageID
+		}
+		if len(repoTags) != 0 {
+			repo := strings.SplitN(repoDigests[0], ":", 2)[0]
+			return repo + "@" + imageID
+		}
 	}
-
-	if len(repoTags) != 0 {
-		repo := strings.SplitN(repoDigests[0], ":", 2)[0]
-		return repo + "@" + imageID
-	}
-
-	// If repo is empty, return imageID without repo
+	// If repo is empty or if could not find it, return imageID without repo
 	return imageID
 }

--- a/pkg/security/resolvers/tags/resolver.go
+++ b/pkg/security/resolvers/tags/resolver.go
@@ -104,6 +104,7 @@ func NewResolver(config *config.Config) *Resolver {
 // Resolove image_id
 func (t *Resolver) ImageIDResolver(containerID string) string {
 	var imageID string
+	var imageName string
 	m := workloadmeta.GetGlobalStore()
 
 	// Get imageID from container with ID == containerID
@@ -111,6 +112,7 @@ func (t *Resolver) ImageIDResolver(containerID string) string {
 	for _, container := range containers {
 		if container.ID == containerID {
 			imageID = container.Image.ID
+			imageName = container.Image.Name
 		}
 	}
 
@@ -132,6 +134,6 @@ func (t *Resolver) ImageIDResolver(containerID string) string {
 			return repo + "@" + imageID
 		}
 	}
-	// If repo is empty or if could not find it, return imageID without repo
-	return imageID
+	// If repo is empty or if could not find it, return imageName+@+imageID
+	return imageName + "@" + imageID
 }

--- a/pkg/security/resolvers/tags/resolver.go
+++ b/pkg/security/resolvers/tags/resolver.go
@@ -102,13 +102,14 @@ func NewResolver(config *config.Config) *Resolver {
 }
 
 // Resolove image_id
-func (t *Resolver) ImageIDResolver(containerID string) string {
+func (t *Resolver) ResolveImageID(containerID string) (string, error) {
 	m := workloadmeta.GetGlobalStore()
 
 	// Get imageID from container so that we can get the image Metadata
 	container, err := m.GetContainer(containerID)
 	if err != nil {
 		log.Errorf("unable to get container %s: %s", containerID, err)
+		return "", err
 	}
 
 	imageID := container.Image.ID
@@ -128,13 +129,13 @@ func (t *Resolver) ImageIDResolver(containerID string) string {
 		repoTags := imageMetadata.RepoTags
 		if len(repoDigests) != 0 {
 			repo := strings.SplitN(repoDigests[0], "@sha256:", 2)[0]
-			return repo + "@" + imageID
+			return repo + "@" + imageID, nil
 		}
 		if len(repoTags) != 0 {
 			repo := strings.SplitN(repoDigests[0], ":", 2)[0]
-			return repo + "@" + imageID
+			return repo + "@" + imageID, nil
 		}
 	}
 	// If repo is empty or if could not find it, return imageName+@+imageID
-	return imageName + "@" + imageID
+	return imageName + "@" + imageID, nil
 }

--- a/pkg/security/resolvers/tags/resolver.go
+++ b/pkg/security/resolvers/tags/resolver.go
@@ -118,15 +118,13 @@ func (t *Resolver) ImageIDResolver(containerID string) string {
 	// Build new imageId (repo + @sha256:XXX) or (name + @sha256:XXX) if repo is empty
 	// To get repo, check repoDigests first. If empty, check repoTags
 	imageMetadata, err := m.GetImage(imageID)
-
-	// If the 'sha256:' prefix is missing, add it
-	if !strings.HasPrefix(imageID, "sha256:") {
-		imageID = "sha256:" + imageID
-	}
-
 	if err != nil {
 		log.Errorf("unable get image metadata for %s: %s", imageID, err)
 	} else {
+		// If the 'sha256:' prefix is missing, add it
+		if !strings.HasPrefix(imageID, "sha256:") {
+			imageID = "sha256:" + imageID
+		}
 		repoDigests := imageMetadata.RepoDigests
 		repoTags := imageMetadata.RepoTags
 		if len(repoDigests) != 0 {

--- a/pkg/security/resolvers/tags/resolver.go
+++ b/pkg/security/resolvers/tags/resolver.go
@@ -109,7 +109,6 @@ func (t *Resolver) ImageIDResolver(containerID string) string {
 	container, err := m.GetContainer(containerID)
 	if err != nil {
 		log.Errorf("unable to get container %s: %s", containerID, err)
-
 	}
 
 	imageID := container.Image.ID

--- a/pkg/security/security_profile/dump/activity_dump.go
+++ b/pkg/security/security_profile/dump/activity_dump.go
@@ -538,6 +538,10 @@ func (ad *ActivityDump) finalize(releaseTracedCgroupSpot bool) {
 		ad.Tags = append(ad.Tags, "container_id:"+ad.ContainerID)
 	}
 
+	// Add image_id in tags
+	image_id := ad.adm.tagsResolvers.ImageIDResolver(ad.ContainerID)
+	ad.Tags = append(ad.Tags, "image_id:"+image_id)
+
 	// scrub processes and retain args envs now
 	ad.scrubAndRetainProcessArgsEnvs()
 }

--- a/pkg/security/security_profile/dump/activity_dump.go
+++ b/pkg/security/security_profile/dump/activity_dump.go
@@ -539,7 +539,10 @@ func (ad *ActivityDump) finalize(releaseTracedCgroupSpot bool) {
 	}
 
 	// Add image_id in tags
-	image_id := ad.adm.tagsResolvers.ImageIDResolver(ad.ContainerID)
+	image_id, err := ad.adm.tagsResolvers.ResolveImageID(ad.ContainerID)
+	if err != nil {
+		seclog.Errorf("Coud not get image_id : %s", err)
+	}
 	ad.Tags = append(ad.Tags, "image_id:"+image_id)
 
 	// scrub processes and retain args envs now

--- a/pkg/util/podman/container.go
+++ b/pkg/util/podman/container.go
@@ -188,23 +188,12 @@ type ContainerConfig struct {
 	Dependencies []string
 
 	// embedded sub-configs
-	ContainerRootFSConfig
+	//ContainerRootFSConfig
 	ContainerSecurityConfig
 	ContainerNameSpaceConfig
 	ContainerNetworkConfig
 	ContainerImageConfig
 	ContainerMiscConfig
-}
-
-// ContainerRootFSConfig is an embedded sub-config providing config info about the container's root fs.
-// We use it to get the container's imageID
-type ContainerRootFSConfig struct {
-	// RootfsImageID is the ID of the image used to create the container.
-	// If the container was created from a Rootfs, this will be empty.
-	// If non-empty, Podman will create a root filesystem for the container
-	// based on an image with this ID.
-	// This conflicts with Rootfs.
-	RootfsImageID string `json:"rootfsImageID,omitempty"`
 }
 
 // ContainerSecurityConfig is an embedded sub-config providing security configuration

--- a/pkg/workloadmeta/collectors/internal/containerd/container_builder.go
+++ b/pkg/workloadmeta/collectors/internal/containerd/container_builder.go
@@ -64,15 +64,16 @@ func buildWorkloadMetaContainer(namespace string, container containerd.Container
 	img, err := container.Image(ctx)
 	if err != nil {
 		log.Debugf("cannot get container's image: %s", err)
+	} else {
+		imgConfig, err := img.Config(ctx)
+		if err != nil {
+			log.Debugf("cannot get image's config: %s", err)
+		} else {
+			imageID := imgConfig.Digest.String()
+			// Add imageID
+			image.ID = imageID
+		}
 	}
-	imgConfig, err := img.Config(ctx)
-	if err != nil {
-		log.Debugf("cannot get image's config: %s", err)
-	}
-	imageID := imgConfig.Digest.String()
-
-	// Add imageID
-	image.ID = imageID
 
 	status, err := containerdClient.Status(namespace, container)
 	if err != nil {

--- a/pkg/workloadmeta/collectors/internal/containerd/container_builder.go
+++ b/pkg/workloadmeta/collectors/internal/containerd/container_builder.go
@@ -56,6 +56,24 @@ func buildWorkloadMetaContainer(namespace string, container containerd.Container
 		log.Debugf("cannot split image name %q: %s", info.Image, err)
 	}
 
+	// Prepare context
+	ctx := context.Background()
+	ctx = namespaces.WithNamespace(ctx, namespace)
+
+	// Get image id from container's image config
+	img, err := container.Image(ctx)
+	if err != nil {
+		log.Debugf("cannot get container's image: %s", err)
+	}
+	imgConfig, err := img.Config(ctx)
+	if err != nil {
+		log.Debugf("cannot get image's config: %s", err)
+	}
+	imageID := imgConfig.Digest.String()
+
+	// Add imageID
+	image.ID = imageID
+
 	status, err := containerdClient.Status(namespace, container)
 	if err != nil {
 		if !errdefs.IsNotFound(err) {

--- a/pkg/workloadmeta/collectors/internal/containerd/container_builder.go
+++ b/pkg/workloadmeta/collectors/internal/containerd/container_builder.go
@@ -9,14 +9,12 @@
 package containerd
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"time"
 
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/errdefs"
-	"github.com/containerd/containerd/namespaces"
 
 	cutil "github.com/DataDog/datadog-agent/pkg/util/containerd"
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
@@ -54,25 +52,6 @@ func buildWorkloadMetaContainer(namespace string, container containerd.Container
 	image, err := workloadmeta.NewContainerImage(imageID, info.Image)
 	if err != nil {
 		log.Debugf("cannot split image name %q: %s", info.Image, err)
-	}
-
-	// Prepare context
-	ctx := context.Background()
-	ctx = namespaces.WithNamespace(ctx, namespace)
-
-	// Get image id from container's image config
-	img, err := container.Image(ctx)
-	if err != nil {
-		log.Debugf("cannot get container's image: %s", err)
-	} else {
-		imgConfig, err := img.Config(ctx)
-		if err != nil {
-			log.Debugf("cannot get image's config: %s", err)
-		} else {
-			imageID := imgConfig.Digest.String()
-			// Add imageID
-			image.ID = imageID
-		}
 	}
 
 	status, err := containerdClient.Status(namespace, container)

--- a/pkg/workloadmeta/collectors/internal/containerd/container_builder_test.go
+++ b/pkg/workloadmeta/collectors/internal/containerd/container_builder_test.go
@@ -78,7 +78,6 @@ func TestBuildWorkloadMetaContainer(t *testing.T) {
 		},
 	}
 	container := mockedContainer{
-		fake.mockedContainer,
 		mockID: func() string {
 			return containerID
 		},

--- a/pkg/workloadmeta/collectors/internal/containerd/container_builder_test.go
+++ b/pkg/workloadmeta/collectors/internal/containerd/container_builder_test.go
@@ -78,6 +78,7 @@ func TestBuildWorkloadMetaContainer(t *testing.T) {
 		},
 	}
 	container := mockedContainer{
+		fake.mockedContainer
 		mockID: func() string {
 			return containerID
 		},

--- a/pkg/workloadmeta/collectors/internal/containerd/container_builder_test.go
+++ b/pkg/workloadmeta/collectors/internal/containerd/container_builder_test.go
@@ -78,7 +78,7 @@ func TestBuildWorkloadMetaContainer(t *testing.T) {
 		},
 	}
 	container := mockedContainer{
-		fake.mockedContainer
+		fake.mockedContainer,
 		mockID: func() string {
 			return containerID
 		},

--- a/pkg/workloadmeta/collectors/internal/containerd/event_builder_test.go
+++ b/pkg/workloadmeta/collectors/internal/containerd/event_builder_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/containerd/containerd/oci"
 	"github.com/gogo/protobuf/proto"
 	"github.com/gogo/protobuf/types"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/assert"
 
@@ -32,18 +31,9 @@ func TestBuildCollectorEvent(t *testing.T) {
 	containerID := "10"
 	namespace := "test_namespace"
 
-	image := &mockedImage{
-		mockConfig: func() (ocispec.Descriptor, error) {
-			return ocispec.Descriptor{Digest: "my_image_id"}, nil
-		},
-	}
-
 	container := mockedContainer{
 		mockID: func() string {
 			return containerID
-		},
-		mockImage: func() (containerd.Image, error) {
-			return image, nil
 		},
 	}
 

--- a/pkg/workloadmeta/collectors/internal/docker/docker.go
+++ b/pkg/workloadmeta/collectors/internal/docker/docker.go
@@ -41,6 +41,7 @@ const (
 )
 
 type resolveHook func(ctx context.Context, co types.ContainerJSON) (string, error)
+type resolveContainerListWithFilter func(ctx context.Context, options types.ContainerListOptions, filter *containers.Filter) ([]types.Container, error)
 
 type collector struct {
 	store workloadmeta.Store
@@ -277,7 +278,7 @@ func (c *collector) buildCollectorEvent(ctx context.Context, ev *docker.Containe
 				Name:   strings.TrimPrefix(container.Name, "/"),
 				Labels: container.Config.Labels,
 			},
-			Image:   extractImage(ctx, container, c.dockerUtil.ResolveImageNameFromContainer),
+			Image:   extractImage(ctx, container, c.dockerUtil.ResolveImageNameFromContainer, c.dockerUtil.RawContainerListWithFilter),
 			EnvVars: extractEnvVars(container.Config.Env),
 			Ports:   extractPorts(container),
 			Runtime: workloadmeta.ContainerRuntimeDocker,
@@ -322,7 +323,7 @@ func (c *collector) buildCollectorEvent(ctx context.Context, ev *docker.Containe
 	return event, nil
 }
 
-func extractImage(ctx context.Context, container types.ContainerJSON, resolve resolveHook) workloadmeta.ContainerImage {
+func extractImage(ctx context.Context, container types.ContainerJSON, resolve resolveHook, resolveContainersList resolveContainerListWithFilter) workloadmeta.ContainerImage {
 	imageSpec := container.Config.Image
 	image := workloadmeta.ContainerImage{
 		RawName: imageSpec,
@@ -372,7 +373,26 @@ func extractImage(ctx context.Context, container types.ContainerJSON, resolve re
 	image.Registry = registry
 	image.ShortName = shortName
 	image.Tag = tag
-	image.ID = container.Image
+
+	// Get imageID from running container with mathing ID
+	var imageID string
+	filter, err := containers.GetPauseContainerFilter()
+	if err != nil {
+		log.Warnf("Can't get pause container filter, no filtering will be applied: %v", err)
+	}
+	running_containers, err := resolveContainersList(ctx, types.ContainerListOptions{}, filter)
+	if err != nil {
+		log.Debugf("cannot get running containers: %v", err)
+	}
+
+	for _, c := range running_containers {
+		if c.ID == container.ContainerJSONBase.ID {
+			imageID = c.ImageID
+		}
+	}
+	// Add imageID to image
+	image.ID = imageID
+
 	return image
 }
 

--- a/pkg/workloadmeta/collectors/internal/ecsfargate/ecsfargate.go
+++ b/pkg/workloadmeta/collectors/internal/ecsfargate/ecsfargate.go
@@ -159,10 +159,6 @@ func (c *collector) parseTaskContainers(
 		seen[entityID] = struct{}{}
 
 		image, err := workloadmeta.NewContainerImage(container.Image)
-
-		// Add imageID to image
-		image.ID = container.ImageID
-
 		if err != nil {
 			log.Debugf("cannot split image name %q: %s", container.Image, err)
 		}

--- a/pkg/workloadmeta/collectors/internal/ecsfargate/ecsfargate.go
+++ b/pkg/workloadmeta/collectors/internal/ecsfargate/ecsfargate.go
@@ -158,7 +158,10 @@ func (c *collector) parseTaskContainers(
 
 		seen[entityID] = struct{}{}
 
-		image, err := workloadmeta.NewContainerImage(container.ImageID, container.Image)
+		image, err := workloadmeta.NewContainerImage(container.Image)
+
+		// Add imageID to image
+		image.ID = container.ImageID
 
 		if err != nil {
 			log.Debugf("cannot split image name %q: %s", container.Image, err)

--- a/pkg/workloadmeta/collectors/internal/podman/podman.go
+++ b/pkg/workloadmeta/collectors/internal/podman/podman.go
@@ -110,6 +110,13 @@ func convertToEvent(container *podman.Container) workloadmeta.CollectorEvent {
 		log.Warnf("Could not get image for container %s", containerID)
 	}
 
+	// Add imageID to image
+	imageID := container.Config.ContainerRootFSConfig.RootfsImageID
+	if !strings.HasPrefix(imageID, "sha256:") {
+		imageID = "sha256:" + imageID
+	}
+	image.ID = imageID
+
 	var ports []workloadmeta.ContainerPort
 	for _, portMapping := range container.Config.PortMappings {
 		ports = append(ports, workloadmeta.ContainerPort{

--- a/pkg/workloadmeta/collectors/internal/podman/podman.go
+++ b/pkg/workloadmeta/collectors/internal/podman/podman.go
@@ -112,9 +112,6 @@ func convertToEvent(container *podman.Container) workloadmeta.CollectorEvent {
 
 	// Add imageID to image
 	imageID := container.Config.ContainerRootFSConfig.RootfsImageID
-	if !strings.HasPrefix(imageID, "sha256:") {
-		imageID = "sha256:" + imageID
-	}
 	image.ID = imageID
 
 	var ports []workloadmeta.ContainerPort

--- a/pkg/workloadmeta/collectors/internal/podman/podman.go
+++ b/pkg/workloadmeta/collectors/internal/podman/podman.go
@@ -110,10 +110,6 @@ func convertToEvent(container *podman.Container) workloadmeta.CollectorEvent {
 		log.Warnf("Could not get image for container %s", containerID)
 	}
 
-	// Add imageID to image
-	imageID := container.Config.ContainerRootFSConfig.RootfsImageID
-	image.ID = imageID
-
 	var ports []workloadmeta.ContainerPort
 	for _, portMapping := range container.Config.PortMappings {
 		ports = append(ports, workloadmeta.ContainerPort{

--- a/pkg/workloadmeta/collectors/internal/podman/podman_test.go
+++ b/pkg/workloadmeta/collectors/internal/podman/podman_test.go
@@ -75,9 +75,6 @@ func TestPull(t *testing.T) {
 						"label-b": "value-b",
 					},
 				},
-				ContainerRootFSConfig: podman.ContainerRootFSConfig{
-					RootfsImageID: "my_image_id_1",
-				},
 			},
 			State: &podman.ContainerState{
 				State:       podman.ContainerStateRunning,
@@ -126,9 +123,6 @@ func TestPull(t *testing.T) {
 						"label-a-dev": "value-a-dev",
 						"label-b-dev": "value-b-dev",
 					},
-				},
-				ContainerRootFSConfig: podman.ContainerRootFSConfig{
-					RootfsImageID: "my_image_id_2",
 				},
 			},
 			State: &podman.ContainerState{
@@ -182,7 +176,6 @@ func TestPull(t *testing.T) {
 					Registry:  "docker.io",
 					ShortName: "agent",
 					Tag:       "latest",
-					ID:        "my_image_id_1",
 				},
 				NetworkIPs: map[string]string{
 					"podman": "10.88.0.13",
@@ -231,7 +224,6 @@ func TestPull(t *testing.T) {
 					Registry:  "docker.io",
 					ShortName: "agent-dev",
 					Tag:       "latest",
-					ID:        "my_image_id_2",
 				},
 				NetworkIPs: map[string]string{
 					"podman": "10.88.0.14",

--- a/releasenotes/notes/add-image_id-field-to-ad-tags-331636a9c11a2131.yaml
+++ b/releasenotes/notes/add-image_id-field-to-ad-tags-331636a9c11a2131.yaml
@@ -1,0 +1,5 @@
+
+---
+upgrade:
+  - |
+    Tags in activity dumps now have an additional field called "image_id". It is constrcuted as such: "repo+@+sha256:XXX"

--- a/releasenotes/notes/add-image_id-field-to-ad-tags-331636a9c11a2131.yaml
+++ b/releasenotes/notes/add-image_id-field-to-ad-tags-331636a9c11a2131.yaml
@@ -2,4 +2,4 @@
 ---
 upgrade:
   - |
-    Tags in activity dumps now have an additional field called "image_id". It is constrcuted as such: "repo+@+sha256:XXX"
+    Tags in activity dumps now have an additional field called "image_id". It is reported as such: "repo+@+sha256:XXX"


### PR DESCRIPTION
This PR aims to add 'image_id' field to activity dumps's tags
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
