### PR TITLE
Maxime/backport site update

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -16,6 +16,7 @@ api_key:
 ## Set to 'datadoghq.eu' to send data to the EU site.
 ## Set to 'us3.datadoghq.com' to send data to the US3 site.
 ## Set to 'us5.datadoghq.com' to send data to the US5 site.
+## Set to 'ap1.datadoghq.com' to send data to the AP1 site.
 ## Set to 'ddog-gov.com' to send data to the US1-FED site.
 #
 # site: datadoghq.com


### PR DESCRIPTION
### What does this PR do?

Backporting 394880a8e63d5e4dacdb98adde0402c85a27984c to 7.45.x.
 
This doesn't require any QA since we're only changing the comment on the default configuration.