### PR TITLE
[USM] tests https prefetch lib.so  (#16813)

### DIFF
--- a/pkg/network/tracer/testutil/prefetch_file/.gitignore
+++ b/pkg/network/tracer/testutil/prefetch_file/.gitignore
@@ -1,0 +1,1 @@
+prefetch_file

--- a/pkg/network/tracer/testutil/prefetch_file/prefetch_file.go
+++ b/pkg/network/tracer/testutil/prefetch_file/prefetch_file.go
@@ -1,0 +1,31 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"time"
+)
+
+func main() {
+	if len(os.Args) != 3 {
+		fmt.Println("usage: prefetch_file <filename> <wait_time>")
+		os.Exit(1)
+	}
+	waitTime, err := time.ParseDuration(os.Args[2])
+	if err != nil {
+		fmt.Printf("%s is not a valid format of duration\n", os.Args[2])
+		os.Exit(1)
+	}
+	f, err := os.Open(os.Args[1])
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer f.Close()
+	time.Sleep(waitTime)
+}

--- a/pkg/network/tracer/tracer_usm_linux_test.go
+++ b/pkg/network/tracer/tracer_usm_linux_test.go
@@ -179,6 +179,7 @@ func TestHTTPSViaLibraryIntegration(t *testing.T) {
 				EnableKeepAlives: keepAlives.value,
 			})
 			t.Cleanup(serverDoneFn)
+			buildPrefetchFileBin(t)
 
 			for _, test := range tests {
 				t.Run(test.name, func(t *testing.T) {
@@ -192,23 +193,55 @@ func TestHTTPSViaLibraryIntegration(t *testing.T) {
 					}
 					linked, _ := exec.Command(ldd, fetch).Output()
 
-					var prefechLibs []string
+					var prefetchLibs []string
 					for _, lib := range tlsLibs {
 						libSSLPath := lib.FindString(string(linked))
 						if _, err := os.Stat(libSSLPath); err == nil {
-							prefechLibs = append(prefechLibs, libSSLPath)
+							prefetchLibs = append(prefetchLibs, libSSLPath)
 						}
 					}
-					if len(prefechLibs) == 0 {
+					if len(prefetchLibs) == 0 {
 						t.Fatalf("%s not linked with any of these libs %v", test.name, tlsLibs)
 					}
 
-					testHTTPSLibrary(t, test.fetchCmd, prefechLibs)
+					testHTTPSLibrary(t, test.fetchCmd, prefetchLibs)
 
 				})
 			}
 		})
 	}
+}
+
+func buildPrefetchFileBin(t *testing.T) string {
+	const srcPath = "prefetch_file"
+	const binaryPath = "testutil/prefetch_file/prefetch_file"
+
+	t.Helper()
+
+	cur, err := testutil.CurDir()
+	require.NoError(t, err)
+
+	binary := fmt.Sprintf("%s/%s", cur, binaryPath)
+	// If there is a compiled binary already, skip the compilation.
+	// Meant for the CI.
+	if _, err = os.Stat(binary); err == nil {
+		return binary
+	}
+
+	srcDir := fmt.Sprintf("%s/testutil/%s", cur, srcPath)
+
+	c := exec.Command("go", "build", "-buildvcs=false", "-a", "-ldflags=-extldflags '-static'", "-o", binary, srcDir)
+	out, err := c.CombinedOutput()
+	t.Log(c, string(out))
+	require.NoError(t, err, "could not build test binary: %s\noutput: %s", err, string(out))
+
+	return binary
+}
+
+func prefetchLib(t *testing.T, filename string) {
+	prefetchBin := buildPrefetchFileBin(t)
+	cmd := exec.Command(prefetchBin, filename, "3s")
+	require.NoError(t, cmd.Start())
 }
 
 func testHTTPSLibrary(t *testing.T, fetchCmd []string, prefetchLibs []string) {
@@ -224,10 +257,7 @@ func testHTTPSLibrary(t *testing.T, fetchCmd []string, prefetchLibs []string) {
 
 	// not ideal but, short process are hard to catch
 	for _, lib := range prefetchLibs {
-		f, err := os.Open(lib)
-		if err == nil {
-			t.Cleanup(func() { f.Close() })
-		}
+		prefetchLib(t, lib)
 	}
 	time.Sleep(time.Second)
 

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -652,23 +652,14 @@ def kitchen_prepare(ctx, windows=is_windows, kernel_release=None, ci=False):
         if pkg.endswith("java"):
             shutil.copy(os.path.join(pkg, "agent-usm.jar"), os.path.join(target_path, "agent-usm.jar"))
 
-        gotls_client_dir = os.path.join("testutil", "gotls_client")
-        gotls_extra_path = os.path.join(pkg, gotls_client_dir)
-        if not windows and os.path.isdir(gotls_extra_path):
-            gotls_client_binary = os.path.join(gotls_client_dir, "gotls_client")
-            gotls_binary_path = os.path.join(target_path, gotls_client_binary)
-            with chdir(gotls_extra_path):
-                ctx.run(f"go build -o {gotls_binary_path} -ldflags=\"-extldflags '-static'\" gotls_client.go")
-
-        sowatcher_client_dir = os.path.join("testutil", "sowatcher_client")
-        sowatcher_client_extra_path = os.path.join(pkg, sowatcher_client_dir)
-        if not windows and os.path.isdir(sowatcher_client_extra_path):
-            sowatcher_client_client_binary = os.path.join(sowatcher_client_dir, "sowatcher_client")
-            sowatcher_client_binary_path = os.path.join(target_path, sowatcher_client_client_binary)
-            with chdir(sowatcher_client_extra_path):
-                ctx.run(
-                    f"go build -o {sowatcher_client_binary_path} -ldflags=\"-extldflags '-static'\" sowatcher_client.go"
-                )
+        for gobin in ["gotls_client", "sowatcher_client", "prefetch_file"]:
+            client_dir = os.path.join("testutil", gobin)
+            extra_path = os.path.join(pkg, client_dir)
+            if not windows and os.path.isdir(extra_path):
+                client_binary = os.path.join(client_dir, gobin)
+                binary_path = os.path.join(target_path, client_binary)
+                with chdir(extra_path):
+                    ctx.run(f"go build -o {binary_path} -ldflags=\"-extldflags '-static'\" {gobin}.go")
 
     gopath = os.getenv("GOPATH")
     copy_files = [


### PR DESCRIPTION
### What does this PR do?

Fix bug prefetch bug introduce by a previous [PR](https://github.com/DataDog/datadog-agent/pull/16650)
As we relay only by checking the pid (we don't scan ourself)

### Motivation

backport of [PR](https://github.com/DataDog/datadog-agent/pull/16813)

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
