### PR TITLE
[CWS] Fix: anomaly detections events for bad events

### DIFF
--- a/pkg/security/security_profile/profile/manager.go
+++ b/pkg/security/security_profile/profile/manager.go
@@ -558,11 +558,11 @@ func (m *SecurityProfileManager) LookupEventInProfiles(event *model.Event) {
 		return
 	}
 
-	FillProfileContextFromProfile(&event.SecurityProfileContext, profile)
-
 	// check if the event should be injected in the profile automatically
 	if profile.autolearnEnabled {
 		if autoLearned, autoLearnErr := m.tryAutolearn(profile, event); autoLearnErr != nil || autoLearned {
+			// link the profile to the event only if it's a valid event for profile without any error
+			FillProfileContextFromProfile(&event.SecurityProfileContext, profile)
 			return
 		}
 	}
@@ -574,6 +574,8 @@ func (m *SecurityProfileManager) LookupEventInProfiles(event *model.Event) {
 		m.eventFiltering[event.GetEventType()][NoProfile].Inc()
 		return
 	}
+	// link the profile to the event only if it's a valid event for profile without any error
+	FillProfileContextFromProfile(&event.SecurityProfileContext, profile)
 	if ok {
 		event.AddToFlags(model.EventFlagsSecurityProfileInProfile)
 		m.eventFiltering[event.GetEventType()][InProfile].Inc()

--- a/pkg/security/security_profile/profile/manager.go
+++ b/pkg/security/security_profile/profile/manager.go
@@ -560,7 +560,10 @@ func (m *SecurityProfileManager) LookupEventInProfiles(event *model.Event) {
 
 	// check if the event should be injected in the profile automatically
 	if profile.autolearnEnabled {
-		if autoLearned, autoLearnErr := m.tryAutolearn(profile, event); autoLearnErr != nil || autoLearned {
+		autoLearned, autoLearnErr := m.tryAutolearn(profile, event)
+		if autoLearnErr != nil {
+			return
+		} else if autoLearned {
 			// link the profile to the event only if it's a valid event for profile without any error
 			FillProfileContextFromProfile(&event.SecurityProfileContext, profile)
 			return


### PR DESCRIPTION


### What does this PR do?

Now we only link the profile to the event when there is no errors, this prevent to send anomaly for events like runc.
The issue was that, even if `Contains()` returned with an error (like if `isValidRootNode()` returned false), as long as the event have a profile linked and did not have the tag "in profile", `handleAnomalyDetection()` will generate an anomaly.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
