### PR TITLE
[Orchestrator] Check node collector if cluster collector is activated

### DIFF
--- a/pkg/collector/corechecks/cluster/orchestrator/collector_bundle.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collector_bundle.go
@@ -171,13 +171,6 @@ func (cb *CollectorBundle) addCollectorFromConfig(collectorName string, isCRD bo
 
 	cb.activatedCollectors[collector.Metadata().FullName()] = struct{}{}
 	cb.collectors = append(cb.collectors, collector)
-
-	// Enable the cluster collector when the node resource is discovered.
-	if collector.Metadata().NodeType == orchestrator.K8sNode {
-		clusterCollector, _ := cb.inventory.CollectorForDefaultVersion("clusters")
-		cb.collectors = append(cb.collectors, clusterCollector)
-		cb.activatedCollectors[clusterCollector.Metadata().FullName()] = struct{}{}
-	}
 }
 
 // importCollectorsFromCheckConfig tries to fill the bundle with the list of
@@ -188,9 +181,6 @@ func (cb *CollectorBundle) importCollectorsFromCheckConfig() bool {
 		return false
 	}
 	for _, c := range cb.check.instance.Collectors {
-		if c == "clusters" {
-			continue
-		}
 		cb.addCollectorFromConfig(c, false)
 	}
 	return true

--- a/pkg/collector/corechecks/cluster/orchestrator/collector_bundle.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collector_bundle.go
@@ -171,6 +171,13 @@ func (cb *CollectorBundle) addCollectorFromConfig(collectorName string, isCRD bo
 
 	cb.activatedCollectors[collector.Metadata().FullName()] = struct{}{}
 	cb.collectors = append(cb.collectors, collector)
+
+	// Enable the cluster collector when the node resource is discovered.
+	if collector.Metadata().NodeType == orchestrator.K8sNode {
+		clusterCollector, _ := cb.inventory.CollectorForDefaultVersion("clusters")
+		cb.collectors = append(cb.collectors, clusterCollector)
+		cb.activatedCollectors[clusterCollector.Metadata().FullName()] = struct{}{}
+	}
 }
 
 // importCollectorsFromCheckConfig tries to fill the bundle with the list of
@@ -181,6 +188,9 @@ func (cb *CollectorBundle) importCollectorsFromCheckConfig() bool {
 		return false
 	}
 	for _, c := range cb.check.instance.Collectors {
+		if c == "clusters" {
+			continue
+		}
 		cb.addCollectorFromConfig(c, false)
 	}
 	return true

--- a/pkg/collector/corechecks/cluster/orchestrator/discovery/collector_discovery_crd.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/discovery/collector_discovery_crd.go
@@ -106,6 +106,9 @@ func (d *DiscoveryCollector) DiscoverRegularResource(resource string, groupVersi
 	if err != nil {
 		return nil, err
 	}
+	if resource == "clusters" {
+		return d.isSupportClusterCollector(collector, collectorInventory)
+	}
 
 	return d.isSupportCollector(collector)
 }
@@ -118,4 +121,17 @@ func (d *DiscoveryCollector) isSupportCollector(collector collectors.Collector) 
 		return collector, nil
 	}
 	return nil, fmt.Errorf("failed to discover resource %s", collector.Metadata().Name)
+}
+
+func (d *DiscoveryCollector) isSupportClusterCollector(collector collectors.Collector, collectorInventory *inventory.CollectorInventory) (collectors.Collector, error) {
+	nodeCollector, err := collectorInventory.CollectorForDefaultVersion("nodes")
+	if err != nil {
+		return nil, fmt.Errorf("failed to discover cluster resource %w", err)
+	}
+	_, err = d.isSupportCollector(nodeCollector)
+	if err != nil {
+		return nil, fmt.Errorf("failed to discover resource %s", collector.Metadata().Name)
+	}
+	return collector, nil
+
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
Fix https://github.com/DataDog/datadog-agent/pull/16073 which can cause 
```
2023-04-20 13:04:01 UTC | CLUSTER | WARN | (pkg/collector/corechecks/checkbase.go:162 in Warnf) | Unsupported collector: clusters

```

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
