### PR TITLE
[SNMP] Fix unwanted warn log when using tag value mapping

### DIFF
--- a/pkg/collector/corechecks/snmp/internal/checkconfig/config_validate_enrich.go
+++ b/pkg/collector/corechecks/snmp/internal/checkconfig/config_validate_enrich.go
@@ -175,8 +175,8 @@ func validateEnrichMetricTag(metricTag *MetricTagConfig) []string {
 			errors = append(errors, fmt.Sprintf("`tags` mapping must be provided if `match` (`%s`) is defined", metricTag.Match))
 		}
 	}
-	if len(metricTag.Mapping) > 0 && (metricTag.Index == 0 || metricTag.Tag == "") {
-		log.Warnf("`index` or `tag` must be provided if `mapping` (`%s`) is defined", metricTag.Mapping)
+	if len(metricTag.Mapping) > 0 && metricTag.Tag == "" {
+		log.Warnf("``tag` must be provided if `mapping` (`%s`) is defined", metricTag.Mapping)
 	}
 	for _, transform := range metricTag.IndexTransform {
 		if transform.Start > transform.End {

--- a/pkg/collector/corechecks/snmp/internal/checkconfig/config_validate_enrich_test.go
+++ b/pkg/collector/corechecks/snmp/internal/checkconfig/config_validate_enrich_test.go
@@ -442,7 +442,7 @@ func Test_ValidateEnrichMetrics(t *testing.T) {
 			},
 		},
 		{
-			name: "mapping used without tag",
+			name: "mapping used without tag should raise a warning",
 			metrics: []MetricsConfig{
 				{
 					Symbols: []SymbolConfig{

--- a/pkg/collector/corechecks/snmp/internal/checkconfig/config_validate_enrich_test.go
+++ b/pkg/collector/corechecks/snmp/internal/checkconfig/config_validate_enrich_test.go
@@ -6,19 +6,30 @@
 package checkconfig
 
 import (
+	"bufio"
+	"bytes"
 	"fmt"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/cihub/seelog"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func Test_ValidateEnrichMetrics(t *testing.T) {
+	type logCount struct {
+		log   string
+		count int
+	}
+
 	tests := []struct {
 		name            string
 		metrics         []MetricsConfig
 		expectedErrors  []string
 		expectedMetrics []MetricsConfig
+		expectedLogs    []logCount
 	}{
 		{
 			name: "either table symbol or scalar symbol must be provided",
@@ -430,9 +441,47 @@ func Test_ValidateEnrichMetrics(t *testing.T) {
 				"`constant_value_one` cannot be used outside of tables",
 			},
 		},
+		{
+			name: "mapping used without tag",
+			metrics: []MetricsConfig{
+				{
+					Symbols: []SymbolConfig{
+						{
+							OID:  "1.2",
+							Name: "abc",
+						},
+					},
+					MetricTags: MetricTagConfigList{
+						MetricTagConfig{
+							Column: SymbolConfig{
+								OID:  "1.2",
+								Name: "abc",
+							},
+							Mapping: map[string]string{
+								"1": "abc",
+								"2": "def",
+							},
+						},
+					},
+				},
+			},
+			expectedErrors: []string{},
+			expectedLogs: []logCount{
+				{
+					"[WARN] validateEnrichMetricTag: ``tag` must be provided if `mapping` (`map[1:abc 2:def]`) is defined",
+					1,
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			var b bytes.Buffer
+			w := bufio.NewWriter(&b)
+			l, err := seelog.LoggerFromWriterWithMinLevelAndFormat(w, seelog.DebugLvl, "[%LEVEL] %FuncShort: %Msg")
+			assert.Nil(t, err)
+			log.SetupLogger(l, "debug")
+
 			errors := ValidateEnrichMetrics(tt.metrics)
 			assert.Equal(t, len(tt.expectedErrors), len(errors), fmt.Sprintf("ERRORS: %v", errors))
 			for i := range errors {
@@ -440,6 +489,13 @@ func Test_ValidateEnrichMetrics(t *testing.T) {
 			}
 			if tt.expectedMetrics != nil {
 				assert.Equal(t, tt.expectedMetrics, tt.metrics)
+			}
+
+			w.Flush()
+			logs := b.String()
+
+			for _, aLogCount := range tt.expectedLogs {
+				assert.Equal(t, aLogCount.count, strings.Count(logs, aLogCount.log), logs)
 			}
 		})
 	}

--- a/releasenotes/notes/snmp-fix-unexpected-mapping-warn-log-b52db069bb096e11.yaml
+++ b/releasenotes/notes/snmp-fix-unexpected-mapping-warn-log-b52db069bb096e11.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix unexpected warn log when using mapping in SNMP profiles.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
Fix unexpected warning log on agent startup for SNMP profiles using the tag mapping feature.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
