### PR TITLE
Remove fips.https and fips.port_range_start from config_template.yaml

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -564,20 +564,6 @@ api_key:
   #
   # local_address: localhost
 
-  ## @param https - boolean - optional - default: true
-  ## @env DD_FIPS_HTTPS - boolean - optional - default: true
-  ## Use HTTPS when communicating with the FIPS proxy.
-  #
-  # https: true
-
-  ## @param port_range_start - integer - optional - default: 9803
-  ## @env DD_FIPS_LOCAL_PORT_RANGE_START - integer - optional - default: 9803
-  ## The FIPS proxy will bind a range of consecutive ports, each dedicated to a specific product (Metrics, Logs, APM.
-  ## Database monitoring, ...). 'port_range_start' is the first port in this range. The Agent will automatically assign
-  ## the right port to the right product based on this information.
-  #
-  # port_range_start: 3833
-
 ## @param observability_pipelines_worker - custom object - optional
 ## Configuration for forwarding telemetry to an Observability Pipelines Worker instead of Datadog.
 ## https://www.datadoghq.com/product/observability-pipelines/


### PR DESCRIPTION

### What does this PR do?

Remove some fips documentation in `config_template.yaml`. (will be re added later)

### Motivation

- `fips.https` can only be used with value False since https is not implemented yet
- `fips.port_range_start` equivalent on the fips proxy side is not implemented yet

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
