### PR TITLE
Simplify context removal in time sampler

### DIFF
--- a/pkg/aggregator/context_resolver.go
+++ b/pkg/aggregator/context_resolver.go
@@ -93,15 +93,13 @@ func (cr *contextResolver) length() int {
 	return len(cr.contextsByKey)
 }
 
-func (cr *contextResolver) removeKeys(expiredContextKeys []ckey.ContextKey) {
-	for _, expiredContextKey := range expiredContextKeys {
-		context := cr.contextsByKey[expiredContextKey]
-		delete(cr.contextsByKey, expiredContextKey)
+func (cr *contextResolver) remove(expiredContextKey ckey.ContextKey) {
+	context := cr.contextsByKey[expiredContextKey]
+	delete(cr.contextsByKey, expiredContextKey)
 
-		if context != nil {
-			cr.countsByMtype[context.mtype]--
-			context.release()
-		}
+	if context != nil {
+		cr.countsByMtype[context.mtype]--
+		context.release()
 	}
 }
 
@@ -187,24 +185,13 @@ func (cr *timestampContextResolver) get(key ckey.ContextKey) (*Context, bool) {
 // expireContexts cleans up the contexts that haven't been tracked since the given timestamp
 // and returns the associated contextKeys.
 // keep can be used to retain contexts longer than their natural expiration time based on some condition.
-func (cr *timestampContextResolver) expireContexts(expireTimestamp float64, keep func(ckey.ContextKey) bool) []ckey.ContextKey {
-	var expiredContextKeys []ckey.ContextKey
-
-	// Find expired context keys
+func (cr *timestampContextResolver) expireContexts(expireTimestamp float64, keep func(ckey.ContextKey) bool) {
 	for contextKey, lastSeen := range cr.lastSeenByKey {
 		if lastSeen < expireTimestamp && (keep == nil || !keep(contextKey)) {
-			expiredContextKeys = append(expiredContextKeys, contextKey)
+			delete(cr.lastSeenByKey, contextKey)
+			cr.resolver.remove(contextKey)
 		}
 	}
-
-	cr.resolver.removeKeys(expiredContextKeys)
-
-	// Delete expired context keys
-	for _, expiredContextKey := range expiredContextKeys {
-		delete(cr.lastSeenByKey, expiredContextKey)
-	}
-
-	return expiredContextKeys
 }
 
 func (cr *timestampContextResolver) sendOriginTelemetry(timestamp float64, series metrics.SerieSink, hostname string, tags []string) {
@@ -248,9 +235,9 @@ func (cr *countBasedContextResolver) expireContexts() []ckey.ContextKey {
 		if index <= cr.expireCount-cr.expireCountInterval {
 			keys = append(keys, key)
 			delete(cr.expireCountByKey, key)
+			cr.resolver.remove(key)
 		}
 	}
-	cr.resolver.removeKeys(keys)
 	cr.expireCount++
 	return keys
 }

--- a/pkg/aggregator/context_resolver_test.go
+++ b/pkg/aggregator/context_resolver_test.go
@@ -130,17 +130,14 @@ func testExpireContexts(t *testing.T, store *tags.Store) {
 	contextKey2 := contextResolver.trackContext(&mSample2, 6)
 
 	// With an expireTimestap of 3, both contexts are still valid
-	assert.Len(t, contextResolver.expireContexts(3, nil), 0)
+	contextResolver.expireContexts(3, nil)
 	_, ok1 := contextResolver.resolver.contextsByKey[contextKey1]
 	_, ok2 := contextResolver.resolver.contextsByKey[contextKey2]
 	assert.True(t, ok1)
 	assert.True(t, ok2)
 
 	// With an expireTimestap of 5, context 1 is expired
-	expiredContextKeys := contextResolver.expireContexts(5, nil)
-	if assert.Len(t, expiredContextKeys, 1) {
-		assert.Equal(t, contextKey1, expiredContextKeys[0])
-	}
+	contextResolver.expireContexts(5, nil)
 
 	// context 1 is not tracked anymore, but context 2 still is
 	_, ok := contextResolver.resolver.contextsByKey[contextKey1]
@@ -183,7 +180,7 @@ func testExpireContextsWithKeep(t *testing.T, store *tags.Store) {
 	}
 
 	// With an expireTimestap of 3, both contexts are still valid
-	assert.Len(t, contextResolver.expireContexts(3, keeper), 0)
+	contextResolver.expireContexts(3, keeper)
 	_, ok1 := contextResolver.resolver.contextsByKey[contextKey1]
 	_, ok2 := contextResolver.resolver.contextsByKey[contextKey2]
 	assert.True(t, ok1)
@@ -191,7 +188,7 @@ func testExpireContextsWithKeep(t *testing.T, store *tags.Store) {
 	assert.Equal(t, keeperCalled, 0)
 
 	// With an expireTimestap of 5, context 1 is expired, but we explicitly keep it
-	assert.Len(t, contextResolver.expireContexts(5, keeper), 0)
+	contextResolver.expireContexts(5, keeper)
 	assert.Equal(t, keeperCalled, 1)
 
 	// both contexts are still tracked
@@ -202,10 +199,7 @@ func testExpireContextsWithKeep(t *testing.T, store *tags.Store) {
 
 	// With an expireTimestap of 6, context 1 is expired, and we don't keep it this time
 	keep = false
-	expiredContextKeys := contextResolver.expireContexts(6, keeper)
-	if assert.Len(t, expiredContextKeys, 1) {
-		assert.Equal(t, contextKey1, expiredContextKeys[0])
-	}
+	contextResolver.expireContexts(6, keeper)
 	assert.Equal(t, keeperCalled, 2)
 
 	// context 1 is not tracked anymore


### PR DESCRIPTION

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Remove unused return value and rework internal API to remove contexts directly, without collecting keys into a slice first.

### Motivation

Simplify code before adding a new feature.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
