### PR TITLE
Remove duplicated Logger and Config name in Agent cmd

### DIFF
--- a/cmd/agent/command/command.go
+++ b/cmd/agent/command/command.go
@@ -10,8 +10,16 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/DataDog/datadog-agent/comp/core"
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/log"
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
+)
+
+const (
+	ConfigName = "datadog"
+	LoggerName = "CORE"
 )
 
 // GlobalParams contains the values of agent-global Cobra flags.
@@ -30,6 +38,14 @@ type GlobalParams struct {
 
 // SubcommandFactory is a callable that will return a slice of subcommands.
 type SubcommandFactory func(globalParams *GlobalParams) []*cobra.Command
+
+// GetDefaultCoreBundleParams returns the default params for the Core Bundle (config loaded from the "datadog" file,
+// without secrets and logger disabled).
+func GetDefaultCoreBundleParams(globalParams *GlobalParams) core.BundleParams {
+	return core.BundleParams{
+		ConfigParams: config.NewAgentParamsWithoutSecrets(globalParams.ConfFilePath),
+		LogParams:    log.LogForOneShot(LoggerName, "off", true)}
+}
 
 // MakeCommand makes the top-level Cobra command for this app.
 func MakeCommand(subcommandFactories []SubcommandFactory) *cobra.Command {

--- a/cmd/agent/subcommands/check/command.go
+++ b/cmd/agent/subcommands/check/command.go
@@ -19,8 +19,8 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		return check.GlobalParams{
 			ConfFilePath:         globalParams.ConfFilePath,
 			SysProbeConfFilePath: globalParams.SysProbeConfFilePath,
-			ConfigName:           "datadog",
-			LoggerName:           "CORE",
+			ConfigName:           command.ConfigName,
+			LoggerName:           command.LoggerName,
 		}
 	})
 

--- a/cmd/agent/subcommands/closedsourceconsent/command.go
+++ b/cmd/agent/subcommands/closedsourceconsent/command.go
@@ -21,8 +21,8 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 	cmd := consentcmd.MakeCommand(func() consentcmd.GlobalParams {
 		return consentcmd.GlobalParams{
 			ConfFilePath: globalParams.ConfFilePath,
-			ConfigName:   "datadog",
-			LoggerName:   "CORE",
+			ConfigName:   command.ConfigName,
+			LoggerName:   command.LoggerName,
 		}
 	})
 

--- a/cmd/agent/subcommands/config/command.go
+++ b/cmd/agent/subcommands/config/command.go
@@ -19,8 +19,8 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 	cmd := configcmd.MakeCommand(func() configcmd.GlobalParams {
 		return configcmd.GlobalParams{
 			ConfFilePath:   globalParams.ConfFilePath,
-			ConfigName:     "datadog",
-			LoggerName:     "CORE",
+			ConfigName:     command.ConfigName,
+			LoggerName:     command.LoggerName,
 			SettingsClient: common.NewSettingsClient,
 		}
 	})

--- a/cmd/agent/subcommands/diagnose/command.go
+++ b/cmd/agent/subcommands/diagnose/command.go
@@ -56,7 +56,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
 					ConfigParams: config.NewAgentParamsWithoutSecrets(globalParams.ConfFilePath),
-					LogParams:    log.LogForOneShot("CORE", "info", true)}),
+					LogParams:    log.LogForOneShot(command.LoggerName, "info", true)}),
 				core.Bundle,
 			)
 		},
@@ -71,7 +71,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
 					ConfigParams: config.NewAgentParamsWithoutSecrets(globalParams.ConfFilePath),
-					LogParams:    log.LogForOneShot("CORE", "info", true)}),
+					LogParams:    log.LogForOneShot(command.LoggerName, "info", true)}),
 				core.Bundle,
 			)
 		},
@@ -98,9 +98,7 @@ This command print the V5 metadata payload for the Agent. This payload is used t
 			cliParams.payloadName = "v5"
 			return fxutil.OneShot(printPayload,
 				fx.Supply(cliParams),
-				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewAgentParamsWithoutSecrets(globalParams.ConfFilePath),
-					LogParams:    log.LogForOneShot("CORE", "off", true)}),
+				fx.Supply(command.GetDefaultCoreBundleParams(cliParams.GlobalParams)),
 				core.Bundle,
 			)
 		},
@@ -115,9 +113,7 @@ This command print the last Inventory metadata payload sent by the Agent. This p
 			cliParams.payloadName = "inventory"
 			return fxutil.OneShot(printPayload,
 				fx.Supply(cliParams),
-				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewAgentParamsWithoutSecrets(globalParams.ConfFilePath),
-					LogParams:    log.LogForOneShot("CORE", "off", true)}),
+				fx.Supply(command.GetDefaultCoreBundleParams(cliParams.GlobalParams)),
 				core.Bundle,
 			)
 		},

--- a/cmd/agent/subcommands/dogstatsdcapture/command.go
+++ b/cmd/agent/subcommands/dogstatsdcapture/command.go
@@ -58,9 +58,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(dogstatsdCapture,
 				fx.Supply(cliParams),
-				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewAgentParamsWithoutSecrets(globalParams.ConfFilePath),
-					LogParams:    log.LogForOneShot("CORE", "off", true)}),
+				fx.Supply(command.GetDefaultCoreBundleParams(cliParams.GlobalParams)),
 				core.Bundle,
 			)
 		},

