### PR TITLE
[Network/system-probe] stream-ish network connections over our unix socket

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	code.cloudfoundry.org/garden v0.0.0-20210208153517-580cadd489d2
 	code.cloudfoundry.org/lager v2.0.0+incompatible
 	github.com/CycloneDX/cyclonedx-go v0.7.1
-	github.com/DataDog/agent-payload/v5 v5.0.85
+	github.com/DataDog/agent-payload/v5 v5.0.88-0.20230609154232-86c8dc081bc8
 	github.com/DataDog/appsec-internal-go v0.0.0-20230215162203-5149228be86a
 	github.com/DataDog/datadog-agent/pkg/gohai v0.46.0-rc.2
 	github.com/DataDog/datadog-agent/pkg/obfuscate v0.46.0-rc.2

--- a/go.sum
+++ b/go.sum
@@ -124,8 +124,8 @@ github.com/BurntSushi/toml v1.2.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbi
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/CycloneDX/cyclonedx-go v0.7.1 h1:5w1SxjGm9MTMNTuRbEPyw21ObdbaagTWF/KfF0qHTRE=
 github.com/CycloneDX/cyclonedx-go v0.7.1/go.mod h1:N/nrdWQI2SIjaACyyDs/u7+ddCkyl/zkNs8xFsHF2Ps=
-github.com/DataDog/agent-payload/v5 v5.0.85 h1:kmcBpkNwbfKCP3fBENZ6uvahvheTMgwjVjONKajVbI8=
-github.com/DataDog/agent-payload/v5 v5.0.85/go.mod h1:oQZi1VZp1e3QvlSUX4iphZCpJaFepUxWq0hNXxihKBM=
+github.com/DataDog/agent-payload/v5 v5.0.88-0.20230609154232-86c8dc081bc8 h1:HLWEi9ELvMfKba64nX9kUQJ9EjPToGuHbaVzx8GjNJM=
+github.com/DataDog/agent-payload/v5 v5.0.88-0.20230609154232-86c8dc081bc8/go.mod h1:oQZi1VZp1e3QvlSUX4iphZCpJaFepUxWq0hNXxihKBM=
 github.com/DataDog/appsec-internal-go v0.0.0-20230215162203-5149228be86a h1:7ZiVdU4j19IYuy8rR0uUzC7I7HjWul61ZEyUgvLkZBM=
 github.com/DataDog/appsec-internal-go v0.0.0-20230215162203-5149228be86a/go.mod h1:ILSJBuOg3E0Jg8qgSnm7+g8DXa0KrfahnS7jhS1DoWs=
 github.com/DataDog/aptly v1.5.1 h1:Znm0WZ/cSjjTLe0HY3rKN1uqa7YIu+uIo3UQG/0WlIM=

