### PR TITLE
[windows] conditionally add apm injection module to installer

### DIFF
--- a/omnibus/config/projects/agent.rb
+++ b/omnibus/config/projects/agent.rb
@@ -215,6 +215,12 @@ package :msi do
     include_sysprobe = "true"
     additional_sign_files_list << "#{Omnibus::Config.source_dir()}\\datadog-agent\\src\\github.com\\DataDog\\datadog-agent\\bin\\agent\\system-probe.exe"
   end
+
+  include_apminject = "false"
+  if not windows_arch_i386? and ENV['WINDOWS_APMINJECT_MODULE'] and not ENV['WINDOWS_APMINJECT_MODULE'].empty?
+    include_apminject = "true"
+  end
+
   additional_sign_files additional_sign_files_list
   parameters({
     'InstallDir' => install_dir,
@@ -225,6 +231,7 @@ package :msi do
     'IncludePython3' => "#{with_python_runtime? '3'}",
     'Platform' => "#{arch}",
     'IncludeSysprobe' => "#{include_sysprobe}",
+    'IncludeAPMInject' => "#{include_apminject}"
   })
   # This block runs before harvesting with heat.exe
   # It runs in the scope of the packager, so all variables access are from the point-of-view of the packager.
@@ -278,6 +285,9 @@ end
 if windows?
   if ENV['WINDOWS_DDNPM_DRIVER'] and not ENV['WINDOWS_DDNPM_DRIVER'].empty?
     dependency 'datadog-windows-filter-driver'
+  end
+  if ENV['WINDOWS_APMINJECT_MODULE'] and not ENV['WINDOWS_APMINJECT_MODULE'].empty?
+    dependency 'datadog-windows-apminject'
   end
   if ENV['WINDOWS_DDPROCMON_DRIVER'] and not ENV['WINDOWS_DDPROCMON_DRIVER'].empty?
     dependency 'datadog-windows-procmon-driver'

--- a/omnibus/config/software/datadog-windows-apminject.rb
+++ b/omnibus/config/software/datadog-windows-apminject.rb
@@ -1,0 +1,26 @@
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2016-present Datadog, Inc.
+
+name "datadog-windows-apminject"
+# at this moment,builds are stored by branch name.  Will need to correct at some point
+
+
+default_version "master"
+#
+# this should only ever be included by a windows build.
+if ohai["platform"] == "windows"
+    driverpath = ENV['WINDOWS_APMINJECT_MODULE']
+    driverver = ENV['WINDOWS_APMINJECT_VERSION']
+    drivermsmsha = ENV['WINDOWS_APMINJECT_SHASUM']
+
+    source :url => "https://s3.amazonaws.com/dd-windowsfilter/builds/#{driverpath}/ddapminstall-#{driverver}.msm",
+           :sha256 => "#{drivermsmsha}",
+           :target_filename => "ddapminstall.msm"
+
+    build do
+        copy "ddapminstall.msm", "#{Omnibus::Config.source_dir()}/datadog-agent/src/github.com/DataDog/datadog-agent/bin/agent/ddapminstall.msm"
+    end
+
+end

--- a/omnibus/resources/agent/msi/localbuild/parameters.wxi
+++ b/omnibus/resources/agent/msi/localbuild/parameters.wxi
@@ -10,6 +10,7 @@
   <?define ResourcesDir="c:\dev\go\src\github.com\datadog\datadog-agent\omnibus\resources\agent\msi"?>
   <?define IncludePython2= "false" ?>
   <?define IncludePython3= "true" ?>
+  <?define IncludeAPMInject= "true" ?>
   <?define Platform= "x64" ?>
   <?define IncludeSysprobe="true" ?>
 </Include>

--- a/omnibus/resources/agent/msi/source.wxs.erb
+++ b/omnibus/resources/agent/msi/source.wxs.erb
@@ -330,6 +330,7 @@
                 <!-- for now, just comment out.  Needs actual variable to determine whether to include or not 
                 <Merge Id="ddprocmoninstall" SourceFile="$(var.BinFiles)\ddprocmon.msm" DiskId="1" Language="1033" />
                 -->
+        
               </Directory>
             <Component Id="DATADOGSYSPROBESERVICE" Guid="5D41ECDB-B91E-4802-878C-CDBA84721623">
               <File Id="system_probe.exe"