--- a/cmd/agent/subcommands/dogstatsdreplay/command.go
+++ b/cmd/agent/subcommands/dogstatsdreplay/command.go
@@ -62,9 +62,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(dogstatsdReplay,
 				fx.Supply(cliParams),
-				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewAgentParamsWithoutSecrets(globalParams.ConfFilePath),
-					LogParams:    log.LogForOneShot("CORE", "off", true)}),
+				fx.Supply(command.GetDefaultCoreBundleParams(cliParams.GlobalParams)),
 				core.Bundle,
 			)
 		},

--- a/cmd/agent/subcommands/dogstatsdstats/command.go
+++ b/cmd/agent/subcommands/dogstatsdstats/command.go
@@ -51,9 +51,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(requestDogstatsdStats,
 				fx.Supply(cliParams),
-				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewAgentParamsWithoutSecrets(globalParams.ConfFilePath),
-					LogParams:    log.LogForOneShot("CORE", "off", true)}),
+				fx.Supply(command.GetDefaultCoreBundleParams(cliParams.GlobalParams)),
 				core.Bundle,
 			)
 		},

--- a/cmd/agent/subcommands/flare/command.go
+++ b/cmd/agent/subcommands/flare/command.go
@@ -76,7 +76,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 				fx.Supply(core.BundleParams{
 					ConfigParams:         config,
 					SysprobeConfigParams: sysprobeconfig.NewParams(sysprobeconfig.WithSysProbeConfFilePath(globalParams.SysProbeConfFilePath)),
-					LogParams:            log.LogForOneShot("CORE", "off", false),
+					LogParams:            log.LogForOneShot(command.LoggerName, "off", false),
 				}),
 				flare.Module,
 				core.Bundle,

--- a/cmd/agent/subcommands/health/command.go
+++ b/cmd/agent/subcommands/health/command.go
@@ -18,8 +18,8 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 	cmd := health.MakeCommand(func() health.GlobalParams {
 		return health.GlobalParams{
 			ConfFilePath: globalParams.ConfFilePath,
-			ConfigName:   "datadog",
-			LoggerName:   "CORE",
+			ConfigName:   command.ConfigName,
+			LoggerName:   command.LoggerName,
 		}
 	})
 

--- a/cmd/agent/subcommands/hostname/command.go
+++ b/cmd/agent/subcommands/hostname/command.go
@@ -40,7 +40,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
 					ConfigParams: config.NewAgentParamsWithoutSecrets(globalParams.ConfFilePath),
-					LogParams:    log.LogForOneShot("CORE", "off", false)}), // never output anything but hostname
+					LogParams:    log.LogForOneShot(command.LoggerName, "off", false)}), // never output anything but hostname
 				core.Bundle,
 			)
 		},

--- a/cmd/agent/subcommands/jmx/command.go
+++ b/cmd/agent/subcommands/jmx/command.go
@@ -88,7 +88,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		}
 		params := core.BundleParams{
 			ConfigParams: config.NewAgentParamsWithSecrets(globalParams.ConfFilePath),
-			LogParams:    log.LogForOneShot("CORE", cliParams.jmxLogLevel, false)}
+			LogParams:    log.LogForOneShot(command.LoggerName, cliParams.jmxLogLevel, false)}
 		if cliParams.logFile != "" {
 			params.LogParams.LogToFile(cliParams.logFile)
 		}

--- a/cmd/agent/subcommands/run/command.go
+++ b/cmd/agent/subcommands/run/command.go
@@ -127,7 +127,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 			fx.Supply(core.BundleParams{
 				ConfigParams:         config.NewAgentParamsWithSecrets(globalParams.ConfFilePath),
 				SysprobeConfigParams: sysprobeconfig.NewParams(sysprobeconfig.WithSysProbeConfFilePath(globalParams.SysProbeConfFilePath)),
-				LogParams:            log.LogForDaemon("CORE", "log_file", path.DefaultLogFile),
+				LogParams:            log.LogForDaemon(command.LoggerName, "log_file", path.DefaultLogFile),
 			}),
 			getSharedFxOption(),
 		)
@@ -235,7 +235,7 @@ func StartAgentWithDefaults() (dogstatsdServer.Component, error) {
 		fx.Supply(core.BundleParams{
 			ConfigParams:         config.NewAgentParamsWithSecrets(""),
 			SysprobeConfigParams: sysprobeconfig.NewParams(),
-			LogParams:            log.LogForDaemon("CORE", "log_file", path.DefaultLogFile),
+			LogParams:            log.LogForDaemon(command.LoggerName, "log_file", path.DefaultLogFile),
 		}),
 		getSharedFxOption(),
 	)

