### PR TITLE
Added debug log for successfully unregistering path

### DIFF
--- a/pkg/network/protocols/http/shared_libraries.go
+++ b/pkg/network/protocols/http/shared_libraries.go
@@ -141,6 +141,8 @@ func (r *soRegistration) unregister(pathID pathIdentifier) bool {
 			// Even if we fail here, we have to return true, as best effort methodology.
 			// We cannot handle the failure, and thus we should continue.
 			log.Warnf("error while unregistering %s : %s", pathID.String(), err)
+		} else {
+			log.Debugf("successfully unregistered %s", pathID.String())
 		}
 	}
 	return true

--- a/pkg/network/protocols/http/shared_libraries.go
+++ b/pkg/network/protocols/http/shared_libraries.go
@@ -132,8 +132,10 @@ type soRegistration struct {
 
 // unregister return true if there are no more reference to this registration
 func (r *soRegistration) unregister(pathID pathIdentifier) bool {
+	log.Debugf("Trying to unregister %s", pathID.String())
 	r.uniqueProcessesCount--
 	if r.uniqueProcessesCount > 0 {
+		log.Debugf("Unique process count is greater than 0, thus not unregistering %s", pathID.String())
 		return false
 	}
 	if r.unregisterCB != nil {

--- a/pkg/network/protocols/http/shared_libraries.go
+++ b/pkg/network/protocols/http/shared_libraries.go
@@ -269,13 +269,16 @@ func (r *soRegistry) unregister(pid uint32) {
 	r.m.Lock()
 	defer r.m.Unlock()
 
+	log.Debugf("Trying to unregister pid %d", pid)
 	paths, found := r.byPID[pid]
 	if !found {
+		log.Debugf("Couldn't find the following pid in the byPID map: %d", pid)
 		return
 	}
 	for pathID := range paths {
 		reg, found := r.byID[pathID]
 		if !found {
+			log.Debugf("Couldn't find the following path id in the byID map: %s", pathID.String())
 			continue
 		}
 		if reg.unregister(pathID) {

--- a/pkg/process/monitor/process_monitor.go
+++ b/pkg/process/monitor/process_monitor.go
@@ -259,6 +259,7 @@ func (pm *ProcessMonitor) Initialize() error {
 						pm.evalEXECCallback(c, ev.ProcessPid)
 					}
 				case *netlink.ExitProcEvent:
+					log.Debugf("Got exit event for pid: %d", ev.ProcessPid)
 					for _, c := range pm.procEventCallbacks[EXIT] {
 						pm.evalEXITCallback(c, ev.ProcessPid)
 					}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Adding debug log to soRegistration's unregister function in the context of an issue of a customer.
I was able to see this debug log by opening and closing an ipython process

This is an example of the logs after opening and closing an ipython process:
```
2023-04-25 04:23:52 PDT | SYS-PROBE | DEBUG | (pkg/network/protocols/http/shared_libraries.go:342 in register) | registering library dev/inode 253.0/139862 path /proc/42524/root/home/vagrant/miniconda3/envs/ddpy3/lib/python3.8/lib-dynload/../../libcrypto.so.1.1 by pid 42524
2023-04-25 04:23:52 PDT | SYS-PROBE | DEBUG | (pkg/network/protocols/http/shared_libraries.go:342 in register) | registering library dev/inode 253.0/798670 path /proc/42524/root/home/vagrant/miniconda3/envs/ddpy3/lib/python3.8/lib-dynload/../../libssl.so.1.1 by pid 42524
2023-04-25 04:23:52 PDT | SYS-PROBE | DEBUG | (pkg/process/monitor/process_monitor.go:262 in func3) | Got exit event for pid: 42525
2023-04-25 04:23:52 PDT | SYS-PROBE | DEBUG | (pkg/network/protocols/http/shared_libraries.go:272 in unregister) | Trying to unregister pid 42525
2023-04-25 04:23:52 PDT | SYS-PROBE | DEBUG | (pkg/network/protocols/http/shared_libraries.go:275 in unregister) | Couldn't find the following pid in the byPID map: 42525
2023-04-25 04:23:55 PDT | SYS-PROBE | DEBUG | (pkg/process/monitor/process_monitor.go:262 in func3) | Got exit event for pid: 42527
2023-04-25 04:23:55 PDT | SYS-PROBE | DEBUG | (pkg/network/protocols/http/shared_libraries.go:272 in unregister) | Trying to unregister pid 42527
2023-04-25 04:23:55 PDT | SYS-PROBE | DEBUG | (pkg/network/protocols/http/shared_libraries.go:275 in unregister) | Couldn't find the following pid in the byPID map: 42527
2023-04-25 04:23:55 PDT | SYS-PROBE | DEBUG | (pkg/process/monitor/process_monitor.go:262 in func3) | Got exit event for pid: 42526
2023-04-25 04:23:55 PDT | SYS-PROBE | DEBUG | (pkg/network/protocols/http/shared_libraries.go:272 in unregister) | Trying to unregister pid 42526
2023-04-25 04:23:55 PDT | SYS-PROBE | DEBUG | (pkg/network/protocols/http/shared_libraries.go:275 in unregister) | Couldn't find the following pid in the byPID map: 42526
2023-04-25 04:23:55 PDT | SYS-PROBE | DEBUG | (pkg/process/monitor/process_monitor.go:262 in func3) | Got exit event for pid: 42524
2023-04-25 04:23:55 PDT | SYS-PROBE | DEBUG | (pkg/network/protocols/http/shared_libraries.go:272 in unregister) | Trying to unregister pid 42524
2023-04-25 04:23:55 PDT | SYS-PROBE | DEBUG | (pkg/network/protocols/http/shared_libraries.go:135 in unregister) | Trying to unregister dev/inode 253.0/139862
2023-04-25 04:23:55 PDT | SYS-PROBE | DEBUG | (pkg/network/protocols/http/shared_libraries.go:147 in unregister) | successfully unregistered dev/inode 253.0/139862
2023-04-25 04:23:55 PDT | SYS-PROBE | DEBUG | (pkg/network/protocols/http/shared_libraries.go:135 in unregister) | Trying to unregister dev/inode 253.0/798670
2023-04-25 04:23:55 PDT | SYS-PROBE | DEBUG | (pkg/network/protocols/http/shared_libraries.go:147 in unregister) | successfully unregistered dev/inode 253.0/798670
```

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
