### PR TITLE
Fix dynamic secrets scrubbing in flare

### DIFF
--- a/pkg/util/scrubber/default_test.go
+++ b/pkg/util/scrubber/default_test.go
@@ -440,18 +440,29 @@ other_config_with_list: [abc]
 		`privacy_key: "********"`)
 }
 
-func TestYamlConfig(t *testing.T) {
+func TestAddStrippedKeys(t *testing.T) {
 	contents := `foobar: baz`
 	cleaned, err := ScrubBytes([]byte(contents))
-	assert.Nil(t, err)
-	cleanedString := string(cleaned)
+	require.Nil(t, err)
 
 	// Sanity check
-	assert.Equal(t, contents, cleanedString)
+	assert.Equal(t, contents, string(cleaned))
 
 	AddStrippedKeys([]string{"foobar"})
 
 	assertClean(t, contents, `foobar: "********"`)
+}
+
+func TestAddStrippedKeysNewReplacer(t *testing.T) {
+	contents := `foobar: baz`
+	AddStrippedKeys([]string{"foobar"})
+
+	newScrubber := New()
+	AddDefaultReplacers(newScrubber)
+
+	cleaned, err := newScrubber.ScrubBytes([]byte(contents))
+	require.Nil(t, err)
+	assert.Equal(t, strings.TrimSpace(`foobar: "********"`), strings.TrimSpace(string(cleaned)))
 }
 
 func TestCertConfig(t *testing.T) {

--- a/pkg/util/scrubber/scrubber.go
+++ b/pkg/util/scrubber/scrubber.go
@@ -69,7 +69,8 @@ var blankRegex = regexp.MustCompile(`^\s*$`)
 //
 // It then applies all MultiLine replacers to the entire text of the input.
 type Scrubber struct {
-	singleLineReplacers, multiLineReplacers []Replacer
+	singleLineReplacers []Replacer
+	multiLineReplacers  []Replacer
 }
 
 // New creates a new scrubber with no replacers installed.


### PR DESCRIPTION
### What does this PR do?

The flare now request a new scubber each time. We need to propagate the dynamic replacers from secrets and config.

### Describe how to test/QA your changes

Add secrets to the configuration and create a flare. Then check that those secrets were correctly scrubbed from the runtime configuration dump.