### PR TITLE
[fakeintake] add flush endpoint

### DIFF
--- a/test/fakeintake/aggregator/common.go
+++ b/test/fakeintake/aggregator/common.go
@@ -40,7 +40,7 @@ func newAggregator[P PayloadItem](parse parseFunc[P]) Aggregator[P] {
 
 func (agg *Aggregator[P]) UnmarshallPayloads(payloads []api.Payload) error {
 	// reset map
-	agg.payloadsByName = map[string][]P{}
+	agg.Reset()
 	// build map
 	for _, p := range payloads {
 		payloads, err := agg.parse(p)
@@ -105,6 +105,10 @@ func getReadCloserForEncoding(payload []byte, encoding string) (rc io.ReadCloser
 
 func (agg *Aggregator[P]) GetPayloadsByName(name string) []P {
 	return agg.payloadsByName[name]
+}
+
+func (agg *Aggregator[P]) Reset() {
+	agg.payloadsByName = map[string][]P{}
 }
 
 func FilterByTags[P PayloadItem](payloads []P, tags []string) []P {

--- a/test/fakeintake/aggregator/common_test.go
+++ b/test/fakeintake/aggregator/common_test.go
@@ -102,4 +102,12 @@ func TestCommonAggregator(t *testing.T) {
 		assert.Empty(t, FilterByTags(items, []string{"age:123", "country:it"}))
 		assert.NotEmpty(t, FilterByTags(items, []string{"age:43"}))
 	})
+
+	t.Run("Reset", func(t *testing.T) {
+		_, err := generateTestData()
+		require.NoError(t, err)
+		agg := newAggregator(parseMockPayloadItem)
+		agg.Reset()
+		assert.Equal(t, 0, len(agg.payloadsByName))
+	})
 }

--- a/test/fakeintake/client/client.go
+++ b/test/fakeintake/client/client.go
@@ -240,3 +240,28 @@ func (c *Client) GetCheckRun(name string) ([]*aggregator.CheckRun, error) {
 	}
 	return c.checkRunAggregator.GetPayloadsByName(name), nil
 }
+
+// FlushPayloads sends a request to delete any stored payload
+// and resets client's  aggregators
+func (c *Client) FlushPayloads() error {
+	err := c.flushPayloads()
+	if err != nil {
+		return err
+	}
+	c.checkRunAggregator.Reset()
+	c.metricAggregator.Reset()
+	c.logAggregator.Reset()
+	return nil
+}
+
+func (c *Client) flushPayloads() error {
+	resp, err := http.Get(fmt.Sprintf("%s/fakeintake/flushPayloads", c.fakeIntakeURL))
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("error code %v", resp.StatusCode)
+	}
+	return nil
+}

--- a/test/fakeintake/client/client.go
+++ b/test/fakeintake/client/client.go
@@ -241,9 +241,10 @@ func (c *Client) GetCheckRun(name string) ([]*aggregator.CheckRun, error) {
 	return c.checkRunAggregator.GetPayloadsByName(name), nil
 }
 
-// FlushPayloads sends a request to delete any stored payload
+// FlushServerAndResetAggregators sends a request to delete any stored payload
 // and resets client's  aggregators
-func (c *Client) FlushPayloads() error {
+// Call this in between tests to reset the fakeintake status on both client and server side
+func (c *Client) FlushServerAndResetAggregators() error {
 	err := c.flushPayloads()
 	if err != nil {
 		return err

--- a/test/fakeintake/client/client_integration_test.go
+++ b/test/fakeintake/client/client_integration_test.go
@@ -55,7 +55,6 @@ func TestIntegrationClient(t *testing.T) {
 		require.True(t, isReady)
 
 		// post a test payloads to fakeintake
-		// serverUrl := "http://localhost:8080"
 		testEndpoint := "/foo/bar"
 		resp, err := http.Post(fmt.Sprintf("%s%s", fi.URL(), testEndpoint), "text/plain", strings.NewReader("totoro|5|tag:valid,owner:pducolin"))
 		assert.NoError(t, err)
@@ -71,6 +70,45 @@ func TestIntegrationClient(t *testing.T) {
 		assert.NoError(t, err, "Error getting payloads")
 		assert.Equal(t, 1, len(payloads))
 		assert.Equal(t, "totoro|5|tag:valid,owner:pducolin", string(payloads[0].Data))
+		assert.Equal(t, "", payloads[0].Encoding)
+		assert.Equal(t, mockClock.Now(), payloads[0].Timestamp)
+	})
+
+	t.Run("should flush payloads from a server on flush request", func(t *testing.T) {
+		ready := make(chan bool, 1)
+		fi := server.NewServer(server.WithReadyChannel(ready), server.WithClock(mockClock))
+		fi.Start()
+		defer fi.Stop()
+		isReady := <-ready
+		require.True(t, isReady)
+
+		// post a test payloads to fakeintake
+		testEndpoint := "/foo/bar"
+		resp, err := http.Post(fmt.Sprintf("%s%s", fi.URL(), testEndpoint), "text/plain", strings.NewReader("totoro|5|tag:before,owner:pducolin"))
+		assert.NoError(t, err)
+		defer resp.Body.Close()
+		assert.Equal(t, http.StatusAccepted, resp.StatusCode)
+
+		client := NewClient(fi.URL())
+		// max wait for 250 ms
+		err = backoff.Retry(client.GetServerHealth, backoff.WithMaxRetries(backoff.NewConstantBackOff(10*time.Millisecond), 25))
+		require.NoError(t, err, "Failed waiting for fakeintake")
+
+		// flush
+		err = client.FlushPayloads()
+		assert.NoError(t, err, "Error getting payloads")
+
+		// post another payload
+		resp, err = http.Post(fmt.Sprintf("%s%s", fi.URL(), testEndpoint), "text/plain", strings.NewReader("ponyo|7|tag:after,owner:pducolin"))
+		assert.NoError(t, err)
+		defer resp.Body.Close()
+		assert.Equal(t, http.StatusAccepted, resp.StatusCode)
+
+		// should return only the second payload
+		payloads, err := client.getFakePayloads(testEndpoint)
+		assert.NoError(t, err, "Error getting payloads")
+		assert.Equal(t, 1, len(payloads))
+		assert.Equal(t, "ponyo|7|tag:after,owner:pducolin", string(payloads[0].Data))
 		assert.Equal(t, "", payloads[0].Encoding)
 		assert.Equal(t, mockClock.Now(), payloads[0].Timestamp)
 	})

--- a/test/fakeintake/client/client_integration_test.go
+++ b/test/fakeintake/client/client_integration_test.go
@@ -95,7 +95,7 @@ func TestIntegrationClient(t *testing.T) {
 		require.NoError(t, err, "Failed waiting for fakeintake")
 
 		// flush
-		err = client.FlushPayloads()
+		err = client.FlushServerAndResetAggregators()
 		assert.NoError(t, err, "Error getting payloads")
 
 		// post another payload

--- a/test/fakeintake/client/client_test.go
+++ b/test/fakeintake/client/client_test.go
@@ -202,4 +202,19 @@ func TestClient(t *testing.T) {
 		err := client.GetServerHealth()
 		assert.NoError(t, err)
 	})
+
+	t.Run("FlushPayloads", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/fakeintake/flushPayloads" {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer ts.Close()
+
+		client := NewClient(ts.URL)
+		err := client.FlushPayloads()
+		assert.NoError(t, err)
+	})
 }

--- a/test/fakeintake/client/client_test.go
+++ b/test/fakeintake/client/client_test.go
@@ -214,7 +214,7 @@ func TestClient(t *testing.T) {
 		defer ts.Close()
 
 		client := NewClient(ts.URL)
-		err := client.FlushPayloads()
+		err := client.FlushServerAndResetAggregators()
 		assert.NoError(t, err)
 	})
 }