@@ -346,6 +347,9 @@
                     SupportsWarnings="yes"/>
             </Component>
           <?endif?>
+          <?if $(var.IncludeAPMInject) = true ?>
+            <Merge Id="ddapminstall" SourceFile="$(var.BinFiles)\ddapminstall.msm" DiskId="1" Language="1033" />
+          <?endif ?>
         </Directory>
       </Directory>
     </DirectoryRef>
@@ -493,9 +497,14 @@
         <?if $(var.IncludePython2) = true ?>
           <ComponentRef Id="MSVCRUNTIME" />
         <?endif ?>
-          <ComponentRef Id="DATADOGSYSPROBESERVICE" />
-          <ComponentRef Id="system_probe.yaml.example" />
-          <MergeRef Id="ddnpminstall"/>
+        <ComponentRef Id="DATADOGSYSPROBESERVICE" />
+        <ComponentRef Id="system_probe.yaml.example" />
+        <MergeRef Id="ddnpminstall"/>
+        <?if $(var.IncludeAPMInject) = true ?>
+          <MergeRef Id="ddapminstall"/>
+        <?endif ?>
+        
+
       <!-- don't install by default (indicated by level 100)  Only things with level
         <= INSTALLLEVEL (1 by default) will be installed.  Can be changed via gui or command line params to optionally install -->
       <Feature  Id="NPM"

--- a/tasks/winbuildscripts/dobuild.bat
+++ b/tasks/winbuildscripts/dobuild.bat
@@ -56,6 +56,6 @@ inv -e %OMNIBUS_BUILD% %OMNIBUS_ARGS% --skip-deps --major-version %MAJOR_VERSION
 
 REM only build MSI for main targets for now.
 if "%OMNIBUS_TARGET%" == "main" (
-    @echo "inv -e msi.build --major-version %MAJOR_VERSION% --python-runtimes "%PY_RUNTIMES%"
-    inv -e msi.build --major-version %MAJOR_VERSION% --python-runtimes "%PY_RUNTIMES%" || exit /b 106
+    @echo "inv -e msi.build --major-version %MAJOR_VERSION% --python-runtimes "%PY_RUNTIMES%" --release-version %RELEASE_VERSION%
+    inv -e msi.build --major-version %MAJOR_VERSION% --python-runtimes "%PY_RUNTIMES%" --release-version %RELEASE_VERSION% || exit /b 106
 )

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentInstaller.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentInstaller.cs
@@ -249,7 +249,7 @@ namespace WixSetup.Datadog
                 {
                     document
                         .FindAll("Directory")
-                        .First(x => x.HasAttribute("Id", value => value == "DRIVER"))
+                        .First(x => x.HasAttribute("Id", value => value == "AGENT"))
                         .AddElement("Merge",
                             $"Id=ddapminstall; SourceFile={BinSource}\\agent\\ddapminstall.msm; DiskId=1; Language=1033");
                     document

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentInstaller.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentInstaller.cs
@@ -243,6 +243,20 @@ namespace WixSetup.Datadog
                     .FindAll("Feature")
                     .First(x => x.HasAttribute("Id", value => value == "MainApplication"))
                     .AddElement("MergeRef", "Id=ddnpminstall");
+                // Conditionally include the APM injection MSM while it is in active development to make it easier
+                // to build/ship without it.
+                if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("WINDOWS_APMINJECT_MODULE")))
+                {
+                    document
+                        .FindAll("Directory")
+                        .First(x => x.HasAttribute("Id", value => value == "DRIVER"))
+                        .AddElement("Merge",
+                            $"Id=ddapminstall; SourceFile={BinSource}\\agent\\ddapminstall.msm; DiskId=1; Language=1033");
+                    document
+                        .FindAll("Feature")
+                        .First(x => x.HasAttribute("Id", value => value == "MainApplication"))
+                        .AddElement("MergeRef", "Id=ddapminstall");
+                }
             };
             project.WixSourceFormated += (ref string content) => WixSourceFormated?.Invoke(content);
             project.WixSourceSaved += name => WixSourceSaved?.Invoke(name);


### PR DESCRIPTION
Conditionally addsd apm injection module to installer. Can be controlled by adding/removing relevant entries in `release.json`

### Motivation

Add support for new auto-inject feature

### Additional Notes
### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

When module is enabled at compile time (in `release.json`) check that result of install includes configured, but disabled, `ddapm` service and driver

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
