### PR TITLE
usm: kafka: reduce code duplication

### DIFF
--- a/pkg/network/ebpf/c/protocols/kafka/kafka-parsing.h
+++ b/pkg/network/ebpf/c/protocols/kafka/kafka-parsing.h
@@ -55,64 +55,7 @@ int socket__kafka_filter(struct __sk_buff* skb) {
     return 0;
 }
 
-static __always_inline void parser_read_into_buffer_topic_name(char *buffer, struct __sk_buff *skb, u32 initial_offset) {
-    u64 offset = (u64)initial_offset;
-
-#define BLK_SIZE (16)
-    const u32 len = TOPIC_NAME_MAX_STRING_SIZE < (skb->len - (u32)offset) ? (u32)offset + TOPIC_NAME_MAX_STRING_SIZE : skb->len;
-
-    unsigned i = 0;
-
-#pragma unroll(TOPIC_NAME_MAX_STRING_SIZE / BLK_SIZE)
-    for (; i < (TOPIC_NAME_MAX_STRING_SIZE / BLK_SIZE); i++) {
-        if (offset + BLK_SIZE - 1 >= len) { break; }
-
-        bpf_skb_load_bytes_with_telemetry(skb, offset, &buffer[i * BLK_SIZE], BLK_SIZE);
-        offset += BLK_SIZE;
-    }
-
-    // This part is very hard to write in a loop and unroll it.
-    // Indeed, mostly because of older kernel verifiers, we want to make sure the offset into the buffer is not
-    // stored on the stack, so that the verifier is able to verify that we're not doing out-of-bound on
-    // the stack.
-    // Basically, we should get a register from the code block above containing an fp relative address. As
-    // we are doing `buffer[0]` here, there is not dynamic computation on that said register after this,
-    // and thus the verifier is able to ensure that we are in-bound.
-    void *buf = &buffer[i * BLK_SIZE];
-    if (i * BLK_SIZE >= TOPIC_NAME_MAX_STRING_SIZE) {
-        return;
-    } else if (offset + 14 < len) {
-        bpf_skb_load_bytes_with_telemetry(skb, offset, buf, 15);
-    } else if (offset + 13 < len) {
-        bpf_skb_load_bytes_with_telemetry(skb, offset, buf, 14);
-    } else if (offset + 12 < len) {
-        bpf_skb_load_bytes_with_telemetry(skb, offset, buf, 13);
-    } else if (offset + 11 < len) {
-        bpf_skb_load_bytes_with_telemetry(skb, offset, buf, 12);
-    } else if (offset + 10 < len) {
-        bpf_skb_load_bytes_with_telemetry(skb, offset, buf, 11);
-    } else if (offset + 9 < len) {
-        bpf_skb_load_bytes_with_telemetry(skb, offset, buf, 10);
-    } else if (offset + 8 < len) {
-        bpf_skb_load_bytes_with_telemetry(skb, offset, buf, 9);
-    } else if (offset + 7 < len) {
-        bpf_skb_load_bytes_with_telemetry(skb, offset, buf, 8);
-    } else if (offset + 6 < len) {
-        bpf_skb_load_bytes_with_telemetry(skb, offset, buf, 7);
-    } else if (offset + 5 < len) {
-        bpf_skb_load_bytes_with_telemetry(skb, offset, buf, 6);
-    } else if (offset + 4 < len) {
-        bpf_skb_load_bytes_with_telemetry(skb, offset, buf, 5);
-    } else if (offset + 3 < len) {
-        bpf_skb_load_bytes_with_telemetry(skb, offset, buf, 4);
-    } else if (offset + 2 < len) {
-        bpf_skb_load_bytes_with_telemetry(skb, offset, buf, 3);
-    } else if (offset + 1 < len) {
-        bpf_skb_load_bytes_with_telemetry(skb, offset, buf, 2);
-    } else if (offset < len) {
-        bpf_skb_load_bytes_with_telemetry(skb, offset, buf, 1);
-    }
-}
+READ_INTO_BUFFER(topic_name_parser, TOPIC_NAME_MAX_STRING_SIZE, BLK_SIZE)
 
 static __always_inline bool kafka_process(kafka_transaction_t *kafka_transaction, struct __sk_buff* skb, __u32 offset) {
     /*
@@ -171,7 +114,7 @@ static __always_inline bool kafka_process(kafka_transaction_t *kafka_transaction
         return false;
     }
     bpf_memset(kafka_transaction->base.topic_name, 0, TOPIC_NAME_MAX_STRING_SIZE);
-    parser_read_into_buffer_topic_name((char *)kafka_transaction->base.topic_name, skb, offset);
+    read_into_buffer_topic_name_parser((char *)kafka_transaction->base.topic_name, skb, offset);
     offset += topic_name_size;
     kafka_transaction->base.topic_name_size = topic_name_size;
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Uses a macro to implement a specific function.
The macro was introduced a while ago, and we missed a single duplication during the merge.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Simplifies code (reduces instruction count by 10%), and ensures we're using a single method to read from skb into a buffer.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
