### PR TITLE
[CWS] Fix SBOM generation for container root filesystems

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -602,8 +602,8 @@ replace k8s.io/kube-state-metrics/v2 => github.com/datadog/kube-state-metrics/v2
 // Use custom Trivy fork to reduce binary size
 // Pull in replacements needed by upstream Trivy
 replace (
-	github.com/aquasecurity/trivy => github.com/DataDog/trivy v0.0.0-20230120171913-9b1b011fb2fe
-	github.com/saracen/walker => github.com/DataDog/walker v0.0.0-20221128132416-4ca87a1f1023
+	github.com/aquasecurity/trivy => github.com/DataDog/trivy v0.0.0-20230418154509-807f757a8339
+	github.com/saracen/walker => github.com/DataDog/walker v0.0.0-20230418153152-7f29bb2dc950
 	github.com/spdx/tools-golang => github.com/spdx/tools-golang v0.3.0
 	oras.land/oras-go => oras.land/oras-go v1.1.1
 )

--- a/go.sum
+++ b/go.sum
@@ -172,12 +172,12 @@ github.com/DataDog/opentelemetry-mapping-go/pkg/quantile v0.1.5 h1:Coq8AY8Wr9SiR
 github.com/DataDog/opentelemetry-mapping-go/pkg/quantile v0.1.5/go.mod h1:nw6wfcZqEiFh/F68YO96zOjrlZjtKOKoXmRNQ3wgjLc=
 github.com/DataDog/sketches-go v1.4.1 h1:j5G6as+9FASM2qC36lvpvQAj9qsv/jUs3FtO8CwZNAY=
 github.com/DataDog/sketches-go v1.4.1/go.mod h1:xJIXldczJyyjnbDop7ZZcLxJdV3+7Kra7H1KMgpgkLk=
-github.com/DataDog/trivy v0.0.0-20230120171913-9b1b011fb2fe h1:37VGGoe+SJ/blsYK0xZDy84m8hp/suVx6MBSeiZJKLc=
-github.com/DataDog/trivy v0.0.0-20230120171913-9b1b011fb2fe/go.mod h1:f1nyvEyWU3w5L8dYIQljloMO/BX0i0OK9NwGeZtvmFw=
+github.com/DataDog/trivy v0.0.0-20230418154509-807f757a8339 h1:ursx1WwFb+b0arV1d4061adoX0qGKGvZbBYKWiwYza4=
+github.com/DataDog/trivy v0.0.0-20230418154509-807f757a8339/go.mod h1:f1nyvEyWU3w5L8dYIQljloMO/BX0i0OK9NwGeZtvmFw=
 github.com/DataDog/viper v1.12.0 h1:FufyZpZPxyszafSV5B8Q8it75IhhuJwH0T7QpT6HnD0=
 github.com/DataDog/viper v1.12.0/go.mod h1:wDdUVJ2SHaMaPrCZrlRCObwkubsX8j5sme3LaR/SGTc=
-github.com/DataDog/walker v0.0.0-20221128132416-4ca87a1f1023 h1:LUHj8naCkkZ2FQGf2OBPiYZbMfzH3T8nCANmjFyLvDg=
-github.com/DataDog/walker v0.0.0-20221128132416-4ca87a1f1023/go.mod h1:G0Z6yVPru183i2MuRJx1DcR4dgIZtLcTdaaE/pC1BJU=
+github.com/DataDog/walker v0.0.0-20230418153152-7f29bb2dc950 h1:2imDajw3V85w1iqHsuXN+hUBZQVF+r9eME8tsPq/HpA=
+github.com/DataDog/walker v0.0.0-20230418153152-7f29bb2dc950/go.mod h1:FU+7qU8DeQQgSZDmmThMJi93kPkLFgy0oVAcLxurjIk=
 github.com/DataDog/watermarkpodautoscaler v0.5.2 h1:hPbhnpWQrM1bRPmwCgFMmSQWohHHCDkzgsMlegGr5t8=
 github.com/DataDog/watermarkpodautoscaler v0.5.2/go.mod h1:wmxU62NOlfdWqlGf9Te/j+BiyZkjock5S5265g/KvK8=
 github.com/DataDog/zstd v1.4.5/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
@@ -2455,7 +2455,6 @@ golang.org/x/tools v0.0.0-20190706070813-72ffa07ba3db/go.mod h1:jcCCGcm9btYwXyDq
 golang.org/x/tools v0.0.0-20190816200558-6889da9d5479/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20190907020128-2ca718005c18/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20190911174233-4f2ddba30aff/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
-golang.org/x/tools v0.0.0-20191011211836-4c025a95b26e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191012152004-8de300cfc20a/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191029041327-9cc4af7d6b2c/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191029190741-b9c20aec41a5/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=

