### PR TITLE
fix macos tests

### DIFF
--- a/pkg/network/event_common_linux.go
+++ b/pkg/network/event_common_linux.go
@@ -8,10 +8,6 @@
 
 package network
 
-import (
-	"github.com/DataDog/datadog-agent/pkg/network/types"
-)
-
 // Sub returns s-other.
 //
 // This implementation is different from the implementation on

--- a/pkg/network/event_common_linux.go
+++ b/pkg/network/event_common_linux.go
@@ -55,29 +55,3 @@ func (s StatCounters) Sub(other StatCounters) (sc StatCounters, underflow bool) 
 
 	return sc, false
 }
-
-// ConnectionKeysFromConnectionStats constructs connection key using the underlying raw connection stats object, which is produced by the tracer.
-// Each ConnectionStats object contains both the source and destination addresses, as well as an IPTranslation object that stores the original addresses in the event that the connection is NAT'd.
-// This function generates all relevant combinations of connection keys: [(source, dest), (dest, source), (NAT'd source, NAT'd dest), (NAT'd dest, NAT'd source)].
-// This is necessary to handle all possible scenarios for connections originating from the USM module (i.e., whether they are NAT'd or not, and whether they use TLS).
-func ConnectionKeysFromConnectionStats(connectionStats ConnectionStats) []types.ConnectionKey {
-
-	// USM data is always indexed as (client, server), but we don't know which is the remote
-	// and which is the local address. To account for this, we'll construct 2 possible
-	// connection keys and check for both of them in the aggregations map.
-	connectionKeys := []types.ConnectionKey{
-		types.NewConnectionKey(connectionStats.Source, connectionStats.Dest, connectionStats.SPort, connectionStats.DPort),
-		types.NewConnectionKey(connectionStats.Dest, connectionStats.Source, connectionStats.DPort, connectionStats.SPort),
-	}
-
-	// if IPTranslation is not nil, at least one of the sides has a translation, thus we need to add translated addresses.
-	if connectionStats.IPTranslation != nil {
-		localAddress, localPort := GetNATLocalAddress(connectionStats)
-		remoteAddress, remotePort := GetNATRemoteAddress(connectionStats)
-		connectionKeys = append(connectionKeys,
-			types.NewConnectionKey(localAddress, remoteAddress, localPort, remotePort),
-			types.NewConnectionKey(remoteAddress, localAddress, remotePort, localPort))
-	}
-
-	return connectionKeys
-}

--- a/pkg/network/event_common_notwindows.go
+++ b/pkg/network/event_common_notwindows.go
@@ -12,9 +12,9 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/network/types"
 )
 
-
 // this file is here because Windows has its own ConnectionKeysFromConnectionStats.
-// however, putting this in `_linux.go`
+// however, putting this in `_linux.go` broke the mac build ?
+
 // ConnectionKeysFromConnectionStats constructs connection key using the underlying raw connection stats object, which is produced by the tracer.
 // Each ConnectionStats object contains both the source and destination addresses, as well as an IPTranslation object that stores the original addresses in the event that the connection is NAT'd.
 // This function generates all relevant combinations of connection keys: [(source, dest), (dest, source), (NAT'd source, NAT'd dest), (NAT'd dest, NAT'd source)].

--- a/pkg/network/event_common_notwindows.go
+++ b/pkg/network/event_common_notwindows.go
@@ -1,0 +1,42 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !windows
+// +build !windows
+
+package network
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/network/types"
+)
+
+
+// this file is here because Windows has its own ConnectionKeysFromConnectionStats.
+// however, putting this in `_linux.go`
+// ConnectionKeysFromConnectionStats constructs connection key using the underlying raw connection stats object, which is produced by the tracer.
+// Each ConnectionStats object contains both the source and destination addresses, as well as an IPTranslation object that stores the original addresses in the event that the connection is NAT'd.
+// This function generates all relevant combinations of connection keys: [(source, dest), (dest, source), (NAT'd source, NAT'd dest), (NAT'd dest, NAT'd source)].
+// This is necessary to handle all possible scenarios for connections originating from the USM module (i.e., whether they are NAT'd or not, and whether they use TLS).
+func ConnectionKeysFromConnectionStats(connectionStats ConnectionStats) []types.ConnectionKey {
+
+	// USM data is always indexed as (client, server), but we don't know which is the remote
+	// and which is the local address. To account for this, we'll construct 2 possible
+	// connection keys and check for both of them in the aggregations map.
+	connectionKeys := []types.ConnectionKey{
+		types.NewConnectionKey(connectionStats.Source, connectionStats.Dest, connectionStats.SPort, connectionStats.DPort),
+		types.NewConnectionKey(connectionStats.Dest, connectionStats.Source, connectionStats.DPort, connectionStats.SPort),
+	}
+
+	// if IPTranslation is not nil, at least one of the sides has a translation, thus we need to add translated addresses.
+	if connectionStats.IPTranslation != nil {
+		localAddress, localPort := GetNATLocalAddress(connectionStats)
+		remoteAddress, remotePort := GetNATRemoteAddress(connectionStats)
+		connectionKeys = append(connectionKeys,
+			types.NewConnectionKey(localAddress, remoteAddress, localPort, remotePort),
+			types.NewConnectionKey(remoteAddress, localAddress, remotePort, localPort))
+	}
+
+	return connectionKeys
+}


### PR DESCRIPTION
### What does this PR do?

Fixes mistake in previous pr (#16220 ) which breaks mac build

### Motivation

### Additional Notes


### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
