### PR TITLE
[serverless] Fix KMS key parsing

### DIFF
--- a/cmd/serverless/api_key.go
+++ b/cmd/serverless/api_key.go
@@ -158,6 +158,7 @@ func extractRegionFromSecretsManagerArn(secretsManagerArn string) (string, error
 
 func hasApiKey() bool {
 	return config.Datadog.IsSet("api_key") ||
+		len(os.Getenv(kmsAPIKeyEnvVarLegacy)) > 0 ||
 		len(os.Getenv(kmsAPIKeyEnvVar)) > 0 ||
 		len(os.Getenv(secretsManagerAPIKeyEnvVar)) > 0
 }

--- a/cmd/serverless/main.go
+++ b/cmd/serverless/main.go
@@ -166,7 +166,7 @@ func runAgent(stopCh chan struct{}) (serverlessDaemon *daemon.Daemon, err error)
 
 	var apikeySetIn = []string{}
 	if os.Getenv(kmsAPIKeyEnvVarLegacy) != "" && os.Getenv(kmsAPIKeyEnvVar) == "" {
-		os.Setenv(os.Getenv(kmsAPIKeyEnvVar), os.Getenv(kmsAPIKeyEnvVarLegacy))
+		os.Setenv(kmsAPIKeyEnvVar, os.Getenv(kmsAPIKeyEnvVarLegacy))
 	}
 	if os.Getenv(kmsAPIKeyEnvVar) != "" {
 		apikeySetIn = append(apikeySetIn, "KMS")


### PR DESCRIPTION
### What does this PR do?

Fixes a regression with the AWS Lambda Extension, where api keys specified in the form "DD_KMS_API_KEY" no longer worked.

### Motivation


### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
