### PR TITLE
[kitchen] Split Win2008R2/2012/2012R2 kitchen tests from the rest, allow them to fail

### DIFF
--- a/.gitlab/kitchen_testing/windows.yml
+++ b/.gitlab/kitchen_testing/windows.yml
@@ -13,7 +13,7 @@
     - .kitchen_azure_x64
   variables:
     KITCHEN_PLATFORM: "windows"
-    KITCHEN_OSVERS: "win2008r2,win2012,win2012r2,win2016,win2019,win2019cn,win2022"
+    KITCHEN_OSVERS: "win2016,win2019,win2019cn,win2022"
     DEFAULT_KITCHEN_OSVERS: "win2022"
   before_script:  # Note: if you are changing this, remember to also change .kitchen_test_windows_installer, which has a copy of this with less TEST_PLATFORMS defined.
     - if [ $AGENT_MAJOR_VERSION == "7" ]; then export WINDOWS_TESTING_S3_BUCKET=$WINDOWS_TESTING_S3_BUCKET_A7; else export WINDOWS_TESTING_S3_BUCKET=$WINDOWS_TESTING_S3_BUCKET_A6; fi
@@ -23,6 +23,23 @@
   # Give them one more chance before failing.
   # TODO: understand why they fail more often than Linux jobs on network errors.
   retry: 2
+
+.kitchen_os_windows_old:
+  extends:
+    - .kitchen_azure_x64
+  variables:
+    KITCHEN_PLATFORM: "windows"
+    KITCHEN_OSVERS: "win2008r2,win2012,win2012r2"
+  before_script:  # Note: if you are changing this, remember to also change .kitchen_test_windows_installer, which has a copy of this with less TEST_PLATFORMS defined.
+    - if [ $AGENT_MAJOR_VERSION == "7" ]; then export WINDOWS_TESTING_S3_BUCKET=$WINDOWS_TESTING_S3_BUCKET_A7; else export WINDOWS_TESTING_S3_BUCKET=$WINDOWS_TESTING_S3_BUCKET_A6; fi
+    - cd $DD_AGENT_TESTING_DIR
+    - tasks/kitchen_setup.sh
+  # Windows kitchen tests are slower and more fragile (lots of WinRM::WinRMAuthorizationError and/or execution expired errors)
+  # Give them one more chance before failing.
+  # TODO: understand why they fail more often than Linux jobs on network errors.
+  retry: 2
+  # Kitchen tests on old OSes fail due a Rubygems API deprecation: https://blog.rubygems.org/2023/04/07/dependency-api-deprecation-delayed.html
+  allow_failure: true
 
 # Kitchen: tests
 # --------------
@@ -40,6 +57,8 @@
   script:
     - export LAST_STABLE_VERSION=$(cd ../.. && invoke release.get-release-json-value "last_stable::$AGENT_MAJOR_VERSION")
     - tasks/run-test-kitchen.sh windows-install-test $AGENT_MAJOR_VERSION
+  # Kitchen tests on old OSes fail due a Rubygems API deprecation: https://blog.rubygems.org/2023/04/07/dependency-api-deprecation-delayed.html
+  allow_failure: true
 
 # Base test for Next Gen installer - only difference with the standard one
 # is that we override the WINDOWS_AGENT_FILE name.
@@ -55,13 +74,9 @@
   # Until the code is stabilized
   allow_failure: true
 
-.kitchen_test_windows_npm_driver:
+.kitchen_test_windows_npm_driver_base:
   extends:
     - .kitchen_azure_x64
-  variables:
-    KITCHEN_PLATFORM: "windows"
-    KITCHEN_OSVERS: "win2012r2,win2016,win2019,win2019cn,win2022"
-    DEFAULT_KITCHEN_OSVERS: "win2022"
   before_script:  # test all of the kernels to make sure the driver loads and runs properly
     - if [ $AGENT_MAJOR_VERSION == "7" ]; then export WINDOWS_TESTING_S3_BUCKET=$WINDOWS_TESTING_S3_BUCKET_A7; else export WINDOWS_TESTING_S3_BUCKET=$WINDOWS_TESTING_S3_BUCKET_A6; fi
     - if [ $AGENT_MAJOR_VERSION == "7" ]; then export RELEASE_VERSION=$RELEASE_VERSION_7; else export RELEASE_VERSION=$RELEASE_VERSION_6; fi
@@ -70,6 +85,23 @@
     - tasks/kitchen_setup.sh
   script:
     - tasks/run-test-kitchen.sh windows-npmdriver $AGENT_MAJOR_VERSION
+
+.kitchen_test_windows_old_npm_driver:
+  extends:
+    - .kitchen_test_windows_npm_driver_base
+  variables:
+    KITCHEN_PLATFORM: "windows"
+    KITCHEN_OSVERS: "win2012r2"
+  # Kitchen tests on old OSes fail due a Rubygems API deprecation: https://blog.rubygems.org/2023/04/07/dependency-api-deprecation-delayed.html
+  allow_failure: true
+
+.kitchen_test_windows_npm_driver:
+  extends:
+    - .kitchen_test_windows_npm_driver_base
+  variables:
+    KITCHEN_PLATFORM: "windows"
+    KITCHEN_OSVERS: "win2016,win2019,win2019cn,win2022"
+    DEFAULT_KITCHEN_OSVERS: "win2022"
 
 .kitchen_test_windows_npm_installer:
   extends:
