### PR TITLE
Optional limit on number of dogstatsd contexts per origin

### DIFF
--- a/pkg/aggregator/context_resolver.go
+++ b/pkg/aggregator/context_resolver.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator/ckey"
+	"github.com/DataDog/datadog-agent/pkg/aggregator/internal/limiter"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/internal/tags"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
 	"github.com/DataDog/datadog-agent/pkg/tagset"
@@ -42,6 +43,7 @@ type contextResolver struct {
 	keyGenerator  *ckey.KeyGenerator
 	taggerBuffer  *tagset.HashingTagsAccumulator
 	metricBuffer  *tagset.HashingTagsAccumulator
+	limiter       *limiter.Limiter
 }
 
 // generateContextKey generates the contextKey associated with the context of the metricSample
@@ -49,7 +51,7 @@ func (cr *contextResolver) generateContextKey(metricSampleContext metrics.Metric
 	return cr.keyGenerator.GenerateWithTags2(metricSampleContext.GetName(), metricSampleContext.GetHost(), cr.taggerBuffer, cr.metricBuffer)
 }
 
-func newContextResolver(cache *tags.Store) *contextResolver {
+func newContextResolver(cache *tags.Store, limiter *limiter.Limiter) *contextResolver {
 	return &contextResolver{
 		contextsByKey: make(map[ckey.ContextKey]*Context),
 		countsByMtype: make([]uint64, metrics.NumMetricTypes),
@@ -57,15 +59,23 @@ func newContextResolver(cache *tags.Store) *contextResolver {
 		keyGenerator:  ckey.NewKeyGenerator(),
 		taggerBuffer:  tagset.NewHashingTagsAccumulator(),
 		metricBuffer:  tagset.NewHashingTagsAccumulator(),
+		limiter:       limiter,
 	}
 }
 
 // trackContext returns the contextKey associated with the context of the metricSample and tracks that context
-func (cr *contextResolver) trackContext(metricSampleContext metrics.MetricSampleContext) ckey.ContextKey {
-	metricSampleContext.GetTags(cr.taggerBuffer, cr.metricBuffer)                  // tags here are not sorted and can contain duplicates
+func (cr *contextResolver) trackContext(metricSampleContext metrics.MetricSampleContext) (ckey.ContextKey, bool) {
+	metricSampleContext.GetTags(cr.taggerBuffer, cr.metricBuffer) // tags here are not sorted and can contain duplicates
+	defer cr.taggerBuffer.Reset()
+	defer cr.metricBuffer.Reset()
+
 	contextKey, taggerKey, metricKey := cr.generateContextKey(metricSampleContext) // the generator will remove duplicates (and doesn't mind the order)
 
 	if _, ok := cr.contextsByKey[contextKey]; !ok {
+		if !cr.canAdd() {
+			return contextKey, false
+		}
+
 		mtype := metricSampleContext.GetMetricType()
 		cr.contextsByKey[contextKey] = &Context{
 			Name:       metricSampleContext.GetName(),
@@ -78,10 +88,11 @@ func (cr *contextResolver) trackContext(metricSampleContext metrics.MetricSample
 		cr.countsByMtype[mtype]++
 	}
 
-	cr.taggerBuffer.Reset()
-	cr.metricBuffer.Reset()
+	return contextKey, true
+}
 
-	return contextKey
+func (cr *contextResolver) canAdd() bool {
+	return cr.limiter.Track(cr.taggerBuffer.Get())
 }
 
 func (cr *contextResolver) get(key ckey.ContextKey) (*Context, bool) {
@@ -100,6 +111,7 @@ func (cr *contextResolver) removeKeys(expiredContextKeys []ckey.ContextKey) {
 
 		if context != nil {
 			cr.countsByMtype[context.mtype]--
+			cr.limiter.Remove(context.taggerTags.Tags())
 			context.release()
 		}
 	}
@@ -141,15 +153,19 @@ func (c *contextResolver) sendOriginTelemetry(timestamp float64, series metrics.
 	}
 }
 
+func (c *contextResolver) sendLimiterTelemetry(timestamp float64, series metrics.SerieSink, hostname string, constTags []string) {
+	c.limiter.SendTelemetry(timestamp, series, hostname, constTags)
+}
+
 // timestampContextResolver allows tracking and expiring contexts based on time.
 type timestampContextResolver struct {
 	resolver      *contextResolver
 	lastSeenByKey map[ckey.ContextKey]float64
 }
 
-func newTimestampContextResolver(cache *tags.Store) *timestampContextResolver {
+func newTimestampContextResolver(cache *tags.Store, limiter *limiter.Limiter) *timestampContextResolver {
 	return &timestampContextResolver{
-		resolver:      newContextResolver(cache),
+		resolver:      newContextResolver(cache, limiter),
 		lastSeenByKey: make(map[ckey.ContextKey]float64),
 	}
 }
@@ -166,10 +182,10 @@ func (cr *timestampContextResolver) updateTrackedContext(contextKey ckey.Context
 }
 
 // trackContext returns the contextKey associated with the context of the metricSample and tracks that context
-func (cr *timestampContextResolver) trackContext(metricSampleContext metrics.MetricSampleContext, currentTimestamp float64) ckey.ContextKey {
-	contextKey := cr.resolver.trackContext(metricSampleContext)
+func (cr *timestampContextResolver) trackContext(metricSampleContext metrics.MetricSampleContext, currentTimestamp float64) (ckey.ContextKey, bool) {
+	contextKey, ok := cr.resolver.trackContext(metricSampleContext)
 	cr.lastSeenByKey[contextKey] = currentTimestamp
-	return contextKey
+	return contextKey, ok
 }
 
 func (cr *timestampContextResolver) length() int {
@@ -211,6 +227,10 @@ func (cr *timestampContextResolver) sendOriginTelemetry(timestamp float64, serie
 	cr.resolver.sendOriginTelemetry(timestamp, series, hostname, tags)
 }
 
+func (cr *timestampContextResolver) sendLimiterTelemetry(timestamp float64, series metrics.SerieSink, hostname string, tags []string) {
+	cr.resolver.sendLimiterTelemetry(timestamp, series, hostname, tags)
+}
+
 // countBasedContextResolver allows tracking and expiring contexts based on the number
 // of calls of `expireContexts`.
 type countBasedContextResolver struct {
@@ -222,7 +242,7 @@ type countBasedContextResolver struct {
 
 func newCountBasedContextResolver(expireCountInterval int, cache *tags.Store) *countBasedContextResolver {
 	return &countBasedContextResolver{
-		resolver:            newContextResolver(cache),
+		resolver:            newContextResolver(cache, nil),
 		expireCountByKey:    make(map[ckey.ContextKey]int64),
 		expireCount:         0,
 		expireCountInterval: int64(expireCountInterval),
@@ -231,7 +251,7 @@ func newCountBasedContextResolver(expireCountInterval int, cache *tags.Store) *c
 
 // trackContext returns the contextKey associated with the context of the metricSample and tracks that context
 func (cr *countBasedContextResolver) trackContext(metricSampleContext metrics.MetricSampleContext) ckey.ContextKey {
-	contextKey := cr.resolver.trackContext(metricSampleContext)
+	contextKey, _ := cr.resolver.trackContext(metricSampleContext)
 	cr.expireCountByKey[contextKey] = cr.expireCount
 	return contextKey
 }

--- a/pkg/aggregator/context_resolver.go
+++ b/pkg/aggregator/context_resolver.go
@@ -72,7 +72,7 @@ func (cr *contextResolver) trackContext(metricSampleContext metrics.MetricSample
 	contextKey, taggerKey, metricKey := cr.generateContextKey(metricSampleContext) // the generator will remove duplicates (and doesn't mind the order)
 
 	if _, ok := cr.contextsByKey[contextKey]; !ok {
-		if !cr.canAdd() {
+		if !cr.tryAdd() {
 			return contextKey, false
 		}
 
@@ -91,7 +91,7 @@ func (cr *contextResolver) trackContext(metricSampleContext metrics.MetricSample
 	return contextKey, true
 }
 
-func (cr *contextResolver) canAdd() bool {
+func (cr *contextResolver) tryAdd() bool {
 	return cr.limiter.Track(cr.taggerBuffer.Get())
 }
 

--- a/pkg/aggregator/context_resolver_test.go
+++ b/pkg/aggregator/context_resolver_test.go
@@ -337,15 +337,9 @@ func TestLimiterTelemetry(t *testing.T) {
 		MType:  metrics.APIGaugeType,
 		Points: []metrics.Point{{Ts: ts, Value: 2.0}},
 	}, {
-		Name:   "datadog.agent.aggregator.dogstatsd_context_limiter.accepted",
+		Name:   "datadog.agent.aggregator.dogstatsd_samples_dropped",
 		Host:   "test",
-		Tags:   tagset.NewCompositeTags([]string{"test"}, []string{"pod:foo", "srv:foo"}),
-		MType:  metrics.APICountType,
-		Points: []metrics.Point{{Ts: ts, Value: 2.0}},
-	}, {
-		Name:   "datadog.agent.aggregator.dogstatsd_context_limiter.rejected",
-		Host:   "test",
-		Tags:   tagset.NewCompositeTags([]string{"test"}, []string{"pod:foo", "srv:foo"}),
+		Tags:   tagset.NewCompositeTags([]string{"test", "reason:too_many_contexts"}, []string{"pod:foo", "srv:foo"}),
 		MType:  metrics.APICountType,
 		Points: []metrics.Point{{Ts: ts, Value: 1.0}},
 	}, {
@@ -355,15 +349,9 @@ func TestLimiterTelemetry(t *testing.T) {
 		MType:  metrics.APIGaugeType,
 		Points: []metrics.Point{{Ts: ts, Value: 2.0}},
 	}, {
-		Name:   "datadog.agent.aggregator.dogstatsd_context_limiter.accepted",
+		Name:   "datadog.agent.aggregator.dogstatsd_samples_dropped",
 		Host:   "test",
-		Tags:   tagset.NewCompositeTags([]string{"test"}, []string{"pod:bar"}),
-		MType:  metrics.APICountType,
-		Points: []metrics.Point{{Ts: ts, Value: 2.0}},
-	}, {
-		Name:   "datadog.agent.aggregator.dogstatsd_context_limiter.rejected",
-		Host:   "test",
-		Tags:   tagset.NewCompositeTags([]string{"test"}, []string{"pod:bar"}),
+		Tags:   tagset.NewCompositeTags([]string{"test", "reason:too_many_contexts"}, []string{"pod:bar"}),
 		MType:  metrics.APICountType,
 		Points: []metrics.Point{{Ts: ts, Value: 0.0}},
 	}, {
@@ -373,15 +361,9 @@ func TestLimiterTelemetry(t *testing.T) {
 		MType:  metrics.APIGaugeType,
 		Points: []metrics.Point{{Ts: ts, Value: 1.0}},
 	}, {
-		Name:   "datadog.agent.aggregator.dogstatsd_context_limiter.accepted",
+		Name:   "datadog.agent.aggregator.dogstatsd_samples_dropped",
 		Host:   "test",
-		Tags:   tagset.NewCompositeTags([]string{"test"}, []string{"pod:baz"}),
-		MType:  metrics.APICountType,
-		Points: []metrics.Point{{Ts: ts, Value: 1.0}},
-	}, {
-		Name:   "datadog.agent.aggregator.dogstatsd_context_limiter.rejected",
-		Host:   "test",
-		Tags:   tagset.NewCompositeTags([]string{"test"}, []string{"pod:baz"}),
+		Tags:   tagset.NewCompositeTags([]string{"test", "reason:too_many_contexts"}, []string{"pod:baz"}),
 		MType:  metrics.APICountType,
 		Points: []metrics.Point{{Ts: ts, Value: 0.0}},
 	}})

--- a/pkg/aggregator/demultiplexer_serverless.go
+++ b/pkg/aggregator/demultiplexer_serverless.go
@@ -43,7 +43,7 @@ func InitAndStartServerlessDemultiplexer(domainResolvers map[string]resolver.Dom
 	metricSamplePool := metrics.NewMetricSamplePool(MetricSamplePoolBatchSize)
 	tagsStore := tags.NewStore(config.Datadog.GetBool("aggregator_use_tags_store"), "timesampler")
 
-	statsdSampler := NewTimeSampler(TimeSamplerID(0), bucketSize, tagsStore, "")
+	statsdSampler := NewTimeSampler(TimeSamplerID(0), bucketSize, tagsStore, nil, "")
 	flushAndSerializeInParallel := NewFlushAndSerializeInParallel(config.Datadog)
 	statsdWorker := newTimeSamplerWorker(statsdSampler, DefaultFlushInterval, bufferSize, metricSamplePool, flushAndSerializeInParallel, tagsStore)
 

--- a/pkg/aggregator/internal/limiter/limiter.go
+++ b/pkg/aggregator/internal/limiter/limiter.go
@@ -1,0 +1,167 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package limiter
+
+import (
+	"strings"
+
+	"github.com/DataDog/datadog-agent/pkg/metrics"
+	"github.com/DataDog/datadog-agent/pkg/tagset"
+)
+
+type entry struct {
+	current  int // number of contexts currently in aggregator
+	accepted int // number of accepted samples
+	rejected int // number of rejected samples
+	tags     []string
+}
+
+// Limiter tracks number of contexts based on origin detection metrics
+// and rejects samples if the number goes over the limit.
+//
+// Not thread safe.
+type Limiter struct {
+	key   string
+	tags  []string
+	limit int
+	usage map[string]*entry
+}
+
+// New returns a new instance of limiter.
+//
+// If limit is zero or less the limiter is disabled.
+func New(limit int, key string, tags []string) *Limiter {
+	if limit <= 0 {
+		return nil
+	}
+
+	if !strings.HasSuffix(key, ":") {
+		key += ":"
+	}
+
+	tags = append([]string{}, tags...)
+	for i := range tags {
+		if !strings.HasSuffix(tags[i], ":") {
+			tags[i] += ":"
+		}
+	}
+
+	return &Limiter{
+		key:   key,
+		tags:  tags,
+		limit: limit,
+		usage: map[string]*entry{},
+	}
+}
+
+func (l *Limiter) identify(tags []string) string {
+	for _, t := range tags {
+		if strings.HasPrefix(t, l.key) {
+			return t
+		}
+	}
+	return ""
+}
+
+func (l *Limiter) extractTags(src []string) []string {
+	dst := make([]string, 0, len(l.tags))
+
+	for _, t := range src {
+		for _, p := range l.tags {
+			if strings.HasPrefix(t, p) {
+				dst = append(dst, t)
+			}
+		}
+	}
+
+	return dst
+}
+
+// Track is called for each new context. Returns true if the sample should be accepted, false
+// otherwise.
+func (l *Limiter) Track(tags []string) bool {
+	if l == nil {
+		return true
+	}
+
+	id := l.identify(tags)
+
+	e := l.usage[id]
+	if e == nil {
+		e = &entry{
+			tags: l.extractTags(tags),
+		}
+		l.usage[id] = e
+	}
+
+	if e.current >= l.limit {
+		e.rejected++
+		return false
+	}
+
+	e.current++
+	e.accepted++
+	return true
+}
+
+// Remove is called when context is expired to decrement current usage.
+func (l *Limiter) Remove(tags []string) {
+	if l == nil {
+		return
+	}
+
+	id := l.identify(tags)
+
+	if e := l.usage[id]; e != nil {
+		e.current--
+		if e.current <= 0 {
+			delete(l.usage, id)
+		}
+	}
+}
+
+// SendTelemetry appends limiter metrics to the series sink.
+func (l *Limiter) SendTelemetry(timestamp float64, series metrics.SerieSink, hostname string, constTags []string) {
+	if l == nil {
+		return
+	}
+
+	for _, e := range l.usage {
+		series.Append(&metrics.Serie{
+			Name:   "datadog.agent.aggregator.dogstatsd_context_limiter.limit",
+			Host:   hostname,
+			Tags:   tagset.NewCompositeTags(constTags, e.tags),
+			MType:  metrics.APIGaugeType,
+			Points: []metrics.Point{{Ts: timestamp, Value: float64(l.limit)}},
+		})
+
+		series.Append(&metrics.Serie{
+			Name:   "datadog.agent.aggregator.dogstatsd_context_limiter.current",
+			Host:   hostname,
+			Tags:   tagset.NewCompositeTags(constTags, e.tags),
+			MType:  metrics.APIGaugeType,
+			Points: []metrics.Point{{Ts: timestamp, Value: float64(e.current)}},
+		})
+
+		series.Append(&metrics.Serie{
+			Name:   "datadog.agent.aggregator.dogstatsd_context_limiter.accepted",
+			Host:   hostname,
+			Tags:   tagset.NewCompositeTags(constTags, e.tags),
+			MType:  metrics.APICountType,
+			Points: []metrics.Point{{Ts: timestamp, Value: float64(e.accepted)}},
+		})
+		e.accepted = 0
+
+		series.Append(&metrics.Serie{
+			Name:   "datadog.agent.aggregator.dogstatsd_context_limiter.rejected",
+			Host:   hostname,
+			Tags:   tagset.NewCompositeTags(constTags, e.tags),
+			MType:  metrics.APICountType,
+			Points: []metrics.Point{{Ts: timestamp, Value: float64(e.rejected)}},
+		})
+		e.rejected = 0
+	}
+}

--- a/pkg/aggregator/internal/limiter/limiter.go
+++ b/pkg/aggregator/internal/limiter/limiter.go
@@ -42,11 +42,17 @@ func New(limit int, key string, tags []string) *Limiter {
 		key += ":"
 	}
 
+	hasKey := false
 	tags = append([]string{}, tags...)
 	for i := range tags {
 		if !strings.HasSuffix(tags[i], ":") {
 			tags[i] += ":"
 		}
+		hasKey = hasKey || key == tags[i]
+	}
+
+	if !hasKey {
+		tags = append(tags, key)
 	}
 
 	return &Limiter{

--- a/pkg/aggregator/internal/limiter/limiter.go
+++ b/pkg/aggregator/internal/limiter/limiter.go
@@ -34,7 +34,8 @@ type Limiter struct {
 //
 // limit is the maximum number of contexts per sender. If zero or less, the limiter is disabled.
 //
-// keyTagName is the origin-detection tag name that will be used to identify the senders.
+// keyTagName is the origin-detection tag name that will be used to identify the senders. Contexts
+// that have no tag will be tracked as a single sender and the limit will still be applied.
 //
 // telemetryTagNames are additional tags that will be copied to the per-sender telemetry. Telemetry
 // tags should have the same values for all containers that have the same key tag value and will be

--- a/pkg/aggregator/internal/limiter/limiter.go
+++ b/pkg/aggregator/internal/limiter/limiter.go
@@ -47,6 +47,8 @@ func New(limit int, keyTagName string, telemetryTagNames []string) *Limiter {
 		return nil
 	}
 
+	// Make sure all names end with a colon, so we don't accidentally match a part of the tag name, only the full name.
+	// e.g. keyTagName="pod_name" should not match the tag "pod_name_alias:foo"
 	if !strings.HasSuffix(keyTagName, ":") {
 		keyTagName += ":"
 	}
@@ -60,6 +62,7 @@ func New(limit int, keyTagName string, telemetryTagNames []string) *Limiter {
 		hasKey = hasKey || keyTagName == telemetryTagNames[i]
 	}
 
+	// Make sure key tag is always set on the telemetry metrics.
 	if !hasKey {
 		telemetryTagNames = append(telemetryTagNames, keyTagName)
 	}

--- a/pkg/aggregator/internal/limiter/limiter_test.go
+++ b/pkg/aggregator/internal/limiter/limiter_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestLimiter(t *testing.T) {
-	l := New(1, "pod", []string{"pod", "srv"})
+	l := New(1, "pod", []string{"srv"})
 
 	// check that:
 	// - unrelated tags are not used
@@ -20,6 +20,8 @@ func TestLimiter(t *testing.T) {
 	// - missing tag maps to a the same identity
 
 	a := assert.New(t)
+
+	a.Equal(l.tags, []string{"srv:", "pod:"})
 
 	a.True(l.Track([]string{"srv:foo", "cid:1", "pod", "pod:foo"}))
 	a.False(l.Track([]string{"srv:foo", "cid:2", "pod", "pod:foo"}))

--- a/pkg/aggregator/internal/limiter/limiter_test.go
+++ b/pkg/aggregator/internal/limiter/limiter_test.go
@@ -41,7 +41,6 @@ func TestLimiter(t *testing.T) {
 
 	a.Equal(&entry{
 		current:  1,
-		accepted: 1,
 		rejected: 0,
 		tags:     []string{"srv:bar", "pod:foo"},
 	}, l.usage["pod:foo"])

--- a/pkg/aggregator/internal/limiter/limiter_test.go
+++ b/pkg/aggregator/internal/limiter/limiter_test.go
@@ -1,0 +1,49 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package limiter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLimiter(t *testing.T) {
+	l := New(1, "pod", []string{"pod", "srv"})
+
+	// check that:
+	// - unrelated tags are not used
+	// - tags without values are not used
+	// - missing tag maps to a the same identity
+
+	a := assert.New(t)
+
+	a.True(l.Track([]string{"srv:foo", "cid:1", "pod", "pod:foo"}))
+	a.False(l.Track([]string{"srv:foo", "cid:2", "pod", "pod:foo"}))
+
+	a.True(l.Track([]string{"srv:foo", "cid:3", "pod", "pod:bar"}))
+	a.False(l.Track([]string{"srv:foo", "cid:4", "pod", "pod:bar"}))
+
+	a.True(l.Track([]string{"srv:foo", "cid:5", "pod"}))
+	a.False(l.Track([]string{"srv:foo", "cid:6", "pod"}))
+	a.False(l.Track([]string{}))
+
+	l.Remove([]string{})
+	a.True(l.Track([]string{}))
+
+	l.Remove([]string{"srv:bar", "pod:foo"})
+	a.True(l.Track([]string{"srv:bar", "pod:foo"}))
+
+	a.Equal(&entry{
+		current:  1,
+		accepted: 1,
+		rejected: 0,
+		tags:     []string{"srv:bar", "pod:foo"},
+	}, l.usage["pod:foo"])
+
+	l.Remove([]string{"pod:foo"})
+	a.Nil(l.usage["pod:foo"])
+}

--- a/pkg/aggregator/internal/limiter/limiter_test.go
+++ b/pkg/aggregator/internal/limiter/limiter_test.go
@@ -21,7 +21,7 @@ func TestLimiter(t *testing.T) {
 
 	a := assert.New(t)
 
-	a.Equal(l.tags, []string{"srv:", "pod:"})
+	a.Equal(l.telemetryTagNames, []string{"srv:", "pod:"})
 
 	a.True(l.Track([]string{"srv:foo", "cid:1", "pod", "pod:foo"}))
 	a.False(l.Track([]string{"srv:foo", "cid:2", "pod", "pod:foo"}))
@@ -40,9 +40,9 @@ func TestLimiter(t *testing.T) {
 	a.True(l.Track([]string{"srv:bar", "pod:foo"}))
 
 	a.Equal(&entry{
-		current:  1,
-		rejected: 0,
-		tags:     []string{"srv:bar", "pod:foo"},
+		current:       1,
+		rejected:      0,
+		telemetryTags: []string{"srv:bar", "pod:foo"},
 	}, l.usage["pod:foo"])
 
 	l.Remove([]string{"pod:foo"})

--- a/pkg/aggregator/time_sampler_test.go
+++ b/pkg/aggregator/time_sampler_test.go
@@ -555,7 +555,6 @@ func BenchmarkTimeSamplerWithLimiter(b *testing.B) {
 	for limit := range []int{0, 1, 2, 3} {
 		store := tags.NewStore(false, "test")
 		limiter := limiter.New(limit, "pod", []string{"pod"})
-		fmt.Println(limiter)
 		sampler := NewTimeSampler(TimeSamplerID(0), 10, store, limiter, "host")
 
 		b.Run(fmt.Sprintf("limit=%d", limit), func(b *testing.B) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -558,6 +558,10 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("dogstatsd_mem_based_rate_limiter.soft_limit_freeos_check.max", 0.1)
 	config.BindEnvAndSetDefault("dogstatsd_mem_based_rate_limiter.soft_limit_freeos_check.factor", 1.5)
 
+	config.BindEnvAndSetDefault("dogstatsd_context_limiter.limit", 0)
+	config.BindEnvAndSetDefault("dogstatsd_context_limiter.key_tag_name", "pod_name")
+	config.BindEnvAndSetDefault("dogstatsd_context_limiter.telemetry_tag_names", []string{})
+
 	config.BindEnv("dogstatsd_mapper_profiles")
 	config.SetEnvKeyTransformer("dogstatsd_mapper_profiles", func(in string) interface{} {
 		var mappings []MappingProfile
@@ -1045,6 +1049,7 @@ func InitConfig(config Config) {
 	// This create a lot of billable custom metrics.
 	config.BindEnvAndSetDefault("telemetry.enabled", false)
 	config.BindEnvAndSetDefault("telemetry.dogstatsd_origin", false)
+	config.BindEnvAndSetDefault("telemetry.dogstatsd_limiter", true)
 	config.BindEnvAndSetDefault("telemetry.python_memory", true)
 	config.BindEnv("telemetry.checks")
 	// We're using []string as a default instead of []float64 because viper can only parse list of string from the environment

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -558,7 +558,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("dogstatsd_mem_based_rate_limiter.soft_limit_freeos_check.max", 0.1)
 	config.BindEnvAndSetDefault("dogstatsd_mem_based_rate_limiter.soft_limit_freeos_check.factor", 1.5)
 
-	config.BindEnvAndSetDefault("dogstatsd_context_limiter.limit", 0)
+	config.BindEnvAndSetDefault("dogstatsd_context_limiter.limit", 0) // 0 = disabled.
 	config.BindEnvAndSetDefault("dogstatsd_context_limiter.key_tag_name", "pod_name")
 	config.BindEnvAndSetDefault("dogstatsd_context_limiter.telemetry_tag_names", []string{})
 


### PR DESCRIPTION
### What does this PR do?

Add a configurable limit on the number of contexts that each dogstatsd sender is allowed to create in the agent.


### Motivation

Provide a mechanism to control amount of memory agent uses for aggregation of dogstatsd traffic.

### Additional Notes


### Possible Drawbacks / Trade-offs

For simplicity, in configurations with multiple parallel time sampler pipelines, the limit is equally divided between the pipelines. This may make the effective limit slightly smaller due to uneven distribution of contexts between the samplers (around 5% based on testing), but the upside is very simple concurrency free implementation of the limiter.

### Describe how to test/QA your changes

(With #17163 the limit is global and is divided between senders at runtime).

Run the agent in Docker with
```
-v /var/run/docker.sock:/var/run/docker.sock:ro \
-v /var/lib/docker:/var/lib/docker \
-v /proc/:/host/proc/:ro \
-v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
-v /tmp:/tmp \
-e DD_DOGSTATSD_ORIGIN_DETECTION=true \
-e DD_DOGSTATSD_TAG_CARDINALITY=high \
-e DD_DOGSTATSD_CONTEXT_LIMITER_LIMIT=10 \
-e DD_DOGSTATSD_CONTEXT_LIMITER_KEY_TAG_NAME=container_name \
-e DD_DOGSTATSD_CONTEXT_LIMITER_TELEMETRY_TAG_NAMES=image_name \
-e DD_TELEMETRY_ENABLED=true \
-e DD_DOGSTATSD_SOCKET=/tmp/dsd.sock \
```

Send 10 metrics from two different docker containers containers each with a [script](https://gist.github.com/vickenty/4212762acd56a026253eccd3865f15a1):

```
docker run --rm --name qa1 -d -v /tmp:/tmp python:slim python /tmp/send.py /tmp/dsd.sock qa.metric1
docker run --rm --name qa2 -d -v /tmp:/tmp python:slim python /tmp/send.py /tmp/dsd.sock qa.metric1
```

- Check that `qa.metric1` is queryable.
- Check that `sum(datadog.agent.aggregator.contexts_by_origin)` equals 10.
- Check that `sum(datadog.agent.aggregator.dogstatsd_context_limiter.current) by {container_name,image_name}` shows 5 for each container.

Keep the agent running, stop qa1 and restart with a different metric name:
```
docker rm -f qa1
docker run --rm --name qa1 -d -v $(pwd) python:slim python /tmp/send.py /tmp/dsd.sock qa.metric2
```

Check that `qa.metric2` is queryable (there may be gap of ~30s between the two as `qa.metric1` contexts need to expire first).

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
