### PR TITLE
[kitchen] Update WinRM settings on old Windows versions

### DIFF
--- a/test/kitchen/Berksfile
+++ b/test/kitchen/Berksfile
@@ -16,6 +16,7 @@ cookbook 'selinux', '< 4.0.0'
 
 cookbook 'dd-agent-disable-system-repos', path: './site-cookbooks/dd-agent-disable-system-repos'
 cookbook 'dd-agent-enable-fips', path: './site-cookbooks/dd-agent-enable-fips'
+cookbook 'dd-agent-fix-winrm', path: './site-cookbooks/dd-agent-fix-winrm'
 cookbook 'dd-agent-install', path: './site-cookbooks/dd-agent-install'
 cookbook 'dd-agent-reinstall', path: './site-cookbooks/dd-agent-reinstall'
 cookbook 'dd-agent-upgrade', path: './site-cookbooks/dd-agent-upgrade'

--- a/test/kitchen/drivers/azure-driver.yml
+++ b/test/kitchen/drivers/azure-driver.yml
@@ -177,10 +177,10 @@ platforms:
   <% end %>
 
   transport:
+    <% if windows %>
     name: winrm
     username: <%= vm_username %>
     password: <%= vm_password %>
-    <% if windows %>
     connection_retries: 30
     connection_retry_sleep: 5
     <% else %>

--- a/test/kitchen/drivers/azure-driver.yml
+++ b/test/kitchen/drivers/azure-driver.yml
@@ -153,7 +153,7 @@ platforms:
     <% if windows2008 %>
     winrm_powershell_script: |-
       winrm quickconfig -q
-      winrm set winrm/config/winrs '@{MaxMemoryPerShellMB="512"}'
+      winrm set winrm/config/winrs '@{MaxMemoryPerShellMB="2048"}'
       winrm set winrm/config '@{MaxTimeoutms="1800000"}'
       winrm set winrm/config/service '@{AllowUnencrypted="true"}'
       winrm set winrm/config/service/auth '@{Basic="true"}'

--- a/test/kitchen/drivers/azure-driver.yml
+++ b/test/kitchen/drivers/azure-driver.yml
@@ -98,7 +98,8 @@ platforms:
 
       windows = platform_name.include?("win")
       sles15 = platform_name.include?("sles-15")
-      oldwindows = windows && (platform_name.include?("2008") || platform_name.include?("2012"))
+      windows2008 = windows && platform_name.include?("2008")
+      windows2012 = windows && platform_name.include?("2012")
 
       if windows
         windows_platforms << platform_name
@@ -131,7 +132,7 @@ platforms:
     <% if ENV["KITCHEN_CWS_PLATFORM"] %>
     cws_platform: <%= ENV["KITCHEN_CWS_PLATFORM"] %>
     <% end %>
-    <% if oldwindows %>
+    <% if windows2012 %>
     dd-agent-fix-winrm:
       enabled: true
     <% end %>
@@ -149,10 +150,19 @@ platforms:
     location: <%= location %>
     <% if windows %>
     vm_name: ddat<%= platform[0] %>
-    <% if oldwindows %>
+    <% if windows2008 %>
     winrm_powershell_script: |-
       winrm quickconfig -q
-      winrm set winrm/config/winrs '@{MaxMemoryPerShellMB="2048"}'
+      winrm set winrm/config/winrs '@{MaxMemoryPerShellMB="512"}'
+      winrm set winrm/config '@{MaxTimeoutms="1800000"}'
+      winrm set winrm/config/service '@{AllowUnencrypted="true"}'
+      winrm set winrm/config/service/auth '@{Basic="true"}'
+      netsh advfirewall firewall set rule name="Windows Remote Management (HTTP-In)" profile=public protocol=tcp localport=5985 remoteip=localsubnet new remoteip=any
+    <% end %>
+    <% if windows2012 %>
+    winrm_powershell_script: |-
+      winrm quickconfig -q
+      winrm set winrm/config/winrs '@{MaxMemoryPerShellMB="4096"}'
       winrm set winrm/config '@{MaxTimeoutms="1800000"}'
       winrm set winrm/config/service '@{AllowUnencrypted="true"}'
       winrm set winrm/config/service/auth '@{Basic="true"}'