--- a/pkg/collector/corechecks/sbom/check.go
+++ b/pkg/collector/corechecks/sbom/check.go
@@ -30,10 +30,11 @@ func init() {
 
 // Config holds the container_image check configuration
 type Config struct {
-	ChunkSize                       int `yaml:"chunk_size"`
-	NewSBOMMaxLatencySeconds        int `yaml:"new_sbom_max_latency_seconds"`
-	ContainerPeriodicRefreshSeconds int `yaml:"periodic_refresh_seconds"`
-	HostPeriodicRefreshSeconds      int `yaml:"host_periodic_refresh_seconds"`
+	ChunkSize                       int  `yaml:"chunk_size"`
+	NewSBOMMaxLatencySeconds        int  `yaml:"new_sbom_max_latency_seconds"`
+	ContainerPeriodicRefreshSeconds int  `yaml:"periodic_refresh_seconds"`
+	HostSBOM                        bool `yaml:"host_sbom"`
+	HostPeriodicRefreshSeconds      int  `yaml:"host_periodic_refresh_seconds"`
 }
 
 type configValueRange struct {
@@ -125,7 +126,7 @@ func (c *Check) Configure(integrationConfigDigest uint64, config, initConfig int
 		return err
 	}
 
-	c.processor, err = newProcessor(c.workloadmetaStore, sender, c.instance.ChunkSize, time.Duration(c.instance.NewSBOMMaxLatencySeconds)*time.Second)
+	c.processor, err = newProcessor(c.workloadmetaStore, sender, c.instance.ChunkSize, time.Duration(c.instance.NewSBOMMaxLatencySeconds)*time.Second, c.instance.HostSBOM)
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/sbom/processor.go
+++ b/pkg/collector/corechecks/sbom/processor.go
@@ -177,11 +177,18 @@ func (p *processor) processHostRefresh() {
 	}
 
 	if err := p.sbomScanner.Scan(scanRequest, p.hostScanOpts, ch); err != nil {
-		log.Errorf("Failed to generate SBOM for host: %s", err)
+		log.Errorf("Failed to trigger SBOM generation for host: %s", err)
+		return
 	}
 
 	go func() {
 		result := <-ch
+
+		if result.Error != nil {
+			log.Errorf("Failed to generate SBOM for host: %s", result.Error)
+			return
+		}
+
 		log.Debugf("Successfully generated SBOM for host: %v, %v", result.CreatedAt, result.Duration)
 
 		bom, err := result.Report.ToCycloneDX()

--- a/pkg/collector/corechecks/sbom/processor_test.go
+++ b/pkg/collector/corechecks/sbom/processor_test.go
@@ -417,7 +417,7 @@ func TestProcessEvents(t *testing.T) {
 
 			// Define a max size of 1 for the queue. With a size > 1, it's difficult to
 			// control the number of events sent on each call.
-			p, err := newProcessor(fakeworkloadmeta, sender, 1, 50*time.Millisecond)
+			p, err := newProcessor(fakeworkloadmeta, sender, 1, 50*time.Millisecond, false)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1090,14 +1090,7 @@ func InitConfig(config Config) {
 
 	// SBOM configuration
 	bindEnvAndSetLogsConfigKeys(config, "sbom.")
-	config.BindEnvAndSetDefault("sbom.enabled", false)
-	config.BindEnvAndSetDefault("sbom.analyzers", []string{"os"})
-	config.BindEnvAndSetDefault("sbom.cache_directory", defaultRunPath)
-	config.BindEnvAndSetDefault("sbom.clear_cache_on_exit", false)
-	config.BindEnvAndSetDefault("sbom.use_custom_cache", false)
-	config.BindEnvAndSetDefault("sbom.custom_cache_max_disk_size", 1000*1000*10) // used by custom cache: max disk space used by cached objects. Not equal to max disk usage
-	config.BindEnvAndSetDefault("sbom.custom_cache_max_cache_entries", 1000)     // used by custom cache keys stored in memory
-	config.BindEnvAndSetDefault("sbom.cache_clean_interval", "30m")              // used by custom cache.
+	setupSBOMConfig(config, "sbom-agent")
 
 	// Orchestrator Explorer - process agent
 	// DEPRECATED in favor of `orchestrator_explorer.orchestrator_dd_url` setting. If both are set `orchestrator_explorer.orchestrator_dd_url` will take precedence.
@@ -1664,6 +1657,17 @@ func setupFipsLogsConfig(config Config, configPrefix string, url string) {
 	config.Set(configPrefix+"use_http", true)
 	config.Set(configPrefix+"logs_no_ssl", !config.GetBool("fips.https"))
 	config.Set(configPrefix+"logs_dd_url", url)
+}
+
+func setupSBOMConfig(config Config, cacheDir string) {
+	config.BindEnvAndSetDefault("sbom.enabled", false)
+	config.BindEnvAndSetDefault("sbom.analyzers", []string{"os"})
+	config.BindEnvAndSetDefault("sbom.cache_directory", filepath.Join(defaultRunPath, cacheDir))
+	config.BindEnvAndSetDefault("sbom.clear_cache_on_exit", false)
+	config.BindEnvAndSetDefault("sbom.use_custom_cache", false)
+	config.BindEnvAndSetDefault("sbom.custom_cache_max_disk_size", 1000*1000*10) // used by custom cache: max disk space used by cached objects. Not equal to max disk usage
+	config.BindEnvAndSetDefault("sbom.custom_cache_max_cache_entries", 1000)     // used by custom cache keys stored in memory
+	config.BindEnvAndSetDefault("sbom.cache_clean_interval", "30m")              // used by custom cache.
 }
 
 // ResolveSecrets merges all the secret values from origin into config. Secret values

--- a/pkg/config/system_probe.go
+++ b/pkg/config/system_probe.go
@@ -59,6 +59,8 @@ func InitSystemProbeConfig(cfg Config) {
 	cfg.BindEnvAndSetDefault("ignore_host_etc", false)
 	cfg.BindEnvAndSetDefault("go_core_dump", false)
 
+	setupSBOMConfig(cfg, "sbom-sysprobe")
+
 	// Auto exit configuration
 	cfg.BindEnvAndSetDefault("auto_exit.validation_period", 60)
 	cfg.BindEnvAndSetDefault("auto_exit.noprocess.enabled", false)

--- a/pkg/sbom/sbom.go
+++ b/pkg/sbom/sbom.go
@@ -53,6 +53,7 @@ type ScanRequest interface {
 }
 
 type ScanResult struct {
+	Error     error
 	Report    Report
 	CreatedAt time.Time
 	Duration  time.Duration

--- a/pkg/sbom/sbom.go
+++ b/pkg/sbom/sbom.go
@@ -27,6 +27,7 @@ type ScanOptions struct {
 	MinAvailableDisk uint64
 	Timeout          time.Duration
 	WaitAfter        time.Duration
+	Fast             bool
 }
 
 // ScanOptionsFromConfig loads the scanning options from the configuration

--- a/pkg/security/resolvers/sbom/resolver.go
+++ b/pkg/security/resolvers/sbom/resolver.go
@@ -197,7 +197,7 @@ func (r *Resolver) generateSBOM(root string, sbom *SBOM) error {
 
 	scanRequest := &host.ScanRequest{Path: root}
 	ch := make(chan sbompkg.ScanResult, 1)
-	if err := r.sbomScanner.Scan(scanRequest, sbompkg.ScanOptions{Analyzers: []string{trivy.OSAnalyzers}, Fast: false}, ch); err != nil {
+	if err := r.sbomScanner.Scan(scanRequest, sbompkg.ScanOptions{Analyzers: []string{trivy.OSAnalyzers}, Fast: true}, ch); err != nil {
 		r.failedSBOMGenerations.Inc()
 		return fmt.Errorf("failed to trigger SBOM generation for %s: %w", root, err)
 	}

--- a/pkg/security/resolvers/sbom/resolver.go
+++ b/pkg/security/resolvers/sbom/resolver.go
@@ -196,19 +196,23 @@ func (r *Resolver) generateSBOM(root string, sbom *SBOM) error {
 	r.sbomGenerations.Inc()
 
 	scanRequest := &host.ScanRequest{Path: root}
-	ch := make(chan sbompkg.ScanResult)
-	err := r.sbomScanner.Scan(scanRequest, sbompkg.ScanOptions{Analyzers: []string{trivy.OSAnalyzers}}, ch)
-	if err != nil {
+	ch := make(chan sbompkg.ScanResult, 1)
+	if err := r.sbomScanner.Scan(scanRequest, sbompkg.ScanOptions{Analyzers: []string{trivy.OSAnalyzers}, Fast: false}, ch); err != nil {
 		r.failedSBOMGenerations.Inc()
-		return fmt.Errorf("failed to generate SBOM for %s: %w", root, err)
+		return fmt.Errorf("failed to trigger SBOM generation for %s: %w", root, err)
+	}
+
+	result := <-ch
+
+	if result.Error != nil {
+		return fmt.Errorf("failed to generate SBOM for %s: %w", root, result.Error)
 	}
 
 	seclog.Infof("SBOM successfully generated from %s", root)
-	result := <-ch
 
 	trivyReport, ok := result.Report.(*trivy.TrivyReport)
 	if !ok {
-		return fmt.Errorf("failed to convert report for %s: %w", root, err)
+		return fmt.Errorf("failed to convert report for %s", root)
 	}
 	sbom.report = trivyReport
 

--- a/pkg/util/trivy/trivy.go
+++ b/pkg/util/trivy/trivy.go
@@ -189,12 +189,12 @@ func NewCollector(cfg config.Config) (*Collector, error) {
 	}, nil
 }
 
-func GetGlobalCollector(_ config.Config) (*Collector, error) {
+func GetGlobalCollector(cfg config.Config) (*Collector, error) {
 	if globalCollector != nil {
 		return globalCollector, nil
 	}
 
-	collector, err := NewCollector(config.Datadog)
+	collector, err := NewCollector(cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/util/trivy/trivy.go
+++ b/pkg/util/trivy/trivy.go
@@ -72,17 +72,17 @@ type Collector struct {
 
 var globalCollector *Collector
 
-func getDefaultArtifactOption(enabledAnalyzers []string, root string) artifact.Option {
+func getDefaultArtifactOption(root string, opts sbom.ScanOptions) artifact.Option {
 	option := artifact.Option{
 		Offline:           true,
 		NoProgress:        true,
-		DisabledAnalyzers: DefaultDisabledCollectors(enabledAnalyzers),
-		Slow:              true,
+		DisabledAnalyzers: DefaultDisabledCollectors(opts.Analyzers),
+		Slow:              !opts.Fast,
 		SBOMSources:       []string{},
 		DisabledHandlers:  DefaultDisabledHandlers(),
 	}
 
-	if len(enabledAnalyzers) == 1 && enabledAnalyzers[0] == OSAnalyzers {
+	if len(opts.Analyzers) == 1 && opts.Analyzers[0] == OSAnalyzers {
 		option.OnlyDirs = []string{"etc", "var/lib/dpkg", "var/lib/rpm", "lib/apk"}
 		if root != "" {
 			// OnlyDirs is handled differently for image than for filesystem.
@@ -169,6 +169,7 @@ func NewCollector(cfg config.Config) (*Collector, error) {
 	go func() {
 		cleanTicker := time.NewTicker(cfg.GetDuration("sbom.cache_clean_interval"))
 		defer cleanTicker.Stop()
+
 		// Cache can not be cleaned concurrently with a scan
 		for range cleanTicker.C {
 			if err = cacheCleaner.Clean(); err != nil {
@@ -276,7 +277,7 @@ func (c *Collector) ScanContainerdImageFromFilesystem(ctx context.Context, imgMe
 }
 
 func (c *Collector) scanFilesystem(ctx context.Context, path string, imgMeta *workloadmeta.ContainerImageMetadata, scanOptions sbom.ScanOptions) (sbom.Report, error) {
-	fsArtifact, err := local2.NewArtifact(path, c.cache, getDefaultArtifactOption(scanOptions.Analyzers, path))
+	fsArtifact, err := local2.NewArtifact(path, c.cache, getDefaultArtifactOption(path, scanOptions))
 	if err != nil {
 		return nil, fmt.Errorf("unable to create artifact from fs, err: %w", err)
 	}
@@ -319,7 +320,7 @@ func (c *Collector) scan(ctx context.Context, artifact artifact.Artifact, imgMet
 }
 
 func (c *Collector) scanImage(ctx context.Context, fanalImage ftypes.Image, imgMeta *workloadmeta.ContainerImageMetadata, scanOptions sbom.ScanOptions) (sbom.Report, error) {
-	imageArtifact, err := image2.NewArtifact(fanalImage, c.cache, getDefaultArtifactOption(scanOptions.Analyzers, ""))
+	imageArtifact, err := image2.NewArtifact(fanalImage, c.cache, getDefaultArtifactOption("", scanOptions))
 	if err != nil {
 		return nil, fmt.Errorf("unable to create artifact from image, err: %w", err)
 	}

--- a/pkg/workloadmeta/collectors/internal/containerd/image_sbom_trivy.go
+++ b/pkg/workloadmeta/collectors/internal/containerd/image_sbom_trivy.go
@@ -91,6 +91,7 @@ func (c *collector) extractBOMWithTrivy(ctx context.Context, storedImage *worklo
 
 	ch := make(chan sbom.ScanResult, 1)
 	if err = c.sbomScanner.Scan(scanRequest, c.scanOptions, ch); err != nil {
+		log.Errorf("Failed to trigger SBOM generation for containerd: %s", err)
 		return err
 	}
 
@@ -98,6 +99,11 @@ func (c *collector) extractBOMWithTrivy(ctx context.Context, storedImage *worklo
 		select {
 		case <-ctx.Done():
 		case result := <-ch:
+			if result.Error != nil {
+				log.Errorf("Failed to generate SBOM for containerd: %s", result.Error)
+				return
+			}
+
 			bom, err := result.Report.ToCycloneDX()
 			if err != nil {
 				log.Errorf("Failed to extract SBOM from report")


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

The introduction of the SBOM scanner broke a few things:
- SBOM failed to be generated for container root filesystems due to the use of slow walking
- Channels were not properly closed
- Errors during scans were not always properly handled

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
