### PR TITLE
fix: support scheme in EVP forwarder

### DIFF
--- a/pkg/logs/config/config.go
+++ b/pkg/logs/config/config.go
@@ -219,46 +219,31 @@ func BuildHTTPEndpointsWithConfig(logsConfig *LogsConfigKeys, endpointPrefix str
 	}
 
 	if vectorURL, vectorURLDefined := logsConfig.getObsPipelineURL(); logsConfig.obsPipelineWorkerEnabled() && vectorURLDefined {
-		if strings.HasPrefix(vectorURL, "https://") || strings.HasPrefix(vectorURL, "http://") {
-			u, err := url.Parse(vectorURL)
-			if err != nil {
-				return nil, fmt.Errorf("could not parse %s: %v", vectorURL, err)
-			}
-			switch u.Scheme {
-			case "https":
-				main.UseSSL = true
-			case "http":
-				main.UseSSL = false
-			}
-			main.Host = u.Hostname()
-			if u.Port() != "" {
-				port, err := strconv.Atoi(u.Port())
-				if err != nil {
-					return nil, fmt.Errorf("could not parse %s: %v", vectorURL, err)
-				}
-				main.Port = port
-			}
-		} else {
-			host, port, err := parseAddress(vectorURL)
-			if err != nil {
-				return nil, fmt.Errorf("could not parse %s: %v", vectorURL, err)
-			}
-			main.Host = host
-			main.Port = port
-			main.UseSSL = !defaultNoSSL
+		host, port, useSSL, err := parseAddressWithScheme(vectorURL, defaultNoSSL, parseAddress)
+		if err != nil {
+			return nil, fmt.Errorf("could not parse %s: %v", vectorURL, err)
 		}
-
+		main.Host = host
+		main.Port = port
+		main.UseSSL = useSSL
 	} else if logsDDURL, logsDDURLDefined := logsConfig.logsDDURL(); logsDDURLDefined {
-		host, port, err := parseAddress(logsDDURL)
+		host, port, useSSL, err := parseAddressWithScheme(logsDDURL, defaultNoSSL, parseAddress)
 		if err != nil {
 			return nil, fmt.Errorf("could not parse %s: %v", logsDDURL, err)
 		}
 		main.Host = host
 		main.Port = port
-		main.UseSSL = !defaultNoSSL
+		main.UseSSL = useSSL
 	} else {
-		main.Host = utils.GetMainEndpoint(coreConfig.Datadog, endpointPrefix, logsConfig.getConfigKey("dd_url"))
-		main.UseSSL = !logsConfig.devModeNoSSL()
+		addr := utils.GetMainEndpoint(coreConfig.Datadog, endpointPrefix, logsConfig.getConfigKey("dd_url"))
+		host, port, useSSL, err := parseAddressWithScheme(addr, logsConfig.devModeNoSSL(), parseAddressAsHost)
+		if err != nil {
+			return nil, fmt.Errorf("could not parse %s: %v", logsDDURL, err)
+		}
+
+		main.Host = host
+		main.Port = port
+		main.UseSSL = useSSL
 	}
 
 	additionals := logsConfig.getAdditionalEndpoints()
@@ -292,6 +277,45 @@ func BuildHTTPEndpointsWithConfig(logsConfig *LogsConfigKeys, endpointPrefix str
 	return NewEndpointsWithBatchSettings(main, additionals, false, true, batchWait, batchMaxConcurrentSend, batchMaxSize, batchMaxContentSize, inputChanSize), nil
 }
 
+type defaultParseAddressFunc func(string) (host string, port int, err error)
+
+func parseAddressWithScheme(address string, defaultNoSSL bool, defaultParser defaultParseAddressFunc) (host string, port int, useSSL bool, err error) {
+	if strings.HasPrefix(address, "https://") || strings.HasPrefix(address, "http://") {
+		host, port, useSSL, err = parseURL(address)
+	} else {
+		host, port, err = defaultParser(address)
+		if err != nil {
+			err = fmt.Errorf("could not parse %s: %v", address, err)
+			return
+		}
+		useSSL = !defaultNoSSL
+	}
+	return
+}
+
+func parseURL(address string) (host string, port int, useSSL bool, err error) {
+	u, errParse := url.Parse(address)
+	if errParse != nil {
+		err = errParse
+		return
+	}
+	switch u.Scheme {
+	case "https":
+		useSSL = true
+	case "http":
+		useSSL = false
+	}
+	host = u.Hostname()
+	if u.Port() != "" {
+		port, err = strconv.Atoi(u.Port())
+		if err != nil {
+			return
+		}
+	}
+
+	return
+}
+
 // parseAddress returns the host and the port of the address.
 func parseAddress(address string) (string, int, error) {
 	host, portString, err := net.SplitHostPort(address)
@@ -303,6 +327,12 @@ func parseAddress(address string) (string, int, error) {
 		return "", 0, err
 	}
 	return host, port, nil
+}
+
+// parseAddressAsHost returns the host and the port of the address.
+// this function consider that the address is the host
+func parseAddressAsHost(address string) (string, int, error) {
+	return address, 0, nil
 }
 
 // TaggerWarmupDuration is used to configure the tag providers

--- a/pkg/logs/config/config_test.go
+++ b/pkg/logs/config/config_test.go
@@ -10,9 +10,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/suite"
-
 	coreConfig "github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/stretchr/testify/suite"
 )
 
 type ConfigTestSuite struct {
@@ -695,4 +694,192 @@ func (suite *ConfigTestSuite) TestEndpointsSetNonDefaultCustomConfigs() {
 
 	suite.Nil(err)
 	suite.Equal(expectedEndpoints, endpoints)
+}
+
+func (suite *ConfigTestSuite) TestEndpointsSetLogsDDUrlWithPrefix() {
+	suite.config.Set("api_key", "123")
+	suite.config.Set("compliance_config.endpoints.logs_dd_url", "https://my-proxy.com:443")
+
+	logsConfig := NewLogsConfigKeys("compliance_config.endpoints.", suite.config)
+	endpoints, err := BuildHTTPEndpointsWithConfig(logsConfig, "default-intake.mydomain.", "test-track", "test-proto", "test-source")
+
+	suite.Nil(err)
+
+	main := Endpoint{
+		APIKey:           "123",
+		Host:             "my-proxy.com",
+		Port:             443,
+		UseSSL:           true,
+		UseCompression:   true,
+		CompressionLevel: 6,
+		BackoffFactor:    coreConfig.DefaultLogsSenderBackoffFactor,
+		BackoffBase:      coreConfig.DefaultLogsSenderBackoffBase,
+		BackoffMax:       coreConfig.DefaultLogsSenderBackoffMax,
+		RecoveryInterval: coreConfig.DefaultLogsSenderBackoffRecoveryInterval,
+		Version:          EPIntakeVersion2,
+		TrackType:        "test-track",
+		Protocol:         "test-proto",
+		Origin:           "test-source",
+	}
+
+	expectedEndpoints := &Endpoints{
+		UseHTTP:                true,
+		BatchWait:              coreConfig.DefaultBatchWait * time.Second,
+		Main:                   main,
+		Endpoints:              []Endpoint{main},
+		BatchMaxSize:           coreConfig.DefaultBatchMaxSize,
+		BatchMaxContentSize:    coreConfig.DefaultBatchMaxContentSize,
+		BatchMaxConcurrentSend: coreConfig.DefaultBatchMaxConcurrentSend,
+		InputChanSize:          coreConfig.DefaultInputChanSize,
+	}
+
+	suite.Nil(err)
+	suite.Equal(expectedEndpoints, endpoints)
+}
+
+func (suite *ConfigTestSuite) TestEndpointsSetDDUrlWithPrefix() {
+	suite.config.Set("api_key", "123")
+	suite.config.Set("compliance_config.endpoints.dd_url", "https://my-proxy.com:443")
+
+	logsConfig := NewLogsConfigKeys("compliance_config.endpoints.", suite.config)
+	endpoints, err := BuildHTTPEndpointsWithConfig(logsConfig, "default-intake.mydomain.", "test-track", "test-proto", "test-source")
+
+	suite.Nil(err)
+
+	main := Endpoint{
+		APIKey:           "123",
+		Host:             "my-proxy.com",
+		Port:             443,
+		UseSSL:           true,
+		UseCompression:   true,
+		CompressionLevel: 6,
+		BackoffFactor:    coreConfig.DefaultLogsSenderBackoffFactor,
+		BackoffBase:      coreConfig.DefaultLogsSenderBackoffBase,
+		BackoffMax:       coreConfig.DefaultLogsSenderBackoffMax,
+		RecoveryInterval: coreConfig.DefaultLogsSenderBackoffRecoveryInterval,
+		Version:          EPIntakeVersion2,
+		TrackType:        "test-track",
+		Protocol:         "test-proto",
+		Origin:           "test-source",
+	}
+
+	expectedEndpoints := &Endpoints{
+		UseHTTP:                true,
+		BatchWait:              coreConfig.DefaultBatchWait * time.Second,
+		Main:                   main,
+		Endpoints:              []Endpoint{main},
+		BatchMaxSize:           coreConfig.DefaultBatchMaxSize,
+		BatchMaxContentSize:    coreConfig.DefaultBatchMaxContentSize,
+		BatchMaxConcurrentSend: coreConfig.DefaultBatchMaxConcurrentSend,
+		InputChanSize:          coreConfig.DefaultInputChanSize,
+	}
+
+	suite.Nil(err)
+	suite.Equal(expectedEndpoints, endpoints)
+}
+
+func Test_parseAddressWithScheme(t *testing.T) {
+	type args struct {
+		address       string
+		defaultNoSSL  bool
+		defaultParser defaultParseAddressFunc
+	}
+	tests := []struct {
+		name       string
+		args       args
+		wantHost   string
+		wantPort   int
+		wantUseSSL bool
+		wantErr    bool
+	}{
+		{
+			name: "url without scheme and port",
+			args: args{
+				address:       "localhost:8080",
+				defaultNoSSL:  true,
+				defaultParser: parseAddress,
+			},
+			wantHost:   "localhost",
+			wantPort:   8080,
+			wantUseSSL: false,
+			wantErr:    false,
+		},
+		{
+			name: "url with https prefix",
+			args: args{
+				address:       "https://localhost",
+				defaultNoSSL:  true,
+				defaultParser: parseAddress,
+			},
+			wantHost:   "localhost",
+			wantPort:   0,
+			wantUseSSL: true,
+			wantErr:    false,
+		},
+		{
+			name: "url with https prefix and port",
+			args: args{
+				address:       "https://localhost:443",
+				defaultParser: parseAddress,
+			},
+			wantHost:   "localhost",
+			wantPort:   443,
+			wantUseSSL: true,
+			wantErr:    false,
+		},
+		{
+			name: "invalid url",
+			args: args{
+				address:       "https://localhost:443-8080",
+				defaultNoSSL:  true,
+				defaultParser: parseAddressAsHost,
+			},
+			wantHost:   "",
+			wantPort:   0,
+			wantUseSSL: false,
+			wantErr:    true,
+		},
+		{
+			name: "allow emptyPort",
+			args: args{
+				address:       "https://localhost",
+				defaultNoSSL:  true,
+				defaultParser: parseAddressAsHost,
+			},
+			wantHost:   "localhost",
+			wantPort:   0,
+			wantUseSSL: true,
+			wantErr:    false,
+		},
+		{
+			name: "no schema, not port emptyPort",
+			args: args{
+				address:       "localhost",
+				defaultNoSSL:  false,
+				defaultParser: parseAddressAsHost,
+			},
+			wantHost:   "localhost",
+			wantPort:   0,
+			wantUseSSL: true,
+			wantErr:    false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotHost, gotPort, gotUseSSL, err := parseAddressWithScheme(tt.args.address, tt.args.defaultNoSSL, tt.args.defaultParser)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseAddressWithScheme() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if gotHost != tt.wantHost {
+				t.Errorf("parseAddressWithScheme() gotHost = %v, want %v", gotHost, tt.wantHost)
+			}
+			if gotPort != tt.wantPort {
+				t.Errorf("parseAddressWithScheme() gotPort = %v, want %v", gotPort, tt.wantPort)
+			}
+			if gotUseSSL != tt.wantUseSSL {
+				t.Errorf("parseAddressWithScheme() gotUseSSL = %v, want %v", gotUseSSL, tt.wantUseSSL)
+			}
+		})
+	}
 }

