### PR TITLE
[CWS] move away from gopsutil fork

### DIFF
--- a/pkg/security/probe/runtime_monitor.go
+++ b/pkg/security/probe/runtime_monitor.go
@@ -14,7 +14,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/DataDog/gopsutil/process"
+	"github.com/shirou/gopsutil/v3/process"
 
 	"github.com/DataDog/datadog-go/v5/statsd"
 

--- a/pkg/security/resolvers/netns/resolver.go
+++ b/pkg/security/resolvers/netns/resolver.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/DataDog/datadog-go/v5/statsd"
 	manager "github.com/DataDog/ebpf-manager"
-	"github.com/DataDog/gopsutil/process"
 	"github.com/hashicorp/golang-lru/v2/simplelru"
 	"github.com/vishvananda/netlink"
 	"go.uber.org/atomic"
@@ -352,12 +351,12 @@ func (nr *Resolver) IsLazyDeletionInterface(name string) bool {
 }
 
 // SyncCache snapshots /proc for the provided pid. This method returns true if it updated the namespace cache.
-func (nr *Resolver) SyncCache(proc *process.Process) bool {
+func (nr *Resolver) SyncCache(pid uint32) bool {
 	if !nr.config.NetworkEnabled {
 		return false
 	}
 
-	nsPath := utils.NetNSPathFromPid(uint32(proc.Pid))
+	nsPath := utils.NetNSPathFromPid(pid)
 	nsID, err := nsPath.GetProcessNetworkNamespace()
 	if err != nil {
 		return false

--- a/pkg/security/resolvers/process/resolver.go
+++ b/pkg/security/resolvers/process/resolver.go
@@ -22,9 +22,9 @@ import (
 
 	"github.com/DataDog/datadog-go/v5/statsd"
 	manager "github.com/DataDog/ebpf-manager"
-	"github.com/DataDog/gopsutil/process"
 	lib "github.com/cilium/ebpf"
 	"github.com/hashicorp/golang-lru/v2/simplelru"
+	"github.com/shirou/gopsutil/v3/process"
 	"go.uber.org/atomic"
 
 	"github.com/DataDog/datadog-agent/pkg/process/procutil"
@@ -323,7 +323,7 @@ func (p *Resolver) AddExecEntry(entry *model.ProcessCacheEntry) {
 }
 
 // enrichEventFromProc uses /proc to enrich a ProcessCacheEntry with additional metadata
-func (p *Resolver) enrichEventFromProc(entry *model.ProcessCacheEntry, proc *process.Process, filledProc *process.FilledProcess) error {
+func (p *Resolver) enrichEventFromProc(entry *model.ProcessCacheEntry, proc *process.Process, filledProc *utils.FilledProcess) error {
 	// the provided process is a kernel process if its virtual memory size is null
 	if filledProc.MemInfo.VMS == 0 {
 		return fmt.Errorf("cannot snapshot kernel threads")
@@ -1085,7 +1085,7 @@ func (p *Resolver) setAncestor(pce *model.ProcessCacheEntry) {
 }
 
 // syncCache snapshots /proc for the provided pid. This method returns true if it updated the process cache.
-func (p *Resolver) syncCache(proc *process.Process, filledProc *process.FilledProcess) (*model.ProcessCacheEntry, bool) {
+func (p *Resolver) syncCache(proc *process.Process, filledProc *utils.FilledProcess) (*model.ProcessCacheEntry, bool) {
 	pid := uint32(proc.Pid)
 
 	// Check if an entry is already in cache for the given pid.

--- a/pkg/security/resolvers/resolvers_linux.go
+++ b/pkg/security/resolvers/resolvers_linux.go
@@ -226,12 +226,14 @@ func (r *Resolvers) snapshot() error {
 			continue
 		}
 
-		if process.IsKThread(uint32(ppid), uint32(proc.Pid)) {
+		pid := uint32(proc.Pid)
+
+		if process.IsKThread(uint32(ppid), pid) {
 			continue
 		}
 
 		// Start with the mount resolver because the process resolver might need it to resolve paths
-		if err = r.MountResolver.SyncCache(uint32(proc.Pid)); err != nil {
+		if err = r.MountResolver.SyncCache(pid); err != nil {
 			if !os.IsNotExist(err) {
 				log.Debugf("snapshot failed for %d: couldn't sync mount points: %s", proc.Pid, err)
 			}
@@ -241,7 +243,7 @@ func (r *Resolvers) snapshot() error {
 		r.ProcessResolver.SyncCache(proc)
 
 		// Sync the namespace cache
-		r.NamespaceResolver.SyncCache(proc)
+		r.NamespaceResolver.SyncCache(pid)
 	}
 
 	return nil

--- a/pkg/security/resolvers/time/resolver.go
+++ b/pkg/security/resolvers/time/resolver.go
@@ -13,7 +13,7 @@ import (
 
 	_ "unsafe"
 
-	"github.com/DataDog/gopsutil/host"
+	"github.com/shirou/gopsutil/v3/host"
 )
 
 // Resolver converts kernel monotonic timestamps to absolute times

--- a/pkg/security/security_profile/activity_tree/process_node_snapshot.go
+++ b/pkg/security/security_profile/activity_tree/process_node_snapshot.go
@@ -19,8 +19,8 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/DataDog/gopsutil/process"
 	"github.com/prometheus/procfs"
+	"github.com/shirou/gopsutil/v3/process"
 	"golang.org/x/sys/unix"
 
 	"github.com/DataDog/datadog-agent/pkg/process/util"

--- a/pkg/security/utils/numcpu.go
+++ b/pkg/security/utils/numcpu.go
@@ -8,7 +8,9 @@
 
 package utils
 
-import "github.com/DataDog/gopsutil/cpu"
+import (
+	"github.com/shirou/gopsutil/v3/cpu"
+)
 
 // NumCPU returns the count of CPUs in the CPU affinity mask of the pid 1 process
 func NumCPU() (int, error) {

--- a/pkg/security/utils/proc.go
+++ b/pkg/security/utils/proc.go
@@ -19,7 +19,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/DataDog/gopsutil/process"
+	"github.com/shirou/gopsutil/v3/process"
 
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 )
@@ -200,9 +200,19 @@ func GetProcesses() ([]*process.Process, error) {
 	return processes, nil
 }
 
+type FilledProcess struct {
+	Pid        int32
+	Ppid       int32
+	CreateTime int64
+	Name       string
+	Uids       []int32
+	Gids       []int32
+	MemInfo    *process.MemoryInfoStat
+	Cmdline    []string
+}
+
 // GetFilledProcess returns a FilledProcess from a Process input
-// TODO: make a PR to export a similar function in Datadog/gopsutil. We only populate the fields we need for now.
-func GetFilledProcess(p *process.Process) *process.FilledProcess {
+func GetFilledProcess(p *process.Process) *FilledProcess {
 	ppid, err := p.Ppid()
 	if err != nil {
 		return nil
@@ -238,7 +248,7 @@ func GetFilledProcess(p *process.Process) *process.FilledProcess {
 		return nil
 	}
 
-	return &process.FilledProcess{
+	return &FilledProcess{
 		Pid:        p.Pid,
 		Ppid:       ppid,
 		CreateTime: createTime,


### PR DESCRIPTION
### What does this PR do?

This PR moves the `pkg/security` package away from `github.com/DataDog/gopsutil` and to `github.com/shirou/gopsutil/v3`.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
