### PR TITLE
[DCA] Use `Leases` for `leaderelection` when they are available

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -534,7 +534,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.14.0 // indirect
 	go.opentelemetry.io/proto/otlp v0.19.0 // indirect
 	golang.org/x/crypto v0.7.0 // indirect
-	golang.org/x/mod v0.10.0 // indirect
+	golang.org/x/mod v0.10.0
 	golang.org/x/oauth2 v0.6.0 // indirect
 	golang.org/x/term v0.7.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.2.0 // indirect

--- a/internal/third_party/client-go/LICENSE
+++ b/internal/third_party/client-go/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/internal/third_party/client-go/tools/leaderelection/resourcelock/configmaplock.go
+++ b/internal/third_party/client-go/tools/leaderelection/resourcelock/configmaplock.go
@@ -1,15 +1,23 @@
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2016-present Datadog, Inc.
-
 //go:build kubeapiserver
 // +build kubeapiserver
+
+/*
+Copyright 2017 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 // Taken from https://github.com/kubernetes/client-go/blob/v0.27.0/tools/leaderelection/resourcelock/configmaplock.go
 // It was added because k8s.io/client-go/tools/leaderelection does not support ConfigMapLock anymore since v0.24 but
 // it is needed to run leaderlection on kube versions <= 1.14, which do not support LeaseLocks
-package leaderelection
+package resourcelock
 
 import (
 	"context"
@@ -25,7 +33,7 @@ import (
 
 const ConfigMapsResourceLock = "configmaps"
 
-type configMapLock struct {
+type ConfigMapLock struct {
 	// ConfigMapMeta should contain a Name and a Namespace of a
 	// ConfigMapMeta object that the LeaderElector will attempt to lead.
 	ConfigMapMeta metav1.ObjectMeta
@@ -35,7 +43,7 @@ type configMapLock struct {
 }
 
 // Get returns the election record from a ConfigMap Annotation
-func (cml *configMapLock) Get(ctx context.Context) (*rl.LeaderElectionRecord, []byte, error) {
+func (cml *ConfigMapLock) Get(ctx context.Context) (*rl.LeaderElectionRecord, []byte, error) {
 	var record rl.LeaderElectionRecord
 	cm, err := cml.Client.ConfigMaps(cml.ConfigMapMeta.Namespace).Get(ctx, cml.ConfigMapMeta.Name, metav1.GetOptions{})
 	if err != nil {
@@ -56,7 +64,7 @@ func (cml *configMapLock) Get(ctx context.Context) (*rl.LeaderElectionRecord, []
 }
 
 // Create attempts to create a rl.LeaderElectionRecord annotation
-func (cml *configMapLock) Create(ctx context.Context, ler rl.LeaderElectionRecord) error {
+func (cml *ConfigMapLock) Create(ctx context.Context, ler rl.LeaderElectionRecord) error {
 	recordBytes, err := json.Marshal(ler)
 	if err != nil {
 		return err
@@ -74,7 +82,7 @@ func (cml *configMapLock) Create(ctx context.Context, ler rl.LeaderElectionRecor
 }
 
 // Update will update an existing annotation on a given resource.
-func (cml *configMapLock) Update(ctx context.Context, ler rl.LeaderElectionRecord) error {
+func (cml *ConfigMapLock) Update(ctx context.Context, ler rl.LeaderElectionRecord) error {
 	if cml.cm == nil {
 		return errors.New("configmap not initialized, call get or create first")
 	}
@@ -95,7 +103,7 @@ func (cml *configMapLock) Update(ctx context.Context, ler rl.LeaderElectionRecor
 }
 
 // RecordEvent in leader election while adding meta-data
-func (cml *configMapLock) RecordEvent(s string) {
+func (cml *ConfigMapLock) RecordEvent(s string) {
 	if cml.LockConfig.EventRecorder == nil {
 		return
 	}
@@ -109,11 +117,11 @@ func (cml *configMapLock) RecordEvent(s string) {
 
 // Describe is used to convert details on current resource lock
 // into a string
-func (cml *configMapLock) Describe() string {
+func (cml *ConfigMapLock) Describe() string {
 	return fmt.Sprintf("%v/%v", cml.ConfigMapMeta.Namespace, cml.ConfigMapMeta.Name)
 }
 
 // Identity returns the Identity of the lock
-func (cml *configMapLock) Identity() string {
+func (cml *ConfigMapLock) Identity() string {
 	return cml.LockConfig.Identity
 }

--- a/pkg/util/kubernetes/apiserver/leaderelection/configmapslock.go
+++ b/pkg/util/kubernetes/apiserver/leaderelection/configmapslock.go
@@ -1,21 +1,10 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
 //go:build kubeapiserver
 // +build kubeapiserver
-
-/*
-Copyright 2017 The Kubernetes Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
 
 // Taken from https://github.com/kubernetes/client-go/blob/v0.27.0/tools/leaderelection/resourcelock/configmaplock.go
 // It was added because k8s.io/client-go/tools/leaderelection does not support ConfigMapLock anymore since v0.24 but

--- a/pkg/util/kubernetes/apiserver/leaderelection/configmapslock.go
+++ b/pkg/util/kubernetes/apiserver/leaderelection/configmapslock.go
@@ -1,18 +1,10 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
 //go:build kubeapiserver
 // +build kubeapiserver
-
-/*
-Copyright 2017 The Kubernetes Authors.
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-    http://www.apache.org/licenses/LICENSE-2.0
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
 
 // Taken from https://github.com/kubernetes/client-go/blob/v0.27.0/tools/leaderelection/resourcelock/configmaplock.go
 // It was added because k8s.io/client-go/tools/leaderelection does not support ConfigMapLock anymore since v0.24 but

--- a/pkg/util/kubernetes/apiserver/leaderelection/configmapslock.go
+++ b/pkg/util/kubernetes/apiserver/leaderelection/configmapslock.go
@@ -1,0 +1,147 @@
+//go:build kubeapiserver
+// +build kubeapiserver
+
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Taken from https://github.com/kubernetes/client-go/blob/v0.27.0/tools/leaderelection/resourcelock/configmaplock.go
+// It was added because k8s.io/client-go/tools/leaderelection does not support ConfigMapLock anymore since v0.24 but
+// it is needed to run leaderlection on kube versions <= 1.14, which do not support LeaseLocks
+package leaderelection
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	coordinationv1 "k8s.io/client-go/kubernetes/typed/coordination/v1"
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	rl "k8s.io/client-go/tools/leaderelection/resourcelock"
+)
+
+const ConfigMapsResourceLock = "configmaps"
+
+type configMapLock struct {
+	// ConfigMapMeta should contain a Name and a Namespace of a
+	// ConfigMapMeta object that the LeaderElector will attempt to lead.
+	ConfigMapMeta metav1.ObjectMeta
+	Client        corev1client.ConfigMapsGetter
+	LockConfig    rl.ResourceLockConfig
+	cm            *v1.ConfigMap
+}
+
+// Get returns the election record from a ConfigMap Annotation
+func (cml *configMapLock) Get(ctx context.Context) (*rl.LeaderElectionRecord, []byte, error) {
+	var record rl.LeaderElectionRecord
+	cm, err := cml.Client.ConfigMaps(cml.ConfigMapMeta.Namespace).Get(ctx, cml.ConfigMapMeta.Name, metav1.GetOptions{})
+	if err != nil {
+		return nil, nil, err
+	}
+	cml.cm = cm
+	if cml.cm.Annotations == nil {
+		cml.cm.Annotations = make(map[string]string)
+	}
+	recordStr, found := cml.cm.Annotations[rl.LeaderElectionRecordAnnotationKey]
+	recordBytes := []byte(recordStr)
+	if found {
+		if err := json.Unmarshal(recordBytes, &record); err != nil {
+			return nil, nil, err
+		}
+	}
+	return &record, recordBytes, nil
+}
+
+// Create attempts to create a rl.LeaderElectionRecord annotation
+func (cml *configMapLock) Create(ctx context.Context, ler rl.LeaderElectionRecord) error {
+	recordBytes, err := json.Marshal(ler)
+	if err != nil {
+		return err
+	}
+	cml.cm, err = cml.Client.ConfigMaps(cml.ConfigMapMeta.Namespace).Create(ctx, &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cml.ConfigMapMeta.Name,
+			Namespace: cml.ConfigMapMeta.Namespace,
+			Annotations: map[string]string{
+				rl.LeaderElectionRecordAnnotationKey: string(recordBytes),
+			},
+		},
+	}, metav1.CreateOptions{})
+	return err
+}
+
+// Update will update an existing annotation on a given resource.
+func (cml *configMapLock) Update(ctx context.Context, ler rl.LeaderElectionRecord) error {
+	if cml.cm == nil {
+		return errors.New("configmap not initialized, call get or create first")
+	}
+	recordBytes, err := json.Marshal(ler)
+	if err != nil {
+		return err
+	}
+	if cml.cm.Annotations == nil {
+		cml.cm.Annotations = make(map[string]string)
+	}
+	cml.cm.Annotations[rl.LeaderElectionRecordAnnotationKey] = string(recordBytes)
+	cm, err := cml.Client.ConfigMaps(cml.ConfigMapMeta.Namespace).Update(ctx, cml.cm, metav1.UpdateOptions{})
+	if err != nil {
+		return err
+	}
+	cml.cm = cm
+	return nil
+}
+
+// RecordEvent in leader election while adding meta-data
+func (cml *configMapLock) RecordEvent(s string) {
+	if cml.LockConfig.EventRecorder == nil {
+		return
+	}
+	events := fmt.Sprintf("%v %v", cml.LockConfig.Identity, s)
+	subject := &v1.ConfigMap{ObjectMeta: cml.cm.ObjectMeta}
+	// Populate the type meta, so we don't have to get it from the schema
+	subject.Kind = "ConfigMap"
+	subject.APIVersion = v1.SchemeGroupVersion.String()
+	cml.LockConfig.EventRecorder.Eventf(subject, v1.EventTypeNormal, "LeaderElection", events)
+}
+
+// Describe is used to convert details on current resource lock
+// into a string
+func (cml *configMapLock) Describe() string {
+	return fmt.Sprintf("%v/%v", cml.ConfigMapMeta.Namespace, cml.ConfigMapMeta.Name)
+}
+
+// Identity returns the Identity of the lock
+func (cml *configMapLock) Identity() string {
+	return cml.LockConfig.Identity
+}
+
+func NewReleaseLock(lockType string, ns string, name string, coreClient corev1.CoreV1Interface, coordinationClient coordinationv1.CoordinationV1Interface, rlc rl.ResourceLockConfig) (rl.Interface, error) {
+	if lockType == ConfigMapsResourceLock {
+		return &configMapLock{
+			ConfigMapMeta: metav1.ObjectMeta{
+				Namespace: ns,
+				Name:      name,
+			},
+			Client:     coreClient,
+			LockConfig: rlc,
+		}, nil
+	} else {
+		return rl.New(lockType, ns, name, coreClient, coordinationClient, rlc)
+	}
+}

--- a/pkg/util/kubernetes/apiserver/leaderelection/configmapslock.go
+++ b/pkg/util/kubernetes/apiserver/leaderelection/configmapslock.go
@@ -1,10 +1,18 @@
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2016-present Datadog, Inc.
-
 //go:build kubeapiserver
 // +build kubeapiserver
+
+/*
+Copyright 2017 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 // Taken from https://github.com/kubernetes/client-go/blob/v0.27.0/tools/leaderelection/resourcelock/configmaplock.go
 // It was added because k8s.io/client-go/tools/leaderelection does not support ConfigMapLock anymore since v0.24 but
@@ -19,8 +27,6 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	coordinationv1 "k8s.io/client-go/kubernetes/typed/coordination/v1"
-	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	rl "k8s.io/client-go/tools/leaderelection/resourcelock"
 )
@@ -118,19 +124,4 @@ func (cml *configMapLock) Describe() string {
 // Identity returns the Identity of the lock
 func (cml *configMapLock) Identity() string {
 	return cml.LockConfig.Identity
-}
-
-func NewReleaseLock(lockType string, ns string, name string, coreClient corev1.CoreV1Interface, coordinationClient coordinationv1.CoordinationV1Interface, rlc rl.ResourceLockConfig) (rl.Interface, error) {
-	if lockType == ConfigMapsResourceLock {
-		return &configMapLock{
-			ConfigMapMeta: metav1.ObjectMeta{
-				Namespace: ns,
-				Name:      name,
-			},
-			Client:     coreClient,
-			LockConfig: rlc,
-		}, nil
-	} else {
-		return rl.New(lockType, ns, name, coreClient, coordinationClient, rlc)
-	}
 }

--- a/pkg/util/kubernetes/apiserver/leaderelection/leaderelection.go
+++ b/pkg/util/kubernetes/apiserver/leaderelection/leaderelection.go
@@ -16,6 +16,7 @@ import (
 	"sync"
 	"time"
 
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/discovery"
 	coordinationv1 "k8s.io/client-go/kubernetes/typed/coordination/v1"
@@ -261,7 +262,7 @@ func (le *LeaderEngine) Subscribe() <-chan struct{} {
 
 func CanUseLease(client discovery.DiscoveryInterface) (bool, error) {
 	resourceList, err := client.ServerResourcesForGroupVersion("coordination.k8s.io/v1")
-	if apierrors.IsNotFound(err) {
+	if kerrors.IsNotFound(err) {
 		return false, nil
 	}
 	if err != nil {

--- a/pkg/util/kubernetes/apiserver/leaderelection/leaderelection.go
+++ b/pkg/util/kubernetes/apiserver/leaderelection/leaderelection.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/client-go/tools/leaderelection"
 	rl "k8s.io/client-go/tools/leaderelection/resourcelock"
 
+	configmaplock "github.com/DataDog/datadog-agent/internal/third_party/client-go/tools/leaderelection/resourcelock"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
@@ -153,7 +154,7 @@ func (le *LeaderEngine) init() error {
 	} else {
 		// for kubernetes <= 1.13
 		log.Debugf("leader election will use ConfigMaps to store the leader token")
-		le.lockType = ConfigMapsResourceLock
+		le.lockType = configmaplock.ConfigMapsResourceLock
 	}
 	le.leaderElector, err = le.newElection()
 	if err != nil {

--- a/pkg/util/kubernetes/apiserver/leaderelection/leaderelection.go
+++ b/pkg/util/kubernetes/apiserver/leaderelection/leaderelection.go
@@ -17,11 +17,11 @@ import (
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/discovery"
 	coordinationv1 "k8s.io/client-go/kubernetes/typed/coordination/v1"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/leaderelection"
 	rl "k8s.io/client-go/tools/leaderelection/resourcelock"
-	"k8s.io/client-go/discovery"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/telemetry"
@@ -259,12 +259,12 @@ func CanUseLease(client discovery.DiscoveryInterface) bool {
 	if err != nil {
 		log.Errorf("failed to retrieve resource list for coordination.k8s.io/v1, leader election will use configmaps: %v", err)
 		return false
-	} 
+	}
 	if resourceList == nil {
 		return false
 	}
 	for _, resource := range resourceList.APIResources {
-		if resource.Kind == "Lease"{
+		if resource.Kind == "Lease" {
 			return true
 		}
 	}

--- a/pkg/util/kubernetes/apiserver/leaderelection/leaderelection_engine.go
+++ b/pkg/util/kubernetes/apiserver/leaderelection/leaderelection_engine.go
@@ -24,13 +24,14 @@ import (
 	rl "k8s.io/client-go/tools/leaderelection/resourcelock"
 	"k8s.io/client-go/tools/record"
 
+	configmaplock "github.com/DataDog/datadog-agent/internal/third_party/client-go/tools/leaderelection/resourcelock"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/leaderelection/metrics"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 func NewReleaseLock(lockType string, ns string, name string, coreClient corev1.CoreV1Interface, coordinationClient clientcoord.CoordinationV1Interface, rlc rl.ResourceLockConfig) (rl.Interface, error) {
-	if lockType == ConfigMapsResourceLock {
-		return &configMapLock{
+	if lockType == configmaplock.ConfigMapsResourceLock {
+		return &configmaplock.ConfigMapLock{
 			ConfigMapMeta: metav1.ObjectMeta{
 				Namespace: ns,
 				Name:      name,

--- a/pkg/util/kubernetes/apiserver/leaderelection/leaderelection_engine.go
+++ b/pkg/util/kubernetes/apiserver/leaderelection/leaderelection_engine.go
@@ -13,11 +13,12 @@ import (
 	"encoding/json"
 	"strconv"
 
-	coordinationv1 "k8s.io/api/coordination/v1"
+	coordv1 "k8s.io/api/coordination/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	clientcoord "k8s.io/client-go/kubernetes/typed/coordination/v1"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	ld "k8s.io/client-go/tools/leaderelection"
 	rl "k8s.io/client-go/tools/leaderelection/resourcelock"
@@ -27,7 +28,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-func NewReleaseLock(lockType string, ns string, name string, coreClient corev1.CoreV1Interface, coordinationClient coordinationv1.CoordinationV1Interface, rlc rl.ResourceLockConfig) (rl.Interface, error) {
+func NewReleaseLock(lockType string, ns string, name string, coreClient corev1.CoreV1Interface, coordinationClient clientcoord.CoordinationV1Interface, rlc rl.ResourceLockConfig) (rl.Interface, error) {
 	if lockType == ConfigMapsResourceLock {
 		return &configMapLock{
 			ConfigMapMeta: metav1.ObjectMeta{
@@ -95,7 +96,7 @@ func (le *LeaderEngine) CreateLeaderTokenIfNotExists() error {
 				return err
 			}
 
-			_, err = le.coordClient.Leases(le.LeaderNamespace).Create(context.TODO(), &coordinationv1.Lease{
+			_, err = le.coordClient.Leases(le.LeaderNamespace).Create(context.TODO(), &coordv1.Lease{
 				TypeMeta: metav1.TypeMeta{
 					Kind: "Lease",
 				},

--- a/releasenotes/notes/use-leases-leader-election-c278c71fb39c2c84.yaml
+++ b/releasenotes/notes/use-leases-leader-election-c278c71fb39c2c84.yaml
@@ -1,0 +1,4 @@
+
+enhancements:
+  - |
+    Use ``leases.coordination/v1`` for cluster-agent leader election when they are available.

--- a/tasks/libs/copyright.py
+++ b/tasks/libs/copyright.py
@@ -38,6 +38,7 @@ PATH_EXCLUSION_REGEX = [
     '/internal/patch/grpc-go-insecure/',
     '/internal/patch/logr/funcr/funcr(_test){,1}.go',
     '/internal/patch/logr/funcr/internal/logr/',
+    '/internal/third_party/client-go/',
     '/internal/third_party/golang/',
     '/internal/third_party/kubernetes/',
     '/pkg/collector/corechecks/cluster/ksm/customresources/utils.go',

--- a/test/integration/util/leaderelection/leaderelection_test.go
+++ b/test/integration/util/leaderelection/leaderelection_test.go
@@ -237,7 +237,7 @@ func (suite *apiserverSuite) TestLeaderElectionMulti() {
 		lease := leasesList.Items[0]
 		require.Equal(suite.T(), "datadog-leader-election", lease.Name)
 		require.NotNil(suite.T(), lease.Spec.HolderIdentity)
-		require.Equal(suite.T(), testCases[0].leaderEngine.HolderIdentity, lease.Spec.HolderIdentity)
+		require.Equal(suite.T(), testCases[0].leaderEngine.HolderIdentity, *lease.Spec.HolderIdentity)
 	} else {
 		client := c.Cl.CoreV1()
 		require.Nil(suite.T(), err)

--- a/test/integration/util/leaderelection/testdata/apiserver-compose.yaml
+++ b/test/integration/util/leaderelection/testdata/apiserver-compose.yaml
@@ -12,7 +12,7 @@ services:
       retries: 30
 
   apiserver:
-    image: registry.k8s.io/hyperkube:v1.18.20
+    image: registry.k8s.io/hyperkube:APIVERSION_PLACEHOLDER
     command: "kube-apiserver
         --apiserver-count=1
         --insecure-bind-address=0.0.0.0


### PR DESCRIPTION

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
From K8s 1.26, the leader election package doesn’t support anymore using a configmap/endpoint object to store the leader token. This PR uses Leases to store the leaderelection token. Since Leases were added in k8s 1.14, we add support for ConfigMapsLock with a custom configmapslock implementation.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
We need to continue upgrade to recent kubernetes libraries version to use a supported version for bug and security fixes but we also need to support old kubernetes versions. We need to implement this fix to bump `k8s` versions.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
N/A
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs
N/A
<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
Testing requires a Kubernetes cluster with an old version (<= 1.14) and another one with a recent version.
You can deploy multiple `cluster-agent` and verify that they agree on the same leader after a few seconds. You can also delete the pod of the leader or add new replicas and verify that every cluster-agent views the same leader.
To find the leader for a given pod, you can execute `kubectl exec cluster-agent-pod -- agent status | grep -i leader`.

In order to deploy with an old kubernetes cluster, you will need to install a VM. If possible, with an architecture different from `ARM`. Then you will need to install an old version of `minikube` and docker if you do not use arm. I tested it with [`minikube v1.13.0`](https://github.com/kubernetes/minikube/releases/tag/v1.13.0). Finally, deploy your cluster with:
`minikube start --kubernetes-version=v1.13.2 --driver=docker|none`.
You can use the command `kubectl api-resources` to check if `leases.coordination/v1` are available. They should not be.
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
