### PR TITLE
[CI] Update the `/etc/apt/sources.list` file for Debian 9 used in kitchen

### DIFF
--- a/.gitlab/kitchen_testing/debian.yml
+++ b/.gitlab/kitchen_testing/debian.yml
@@ -21,7 +21,7 @@
 
 .kitchen_scenario_debian_a6_x64:
   variables:
-    KITCHEN_OSVERS: "debian-10,debian-11"
+    KITCHEN_OSVERS: "debian-9,debian-10,debian-11"
     KITCHEN_CWS_SUPPORTED_OSVERS: "debian-10,debian-11"
     DEFAULT_KITCHEN_OSVERS: "debian-11"
   extends:
@@ -32,7 +32,7 @@
 
 .kitchen_scenario_debian_a7_x64:
   variables:
-    KITCHEN_OSVERS: "debian-10,debian-11"
+    KITCHEN_OSVERS: "debian-9,debian-10,debian-11"
     KITCHEN_CWS_SUPPORTED_OSVERS: "debian-10,debian-11"
     DEFAULT_KITCHEN_OSVERS: "debian-11"
   extends:

--- a/test/kitchen/drivers/azure-driver.yml
+++ b/test/kitchen/drivers/azure-driver.yml
@@ -99,6 +99,7 @@ platforms:
       windows = platform_name.include?("win")
       sles15 = platform_name.include?("sles-15")
       windows2008 = windows && platform_name.include?("2008")
+      debian9 = platform_name.include?("debian-9")
 
       if windows
         windows_platforms << platform_name
@@ -163,13 +164,24 @@ platforms:
       <% end %>
     username: <%= vm_username %>
     password: <%= vm_password %>
-  <% if ENV['KITCHEN_CI_MOUNT_PATH'] && ENV['KITCHEN_CI_ROOT_PATH'] %>
+  <% if (ENV['KITCHEN_CI_MOUNT_PATH'] && ENV['KITCHEN_CI_ROOT_PATH']) || debian9 %>
   lifecycle:
     post_create:
+    <% if ENV['KITCHEN_CI_MOUNT_PATH'] && ENV['KITCHEN_CI_ROOT_PATH'] %>
     - remote: |
         sudo mkdir -p <%= ENV['KITCHEN_CI_MOUNT_PATH'] %>;
         sudo chmod a+rwx <%= ENV['KITCHEN_CI_MOUNT_PATH'] %>;
         sudo ln -s <%= ENV['KITCHEN_CI_MOUNT_PATH'] %> <%= ENV['KITCHEN_CI_ROOT_PATH'] %>;
+    <% end %>
+    <% if debian9 %>
+    - local: echo 'Updating the sources.list file to use archive.debian.org for the stretch suites'
+    - remote: |
+        # Stretch has been moved to archive.debian.org
+        # See https://lists.debian.org/debian-devel-announce/2023/03/msg00006.html
+        sudo sed -i 's/debian-archive.trafficmanager.net/archive.debian.org/g' /etc/apt/sources.list
+        # The stretch-updates dist doesn't exist in archive.debian.org/debian
+        sudo sed -i '/stretch-updates/d' /etc/apt/sources.list
+    <% end %>
   <% end %>
 
   transport:


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Backport of #16835 on 7.45.x.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
