### PR TITLE
[CWS] Fix releasing of scoped variables

### DIFF
--- a/pkg/security/secl/compiler/eval/variables.go
+++ b/pkg/security/secl/compiler/eval/variables.go
@@ -386,8 +386,13 @@ func NewMutableIntArrayVariable() *MutableIntArrayVariable {
 	return &MutableIntArrayVariable{}
 }
 
+// ScopedVariable is the interface to be implemented by scoped variable in order to be released
+type ScopedVariable interface {
+	SetReleaseCallback(callback func())
+}
+
 // Scoper maps a variable to the entity its scoped to
-type Scoper[T any] func(ctx *Context) T
+type Scoper func(ctx *Context) ScopedVariable
 
 // GlobalVariables holds a set of global variables
 type GlobalVariables struct{}
@@ -469,21 +474,33 @@ func (v *Variables) Set(name string, value interface{}) bool {
 }
 
 // ScopedVariables holds a set of scoped variables
-type ScopedVariables[T comparable] struct {
-	scoper Scoper[T]
-	vars   map[T]*Variables
+type ScopedVariables struct {
+	scoper Scoper
+	vars   map[ScopedVariable]*Variables
+}
+
+// Len returns the length of the variable map
+func (v *ScopedVariables) Len() int {
+	return len(v.vars)
 }
 
 // GetVariable returns new variable of the type of the specified value
-func (v *ScopedVariables[T]) GetVariable(name string, value interface{}) (VariableValue, error) {
+func (v *ScopedVariables) GetVariable(name string, value interface{}) (VariableValue, error) {
 	getVariables := func(ctx *Context) *Variables {
-		return v.vars[v.scoper(ctx)]
+		v := v.vars[v.scoper(ctx)]
+		return v
 	}
 
 	setVariable := func(ctx *Context, value interface{}) error {
 		key := v.scoper(ctx)
+		if key == nil {
+			return fmt.Errorf("failed to scope variable '%s'", name)
+		}
 		vars := v.vars[key]
 		if vars == nil {
+			key.SetReleaseCallback(func() {
+				v.ReleaseVariable(key)
+			})
 			vars = &Variables{}
 			v.vars[key] = vars
 		}
@@ -533,10 +550,15 @@ func (v *ScopedVariables[T]) GetVariable(name string, value interface{}) (Variab
 	}
 }
 
+// ReleaseVariable releases a scoped variable
+func (v *ScopedVariables) ReleaseVariable(key ScopedVariable) {
+	delete(v.vars, key)
+}
+
 // NewScopedVariables returns a new set of scope variables
-func NewScopedVariables[T comparable](scoper Scoper[T]) *ScopedVariables[T] {
-	return &ScopedVariables[T]{
+func NewScopedVariables(scoper Scoper) *ScopedVariables {
+	return &ScopedVariables{
 		scoper: scoper,
-		vars:   make(map[T]*Variables),
+		vars:   make(map[ScopedVariable]*Variables),
 	}
 }

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -799,7 +799,13 @@ func (pc *ProcessCacheEntry) Retain() {
 
 // SetReleaseCallback set the callback called when the entry is released
 func (pc *ProcessCacheEntry) SetReleaseCallback(callback func()) {
-	pc.releaseCb = callback
+	previousCallback := pc.releaseCb
+	pc.releaseCb = func() {
+		callback()
+		if previousCallback != nil {
+			previousCallback()
+		}
+	}
 }
 
 // Release decrement and eventually release the entry

--- a/pkg/security/secl/rules/opts.go
+++ b/pkg/security/secl/rules/opts.go
@@ -65,8 +65,8 @@ func NewEvalOpts(eventTypeEnabled map[eval.EventType]bool) (*Opts, *eval.Opts) {
 		WithEventTypeEnabled(eventTypeEnabled).
 		WithStateScopes(map[Scope]VariableProviderFactory{
 			"process": func() VariableProvider {
-				return eval.NewScopedVariables(func(ctx *eval.Context) *model.ProcessContext {
-					return ctx.Event.(*model.Event).ProcessContext
+				return eval.NewScopedVariables(func(ctx *eval.Context) eval.ScopedVariable {
+					return ctx.Event.(*model.Event).ProcessCacheEntry
 				})
 			},
 		})


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Fix release of 'process' scoped variables.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

- Create a rule that cause a scoped variable to be created
- Make the rule trigger many times, with a different process every time
- Check the memory consumption stays stable

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
