### PR TITLE
[rpm][deb] Fix setting owner on site-packages directories

### DIFF
--- a/omnibus/package-scripts/agent-deb/postinst
+++ b/omnibus/package-scripts/agent-deb/postinst
@@ -9,7 +9,6 @@ LOG_DIR=/var/log/datadog
 CONFIG_DIR=/etc/datadog-agent
 SERVICE_NAME=datadog-agent
 RUN_DIR=/opt/datadog-agent/run
-SITE_PACKAGES_DIR="${INSTALL_DIR}/embedded/lib/python*/site-packages"
 
 # If we are inside the Docker container, do nothing
 if [ -n "$DOCKER_DD_AGENT" ]; then
@@ -77,7 +76,8 @@ find ${CONFIG_DIR} -type f -not -path ${CONFIG_DIR}/conf.d -exec chmod 640 {} \;
 # Allow write access to dd-agent for integration installation
 find ${CONFIG_DIR}/conf.d -type d -exec chmod 3775 {} \;
 find ${CONFIG_DIR}/conf.d -type f -exec chmod 660 {} \;
-chown -R dd-agent:dd-agent "${SITE_PACKAGES_DIR}" || true
+# Glob characters like "*" can't be used inside quotes, so we only quote the variable
+chown -R dd-agent:dd-agent "${INSTALL_DIR}"/embedded/lib/python*/site-packages || true
 
 # This is done to allow integrations to install their binaries
 chown -R root:dd-agent ${INSTALL_DIR}/embedded/bin

--- a/omnibus/package-scripts/agent-rpm/postinst
+++ b/omnibus/package-scripts/agent-rpm/postinst
@@ -9,7 +9,6 @@ INSTALL_DIR=/opt/datadog-agent
 LOG_DIR=/var/log/datadog
 CONFIG_DIR=/etc/datadog-agent
 RUN_DIR=/opt/datadog-agent/run
-SITE_PACKAGES_DIR="${INSTALL_DIR}/embedded/lib/python*/site-packages"
 
 # Set proper rights to the dd-agent user and group
 chown -R root:dd-agent ${CONFIG_DIR}
@@ -21,7 +20,8 @@ find ${CONFIG_DIR} -type f -not -path ${CONFIG_DIR}/conf.d -exec chmod 640 {} \;
 # Allow write access to dd-agent for integration installation
 find ${CONFIG_DIR}/conf.d -type d -exec chmod 3775 {} \;
 find ${CONFIG_DIR}/conf.d -type f -exec chmod 660 {} \;
-chown -R dd-agent:dd-agent "${SITE_PACKAGES_DIR}" || true
+# Glob characters like "*" can't be used inside quotes, so we only quote the variable
+chown -R dd-agent:dd-agent "${INSTALL_DIR}"/embedded/lib/python*/site-packages || true
 
 # This is done to allow integrations to install their binaries
 chown -R root:dd-agent ${INSTALL_DIR}/embedded/bin


### PR DESCRIPTION
### What does this PR do?

As noted in the code comment: Glob characters like "*" can't be used inside quotes, so we only quote the variable in the globbed path. We also remove usage of the `SITE_PACKAGES_DIR` variable, because it feels counter-intuitive to have a variable that can't be used with quotes (plus, it's used in one place only).

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
