### PR TITLE
Adding timeout to the health command

### DIFF
--- a/pkg/api/util/doget.go
+++ b/pkg/api/util/doget.go
@@ -6,6 +6,7 @@
 package util
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"io"
@@ -40,7 +41,12 @@ func GetClient(verify bool) *http.Client {
 
 // DoGet is a wrapper around performing HTTP GET requests
 func DoGet(c *http.Client, url string, conn ShouldCloseConnection) (body []byte, e error) {
-	req, e := http.NewRequest("GET", url, nil)
+	return DoGetWithContext(context.Background(), c, url, conn)
+}
+
+// DoGetWithContext is a wrapper around performing HTTP GET requests
+func DoGetWithContext(ctx context.Context, c *http.Client, url string, conn ShouldCloseConnection) (body []byte, e error) {
+	req, e := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if e != nil {
 		return body, e
 	}
@@ -63,7 +69,6 @@ func DoGet(c *http.Client, url string, conn ShouldCloseConnection) (body []byte,
 		return body, fmt.Errorf("%s", body)
 	}
 	return body, nil
-
 }
 
 // DoPost is a wrapper around performing HTTP POST requests

--- a/releasenotes/notes/add-timeout-health-check-178f2e885af7880b.yaml
+++ b/releasenotes/notes/add-timeout-health-check-178f2e885af7880b.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    The ``health`` command from the Agent and Cluster Agent now have a configurable timeout (60 second by default).


### PR DESCRIPTION
### What does this PR do?

Adding timeout to the health command

Fixes: https://github.com/DataDog/datadog-agent/issues/16267

### Describe how to test/QA your changes

Check that the Agent and Cluster Agent `health` command are still working.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
