### PR TITLE
added fix for http2 resource name

### DIFF
--- a/pkg/network/protocols/http/incomplete_stats_test.go
+++ b/pkg/network/protocols/http/incomplete_stats_test.go
@@ -9,6 +9,7 @@
 package http
 
 import (
+	"golang.org/x/net/http2/hpack"
 	"testing"
 	"time"
 
@@ -16,6 +17,12 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/pkg/network/config"
+)
+
+const (
+	http2MaxPathLen     = 30
+	compressedPathLen   = 21
+	decompressedPathLen = 28
 )
 
 func TestOrphanEntries(t *testing.T) {
@@ -67,5 +74,45 @@ func TestOrphanEntries(t *testing.T) {
 		now = now.Add(35 * time.Second)
 		_ = buffer.Flush(now)
 		assert.True(t, len(buffer.data) == 0)
+	})
+}
+
+func TestHTTP2Path(t *testing.T) {
+	t.Run("validate http2 path backslash", func(t *testing.T) {
+		// create a buffer to store the encoded data
+		paths := []string{"/hello.HelloService/SayHello", "hello.HelloService/SayHello"}
+		results := []bool{true, false}
+		pathsResults := []string{"/hello.HelloService/SayHello", ""}
+
+		for index, currentString := range paths {
+			var buf []byte
+			var arr [http2MaxPathLen]uint8
+			buf = hpack.AppendHuffmanString(buf, currentString)
+			copy(arr[:], buf[:30])
+
+			request := &ebpfHttp2Tx{
+				Request_path: arr,
+				Path_size:    compressedPathLen,
+			}
+
+			outBuf := make([]byte, decompressedPathLen)
+
+			path, ok := request.Path(outBuf)
+			assert.Equal(t, results[index], ok)
+			assert.Equal(t, pathsResults[index], string(path))
+		}
+
+	})
+
+	t.Run("empty path", func(t *testing.T) {
+		request := &ebpfHttp2Tx{
+			Request_path: [http2MaxPathLen]uint8{},
+			Path_size:    compressedPathLen,
+		}
+		outBuf := make([]byte, decompressedPathLen)
+
+		path, ok := request.Path(outBuf)
+		assert.Equal(t, ok, false)
+		assert.Nil(t, path)
 	})
 }

--- a/pkg/network/protocols/http/model_http2_linux.go
+++ b/pkg/network/protocols/http/model_http2_linux.go
@@ -27,6 +27,12 @@ func (tx *ebpfHttp2Tx) Path(buffer []byte) ([]byte, bool) {
 	if err != nil {
 		return nil, false
 	}
+
+	// ensure we found a '/' in the beginning of the path
+	if len(str) == 0 || str[0] != '/' {
+		return nil, false
+	}
+
 	n := copy(buffer, str)
 	// indicate if we knowingly captured the entire path
 	return buffer[:n], true


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Fix http2 resource name

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
