### PR TITLE
[gitlab] Temporarily fix package size checks

### DIFF
--- a/.gitlab/pkg_metrics.yml
+++ b/.gitlab/pkg_metrics.yml
@@ -256,11 +256,11 @@ check_pkg_size-amd64-a6:
     FLAVORS: "datadog-agent"
     ARCH: "amd64"
   before_script:
-    # FIXME: ["datadog-agent"]="60000000" should be replaced by "50000000"
-    # "60000000" is needed as of now because of a large bump in size of the agent package in 7.45
+    # FIXME: ["datadog-agent"]="70000000" should be replaced by "50000000"
+    # "70000000" is needed as of now because of multiple large additions in 7.45
     - |
         declare -Ar max_sizes=(
-            ["datadog-agent"]="60000000"
+            ["datadog-agent"]="70000000"
         )
 
 check_pkg_size-arm64-a6:
@@ -275,11 +275,11 @@ check_pkg_size-arm64-a6:
     FLAVORS: "datadog-agent"
     ARCH: "arm64"
   before_script:
-    # FIXME: ["datadog-agent"]="60000000" should be replaced by "50000000"
-    # "60000000" is needed as of now because of a large bump in size of the agent package in 7.45
+    # FIXME: ["datadog-agent"]="70000000" should be replaced by "50000000"
+    # "70000000" is needed as of now because of multiple large additions in 7.45
     - |
         declare -Ar max_sizes=(
-            ["datadog-agent"]="60000000"
+            ["datadog-agent"]="70000000"
         )
 
 check_pkg_size-amd64-a7:
@@ -302,15 +302,15 @@ check_pkg_size-amd64-a7:
     FLAVORS: "datadog-agent datadog-iot-agent datadog-dogstatsd datadog-heroku-agent"
     ARCH: "amd64"
   before_script:
-    # FIXME: ["datadog-agent"]="60000000" and ["datadog-heroku-agent"]="60000000" should
+    # FIXME: ["datadog-agent"]="70000000" and ["datadog-heroku-agent"]="70000000" should
     # be replaced by "50000000"
-    # "60000000" is needed as of now because of a large bump in size of the agent package in 7.45
+    # "70000000" is needed as of now because of multiple large additions in 7.45
     - |
         declare -Ar max_sizes=(
-            ["datadog-agent"]="60000000"
+            ["datadog-agent"]="70000000"
             ["datadog-iot-agent"]="10000000"
             ["datadog-dogstatsd"]="10000000"
-            ["datadog-heroku-agent"]="60000000"
+            ["datadog-heroku-agent"]="70000000"
         )
 
 check_pkg_size-arm64-a7:
@@ -328,11 +328,11 @@ check_pkg_size-arm64-a7:
     FLAVORS: "datadog-agent datadog-iot-agent datadog-dogstatsd"
     ARCH: "arm64"
   before_script:
-    # FIXME: ["datadog-agent"]="60000000" should be replaced by "50000000"
-    # "60000000" is needed as of now because of a large bump in size of the agent package in 7.45
+    # FIXME: ["datadog-agent"]="70000000" should be replaced by "70000000"
+    # "70000000" is needed as of now because of multiple large additions in 7.45
     - |
         declare -Ar max_sizes=(
-            ["datadog-agent"]="60000000"
+            ["datadog-agent"]="70000000"
             ["datadog-iot-agent"]="10000000"
             ["datadog-dogstatsd"]="10000000"
         )


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Updates the package size check to 70MB (from 60MB).

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Multiple recent changes bumped the package size over the previous limit.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

n/a

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

n/a

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

n/a

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
