### PR TITLE
[gitlab] Refactor package deploy jobs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,6 +17,7 @@ include:
   - /.gitlab/container_scan.yml
   - /.gitlab/check_deploy.yml
   - /.gitlab/dev_container_deploy.yml
+  - /.gitlab/deploy_common.yml
   - /.gitlab/deploy_6.yml
   - /.gitlab/deploy_7.yml
   - /.gitlab/deploy_dca.yml

--- a/.gitlab/deploy_6/nix.yml
+++ b/.gitlab/deploy_6/nix.yml
@@ -1,42 +1,37 @@
 ---
-deploy_packages_deb-6:
-  rules:
-    !reference [.on_deploy_a6]
-  stage: deploy6
-  resource_group: deb_bucket
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
-  tags: ["runner:main"]
-  dependencies: ["agent_deb-x64-a6", "agent_deb-arm64-a6", "agent_heroku_deb-x64-a6"]
-  before_script:
-    - ls $OMNIBUS_PACKAGE_DIR
-  script:
-    - $S3_CP_CMD --recursive --exclude "*" --include "*_6.*amd64.deb" $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/deb/amd64/ || true
-    - $S3_CP_CMD --recursive --exclude "*" --include "*_6.*arm64.deb" $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/deb/arm64/ || true
+deploy_packages_deb-x64-6:
+  extends: .deploy_packages_deb-6
+  needs: [ agent_deb-x64-a6 ]
+  variables:
+    PACKAGE_ARCH: amd64
 
-deploy_packages_rpm-6:
-  rules:
-    !reference [.on_deploy_a6]
-  stage: deploy6
-  resource_group: rpm_bucket
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
-  tags: ["runner:main"]
-  dependencies: ["agent_rpm-x64-a6", "agent_rpm-arm64-a6"]
-  before_script:
-    - ls $OMNIBUS_PACKAGE_DIR
-  script:
-    - $S3_CP_CMD --recursive --exclude "*" --include "*-6.*x86_64.rpm" $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/rpm/x86_64/ || true
-    - $S3_CP_CMD --recursive --exclude "*" --include "*-6.*aarch64.rpm" $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/rpm/aarch64/ || true
+deploy_packages_deb-arm64-6:
+  extends: .deploy_packages_deb-6
+  needs: [ agent_deb-arm64-a6 ]
+  variables:
+    PACKAGE_ARCH: arm64
+
+deploy_packages_heroku_deb-x64-6:
+  extends: .deploy_packages_deb-6
+  needs: [ agent_heroku_deb-x64-a6 ]
+  variables:
+    PACKAGE_ARCH: amd64
+
+deploy_packages_rpm-x64-6:
+  extends: .deploy_packages_rpm-6
+  needs: [ agent_rpm-x64-a6 ]
+  variables:
+    PACKAGE_ARCH: x86_64
+
+deploy_packages_rpm-arm64-6:
+  extends: .deploy_packages_rpm-6
+  needs: [ agent_rpm-arm64-a6 ]
+  variables:
+    PACKAGE_ARCH: aarch64
 
 # NOTE: no SuSE ARM builds currently.
-deploy_packages_suse_rpm-6:
-  rules:
-    !reference [.on_deploy_a6]
-  stage: deploy6
-  resource_group: suse_bucket
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
-  tags: ["runner:main"]
-  dependencies: ["agent_suse-x64-a6"]
-  before_script:
-    - ls $OMNIBUS_PACKAGE_DIR_SUSE
-  script:
-    - $S3_CP_CMD --recursive --exclude "*" --include "*-6.*x86_64.rpm" $OMNIBUS_PACKAGE_DIR_SUSE $S3_RELEASE_ARTIFACTS_URI/suse_rpm/x86_64/ || true
+deploy_packages_suse_rpm-x64-6:
+  extends: .deploy_packages_suse_rpm-6
+  needs: [ agent_suse-x64-a6 ]
+  variables:
+    PACKAGE_ARCH: x86_64

--- a/.gitlab/deploy_6/windows.yml
+++ b/.gitlab/deploy_6/windows.yml
@@ -1,11 +1,11 @@
 ---
-deploy_packages_windows-6:
+deploy_packages_windows-x64-6:
   rules:
     !reference [.on_deploy_a6]
   stage: deploy6
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
   tags: ["runner:main"]
-  dependencies: ["windows_msi_x64-a6"]
+  needs: ["windows_msi_x64-a6"]
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
   script:

