### PR TITLE
[CWS] remove use of internal pointer

### DIFF
--- a/pkg/network/events/monitor.go
+++ b/pkg/network/events/monitor.go
@@ -36,7 +36,7 @@ func Init() error {
 }
 
 // HandlerFunc is the prototype for an event handler callback for process events
-type HandlerFunc func(*model.ProcessCacheEntry)
+type HandlerFunc func(*model.ProcessContext)
 
 // RegisterHandler registers a handler function for getting process events
 func RegisterHandler(handler HandlerFunc) {
@@ -78,24 +78,14 @@ func newEventMonitor() (*eventMonitor, error) {
 }
 
 func (e *eventMonitor) HandleEvent(ev *model.Event) {
-	if ev.Type == uint32(model.ExitEventType) {
-		return
-	}
-
-	_ = ev.FieldHandlers.ResolveProcessEnvp(ev, &ev.ProcessContext.Process)
-
-	entry, ok := ev.ResolveProcessCacheEntry()
-	if !ok {
-		return
-	}
+	ev.ResolveFields()
 
 	e.Lock()
 	defer e.Unlock()
 
 	for _, h := range e.handlers {
-		h(entry)
+		h(ev.ProcessContext)
 	}
-
 }
 
 func (e *eventMonitor) HandleCustomEvent(rule *rules.Rule, event *events.CustomEvent) {

--- a/pkg/network/events/network_consumer.go
+++ b/pkg/network/events/network_consumer.go
@@ -36,9 +36,6 @@ func NewNetworkConsumer(evm *eventmonitor.EventMonitor) (*NetworkConsumer, error
 	if err := evm.AddEventTypeHandler(smodel.ExecEventType, h); err != nil {
 		return nil, err
 	}
-	if err := evm.AddEventTypeHandler(smodel.ExitEventType, h); err != nil {
-		return nil, err
-	}
 
 	return &NetworkConsumer{}, nil
 }

--- a/pkg/network/tracer/process_cache.go
+++ b/pkg/network/tracer/process_cache.go
@@ -135,7 +135,7 @@ func newProcessCache(maxProcs int, filteredEnvs []string) (*processCache, error)
 	return pc, nil
 }
 
-func (pc *processCache) handleProcessEvent(entry *smodel.ProcessCacheEntry) {
+func (pc *processCache) handleProcessEvent(entry *smodel.ProcessContext) {
 
 	select {
 	case <-pc.stopped:
@@ -157,7 +157,7 @@ func (pc *processCache) handleProcessEvent(entry *smodel.ProcessCacheEntry) {
 	}
 }
 
-func (pc *processCache) processEvent(entry *smodel.ProcessCacheEntry) *process {
+func (pc *processCache) processEvent(entry *smodel.ProcessContext) *process {
 	var envs map[string]string
 	if entry.EnvsEntry != nil {
 		for _, v := range entry.EnvsEntry.Values {

--- a/pkg/network/tracer/process_cache_test.go
+++ b/pkg/network/tracer/process_cache_test.go
@@ -55,7 +55,7 @@ func TestProcessCacheProcessEvent(t *testing.T) {
 		{envs: []string{ddService, ddVersion, ddEnv}},
 	}
 
-	testFunc := func(t *testing.T, entry *smodel.ProcessCacheEntry) {
+	testFunc := func(t *testing.T, entry *smodel.ProcessContext) {
 		for i, te := range tests {
 			t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
 				pc, err := newProcessCache(10, te.filter)
@@ -93,14 +93,12 @@ func TestProcessCacheProcessEvent(t *testing.T) {
 	}
 
 	t.Run("without container id", func(t *testing.T) {
-		entry := smodel.ProcessCacheEntry{
-			ProcessContext: smodel.ProcessContext{
-				Process: smodel.Process{
-					PIDContext: smodel.PIDContext{
-						Pid: 1234,
-					},
-					EnvsEntry: &smodel.EnvsEntry{},
+		entry := smodel.ProcessContext{
+			Process: smodel.Process{
+				PIDContext: smodel.PIDContext{
+					Pid: 1234,
 				},
+				EnvsEntry: &smodel.EnvsEntry{},
 			},
 		}
 
@@ -108,15 +106,13 @@ func TestProcessCacheProcessEvent(t *testing.T) {
 	})
 
 	t.Run("with container id", func(t *testing.T) {
-		entry := smodel.ProcessCacheEntry{
-			ProcessContext: smodel.ProcessContext{
-				Process: smodel.Process{
-					PIDContext: smodel.PIDContext{
-						Pid: 1234,
-					},
-					ContainerID: "container",
-					EnvsEntry:   &smodel.EnvsEntry{},
+		entry := smodel.ProcessContext{
+			Process: smodel.Process{
+				PIDContext: smodel.PIDContext{
+					Pid: 1234,
 				},
+				ContainerID: "container",
+				EnvsEntry:   &smodel.EnvsEntry{},
 			},
 		}
 

--- a/pkg/process/events/process_events_consumer.go
+++ b/pkg/process/events/process_events_consumer.go
@@ -81,10 +81,7 @@ func (p *ProcessConsumer) HandleEvent(event *smodel.Event) {
 	event.ResolveFields()
 	event.ResolveEventTime()
 
-	entry, _ := event.ResolveProcessCacheEntry()
-	if entry == nil {
-		return
-	}
+	entry := event.ProcessContext
 
 	var cmdline []string
 	if entry.ArgsEntry != nil {

--- a/pkg/security/probe/probe_linux.go
+++ b/pkg/security/probe/probe_linux.go
@@ -895,19 +895,25 @@ func (p *Probe) handleEvent(CPU int, data []byte) {
 		}
 	}
 	event.ProcessCacheEntry = entry
+	if event.ProcessCacheEntry == nil {
+		panic("should always return a process cache entry")
+	}
 
 	// resolve the container context
 	event.ContainerContext, _ = p.fieldHandlers.ResolveContainerContext(event)
 
 	// use ProcessCacheEntry process context as process context
 	event.ProcessContext = &event.ProcessCacheEntry.ProcessContext
+	if event.ProcessContext == nil {
+		panic("should always return a process context")
+	}
 
 	if process.IsKThread(event.ProcessContext.PPid, event.ProcessContext.Pid) {
 		return
 	}
 
 	if eventType == model.ExitEventType {
-		defer p.resolvers.ProcessResolver.DeleteEntry(event.ProcessCacheEntry.Pid, p.fieldHandlers.ResolveEventTime(event))
+		defer p.resolvers.ProcessResolver.DeleteEntry(event.ProcessContext.Pid, p.fieldHandlers.ResolveEventTime(event))
 	}
 
 	p.DispatchEvent(event)

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -248,7 +248,6 @@ type Event struct {
 	Rules        []*MatchedRule `field:"-"`
 
 	// context shared with all events
-	ProcessCacheEntry      *ProcessCacheEntry     `field:"-" json:"-" platform:"linux"`
 	PIDContext             PIDContext             `field:"-" json:"-" platform:"linux"`
 	SpanContext            SpanContext            `field:"-" json:"-" platform:"linux"`
 	ProcessContext         *ProcessContext        `field:"process" event:"*" platform:"linux"`
@@ -297,14 +296,15 @@ type Event struct {
 	Bind BindEvent `field:"bind" event:"bind" platform:"linux"` // [7.37] [Network] [Experimental] A bind was executed
 
 	// internal usage
-	Umount           UmountEvent           `field:"-" json:"-" platform:"linux"`
-	InvalidateDentry InvalidateDentryEvent `field:"-" json:"-" platform:"linux"`
-	ArgsEnvs         ArgsEnvsEvent         `field:"-" json:"-" platform:"linux"`
-	MountReleased    MountReleasedEvent    `field:"-" json:"-" platform:"linux"`
-	CgroupTracing    CgroupTracingEvent    `field:"-" json:"-" platform:"linux"`
-	NetDevice        NetDeviceEvent        `field:"-" json:"-" platform:"linux"`
-	VethPair         VethPairEvent         `field:"-" json:"-" platform:"linux"`
-	UnshareMountNS   UnshareMountNSEvent   `field:"-" json:"-" platform:"linux"`
+	ProcessCacheEntry *ProcessCacheEntry    `field:"-" json:"-" platform:"linux"`
+	Umount            UmountEvent           `field:"-" json:"-" platform:"linux"`
+	InvalidateDentry  InvalidateDentryEvent `field:"-" json:"-" platform:"linux"`
+	ArgsEnvs          ArgsEnvsEvent         `field:"-" json:"-" platform:"linux"`
+	MountReleased     MountReleasedEvent    `field:"-" json:"-" platform:"linux"`
+	CgroupTracing     CgroupTracingEvent    `field:"-" json:"-" platform:"linux"`
+	NetDevice         NetDeviceEvent        `field:"-" json:"-" platform:"linux"`
+	VethPair          VethPairEvent         `field:"-" json:"-" platform:"linux"`
+	UnshareMountNS    UnshareMountNSEvent   `field:"-" json:"-" platform:"linux"`
 
 	// mark event with having error
 	Error error `field:"-" json:"-"`

--- a/pkg/security/serializers/serializers.go
+++ b/pkg/security/serializers/serializers.go
@@ -1071,17 +1071,14 @@ func MarshalCustomEvent(event *events.CustomEvent) ([]byte, error) {
 
 // NewEventSerializer creates a new event serializer based on the event type
 func NewEventSerializer(event *model.Event, resolvers *resolvers.Resolvers) *EventSerializer {
-	var pc model.ProcessContext
-	if entry, _ := event.FieldHandlers.ResolveProcessCacheEntry(event); entry != nil {
-		pc = entry.ProcessContext
-	}
+	pc := event.ProcessContext
 
 	s := &EventSerializer{
 		EventContextSerializer: EventContextSerializer{
 			Name:  model.EventType(event.Type).String(),
 			Async: event.FieldHandlers.ResolveAsync(event),
 		},
-		ProcessContextSerializer: newProcessContextSerializer(&pc, event, resolvers),
+		ProcessContextSerializer: newProcessContextSerializer(pc, event, resolvers),
 		DDContextSerializer:      newDDContextSerializer(event),
 		UserContextSerializer:    newUserContextSerializer(event),
 		Date:                     utils.NewEasyjsonTime(event.FieldHandlers.ResolveEventTime(event)),

--- a/pkg/security/tests/mount_test.go
+++ b/pkg/security/tests/mount_test.go
@@ -73,7 +73,7 @@ func TestMount(t *testing.T) {
 			}
 
 			// filter by pid
-			if pce, _ := event.ResolveProcessCacheEntry(); pce.Pid != testSuitePid {
+			if event.ProcessContext.Pid != testSuitePid {
 				return false
 			}
 
@@ -125,7 +125,7 @@ func TestMount(t *testing.T) {
 			}
 
 			// filter by process
-			if pce, _ := event.ResolveProcessCacheEntry(); pce.Pid != testSuitePid {
+			if event.ProcessContext.Pid != testSuitePid {
 				return false
 			}
 

--- a/pkg/security/tests/process_test.go
+++ b/pkg/security/tests/process_test.go
@@ -233,8 +233,7 @@ func TestProcessContext(t *testing.T) {
 		}, func(event *model.Event, rule *rules.Rule) {
 			assertFieldEqual(t, event, "process.file.path", executable)
 
-			entry, _ := event.ResolveProcessCacheEntry()
-			assert.Equal(t, getInode(t, executable), entry.FileEvent.Inode, "wrong inode")
+			assert.Equal(t, getInode(t, executable), event.ProcessContext.FileEvent.Inode, "wrong inode")
 		})
 	})
 
@@ -695,10 +694,8 @@ func TestProcessContext(t *testing.T) {
 				t.Errorf("not able to get a tty name: %s\n", name)
 			}
 
-			entry, _ := event.ResolveProcessCacheEntry()
-
-			if inode := getInode(t, executable); inode != entry.FileEvent.Inode {
-				t.Errorf("expected inode %d, got %d => %+v", entry.FileEvent.Inode, inode, event)
+			if inode := getInode(t, executable); inode != event.ProcessContext.FileEvent.Inode {
+				t.Errorf("expected inode %d, got %d => %+v", event.ProcessContext.FileEvent.Inode, inode, event)
 			}
 
 			str, err := test.marshalEvent(event)
@@ -915,9 +912,9 @@ func TestProcessContext(t *testing.T) {
 			assert.Equal(t, "test_rule_container", rule.ID, "wrong rule triggered")
 
 			if kind == dockerWrapperType {
-				assert.Equal(t, event.Exec.Process.ContainerID, event.ProcessCacheEntry.ContainerID)
-				assert.Equal(t, event.Exec.Process.ContainerID, event.ProcessCacheEntry.Ancestor.ContainerID)
-				assert.Equal(t, event.Exec.Process.ContainerID, event.ProcessCacheEntry.Parent.ContainerID)
+				assert.Equal(t, event.Exec.Process.ContainerID, event.ProcessContext.ContainerID)
+				assert.Equal(t, event.Exec.Process.ContainerID, event.ProcessContext.Ancestor.ContainerID)
+				assert.Equal(t, event.Exec.Process.ContainerID, event.ProcessContext.Parent.ContainerID)
 			}
 		}))
 	})
@@ -1349,7 +1346,7 @@ func TestProcessExecExit(t *testing.T) {
 
 		case model.ExitEventType:
 			// assert that exit time >= exec time
-			assert.False(t, event.ProcessCacheEntry.ExitTime.Before(event.ProcessCacheEntry.ExecTime), "exit time < exec time")
+			assert.False(t, event.ProcessContext.ExitTime.Before(event.ProcessContext.ExecTime), "exit time < exec time")
 			if execPid != 0 && event.ProcessContext.Pid == execPid {
 				return true
 			}
@@ -1663,7 +1660,7 @@ func TestProcessExit(t *testing.T) {
 			assertFieldEqual(t, event, "exit.file.path", sleepExec)
 			assert.Equal(t, uint32(model.ExitExited), event.Exit.Cause, "wrong exit cause")
 			assert.Equal(t, uint32(0), event.Exit.Code, "wrong exit code")
-			assert.False(t, event.ProcessCacheEntry.ExitTime.Before(event.ProcessCacheEntry.ExecTime), "exit time < exec time")
+			assert.False(t, event.ProcessContext.ExitTime.Before(event.ProcessContext.ExecTime), "exit time < exec time")
 		})
 	})
 
@@ -1682,7 +1679,7 @@ func TestProcessExit(t *testing.T) {
 			assertFieldEqual(t, event, "exit.file.path", sleepExec)
 			assert.Equal(t, uint32(model.ExitExited), event.Exit.Cause, "wrong exit cause")
 			assert.Equal(t, uint32(1), event.Exit.Code, "wrong exit code")
-			assert.False(t, event.ProcessCacheEntry.ExitTime.Before(event.ProcessCacheEntry.ExecTime), "exit time < exec time")
+			assert.False(t, event.ProcessContext.ExitTime.Before(event.ProcessContext.ExecTime), "exit time < exec time")
 		})
 	})
 
@@ -1701,7 +1698,7 @@ func TestProcessExit(t *testing.T) {
 			assertFieldEqual(t, event, "exit.file.path", sleepExec)
 			assert.Equal(t, uint32(model.ExitCoreDumped), event.Exit.Cause, "wrong exit cause")
 			assert.Equal(t, uint32(syscall.SIGQUIT), event.Exit.Code, "wrong exit code")
-			assert.False(t, event.ProcessCacheEntry.ExitTime.Before(event.ProcessCacheEntry.ExecTime), "exit time < exec time")
+			assert.False(t, event.ProcessContext.ExitTime.Before(event.ProcessContext.ExecTime), "exit time < exec time")
 		})
 	})
 
@@ -1720,7 +1717,7 @@ func TestProcessExit(t *testing.T) {
 			assertFieldEqual(t, event, "exit.file.path", sleepExec)
 			assert.Equal(t, uint32(model.ExitSignaled), event.Exit.Cause, "wrong exit cause")
 			assert.Equal(t, uint32(syscall.SIGKILL), event.Exit.Code, "wrong exit code")
-			assert.False(t, event.ProcessCacheEntry.ExitTime.Before(event.ProcessCacheEntry.ExecTime), "exit time < exec time")
+			assert.False(t, event.ProcessContext.ExitTime.Before(event.ProcessContext.ExecTime), "exit time < exec time")
 		})
 	})
 
@@ -1738,7 +1735,7 @@ func TestProcessExit(t *testing.T) {
 			assertFieldEqual(t, event, "exit.file.path", sleepExec)
 			assert.Equal(t, uint32(model.ExitExited), event.Exit.Cause, "wrong exit cause")
 			assert.Equal(t, uint32(0), event.Exit.Code, "wrong exit code")
-			assert.False(t, event.ProcessCacheEntry.ExitTime.Before(event.ProcessCacheEntry.ExecTime), "exit time < exec time")
+			assert.False(t, event.ProcessContext.ExitTime.Before(event.ProcessContext.ExecTime), "exit time < exec time")
 		})
 	})
 
@@ -1756,7 +1753,7 @@ func TestProcessExit(t *testing.T) {
 			assertFieldEqual(t, event, "exit.file.path", sleepExec)
 			assert.Equal(t, uint32(model.ExitExited), event.Exit.Cause, "wrong exit cause")
 			assert.Equal(t, uint32(0), event.Exit.Code, "wrong exit code")
-			assert.False(t, event.ProcessCacheEntry.ExitTime.Before(event.ProcessCacheEntry.ExecTime), "exit time < exec time")
+			assert.False(t, event.ProcessContext.ExitTime.Before(event.ProcessContext.ExecTime), "exit time < exec time")
 		})
 	})
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Remove the use of the process cache entry pointer. This pointer is used internally to track process context. Only the process context should be used outside of the probe package.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
