### PR TITLE
[CWS] Use admission controller to get container tags at container startup

### DIFF
--- a/Dockerfiles/cluster-agent/Dockerfile
+++ b/Dockerfiles/cluster-agent/Dockerfile
@@ -11,6 +11,9 @@ LABEL org.opencontainers.image.source "https://github.com/DataDog/datadog-agent"
 
 WORKDIR /output
 
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt update && apt install --no-install-recommends -y gcc libc6-dev libseccomp-dev
+
 COPY datadog-cluster-agent.$TARGETARCH opt/datadog-agent/bin/datadog-cluster-agent
 COPY --chmod=644 ./conf.d etc/datadog-agent/conf.d
 COPY ./datadog-cluster.yaml etc/datadog-agent/datadog-cluster.yaml
@@ -29,8 +32,6 @@ RUN chmod 755 entrypoint.sh \
 FROM builder AS nosys-seccomp
 COPY nosys-seccomp/nosys.c   /tmp/nosys.c
 COPY nosys-seccomp/nosys.sym /tmp/nosys.sym
-ENV DEBIAN_FRONTEND=noninteractive
-RUN apt update && apt install --no-install-recommends -y gcc libc6-dev libseccomp-dev
 RUN gcc -pipe -Wall -Wextra -O2 -shared -fPIC -Wl,--version-script=/tmp/nosys.sym -o /tmp/nosys.so /tmp/nosys.c -lseccomp
 
 ####################################

--- a/pkg/clusteragent/admission/mutate/auto_instrumentation.go
+++ b/pkg/clusteragent/admission/mutate/auto_instrumentation.go
@@ -433,7 +433,7 @@ func injectLibConfig(pod *corev1.Pod, lang language) error {
 		return fmt.Errorf("invalid json config in annotation %s=%s: %w", configAnnotKey, confString, err)
 	}
 	for _, env := range libConfig.ToEnvs() {
-		_ = injectEnv(pod, env)
+		_ = injectEnvIntoPod(pod, env)
 	}
 
 	return nil

--- a/pkg/clusteragent/admission/mutate/common.go
+++ b/pkg/clusteragent/admission/mutate/common.go
@@ -67,29 +67,35 @@ func envIndex(envs []corev1.EnvVar, name string) int {
 	return -1
 }
 