--- a/cmd/agent/subcommands/secret/command.go
+++ b/cmd/agent/subcommands/secret/command.go
@@ -39,9 +39,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(secret,
 				fx.Supply(cliParams),
-				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewAgentParamsWithoutSecrets(globalParams.ConfFilePath),
-					LogParams:    log.LogForOneShot("CORE", "off", true)}),
+				fx.Supply(command.GetDefaultCoreBundleParams(cliParams.GlobalParams)),
 				core.Bundle,
 			)
 		},

--- a/cmd/agent/subcommands/snmp/command.go
+++ b/cmd/agent/subcommands/snmp/command.go
@@ -95,7 +95,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 				fx.Supply(cliParams),
 				fx.Supply(core.BundleParams{
 					ConfigParams: config.NewAgentParamsWithSecrets(globalParams.ConfFilePath),
-					LogParams:    log.LogForOneShot("CORE", "off", true)}),
+					LogParams:    log.LogForOneShot(command.LoggerName, "off", true)}),
 				core.Bundle,
 			)
 		},

--- a/cmd/agent/subcommands/status/command.go
+++ b/cmd/agent/subcommands/status/command.go
@@ -66,7 +66,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 				fx.Supply(core.BundleParams{
 					ConfigParams:         config.NewAgentParamsWithoutSecrets(globalParams.ConfFilePath),
 					SysprobeConfigParams: sysprobeconfig.NewParams(sysprobeconfig.WithSysProbeConfFilePath(globalParams.SysProbeConfFilePath)),
-					LogParams:            log.LogForOneShot("CORE", "off", true)}),
+					LogParams:            log.LogForOneShot(command.LoggerName, "off", true)}),
 				core.Bundle,
 			)
 		},
@@ -90,9 +90,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 
 			return fxutil.OneShot(componentStatusCmd,
 				fx.Supply(cliParams),
-				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewAgentParamsWithoutSecrets(globalParams.ConfFilePath),
-					LogParams:    log.LogForOneShot("CORE", "off", true)}),
+				fx.Supply(command.GetDefaultCoreBundleParams(cliParams.GlobalParams)),
 				core.Bundle,
 			)
 		},

--- a/cmd/agent/subcommands/stop/command.go
+++ b/cmd/agent/subcommands/stop/command.go
@@ -19,7 +19,6 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/agent/command"
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/config"
-	"github.com/DataDog/datadog-agent/comp/core/log"
 	"github.com/DataDog/datadog-agent/pkg/api/util"
 	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
@@ -42,9 +41,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(stop,
 				fx.Supply(cliParams),
-				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewAgentParamsWithoutSecrets(globalParams.ConfFilePath),
-					LogParams:    log.LogForOneShot("CORE", "off", true)}),
+				fx.Supply(command.GetDefaultCoreBundleParams(cliParams.GlobalParams)),
 				core.Bundle,
 			)
 		},

--- a/cmd/agent/subcommands/streamlogs/command.go
+++ b/cmd/agent/subcommands/streamlogs/command.go
@@ -45,9 +45,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(streamLogs,
 				fx.Supply(cliParams),
-				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewAgentParamsWithoutSecrets(globalParams.ConfFilePath),
-					LogParams:    log.LogForOneShot("CORE", "off", true)}),
+				fx.Supply(command.GetDefaultCoreBundleParams(cliParams.GlobalParams)),
 				core.Bundle,
 			)
 		},

--- a/cmd/agent/subcommands/taggerlist/command.go
+++ b/cmd/agent/subcommands/taggerlist/command.go
@@ -18,8 +18,8 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 	cmd := taggerlistcmd.MakeCommand(func() taggerlistcmd.GlobalParams {
 		return taggerlistcmd.GlobalParams{
 			ConfFilePath: globalParams.ConfFilePath,
-			ConfigName:   "datadog",
-			LoggerName:   "CORE",
+			ConfigName:   command.ConfigName,
+			LoggerName:   command.LoggerName,
 		}
 	})
 

--- a/cmd/agent/subcommands/workloadlist/command.go
+++ b/cmd/agent/subcommands/workloadlist/command.go
@@ -18,8 +18,8 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 	cmd := workloadlistcmd.MakeCommand(func() workloadlistcmd.GlobalParams {
 		return workloadlistcmd.GlobalParams{
 			ConfFilePath: globalParams.ConfFilePath,
-			ConfigName:   "datadog",
-			LoggerName:   "CORE",
+			ConfigName:   command.ConfigName,
+			LoggerName:   command.LoggerName,
 		}
 	})
 

--- a/cmd/cluster-agent/subcommands/health/command.go
+++ b/cmd/cluster-agent/subcommands/health/command.go
@@ -10,10 +10,10 @@
 package health
 
 import (
+	"github.com/spf13/cobra"
+
 	"github.com/DataDog/datadog-agent/cmd/cluster-agent/command"
 	"github.com/DataDog/datadog-agent/pkg/cli/subcommands/health"
-
-	"github.com/spf13/cobra"
 )
 
 // Commands returns a slice of subcommands for the 'cluster-agent' command.


### PR DESCRIPTION
### What does this PR do?

Remove duplicated Logger and Config name in Agent cmd.

Similar to what the cluster agent does, we don't want to duplicate the logger and config name in every command.

### Describe how to test/QA your changes

Sanity check that the logger and config for the Agent CLI are still working.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
