### PR TITLE
[CWS] cleanup syscall hooks

### DIFF
--- a/pkg/security/ebpf/c/include/constants/syscall_macro.h
+++ b/pkg/security/ebpf/c/include/constants/syscall_macro.h
@@ -2,8 +2,13 @@
 #define _CONSTANTS_SYSCALL_MACRO_H_
 
 #if defined(__x86_64__)
-  #define SYSCALL64_PREFIX "__x64_"
-  #define SYSCALL32_PREFIX "__ia32_"
+  #if USE_SYSCALL_WRAPPER == 1
+    #define SYSCALL64_PREFIX "__x64_"
+    #define SYSCALL32_PREFIX "__ia32_"
+  #else
+    #define SYSCALL32_PREFIX ""
+    #define SYSCALL64_PREFIX ""
+  #endif
 
   #define SYSCALL64_PT_REGS_PARM1(x) ((x)->di)
   #define SYSCALL64_PT_REGS_PARM2(x) ((x)->si)
@@ -24,8 +29,13 @@
   #define SYSCALL32_PT_REGS_PARM6(x) ((x)->bp)
 
 #elif defined(__aarch64__)
-  #define SYSCALL64_PREFIX "__arm64_"
-  #define SYSCALL32_PREFIX "__arm32_"
+  #if USE_SYSCALL_WRAPPER == 1
+    #define SYSCALL64_PREFIX "__arm64_"
+    #define SYSCALL32_PREFIX "__arm32_"
+  #else
+    #define SYSCALL32_PREFIX ""
+    #define SYSCALL64_PREFIX ""
+  #endif
 
   #define SYSCALL64_PT_REGS_PARM1(x) PT_REGS_PARM1(x)
   #define SYSCALL64_PT_REGS_PARM2(x) PT_REGS_PARM2(x)
@@ -110,10 +120,6 @@
     SYSCALL_ABI_HOOKx(x,64,type,TYPE,,name,_time32,__VA_ARGS__) \
     SYSCALL_HOOK_COMMON(x,type,name,__VA_ARGS__)
 #else
-  #undef SYSCALL32_PREFIX
-  #undef SYSCALL64_PREFIX
-  #define SYSCALL32_PREFIX ""
-  #define SYSCALL64_PREFIX ""
   #define __SC_64_PARAM(n, t, a) t a = (t) SYSCALL64_PT_REGS_PARM##n(ctx);
   #define __SC_32_PARAM(n, t, a) t a = (t) SYSCALL32_PT_REGS_PARM##n(ctx);
   #define SYSCALL_KPROBE_PROLOG(x,m,syscall,...) \

--- a/pkg/security/ebpf/c/include/constants/syscall_macro.h
+++ b/pkg/security/ebpf/c/include/constants/syscall_macro.h
@@ -14,9 +14,9 @@
   #define SYSCALL64_PT_REGS_PARM2(x) ((x)->si)
   #define SYSCALL64_PT_REGS_PARM3(x) ((x)->dx)
   #if USE_SYSCALL_WRAPPER == 1
-   #define SYSCALL64_PT_REGS_PARM4(x) ((x)->r10)
+    #define SYSCALL64_PT_REGS_PARM4(x) ((x)->r10)
   #else
-  #define SYSCALL64_PT_REGS_PARM4(x) ((x)->cx)
+    #define SYSCALL64_PT_REGS_PARM4(x) ((x)->cx)
   #endif
   #define SYSCALL64_PT_REGS_PARM5(x) ((x)->r8)
   #define SYSCALL64_PT_REGS_PARM6(x) ((x)->r9)

--- a/pkg/security/ebpf/c/include/constants/syscall_macro.h
+++ b/pkg/security/ebpf/c/include/constants/syscall_macro.h
@@ -105,20 +105,6 @@
     struct pt_regs *rctx = (struct pt_regs *) PT_REGS_PARM1(ctx); \
     if (!rctx) return 0; \
     __MAP(x,m,__VA_ARGS__)