--- a/releasenotes/notes/logs_config-support-url-in-dd_url-4e28e17d0b3ad6d0.yaml
+++ b/releasenotes/notes/logs_config-support-url-in-dd_url-4e28e17d0b3ad6d0.yaml
@@ -8,6 +8,6 @@
 ---
 enhancements:
   - |
-    Support url with `http|https` scheme in the `dd_url` or `logs_dd_url` parameters
-    when configuring an endpoint or an additional endpoint.
-    Also automatically detect SSL needs, based on the scheme when it is present.
+    Add support for URLs with the `http|https` scheme in the `dd_url` or `logs_dd_url` parameters
+    when configuring endpoints.
+    Also automatically detects SSL needs, based on the scheme when it is present.

--- a/releasenotes/notes/logs_config-support-url-in-dd_url-4e28e17d0b3ad6d0.yaml
+++ b/releasenotes/notes/logs_config-support-url-in-dd_url-4e28e17d0b3ad6d0.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Support url with `http|https` scheme in the `dd_url` or `logs_dd_url` parameters
+    when configuring an endpoint or an additional endpoint.
+    Also automatically detect SSL needs, based on the scheme when it is present.


### PR DESCRIPTION
### What does this PR do?

Add support of url containing http/https scheme in the log config `logs_dd_url` or `dd_url`.


