### PR TITLE
Send `agent_checks` payload 1 min after startup

### DIFF
--- a/pkg/collector/metadata/agentchecks.go
+++ b/pkg/collector/metadata/agentchecks.go
@@ -8,6 +8,7 @@ package metadata
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/metadata/agentchecks"
 	md "github.com/DataDog/datadog-agent/pkg/metadata"
@@ -25,6 +26,11 @@ func (hp *AgentChecksCollector) Send(ctx context.Context, s serializer.MetricSer
 		return fmt.Errorf("unable to submit agentchecks metadata payload, %s", err)
 	}
 	return nil
+}
+
+// FirstRunInterval returns the Interval after which to send the first payload
+func (hp *AgentChecksCollector) FirstRunInterval() time.Duration {
+	return 1 * time.Minute
 }
 
 func init() {

--- a/pkg/metadata/helper.go
+++ b/pkg/metadata/helper.go
@@ -20,7 +20,8 @@ const (
 	// run the host metadata collector interval can be set through configuration within acceptable bounds
 	hostMetadataCollectorMinInterval = 300   // 5min minimum
 	hostMetadataCollectorMaxInterval = 14400 // 4h maximum
-	// run the agent checks metadata collector every 600 seconds (10 minutes)
+	// run the Agent checks metadata collector every 600 seconds (10 minutes). AgentChecksCollector implements the
+	// CollectorWithFirstRun and will send its first payload after a minute.
 	agentChecksMetadataCollectorInterval = 600
 	// run the resources metadata collector every 300 seconds (5 minutes) by default, configurable
 	resourcesMetadataCollectorInterval = 300

--- a/pkg/metadata/scheduler.go
+++ b/pkg/metadata/scheduler.go
@@ -80,8 +80,13 @@ func (c *Scheduler) AddCollector(name string, interval time.Duration) error {
 		return fmt.Errorf("Unable to find metadata collector: %s", name)
 	}
 
+	firstInterval := interval
+	if withFirstRun, ok := p.(CollectorWithFirstRun); ok {
+		firstInterval = withFirstRun.FirstRunInterval()
+	}
+
 	sc := &scheduledCollector{
-		sendTimer:    newTimer(interval),
+		sendTimer:    newTimer(firstInterval),
 		healthHandle: health.RegisterLiveness("metadata-" + name),
 	}
 

--- a/pkg/metadata/types.go
+++ b/pkg/metadata/types.go
@@ -7,6 +7,7 @@ package metadata
 
 import (
 	"context"
+	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/serializer"
 )
@@ -18,9 +19,17 @@ type Collector interface {
 	Send(ctx context.Context, s serializer.MetricSerializer) error
 }
 
-// CollectorWithInit is an optional interface that collectors that need to be
+// CollectorWithInit is an optional interface for collectors that need to be
 // initialized can implement. If implemented, the Init method will be called
 // when the collector is scheduled
 type CollectorWithInit interface {
 	Init() error
+}
+
+// CollectorWithFirstRun is an optional interface for collectors that want to send their first payload after a different
+// interval. This allows collectors to send a payload shortly after the Agent starts.
+type CollectorWithFirstRun interface {
+	// FirstRunInterval returns the interval after which to send the first payload. This allows the collector to
+	// send a payload shortly after Agent startup.
+	FirstRunInterval() time.Duration
 }

--- a/releasenotes/notes/agent-check-at-startup-06a1df7080bc9c2a.yaml
+++ b/releasenotes/notes/agent-check-at-startup-06a1df7080bc9c2a.yaml
@@ -1,0 +1,7 @@
+---
+enhancements:
+  - |
+    The metadata payload containing the status of every integration run by the Agent is now sent one minute after startup
+    and then every ten minutes after that, as before. This means that the integration status will be visible in the app one
+    minute after the Agent starts instead of ten minutes. The payload waits for a minute so the Agent has time to run every configured
+    integration twice and collect an accurate status.


### PR DESCRIPTION
### What does this PR do?

The `agent_checks` payload contains the status of every checks run by the agent. It's sent every 10 min. We no longer wait 10 min for the first payload to be sent. Instead we send the first payload after 1 min and every 10 min after that.

### Describe how to test/QA your changes

Start the Agent and check that the `agent_check` payload is send after a minute and every 10min after that.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