--- a/pkg/network/event_common.go
+++ b/pkg/network/event_common.go
@@ -127,6 +127,7 @@ type BufferedData struct {
 // Connections wraps a collection of ConnectionStats
 type Connections struct {
 	BufferedData
+	PageToken                   uint
 	DNS                         map[util.Address][]dns.Hostname
 	ConnTelemetry               map[ConnTelemetryType]int64
 	CompilationTelemetryByAsset map[string]RuntimeCompilationTelemetry

--- a/pkg/network/tracer/tracer_shared.go
+++ b/pkg/network/tracer/tracer_shared.go
@@ -11,6 +11,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/network"
 )
 
+const AllConnections = -1
+
 // shouldSkipConnection returns whether or not the tracer should ignore a given connection:
 //   - Local DNS (*:53) requests if configured (default: true)
 func (t *Tracer) shouldSkipConnection(conn *network.ConnectionStats) bool {

--- a/pkg/network/tracer/tracer_unsupported.go
+++ b/pkg/network/tracer/tracer_unsupported.go
@@ -27,8 +27,8 @@ func NewTracer(_ *config.Config) (*Tracer, error) {
 func (t *Tracer) Stop() {}
 
 // GetActiveConnections is not implemented on this OS for Tracer
-func (t *Tracer) GetActiveConnections(_ string) (*network.Connections, error) {
-	return nil, ebpf.ErrNotImplemented
+func (t *Tracer) GetActiveConnections(_ string, _ int) (*network.Connections, bool, error) {
+	return nil, false, ebpf.ErrNotImplemented
 }
 
 // RegisterClient registers the client

--- a/pkg/network/tracer/tracer_windows.go
+++ b/pkg/network/tracer/tracer_windows.go
@@ -149,7 +149,7 @@ func (t *Tracer) Stop() {
 }
 
 // GetActiveConnections returns all active connections
-func (t *Tracer) GetActiveConnections(clientID string) (*network.Connections, error) {
+func (t *Tracer) GetActiveConnections(clientID string, maxConnectionPerMessage int) (*network.Connections, bool, error) {
 	t.connLock.Lock()
 	defer t.connLock.Unlock()
 

--- a/pkg/process/net/common.go
+++ b/pkg/process/net/common.go
@@ -127,8 +127,8 @@ func (r *RemoteSysProbeUtil) GetProcStats(pids []int32) (*model.ProcStatsWithPer
 }
 
 // GetConnections returns a set of active network connections, retrieved from the system probe service
-func (r *RemoteSysProbeUtil) GetConnections(clientID string) (*model.Connections, error) {
-	req, err := http.NewRequest("GET", fmt.Sprintf("%s?client_id=%s", connectionsURL, clientID), nil)
+func (r *RemoteSysProbeUtil) GetConnections(clientID string, pageSize int, pageToken int) (*model.Connections, error) {
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s?client_id=%s&page_size=%d&page_token=%d", connectionsURL, clientID, pageSize, pageToken), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/process/net/common_unsupported.go
+++ b/pkg/process/net/common_unsupported.go
@@ -29,7 +29,7 @@ func GetRemoteSystemProbeUtil(path string) (*RemoteSysProbeUtil, error) {
 }
 
 // GetConnections is not supported
-func (r *RemoteSysProbeUtil) GetConnections(clientID string) (*model.Connections, error) {
+func (r *RemoteSysProbeUtil) GetConnections(clientID string, pageSize int, pageToken int) (*model.Connections, error) {
 	return nil, ebpf.ErrNotImplemented
 }
 

--- a/pkg/process/net/mocks/sys_probe_util.go
+++ b/pkg/process/net/mocks/sys_probe_util.go
@@ -13,15 +13,20 @@ type SysProbeUtil struct {
 	mock.Mock
 }
 
-// GetConnections provides a mock function with given fields: clientID
-func (_m *SysProbeUtil) GetConnections(clientID string) (*process.Connections, error) {
-	ret := _m.Called(clientID)
+// GetConnections provides a mock function with given fields: clientID, maxConnsPerMessage
+func (_m *SysProbeUtil) GetConnections(clientID string, pageSize int, pageToken int) (*process.Connections, error) {
+	ret := _m.Called(clientID, maxConnsPerMessage)
 
 	var r0 *process.Connections
 	var r1 error
-	if rf, ok := ret.Get(0).(func(string) (*process.Connections, error)); ok {
-		return rf(clientID)
+	if rf, ok := ret.Get(0).(func(string, int, int) (*process.Connections, error)); ok {
+		return rf(clientID, pageSize, pageToken)
 	}
+
+	if rf, ok := ret.Get(0).(func(string) (*process.Connections, error)); ok {
+		r0, r1 = rf(clientID)
+	}
+
 	if rf, ok := ret.Get(0).(func(string) *process.Connections); ok {
 		r0 = rf(clientID)
 	} else {

--- a/pkg/process/net/shared.go
+++ b/pkg/process/net/shared.go
@@ -5,11 +5,13 @@
 
 package net
 
-import model "github.com/DataDog/agent-payload/v5/process"
+import (
+	model "github.com/DataDog/agent-payload/v5/process"
+)
 
 // SysProbeUtil fetches info from the SysProbe running remotely
 type SysProbeUtil interface {
-	GetConnections(clientID string) (*model.Connections, error)
+	GetConnections(clientID string, pageSize int, pageToken int) (conns *model.Connections, err error)
 	GetStats() (map[string]interface{}, error)
 	GetProcStats(pids []int32) (*model.ProcStatsWithPermByPID, error)
 	Register(clientID string) error


### PR DESCRIPTION
### What does this PR do?

This would avoid spike memory allocation on system-probe as
we will pull all the NPM connections, but for DNS and USM we will populate only a bucket (maxConnectionsPerMessage)
and send it to process-agent when requested.

The mechanism relay on http status code 206 (StatusPartialContent), meaning the caller need to call system-probe again as we have more data.

### Motivation

Avoid spike allocation and OOMs in containerized production

### Additional Notes

Depend on agent-payload [PR](https://github.com/DataDog/agent-payload/pull/249)

Let's say it's a first step, as we could a better job on process-agent and system-probe
Would require specific E2E tests

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
