### PR TITLE
[process-agent] Fix bug where disabled message is not shown

### DIFF
--- a/cmd/process-agent/main_common.go
+++ b/cmd/process-agent/main_common.go
@@ -98,6 +98,7 @@ func runAgent(globalParams *command.GlobalParams, exit chan struct{}) {
 }
 
 func runApp(exit chan struct{}, globalParams *command.GlobalParams) error {
+	defer log.Flush() // Flush the log in case of an unclean shutdown
 	go util.HandleSignals(exit)
 
 	var appInitDeps struct {
@@ -157,7 +158,7 @@ func runApp(exit chan struct{}, globalParams *command.GlobalParams) error {
 
 	// Look to see if any checks are enabled, if not, return since the agent doesn't need to be enabled.
 	if !anyChecksEnabled(appInitDeps.Checks) {
-		log.Infof(agent6DisabledMessage)
+		appInitDeps.Logger.Infof(agent6DisabledMessage)
 		return nil
 	}
 

--- a/cmd/process-agent/main_common.go
+++ b/cmd/process-agent/main_common.go
@@ -158,7 +158,7 @@ func runApp(exit chan struct{}, globalParams *command.GlobalParams) error {
 
 	// Look to see if any checks are enabled, if not, return since the agent doesn't need to be enabled.
 	if !anyChecksEnabled(appInitDeps.Checks) {
-		appInitDeps.Logger.Infof(agent6DisabledMessage)
+		log.Infof(agent6DisabledMessage)
 		return nil
 	}
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR adds a `defer log.Flush()` in the case that `app.Stop` is not called or fails and therefore cannot call the logger component's `Stop` hook.

It should fix the bug where the process agent disabled message is not shown if no checks are set to run.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Bugfix

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Using this config:
```yaml
process_config:
  process_collection: { enabled: false }
  container_collection: { enabled: false }
  process_discovery: { enabled: false }
```
Run the process agent and make sure this message is logged:
```
2023-04-20 15:49:21 CDT | PROCESS | INFO | (main_common.go:160 in runApp) | process-agent not enabled.                                                           
Set env var DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED=true or add                                                                                             
process_config:                                                                                                                                                  
  process_collection:                                                                                                                                            
    enabled: true                                                                                                                                                
to your datadog.yaml file.                                                                                                                                       
Exiting.  
```

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
