### PR TITLE
[CWS] Add an option to configure the max depth of DNS subdomain matching

### DIFF
--- a/pkg/config/system_probe.go
+++ b/pkg/config/system_probe.go
@@ -319,6 +319,7 @@ func InitSystemProbeConfig(cfg Config) {
 	cfg.BindEnvAndSetDefault("runtime_security_config.security_profile.cache_size", 10)
 	cfg.BindEnvAndSetDefault("runtime_security_config.security_profile.max_count", 400)
 	cfg.BindEnvAndSetDefault("runtime_security_config.security_profile.remote_configuration.enabled", true)
+	cfg.BindEnvAndSetDefault("runtime_security_config.security_profile.dns_match_max_depth", 0)
 
 	// CWS - Anomaly detection
 	cfg.BindEnvAndSetDefault("runtime_security_config.security_profile.anomaly_detection.event_types", []string{"exec", "dns"})

--- a/pkg/security/config/config.go
+++ b/pkg/security/config/config.go
@@ -130,6 +130,8 @@ type RuntimeSecurityConfig struct {
 	SecurityProfileMaxCount int
 	// SecurityProfileRCEnabled defines if remote-configuration is enabled
 	SecurityProfileRCEnabled bool
+	// SecurityProfileDNSMatchMaxDepth defines the max depth of subdomain to be matched for DNS anomaly detection (0 to match everything)
+	SecurityProfileDNSMatchMaxDepth int
 
 	// AnomalyDetectionEventTypes defines the list of events that should be allowed to generate anomaly detections
 	AnomalyDetectionEventTypes []model.EventType
@@ -146,7 +148,6 @@ type RuntimeSecurityConfig struct {
 	// AnomalyDetectionWorkloadWarmupPeriod defines the duration we ignore the anomaly detections for
 	// because of workload warm up
 	AnomalyDetectionWorkloadWarmupPeriod time.Duration
-
 	// AnomalyDetectionRateLimiter limit number of anomaly event, one every N second
 	AnomalyDetectionRateLimiter time.Duration
 
@@ -245,12 +246,13 @@ func NewRuntimeSecurityConfig() (*RuntimeSecurityConfig, error) {
 		SBOMResolverWorkloadsCacheSize: coreconfig.SystemProbe.GetInt("runtime_security_config.sbom.workloads_cache_size"),
 
 		// security profiles
-		SecurityProfileEnabled:   coreconfig.SystemProbe.GetBool("runtime_security_config.security_profile.enabled"),
-		SecurityProfileDir:       coreconfig.SystemProbe.GetString("runtime_security_config.security_profile.dir"),
-		SecurityProfileWatchDir:  coreconfig.SystemProbe.GetBool("runtime_security_config.security_profile.watch_dir"),
-		SecurityProfileCacheSize: coreconfig.SystemProbe.GetInt("runtime_security_config.security_profile.cache_size"),
-		SecurityProfileMaxCount:  coreconfig.SystemProbe.GetInt("runtime_security_config.security_profile.max_count"),
-		SecurityProfileRCEnabled: coreconfig.SystemProbe.GetBool("runtime_security_config.security_profile.remote_configuration.enabled"),
+		SecurityProfileEnabled:          coreconfig.SystemProbe.GetBool("runtime_security_config.security_profile.enabled"),
+		SecurityProfileDir:              coreconfig.SystemProbe.GetString("runtime_security_config.security_profile.dir"),
+		SecurityProfileWatchDir:         coreconfig.SystemProbe.GetBool("runtime_security_config.security_profile.watch_dir"),
+		SecurityProfileCacheSize:        coreconfig.SystemProbe.GetInt("runtime_security_config.security_profile.cache_size"),
+		SecurityProfileMaxCount:         coreconfig.SystemProbe.GetInt("runtime_security_config.security_profile.max_count"),
+		SecurityProfileRCEnabled:        coreconfig.SystemProbe.GetBool("runtime_security_config.security_profile.remote_configuration.enabled"),
+		SecurityProfileDNSMatchMaxDepth: coreconfig.SystemProbe.GetInt("runtime_security_config.security_profile.dns_match_max_depth"),
 
 		// anomaly detection
 		AnomalyDetectionEventTypes:                   model.ParseEventTypeStringSlice(coreconfig.SystemProbe.GetStringSlice("runtime_security_config.security_profile.anomaly_detection.event_types")),

--- a/pkg/security/security_profile/activity_tree/activity_tree.go
+++ b/pkg/security/security_profile/activity_tree/activity_tree.go
@@ -84,6 +84,7 @@ type ActivityTree struct {
 
 	treeType          string
 	differentiateArgs bool
+	DNSMatchMaxDepth  int
 
 	validator ActivityTreeOwner
 
@@ -272,7 +273,7 @@ func (at *ActivityTree) insert(event *model.Event, dryRun bool, generationType N
 	case model.FileOpenEventType:
 		return node.InsertFileEvent(&event.Open.File, event, generationType, at.Stats, dryRun), nil
 	case model.DNSEventType:
-		return node.InsertDNSEvent(event, generationType, at.Stats, at.DNSNames, dryRun), nil
+		return node.InsertDNSEvent(event, generationType, at.Stats, at.DNSNames, dryRun, at.DNSMatchMaxDepth), nil
 	case model.BindEventType:
 		return node.InsertBindEvent(event, generationType, at.Stats, dryRun), nil
 	case model.SyscallsEventType:

--- a/pkg/security/security_profile/activity_tree/dns_node.go
+++ b/pkg/security/security_profile/activity_tree/dns_node.go
@@ -7,7 +7,11 @@
 
 package activity_tree
 
-import "github.com/DataDog/datadog-agent/pkg/security/secl/model"
+import (
+	"strings"
+
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+)
 
 // DNSNode is used to store a DNS node
 type DNSNode struct {
@@ -24,4 +28,19 @@ func NewDNSNode(event *model.DNSEvent, rules []*model.MatchedRule, generationTyp
 		GenerationType: generationType,
 		Requests:       []model.DNSEvent{*event},
 	}
+}
+
+func dnsFilterSubdomains(name string, maxDepth int) string {
+	tab := strings.Split(name, ".")
+	if len(tab) < maxDepth {
+		return name
+	}
+	result := ""
+	for i := 0; i < maxDepth; i++ {
+		if result != "" {
+			result = "." + result
+		}
+		result = tab[len(tab)-i-1] + result
+	}
+	return result
 }

--- a/pkg/security/security_profile/activity_tree/process_node.go
+++ b/pkg/security/security_profile/activity_tree/process_node.go
@@ -199,13 +199,10 @@ func (pn *ProcessNode) findDNSNode(DNSName string, DNSMatchMaxDepth int, DNSType
 }
 
 // InsertDNSEvent inserts a DNS event in a process node
-func (pn *ProcessNode) InsertDNSEvent(evt *model.Event, generationType NodeGenerationType, stats *ActivityTreeStats, DNSNames *utils.StringKeys, dryRun bool, DNSMatchMaxDepth int) bool {
+func (pn *ProcessNode) InsertDNSEvent(evt *model.Event, generationType NodeGenerationType, stats *ActivityTreeStats, DNSNames *utils.StringKeys, dryRun bool, dnsMatchMaxDepth int) bool {
 	if dryRun {
 		// Use DNSMatchMaxDepth only when searching for a node, not when trying to insert
-		if pn.findDNSNode(evt.DNS.Name, DNSMatchMaxDepth, evt.DNS.Type) {
-			return false
-		}
-		return true
+		return !pn.findDNSNode(evt.DNS.Name, dnsMatchMaxDepth, evt.DNS.Type)
 	}
 
 	DNSNames.Insert(evt.DNS.Name)
@@ -227,6 +224,7 @@ func (pn *ProcessNode) InsertDNSEvent(evt *model.Event, generationType NodeGener
 	}
 
 	pn.DNSNames[evt.DNS.Name] = NewDNSNode(&evt.DNS, evt.Rules, generationType)
+	stats.DNSNodes++
 	return true
 }
 

--- a/pkg/security/security_profile/activity_tree/process_node.go
+++ b/pkg/security/security_profile/activity_tree/process_node.go
@@ -179,17 +179,40 @@ func (pn *ProcessNode) InsertFileEvent(fileEvent *model.FileEvent, event *model.
 	return true
 }
 
-// InsertDNSEvent inserts a DNS event in a process node
-func (pn *ProcessNode) InsertDNSEvent(evt *model.Event, generationType NodeGenerationType, stats *ActivityTreeStats, DNSNames *utils.StringKeys, dryRun bool) bool {
-	if !dryRun {
-		DNSNames.Insert(evt.DNS.Name)
+func (pn *ProcessNode) findDNSNode(DNSName string, DNSMatchMaxDepth int, DNSType uint16) bool {
+	if DNSMatchMaxDepth == 0 {
+		_, ok := pn.DNSNames[DNSName]
+		return ok
 	}
 
-	if dnsNode, ok := pn.DNSNames[evt.DNS.Name]; ok {
-		// update matched rules
-		if !dryRun {
-			dnsNode.MatchedRules = model.AppendMatchedRule(dnsNode.MatchedRules, evt.Rules)
+	toSearch := dnsFilterSubdomains(DNSName, DNSMatchMaxDepth)
+	for name, dnsNode := range pn.DNSNames {
+		if dnsFilterSubdomains(name, DNSMatchMaxDepth) == toSearch {
+			for _, req := range dnsNode.Requests {
+				if req.Type == DNSType {
+					return true
+				}
+			}
 		}
+	}
+	return false
+}
+
+// InsertDNSEvent inserts a DNS event in a process node
+func (pn *ProcessNode) InsertDNSEvent(evt *model.Event, generationType NodeGenerationType, stats *ActivityTreeStats, DNSNames *utils.StringKeys, dryRun bool, DNSMatchMaxDepth int) bool {
+	if dryRun {
+		// Use DNSMatchMaxDepth only when searching for a node, not when trying to insert
+		if pn.findDNSNode(evt.DNS.Name, DNSMatchMaxDepth, evt.DNS.Type) {
+			return false
+		}
+		return true
+	}
+
+	DNSNames.Insert(evt.DNS.Name)
+	dnsNode, ok := pn.DNSNames[evt.DNS.Name]
+	if ok {
+		// update matched rules
+		dnsNode.MatchedRules = model.AppendMatchedRule(dnsNode.MatchedRules, evt.Rules)
 
 		// look for the DNS request type
 		for _, req := range dnsNode.Requests {
@@ -198,17 +221,12 @@ func (pn *ProcessNode) InsertDNSEvent(evt *model.Event, generationType NodeGener
 			}
 		}
 
-		if !dryRun {
-			// insert the new request
-			dnsNode.Requests = append(dnsNode.Requests, evt.DNS)
-		}
+		// insert the new request
+		dnsNode.Requests = append(dnsNode.Requests, evt.DNS)
 		return true
 	}
 
-	if !dryRun {
-		pn.DNSNames[evt.DNS.Name] = NewDNSNode(&evt.DNS, evt.Rules, generationType)
-		stats.DNSNodes++
-	}
+	pn.DNSNames[evt.DNS.Name] = NewDNSNode(&evt.DNS, evt.Rules, generationType)
 	return true
 }
 

--- a/pkg/security/security_profile/profile/manager.go
+++ b/pkg/security/security_profile/profile/manager.go
@@ -436,6 +436,7 @@ func (m *SecurityProfileManager) OnNewProfileEvent(selector cgroupModel.Workload
 
 	// decode the content of the profile
 	ProtoToSecurityProfile(profile, newProfile)
+	profile.ActivityTree.DNSMatchMaxDepth = m.config.RuntimeSecurity.SecurityProfileDNSMatchMaxDepth
 
 	// compute activity tree initial stats
 	profile.ActivityTree.ComputeActivityTreeStats()


### PR DESCRIPTION
### What does this PR do?

Add an option `runtime_security_config.security_profile.dns_match_max_depth` to tune the way we compare dns requests for anomaly detection. By disabled (with value 0). If value N > 0, we will compare only the first N (sub)domains.
Ex: with a config set to 2, and a DNS request for: `foo.bar.baz.org`, we will match all DNS nodes finishing by `baz.org`.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