--- a/.gitlab/deploy_7/nix.yml
+++ b/.gitlab/deploy_7/nix.yml
@@ -39,7 +39,7 @@ deploy_packages_dogstatsd_deb-x64-7:
   extends: .deploy_packages_deb-7
   needs: [ dogstatsd_deb-x64 ]
   variables:
-    PACKAGE_ARCH: x64
+    PACKAGE_ARCH: amd64
 
 deploy_packages_dogstatsd_deb-arm64-7:
   extends: .deploy_packages_deb-7

--- a/.gitlab/deploy_7/nix.yml
+++ b/.gitlab/deploy_7/nix.yml
@@ -1,76 +1,117 @@
 ---
-deploy_packages_deb-7:
-  rules:
-    !reference [.on_deploy_a7]
-  stage: deploy7
-  resource_group: deb_bucket
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
-  tags: ["runner:main"]
-  dependencies:
-    - agent_deb-x64-a7
-    - agent_deb-arm64-a7
-    - agent_heroku_deb-x64-a7
-    - iot_agent_deb-x64
-    - iot_agent_deb-arm64
-    - iot_agent_deb-armhf
-    - dogstatsd_deb-x64
-    - dogstatsd_deb-arm64
-  before_script:
-    - ls $OMNIBUS_PACKAGE_DIR
-  script:
-    - $S3_CP_CMD --recursive --exclude "*" --include "*_7.*amd64.deb" $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/deb/amd64/ || true
-    - $S3_CP_CMD --recursive --exclude "*" --include "*_7.*arm64.deb" $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/deb/arm64/ || true
-    - $S3_CP_CMD --recursive --exclude "*" --include "*_7.*armhf.deb" $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/deb/armhf/ || true
+deploy_packages_deb-x64-7:
+  extends: .deploy_packages_deb-7
+  needs: [ agent_deb-x64-a7 ]
+  variables:
+    PACKAGE_ARCH: amd64
 
-deploy_packages_rpm-7:
-  rules:
-    !reference [.on_deploy_a7]
-  stage: deploy7
-  resource_group: rpm_bucket
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
-  tags: ["runner:main"]
-  dependencies:
-    - agent_rpm-x64-a7
-    - agent_rpm-arm64-a7
-    - iot_agent_rpm-x64
-    - iot_agent_rpm-arm64
-    - iot_agent_rpm-armhf
-    - dogstatsd_rpm-x64
-  before_script:
-    - ls $OMNIBUS_PACKAGE_DIR
-  script:
-    - $S3_CP_CMD --recursive --exclude "*" --include "*-7.*x86_64.rpm" $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/rpm/x86_64/ || true
-    - $S3_CP_CMD --recursive --exclude "*" --include "*-7.*aarch64.rpm" $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/rpm/aarch64/ || true
-    - $S3_CP_CMD --recursive --exclude "*" --include "*-7.*armv7hl.rpm" $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/rpm/armv7hl/ || true
+deploy_packages_deb-arm64-7:
+  extends: .deploy_packages_deb-7
+  needs: [ agent_deb-arm64-a7 ]
+  variables:
+    PACKAGE_ARCH: arm64
 
-deploy_packages_suse_rpm-7:
-  rules:
-    !reference [.on_deploy_a7]
-  stage: deploy7
-  resource_group: suse_bucket
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
-  tags: ["runner:main"]
-  dependencies:
-    - agent_suse-x64-a7
-    - dogstatsd_suse-x64
-    - iot_agent_suse-x64
-  before_script:
-    - ls $OMNIBUS_PACKAGE_DIR_SUSE
-  script:
-    - $S3_CP_CMD --recursive --exclude "*" --include "*-7.*x86_64.rpm" $OMNIBUS_PACKAGE_DIR_SUSE $S3_RELEASE_ARTIFACTS_URI/suse_rpm/x86_64/ || true
+deploy_packages_heroku_deb-x64-7:
+  extends: .deploy_packages_deb-7
+  needs: [ agent_heroku_deb-x64-a7 ]
+  variables:
+    PACKAGE_ARCH: amd64
 
