### PR TITLE
[system-probe] Fix cookie collision check to not use shared buffers

### DIFF
--- a/pkg/network/state.go
+++ b/pkg/network/state.go
@@ -161,6 +161,8 @@ type networkState struct {
 	maxDNSStats    int
 	maxHTTPStats   int
 	maxKafkaStats  int
+
+	mergeStatsBuffers [2][]byte
 }
 
 // NewState creates a new network state
@@ -174,6 +176,10 @@ func NewState(clientExpiry time.Duration, maxClosedConns, maxClientStats int, ma
 		maxDNSStats:    maxDNSStats,
 		maxHTTPStats:   maxHTTPStats,
 		maxKafkaStats:  maxKafkaStats,
+		mergeStatsBuffers: [2][]byte{
+			make([]byte, ConnectionByteKeyMaxLen),
+			make([]byte, ConnectionByteKeyMaxLen),
+		},
 	}
 }
 
@@ -366,7 +372,7 @@ func (ns *networkState) getConnsByCookie(conns []ConnectionStats) map[uint32]*Co
 			return fmt.Sprintf("duplicate connection in collection: cookie: %d, c1: %+v, c2: %+v", c.Cookie, *c, conns[i])
 		})
 
-		if mergeConnectionStats(c, &conns[i]) {
+		if ns.mergeConnectionStats(c, &conns[i]) {
 			// cookie collision
 			ns.telemetry.statsCookieCollisions++
 		}
@@ -387,7 +393,7 @@ func (ns *networkState) storeClosedConnections(conns []ConnectionStats) {
 	for _, client := range ns.clients {
 		for _, c := range conns {
 			if i, ok := client.closedConnectionsKeys[c.Cookie]; ok {
-				if mergeConnectionStats(&client.closedConnections[i], &c) {
+				if ns.mergeConnectionStats(&client.closedConnections[i], &c) {
 					ns.telemetry.statsCookieCollisions++
 				}
 				continue
@@ -597,7 +603,7 @@ func (ns *networkState) mergeConnections(id string, active map[uint32]*Connectio
 		closedConn := &closed[i]
 		cookie := closedConn.Cookie
 		if activeConn := active[cookie]; activeConn != nil {
-			if mergeConnectionStats(closedConn, activeConn) {
+			if ns.mergeConnectionStats(closedConn, activeConn) {
 				ns.telemetry.statsCookieCollisions++
 			}
 			// not an active connection
@@ -930,14 +936,12 @@ func (a connectionAggregator) WriteTo(buffer *clientBuffer) {
 	}
 }
 
-var mergeConnectionStatsBuffer = make([]byte, ConnectionByteKeyMaxLen)
-
-func mergeConnectionStats(a, b *ConnectionStats) (collision bool) {
+func (ns *networkState) mergeConnectionStats(a, b *ConnectionStats) (collision bool) {
 	if a.Cookie != b.Cookie {
 		return false
 	}
 
-	if bytes.Compare(a.ByteKey(mergeConnectionStatsBuffer), b.ByteKey(mergeConnectionStatsBuffer)) != 0 {
+	if bytes.Compare(a.ByteKey(ns.mergeStatsBuffers[0]), b.ByteKey(ns.mergeStatsBuffers[1])) != 0 {
 		// cookie collision
 		return true
 	}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Fix cookie collision check to not use the same buffer for the two connections being compared. This will cause the check to always fail.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