--- a/test/kitchen/drivers/azure-driver.yml
+++ b/test/kitchen/drivers/azure-driver.yml
@@ -152,7 +152,7 @@ platforms:
     <% if oldwindows %>
     winrm_powershell_script: |-
       winrm quickconfig -q
-      winrm set winrm/config/winrs '@{MaxMemoryPerShellMB="4096"}'
+      winrm set winrm/config/winrs '@{MaxMemoryPerShellMB="2048"}'
       winrm set winrm/config '@{MaxTimeoutms="1800000"}'
       winrm set winrm/config/service '@{AllowUnencrypted="true"}'
       winrm set winrm/config/service/auth '@{Basic="true"}'

--- a/test/kitchen/drivers/azure-driver.yml
+++ b/test/kitchen/drivers/azure-driver.yml
@@ -98,7 +98,7 @@ platforms:
 
       windows = platform_name.include?("win")
       sles15 = platform_name.include?("sles-15")
-      windows2008 = windows && platform_name.include?("2008")
+      oldwindows = windows && (platform_name.include?("2008") || platform_name.include?("2012"))
 
       if windows
         windows_platforms << platform_name
@@ -131,6 +131,10 @@ platforms:
     <% if ENV["KITCHEN_CWS_PLATFORM"] %>
     cws_platform: <%= ENV["KITCHEN_CWS_PLATFORM"] %>
     <% end %>
+    <% if oldwindows %>
+    dd-agent-fix-winrm:
+      enabled: true
+    <% end %>
   <% if ENV['KITCHEN_CI_MOUNT_PATH'] && ENV['KITCHEN_CI_ROOT_PATH'] %>
   provisioner:
     command_prefix: TMPDIR=<%= ENV['KITCHEN_CI_ROOT_PATH'] %>
@@ -145,10 +149,10 @@ platforms:
     location: <%= location %>
     <% if windows %>
     vm_name: ddat<%= platform[0] %>
-    <% if windows2008 %>
+    <% if oldwindows %>
     winrm_powershell_script: |-
       winrm quickconfig -q
-      winrm set winrm/config/winrs '@{MaxMemoryPerShellMB="512"}'
+      winrm set winrm/config/winrs '@{MaxMemoryPerShellMB="4096"}'
       winrm set winrm/config '@{MaxTimeoutms="1800000"}'
       winrm set winrm/config/service '@{AllowUnencrypted="true"}'
       winrm set winrm/config/service/auth '@{Basic="true"}'
@@ -173,10 +177,12 @@ platforms:
   <% end %>
 
   transport:
-    <% if windows %>
     name: winrm
     username: <%= vm_username %>
     password: <%= vm_password %>
+    <% if windows %>
+    connection_retries: 30
+    connection_retry_sleep: 5
     <% else %>
     connection_retries: 30
     connection_retry_sleep: 2

