### PR TITLE
Allow regression detector changes to be added without force

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -204,3 +204,6 @@ test/fakeintake/build/*
 
 # dev container
 .devcontainer/
+
+# Allow Regression Detector material to ignore excludes
+!test/regression/**


### PR DESCRIPTION
### What does this PR do?

Related to #16582 I have introduced the ability to `git add` in `test/regression/**` without the need to provide a force flag. Without this the user may not easily check in agent configuration files.
