### PR TITLE
[CWS] fix profiles dir permissions

### DIFF
--- a/pkg/security/security_profile/dump/local_storage.go
+++ b/pkg/security/security_profile/dump/local_storage.go
@@ -83,7 +83,7 @@ func NewActivityDumpLocalStorage(cfg *config.Config) (ActivityDumpStorage, error
 		if err != nil {
 			if os.IsNotExist(err) {
 				files = make([]os.DirEntry, 0)
-				if err = os.MkdirAll(cfg.RuntimeSecurity.ActivityDumpLocalStorageDirectory, 0400); err != nil {
+				if err = os.MkdirAll(cfg.RuntimeSecurity.ActivityDumpLocalStorageDirectory, 0750); err != nil {
 					return nil, fmt.Errorf("couldn't create output directory for cgroup activity dumps: %w", err)
 				}
 			} else {


### PR DESCRIPTION
### What does this PR do?

The default storage path for profiles/local ADs is `/opt/datadog-agent/run/runtime-security/profiles`. If `/opt/datadog-agent/run/` does not exist, the `MkdirAll` will create it with `0400` permission, preventing the creation of `profiles` and returning an error.

This PR fixes the issue by using `0750` perms, the same as in https://github.com/DataDog/datadog-agent/blob/main/pkg/security/security_profile/profile/profile_dir.go#L74
 
### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
