### PR TITLE
[CWS] utf-8 escape tty/comm/argv0 and path/basename/fs from ADs

### DIFF
--- a/pkg/security/security_profile/dump/activity_dump_proto_enc_v1.go
+++ b/pkg/security/security_profile/dump/activity_dump_proto_enc_v1.go
@@ -129,8 +129,8 @@ func processNodeToProto(p *model.Process) *adproto.ProcessInfo {
 		ContainerId: p.ContainerID,
 		SpanId:      p.SpanID,
 		TraceId:     p.TraceID,
-		Tty:         p.TTYName,
-		Comm:        p.Comm,
+		Tty:         escape(p.TTYName),
+		Comm:        escape(p.Comm),
 
 		ForkTime: timestampToProto(&p.ForkTime),
 		ExitTime: timestampToProto(&p.ExitTime),
@@ -139,7 +139,7 @@ func processNodeToProto(p *model.Process) *adproto.ProcessInfo {
 		Credentials: credentialsToProto(&p.Credentials),
 
 		Args:          copyAndEscape(p.ScrubbedArgv),
-		Argv0:         p.Argv0,
+		Argv0:         escape(p.Argv0),
 		ArgsTruncated: p.ArgsTruncated,
 
 		Envs:          copyAndEscape(p.Envs),
@@ -191,9 +191,9 @@ func fileEventToProto(fe *model.FileEvent) *adproto.FileInfo {
 		MountId:           fe.MountID,
 		Inode:             fe.Inode,
 		InUpperLayer:      fe.InUpperLayer,
-		Path:              fe.PathnameStr,
-		Basename:          fe.BasenameStr,
-		Filesystem:        fe.Filesystem,
+		Path:              escape(fe.PathnameStr),
+		Basename:          escape(fe.BasenameStr),
+		Filesystem:        escape(fe.Filesystem),
 		PackageName:       fe.PkgName,
 		PackageVersion:    fe.PkgVersion,
 		PackageSrcversion: fe.PkgSrcVersion,
@@ -210,7 +210,7 @@ func fileActivityNodeToProto(fan *FileActivityNode) *adproto.FileActivityNode {
 	pfan := adproto.FileActivityNodeFromVTPool()
 	*pfan = adproto.FileActivityNode{
 		MatchedRules:   make([]*adproto.MatchedRule, 0, len(fan.MatchedRules)),
-		Name:           fan.Name,
+		Name:           escape(fan.Name),
 		File:           fileEventToProto(fan.File),
 		GenerationType: adproto.GenerationType(fan.GenerationType),
 		FirstSeen:      timestampToProto(&fan.FirstSeen),
@@ -270,7 +270,7 @@ func dnsEventToProto(ev *model.DNSEvent) *adproto.DNSInfo {
 	}
 
 	return &adproto.DNSInfo{
-		Name:  ev.Name,
+		Name:  escape(ev.Name),
 		Type:  uint32(ev.Type),
 		Class: uint32(ev.Class),
 		Size:  uint32(ev.Size),
@@ -335,4 +335,9 @@ func copyAndEscape(in []string) []string {
 		out = append(out, transformer.String(value))
 	}
 	return out
+}
+
+func escape(in string) string {
+	transformer := runes.ReplaceIllFormed()
+	return transformer.String(in)
 }


### PR DESCRIPTION
### What does this PR do?

This PR guarantees that we are sending correct utf-8 strings to the backend

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
