### PR TITLE
[CWS] Isolate dump and profile metadata

### DIFF
--- a/pkg/security/security_profile/activity_tree/metadata/metadata.go
+++ b/pkg/security/security_profile/activity_tree/metadata/metadata.go
@@ -1,0 +1,30 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+// +build linux
+
+package metadata
+
+import "time"
+
+// Metadata is used to provide context about the activity dump or the profile
+type Metadata struct {
+	AgentVersion      string `json:"agent_version"`
+	AgentCommit       string `json:"agent_commit"`
+	KernelVersion     string `json:"kernel_version"`
+	LinuxDistribution string `json:"linux_distribution"`
+	Arch              string `json:"arch"`
+
+	Name              string    `json:"name"`
+	ProtobufVersion   string    `json:"protobuf_version"`
+	DifferentiateArgs bool      `json:"differentiate_args"`
+	Comm              string    `json:"comm,omitempty"`
+	ContainerID       string    `json:"-"`
+	Start             time.Time `json:"start"`
+	End               time.Time `json:"end"`
+	Size              uint64    `json:"activity_dump_size,omitempty"`
+	Serialization     string    `json:"serialization,omitempty"`
+}

--- a/pkg/security/security_profile/activity_tree/metadata/metadata_proto_dec_v1.go
+++ b/pkg/security/security_profile/activity_tree/metadata/metadata_proto_dec_v1.go
@@ -1,0 +1,40 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+// +build linux
+
+package metadata
+
+import (
+	adproto "github.com/DataDog/agent-payload/v5/cws/dumpsv1"
+
+	"github.com/DataDog/datadog-agent/pkg/security/security_profile/activity_tree"
+)
+
+// ProtoMetadataToMetadata decodes a Metadata structure
+func ProtoMetadataToMetadata(meta *adproto.Metadata) Metadata {
+	if meta == nil {
+		return Metadata{}
+	}
+
+	return Metadata{
+		AgentVersion:      meta.AgentVersion,
+		AgentCommit:       meta.AgentCommit,
+		KernelVersion:     meta.KernelVersion,
+		LinuxDistribution: meta.LinuxDistribution,
+		Arch:              meta.Arch,
+
+		Name:              meta.Name,
+		ProtobufVersion:   meta.ProtobufVersion,
+		DifferentiateArgs: meta.DifferentiateArgs,
+		Comm:              meta.Comm,
+		ContainerID:       meta.ContainerId,
+		Start:             activity_tree.ProtoDecodeTimestamp(meta.Start),
+		End:               activity_tree.ProtoDecodeTimestamp(meta.End),
+		Size:              meta.Size,
+		Serialization:     meta.GetSerialization(),
+	}
+}

--- a/pkg/security/security_profile/activity_tree/metadata/metadata_proto_enc_v1.go
+++ b/pkg/security/security_profile/activity_tree/metadata/metadata_proto_enc_v1.go
@@ -1,0 +1,42 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+// +build linux
+
+package metadata
+
+import (
+	adproto "github.com/DataDog/agent-payload/v5/cws/dumpsv1"
+
+	"github.com/DataDog/datadog-agent/pkg/security/security_profile/activity_tree"
+)
+
+// MetadataToProto encodes a Metadata structure
+func MetadataToProto(meta *Metadata) *adproto.Metadata {
+	if meta == nil {
+		return nil
+	}
+
+	pmeta := &adproto.Metadata{
+		AgentVersion:      meta.AgentVersion,
+		AgentCommit:       meta.AgentCommit,
+		KernelVersion:     meta.KernelVersion,
+		LinuxDistribution: meta.LinuxDistribution,
+
+		Name:              meta.Name,
+		ProtobufVersion:   meta.ProtobufVersion,
+		DifferentiateArgs: meta.DifferentiateArgs,
+		Comm:              meta.Comm,
+		ContainerId:       meta.ContainerID,
+		Start:             activity_tree.TimestampToProto(&meta.Start),
+		End:               activity_tree.TimestampToProto(&meta.End),
+		Size:              meta.Size,
+		Arch:              meta.Arch,
+		Serialization:     meta.Serialization,
+	}
+
+	return pmeta
+}

--- a/pkg/security/security_profile/dump/activity_dump.go
+++ b/pkg/security/security_profile/dump/activity_dump.go
@@ -35,6 +35,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/seclog"
 	"github.com/DataDog/datadog-agent/pkg/security/security_profile/activity_tree"
+	mtdt "github.com/DataDog/datadog-agent/pkg/security/security_profile/activity_tree/metadata"
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
 	"github.com/DataDog/datadog-agent/pkg/version"
 )
@@ -62,25 +63,6 @@ const (
 	Running
 )
 
-// Metadata is used to provide context about the activity dump
-type Metadata struct {
-	AgentVersion      string `json:"agent_version"`
-	AgentCommit       string `json:"agent_commit"`
-	KernelVersion     string `json:"kernel_version"`
-	LinuxDistribution string `json:"linux_distribution"`
-	Arch              string `json:"arch"`
-
-	Name              string    `json:"name"`
-	ProtobufVersion   string    `json:"protobuf_version"`
-	DifferentiateArgs bool      `json:"differentiate_args"`
-	Comm              string    `json:"comm,omitempty"`
-	ContainerID       string    `json:"-"`
-	Start             time.Time `json:"start"`
-	End               time.Time `json:"end"`
-	Size              uint64    `json:"activity_dump_size,omitempty"`
-	Serialization     string    `json:"serialization,omitempty"`
-}
-
 // ActivityDump holds the activity tree for the workload defined by the provided list of tags. The encoding described by
 // the `msg` annotation is used to generate the activity dump file while the encoding described by the `json` annotation
 // is used to generate the activity dump metadata sent to the event platform.
