### PR TITLE
Adding cloud_provider_host_id to the inventories metadata

### DIFF
--- a/pkg/metadata/inventories/README.md
+++ b/pkg/metadata/inventories/README.md
@@ -139,10 +139,14 @@ The payload is a JSON dict with the following fields
     Values on AWS:
     - `IMDSv2`: The Agent successfully contacted IMDSv2 metadata endpoint.
     - `IMDSv1`: The Agent successfully contacted IMDSv1 metadata endpoint.
-    - `DMI`: The Agent successfully used DMI information to fetch the instance ID (only work on EC2 Nitro instances).
+    - `DMI`: The Agent successfully used DMI information to fetch the instance ID (only works on Unix EC2 Nitro instances).
     - `UUID`: The hypervisor or product UUID has the EC2 prefix. The Agent knows it's running on EC2 but don't know on
-      which instance.
+      which instance (see `hypervisor_guest_uuid` or `dmi_product_uuid`).
   - `cloud_provider_account_id` - **string**: The account/subscription ID from the cloud provider.
+  - `cloud_provider_host_id` - **string**: the unique ID the cloud provider uses to reference this instance.
+    This is different for each cloud provider (for now, ony AWS is supported).
+    - On AWS: the instance ID returned by querying the IMDSv2 endpoint. An empty string is returned if we can't reach
+      IMDSv2 (even if IMDSv1 is available).
   - `hypervisor_guest_uuid` - **string**: the hypervisor guest UUID (Unix only, empty string on Windows or if we can't
     read the data). On `ec2` instance this might start by "ec2". This was introduce in `7.41.0`/`6.41.0`.
   - `dmi_product_uuid` - **string**: the DMI product UUID (Unix only, empty string on Windows or if we can't read the
@@ -279,6 +283,9 @@ Here an example of an inventory payload:
         "mac_address": "01:23:45:67:89:AB",
         "agent_version": "7.37.0-devel+git.198.68a5b69",
         "cloud_provider": "AWS",
+        "cloud_provider_source": "DMI",
+        "cloud_provider_account_id": "aws_account_id",
+        "cloud_provider_host_id": "i-abcedf",
         "hypervisor_guest_uuid": "ec24ce06-9ac4-42df-9c10-14772aeb06d7",
         "dmi_product_uuid": "ec24ce06-9ac4-42df-9c10-14772aeb06d7",
         "dmi_board_asset_tag": "i-abcedf",

--- a/pkg/metadata/inventories/inventories.go
+++ b/pkg/metadata/inventories/inventories.go
@@ -111,6 +111,7 @@ const (
 	HostCloudProvider          AgentMetadataName = "cloud_provider"
 	HostCloudProviderSource    AgentMetadataName = "cloud_provider_source"
 	HostCloudProviderAccountID AgentMetadataName = "cloud_provider_account_id"
+	HostCloudProviderID        AgentMetadataName = "cloud_provider_host_id"
 )
 
 // Refresh signals that some data has been updated and a new payload should be sent (ex: when configuration is changed
@@ -129,6 +130,8 @@ func SetAgentMetadata(name AgentMetadataName, value interface{}) {
 		return
 	}
 
+	log.Debugf("setting agent metadata '%s': '%s'", name, value)
+
 	inventoryMutex.Lock()
 	defer inventoryMutex.Unlock()
 
@@ -145,6 +148,7 @@ func SetHostMetadata(name AgentMetadataName, value interface{}) {
 		return
 	}
 
+	log.Debugf("setting host metadata '%s': '%s'", name, value)
 	inventoryMutex.Lock()
 	defer inventoryMutex.Unlock()
 
@@ -160,6 +164,8 @@ func SetCheckMetadata(checkID, key string, value interface{}) {
 	if checkID == "" || !config.Datadog.GetBool("inventories_enabled") {
 		return
 	}
+
+	log.Debugf("setting check metadata for check %s, '%s': '%s'", checkID, key, value)
 
 	inventoryMutex.Lock()
 	defer inventoryMutex.Unlock()

--- a/pkg/util/cloudproviders/cloudproviders.go
+++ b/pkg/util/cloudproviders/cloudproviders.go
@@ -147,9 +147,9 @@ func GetHostAliases(ctx context.Context) []string {
 // GetPublicIPv4 returns the public IPv4 from different providers
 func GetPublicIPv4(ctx context.Context) (string, error) {
 	publicIPProvider := map[string]func(context.Context) (string, error){
-		"EC2":   ec2.GetPublicIPv4,
-		"GCE":   gce.GetPublicIPv4,
-		"Azure": azure.GetPublicIPv4,
+		ec2.CloudProviderName:   ec2.GetPublicIPv4,
+		gce.CloudProviderName:   gce.GetPublicIPv4,
+		azure.CloudProviderName: azure.GetPublicIPv4,
 	}
 	for name, fetcher := range publicIPProvider {
 		publicIPv4, err := fetcher(ctx)

--- a/pkg/util/ec2/ec2.go
+++ b/pkg/util/ec2/ec2.go
@@ -88,10 +88,7 @@ func setCloudProviderSource(source int) {
 var instanceIDFetcher = cachedfetch.Fetcher{
 	Name: "EC2 InstanceID",
 	Attempt: func(ctx context.Context) (interface{}, error) {
-		return getMetadataItemWithMaxLength(ctx,
-			"/instance-id",
-			config.Datadog.GetInt("metadata_endpoints_max_hostname_size"),
-		)
+		return getMetadataItemWithMaxLength(ctx, imdsInstanceID, false)
 	},
 }
 
@@ -114,6 +111,9 @@ func IsRunningOn(ctx context.Context) bool {
 
 // GetHostAliases returns the host aliases from the EC2 metadata API.
 func GetHostAliases(ctx context.Context) ([]string, error) {
+	// We leverage GetHostAliases to register the instance ID in inventories
+	registerCloudProviderHostnameID(ctx)
+
 	instanceID, err := GetInstanceID(ctx)
 	if err == nil {
 		return []string{instanceID}, nil
@@ -133,10 +133,7 @@ func GetHostAliases(ctx context.Context) ([]string, error) {
 var hostnameFetcher = cachedfetch.Fetcher{
 	Name: "EC2 Hostname",
 	Attempt: func(ctx context.Context) (interface{}, error) {
-		return getMetadataItemWithMaxLength(ctx,
-			"/hostname",
-			config.Datadog.GetInt("metadata_endpoints_max_hostname_size"),
-		)
+		return getMetadataItemWithMaxLength(ctx, imdsHostname, false)
 	},
 }
 

--- a/pkg/util/ec2/ec2_tags.go
+++ b/pkg/util/ec2/ec2_tags.go
@@ -57,7 +57,7 @@ func fetchEc2Tags(ctx context.Context) ([]string, error) {
 }
 
 func fetchEc2TagsFromIMDS(ctx context.Context) ([]string, error) {
-	keysStr, err := getMetadataItem(ctx, "/tags/instance")
+	keysStr, err := getMetadataItem(ctx, imdsTags, false)
 	if err != nil {
 		return nil, err
 	}
@@ -74,7 +74,7 @@ func fetchEc2TagsFromIMDS(ctx context.Context) ([]string, error) {
 		// > keys can only use letters (a-z, A-Z), numbers (0-9), and the
 		// > following characters: -_+=,.@:. Instance tag keys can't use spaces,
 		// > /, or the reserved names ., .., or _index.
-		val, err := getMetadataItem(ctx, "/tags/instance/"+key)
+		val, err := getMetadataItem(ctx, imdsTags+"/"+key, false)
 		if err != nil {
 			return nil, err
 		}
@@ -201,7 +201,7 @@ type ec2Identity struct {
 func getInstanceIdentity(ctx context.Context) (*ec2Identity, error) {
 	instanceIdentity := &ec2Identity{}
 
-	res, err := doHTTPRequest(ctx, instanceIdentityURL)
+	res, err := doHTTPRequest(ctx, instanceIdentityURL, false)
 	if err != nil {
 		return instanceIdentity, fmt.Errorf("unable to fetch EC2 API to get identity: %s", err)
 	}
@@ -228,7 +228,7 @@ func getSecurityCreds(ctx context.Context) (*ec2SecurityCred, error) {
 		return iamParams, err
 	}
 
-	res, err := doHTTPRequest(ctx, metadataURL+"/iam/security-credentials/"+iamRole)
+	res, err := doHTTPRequest(ctx, metadataURL+"/iam/security-credentials/"+iamRole, false)
 	if err != nil {
 		return iamParams, fmt.Errorf("unable to fetch EC2 API to get iam role: %s", err)
 	}
@@ -241,7 +241,7 @@ func getSecurityCreds(ctx context.Context) (*ec2SecurityCred, error) {
 }
 
 func getIAMRole(ctx context.Context) (string, error) {
-	res, err := doHTTPRequest(ctx, metadataURL+"/iam/security-credentials/")
+	res, err := doHTTPRequest(ctx, metadataURL+"/iam/security-credentials/", false)
 	if err != nil {
 		return "", fmt.Errorf("unable to fetch EC2 API to get security credentials: %s", err)
 	}

--- a/pkg/util/ec2/network.go
+++ b/pkg/util/ec2/network.go
@@ -18,7 +18,7 @@ import (
 var publicIPv4Fetcher = cachedfetch.Fetcher{
 	Name: "EC2 Public IPv4 Address",
 	Attempt: func(ctx context.Context) (interface{}, error) {
-		return getMetadataItem(ctx, "/public-ipv4")
+		return getMetadataItem(ctx, imdsIPv4, false)
 	},
 }
 
@@ -30,7 +30,7 @@ func GetPublicIPv4(ctx context.Context) (string, error) {
 var networkIDFetcher = cachedfetch.Fetcher{
 	Name: "VPC IDs",
 	Attempt: func(ctx context.Context) (interface{}, error) {
-		resp, err := getMetadataItem(ctx, "/network/interfaces/macs")
+		resp, err := getMetadataItem(ctx, imdsNetworkMacs, false)
 		if err != nil {
 			return "", err
 		}
@@ -43,7 +43,7 @@ var networkIDFetcher = cachedfetch.Fetcher{
 				continue
 			}
 			mac = strings.TrimSuffix(mac, "/")
-			id, err := getMetadataItem(ctx, fmt.Sprintf("/network/interfaces/macs/%s/vpc-id", mac))
+			id, err := getMetadataItem(ctx, fmt.Sprintf("%s/%s/vpc-id", imdsNetworkMacs, mac), false)
 			if err != nil {
 				return "", err
 			}
@@ -83,14 +83,14 @@ func GetSubnetForHardwareAddr(ctx context.Context, hwAddr net.HardwareAddr) (sub
 	}
 
 	var resp string
-	resp, err = getMetadataItem(ctx, fmt.Sprintf("/network/interfaces/macs/%s/subnet-id", hwAddr))
+	resp, err = getMetadataItem(ctx, fmt.Sprintf("%s/%s/subnet-id", imdsNetworkMacs, hwAddr), false)
 	if err != nil {
 		return
 	}
 
 	subnet.ID = strings.TrimSpace(resp)
 
-	resp, err = getMetadataItem(ctx, fmt.Sprintf("/network/interfaces/macs/%s/subnet-ipv4-cidr-block", hwAddr))
+	resp, err = getMetadataItem(ctx, fmt.Sprintf("%s/%s/subnet-ipv4-cidr-block", imdsNetworkMacs, hwAddr), false)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
### What does this PR do?

We now collect the cloud provider unique ID for the host currently running the agent. Depending on the cloud provider this might be the same as the hostname or host aliases already collected.

This is only supported for AWS for now.

### Describe how to test/QA your changes

Run the Agent on EC2 and check that the instance ID is filled in `cloud_provider_id`. Use `datadog-agent diagnose show-metadata inventory` to show the last inventory payload sent.

The QA for this card also cover the QA for PR #17140.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
