### PR TITLE
[apm] Fix incorrect peer service config

### DIFF
--- a/pkg/config/apm.go
+++ b/pkg/config/apm.go
@@ -68,7 +68,7 @@ func setupAPM(config Config) {
 	config.BindEnvAndSetDefault("apm_config.windows_pipe_buffer_size", 1_000_000, "DD_APM_WINDOWS_PIPE_BUFFER_SIZE")                          //nolint:errcheck
 	config.BindEnvAndSetDefault("apm_config.windows_pipe_security_descriptor", "D:AI(A;;GA;;;WD)", "DD_APM_WINDOWS_PIPE_SECURITY_DESCRIPTOR") //nolint:errcheck
 	config.BindEnvAndSetDefault("apm_config.remote_tagger", true, "DD_APM_REMOTE_TAGGER")                                                     //nolint:errcheck
-	config.BindEnvAndSetDefault("apm_config.peer_service_aggregation", false, "DD_APM_PEER_SERVICE_AGGREGATION")                  //nolint:errcheck
+	config.BindEnvAndSetDefault("apm_config.peer_service_aggregation", false, "DD_APM_PEER_SERVICE_AGGREGATION")                              //nolint:errcheck
 	config.BindEnvAndSetDefault("apm_config.compute_stats_by_span_kind", false, "DD_APM_COMPUTE_STATS_BY_SPAN_KIND")                          //nolint:errcheck
 
 	config.BindEnv("apm_config.max_catalog_services", "DD_APM_MAX_CATALOG_SERVICES")

--- a/pkg/config/apm.go
+++ b/pkg/config/apm.go
@@ -68,7 +68,7 @@ func setupAPM(config Config) {
 	config.BindEnvAndSetDefault("apm_config.windows_pipe_buffer_size", 1_000_000, "DD_APM_WINDOWS_PIPE_BUFFER_SIZE")                          //nolint:errcheck
 	config.BindEnvAndSetDefault("apm_config.windows_pipe_security_descriptor", "D:AI(A;;GA;;;WD)", "DD_APM_WINDOWS_PIPE_SECURITY_DESCRIPTOR") //nolint:errcheck
 	config.BindEnvAndSetDefault("apm_config.remote_tagger", true, "DD_APM_REMOTE_TAGGER")                                                     //nolint:errcheck
-	config.BindEnvAndSetDefault("apm_config.peer_service_stats_aggregation", false, "DD_APM_PEER_SERVICE_STATS_AGGREGATION")                  //nolint:errcheck
+	config.BindEnvAndSetDefault("apm_config.peer_service_aggregation", false, "DD_APM_PEER_SERVICE_AGGREGATION")                  //nolint:errcheck
 	config.BindEnvAndSetDefault("apm_config.compute_stats_by_span_kind", false, "DD_APM_COMPUTE_STATS_BY_SPAN_KIND")                          //nolint:errcheck
 
 	config.BindEnv("apm_config.max_catalog_services", "DD_APM_MAX_CATALOG_SERVICES")

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1320,30 +1320,30 @@ fips:
 func TestEnablePeerServiceStatsAggregationYAML(t *testing.T) {
 	datadogYaml := `
 apm_config:
-  peer_service_stats_aggregation: true
+  peer_service_aggregation: true
 `
 	testConfig := setupConfFromYAML(datadogYaml)
 	err := setupFipsEndpoints(testConfig)
 	require.NoError(t, err)
-	require.True(t, testConfig.GetBool("apm_config.peer_service_stats_aggregation"))
+	require.True(t, testConfig.GetBool("apm_config.peer_service_aggregation"))
 
 	datadogYaml = `
 apm_config:
-  peer_service_stats_aggregation: false
+  peer_service_aggregation: false
 `
 	testConfig = setupConfFromYAML(datadogYaml)
 	err = setupFipsEndpoints(testConfig)
 	require.NoError(t, err)
-	require.False(t, testConfig.GetBool("apm_config.peer_service_stats_aggregation"))
+	require.False(t, testConfig.GetBool("apm_config.peer_service_aggregation"))
 }
 
 func TestEnablePeerServiceStatsAggregationEnv(t *testing.T) {
-	t.Setenv("DD_APM_PEER_SERVICE_STATS_AGGREGATION", "true")
+	t.Setenv("DD_APM_PEER_SERVICE_AGGREGATION", "true")
 	testConfig := setupConfFromYAML("")
-	require.True(t, testConfig.GetBool("apm_config.peer_service_stats_aggregation"))
-	t.Setenv("DD_APM_PEER_SERVICE_STATS_AGGREGATION", "false")
+	require.True(t, testConfig.GetBool("apm_config.peer_service_aggregation"))
+	t.Setenv("DD_APM_PEER_SERVICE_AGGREGATION", "false")
 	testConfig = setupConfFromYAML("")
-	require.False(t, testConfig.GetBool("apm_config.peer_service_stats_aggregation"))
+	require.False(t, testConfig.GetBool("apm_config.peer_service_aggregation"))
 }
 
 func TestEnableStatsComputationBySpanKindYAML(t *testing.T) {

--- a/releasenotes/notes/fix-peer-service-config-2ecb186539.yaml
+++ b/releasenotes/notes/fix-peer-service-config-2ecb186539.yaml
@@ -1,4 +1,0 @@
----
-fixes:
-  - |
-    APM: Use the correct config ``peer_service_aggregation`` in the core Agent

--- a/releasenotes/notes/fix-peer-service-config-2ecb186539.yaml
+++ b/releasenotes/notes/fix-peer-service-config-2ecb186539.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    APM: Use the correct config ``peer_service_aggregation`` in the core Agent


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Fix the inconsistent config name: core agent uses `peer_service_stats_aggregation` while trace agent expects `peer_service_aggregation`. Should use `peer_service_aggregation` in both places.

### Motivation

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Test core agent config `peer_service_aggregation` is recognized by the trace agent. 

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
