### PR TITLE
Add `*.additional_endpoints[*].url` config parameter to accept URLs for additional endpoints

### DIFF
--- a/pkg/logs/config/config.go
+++ b/pkg/logs/config/config.go
@@ -266,6 +266,16 @@ func BuildHTTPEndpointsWithConfig(logsConfig *LogsConfigKeys, endpointPrefix str
 			additionals[i].Protocol = intakeProtocol
 			additionals[i].Origin = intakeOrigin
 		}
+
+		if additionals[i].Url != "" {
+			host, port, useSSL, err := parseAddressWithScheme(additionals[i].Url, !additionals[i].UseSSL, parseAddress)
+			if err != nil {
+				return nil, fmt.Errorf("Could not parse %s: %v", additionals[i].Host, err)
+			}
+			additionals[i].Host = host
+			additionals[i].Port = port
+			additionals[i].UseSSL = useSSL
+		}
 	}
 
 	batchWait := logsConfig.batchWait()

--- a/pkg/logs/config/endpoints.go
+++ b/pkg/logs/config/endpoints.go
@@ -35,6 +35,7 @@ const (
 // Endpoint holds all the organization and network parameters to send logs to Datadog.
 type Endpoint struct {
 	APIKey                  string `mapstructure:"api_key" json:"api_key"`
+	Url                     string
 	Host                    string
 	Port                    int
 	UseSSL                  bool

--- a/pkg/logs/config/endpoints_test.go
+++ b/pkg/logs/config/endpoints_test.go
@@ -453,6 +453,40 @@ func (suite *EndpointsTestSuite) TestAdditionalEndpointsMappedCorrectly() {
 	suite.Equal("2", endpoint.APIKey)
 }
 
+func (suite *EndpointsTestSuite) TestAdditionalEndpointsWithUrl() {
+	var (
+		endpoints *Endpoints
+		endpoint  Endpoint
+		err       error
+	)
+
+	suite.config.Set("logs_config.additional_endpoints", []map[string]interface{}{
+		{
+			"url":               "https://foo.com:1234",
+			"api_key":           "12345678",
+			"use_compression":   false,
+			"compression_level": 4,
+		},
+	})
+
+	suite.config.Set("logs_config.use_http", true)
+	endpoints, err = BuildEndpoints(HTTPConnectivityFailure, "test-track", "test-proto", "test-source")
+	suite.Nil(err)
+	suite.Len(endpoints.Endpoints, 2)
+
+	endpoint = endpoints.Endpoints[1]
+	suite.Equal("foo.com", endpoint.Host)
+	suite.Equal(1234, endpoint.Port)
+	suite.Equal("12345678", endpoint.APIKey)
+	suite.True(endpoint.UseSSL)
+
+	// Main should override the compression settings
+	suite.True(endpoint.UseCompression)
+	suite.Equal(6, endpoint.CompressionLevel)
+
+	suite.True(endpoint.UseSSL)
+}
+
 func (suite *EndpointsTestSuite) TestIsReliableDefaultTrue() {
 	var (
 		endpoints *Endpoints


### PR DESCRIPTION
### What does this PR do?

Add `*.additional_endpoints[*].url` config parameter to accept URLs for additional endpoints.

### Motivation

Follow up of #16750 to support `https` or `http` scheme prefixes when configuring additional endpoints.

Ex. of config that should now be accepted:
```yaml
sbom:
  dd_url: https://sbom-intake.ap1.datadoghq.com

  additional_endpoints:
  - url: https://sbom-intake.datadoghq.com
    api_key: *******
```

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Deploy the agent on a cluster with dual-shipping enabled and an URL in the `url` field of additional endpoint. It should work without any error.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
