### PR TITLE
[CWS] do not eval broken event

### DIFF
--- a/pkg/security/events/custom.go
+++ b/pkg/security/events/custom.go
@@ -32,6 +32,8 @@ const (
 	SelfTestRuleID = "self_test"
 	// AnomalyDetectionRuleID is the rule ID for anomaly_detection events
 	AnomalyDetectionRuleID = "anomaly_detection"
+	// ProcessContextErrorRuleID is the rule ID for events without process context
+	ProcessContextErrorRuleID = "no_process_context"
 )
 
 type CustomEventCommonFields struct {
@@ -61,6 +63,7 @@ func AllCustomRuleIDs() []string {
 		AbnormalPathRuleID,
 		SelfTestRuleID,
 		AnomalyDetectionRuleID,
+		ProcessContextErrorRuleID,
 	}
 }
 

--- a/pkg/security/module/cws.go
+++ b/pkg/security/module/cws.go
@@ -404,6 +404,11 @@ func (c *CWSConsumer) EventDiscarderFound(rs *rules.RuleSet, event eval.Event, f
 
 // HandleEvent is called by the probe when an event arrives from the kernel
 func (c *CWSConsumer) HandleEvent(event *model.Event) {
+	// event already marked with an error, skip it
+	if event.Error != nil {
+		return
+	}
+
 	// if the event should have been discarded in kernel space, we don't need to evaluate it
 	if event.IsSavedByActivityDumps() {
 		return
@@ -424,6 +429,11 @@ func (c *CWSConsumer) HandleCustomEvent(rule *rules.Rule, event *events.CustomEv
 // RuleMatch is called by the ruleset when a rule matches
 func (c *CWSConsumer) RuleMatch(rule *rules.Rule, event eval.Event) {
 	ev := event.(*model.Event)
+
+	// do not send broken event
+	if ev.Error != nil {
+		return
+	}
 
 	// ensure that all the fields are resolved before sending
 	ev.FieldHandlers.ResolveContainerID(ev, &ev.ContainerContext)

--- a/pkg/security/module/rate_limiter.go
+++ b/pkg/security/module/rate_limiter.go
@@ -31,8 +31,9 @@ var (
 	defaultBurst int = 40
 
 	defaultPerRuleLimiters = map[eval.RuleID]*Limiter{
-		events.RulesetLoadedRuleID: NewLimiter(rate.Inf, 1), // No limit on ruleset loaded
-		events.AbnormalPathRuleID:  NewLimiter(rate.Every(30*time.Second), 1),
+		events.RulesetLoadedRuleID:       NewLimiter(rate.Inf, 1), // No limit on ruleset loaded
+		events.AbnormalPathRuleID:        NewLimiter(rate.Every(30*time.Second), 1),
+		events.ProcessContextErrorRuleID: NewLimiter(rate.Every(30*time.Second), 1),
 	}
 )
 

--- a/pkg/security/probe/custom_events_easyjson.go
+++ b/pkg/security/probe/custom_events_easyjson.go
@@ -307,7 +307,7 @@ func (v EventLostRead) MarshalEasyJSON(w *jwriter.Writer) {
 func (v *EventLostRead) UnmarshalEasyJSON(l *jlexer.Lexer) {
 	easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe2(l, v)
 }
-func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe3(in *jlexer.Lexer, out *AbnormalPathEvent) {
+func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe3(in *jlexer.Lexer, out *AbnormalEvent) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -336,8 +336,8 @@ func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe3(in *jle
 				}
 				(*out.Event).UnmarshalEasyJSON(in)
 			}
-		case "path_resolution_error":
-			out.PathResolutionError = string(in.String())
+		case "error":
+			out.Error = string(in.String())
 		case "date":
 			if data := in.Raw(); in.Ok() {
 				in.AddError((out.Timestamp).UnmarshalJSON(data))
@@ -354,7 +354,7 @@ func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe3(in *jle
 		in.Consumed()
 	}
 }
-func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe3(out *jwriter.Writer, in AbnormalPathEvent) {
+func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe3(out *jwriter.Writer, in AbnormalEvent) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -368,9 +368,9 @@ func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe3(out *jw
 		}
 	}
 	{
-		const prefix string = ",\"path_resolution_error\":"
+		const prefix string = ",\"error\":"
 		out.RawString(prefix)
-		out.String(string(in.PathResolutionError))
+		out.String(string(in.Error))
 	}
 	{
 		const prefix string = ",\"date\":"
@@ -386,11 +386,11 @@ func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe3(out *jw
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
-func (v AbnormalPathEvent) MarshalEasyJSON(w *jwriter.Writer) {
+func (v AbnormalEvent) MarshalEasyJSON(w *jwriter.Writer) {
 	easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe3(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *AbnormalPathEvent) UnmarshalEasyJSON(l *jlexer.Lexer) {
+func (v *AbnormalEvent) UnmarshalEasyJSON(l *jlexer.Lexer) {
 	easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe3(l, v)
 }

--- a/pkg/security/probe/errors.go
+++ b/pkg/security/probe/errors.go
@@ -1,0 +1,24 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+// +build linux
+
+package probe
+
+// ErrNoProcessContext defines an error for event without process context
+type ErrProcessContext struct {
+	Err error
+}
+
+// Error implements the error interface
+func (e *ErrProcessContext) Error() string {
+	return e.Err.Error()
+}
+
+// Unwrap implements the error interface
+func (e *ErrProcessContext) Unwrap() error {
+	return e.Err
+}

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -257,15 +257,17 @@ type Event struct {
 	Bind BindEvent `field:"bind" event:"bind" platform:"linux"` // [7.37] [Network] [Experimental] A bind was executed
 
 	// internal usage
-	Umount              UmountEvent           `field:"-" json:"-" platform:"linux"`
-	InvalidateDentry    InvalidateDentryEvent `field:"-" json:"-" platform:"linux"`
-	ArgsEnvs            ArgsEnvsEvent         `field:"-" json:"-" platform:"linux"`
-	MountReleased       MountReleasedEvent    `field:"-" json:"-" platform:"linux"`
-	CgroupTracing       CgroupTracingEvent    `field:"-" json:"-" platform:"linux"`
-	NetDevice           NetDeviceEvent        `field:"-" json:"-" platform:"linux"`
-	VethPair            VethPairEvent         `field:"-" json:"-" platform:"linux"`
-	UnshareMountNS      UnshareMountNSEvent   `field:"-" json:"-" platform:"linux"`
-	PathResolutionError error                 `field:"-" json:"-" platform:"linux"` // hold one of the path resolution error
+	Umount           UmountEvent           `field:"-" json:"-" platform:"linux"`
+	InvalidateDentry InvalidateDentryEvent `field:"-" json:"-" platform:"linux"`
+	ArgsEnvs         ArgsEnvsEvent         `field:"-" json:"-" platform:"linux"`
+	MountReleased    MountReleasedEvent    `field:"-" json:"-" platform:"linux"`
+	CgroupTracing    CgroupTracingEvent    `field:"-" json:"-" platform:"linux"`
+	NetDevice        NetDeviceEvent        `field:"-" json:"-" platform:"linux"`
+	VethPair         VethPairEvent         `field:"-" json:"-" platform:"linux"`
+	UnshareMountNS   UnshareMountNSEvent   `field:"-" json:"-" platform:"linux"`
+
+	// mark event with having error
+	Error error `field:"-" json:"-"`
 
 	// field resolution
 	FieldHandlers FieldHandlers `field:"-" json:"-" platform:"linux"`
@@ -382,7 +384,7 @@ func (ev *Event) Release() {
 // SetPathResolutionError sets the Event.pathResolutionError
 func (ev *Event) SetPathResolutionError(fileFields *FileEvent, err error) {
 	fileFields.PathResolutionError = err
-	ev.PathResolutionError = err
+	ev.Error = err
 }
 
 // ResolveProcessCacheEntry uses the field handler

--- a/pkg/security/security_profile/dump/activity_dump.go
+++ b/pkg/security/security_profile/dump/activity_dump.go
@@ -1266,8 +1266,8 @@ func (ad *ActivityDump) InsertFileEventInProcess(pan *ProcessActivityNode, fileE
 		filePath = fileEvent.PathnameStr
 	}
 
-	// drop file events with abnormal paths
-	if event != nil && event.PathResolutionError != nil {
+	// drop event for event with an error
+	if event.Error != nil {
 		return false
 	}
 

--- a/pkg/security/security_profile/profile/manager.go
+++ b/pkg/security/security_profile/profile/manager.go
@@ -510,7 +510,7 @@ func (m *SecurityProfileManager) LookupEventOnProfiles(event *model.Event) {
 		return
 	}
 
-	if event.PathResolutionError != nil {
+	if event.Error != nil {
 		m.eventFilteringAbsent[evtType].Inc()
 		return
 	}


### PR DESCRIPTION
### What does this PR do?

This PR stops evaluating, serializing and sending to the backend events that are malformed and on which no real value can be extracted.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
