### PR TITLE
Revert Linux file permission/ownership changes

### DIFF
--- a/cmd/agent/install_script.sh
+++ b/cmd/agent/install_script.sh
@@ -9,7 +9,7 @@ set -e
 
 echo -e "\033[33m
  install_script.sh is deprecated. Please use one of
-
+ 
  * https://s3.amazonaws.com/dd-agent/scripts/install_script_agent6.sh to install Agent 6
  * https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh to install Agent 7
 \033[0m"

--- a/omnibus/package-scripts/agent-deb/postinst
+++ b/omnibus/package-scripts/agent-deb/postinst
@@ -8,8 +8,6 @@ INSTALL_DIR=/opt/datadog-agent
 LOG_DIR=/var/log/datadog
 CONFIG_DIR=/etc/datadog-agent
 SERVICE_NAME=datadog-agent
-RUN_DIR=/opt/datadog-agent/run
-SITE_PACKAGES_DIR="${INSTALL_DIR}/embedded/lib/python*/site-packages"
 
 # If we are inside the Docker container, do nothing
 if [ -n "$DOCKER_DD_AGENT" ]; then
@@ -67,29 +65,36 @@ install_method:
     echo "$install_info_content" > $CONFIG_DIR/install_info
 fi
 
-# Set proper rights to the dd-agent user and group
-chown -R root:dd-agent ${CONFIG_DIR}
-
-# Only provide read access to dd-agent by default
-find ${CONFIG_DIR} -type d -not -path ${CONFIG_DIR}/conf.d -exec chmod 2750 {} \;
-find ${CONFIG_DIR} -type f -not -path ${CONFIG_DIR}/conf.d -exec chmod 640 {} \;
-
-# Allow write access to dd-agent for integration installation
-find ${CONFIG_DIR}/conf.d -type d -exec chmod 3770 {} \;
-find ${CONFIG_DIR}/conf.d -type f -exec chmod 660 {} \;
-chown -R dd-agent:dd-agent "${SITE_PACKAGES_DIR}" || true
-
-# This is done to allow integrations to install their binaries
-chown -R root:dd-agent ${INSTALL_DIR}/embedded/bin
-chmod g+w ${INSTALL_DIR}/embedded/bin
-chmod +t ${INSTALL_DIR}/embedded/bin
-
+# Set proper rights to the dd-agent user
+chown -R dd-agent:dd-agent ${CONFIG_DIR}
 chown -R dd-agent:dd-agent ${LOG_DIR}
-chown -R dd-agent:dd-agent ${RUN_DIR}
+chown -R dd-agent:dd-agent ${INSTALL_DIR}
 
-# Allow dd-agent to create files such as the auth token
-chmod g+w ${CONFIG_DIR}
-chmod +t ${CONFIG_DIR}
+# Make system-probe configs read-only
+chmod 0440 ${CONFIG_DIR}/system-probe.yaml.example || true
+if [ -f "$CONFIG_DIR/system-probe.yaml" ]; then
+    chmod 0440 ${CONFIG_DIR}/system-probe.yaml || true
+fi
+
+# Make security-agent config read-only
+chmod 0440 ${CONFIG_DIR}/security-agent.yaml.example || true
+if [ -f "$CONFIG_DIR/security-agent.yaml" ]; then
+    chmod 0440 ${CONFIG_DIR}/security-agent.yaml || true
+fi
+
+if [ -d "$CONFIG_DIR/compliance.d" ]; then
+    chown -R root:root ${CONFIG_DIR}/compliance.d || true
+fi
+
+if [ -d "$CONFIG_DIR/runtime-security.d" ]; then
+    chown -R root:root ${CONFIG_DIR}/runtime-security.d || true
+fi
+
+# Make the system-probe and security-agent binaries and eBPF programs owned by root
+chown root:root ${INSTALL_DIR}/embedded/bin/system-probe
+chown root:root ${INSTALL_DIR}/embedded/bin/security-agent
+chown -R root:root ${INSTALL_DIR}/embedded/share/system-probe/ebpf
+chown -R root:root ${INSTALL_DIR}/embedded/share/system-probe/java
 
 # Enable and restart the agent service here on Debian platforms
 # On RHEL, this is done in the posttrans script

--- a/omnibus/package-scripts/agent-deb/postinst
+++ b/omnibus/package-scripts/agent-deb/postinst
@@ -9,6 +9,7 @@ LOG_DIR=/var/log/datadog
 CONFIG_DIR=/etc/datadog-agent
 SERVICE_NAME=datadog-agent
 RUN_DIR=/opt/datadog-agent/run
+SITE_PACKAGES_DIR="${INSTALL_DIR}/embedded/lib/python*/site-packages"
 
 # If we are inside the Docker container, do nothing
 if [ -n "$DOCKER_DD_AGENT" ]; then
@@ -76,8 +77,7 @@ find ${CONFIG_DIR} -type f -not -path ${CONFIG_DIR}/conf.d -exec chmod 640 {} \;
 # Allow write access to dd-agent for integration installation
 find ${CONFIG_DIR}/conf.d -type d -exec chmod 3775 {} \;
 find ${CONFIG_DIR}/conf.d -type f -exec chmod 660 {} \;
-# Glob characters like "*" can't be used inside quotes, so we only quote the variable
-chown -R dd-agent:dd-agent "${INSTALL_DIR}"/embedded/lib/python*/site-packages || true
+chown -R dd-agent:dd-agent "${SITE_PACKAGES_DIR}" || true
 
 # This is done to allow integrations to install their binaries
 chown -R root:dd-agent ${INSTALL_DIR}/embedded/bin

--- a/omnibus/package-scripts/agent-deb/postinst
+++ b/omnibus/package-scripts/agent-deb/postinst
@@ -75,7 +75,7 @@ find ${CONFIG_DIR} -type d -not -path ${CONFIG_DIR}/conf.d -exec chmod 2750 {} \
 find ${CONFIG_DIR} -type f -not -path ${CONFIG_DIR}/conf.d -exec chmod 640 {} \;
 
 # Allow write access to dd-agent for integration installation
-find ${CONFIG_DIR}/conf.d -type d -exec chmod 3775 {} \;
+find ${CONFIG_DIR}/conf.d -type d -exec chmod 3770 {} \;
 find ${CONFIG_DIR}/conf.d -type f -exec chmod 660 {} \;
 chown -R dd-agent:dd-agent "${SITE_PACKAGES_DIR}" || true
 
@@ -87,8 +87,8 @@ chmod +t ${INSTALL_DIR}/embedded/bin
 chown -R dd-agent:dd-agent ${LOG_DIR}
 chown -R dd-agent:dd-agent ${RUN_DIR}
 
-# Allow dd-agent to create files such as the auth token and users to check for file presence
-chmod g+w,o+rx ${CONFIG_DIR}
+# Allow dd-agent to create files such as the auth token
+chmod g+w ${CONFIG_DIR}
 chmod +t ${CONFIG_DIR}
 
 # Enable and restart the agent service here on Debian platforms

--- a/omnibus/package-scripts/agent-rpm/postinst
+++ b/omnibus/package-scripts/agent-rpm/postinst
@@ -8,31 +8,36 @@
 INSTALL_DIR=/opt/datadog-agent
 LOG_DIR=/var/log/datadog
 CONFIG_DIR=/etc/datadog-agent
-RUN_DIR=/opt/datadog-agent/run
-SITE_PACKAGES_DIR="${INSTALL_DIR}/embedded/lib/python*/site-packages"
 
-# Set proper rights to the dd-agent user and group
-chown -R root:dd-agent ${CONFIG_DIR}
-
-# Only provide read access to dd-agent by default
-find ${CONFIG_DIR} -type d -not -path ${CONFIG_DIR}/conf.d -exec chmod 2750 {} \;
-find ${CONFIG_DIR} -type f -not -path ${CONFIG_DIR}/conf.d -exec chmod 640 {} \;
-
-# Allow write access to dd-agent for integration installation
-find ${CONFIG_DIR}/conf.d -type d -exec chmod 3770 {} \;
-find ${CONFIG_DIR}/conf.d -type f -exec chmod 660 {} \;
-chown -R dd-agent:dd-agent "${SITE_PACKAGES_DIR}" || true
-
-# This is done to allow integrations to install their binaries
-chown -R root:dd-agent ${INSTALL_DIR}/embedded/bin
-chmod g+w ${INSTALL_DIR}/embedded/bin
-chmod +t ${INSTALL_DIR}/embedded/bin
-
+# Set proper rights to the dd-agent user
+chown -R dd-agent:dd-agent ${CONFIG_DIR}
 chown -R dd-agent:dd-agent ${LOG_DIR}
-chown -R dd-agent:dd-agent ${RUN_DIR}
+chown -R dd-agent:dd-agent ${INSTALL_DIR}
 
-# Allow dd-agent to create files such as the auth token
-chmod g+w ${CONFIG_DIR}
-chmod +t ${CONFIG_DIR}
+# Make system-probe configs read-only
+chmod 0440 ${CONFIG_DIR}/system-probe.yaml.example || true
+if [ -f "$CONFIG_DIR/system-probe.yaml" ]; then
+    chmod 0440 ${CONFIG_DIR}/system-probe.yaml || true
+fi
+
+# Make security-agent config read-only
+chmod 0440 ${CONFIG_DIR}/security-agent.yaml.example || true
+if [ -f "$CONFIG_DIR/security-agent.yaml" ]; then
+    chmod 0440 ${CONFIG_DIR}/security-agent.yaml || true
+fi
+
+if [ -d "$CONFIG_DIR/compliance.d" ]; then
+    chown -R root:root ${CONFIG_DIR}/compliance.d || true
+fi
+
+if [ -d "$CONFIG_DIR/runtime-security.d" ]; then
+    chown -R root:root ${CONFIG_DIR}/runtime-security.d || true
+fi
+
+# Make the system-probe and security-agent binaries and eBPF programs owned by root
+chown root:root ${INSTALL_DIR}/embedded/bin/system-probe
+chown root:root ${INSTALL_DIR}/embedded/bin/security-agent
+chown -R root:root ${INSTALL_DIR}/embedded/share/system-probe/ebpf
+chown -R root:root ${INSTALL_DIR}/embedded/share/system-probe/java
 
 exit 0

--- a/omnibus/package-scripts/agent-rpm/postinst
+++ b/omnibus/package-scripts/agent-rpm/postinst
@@ -19,7 +19,7 @@ find ${CONFIG_DIR} -type d -not -path ${CONFIG_DIR}/conf.d -exec chmod 2750 {} \
 find ${CONFIG_DIR} -type f -not -path ${CONFIG_DIR}/conf.d -exec chmod 640 {} \;
 
 # Allow write access to dd-agent for integration installation
-find ${CONFIG_DIR}/conf.d -type d -exec chmod 3775 {} \;
+find ${CONFIG_DIR}/conf.d -type d -exec chmod 3770 {} \;
 find ${CONFIG_DIR}/conf.d -type f -exec chmod 660 {} \;
 chown -R dd-agent:dd-agent "${SITE_PACKAGES_DIR}" || true
 
@@ -31,8 +31,8 @@ chmod +t ${INSTALL_DIR}/embedded/bin
 chown -R dd-agent:dd-agent ${LOG_DIR}
 chown -R dd-agent:dd-agent ${RUN_DIR}
 
-# Allow dd-agent to create files such as the auth token and users to check for file presence
-chmod g+w,o+rx ${CONFIG_DIR}
+# Allow dd-agent to create files such as the auth token
+chmod g+w ${CONFIG_DIR}
 chmod +t ${CONFIG_DIR}
 
 exit 0

--- a/omnibus/package-scripts/agent-rpm/postinst
+++ b/omnibus/package-scripts/agent-rpm/postinst
@@ -9,6 +9,7 @@ INSTALL_DIR=/opt/datadog-agent
 LOG_DIR=/var/log/datadog
 CONFIG_DIR=/etc/datadog-agent
 RUN_DIR=/opt/datadog-agent/run
+SITE_PACKAGES_DIR="${INSTALL_DIR}/embedded/lib/python*/site-packages"
 
 # Set proper rights to the dd-agent user and group
 chown -R root:dd-agent ${CONFIG_DIR}
@@ -20,8 +21,7 @@ find ${CONFIG_DIR} -type f -not -path ${CONFIG_DIR}/conf.d -exec chmod 640 {} \;
 # Allow write access to dd-agent for integration installation
 find ${CONFIG_DIR}/conf.d -type d -exec chmod 3775 {} \;
 find ${CONFIG_DIR}/conf.d -type f -exec chmod 660 {} \;
-# Glob characters like "*" can't be used inside quotes, so we only quote the variable
-chown -R dd-agent:dd-agent "${INSTALL_DIR}"/embedded/lib/python*/site-packages || true
+chown -R dd-agent:dd-agent "${SITE_PACKAGES_DIR}" || true
 
 # This is done to allow integrations to install their binaries
 chown -R root:dd-agent ${INSTALL_DIR}/embedded/bin

--- a/omnibus/package-scripts/agent-rpm/posttrans
+++ b/omnibus/package-scripts/agent-rpm/posttrans
@@ -100,6 +100,7 @@ install_method:
   installer_version: $installer_version
 "
     echo "$install_info_content" > $CONFIG_DIR/install_info
+    chown -R dd-agent:dd-agent ${CONFIG_DIR}
 fi
 
 # TODO: Use a configcheck command on the agent to determine if it's safe to restart,

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -677,8 +677,6 @@ api_key:
 ## Default is:
 ##  * Windows & macOS : `5002`
 ##  * Linux: `-1`
-## On Linux, to be able to edit the configuration from the GUI
-## you need to give write access on this file to the dd-agent user.
 ##
 #
 # GUI_port: <GUI_PORT>

--- a/releasenotes/notes/agent-file-ownership-13f077681711995c.yaml
+++ b/releasenotes/notes/agent-file-ownership-13f077681711995c.yaml
@@ -1,8 +1,0 @@
----
-upgrade:
-  - |
-    The files provided by the agent and its configuration are no longer
-    owned by the ``dd-agent`` user but by ``root`` instead.
-    Users of the embedded agent GUI on Linux who need to edit the agent
-    configuration file should change the file permission to keep using
-    this feature.


### PR DESCRIPTION
### What does this PR do?

Reverts these PRs:
* https://github.com/DataDog/datadog-agent/pull/14078
* https://github.com/DataDog/datadog-agent/pull/16651
* https://github.com/DataDog/datadog-agent/pull/16684
* https://github.com/DataDog/datadog-agent/pull/16686

### Motivation

As we found out during QA, there are some unforeseen implications of doing this. While this change is desirable, we will need to test it more before actually proposing again.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