-// injectEnv injects an env var into a pod template if it doesn't exist
-func injectEnv(pod *corev1.Pod, env corev1.EnvVar) bool {
+func injectEnvIntoContainer(container *corev1.Container, env corev1.EnvVar) bool {
+	if contains(container.Env, env.Name) {
+		return false
+	}
+
+	// prepend rather than append so that our new vars precede container vars in the final list, so that they
+	// can be referenced in other env vars downstream.  (see:  Kubernetes dependent environment variables.)
+	container.Env = append([]corev1.EnvVar{env}, container.Env...)
+	return true
+
+}
+
+// injectEnvIntoPod injects an env var into a pod template if it doesn't exist
+func injectEnvIntoPod(pod *corev1.Pod, env corev1.EnvVar) bool {
 	injected := false
 	podStr := podString(pod)
 	log.Debugf("Injecting env var '%s' into pod %s", env.Name, podStr)
 	for i, ctr := range pod.Spec.Containers {
-		if contains(ctr.Env, env.Name) {
+		if !injectEnvIntoContainer(&pod.Spec.Containers[i], env) {
 			log.Debugf("Ignoring container '%s' in pod %s: env var '%s' already exist", ctr.Name, podStr, env.Name)
 			continue
 		}
-		// prepend rather than append so that our new vars precede container vars in the final list, so that they
-		// can be referenced in other env vars downstream.  (see:  Kubernetes dependent environment variables.)
-		pod.Spec.Containers[i].Env = append([]corev1.EnvVar{env}, pod.Spec.Containers[i].Env...)
 		injected = true
 	}
 	for i, ctr := range pod.Spec.InitContainers {
-		if contains(ctr.Env, env.Name) {
+		if !injectEnvIntoContainer(&pod.Spec.InitContainers[i], env) {
 			log.Debugf("Ignoring init container '%s' in pod %s: env var '%s' already exist", ctr.Name, podStr, env.Name)
 			continue
 		}
-		// prepend rather than append so that our new vars precede container vars in the final list, so that they
-		// can be referenced in other env vars downstream.  (see:  Kubernetes dependent environment variables.)
-		pod.Spec.InitContainers[i].Env = append([]corev1.EnvVar{env}, pod.Spec.InitContainers[i].Env...)
 		injected = true
 	}
 	return injected

--- a/pkg/clusteragent/admission/mutate/common_test.go
+++ b/pkg/clusteragent/admission/mutate/common_test.go
@@ -141,7 +141,7 @@ func Test_injectEnv(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := injectEnv(tt.args.pod, tt.args.env)
+			got := injectEnvIntoPod(tt.args.pod, tt.args.env)
 			if got != tt.injected {
 				t.Errorf("injectEnv() = %v, want %v", got, tt.injected)
 			}

--- a/pkg/clusteragent/admission/mutate/config.go
+++ b/pkg/clusteragent/admission/mutate/config.go
@@ -100,21 +100,21 @@ func injectConfig(pod *corev1.Pod, _ string, _ dynamic.Interface) error {
 	mode := injectionMode(pod, config.Datadog.GetString("admission_controller.inject_config.mode"))
 	switch mode {
 	case hostIP:
-		injectedConfig = injectEnv(pod, agentHostIPEnvVar)
+		injectedConfig = injectEnvIntoPod(pod, agentHostIPEnvVar)
 	case service:
-		injectedConfig = injectEnv(pod, agentHostServiceEnvVar)
+		injectedConfig = injectEnvIntoPod(pod, agentHostServiceEnvVar)
 	case socket:
 		volume, volumeMount := buildVolume(datadogVolumeName, config.Datadog.GetString("admission_controller.inject_config.socket_path"), true)
 		injectedVol := injectVolume(pod, volume, volumeMount)
-		injectedEnv := injectEnv(pod, traceURLSocketEnvVar)
-		injectedEnv = injectEnv(pod, dogstatsdURLSocketEnvVar) || injectedEnv
+		injectedEnv := injectEnvIntoPod(pod, traceURLSocketEnvVar)
+		injectedEnv = injectEnvIntoPod(pod, dogstatsdURLSocketEnvVar) || injectedEnv
 		injectedConfig = injectedEnv || injectedVol
 	default:
 		metrics.MutationErrors.Inc(metrics.ConfigMutationType, "unknown mode")
 		return fmt.Errorf("invalid injection mode %q", mode)
 	}
 
-	injectedEntity = injectEnv(pod, ddEntityIDEnvVar)
+	injectedEntity = injectEnvIntoPod(pod, ddEntityIDEnvVar)
 
 	return nil
 }

--- a/pkg/clusteragent/admission/mutate/tags.go
+++ b/pkg/clusteragent/admission/mutate/tags.go
@@ -144,7 +144,7 @@ func injectTagsFromLabels(labels map[string]string, pod *corev1.Pod) (bool, bool
 		injectTag(l, envName)
 	}
 
-	if config.Datadog.GetBool("admission_controller.inject_tags.workload_tags") {
+	if config.Datadog.GetBool("admission_controller.inject_tags.workload_context") {
 		for _, entry := range labelsToWorkloadEnv {
 			l, envName := entry[0], entry[1]
 			injectTag(l, envName)

--- a/pkg/clusteragent/admission/mutate/tags.go
+++ b/pkg/clusteragent/admission/mutate/tags.go
@@ -38,7 +38,6 @@ var labelsToEnv = map[string]string{
 }
 
 var labelsToWorkloadEnv = [][2]string{
-	{kubernetes.EnvTagLabelKey, "DD_WORKLOAD_ENV"},
 	{kubernetes.ServiceTagLabelKey, "DD_WORKLOAD_SERVICE"},
 	{kubernetes.KubeAppNameLabelKey, "DD_WORKLOAD_SERVICE"},
 	{kubernetes.VersionTagLabelKey, "DD_WORKLOAD_VERSION"},

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1042,7 +1042,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("admission_controller.inject_config.trace_agent_socket", "unix:///var/run/datadog/apm.socket")
 	config.BindEnvAndSetDefault("admission_controller.inject_config.dogstatsd_socket", "unix:///var/run/datadog/dsd.socket")
 	config.BindEnvAndSetDefault("admission_controller.inject_tags.enabled", true)
-	config.BindEnvAndSetDefault("admission_controller.inject_tags.workload_tags", false)
+	config.BindEnvAndSetDefault("admission_controller.inject_tags.workload_context", false)
 	config.BindEnvAndSetDefault("admission_controller.inject_tags.endpoint", "/injecttags")
 	config.BindEnvAndSetDefault("admission_controller.pod_owners_cache_validity", 10) // in minutes
 	config.BindEnvAndSetDefault("admission_controller.namespace_selector_fallback", false)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1042,6 +1042,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("admission_controller.inject_config.trace_agent_socket", "unix:///var/run/datadog/apm.socket")
 	config.BindEnvAndSetDefault("admission_controller.inject_config.dogstatsd_socket", "unix:///var/run/datadog/dsd.socket")
 	config.BindEnvAndSetDefault("admission_controller.inject_tags.enabled", true)
+	config.BindEnvAndSetDefault("admission_controller.inject_tags.workload_tags", false)
 	config.BindEnvAndSetDefault("admission_controller.inject_tags.endpoint", "/injecttags")
 	config.BindEnvAndSetDefault("admission_controller.pod_owners_cache_validity", 10) // in minutes
 	config.BindEnvAndSetDefault("admission_controller.namespace_selector_fallback", false)

--- a/pkg/security/probe/field_handlers_linux.go
+++ b/pkg/security/probe/field_handlers_linux.go
@@ -8,6 +8,7 @@
 package probe
 
 import (
+	"fmt"
 	"path"
 	"sort"
 	"strings"
@@ -19,6 +20,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/resolvers"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/args"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+	"github.com/DataDog/datadog-agent/pkg/tagger/utils"
 )
 
 type FieldHandlers struct {
@@ -151,11 +153,37 @@ func (fh *FieldHandlers) ResolveContainerCreatedAt(ev *model.Event, e *model.Con
 	return int(e.CreatedAt)
 }
 
+func (fh *FieldHandlers) resolveContainerEnvTags(ev *model.Event, e *model.ContainerContext) {
+	if !e.EnvTagsResolved {
+		envp := fh.ResolveProcessEnvp(ev, &ev.ProcessContext.Process)
+		for _, env := range envp {
+			if split := strings.SplitN(env, "=", 2); len(split) > 1 {
+				if containerTagKey, found := workloadLabelsAsEnvVars[split[0]]; found {
+					containerTag := fmt.Sprintf("%s:%s", containerTagKey, split[1])
+					e.Tags = append(e.Tags, containerTag)
+				}
+			}
+		}
+		e.EnvTagsResolved = true
+	}
+}
+
+func (fh *FieldHandlers) resolveContainerRemoteTags(ev *model.Event, e *model.ContainerContext) {
+	if !e.RemoteTagsResolved {
+		if remoteTags := fh.resolvers.TagsResolver.Resolve(e.ID); len(remoteTags) > 0 {
+			e.Tags = utils.ConcatenateTags(remoteTags, e.Tags)
+			e.RemoteTagsResolved = true
+		}
+	}
+}
+
 // ResolveContainerTags resolves the container tags of the event
 func (fh *FieldHandlers) ResolveContainerTags(ev *model.Event, e *model.ContainerContext) []string {
-	if len(e.Tags) == 0 && e.ID != "" {
-		e.Tags = fh.resolvers.TagsResolver.Resolve(e.ID)
+	if e.ID != "" {
+		fh.resolveContainerEnvTags(ev, e)
+		fh.resolveContainerRemoteTags(ev, e)
 	}
+
 	return e.Tags
 }
 
@@ -335,7 +363,11 @@ func (fh *FieldHandlers) GetProcessService(ev *model.Event) string {
 
 	// first search in the process context itself
 	if entry.EnvsEntry != nil {
-		if service := entry.EnvsEntry.Get(ServiceEnvVar); service != "" {
+		service := entry.EnvsEntry.Get(ServiceEnvVar)
+		if service == "" {
+			service = entry.EnvsEntry.Get(WorkloadServiceEnvVar)
+		}
+		if service != "" {
 			serviceValues = append(serviceValues, service)
 		}
 	}

--- a/pkg/security/probe/model.go
+++ b/pkg/security/probe/model.go
@@ -18,7 +18,17 @@ import (
 const (
 	// ServiceEnvVar environment variable used to report service
 	ServiceEnvVar = "DD_SERVICE"
+	// WorkloadServiceEnvVar environment variable used to report service when DD_SERVICE is not defined
+	WorkloadServiceEnvVar = "DD_WORKLOAD_SERVICE"
 )
+
+var workloadLabelsAsEnvVars = map[string]string{
+	"DD_WORKLOAD_IMAGE_NAME": "image_name",
+	"DD_WORKLOAD_IMAGE_TAG":  "image_tag",
+	"DD_WORKLOAD_SERVICE":    "service",
+	"DD_WORKLOAD_VERSION":    "version",
+	"DD_WORKLOAD_ENV":        "env",
+}
 
 // NewModel returns a new model with some extra field validation
 func NewModel(probe *Probe) *model.Model {

--- a/pkg/security/probe/model.go
+++ b/pkg/security/probe/model.go
@@ -27,7 +27,6 @@ var workloadLabelsAsEnvVars = map[string]string{
 	"DD_WORKLOAD_IMAGE_TAG":  "image_tag",
 	"DD_WORKLOAD_SERVICE":    "service",
 	"DD_WORKLOAD_VERSION":    "version",
-	"DD_WORKLOAD_ENV":        "env",
 }
 
 // NewModel returns a new model with some extra field validation

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -184,9 +184,11 @@ func (r *Releasable) OnRelease() {
 // ContainerContext holds the container context of an event
 type ContainerContext struct {
 	Releasable
-	ID        string   `field:"id,handler:ResolveContainerID"`                              // SECLDoc[id] Definition:`ID of the container`
-	CreatedAt uint64   `field:"created_at,handler:ResolveContainerCreatedAt"`               // SECLDoc[created_at] Definition:`Timestamp of the creation of the container``
-	Tags      []string `field:"tags,handler:ResolveContainerTags,opts:skip_ad,weight:9999"` // SECLDoc[tags] Definition:`Tags of the container`
+	ID                 string   `field:"id,handler:ResolveContainerID"`                              // SECLDoc[id] Definition:`ID of the container`
+	CreatedAt          uint64   `field:"created_at,handler:ResolveContainerCreatedAt"`               // SECLDoc[created_at] Definition:`Timestamp of the creation of the container``
+	Tags               []string `field:"tags,handler:ResolveContainerTags,opts:skip_ad,weight:9999"` // SECLDoc[tags] Definition:`Tags of the container`
+	EnvTagsResolved    bool     `field:"-" json:"-"`
+	RemoteTagsResolved bool     `field:"-" json:"-"`
 }
 
 type Status uint32

--- a/pkg/security/security_profile/profile/manager.go
+++ b/pkg/security/security_profile/profile/manager.go
@@ -648,7 +648,16 @@ func (m *SecurityProfileManager) LookupEventInProfiles(event *model.Event) {
 		return
 	}
 
-	selector, err := cgroupModel.NewWorkloadSelector(utils.GetTagValue("image_name", event.ContainerContext.Tags), utils.GetTagValue("image_tag", event.ContainerContext.Tags))
+	imageName := utils.GetTagValue("image_name", event.ContainerContext.Tags)
+	if imageName == "" {
+		return
+	}
+	imageTag := utils.GetTagValue("image_tag", event.ContainerContext.Tags)
+	if imageTag == "" {
+		imageTag = "latest"
+	}
+
+	selector, err := cgroupModel.NewWorkloadSelector(imageName, imageTag)
 	if err != nil {
 		return
 	}

--- a/pkg/tagger/collectors/workloadmeta_extract.go
+++ b/pkg/tagger/collectors/workloadmeta_extract.go
@@ -43,9 +43,9 @@ const (
 	tagKeyKubeAppManagedBy = "kube_app_managed_by"
 
 	// Standard tag - Environment variables
-	envVarEnv     = "DD_ENV"
-	envVarVersion = "DD_VERSION"
-	envVarService = "DD_SERVICE"
+	envVarEnv     = kubernetes.EnvTagEnvVar
+	envVarVersion = kubernetes.VersionTagEnvVar
+	envVarService = kubernetes.ServiceTagEnvVar
 
 	// Docker label keys
 	dockerLabelEnv     = "com.datadoghq.tags.env"

--- a/test/e2e/argo-workflows/templates/datadog-agent.yaml
+++ b/test/e2e/argo-workflows/templates/datadog-agent.yaml
@@ -182,7 +182,7 @@ spec:
                 value: {{inputs.parameters.dd-url}}
               - name: DD_ADMISSION_CONTROLLER_INJECT_TAGS_ENABLED
                 value: "true"
-              - name: DD_ADMISSION_CONTROLLER_INJECT_TAGS_WORKLOAD_TAGS
+              - name: DD_ADMISSION_CONTROLLER_INJECT_TAGS_WORKLOAD_CONTEXT
                 value: "true"
           EOF
 

--- a/test/e2e/argo-workflows/templates/datadog-agent.yaml
+++ b/test/e2e/argo-workflows/templates/datadog-agent.yaml
@@ -180,6 +180,10 @@ spec:
                 value: "false"
               - name: DATADOG_HOST
                 value: {{inputs.parameters.dd-url}}
+              - name: DD_ADMISSION_CONTROLLER_INJECT_TAGS_ENABLED
+                value: "true"
+              - name: DD_ADMISSION_CONTROLLER_INJECT_TAGS_WORKLOAD_TAGS
+                value: "true"
           EOF
 
           helm repo add datadog https://helm.datadoghq.com

--- a/test/e2e/cws-tests/tests/lib/kubernetes.py
+++ b/test/e2e/cws-tests/tests/lib/kubernetes.py
@@ -20,6 +20,9 @@ class KubernetesHelper(LogGetter):
         self.namespace = namespace
         self.pod_name = None
 
+    def create_pod(self, body):
+        return self.api_client.create_namespaced_pod(namespace=self.namespace, body=body)
+
     def select_pod_name(self, label_selector):
         resp = self.api_client.list_namespaced_pod(namespace=self.namespace, label_selector=label_selector)
         for i in resp.items:

--- a/test/e2e/cws-tests/tests/test_e2e_cws_kubernetes.py
+++ b/test/e2e/cws-tests/tests/test_e2e_cws_kubernetes.py
@@ -8,6 +8,7 @@ import uuid
 import warnings
 
 import emoji
+from kubernetes import client
 from lib.const import SECURITY_START_LOG, SYS_PROBE_START_LOG
 from lib.cws.app import App
 from lib.cws.policy import PolicyLoader
@@ -174,6 +175,25 @@ class TestE2EKubernetes(unittest.TestCase):
             self.app.wait_for_metric(
                 "datadog.security_agent.runtime.containers_running", host=TestE2EKubernetes.hostname
             )
+
+        with Step(msg="check workload tags are added by the admission controller", emoji=":footprints:"):
+            container = client.V1Container(name="busybox", image="busybox:latest", args=["sleep", "100000"])
+            pod_spec = client.V1PodSpec(containers=[container])
+            pod_metadata = client.V1ObjectMeta(
+                name="test",
+                namespace=self.namespace,
+                labels={
+                    "admission.datadoghq.com/enabled": "true",
+                },
+            )
+            pod_body = client.V1Pod(api_version="v1", kind="Pod", metadata=pod_metadata, spec=pod_spec)
+            pod = self.kubernetes_helper.create_pod(pod_body)
+            self.assertNotEqual(len(pod.spec.containers), 0, "no container found")
+            for container in pod.spec.containers:
+                self.assertIn("DD_WORKLOAD_IMAGE_NAME", [env.name for env in container.env])
+                self.assertIn("DD_WORKLOAD_IMAGE_TAG", [env.name for env in container.env])
+                self.assertIn("busybox", [env.value for env in container.env if env.name == "DD_WORKLOAD_IMAGE_NAME"])
+                self.assertIn("latest", [env.value for env in container.env if env.name == "DD_WORKLOAD_IMAGE_TAG"])
 
         print(emoji.emojize(":heart_on_fire:"), flush=True)
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This PR adds the ability for the admission controller to inject information about the running workload
(such as image name, image tag) as environment variables.

### Motivation

With this PR, the security probe is able to resolve the workload at the first event of it, without having to wait for the tagger to resolve the tags (which can take a few seconds). This allows to apply security profiles at the very beginning of a workload startup.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
