### PR TITLE
[CWS] fix handling of empty argv in module init

### DIFF
--- a/pkg/security/probe/field_handlers_linux.go
+++ b/pkg/security/probe/field_handlers_linux.go
@@ -478,7 +478,7 @@ func (fh *FieldHandlers) ResolvePackageSourceVersion(ev *model.Event, f *model.F
 func (fh *FieldHandlers) ResolveModuleArgv(ev *model.Event, module *model.LoadModuleEvent) []string {
 	// strings.Split return [""] if args is empty, so we do a manual check before
 	if len(module.Args) == 0 {
-		module.Argv = []
+		module.Argv = nil
 		return module.Argv
 	}
 

--- a/pkg/security/probe/field_handlers_linux.go
+++ b/pkg/security/probe/field_handlers_linux.go
@@ -476,6 +476,12 @@ func (fh *FieldHandlers) ResolvePackageSourceVersion(ev *model.Event, f *model.F
 
 // ResolveModuleArgv resolves the args of the event as an array
 func (fh *FieldHandlers) ResolveModuleArgv(ev *model.Event, module *model.LoadModuleEvent) []string {
+	// strings.Split return [""] if args is empty, so we do a manual check before
+	if len(module.Args) == 0 {
+		module.Argv = []
+		return module.Argv
+	}
+
 	module.Argv = strings.Split(module.Args, " ")
 	if module.ArgsTruncated {
 		module.Argv = module.Argv[:len(module.Argv)-1]

--- a/pkg/security/tests/kernel_module_test.go
+++ b/pkg/security/tests/kernel_module_test.go
@@ -173,6 +173,8 @@ func TestLoadModule(t *testing.T) {
 			event.ResolveFields()
 			assert.Equal(t, "", event.LoadModule.File.PathnameStr, "shouldn't get a path")
 
+			assert.Empty(t, event.LoadModule.Argv, "shouldn't get args")
+
 			test.validateLoadModuleNoFileSchema(t, event)
 		})
 	})


### PR DESCRIPTION
### What does this PR do?

This PR fixes the case (common one) of no args passed in a module load. It now serializes correct argv to `[]` instead of `[""]`.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
