### PR TITLE
Fix labels/annotations as tags feature on APIService KSM metrics

### DIFF
--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_defaults.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_defaults.go
@@ -222,14 +222,16 @@ func defaultLabelJoins() map[string]*JoinsConfigWithoutLabelsMapping {
 // label or and because some other resource doesn't need the `namespace` label.
 func getLabelToMatchForKind(kind string) []string {
 	switch kind {
+	case "apiservice": // API Services are not namespaced
+		return []string{"apiservice"}
+	case "customresourcedefinition": // CRD are not namespaced
+		return []string{"customresourcedefinition"}
 	case "job": // job metrics use specific label
 		return []string{"job_name", "namespace"}
 	case "node": // persistent nodes are not namespaced
 		return []string{"node"}
 	case "persistentvolume": // persistent volumes are not namespaced
 		return []string{"persistentvolume"}
-	case "customresourcedefinition": // CRD are not namespaced
-		return []string{"customresourcedefinition"}
 	default:
 		return []string{kind, "namespace"}
 	}


### PR DESCRIPTION
### What does this PR do?
* Adds `apiservice` to the list of non-namespaced resources for the KSM check in order for `getLabelToMatchForKind` to work (i.e. to be able to receive labels and annotations as tags on `kubernetes_state.apiservice.*` metrics introduced in https://github.com/DataDog/datadog-agent/pull/16570)
* Re-orders the `customresourcedefinition` entry to follow alphabetical order

### Motivation

* Q/Aing with labels and annotations on APIServices did not bring tags to the metrics, saw it was linked to https://github.com/DataDog/datadog-agent/pull/16656

### Describe how to test/QA your changes

* Deploy the cluster Agent with a configured KSM that includes `apiservices`, i.e. with Helm : 
```
clusterAgent:
  confd:
    kubernetes_state_core.yaml: |-
      init_config:
      instances:
        - collectors:
          - apiservices
          labels_as_tags:
            apiservice:
              lenaic: mycustomlabel
          annotations_as_tags:
            apiservice:
              lenaic: mycustomannotation
``` 
* Edit the ksm core clusterrole created by the chart : 
```
 apiGroups:
  - apiregistration.k8s.io
  resources:
  - apiservices
  verbs:
  - list
  - watch
```
* Re-deploy the cluster Agent pod to ensure it uses the "new" RBAC when starting the KSM core check, i.e. `k delete pod <DD_CLUSTER_AGENT_POD>`
* Observe that `kubernetes_state.apiservice.condition` and `kubernetes_state.apiservice.count` are collected, while other KSM metrics are still being collected (depending on your config). Check that annotated/labelled APIServices objects have their KSM metrics tagged : 
<img width="2390" alt="Image 2023-04-24 at 3 00 25 PM" src="https://user-images.githubusercontent.com/97530782/234004108-20f6b36d-e16b-40b6-b785-f97d28596eb0.png">

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