-  #define SYSCALL_HOOKx(x,type,TYPE,prefix,name,...) \
-    SYSCALL_ABI_HOOKx(x,32,type,TYPE,prefix,name,,__VA_ARGS__) \
-    SYSCALL_ABI_HOOKx(x,64,type,TYPE,,name,,__VA_ARGS__) \
-    SYSCALL_HOOK_COMMON(x,type,name,__VA_ARGS__)
-  #define SYSCALL_COMPAT_HOOKx(x,type,TYPE,name,...) \
-    SYSCALL_ABI_HOOKx(x,32,type,TYPE,compat_,name,,__VA_ARGS__) \
-    SYSCALL_ABI_HOOKx(x,64,type,TYPE,,name,,__VA_ARGS__) \
-    SYSCALL_HOOK_COMMON(x,type,name,__VA_ARGS__)
-  #define SYSCALL_COMPAT_TIME_HOOKx(x,type,TYPE,name,...) \
-    SYSCALL_ABI_HOOKx(x,32,type,TYPE,compat_,name,,__VA_ARGS__) \
-    SYSCALL_ABI_HOOKx(x,32,type,TYPE,,name,_time32,__VA_ARGS__) \
-    SYSCALL_ABI_HOOKx(x,64,type,TYPE,,name,,__VA_ARGS__) \
-    SYSCALL_ABI_HOOKx(x,64,type,TYPE,,name,_time32,__VA_ARGS__) \
-    SYSCALL_HOOK_COMMON(x,type,name,__VA_ARGS__)
 #else
   #define __SC_64_PARAM(n, t, a) t a = (t) SYSCALL64_PT_REGS_PARM##n(ctx);
   #define __SC_32_PARAM(n, t, a) t a = (t) SYSCALL32_PT_REGS_PARM##n(ctx);
@@ -126,19 +112,25 @@
     struct pt_regs *rctx = ctx; \
     if (!rctx) return 0; \
     __MAP(x,m,__VA_ARGS__)
-  #define SYSCALL_HOOKx(x,type,TYPE,prefix,name,...) \
-    SYSCALL_ABI_HOOKx(x,64,type,TYPE,compat_,name,,__VA_ARGS__) \
-    SYSCALL_ABI_HOOKx(x,64,type,TYPE,,name,,__VA_ARGS__) \
-    SYSCALL_HOOK_COMMON(x,type,name,__VA_ARGS__)
-  #define SYSCALL_COMPAT_HOOKx(x,type,TYPE,name,...) \
-    SYSCALL_ABI_HOOKx(x,64,type,TYPE,compat_,name,,__VA_ARGS__) \
-    SYSCALL_ABI_HOOKx(x,64,type,TYPE,,name,,__VA_ARGS__) \
-    SYSCALL_HOOK_COMMON(x,type,name,__VA_ARGS__)
-  #define SYSCALL_COMPAT_TIME_HOOKx(x,type,TYPE,name,...) \
-    SYSCALL_ABI_HOOKx(x,64,type,TYPE,compat_,name,,__VA_ARGS__) \
-    SYSCALL_ABI_HOOKx(x,64,type,TYPE,,name,,__VA_ARGS__) \
-    SYSCALL_HOOK_COMMON(x,type,name,__VA_ARGS__)
 #endif
+
+#define SYSCALL_HOOKx(x,type,TYPE,prefix,name,...) \
+  SYSCALL_ABI_HOOKx(x,32,type,TYPE,prefix,name,,__VA_ARGS__) \
+  SYSCALL_ABI_HOOKx(x,64,type,TYPE,compat_,name,,__VA_ARGS__) \
+  SYSCALL_ABI_HOOKx(x,64,type,TYPE,,name,,__VA_ARGS__) \
+  SYSCALL_HOOK_COMMON(x,type,name,__VA_ARGS__)
+#define SYSCALL_COMPAT_HOOKx(x,type,TYPE,name,...) \
+  SYSCALL_ABI_HOOKx(x,32,type,TYPE,compat_,name,,__VA_ARGS__) \
+  SYSCALL_ABI_HOOKx(x,64,type,TYPE,compat_,name,,__VA_ARGS__) \
+  SYSCALL_ABI_HOOKx(x,64,type,TYPE,,name,,__VA_ARGS__) \
+  SYSCALL_HOOK_COMMON(x,type,name,__VA_ARGS__)
+#define SYSCALL_COMPAT_TIME_HOOKx(x,type,TYPE,name,...) \
+  SYSCALL_ABI_HOOKx(x,32,type,TYPE,compat_,name,,__VA_ARGS__) \
+  SYSCALL_ABI_HOOKx(x,32,type,TYPE,,name,_time32,__VA_ARGS__) \
+  SYSCALL_ABI_HOOKx(x,64,type,TYPE,compat_,name,,__VA_ARGS__) \
+  SYSCALL_ABI_HOOKx(x,64,type,TYPE,,name,,__VA_ARGS__) \
+  SYSCALL_ABI_HOOKx(x,64,type,TYPE,,name,_time32,__VA_ARGS__) \
+  SYSCALL_HOOK_COMMON(x,type,name,__VA_ARGS__)
 
 #define SYSCALL_KPROBE0(name, ...) SYSCALL_HOOKx(0,kprobe,KPROBE,,_##name,__VA_ARGS__)
 #define SYSCALL_KPROBE1(name, ...) SYSCALL_HOOKx(1,kprobe,KPROBE,,_##name,__VA_ARGS__)

