### PR TITLE
[CWS] Simplify the code in the raw_syscalls/sys_enter hook point

### DIFF
--- a/pkg/security/ebpf/c/include/hooks/raw_syscalls.h
+++ b/pkg/security/ebpf/c/include/hooks/raw_syscalls.h
@@ -11,21 +11,22 @@ int sys_enter(struct _tracepoint_raw_syscalls_sys_enter *args) {
     struct syscall_monitor_entry_t zero = {};
     u64 pid_tgid = bpf_get_current_pid_tgid();
     u32 pid = pid_tgid >> 32;
-
     u64 now = bpf_ktime_get_ns();
     struct syscall_monitor_event_t event = {};
-    struct proc_cache_t *proc_cache_entry = fill_process_context(&event.process);
-    fill_container_context(proc_cache_entry, &event.container);
 
     // check if this workload has a security profile
     if (is_anomaly_syscalls_enabled()) {
         evaluate_security_profile_syscalls(args, &event, args->id);
     }
 
-    // check if we are monitoring the syscalls of the current process
-    char comm[TASK_COMM_LEN];
-    bpf_get_current_comm(&comm, TASK_COMM_LEN);
-    if (!should_trace_new_process(args, now, pid, event.container.container_id, comm)) {
+    // are we dumping the syscalls of this process ?
+    struct activity_dump_config *config = lookup_or_delete_traced_pid(pid, now, NULL);
+    if (config) {
+        if (!mask_has_event(config->event_mask, EVENT_SYSCALLS)) {
+            // we're not tracing syscalls, ignore
+            return 0;
+        }
+    } else {
         // we're not tracing this process, ignore
         return 0;
     }
@@ -86,6 +87,9 @@ shoud_send_event:
         entry->last_sent = now;
         entry->dirty = 0;
 
+        struct proc_cache_t *proc_cache_entry = fill_process_context(&event.process);
+        fill_container_context(proc_cache_entry, &event.container);
+
         // remove last_sent and dirty from the event size, we don't care about these fields
         send_event_with_size_ptr(args, EVENT_SYSCALLS, &event, offsetof(struct syscall_monitor_event_t, syscall_data) + SYSCALL_ENCODING_TABLE_SIZE);
     }
@@ -96,9 +100,6 @@ shoud_send_event:
         bpf_probe_read(&entry->syscalls[0], sizeof(entry->syscalls), &zero.syscalls[0]);
         entry->dirty = 1;
         entry->last_sent = now;
-
-        // add execve syscall again
-        entry->syscalls[index & (SYSCALL_ENCODING_TABLE_SIZE - 1)] |= bit;
     }
     key.syscall_key = EXIT_SYSCALL_KEY;
     if (is_syscall(&key)) {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR simplifies the amount of checks performed in the raw_syscalls/sys_enter hook point. In some cases, this version will be less powerful at monitoring hook points but overall the performance improvement prevails.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Improve the performance impact of this feature by reducing the amount of work we do at each syscall. With this fix, it might take longer to detect a new workload (we will have to wait for at least a FIM or an exec event), but the performance improvement on the network side of things is worth it.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
