### PR TITLE
[system-probe] Add logging and check kprobe misses on test failure

### DIFF
--- a/pkg/network/tracer/tracer_classification_linux_test.go
+++ b/pkg/network/tracer/tracer_classification_linux_test.go
@@ -9,6 +9,7 @@
 package tracer
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -31,6 +32,35 @@ func testProtocolClassificationInner(t *testing.T, params protocolClassification
 	if params.preTracerSetup != nil {
 		params.preTracerSetup(t, params.context)
 	}
+
+	var kStatsPre map[string]int64
+	if m, _ := tr.getStats(kprobesStats); m != nil {
+		if m := m["kprobes"]; m != nil {
+			kStatsPre = m.(map[string]int64)
+		}
+	}
+
+	t.Cleanup(func() {
+		if kStatsPre != nil && t.Failed() {
+			var kStatsPost map[string]int64
+			if m, _ := tr.getStats(kprobesStats); m != nil {
+				if m := m["kprobes"]; m != nil {
+					kStatsPost = m.(map[string]int64)
+				}
+				if kStatsPost == nil {
+					return
+				}
+				for k, pre := range kStatsPre {
+					if !strings.HasSuffix(k, "_misses") {
+						continue
+					}
+					if post, ok := kStatsPost[k]; ok && pre != post {
+						t.Logf("kprobe stat %s differs pre=%v post=%v", k, pre, post)
+					}
+				}
+			}
+		}
+	})
 
 	tr.removeClient(clientID)
 	initTracerState(t, tr)

--- a/pkg/network/tracer/tracer_classification_test.go
+++ b/pkg/network/tracer/tracer_classification_test.go
@@ -1654,6 +1654,10 @@ func waitForConnectionsWithProtocol(t *testing.T, tr *Tracer, targetAddr, server
 			}
 		}
 
-		return incoming != nil && outgoing != nil
+		failed := !(incoming != nil && outgoing != nil)
+		if failed {
+			t.Log(conns)
+		}
+		return !failed
 	}, 5*time.Second, 500*time.Millisecond, "could not find incoming or outgoing connections, incoming=%+v outgoing=%+v", incoming, outgoing)
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Adds more logging to debug test failures in the protocol classification tests.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
