### PR TITLE
[process-agent] Log errors on failure to initialize

### DIFF
--- a/cmd/process-agent/main_common.go
+++ b/cmd/process-agent/main_common.go
@@ -142,7 +142,7 @@ func runApp(exit chan struct{}, globalParams *command.GlobalParams) error {
 	)
 
 	if err := app.Err(); err != nil {
-		fmt.Println("Failed to initalize the process agent: ", fxutil.UnwrapIfErrArgumentsFailed(err))
+		fmt.Println("Failed to initialize the process agent: ", fxutil.UnwrapIfErrArgumentsFailed(err))
 		return err
 	}
 

--- a/cmd/process-agent/main_common.go
+++ b/cmd/process-agent/main_common.go
@@ -7,6 +7,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	_ "net/http/pprof"
 	"os"
 
@@ -19,6 +20,7 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/process-agent/subcommands"
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/config"
+	logComponent "github.com/DataDog/datadog-agent/comp/core/log"
 	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig"
 	"github.com/DataDog/datadog-agent/comp/process"
 	"github.com/DataDog/datadog-agent/comp/process/apiserver"
@@ -104,6 +106,7 @@ func runApp(exit chan struct{}, globalParams *command.GlobalParams) error {
 		Checks []types.CheckComponent `group:"check"`
 		Syscfg sysprobeconfig.Component
 		Config config.Component
+		Logger logComponent.Component
 	}
 	app := fx.New(
 		fx.Supply(
@@ -139,6 +142,11 @@ func runApp(exit chan struct{}, globalParams *command.GlobalParams) error {
 		) {
 		}),
 	)
+
+	if err := app.Err(); err != nil {
+		fmt.Println("Failed to initalize the process agent: ", fxutil.UnwrapIfErrArgumentsFailed(err))
+		return err
+	}
 
 	// Look to see if any checks are enabled, if not, return since the agent doesn't need to be enabled.
 	if !anyChecksEnabled(appInitDeps.Checks) {

--- a/cmd/process-agent/main_common.go
+++ b/cmd/process-agent/main_common.go
@@ -20,7 +20,6 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/process-agent/subcommands"
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/config"
-	logComponent "github.com/DataDog/datadog-agent/comp/core/log"
 	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig"
 	"github.com/DataDog/datadog-agent/comp/process"
 	"github.com/DataDog/datadog-agent/comp/process/apiserver"
@@ -106,7 +105,6 @@ func runApp(exit chan struct{}, globalParams *command.GlobalParams) error {
 		Checks []types.CheckComponent `group:"check"`
 		Syscfg sysprobeconfig.Component
 		Config config.Component
-		Logger logComponent.Component
 	}
 	app := fx.New(
 		fx.Supply(

--- a/pkg/util/fxutil/errorunwrapper.go
+++ b/pkg/util/fxutil/errorunwrapper.go
@@ -11,8 +11,8 @@ import (
 	"regexp"
 )
 
-// unwrapIfErrArgumentsFailed unwrap the error if the error was returned by an FX invoke method otherwise return the error.
-func unwrapIfErrArgumentsFailed(err error) error {
+// UnwrapIfErrArgumentsFailed unwrap the error if the error was returned by an FX invoke method otherwise return the error.
+func UnwrapIfErrArgumentsFailed(err error) error {
 	// This is a workaround until https://github.com/uber-go/fx/issues/988 will be done.
 	if reflect.TypeOf(err).Name() == "errArgumentsFailed" {
 		re := regexp.MustCompile(`.*received non-nil error from function.*\(.*\): (.*)`)

--- a/pkg/util/fxutil/oneshot.go
+++ b/pkg/util/fxutil/oneshot.go
@@ -44,7 +44,7 @@ func OneShot(oneShotFunc interface{}, opts ...fx.Option) error {
 	startCtx, cancel := context.WithTimeout(context.Background(), app.StartTimeout())
 	defer cancel()
 	if err := app.Start(startCtx); err != nil {
-		return unwrapIfErrArgumentsFailed(err)
+		return UnwrapIfErrArgumentsFailed(err)
 	}
 
 	// call the original oneShotFunc with the args captured during app startup

--- a/pkg/util/fxutil/run.go
+++ b/pkg/util/fxutil/run.go
@@ -23,7 +23,7 @@ func Run(opts ...fx.Option) error {
 	defer cancel()
 
 	if err := app.Start(startCtx); err != nil {
-		return unwrapIfErrArgumentsFailed(err)
+		return UnwrapIfErrArgumentsFailed(err)
 	}
 
 	_ = <-app.Done()


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR simply logs errors when the call to `fx.New` fails to `stdout`.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Fix a small bug where the agent won't print an error when the config is missing.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Delete `/etc/datadog-agent/datadog.yaml`, start the process agent and make sure an error is printed to stdout

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
