### PR TITLE
[Serverless] fix missing log

### DIFF
--- a/pkg/logs/agent_serverless.go
+++ b/pkg/logs/agent_serverless.go
@@ -60,5 +60,10 @@ func NewAgent(sources *sources.LogSources, services *service.Services, processin
 
 // buildEndpoints builds endpoints for the logs agent
 func buildEndpoints() (*config.Endpoints, error) {
-	return config.BuildServerlessEndpoints(intakeTrackType, config.DefaultIntakeProtocol)
+	config, err := config.BuildServerlessEndpoints(intakeTrackType, config.DefaultIntakeProtocol); err != nil {
+		return nil, err
+	}
+	// in serverless mode, we never want the batch strategy to flush with a tick
+	config.BatchWait = 365 * 24 * duration.Hour
+	return config, nil
 }

--- a/pkg/logs/agent_serverless.go
+++ b/pkg/logs/agent_serverless.go
@@ -60,7 +60,8 @@ func NewAgent(sources *sources.LogSources, services *service.Services, processin
 
 // buildEndpoints builds endpoints for the logs agent
 func buildEndpoints() (*config.Endpoints, error) {
-	config, err := config.BuildServerlessEndpoints(intakeTrackType, config.DefaultIntakeProtocol); err != nil {
+	config, err := config.BuildServerlessEndpoints(intakeTrackType, config.DefaultIntakeProtocol)
+	if err != nil {
 		return nil, err
 	}
 	// in serverless mode, we never want the batch strategy to flush with a tick

--- a/pkg/logs/logs_serverless_test.go
+++ b/pkg/logs/logs_serverless_test.go
@@ -10,7 +10,9 @@ package logs
 
 import (
 	"testing"
+	"time"
 
+	coreConfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -19,4 +21,5 @@ func TestBuildServerlessEndpoints(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, "http-intake.logs.datadoghq.com", endpoints.Main.Host)
 	assert.Equal(t, "lambda-extension", string(endpoints.Main.Origin))
+	assert.True(t, endpoints.BatchWait > coreConfig.DefaultBatchWait*time.Second)
 }


### PR DESCRIPTION
### What does this PR do?

https://github.com/DataDog/datadog-agent/pull/12425 was closed for of https://github.com/DataDog/datadog-agent/pull/15897 but there were not fully overlapping.
We could still have a regular tick flushing logs when it was not supposed to be here: https://github.com/DataDog/datadog-agent/blob/main/pkg/logs/sender/batch_strategy.go#L102

### Motivation

Fix logs missing

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
