### PR TITLE
[kitchen] Update WinRM settings on old Windows versions

### DIFF
--- a/test/kitchen/drivers/azure-driver.yml
+++ b/test/kitchen/drivers/azure-driver.yml
@@ -148,7 +148,7 @@ platforms:
     <% if windows2008 %>
     winrm_powershell_script: |-
       winrm quickconfig -q
-      winrm set winrm/config/winrs '@{MaxMemoryPerShellMB="512"}'
+      winrm set winrm/config/winrs '@{MaxMemoryPerShellMB="2048"}'
       winrm set winrm/config '@{MaxTimeoutms="1800000"}'
       winrm set winrm/config/service '@{AllowUnencrypted="true"}'
       winrm set winrm/config/service/auth '@{Basic="true"}'

--- a/test/kitchen/platforms.json
+++ b/test/kitchen/platforms.json
@@ -115,8 +115,8 @@
         "azure": {
             "x86_64": {
                 "win2008r2": "id,/subscriptions/a53d2c33-d372-4e36-9e33-eaf32ce95b28/resourceGroups/agentcustomimages/providers/Microsoft.Compute/galleries/agentcustomimages/images/Windows2008-R2-SP1/versions/1.0.0",
-                "win2012": "urn,MicrosoftWindowsServer:WindowsServer:2012-Datacenter:9200.23920.221007",
-                "win2012r2": "urn,MicrosoftWindowsServer:WindowsServer:2012-R2-Datacenter:9600.20625.221005",
+                "win2012": "id,/subscriptions/a53d2c33-d372-4e36-9e33-eaf32ce95b28/resourceGroups/agentcustomimages/providers/Microsoft.Compute/galleries/agentcustomimages/images/Windows-2012/versions/1.0.0",
+                "win2012r2": "id,/subscriptions/a53d2c33-d372-4e36-9e33-eaf32ce95b28/resourceGroups/agentcustomimages/providers/Microsoft.Compute/galleries/agentcustomimages/images/Windows-2012-R2/versions/1.0.0",
                 "win2016": "urn,MicrosoftWindowsServer:WindowsServer:2016-Datacenter-Server-Core:14393.5429.221014",
                 "win2019": "urn,MicrosoftWindowsServer:WindowsServer:2019-Datacenter-Core:17763.3534.221015",
                 "win2019cn": "urn,MicrosoftWindowsServer:WindowsServer:2019-Datacenter-zhcn:17763.3534.221015",

--- a/test/kitchen/platforms.json
+++ b/test/kitchen/platforms.json
@@ -116,7 +116,7 @@
             "x86_64": {
                 "win2008r2": "id,/subscriptions/a53d2c33-d372-4e36-9e33-eaf32ce95b28/resourceGroups/agentcustomimages/providers/Microsoft.Compute/galleries/agentcustomimages/images/Windows2008-R2-SP1/versions/1.0.0",
                 "win2012": "id,/subscriptions/a53d2c33-d372-4e36-9e33-eaf32ce95b28/resourceGroups/agentcustomimages/providers/Microsoft.Compute/galleries/agentcustomimages/images/Windows-2012/versions/1.0.0",
-                "win2012r2": "id,/subscriptions/a53d2c33-d372-4e36-9e33-eaf32ce95b28/resourceGroups/agentcustomimages/providers/Microsoft.Compute/galleries/agentcustomimages/images/Windows-2012-R2/versions/1.0.0",
+                "win2012r2": "id,/subscriptions/a53d2c33-d372-4e36-9e33-eaf32ce95b28/resourceGroups/agentcustomimages/providers/Microsoft.Compute/galleries/agentcustomimages/images/Windows-2012-R2/versions/1.0.1",
                 "win2016": "urn,MicrosoftWindowsServer:WindowsServer:2016-Datacenter-Server-Core:14393.5429.221014",
                 "win2019": "urn,MicrosoftWindowsServer:WindowsServer:2019-Datacenter-Core:17763.3534.221015",
                 "win2019cn": "urn,MicrosoftWindowsServer:WindowsServer:2019-Datacenter-zhcn:17763.3534.221015",


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Updates the WinRM settings for Windows Server 2008 R2, 2012, and 2012 R2, to avoid OOM errors. In detail:
- updates the Windows Server 2012 / 2012 R2 images used in kitchen. These new images have 4096MB instead of the default 1024MB allocated for WinRM. On these versions, the setting is only applied if you also run `Set-Item WSMan:\localhost\Plugin\Microsoft.PowerShell\Quotas\MaxMemoryPerShellMB 4096` and restart the `winrm` service, so for simplicity this is baked in the image.
- updates the Windows Server 2008 R2 WinRM settings to use 2048MB instead of the previous 512MB (setting to 4096MB breaks WinRM on this version). On this version, nothing else is required.



### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Simpler alternative for #16756.

Instead of updating the WinRM settings during the kitchen run & rebooting the Windows Server 2012 / 2012 R2 VMs, we created custom Windows Server 2012 / 2012R2 images with the correct parameters baked in.

There is an ongoing [Rubygems dependencies API deprecation](https://blog.rubygems.org/2023/02/22/dependency-api-deprecation.html). It doesn't have a direct effect on the kitchen tests, but the use of the new dependencies API needs more memory, which, in older Windows OSes, exceeded the default memory allocated to the WinRM connection (512MB on Windows Server 2008, 1024MB on Windows Server 2012 / 2012 R2).

Windows system-probe kitchen tests were also failing due to memory allocation issues. This also fixes them.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

n/a

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

The use of custom images means these tests can only be run in our dedicated Azure subscription for kitchen tests.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

All Agent and system-probe Windows kitchen tests pass.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