-deploy_packages_dmg-a7:
+deploy_packages_iot_deb-x64-7:
+  extends: .deploy_packages_deb-7
+  needs: [ iot_agent_deb-x64 ]
+  variables:
+    PACKAGE_ARCH: amd64
+
+deploy_packages_iot_deb-arm64-7:
+  extends: .deploy_packages_deb-7
+  needs: [ iot_agent_deb-arm64 ]
+  variables:
+    PACKAGE_ARCH: arm64
+
+deploy_packages_iot_deb-armhf-7:
+  extends: .deploy_packages_deb-7
+  needs: [ iot_agent_deb-armhf ]
+  variables:
+    PACKAGE_ARCH: armhf
+
+deploy_packages_dogstatsd_deb-x64-7:
+  extends: .deploy_packages_deb-7
+  needs: [ dogstatsd_deb-x64 ]
+  variables:
+    PACKAGE_ARCH: x64
+
+deploy_packages_dogstatsd_deb-arm64-7:
+  extends: .deploy_packages_deb-7
+  needs: [ dogstatsd_deb-arm64 ]
+  variables:
+    PACKAGE_ARCH: arm64
+
+deploy_packages_rpm-x64-7:
+  extends: .deploy_packages_rpm-7
+  needs: [ agent_rpm-x64-a7 ]
+  variables:
+    PACKAGE_ARCH: x86_64
+
+deploy_packages_rpm-arm64-7:
+  extends: .deploy_packages_rpm-7
+  needs: [ agent_rpm-arm64-a7 ]
+  variables:
+    PACKAGE_ARCH: aarch64
+
+deploy_packages_iot_rpm-x64-7:
+  extends: .deploy_packages_rpm-7
+  needs: [ iot_agent_rpm-x64 ]
+  variables:
+    PACKAGE_ARCH: x86_64
+
+deploy_packages_iot_rpm-arm64-7:
+  extends: .deploy_packages_rpm-7
+  needs: [ iot_agent_rpm-arm64 ]
+  variables:
+    PACKAGE_ARCH: aarch64
+
+deploy_packages_iot_rpm-armhf-7:
+  extends: .deploy_packages_rpm-7
+  needs: [ iot_agent_rpm-armhf ]
+  variables:
+    PACKAGE_ARCH: armv7hl
+
+deploy_packages_dogstatsd_rpm-x64-7:
+  extends: .deploy_packages_rpm-7
+  needs: [ dogstatsd_rpm-x64 ]
+  variables:
+    PACKAGE_ARCH: x86_64
+
+deploy_packages_suse_rpm-x64-7:
+  extends: .deploy_packages_suse_rpm-7
+  needs: [ agent_suse-x64-a7 ]
+  variables:
+    PACKAGE_ARCH: x86_64
+
+deploy_packages_iot_suse_rpm-x64-7:
+  extends: .deploy_packages_suse_rpm-7
+  needs: [ iot_agent_suse-x64 ]
+  variables:
+    PACKAGE_ARCH: x86_64
+
+deploy_packages_dogstatsd_suse_rpm-x64-7:
+  extends: .deploy_packages_suse_rpm-7
+  needs: [ dogstatsd_suse-x64 ]
+  variables:
+    PACKAGE_ARCH: x86_64
+
+deploy_packages_dmg-x64-a7:
   rules:
     !reference [.on_deploy_a7]
   stage: deploy7
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
   tags: ["runner:main"]
-  dependencies: ["agent_dmg-x64-a7"]
+  needs: ["agent_dmg-x64-a7"]
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
   script:
     - $S3_CP_CMD --recursive --exclude "*" --include "datadog-agent-7*.dmg" $OMNIBUS_PACKAGE_DIR $S3_RELEASE_ARTIFACTS_URI/dmg/x86_64/ || true
-
 
 # deploy dogstatsd x64, non-static binary to staging bucket
 deploy_staging_dsd:

--- a/.gitlab/deploy_7/windows.yml
+++ b/.gitlab/deploy_7/windows.yml
@@ -1,11 +1,11 @@
 ---
-deploy_packages_windows-7:
+deploy_packages_windows-x64-7:
   rules:
     !reference [.on_deploy_a7]
   stage: deploy7
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
   tags: ["runner:main"]
-  dependencies: ["windows_msi_and_bosh_zip_x64-a7"]
+  needs: ["windows_msi_and_bosh_zip_x64-a7"]
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
   script:
@@ -25,7 +25,7 @@ deploy_staging_windows_tags-7:
   stage: deploy7
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
   tags: ["runner:main"]
-  dependencies: ["windows_msi_and_bosh_zip_x64-a7", "windows_zip_agent_binaries_x64-a7"]
+  needs: ["windows_msi_and_bosh_zip_x64-a7", "windows_zip_agent_binaries_x64-a7"]
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
   script:

