### PR TITLE
usm: tests: Disables http2 when tls is enabled

### DIFF
--- a/pkg/network/tracer/testutil/gotls_client/gotls_client.go
+++ b/pkg/network/tracer/testutil/gotls_client/gotls_client.go
@@ -29,6 +29,8 @@ func main() {
 
 	client := http.Client{
 		Transport: &http.Transport{
+			ForceAttemptHTTP2: false,
+			TLSNextProto:      make(map[string]func(authority string, c *tls.Conn) http.RoundTripper),
 			TLSClientConfig: &tls.Config{
 				InsecureSkipVerify: true,
 			},

--- a/pkg/network/tracer/tracer_usm_linux_test.go
+++ b/pkg/network/tracer/tracer_usm_linux_test.go
@@ -193,24 +193,24 @@ func TestHTTPSViaLibraryIntegration(t *testing.T) {
 		}
 	}
 
-	for _, keepAlives := range []struct {
+	for _, keepAlive := range []struct {
 		name  string
 		value bool
 	}{
 		{
-			name:  "without keep-alives",
+			name:  "without keep-alive",
 			value: false,
 		},
 		{
-			name:  "with keep-alives",
+			name:  "with keep-alive",
 			value: true,
 		},
 	} {
-		t.Run(keepAlives.name, func(t *testing.T) {
+		t.Run(keepAlive.name, func(t *testing.T) {
 			// Spin-up HTTPS server
 			serverDoneFn := testutil.HTTPServer(t, "127.0.0.1:443", testutil.Options{
-				EnableTLS:        true,
-				EnableKeepAlives: keepAlives.value,
+				EnableTLS:       true,
+				EnableKeepAlive: keepAlive.value,
 			})
 			t.Cleanup(serverDoneFn)
 
@@ -1264,8 +1264,8 @@ func testHTTPSClassification(t *testing.T, tr *Tracer, clientHost, targetHost, s
 			},
 			preTracerSetup: func(t *testing.T, ctx testContext) {
 				closer, err := testutil.HTTPPythonServer(t, ctx.serverAddress, testutil.Options{
-					EnableKeepAlives: false,
-					EnableTLS:        true,
+					EnableKeepAlive: false,
+					EnableTLS:       true,
 				})
 				require.NoError(t, err)
 				t.Cleanup(closer)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
Disables http2 when tls is enabled
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Making sure we're not mixing protocols in the tests.
Golang's http servers tends to upgrade the connection to http2, if tls is enabled.
So disabling the option of http2 upgrade of connections

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