### Motivation

the PR https://github.com/DataDog/datadog-agent/pull/16084 introduced in milestone 7.45.0 has refactor how 3 EVP platform endpoints are configured. The 3 endpoints config now use the generic and standard `logconfig` config parser.

But previously (previous agent version) it was possible to configure these endpoint and additional_endpoints with an URL containing the `https` or `http` scheme prefix.

for example:
```yaml
sbom:
  dd_url: https://sbom-intake.ap1.datadoghq.com

  additional_endpoints:
  - host: https://sbom-intake.datadoghq.com
    api_key: *******

```

example of error seen with this configuration

```
2023-04-24 18:31:32 UTC | CORE | WARN | (pkg/logs/client/http/destination.go:224 in sendAndRetry) | Could not send payload: parse "https://https/:%2F%2Fsbom-intake.datadoghq.com/api/v2/sbom": invalid port ":%2F%2Fsbom-intake.datadoghq.com" after host
```

To keep the backward compatibility for user configs, the `logconfig` parser logic need to support the presence of a scheme prefix. 

### Additional Notes

Now, if the scheme is present and it is `https` the option `useSSL` is automatically set to `true`.

### Possible Drawbacks / Trade-offs



### Describe how to test/QA your changes

deploy the agent with for example `logs_config.dd_url` set to `https://http-intake.logs.datadoghq.com` and it should work

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
