### PR TITLE
pkg/serverless/proxy: synchronously start the proxy server listener

### DIFF
--- a/cmd/serverless/main.go
+++ b/cmd/serverless/main.go
@@ -330,11 +330,13 @@ func runAgent(stopCh chan struct{}) (serverlessDaemon *daemon.Daemon, err error)
 	} else if enabled, _ := strconv.ParseBool(os.Getenv("DD_EXPERIMENTAL_ENABLE_PROXY")); enabled {
 		// start the experimental proxy if enabled
 		log.Debug("Starting the experimental runtime api proxy")
-		proxy.Start(
+		if err := proxy.Start(
 			"127.0.0.1:9000",
 			"127.0.0.1:9001",
 			serverlessDaemon.InvocationProcessor,
-		)
+		); err != nil {
+			log.Errorf("Could not start the experimental runtime api proxy: %v", err)
+		}
 	}
 
 	// run the invocation loop in a routine

--- a/pkg/serverless/appsec/appsec.go
+++ b/pkg/serverless/appsec/appsec.go
@@ -47,11 +47,13 @@ func New() (*httpsec.InvocationSubProcessor, *httpsec.ProxyLifecycleProcessor, e
 			SubProcessor: httpsec.NewProxyProcessor(appsecInstance),
 		}
 		// start the experimental proxy if enabled
-		proxy.Start(
+		if err := proxy.Start(
 			"127.0.0.1:9000",
 			"127.0.0.1:9001",
 			lp,
-		)
+		); err != nil {
+			return nil, nil, errors.Wrap(err, "could not start the runtime api proxy")
+		}
 		log.Debug("appsec: started successfully using the runtime api proxy monitoring mode")
 		return nil, lp, nil
 

--- a/pkg/serverless/proxy/proxy.go
+++ b/pkg/serverless/proxy/proxy.go
@@ -21,7 +21,8 @@ type runtimeProxy struct {
 	processor invocationlifecycle.InvocationProcessor
 }
 
-// Start starts the proxy
+// Start starts the proxy and returns an error if the given proxyHostPort could
+// not be listened to.
 // This proxy allows us to inspect traffic from/to the AWS Lambda Runtime API
 func Start(proxyHostPort string, originalRuntimeHostPort string, processor invocationlifecycle.InvocationProcessor) error {
 	log.Debugf("runtime api proxy: starting reverse proxy on %s and forwarding to %s", proxyHostPort, originalRuntimeHostPort)

--- a/pkg/serverless/proxy/proxy_test.go
+++ b/pkg/serverless/proxy/proxy_test.go
@@ -13,9 +13,9 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/pkg/serverless/invocationlifecycle"
 )
@@ -80,8 +80,8 @@ func TestProxyResponseValid(t *testing.T) {
 
 	t.Setenv("DD_EXPERIMENTAL_ENABLE_PROXY", "true")
 
-	go setup("127.0.0.1:5000", "127.0.0.1:5001", &testProcessorResponseValid{})
-	time.Sleep(100 * time.Millisecond)
+	err = Start("127.0.0.1:5000", "127.0.0.1:5001", &testProcessorResponseValid{})
+	require.NoError(t, err)
 	resp, err := http.Get("http://127.0.0.1:5000/xxx/next")
 	assert.Nil(t, err)
 	assert.Equal(t, 200, resp.StatusCode)
@@ -107,8 +107,8 @@ func TestProxyResponseError(t *testing.T) {
 
 	t.Setenv("DD_EXPERIMENTAL_ENABLE_PROXY", "true")
 
-	go setup("127.0.0.1:6000", "127.0.0.1:6001", &testProcessorResponseError{})
-	time.Sleep(100 * time.Millisecond)
+	err = Start("127.0.0.1:6000", "127.0.0.1:6001", &testProcessorResponseError{})
+	require.NoError(t, err)
 	resp, err := http.Get("http://127.0.0.1:6000/xxx/next")
 	assert.Nil(t, err)
 	resp.Body.Close()


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

The function `proxy.Start()` now ensures the listener is started on the given address before returning.
This fixes a synchronization issue when starting the experimental runtime api proxy to avoid reaching the extension invocation loop before the runtime api proxy gets properly started. The functions might otherwise start faster than the proxy and fail when requesting it.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Bugfix found by a user.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
