### PR TITLE
Return error from RunDockerServer to allow negative testing

### DIFF
--- a/pkg/network/java/testutil/inject.go
+++ b/pkg/network/java/testutil/inject.go
@@ -17,7 +17,7 @@ import (
 )
 
 // RunJavaVersion run class under java version
-func RunJavaVersion(t *testing.T, version string, class string, waitForParam ...*regexp.Regexp) bool {
+func RunJavaVersion(t testing.TB, version string, class string, waitForParam ...*regexp.Regexp) error {
 	t.Helper()
 	var waitFor *regexp.Regexp
 	if len(waitForParam) == 0 {

--- a/pkg/network/protocols/amqp/server.go
+++ b/pkg/network/protocols/amqp/server.go
@@ -19,7 +19,7 @@ const (
 	Pass = "guest"
 )
 
-func RunServer(t *testing.T, serverAddr, serverPort string) bool {
+func RunServer(t testing.TB, serverAddr, serverPort string) error {
 	env := []string{
 		"AMQP_ADDR=" + serverAddr,
 		"AMQP_PORT=" + serverPort,

--- a/pkg/network/protocols/gotls/server.go
+++ b/pkg/network/protocols/gotls/server.go
@@ -6,13 +6,14 @@
 package gotls
 
 import (
-	"github.com/DataDog/datadog-agent/pkg/network/protocols/http/testutil"
-	protocolsUtils "github.com/DataDog/datadog-agent/pkg/network/protocols/testutil"
 	"regexp"
 	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/network/protocols/http/testutil"
+	protocolsUtils "github.com/DataDog/datadog-agent/pkg/network/protocols/testutil"
 )
 
-func RunServer(t *testing.T, serverPort string) bool {
+func RunServer(t testing.TB, serverPort string) error {
 	env := []string{
 		"HTTPS_PORT=" + serverPort,
 	}

--- a/pkg/network/protocols/kafka/server.go
+++ b/pkg/network/protocols/kafka/server.go
@@ -13,7 +13,7 @@ import (
 	protocolsUtils "github.com/DataDog/datadog-agent/pkg/network/protocols/testutil"
 )
 
-func RunServer(t *testing.T, serverAddr, serverPort string) bool {
+func RunServer(t testing.TB, serverAddr, serverPort string) error {
 	env := []string{
 		"KAFKA_ADDR=" + serverAddr,
 		"KAFKA_PORT=" + serverPort,

--- a/pkg/network/protocols/mongo/server.go
+++ b/pkg/network/protocols/mongo/server.go
@@ -19,7 +19,7 @@ const (
 	Pass = "password"
 )
 
-func RunServer(t *testing.T, serverAddress, serverPort string) bool {
+func RunServer(t testing.TB, serverAddress, serverPort string) error {
 	env := []string{
 		"MONGO_ADDR=" + serverAddress,
 		"MONGO_PORT=" + serverPort,

--- a/pkg/network/protocols/mysql/server.go
+++ b/pkg/network/protocols/mysql/server.go
@@ -20,7 +20,7 @@ const (
 	Pass = "root"
 )
 
-func RunServer(t *testing.T, serverAddr, serverPort string) bool {
+func RunServer(t testing.TB, serverAddr, serverPort string) error {
 	env := []string{
 		"MYSQL_ADDR=" + serverAddr,
 		"MYSQL_PORT=" + serverPort,

--- a/pkg/network/protocols/postgres/server.go
+++ b/pkg/network/protocols/postgres/server.go
@@ -13,7 +13,7 @@ import (
 	protocolsUtils "github.com/DataDog/datadog-agent/pkg/network/protocols/testutil"
 )
 
-func RunServer(t *testing.T, serverAddr string, serverPort string) bool {
+func RunServer(t testing.TB, serverAddr string, serverPort string) error {
 	t.Helper()
 
 	env := []string{

--- a/pkg/network/protocols/redis/server.go
+++ b/pkg/network/protocols/redis/server.go
@@ -13,7 +13,7 @@ import (
 	protocolsUtils "github.com/DataDog/datadog-agent/pkg/network/protocols/testutil"
 )
 
-func RunServer(t *testing.T, serverAddr, serverPort string) bool {
+func RunServer(t testing.TB, serverAddr, serverPort string) error {
 	env := []string{
 		"REDIS_ADDR=" + serverAddr,
 		"REDIS_PORT=" + serverPort,

--- a/pkg/network/protocols/testutil/patternscanner.go
+++ b/pkg/network/protocols/testutil/patternscanner.go
@@ -52,6 +52,6 @@ func (ps *PatternScanner) Write(p []byte) (n int, err error) {
 	return
 }
 
-func (ps *PatternScanner) PrintLogs(t *testing.T) {
+func (ps *PatternScanner) PrintLogs(t testing.TB) {
 	t.Log(strings.Join(ps.buffers, ""))
 }

--- a/pkg/network/protocols/tls/openssl.go
+++ b/pkg/network/protocols/tls/openssl.go
@@ -13,7 +13,7 @@ import (
 	protocolsUtils "github.com/DataDog/datadog-agent/pkg/network/protocols/testutil"
 )
 
-func RunServerOpenssl(t *testing.T, serverPort string, args ...string) bool {
+func RunServerOpenssl(t *testing.T, serverPort string, args ...string) error {
 	env := []string{
 		"OPENSSL_PORT=" + serverPort,
 	}

--- a/pkg/network/tracer/tracer_classification_test.go
+++ b/pkg/network/tracer/tracer_classification_test.go
@@ -217,7 +217,7 @@ func testKafkaProtocolClassification(t *testing.T, tr *Tracer, clientHost, targe
 
 	serverAddress := net.JoinHostPort(serverHost, kafkaPort)
 	targetAddress := net.JoinHostPort(targetHost, kafkaPort)
-	require.True(t, kafka.RunServer(t, serverHost, kafkaPort))
+	require.NoError(t, kafka.RunServer(t, serverHost, kafkaPort))
 
 	tests := []protocolClassificationAttributes{
 		{
@@ -444,7 +444,7 @@ func testMySQLProtocolClassification(t *testing.T, tr *Tracer, clientHost, targe
 
 	serverAddress := net.JoinHostPort(serverHost, mysqlPort)
 	targetAddress := net.JoinHostPort(targetHost, mysqlPort)
-	require.True(t, mysql.RunServer(t, serverHost, mysqlPort))
+	require.NoError(t, mysql.RunServer(t, serverHost, mysqlPort))
 
 	tests := []protocolClassificationAttributes{
 		{
@@ -756,7 +756,7 @@ func testPostgresProtocolClassification(t *testing.T, tr *Tracer, clientHost, ta
 	// Setting one instance of postgres server for all tests.
 	serverAddress := net.JoinHostPort(serverHost, postgresPort)
 	targetAddress := net.JoinHostPort(targetHost, postgresPort)
-	require.True(t, pgutils.RunServer(t, serverHost, postgresPort))
+	require.NoError(t, pgutils.RunServer(t, serverHost, postgresPort))
 
 	tests := []protocolClassificationAttributes{
 		{
@@ -965,7 +965,7 @@ func testMongoProtocolClassification(t *testing.T, tr *Tracer, clientHost, targe
 	// Setting one instance of mongo server for all tests.
 	serverAddress := net.JoinHostPort(serverHost, mongoPort)
 	targetAddress := net.JoinHostPort(targetHost, mongoPort)
-	require.True(t, protocolsmongo.RunServer(t, serverHost, mongoPort))
+	require.NoError(t, protocolsmongo.RunServer(t, serverHost, mongoPort))
 
 	tests := []protocolClassificationAttributes{
 		{
@@ -1118,7 +1118,7 @@ func testRedisProtocolClassification(t *testing.T, tr *Tracer, clientHost, targe
 	// Setting one instance of redis server for all tests.
 	serverAddress := net.JoinHostPort(serverHost, redisPort)
 	targetAddress := net.JoinHostPort(targetHost, redisPort)
-	require.True(t, redis.RunServer(t, serverHost, redisPort))
+	require.NoError(t, redis.RunServer(t, serverHost, redisPort))
 
 	tests := []protocolClassificationAttributes{
 		{
@@ -1272,7 +1272,7 @@ func testAMQPProtocolClassification(t *testing.T, tr *Tracer, clientHost, target
 	// Setting one instance of amqp server for all tests.
 	serverAddress := net.JoinHostPort(serverHost, amqpPort)
 	targetAddress := net.JoinHostPort(targetHost, amqpPort)
-	require.True(t, amqp.RunServer(t, serverHost, amqpPort))
+	require.NoError(t, amqp.RunServer(t, serverHost, amqpPort))
 
 	tests := []protocolClassificationAttributes{
 		{

--- a/pkg/network/tracer/tracer_usm_linux_test.go
+++ b/pkg/network/tracer/tracer_usm_linux_test.go
@@ -654,7 +654,7 @@ func TestJavaInjection(t *testing.T) {
 			},
 			postTracerSetup: func(t *testing.T, ctx testContext) {
 				// if RunJavaVersion failing to start it's probably because the java process has not been injected
-				require.True(t, javatestutil.RunJavaVersion(t, "openjdk:8u151-jre", "JustWait"), "Failed running Java version")
+				require.NoError(t, javatestutil.RunJavaVersion(t, "openjdk:8u151-jre", "JustWait"), "Failed running Java version")
 			},
 			validation: commonValidation,
 			teardown:   commonTearDown,
@@ -679,9 +679,8 @@ func TestJavaInjection(t *testing.T) {
 			},
 			postTracerSetup: func(t *testing.T, ctx testContext) {
 				// if RunJavaVersion failing to start it's probably because the java process has not been injected
-				require.True(t, javatestutil.RunJavaVersion(t, "openjdk:21-oraclelinux8", "JustWait"), "Failed running Java version")
-				var fake testing.T
-				require.Falsef(t, javatestutil.RunJavaVersion(&fake, "openjdk:21-oraclelinux8", "AnotherWait"), "AnotherWait should not be attached")
+				require.NoError(t, javatestutil.RunJavaVersion(t, "openjdk:21-oraclelinux8", "JustWait"), "Failed running Java version")
+				require.Error(t, javatestutil.RunJavaVersion(t, "openjdk:21-oraclelinux8", "AnotherWait"), "AnotherWait should not be attached")
 			},
 			validation: commonValidation,
 			teardown:   commonTearDown,
@@ -704,9 +703,8 @@ func TestJavaInjection(t *testing.T) {
 			},
 			postTracerSetup: func(t *testing.T, ctx testContext) {
 				// if RunJavaVersion failing to start it's probably because the java process has not been injected
-				require.True(t, javatestutil.RunJavaVersion(t, "openjdk:21-oraclelinux8", "AnotherWait"), "Failed running Java version")
-				var fake testing.T
-				require.Falsef(t, javatestutil.RunJavaVersion(&fake, "openjdk:21-oraclelinux8", "JustWait"), "JustWait should not be attached")
+				require.NoError(t, javatestutil.RunJavaVersion(t, "openjdk:21-oraclelinux8", "AnotherWait"), "Failed running Java version")
+				require.Error(t, javatestutil.RunJavaVersion(t, "openjdk:21-oraclelinux8", "JustWait"), "JustWait should not be attached")
 			},
 			validation: commonValidation,
 			teardown:   commonTearDown,
@@ -727,9 +725,8 @@ func TestJavaInjection(t *testing.T) {
 				cfg.JavaAgentBlockRegex = ".*AnotherWait.*"
 			},
 			postTracerSetup: func(t *testing.T, ctx testContext) {
-				require.True(t, javatestutil.RunJavaVersion(t, "openjdk:21-oraclelinux8", "JustWait"), "Failed running Java version")
-				var fake testing.T
-				require.Falsef(t, javatestutil.RunJavaVersion(&fake, "openjdk:21-oraclelinux8", "AnotherWait"), "AnotherWait should not be attached")
+				require.NoError(t, javatestutil.RunJavaVersion(t, "openjdk:21-oraclelinux8", "JustWait"), "Failed running Java version")
+				require.Error(t, javatestutil.RunJavaVersion(t, "openjdk:21-oraclelinux8", "AnotherWait"), "AnotherWait should not be attached")
 			},
 			validation: commonValidation,
 			teardown:   commonTearDown,
@@ -750,7 +747,7 @@ func TestJavaInjection(t *testing.T) {
 				cfg.JavaAgentBlockRegex = ".*JustWait.*"
 			},
 			postTracerSetup: func(t *testing.T, ctx testContext) {
-				require.True(t, javatestutil.RunJavaVersion(t, "openjdk:21-oraclelinux8", "JustWait"), "Failed running Java version")
+				require.NoError(t, javatestutil.RunJavaVersion(t, "openjdk:21-oraclelinux8", "JustWait"), "Failed running Java version")
 			},
 			validation: commonValidation,
 			teardown:   commonTearDown,
@@ -764,7 +761,7 @@ func TestJavaInjection(t *testing.T) {
 				cfg.CollectTCPConns = true
 			},
 			postTracerSetup: func(t *testing.T, ctx testContext) {
-				require.True(t, javatestutil.RunJavaVersion(t, "openjdk:15-oraclelinux8", "Wget https://httpbin.org/anything/java-tls-request", regexp.MustCompile("Response code = .*")), "Failed running Java version")
+				require.NoError(t, javatestutil.RunJavaVersion(t, "openjdk:15-oraclelinux8", "Wget https://httpbin.org/anything/java-tls-request", regexp.MustCompile("Response code = .*")), "Failed running Java version")
 			},
 			validation: func(t *testing.T, ctx testContext, tr *Tracer) {
 				// Iterate through active connections until we find connection created above
@@ -980,7 +977,7 @@ func testHTTPsGoTLSCaptureNewProcessContainer(t *testing.T, cfg *config.Config) 
 
 	tr := setupTracer(t, cfg)
 
-	gotls.RunServer(t, serverPort)
+	require.NoError(t, gotls.RunServer(t, serverPort))
 	reqs := make(requestsMap)
 	for i := 0; i < expectedOccurrences; i++ {
 		resp, err := client.Get(fmt.Sprintf("https://localhost:%s/status/%d", serverPort, 200+i))
@@ -999,7 +996,7 @@ func testHTTPsGoTLSCaptureAlreadyRunningContainer(t *testing.T, cfg *config.Conf
 		expectedOccurrences = 10
 	)
 
-	gotls.RunServer(t, serverPort)
+	require.NoError(t, gotls.RunServer(t, serverPort))
 
 	client := &nethttp.Client{
 		Transport: &nethttp.Transport{
@@ -1081,7 +1078,7 @@ func TestTLSClassification(t *testing.T) {
 					time.Sleep(5 * time.Second)
 					clientSuccess = prototls.RunClientOpenssl(t, "localhost", "44330", scenario.openSSLCommand)
 				}()
-				prototls.RunServerOpenssl(t, "44330", "-www")
+				require.NoError(t, prototls.RunServerOpenssl(t, "44330", "-www"))
 				wg.Wait()
 				if !clientSuccess {
 					t.Fatalf("openssl client failed")

--- a/pkg/network/usm/kafka_monitor_test.go
+++ b/pkg/network/usm/kafka_monitor_test.go
@@ -18,14 +18,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+	"github.com/twmb/franz-go/pkg/kgo"
+	"github.com/twmb/franz-go/pkg/kversion"
+
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/http"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/http/testutil"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/kafka"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
-	"github.com/stretchr/testify/require"
-	"github.com/twmb/franz-go/pkg/kgo"
-	"github.com/twmb/franz-go/pkg/kversion"
 )
 
 type BinaryType int
@@ -113,7 +114,7 @@ func TestKafkaProtocolParsing(t *testing.T) {
 
 	serverAddress := net.JoinHostPort(serverHost, kafkaPort)
 	targetAddress := net.JoinHostPort(targetHost, kafkaPort)
-	require.True(t, kafka.RunServer(t, serverHost, kafkaPort))
+	require.NoError(t, kafka.RunServer(t, serverHost, kafkaPort))
 
 	defaultDialer := &net.Dialer{
 		LocalAddr: &net.TCPAddr{


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Returns an error from `RunDockerServer`.

### Motivation

The tests that expect an error can do so without trying to fake a `testing.T` object.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
