### PR TITLE
[CWS] merge `Open + ReadAll` into `ReadFile`

### DIFF
--- a/pkg/security/security_profile/profile/profile_dir.go
+++ b/pkg/security/security_profile/profile/profile_dir.go
@@ -11,7 +11,6 @@ package profile
 import (
 	"context"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -175,13 +174,7 @@ func (dp *DirectoryProvider) SetOnNewProfileCallback(onNewProfileCallback func(s
 }
 
 func (dp *DirectoryProvider) parseProfile(filepath string) (*proto.SecurityProfile, error) {
-	f, err := os.Open(filepath)
-	if err != nil {
-		return nil, fmt.Errorf("couldn't open profile: %w", err)
-	}
-	defer f.Close()
-
-	raw, err := io.ReadAll(f)
+	raw, err := os.ReadFile(filepath)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't open profile: %w", err)
 	}

--- a/pkg/security/tests/kernel_module_test.go
+++ b/pkg/security/tests/kernel_module_test.go
@@ -10,7 +10,6 @@ package tests
 
 import (
 	"fmt"
-	"io"
 	"os"
 	"os/exec"
 	"path/filepath"

--- a/pkg/security/tests/kernel_module_test.go
+++ b/pkg/security/tests/kernel_module_test.go
@@ -155,15 +155,7 @@ func TestLoadModule(t *testing.T) {
 
 	t.Run("init_module", func(t *testing.T) {
 		test.WaitSignal(t, func() error {
-			var f *os.File
-			f, err = os.Open(modulePath)
-			if err != nil {
-				return fmt.Errorf("couldn't open module: %w", err)
-			}
-			defer f.Close()
-
-			var module []byte
-			module, err = io.ReadAll(f)
+			module, err := os.ReadFile(modulePath)
 			if err != nil {
 				return fmt.Errorf("couldn't load module content: %w", err)
 			}
@@ -188,8 +180,7 @@ func TestLoadModule(t *testing.T) {
 
 	t.Run("finit_module", func(t *testing.T) {
 		test.WaitSignal(t, func() error {
-			var f *os.File
-			f, err = os.Open(modulePath)
+			f, err := os.Open(modulePath)
 			if err != nil {
 				return fmt.Errorf("couldn't open module: %w", err)
 			}
@@ -237,8 +228,7 @@ func TestLoadModule(t *testing.T) {
 
 	t.Run("load_module_with_any_params", func(t *testing.T) {
 		test.WaitSignal(t, func() error {
-			var f *os.File
-			f, err = os.Open(modulePath)
+			f, err := os.Open(modulePath)
 			if err != nil {
 				return fmt.Errorf("couldn't open module: %w", err)
 			}
@@ -259,15 +249,7 @@ func TestLoadModule(t *testing.T) {
 
 	t.Run("load_module_with_specific_param", func(t *testing.T) {
 		test.WaitSignal(t, func() error {
-			var f *os.File
-			f, err = os.Open(modulePath)
-			if err != nil {
-				return fmt.Errorf("couldn't open module: %w", err)
-			}
-			defer f.Close()
-
-			var module []byte
-			module, err = io.ReadAll(f)
+			module, err := os.ReadFile(modulePath)
 			if err != nil {
 				return fmt.Errorf("couldn't load module content: %w", err)
 			}
@@ -288,15 +270,7 @@ func TestLoadModule(t *testing.T) {
 
 	t.Run("load_module_args_should_be_truncated", func(t *testing.T) {
 		test.WaitSignal(t, func() error {
-			var f *os.File
-			f, err = os.Open(modulePath)
-			if err != nil {
-				return fmt.Errorf("couldn't open module: %w", err)
-			}
-			defer f.Close()
-
-			var module []byte
-			module, err = io.ReadAll(f)
+			module, err := os.ReadFile(modulePath)
 			if err != nil {
 				return fmt.Errorf("couldn't load module content: %w", err)
 			}
@@ -354,15 +328,7 @@ func TestUnloadModule(t *testing.T) {
 
 	t.Run("delete_module", func(t *testing.T) {
 		test.WaitSignal(t, func() error {
-			var f *os.File
-			f, err = os.Open(modulePath)
-			if err != nil {
-				return fmt.Errorf("couldn't open module: %w", err)
-			}
-			defer f.Close()
-
-			var module []byte
-			module, err = io.ReadAll(f)
+			module, err := os.ReadFile(modulePath)
 			if err != nil {
 				return fmt.Errorf("couldn't load module content: %w", err)
 			}

--- a/pkg/security/tests/module_stresser.go
+++ b/pkg/security/tests/module_stresser.go
@@ -12,7 +12,6 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
-	"io"
 	"os"
 	"runtime"
 	"runtime/pprof"

--- a/pkg/security/tests/module_stresser.go
+++ b/pkg/security/tests/module_stresser.go
@@ -187,13 +187,7 @@ func (s *StressReport) Save(filename string, name string) error {
 
 // Load previous report
 func (s *StressReports) Load(filename string) error {
-	jsonFile, err := os.Open(filename)
-	if err != nil {
-		return err
-	}
-	defer jsonFile.Close()
-
-	data, err := io.ReadAll(jsonFile)
+	data, err := os.ReadFile(filename)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### What does this PR do?

Small code cleanup

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