--- a/pkg/security/ebpf/c/include/constants/syscall_macro.h
+++ b/pkg/security/ebpf/c/include/constants/syscall_macro.h
@@ -2,13 +2,8 @@
 #define _CONSTANTS_SYSCALL_MACRO_H_
 
 #if defined(__x86_64__)
-  #if USE_SYSCALL_WRAPPER == 1
-    #define SYSCALL64_PREFIX "__x64_"
-    #define SYSCALL32_PREFIX "__ia32_"
-  #else
-    #define SYSCALL32_PREFIX ""
-    #define SYSCALL64_PREFIX ""
-  #endif
+  #define SYSCALL64_PREFIX "__x64_"
+  #define SYSCALL32_PREFIX "__ia32_"
 
   #define SYSCALL64_PT_REGS_PARM1(x) ((x)->di)
   #define SYSCALL64_PT_REGS_PARM2(x) ((x)->si)
@@ -29,13 +24,8 @@
   #define SYSCALL32_PT_REGS_PARM6(x) ((x)->bp)
 
 #elif defined(__aarch64__)
-  #if USE_SYSCALL_WRAPPER == 1
-    #define SYSCALL64_PREFIX "__arm64_"
-    #define SYSCALL32_PREFIX "__arm32_"
-  #else
-    #define SYSCALL32_PREFIX ""
-    #define SYSCALL64_PREFIX ""
-  #endif
+  #define SYSCALL64_PREFIX "__arm64_"
+  #define SYSCALL32_PREFIX "__arm32_"
 
   #define SYSCALL64_PT_REGS_PARM1(x) PT_REGS_PARM1(x)
   #define SYSCALL64_PT_REGS_PARM2(x) PT_REGS_PARM2(x)
@@ -89,8 +79,13 @@
 
 #define SYSCALL_ABI_HOOKx(x,word_size,type,TYPE,prefix,syscall,suffix,...) \
     int __attribute__((always_inline)) type##__##sys##syscall(struct pt_regs *ctx __JOIN(x,__SC_DECL,__VA_ARGS__)); \
-    SEC(#type "/" SYSCALL##word_size##_PREFIX #prefix SYSCALL_PREFIX #syscall #suffix) \
+    SEC(#type "/" #prefix SYSCALL_PREFIX #syscall #suffix) \
     int type##__ ##word_size##_##prefix ##sys##syscall##suffix(struct pt_regs *ctx) { \
+        SYSCALL_##TYPE##_PROLOG(x,__SC_##word_size##_PARAM,syscall,__VA_ARGS__) \
+        return type##__sys##syscall(ctx __JOIN(x,__SC_PASS,__VA_ARGS__)); \
+    } \
+    SEC(#type "/" SYSCALL##word_size##_PREFIX #prefix SYSCALL_PREFIX #syscall #suffix) \
+    int type##__ ##word_size##_##prefix ##sys##syscall##suffix##wrapper(struct pt_regs *ctx) { \
         SYSCALL_##TYPE##_PROLOG(x,__SC_##word_size##_PARAM,syscall,__VA_ARGS__) \
         return type##__sys##syscall(ctx __JOIN(x,__SC_PASS,__VA_ARGS__)); \
     }

--- a/pkg/security/ebpf/probes/rename.go
+++ b/pkg/security/ebpf/probes/rename.go
@@ -7,7 +7,9 @@
 
 package probes
 
-import manager "github.com/DataDog/ebpf-manager"
+import (
+	manager "github.com/DataDog/ebpf-manager"
+)
 
 // renameProbes holds the list of probes used to track file rename events
 var renameProbes = []*manager.Probe{

--- a/pkg/security/ebpf/probes/syscall_helpers.go
+++ b/pkg/security/ebpf/probes/syscall_helpers.go
@@ -141,6 +141,9 @@ func getFunctionNameFromSection(section string) string {
 		funcName = strings.ReplaceAll(funcName, "__arm32_", "__32_")
 		// utils
 		funcName = strings.ReplaceAll(funcName, "/_", "_")
+
+		// if syscall wrapper, the function is suffixed with `wrapper`
+		funcName += "wrapper"
 	}
 	funcName = strings.ReplaceAll(funcName, "tracepoint/syscalls/", "tracepoint_syscalls_")
 	return funcName


### PR DESCRIPTION
### What does this PR do?



### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