--- a/.gitlab/deploy_common.yml
+++ b/.gitlab/deploy_common.yml
@@ -1,0 +1,74 @@
+---
+.deploy_packages_deb:
+  resource_group: deb_bucket
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
+  tags: ["runner:main"]
+  before_script:
+    - ls $OMNIBUS_PACKAGE_DIR
+  script:
+    - $S3_CP_CMD --recursive --exclude "*" --include "*_${MAJOR_VERSION}.*${PACKAGE_ARCH}.deb" "$OMNIBUS_PACKAGE_DIR" "$S3_RELEASE_ARTIFACTS_URI/deb/${PACKAGE_ARCH}/" || true
+
+.deploy_packages_deb-6:
+  extends: .deploy_packages_deb
+  stage: deploy6
+  rules:
+    !reference [.on_deploy_a6]
+  variables:
+    MAJOR_VERSION: 6
+
+.deploy_packages_deb-7:
+  extends: .deploy_packages_deb
+  stage: deploy7
+  rules:
+    !reference [.on_deploy_a7]
+  variables:
+    MAJOR_VERSION: 7
+
+.deploy_packages_rpm:
+  resource_group: rpm_bucket
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
+  tags: ["runner:main"]
+  variables:
+    ARTIFACTS_PREFIX: ""
+  before_script:
+    - ls $OMNIBUS_PACKAGE_DIR
+  script:
+    - $S3_CP_CMD --recursive --exclude "*" --include "*-${MAJOR_VERSION}.*${PACKAGE_ARCH}.rpm" "$OMNIBUS_PACKAGE_DIR" "$S3_RELEASE_ARTIFACTS_URI/${ARTIFACTS_PREFIX}rpm/${PACKAGE_ARCH}/" || true
+
+.deploy_packages_rpm-6:
+  extends: .deploy_packages_rpm
+  stage: deploy6
+  rules:
+    !reference [.on_deploy_a6]
+  variables:
+    MAJOR_VERSION: 6
+
+.deploy_packages_rpm-7:
+  extends: .deploy_packages_rpm
+  stage: deploy7
+  rules:
+    !reference [.on_deploy_a7]
+  variables:
+    MAJOR_VERSION: 7
+
+.deploy_packages_suse_rpm:
+  extends: .deploy_packages_rpm
+  variables:
+    ARTIFACTS_PREFIX: suse_
+    OMNIBUS_PACKAGE_DIR: $OMNIBUS_PACKAGE_DIR_SUSE
+
+.deploy_packages_suse_rpm-6:
+  extends: .deploy_packages_suse_rpm
+  stage: deploy6
+  rules:
+    !reference [.on_deploy_a6]
+  variables:
+    MAJOR_VERSION: 6
+
+.deploy_packages_suse_rpm-7:
+  extends: .deploy_packages_suse_rpm
+  stage: deploy7
+  rules:
+    !reference [.on_deploy_a7]
+  variables:
+    MAJOR_VERSION: 7

--- a/.gitlab/trigger_release.yml
+++ b/.gitlab/trigger_release.yml
@@ -6,16 +6,10 @@
   stage: trigger_release
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["runner:main"]
-  needs:
-    - deploy_packages_deb-6
-    - deploy_packages_rpm-6
-    - deploy_packages_suse_rpm-6
-    - deploy_packages_windows-6
-    - deploy_packages_deb-7
-    - deploy_packages_rpm-7
-    - deploy_packages_suse_rpm-7
-    - deploy_packages_dmg-a7
-    - deploy_packages_windows-7
+  # We don't directly depend/need the package deploy jobs, because
+  # that would make us deploy even when there are kitchen failures etc
+  # We only want to allow automatically triggering agent-release-manangement
+  # pipelines when everything goes well
   variables:
     ACTION: promote
     BUILD_PIPELINE_ID: $CI_PIPELINE_ID


### PR DESCRIPTION
### What does this PR do?

- Split package deploy jobs to be 1:1 to package build jobs
- Use 'needs' instead of 'dependencies' to upload each package as soon as it's built
- Only trigger agent-release-management pipelines when kitchen (and any other) testing succeeds

### Motivation

We need to be able to do even partial releases (manually). Previously, we would only ever upload packages to the release bucket if all builds (and jobs in the previous stages, e.g. kitchen tests) succeeded. With this PR, we will upload packages for individual build jobs as soon as the builds succeed. The requirements on previous stages (e.g. kitchen tests) succeeding is effectively moved to the trigger release jobs.

When we want to do a partial release, we'll be able to do it manually with these changes, because the packages will be uploaded to the release bucket once built.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
