### PR TITLE
Disable `SBOM` collection when running `agent check` command.

### DIFF
--- a/pkg/cli/subcommands/check/command.go
+++ b/pkg/cli/subcommands/check/command.go
@@ -182,7 +182,9 @@ func run(log log.Component, config config.Component, sysprobeconfig sysprobeconf
 
 	// Always disable SBOM collection in `check` command to avoid BoltDB flock issue
 	// and consuming CPU & Memory for asynchronous scans that would not be shown in `agent check` output.
+	pkgconfig.Datadog.Set("sbom.enabled", "false")
 	pkgconfig.Datadog.Set("container_image_collection.sbom.enabled", "false")
+	pkgconfig.Datadog.Set("runtime_security_config.sbom.enabled", "false")
 
 	hostnameDetected, err := hostname.Get(context.TODO())
 	if err != nil {


### PR DESCRIPTION
### What does this PR do?

Disable `SBOM` collection when running `agent check` command.

### Motivation

* SBOM collection relies on Bolt DB which get a `flock` on its data file. So, if a running daemon agent has already taken the `flock`, the `agent check` process will wait for it forever.
* SBOM collection happens in the background. It is very I/O and CPU intensive. As it is not needed for `agent check` execution, let’s save some resources.

Here is where `agent check` gets stuck:
```
  Goroutine 1 - User: .usr/lib/go-1.19/src/runtime/time.go:195 time.Sleep (0x245f805) [sleep]
         0  0x000000000242f95d in runtime.gopark
             at .usr/lib/go-1.19/src/runtime/proc.go:364
         1  0x000000000245f805 in time.Sleep
             at .usr/lib/go-1.19/src/runtime/time.go:195
         2  0x0000000006107f32 in go.etcd.io/bbolt.flock
             at .home/lenaic/go/pkg/mod/go.etcd.io/bbolt@v1.3.6/bolt_unix.go:42
         3  0x0000000006110f9d in go.etcd.io/bbolt.Open
             at .home/lenaic/go/pkg/mod/go.etcd.io/bbolt@v1.3.6/db.go:230
         4  0x0000000006144f13 in github.com/aquasecurity/trivy/pkg/fanal/cache.NewFSCache
             at .home/lenaic/go/pkg/mod/github.com/!data!dog/trivy@v0.0.0-20230418154509-807f757a8339/pkg/fanal/cache/fs.go:28
         5  0x0000000007b7651e in github.com/DataDog/datadog-agent/pkg/util/trivy.NewBoltCache
             at .home/lenaic/doc/devel/DataDog/datadog-agent/pkg/util/trivy/cache.go:61
         6  0x0000000007b83a4b in github.com/DataDog/datadog-agent/pkg/util/trivy.cacheProvider.func2
             at .home/lenaic/doc/devel/DataDog/datadog-agent/pkg/util/trivy/trivy.go:124
         7  0x0000000007b8475c in github.com/DataDog/datadog-agent/pkg/util/trivy.NewCollector
             at .home/lenaic/doc/devel/DataDog/datadog-agent/pkg/util/trivy/trivy.go:164
         8  0x0000000007b84f45 in github.com/DataDog/datadog-agent/pkg/util/trivy.GetGlobalCollector
             at .home/lenaic/doc/devel/DataDog/datadog-agent/pkg/util/trivy/trivy.go:198
         9  0x0000000007b8b04b in github.com/DataDog/datadog-agent/pkg/sbom/collectors/containerd.(*ContainerdCollector).Init
             at .home/lenaic/doc/devel/DataDog/datadog-agent/pkg/sbom/collectors/containerd/containerd.go:62
        10  0x000000000604dfdd in github.com/DataDog/datadog-agent/pkg/sbom/scanner.CreateGlobalScanner
             at .home/lenaic/doc/devel/DataDog/datadog-agent/pkg/sbom/scanner/scanner.go:186
        11  0x0000000007bdfb31 in github.com/DataDog/datadog-agent/cmd/agent/common.LoadComponents
             at .home/lenaic/doc/devel/DataDog/datadog-agent/cmd/agent/common/loader.go:31
        12  0x0000000008464705 in github.com/DataDog/datadog-agent/pkg/cli/subcommands/check.run
             at .home/lenaic/doc/devel/DataDog/datadog-agent/pkg/cli/subcommands/check/command.go:200
        13  0x00000000024610eb in runtime.call128
             at .usr/lib/go-1.19/src/runtime/asm_amd64.s:727
        14  0x00000000024653fc in runtime.reflectcall
             at <autogenerated>:1
        15  0x00000000024c18b6 in reflect.Value.call
             at .usr/lib/go-1.19/src/reflect/value.go:584
        16  0x00000000024c0a77 in reflect.Value.Call
             at .usr/lib/go-1.19/src/reflect/value.go:368
        17  0x0000000005653136 in github.com/DataDog/datadog-agent/pkg/util/fxutil.(*delayedFxInvocation).call
             at .home/lenaic/doc/devel/DataDog/datadog-agent/pkg/util/fxutil/args.go:72
        18  0x000000000565437e in github.com/DataDog/datadog-agent/pkg/util/fxutil.OneShot
             at .home/lenaic/doc/devel/DataDog/datadog-agent/pkg/util/fxutil/oneshot.go:51
        19  0x000000000846408f in github.com/DataDog/datadog-agent/pkg/cli/subcommands/check.MakeCommand.func1
             at .home/lenaic/doc/devel/DataDog/datadog-agent/pkg/cli/subcommands/check/command.go:112
        20  0x00000000029de6ad in github.com/spf13/cobra.(*Command).execute
             at .home/lenaic/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:940
        (truncated)
```

### Additional Notes

A similar fix was already done in the past in #15327 but it needs to be refreshed following this change: https://github.com/DataDog/datadog-agent/pull/16598/files#diff-da24f9071eda1abf26bffaab595afe3cd3188758a24b25fa109ac285e994df4aR167

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Run the Agent with SBOM collection enabled.
Exec into the Agent container and run `agent check <any check>`, the command should work correctly.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
