### PR TITLE
inventories: add cloud providers account IDs to inventory

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1104,8 +1104,9 @@ func InitConfig(config Config) {
 
 	// inventories
 	config.BindEnvAndSetDefault("inventories_enabled", true)
-	config.BindEnvAndSetDefault("inventories_configuration_enabled", false)        // controls the agent configurations
-	config.BindEnvAndSetDefault("inventories_checks_configuration_enabled", false) // controls the checks configurations
+	config.BindEnvAndSetDefault("inventories_configuration_enabled", false)            // controls the agent configurations
+	config.BindEnvAndSetDefault("inventories_checks_configuration_enabled", false)     // controls the checks configurations
+	config.BindEnvAndSetDefault("inventories_collect_cloud_provider_account_id", true) // collect collection of `cloud_provider_account_id`
 	// when updating the default here also update pkg/metadata/inventories/README.md
 	config.BindEnvAndSetDefault("inventories_max_interval", DefaultInventoriesMaxInterval) // integer seconds
 	config.BindEnvAndSetDefault("inventories_min_interval", DefaultInventoriesMinInterval) // integer seconds

--- a/pkg/metadata/inventories/README.md
+++ b/pkg/metadata/inventories/README.md
@@ -142,6 +142,7 @@ The payload is a JSON dict with the following fields
     - `DMI`: The Agent successfully used DMI information to fetch the instance ID (only work on EC2 Nitro instances).
     - `UUID`: The hypervisor or product UUID has the EC2 prefix. The Agent knows it's running on EC2 but don't know on
       which instance.
+  - `cloud_provider_account_id` - **string**: The account/subscription ID from the cloud provider.
   - `hypervisor_guest_uuid` - **string**: the hypervisor guest UUID (Unix only, empty string on Windows or if we can't
     read the data). On `ec2` instance this might start by "ec2". This was introduce in `7.41.0`/`6.41.0`.
   - `dmi_product_uuid` - **string**: the DMI product UUID (Unix only, empty string on Windows or if we can't read the

--- a/pkg/metadata/inventories/host_metadata.go
+++ b/pkg/metadata/inventories/host_metadata.go
@@ -53,10 +53,11 @@ type HostMetadata struct {
 	MacAddress  string `json:"mac_address"`
 
 	// from the agent itself
-	AgentVersion        string `json:"agent_version"`
-	CloudProvider       string `json:"cloud_provider"`
-	CloudProviderSource string `json:"cloud_provider_source"`
-	OsVersion           string `json:"os_version"`
+	AgentVersion           string `json:"agent_version"`
+	CloudProvider          string `json:"cloud_provider"`
+	CloudProviderSource    string `json:"cloud_provider_source"`
+	CloudProviderAccountID string `json:"cloud_provider_account_id"`
+	OsVersion              string `json:"os_version"`
 
 	// From file system
 	HypervisorGuestUUID string `json:"hypervisor_guest_uuid"`
@@ -144,6 +145,8 @@ func getHostMetadata() *HostMetadata {
 	metadata.CloudProvider = fetchFromMetadata(string(HostCloudProvider), agentMetadata)
 	metadata.CloudProviderSource = fetchFromMetadata(string(HostCloudProviderSource), hostMetadata)
 	metadata.OsVersion = fetchFromMetadata(string(HostOSVersion), hostMetadata)
+
+	metadata.CloudProviderAccountID = fetchFromMetadata(string(HostCloudProviderAccountID), hostMetadata)
 
 	metadata.HypervisorGuestUUID = dmi.GetHypervisorUUID()
 	metadata.DmiProductUUID = dmi.GetProductUUID()

--- a/pkg/metadata/inventories/inventories.go
+++ b/pkg/metadata/inventories/inventories.go
@@ -107,9 +107,10 @@ const (
 	agentFullConf     AgentMetadataName = "full_configuration"
 
 	// key for the host metadata cache. See host_metadata.go
-	HostOSVersion           AgentMetadataName = "os_version"
-	HostCloudProvider       AgentMetadataName = "cloud_provider"
-	HostCloudProviderSource AgentMetadataName = "cloud_provider_source"
+	HostOSVersion              AgentMetadataName = "os_version"
+	HostCloudProvider          AgentMetadataName = "cloud_provider"
+	HostCloudProviderSource    AgentMetadataName = "cloud_provider_source"
+	HostCloudProviderAccountID AgentMetadataName = "cloud_provider_account_id"
 )
 
 // Refresh signals that some data has been updated and a new payload should be sent (ex: when configuration is changed

--- a/pkg/metadata/inventories/inventories_test.go
+++ b/pkg/metadata/inventories/inventories_test.go
@@ -296,6 +296,7 @@ func TestGetPayload(t *testing.T) {
 			"agent_version": "%v",
 			"cloud_provider": "some_cloud_provider",
 			"cloud_provider_source": "",
+			"cloud_provider_account_id": "",
 			"os_version": "testOS",
 			"hypervisor_guest_uuid": "hypervisorUUID",
 			"dmi_product_uuid": "dmiUUID",

--- a/pkg/util/cloudproviders/azure/azure.go
+++ b/pkg/util/cloudproviders/azure/azure.go
@@ -189,3 +189,21 @@ var publicIPv4Fetcher = cachedfetch.Fetcher{
 func GetPublicIPv4(ctx context.Context) (string, error) {
 	return publicIPv4Fetcher.FetchString(ctx)
 }
+
+var subscriptionIdFetcher = cachedfetch.Fetcher{
+	Name: "Azure Subscription ID",
+	Attempt: func(ctx context.Context) (interface{}, error) {
+		subscriptionID, err := getResponse(ctx,
+			metadataURL+"/metadata/instance/compute/subscriptionId?api-version=2017-04-02&format=text")
+		if err != nil {
+			return "", fmt.Errorf("failed to get Azure Subscription ID: %s", err)
+		}
+
+		return subscriptionID, nil
+	},
+}
+
+// GetSubscriptionID returns the subscription ID of the current Azure instance
+func GetSubscriptionID(ctx context.Context) (string, error) {
+	return subscriptionIdFetcher.FetchString(ctx)
+}

--- a/pkg/util/cloudproviders/cloudproviders.go
+++ b/pkg/util/cloudproviders/cloudproviders.go
@@ -38,7 +38,7 @@ type cloudProviderDetector struct {
 func DetectCloudProvider(ctx context.Context) {
 	detectors := []cloudProviderDetector{
 		{name: ec2.CloudProviderName, callback: ec2.IsRunningOn, accountIdCallback: ec2.GetAccountID},
-		{name: gce.CloudProviderName, callback: gce.IsRunningOn},
+		{name: gce.CloudProviderName, callback: gce.IsRunningOn, accountIdCallback: gce.GetProjectID},
 		{name: azure.CloudProviderName, callback: azure.IsRunningOn},
 		{name: alibaba.CloudProviderName, callback: alibaba.IsRunningOn},
 		{name: tencent.CloudProviderName, callback: tencent.IsRunningOn},

--- a/pkg/util/cloudproviders/cloudproviders.go
+++ b/pkg/util/cloudproviders/cloudproviders.go
@@ -46,13 +46,15 @@ func DetectCloudProvider(ctx context.Context) {
 		{name: ibm.CloudProviderName, callback: ibm.IsRunningOn},
 	}
 
+	collectAccountID := config.Datadog.GetBool("inventories_collect_cloud_provider_account_id")
+
 	for _, cloudDetector := range detectors {
 		if cloudDetector.callback(ctx) {
 			inventories.SetAgentMetadata(inventories.HostCloudProvider, cloudDetector.name)
 			log.Infof("Cloud provider %s detected", cloudDetector.name)
 
 			// fetch the account ID for this cloud provider
-			if cloudDetector.accountIdCallback != nil {
+			if collectAccountID && cloudDetector.accountIdCallback != nil {
 				if accountID, err := cloudDetector.accountIdCallback(ctx); err != nil && accountID != "" {
 					log.Infof("Detecting `%s` from %s cloud provider: %+q", inventories.HostCloudProviderAccountID, cloudDetector.name, accountID)
 					inventories.SetHostMetadata(inventories.HostCloudProviderAccountID, accountID)

--- a/pkg/util/cloudproviders/cloudproviders.go
+++ b/pkg/util/cloudproviders/cloudproviders.go
@@ -55,7 +55,10 @@ func DetectCloudProvider(ctx context.Context) {
 
 			// fetch the account ID for this cloud provider
 			if collectAccountID && cloudDetector.accountIdCallback != nil {
-				if accountID, err := cloudDetector.accountIdCallback(ctx); err != nil && accountID != "" {
+				accountID, err := cloudDetector.accountIdCallback(ctx)
+				if err != nil {
+					log.Debugf("Could not detect cloud provider account ID: %v", err)
+				} else if accountID != "" {
 					log.Infof("Detecting `%s` from %s cloud provider: %+q", inventories.HostCloudProviderAccountID, cloudDetector.name, accountID)
 					inventories.SetHostMetadata(inventories.HostCloudProviderAccountID, accountID)
 				}

--- a/pkg/util/cloudproviders/cloudproviders.go
+++ b/pkg/util/cloudproviders/cloudproviders.go
@@ -39,7 +39,7 @@ func DetectCloudProvider(ctx context.Context) {
 	detectors := []cloudProviderDetector{
 		{name: ec2.CloudProviderName, callback: ec2.IsRunningOn, accountIdCallback: ec2.GetAccountID},
 		{name: gce.CloudProviderName, callback: gce.IsRunningOn, accountIdCallback: gce.GetProjectID},
-		{name: azure.CloudProviderName, callback: azure.IsRunningOn},
+		{name: azure.CloudProviderName, callback: azure.IsRunningOn, accountIdCallback: azure.GetSubscriptionID},
 		{name: alibaba.CloudProviderName, callback: alibaba.IsRunningOn},
 		{name: tencent.CloudProviderName, callback: tencent.IsRunningOn},
 		{name: oracle.CloudProviderName, callback: oracle.IsRunningOn},

--- a/pkg/util/cloudproviders/gce/gce.go
+++ b/pkg/util/cloudproviders/gce/gce.go
@@ -93,6 +93,11 @@ var projectIDFetcher = cachedfetch.Fetcher{
 	},
 }
 
+// GetProjectID returns the project ID of the current GCE instance
+func GetProjectID(ctx context.Context) (string, error) {
+	return projectIDFetcher.FetchString(ctx)
+}
+
 func getInstanceAlias(ctx context.Context, hostname string) (string, error) {
 	instanceName, err := nameFetcher.FetchString(ctx)
 	if err != nil {

--- a/pkg/util/ec2/ec2_account_id.go
+++ b/pkg/util/ec2/ec2_account_id.go
@@ -1,0 +1,30 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build ec2
+// +build ec2
+
+package ec2
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+)
+
+// GetAccountID returns the account ID of the current AWS instance
+func GetAccountID(ctx context.Context) (string, error) {
+	if !config.IsCloudProviderEnabled(CloudProviderName) {
+		return "", fmt.Errorf("cloud provider is disabled by configuration")
+	}
+
+	ec2id, err := getInstanceIdentity(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	return ec2id.AccountID, nil
+}

--- a/pkg/util/ec2/ec2_account_id_unsupported.go
+++ b/pkg/util/ec2/ec2_account_id_unsupported.go
@@ -1,0 +1,19 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !ec2
+// +build !ec2
+
+package ec2
+
+import (
+	"context"
+	"fmt"
+)
+
+// GetAccountID returns the account ID of the current AWS instance
+func GetAccountID(ctx context.Context) (string, error) {
+	return "", fmt.Errorf("ec2 is disabled in the binary")
+}

--- a/pkg/util/ec2/ec2_tags.go
+++ b/pkg/util/ec2/ec2_tags.go
@@ -195,6 +195,7 @@ func GetTags(ctx context.Context) ([]string, error) {
 type ec2Identity struct {
 	Region     string
 	InstanceID string
+	AccountID  string
 }
 
 func getInstanceIdentity(ctx context.Context) (*ec2Identity, error) {

--- a/pkg/util/ec2/ec2_tags_test.go
+++ b/pkg/util/ec2/ec2_tags_test.go
@@ -90,6 +90,7 @@ func TestGetInstanceIdentity(t *testing.T) {
 	require.Nil(t, err)
 	assert.Equal(t, "us-east-1", val.Region)
 	assert.Equal(t, "i-aaaaaaaaaaaaaaaaa", val.InstanceID)
+	assert.Equal(t, "REMOVED", val.AccountID)
 }
 
 func TestFetchEc2TagsFromIMDS(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

This PR adds AWS account ID, GCP project ID and Azure subscription ID to the host metadata inventories.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

The agent should be deployed on AWS, GCP and Azure infrastructure. The host metadata in the inventory should then be checked for present and valid account ID.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
