### PR TITLE
Allow individual control of TCPv6 and UDPv6

### DIFF
--- a/pkg/network/driver_interface.go
+++ b/pkg/network/driver_interface.go
@@ -459,7 +459,7 @@ func (di *DriverInterface) setFlowParams() error {
 func (di *DriverInterface) createFlowHandleFilters() ([]driver.FilterDefinition, error) {
 	var filters []driver.FilterDefinition
 	log.Debugf("Creating filters for all interfaces")
-	if di.cfg.CollectTCPConns {
+	if di.cfg.CollectTCPv4Conns {
 		filters = append(filters, driver.FilterDefinition{
 			FilterVersion:  driver.Signature,
 			Size:           driver.FilterDefinitionSize,
@@ -477,28 +477,28 @@ func (di *DriverInterface) createFlowHandleFilters() ([]driver.FilterDefinition,
 			Af:             windows.AF_INET,
 			Protocol:       windows.IPPROTO_TCP,
 		})
-		if di.cfg.CollectIPv6Conns {
-			filters = append(filters, driver.FilterDefinition{
-				FilterVersion:  driver.Signature,
-				Size:           driver.FilterDefinitionSize,
-				Direction:      driver.DirectionOutbound,
-				FilterLayer:    driver.LayerTransport,
-				InterfaceIndex: uint64(0),
-				Af:             windows.AF_INET6,
-				Protocol:       windows.IPPROTO_TCP,
-			}, driver.FilterDefinition{
-				FilterVersion:  driver.Signature,
-				Size:           driver.FilterDefinitionSize,
-				Direction:      driver.DirectionInbound,
-				FilterLayer:    driver.LayerTransport,
-				InterfaceIndex: uint64(0),
-				Af:             windows.AF_INET6,
-				Protocol:       windows.IPPROTO_TCP,
-			})
-		}
+	}
+	if di.cfg.CollectTCPv6Conns {
+		filters = append(filters, driver.FilterDefinition{
+			FilterVersion:  driver.Signature,
+			Size:           driver.FilterDefinitionSize,
+			Direction:      driver.DirectionOutbound,
+			FilterLayer:    driver.LayerTransport,
+			InterfaceIndex: uint64(0),
+			Af:             windows.AF_INET6,
+			Protocol:       windows.IPPROTO_TCP,
+		}, driver.FilterDefinition{
+			FilterVersion:  driver.Signature,
+			Size:           driver.FilterDefinitionSize,
+			Direction:      driver.DirectionInbound,
+			FilterLayer:    driver.LayerTransport,
+			InterfaceIndex: uint64(0),
+			Af:             windows.AF_INET6,
+			Protocol:       windows.IPPROTO_TCP,
+		})
 	}
 
-	if di.cfg.CollectUDPConns {
+	if di.cfg.CollectUDPv4Conns {
 		filters = append(filters, driver.FilterDefinition{
 			FilterVersion:  driver.Signature,
 			Size:           driver.FilterDefinitionSize,
@@ -516,25 +516,25 @@ func (di *DriverInterface) createFlowHandleFilters() ([]driver.FilterDefinition,
 			Af:             windows.AF_INET,
 			Protocol:       windows.IPPROTO_UDP,
 		})
-		if di.cfg.CollectIPv6Conns {
-			filters = append(filters, driver.FilterDefinition{
-				FilterVersion:  driver.Signature,
-				Size:           driver.FilterDefinitionSize,
-				Direction:      driver.DirectionOutbound,
-				FilterLayer:    driver.LayerTransport,
-				InterfaceIndex: uint64(0),
-				Af:             windows.AF_INET6,
-				Protocol:       windows.IPPROTO_UDP,
-			}, driver.FilterDefinition{
-				FilterVersion:  driver.Signature,
-				Size:           driver.FilterDefinitionSize,
-				Direction:      driver.DirectionInbound,
-				FilterLayer:    driver.LayerTransport,
-				InterfaceIndex: uint64(0),
-				Af:             windows.AF_INET6,
-				Protocol:       windows.IPPROTO_UDP,
-			})
-		}
+	}
+	if di.cfg.CollectUDPv6Conns {
+		filters = append(filters, driver.FilterDefinition{
+			FilterVersion:  driver.Signature,
+			Size:           driver.FilterDefinitionSize,
+			Direction:      driver.DirectionOutbound,
+			FilterLayer:    driver.LayerTransport,
+			InterfaceIndex: uint64(0),
+			Af:             windows.AF_INET6,
+			Protocol:       windows.IPPROTO_UDP,
+		}, driver.FilterDefinition{
+			FilterVersion:  driver.Signature,
+			Size:           driver.FilterDefinitionSize,
+			Direction:      driver.DirectionInbound,
+			FilterLayer:    driver.LayerTransport,
+			InterfaceIndex: uint64(0),
+			Af:             windows.AF_INET6,
+			Protocol:       windows.IPPROTO_UDP,
+		})
 	}
 
 	return filters, nil

--- a/pkg/network/ebpf/c/conntrack-helpers.h
+++ b/pkg/network/ebpf/c/conntrack-helpers.h
@@ -70,7 +70,7 @@ static __always_inline int nf_conntrack_tuple_to_conntrack_tuple(conntrack_tuple
             log_debug("ERR(to_conn_tuple.v4): src/dst addr not set src:%u, dst:%u\n", t->saddr_l, t->daddr_l);
             return 0;
         }
-    } else if (ct->src.l3num == AF_INET6 && is_ipv6_enabled()) {
+    } else if (ct->src.l3num == AF_INET6 && (is_tcpv6_enabled() || is_udpv6_enabled())) {
         t->metadata |= CONN_V6;
         read_in6_addr(&t->saddr_h, &t->saddr_l, &ct->src.u3.in6);
         read_in6_addr(&t->daddr_h, &t->daddr_l, &ct->dst.u3.in6);

--- a/pkg/network/ebpf/c/ipv6.h
+++ b/pkg/network/ebpf/c/ipv6.h
@@ -38,16 +38,30 @@ static __always_inline void read_in6_addr(u64 *addr_h, u64 *addr_l, const struct
 #endif
 }
 
-static __maybe_unused __always_inline bool is_ipv6_enabled() {
+static __maybe_unused __always_inline bool is_tcpv6_enabled() {
 #ifdef COMPILE_RUNTIME
-#ifdef FEATURE_IPV6_ENABLED
+#ifdef FEATURE_TCPV6_ENABLED
     return true;
 #else
     return false;
 #endif
 #else
     __u64 val = 0;
-    LOAD_CONSTANT("ipv6_enabled", val);
+    LOAD_CONSTANT("tcpv6_enabled", val);
+    return val == ENABLED;
+#endif
+}
+
+static __maybe_unused __always_inline bool is_udpv6_enabled() {
+#ifdef COMPILE_RUNTIME
+#ifdef FEATURE_UDPV6_ENABLED
+    return true;
+#else
+    return false;
+#endif
+#else
+    __u64 val = 0;
+    LOAD_CONSTANT("udpv6_enabled", val);
     return val == ENABLED;
 #endif
 }

--- a/pkg/network/ebpf/c/prebuilt/offset-guess.h
+++ b/pkg/network/ebpf/c/prebuilt/offset-guess.h
@@ -101,7 +101,8 @@ typedef struct {
     __u16 network_header;
     __u16 mac_header;
 
-    __u8 ipv6_enabled;
+    __u8 tcpv6_enabled;
+    __u8 udpv6_enabled;
     __u8 fl4_offsets;
     __u8 fl6_offsets;
 

--- a/pkg/network/ebpf/c/prebuilt/offset-guess.h
+++ b/pkg/network/ebpf/c/prebuilt/offset-guess.h
@@ -101,8 +101,6 @@ typedef struct {
     __u16 network_header;
     __u16 mac_header;
 
-    __u8 tcpv6_enabled;
-    __u8 udpv6_enabled;
     __u8 fl4_offsets;
     __u8 fl6_offsets;
 

--- a/pkg/network/ebpf/c/runtime/conntrack.c
+++ b/pkg/network/ebpf/c/runtime/conntrack.c
@@ -15,7 +15,7 @@
 #include "netns.h"
 #include "ip.h"
 
-#ifdef FEATURE_IPV6_ENABLED
+#if defined(FEATURE_TCPV6_ENABLED) || defined(FEATURE_UDPV6_ENABLED)
 #include "ipv6.h"
 #endif
 

--- a/pkg/network/ebpf/c/runtime/offsetguess-test.c
+++ b/pkg/network/ebpf/c/runtime/offsetguess-test.c
@@ -90,7 +90,7 @@ int kprobe__tcp_getsockopt(struct pt_regs* ctx) {
     offset = offsetof(struct tcp_sock, mdev_us);
     bpf_map_update_elem(&offsets, &o, &offset, BPF_ANY);
 
-#ifdef FEATURE_IPV6_ENABLED
+#if defined(FEATURE_TCPV6_ENABLED) || defined(FEATURE_UDPV6_ENABLED)
     o = OFFSET_DADDR_IPV6;
     offset = offsetof(struct sock, sk_v6_daddr);
     bpf_map_update_elem(&offsets, &o, &offset, BPF_ANY);
@@ -112,7 +112,7 @@ int kprobe__tcp_getsockopt(struct pt_regs* ctx) {
     offset = offsetof(struct flowi4, fl4_dport);
     bpf_map_update_elem(&offsets, &o, &offset, BPF_ANY);
 
-#ifdef FEATURE_IPV6_ENABLED
+#ifdef FEATURE_UDPV6_ENABLED
     o = OFFSET_SADDR_FL6;
     offset = offsetof(struct flowi6, saddr);
     bpf_map_update_elem(&offsets, &o, &offset, BPF_ANY);

--- a/pkg/network/ebpf/c/skb.h
+++ b/pkg/network/ebpf/c/skb.h
@@ -118,8 +118,8 @@ static __always_inline int sk_buff_to_tuple(struct sk_buff *skb, conn_tuple_t *t
         bpf_probe_read_kernel_with_telemetry(&tup->saddr_l, sizeof(__be32), &iph.saddr);
         bpf_probe_read_kernel_with_telemetry(&tup->daddr_l, sizeof(__be32), &iph.daddr);
     }
-#if !defined(COMPILE_RUNTIME) || defined(FEATURE_IPV6_ENABLED)
-    else if (is_ipv6_enabled() && iph.version == 6) {
+#if !defined(COMPILE_RUNTIME) || defined(FEATURE_TCPV6_ENABLED) || defined(FEATURE_UDPV6_ENABLED)
+    else if ((is_tcpv6_enabled() || is_udpv6_enabled()) && iph.version == 6) {
         struct ipv6hdr ip6h;
         bpf_memset(&ip6h, 0, sizeof(struct ipv6hdr));
         ret = bpf_probe_read_kernel_with_telemetry(&ip6h, sizeof(ip6h), (struct ipv6hdr *)(head + net_head));
@@ -144,7 +144,7 @@ static __always_inline int sk_buff_to_tuple(struct sk_buff *skb, conn_tuple_t *t
         read_in6_addr(&tup->saddr_h, &tup->saddr_l, &ip6h.saddr);
         read_in6_addr(&tup->daddr_h, &tup->daddr_l, &ip6h.daddr);
     }
-#endif // !COMPILE_RUNTIME || FEATURE_IPV6_ENABLED
+#endif // !COMPILE_RUNTIME || FEATURE_TCPV6_ENABLED || FEATURE_UDPV6_ENABLED
     else {
         log_debug("unknown IP version: %d\n", iph.version);
         return 0;

--- a/pkg/network/ebpf/c/sock.h
+++ b/pkg/network/ebpf/c/sock.h
@@ -201,7 +201,7 @@ static __always_inline int read_conn_tuple_partial(conn_tuple_t* t, struct sock*
             err = 1;
         }
     } else if (family == AF_INET6) {
-        if (!is_ipv6_enabled()) {
+        if (!is_tcpv6_enabled() && !is_udpv6_enabled()) {
             return 0;
         }
 

--- a/pkg/network/ebpf/c/tracer.c
+++ b/pkg/network/ebpf/c/tracer.c
@@ -232,7 +232,7 @@ int kretprobe__tcp_close_flush(struct pt_regs *ctx) {
     return 0;
 }
 
-#if !defined(COMPILE_RUNTIME) || defined(FEATURE_TCPV6_ENABLED) || defined(FEATURE_UDPV6_ENABLED)
+#if !defined(COMPILE_RUNTIME) || defined(FEATURE_UDPV6_ENABLED)
 
 static __always_inline void fl6_saddr(struct flowi6 *fl6, u64 *addr_h, u64 *addr_l) {
     if (!fl6 || !addr_h || !addr_l) {
@@ -409,7 +409,7 @@ int kretprobe__ip6_make_skb(struct pt_regs *ctx) {
     return handle_ip6_skb(sk, size, fl6);
 }
 
-#endif // !COMPILE_RUNTIME || FEATURE_IVP6_ENABLED
+#endif // !COMPILE_RUNTIME || FEATURE_UDPV6_ENABLED
 
 
 static __always_inline u32 fl4_saddr(struct flowi4 *fl4) {
@@ -567,7 +567,7 @@ int kprobe__udp_recvmsg(struct pt_regs *ctx) {
     handle_udp_recvmsg(sk, msg, flags, udp_recv_sock);
 }
 
-#if !defined(COMPILE_RUNTIME) || defined(FEATURE_TCPV6_ENABLED) || defined(FEATURE_UDPV6_ENABLED)
+#if !defined(COMPILE_RUNTIME) || defined(FEATURE_UDPV6_ENABLED)
 SEC("kprobe/udpv6_recvmsg")
 int kprobe__udpv6_recvmsg(struct pt_regs *ctx) {
 #if defined(COMPILE_RUNTIME) && LINUX_VERSION_CODE < KERNEL_VERSION(4, 1, 0)
@@ -581,7 +581,7 @@ int kprobe__udpv6_recvmsg(struct pt_regs *ctx) {
     struct msghdr *msg = NULL;
     handle_udp_recvmsg(sk, msg, flags, udp_recv_sock);
 }
-#endif // !COMPILE_RUNTIME || defined(FEATURE_TCPV6_ENABLED) || defined(FEATURE_UDPV6_ENABLED)
+#endif // !COMPILE_RUNTIME || defined(FEATURE_UDPV6_ENABLED)
 
 static __always_inline int handle_udp_recvmsg_ret() {
     u64 pid_tgid = bpf_get_current_pid_tgid();
@@ -594,12 +594,12 @@ int kretprobe__udp_recvmsg(struct pt_regs *ctx) {
     return handle_udp_recvmsg_ret();
 }
 
-#if !defined(COMPILE_RUNTIME) || defined(FEATURE_TCPV6_ENABLED) || defined(FEATURE_UDPV6_ENABLED)
+#if !defined(COMPILE_RUNTIME) || defined(FEATURE_UDPV6_ENABLED)
 SEC("kretprobe/udpv6_recvmsg")
 int kretprobe__udpv6_recvmsg(struct pt_regs *ctx) {
     return handle_udp_recvmsg_ret();
 }
-#endif // !COMPILE_RUNTIME || defined(FEATURE_TCPV6_ENABLED) || defined(FEATURE_UDPV6_ENABLED)
+#endif // !COMPILE_RUNTIME || defined(FEATURE_UDPV6_ENABLED)
 
 #if defined(COMPILE_CORE) || defined(COMPILE_PREBUILT)
 

--- a/pkg/network/ebpf/c/tracer.c
+++ b/pkg/network/ebpf/c/tracer.c
@@ -232,7 +232,7 @@ int kretprobe__tcp_close_flush(struct pt_regs *ctx) {
     return 0;
 }
 
-#if !defined(COMPILE_RUNTIME) || defined(FEATURE_IPV6_ENABLED)
+#if !defined(COMPILE_RUNTIME) || defined(FEATURE_TCPV6_ENABLED) || defined(FEATURE_UDPV6_ENABLED)
 
 static __always_inline void fl6_saddr(struct flowi6 *fl6, u64 *addr_h, u64 *addr_l) {
     if (!fl6 || !addr_h || !addr_l) {
@@ -567,7 +567,7 @@ int kprobe__udp_recvmsg(struct pt_regs *ctx) {
     handle_udp_recvmsg(sk, msg, flags, udp_recv_sock);
 }
 
-#if !defined(COMPILE_RUNTIME) || defined(FEATURE_IPV6_ENABLED)
+#if !defined(COMPILE_RUNTIME) || defined(FEATURE_TCPV6_ENABLED) || defined(FEATURE_UDPV6_ENABLED)
 SEC("kprobe/udpv6_recvmsg")
 int kprobe__udpv6_recvmsg(struct pt_regs *ctx) {
 #if defined(COMPILE_RUNTIME) && LINUX_VERSION_CODE < KERNEL_VERSION(4, 1, 0)
@@ -581,7 +581,7 @@ int kprobe__udpv6_recvmsg(struct pt_regs *ctx) {
     struct msghdr *msg = NULL;
     handle_udp_recvmsg(sk, msg, flags, udp_recv_sock);
 }
-#endif // !COMPILE_RUNTIME || FEATURE_IPV6_ENABLED
+#endif // !COMPILE_RUNTIME || defined(FEATURE_TCPV6_ENABLED) || defined(FEATURE_UDPV6_ENABLED)
 
 static __always_inline int handle_udp_recvmsg_ret() {
     u64 pid_tgid = bpf_get_current_pid_tgid();
@@ -594,12 +594,12 @@ int kretprobe__udp_recvmsg(struct pt_regs *ctx) {
     return handle_udp_recvmsg_ret();
 }
 
-#if !defined(COMPILE_RUNTIME) || defined(FEATURE_IPV6_ENABLED)
+#if !defined(COMPILE_RUNTIME) || defined(FEATURE_TCPV6_ENABLED) || defined(FEATURE_UDPV6_ENABLED)
 SEC("kretprobe/udpv6_recvmsg")
 int kretprobe__udpv6_recvmsg(struct pt_regs *ctx) {
     return handle_udp_recvmsg_ret();
 }
-#endif // !COMPILE_RUNTIME || FEATURE_IPV6_ENABLED
+#endif // !COMPILE_RUNTIME || defined(FEATURE_TCPV6_ENABLED) || defined(FEATURE_UDPV6_ENABLED)
 
 #if defined(COMPILE_CORE) || defined(COMPILE_PREBUILT)
 
@@ -933,9 +933,7 @@ int kprobe__inet_csk_listen_stop(struct pt_regs *ctx) {
     return 0;
 }
 
-SEC("kprobe/udp_destroy_sock")
-int kprobe__udp_destroy_sock(struct pt_regs *ctx) {
-    struct sock *skp = (struct sock *)PT_REGS_PARM1(ctx);
+static __always_inline int handle_udp_destroy_sock(struct sock *skp) {
     conn_tuple_t tup = {};
     u64 pid_tgid = bpf_get_current_pid_tgid();
     int valid_tuple = read_conn_tuple(&tup, skp, pid_tgid, CONN_TYPE_UDP);
@@ -963,8 +961,25 @@ int kprobe__udp_destroy_sock(struct pt_regs *ctx) {
     return 0;
 }
 
+SEC("kprobe/udp_destroy_sock")
+int kprobe__udp_destroy_sock(struct pt_regs *ctx) {
+    struct sock *sk = (struct sock *)PT_REGS_PARM1(ctx);
+    return handle_udp_destroy_sock(sk);
+}
+
+SEC("kprobe/udpv6_destroy_sock")
+int kprobe__udpv6_destroy_sock(struct pt_regs *ctx) {
+    struct sock *sk = (struct sock *)PT_REGS_PARM1(ctx);
+    return handle_udp_destroy_sock(sk);
+}
+
 SEC("kretprobe/udp_destroy_sock")
 int kretprobe__udp_destroy_sock(struct pt_regs *ctx) {
+    flush_conn_close_if_full(ctx);
+    return 0;
+}
+SEC("kretprobe/udpv6_destroy_sock")
+int kretprobe__udpv6_destroy_sock(struct pt_regs *ctx) {
     flush_conn_close_if_full(ctx);
     return 0;
 }

--- a/pkg/network/ebpf/probes/probes.go
+++ b/pkg/network/ebpf/probes/probes.go
@@ -137,6 +137,9 @@ const (
 	// UDPDestroySockReturn traces the return of the udp_destroy_sock() system call
 	UDPDestroySockReturn ProbeFuncName = "kretprobe__udp_destroy_sock"
 
+	UDPv6DestroySock       ProbeFuncName = "kprobe__udpv6_destroy_sock"
+	UDPv6DestroySockReturn ProbeFuncName = "kretprobe__udpv6_destroy_sock"
+
 	// TCPRetransmit traces the params for the tcp_retransmit_skb() system call
 	TCPRetransmit ProbeFuncName = "kprobe__tcp_retransmit_skb"
 	// TCPRetransmitPre470 traces the params for the tcp_retransmit_skb() system call on kernel version < 4.7

--- a/pkg/network/java/testdata/.gitignore
+++ b/pkg/network/java/testdata/.gitignore
@@ -1,0 +1,1 @@
+TestAgentLoaded.agentmain.*

--- a/pkg/network/tracer/compile.go
+++ b/pkg/network/tracer/compile.go
@@ -24,8 +24,11 @@ func getRuntimeCompiledConntracker(config *config.Config) (runtime.CompiledOutpu
 func getCFlags(config *config.Config) []string {
 	cflags := []string{"-g"}
 
-	if config.CollectIPv6Conns {
-		cflags = append(cflags, "-DFEATURE_IPV6_ENABLED")
+	if config.CollectTCPv6Conns {
+		cflags = append(cflags, "-DFEATURE_TCPV6_ENABLED")
+	}
+	if config.CollectUDPv6Conns {
+		cflags = append(cflags, "-DFEATURE_UDPV6_ENABLED")
 	}
 	if config.BPFDebug {
 		cflags = append(cflags, "-DDEBUG=1")

--- a/pkg/network/tracer/connection/kprobe/compile.go
+++ b/pkg/network/tracer/connection/kprobe/compile.go
@@ -24,8 +24,11 @@ func getRuntimeCompiledTracer(config *config.Config) (runtime.CompiledOutput, er
 func getCFlags(config *config.Config) []string {
 	cflags := []string{"-g"}
 
-	if config.CollectIPv6Conns {
-		cflags = append(cflags, "-DFEATURE_IPV6_ENABLED")
+	if config.CollectTCPv6Conns {
+		cflags = append(cflags, "-DFEATURE_TCPV6_ENABLED")
+	}
+	if config.CollectUDPv6Conns {
+		cflags = append(cflags, "-DFEATURE_UDPV6_ENABLED")
 	}
 	if config.BPFDebug {
 		cflags = append(cflags, "-DDEBUG=1")

--- a/pkg/network/tracer/connection/kprobe/config.go
+++ b/pkg/network/tracer/connection/kprobe/config.go
@@ -34,7 +34,7 @@ func enabledProbes(c *config.Config, runtimeTracer, coreTracer bool) (map[probes
 		return nil, err
 	}
 
-	if c.CollectTCPConns {
+	if c.CollectTCPv4Conns || c.CollectTCPv6Conns {
 		if ClassificationSupported(c) {
 			enableProbe(enabled, probes.ProtocolClassifierEntrySocketFilter)
 			enableProbe(enabled, probes.ProtocolClassifierQueuesSocketFilter)
@@ -72,7 +72,7 @@ func enabledProbes(c *config.Config, runtimeTracer, coreTracer bool) (map[probes
 		}
 	}
 
-	if c.CollectUDPConns {
+	if c.CollectUDPv4Conns {
 		enableProbe(enabled, probes.UDPDestroySock)
 		enableProbe(enabled, probes.UDPDestroySockReturn)
 		enableProbe(enabled, probes.IPMakeSkb)
@@ -91,42 +91,54 @@ func enabledProbes(c *config.Config, runtimeTracer, coreTracer bool) (map[probes
 			enableProbe(enabled, probes.UDPRecvMsgPre410)
 		}
 		enableProbe(enabled, selectVersionBasedProbe(runtimeTracer || coreTracer, kv, probes.UDPRecvMsgReturn, probes.UDPRecvMsgReturnPre470, kv470))
-		if c.CollectIPv6Conns {
-			enableProbe(enabled, selectVersionBasedProbe(runtimeTracer, kv, probes.IP6MakeSkb, probes.IP6MakeSkbPre470, kv470))
-			if kv >= kv5190 || runtimeTracer {
-				enableProbe(enabled, probes.UDPv6RecvMsg)
-			} else if kv >= kv470 {
-				enableProbe(enabled, probes.UDPv6RecvMsgPre5190)
-			} else if kv >= kv410 {
-				enableProbe(enabled, probes.UDPv6RecvMsgPre470)
-			} else {
-				enableProbe(enabled, probes.UDPv6RecvMsgPre410)
-			}
-			enableProbe(enabled, selectVersionBasedProbe(runtimeTracer || coreTracer, kv, probes.UDPv6RecvMsgReturn, probes.UDPv6RecvMsgReturnPre470, kv470))
-			enableProbe(enabled, probes.IP6MakeSkbReturn)
-			enableProbe(enabled, probes.Inet6Bind)
-			enableProbe(enabled, probes.Inet6BindRet)
+	}
+
+	if c.CollectUDPv6Conns {
+		enableProbe(enabled, probes.UDPv6DestroySock)
+		enableProbe(enabled, probes.UDPv6DestroySockReturn)
+		enableProbe(enabled, selectVersionBasedProbe(runtimeTracer, kv, probes.IP6MakeSkb, probes.IP6MakeSkbPre470, kv470))
+		enableProbe(enabled, probes.IP6MakeSkbReturn)
+		enableProbe(enabled, probes.Inet6Bind)
+		enableProbe(enabled, probes.Inet6BindRet)
+		enableProbe(enabled, probes.UDPSendPage)
+		enableProbe(enabled, probes.UDPSendPageReturn)
+		if kv >= kv5190 || runtimeTracer {
+			enableProbe(enabled, probes.UDPv6RecvMsg)
+		} else if kv >= kv470 {
+			enableProbe(enabled, probes.UDPv6RecvMsgPre5190)
+		} else if kv >= kv410 {
+			enableProbe(enabled, probes.UDPv6RecvMsgPre470)
+		} else {
+			enableProbe(enabled, probes.UDPv6RecvMsgPre410)
 		}
+		enableProbe(enabled, selectVersionBasedProbe(runtimeTracer || coreTracer, kv, probes.UDPv6RecvMsgReturn, probes.UDPv6RecvMsgReturnPre470, kv470))
+	}
 
-		if runtimeTracer || coreTracer || kv >= kv470 {
-			missing, err := ebpf.VerifyKernelFuncs("skb_consume_udp", "__skb_free_datagram_locked", "skb_free_datagram_locked")
-			if err != nil {
-				return nil, fmt.Errorf("error verifying kernel function presence: %s", err)
-			}
-
-			if _, miss := missing["skb_consume_udp"]; !miss {
-				enableProbe(enabled, probes.SKBConsumeUDP)
-			} else if _, miss := missing["__skb_free_datagram_locked"]; !miss {
-				enableProbe(enabled, probes.UnderscoredSKBFreeDatagramLocked)
-			} else if _, miss := missing["skb_free_datagram_locked"]; !miss {
-				enableProbe(enabled, probes.SKBFreeDatagramLocked)
-			} else {
-				return nil, fmt.Errorf("missing desired UDP receive kernel functions")
-			}
+	if (c.CollectUDPv4Conns || c.CollectUDPv6Conns) && (runtimeTracer || coreTracer || kv >= kv470) {
+		if err := enableAdvancedUDP(enabled); err != nil {
+			return nil, err
 		}
 	}
 
 	return enabled, nil
+}
+
+func enableAdvancedUDP(enabled map[probes.ProbeFuncName]struct{}) error {
+	missing, err := ebpf.VerifyKernelFuncs("skb_consume_udp", "__skb_free_datagram_locked", "skb_free_datagram_locked")
+	if err != nil {
+		return fmt.Errorf("error verifying kernel function presence: %s", err)
+	}
+
+	if _, miss := missing["skb_consume_udp"]; !miss {
+		enableProbe(enabled, probes.SKBConsumeUDP)
+	} else if _, miss := missing["__skb_free_datagram_locked"]; !miss {
+		enableProbe(enabled, probes.UnderscoredSKBFreeDatagramLocked)
+	} else if _, miss := missing["skb_free_datagram_locked"]; !miss {
+		enableProbe(enabled, probes.SKBFreeDatagramLocked)
+	} else {
+		return fmt.Errorf("missing desired UDP receive kernel functions")
+	}
+	return nil
 }
 
 func selectVersionBasedProbe(runtimeTracer bool, kv kernel.Version, dfault probes.ProbeFuncName, versioned probes.ProbeFuncName, reqVer kernel.Version) probes.ProbeFuncName {

--- a/pkg/network/tracer/connection/kprobe/manager.go
+++ b/pkg/network/tracer/connection/kprobe/manager.go
@@ -58,6 +58,8 @@ var mainProbes = []probes.ProbeFuncName{
 	probes.InetCskListenStop,
 	probes.UDPDestroySock,
 	probes.UDPDestroySockReturn,
+	probes.UDPv6DestroySock,
+	probes.UDPv6DestroySockReturn,
 	probes.InetBind,
 	probes.Inet6Bind,
 	probes.InetBindRet,

--- a/pkg/network/tracer/connection/kprobe/tracer.go
+++ b/pkg/network/tracer/connection/kprobe/tracer.go
@@ -14,6 +14,8 @@ import (
 
 	"github.com/cilium/ebpf"
 
+	manager "github.com/DataDog/ebpf-manager"
+
 	ddebpf "github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/ebpf/bytecode"
 	"github.com/DataDog/datadog-agent/pkg/metadata/host"
@@ -24,7 +26,6 @@ import (
 	errtelemetry "github.com/DataDog/datadog-agent/pkg/network/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	manager "github.com/DataDog/ebpf-manager"
 )
 
 const probeUID = "net"
@@ -84,7 +85,7 @@ func ClassificationSupported(config *config.Config) bool {
 	if !config.ProtocolClassificationEnabled {
 		return false
 	}
-	if !config.CollectTCPConns {
+	if !config.CollectTCPv4Conns && !config.CollectTCPv6Conns {
 		return false
 	}
 	currentKernelVersion, err := kernel.HostVersion()
@@ -134,6 +135,8 @@ func LoadTracer(config *config.Config, m *manager.Manager, mgrOpts manager.Optio
 			if err == nil || errors.As(err, &ve) {
 				return closeFn, TracerTypeCORE, err
 			}
+			// do not use offset guessing constants with runtime compilation
+			mgrOpts.ConstantEditors = nil
 		}
 
 		if !config.AllowRuntimeCompiledFallback {
@@ -283,6 +286,15 @@ func loadPrebuiltTracer(config *config.Config, m *manager.Manager, mgrOpts manag
 		return nil, fmt.Errorf("could not read bpf module: %w", err)
 	}
 	defer buf.Close()
+
+	kv, err := kernel.HostVersion()
+	if err != nil {
+		return nil, fmt.Errorf("kernel version: %s", err)
+	}
+	// prebuilt on 5.18+ cannot support UDPv6
+	if kv >= kernel.VersionCode(5, 18, 0) {
+		config.CollectUDPv6Conns = false
+	}
 
 	return loadTracerFromAsset(buf, false, false, config, m, mgrOpts, perfHandlerTCP)
 }

--- a/pkg/network/tracer/offsetguess/conntrack.go
+++ b/pkg/network/tracer/offsetguess/conntrack.go
@@ -20,31 +20,35 @@ import (
 	"github.com/cilium/ebpf"
 	"github.com/vishvananda/netns"
 
+	manager "github.com/DataDog/ebpf-manager"
+
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 	"github.com/DataDog/datadog-agent/pkg/network/ebpf/probes"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	manager "github.com/DataDog/ebpf-manager"
 )
 
 // sizeof(struct nf_conntrack_tuple), see https://github.com/torvalds/linux/blob/master/include/net/netfilter/nf_conntrack_tuple.h
 const sizeofNfConntrackTuple = 40
 
 type conntrackOffsetGuesser struct {
-	m           *manager.Manager
-	status      *ConntrackStatus
-	ipv6Enabled uint64
+	m            *manager.Manager
+	status       *ConntrackStatus
+	tcpv6Enabled uint64
+	udpv6Enabled uint64
 }
 
 func NewConntrackOffsetGuesser(consts []manager.ConstantEditor) (OffsetGuesser, error) {
 	var offsetIno uint64
-	var ipv6Enabled uint64
+	var tcpv6Enabled, udpv6Enabled uint64
 	for _, c := range consts {
 		switch c.Name {
 		case "offset_ino":
 			offsetIno = c.Value.(uint64)
-		case "ipv6_enabled":
-			ipv6Enabled = c.Value.(uint64)
+		case "tcpv6_enabled":
+			tcpv6Enabled = c.Value.(uint64)
+		case "udpv6_enabled":
+			udpv6Enabled = c.Value.(uint64)
 			if offsetIno > 0 {
 				break
 			}
@@ -69,8 +73,9 @@ func NewConntrackOffsetGuesser(consts []manager.ConstantEditor) (OffsetGuesser, 
 				// so explicitly disabled, and the manager won't load it
 				{ProbeIdentificationPair: idPair(probes.NetDevQueue)}},
 		},
-		status:      &ConntrackStatus{Offset_ino: offsetIno},
-		ipv6Enabled: ipv6Enabled,
+		status:       &ConntrackStatus{Offset_ino: offsetIno},
+		tcpv6Enabled: tcpv6Enabled,
+		udpv6Enabled: udpv6Enabled,
 	}, nil
 }
 
@@ -97,7 +102,8 @@ func (c *conntrackOffsetGuesser) getConstantEditors() []manager.ConstantEditor {
 		{Name: "offset_ct_status", Value: c.status.Offset_status},
 		{Name: "offset_ct_netns", Value: c.status.Offset_netns},
 		{Name: "offset_ct_ino", Value: c.status.Offset_ino},
-		{Name: "ipv6_enabled", Value: c.ipv6Enabled},
+		{Name: "tcpv6_enabled", Value: c.tcpv6Enabled},
+		{Name: "udpv6_enabled", Value: c.udpv6Enabled},
 	}
 }
 

--- a/pkg/network/tracer/offsetguess/offsetguess_types_linux.go
+++ b/pkg/network/tracer/offsetguess/offsetguess_types_linux.go
@@ -61,10 +61,11 @@ type TracerStatus struct {
 	Transport_header                uint16
 	Network_header                  uint16
 	Mac_header                      uint16
-	Ipv6_enabled                    uint8
+	Tcpv6_enabled                   uint8
+	Udpv6_enabled                   uint8
 	Fl4_offsets                     uint8
 	Fl6_offsets                     uint8
-	Pad_cgo_0                       [3]byte
+	Pad_cgo_0                       [2]byte
 }
 
 type State uint8

--- a/pkg/network/tracer/offsetguess/offsetguess_types_linux.go
+++ b/pkg/network/tracer/offsetguess/offsetguess_types_linux.go
@@ -61,11 +61,9 @@ type TracerStatus struct {
 	Transport_header                uint16
 	Network_header                  uint16
 	Mac_header                      uint16
-	Tcpv6_enabled                   uint8
-	Udpv6_enabled                   uint8
 	Fl4_offsets                     uint8
 	Fl6_offsets                     uint8
-	Pad_cgo_0                       [2]byte
+	Pad_cgo_0                       [4]byte
 }
 
 type State uint8

--- a/pkg/network/tracer/offsetguess/tracer.go
+++ b/pkg/network/tracer/offsetguess/tracer.go
@@ -275,7 +275,7 @@ func GetIPv6LinkLocalAddress() (*net.UDPAddr, error) {
 			continue
 		}
 		for _, a := range addrs {
-			if strings.HasPrefix(a.String(), "fe80::") {
+			if strings.HasPrefix(a.String(), "fe80::") && !strings.HasPrefix(i.Name, "dummy") {
 				// this address *may* have CIDR notation
 				if ar, _, err := net.ParseCIDR(a.String()); err == nil {
 					return &net.UDPAddr{IP: ar, Zone: i.Name}, nil

--- a/pkg/network/tracer/offsetguess_test.go
+++ b/pkg/network/tracer/offsetguess_test.go
@@ -139,6 +139,10 @@ func TestOffsetGuess(t *testing.T) {
 	require.NoError(t, err, "could not read offset bpf module")
 	t.Cleanup(func() { offsetBuf.Close() })
 
+	// prebuilt on 5.18+ does not support UDPv6
+	if kv >= kernel.VersionCode(5, 18, 0) {
+		cfg.CollectUDPv6Conns = false
+	}
 	_consts, err := runOffsetGuessing(cfg, offsetBuf, offsetguess.NewTracerOffsetGuesser)
 	require.NoError(t, err)
 	cts, err := runOffsetGuessing(cfg, offsetBuf, func() (offsetguess.OffsetGuesser, error) {

--- a/pkg/network/tracer/tracer_usm_linux_test.go
+++ b/pkg/network/tracer/tracer_usm_linux_test.go
@@ -273,7 +273,8 @@ func testHTTPSLibrary(t *testing.T, fetchCmd []string, prefetchLibs []string) {
 	cfg.EnableHTTPSMonitoring = true
 	/* enable protocol classification : TLS */
 	cfg.ProtocolClassificationEnabled = true
-	cfg.CollectTCPConns = true
+	cfg.CollectTCPv4Conns = true
+	cfg.CollectTCPv6Conns = true
 	tr := setupTracer(t, cfg)
 	fentryTracerEnabled := tr.ebpfTracer.Type() == connection.TracerTypeFentry
 
@@ -636,6 +637,7 @@ func createJavaTempFile(t *testing.T, dir string) string {
 	require.NoError(t, err)
 	tempfile.Close()
 	os.Remove(tempfile.Name())
+	t.Cleanup(func() { os.Remove(tempfile.Name()) })
 
 	return tempfile.Name()
 }
@@ -812,7 +814,8 @@ func TestJavaInjection(t *testing.T) {
 			preTracerSetup: func(t *testing.T, ctx testContext) {
 				cfg.JavaDir = legacyJavaDir
 				cfg.ProtocolClassificationEnabled = true
-				cfg.CollectTCPConns = true
+				cfg.CollectTCPv4Conns = true
+				cfg.CollectTCPv6Conns = true
 			},
 			postTracerSetup: func(t *testing.T, ctx testContext) {
 				require.NoError(t, javatestutil.RunJavaVersion(t, "openjdk:15-oraclelinux8", "Wget https://httpbin.org/anything/java-tls-request", regexp.MustCompile("Response code = .*")), "Failed running Java version")
@@ -867,37 +870,35 @@ func TestHTTPGoTLSAttachProbes(t *testing.T) {
 		t.Skip("GoTLS not supported for this setup")
 	}
 
-	t.Run("new process (runtime compilation)", func(t *testing.T) {
+	t.Run("runtime compilation", func(t *testing.T) {
 		cfg := testConfig()
 		cfg.EnableRuntimeCompiler = true
+		cfg.AllowPrecompiledFallback = false
 		cfg.EnableCORE = false
-		testHTTPGoTLSCaptureNewProcess(t, cfg)
+
+		t.Run("new process", func(t *testing.T) {
+			testHTTPGoTLSCaptureNewProcess(t, cfg)
+		})
+		t.Run("already running process", func(t *testing.T) {
+			testHTTPGoTLSCaptureAlreadyRunning(t, cfg)
+		})
 	})
 
-	t.Run("already running process (runtime compilation)", func(t *testing.T) {
-		cfg := testConfig()
-		cfg.EnableRuntimeCompiler = true
-		cfg.EnableCORE = false
-		testHTTPGoTLSCaptureAlreadyRunning(t, cfg)
-	})
-
-	// note: this is a bit of hack since CI runs an entire package either as
-	// runtime, CO-RE, or pre-built. here we're piggybacking on the runtime pass
-	// and running the CO-RE tests as well
-	t.Run("new process (co-re)", func(t *testing.T) {
+	t.Run("CO-RE", func(t *testing.T) {
+		// note: this is a bit of hack since CI runs an entire package either as
+		// runtime, CO-RE, or pre-built. here we're piggybacking on the runtime pass
+		// and running the CO-RE tests as well
 		cfg := testConfig()
 		cfg.EnableCORE = true
 		cfg.EnableRuntimeCompiler = false
 		cfg.AllowRuntimeCompiledFallback = false
-		testHTTPGoTLSCaptureNewProcess(t, cfg)
-	})
 
-	t.Run("already running process (co-re)", func(t *testing.T) {
-		cfg := testConfig()
-		cfg.EnableCORE = true
-		cfg.EnableRuntimeCompiler = false
-		cfg.AllowRuntimeCompiledFallback = false
-		testHTTPGoTLSCaptureAlreadyRunning(t, cfg)
+		t.Run("new process", func(t *testing.T) {
+			testHTTPGoTLSCaptureNewProcess(t, cfg)
+		})
+		t.Run("already running process", func(t *testing.T) {
+			testHTTPGoTLSCaptureAlreadyRunning(t, cfg)
+		})
 	})
 }
 
@@ -1088,7 +1089,8 @@ type tlsTestCommand struct {
 func TestTLSClassification(t *testing.T) {
 	cfg := testConfig()
 	cfg.ProtocolClassificationEnabled = true
-	cfg.CollectTCPConns = true
+	cfg.CollectTCPv4Conns = true
+	cfg.CollectTCPv6Conns = true
 
 	if !classificationSupported(cfg) {
 		t.Skip("TLS classification platform not supported")

--- a/pkg/network/tracer/tracer_windows_test.go
+++ b/pkg/network/tracer/tracer_windows_test.go
@@ -24,6 +24,7 @@ func classificationSupported(config *config.Config) bool {
 	return true
 }
 
-func isTestIPv6Enabled(cfg *config.Config) bool {
-	return true
+func testConfig() *config.Config {
+	cfg := config.New()
+	return cfg
 }

--- a/pkg/network/usm/compile.go
+++ b/pkg/network/usm/compile.go
@@ -24,8 +24,11 @@ func getRuntimeCompiledUSM(config *config.Config) (runtime.CompiledOutput, error
 func getCFlags(config *config.Config) []string {
 	cflags := []string{"-g"}
 
-	if config.CollectIPv6Conns {
-		cflags = append(cflags, "-DFEATURE_IPV6_ENABLED")
+	if config.CollectTCPv6Conns {
+		cflags = append(cflags, "-DFEATURE_TCPV6_ENABLED")
+	}
+	if config.CollectUDPv6Conns {
+		cflags = append(cflags, "-DFEATURE_UDPV6_ENABLED")
 	}
 	if config.BPFDebug {
 		cflags = append(cflags, "-DDEBUG=1")


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Adds config options to individually control TCPv4/UDPv4 and TCPv6/UDPv6.

### Motivation

We need to disable UDPv6 on prebuilt w/ 5.18+ kernels dues to argument changes to `ip6_make_skb`. See #16246

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
