### PR TITLE
Optional limit on number of dogstatsd tags

### DIFF
--- a/pkg/aggregator/context_resolver.go
+++ b/pkg/aggregator/context_resolver.go
@@ -11,6 +11,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/aggregator/ckey"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/internal/limiter"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/internal/tags"
+	"github.com/DataDog/datadog-agent/pkg/aggregator/internal/tags_limiter"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
 	"github.com/DataDog/datadog-agent/pkg/tagset"
 )
@@ -37,13 +38,14 @@ func (c *Context) release() {
 
 // contextResolver allows tracking and expiring contexts
 type contextResolver struct {
-	contextsByKey map[ckey.ContextKey]*Context
-	countsByMtype []uint64
-	tagsCache     *tags.Store
-	keyGenerator  *ckey.KeyGenerator
-	taggerBuffer  *tagset.HashingTagsAccumulator
-	metricBuffer  *tagset.HashingTagsAccumulator
-	limiter       *limiter.Limiter
+	contextsByKey   map[ckey.ContextKey]*Context
+	countsByMtype   []uint64
+	tagsCache       *tags.Store
+	keyGenerator    *ckey.KeyGenerator
+	taggerBuffer    *tagset.HashingTagsAccumulator
+	metricBuffer    *tagset.HashingTagsAccumulator
+	contextsLimiter *limiter.Limiter
+	tagsLimiter     *tags_limiter.Limiter
 }
 
 // generateContextKey generates the contextKey associated with the context of the metricSample
@@ -51,15 +53,16 @@ func (cr *contextResolver) generateContextKey(metricSampleContext metrics.Metric
 	return cr.keyGenerator.GenerateWithTags2(metricSampleContext.GetName(), metricSampleContext.GetHost(), cr.taggerBuffer, cr.metricBuffer)
 }
 
-func newContextResolver(cache *tags.Store, limiter *limiter.Limiter) *contextResolver {
+func newContextResolver(cache *tags.Store, contextsLimiter *limiter.Limiter, tagsLimiter *tags_limiter.Limiter) *contextResolver {
 	return &contextResolver{
-		contextsByKey: make(map[ckey.ContextKey]*Context),
-		countsByMtype: make([]uint64, metrics.NumMetricTypes),
-		tagsCache:     cache,
-		keyGenerator:  ckey.NewKeyGenerator(),
-		taggerBuffer:  tagset.NewHashingTagsAccumulator(),
-		metricBuffer:  tagset.NewHashingTagsAccumulator(),
-		limiter:       limiter,
+		contextsByKey:   make(map[ckey.ContextKey]*Context),
+		countsByMtype:   make([]uint64, metrics.NumMetricTypes),
+		tagsCache:       cache,
+		keyGenerator:    ckey.NewKeyGenerator(),
+		taggerBuffer:    tagset.NewHashingTagsAccumulator(),
+		metricBuffer:    tagset.NewHashingTagsAccumulator(),
+		contextsLimiter: contextsLimiter,
+		tagsLimiter:     tagsLimiter,
 	}
 }
 
@@ -72,7 +75,7 @@ func (cr *contextResolver) trackContext(metricSampleContext metrics.MetricSample
 	contextKey, taggerKey, metricKey := cr.generateContextKey(metricSampleContext) // the generator will remove duplicates (and doesn't mind the order)
 
 	if _, ok := cr.contextsByKey[contextKey]; !ok {
-		if !cr.tryAdd() {
+		if !cr.tryAdd(taggerKey) {
 			return contextKey, false
 		}
 
@@ -91,8 +94,11 @@ func (cr *contextResolver) trackContext(metricSampleContext metrics.MetricSample
 	return contextKey, true
 }
 
-func (cr *contextResolver) tryAdd() bool {
-	return cr.limiter.Track(cr.taggerBuffer.Get())
+func (cr *contextResolver) tryAdd(taggerKey ckey.TagsKey) bool {
+	taggerTags := cr.taggerBuffer.Get()
+	metricTags := cr.metricBuffer.Get()
+	// tagsLimiter should come first, contextsLimiter is stateful and successful calls to Track must be paired with Remove.
+	return cr.tagsLimiter.Check(taggerKey, taggerTags, metricTags) && cr.contextsLimiter.Track(taggerTags)
 }
 
 func (cr *contextResolver) get(key ckey.ContextKey) (*Context, bool) {
@@ -111,7 +117,7 @@ func (cr *contextResolver) removeKeys(expiredContextKeys []ckey.ContextKey) {
 
 		if context != nil {
 			cr.countsByMtype[context.mtype]--
-			cr.limiter.Remove(context.taggerTags.Tags())
+			cr.contextsLimiter.Remove(context.taggerTags.Tags())
 			context.release()
 		}
 	}
@@ -154,7 +160,8 @@ func (c *contextResolver) sendOriginTelemetry(timestamp float64, series metrics.
 }
 
 func (c *contextResolver) sendLimiterTelemetry(timestamp float64, series metrics.SerieSink, hostname string, constTags []string) {
-	c.limiter.SendTelemetry(timestamp, series, hostname, constTags)
+	c.contextsLimiter.SendTelemetry(timestamp, series, hostname, constTags)
+	c.tagsLimiter.SendTelemetry(timestamp, series, hostname, constTags)
 }
 
 // timestampContextResolver allows tracking and expiring contexts based on time.
@@ -163,9 +170,9 @@ type timestampContextResolver struct {
 	lastSeenByKey map[ckey.ContextKey]float64
 }
 
-func newTimestampContextResolver(cache *tags.Store, limiter *limiter.Limiter) *timestampContextResolver {
+func newTimestampContextResolver(cache *tags.Store, contextsLimiter *limiter.Limiter, tagsLimiter *tags_limiter.Limiter) *timestampContextResolver {
 	return &timestampContextResolver{
-		resolver:      newContextResolver(cache, limiter),
+		resolver:      newContextResolver(cache, contextsLimiter, tagsLimiter),
 		lastSeenByKey: make(map[ckey.ContextKey]float64),
 	}
 }
@@ -242,7 +249,7 @@ type countBasedContextResolver struct {
 
 func newCountBasedContextResolver(expireCountInterval int, cache *tags.Store) *countBasedContextResolver {
 	return &countBasedContextResolver{
-		resolver:            newContextResolver(cache, nil),
+		resolver:            newContextResolver(cache, nil, nil),
 		expireCountByKey:    make(map[ckey.ContextKey]int64),
 		expireCount:         0,
 		expireCountInterval: int64(expireCountInterval),

--- a/pkg/aggregator/context_resolver_test.go
+++ b/pkg/aggregator/context_resolver_test.go
@@ -9,7 +9,6 @@ package aggregator
 
 import (
 	// stdlib
-
 	"testing"
 
 	// 3p
@@ -19,6 +18,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/aggregator/ckey"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/internal/limiter"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/internal/tags"
+	"github.com/DataDog/datadog-agent/pkg/aggregator/internal/tags_limiter"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
 	"github.com/DataDog/datadog-agent/pkg/tagset"
 )
@@ -78,7 +78,7 @@ func testTrackContext(t *testing.T, store *tags.Store) {
 		SampleRate: 1,
 	}
 
-	contextResolver := newContextResolver(store, nil)
+	contextResolver := newContextResolver(store, nil, nil)
 
 	// Track the 2 contexts
 	contextKey1, _ := contextResolver.trackContext(&mSample1)
@@ -123,7 +123,7 @@ func testExpireContexts(t *testing.T, store *tags.Store) {
 		Tags:       []string{"foo", "bar", "baz"},
 		SampleRate: 1,
 	}
-	contextResolver := newTimestampContextResolver(store, nil)
+	contextResolver := newTimestampContextResolver(store, nil, nil)
 
 	// Track the 2 contexts
 	contextKey1, _ := contextResolver.trackContext(&mSample1, 4)
@@ -168,7 +168,7 @@ func testExpireContextsWithKeep(t *testing.T, store *tags.Store) {
 		Tags:       []string{"foo", "bar", "baz"},
 		SampleRate: 1,
 	}
-	contextResolver := newTimestampContextResolver(store, nil)
+	contextResolver := newTimestampContextResolver(store, nil, nil)
 
 	// Track the 2 contexts
 	contextKey1, _ := contextResolver.trackContext(&mSample1, 4)
@@ -248,7 +248,7 @@ func TestCountBasedExpireContexts(t *testing.T) {
 }
 
 func testTagDeduplication(t *testing.T, store *tags.Store) {
-	resolver := newContextResolver(store, nil)
+	resolver := newContextResolver(store, nil, nil)
 
 	ckey, _ := resolver.trackContext(&metrics.MetricSample{
 		Name: "foo",
@@ -285,7 +285,7 @@ func (s *mockSample) GetTags(tb, mb tagset.TagsAccumulator) {
 }
 
 func TestOriginTelemetry(t *testing.T) {
-	r := newContextResolver(tags.NewStore(true, "test"), nil)
+	r := newContextResolver(tags.NewStore(true, "test"), nil, nil)
 	r.trackContext(&mockSample{"foo", []string{"foo"}, []string{"ook"}})
 	r.trackContext(&mockSample{"foo", []string{"foo"}, []string{"eek"}})
 	r.trackContext(&mockSample{"foo", []string{"bar"}, []string{"ook"}})
@@ -318,13 +318,15 @@ func TestOriginTelemetry(t *testing.T) {
 
 func TestLimiterTelemetry(t *testing.T) {
 	l := limiter.New(2, "pod", []string{"pod", "srv"})
-	r := newContextResolver(tags.NewStore(true, "test"), l)
+	tl := tags_limiter.New(4)
+	r := newContextResolver(tags.NewStore(true, "test"), l, tl)
 	r.trackContext(&mockSample{"foo", []string{"pod:foo", "srv:foo"}, []string{"pod:bar"}})
 	r.trackContext(&mockSample{"foo", []string{"pod:foo", "srv:foo"}, []string{"srv:bar"}})
 	r.trackContext(&mockSample{"bar", []string{"pod:foo", "srv:foo"}, []string{"srv:bar"}})
 	r.trackContext(&mockSample{"foo", []string{"pod:bar"}, []string{"srv:foo"}})
 	r.trackContext(&mockSample{"bar", []string{"pod:bar"}, []string{"srv:bar"}})
 	r.trackContext(&mockSample{"bar", []string{"pod:baz"}, []string{}})
+	r.trackContext(&mockSample{"bar", []string{"pod:baz"}, []string{"1", "2", "3", "4", "5"}})
 	sink := mockSink{}
 	ts := 1672835152.0
 	r.sendLimiterTelemetry(ts, &sink, "test", []string{"test"})
@@ -365,5 +367,11 @@ func TestLimiterTelemetry(t *testing.T) {
 		Tags:   tagset.NewCompositeTags([]string{"test", "reason:too_many_contexts"}, []string{"pod:baz"}),
 		MType:  metrics.APICountType,
 		Points: []metrics.Point{{Ts: ts, Value: 0.0}},
+	}, {
+		Name:   "datadog.agent.aggregator.dogstatsd_samples_dropped",
+		Host:   "test",
+		Tags:   tagset.NewCompositeTags([]string{"test", "reason:too_many_tags"}, []string{"pod:baz"}),
+		MType:  metrics.APICountType,
+		Points: []metrics.Point{{Ts: ts, Value: 1.0}},
 	}})
 }

--- a/pkg/aggregator/demultiplexer_serverless.go
+++ b/pkg/aggregator/demultiplexer_serverless.go
@@ -43,7 +43,7 @@ func InitAndStartServerlessDemultiplexer(domainResolvers map[string]resolver.Dom
 	metricSamplePool := metrics.NewMetricSamplePool(MetricSamplePoolBatchSize)
 	tagsStore := tags.NewStore(config.Datadog.GetBool("aggregator_use_tags_store"), "timesampler")
 
-	statsdSampler := NewTimeSampler(TimeSamplerID(0), bucketSize, tagsStore, nil, "")
+	statsdSampler := NewTimeSampler(TimeSamplerID(0), bucketSize, tagsStore, nil, nil, "")
 	flushAndSerializeInParallel := NewFlushAndSerializeInParallel(config.Datadog)
 	statsdWorker := newTimeSamplerWorker(statsdSampler, DefaultFlushInterval, bufferSize, metricSamplePool, flushAndSerializeInParallel, tagsStore)
 

--- a/pkg/aggregator/internal/tags_limiter/tags_limiter.go
+++ b/pkg/aggregator/internal/tags_limiter/tags_limiter.go
@@ -1,0 +1,76 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package tags_limiter
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/aggregator/ckey"
+	"github.com/DataDog/datadog-agent/pkg/metrics"
+	"github.com/DataDog/datadog-agent/pkg/tagset"
+)
+
+type entry struct {
+	count uint64
+	tags  []string
+}
+
+type Limiter struct {
+	limit   int
+	dropped map[ckey.TagsKey]*entry
+}
+
+func New(limit int) *Limiter {
+	if limit <= 0 {
+		return nil
+	}
+
+	return &Limiter{
+		limit:   limit,
+		dropped: map[ckey.TagsKey]*entry{},
+	}
+}
+
+func (l *Limiter) Check(taggerKey ckey.TagsKey, taggerTags, metricTags []string) bool {
+	if l == nil {
+		return true
+	}
+
+	if len(taggerTags)+len(metricTags) > l.limit {
+		if e, ok := l.dropped[taggerKey]; !ok {
+			e = &entry{
+				count: 1,
+				tags:  taggerTags,
+			}
+			l.dropped[taggerKey] = e
+		} else {
+			e.count++
+		}
+
+		return false
+	}
+
+	return true
+}
+
+func (l *Limiter) SendTelemetry(timestamp float64, series metrics.SerieSink, hostname string, constTags []string) {
+	if l == nil {
+		return
+	}
+
+	constTags = append([]string{}, constTags...)
+	constTags = append(constTags, "reason:too_many_tags")
+
+	for _, e := range l.dropped {
+		series.Append(&metrics.Serie{
+			Name:   "datadog.agent.aggregator.dogstatsd_samples_dropped",
+			Host:   hostname,
+			Tags:   tagset.NewCompositeTags(constTags, e.tags),
+			MType:  metrics.APICountType,
+			Points: []metrics.Point{{Ts: timestamp, Value: float64(e.count)}},
+		})
+	}
+
+	l.dropped = map[ckey.TagsKey]*entry{}
+}

--- a/pkg/aggregator/internal/tags_limiter/tags_limiter_test.go
+++ b/pkg/aggregator/internal/tags_limiter/tags_limiter_test.go
@@ -1,0 +1,24 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package tags_limiter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTagsLimiter(t *testing.T) {
+	const limit int = 5
+	l := New(limit)
+	for n := 0; n <= 10; n += 2 {
+		for i := 0; i <= n; i++ {
+			taggerTags := make([]string, i)
+			metricTags := make([]string, n-i)
+			assert.Equal(t, n < limit, l.Check(0, taggerTags, metricTags))
+		}
+	}
+}

--- a/pkg/aggregator/time_sampler.go
+++ b/pkg/aggregator/time_sampler.go
@@ -11,6 +11,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/aggregator/ckey"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/internal/limiter"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/internal/tags"
+	"github.com/DataDog/datadog-agent/pkg/aggregator/internal/tags_limiter"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -43,7 +44,7 @@ type TimeSampler struct {
 }
 
 // NewTimeSampler returns a newly initialized TimeSampler
-func NewTimeSampler(id TimeSamplerID, interval int64, cache *tags.Store, limiter *limiter.Limiter, hostname string) *TimeSampler {
+func NewTimeSampler(id TimeSamplerID, interval int64, cache *tags.Store, contextsLimiter *limiter.Limiter, tagsLimiter *tags_limiter.Limiter, hostname string) *TimeSampler {
 	if interval == 0 {
 		interval = bucketSize
 	}
@@ -52,7 +53,7 @@ func NewTimeSampler(id TimeSamplerID, interval int64, cache *tags.Store, limiter
 
 	s := &TimeSampler{
 		interval:                    interval,
-		contextResolver:             newTimestampContextResolver(cache, limiter),
+		contextResolver:             newTimestampContextResolver(cache, contextsLimiter, tagsLimiter),
 		metricsByTimestamp:          map[int64]metrics.ContextMetrics{},
 		counterLastSampledByContext: map[ckey.ContextKey]float64{},
 		sketchMap:                   make(sketchMap),

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -543,6 +543,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("dogstatsd_no_aggregation_pipeline", true)
 	// How many metrics maximum in payloads sent by the no-aggregation pipeline to the intake.
 	config.BindEnvAndSetDefault("dogstatsd_no_aggregation_pipeline_batch_size", 2048)
+	config.BindEnvAndSetDefault("dogstatsd_max_metrics_tags", 0)
 
 	// To enable the following feature, GODEBUG must contain `madvdontneed=1`
 	config.BindEnvAndSetDefault("dogstatsd_mem_based_rate_limiter.enabled", false)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -543,7 +543,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("dogstatsd_no_aggregation_pipeline", true)
 	// How many metrics maximum in payloads sent by the no-aggregation pipeline to the intake.
 	config.BindEnvAndSetDefault("dogstatsd_no_aggregation_pipeline_batch_size", 2048)
-	config.BindEnvAndSetDefault("dogstatsd_max_metrics_tags", 0)
+	config.BindEnvAndSetDefault("dogstatsd_max_metrics_tags", 0) // 0 = disabled.
 
 	// To enable the following feature, GODEBUG must contain `madvdontneed=1`
 	config.BindEnvAndSetDefault("dogstatsd_mem_based_rate_limiter.enabled", false)


### PR DESCRIPTION
### What does this PR do?

Add an optional limit on number of tags for dogstatsd metrics.

### Motivation

Together with context limits in (#16734) puts a boundary on how much memory a dogstatsd sender may use, and improves robustness when memory is constrained.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

To minimize impact on existing applications, we want to apply the limit to tags as they would be sent out: after origin detection and de-duplication. Tags in this form exist for a small time window in the context resolver only, which constrains where we can implement this.

### Describe how to test/QA your changes

Run the agent with:

```
DD_TELEMETRY_ENABLED=true
DD_TELEMETRY_DOGSTATSD_LIMITER=true
DD_LOG_LEVEL=debug
DD_LOG_PAYLOADS=true
DD_DOGSTATSD_SOCKET=/tmp/dsd.sock
```

Send a dogstatsd metric with lots of tags, check that it is flushed to the backend.

```
echo "foo:1|g|#" {a..z}{a..z}, | nc -uUw0 /tmp/dsd.sock
```

Restart the agent with added `DD_DOGSTATSD_MAX_METRICS_TAGS=100`, send again, check that:

- `foo` is not sent to the backend
- `datadog.agent.aggregator.dogstatsd_samples_dropped{reason:too_many_tags}` is present

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