@@ -103,7 +85,7 @@ type ActivityDump struct {
 	StorageRequests map[config.StorageFormat][]config.StorageRequest `json:"-"`
 
 	// Dump metadata
-	Metadata
+	mtdt.Metadata
 
 	// Used to store the global list of DNS names contained in this dump
 	// this is a hack used to provide this global list to the backend in the JSON header
@@ -148,7 +130,7 @@ type WithDumpOption func(ad *ActivityDump)
 func NewActivityDump(adm *ActivityDumpManager, options ...WithDumpOption) *ActivityDump {
 	ad := NewEmptyActivityDump()
 	now := time.Now()
-	ad.Metadata = Metadata{
+	ad.Metadata = mtdt.Metadata{
 		AgentVersion:      version.AgentVersion,
 		AgentCommit:       version.Commit,
 		KernelVersion:     adm.kernelVersion.Code.String(),
@@ -201,7 +183,7 @@ func NewActivityDumpFromMessage(msg *api.ActivityDumpMessage) (*ActivityDump, er
 	ad.Service = msg.GetService()
 	ad.Source = msg.GetSource()
 	ad.Tags = msg.GetTags()
-	ad.Metadata = Metadata{
+	ad.Metadata = mtdt.Metadata{
 		AgentVersion:      metadata.GetAgentVersion(),
 		AgentCommit:       metadata.GetAgentCommit(),
 		KernelVersion:     metadata.GetKernelVersion(),

--- a/pkg/security/security_profile/dump/activity_dump_profile_proto_dec_v1.go
+++ b/pkg/security/security_profile/dump/activity_dump_profile_proto_dec_v1.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/security/config"
 	"github.com/DataDog/datadog-agent/pkg/security/security_profile/activity_tree"
+	mtdt "github.com/DataDog/datadog-agent/pkg/security/security_profile/activity_tree/metadata"
 )
 
 func securityProfileProtoToActivityDump(dest *ActivityDump, ad *proto.SecurityProfile) {
@@ -20,7 +21,7 @@ func securityProfileProtoToActivityDump(dest *ActivityDump, ad *proto.SecurityPr
 		return
 	}
 
-	dest.Metadata = ProtoMetadataToMetadata(ad.Metadata)
+	dest.Metadata = mtdt.ProtoMetadataToMetadata(ad.Metadata)
 
 	dest.Tags = make([]string, len(ad.Tags))
 	copy(dest.Tags, ad.Tags)

--- a/pkg/security/security_profile/dump/activity_dump_profile_proto_enc_v1.go
+++ b/pkg/security/security_profile/dump/activity_dump_profile_proto_enc_v1.go
@@ -14,6 +14,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/security_profile"
 	"github.com/DataDog/datadog-agent/pkg/security/security_profile/activity_tree"
+	mtdt "github.com/DataDog/datadog-agent/pkg/security/security_profile/activity_tree/metadata"
 )
 
 // ActivityDumpToSecurityProfileProto serializes an Activity Dump to a Security Profile protobuf representation
@@ -25,7 +26,7 @@ func ActivityDumpToSecurityProfileProto(input *ActivityDump) *proto.SecurityProf
 	output := proto.SecurityProfile{
 		Status:   uint32(model.AnomalyDetection + model.AutoSuppression),
 		Version:  security_profile.LocalProfileVersion,
-		Metadata: adMetadataToProto(&input.Metadata),
+		Metadata: mtdt.MetadataToProto(&input.Metadata),
 		Syscalls: input.ActivityTree.ComputeSyscallsList(),
 		Tags:     make([]string, len(input.Tags)),
 		Tree:     activity_tree.ActivityTreeToProto(input.ActivityTree),

--- a/pkg/security/security_profile/dump/activity_dump_proto_dec_v1.go
+++ b/pkg/security/security_profile/dump/activity_dump_proto_dec_v1.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/security/config"
 	"github.com/DataDog/datadog-agent/pkg/security/security_profile/activity_tree"
+	mtdt "github.com/DataDog/datadog-agent/pkg/security/security_profile/activity_tree/metadata"
 )
 
 func protoToActivityDump(dest *ActivityDump, ad *adproto.SecDump) {
@@ -23,7 +24,7 @@ func protoToActivityDump(dest *ActivityDump, ad *adproto.SecDump) {
 	dest.Host = ad.Host
 	dest.Service = ad.Service
 	dest.Source = ad.Source
-	dest.Metadata = ProtoMetadataToMetadata(ad.Metadata)
+	dest.Metadata = mtdt.ProtoMetadataToMetadata(ad.Metadata)
 
 	dest.Tags = make([]string, len(ad.Tags))
 	copy(dest.Tags, ad.Tags)
@@ -31,29 +32,4 @@ func protoToActivityDump(dest *ActivityDump, ad *adproto.SecDump) {
 
 	dest.ActivityTree = activity_tree.NewActivityTree(dest, "activity_dump")
 	activity_tree.ProtoDecodeActivityTree(dest.ActivityTree, ad.Tree)
-}
-
-// ProtoMetadataToMetadata decodes a Metadata structure
-func ProtoMetadataToMetadata(meta *adproto.Metadata) Metadata {
-	if meta == nil {
-		return Metadata{}
-	}
-
-	return Metadata{
-		AgentVersion:      meta.AgentVersion,
-		AgentCommit:       meta.AgentCommit,
-		KernelVersion:     meta.KernelVersion,
-		LinuxDistribution: meta.LinuxDistribution,
-		Arch:              meta.Arch,
-
-		Name:              meta.Name,
-		ProtobufVersion:   meta.ProtobufVersion,
-		DifferentiateArgs: meta.DifferentiateArgs,
-		Comm:              meta.Comm,
-		ContainerID:       meta.ContainerId,
-		Start:             activity_tree.ProtoDecodeTimestamp(meta.Start),
-		End:               activity_tree.ProtoDecodeTimestamp(meta.End),
-		Size:              meta.Size,
-		Serialization:     meta.GetSerialization(),
-	}
 }

--- a/pkg/security/security_profile/dump/activity_dump_proto_enc_v1.go
+++ b/pkg/security/security_profile/dump/activity_dump_proto_enc_v1.go
@@ -12,6 +12,7 @@ import (
 	adproto "github.com/DataDog/agent-payload/v5/cws/dumpsv1"
 
 	"github.com/DataDog/datadog-agent/pkg/security/security_profile/activity_tree"
+	mtdt "github.com/DataDog/datadog-agent/pkg/security/security_profile/activity_tree/metadata"
 )
 
 func activityDumpToProto(ad *ActivityDump) *adproto.SecDump {
@@ -25,7 +26,7 @@ func activityDumpToProto(ad *ActivityDump) *adproto.SecDump {
 		Service: ad.Service,
 		Source:  ad.Source,
 
-		Metadata: adMetadataToProto(&ad.Metadata),
+		Metadata: mtdt.MetadataToProto(&ad.Metadata),
 
 		Tags: make([]string, len(ad.Tags)),
 		Tree: activity_tree.ActivityTreeToProto(ad.ActivityTree),
@@ -34,30 +35,4 @@ func activityDumpToProto(ad *ActivityDump) *adproto.SecDump {
 	copy(pad.Tags, ad.Tags)
 
 	return pad
-}
-
-func adMetadataToProto(meta *Metadata) *adproto.Metadata {
-	if meta == nil {
-		return nil
-	}
-
-	pmeta := &adproto.Metadata{
-		AgentVersion:      meta.AgentVersion,
-		AgentCommit:       meta.AgentCommit,
-		KernelVersion:     meta.KernelVersion,
-		LinuxDistribution: meta.LinuxDistribution,
-
-		Name:              meta.Name,
-		ProtobufVersion:   meta.ProtobufVersion,
-		DifferentiateArgs: meta.DifferentiateArgs,
-		Comm:              meta.Comm,
-		ContainerId:       meta.ContainerID,
-		Start:             activity_tree.TimestampToProto(&meta.Start),
-		End:               activity_tree.TimestampToProto(&meta.End),
-		Size:              meta.Size,
-		Arch:              meta.Arch,
-		Serialization:     meta.Serialization,
-	}
-
-	return pmeta
 }

--- a/pkg/security/security_profile/dump/manager_test.go
+++ b/pkg/security/security_profile/dump/manager_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/security/config"
 	"github.com/DataDog/datadog-agent/pkg/security/security_profile/activity_tree"
+	mtdt "github.com/DataDog/datadog-agent/pkg/security/security_profile/activity_tree/metadata"
 )
 
 func compareListOfDumps(t *testing.T, out, expectedOut []*ActivityDump) {
@@ -64,11 +65,11 @@ func TestActivityDumpManager_getExpiredDumps(t *testing.T) {
 			"one_dump/one_expired_dump",
 			fields{
 				activeDumps: []*ActivityDump{
-					{Metadata: Metadata{Name: "1", End: time.Now().Add(-time.Minute)}},
+					{Metadata: mtdt.Metadata{Name: "1", End: time.Now().Add(-time.Minute)}},
 				},
 			},
 			[]*ActivityDump{
-				{Metadata: Metadata{Name: "1", End: time.Now().Add(-time.Minute)}},
+				{Metadata: mtdt.Metadata{Name: "1", End: time.Now().Add(-time.Minute)}},
 			},
 			[]*ActivityDump{},
 		},
@@ -76,51 +77,51 @@ func TestActivityDumpManager_getExpiredDumps(t *testing.T) {
 			"one_dump/no_expired_dump",
 			fields{
 				activeDumps: []*ActivityDump{
-					{Metadata: Metadata{Name: "1", End: time.Now().Add(time.Minute)}},
+					{Metadata: mtdt.Metadata{Name: "1", End: time.Now().Add(time.Minute)}},
 				},
 			},
 			[]*ActivityDump{},
 			[]*ActivityDump{
-				{Metadata: Metadata{Name: "1", End: time.Now().Add(time.Minute)}},
+				{Metadata: mtdt.Metadata{Name: "1", End: time.Now().Add(time.Minute)}},
 			},
 		},
 		{
 			"5_dumps/no_expired_dump",
 			fields{
 				activeDumps: []*ActivityDump{
-					{Metadata: Metadata{Name: "1", End: time.Now().Add(time.Minute)}},
-					{Metadata: Metadata{Name: "2", End: time.Now().Add(time.Minute)}},
-					{Metadata: Metadata{Name: "3", End: time.Now().Add(time.Minute)}},
-					{Metadata: Metadata{Name: "4", End: time.Now().Add(time.Minute)}},
-					{Metadata: Metadata{Name: "5", End: time.Now().Add(time.Minute)}},
+					{Metadata: mtdt.Metadata{Name: "1", End: time.Now().Add(time.Minute)}},
+					{Metadata: mtdt.Metadata{Name: "2", End: time.Now().Add(time.Minute)}},
+					{Metadata: mtdt.Metadata{Name: "3", End: time.Now().Add(time.Minute)}},
+					{Metadata: mtdt.Metadata{Name: "4", End: time.Now().Add(time.Minute)}},
+					{Metadata: mtdt.Metadata{Name: "5", End: time.Now().Add(time.Minute)}},
 				},
 			},
 			[]*ActivityDump{},
 			[]*ActivityDump{
-				{Metadata: Metadata{Name: "1", End: time.Now().Add(time.Minute)}},
-				{Metadata: Metadata{Name: "2", End: time.Now().Add(time.Minute)}},
-				{Metadata: Metadata{Name: "3", End: time.Now().Add(time.Minute)}},
-				{Metadata: Metadata{Name: "4", End: time.Now().Add(time.Minute)}},
-				{Metadata: Metadata{Name: "5", End: time.Now().Add(time.Minute)}},
+				{Metadata: mtdt.Metadata{Name: "1", End: time.Now().Add(time.Minute)}},
+				{Metadata: mtdt.Metadata{Name: "2", End: time.Now().Add(time.Minute)}},
+				{Metadata: mtdt.Metadata{Name: "3", End: time.Now().Add(time.Minute)}},
+				{Metadata: mtdt.Metadata{Name: "4", End: time.Now().Add(time.Minute)}},
+				{Metadata: mtdt.Metadata{Name: "5", End: time.Now().Add(time.Minute)}},
 			},
 		},
 		{
 			"5_dumps/5_expired_dumps",
 			fields{
 				activeDumps: []*ActivityDump{
-					{Metadata: Metadata{Name: "1", End: time.Now().Add(-time.Minute)}},
-					{Metadata: Metadata{Name: "2", End: time.Now().Add(-time.Minute)}},
-					{Metadata: Metadata{Name: "3", End: time.Now().Add(-time.Minute)}},
-					{Metadata: Metadata{Name: "4", End: time.Now().Add(-time.Minute)}},
-					{Metadata: Metadata{Name: "5", End: time.Now().Add(-time.Minute)}},
+					{Metadata: mtdt.Metadata{Name: "1", End: time.Now().Add(-time.Minute)}},
+					{Metadata: mtdt.Metadata{Name: "2", End: time.Now().Add(-time.Minute)}},
+					{Metadata: mtdt.Metadata{Name: "3", End: time.Now().Add(-time.Minute)}},
+					{Metadata: mtdt.Metadata{Name: "4", End: time.Now().Add(-time.Minute)}},
+					{Metadata: mtdt.Metadata{Name: "5", End: time.Now().Add(-time.Minute)}},
 				},
 			},
 			[]*ActivityDump{
-				{Metadata: Metadata{Name: "1", End: time.Now().Add(-time.Minute)}},
-				{Metadata: Metadata{Name: "2", End: time.Now().Add(-time.Minute)}},
-				{Metadata: Metadata{Name: "3", End: time.Now().Add(-time.Minute)}},
-				{Metadata: Metadata{Name: "4", End: time.Now().Add(-time.Minute)}},
-				{Metadata: Metadata{Name: "5", End: time.Now().Add(-time.Minute)}},
+				{Metadata: mtdt.Metadata{Name: "1", End: time.Now().Add(-time.Minute)}},
+				{Metadata: mtdt.Metadata{Name: "2", End: time.Now().Add(-time.Minute)}},
+				{Metadata: mtdt.Metadata{Name: "3", End: time.Now().Add(-time.Minute)}},
+				{Metadata: mtdt.Metadata{Name: "4", End: time.Now().Add(-time.Minute)}},
+				{Metadata: mtdt.Metadata{Name: "5", End: time.Now().Add(-time.Minute)}},
 			},
 			[]*ActivityDump{},
 		},
@@ -128,63 +129,63 @@ func TestActivityDumpManager_getExpiredDumps(t *testing.T) {
 			"5_dumps/2_expired_dumps",
 			fields{
 				activeDumps: []*ActivityDump{
-					{Metadata: Metadata{Name: "1", End: time.Now().Add(time.Minute)}},
-					{Metadata: Metadata{Name: "2", End: time.Now().Add(-time.Minute)}},
-					{Metadata: Metadata{Name: "3", End: time.Now().Add(time.Minute)}},
-					{Metadata: Metadata{Name: "4", End: time.Now().Add(-time.Minute)}},
-					{Metadata: Metadata{Name: "5", End: time.Now().Add(time.Minute)}},
+					{Metadata: mtdt.Metadata{Name: "1", End: time.Now().Add(time.Minute)}},
+					{Metadata: mtdt.Metadata{Name: "2", End: time.Now().Add(-time.Minute)}},
+					{Metadata: mtdt.Metadata{Name: "3", End: time.Now().Add(time.Minute)}},
+					{Metadata: mtdt.Metadata{Name: "4", End: time.Now().Add(-time.Minute)}},
+					{Metadata: mtdt.Metadata{Name: "5", End: time.Now().Add(time.Minute)}},
 				},
 			},
 			[]*ActivityDump{
-				{Metadata: Metadata{Name: "2", End: time.Now().Add(-time.Minute)}},
-				{Metadata: Metadata{Name: "4", End: time.Now().Add(-time.Minute)}},
+				{Metadata: mtdt.Metadata{Name: "2", End: time.Now().Add(-time.Minute)}},
+				{Metadata: mtdt.Metadata{Name: "4", End: time.Now().Add(-time.Minute)}},
 			},
 			[]*ActivityDump{
-				{Metadata: Metadata{Name: "1", End: time.Now().Add(time.Minute)}},
-				{Metadata: Metadata{Name: "3", End: time.Now().Add(time.Minute)}},
-				{Metadata: Metadata{Name: "5", End: time.Now().Add(time.Minute)}},
+				{Metadata: mtdt.Metadata{Name: "1", End: time.Now().Add(time.Minute)}},
+				{Metadata: mtdt.Metadata{Name: "3", End: time.Now().Add(time.Minute)}},
+				{Metadata: mtdt.Metadata{Name: "5", End: time.Now().Add(time.Minute)}},
 			},
 		},
 		{
 			"5_dumps/2_expired_dumps_at_the_start",
 			fields{
 				activeDumps: []*ActivityDump{
-					{Metadata: Metadata{Name: "1", End: time.Now().Add(-time.Minute)}},
-					{Metadata: Metadata{Name: "2", End: time.Now().Add(-time.Minute)}},
-					{Metadata: Metadata{Name: "3", End: time.Now().Add(time.Minute)}},
-					{Metadata: Metadata{Name: "4", End: time.Now().Add(time.Minute)}},
-					{Metadata: Metadata{Name: "5", End: time.Now().Add(time.Minute)}},
+					{Metadata: mtdt.Metadata{Name: "1", End: time.Now().Add(-time.Minute)}},
+					{Metadata: mtdt.Metadata{Name: "2", End: time.Now().Add(-time.Minute)}},
+					{Metadata: mtdt.Metadata{Name: "3", End: time.Now().Add(time.Minute)}},
+					{Metadata: mtdt.Metadata{Name: "4", End: time.Now().Add(time.Minute)}},
+					{Metadata: mtdt.Metadata{Name: "5", End: time.Now().Add(time.Minute)}},
 				},
 			},
 			[]*ActivityDump{
-				{Metadata: Metadata{Name: "1", End: time.Now().Add(-time.Minute)}},
-				{Metadata: Metadata{Name: "2", End: time.Now().Add(-time.Minute)}},
+				{Metadata: mtdt.Metadata{Name: "1", End: time.Now().Add(-time.Minute)}},
+				{Metadata: mtdt.Metadata{Name: "2", End: time.Now().Add(-time.Minute)}},
 			},
 			[]*ActivityDump{
-				{Metadata: Metadata{Name: "3", End: time.Now().Add(time.Minute)}},
-				{Metadata: Metadata{Name: "4", End: time.Now().Add(time.Minute)}},
-				{Metadata: Metadata{Name: "5", End: time.Now().Add(time.Minute)}},
+				{Metadata: mtdt.Metadata{Name: "3", End: time.Now().Add(time.Minute)}},
+				{Metadata: mtdt.Metadata{Name: "4", End: time.Now().Add(time.Minute)}},
+				{Metadata: mtdt.Metadata{Name: "5", End: time.Now().Add(time.Minute)}},
 			},
 		},
 		{
 			"5_dumps/2_expired_dumps_at_the_end",
 			fields{
 				activeDumps: []*ActivityDump{
-					{Metadata: Metadata{Name: "1", End: time.Now().Add(time.Minute)}},
-					{Metadata: Metadata{Name: "2", End: time.Now().Add(time.Minute)}},
-					{Metadata: Metadata{Name: "3", End: time.Now().Add(time.Minute)}},
-					{Metadata: Metadata{Name: "4", End: time.Now().Add(-time.Minute)}},
-					{Metadata: Metadata{Name: "5", End: time.Now().Add(-time.Minute)}},
+					{Metadata: mtdt.Metadata{Name: "1", End: time.Now().Add(time.Minute)}},
+					{Metadata: mtdt.Metadata{Name: "2", End: time.Now().Add(time.Minute)}},
+					{Metadata: mtdt.Metadata{Name: "3", End: time.Now().Add(time.Minute)}},
+					{Metadata: mtdt.Metadata{Name: "4", End: time.Now().Add(-time.Minute)}},
+					{Metadata: mtdt.Metadata{Name: "5", End: time.Now().Add(-time.Minute)}},
 				},
 			},
 			[]*ActivityDump{
-				{Metadata: Metadata{Name: "4", End: time.Now().Add(-time.Minute)}},
-				{Metadata: Metadata{Name: "5", End: time.Now().Add(-time.Minute)}},
+				{Metadata: mtdt.Metadata{Name: "4", End: time.Now().Add(-time.Minute)}},
+				{Metadata: mtdt.Metadata{Name: "5", End: time.Now().Add(-time.Minute)}},
 			},
 			[]*ActivityDump{
-				{Metadata: Metadata{Name: "1", End: time.Now().Add(time.Minute)}},
-				{Metadata: Metadata{Name: "2", End: time.Now().Add(time.Minute)}},
-				{Metadata: Metadata{Name: "3", End: time.Now().Add(time.Minute)}},
+				{Metadata: mtdt.Metadata{Name: "1", End: time.Now().Add(time.Minute)}},
+				{Metadata: mtdt.Metadata{Name: "2", End: time.Now().Add(time.Minute)}},
+				{Metadata: mtdt.Metadata{Name: "3", End: time.Now().Add(time.Minute)}},
 			},
 		},
 	}
@@ -222,13 +223,13 @@ func TestActivityDumpManager_getOverweightDumps(t *testing.T) {
 			"one_dump/one_overweight_dump",
 			fields{
 				activeDumps: []*ActivityDump{
-					{Mutex: &sync.Mutex{}, Metadata: Metadata{Name: "1"}, ActivityTree: &activity_tree.ActivityTree{
+					{Mutex: &sync.Mutex{}, Metadata: mtdt.Metadata{Name: "1"}, ActivityTree: &activity_tree.ActivityTree{
 						Stats: &activity_tree.ActivityTreeStats{ProcessNodes: 2},
 					}},
 				},
 			},
 			[]*ActivityDump{
-				{Metadata: Metadata{Name: "1"}, ActivityTree: &activity_tree.ActivityTree{
+				{Metadata: mtdt.Metadata{Name: "1"}, ActivityTree: &activity_tree.ActivityTree{
 					Stats: &activity_tree.ActivityTreeStats{ProcessNodes: 2},
 				}},
 			},
@@ -238,52 +239,52 @@ func TestActivityDumpManager_getOverweightDumps(t *testing.T) {
 			"one_dump/no_overweight_dump",
 			fields{
 				activeDumps: []*ActivityDump{
-					{Mutex: &sync.Mutex{}, Metadata: Metadata{Name: "1"}, ActivityTree: &activity_tree.ActivityTree{
+					{Mutex: &sync.Mutex{}, Metadata: mtdt.Metadata{Name: "1"}, ActivityTree: &activity_tree.ActivityTree{
 						Stats: &activity_tree.ActivityTreeStats{},
 					}},
 				},
 			},
 			[]*ActivityDump{},
 			[]*ActivityDump{
-				{Metadata: Metadata{Name: "1"}},
+				{Metadata: mtdt.Metadata{Name: "1"}},
 			},
 		},
 		{
 			"5_dumps/no_overweight_dump",
 			fields{
 				activeDumps: []*ActivityDump{
-					{Mutex: &sync.Mutex{}, Metadata: Metadata{Name: "1"}, ActivityTree: &activity_tree.ActivityTree{
+					{Mutex: &sync.Mutex{}, Metadata: mtdt.Metadata{Name: "1"}, ActivityTree: &activity_tree.ActivityTree{
 						Stats: &activity_tree.ActivityTreeStats{},
 					}},
-					{Mutex: &sync.Mutex{}, Metadata: Metadata{Name: "2"}, ActivityTree: &activity_tree.ActivityTree{
+					{Mutex: &sync.Mutex{}, Metadata: mtdt.Metadata{Name: "2"}, ActivityTree: &activity_tree.ActivityTree{
 						Stats: &activity_tree.ActivityTreeStats{},
 					}},
-					{Mutex: &sync.Mutex{}, Metadata: Metadata{Name: "3"}, ActivityTree: &activity_tree.ActivityTree{
+					{Mutex: &sync.Mutex{}, Metadata: mtdt.Metadata{Name: "3"}, ActivityTree: &activity_tree.ActivityTree{
 						Stats: &activity_tree.ActivityTreeStats{},
 					}},
-					{Mutex: &sync.Mutex{}, Metadata: Metadata{Name: "4"}, ActivityTree: &activity_tree.ActivityTree{
+					{Mutex: &sync.Mutex{}, Metadata: mtdt.Metadata{Name: "4"}, ActivityTree: &activity_tree.ActivityTree{
 						Stats: &activity_tree.ActivityTreeStats{},
 					}},
-					{Mutex: &sync.Mutex{}, Metadata: Metadata{Name: "5"}, ActivityTree: &activity_tree.ActivityTree{
+					{Mutex: &sync.Mutex{}, Metadata: mtdt.Metadata{Name: "5"}, ActivityTree: &activity_tree.ActivityTree{
 						Stats: &activity_tree.ActivityTreeStats{},
 					}},
 				},
 			},
 			[]*ActivityDump{},
 			[]*ActivityDump{
-				{Metadata: Metadata{Name: "1"}, ActivityTree: &activity_tree.ActivityTree{
+				{Metadata: mtdt.Metadata{Name: "1"}, ActivityTree: &activity_tree.ActivityTree{
 					Stats: &activity_tree.ActivityTreeStats{},
 				}},
-				{Metadata: Metadata{Name: "2"}, ActivityTree: &activity_tree.ActivityTree{
+				{Metadata: mtdt.Metadata{Name: "2"}, ActivityTree: &activity_tree.ActivityTree{
 					Stats: &activity_tree.ActivityTreeStats{},
 				}},
-				{Metadata: Metadata{Name: "3"}, ActivityTree: &activity_tree.ActivityTree{
+				{Metadata: mtdt.Metadata{Name: "3"}, ActivityTree: &activity_tree.ActivityTree{
 					Stats: &activity_tree.ActivityTreeStats{},
 				}},
-				{Metadata: Metadata{Name: "4"}, ActivityTree: &activity_tree.ActivityTree{
+				{Metadata: mtdt.Metadata{Name: "4"}, ActivityTree: &activity_tree.ActivityTree{
 					Stats: &activity_tree.ActivityTreeStats{},
 				}},
-				{Metadata: Metadata{Name: "5"}, ActivityTree: &activity_tree.ActivityTree{
+				{Metadata: mtdt.Metadata{Name: "5"}, ActivityTree: &activity_tree.ActivityTree{
 					Stats: &activity_tree.ActivityTreeStats{},
 				}},
 			},
@@ -292,37 +293,37 @@ func TestActivityDumpManager_getOverweightDumps(t *testing.T) {
 			"5_dumps/5_overweight_dumps",
 			fields{
 				activeDumps: []*ActivityDump{
-					{Mutex: &sync.Mutex{}, Metadata: Metadata{Name: "1"}, ActivityTree: &activity_tree.ActivityTree{
+					{Mutex: &sync.Mutex{}, Metadata: mtdt.Metadata{Name: "1"}, ActivityTree: &activity_tree.ActivityTree{
 						Stats: &activity_tree.ActivityTreeStats{ProcessNodes: 2},
 					}},
-					{Mutex: &sync.Mutex{}, Metadata: Metadata{Name: "2"}, ActivityTree: &activity_tree.ActivityTree{
+					{Mutex: &sync.Mutex{}, Metadata: mtdt.Metadata{Name: "2"}, ActivityTree: &activity_tree.ActivityTree{
 						Stats: &activity_tree.ActivityTreeStats{ProcessNodes: 3},
 					}},
-					{Mutex: &sync.Mutex{}, Metadata: Metadata{Name: "3"}, ActivityTree: &activity_tree.ActivityTree{
+					{Mutex: &sync.Mutex{}, Metadata: mtdt.Metadata{Name: "3"}, ActivityTree: &activity_tree.ActivityTree{
 						Stats: &activity_tree.ActivityTreeStats{ProcessNodes: 2},
 					}},
-					{Mutex: &sync.Mutex{}, Metadata: Metadata{Name: "4"}, ActivityTree: &activity_tree.ActivityTree{
+					{Mutex: &sync.Mutex{}, Metadata: mtdt.Metadata{Name: "4"}, ActivityTree: &activity_tree.ActivityTree{
 						Stats: &activity_tree.ActivityTreeStats{ProcessNodes: 3},
 					}},
-					{Mutex: &sync.Mutex{}, Metadata: Metadata{Name: "5"}, ActivityTree: &activity_tree.ActivityTree{
+					{Mutex: &sync.Mutex{}, Metadata: mtdt.Metadata{Name: "5"}, ActivityTree: &activity_tree.ActivityTree{
 						Stats: &activity_tree.ActivityTreeStats{ProcessNodes: 2},
 					}},
 				},
 			},
 			[]*ActivityDump{
-				{Metadata: Metadata{Name: "1"}, ActivityTree: &activity_tree.ActivityTree{
+				{Metadata: mtdt.Metadata{Name: "1"}, ActivityTree: &activity_tree.ActivityTree{
 					Stats: &activity_tree.ActivityTreeStats{ProcessNodes: 2},
 				}},
-				{Metadata: Metadata{Name: "2"}, ActivityTree: &activity_tree.ActivityTree{
+				{Metadata: mtdt.Metadata{Name: "2"}, ActivityTree: &activity_tree.ActivityTree{
 					Stats: &activity_tree.ActivityTreeStats{ProcessNodes: 3},
 				}},
-				{Metadata: Metadata{Name: "3"}, ActivityTree: &activity_tree.ActivityTree{
+				{Metadata: mtdt.Metadata{Name: "3"}, ActivityTree: &activity_tree.ActivityTree{
 					Stats: &activity_tree.ActivityTreeStats{ProcessNodes: 2},
 				}},
-				{Metadata: Metadata{Name: "4"}, ActivityTree: &activity_tree.ActivityTree{
+				{Metadata: mtdt.Metadata{Name: "4"}, ActivityTree: &activity_tree.ActivityTree{
 					Stats: &activity_tree.ActivityTreeStats{ProcessNodes: 3},
 				}},
-				{Metadata: Metadata{Name: "5"}, ActivityTree: &activity_tree.ActivityTree{
+				{Metadata: mtdt.Metadata{Name: "5"}, ActivityTree: &activity_tree.ActivityTree{
 					Stats: &activity_tree.ActivityTreeStats{ProcessNodes: 2},
 				}},
 			},
@@ -332,39 +333,39 @@ func TestActivityDumpManager_getOverweightDumps(t *testing.T) {
 			"5_dumps/2_expired_dumps",
 			fields{
 				activeDumps: []*ActivityDump{
-					{Mutex: &sync.Mutex{}, Metadata: Metadata{Name: "1"}, ActivityTree: &activity_tree.ActivityTree{
+					{Mutex: &sync.Mutex{}, Metadata: mtdt.Metadata{Name: "1"}, ActivityTree: &activity_tree.ActivityTree{
 						Stats: &activity_tree.ActivityTreeStats{},
 					}},
-					{Mutex: &sync.Mutex{}, Metadata: Metadata{Name: "2"}, ActivityTree: &activity_tree.ActivityTree{
+					{Mutex: &sync.Mutex{}, Metadata: mtdt.Metadata{Name: "2"}, ActivityTree: &activity_tree.ActivityTree{
 						Stats: &activity_tree.ActivityTreeStats{ProcessNodes: 3},
 					}},
-					{Mutex: &sync.Mutex{}, Metadata: Metadata{Name: "3"}, ActivityTree: &activity_tree.ActivityTree{
+					{Mutex: &sync.Mutex{}, Metadata: mtdt.Metadata{Name: "3"}, ActivityTree: &activity_tree.ActivityTree{
 						Stats: &activity_tree.ActivityTreeStats{},
 					}},
-					{Mutex: &sync.Mutex{}, Metadata: Metadata{Name: "4"}, ActivityTree: &activity_tree.ActivityTree{
+					{Mutex: &sync.Mutex{}, Metadata: mtdt.Metadata{Name: "4"}, ActivityTree: &activity_tree.ActivityTree{
 						Stats: &activity_tree.ActivityTreeStats{ProcessNodes: 2},
 					}},
-					{Mutex: &sync.Mutex{}, Metadata: Metadata{Name: "5"}, ActivityTree: &activity_tree.ActivityTree{
+					{Mutex: &sync.Mutex{}, Metadata: mtdt.Metadata{Name: "5"}, ActivityTree: &activity_tree.ActivityTree{
 						Stats: &activity_tree.ActivityTreeStats{},
 					}},
 				},
 			},
 			[]*ActivityDump{
-				{Metadata: Metadata{Name: "2"}, ActivityTree: &activity_tree.ActivityTree{
+				{Metadata: mtdt.Metadata{Name: "2"}, ActivityTree: &activity_tree.ActivityTree{
 					Stats: &activity_tree.ActivityTreeStats{ProcessNodes: 3},
 				}},
-				{Metadata: Metadata{Name: "4"}, ActivityTree: &activity_tree.ActivityTree{
+				{Metadata: mtdt.Metadata{Name: "4"}, ActivityTree: &activity_tree.ActivityTree{
 					Stats: &activity_tree.ActivityTreeStats{ProcessNodes: 2},
 				}},
 			},
 			[]*ActivityDump{
-				{Metadata: Metadata{Name: "1"}, ActivityTree: &activity_tree.ActivityTree{
+				{Metadata: mtdt.Metadata{Name: "1"}, ActivityTree: &activity_tree.ActivityTree{
 					Stats: &activity_tree.ActivityTreeStats{},
 				}},
-				{Metadata: Metadata{Name: "3"}, ActivityTree: &activity_tree.ActivityTree{
+				{Metadata: mtdt.Metadata{Name: "3"}, ActivityTree: &activity_tree.ActivityTree{
 					Stats: &activity_tree.ActivityTreeStats{},
 				}},
-				{Metadata: Metadata{Name: "5"}, ActivityTree: &activity_tree.ActivityTree{
+				{Metadata: mtdt.Metadata{Name: "5"}, ActivityTree: &activity_tree.ActivityTree{
 					Stats: &activity_tree.ActivityTreeStats{},
 				}},
 			},
@@ -373,39 +374,39 @@ func TestActivityDumpManager_getOverweightDumps(t *testing.T) {
 			"5_dumps/2_expired_dumps_at_the_start",
 			fields{
 				activeDumps: []*ActivityDump{
-					{Mutex: &sync.Mutex{}, Metadata: Metadata{Name: "1"}, ActivityTree: &activity_tree.ActivityTree{
+					{Mutex: &sync.Mutex{}, Metadata: mtdt.Metadata{Name: "1"}, ActivityTree: &activity_tree.ActivityTree{
 						Stats: &activity_tree.ActivityTreeStats{ProcessNodes: 3},
 					}},
-					{Mutex: &sync.Mutex{}, Metadata: Metadata{Name: "2"}, ActivityTree: &activity_tree.ActivityTree{
+					{Mutex: &sync.Mutex{}, Metadata: mtdt.Metadata{Name: "2"}, ActivityTree: &activity_tree.ActivityTree{
 						Stats: &activity_tree.ActivityTreeStats{ProcessNodes: 2},
 					}},
-					{Mutex: &sync.Mutex{}, Metadata: Metadata{Name: "3"}, ActivityTree: &activity_tree.ActivityTree{
+					{Mutex: &sync.Mutex{}, Metadata: mtdt.Metadata{Name: "3"}, ActivityTree: &activity_tree.ActivityTree{
 						Stats: &activity_tree.ActivityTreeStats{},
 					}},
-					{Mutex: &sync.Mutex{}, Metadata: Metadata{Name: "4"}, ActivityTree: &activity_tree.ActivityTree{
+					{Mutex: &sync.Mutex{}, Metadata: mtdt.Metadata{Name: "4"}, ActivityTree: &activity_tree.ActivityTree{
 						Stats: &activity_tree.ActivityTreeStats{},
 					}},
-					{Mutex: &sync.Mutex{}, Metadata: Metadata{Name: "5"}, ActivityTree: &activity_tree.ActivityTree{
+					{Mutex: &sync.Mutex{}, Metadata: mtdt.Metadata{Name: "5"}, ActivityTree: &activity_tree.ActivityTree{
 						Stats: &activity_tree.ActivityTreeStats{},
 					}},
 				},
 			},
 			[]*ActivityDump{
-				{Metadata: Metadata{Name: "1"}, ActivityTree: &activity_tree.ActivityTree{
+				{Metadata: mtdt.Metadata{Name: "1"}, ActivityTree: &activity_tree.ActivityTree{
 					Stats: &activity_tree.ActivityTreeStats{ProcessNodes: 3},
 				}},
-				{Metadata: Metadata{Name: "2"}, ActivityTree: &activity_tree.ActivityTree{
+				{Metadata: mtdt.Metadata{Name: "2"}, ActivityTree: &activity_tree.ActivityTree{
 					Stats: &activity_tree.ActivityTreeStats{ProcessNodes: 2},
 				}},
 			},
 			[]*ActivityDump{
-				{Metadata: Metadata{Name: "3", End: time.Now().Add(time.Minute)}, ActivityTree: &activity_tree.ActivityTree{
+				{Metadata: mtdt.Metadata{Name: "3", End: time.Now().Add(time.Minute)}, ActivityTree: &activity_tree.ActivityTree{
 					Stats: &activity_tree.ActivityTreeStats{},
 				}},
-				{Metadata: Metadata{Name: "4", End: time.Now().Add(time.Minute)}, ActivityTree: &activity_tree.ActivityTree{
+				{Metadata: mtdt.Metadata{Name: "4", End: time.Now().Add(time.Minute)}, ActivityTree: &activity_tree.ActivityTree{
 					Stats: &activity_tree.ActivityTreeStats{},
 				}},
-				{Metadata: Metadata{Name: "5", End: time.Now().Add(time.Minute)}, ActivityTree: &activity_tree.ActivityTree{
+				{Metadata: mtdt.Metadata{Name: "5", End: time.Now().Add(time.Minute)}, ActivityTree: &activity_tree.ActivityTree{
 					Stats: &activity_tree.ActivityTreeStats{},
 				}},
 			},
@@ -414,39 +415,39 @@ func TestActivityDumpManager_getOverweightDumps(t *testing.T) {
 			"5_dumps/2_expired_dumps_at_the_end",
 			fields{
 				activeDumps: []*ActivityDump{
-					{Mutex: &sync.Mutex{}, Metadata: Metadata{Name: "1"}, ActivityTree: &activity_tree.ActivityTree{
+					{Mutex: &sync.Mutex{}, Metadata: mtdt.Metadata{Name: "1"}, ActivityTree: &activity_tree.ActivityTree{
 						Stats: &activity_tree.ActivityTreeStats{},
 					}},
-					{Mutex: &sync.Mutex{}, Metadata: Metadata{Name: "2"}, ActivityTree: &activity_tree.ActivityTree{
+					{Mutex: &sync.Mutex{}, Metadata: mtdt.Metadata{Name: "2"}, ActivityTree: &activity_tree.ActivityTree{
 						Stats: &activity_tree.ActivityTreeStats{},
 					}},
-					{Mutex: &sync.Mutex{}, Metadata: Metadata{Name: "3"}, ActivityTree: &activity_tree.ActivityTree{
+					{Mutex: &sync.Mutex{}, Metadata: mtdt.Metadata{Name: "3"}, ActivityTree: &activity_tree.ActivityTree{
 						Stats: &activity_tree.ActivityTreeStats{},
 					}},
-					{Mutex: &sync.Mutex{}, Metadata: Metadata{Name: "4"}, ActivityTree: &activity_tree.ActivityTree{
+					{Mutex: &sync.Mutex{}, Metadata: mtdt.Metadata{Name: "4"}, ActivityTree: &activity_tree.ActivityTree{
 						Stats: &activity_tree.ActivityTreeStats{ProcessNodes: 3},
 					}},
-					{Mutex: &sync.Mutex{}, Metadata: Metadata{Name: "5"}, ActivityTree: &activity_tree.ActivityTree{
+					{Mutex: &sync.Mutex{}, Metadata: mtdt.Metadata{Name: "5"}, ActivityTree: &activity_tree.ActivityTree{
 						Stats: &activity_tree.ActivityTreeStats{ProcessNodes: 2},
 					}},
 				},
 			},
 			[]*ActivityDump{
-				{Metadata: Metadata{Name: "4"}, ActivityTree: &activity_tree.ActivityTree{
+				{Metadata: mtdt.Metadata{Name: "4"}, ActivityTree: &activity_tree.ActivityTree{
 					Stats: &activity_tree.ActivityTreeStats{ProcessNodes: 3},
 				}},
-				{Metadata: Metadata{Name: "5"}, ActivityTree: &activity_tree.ActivityTree{
+				{Metadata: mtdt.Metadata{Name: "5"}, ActivityTree: &activity_tree.ActivityTree{
 					Stats: &activity_tree.ActivityTreeStats{ProcessNodes: 2},
 				}},
 			},
 			[]*ActivityDump{
-				{Metadata: Metadata{Name: "1"}, ActivityTree: &activity_tree.ActivityTree{
+				{Metadata: mtdt.Metadata{Name: "1"}, ActivityTree: &activity_tree.ActivityTree{
 					Stats: &activity_tree.ActivityTreeStats{},
 				}},
-				{Metadata: Metadata{Name: "2"}, ActivityTree: &activity_tree.ActivityTree{
+				{Metadata: mtdt.Metadata{Name: "2"}, ActivityTree: &activity_tree.ActivityTree{
 					Stats: &activity_tree.ActivityTreeStats{},
 				}},
-				{Metadata: Metadata{Name: "3"}, ActivityTree: &activity_tree.ActivityTree{
+				{Metadata: mtdt.Metadata{Name: "3"}, ActivityTree: &activity_tree.ActivityTree{
 					Stats: &activity_tree.ActivityTreeStats{},
 				}},
 			},

--- a/pkg/security/security_profile/profile/profile.go
+++ b/pkg/security/security_profile/profile/profile.go
@@ -20,7 +20,7 @@ import (
 	cgroupModel "github.com/DataDog/datadog-agent/pkg/security/resolvers/cgroup/model"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/security_profile/activity_tree"
-	"github.com/DataDog/datadog-agent/pkg/security/security_profile/dump"
+	mtdt "github.com/DataDog/datadog-agent/pkg/security/security_profile/activity_tree/metadata"
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
 )
 
@@ -45,7 +45,7 @@ type SecurityProfile struct {
 	Version string
 
 	// Metadata contains metadata for the current profile
-	Metadata dump.Metadata
+	Metadata mtdt.Metadata
 
 	// Tags defines the tags used to compute this profile
 	Tags []string

--- a/pkg/security/security_profile/profile/profile_proto_dec_v1.go
+++ b/pkg/security/security_profile/profile/profile_proto_dec_v1.go
@@ -14,7 +14,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/security_profile"
 	"github.com/DataDog/datadog-agent/pkg/security/security_profile/activity_tree"
-	"github.com/DataDog/datadog-agent/pkg/security/security_profile/dump"
+	mtdt "github.com/DataDog/datadog-agent/pkg/security/security_profile/activity_tree/metadata"
 )
 
 func protoToSecurityProfile(output *SecurityProfile, input *proto.SecurityProfile) {
@@ -27,7 +27,7 @@ func protoToSecurityProfile(output *SecurityProfile, input *proto.SecurityProfil
 	if input.Version == security_profile.LocalProfileVersion {
 		output.autolearnEnabled = true
 	}
-	output.Metadata = dump.ProtoMetadataToMetadata(input.Metadata)
+	output.Metadata = mtdt.ProtoMetadataToMetadata(input.Metadata)
 
 	output.Tags = make([]string, len(input.Tags))
 	copy(output.Tags, input.Tags)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR isolates the ActivityDump and SecurityProfile `Metadata` structure into a shared package.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Last part of the refactor initiated with https://github.com/DataDog/datadog-agent/pull/16744
It will help prevent duplication of shared fields and make sure we have a coherent package organization.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
