### PR TITLE
[ksm-core] Remove the `kube_namespace` tag from the CRD metrics

### DIFF
--- a/pkg/collector/corechecks/cluster/ksm/customresources/crd.go
+++ b/pkg/collector/corechecks/cluster/ksm/customresources/crd.go
@@ -32,7 +32,7 @@ var (
 	descCustomResourceDefinitionAnnotationsHelp     = "Kubernetes annotations converted to Prometheus labels."
 	descCustomResourceDefinitionLabelsName          = "kube_customresourcedefinition_labels"
 	descCustomResourceDefinitionLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
-	descCustomResourceDefinitionLabelsDefaultLabels = []string{"namespace", "customresourcedefinition"}
+	descCustomResourceDefinitionLabelsDefaultLabels = []string{"customresourcedefinition"}
 )
 
 // NewCustomResourceDefinitionFactory returns a new CustomResourceDefinition
@@ -146,7 +146,7 @@ func wrapCustomResourceDefinition(f func(*v1.CustomResourceDefinition) *metric.F
 		metricFamily := f(crd)
 
 		for _, m := range metricFamily.Metrics {
-			m.LabelKeys, m.LabelValues = mergeKeyValues(descCustomResourceDefinitionLabelsDefaultLabels, []string{crd.Namespace, crd.Name}, m.LabelKeys, m.LabelValues)
+			m.LabelKeys, m.LabelValues = mergeKeyValues(descCustomResourceDefinitionLabelsDefaultLabels, []string{crd.Name}, m.LabelKeys, m.LabelValues)
 		}
 
 		return metricFamily

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state.md
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state.md
@@ -167,10 +167,10 @@
 : Describes the reason the container is currently in terminated state. Tags:`kube_namespace` `pod_name` `kube_container_name` `reason` (`env` `service` `version` from standard labels).
 
 `kubernetes_state.crd.count`
-: Number of custom resource definition. Tags: `kube_namespace`.
+: Number of custom resource definition.
 
 `kubernetes_state.crd.condition`
-: The condition of this custom resource definition. Tags:`kube_namespace` `customresourcedefinition` `condition` `status`.
+: The condition of this custom resource definition. Tags:`customresourcedefinition` `condition` `status`.
 
 `kubernetes_state.pod.ready`
 : Describes whether the pod is ready to serve requests. Tags:`node` `kube_namespace` `pod_name` `condition` (`env` `service` `version` from standard labels).

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_aggregators.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_aggregators.go
@@ -233,7 +233,7 @@ func defaultMetricAggregators() map[string]metricAggregator {
 		"kube_customresourcedefinition_labels": newCountObjectsAggregator(
 			"crd.count",
 			"kube_customresourcedefinition_labels",
-			[]string{"namespace"},
+			[]string{},
 		),
 		"kube_persistentvolume_status_phase": newSumValuesAggregator(
 			"persistentvolumes.by_phase",

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_defaults.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_defaults.go
@@ -228,6 +228,8 @@ func getLabelToMatchForKind(kind string) []string {
 		return []string{"node"}
 	case "persistentvolume": // persistent volumes are not namespaced
 		return []string{"persistentvolume"}
+	case "customresourcedefinition": // CRD are not namespaced
+		return []string{"customresourcedefinition"}
 	default:
 		return []string{kind, "namespace"}
 	}


### PR DESCRIPTION
### What does this PR do?

Remove the `kube_namespace` tag from the CRD-related KSM metrics.

### Motivation

[CRD are non-namespaced](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#create-a-customresourcedefinition).

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

See #16141 for enabling CRD metrics collection in the KSM core check.
Label and annotate some CRDs.
Set `labels_as_tags` and `annotations_as_tags` to get those custom labels and annotations

Ex. with this `values.yaml` file for the public Helm chart.
```yaml
clusterAgent:
  confd:
    kubernetes_state_core.yaml: |-
      init_config:
      instances:
        - collectors:
          - customresourcedefinitions
          - secrets
          - nodes
          - pods
          - services
          - resourcequotas
          - replicationcontrollers
          - limitranges
          - persistentvolumeclaims
          - persistentvolumes
          - namespaces
          - endpoints
          - daemonsets
          - deployments
          - replicasets
          - statefulsets
          - cronjobs
          - jobs
          - horizontalpodautoscalers
          - poddisruptionbudgets
          - storageclasses
          - volumeattachments
          - ingresses
          labels_as_tags:
            customresourcedefinition:
              lenaic: lenaic
          annotations_as_tags:
            customresourcedefinition:
              lenaic: lenaic
```

Run the check with:
```
kubectl exec pod/datadog-agent-linux-cluster-agent-6bb4b7b656-55prb -c cluster-agent -- agent check -r kubernetes_state_core --table | grep crd
```

Check that there is no `kube_namespace:` (empty value) tag anymore on the `kubernetes_state.crd.*` metrics.
Check that label joins is still working with the custom labels and annotations.

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