@@ -102,6 +134,12 @@
     - .kitchen_datadog_agent_flavor
     - .kitchen_azure_location_north_central_us
 
+.kitchen_test_windows_old_installer_driver:
+  extends:
+    - .kitchen_test_windows_old_npm_driver
+    - .kitchen_datadog_agent_flavor
+    - .kitchen_azure_location_north_central_us
+
 .kitchen_test_windows_installer_driver:
   extends:
     - .kitchen_test_windows_npm_driver
@@ -123,10 +161,22 @@
     - .kitchen_os_windows
   needs: ["deploy_windows_testing-a6"]
 
+.kitchen_scenario_windows_old_a6:
+  extends:
+    - .kitchen_agent_a6
+    - .kitchen_os_windows_old
+  needs: ["deploy_windows_testing-a6"]
+
 .kitchen_scenario_windows_a7:
   extends:
     - .kitchen_agent_a7
     - .kitchen_os_windows
+  needs: ["deploy_windows_testing-a7"]
+
+.kitchen_scenario_windows_old_a7:
+  extends:
+    - .kitchen_agent_a7
+    - .kitchen_os_windows_old
   needs: ["deploy_windows_testing-a7"]
 
 # Kitchen: final test matrix (test types * scenarios)
@@ -144,6 +194,11 @@ kitchen_windows_installer_npm_driver-a7:
   extends:
     - .kitchen_scenario_windows_a7
     - .kitchen_test_windows_installer_driver
+
+kitchen_windows_old_installer_npm_driver-a7:
+  extends:
+    - .kitchen_scenario_windows_a7
+    - .kitchen_test_windows_old_installer_driver
 
 kitchen_windows_installer_agent-a6:
   extends:
@@ -170,6 +225,11 @@ kitchen_windows_chef_agent-a6:
     - .kitchen_scenario_windows_a6
     - .kitchen_test_chef_agent
 
+kitchen_windows_old_chef_agent-a6:
+  extends:
+    - .kitchen_scenario_windows_old_a6
+    - .kitchen_test_chef_agent
+
 kitchen_windows_chef_agent-a7:
   # Run chef test on branches, on a reduced number of platforms
   rules:
@@ -178,9 +238,19 @@ kitchen_windows_chef_agent-a7:
     - .kitchen_scenario_windows_a7
     - .kitchen_test_chef_agent
 
+kitchen_windows_old_chef_agent-a7:
+  extends:
+    - .kitchen_scenario_windows_old_a7
+    - .kitchen_test_chef_agent
+
 kitchen_windows_upgrade5_agent-a6:
   extends:
     - .kitchen_scenario_windows_a6
+    - .kitchen_test_upgrade5_agent
+
+kitchen_windows_old_upgrade5_agent-a6:
+  extends:
+    - .kitchen_scenario_windows_old_a6
     - .kitchen_test_upgrade5_agent
 
 kitchen_windows_upgrade5_agent-a7:
@@ -188,9 +258,19 @@ kitchen_windows_upgrade5_agent-a7:
     - .kitchen_scenario_windows_a7
     - .kitchen_test_upgrade5_agent
 
+kitchen_windows_old_upgrade5_agent-a7:
+  extends:
+    - .kitchen_scenario_windows_old_a7
+    - .kitchen_test_upgrade5_agent
+
 kitchen_windows_upgrade6_agent-a6:
   extends:
     - .kitchen_scenario_windows_a6
+    - .kitchen_test_upgrade6_agent
+
+kitchen_windows_old_upgrade6_agent-a6:
+  extends:
+    - .kitchen_scenario_windows_old_a6
     - .kitchen_test_upgrade6_agent
 
 kitchen_windows_upgrade6_agent-a7:
@@ -198,9 +278,19 @@ kitchen_windows_upgrade6_agent-a7:
     - .kitchen_scenario_windows_a7
     - .kitchen_test_upgrade6_agent
 
+kitchen_windows_old_upgrade6_agent-a7:
+  extends:
+    - .kitchen_scenario_windows_old_a7
+    - .kitchen_test_upgrade6_agent
+
 kitchen_windows_upgrade7_agent-a7:
   extends:
     - .kitchen_scenario_windows_a7
+    - .kitchen_test_upgrade7_agent
+
+kitchen_windows_old_upgrade7_agent-a7:
+  extends:
+    - .kitchen_scenario_windows_old_a7
     - .kitchen_test_upgrade7_agent
 
 kitchen_windows_process_agent-a7:


### PR DESCRIPTION


<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Separates Windows kitchen tests in two parts:
- "old" ones, running Windows Server 2012R2 and below,
- current ones, running Windows Server 2016 and above.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Allow the lower ones to fail, as they are currently affected by [a deprecation in the Rubygems API](https://blog.rubygems.org/2023/04/07/dependency-api-deprecation-delayed.html).

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

n/a

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

n/a

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Kitchen tests should pass, and run the same set of OSes as before.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
