### PR TITLE
feat(AML-661): Added support for JMXFetch snapshots

### DIFF
--- a/omnibus/config/software/jmxfetch.rb
+++ b/omnibus/config/software/jmxfetch.rb
@@ -15,9 +15,17 @@ end
 default_version jmxfetch_version
 
 source sha256: jmxfetch_hash
-source url: "https://oss.sonatype.org/service/local/repositories/releases/content/com/datadoghq/jmxfetch/#{version}/jmxfetch-#{version}-jar-with-dependencies.jar",
-       target_filename: "jmxfetch.jar"
 
+if jmxfetch_snapshot_version = Regexp.new('(?<current_version>\d+\.\d+\.\d+)[-]').freeze.match(jmxfetch_version)
+    license_file_version = 'master'
+    jmxfetch_snapshot_version = jmxfetch_snapshot_version['current_version']
+    source url: "https://oss.sonatype.org/content/repositories/snapshots/com/datadoghq/jmxfetch/#{jmxfetch_snapshot_version}-SNAPSHOT/jmxfetch-#{version}-jar-with-dependencies.jar",
+           target_filename: "jmxfetch.jar"
+else
+    license_file_version = jmxfetch_version
+    source url: "https://oss.sonatype.org/service/local/repositories/releases/content/com/datadoghq/jmxfetch/#{version}/jmxfetch-#{version}-jar-with-dependencies.jar",
+           target_filename: "jmxfetch.jar"
+end
 
 jar_dir = "#{install_dir}/bin/agent/dist/jmx"
 
@@ -25,7 +33,7 @@ relative_path "jmxfetch"
 
 build do
   license "BSD-3-Clause"
-  license_file "https://raw.githubusercontent.com/DataDog/jmxfetch/#{version}/LICENSE"
+  license_file "https://raw.githubusercontent.com/DataDog/jmxfetch/#{license_file_version}/LICENSE"
 
   mkdir jar_dir
 


### PR DESCRIPTION
### What does this PR do?

This allows us to use `SNAPSHOT` builds of JMXFetch when building images for testing.  By changing the version in the `release.json` to:

```
    "release-a7": {
        ...
        "JMXFETCH_VERSION": "0.47.9-20230424.173024-5",
        "JMXFETCH_HASH": "aff48a7589b507fd41367686f15307005d498d94a260efbc771963cedd52f16f",
    },
```

Or (if only one snapshot was ever created):

```
    "release-a7": {
        ...
        "JMXFETCH_VERSION": "0.47.9-SNAPSHOT",
        "JMXFETCH_HASH": "aff48a7589b507fd41367686f15307005d498d94a260efbc771963cedd52f16f",
    },
```

The value of `JMXFETCH_HASH` still has to be a valid `shas256` of the `jar-with-dependencies` file.

An example of such a build can be found in this commit [here](https://github.com/DataDog/datadog-agent/commit/7387dbf2ea02f230a0b0e7aa93b5c889a8db0606).

### Motivation

This helps to speed up the testing of new JMXFetch features as we no longer have to create a new release to include it in an Agent build. Java snapshots are published to a different repo and have a different filename pattern so we could not just use the value `0.47.9-20230424.173024-5` without making these changes. 

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

Potentially someone may commit to main a version of the `release.json` that has a reference to a snapshot version of JMXFetch. These snapshots are sometimes removed (not controlled by us) so could create a none recreatable build of the Agent. 

### Describe how to test/QA your changes

No QA needed as this change will break the build if JMXFetch can not be downloaded. This feature will only be used when testing JMXFetch snapshots so the main build will carry on behaving the same.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
