### PR TITLE
[SBOM] Replace BadgerDB cache by a custom LRU cache with a cleaning mechanism for Trivy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -201,3 +201,6 @@ tools/windows/DatadogAgentInstaller/WixSetup/cabcache/
 
 # e2e test intake generated binary
 test/fakeintake/build/*
+
+# dev container
+.devcontainer/

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -538,7 +538,6 @@ core,github.com/cavaliergopher/grab/v3,BSD-3-Clause,Copyright (c) 2017 Ryan Arms
 core,github.com/cavaliergopher/grab/v3/pkg/bps,BSD-3-Clause,Copyright (c) 2017 Ryan Armstrong. All rights reserved
 core,github.com/cenkalti/backoff,MIT,Copyright (c) 2014 Cenk Altı
 core,github.com/cenkalti/backoff/v4,MIT,Copyright (c) 2014 Cenk Altı
-core,github.com/cespare/xxhash,MIT,Copyright (c) 2016 Caleb Spare
 core,github.com/cespare/xxhash/v2,MIT,Copyright (c) 2016 Caleb Spare
 core,github.com/cihub/seelog,BSD-3-Clause,"Copyright (c) 2012, Cloud Instruments Co., Ltd. <info@cin.io>"
 core,github.com/cilium/ebpf,MIT,"Copyright (c) 2017 Nathan Sweet | Copyright (c) 2018, 2019 Cloudflare | Copyright (c) 2019 Authors of Cilium"
@@ -654,17 +653,6 @@ core,github.com/coreos/pkg/dlopen,Apache-2.0,"Copyright 2017 CoreOS, Inc"
 core,github.com/cri-o/ocicni/pkg/ocicni,Apache-2.0,"Copyright 2016 Red Hat, Inc"
 core,github.com/cyphar/filepath-securejoin,BSD-3-Clause,Copyright (C) 2014-2015 Docker Inc & Go Authors. All rights reserved | Copyright (C) 2017 SUSE LLC. All rights reserved
 core,github.com/davecgh/go-spew/spew,ISC,Copyright (c) 2012-2016 Dave Collins <dave@davec.name>
-core,github.com/dgraph-io/badger/v3,Apache-2.0,"Copyright 2013 The LevelDB-Go Authors. All rights reserved. | Copyright 2017 Dgraph Labs, Inc. and Contributors | Copyright 2018 Dgraph Labs, Inc. and Contributors | Copyright 2019 Dgraph Labs, Inc. and Contributors | Copyright 2020 Dgraph Labs, Inc. and Contributors | Copyright 2021 Dgraph Labs, Inc. and Contributors"
-core,github.com/dgraph-io/badger/v3/fb,Apache-2.0,"Copyright 2013 The LevelDB-Go Authors. All rights reserved. | Copyright 2017 Dgraph Labs, Inc. and Contributors | Copyright 2018 Dgraph Labs, Inc. and Contributors | Copyright 2019 Dgraph Labs, Inc. and Contributors | Copyright 2020 Dgraph Labs, Inc. and Contributors | Copyright 2021 Dgraph Labs, Inc. and Contributors"
-core,github.com/dgraph-io/badger/v3/options,Apache-2.0,"Copyright 2013 The LevelDB-Go Authors. All rights reserved. | Copyright 2017 Dgraph Labs, Inc. and Contributors | Copyright 2018 Dgraph Labs, Inc. and Contributors | Copyright 2019 Dgraph Labs, Inc. and Contributors | Copyright 2020 Dgraph Labs, Inc. and Contributors | Copyright 2021 Dgraph Labs, Inc. and Contributors"
-core,github.com/dgraph-io/badger/v3/pb,Apache-2.0,"Copyright 2013 The LevelDB-Go Authors. All rights reserved. | Copyright 2017 Dgraph Labs, Inc. and Contributors | Copyright 2018 Dgraph Labs, Inc. and Contributors | Copyright 2019 Dgraph Labs, Inc. and Contributors | Copyright 2020 Dgraph Labs, Inc. and Contributors | Copyright 2021 Dgraph Labs, Inc. and Contributors"
-core,github.com/dgraph-io/badger/v3/skl,Apache-2.0,"Copyright 2013 The LevelDB-Go Authors. All rights reserved. | Copyright 2017 Dgraph Labs, Inc. and Contributors | Copyright 2018 Dgraph Labs, Inc. and Contributors | Copyright 2019 Dgraph Labs, Inc. and Contributors | Copyright 2020 Dgraph Labs, Inc. and Contributors | Copyright 2021 Dgraph Labs, Inc. and Contributors"
-core,github.com/dgraph-io/badger/v3/table,Apache-2.0,"Copyright 2013 The LevelDB-Go Authors. All rights reserved. | Copyright 2017 Dgraph Labs, Inc. and Contributors | Copyright 2018 Dgraph Labs, Inc. and Contributors | Copyright 2019 Dgraph Labs, Inc. and Contributors | Copyright 2020 Dgraph Labs, Inc. and Contributors | Copyright 2021 Dgraph Labs, Inc. and Contributors"
-core,github.com/dgraph-io/badger/v3/trie,Apache-2.0,"Copyright 2013 The LevelDB-Go Authors. All rights reserved. | Copyright 2017 Dgraph Labs, Inc. and Contributors | Copyright 2018 Dgraph Labs, Inc. and Contributors | Copyright 2019 Dgraph Labs, Inc. and Contributors | Copyright 2020 Dgraph Labs, Inc. and Contributors | Copyright 2021 Dgraph Labs, Inc. and Contributors"
-core,github.com/dgraph-io/badger/v3/y,Apache-2.0,"Copyright 2013 The LevelDB-Go Authors. All rights reserved. | Copyright 2017 Dgraph Labs, Inc. and Contributors | Copyright 2018 Dgraph Labs, Inc. and Contributors | Copyright 2019 Dgraph Labs, Inc. and Contributors | Copyright 2020 Dgraph Labs, Inc. and Contributors | Copyright 2021 Dgraph Labs, Inc. and Contributors"
-core,github.com/dgraph-io/ristretto,Apache-2.0,"Copyright (c) 2014 Andreas Briese, eduToolbox@Bri-C GmbH, Sarstedt | Copyright (c) 2019 Ewan Chou | Copyright 2019 Dgraph Labs, Inc. and Contributors | Copyright 2020 Dgraph Labs, Inc. and Contributors | Copyright 2020 The LevelDB-Go and Pebble Authors. All rights reserved."
-core,github.com/dgraph-io/ristretto/z,MIT,"Copyright (c) 2014 Andreas Briese, eduToolbox@Bri-C GmbH, Sarstedt | Copyright (c) 2019 Ewan Chou | Copyright 2019 Dgraph Labs, Inc. and Contributors | Copyright 2020 Dgraph Labs, Inc. and Contributors | Copyright 2020 The LevelDB-Go and Pebble Authors. All rights reserved."
-core,github.com/dgraph-io/ristretto/z/simd,MIT,"Copyright (c) 2014 Andreas Briese, eduToolbox@Bri-C GmbH, Sarstedt | Copyright (c) 2019 Ewan Chou | Copyright 2019 Dgraph Labs, Inc. and Contributors | Copyright 2020 Dgraph Labs, Inc. and Contributors | Copyright 2020 The LevelDB-Go and Pebble Authors. All rights reserved."
 core,github.com/dgryski/go-jump,MIT,Copyright (c) 2014 Damian Gryski <damian@gryski.com>
 core,github.com/dgryski/go-rendezvous,MIT,Copyright (c) 2017-2020 Damian Gryski <damian@gryski.com>
 core,github.com/dimchansky/utfbom,Apache-2.0,"Copyright (c) 2018-2020, Dmitrij Koniajev (dimchansky@gmail.com)"
@@ -878,7 +866,6 @@ core,github.com/golang/protobuf/ptypes/struct,BSD-3-Clause,Copyright (c) 2009 Th
 core,github.com/golang/protobuf/ptypes/timestamp,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved.
 core,github.com/golang/protobuf/ptypes/wrappers,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved.
 core,github.com/golang/snappy,BSD-3-Clause,Copyright (c) 2011 The Snappy-Go Authors. All rights reserved.
-core,github.com/google/flatbuffers/go,Apache-2.0,Copyright (c) 2014 Google
 core,github.com/google/go-cmp/cmp,BSD-3-Clause,Copyright (c) 2017 The Go Authors. All rights reserved.
 core,github.com/google/go-cmp/cmp/internal/diff,BSD-3-Clause,Copyright (c) 2017 The Go Authors. All rights reserved.
 core,github.com/google/go-cmp/cmp/internal/flags,BSD-3-Clause,Copyright (c) 2017 The Go Authors. All rights reserved.

--- a/go.mod
+++ b/go.mod
@@ -98,7 +98,6 @@ require (
 	github.com/cri-o/ocicni v0.4.0
 	github.com/cyphar/filepath-securejoin v0.2.3
 	github.com/davecgh/go-spew v1.1.1
-	github.com/dgraph-io/badger/v3 v3.2103.5
 	github.com/docker/docker v23.0.0-rc.1+incompatible
 	github.com/docker/go-connections v0.4.0
 	github.com/dustin/go-humanize v1.0.1
@@ -300,6 +299,7 @@ require (
 	github.com/aquasecurity/go-version v0.0.0-20210121072130-637058cfe492 // indirect
 	github.com/aquasecurity/table v1.8.0 // indirect
 	github.com/aquasecurity/tml v0.6.1 // indirect
+	github.com/aquasecurity/trivy v0.39.0
 	github.com/arduino/go-apt-client v0.0.0-20190812130613-5613f843fdc8 // indirect
 	github.com/armon/go-metrics v0.4.0 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d // indirect
@@ -324,7 +324,6 @@ require (
 	github.com/briandowns/spinner v1.12.0 // indirect
 	github.com/caarlos0/env/v6 v6.10.1 // indirect
 	github.com/cavaliergopher/grab/v3 v3.0.1 // indirect
-	github.com/cespare/xxhash v1.1.0 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/containerd/continuity v0.3.0 // indirect
 	github.com/containerd/fifo v1.0.0 // indirect
@@ -333,7 +332,6 @@ require (
 	github.com/containernetworking/plugins v1.1.1 // indirect
 	github.com/coreos/go-systemd/v22 v22.4.0 // indirect
 	github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f // indirect
-	github.com/dgraph-io/ristretto v0.1.1 // indirect
 	github.com/dgryski/go-jump v0.0.0-20211018200510-ba001c3ffce0 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/dimchansky/utfbom v1.1.1 // indirect
@@ -372,7 +370,6 @@ require (
 	github.com/golang-jwt/jwt/v4 v4.4.2 // indirect
 	github.com/golang/glog v1.0.0 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
-	github.com/google/flatbuffers v1.12.1 // indirect
 	github.com/google/licenseclassifier/v2 v2.0.0 // indirect
 	github.com/google/uuid v1.3.0
 	github.com/google/wire v0.5.0 // indirect
@@ -570,7 +567,6 @@ require (
 )
 
 require (
-	github.com/aquasecurity/trivy v0.0.0-00010101000000-000000000000
 	github.com/godror/godror v0.37.0
 	github.com/jmoiron/sqlx v1.3.5
 	github.com/sijms/go-ora/v2 v2.6.12

--- a/go.sum
+++ b/go.sum
@@ -590,7 +590,6 @@ github.com/coreos/go-systemd/v22 v22.4.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSV
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f h1:lBNOc5arjvs8E5mO2tbpBpLoyyu8B6e44T7hJy6potg=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cosiner/argv v0.1.0/go.mod h1:EusR6TucWKX+zFgtdUsKT2Cvg45K5rtpCcWz4hK06d8=
-github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
@@ -613,9 +612,7 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/denverdino/aliyungo v0.0.0-20190125010748-a747050bb1ba/go.mod h1:dV8lFg6daOBZbT6/BDGIz6Y3WFGn8juu6G+CQ6LHtl0=
 github.com/derekparker/trie v0.0.0-20200317170641-1fdf38b7b0e9/go.mod h1:D6ICZm05D9VN1n/8iOtBxLpXtoGp6HDFUJ1RNVieOSE=
 github.com/dgraph-io/badger/v3 v3.2103.5 h1:ylPa6qzbjYRQMU6jokoj4wzcaweHylt//CH0AKt0akg=
-github.com/dgraph-io/badger/v3 v3.2103.5/go.mod h1:4MPiseMeDQ3FNCYwRbbcBOGJLf5jsE0PPFzRiKjtcdw=
 github.com/dgraph-io/ristretto v0.1.1 h1:6CWw5tJNgpegArSHpNHJKldNeq03FQCwYvfMVWajOK8=
-github.com/dgraph-io/ristretto v0.1.1/go.mod h1:S1GPSBCYCIhmVNfcth17y2zZtQT6wzkzgwUve0VDWWA=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/dgryski/go-farm v0.0.0-20200201041132-a6ae2369ad13 h1:fAjc9m62+UWV/WAFKLNi6ZS0675eEUC9y3AlwSbQu1Y=
 github.com/dgryski/go-jump v0.0.0-20211018200510-ba001c3ffce0 h1:0wH6nO9QEa02Qx8sIQGw6ieKdz+BXjpccSOo9vXNl4U=
@@ -929,7 +926,6 @@ github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg
 github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.2/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
-github.com/golang/snappy v0.0.3/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.4 h1:yAGX7huGHXlcLOEtBnF4w7FQwA26wojNCwOYAEhLjQM=
 github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
@@ -939,7 +935,6 @@ github.com/google/btree v1.0.1/go.mod h1:xXMiIv4Fb/0kKde4SpL7qlzvu5cMJDRkFDxJfI9
 github.com/google/cel-go v0.9.0/go.mod h1:U7ayypeSkw23szu4GaQTPJGx66c20mx8JklMSxrmI1w=
 github.com/google/cel-spec v0.6.0/go.mod h1:Nwjgxy5CbjlPrtCWjeDjUyKMl8w41YBYGjsyDdqk0xA=
 github.com/google/flatbuffers v1.12.1 h1:MVlul7pQNoDzWRLTw5imwYsl+usrS1TXG2H4jg6ImGw=
-github.com/google/flatbuffers v1.12.1/go.mod h1:1AeVuKshWv4vARoZatz6mlQ0JxURH0Kv5+zNeJKJCa8=
 github.com/google/gnostic v0.5.7-v3refs h1:FhTMOKj2VhjpouxvWJAV1TL304uMlb9zcDqkl6cEI54=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
@@ -1223,7 +1218,6 @@ github.com/klauspost/compress v1.11.3/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYs
 github.com/klauspost/compress v1.11.4/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/klauspost/compress v1.11.7/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/klauspost/compress v1.11.13/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
-github.com/klauspost/compress v1.12.3/go.mod h1:8dP1Hq4DHOhN9w426knH3Rhby4rFm6D8eO+e+Dq5Gzg=
 github.com/klauspost/compress v1.13.6/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
 github.com/klauspost/compress v1.15.9/go.mod h1:PhcZ0MbTNciWF3rruxRgKxI5NkcHHrHUDtV4Yw2GlzU=
 github.com/klauspost/compress v1.15.12/go.mod h1:QPwzmACJjUTFsnSHH934V6woptycfrDDJnH7hvFVbGM=
@@ -1659,7 +1653,6 @@ github.com/rs/zerolog v1.28.0/go.mod h1:NILgTygv/Uej1ra5XxGf82ZFSLk58MFGAUS2o6us
 github.com/rs/zerolog v1.29.0 h1:Zes4hju04hjbvkVkOhdl2HpZa+0PmVwigmo8XoORE5w=
 github.com/rs/zerolog v1.29.0/go.mod h1:NILgTygv/Uej1ra5XxGf82ZFSLk58MFGAUS2o6usyD0=
 github.com/rubenv/sql-migrate v1.1.2 h1:9M6oj4e//owVVHYrFISmY9LBRw6gzkCNmD9MV36tZeQ=
-github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/russross/blackfriday v1.6.0 h1:KqfZb0pUVN2lYqZUYRddxF4OR8ZMURnJIG5Y3VRLtww=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
@@ -1744,7 +1737,6 @@ github.com/spf13/afero v1.9.3 h1:41FoI0fD7OR7mGcKE/aOiLkGreyf8ifIOQmJANWogMk=
 github.com/spf13/afero v1.9.3/go.mod h1:iUV7ddyEEZPO5gA3zD4fJt6iStLlL+Lg4m2cihcDf8Y=
 github.com/spf13/cobra v0.0.2-0.20171109065643-2da4a54c5cee/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
-github.com/spf13/cobra v0.0.5/go.mod h1:3K3wKZymM7VvHMDS9+Akkh4K60UwM26emMESw8tLCHU=
 github.com/spf13/cobra v1.0.0/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
 github.com/spf13/cobra v1.1.3/go.mod h1:pGADOWyqRD/YMrPZigI/zbliZ2wVD/23d+is3pSWzOo=
 github.com/spf13/cobra v1.2.1/go.mod h1:ExllRjgxM/piMAM+3tAZvg8fsklGAf3tPfi+i8t68Nk=
@@ -1757,7 +1749,6 @@ github.com/spf13/pflag v1.0.1-0.20171106142849-4c012f6dcd95/go.mod h1:DYY7MBk1bd
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
-github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
 github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/yZzE=
 github.com/spf13/viper v1.6.2/go.mod h1:t3iDnF5Jlj76alVNuyFBk5oUMCvsrkbvZK0WQdfDi5k=
 github.com/spf13/viper v1.7.0/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5qpdg=
@@ -1839,7 +1830,6 @@ github.com/twmb/franz-go/pkg/kmsg v1.4.0/go.mod h1:SxG/xJKhgPu25SamAq0rrucfp7lbz
 github.com/twmb/murmur3 v1.1.6 h1:mqrRot1BRxm+Yct+vavLMou2/iJt0tNVTTC0QoIjaZg=
 github.com/twmb/murmur3 v1.1.6/go.mod h1:Qq/R7NUyOfr65zD+6Q5IHKsJLwP7exErjN6lyyq3OSQ=
 github.com/ugorji/go v1.1.7/go.mod h1:kZn38zHttfInRq0xu/PH0az30d+z6vm202qpg1oXVMw=
-github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/ugorji/go/codec v1.1.7/go.mod h1:Ax+UKWsSmolVDwsd+7N3ZtXu+yMGCf907BLYF3GoBXY=
 github.com/ugorji/go/codec v1.2.7 h1:YPXUKf7fYbp/y8xloBqZOw2qaVggbfwMlI8WM3wZUJ0=
 github.com/ugorji/go/codec v1.2.7/go.mod h1:WGN1fab3R1fzQlVQTkfxVtIBhWDRqOviHU95kRgeqEY=
@@ -2088,7 +2078,6 @@ golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnf
 golang.org/x/crypto v0.0.0-20181009213950-7c1a557ab941/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20181029021203-45a5f77698d3/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20181127143415-eb0de9b17e85/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
-golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190219172222-a4c6cb3142f2/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190422162423-af44ce270edf/go.mod h1:WFFai1msRO1wXaEeE5yQxYXgSfI8pQAWXbQop6sCtWE=
@@ -2278,7 +2267,6 @@ golang.org/x/sys v0.0.0-20181026203630-95b1ffbd15a5/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20181107165924-66b7b1311ac8/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181128092732-4ed8d59d0b35/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
-golang.org/x/sys v0.0.0-20181205085412-a5c9d58dba9a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190129075346-302c3dd5f1cc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -2401,7 +2389,6 @@ golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220829200755-d48e67d00261/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20221010170243-090e33056c14/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1094,7 +1094,10 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("sbom.analyzers", []string{"os"})
 	config.BindEnvAndSetDefault("sbom.cache_directory", defaultRunPath)
 	config.BindEnvAndSetDefault("sbom.clear_cache_on_exit", false)
-	config.BindEnvAndSetDefault("sbom.cache_ttl", 60*60) // Integer seconds. Only used with Badger
+	config.BindEnvAndSetDefault("sbom.use_custom_cache", false)
+	config.BindEnvAndSetDefault("sbom.custom_cache_max_disk_size", 1000*1000*10) // used by custom cache: max disk space used by cached objects. Not equal to max disk usage
+	config.BindEnvAndSetDefault("sbom.custom_cache_max_cache_entries", 1000)     // used by custom cache keys stored in memory
+	config.BindEnvAndSetDefault("sbom.cache_clean_interval", "30m")              // used by custom cache.
 
 	// Orchestrator Explorer - process agent
 	// DEPRECATED in favor of `orchestrator_explorer.orchestrator_dd_url` setting. If both are set `orchestrator_explorer.orchestrator_dd_url` will take precedence.

--- a/pkg/sbom/collectors/collectors.go
+++ b/pkg/sbom/collectors/collectors.go
@@ -13,6 +13,7 @@ import (
 )
 
 type Collector interface {
+	CleanCache() error
 	Init(config.Config) error
 	Scan(context.Context, sbom.ScanRequest, sbom.ScanOptions) (sbom.Report, error)
 }

--- a/pkg/sbom/collectors/containerd/containerd.go
+++ b/pkg/sbom/collectors/containerd/containerd.go
@@ -54,6 +54,10 @@ type ContainerdCollector struct {
 	trivyCollector *trivy.Collector
 }
 
+func (c *ContainerdCollector) CleanCache() error {
+	return c.trivyCollector.GetCacheCleaner().Clean()
+}
+
 func (c *ContainerdCollector) Init(cfg config.Config) error {
 	trivyCollector, err := trivy.GetGlobalCollector(cfg)
 	if err != nil {

--- a/pkg/sbom/collectors/docker/docker.go
+++ b/pkg/sbom/collectors/docker/docker.go
@@ -47,6 +47,10 @@ type Collector struct {
 	trivyCollector *trivy.Collector
 }
 
+func (c *Collector) CleanCache() error {
+	return c.trivyCollector.GetCacheCleaner().Clean()
+}
+
 func (c *Collector) Init(cfg config.Config) error {
 	trivyCollector, err := trivy.GetGlobalCollector(cfg)
 	if err != nil {

--- a/pkg/sbom/collectors/host/host.go
+++ b/pkg/sbom/collectors/host/host.go
@@ -43,6 +43,10 @@ type HostCollector struct {
 	trivyCollector *trivy.Collector
 }
 
+func (c *HostCollector) CleanCache() error {
+	return c.trivyCollector.GetCacheCleaner().Clean()
+}
+
 func (c *HostCollector) Init(cfg config.Config) error {
 	trivyCollector, err := trivy.GetGlobalCollector(cfg)
 	if err != nil {

--- a/pkg/sbom/scanner/scanner.go
+++ b/pkg/sbom/scanner/scanner.go
@@ -81,7 +81,6 @@ func (s *Scanner) start(ctx context.Context) {
 	go func() {
 		cleanTicker := time.NewTicker(config.Datadog.GetDuration("sbom.cache_clean_interval"))
 		defer cleanTicker.Stop()
-	go func() {
 		s.running = true
 		defer func() { s.running = false }()
 		for {

--- a/pkg/sbom/scanner/scanner.go
+++ b/pkg/sbom/scanner/scanner.go
@@ -78,7 +78,9 @@ func (s *Scanner) start(ctx context.Context) {
 	if s.running {
 		return
 	}
-	cleanTicker := time.NewTicker(config.Datadog.GetDuration("sbom.cache_clean_interval"))
+	go func() {
+		cleanTicker := time.NewTicker(config.Datadog.GetDuration("sbom.cache_clean_interval"))
+		defer cleanTicker.Stop()
 	go func() {
 		s.running = true
 		defer func() { s.running = false }()

--- a/pkg/sbom/scanner/scanner.go
+++ b/pkg/sbom/scanner/scanner.go
@@ -78,17 +78,21 @@ func (s *Scanner) start(ctx context.Context) {
 	if s.running {
 		return
 	}
-
+	cleanTicker := time.NewTicker(config.Datadog.GetDuration("sbom.cache_clean_interval"))
 	go func() {
 		s.running = true
 		defer func() { s.running = false }()
-
 		for {
 			select {
 			// We don't want to keep scanning if image channel is not empty but context is expired
 			case <-ctx.Done():
 				return
-
+			case <-cleanTicker.C:
+				for _, collector := range collectors.Collectors {
+					if err := collector.CleanCache(); err != nil {
+						log.Warnf("could not clean SBOM cache: %v", err)
+					}
+				}
 			case request, ok := <-s.scanQueue:
 				// Channel has been closed we should exit
 				if !ok {

--- a/pkg/util/trivy/cache.go
+++ b/pkg/util/trivy/cache.go
@@ -11,194 +11,172 @@ package trivy
 import (
 	"encoding/json"
 	"fmt"
-	"os"
-	"path/filepath"
+	"sync"
 	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
+	"github.com/DataDog/datadog-agent/pkg/workloadmeta/telemetry"
 
 	"github.com/aquasecurity/trivy/pkg/fanal/cache"
 	"github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/aquasecurity/trivy/pkg/utils"
-	"github.com/dgraph-io/badger/v3"
-	"github.com/hashicorp/go-multierror"
-
-	"github.com/DataDog/datadog-agent/pkg/sbom/telemetry"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/hashicorp/golang-lru/simplelru"
 )
 
-var garbageCollectionTick = 10 * time.Minute
-var garbageCollectionDiscardRatio = 0.5 // Recommended value: https://github.com/dgraph-io/badger/blob/3aa7bd6841baa884ff03f00f789317509dbcb051/db.go#L1192
+// telemetryTick is the frequency at which the cache usage metrics are collected.
 var telemetryTick = 1 * time.Minute
 
-type CacheProvider func() (cache.Cache, error)
+// CacheProvider describes a function that provides a type implementing the trivy cache interface
+// and a cache cleaner
+type CacheProvider func() (cache.Cache, CacheCleaner, error)
 
-func NewBoltCache(cacheDir string) (cache.Cache, error) {
+// NewCustomBoltCache is a CacheProvider. It returns a custom implementation of a BoltDB cache using an LRU algorithm with a
+// maximum number of cache entries, maximum disk size and garbage collection of unused images with its custom cleaner.
+func NewCustomBoltCache(cacheDir string, maxCacheEntries int, maxDiskSize int) (cache.Cache, CacheCleaner, error) {
 	if cacheDir == "" {
 		cacheDir = utils.DefaultCacheDir()
 	}
-
-	return cache.NewFSCache(cacheDir)
+	db, err := NewBoltDB(cacheDir)
+	if err != nil {
+		return nil, &StubCacheCleaner{}, err
+	}
+	cache, err := NewPersistentCache(
+		maxCacheEntries,
+		maxDiskSize,
+		db,
+	)
+	if err != nil {
+		return nil, &StubCacheCleaner{}, err
+	}
+	trivyCache := &TrivyCache{Cache: cache}
+	return trivyCache, NewTrivyCacheCleaner(trivyCache), nil
 }
 
-// BadgerCache implements the Trivy Cache interface. It's provided as an
-// alternative to BoltDB, the cache used by default in Trivy. The main advantage
-// of Badger is that it allows to specify a TTL for the objects stored in the
-// cache.
-type BadgerCache struct {
-	db                      *badger.DB
-	ttl                     time.Duration
-	garbageCollectionTicker *time.Ticker
-	telemetryTicker         *time.Ticker
-}
-
-// This is needed so that Badger logs using the same format as the Agent
-type badgerLogger struct{}
-
-func (l badgerLogger) Errorf(format string, params ...interface{}) {
-	log.Errorf(format, params...)
-}
-
-func (l badgerLogger) Warningf(format string, params ...interface{}) {
-	log.Warnf(format, params...)
-}
-
-func (l badgerLogger) Infof(format string, params ...interface{}) {
-	log.Infof(format, params...)
-}
-
-func (l badgerLogger) Debugf(format string, params ...interface{}) {
-	log.Debugf(format, params...)
-}
-
-func NewBadgerCache(cacheDir string, ttl time.Duration) (*BadgerCache, error) {
+// NewBoltCache is a CacheProvider. It returns a BoltDB cache provided by Trivy and an empty cleaner.
+func NewBoltCache(cacheDir string) (cache.Cache, CacheCleaner, error) {
 	if cacheDir == "" {
-		cacheDir = filepath.Join(os.TempDir(), "datadog-agent-sbom-cache")
+		cacheDir = utils.DefaultCacheDir()
 	}
-
-	db, err := badger.Open(badger.DefaultOptions(cacheDir).WithLogger(badgerLogger{}))
-	if err != nil {
-		return nil, fmt.Errorf("error creating Badger cache: %w", err)
-	}
-
-	telemetryTicker := time.NewTicker(telemetryTick)
-	gcTicker := time.NewTicker(garbageCollectionTick)
-
-	badgerCache := &BadgerCache{
-		db:                      db,
-		ttl:                     ttl,
-		garbageCollectionTicker: gcTicker,
-		telemetryTicker:         telemetryTicker,
-	}
-
-	go func() {
-		for {
-			select {
-			case <-telemetryTicker.C:
-				badgerCache.collectTelemetry()
-			case <-gcTicker.C:
-				// Run garbage collection periodically. It's needed because Badger relies on
-				// the client to run the garbage collection
-				// (https://dgraph.io/docs/badger/get-started/#garbage-collection).
-				if err := db.RunValueLogGC(garbageCollectionDiscardRatio); err != nil && err != badger.ErrNoRewrite {
-					// ErrNoRewrite is returned when the GC runs fine but doesn't
-					// result any cleanup. That's why we don't log anything in that
-					// case.
-					log.Warnf("error while running garbage collection in Badger: %s", err)
-				}
-			}
-		}
-	}()
-
-	return badgerCache, nil
+	cache, err := cache.NewFSCache(cacheDir)
+	return cache, &StubCacheCleaner{}, err
 }
 
-func (cache *BadgerCache) MissingBlobs(artifactID string, blobIDs []string) (bool, []string, error) {
-	var missingArtifact bool
-	var missingBlobIDs []string
-
-	err := cache.db.View(func(txn *badger.Txn) error {
-		if _, err := txn.Get([]byte(artifactID)); err != nil {
-			if err == badger.ErrKeyNotFound {
-				missingArtifact = true
-			} else {
-				return err
-			}
-		}
-
-		for _, blobID := range blobIDs {
-			if _, err := txn.Get([]byte(blobID)); err != nil {
-				if err == badger.ErrKeyNotFound {
-					missingBlobIDs = append(missingBlobIDs, blobID)
-				} else {
-					return err
-				}
-			}
-		}
-
-		return nil
-	})
-	if err != nil {
-		return false, nil, fmt.Errorf("error getting missing blobs from Badger cache: %w", err)
-	}
-
-	return missingArtifact, missingBlobIDs, nil
+// CacheCleaner interface
+type CacheCleaner interface {
+	Clean() error
+	setKeysForEntity(entity string, cachedKeys []string)
 }
 
+// StubCacheCleaner is a stub
+type StubCacheCleaner struct{}
+
+// Clean does nothing
+func (c *StubCacheCleaner) Clean() error { return nil }
+
+// setKeysForEntity does nothing
+func (c *StubCacheCleaner) setKeysForEntity(entity string, keys []string) {}
+
+// GetKeysForEntity does nothing
+func (c *StubCacheCleaner) GetKeysForEntity(entity string) []string { return nil }
+
+// Cache describes an interface for a key-value cache.
+type Cache interface {
+	// Clear removes all entries from the cache and closes it.
+	Clear() error
+	// Close closes the cache.
+	Close() error
+	// Contains returns true if the given key exists in the cache.
+	Contains(key string) bool
+	// Remove deletes the entries associated with the given keys from the cache.
+	Remove(keys []string) error
+	// Set inserts or updates an entry in the cache with the given key-value pair.
+	Set(key string, value []byte) error
+	// Get returns the value associated with the given key. It returns an error if the key was not found.
+	Get(key string) ([]byte, error)
+	// Keys returns the cached keys. Required for the cache cleaning logic.
+	Keys() []string
+	// Len returns the length of the cache. Required for the cache cleaning logic.
+	Len() int
+}
+
+// TrivyCache holds a generic Cache and implements cache.Cache from Trivy.
+type TrivyCache struct {
+	Cache Cache
+}
+
+// TrivyCacheCleaner is a cache cleaner for a TrivyCache instance. It holds a map
+// that keeps track of all the entities using a given key.
+type TrivyCacheCleaner struct {
+	cachedKeysForEntity map[string][]string
+	target              *TrivyCache
+}
+
+// NewTrivyCacheCleaner creates a new instance of TrivyCacheCleaner and returns a pointer to it.
+func NewTrivyCacheCleaner(target *TrivyCache) *TrivyCacheCleaner {
+	return &TrivyCacheCleaner{
+		cachedKeysForEntity: make(map[string][]string),
+		target:              target,
+	}
+}
+
+// Clean implements CacheCleaner#Clean. It removes unused cached entries from the cache.
+func (c *TrivyCacheCleaner) Clean() error {
+	images := workloadmeta.GetGlobalStore().ListImages()
+
+	toKeep := make(map[string]struct{}, len(images))
+	for _, imageMetadata := range images {
+		for _, key := range c.cachedKeysForEntity[imageMetadata.EntityID.ID] {
+			toKeep[key] = struct{}{}
+		}
+	}
+
+	toRemove := make([]string, 0, c.target.Cache.Len())
+	for _, key := range c.target.Cache.Keys() {
+		if _, ok := toKeep[key]; !ok {
+			toRemove = append(toRemove, key)
+		}
+	}
+
+	if err := c.target.Cache.Remove(toRemove); err != nil {
+		return err
+	}
+	return nil
+}
+
+// setKeysForEntity implements CacheCleaner#setKeysForEntity.
+func (c *TrivyCacheCleaner) setKeysForEntity(entity string, cachedKeys []string) {
+	c.cachedKeysForEntity[entity] = cachedKeys
+}
+
+// cachedObject describes an object that can be stored with TrivyCache
 type cachedObject interface {
 	types.ArtifactInfo | types.BlobInfo
 }
 
-// Cannot be a BadgerCache method because methods cannot have type parameters
-func badgerCachePut[T cachedObject](cache *BadgerCache, id string, info T) error {
+// NewTrivyCache creates a new TrivyCache instance with the provided Cache.
+func NewTrivyCache(cache Cache) *TrivyCache {
+	return &TrivyCache{
+		Cache: cache,
+	}
+}
+
+// trivyCachePut stores the provided cachedObject in the TrivyCache with the provided key.
+func trivyCachePut[T cachedObject](cache *TrivyCache, id string, info T) error {
 	objectBytes, err := json.Marshal(info)
 	if err != nil {
 		return fmt.Errorf("error converting object with ID %q to JSON: %w", id, err)
 	}
-
-	err = cache.db.Update(func(txn *badger.Txn) error {
-		entry := badger.NewEntry([]byte(id), objectBytes).WithTTL(cache.ttl)
-		return txn.SetEntry(entry)
-	})
-	if err != nil {
-		return fmt.Errorf("error saving object with ID %q into Badger cache: %w", id, err)
-	}
-
-	return nil
+	return cache.Cache.Set(id, objectBytes)
 }
 
-func (cache *BadgerCache) PutArtifact(artifactID string, artifactInfo types.ArtifactInfo) error {
-	return badgerCachePut(cache, artifactID, artifactInfo)
-}
-
-func (cache *BadgerCache) PutBlob(blobID string, blobInfo types.BlobInfo) error {
-	return badgerCachePut(cache, blobID, blobInfo)
-}
-
-func (cache *BadgerCache) DeleteBlobs(blobIDs []string) error {
-	var errs error
-
-	err := cache.db.Update(func(txn *badger.Txn) error {
-		for _, blobID := range blobIDs {
-			if err := txn.Delete([]byte(blobID)); err != nil {
-				errs = multierror.Append(errs, err)
-			}
-		}
-
-		return nil
-	})
-	if err != nil {
-		return fmt.Errorf("error deleting blobs from Badger cache: %w", err)
-	}
-
-	return errs
-}
-
-// Cannot be a BadgerCache method because methods cannot have type parameters
-func badgerCacheGet[T cachedObject](cache *BadgerCache, id string) (T, error) {
-	rawValue, err := cache.getRawValue(id)
+// trivyCacheGet retrieves the object stored with the provided key.
+func trivyCacheGet[T cachedObject](cache *TrivyCache, id string) (T, error) {
+	rawValue, err := cache.Cache.Get(id)
 	var empty T
 
 	if err != nil {
-		return empty, fmt.Errorf("error getting object with ID %q from Badger cache: %w", id, err)
+		return empty, fmt.Errorf("error getting object with ID %q from cache: %w", id, err)
 	}
 
 	var res T
@@ -209,56 +187,340 @@ func badgerCacheGet[T cachedObject](cache *BadgerCache, id string) (T, error) {
 	return res, nil
 }
 
-func (cache *BadgerCache) GetArtifact(artifactID string) (types.ArtifactInfo, error) {
-	return badgerCacheGet[types.ArtifactInfo](cache, artifactID)
-}
-
-func (cache *BadgerCache) GetBlob(blobID string) (types.BlobInfo, error) {
-	return badgerCacheGet[types.BlobInfo](cache, blobID)
-}
-
-func (cache *BadgerCache) Close() error {
-	cache.telemetryTicker.Stop()
-	cache.garbageCollectionTicker.Stop()
-
-	if err := cache.db.Close(); err != nil {
-		return fmt.Errorf("error closing the Badger cache: %w", err)
-	}
-
-	return nil
-}
-
-func (cache *BadgerCache) Clear() error {
-	if err := cache.db.DropAll(); err != nil {
-		return fmt.Errorf("error clearing the Badger cache: %w", err)
-	}
-
-	return nil
-}
-
-func (cache *BadgerCache) getRawValue(key string) ([]byte, error) {
-	var rawValue []byte
-	err := cache.db.View(func(txn *badger.Txn) error {
-		item, err := txn.Get([]byte(key))
-		if err != nil {
-			return err
+// Implements cache.Cache#MissingBlobs
+func (c *TrivyCache) MissingBlobs(artifactID string, blobIDs []string) (bool, []string, error) {
+	var missingBlobIDs []string
+	for _, blobID := range blobIDs {
+		if ok := c.Cache.Contains(blobID); !ok {
+			missingBlobIDs = append(missingBlobIDs, blobID)
+			telemetry.SBOMCacheMisses.Inc()
+		} else {
+			telemetry.SBOMCacheHits.Inc()
 		}
+	}
+	return !c.Cache.Contains(artifactID), missingBlobIDs, nil
+}
 
-		return item.Value(func(val []byte) error {
-			rawValue = append([]byte{}, val...)
-			return nil
-		})
+// Implements cache.Cache#PutArtifact
+func (c *TrivyCache) PutArtifact(artifactID string, artifactInfo types.ArtifactInfo) error {
+	return trivyCachePut(c, artifactID, artifactInfo)
+}
+
+// Implements cache.Cache#PutBlob
+func (c *TrivyCache) PutBlob(blobID string, blobInfo types.BlobInfo) error {
+	return trivyCachePut(c, blobID, blobInfo)
+}
+
+// Implements cache.Cache#DeleteBlobs
+func (c *TrivyCache) DeleteBlobs(blobIDs []string) error {
+	return c.Cache.Remove(blobIDs)
+}
+
+// Implements cache.Cache#Clear
+func (c *TrivyCache) Clear() error {
+	return c.Cache.Clear()
+}
+
+// Implements cache.Cache#Close
+func (c *TrivyCache) Close() error {
+	return c.Cache.Close()
+}
+
+// Implements cache.Cache#GetArtifact
+func (c *TrivyCache) GetArtifact(id string) (types.ArtifactInfo, error) {
+	return trivyCacheGet[types.ArtifactInfo](c, id)
+}
+
+// Implements cache.Cache#GetBlob
+func (c *TrivyCache) GetBlob(id string) (types.BlobInfo, error) {
+	return trivyCacheGet[types.BlobInfo](c, id)
+}
+
+// PersistentCache is a cache that uses a persistent database for storage.
+type PersistentCache struct {
+	lruCache                     *simplelru.LRU
+	db                           PersistentDB
+	mutex                        sync.RWMutex
+	currentCachedObjectTotalSize int
+	maximumCachedObjectSize      int
+	lastEvicted                  string
+}
+
+// NewPersistentCache creates a new instance of PersistentCache and returns a pointer to it.
+func NewPersistentCache(
+	maxCacheSize int,
+	maxCachedObjectSize int,
+	localDB PersistentDB,
+) (*PersistentCache, error) {
+
+	persistentCache := &PersistentCache{
+		db:                           localDB,
+		currentCachedObjectTotalSize: 0,
+		maximumCachedObjectSize:      maxCachedObjectSize,
+	}
+
+	lruCache, err := simplelru.NewLRU(maxCacheSize, func(key interface{}, _ interface{}) {
+		persistentCache.lastEvicted = key.(string)
 	})
+	if err != nil {
+		return nil, err
+	}
+	persistentCache.lruCache = lruCache
 
+	var evicted []string
+	if err = localDB.ForEach(func(key string, value []byte) error {
+		if ok := persistentCache.addKeyInMemory(key); ok {
+			evicted = append(evicted, persistentCache.lastEvicted)
+		}
+		persistentCache.addCurrentCachedObjectTotalSize(len(value))
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	err = persistentCache.Remove(evicted)
 	if err != nil {
 		return nil, err
 	}
 
-	return rawValue, nil
+	go func() {
+		ticker := time.NewTicker(telemetryTick)
+		for {
+			for range ticker.C {
+				persistentCache.collectTelemetry()
+			}
+		}
+	}()
+
+	return persistentCache, nil
 }
 
-func (cache *BadgerCache) collectTelemetry() {
-	lsmSize, vlogSize := cache.db.Size()
-	telemetry.SBOMCacheMemSize.Set(float64(lsmSize))
-	telemetry.SBOMCacheDiskSize.Set(float64(vlogSize))
+// Contains implements Cache#Contains. It only performs an in-memory check.
+func (c *PersistentCache) Contains(key string) bool {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	// using lruCache.Get moves the key to the head of the evictList
+	// it is necessary to avoid evicting a key after calling MissingBlobs
+	_, ok := c.lruCache.Get(key)
+	return ok
+}
+
+// Keys returns all the keys stored in the lru cache.
+func (c *PersistentCache) Keys() []string {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+	keys := make([]string, c.lruCache.Len())
+	for i, key := range c.lruCache.Keys() {
+		keys[i] = key.(string)
+	}
+	return keys
+}
+
+// Len returns the number of items in the cache.
+func (c *PersistentCache) Len() int {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+	return c.lruCache.Len()
+}
+
+// Clear implements Cache#Clear.
+func (c *PersistentCache) Clear() error {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	if err := c.db.Clear(); err != nil {
+		return err
+	}
+	c.lruCache.Purge()
+	c.currentCachedObjectTotalSize = 0
+	telemetry.SBOMCachedObjectSize.Set(0)
+	return nil
+}
+
+// removeOldest removes the least recently used item from the cache.
+func (c *PersistentCache) removeOldest() error {
+	key, ok := c.removeOldestKeyFromMemory()
+	if !ok {
+		return fmt.Errorf("in-memory cache is empty")
+	}
+
+	evicted := 0
+	if err := c.db.Delete([]string{key}, func(key string, value []byte) error {
+		evicted += len(value)
+		return nil
+	}); err != nil {
+		_ = c.addKeyInMemory(key)
+		return err
+	}
+
+	c.subCurrentCachedObjectTotalSize(evicted)
+
+	return nil
+}
+
+// RemoveOldest is a thread-safe version of removeOldest
+func (c *PersistentCache) RemoveOldest() error {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	return c.removeOldest()
+}
+
+// reduceSize reduces the size of the cache to the target size by evicting the oldest items.
+func (c *PersistentCache) reduceSize(target int) error {
+	for c.currentCachedObjectTotalSize > target {
+		prev := c.currentCachedObjectTotalSize
+		err := c.removeOldest()
+		if err != nil {
+			return err
+		}
+		if prev == c.currentCachedObjectTotalSize {
+			// if c.currentCachedObjectTotalSize is not updated by removeOldest then an item is stored in the lrucache without being stored in the local storage
+			return fmt.Errorf("cache and db are out of sync")
+		}
+	}
+	return nil
+}
+
+// Close implements Cache#Close
+func (c *PersistentCache) Close() error {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	return c.db.Close()
+}
+
+// set stores the key-value pair in the cache.
+func (c *PersistentCache) set(key string, value []byte) error {
+	if len(value) > c.maximumCachedObjectSize {
+		return fmt.Errorf("value of [%s] is too big for the cache : %d", key, c.maximumCachedObjectSize)
+	}
+
+	if err := c.reduceSize(c.maximumCachedObjectSize - len(value)); err != nil {
+		return fmt.Errorf("failed to reduce the size of the cache to store [%s]: %v", key, err)
+	}
+
+	if evict := c.addKeyInMemory(key); evict {
+		evictedSize := 0
+		if err := c.db.Delete([]string{c.lastEvicted}, func(_ string, value []byte) error {
+			evictedSize += len(value)
+			return nil
+		}); err != nil {
+			c.removeKeyFromMemory(key)
+			c.addKeyInMemory(c.lastEvicted)
+			return err
+		}
+		telemetry.SBOMCacheEvicts.Inc()
+		c.subCurrentCachedObjectTotalSize(evictedSize)
+	}
+
+	err := c.db.Store(key, value)
+	if err != nil {
+		c.removeKeyFromMemory(key)
+		return err
+	}
+
+	c.addCurrentCachedObjectTotalSize(len(value))
+	return nil
+}
+
+// Set implements Cache#Set. It is a thread-safe version of set.
+func (c *PersistentCache) Set(key string, value []byte) error {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	return c.set(key, value)
+}
+
+// Get implements Cache#Get.
+func (c *PersistentCache) Get(key string) ([]byte, error) {
+	ok := c.Contains(key)
+	if !ok {
+		return nil, fmt.Errorf("key not found")
+	}
+
+	res, err := c.db.Get(key)
+	if err != nil {
+		_ = c.Remove([]string{key})
+		return nil, err
+	}
+	return res, nil
+}
+
+// remove removes an entry from the cache.
+func (c *PersistentCache) remove(keys []string) error {
+	removedSize := 0
+	if err := c.db.Delete(keys, func(_ string, value []byte) error {
+		removedSize += len(value)
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	for _, key := range keys {
+		_ = c.removeKeyFromMemory(key)
+	}
+
+	c.subCurrentCachedObjectTotalSize(removedSize)
+	return nil
+}
+
+// Remove implements Cache#Remove. It is a thread safe version of remove.
+func (c *PersistentCache) Remove(keys []string) error {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	return c.remove(keys)
+}
+
+// addKeyInMemory adds the provided key in the lrucache, returning if an entry was evicted.
+func (c *PersistentCache) addKeyInMemory(key string) bool {
+	ok := c.lruCache.Add(key, struct{}{})
+	if !ok {
+		telemetry.SBOMCacheEntries.Inc()
+	}
+	return ok
+}
+
+// removeKeyFromMemory removes the provided key from the lrucache, returning if the
+// key was contained.
+func (c *PersistentCache) removeKeyFromMemory(key string) bool {
+	ok := c.lruCache.Remove(key)
+	if ok {
+		telemetry.SBOMCacheEntries.Dec()
+	}
+	return ok
+}
+
+// removeOldestKeyFromMemory removes the oldest key from the lrucache returning the key and
+// if a key was removed.
+func (c *PersistentCache) removeOldestKeyFromMemory() (string, bool) {
+	key, _, ok := c.lruCache.RemoveOldest()
+	if ok {
+		telemetry.SBOMCacheEntries.Dec()
+	}
+	return key.(string), ok
+}
+
+// GetCurrentCachedObjectTotalSize returns the current cached object total size.
+func (c *PersistentCache) GetCurrentCachedObjectTotalSize() int {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+	return c.currentCachedObjectTotalSize
+}
+
+// addCurrentCachedObjectTotalSize adds val to the current cached object total size.
+func (c *PersistentCache) addCurrentCachedObjectTotalSize(val int) {
+	c.currentCachedObjectTotalSize += val
+	telemetry.SBOMCachedObjectSize.Add(float64(val))
+}
+
+// subCurrentCachedObjectTotalSize subtract val to the current cached object total size.
+func (c *PersistentCache) subCurrentCachedObjectTotalSize(val int) {
+	c.currentCachedObjectTotalSize -= val
+	telemetry.SBOMCachedObjectSize.Sub(float64(val))
+}
+
+// collectTelemetry collects the database's size
+func (cache *PersistentCache) collectTelemetry() {
+	diskSize, err := cache.db.Size()
+	if err != nil {
+		log.Errorf("could not collect telemetry: %v", err)
+	}
+	telemetry.SBOMCacheDiskSize.Set(float64(diskSize))
 }

--- a/pkg/util/trivy/cache_test.go
+++ b/pkg/util/trivy/cache_test.go
@@ -9,19 +9,25 @@
 package trivy
 
 import (
+	"context"
+	"encoding/json"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 	"github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/stretchr/testify/require"
 )
 
-// TTL needs to be long enough so that keys don't expire in the middle of a test
-var testCacheTTL = 1 * time.Hour
+var (
+	defaultCacheSize = 100
+	defaultDiskSize  = 1000000
+)
 
-func TestBadgerCache_Artifacts(t *testing.T) {
-	cache, err := NewBadgerCache(t.TempDir(), testCacheTTL)
+func TestCustomBoltCache_Artifacts(t *testing.T) {
+	cache, _, err := NewCustomBoltCache(t.TempDir(), defaultCacheSize, defaultDiskSize)
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, cache.Close())
@@ -41,8 +47,8 @@ func TestBadgerCache_Artifacts(t *testing.T) {
 	require.Equal(t, artifactInfo, storedArtifact)
 }
 
-func TestBadgerCache_Blobs(t *testing.T) {
-	cache, err := NewBadgerCache(t.TempDir(), testCacheTTL)
+func TestCustomBoltCache_Blobs(t *testing.T) {
+	cache, _, err := NewCustomBoltCache(t.TempDir(), defaultCacheSize, defaultDiskSize)
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, cache.Close())
@@ -62,8 +68,8 @@ func TestBadgerCache_Blobs(t *testing.T) {
 	require.Equal(t, blobInfo, storedBlobInfo)
 }
 
-func TestBadgerCache_DeleteBlobs(t *testing.T) {
-	cache, err := NewBadgerCache(t.TempDir(), testCacheTTL)
+func TestCustomBoltCache_DeleteBlobs(t *testing.T) {
+	cache, _, err := NewCustomBoltCache(t.TempDir(), defaultCacheSize, defaultDiskSize)
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, cache.Close())
@@ -96,8 +102,8 @@ func TestBadgerCache_DeleteBlobs(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestBadgerCache_MissingBlobs(t *testing.T) {
-	cache, err := NewBadgerCache(t.TempDir(), testCacheTTL)
+func TestCustomBoltCache_MissingBlobs(t *testing.T) {
+	cache, _, err := NewCustomBoltCache(t.TempDir(), defaultCacheSize, defaultDiskSize)
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, cache.Close())
@@ -128,8 +134,8 @@ func TestBadgerCache_MissingBlobs(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestBadgerCache_Clear(t *testing.T) {
-	cache, err := NewBadgerCache(t.TempDir(), testCacheTTL)
+func TestCustomBoltCache_Clear(t *testing.T) {
+	cache, _, err := NewCustomBoltCache(t.TempDir(), defaultCacheSize, defaultDiskSize)
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, cache.Close())
@@ -145,6 +151,231 @@ func TestBadgerCache_Clear(t *testing.T) {
 
 	_, err = cache.GetArtifact(artifactID)
 	require.Error(t, err)
+}
+
+func TestCustomBoltCache_CurrentObjectSize(t *testing.T) {
+	cache, _, err := NewCustomBoltCache(t.TempDir(), defaultCacheSize, defaultDiskSize)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, cache.Close())
+	}()
+
+	serializedArtifactInfo, err := json.Marshal(newTestArtifactInfo())
+	require.NoError(t, err)
+
+	// Store two artifacts
+	artifactIDs := []string{"some_ID", "some_other_ID"}
+	for _, id := range artifactIDs {
+		err = cache.PutArtifact(id, newTestArtifactInfo())
+		require.NoError(t, err)
+	}
+
+	// Check that the currentCachedObjectTotalSize is equal to the size of the two artifacts
+	persistentCache := cache.(*TrivyCache).Cache.(*PersistentCache)
+	require.Equal(t, len(serializedArtifactInfo)*len(artifactIDs), persistentCache.GetCurrentCachedObjectTotalSize())
+
+	// Remove one artifact and check that currentCachedObjectTotalSize is the size of 1 artifact
+	err = persistentCache.Remove([]string{"some_ID"})
+	require.NoError(t, err)
+	require.Equal(t, len(serializedArtifactInfo)*(len(artifactIDs)-1), persistentCache.GetCurrentCachedObjectTotalSize())
+
+	// Remove the already removed artifact and the last one, check that currentCachedObjectTotalSize is 0
+	err = persistentCache.Remove(artifactIDs)
+	require.NoError(t, err)
+	require.Equal(t, 0, persistentCache.GetCurrentCachedObjectTotalSize())
+}
+
+func TestCustomBoltCache_Eviction(t *testing.T) {
+	// Set the maximum cache entries to 2
+	cache, _, err := NewCustomBoltCache(t.TempDir(), 2, defaultDiskSize)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, cache.Close())
+	}()
+
+	// store 3 artifacts with different sizes
+	artifactIDs := []string{"key1", "key2", "key3"}
+	artifactSize := make(map[string]int)
+	for i, id := range artifactIDs {
+
+		artifact := newTestArtifactInfo()
+		artifact.Architecture = strings.Repeat("A", i*7)
+
+		serializedArtifactInfo, err := json.Marshal(artifact)
+		require.NoError(t, err)
+		artifactSize[id] = len(serializedArtifactInfo)
+
+		err = cache.PutArtifact(id, artifact)
+		require.NoError(t, err)
+	}
+
+	// Make sure only the artifact 2 and 3 are stored and currentCachedObjectTotalSize is correctly updated
+	persistentCache := cache.(*TrivyCache).Cache.(*PersistentCache)
+	require.Equal(t, artifactSize["key2"]+artifactSize["key3"], persistentCache.GetCurrentCachedObjectTotalSize())
+
+	_, err = cache.GetArtifact("key2")
+	require.NoError(t, err)
+
+	_, err = cache.GetArtifact("key3")
+	require.NoError(t, err)
+
+	_, err = cache.GetArtifact("key1")
+	require.Error(t, err)
+}
+
+func TestCustomBoltCache_DiskSizeLimit(t *testing.T) {
+	// Set the max disk size to the size of one item
+	artifact := newTestArtifactInfo()
+	artifact.Architecture = "architecture1"
+	serializedArtifactInfo, err := json.Marshal(artifact)
+	require.NoError(t, err)
+
+	cache, _, err := NewCustomBoltCache(t.TempDir(), defaultCacheSize, len(serializedArtifactInfo))
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, cache.Close())
+	}()
+	// Store two items
+	err = cache.PutArtifact("key1", artifact)
+	require.NoError(t, err)
+
+	artifact.Architecture = "architecture2"
+	err = cache.PutArtifact("key2", artifact)
+	require.NoError(t, err)
+
+	// Verify that only the second item is stored and currentCachedObjectTotalSize is correctly updated
+	retrievedArtifact, err := cache.GetArtifact("key2")
+	require.NoError(t, err)
+	require.Equal(t, artifact, retrievedArtifact)
+
+	_, err = cache.GetArtifact("key1")
+	require.Error(t, err)
+
+	persistentCache := cache.(*TrivyCache).Cache.(*PersistentCache)
+	require.Equal(t, len(serializedArtifactInfo), persistentCache.GetCurrentCachedObjectTotalSize())
+}
+
+func TestCustomBoltCache_GarbageCollector(t *testing.T) {
+	// Create a workload meta global store containing two images with a distinct artifactID/blobs and a shared blob
+	globalStore := workloadmeta.CreateGlobalStore(workloadmeta.NodeAgentCatalog)
+	globalStore.Start(context.TODO())
+	image1 := &workloadmeta.ContainerImageMetadata{
+		EntityID: workloadmeta.EntityID{
+			Kind: workloadmeta.KindContainerImageMetadata,
+			ID:   "image1",
+		},
+	}
+
+	image2 := &workloadmeta.ContainerImageMetadata{
+		EntityID: workloadmeta.EntityID{
+			Kind: workloadmeta.KindContainerImageMetadata,
+			ID:   "image2",
+		},
+	}
+
+	// Test with no SBOM
+	image3 := &workloadmeta.ContainerImageMetadata{
+		EntityID: workloadmeta.EntityID{
+			Kind: workloadmeta.KindContainerImageMetadata,
+			ID:   "image3",
+		},
+	}
+
+	globalStore.Reset([]workloadmeta.Entity{image1, image2, image3}, workloadmeta.SourceAll)
+
+	cache, cacheCleaner, err := NewCustomBoltCache(t.TempDir(), defaultCacheSize, defaultDiskSize)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, cache.Close())
+	}()
+
+	// link image1 to artifact key1, an owned blob and a shared blob
+	cacheCleaner.setKeysForEntity("image1", []string{"key1", "blob1", "sharedBlob"})
+	// link image2 to artifact key2, an owned blob and a shared blob
+	cacheCleaner.setKeysForEntity("image2", []string{"key2", "blob2", "sharedBlob"})
+
+	// Create a goroutine that calls cacheCleaner.Clean every 500ms
+	go func() {
+		cleanTicker := time.NewTicker(500 * time.Millisecond)
+		for range cleanTicker.C {
+			cacheCleaner.Clean()
+		}
+	}()
+
+	// Store the artifacts of both images, the exclusive blobs and the shared blob
+	err = cache.PutArtifact("key1", newTestArtifactInfo())
+	require.NoError(t, err)
+
+	err = cache.PutArtifact("key2", newTestArtifactInfo())
+	require.NoError(t, err)
+
+	err = cache.PutBlob("sharedBlob", newTestBlobInfo())
+	require.NoError(t, err)
+
+	err = cache.PutBlob("blob1", newTestBlobInfo())
+	require.NoError(t, err)
+
+	err = cache.PutBlob("blob2", newTestBlobInfo())
+	require.NoError(t, err)
+
+	// Wait for the garbage collector to be called
+	time.Sleep(time.Second)
+
+	// Check that no cache object was removed
+	artifact, err := cache.GetArtifact("key1")
+	require.NoError(t, err)
+	require.Equal(t, newTestArtifactInfo(), artifact)
+
+	artifact, err = cache.GetArtifact("key2")
+	require.NoError(t, err)
+	require.Equal(t, newTestArtifactInfo(), artifact)
+
+	blob, err := cache.GetBlob("sharedBlob")
+	require.NoError(t, err)
+	require.Equal(t, newTestBlobInfo(), blob)
+
+	blob, err = cache.GetBlob("blob1")
+	require.NoError(t, err)
+	require.Equal(t, newTestBlobInfo(), blob)
+
+	blob, err = cache.GetBlob("blob2")
+	require.NoError(t, err)
+	require.Equal(t, newTestBlobInfo(), blob)
+
+	// Remove the second image from the workloadmeta
+	globalStore.Reset([]workloadmeta.Entity{image1}, workloadmeta.SourceAll)
+
+	// Wait for the garbage collector to clean up the unused artifact
+	time.Sleep(time.Second)
+
+	// Check that only artifact "key2" and "blob2" were removed
+	_, err = cache.GetArtifact("key2")
+	require.Error(t, err)
+
+	_, err = cache.GetBlob("blob2")
+	require.Error(t, err)
+
+	artifact, err = cache.GetArtifact("key1")
+	require.NoError(t, err)
+	require.Equal(t, newTestArtifactInfo(), artifact)
+
+	blob, err = cache.GetBlob("sharedBlob")
+	require.NoError(t, err)
+	require.Equal(t, newTestBlobInfo(), blob)
+
+	blob, err = cache.GetBlob("blob1")
+	require.NoError(t, err)
+	require.Equal(t, newTestBlobInfo(), blob)
+
+	// Check that the currentCachedObjectTotalSize is correct
+	serializedArtifactInfo, err := json.Marshal(newTestArtifactInfo())
+	require.NoError(t, err)
+
+	serializedBlobInfo, err := json.Marshal(newTestBlobInfo())
+	require.NoError(t, err)
+
+	persistentCache := cache.(*TrivyCache).Cache.(*PersistentCache)
+	require.Equal(t, 2*len(serializedBlobInfo)+len(serializedArtifactInfo), persistentCache.GetCurrentCachedObjectTotalSize())
 }
 
 func newTestArtifactInfo() types.ArtifactInfo {

--- a/pkg/util/trivy/containerd.go
+++ b/pkg/util/trivy/containerd.go
@@ -148,13 +148,17 @@ func inspect(ctx context.Context, imgMeta *workloadmeta.ContainerImageMetadata, 
 	for k := range imgConfig.Config.ExposedPorts {
 		portSet[nat.Port(k)] = struct{}{}
 	}
+	created := ""
+	if lastHistory.Created != nil {
+		created = lastHistory.Created.Format(time.RFC3339Nano)
+	}
 
 	return api.ImageInspect{
 		ID:          imgConfigDesc.Digest.String(),
 		RepoTags:    imgMeta.RepoTags,
 		RepoDigests: imgMeta.RepoDigests,
 		Comment:     lastHistory.Comment,
-		Created:     lastHistory.Created.Format(time.RFC3339Nano),
+		Created:     created,
 		Author:      lastHistory.Author,
 		Config: &container.Config{
 			User:         imgConfig.Config.User,

--- a/pkg/util/trivy/db.go
+++ b/pkg/util/trivy/db.go
@@ -1,0 +1,156 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build trivy
+// +build trivy
+
+package trivy
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	bolt "go.etcd.io/bbolt"
+)
+
+const (
+	// cacheDirName is the name of the directory where the cache files are stored.
+	cacheDirName = "fanal"
+	// boltBucket is the name of the BoltDB bucket that stores key-value pairs.
+	boltBucket = "boltdb"
+)
+
+// onDeleteCallback describes a callback function that is called before deleting an entry from a PersistentDB.
+type onDeleteCallback = func(key string, value []byte) error
+
+// PersistentDB describes an interface for a persistent key-value store.
+type PersistentDB interface {
+	// Clear closes the database and removes all stored data.
+	Clear() error
+	// Close closes the database connection.
+	Close() error
+	// Delete deletes a set of keys from the database and invokes the specified callback for each key before committing the transaction.
+	Delete(keys []string, callback onDeleteCallback) error
+	// Get returns the value associated with the given key. If the key is not found, it returns nil.
+	Get(key string) ([]byte, error)
+	// Store stores a key-value pair in the database.
+	Store(key string, value []byte) error
+	// ForEach invokes the specified function for every key-value pair in the database.
+	ForEach(func(string, []byte) error) error
+	// Size returns the number of key-value pairs in the database.
+	Size() (uint, error)
+}
+
+// BoltDB implements the PersistentDB interface. It holds a bolt.DB instance and the storage directory.
+type BoltDB struct {
+	db        *bolt.DB
+	directory string
+}
+
+// NewBoltDB creates a new BoltDB instance.
+func NewBoltDB(cacheDir string) (BoltDB, error) {
+	dir := filepath.Join(cacheDir, cacheDirName)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return BoltDB{}, fmt.Errorf("failed to create cache dir: %v", err)
+	}
+
+	db, err := bolt.Open(filepath.Join(dir, "fanal.db"), 0600, nil)
+	if err != nil {
+		return BoltDB{}, fmt.Errorf("unable to open DB: %v", err)
+	}
+
+	if err = db.Update(func(tx *bolt.Tx) error {
+		if _, err := tx.CreateBucketIfNotExists([]byte(boltBucket)); err != nil {
+			return fmt.Errorf("unable to create %s bucket: %v", boltBucket, err)
+		}
+		return nil
+	}); err != nil {
+		return BoltDB{}, err
+	}
+
+	return BoltDB{
+		db:        db,
+		directory: dir,
+	}, nil
+}
+
+// Clear implements PersistentDB
+func (b BoltDB) Clear() error {
+	if err := b.Close(); err != nil {
+		return err
+	}
+	return os.RemoveAll(b.directory)
+}
+
+// Close implements PersistentDB
+func (b BoltDB) Close() error {
+	return b.db.Close()
+}
+
+// Delete implements PersistentDB
+func (b BoltDB) Delete(keys []string, callback onDeleteCallback) error {
+	err := b.db.Update(func(tx *bolt.Tx) error {
+		bucket, err := tx.CreateBucketIfNotExists([]byte(boltBucket))
+		if err != nil {
+			return err
+		}
+		for _, key := range keys {
+			value := bucket.Get([]byte(key))
+			if err = bucket.Delete([]byte(key)); err != nil {
+				return err
+			}
+			if err = callback(key, value); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	return err
+}
+
+// Get implements PersistentDB
+func (b BoltDB) Get(key string) ([]byte, error) {
+	var res []byte
+	return res, b.db.View(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket([]byte(boltBucket))
+		if bucket == nil {
+			return fmt.Errorf("bucket %s not found", boltBucket)
+		}
+		res = bucket.Get([]byte(key))
+		return nil
+	})
+}
+
+// Store implements PersistentDB
+func (b BoltDB) Store(key string, value []byte) error {
+	return b.db.Update(func(tx *bolt.Tx) error {
+		bucket, err := tx.CreateBucketIfNotExists([]byte(boltBucket))
+		if err != nil {
+			return err
+		}
+		return bucket.Put([]byte(key), value)
+	})
+}
+
+// ForEach implements PersistentDB
+func (b BoltDB) ForEach(f func(string, []byte) error) error {
+	return b.db.View(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket([]byte(boltBucket))
+		if bucket == nil {
+			return fmt.Errorf("bucket %s not found", boltBucket)
+		}
+		return bucket.ForEach(func(k []byte, v []byte) error { return f(string(k), v) })
+	})
+}
+
+// Size implements PersistentDB. It is different from the total size of cached objects
+func (b BoltDB) Size() (uint, error) {
+	var res uint
+	return res, b.db.View(func(tx *bolt.Tx) error {
+		res = uint(tx.Size())
+		return nil
+	})
+}

--- a/pkg/util/trivy/db_test.go
+++ b/pkg/util/trivy/db_test.go
@@ -1,0 +1,121 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build trivy
+// +build trivy
+
+package trivy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBoltDB_Close(t *testing.T) {
+	db, err := NewBoltDB(t.TempDir())
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+	require.Error(t, db.Store("key", []byte("value")))
+}
+
+func TestBoltDB_Clear(t *testing.T) {
+	db, err := NewBoltDB(t.TempDir())
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, db.Close())
+	}()
+
+	require.NoError(t, db.Store("key", []byte("value")))
+	require.NoError(t, db.Clear())
+
+	require.Error(t, db.Store("key", []byte("value")))
+	_, err = db.Get("key")
+	require.Error(t, err)
+}
+
+func TestBoltDB_StoreAndGet(t *testing.T) {
+	db, err := NewBoltDB(t.TempDir())
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, db.Close())
+	}()
+	key := "key"
+	value := []byte("value")
+	require.NoError(t, db.Store(key, value))
+
+	retrieved, err := db.Get(key)
+	require.NoError(t, err)
+	require.Equal(t, value, retrieved)
+}
+
+func TestBoltDB_Delete(t *testing.T) {
+	db, err := NewBoltDB(t.TempDir())
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, db.Close())
+	}()
+
+	require.NoError(t, db.Store("key1", []byte("value1")))
+	require.NoError(t, db.Store("key2", []byte("value2")))
+	require.NoError(t, db.Store("key3", []byte("value3")))
+
+	deletedValues := 0
+	keysToDelete := []string{"key1", "key3"}
+	err = db.Delete(keysToDelete, func(_ string, _ []byte) error {
+		deletedValues += 1
+		return nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, 2, deletedValues)
+
+	value1, err := db.Get("key1")
+	require.NoError(t, err)
+	require.Equal(t, []byte(nil), value1)
+
+	value2, err := db.Get("key2")
+	require.NoError(t, err)
+	require.Equal(t, []byte("value2"), value2)
+
+	value3, err := db.Get("key3")
+	require.NoError(t, err)
+	require.Equal(t, []byte(nil), value3)
+}
+
+func TestBoltDB_ForEach(t *testing.T) {
+	db, err := NewBoltDB(t.TempDir())
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, db.Close())
+	}()
+
+	testData := map[string][]byte{
+		"key1": []byte("value1"),
+		"key2": []byte("value2"),
+	}
+
+	for key, value := range testData {
+		require.NoError(t, db.Store(key, value))
+	}
+
+	var receivedKeys []string
+	var receivedValues [][]byte
+
+	err = db.ForEach(func(key string, value []byte) error {
+		receivedKeys = append(receivedKeys, key)
+		receivedValues = append(receivedValues, value)
+		return nil
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, len(receivedKeys), len(testData))
+	require.Equal(t, len(receivedValues), len(testData))
+
+	for i, key := range receivedKeys {
+		value, ok := testData[key]
+		require.True(t, ok)
+		require.Equal(t, value, receivedValues[i])
+	}
+}

--- a/pkg/util/trivy/trivy.go
+++ b/pkg/util/trivy/trivy.go
@@ -166,8 +166,9 @@ func NewCollector(cfg config.Config) (*Collector, error) {
 		return nil, err
 	}
 
-	cleanTicker := time.NewTicker(cfg.GetDuration("sbom.cache_clean_interval"))
 	go func() {
+	    cleanTicker := time.NewTicker(cfg.GetDuration("sbom.cache_clean_interval"))
+	    defer cleanTicker.Close()
 		// Cache can not be cleaned concurrently with a scan
 		for range cleanTicker.C {
 			if err = cacheCleaner.Clean(); err != nil {

--- a/pkg/util/trivy/trivy.go
+++ b/pkg/util/trivy/trivy.go
@@ -167,8 +167,8 @@ func NewCollector(cfg config.Config) (*Collector, error) {
 	}
 
 	go func() {
-	    cleanTicker := time.NewTicker(cfg.GetDuration("sbom.cache_clean_interval"))
-	    defer cleanTicker.Close()
+		cleanTicker := time.NewTicker(cfg.GetDuration("sbom.cache_clean_interval"))
+		defer cleanTicker.Stop()
 		// Cache can not be cleaned concurrently with a scan
 		for range cleanTicker.C {
 			if err = cacheCleaner.Clean(); err != nil {

--- a/pkg/workloadmeta/telemetry/telemetry.go
+++ b/pkg/workloadmeta/telemetry/telemetry.go
@@ -97,4 +97,68 @@ var (
 		"Number of errors on the remote workloadmeta server while streaming events",
 		commonOpts,
 	)
+	// SBOMGenerationDuration measures the time that it takes to generate SBOMs
+	// in seconds.
+	SBOMGenerationDuration = telemetry.NewHistogramWithOpts(
+		subsystem,
+		"sbom_generation_duration",
+		[]string{},
+		"SBOM generation duration (in seconds)",
+		[]float64{10, 30, 60, 120, 180, 240, 300, 360, 420, 480, 540, 600},
+		commonOpts,
+	)
+
+	// SBOM number of cache keys stored in memory
+	SBOMCacheEntries = telemetry.NewGaugeWithOpts(
+		subsystem,
+		"sbom_cached_keys",
+		[]string{},
+		"Number of cache keys stored in memory",
+		commonOpts,
+	)
+
+	// SBOMCacheDiskSize size in disk of the custom cache used for SBOM collection
+	SBOMCacheDiskSize = telemetry.NewGaugeWithOpts(
+		subsystem,
+		"sbom_cache_disk_size",
+		[]string{},
+		"SBOM size in disk of the custom cache (in bytes)",
+		commonOpts,
+	)
+
+	// SBOMCachedObjectSize total size of cached objects in disk (in bytes) used for SBOM collection
+	SBOMCachedObjectSize = telemetry.NewGaugeWithOpts(
+		subsystem,
+		"sbom_cached_object_size",
+		[]string{},
+		"SBOM total size of cached objects in disk (in bytes)",
+		commonOpts,
+	)
+
+	// SBOMCacheHits number of cache hits during SBOM collection
+	SBOMCacheHits = telemetry.NewCounterWithOpts(
+		subsystem,
+		"sbom_cache_hits_total",
+		[]string{},
+		"SBOM total number of cache hits during SBOM collection",
+		commonOpts,
+	)
+
+	// SBOMCacheMisses number of cache misses during SBOM collection
+	SBOMCacheMisses = telemetry.NewCounterWithOpts(
+		subsystem,
+		"sbom_cache_misses_total",
+		[]string{},
+		"SBOM total number of cache misses during SBOM collection",
+		commonOpts,
+	)
+
+	// SBOMCacheEvicts number of cache evicts during SBOM collection
+	SBOMCacheEvicts = telemetry.NewCounterWithOpts(
+		subsystem,
+		"sbom_cache_evicts_total",
+		[]string{},
+		"SBOM total number of cache misses during SBOM collection",
+		commonOpts,
+	)
 )

--- a/releasenotes/notes/add-custom-local-cache-sbom-d64e46b509e40161.yaml
+++ b/releasenotes/notes/add-custom-local-cache-sbom-d64e46b509e40161.yaml
@@ -1,0 +1,16 @@
+enhancements:
+  - |
+    * Remove BadgerDB cache for Trivy.
+    * Add new custom LRU cache for Trivy backed by BoltDB and parametrized by:
+      - ``sbom.use_custom_cache``: Enables the custom cache.
+      - ``sbom.custom_cache_max_cache_entries``: Maximum number of cached objects.
+      - ``sbom.custom_cache_max_disk_size``: Maximum total size of the cached objects.
+      - ``sbom.cache_clean_interval``: Duration interval of garbage collection.
+    * Periodically delete unused entries from the custom cache.
+    * Add telemetry metrics to monitor the cache:
+      - ``sbom_cached_keys``: Number of cache keys stored in memory
+      - ``sbom_cache_disk_size``: Total size, in bytes, of the database as reported by BoltDB.
+      - ``sbom_cached_object_size``: Total size, in bytes, of cached SBOM objects on disk. Limited by sbom.custom_cache_max_disk_size.
+      - ``sbom_cache_hits_total``: Total number of cache hits.
+      - ``sbom_cache_misses_total``: Total number of cache misses.
+      - ``sbom_cache_evicts_total``: Total number of cache evicts.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Replaces BadgerDB cache by a new custom LRU cache for Trivy with a local storage backed by BoltDB and a clean up mechanism to remove unused entries. It has mechanisms to limit the size in memory and on disk.
The clean up mechanism required to store ArtifactIDs and BlobIDs in the workloadmeta.SBOM so that they can be removed from the cache.

It adds config options to parametrize the cache:
- `sbom.use_custom_cache`: Enables the custom cache.
- `sbom.custom_cache_max_disk_size`: Maximum total size of the cached objects. It is not equivalent to disk usage. If BoltDB uses extra storage, it will not limited by this config option.
- `sbom.custom_cache_max_cache_entries`: Maximum number of cached objects.
- `sbom.cache_clean_interval` : Duration interval of garbage collection.

It also adds the following metrics to monitor the custom cache:

- `sbom_cache_disk_size`: Total size, in bytes, of the database as reported by BoltDB.
- `sbom_cached_object_size`: Total size, in bytes, of cached SBOM objects on disk. Limited by `sbom.custom_cache_max_disk_size`
- `sbom_cache_hits_total`: Total number of cache hits
- `sbom_cache_misses_total`: Total number of cache misses
- `sbom_cache_evicts_total`: Total number of cache evicts


<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

The default Trivy cache based on Boltdb doesn’t work for us, because it doesn’t have any cleanup mechanism. It is ok for a CLI based approach, but for a long running process like the Datadog-Agent it can trigger an high memory and disc usage.

We tried to implement a custom cache based on badgerDB that provide a TTL mechanism, but after some tests we discovered that the DB doesn't fit other criterias that we have:

BadgerDB doesn’t offer an easy way to update TTL of a specific entry

BadgerDB is optimized for large dataset (millions of entries). But it is not our case.

BadgerDB allocate a large disk space event if it doesn’t use it.


<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
Tested and deployed on 7.44.x first: https://github.com/DataDog/datadog-agent/pull/16438

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs
N/A. No disk or memory pressure observed during tests.
<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

See https://github.com/DataDog/datadog-agent/pull/16438
Verify that the unit tests are passing.
Deploy the agent on an environment with `containerd` and/or `docker` with these settings:

```yaml
DD_TELEMETRY_ENABLED=TRUE
DD_CONTAINER_IMAGE_COLLECTION_METADATA_ENABLED=true
DD_SBOM_ENABLED=true
DD_SBOM_USE_CUSTOM_CACHE=true
DD_SBOM_CACHE_CLEAN_INTERVAL=180
```

- Pull an image. 

- Check the SBOM generation time with `agent workload-list --verbose`. In my case, the `datadog/agent:latest` images takes a few seconds.

- Now delete the image, pull it again, and check the generation time again. It should be faster because of the cache.

- Delete the image again and wait for the garbage collector which should run every 180s with the settings above.

- Pull the image again, it should take a few seconds.

- To test the max disk size and max cache entries, the unit tests should be enough. Otherwise you can add log lines to MissingBlobs, set low values to the following parameters and pull many images. 
```
DD_CONTAINER_IMAGE_COLLECTION_SBOM_CUSTOM_CACHE_MAX_CACHE_ENTRIES and DD_CONTAINER_IMAGE_COLLECTION_SBOM_CUSTOM_CACHE_MAX_DISK_SIZE 
```
* Be careful, if the values are too low, GetArtifact and GetBlob will return an error, making the scan fail. 

You should be able to see the metrics showing up:
`kube exec pod -- curl -s localhost:6000/telemetry | grep sbom`

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
