### PR TITLE
logs/client/tcp: simplify Delimiters implementation

### DIFF
--- a/pkg/logs/client/tcp/delimiter.go
+++ b/pkg/logs/client/tcp/delimiter.go
@@ -17,12 +17,12 @@ type Delimiter interface {
 // NewDelimiter returns a delimiter.
 func NewDelimiter(useProto bool) Delimiter {
 	if useProto {
-		return &lengthPrefix
+		return lengthPrefixDelimiter{}
 	}
-	return &lineBreak
+	return lineBreakDelimiter{}
 }
 
-// LengthPrefix is a delimiter that prepends the length of each message as an unsigned 32-bit integer, encoded in
+// lengthPrefixDelimiter is a delimiter that prepends the length of each message as an unsigned 32-bit integer, encoded in
 // binary (big-endian).
 //
 // For example:
@@ -31,18 +31,16 @@ func NewDelimiter(useProto bool) Delimiter {
 // | Raw Data      |-------------->| Length | Raw Data      |
 // |  (300 bytes)  |               | 0xAC02 |  (300 bytes)  |
 // +---------------+               +--------+---------------+
-var lengthPrefix lengthPrefixDelimiter
-
 type lengthPrefixDelimiter struct{}
 
-func (l *lengthPrefixDelimiter) delimit(content []byte) ([]byte, error) {
+func (l lengthPrefixDelimiter) delimit(content []byte) ([]byte, error) {
 	buf := make([]byte, 4+len(content))
 	binary.BigEndian.PutUint32(buf[:4], uint32(len(content)))
 	copy(buf[4:], content)
 	return buf, nil
 }
 
-// LineBreak is a delimiter that appends a line break after each message.
+// lineBreakDelimiter is a delimiter that appends a line break after each message.
 //
 // For example:
 // BEFORE ENCODE (300 bytes)       AFTER ENCODE (301 bytes)
@@ -50,10 +48,8 @@ func (l *lengthPrefixDelimiter) delimit(content []byte) ([]byte, error) {
 // | Raw Data      |-------------->| Raw Data      | Line Break |
 // |  (300 bytes)  |               |  (300 bytes)  | 0x0A       |
 // +---------------+               +---------------+------------+
-var lineBreak lineBreakDelimiter
-
 type lineBreakDelimiter struct{}
 
-func (l *lineBreakDelimiter) delimit(content []byte) ([]byte, error) {
+func (l lineBreakDelimiter) delimit(content []byte) ([]byte, error) {
 	return append(content, '\n'), nil
 }

--- a/pkg/logs/client/tcp/delimiter.go
+++ b/pkg/logs/client/tcp/delimiter.go
@@ -33,9 +33,7 @@ func NewDelimiter(useProto bool) Delimiter {
 // +---------------+               +--------+---------------+
 var lengthPrefix lengthPrefixDelimiter
 
-type lengthPrefixDelimiter struct {
-	Delimiter
-}
+type lengthPrefixDelimiter struct{}
 
 func (l *lengthPrefixDelimiter) delimit(content []byte) ([]byte, error) {
 	buf := make([]byte, 4+len(content))
@@ -54,9 +52,7 @@ func (l *lengthPrefixDelimiter) delimit(content []byte) ([]byte, error) {
 // +---------------+               +---------------+------------+
 var lineBreak lineBreakDelimiter
 
-type lineBreakDelimiter struct {
-	Delimiter
-}
+type lineBreakDelimiter struct{}
 
 func (l *lineBreakDelimiter) delimit(content []byte) ([]byte, error) {
 	return append(content, '\n'), nil

--- a/pkg/logs/client/tcp/delimiter.go
+++ b/pkg/logs/client/tcp/delimiter.go
@@ -6,7 +6,6 @@
 package tcp
 
 import (
-	"bytes"
 	"encoding/binary"
 )
 
@@ -39,15 +38,10 @@ type lengthPrefixDelimiter struct {
 }
 
 func (l *lengthPrefixDelimiter) delimit(content []byte) ([]byte, error) {
-	buf := bytes.NewBuffer(make([]byte, 0, 32))
-	length := uint32(len(content))
-	// Use big-endian to respect network byte order
-	err := binary.Write(buf, binary.BigEndian, length)
-	if err != nil {
-		return nil, err
-	}
-	return append(buf.Bytes(), content...), nil
-
+	buf := make([]byte, 4+len(content))
+	binary.BigEndian.PutUint32(buf[:4], uint32(len(content)))
+	copy(buf[4:], content)
+	return buf, nil
 }
 
 // LineBreak is a delimiter that appends a line break after each message.

--- a/pkg/logs/client/tcp/delimiter_test.go
+++ b/pkg/logs/client/tcp/delimiter_test.go
@@ -22,6 +22,8 @@ func TestNewDelimiter(t *testing.T) {
 
 func TestLengthPrefixDelimiter(t *testing.T) {
 
+	lengthPrefix := NewDelimiter(true)
+
 	bytes, err := lengthPrefix.delimit([]byte{})
 	assert.Nil(t, err)
 	assert.Equal(t, 4, len(bytes))
@@ -36,6 +38,8 @@ func TestLengthPrefixDelimiter(t *testing.T) {
 }
 
 func TestLineBreakDelimiter(t *testing.T) {
+
+	lineBreak := NewDelimiter(false)
 
 	bytes, err := lineBreak.delimit([]byte{})
 	assert.Nil(t, err)

--- a/pkg/logs/client/tcp/delimiter_test.go
+++ b/pkg/logs/client/tcp/delimiter_test.go
@@ -12,8 +12,12 @@ import (
 )
 
 func TestNewDelimiter(t *testing.T) {
-	assert.Equal(t, &lengthPrefix, NewDelimiter(true))
-	assert.Equal(t, &lineBreak, NewDelimiter(false))
+	lengthD, err := NewDelimiter(true).delimit([]byte("abc"))
+	assert.Nil(t, err)
+	assert.Equal(t, []byte{0, 0, 0, 3, 'a', 'b', 'c'}, lengthD)
+	lineD, err := NewDelimiter(false).delimit([]byte("abc"))
+	assert.Nil(t, err)
+	assert.Equal(t, []byte("abc\n"), lineD)
 }
 
 func TestLengthPrefixDelimiter(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

Refactor delimiters.go in logs/client/tcp

### Motivation

* The LengthPrefixDelimiter implementation was inefficient: the use of a byte.Buffer for each message was unnecessary. Then further optimisation were added, but still only affecting `delimiter.go` and `delimiter_test.go`.
* I like clean code.
* I like short code.

### Additional Notes

Review should be done commit by commit: this is a journey.

The implementation of delimiters could be further simplified. However the two symbols `Delimiter` and `NewDelimiter` are exported from the package, so even if I think they could just be removed, that would still be an API breaking change. This needs approval from the project maintainers before I can propose more aggressive simplifications.

### Possible Drawbacks / Trade-offs

The existing test suite is modified. But this was necessary to decorellate the tests from the implementation.

The code would be cleaner and shorter.

### Describe how to test/QA your changes

```console
$ go test logs/client/tcp
```

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
