### PR TITLE
Add a status page verbose mode with per-tailer logs stats

### DIFF
--- a/cmd/agent/api/internal/agent/agent.go
+++ b/cmd/agent/api/internal/agent/agent.go
@@ -190,7 +190,8 @@ func componentStatusHandler(w http.ResponseWriter, r *http.Request) {
 
 func getStatus(w http.ResponseWriter, r *http.Request) {
 	log.Info("Got a request for the status. Making status.")
-	s, err := status.GetStatus()
+	verbose := r.URL.Query().Get("verbose") == "true"
+	s, err := status.GetStatus(verbose)
 	w.Header().Set("Content-Type", "application/json")
 	if err != nil {
 		setJSONError(w, log.Errorf("Error getting status. Error: %v, Status: %v", err, s), 500)

--- a/cmd/agent/gui/agent.go
+++ b/cmd/agent/gui/agent.go
@@ -51,7 +51,8 @@ func ping(w http.ResponseWriter, r *http.Request) {
 func getStatus(w http.ResponseWriter, r *http.Request) {
 	statusType := mux.Vars(r)["type"]
 
-	status, e := status.GetStatus()
+	verbose := r.URL.Query().Get("verbose") == "true"
+	status, e := status.GetStatus(verbose)
 	if e != nil {
 		log.Errorf("Error getting status: " + e.Error())
 		w.Write([]byte("Error getting status: " + e.Error()))

--- a/cmd/agent/subcommands/status/command.go
+++ b/cmd/agent/subcommands/status/command.go
@@ -41,6 +41,7 @@ type cliParams struct {
 	jsonStatus      bool
 	prettyPrintJSON bool
 	statusFilePath  string
+	verbose         bool
 }
 
 // Commands returns a slice of subcommands for the 'agent' command.
@@ -74,6 +75,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 	cmd.Flags().BoolVarP(&cliParams.jsonStatus, "json", "j", false, "print out raw json")
 	cmd.Flags().BoolVarP(&cliParams.prettyPrintJSON, "pretty-json", "p", false, "pretty print JSON")
 	cmd.Flags().StringVarP(&cliParams.statusFilePath, "file", "o", "", "Output the status command to a file")
+	cmd.Flags().BoolVarP(&cliParams.verbose, "verbose", "v", false, "print out verbose status")
 
 	componentCmd := &cobra.Command{
 		Use:   "component",
@@ -141,7 +143,11 @@ func requestStatus(config config.Component, cliParams *cliParams) error {
 	if err != nil {
 		return err
 	}
-	urlstr := fmt.Sprintf("https://%v:%v/agent/status", ipcAddress, config.GetInt("cmd_port"))
+	args := ""
+	if cliParams.verbose {
+		args = "?verbose=true"
+	}
+	urlstr := fmt.Sprintf("https://%v:%v/agent/status%v", ipcAddress, config.GetInt("cmd_port"), args)
 	r, err := makeRequest(urlstr)
 	if err != nil {
 		return err

--- a/cmd/agent/subcommands/status/command.go
+++ b/cmd/agent/subcommands/status/command.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"os"
 	"time"
 
@@ -143,12 +144,20 @@ func requestStatus(config config.Component, cliParams *cliParams) error {
 	if err != nil {
 		return err
 	}
-	args := ""
+
+	v := url.Values{}
 	if cliParams.verbose {
-		args = "?verbose=true"
+		v.Set("verbose", "true")
 	}
-	urlstr := fmt.Sprintf("https://%v:%v/agent/status%v", ipcAddress, config.GetInt("cmd_port"), args)
-	r, err := makeRequest(urlstr)
+
+	url := url.URL{
+		Scheme:   "https",
+		Host:     fmt.Sprintf("%v:%v", ipcAddress, config.GetInt("cmd_port")),
+		Path:     "/agent/status",
+		RawQuery: v.Encode(),
+	}
+
+	r, err := makeRequest(url.String())
 	if err != nil {
 		return err
 	}

--- a/cmd/cluster-agent/api/agent/agent.go
+++ b/cmd/cluster-agent/api/agent/agent.go
@@ -53,7 +53,8 @@ func SetupHandlers(r *mux.Router) {
 
 func getStatus(w http.ResponseWriter, r *http.Request) {
 	log.Info("Got a request for the status. Making status.")
-	s, err := status.GetDCAStatus()
+	verbose := r.URL.Query().Get("verbose") == "true"
+	s, err := status.GetDCAStatus(verbose)
 	w.Header().Set("Content-Type", "application/json")
 	if err != nil {
 		log.Errorf("Error getting status. Error: %v, Status: %v", err, s)

--- a/cmd/security-agent/api/agent/agent.go
+++ b/cmd/security-agent/api/agent/agent.go
@@ -85,7 +85,7 @@ func (a *Agent) getHostname(w http.ResponseWriter, r *http.Request) {
 
 func (a *Agent) getStatus(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
-	s, err := status.GetStatus()
+	s, err := status.GetStatus(false)
 	if err != nil {
 		log.Errorf("Error getting status. Error: %v, Status: %v", err, s)
 		body, _ := json.Marshal(map[string]string{"error": err.Error()})

--- a/pkg/logs/agent_not_serverless.go
+++ b/pkg/logs/agent_not_serverless.go
@@ -24,6 +24,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/launchers/journald"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/launchers/listener"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/launchers/windowsevent"
+	"github.com/DataDog/datadog-agent/pkg/logs/internal/tailers"
 	"github.com/DataDog/datadog-agent/pkg/logs/pipeline"
 	"github.com/DataDog/datadog-agent/pkg/logs/schedulers"
 	adScheduler "github.com/DataDog/datadog-agent/pkg/logs/schedulers/ad"
@@ -33,7 +34,7 @@ import (
 )
 
 // NewAgent returns a new Logs Agent
-func NewAgent(sources *sources.LogSources, services *service.Services, processingRules []*config.ProcessingRule, endpoints *config.Endpoints) *Agent {
+func NewAgent(sources *sources.LogSources, services *service.Services, tailers *tailers.TailerTracker, processingRules []*config.ProcessingRule, endpoints *config.Endpoints) *Agent {
 	health := health.RegisterLiveness("logs-agent")
 
 	// setup the auditor
@@ -48,7 +49,7 @@ func NewAgent(sources *sources.LogSources, services *service.Services, processin
 	pipelineProvider := pipeline.NewProvider(config.NumberOfPipelines, auditor, diagnosticMessageReceiver, processingRules, endpoints, destinationsCtx)
 
 	// setup the launchers
-	lnchrs := launchers.NewLaunchers(sources, pipelineProvider, auditor)
+	lnchrs := launchers.NewLaunchers(sources, pipelineProvider, auditor, tailers)
 	lnchrs.AddLauncher(filelauncher.NewLauncher(
 		coreConfig.Datadog.GetInt("logs_config.open_files_limit"),
 		filelauncher.DefaultSleepDuration,

--- a/pkg/logs/agent_not_serverless.go
+++ b/pkg/logs/agent_not_serverless.go
@@ -34,7 +34,7 @@ import (
 )
 
 // NewAgent returns a new Logs Agent
-func NewAgent(sources *sources.LogSources, services *service.Services, tailers *tailers.TailerTracker, processingRules []*config.ProcessingRule, endpoints *config.Endpoints) *Agent {
+func NewAgent(sources *sources.LogSources, services *service.Services, tracker *tailers.TailerTracker, processingRules []*config.ProcessingRule, endpoints *config.Endpoints) *Agent {
 	health := health.RegisterLiveness("logs-agent")
 
 	// setup the auditor
@@ -49,7 +49,7 @@ func NewAgent(sources *sources.LogSources, services *service.Services, tailers *
 	pipelineProvider := pipeline.NewProvider(config.NumberOfPipelines, auditor, diagnosticMessageReceiver, processingRules, endpoints, destinationsCtx)
 
 	// setup the launchers
-	lnchrs := launchers.NewLaunchers(sources, pipelineProvider, auditor, tailers)
+	lnchrs := launchers.NewLaunchers(sources, pipelineProvider, auditor, tracker)
 	lnchrs.AddLauncher(filelauncher.NewLauncher(
 		coreConfig.Datadog.GetInt("logs_config.open_files_limit"),
 		filelauncher.DefaultSleepDuration,

--- a/pkg/logs/agent_serverless.go
+++ b/pkg/logs/agent_serverless.go
@@ -15,6 +15,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/diagnostic"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/launchers"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/launchers/channel"
+	"github.com/DataDog/datadog-agent/pkg/logs/internal/tailers"
 	"github.com/DataDog/datadog-agent/pkg/logs/pipeline"
 	"github.com/DataDog/datadog-agent/pkg/logs/schedulers"
 	"github.com/DataDog/datadog-agent/pkg/logs/service"
@@ -29,7 +30,7 @@ import (
 // NewAgent returns a Logs Agent instance to run in a serverless environment.
 // The Serverless Logs Agent has only one input being the channel to receive the logs to process.
 // It is using a NullAuditor because we've nothing to do after having sent the logs to the intake.
-func NewAgent(sources *sources.LogSources, services *service.Services, processingRules []*config.ProcessingRule, endpoints *config.Endpoints) *Agent {
+func NewAgent(sources *sources.LogSources, services *service.Services, tailers *tailers.TailerTracker, processingRules []*config.ProcessingRule, endpoints *config.Endpoints) *Agent {
 	health := health.RegisterLiveness("logs-agent")
 
 	diagnosticMessageReceiver := diagnostic.NewBufferedMessageReceiver()
@@ -42,7 +43,7 @@ func NewAgent(sources *sources.LogSources, services *service.Services, processin
 	pipelineProvider := pipeline.NewServerlessProvider(config.NumberOfPipelines, auditor, processingRules, endpoints, destinationsCtx)
 
 	// setup the sole launcher for this agent
-	lnchrs := launchers.NewLaunchers(sources, pipelineProvider, auditor)
+	lnchrs := launchers.NewLaunchers(sources, pipelineProvider, auditor, tailers)
 	lnchrs.AddLauncher(channel.NewLauncher())
 
 	return &Agent{

--- a/pkg/logs/agent_serverless.go
+++ b/pkg/logs/agent_serverless.go
@@ -30,7 +30,7 @@ import (
 // NewAgent returns a Logs Agent instance to run in a serverless environment.
 // The Serverless Logs Agent has only one input being the channel to receive the logs to process.
 // It is using a NullAuditor because we've nothing to do after having sent the logs to the intake.
-func NewAgent(sources *sources.LogSources, services *service.Services, tailers *tailers.TailerTracker, processingRules []*config.ProcessingRule, endpoints *config.Endpoints) *Agent {
+func NewAgent(sources *sources.LogSources, services *service.Services, tracker *tailers.TailerTracker, processingRules []*config.ProcessingRule, endpoints *config.Endpoints) *Agent {
 	health := health.RegisterLiveness("logs-agent")
 
 	diagnosticMessageReceiver := diagnostic.NewBufferedMessageReceiver()
@@ -43,7 +43,7 @@ func NewAgent(sources *sources.LogSources, services *service.Services, tailers *
 	pipelineProvider := pipeline.NewServerlessProvider(config.NumberOfPipelines, auditor, processingRules, endpoints, destinationsCtx)
 
 	// setup the sole launcher for this agent
-	lnchrs := launchers.NewLaunchers(sources, pipelineProvider, auditor, tailers)
+	lnchrs := launchers.NewLaunchers(sources, pipelineProvider, auditor, tracker)
 	lnchrs.AddLauncher(channel.NewLauncher())
 
 	return &Agent{

--- a/pkg/logs/agent_test.go
+++ b/pkg/logs/agent_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/metrics"
+	"github.com/DataDog/datadog-agent/pkg/logs/internal/tailers"
 	"github.com/DataDog/datadog-agent/pkg/logs/service"
 
 	"github.com/DataDog/datadog-agent/pkg/util/testutil"
@@ -81,7 +82,7 @@ func createAgent(endpoints *config.Endpoints) (*Agent, *sources.LogSources, *ser
 	services := service.NewServices()
 
 	// setup and start the agent
-	agent = NewAgent(sources, services, nil, endpoints)
+	agent = NewAgent(sources, services, tailers.NewTailerTracker(), nil, endpoints)
 	return agent, sources, services
 }
 

--- a/pkg/logs/internal/decoder/auto_multiline_handler.go
+++ b/pkg/logs/internal/decoder/auto_multiline_handler.go
@@ -6,6 +6,7 @@
 package decoder
 
 import (
+	"fmt"
 	"regexp"
 	"sort"
 	"sync"
@@ -13,6 +14,7 @@ import (
 
 	"github.com/benbjohnson/clock"
 
+	"github.com/DataDog/datadog-agent/pkg/logs/internal/status"
 	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 	"github.com/DataDog/datadog-agent/pkg/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -48,22 +50,24 @@ func (d *DetectedPattern) Get() *regexp.Regexp {
 // AutoMultilineHandler can attempts to detect a known/commob pattern (a timestamp) in the logs
 // and will switch to a MultiLine handler if one is detected and the thresholds are met.
 type AutoMultilineHandler struct {
-	multiLineHandler  *MultiLineHandler
-	singleLineHandler *SingleLineHandler
-	outputFn          func(*Message)
-	isRunning         bool
-	linesToAssess     int
-	linesTested       int
-	lineLimit         int
-	matchThreshold    float64
-	scoredMatches     []*scoredPattern
-	processFunc       func(message *Message)
-	flushTimeout      time.Duration
-	source            *sources.ReplaceableSource
-	matchTimeout      time.Duration
-	timeoutTimer      *clock.Timer
-	detectedPattern   *DetectedPattern
-	clk               clock.Clock
+	multiLineHandler    *MultiLineHandler
+	singleLineHandler   *SingleLineHandler
+	outputFn            func(*Message)
+	isRunning           bool
+	linesToAssess       int
+	linesTested         int
+	lineLimit           int
+	matchThreshold      float64
+	scoredMatches       []*scoredPattern
+	processFunc         func(message *Message)
+	flushTimeout        time.Duration
+	source              *sources.ReplaceableSource
+	matchTimeout        time.Duration
+	timeoutTimer        *clock.Timer
+	detectedPattern     *DetectedPattern
+	clk                 clock.Clock
+	tailerInfo          *status.InfoRegistry
+	autoMultiLineStatus *status.MappedInfo
 }
 
 // NewAutoMultilineHandler returns a new AutoMultilineHandler.
@@ -76,6 +80,7 @@ func NewAutoMultilineHandler(
 	source *sources.ReplaceableSource,
 	additionalPatterns []*regexp.Regexp,
 	detectedPattern *DetectedPattern,
+	tailerInfo *status.InfoRegistry,
 ) *AutoMultilineHandler {
 
 	// Put the user patterns at the beginning of the list so we prioritize them if there is a conflicting match.
@@ -89,22 +94,26 @@ func NewAutoMultilineHandler(
 		}
 	}
 	h := &AutoMultilineHandler{
-		outputFn:        outputFn,
-		isRunning:       true,
-		lineLimit:       lineLimit,
-		matchThreshold:  matchThreshold,
-		scoredMatches:   scoredMatches,
-		linesToAssess:   linesToAssess,
-		flushTimeout:    flushTimeout,
-		source:          source,
-		matchTimeout:    matchTimeout,
-		timeoutTimer:    nil,
-		detectedPattern: detectedPattern,
-		clk:             clock.New(),
+		outputFn:            outputFn,
+		isRunning:           true,
+		lineLimit:           lineLimit,
+		matchThreshold:      matchThreshold,
+		scoredMatches:       scoredMatches,
+		linesToAssess:       linesToAssess,
+		flushTimeout:        flushTimeout,
+		source:              source,
+		matchTimeout:        matchTimeout,
+		timeoutTimer:        nil,
+		detectedPattern:     detectedPattern,
+		clk:                 clock.New(),
+		tailerInfo:          tailerInfo,
+		autoMultiLineStatus: status.NewMappedInfo("Auto Multi-line"),
 	}
 
 	h.singleLineHandler = NewSingleLineHandler(outputFn, lineLimit)
 	h.processFunc = h.processAndTry
+	h.tailerInfo.Register(h.autoMultiLineStatus)
+	h.autoMultiLineStatus.SetMessage("state", "Waiting for logs")
 
 	return h
 }
@@ -152,32 +161,40 @@ func (h *AutoMultilineHandler) processAndTry(message *Message) {
 		h.timeoutTimer = h.clk.Timer(h.matchTimeout)
 	}
 
+	h.linesTested++
+
 	timeout := false
 	select {
 	case <-h.timeoutTimer.C:
 		log.Debug("Multiline auto detect timed out before reaching line test threshold")
+		h.autoMultiLineStatus.SetMessage("message", fmt.Sprintf("Timeout reached. Processed (%d of %d) logs during detection", h.linesTested, h.linesToAssess))
 		timeout = true
 		break
 	default:
 		break
 	}
 
-	h.linesTested++
+	h.autoMultiLineStatus.SetMessage("state", fmt.Sprintf("Detecting (%d of %d)", h.linesTested, h.linesToAssess))
+
 	if h.linesTested >= h.linesToAssess || timeout {
 		topMatch := h.scoredMatches[0]
 		matchRatio := float64(topMatch.score) / float64(h.linesTested)
+		var message string
 
 		if matchRatio >= h.matchThreshold {
-			log.Debugf("Pattern %v matched %d lines with a ratio of %f", topMatch.regexp.String(), topMatch.score, matchRatio)
+			message = fmt.Sprintf("Pattern %v matched %d lines with a ratio of %f", topMatch.regexp.String(), topMatch.score, matchRatio)
 			telemetry.GetStatsTelemetryProvider().Count(autoMultiLineTelemetryMetricName, 1, []string{"success:true"})
 			h.detectedPattern.Set(topMatch.regexp)
 			h.switchToMultilineHandler(topMatch.regexp)
 		} else {
-			log.Debugf("No pattern met the line match threshold: %f during multiline auto detection. Top match was %v with a match ratio of: %f - using single line handler", h.matchThreshold, topMatch.regexp.String(), matchRatio)
+			message = fmt.Sprintf("No pattern met the line match threshold: %f during multiline auto detection. Top match was %v with a match ratio of: %f - using single line handler", h.matchThreshold, topMatch.regexp.String(), matchRatio)
+
 			telemetry.GetStatsTelemetryProvider().Count(autoMultiLineTelemetryMetricName, 1, []string{"success:false"})
 			// Stay with the single line handler and no longer attempt to detect multiline matches.
 			h.processFunc = h.singleLineHandler.process
 		}
+		h.autoMultiLineStatus.SetMessage("state", message)
+		log.Debugf(message)
 	}
 }
 

--- a/pkg/logs/internal/decoder/auto_multiline_handler.go
+++ b/pkg/logs/internal/decoder/auto_multiline_handler.go
@@ -177,25 +177,24 @@ func (h *AutoMultilineHandler) processAndTry(message *Message) {
 	if h.linesTested >= h.linesToAssess || timeout {
 		topMatch := h.scoredMatches[0]
 		matchRatio := float64(topMatch.score) / float64(h.linesTested)
-		var message string
 
 		if matchRatio >= h.matchThreshold {
 			h.autoMultiLineStatus.SetMessage("state", "State: Using multi-line handler")
-			message = fmt.Sprintf("Pattern %v matched %d lines with a ratio of %f", topMatch.regexp.String(), topMatch.score, matchRatio)
+			h.autoMultiLineStatus.SetMessage("message", fmt.Sprintf("Pattern %v matched %d lines with a ratio of %f", topMatch.regexp.String(), topMatch.score, matchRatio))
 			log.Debug(fmt.Sprintf("Pattern %v matched %d lines with a ratio of %f - using multi-line handler", topMatch.regexp.String(), topMatch.score, matchRatio))
 			telemetry.GetStatsTelemetryProvider().Count(autoMultiLineTelemetryMetricName, 1, []string{"success:true"})
+
 			h.detectedPattern.Set(topMatch.regexp)
 			h.switchToMultilineHandler(topMatch.regexp)
 		} else {
 			h.autoMultiLineStatus.SetMessage("state", "State: Using single-line handler")
-			message = fmt.Sprintf("No pattern met the line match threshold: %f during multiline auto detection. Top match was %v with a match ratio of: %f", h.matchThreshold, topMatch.regexp.String(), matchRatio)
+			h.autoMultiLineStatus.SetMessage("message", fmt.Sprintf("No pattern met the line match threshold: %f during multiline auto detection. Top match was %v with a match ratio of: %f", h.matchThreshold, topMatch.regexp.String(), matchRatio))
 			log.Debugf(fmt.Sprintf("No pattern met the line match threshold: %f during multiline auto detection. Top match was %v with a match ratio of: %f - using single-line handler", h.matchThreshold, topMatch.regexp.String(), matchRatio))
-
 			telemetry.GetStatsTelemetryProvider().Count(autoMultiLineTelemetryMetricName, 1, []string{"success:false"})
+
 			// Stay with the single line handler and no longer attempt to detect multiline matches.
 			h.processFunc = h.singleLineHandler.process
 		}
-		h.autoMultiLineStatus.SetMessage("message", message)
 	}
 }
 

--- a/pkg/logs/internal/decoder/auto_multiline_handler.go
+++ b/pkg/logs/internal/decoder/auto_multiline_handler.go
@@ -66,7 +66,6 @@ type AutoMultilineHandler struct {
 	timeoutTimer        *clock.Timer
 	detectedPattern     *DetectedPattern
 	clk                 clock.Clock
-	tailerInfo          *status.InfoRegistry
 	autoMultiLineStatus *status.MappedInfo
 }
 
@@ -106,13 +105,12 @@ func NewAutoMultilineHandler(
 		timeoutTimer:        nil,
 		detectedPattern:     detectedPattern,
 		clk:                 clock.New(),
-		tailerInfo:          tailerInfo,
 		autoMultiLineStatus: status.NewMappedInfo("Auto Multi-line"),
 	}
 
 	h.singleLineHandler = NewSingleLineHandler(outputFn, lineLimit)
 	h.processFunc = h.processAndTry
-	h.tailerInfo.Register(h.autoMultiLineStatus)
+	tailerInfo.Register(h.autoMultiLineStatus)
 	h.autoMultiLineStatus.SetMessage("state", "Waiting for logs")
 
 	return h

--- a/pkg/logs/internal/decoder/decoder_test.go
+++ b/pkg/logs/internal/decoder/decoder_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/parsers/encodedtext"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/parsers/kubernetes"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/parsers/noop"
+	"github.com/DataDog/datadog-agent/pkg/logs/internal/status"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
 	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 
@@ -24,7 +25,8 @@ import (
 )
 
 func InitializeDecoderForTest(source *sources.LogSource, parser parsers.Parser) *Decoder {
-	return InitializeDecoder(sources.NewReplaceableSource(source), parser)
+	info := status.NewInfoRegistry()
+	return InitializeDecoder(sources.NewReplaceableSource(source), parser, info)
 }
 
 func TestDecoderWithDockerHeader(t *testing.T) {
@@ -244,7 +246,8 @@ func TestDecoderWithDockerJSONSplittedByDocker(t *testing.T) {
 func TestDecoderWithDecodingParser(t *testing.T) {
 	source := sources.NewLogSource("config", &config.LogsConfig{})
 
-	d := NewDecoderWithFraming(sources.NewReplaceableSource(source), encodedtext.New(encodedtext.UTF16LE), framer.UTF16LENewline, nil)
+	info := status.NewInfoRegistry()
+	d := NewDecoderWithFraming(sources.NewReplaceableSource(source), encodedtext.New(encodedtext.UTF16LE), framer.UTF16LENewline, nil, info)
 	d.Start()
 
 	input := []byte{'h', 0x0, 'e', 0x0, 'l', 0x0, 'l', 0x0, 'o', 0x0, '\n', 0x0}

--- a/pkg/logs/internal/decoder/file_decoder.go
+++ b/pkg/logs/internal/decoder/file_decoder.go
@@ -16,16 +16,17 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/parsers/encodedtext"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/parsers/kubernetes"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/parsers/noop"
+	"github.com/DataDog/datadog-agent/pkg/logs/internal/status"
 	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 )
 
 // NewDecoderFromSource creates a new decoder from a log source
-func NewDecoderFromSource(source *sources.ReplaceableSource) *Decoder {
-	return NewDecoderFromSourceWithPattern(source, nil)
+func NewDecoderFromSource(source *sources.ReplaceableSource, tailerInfo *status.InfoRegistry) *Decoder {
+	return NewDecoderFromSourceWithPattern(source, nil, tailerInfo)
 }
 
 // NewDecoderFromSourceWithPattern creates a new decoder from a log source with a multiline pattern
-func NewDecoderFromSourceWithPattern(source *sources.ReplaceableSource, multiLinePattern *regexp.Regexp) *Decoder {
+func NewDecoderFromSourceWithPattern(source *sources.ReplaceableSource, multiLinePattern *regexp.Regexp, tailerInfo *status.InfoRegistry) *Decoder {
 
 	// TODO: remove those checks and add to source a reference to a tagProvider and a lineParser.
 	var lineParser parsers.Parser
@@ -57,5 +58,5 @@ func NewDecoderFromSourceWithPattern(source *sources.ReplaceableSource, multiLin
 		}
 	}
 
-	return NewDecoderWithFraming(source, lineParser, framing, multiLinePattern)
+	return NewDecoderWithFraming(source, lineParser, framing, multiLinePattern, tailerInfo)
 }

--- a/pkg/logs/internal/decoder/line_handler_benchmark_test.go
+++ b/pkg/logs/internal/decoder/line_handler_benchmark_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
+	"github.com/DataDog/datadog-agent/pkg/logs/internal/status"
 	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 )
 
@@ -38,7 +39,7 @@ func benchmarkAutoMultiLineHandler(b *testing.B, logs int, line string) {
 	}
 
 	source := sources.NewReplaceableSource(sources.NewLogSource("config", &config.LogsConfig{}))
-	h := NewAutoMultilineHandler(func(*Message) {}, defaultContentLenLimit, 1000, 0.9, 30*time.Second, 1000*time.Millisecond, source, []*regexp.Regexp{}, &DetectedPattern{})
+	h := NewAutoMultilineHandler(func(*Message) {}, defaultContentLenLimit, 1000, 0.9, 30*time.Second, 1000*time.Millisecond, source, []*regexp.Regexp{}, &DetectedPattern{}, status.NewInfoRegistry())
 
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {

--- a/pkg/logs/internal/decoder/line_handler_test.go
+++ b/pkg/logs/internal/decoder/line_handler_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
+	"github.com/DataDog/datadog-agent/pkg/logs/internal/status"
 	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 )
 
@@ -256,7 +257,7 @@ func TestAutoMultiLineHandlerStaysSingleLineMode(t *testing.T) {
 	outputFn, outputChan := lineHandlerChans()
 	source := sources.NewReplaceableSource(sources.NewLogSource("config", &config.LogsConfig{}))
 	detectedPattern := &DetectedPattern{}
-	h := NewAutoMultilineHandler(outputFn, 100, 5, 1.0, 10*time.Millisecond, 10*time.Millisecond, source, []*regexp.Regexp{}, detectedPattern)
+	h := NewAutoMultilineHandler(outputFn, 100, 5, 1.0, 10*time.Millisecond, 10*time.Millisecond, source, []*regexp.Regexp{}, detectedPattern, status.NewInfoRegistry())
 
 	for i := 0; i < 6; i++ {
 		h.process(getDummyMessageWithLF("blah"))
@@ -271,7 +272,7 @@ func TestAutoMultiLineHandlerSwitchesToMultiLineMode(t *testing.T) {
 	outputFn, outputChan := lineHandlerChans()
 	source := sources.NewReplaceableSource(sources.NewLogSource("config", &config.LogsConfig{}))
 	detectedPattern := &DetectedPattern{}
-	h := NewAutoMultilineHandler(outputFn, 100, 5, 1.0, 10*time.Millisecond, 10*time.Millisecond, source, []*regexp.Regexp{}, detectedPattern)
+	h := NewAutoMultilineHandler(outputFn, 100, 5, 1.0, 10*time.Millisecond, 10*time.Millisecond, source, []*regexp.Regexp{}, detectedPattern, status.NewInfoRegistry())
 
 	for i := 0; i < 6; i++ {
 		h.process(getDummyMessageWithLF("Jul 12, 2021 12:55:15 PM test message"))
@@ -286,7 +287,7 @@ func TestAutoMultiLineHandlerSwitchesToMultiLineMode(t *testing.T) {
 func TestAutoMultiLineHandlerHandelsMessage(t *testing.T) {
 	outputFn, outputChan := lineHandlerChans()
 	source := sources.NewReplaceableSource(sources.NewLogSource("config", &config.LogsConfig{}))
-	h := NewAutoMultilineHandler(outputFn, 500, 1, 1.0, 10*time.Millisecond, 10*time.Millisecond, source, []*regexp.Regexp{}, &DetectedPattern{})
+	h := NewAutoMultilineHandler(outputFn, 500, 1, 1.0, 10*time.Millisecond, 10*time.Millisecond, source, []*regexp.Regexp{}, &DetectedPattern{}, status.NewInfoRegistry())
 
 	h.process(getDummyMessageWithLF("Jul 12, 2021 12:55:15 PM test message 1"))
 	<-outputChan
@@ -304,7 +305,7 @@ func TestAutoMultiLineHandlerHandelsMessage(t *testing.T) {
 func TestAutoMultiLineHandlerHandelsMessageConflictingPatterns(t *testing.T) {
 	outputFn, outputChan := lineHandlerChans()
 	source := sources.NewReplaceableSource(sources.NewLogSource("config", &config.LogsConfig{}))
-	h := NewAutoMultilineHandler(outputFn, 500, 4, 0.75, 10*time.Millisecond, 10*time.Millisecond, source, []*regexp.Regexp{}, &DetectedPattern{})
+	h := NewAutoMultilineHandler(outputFn, 500, 4, 0.75, 10*time.Millisecond, 10*time.Millisecond, source, []*regexp.Regexp{}, &DetectedPattern{}, status.NewInfoRegistry())
 
 	// we will match both patterns, but one will win with a threshold of 0.75
 	h.process(getDummyMessageWithLF("Jul 12, 2021 12:55:15 PM test message 1"))
@@ -329,7 +330,7 @@ func TestAutoMultiLineHandlerHandelsMessageConflictingPatterns(t *testing.T) {
 func TestAutoMultiLineHandlerHandelsMessageConflictingPatternsNoWinner(t *testing.T) {
 	outputFn, outputChan := lineHandlerChans()
 	source := sources.NewReplaceableSource(sources.NewLogSource("config", &config.LogsConfig{}))
-	h := NewAutoMultilineHandler(outputFn, 500, 4, 0.75, 10*time.Millisecond, 10*time.Millisecond, source, []*regexp.Regexp{}, &DetectedPattern{})
+	h := NewAutoMultilineHandler(outputFn, 500, 4, 0.75, 10*time.Millisecond, 10*time.Millisecond, source, []*regexp.Regexp{}, &DetectedPattern{}, status.NewInfoRegistry())
 
 	// we will match both patterns, but neither will win because it doesn't meet the threshold
 	h.process(getDummyMessageWithLF("Jul 12, 2021 12:55:15 PM test message 1"))
@@ -354,7 +355,7 @@ func TestAutoMultiLineHandlerSwitchesToMultiLineModeWithDelay(t *testing.T) {
 	source := sources.NewReplaceableSource(sources.NewLogSource("config", &config.LogsConfig{}))
 	detectedPattern := &DetectedPattern{}
 
-	h := NewAutoMultilineHandler(outputFn, 100, 5, 1.0, 10*time.Millisecond, 10*time.Millisecond, source, []*regexp.Regexp{}, detectedPattern)
+	h := NewAutoMultilineHandler(outputFn, 100, 5, 1.0, 10*time.Millisecond, 10*time.Millisecond, source, []*regexp.Regexp{}, detectedPattern, status.NewInfoRegistry())
 	clock := clock.NewMock()
 	h.clk = clock
 

--- a/pkg/logs/internal/launchers/channel/launcher.go
+++ b/pkg/logs/internal/launchers/channel/launcher.go
@@ -34,7 +34,7 @@ func NewLauncher() *Launcher {
 }
 
 // Start starts the launcher.
-func (l *Launcher) Start(sourceProvider launchers.SourceProvider, pipelineProvider pipeline.Provider, registry auditor.Registry, tailers *tailers.TailerTracker) {
+func (l *Launcher) Start(sourceProvider launchers.SourceProvider, pipelineProvider pipeline.Provider, registry auditor.Registry, tracker *tailers.TailerTracker) {
 	l.pipelineProvider = pipelineProvider
 	l.sources = sourceProvider.GetAddedForType(config.StringChannelType)
 	go l.run()

--- a/pkg/logs/internal/launchers/channel/launcher.go
+++ b/pkg/logs/internal/launchers/channel/launcher.go
@@ -9,6 +9,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/auditor"
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/launchers"
+	"github.com/DataDog/datadog-agent/pkg/logs/internal/tailers"
 	tailer "github.com/DataDog/datadog-agent/pkg/logs/internal/tailers/channel"
 	"github.com/DataDog/datadog-agent/pkg/logs/pipeline"
 	"github.com/DataDog/datadog-agent/pkg/logs/sources"
@@ -33,7 +34,7 @@ func NewLauncher() *Launcher {
 }
 
 // Start starts the launcher.
-func (l *Launcher) Start(sourceProvider launchers.SourceProvider, pipelineProvider pipeline.Provider, registry auditor.Registry) {
+func (l *Launcher) Start(sourceProvider launchers.SourceProvider, pipelineProvider pipeline.Provider, registry auditor.Registry, tailers *tailers.TailerTracker) {
 	l.pipelineProvider = pipelineProvider
 	l.sources = sourceProvider.GetAddedForType(config.StringChannelType)
 	go l.run()

--- a/pkg/logs/internal/launchers/container/launcher.go
+++ b/pkg/logs/internal/launchers/container/launcher.go
@@ -14,6 +14,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/auditor"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/launchers"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/launchers/container/tailerfactory"
+	"github.com/DataDog/datadog-agent/pkg/logs/internal/tailers"
 	"github.com/DataDog/datadog-agent/pkg/logs/pipeline"
 	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 	sourcesPkg "github.com/DataDog/datadog-agent/pkg/logs/sources"
@@ -66,7 +67,7 @@ func NewLauncher(sources *sourcesPkg.LogSources) *Launcher {
 }
 
 // Start starts the Launcher
-func (l *Launcher) Start(sourceProvider launchers.SourceProvider, pipelineProvider pipeline.Provider, registry auditor.Registry) {
+func (l *Launcher) Start(sourceProvider launchers.SourceProvider, pipelineProvider pipeline.Provider, registry auditor.Registry, tailers *tailers.TailerTracker) {
 	// only start this launcher once it's determined that we should be logging containers, and not pods.
 	ctx, cancel := context.WithCancel(context.Background())
 	l.cancel = cancel

--- a/pkg/logs/internal/launchers/container/launcher.go
+++ b/pkg/logs/internal/launchers/container/launcher.go
@@ -67,7 +67,7 @@ func NewLauncher(sources *sourcesPkg.LogSources) *Launcher {
 }
 
 // Start starts the Launcher
-func (l *Launcher) Start(sourceProvider launchers.SourceProvider, pipelineProvider pipeline.Provider, registry auditor.Registry, tailers *tailers.TailerTracker) {
+func (l *Launcher) Start(sourceProvider launchers.SourceProvider, pipelineProvider pipeline.Provider, registry auditor.Registry, tracker *tailers.TailerTracker) {
 	// only start this launcher once it's determined that we should be logging containers, and not pods.
 	ctx, cancel := context.WithCancel(context.Background())
 	l.cancel = cancel

--- a/pkg/logs/internal/launchers/container/launcher_nodocker.go
+++ b/pkg/logs/internal/launchers/container/launcher_nodocker.go
@@ -11,6 +11,7 @@ package container
 import (
 	"github.com/DataDog/datadog-agent/pkg/logs/auditor"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/launchers"
+	"github.com/DataDog/datadog-agent/pkg/logs/internal/tailers"
 	"github.com/DataDog/datadog-agent/pkg/logs/pipeline"
 	sourcesPkg "github.com/DataDog/datadog-agent/pkg/logs/sources"
 )
@@ -26,7 +27,7 @@ func NewLauncher(sources *sourcesPkg.LogSources) *Launcher {
 }
 
 // Start implements Launcher#Start.
-func (l *Launcher) Start(launchers.SourceProvider, pipeline.Provider, auditor.Registry) {
+func (l *Launcher) Start(launchers.SourceProvider, pipeline.Provider, auditor.Registry, *tailers.TailerTracker) {
 }
 
 // Stop implements Launcher#Stop.

--- a/pkg/logs/internal/launchers/container/launcher_test.go
+++ b/pkg/logs/internal/launchers/container/launcher_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/launchers"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/launchers/container/tailerfactory"
+	"github.com/DataDog/datadog-agent/pkg/logs/internal/tailers"
 	"github.com/DataDog/datadog-agent/pkg/logs/pipeline"
 	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 )
@@ -39,7 +40,8 @@ func TestStartStop(t *testing.T) {
 	sp := launchers.NewMockSourceProvider()
 	pl := pipeline.NewMockProvider()
 	reg := auditor.New("/run", "agent", 0, nil)
-	l.Start(sp, pl, reg)
+	tailerTracker := tailers.NewTailerTracker()
+	l.Start(sp, pl, reg, tailerTracker)
 
 	require.NotNil(t, l.cancel)
 	require.NotNil(t, l.stopped)

--- a/pkg/logs/internal/launchers/file/launcher.go
+++ b/pkg/logs/internal/launchers/file/launcher.go
@@ -73,7 +73,7 @@ func NewLauncher(tailingLimit int, tailerSleepDuration time.Duration, validatePo
 }
 
 // Start starts the Launcher
-func (s *Launcher) Start(sourceProvider launchers.SourceProvider, pipelineProvider pipeline.Provider, registry auditor.Registry) {
+func (s *Launcher) Start(sourceProvider launchers.SourceProvider, pipelineProvider pipeline.Provider, registry auditor.Registry, tailers *tailers.TailerTracker) {
 	s.pipelineProvider = pipelineProvider
 	s.addedSources, s.removedSources = sourceProvider.SubscribeForType(config.FileType)
 	s.registry = registry

--- a/pkg/logs/internal/launchers/file/launcher.go
+++ b/pkg/logs/internal/launchers/file/launcher.go
@@ -75,11 +75,11 @@ func NewLauncher(tailingLimit int, tailerSleepDuration time.Duration, validatePo
 }
 
 // Start starts the Launcher
-func (s *Launcher) Start(sourceProvider launchers.SourceProvider, pipelineProvider pipeline.Provider, registry auditor.Registry, tailers *tailers.TailerTracker) {
+func (s *Launcher) Start(sourceProvider launchers.SourceProvider, pipelineProvider pipeline.Provider, registry auditor.Registry, tracker *tailers.TailerTracker) {
 	s.pipelineProvider = pipelineProvider
 	s.addedSources, s.removedSources = sourceProvider.SubscribeForType(config.FileType)
 	s.registry = registry
-	tailers.Add(s.tailers)
+	tracker.Add(s.tailers)
 	go s.run()
 }
 
@@ -228,7 +228,7 @@ func (s *Launcher) removeSource(source *sources.LogSource) {
 // launch launches new tailers for a new source.
 func (s *Launcher) launchTailers(source *sources.LogSource) {
 	// If we're at the limit already, no need to do a 'CollectFiles', just wait for the next 'scan'
-	if len(s.tailers.All()) >= s.tailingLimit {
+	if s.tailers.Count() >= s.tailingLimit {
 		return
 	}
 	files, err := s.fileProvider.CollectFiles(source)

--- a/pkg/logs/internal/launchers/file/launcher.go
+++ b/pkg/logs/internal/launchers/file/launcher.go
@@ -17,6 +17,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/decoder"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/launchers"
 	fileprovider "github.com/DataDog/datadog-agent/pkg/logs/internal/launchers/file/provider"
+	"github.com/DataDog/datadog-agent/pkg/logs/internal/status"
+	"github.com/DataDog/datadog-agent/pkg/logs/internal/tailers"
 	tailer "github.com/DataDog/datadog-agent/pkg/logs/internal/tailers/file"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
 	"github.com/DataDog/datadog-agent/pkg/logs/pipeline"
@@ -36,7 +38,7 @@ type Launcher struct {
 	activeSources       []*sources.LogSource
 	tailingLimit        int
 	fileProvider        *fileprovider.FileProvider
-	tailers             map[string]*tailer.Tailer
+	tailers             *tailers.TailerContainer[*tailer.Tailer]
 	registry            auditor.Registry
 	tailerSleepDuration time.Duration
 	stop                chan struct{}
@@ -64,7 +66,7 @@ func NewLauncher(tailingLimit int, tailerSleepDuration time.Duration, validatePo
 	return &Launcher{
 		tailingLimit:           tailingLimit,
 		fileProvider:           fileprovider.NewFileProvider(tailingLimit, wildcardStrategy),
-		tailers:                make(map[string]*tailer.Tailer),
+		tailers:                tailers.NewTailerContainer[*tailer.Tailer](),
 		tailerSleepDuration:    tailerSleepDuration,
 		stop:                   make(chan struct{}),
 		validatePodContainerID: validatePodContainerID,
@@ -77,6 +79,7 @@ func (s *Launcher) Start(sourceProvider launchers.SourceProvider, pipelineProvid
 	s.pipelineProvider = pipelineProvider
 	s.addedSources, s.removedSources = sourceProvider.SubscribeForType(config.FileType)
 	s.registry = registry
+	tailers.Add(s.tailers)
 	go s.run()
 }
 
@@ -110,9 +113,9 @@ func (s *Launcher) run() {
 // cleanup all tailers
 func (s *Launcher) cleanup() {
 	stopper := startstop.NewParallelStopper()
-	for scanKey, tailer := range s.tailers {
+	for _, tailer := range s.tailers.All() {
 		stopper.Add(tailer)
-		delete(s.tailers, scanKey)
+		s.tailers.Remove(tailer)
 	}
 	stopper.Stop()
 }
@@ -125,7 +128,7 @@ func (s *Launcher) scan() {
 	files := s.fileProvider.FilesToTail(s.validatePodContainerID, s.activeSources)
 	filesTailed := make(map[string]bool)
 
-	log.Debugf("Scan - got %d files from FilesToTail and currently tailing %d files\n", len(files), len(s.tailers))
+	log.Debugf("Scan - got %d files from FilesToTail and currently tailing %d files\n", len(files), s.tailers.Count())
 
 	// Pass 1 - Compare 'files' to our current set of tailed files. If any no longer need to be tailed,
 	// stop the tailers.
@@ -141,7 +144,7 @@ func (s *Launcher) scan() {
 		// when a tailer for a dead container is still tailing the file, and another
 		// tailer is tailing the file for the new container).
 		scanKey := file.GetScanKey()
-		tailer, isTailed := s.tailers[scanKey]
+		tailer, isTailed := s.tailers.Get(scanKey)
 		if isTailed && tailer.IsFinished() {
 			// skip this tailer as it must be stopped
 			continue
@@ -170,20 +173,20 @@ func (s *Launcher) scan() {
 		filesTailed[scanKey] = true
 	}
 
-	for scanKey, tailer := range s.tailers {
+	for _, tailer := range s.tailers.All() {
 		// stop all tailers which have not been selected
-		_, shouldTail := filesTailed[scanKey]
+		_, shouldTail := filesTailed[tailer.GetId()]
 		if !shouldTail {
-			s.stopTailer(scanKey, tailer)
+			s.stopTailer(tailer)
 		}
 	}
 
-	tailersLen := len(s.tailers)
+	tailersLen := s.tailers.Count()
 	log.Debugf("After stopping tailers, there are %d tailers running.\n", tailersLen)
 
 	for _, file := range files {
 		scanKey := file.GetScanKey()
-		_, isTailed := s.tailers[scanKey]
+		isTailed := s.tailers.Contains(scanKey)
 		if !isTailed && tailersLen < s.tailingLimit {
 			// create a new tailer tailing from the beginning of the file if no offset has been recorded
 			succeeded := s.startNewTailer(file, config.Beginning)
@@ -225,7 +228,7 @@ func (s *Launcher) removeSource(source *sources.LogSource) {
 // launch launches new tailers for a new source.
 func (s *Launcher) launchTailers(source *sources.LogSource) {
 	// If we're at the limit already, no need to do a 'CollectFiles', just wait for the next 'scan'
-	if len(s.tailers) >= s.tailingLimit {
+	if len(s.tailers.All()) >= s.tailingLimit {
 		return
 	}
 	files, err := s.fileProvider.CollectFiles(source)
@@ -235,10 +238,10 @@ func (s *Launcher) launchTailers(source *sources.LogSource) {
 		return
 	}
 	for _, file := range files {
-		if len(s.tailers) >= s.tailingLimit {
+		if s.tailers.Count() >= s.tailingLimit {
 			return
 		}
-		if tailer, isTailed := s.tailers[file.GetScanKey()]; isTailed {
+		if tailer, isTailed := s.tailers.Get(file.GetScanKey()); isTailed {
 			// the file is already tailed, update the existing tailer's source so that the tailer
 			// uses this new source going forward
 			tailer.ReplaceSource(source)
@@ -284,7 +287,7 @@ func (s *Launcher) startNewTailer(file *tailer.File, m config.TailingMode) bool 
 		return false
 	}
 
-	s.tailers[file.GetScanKey()] = tailer
+	s.tailers.Add(tailer)
 	return true
 }
 
@@ -311,9 +314,9 @@ func (s *Launcher) handleTailingModeChange(tailerID string, currentTailingMode c
 }
 
 // stopTailer stops the tailer
-func (s *Launcher) stopTailer(scanKey string, tailer *tailer.Tailer) {
+func (s *Launcher) stopTailer(tailer *tailer.Tailer) {
 	go tailer.Stop()
-	delete(s.tailers, scanKey)
+	s.tailers.Remove(tailer)
 }
 
 // restartTailer safely stops tailer and starts a new one
@@ -328,17 +331,19 @@ func (s *Launcher) restartTailerAfterFileRotation(tailer *tailer.Tailer, file *t
 		log.Warn(err)
 		return false
 	}
-	s.tailers[file.GetScanKey()] = tailer
+	s.tailers.Add(tailer)
 	return true
 }
 
 // createTailer returns a new initialized tailer
 func (s *Launcher) createTailer(file *tailer.File, outputChan chan *message.Message) *tailer.Tailer {
-	return tailer.NewTailer(outputChan, file, s.tailerSleepDuration, decoder.NewDecoderFromSource(file.Source))
+	tailerInfo := status.NewInfoRegistry()
+	return tailer.NewTailer(outputChan, file, s.tailerSleepDuration, decoder.NewDecoderFromSource(file.Source, tailerInfo), tailerInfo)
 }
 
 func (s *Launcher) createRotatedTailer(t *tailer.Tailer, file *tailer.File, pattern *regexp.Regexp) *tailer.Tailer {
-	return t.NewRotatedTailer(file, decoder.NewDecoderFromSourceWithPattern(file.Source, pattern))
+	tailerInfo := status.NewInfoRegistry()
+	return t.NewRotatedTailer(file, decoder.NewDecoderFromSourceWithPattern(file.Source, pattern, tailerInfo), tailerInfo)
 }
 
 func CheckProcessTelemetry(stats *util.ProcessFileStats) {

--- a/pkg/logs/internal/launchers/file/provider/file_provider_test.go
+++ b/pkg/logs/internal/launchers/file/provider/file_provider_test.go
@@ -150,7 +150,7 @@ func (suite *ProviderTestSuite) TestFilesToTailReturnsAllFilesFromDirectory() {
 		[]string{
 			"The limit on the maximum number of files in use (3) has been reached. Increase this limit (thanks to the attribute logs_config.open_files_limit in datadog.yaml) or decrease the number of tailed file.",
 		},
-		status.Get().Warnings,
+		status.Get(false).Warnings,
 	)
 }
 
@@ -212,7 +212,7 @@ func (suite *ProviderTestSuite) TestFilesToTailReturnsSpecificFileWithWildcard()
 		[]string{
 			"The limit on the maximum number of files in use (3) has been reached. Increase this limit (thanks to the attribute logs_config.open_files_limit in datadog.yaml) or decrease the number of tailed file.",
 		},
-		status.Get().Warnings,
+		status.Get(false).Warnings,
 	)
 }
 
@@ -245,7 +245,7 @@ func (suite *ProviderTestSuite) TestNumberOfFilesToTailDoesNotExceedLimit() {
 		[]string{
 			"The limit on the maximum number of files in use (3) has been reached. Increase this limit (thanks to the attribute logs_config.open_files_limit in datadog.yaml) or decrease the number of tailed file.",
 		},
-		status.Get().Warnings,
+		status.Get(false).Warnings,
 	)
 }
 
@@ -264,14 +264,14 @@ func (suite *ProviderTestSuite) TestAllWildcardPathsAreUpdated() {
 		[]string{
 			"The limit on the maximum number of files in use (2) has been reached. Increase this limit (thanks to the attribute logs_config.open_files_limit in datadog.yaml) or decrease the number of tailed file.",
 		},
-		status.Get().Warnings,
+		status.Get(false).Warnings,
 	)
 	suite.Equal([]string{"0 files tailed out of 2 files matching"}, logSources[1].Messages.GetMessages())
 	suite.Equal(
 		[]string{
 			"The limit on the maximum number of files in use (2) has been reached. Increase this limit (thanks to the attribute logs_config.open_files_limit in datadog.yaml) or decrease the number of tailed file.",
 		},
-		status.Get().Warnings,
+		status.Get(false).Warnings,
 	)
 
 	os.Remove(fmt.Sprintf("%s/1/2.log", suite.testDir))
@@ -286,7 +286,7 @@ func (suite *ProviderTestSuite) TestAllWildcardPathsAreUpdated() {
 		[]string{
 			"The limit on the maximum number of files in use (2) has been reached. Increase this limit (thanks to the attribute logs_config.open_files_limit in datadog.yaml) or decrease the number of tailed file.",
 		},
-		status.Get().Warnings,
+		status.Get(false).Warnings,
 	)
 
 	os.Remove(fmt.Sprintf("%s/2/1.log", suite.testDir))

--- a/pkg/logs/internal/launchers/journald/launcher.go
+++ b/pkg/logs/internal/launchers/journald/launcher.go
@@ -57,7 +57,7 @@ func NewLauncherWithFactory(journalFactory tailer.JournalFactory) *Launcher {
 }
 
 // Start starts the launcher.
-func (l *Launcher) Start(sourceProvider launchers.SourceProvider, pipelineProvider pipeline.Provider, registry auditor.Registry, tailers *tailers.TailerTracker) {
+func (l *Launcher) Start(sourceProvider launchers.SourceProvider, pipelineProvider pipeline.Provider, registry auditor.Registry, tracker *tailers.TailerTracker) {
 	l.sources = sourceProvider.GetAddedForType(config.JournaldType)
 	l.pipelineProvider = pipelineProvider
 	l.registry = registry

--- a/pkg/logs/internal/launchers/journald/launcher.go
+++ b/pkg/logs/internal/launchers/journald/launcher.go
@@ -12,6 +12,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/auditor"
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/launchers"
+	"github.com/DataDog/datadog-agent/pkg/logs/internal/tailers"
 	tailer "github.com/DataDog/datadog-agent/pkg/logs/internal/tailers/journald"
 	"github.com/DataDog/datadog-agent/pkg/logs/pipeline"
 	"github.com/DataDog/datadog-agent/pkg/logs/sources"
@@ -56,7 +57,7 @@ func NewLauncherWithFactory(journalFactory tailer.JournalFactory) *Launcher {
 }
 
 // Start starts the launcher.
-func (l *Launcher) Start(sourceProvider launchers.SourceProvider, pipelineProvider pipeline.Provider, registry auditor.Registry) {
+func (l *Launcher) Start(sourceProvider launchers.SourceProvider, pipelineProvider pipeline.Provider, registry auditor.Registry, tailers *tailers.TailerTracker) {
 	l.sources = sourceProvider.GetAddedForType(config.JournaldType)
 	l.pipelineProvider = pipelineProvider
 	l.registry = registry

--- a/pkg/logs/internal/launchers/journald/launcher_nosystemd.go
+++ b/pkg/logs/internal/launchers/journald/launcher_nosystemd.go
@@ -24,7 +24,7 @@ func NewLauncher() *Launcher {
 }
 
 // Start does nothing
-func (l *Launcher) Start(sources launchers.SourceProvider, pipelineProvider pipeline.Provider, registry auditor.Registry, tailers *tailers.TailerTracker) {
+func (l *Launcher) Start(sources launchers.SourceProvider, pipelineProvider pipeline.Provider, registry auditor.Registry, tracker *tailers.TailerTracker) {
 }
 
 // Stop does nothing

--- a/pkg/logs/internal/launchers/journald/launcher_nosystemd.go
+++ b/pkg/logs/internal/launchers/journald/launcher_nosystemd.go
@@ -11,6 +11,7 @@ package journald
 import (
 	"github.com/DataDog/datadog-agent/pkg/logs/auditor"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/launchers"
+	"github.com/DataDog/datadog-agent/pkg/logs/internal/tailers"
 	"github.com/DataDog/datadog-agent/pkg/logs/pipeline"
 )
 
@@ -23,7 +24,7 @@ func NewLauncher() *Launcher {
 }
 
 // Start does nothing
-func (l *Launcher) Start(sources launchers.SourceProvider, pipelineProvider pipeline.Provider, registry auditor.Registry) {
+func (l *Launcher) Start(sources launchers.SourceProvider, pipelineProvider pipeline.Provider, registry auditor.Registry, tailers *tailers.TailerTracker) {
 }
 
 // Stop does nothing

--- a/pkg/logs/internal/launchers/journald/launcher_test.go
+++ b/pkg/logs/internal/launchers/journald/launcher_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/auditor"
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/launchers"
+	"github.com/DataDog/datadog-agent/pkg/logs/internal/tailers"
 	tailer "github.com/DataDog/datadog-agent/pkg/logs/internal/tailers/journald"
 	"github.com/DataDog/datadog-agent/pkg/logs/pipeline"
 	"github.com/DataDog/datadog-agent/pkg/logs/sources"
@@ -50,7 +51,7 @@ func (s *MockJournalFactory) NewJournalFromPath(path string) (tailer.Journal, er
 
 func newTestLauncher() *Launcher {
 	launcher := NewLauncherWithFactory(&MockJournalFactory{})
-	launcher.Start(launchers.NewMockSourceProvider(), pipeline.NewMockProvider(), auditor.New("", "registry.json", time.Hour, health.RegisterLiveness("fake")))
+	launcher.Start(launchers.NewMockSourceProvider(), pipeline.NewMockProvider(), auditor.New("", "registry.json", time.Hour, health.RegisterLiveness("fake")), tailers.NewTailerTracker())
 	return launcher
 }
 

--- a/pkg/logs/internal/launchers/launchers.go
+++ b/pkg/logs/internal/launchers/launchers.go
@@ -26,7 +26,7 @@ type Launchers struct {
 	registry auditor.Registry
 
 	// tailers will be given to launchers' Start method.
-	tailers *tailers.TailerTracker
+	tracker *tailers.TailerTracker
 
 	// launchers is the set of running launchers
 	launchers []Launcher
@@ -40,13 +40,13 @@ func NewLaunchers(
 	sources *sources.LogSources,
 	pipelineProvider pipeline.Provider,
 	registry auditor.Registry,
-	tailers *tailers.TailerTracker,
+	tracker *tailers.TailerTracker,
 ) *Launchers {
 	return &Launchers{
 		sourceProvider:   sources,
 		pipelineProvider: pipelineProvider,
 		registry:         registry,
-		tailers:          tailers,
+		tracker:          tracker,
 	}
 }
 
@@ -55,14 +55,14 @@ func NewLaunchers(
 func (ls *Launchers) AddLauncher(launcher Launcher) {
 	ls.launchers = append(ls.launchers, launcher)
 	if ls.started {
-		launcher.Start(ls.sourceProvider, ls.pipelineProvider, ls.registry, ls.tailers)
+		launcher.Start(ls.sourceProvider, ls.pipelineProvider, ls.registry, ls.tracker)
 	}
 }
 
 // Start starts all launchers in the collection.
 func (ls *Launchers) Start() {
 	for _, s := range ls.launchers {
-		s.Start(ls.sourceProvider, ls.pipelineProvider, ls.registry, ls.tailers)
+		s.Start(ls.sourceProvider, ls.pipelineProvider, ls.registry, ls.tracker)
 	}
 	ls.started = true
 }

--- a/pkg/logs/internal/launchers/launchers.go
+++ b/pkg/logs/internal/launchers/launchers.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 
 	"github.com/DataDog/datadog-agent/pkg/logs/auditor"
+	"github.com/DataDog/datadog-agent/pkg/logs/internal/tailers"
 	"github.com/DataDog/datadog-agent/pkg/logs/pipeline"
 	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 )
@@ -24,6 +25,9 @@ type Launchers struct {
 	// registry will be given to launchers' Start method.
 	registry auditor.Registry
 
+	// tailers will be given to launchers' Start method.
+	tailers *tailers.TailerTracker
+
 	// launchers is the set of running launchers
 	launchers []Launcher
 
@@ -36,11 +40,13 @@ func NewLaunchers(
 	sources *sources.LogSources,
 	pipelineProvider pipeline.Provider,
 	registry auditor.Registry,
+	tailers *tailers.TailerTracker,
 ) *Launchers {
 	return &Launchers{
 		sourceProvider:   sources,
 		pipelineProvider: pipelineProvider,
 		registry:         registry,
+		tailers:          tailers,
 	}
 }
 
@@ -49,14 +55,14 @@ func NewLaunchers(
 func (ls *Launchers) AddLauncher(launcher Launcher) {
 	ls.launchers = append(ls.launchers, launcher)
 	if ls.started {
-		launcher.Start(ls.sourceProvider, ls.pipelineProvider, ls.registry)
+		launcher.Start(ls.sourceProvider, ls.pipelineProvider, ls.registry, ls.tailers)
 	}
 }
 
 // Start starts all launchers in the collection.
 func (ls *Launchers) Start() {
 	for _, s := range ls.launchers {
-		s.Start(ls.sourceProvider, ls.pipelineProvider, ls.registry)
+		s.Start(ls.sourceProvider, ls.pipelineProvider, ls.registry, ls.tailers)
 	}
 	ls.started = true
 }

--- a/pkg/logs/internal/launchers/listener/launcher.go
+++ b/pkg/logs/internal/launchers/listener/launcher.go
@@ -9,6 +9,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/auditor"
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/launchers"
+	"github.com/DataDog/datadog-agent/pkg/logs/internal/tailers"
 	"github.com/DataDog/datadog-agent/pkg/logs/pipeline"
 	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 	"github.com/DataDog/datadog-agent/pkg/util/startstop"
@@ -33,7 +34,7 @@ func NewLauncher(frameSize int) *Launcher {
 }
 
 // Start starts the listener.
-func (l *Launcher) Start(sourceProvider launchers.SourceProvider, pipelineProvider pipeline.Provider, registry auditor.Registry) {
+func (l *Launcher) Start(sourceProvider launchers.SourceProvider, pipelineProvider pipeline.Provider, registry auditor.Registry, tailers *tailers.TailerTracker) {
 	l.pipelineProvider = pipelineProvider
 	l.tcpSources = sourceProvider.GetAddedForType(config.TCPType)
 	l.udpSources = sourceProvider.GetAddedForType(config.UDPType)

--- a/pkg/logs/internal/launchers/listener/launcher.go
+++ b/pkg/logs/internal/launchers/listener/launcher.go
@@ -34,7 +34,7 @@ func NewLauncher(frameSize int) *Launcher {
 }
 
 // Start starts the listener.
-func (l *Launcher) Start(sourceProvider launchers.SourceProvider, pipelineProvider pipeline.Provider, registry auditor.Registry, tailers *tailers.TailerTracker) {
+func (l *Launcher) Start(sourceProvider launchers.SourceProvider, pipelineProvider pipeline.Provider, registry auditor.Registry, tracker *tailers.TailerTracker) {
 	l.pipelineProvider = pipelineProvider
 	l.tcpSources = sourceProvider.GetAddedForType(config.TCPType)
 	l.udpSources = sourceProvider.GetAddedForType(config.UDPType)

--- a/pkg/logs/internal/launchers/types.go
+++ b/pkg/logs/internal/launchers/types.go
@@ -7,6 +7,7 @@ package launchers
 
 import (
 	"github.com/DataDog/datadog-agent/pkg/logs/auditor"
+	"github.com/DataDog/datadog-agent/pkg/logs/internal/tailers"
 	"github.com/DataDog/datadog-agent/pkg/logs/pipeline"
 	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 )
@@ -18,7 +19,7 @@ import (
 // the agent, and stopped when it stops.
 type Launcher interface {
 	// Start the launcher.
-	Start(sourceProvider SourceProvider, pipelineProvider pipeline.Provider, registry auditor.Registry)
+	Start(sourceProvider SourceProvider, pipelineProvider pipeline.Provider, registry auditor.Registry, tailers *tailers.TailerTracker)
 
 	// Stop the launcher, and wait until shutdown is complete.  It is not
 	// necessary to unsubscribe from the sourceProvider, but any background

--- a/pkg/logs/internal/launchers/types.go
+++ b/pkg/logs/internal/launchers/types.go
@@ -19,7 +19,7 @@ import (
 // the agent, and stopped when it stops.
 type Launcher interface {
 	// Start the launcher.
-	Start(sourceProvider SourceProvider, pipelineProvider pipeline.Provider, registry auditor.Registry, tailers *tailers.TailerTracker)
+	Start(sourceProvider SourceProvider, pipelineProvider pipeline.Provider, registry auditor.Registry, tracker *tailers.TailerTracker)
 
 	// Stop the launcher, and wait until shutdown is complete.  It is not
 	// necessary to unsubscribe from the sourceProvider, but any background

--- a/pkg/logs/internal/launchers/windowsevent/launcher.go
+++ b/pkg/logs/internal/launchers/windowsevent/launcher.go
@@ -35,7 +35,7 @@ func NewLauncher() *Launcher {
 }
 
 // Start starts the launcher.
-func (l *Launcher) Start(sourceProvider launchers.SourceProvider, pipelineProvider pipeline.Provider, registry auditor.Registry, tailers *tailers.TailerTracker) {
+func (l *Launcher) Start(sourceProvider launchers.SourceProvider, pipelineProvider pipeline.Provider, registry auditor.Registry, tracker *tailers.TailerTracker) {
 	l.pipelineProvider = pipelineProvider
 	l.sources = sourceProvider.GetAddedForType(config.WindowsEventType)
 	availableChannels, err := EnumerateChannels()

--- a/pkg/logs/internal/launchers/windowsevent/launcher.go
+++ b/pkg/logs/internal/launchers/windowsevent/launcher.go
@@ -11,6 +11,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/auditor"
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/launchers"
+	"github.com/DataDog/datadog-agent/pkg/logs/internal/tailers"
 	tailer "github.com/DataDog/datadog-agent/pkg/logs/internal/tailers/windowsevent"
 	"github.com/DataDog/datadog-agent/pkg/logs/pipeline"
 	"github.com/DataDog/datadog-agent/pkg/logs/sources"
@@ -34,7 +35,7 @@ func NewLauncher() *Launcher {
 }
 
 // Start starts the launcher.
-func (l *Launcher) Start(sourceProvider launchers.SourceProvider, pipelineProvider pipeline.Provider, registry auditor.Registry) {
+func (l *Launcher) Start(sourceProvider launchers.SourceProvider, pipelineProvider pipeline.Provider, registry auditor.Registry, tailers *tailers.TailerTracker) {
 	l.pipelineProvider = pipelineProvider
 	l.sources = sourceProvider.GetAddedForType(config.WindowsEventType)
 	availableChannels, err := EnumerateChannels()

--- a/pkg/logs/internal/status/info_test.go
+++ b/pkg/logs/internal/status/info_test.go
@@ -11,24 +11,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestInfoRegistryOrder(t *testing.T) {
-
-	reg := NewInfoRegistry()
-	info1 := NewCountInfo("1")
-	info2 := NewCountInfo("2")
-	info3 := NewCountInfo("3")
-
-	reg.Register(info1)
-	reg.Register(info2)
-	reg.Register(info3)
-
-	all := reg.All()
-
-	assert.Equal(t, all[0].InfoKey(), "1")
-	assert.Equal(t, all[1].InfoKey(), "2")
-	assert.Equal(t, all[2].InfoKey(), "3")
-}
-
 func TestInfoRegistryReplace(t *testing.T) {
 
 	reg := NewInfoRegistry()

--- a/pkg/logs/internal/status/info_test.go
+++ b/pkg/logs/internal/status/info_test.go
@@ -1,0 +1,48 @@
+package status
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInfoRegistryOrder(t *testing.T) {
+
+	reg := NewInfoRegistry()
+	info1 := NewCountInfo("1")
+	info2 := NewCountInfo("2")
+	info3 := NewCountInfo("3")
+
+	reg.Register(info1)
+	reg.Register(info2)
+	reg.Register(info3)
+
+	all := reg.All()
+
+	assert.Equal(t, all[0].InfoKey(), "1")
+	assert.Equal(t, all[1].InfoKey(), "2")
+	assert.Equal(t, all[2].InfoKey(), "3")
+}
+
+func TestInfoRegistryReplace(t *testing.T) {
+
+	reg := NewInfoRegistry()
+	info1 := NewCountInfo("1")
+	info1.Add(1)
+
+	reg.Register(info1)
+
+	all := reg.All()
+
+	assert.Equal(t, "1", all[0].InfoKey())
+	assert.Equal(t, "1", all[0].Info()[0])
+
+	info2 := NewCountInfo("1")
+	info2.Add(10)
+	reg.Register(info2)
+
+	all = reg.All()
+
+	assert.Equal(t, "1", all[0].InfoKey())
+	assert.Equal(t, "10", all[0].Info()[0])
+}

--- a/pkg/logs/internal/status/info_test.go
+++ b/pkg/logs/internal/status/info_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
 package status
 
 import (

--- a/pkg/logs/internal/tailers/docker/tailer.go
+++ b/pkg/logs/internal/tailers/docker/tailer.go
@@ -24,6 +24,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/decoder"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/framer"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/parsers/dockerstream"
+	"github.com/DataDog/datadog-agent/pkg/logs/internal/status"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/tag"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
 	"github.com/DataDog/datadog-agent/pkg/logs/sources"
@@ -84,7 +85,7 @@ func NewTailer(cli *dockerutil.DockerUtil, containerID string, source *sources.L
 	return &Tailer{
 		ContainerID:        containerID,
 		outputChan:         outputChan,
-		decoder:            decoder.NewDecoderWithFraming(sources.NewReplaceableSource(source), dockerstream.New(containerID), framer.DockerStream, nil),
+		decoder:            decoder.NewDecoderWithFraming(sources.NewReplaceableSource(source), dockerstream.New(containerID), framer.DockerStream, nil, status.NewInfoRegistry()),
 		Source:             source,
 		tagProvider:        tag.NewProvider(containers.BuildTaggerEntityName(containerID)),
 		dockerutil:         cli,

--- a/pkg/logs/internal/tailers/socket/tailer.go
+++ b/pkg/logs/internal/tailers/socket/tailer.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/decoder"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/parsers/noop"
+	"github.com/DataDog/datadog-agent/pkg/logs/internal/status"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
 	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 )
@@ -36,9 +37,10 @@ func NewTailer(source *sources.LogSource, conn net.Conn, outputChan chan *messag
 		Conn:       conn,
 		outputChan: outputChan,
 		read:       read,
-		decoder:    decoder.InitializeDecoder(sources.NewReplaceableSource(source), noop.New()),
-		stop:       make(chan struct{}, 1),
-		done:       make(chan struct{}, 1),
+		// tailer info is currently unused for this tailer type.
+		decoder: decoder.InitializeDecoder(sources.NewReplaceableSource(source), noop.New(), status.NewInfoRegistry()),
+		stop:    make(chan struct{}, 1),
+		done:    make(chan struct{}, 1),
 	}
 }
 

--- a/pkg/logs/internal/tailers/tailer.go
+++ b/pkg/logs/internal/tailers/tailer.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
 package tailers
 
 import (

--- a/pkg/logs/internal/tailers/tailer.go
+++ b/pkg/logs/internal/tailers/tailer.go
@@ -1,0 +1,12 @@
+package tailers
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/logs/internal/status"
+)
+
+// Tailer the base interface for a tailer.
+type Tailer interface {
+	GetId() string
+	GetType() string
+	GetInfo() *status.InfoRegistry
+}

--- a/pkg/logs/internal/tailers/tailer.go
+++ b/pkg/logs/internal/tailers/tailer.go
@@ -9,7 +9,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/status"
 )
 
-// Tailer the base interface for a tailer.
+// Tailer is the base interface for a tailer.
 type Tailer interface {
 	GetId() string
 	GetType() string

--- a/pkg/logs/internal/tailers/tailer_tracker.go
+++ b/pkg/logs/internal/tailers/tailer_tracker.go
@@ -89,7 +89,7 @@ func (t *TailerContainer[T]) Remove(tailer T) {
 func (t *TailerContainer[T]) All() []T {
 	t.RLock()
 	defer t.RUnlock()
-	tailers := []T{}
+	tailers := make([]T, 0, len(t.tailers))
 	for _, tailer := range t.tailers {
 		tailers = append(tailers, tailer)
 	}
@@ -107,7 +107,7 @@ func (t *TailerContainer[T]) Count() int {
 func (t *TailerContainer[T]) Tailers() []Tailer {
 	t.RLock()
 	defer t.RUnlock()
-	tailers := []Tailer{}
+	tailers := make([]Tailer, 0, len(t.tailers))
 	for _, tailer := range t.tailers {
 		tailers = append(tailers, tailer)
 	}

--- a/pkg/logs/internal/tailers/tailer_tracker.go
+++ b/pkg/logs/internal/tailers/tailer_tracker.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
 package tailers
 
 import "sync"

--- a/pkg/logs/internal/tailers/tailer_tracker.go
+++ b/pkg/logs/internal/tailers/tailer_tracker.go
@@ -1,0 +1,109 @@
+package tailers
+
+import "sync"
+
+// TailerTracker keeps track of all the active tailers in the agent.
+type TailerTracker struct {
+	sync.RWMutex
+	containers []AnyTailerContainer
+}
+
+// NewTailerTracker creates a new TailerTracker instance
+func NewTailerTracker() *TailerTracker {
+	return &TailerTracker{}
+}
+
+// Add a tailer container to the tracker
+func (t *TailerTracker) Add(container AnyTailerContainer) {
+	t.Lock()
+	defer t.Unlock()
+	t.containers = append(t.containers, container)
+}
+
+// All returns all active tailers.
+func (t *TailerTracker) All() []Tailer {
+	t.RLock()
+	defer t.RUnlock()
+	tailers := []Tailer{}
+	for _, container := range t.containers {
+		tailers = append(tailers, container.Tailers()...)
+	}
+	return tailers
+}
+
+// AnyTailerContainer is a type erased tailer container. This is used a proxy for typed tailer containers to mix and match collections of tailers of any underlying type.
+type AnyTailerContainer interface {
+	Tailers() []Tailer
+}
+
+// TailerContainer is a container for a concrete tailer type.
+type TailerContainer[T Tailer] struct {
+	sync.RWMutex
+	tailers map[string]T
+}
+
+// NewTailerContainer creates a new TailerContainer instance
+func NewTailerContainer[T Tailer]() *TailerContainer[T] {
+	return &TailerContainer[T]{
+		tailers: make(map[string]T),
+	}
+}
+
+// Get returns a tailer with the provided id if it exists.
+func (t *TailerContainer[T]) Get(id string) (T, bool) {
+	t.RLock()
+	defer t.RUnlock()
+	tailer, ok := t.tailers[id]
+	return tailer, ok
+}
+
+// Contains returns true if the key exists
+func (t *TailerContainer[T]) Contains(id string) bool {
+	t.RLock()
+	defer t.RUnlock()
+	_, ok := t.tailers[id]
+	return ok
+}
+
+// Add adds a new tailer to the container
+func (t *TailerContainer[T]) Add(tailer T) {
+	t.Lock()
+	defer t.Unlock()
+	t.tailers[tailer.GetId()] = tailer
+}
+
+// Remove removes a tailer from the container.
+func (t *TailerContainer[T]) Remove(tailer T) {
+	t.Lock()
+	defer t.Unlock()
+	delete(t.tailers, tailer.GetId())
+}
+
+// All returns a slice of all tailers in the container
+func (t *TailerContainer[T]) All() []T {
+	t.RLock()
+	defer t.RUnlock()
+	tailers := []T{}
+	for _, tailer := range t.tailers {
+		tailers = append(tailers, tailer)
+	}
+	return tailers
+}
+
+// Count returns the number of tailers in the container
+func (t *TailerContainer[T]) Count() int {
+	t.RLock()
+	defer t.RUnlock()
+	return len(t.tailers)
+}
+
+// Tailers returns a slice of all tailers in the container without their concrete types.
+func (t *TailerContainer[T]) Tailers() []Tailer {
+	t.RLock()
+	defer t.RUnlock()
+	tailers := []Tailer{}
+	for _, tailer := range t.tailers {
+		tailers = append(tailers, tailer)
+	}
+	return tailers
+}

--- a/pkg/logs/internal/tailers/tailer_tracker.go
+++ b/pkg/logs/internal/tailers/tailer_tracker.go
@@ -13,12 +13,12 @@ type TailerTracker struct {
 	containers []AnyTailerContainer
 }
 
-// NewTailerTracker creates a new TailerTracker instance
+// NewTailerTracker creates a new TailerTracker instance.
 func NewTailerTracker() *TailerTracker {
 	return &TailerTracker{}
 }
 
-// Add a tailer container to the tracker
+// Add a tailer container to the tracker.
 func (t *TailerTracker) Add(container AnyTailerContainer) {
 	t.Lock()
 	defer t.Unlock()
@@ -36,7 +36,8 @@ func (t *TailerTracker) All() []Tailer {
 	return tailers
 }
 
-// AnyTailerContainer is a type erased tailer container. This is used a proxy for typed tailer containers to mix and match collections of tailers of any underlying type.
+// AnyTailerContainer is a type erased tailer container. This is used as a proxy for
+// typed tailer containers to mix and match collections of tailers of any underlying type.
 type AnyTailerContainer interface {
 	Tailers() []Tailer
 }
@@ -47,7 +48,7 @@ type TailerContainer[T Tailer] struct {
 	tailers map[string]T
 }
 
-// NewTailerContainer creates a new TailerContainer instance
+// NewTailerContainer creates a new TailerContainer instance.
 func NewTailerContainer[T Tailer]() *TailerContainer[T] {
 	return &TailerContainer[T]{
 		tailers: make(map[string]T),
@@ -62,7 +63,7 @@ func (t *TailerContainer[T]) Get(id string) (T, bool) {
 	return tailer, ok
 }
 
-// Contains returns true if the key exists
+// Contains returns true if the key exists.
 func (t *TailerContainer[T]) Contains(id string) bool {
 	t.RLock()
 	defer t.RUnlock()
@@ -70,7 +71,7 @@ func (t *TailerContainer[T]) Contains(id string) bool {
 	return ok
 }
 
-// Add adds a new tailer to the container
+// Add adds a new tailer to the container.
 func (t *TailerContainer[T]) Add(tailer T) {
 	t.Lock()
 	defer t.Unlock()
@@ -84,7 +85,7 @@ func (t *TailerContainer[T]) Remove(tailer T) {
 	delete(t.tailers, tailer.GetId())
 }
 
-// All returns a slice of all tailers in the container
+// All returns a slice of all tailers in the container.
 func (t *TailerContainer[T]) All() []T {
 	t.RLock()
 	defer t.RUnlock()
@@ -95,7 +96,7 @@ func (t *TailerContainer[T]) All() []T {
 	return tailers
 }
 
-// Count returns the number of tailers in the container
+// Count returns the number of tailers in the container.
 func (t *TailerContainer[T]) Count() int {
 	t.RLock()
 	defer t.RUnlock()

--- a/pkg/logs/internal/tailers/tailer_tracker_test.go
+++ b/pkg/logs/internal/tailers/tailer_tracker_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
 package tailers
 
 import (

--- a/pkg/logs/internal/tailers/tailer_tracker_test.go
+++ b/pkg/logs/internal/tailers/tailer_tracker_test.go
@@ -17,7 +17,7 @@ type TestTailer1 struct {
 	info *status.InfoRegistry
 }
 
-func NewTestTaler1(id string) *TestTailer1 {
+func NewTestTailer1(id string) *TestTailer1 {
 	return &TestTailer1{
 		id:   id,
 		info: status.NewInfoRegistry(),
@@ -39,7 +39,7 @@ type TestTailer2 struct {
 	info *status.InfoRegistry
 }
 
-func NewTestTaler2(id string) *TestTailer2 {
+func NewTestTailer2(id string) *TestTailer2 {
 	return &TestTailer2{
 		id:   id,
 		info: status.NewInfoRegistry(),
@@ -59,13 +59,13 @@ func (t *TestTailer2) GetInfo() *status.InfoRegistry {
 func TestCollectAllTailers(t *testing.T) {
 
 	container1 := NewTailerContainer[*TestTailer1]()
-	container1.Add(NewTestTaler1("1a"))
-	t1b := NewTestTaler1("1b")
+	container1.Add(NewTestTailer1("1a"))
+	t1b := NewTestTailer1("1b")
 	container1.Add(t1b)
 
 	container2 := NewTailerContainer[*TestTailer2]()
-	container2.Add(NewTestTaler2("2a"))
-	container2.Add(NewTestTaler2("2b"))
+	container2.Add(NewTestTailer2("2a"))
+	container2.Add(NewTestTailer2("2b"))
 
 	tracker := NewTailerTracker()
 	tracker.Add(container1)

--- a/pkg/logs/logs.go
+++ b/pkg/logs/logs.go
@@ -58,7 +58,7 @@ func start() (*Agent, error) {
 	// setup the sources and the services
 	sources := sources.NewLogSources()
 	services := service.NewServices()
-	tailers := tailers.NewTailerTracker()
+	tracker := tailers.NewTailerTracker()
 
 	// setup the server config
 	endpoints, err := buildEndpoints()
@@ -75,7 +75,7 @@ func start() (*Agent, error) {
 	inventories.SetAgentMetadata(inventories.AgentLogsTransport, status.CurrentTransport)
 
 	// setup the status
-	status.Init(isRunning, endpoints, sources, tailers, metrics.LogsExpvars)
+	status.Init(isRunning, endpoints, sources, tracker, metrics.LogsExpvars)
 
 	// setup global processing rules
 	processingRules, err := config.GlobalProcessingRules()
@@ -92,7 +92,7 @@ func start() (*Agent, error) {
 
 	// setup and start the logs agent
 	log.Info("Starting logs-agent...")
-	agent = NewAgent(sources, services, tailers, processingRules, endpoints)
+	agent = NewAgent(sources, services, tracker, processingRules, endpoints)
 
 	agent.Start()
 	isRunning.Store(true)

--- a/pkg/logs/logs.go
+++ b/pkg/logs/logs.go
@@ -13,6 +13,7 @@ import (
 	"go.uber.org/atomic"
 
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/metrics"
+	"github.com/DataDog/datadog-agent/pkg/logs/internal/tailers"
 	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 	"github.com/DataDog/datadog-agent/pkg/metadata/inventories"
 
@@ -57,6 +58,7 @@ func start() (*Agent, error) {
 	// setup the sources and the services
 	sources := sources.NewLogSources()
 	services := service.NewServices()
+	tailers := tailers.NewTailerTracker()
 
 	// setup the server config
 	endpoints, err := buildEndpoints()
@@ -73,7 +75,7 @@ func start() (*Agent, error) {
 	inventories.SetAgentMetadata(inventories.AgentLogsTransport, status.CurrentTransport)
 
 	// setup the status
-	status.Init(isRunning, endpoints, sources, metrics.LogsExpvars)
+	status.Init(isRunning, endpoints, sources, tailers, metrics.LogsExpvars)
 
 	// setup global processing rules
 	processingRules, err := config.GlobalProcessingRules()
@@ -90,7 +92,7 @@ func start() (*Agent, error) {
 
 	// setup and start the logs agent
 	log.Info("Starting logs-agent...")
-	agent = NewAgent(sources, services, processingRules, endpoints)
+	agent = NewAgent(sources, services, tailers, processingRules, endpoints)
 
 	agent.Start()
 	isRunning.Store(true)

--- a/pkg/logs/logs.go
+++ b/pkg/logs/logs.go
@@ -128,12 +128,12 @@ func Flush(ctx context.Context) {
 
 // IsAgentRunning returns true if the logs-agent is running.
 func IsAgentRunning() bool {
-	return status.Get().IsRunning
+	return status.Get(false).IsRunning
 }
 
 // GetStatus returns logs-agent status
-func GetStatus() status.Status {
-	return status.Get()
+func GetStatus(verbose bool) status.Status {
+	return status.Get(verbose)
 }
 
 // GetMessageReceiver returns the diagnostic message receiver

--- a/pkg/logs/sources/source.go
+++ b/pkg/logs/sources/source.go
@@ -41,7 +41,7 @@ type LogSource struct {
 	// that reads log lines for this source. E.g, a sourceType == containerd and Config.Type == file means that
 	// the agent is tailing a file to read logs of a containerd container
 	sourceType SourceType
-	info       map[string]status.InfoProvider
+	info       *status.InfoRegistry
 	// In the case that the source is overridden, keep a reference to the parent for bubbling up information about the child
 	ParentSource *LogSource
 	// LatencyStats tracks internal stats on the time spent by messages from this source in a processing pipeline, i.e.
@@ -61,7 +61,7 @@ func NewLogSource(name string, cfg *config.LogsConfig) *LogSource {
 		lock:             &sync.Mutex{},
 		Messages:         config.NewMessages(),
 		BytesRead:        status.NewCountInfo("Bytes Read"),
-		info:             make(map[string]status.InfoProvider),
+		info:             status.NewInfoRegistry(),
 		LatencyStats:     util.NewStatsTracker(time.Hour*24, time.Hour),
 		hiddenFromStatus: false,
 	}
@@ -113,29 +113,21 @@ func (s *LogSource) GetSourceType() SourceType {
 func (s *LogSource) RegisterInfo(i status.InfoProvider) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
-	s.info[i.InfoKey()] = i
+	s.info.Register(i)
 }
 
 // GetInfo gets an InfoProvider instance by the key
 func (s *LogSource) GetInfo(key string) status.InfoProvider {
 	s.lock.Lock()
 	defer s.lock.Unlock()
-	return s.info[key]
+	return s.info.Get(key)
 }
 
 // GetInfoStatus returns a primitive representation of the info for the status page
 func (s *LogSource) GetInfoStatus() map[string][]string {
 	s.lock.Lock()
 	defer s.lock.Unlock()
-	info := make(map[string][]string)
-
-	for _, v := range s.info {
-		if len(v.Info()) == 0 {
-			continue
-		}
-		info[v.InfoKey()] = v.Info()
-	}
-	return info
+	return s.info.Rendered()
 }
 
 // HideFromStatus hides the source from the status output

--- a/pkg/logs/status/builder.go
+++ b/pkg/logs/status/builder.go
@@ -113,18 +113,19 @@ func (b *Builder) getIntegrations() []Integration {
 
 // getTailers returns all the information about the logs integrations.
 func (b *Builder) getTailers() []Tailer {
-	var tailers []Tailer
-	for _, tailer := range b.tailers.All() {
+	tailers := b.tailers.All()
+	tailerStatus := make([]Tailer, 0, len(tailers))
+	for _, tailer := range tailers {
 
 		info := tailer.GetInfo().Rendered()
 
-		tailers = append(tailers, Tailer{
+		tailerStatus = append(tailerStatus, Tailer{
 			Id:   tailer.GetId(),
 			Type: tailer.GetType(),
 			Info: info,
 		})
 	}
-	return tailers
+	return tailerStatus
 }
 
 // groupSourcesByName groups all logs sources by name so that they get properly displayed

--- a/pkg/logs/status/builder.go
+++ b/pkg/logs/status/builder.go
@@ -30,12 +30,12 @@ type Builder struct {
 }
 
 // NewBuilder returns a new builder.
-func NewBuilder(isRunning *atomic.Bool, endpoints *config.Endpoints, sources *sourcesPkg.LogSources, tailers *tailers.TailerTracker, warnings *config.Messages, errors *config.Messages, logExpVars *expvar.Map) *Builder {
+func NewBuilder(isRunning *atomic.Bool, endpoints *config.Endpoints, sources *sourcesPkg.LogSources, tracker *tailers.TailerTracker, warnings *config.Messages, errors *config.Messages, logExpVars *expvar.Map) *Builder {
 	return &Builder{
 		isRunning:   isRunning,
 		endpoints:   endpoints,
 		sources:     sources,
-		tailers:     tailers,
+		tailers:     tracker,
 		warnings:    warnings,
 		errors:      errors,
 		logsExpVars: logExpVars,

--- a/pkg/logs/status/builder.go
+++ b/pkg/logs/status/builder.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/status"
+	"github.com/DataDog/datadog-agent/pkg/logs/internal/tailers"
 	sourcesPkg "github.com/DataDog/datadog-agent/pkg/logs/sources"
 	"github.com/DataDog/datadog-agent/pkg/util"
 )
@@ -22,17 +23,19 @@ type Builder struct {
 	isRunning   *atomic.Bool
 	endpoints   *config.Endpoints
 	sources     *sourcesPkg.LogSources
+	tailers     *tailers.TailerTracker
 	warnings    *config.Messages
 	errors      *config.Messages
 	logsExpVars *expvar.Map
 }
 
 // NewBuilder returns a new builder.
-func NewBuilder(isRunning *atomic.Bool, endpoints *config.Endpoints, sources *sourcesPkg.LogSources, warnings *config.Messages, errors *config.Messages, logExpVars *expvar.Map) *Builder {
+func NewBuilder(isRunning *atomic.Bool, endpoints *config.Endpoints, sources *sourcesPkg.LogSources, tailers *tailers.TailerTracker, warnings *config.Messages, errors *config.Messages, logExpVars *expvar.Map) *Builder {
 	return &Builder{
 		isRunning:   isRunning,
 		endpoints:   endpoints,
 		sources:     sources,
+		tailers:     tailers,
 		warnings:    warnings,
 		errors:      errors,
 		logsExpVars: logExpVars,
@@ -40,11 +43,16 @@ func NewBuilder(isRunning *atomic.Bool, endpoints *config.Endpoints, sources *so
 }
 
 // BuildStatus returns the status of the logs-agent.
-func (b *Builder) BuildStatus() Status {
+func (b *Builder) BuildStatus(verbose bool) Status {
+	tailers := []Tailer{}
+	if verbose {
+		tailers = b.getTailers()
+	}
 	return Status{
 		IsRunning:        b.getIsRunning(),
 		Endpoints:        b.getEndpoints(),
 		Integrations:     b.getIntegrations(),
+		Tailers:          tailers,
 		StatusMetrics:    b.getMetricsStatus(),
 		ProcessFileStats: b.getProcessFileStats(),
 		Warnings:         b.getWarnings(),
@@ -101,6 +109,22 @@ func (b *Builder) getIntegrations() []Integration {
 		})
 	}
 	return integrations
+}
+
+// getTailers returns all the information about the logs integrations.
+func (b *Builder) getTailers() []Tailer {
+	var tailers []Tailer
+	for _, tailer := range b.tailers.All() {
+
+		info := tailer.GetInfo().Rendered()
+
+		tailers = append(tailers, Tailer{
+			Id:   tailer.GetId(),
+			Type: tailer.GetType(),
+			Info: info,
+		})
+	}
+	return tailers
 }
 
 // groupSourcesByName groups all logs sources by name so that they get properly displayed

--- a/pkg/logs/status/status.go
+++ b/pkg/logs/status/status.go
@@ -72,10 +72,10 @@ type Status struct {
 }
 
 // Init instantiates the builder that builds the status on the fly.
-func Init(isRunning *atomic.Bool, endpoints *config.Endpoints, sources *sources.LogSources, tailers *tailers.TailerTracker, logExpVars *expvar.Map) {
+func Init(isRunning *atomic.Bool, endpoints *config.Endpoints, sources *sources.LogSources, tracker *tailers.TailerTracker, logExpVars *expvar.Map) {
 	warnings = config.NewMessages()
 	errors = config.NewMessages()
-	builder = NewBuilder(isRunning, endpoints, sources, tailers, warnings, errors, logExpVars)
+	builder = NewBuilder(isRunning, endpoints, sources, tracker, warnings, errors, logExpVars)
 }
 
 // Clear clears the status which means it needs to be initialized again to be used.

--- a/pkg/logs/status/status.go
+++ b/pkg/logs/status/status.go
@@ -78,13 +78,13 @@ func Clear() {
 }
 
 // Get returns the status of the logs-agent computed on the fly.
-func Get() Status {
+func Get(verbose bool) Status {
 	if builder == nil {
 		return Status{
 			IsRunning: false,
 		}
 	}
-	return builder.BuildStatus()
+	return builder.BuildStatus(verbose)
 }
 
 // AddGlobalWarning keeps track of a warning message to display on the status.
@@ -111,12 +111,12 @@ func AddGlobalError(key string, errorMessage string) {
 
 func init() {
 	metrics.LogsExpvars.Set("Errors", expvar.Func(func() interface{} {
-		return strings.Join(Get().Errors, ", ")
+		return strings.Join(Get(false).Errors, ", ")
 	}))
 	metrics.LogsExpvars.Set("Warnings", expvar.Func(func() interface{} {
-		return strings.Join(Get().Warnings, ", ")
+		return strings.Join(Get(false).Warnings, ", ")
 	}))
 	metrics.LogsExpvars.Set("IsRunning", expvar.Func(func() interface{} {
-		return Get().IsRunning
+		return Get(false).IsRunning
 	}))
 }

--- a/pkg/logs/status/status.go
+++ b/pkg/logs/status/status.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/metrics"
+	"github.com/DataDog/datadog-agent/pkg/logs/internal/tailers"
 	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 )
 
@@ -45,6 +46,12 @@ type Source struct {
 	Info          map[string][]string    `json:"info"`
 }
 
+type Tailer struct {
+	Id   string              `json:"id"`
+	Type string              `json:"type"`
+	Info map[string][]string `json:"info"`
+}
+
 // Integration provides some information about a logs integration.
 type Integration struct {
 	Name    string   `json:"name"`
@@ -58,16 +65,17 @@ type Status struct {
 	StatusMetrics    map[string]int64  `json:"metrics"`
 	ProcessFileStats map[string]uint64 `json:"process_file_stats"`
 	Integrations     []Integration     `json:"integrations"`
+	Tailers          []Tailer          `json:"tailers"`
 	Errors           []string          `json:"errors"`
 	Warnings         []string          `json:"warnings"`
 	UseHTTP          bool              `json:"use_http"`
 }
 
 // Init instantiates the builder that builds the status on the fly.
-func Init(isRunning *atomic.Bool, endpoints *config.Endpoints, sources *sources.LogSources, logExpVars *expvar.Map) {
+func Init(isRunning *atomic.Bool, endpoints *config.Endpoints, sources *sources.LogSources, tailers *tailers.TailerTracker, logExpVars *expvar.Map) {
 	warnings = config.NewMessages()
 	errors = config.NewMessages()
-	builder = NewBuilder(isRunning, endpoints, sources, warnings, errors, logExpVars)
+	builder = NewBuilder(isRunning, endpoints, sources, tailers, warnings, errors, logExpVars)
 }
 
 // Clear clears the status which means it needs to be initialized again to be used.

--- a/pkg/logs/status/status_test.go
+++ b/pkg/logs/status/status_test.go
@@ -30,7 +30,7 @@ func TestSourceAreGroupedByIntegrations(t *testing.T) {
 	defer Clear()
 	initStatus()
 
-	status := Get()
+	status := Get(false)
 	assert.Equal(t, true, status.IsRunning)
 	assert.Equal(t, 2, len(status.Integrations))
 
@@ -55,11 +55,11 @@ func TestStatusDeduplicateWarnings(t *testing.T) {
 	AddGlobalWarning("foo", "Identical Warning")
 	AddGlobalWarning("foo", "Identical Warning")
 
-	status := Get()
+	status := Get(false)
 	assert.ElementsMatch(t, []string{"Identical Warning", "Unique Warning"}, status.Warnings)
 
 	RemoveGlobalWarning("foo")
-	status = Get()
+	status = Get(false)
 	assert.ElementsMatch(t, []string{"Unique Warning"}, status.Warnings)
 }
 
@@ -71,7 +71,7 @@ func TestStatusDeduplicateErrors(t *testing.T) {
 	AddGlobalError("foo", "Identical Error")
 	AddGlobalError("foo", "Identical Error")
 
-	status := Get()
+	status := Get(false)
 	assert.ElementsMatch(t, []string{"Identical Error", "Unique Error"}, status.Errors)
 }
 
@@ -86,7 +86,7 @@ func TestStatusDeduplicateErrorsAndWarnings(t *testing.T) {
 	AddGlobalError("foo", "Identical Error")
 	AddGlobalError("foo", "Identical Error")
 
-	status := Get()
+	status := Get(false)
 	assert.ElementsMatch(t, []string{"Identical Error", "Unique Error"}, status.Errors)
 	assert.ElementsMatch(t, []string{"Identical Warning", "Unique Warning"}, status.Warnings)
 }
@@ -108,7 +108,7 @@ func TestStatusMetrics(t *testing.T) {
 	defer Clear()
 	initStatus()
 
-	status := Get()
+	status := Get(false)
 	assert.Equal(t, int64(0), status.StatusMetrics["LogsProcessed"])
 	assert.Equal(t, int64(0), status.StatusMetrics["LogsSent"])
 	assert.Equal(t, int64(0), status.StatusMetrics["BytesSent"])
@@ -118,7 +118,7 @@ func TestStatusMetrics(t *testing.T) {
 	metrics.LogsSent.Set(3)
 	metrics.BytesSent.Set(42)
 	metrics.EncodedBytesSent.Set(21)
-	status = Get()
+	status = Get(false)
 
 	assert.Equal(t, int64(5), status.StatusMetrics["LogsProcessed"])
 	assert.Equal(t, int64(3), status.StatusMetrics["LogsSent"])
@@ -127,7 +127,7 @@ func TestStatusMetrics(t *testing.T) {
 
 	metrics.LogsProcessed.Set(math.MaxInt64)
 	metrics.LogsProcessed.Add(1)
-	status = Get()
+	status = Get(false)
 	assert.Equal(t, int64(math.MinInt64), status.StatusMetrics["LogsProcessed"])
 }
 
@@ -135,6 +135,6 @@ func TestStatusEndpoints(t *testing.T) {
 	defer Clear()
 	initStatus()
 
-	status := Get()
+	status := Get(false)
 	assert.Equal(t, "Reliable: Sending uncompressed logs in SSL encrypted TCP to agent-intake.logs.datadoghq.com on port 10516", status.Endpoints[0])
 }

--- a/pkg/logs/status/test_utils.go
+++ b/pkg/logs/status/test_utils.go
@@ -17,7 +17,7 @@ import (
 // InitStatus initialize a status builder
 func InitStatus(sources *sources.LogSources) {
 	var isRunning = atomic.NewBool(true)
-	tailers := tailers.NewTailerTracker()
+	tracker := tailers.NewTailerTracker()
 	endpoints, _ := config.BuildEndpoints(config.HTTPConnectivityFailure, "test-track", "test-proto", "test-source")
-	Init(isRunning, endpoints, sources, tailers, metrics.LogsExpvars)
+	Init(isRunning, endpoints, sources, tracker, metrics.LogsExpvars)
 }

--- a/pkg/logs/status/test_utils.go
+++ b/pkg/logs/status/test_utils.go
@@ -10,12 +10,14 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/metrics"
+	"github.com/DataDog/datadog-agent/pkg/logs/internal/tailers"
 	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 )
 
 // InitStatus initialize a status builder
 func InitStatus(sources *sources.LogSources) {
 	var isRunning = atomic.NewBool(true)
+	tailers := tailers.NewTailerTracker()
 	endpoints, _ := config.BuildEndpoints(config.HTTPConnectivityFailure, "test-track", "test-proto", "test-source")
-	Init(isRunning, endpoints, sources, metrics.LogsExpvars)
+	Init(isRunning, endpoints, sources, tailers, metrics.LogsExpvars)
 }

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -40,7 +40,7 @@ import (
 var timeFormat = "2006-01-02 15:04:05.999 MST"
 
 // GetStatus grabs the status from expvar and puts it into a map
-func GetStatus() (map[string]interface{}, error) {
+func GetStatus(verbose bool) (map[string]interface{}, error) {
 	stats, err := getCommonStatus()
 	if err != nil {
 		return nil, err
@@ -60,7 +60,7 @@ func GetStatus() (map[string]interface{}, error) {
 	stats["JMXStatus"] = GetJMXStatus()
 	stats["JMXStartupError"] = GetJMXStartupError()
 
-	stats["logsStats"] = logs.GetStatus()
+	stats["logsStats"] = logs.GetStatus(verbose)
 
 	stats["otlp"] = GetOTLPStatus()
 
@@ -103,7 +103,7 @@ func GetStatus() (map[string]interface{}, error) {
 
 // GetAndFormatStatus gets and formats the status all in one go
 func GetAndFormatStatus() ([]byte, error) {
-	s, err := GetStatus()
+	s, err := GetStatus(true)
 	if err != nil {
 		return nil, err
 	}
@@ -123,7 +123,7 @@ func GetAndFormatStatus() ([]byte, error) {
 
 // GetCheckStatusJSON gets the status of a single check as JSON
 func GetCheckStatusJSON(c check.Check, cs *check.Stats) ([]byte, error) {
-	s, err := GetStatus()
+	s, err := GetStatus(false)
 	if err != nil {
 		return nil, err
 	}
@@ -155,7 +155,7 @@ func GetCheckStatus(c check.Check, cs *check.Stats) ([]byte, error) {
 }
 
 // GetDCAStatus grabs the status from expvar and puts it into a map
-func GetDCAStatus() (map[string]interface{}, error) {
+func GetDCAStatus(verbose bool) (map[string]interface{}, error) {
 	stats, err := getCommonStatus()
 	if err != nil {
 		return nil, err
@@ -164,7 +164,7 @@ func GetDCAStatus() (map[string]interface{}, error) {
 	stats["config"] = getDCAPartialConfig()
 	stats["leaderelection"] = getLeaderElectionDetails()
 
-	stats["logsStats"] = logs.GetStatus()
+	stats["logsStats"] = logs.GetStatus(verbose)
 
 	endpointsInfos, err := getEndpointsInfos()
 	if endpointsInfos != nil && err == nil {
@@ -211,7 +211,7 @@ func GetDCAStatus() (map[string]interface{}, error) {
 
 // GetAndFormatDCAStatus gets and formats the DCA status all in one go.
 func GetAndFormatDCAStatus() ([]byte, error) {
-	s, err := GetDCAStatus()
+	s, err := GetDCAStatus(true)
 	if err != nil {
 		log.Infof("Error while getting status %q", err)
 		return nil, err
@@ -231,7 +231,7 @@ func GetAndFormatDCAStatus() ([]byte, error) {
 
 // GetAndFormatSecurityAgentStatus gets and formats the security agent status
 func GetAndFormatSecurityAgentStatus(runtimeStatus, complianceStatus map[string]interface{}) ([]byte, error) {
-	s, err := GetStatus()
+	s, err := GetStatus(true)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/status/templates/logsagent.tmpl
+++ b/pkg/status/templates/logsagent.tmpl
@@ -54,6 +54,7 @@ Logs Agent
   {{- end }}
 {{- end }}
 
+{{ if .integrations }}
   ============
   Integrations
   ============
@@ -88,6 +89,7 @@ Logs Agent
       {{- end }}
   {{- end }}
   {{- end }}
+{{- end }}
 {{ if .tailers }}
   =======
   Tailers

--- a/pkg/status/templates/logsagent.tmpl
+++ b/pkg/status/templates/logsagent.tmpl
@@ -54,7 +54,10 @@ Logs Agent
   {{- end }}
 {{- end }}
 
-{{- range .integrations }}
+  ============
+  Integrations
+  ============
+  {{- range .integrations }}
 
   {{ .name }}
   {{ printDashes .name "-" }}
@@ -84,5 +87,24 @@ Logs Agent
       {{- end }}
       {{- end }}
   {{- end }}
-{{- end }}
+  {{- end }}
+{{ if .tailers }}
+  =======
+  Tailers
+  =======
+  {{- range .tailers }}
 
+    - ID: {{ .id }}
+      Type: {{ .type }}
+      {{- if .info }}
+      {{- range $key, $value := .info }} {{ $len := len $value }} {{ if eq $len 1 }}
+      {{$key}}: {{index $value 0}} {{ else }}
+      {{$key}}:
+      {{- range $inf := $value }}
+        {{ $inf }}
+      {{- end }}
+      {{- end }}
+      {{- end }}
+      {{- end }}
+  {{- end }}
+{{- end }}

--- a/releasenotes/notes/add-tailer-stats-5d9a03e918f57bf5.yaml
+++ b/releasenotes/notes/add-tailer-stats-5d9a03e918f57bf5.yaml
@@ -9,5 +9,5 @@
 enhancements:
   - |
     ``agent status -v`` now shows verbose diagnostic information. 
-    Added tailer specific stats to the verbose status page with 
-    improved auto mutli-line detection information.
+    Added tailer-specific stats to the verbose status page with 
+    improved auto multi-line detection information.

--- a/releasenotes/notes/add-tailer-stats-5d9a03e918f57bf5.yaml
+++ b/releasenotes/notes/add-tailer-stats-5d9a03e918f57bf5.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    ``agent status -v`` now shows verbose diagnostic information. 
+    Added tailer specific stats to the verbose status page with 
+    improved auto mutli-line detection information.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This PR adds the ground work to easily display per-tailer stats on the status page when `agent status -v` is used. 

The status page is getting very large, but there is still demand to expose more diagnostics information. This PR adds some needed diagnostics information for auto multi line detection as well as introduces some new constructs to make this easier in the future. 

Some highlights:
- `agent status -v` will always be used when generating a flare. 
- The GUI does not support the verbose flag (I don't think it's needed here, but please let me know if you disagree). 
- Currently only file tailers display verbose stats. I will add diagnostics for other tailers in a followup PR (as this one was getting large). 

This PR is best reviewed commit by commit as there are several important changes that are dependent on one another. 

1. [Add verbose flag to `agent status`](https://github.com/DataDog/datadog-agent/commit/fe9aa2c9b01e5782d1c54ddb31bce7be97242e0e)
2. [Introduce InfoRegistry and update source](https://github.com/DataDog/datadog-agent/pull/16814/commits/7dd5f4be835f1d09c0c151c59844afdbd1a7eb2c)
3. [Introduce TailerTracker and TailerContainer](https://github.com/DataDog/datadog-agent/pull/16814/commits/5a1d2adef29c3818354df99fff5bf765617bd712)
4. [File launcher uses TailerContainer](https://github.com/DataDog/datadog-agent/pull/16814/commits/61877e56f2ab644cf8c2c631a0958a66f87afc3a)
5. [Status page updated with tailer stats](https://github.com/DataDog/datadog-agent/pull/16814/commits/807ac9f66053d53854a98a645e19923d706bf200)
6. [Auto multi line stats added to tailer info](https://github.com/DataDog/datadog-agent/pull/16814/commits/3367ddc9ef3329956a33d2c0eff1fbe83334ce2b)

Details

`TailerTracker` and `TailerContainer` work together to keep an accurate list of all the active tailers in the agent across different launchers. In this PR, it's only actually used by the file tailer (support for other launchers will come next). `TailerContainer` is meant to replace the internal list of tailers within a launcher. `TailerContainer`s also provide read access to the `TailerTracker` when we want to query the tailers for diagnostics. 

`InfoRegistery` is a generalization of what already existed in `LogSource`, but factored out so it can be shared with tailers. It maintains key ordering so items remain consistently ordered on the status page. 


Example of the new tailer status section:
```
  =======
  Tailers
  =======

    - ID: /Users/brian.floersch/scratch/logs/test2.log
      Type: file  
      Auto Multi-line: Waiting for logs   
      Bytes Read: 0 
```

Auto multi line detection mode
```
  =======
  Tailers
  =======

    - ID: /Users/brian.floersch/scratch/logs/test2.log
      Type: file  
      Auto Multi-line:
        State: Using auto multi-line handler
        Detecting (4 of 500)  
      Bytes Read: 1060 
```

Auto multi line detection finished (failed)
```
  =======
  Tailers
  =======

    - ID: /Users/brian.floersch/scratch/logs/test2.log
      Type: file  
      Auto Multi-line:
        State: Using single-line handler
        No pattern met the line match threshold: 0.480000 during multiline auto detection. Top match was ^\s+\[java\]\s*\d{4}-\d{2}-\d{2}\s* with a match ratio of: 0.000000
        Timeout reached. Processed (7 of 500) logs during detection  
      Bytes Read: 1855 
```

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Improve diagnostic experience of the logs agent.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Test file tailing:
- multiple sources
- wild card match
- file rotations

Spot check new auto multi line messages on the status page. 

Spot check existing status page messages for log sources are still correct. 

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