--- a/test/fakeintake/server/server_test.go
+++ b/test/fakeintake/server/server_test.go
@@ -57,7 +57,7 @@ func TestServer(t *testing.T) {
 		assert.NoError(t, err, "Error creating GET request")
 		response := httptest.NewRecorder()
 
-		fi.getPayloads(response, request)
+		fi.handleGetPayloads(response, request)
 		assert.Equal(t, http.StatusOK, response.Code, "unexpected code")
 
 		expectedResponse := api.APIFakeIntakePayloadsGETResponse{
@@ -79,7 +79,7 @@ func TestServer(t *testing.T) {
 		assert.NoError(t, err, "Error creating GET request")
 		response := httptest.NewRecorder()
 
-		fi.getPayloads(response, request)
+		fi.handleGetPayloads(response, request)
 		assert.Equal(t, http.StatusBadRequest, response.Code, "unexpected code")
 	})
 
@@ -93,7 +93,7 @@ func TestServer(t *testing.T) {
 		assert.NoError(t, err, "Error creating GET request")
 		getResponse := httptest.NewRecorder()
 
-		fi.getPayloads(getResponse, request)
+		fi.handleGetPayloads(getResponse, request)
 
 		assert.Equal(t, http.StatusOK, getResponse.Code)
 
@@ -127,7 +127,7 @@ func TestServer(t *testing.T) {
 		assert.NoError(t, err, "Error creating GET request")
 		response := httptest.NewRecorder()
 
-		fi.getFakeHealth(response, request)
+		fi.handleFakeHealth(response, request)
 		assert.Equal(t, http.StatusOK, response.Code, "unexpected code")
 	})
 
@@ -207,7 +207,7 @@ func TestServer(t *testing.T) {
 		assert.NoError(t, err, "Error creating GET request")
 		getResponse := httptest.NewRecorder()
 
-		fi.getRouteStats(getResponse, request)
+		fi.handleGetRouteStats(getResponse, request)
 
 		assert.Equal(t, http.StatusOK, getResponse.Code)
 
@@ -229,6 +229,20 @@ func TestServer(t *testing.T) {
 		json.Unmarshal(body, &actualGETResponse)
 
 		assert.Equal(t, expectedGETResponse, actualGETResponse, "unexpected GET response")
+	})
+
+	t.Run("should handle flush requests", func(t *testing.T) {
+		clock := clock.NewMock()
+		fi := NewServer(WithClock(clock))
+
+		postSomePayloads(t, fi)
+
+		request, err := http.NewRequest(http.MethodDelete, "/fakeintake/flushPayloads", nil)
+		assert.NoError(t, err, "Error creating flush request")
+		response := httptest.NewRecorder()
+
+		fi.handleFlushPayloads(response, request)
+		assert.Equal(t, http.StatusAccepted, response.Code, "unexpected code")
 	})
 }
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Add flush endpoint to the fake intake

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

In e2e tests we could reuse the same instance of fakeintake in different tests. As discussed in the RFC there is the need for a flush endpoint to reset storage on both server and client side.

Note: in the RFC the endpoint was flushing per route and returning those payloads in the request response. Here I decided to have a single flush to reset everything as I considered payloads can be retrieved with a Get or Filter request before sending a flush request. 

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
