### PR TITLE
[Windows] Fix install flow with closed source PR

### DIFF
--- a/tools/windows/install-help/cal/customactiondata.cpp
+++ b/tools/windows/install-help/cal/customactiondata.cpp
@@ -146,11 +146,32 @@ void CustomActionData::setClosedSourceConfig()
         }
         // else what do we do here?
     }
-
+    if (!setEnabledFlag)
+    {
+        
+        if (this->_propertyView->value(L"CLOSEDSOURCE", csProperty))
+        {
+            // this property is set to "1" or "0" depending on the checkbox
+            // since the checkbox value of zero is off, assume any other state
+            // means on, so it can also be set on the command line.
+            WcaLog(LOGMSG_STANDARD, "CLOSEDSOURCE key is present and (%S)", csProperty.c_str());
+            setEnabledFlag = true;
+            newEnabledFlag = _wcsicmp(csProperty.c_str(), L"0") != 0;
+        }
+    }
    
     // check the ADDLOCAL flag
     if(!setEnabledFlag)
     {
+        /*
+         * the ADDLOCAL key has memory.
+         * If you set the addlocal key when you install, say, in 7.42, when you run the 7.43
+         * upgrade, MSI will persist it for you. That's probably the right answer, but it's
+         * confusing in this case.
+         * 
+         * use the CLOSEDSOURCE key above so that the command line parameter
+         * ALLOWCLOSEDSOURCE and/or the GUI option will take precedence
+         */
         if(this->_propertyView->value(L"ADDLOCAL", addlocal)) 
         {
             // Convert to upper when normalizing string for comparison
@@ -188,19 +209,7 @@ void CustomActionData::setClosedSourceConfig()
         }
     }
 
-    if (!setEnabledFlag)
-    {
-        
-        if (this->_propertyView->value(L"CLOSEDSOURCE", csProperty))
-        {
-            // this property is set to "1" or "0" depending on the checkbox
-            // since the checkbox value of zero is off, assume any other state
-            // means on, so it can also be set on the command line.
-            WcaLog(LOGMSG_STANDARD, "CLOSEDSOURCE key is present and (%S)", csProperty.c_str());
-            setEnabledFlag = true;
-            newEnabledFlag = _wcsicmp(csProperty.c_str(), L"0") != 0;
-        }
-    }
+    
      // check to see if previously installed.
     if(!setEnabledFlag)
     {


### PR DESCRIPTION
Fixes problem found in QA wherein a previous install with the NPM option set led to the gui selection of no closed source to be ignored


### Motivation

Fix bug found in qa

### Additional Notes


### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Install previous version (<= 7.44), with the `ADDLOCAL=ALL` or `ADDLOCAL=MainApplication,NPM` flag
run gui install of this version
deselect closed source option
after install is complete, note that closed source registry option is set to 0 (not accepted) in accordance with dialog selection

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
