### PR TITLE
[windows] Fix unit tests not being reported as failing

### DIFF
--- a/tasks/winbuildscripts/lint.bat
+++ b/tasks/winbuildscripts/lint.bat
@@ -14,7 +14,7 @@ mkdir \dev\go\src\github.com\DataDog\datadog-agent
 cd \dev\go\src\github.com\DataDog\datadog-agent
 xcopy /e/s/h/q c:\mnt\*.*
 
-Powershell -C "c:\mnt\tasks\winbuildscripts\lint.ps1"
+Powershell -C "c:\mnt\tasks\winbuildscripts\lint.ps1" || exit /b 2
 
 goto :EOF
 

--- a/tasks/winbuildscripts/unittests.bat
+++ b/tasks/winbuildscripts/unittests.bat
@@ -14,7 +14,7 @@ mkdir \dev\go\src\github.com\DataDog\datadog-agent
 cd \dev\go\src\github.com\DataDog\datadog-agent
 xcopy /e/s/h/q c:\mnt\*.*
 
-Powershell -C "c:\mnt\tasks\winbuildscripts\unittests.ps1"
+Powershell -C "c:\mnt\tasks\winbuildscripts\unittests.ps1" || exit /b 2
 
 goto :EOF
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Modifies the `lint.bat` and `unittests.bat` scripts to ensure they fail when at least one test fails.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Side-effect of https://github.com/DataDog/datadog-agent/pull/14621: in this PR, the now-separated lint and unit test scripts had the following bit added, to match the build script (and make use of the `nomntdir` label used earlier):
```
goto :EOF

:nomntdir
@echo directory not mounted, parameters incorrect
exit /b 1
```
This means the `Powershell -C` line running the script isn't the last line anymore, and therefore the script doesn't report an error when it should.

Ensure that Gitlab jobs properly reflect their status.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

Will be backported to 7.45.x.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

n/a

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Check that failing tests are indeed reported as failing: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/260425631

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
