### PR TITLE
[process-agent] Change sysprobe config missing error to info on Darwin

### DIFF
--- a/cmd/system-probe/config/config.go
+++ b/cmd/system-probe/config/config.go
@@ -103,11 +103,11 @@ func newSysprobeConfig(configPath string, loadSecrets bool) (*Config, error) {
 			if runtime.GOOS == "darwin" {
 				log.Infof("Error loading config: %v (check config file permissions for dd-agent user)", err)
 			} else {
-				log.Warnf("Error loading config: %v", err)
+				log.Warnf("Error loading config: %v (check config file permissions for dd-agent user)", err)
 			}
 		} else {
 			if runtime.GOOS == "darwin" {
-				log.Infof("Error loading config: %v (check config file permissions for dd-agent user)", err)
+				log.Infof("Error loading config: %v", err)
 			} else {
 				log.Warnf("Error loading config: %v", err)
 			}

--- a/cmd/system-probe/config/config.go
+++ b/cmd/system-probe/config/config.go
@@ -99,15 +99,10 @@ func newSysprobeConfig(configPath string, loadSecrets bool) (*Config, error) {
 	// load the configuration
 	_, err := aconfig.LoadCustom(aconfig.SystemProbe, "system-probe", loadSecrets, aconfig.Datadog.GetEnvVars())
 	if err != nil {
-		if errors.Is(err, os.ErrPermission) {
-			if runtime.GOOS == "darwin" {
-				log.Infof("Error loading config: %v (check config file permissions for dd-agent user)", err)
-			} else {
+		// System probe is not supported on darwin, so we should fail gracefully in this case.
+		if runtime.GOOS != "darwin" {
+			if errors.Is(err, os.ErrPermission) {
 				log.Warnf("Error loading config: %v (check config file permissions for dd-agent user)", err)
-			}
-		} else {
-			if runtime.GOOS == "darwin" {
-				log.Infof("Error loading config: %v", err)
 			} else {
 				log.Warnf("Error loading config: %v", err)
 			}

--- a/cmd/system-probe/config/config.go
+++ b/cmd/system-probe/config/config.go
@@ -99,6 +99,20 @@ func newSysprobeConfig(configPath string, loadSecrets bool) (*Config, error) {
 	// load the configuration
 	_, err := aconfig.LoadCustom(aconfig.SystemProbe, "system-probe", loadSecrets, aconfig.Datadog.GetEnvVars())
 	if err != nil {
+		if errors.Is(err, os.ErrPermission) {
+			if runtime.GOOS == "darwin" {
+				log.Infof("Error loading config: %v (check config file permissions for dd-agent user)", err)
+			} else {
+				log.Warnf("Error loading config: %v", err)
+			}
+		} else {
+			if runtime.GOOS == "darwin" {
+				log.Infof("Error loading config: %v (check config file permissions for dd-agent user)", err)
+			} else {
+				log.Warnf("Error loading config: %v", err)
+			}
+		}
+
 		var e viper.ConfigFileNotFoundError
 		if errors.As(err, &e) || errors.Is(err, os.ErrNotExist) {
 			// do nothing, we can ignore a missing system-probe.yaml config file

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1481,6 +1481,11 @@ func LoadDatadogCustomWithKnownEnvVars(config Config, origin string, loadSecret 
 
 	warnings, err := LoadCustom(config, origin, loadSecret, additionalKnownEnvVars)
 	if err != nil {
+		if errors.Is(err, os.ErrPermission) {
+			log.Warnf("Error loading config: %v (check config file permissions for dd-agent user)", err)
+		} else {
+			log.Warnf("Error loading config: %v", err)
+		}
 		return warnings, err
 	}
 
@@ -1515,11 +1520,6 @@ func LoadCustom(config Config, origin string, loadSecret bool, additionalKnownEn
 		if IsServerless() {
 			log.Debug("No config file detected, using environment variable based configuration only")
 			return &warnings, nil
-		}
-		if errors.Is(err, os.ErrPermission) {
-			log.Warnf("Error loading config: %v (check config file permissions for dd-agent user)", err)
-		} else {
-			log.Warnf("Error loading config: %v", err)
 		}
 		return &warnings, err
 	}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR fixes a bug where this error:
```
2023-04-24 12:36:54 EDT | PROCESS | INFO | (cmd/system-probe/config/config.go:110 in newSysprobeConfig) | Error loading config: Config File "system-probe" Not Found in "[]" (check config file permissions for dd-agent user)
```
Is printed as a warning on MacOS, even though system probe is not supported on that platform. This PR changes this log line to be an info message on Mac, and a warning everywhere else.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Buxfix

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

On Darwin, without the system probe config, run the process agent and make sure this line:
```
2023-04-24 12:36:54 EDT | PROCESS | INFO | (cmd/system-probe/config/config.go:110 in newSysprobeConfig) | Error loading config: Config File "system-probe" Not Found in "[]" (check config file permissions for dd-agent user)
```
Is logged as `INFO`, not `WARN`. On linux, make sure it is logged as `WARN`.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