--- a/test/kitchen/site-cookbooks/dd-agent-fix-winrm/.gitignore
+++ b/test/kitchen/site-cookbooks/dd-agent-fix-winrm/.gitignore
@@ -1,0 +1,15 @@
+.vagrant
+Berksfile.lock
+*~
+*#
+.#*
+\#*#
+.*.sw[a-z]
+*.un~
+/cookbooks
+
+# Bundler
+Gemfile.lock
+bin/*
+.bundle/*
+

--- a/test/kitchen/site-cookbooks/dd-agent-fix-winrm/Berksfile
+++ b/test/kitchen/site-cookbooks/dd-agent-fix-winrm/Berksfile
@@ -1,0 +1,3 @@
+site :opscode
+
+metadata

--- a/test/kitchen/site-cookbooks/dd-agent-fix-winrm/README.md
+++ b/test/kitchen/site-cookbooks/dd-agent-fix-winrm/README.md
@@ -1,0 +1,3 @@
+# dd-agent-enable-fips cookbook
+
+Cookbook that enables FIPS mode

--- a/test/kitchen/site-cookbooks/dd-agent-fix-winrm/README.md
+++ b/test/kitchen/site-cookbooks/dd-agent-fix-winrm/README.md
@@ -1,3 +1,22 @@
-# dd-agent-enable-fips cookbook
+# dd-agent-fix-winrm cookbook
 
-Cookbook that enables FIPS mode
+Cookbook that updates the WinRM maximum memory used on old Windows Server versions.
+
+## Why?
+
+In old Windows Server versions, doing:
+
+```
+winrm set winrm/config/winrs '@{MaxMemoryPerShellMB="<new amount>"}'
+```
+
+is not enough to increase the maximum memory usable by the WinRM connection. You also need to run:
+
+```
+Set-Item WSMan:\localhost\Plugin\Microsoft.PowerShell\Quotas\MaxMemoryPerShellMB <new amount>
+```
+
+and then restart the winrm service, or reboot the host.
+
+This cookbook performs the `Set-Item` operation (only if its value is not the one we need, default `4096`), and then reboots the host.
+To use the host, you need to allow Chef to automatically retry converging (`max_retries` > 1 in the `provisioner` config), and also configure the `transport` settings to retry the WinRM connection enough times to let the server get back up.

--- a/test/kitchen/site-cookbooks/dd-agent-fix-winrm/attributes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-agent-fix-winrm/attributes/default.rb
@@ -1,0 +1,11 @@
+#
+# Cookbook Name:: dd-agent-fix-winrm
+# Attributes:: default
+#
+# Copyright (C) 2023-present Datadog
+#
+# All rights reserved - Do Not Redistribute
+#
+
+default['dd-agent-fix-winrm']['enabled'] = false
+default['dd-agent-fix-winrm']['target_mb'] = "4096"

--- a/test/kitchen/site-cookbooks/dd-agent-fix-winrm/attributes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-agent-fix-winrm/attributes/default.rb
@@ -8,4 +8,5 @@
 #
 
 default['dd-agent-fix-winrm']['enabled'] = false
+# The amount here needs to match the MaxMemoryPerShellMB parameter set in driver_config
 default['dd-agent-fix-winrm']['target_mb'] = "4096"

--- a/test/kitchen/site-cookbooks/dd-agent-fix-winrm/attributes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-agent-fix-winrm/attributes/default.rb
@@ -9,4 +9,4 @@
 
 default['dd-agent-fix-winrm']['enabled'] = false
 # The amount here needs to match the MaxMemoryPerShellMB parameter set in driver_config
-default['dd-agent-fix-winrm']['target_mb'] = "2048"
+default['dd-agent-fix-winrm']['target_mb'] = "4096"

--- a/test/kitchen/site-cookbooks/dd-agent-fix-winrm/attributes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-agent-fix-winrm/attributes/default.rb
@@ -9,4 +9,4 @@
 
 default['dd-agent-fix-winrm']['enabled'] = false
 # The amount here needs to match the MaxMemoryPerShellMB parameter set in driver_config
-default['dd-agent-fix-winrm']['target_mb'] = "4096"
+default['dd-agent-fix-winrm']['target_mb'] = "2048"

--- a/test/kitchen/site-cookbooks/dd-agent-fix-winrm/chefignore
+++ b/test/kitchen/site-cookbooks/dd-agent-fix-winrm/chefignore
@@ -1,0 +1,96 @@
+# Put files/directories that should be ignored in this file when uploading
+# or sharing to the community site.
+# Lines that start with '# ' are comments.
+
+# OS generated files #
+######################
+.DS_Store
+Icon?
+nohup.out
+ehthumbs.db
+Thumbs.db
+
+# SASS #
+########
+.sass-cache
+
+# EDITORS #
+###########
+\#*
+.#*
+*~
+*.sw[a-z]
+*.bak
+REVISION
+TAGS*
+tmtags
+*_flymake.*
+*_flymake
+*.tmproj
+.project
+.settings
+mkmf.log
+
+## COMPILED ##
+##############
+a.out
+*.o
+*.pyc
+*.so
+*.com
+*.class
+*.dll
+*.exe
+*/rdoc/
+
+# Testing #
+###########
+.watchr
+.rspec
+spec/*
+spec/fixtures/*
+test/*
+features/*
+Guardfile
+Procfile
+
+# SCM #
+#######
+.git
+*/.git
+.gitignore
+.gitmodules
+.gitconfig
+.gitattributes
+.svn
+*/.bzr/*
+*/.hg/*
+*/.svn/*
+
+# Berkshelf #
+#############
+Berksfile
+Berksfile.lock
+cookbooks/*
+tmp
+
+# Cookbooks #
+#############
+CONTRIBUTING
+CHANGELOG*
+
+# Strainer #
+############
+Colanderfile
+Strainerfile
+.colander
+.strainer
+
+# Vagrant #
+###########
+.vagrant
+Vagrantfile
+
+# Travis #
+##########
+.travis.yml

--- a/test/kitchen/site-cookbooks/dd-agent-fix-winrm/metadata.rb
+++ b/test/kitchen/site-cookbooks/dd-agent-fix-winrm/metadata.rb
@@ -1,0 +1,5 @@
+name             "dd-agent-fix-winrm"
+maintainer       "Datadog"
+description      "Cookbook that fixes WinRM settings on old Windows Server OSes"
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+version          "0.0.1"

--- a/test/kitchen/site-cookbooks/dd-agent-fix-winrm/recipes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-agent-fix-winrm/recipes/default.rb
@@ -12,7 +12,6 @@ if node['dd-agent-fix-winrm']['enabled']
 
   winrm_memory = powershell_out!('(Get-Item WSMan:\localhost\Plugin\Microsoft.PowerShell\Quotas\MaxMemoryPerShellMB).value').stdout.chomp
   if winrm_memory != node['dd-agent-fix-winrm']['target_mb']
-    # The amount here needs to match the MaxMemoryPerShellMB parameter set in driver_config
     powershell_script 'Update WinRM Powershell memory settings' do
       code "Set-Item WSMan:\\localhost\\Plugin\\Microsoft.PowerShell\\Quotas\\MaxMemoryPerShellMB #{node['dd-agent-fix-winrm']['target_mb']}"
       notifies :reboot_now, 'reboot[WinRM]', :immediately

--- a/test/kitchen/site-cookbooks/dd-agent-fix-winrm/recipes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-agent-fix-winrm/recipes/default.rb
@@ -1,0 +1,25 @@
+#
+# Cookbook Name:: dd-agent-fix-winrm
+# Recipe:: default
+#
+# Copyright (C) 2023-present Datadog
+#
+# All rights reserved - Do Not Redistribute
+#
+if node['dd-agent-fix-winrm']['enabled']
+  require "chef/mixin/powershell_out"
+  ::Chef::Recipe.send(:include, Chef::Mixin::PowershellOut)
+
+  winrm_memory = powershell_out!('(Get-Item WSMan:\localhost\Plugin\Microsoft.PowerShell\Quotas\MaxMemoryPerShellMB).value').stdout.chomp
+  if winrm_memory != node['dd-agent-fix-winrm']['target_mb']
+    # The amount here needs to match the MaxMemoryPerShellMB parameter set in driver_config
+    powershell_script 'Update WinRM Powershell memory settings' do
+      code "Set-Item WSMan:\\localhost\\Plugin\\Microsoft.PowerShell\\Quotas\\MaxMemoryPerShellMB #{node['dd-agent-fix-winrm']['target_mb']}"
+      notifies :reboot_now, 'reboot[WinRM]', :immediately
+    end
+
+    reboot 'WinRM' do
+      reason 'Rebooting to reload WinRM service settings'
+    end
+  end
+end

--- a/test/kitchen/test-definitions/chef-test.yml
+++ b/test/kitchen/test-definitions/chef-test.yml
@@ -3,6 +3,7 @@ suites:
 # Install the latest release candidate using Chef
 - name: chef
   run_list:
+    - "recipe[dd-agent-fix-winrm]"
     - "recipe[dd-agent-disable-system-repos]"
     - "recipe[dd-agent-sles-workaround]"
     - "recipe[dd-agent-system-files-check::list-files-before-install]"

--- a/test/kitchen/test-definitions/install-script-test.yml
+++ b/test/kitchen/test-definitions/install-script-test.yml
@@ -7,6 +7,7 @@ suites:
     - "recipe[dd-agent-enable-fips::enable]"
     - "recipe[dd-agent-enable-fips::ensure]"
     <% end %>
+    - "recipe[dd-agent-fix-winrm]"
     - "recipe[dd-agent-disable-system-repos]"
     - "recipe[dd-agent-sles-workaround]"
     - "recipe[dd-agent-install-script]"

--- a/test/kitchen/test-definitions/process-agent-test.yml
+++ b/test/kitchen/test-definitions/process-agent-test.yml
@@ -1,6 +1,7 @@
 suites:
 - name: "process-collection-test"
   run_list:
+    - "recipe[dd-agent-fix-winrm]"
     - "recipe[dd-agent-disable-system-repos]"
     - "recipe[dd-agent-sles-workaround]"
     - "recipe[dd-agent-install]"

--- a/test/kitchen/test-definitions/security-agent-stress.yml
+++ b/test/kitchen/test-definitions/security-agent-stress.yml
@@ -3,6 +3,7 @@ suites:
 # Deploys and run the stress tests
 - name: security-agent-stress
   run_list:
+    - "recipe[dd-agent-fix-winrm]"
     - "recipe[dd-agent-rhel-workaround]"
     - "recipe[dd-agent-sles-workaround]"
     - "recipe[dd-security-agent-check]"

--- a/test/kitchen/test-definitions/security-agent-test.yml
+++ b/test/kitchen/test-definitions/security-agent-test.yml
@@ -3,6 +3,7 @@ suites:
 # Deploys and run the functional tests
 - name: security-agent-test
   run_list:
+    - "recipe[dd-agent-fix-winrm]"
     - "recipe[dd-agent-rhel-workaround]"
     - "recipe[dd-agent-sles-workaround]"
     - "recipe[dd-security-agent-check]"

--- a/test/kitchen/test-definitions/step-by-step-test.yml
+++ b/test/kitchen/test-definitions/step-by-step-test.yml
@@ -7,6 +7,7 @@ suites:
     - "recipe[dd-agent-enable-fips::enable]"
     - "recipe[dd-agent-enable-fips::ensure]"
     <% end %>
+    - "recipe[dd-agent-fix-winrm]"
     - "recipe[dd-agent-disable-system-repos]"
     - "recipe[dd-agent-sles-workaround]"
     - "recipe[dd-agent-step-by-step]"

--- a/test/kitchen/test-definitions/system-probe-test.yml
+++ b/test/kitchen/test-definitions/system-probe-test.yml
@@ -1,6 +1,7 @@
 suites:
 - name: system-probe-test
   run_list:
+    - recipe[dd-agent-fix-winrm]
     - recipe[dd-system-probe-check]
   attributes:
     apt:

--- a/test/kitchen/test-definitions/upgrade5-test.yml
+++ b/test/kitchen/test-definitions/upgrade5-test.yml
@@ -8,6 +8,7 @@ suites:
     - <%= p %>
     <% end %>
   run_list:
+    - "recipe[dd-agent-fix-winrm]"
     - "recipe[dd-agent-disable-system-repos]"
     - "recipe[dd-agent-rhel-workaround]"
     - "recipe[dd-agent-sles-workaround]"

--- a/test/kitchen/test-definitions/upgrade6-test.yml
+++ b/test/kitchen/test-definitions/upgrade6-test.yml
@@ -8,6 +8,7 @@ suites:
     - "recipe[dd-agent-enable-fips::enable]"
     - "recipe[dd-agent-enable-fips::ensure]"
     <% end %>
+    - "recipe[dd-agent-fix-winrm]"
     - "recipe[dd-agent-disable-system-repos]"
     - "recipe[dd-agent-rhel-workaround]"
     - "recipe[dd-agent-sles-workaround]"

--- a/test/kitchen/test-definitions/upgrade7-test.yml
+++ b/test/kitchen/test-definitions/upgrade7-test.yml
@@ -8,6 +8,7 @@ suites:
     - "recipe[dd-agent-enable-fips::enable]"
     - "recipe[dd-agent-enable-fips::ensure]"
     <% end %>
+    - "recipe[dd-agent-fix-winrm]"
     - "recipe[dd-agent-disable-system-repos]"
     - "recipe[dd-agent-rhel-workaround]"
     - "recipe[dd-agent-sles-workaround]"

--- a/test/kitchen/test-definitions/windows-install-test.yml
+++ b/test/kitchen/test-definitions/windows-install-test.yml
@@ -1,6 +1,7 @@
 suites:
   - name: win-repair
     run_list:
+      - "recipe[dd-agent-fix-winrm]"
       - "recipe[dd-agent-install::_install_windows_base]"
       - "recipe[dd-agent-install::_stop_windows_agent]"
       - "recipe[dd-agent-install::_damage_windows_install]"

--- a/test/kitchen/test-definitions/windows-install-test.yml
+++ b/test/kitchen/test-definitions/windows-install-test.yml
@@ -24,6 +24,7 @@ suites:
 
   - name: win-upgrade-rollback
     run_list:
+      - "recipe[dd-agent-fix-winrm]"
       - "recipe[dd-agent-install]"
       - "recipe[dd-agent-upgrade]"
     attributes:
@@ -51,6 +52,7 @@ suites:
 
   - name: win-installopts
     run_list:
+      - "recipe[dd-agent-fix-winrm]"
       - "recipe[dd-agent-install::_install_windows_base]"
     attributes:
       datadog:
@@ -84,6 +86,7 @@ suites:
 
   - name: win-all-subservices
     run_list:
+      - "recipe[dd-agent-fix-winrm]"
       - "recipe[dd-agent-install::_install_windows_base]"
     attributes:
       datadog:
@@ -109,6 +112,7 @@ suites:
 
   - name: win-no-subservices
     run_list:
+      - "recipe[dd-agent-fix-winrm]"
       - "recipe[dd-agent-install::_install_windows_base]"
     attributes:
       datadog:
@@ -135,6 +139,7 @@ suites:
 
   - name: win-user
     run_list:
+      - "recipe[dd-agent-fix-winrm]"
       - "recipe[dd-agent-install::_install_windows_base]"
     attributes:
       datadog:
@@ -159,6 +164,7 @@ suites:
 
   - name: win-install-fail
     run_list:
+        - "recipe[dd-agent-fix-winrm]"
         - "recipe[dd-agent-install::_install_windows_base]"
     attributes:
       datadog:
@@ -185,6 +191,7 @@ suites:
 
   - name: win-alt-dir
     run_list:
+        - "recipe[dd-agent-fix-winrm]"
         - "recipe[dd-agent-install::_install_windows_base]"
     attributes:
       datadog:

--- a/test/kitchen/test-definitions/windows-npm-test.yml
+++ b/test/kitchen/test-definitions/windows-npm-test.yml
@@ -5,6 +5,7 @@ suites:
 #    - expect driver installed, system probe to enable & start
 - name: win-npm-upgrade-to-npm
   run_list:
+    - "recipe[dd-agent-fix-winrm]"
     - "recipe[dd-agent-install]"
     - "recipe[dd-agent-upgrade]"
   attributes:

--- a/test/kitchen/test-definitions/windows-npm-test.yml
+++ b/test/kitchen/test-definitions/windows-npm-test.yml
@@ -52,6 +52,7 @@ suites:
 # scenario 2
 - name: win-npm-upgrade-no-npm
   run_list:
+    - "recipe[dd-agent-fix-winrm]"
     - "recipe[dd-agent-install]"
     - "recipe[dd-agent-upgrade]"
   attributes:
@@ -93,6 +94,7 @@ suites:
 #    - expect driver installed, system probe to enable & start
 - name: win-npm-upgrade-to-npm-no-csflag
   run_list:
+    - "recipe[dd-agent-fix-winrm]"
     - "recipe[dd-agent-install]"
     - "recipe[dd-agent-upgrade]"
   attributes:
@@ -135,6 +137,7 @@ suites:
 # Scenario 4
 - name: win-npm-no-npm-option
   run_list:
+    - "recipe[dd-agent-fix-winrm]"
     - "recipe[dd-agent-install]"
   attributes:
     datadog:
@@ -160,6 +163,7 @@ suites:
 #Scenario 5
 - name: win-npm-with-cs-option
   run_list:
+    - "recipe[dd-agent-fix-winrm]"
     - "recipe[dd-agent-install]"
   attributes:
     datadog:
@@ -187,6 +191,7 @@ suites:
 # scenario 7
 - name: win-npm-reinstall-option
   run_list:
+    - "recipe[dd-agent-fix-winrm]"
     - "recipe[dd-agent-install]"
     - "recipe[dd-agent-reinstall]"
   attributes:
@@ -223,6 +228,7 @@ suites:
 #Scenario 8
 - name: win-npm-with-addlocal-all
   run_list:
+    - "recipe[dd-agent-fix-winrm]"
     - "recipe[dd-agent-install]"
   attributes:
     datadog:
@@ -251,6 +257,7 @@ suites:
 #Scenario 9
 - name: win-npm-with-addlocal-npm
   run_list:
+    - "recipe[dd-agent-fix-winrm]"
     - "recipe[dd-agent-install]"
   attributes:
     datadog:
@@ -277,6 +284,7 @@ suites:
 
 - name: win-npm-beta-upgrade
   run_list:
+    - "recipe[dd-agent-fix-winrm]"
     - "recipe[dd-agent-install]"
     - "recipe[dd-agent-upgrade]"
   attributes:

--- a/test/kitchen/test-definitions/windows-npmdriver.yml
+++ b/test/kitchen/test-definitions/windows-npmdriver.yml
@@ -2,6 +2,7 @@ suites:
 
 - name: win-npm-with-npm-option
   run_list:
+    - "recipe[dd-agent-fix-winrm]"
     - "recipe[dd-agent-install]"
   attributes:
     datadog:

--- a/test/kitchen/test-definitions/windows-sysprobe-test.yml
+++ b/test/kitchen/test-definitions/windows-sysprobe-test.yml
@@ -2,6 +2,7 @@ suites:
 
 - name: win-sysprobe-test
   run_list:
+    - "recipe[dd-agent-fix-winrm]"
     - "recipe[dd-system-probe-check]"
   attributes:
     dd-agent-rspec:


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Updates the WinRM settings for Windows Server 2008 R2, 2012, and 2012 R2, to avoid OOM errors. In detail:
- updates the Windows Server 2012 / 2012 R2 WinRM settings to use 4096MB instead of the default 1024MB. On these versions, the setting is only applied if you also run `Set-Item WSMan:\localhost\Plugin\Microsoft.PowerShell\Quotas\MaxMemoryPerShellMB 4096`. This requires a restart of the WinRM service or a reboot, which is why a new cookbook (similar to the FIPS one) has been created, to take care of this.
- updates the Windows Server 2008 R2 WinRM settings to use 2048MB instead of the previous 512MB (setting to 4096MB breaks WinRM on this version). On this version, nothing else is required.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

There is an ongoing [Rubygems dependencies API deprecation](https://blog.rubygems.org/2023/02/22/dependency-api-deprecation.html). It doesn't have a direct effect on the kitchen tests, but the use of the new dependencies API needs more memory, which, in older Windows OSes, exceeded the default memory allocated to the WinRM connection (512MB on Windows Server 2008, 1024MB on Windows Server 2012 / 2012 R2).

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

Failing Debian kitchen tests are unrelated, and fixed by #16728.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

This makes Windows kitchen tests around 2 minutes slower, due to the settings & reboot steps.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

All kitchen tests should pass, even when the Rubygems dependencies API deprecation is enforced.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
