### PR TITLE
[USM] Avoid https flaky tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -568,12 +568,15 @@ require (
 require (
 	github.com/godror/godror v0.37.0
 	github.com/jmoiron/sqlx v1.3.5
+	github.com/kr/pretty v0.3.1
 	github.com/sijms/go-ora/v2 v2.7.6
 )
 
 require (
 	github.com/cloudflare/circl v1.1.0 // indirect
 	github.com/godror/knownpb v0.1.0 // indirect
+	github.com/kr/text v0.2.0 // indirect
+	github.com/rogpeppe/go-internal v1.9.0 // indirect
 	github.com/rs/zerolog v1.29.0 // indirect
 	github.com/sigstore/rekor v1.0.1 // indirect
 	github.com/spaolacci/murmur3 v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1248,6 +1248,7 @@ github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfn
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
+github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
@@ -1644,6 +1645,7 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/rogpeppe/go-internal v1.8.0/go.mod h1:WmiCO8CzOY8rg0OYDC4/i/2WRWAB6poM+XZ2dLUbcbE=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
+github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/rs/cors v1.8.3 h1:O+qNyWn7Z+F9M0ILBHgMVPuB1xTOucVd5gtaYyXBpRo=
 github.com/rs/cors v1.8.3/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
 github.com/rs/xid v1.4.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=

--- a/pkg/network/ebpf/c/protocols/classification/dispatcher-helpers.h
+++ b/pkg/network/ebpf/c/protocols/classification/dispatcher-helpers.h
@@ -89,7 +89,9 @@ static __always_inline void protocol_dispatcher_entrypoint(struct __sk_buff *skb
         return;
     }
 
-    // TODO: consider adding early return if `is_layer_known(stack, LAYER_ENCRYPTION)`
+    if (is_fully_classified(stack) || is_protocol_layer_known(stack, LAYER_ENCRYPTION)) {
+        return;
+    }
 
     protocol_t cur_fragment_protocol = get_protocol_from_stack(stack, LAYER_APPLICATION);
     if (cur_fragment_protocol == PROTOCOL_UNKNOWN) {

--- a/pkg/network/ebpf/c/protocols/classification/dispatcher-helpers.h
+++ b/pkg/network/ebpf/c/protocols/classification/dispatcher-helpers.h
@@ -88,10 +88,7 @@ static __always_inline void protocol_dispatcher_entrypoint(struct __sk_buff *skb
         // should never happen, but it is required by the eBPF verifier
         return;
     }
-
-    if (is_fully_classified(stack) || is_protocol_layer_known(stack, LAYER_ENCRYPTION)) {
-        return;
-    }
+    // TODO: consider adding early return if `is_layer_known(stack, LAYER_ENCRYPTION)`
 
     protocol_t cur_fragment_protocol = get_protocol_from_stack(stack, LAYER_APPLICATION);
     if (cur_fragment_protocol == PROTOCOL_UNKNOWN) {

--- a/pkg/network/ebpf/c/protocols/http/http.h
+++ b/pkg/network/ebpf/c/protocols/http/http.h
@@ -164,6 +164,14 @@ static __always_inline bool http_allow_packet(http_transaction_t *http, struct _
         return false;
     }
 
+    protocol_stack_t *stack = get_protocol_stack(&http->tup);
+    if (!stack) {
+        return false;
+    }
+    if (is_fully_classified(stack) || is_protocol_layer_known(stack, LAYER_ENCRYPTION)) {
+        return false;
+    }
+
     // if payload data is empty or if this is an encrypted packet, we only
     // process it if the packet represents a TCP termination
     bool empty_payload = skb_info->data_off == skb->len;

--- a/pkg/network/ebpf/c/protocols/http/http.h
+++ b/pkg/network/ebpf/c/protocols/http/http.h
@@ -168,8 +168,9 @@ static __always_inline bool http_allow_packet(http_transaction_t *http, struct _
     if (!stack) {
         return false;
     }
-    if (is_fully_classified(stack) || is_protocol_layer_known(stack, LAYER_ENCRYPTION)) {
-        // if this is an encrypted packet, we only
+    bool empty_payload = skb_info->data_off == skb->len;
+    if (empty_payload || is_fully_classified(stack) || is_protocol_layer_known(stack, LAYER_ENCRYPTION)) {
+        // if the payload data is empty or encrypted packet, we only
         // process it if the packet represents a TCP termination
         return skb_info->tcp_flags&(TCPHDR_FIN|TCPHDR_RST);
     }

--- a/pkg/network/ebpf/c/protocols/http/http.h
+++ b/pkg/network/ebpf/c/protocols/http/http.h
@@ -169,13 +169,8 @@ static __always_inline bool http_allow_packet(http_transaction_t *http, struct _
         return false;
     }
     if (is_fully_classified(stack) || is_protocol_layer_known(stack, LAYER_ENCRYPTION)) {
-        return false;
-    }
-
-    // if payload data is empty or if this is an encrypted packet, we only
-    // process it if the packet represents a TCP termination
-    bool empty_payload = skb_info->data_off == skb->len;
-    if (empty_payload || http->tup.sport == HTTPS_PORT || http->tup.dport == HTTPS_PORT) {
+        // if this is an encrypted packet, we only
+        // process it if the packet represents a TCP termination
         return skb_info->tcp_flags&(TCPHDR_FIN|TCPHDR_RST);
     }
 

--- a/pkg/network/ebpf/c/protocols/tls/https.h
+++ b/pkg/network/ebpf/c/protocols/tls/https.h
@@ -27,8 +27,6 @@
 #include "protocols/tls/tags-types.h"
 #include "protocols/tls/go-tls-types.h"
 
-#define HTTPS_PORT 443
-
 /* this function is called by all TLS hookpoints (OpenSSL, GnuTLS and GoTLS) and */
 /* it's used for classify the subset of protocols that is supported by `classify_protocol_for_dispatcher` */
 static __always_inline void classify_decrypted_payload(conn_tuple_t *t, void *buffer, size_t len) {

--- a/pkg/network/ebpf/c/tracer/tracer.h
+++ b/pkg/network/ebpf/c/tracer/tracer.h
@@ -43,8 +43,6 @@ typedef struct {
     __u64 sent_packets;
     __u64 recv_packets;
     __u8 direction;
-    // keep the conn_tags u8 to keep the struct slim
-    __u8 conn_tags;
     protocol_stack_t protocol_stack;
 } conn_stats_ts_t;
 

--- a/pkg/network/ebpf/kprobe_types_linux.go
+++ b/pkg/network/ebpf/kprobe_types_linux.go
@@ -30,9 +30,8 @@ type ConnStats struct {
 	Sent_packets   uint64
 	Recv_packets   uint64
 	Direction      uint8
-	Conn_tags      uint8
 	Protocol_stack ProtocolStack
-	Pad_cgo_0      [2]byte
+	Pad_cgo_0      [3]byte
 }
 type Conn struct {
 	Tup        ConnTuple

--- a/pkg/network/tracer/connection/tracer.go
+++ b/pkg/network/tracer/connection/tracer.go
@@ -559,7 +559,6 @@ func populateConnStats(stats *network.ConnectionStats, t *netebpf.ConnTuple, s *
 		Application: protocols.Application(s.Protocol_stack.Application),
 		Encryption:  protocols.Encryption(s.Protocol_stack.Encryption),
 	}
-	stats.StaticTags |= uint64(s.Conn_tags)
 
 	if t.Type() == netebpf.TCP {
 		stats.Type = network.TCP

--- a/pkg/network/tracer/tracer_usm_linux_test.go
+++ b/pkg/network/tracer/tracer_usm_linux_test.go
@@ -1292,11 +1292,14 @@ func testHTTPSClassification(t *testing.T, tr *Tracer, clientHost, targetHost, s
 						DialContext:     defaultDialer.DialContext,
 					},
 				}
-				resp, err := client.Get(fmt.Sprintf("https://%s/200/request-1", ctx.targetAddress))
-				require.NoError(t, err)
-				_, _ = io.Copy(io.Discard, resp.Body)
-				_ = resp.Body.Close()
-				client.CloseIdleConnections()
+				t.Log("run 3 clients request as we can have a race between the closing tcp socket and the http response")
+				for i := 0; i < 3; i++ {
+					resp, err := client.Get(fmt.Sprintf("https://%s/200/request-1", ctx.targetAddress))
+					require.NoError(t, err)
+					_, _ = io.Copy(io.Discard, resp.Body)
+					_ = resp.Body.Close()
+					client.CloseIdleConnections()
+				}
 			},
 			validation: validateProtocolConnection(protocols.HTTP, tlsExpected),
 		},

--- a/pkg/network/tracer/tracer_usm_linux_test.go
+++ b/pkg/network/tracer/tracer_usm_linux_test.go
@@ -320,11 +320,19 @@ func testHTTPSLibrary(t *testing.T, fetchCmd []string, prefetchLibs []string) {
 				httpKeys[key.SrcPort] = key
 				found = true
 				continue
+			} else {
+				s, _ := tr.getStats(allStats...)
+				t.Logf("==== %# v\n%# v", krpretty.Formatter(req), krpretty.Formatter(s))
 			}
 			if len(httpKeys) == 3 {
 				return true
 			}
 			t.Logf("HTTP stat didn't match criteria %v tags 0x%x\n", key, statsTags)
+		}
+
+		if !found {
+			s, _ := tr.getStats(allStats...)
+			t.Logf("=====loop= %# v", krpretty.Formatter(s))
 		}
 		return found
 	}, 15*time.Second, 5*time.Second, "couldn't find USM HTTPS stats")

--- a/pkg/network/tracer/tracer_usm_linux_test.go
+++ b/pkg/network/tracer/tracer_usm_linux_test.go
@@ -46,12 +46,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/network/tracer/testutil/grpc"
 )
 
-func isTLSTag(staticTags uint64) bool {
-	// We check only if the TLS tag has set, not like network.IsTLSTag()
-	// This meaning we classified the TLS flow from the packets / socket_filter
-	return staticTags&network.ConnTagTLS > 0
-}
-
 func httpSupported() bool {
 	if isFentry() {
 		return false
@@ -334,7 +328,7 @@ func testHTTPSLibrary(t *testing.T, fetchCmd []string, prefetchLibs []string) {
 	found := false
 	for _, c := range allConnections {
 		_, foundPid := fetchPids[c.Pid]
-		if foundPid && c.SPort == httpKey.SrcPort && c.DPort == httpKey.DstPort && isTLSTag(c.StaticTags) && c.ProtocolStack.Contains(protocols.TLS) {
+		if foundPid && c.SPort == httpKey.SrcPort && c.DPort == httpKey.DstPort && c.ProtocolStack.Contains(protocols.TLS) {
 			found = true
 			break
 		}
@@ -853,7 +847,7 @@ func TestJavaInjection(t *testing.T) {
 							}
 
 							for _, c := range payload.Conns {
-								if c.SPort == key.SrcPort && c.DPort == key.DstPort && isTLSTag(c.StaticTags) && c.ProtocolStack.Contains(protocols.TLS) {
+								if c.SPort == key.SrcPort && c.DPort == key.DstPort && c.ProtocolStack.Contains(protocols.TLS) {
 									return true
 								}
 							}
@@ -1164,7 +1158,7 @@ func TestTLSClassification(t *testing.T) {
 				require.Eventuallyf(t, func() bool {
 					payload := getConnections(t, tr)
 					for _, c := range payload.Conns {
-						if c.DPort == 44330 && isTLSTag(c.StaticTags) && c.ProtocolStack.Contains(protocols.TLS) {
+						if c.DPort == 44330 && c.ProtocolStack.Contains(protocols.TLS) {
 							return true
 						}
 					}

--- a/pkg/network/tracer/tracer_usm_linux_test.go
+++ b/pkg/network/tracer/tracer_usm_linux_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 	"time"
 
+	krpretty "github.com/kr/pretty"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sys/unix"
 
@@ -271,13 +272,12 @@ func testHTTPSLibrary(t *testing.T, fetchCmd []string, prefetchLibs []string) {
 	cfg.CollectTCPv4Conns = true
 	cfg.CollectTCPv6Conns = true
 	tr := setupTracer(t, cfg)
-	fentryTracerEnabled := tr.ebpfTracer.Type() == connection.TracerTypeFentry
 
 	// not ideal but, short process are hard to catch
 	for _, lib := range prefetchLibs {
 		prefetchLib(t, lib)
 	}
-	time.Sleep(time.Second)
+	time.Sleep(2 * time.Second)
 
 	// Issue request using fetchCmd (wget, curl, ...)
 	// This is necessary (as opposed to using net/http) because we want to
@@ -287,43 +287,53 @@ func testHTTPSLibrary(t *testing.T, fetchCmd []string, prefetchLibs []string) {
 	requestCmd := exec.Command(cmd[0], cmd[1:]...)
 	out, err := requestCmd.CombinedOutput()
 	require.NoErrorf(t, err, "failed to issue request via %s: %s\n%s", fetchCmd, err, string(out))
+	fetchPid := uint32(requestCmd.Process.Pid)
+	t.Logf("%s pid %d", cmd[0], fetchPid)
 
+	var allConnections []network.ConnectionStats
+	var httpKey http.Key
 	require.Eventuallyf(t, func() bool {
 		payload := getConnections(t, tr)
+		allConnections = append(allConnections, payload.Conns...)
 		for key, stats := range payload.HTTP {
+			if key.Path.Content != "/200/foobar" {
+				continue
+			}
 			req, exists := stats.Data[200]
 			if !exists {
-				continue
+				t.Errorf("http %# v stats %# v", krpretty.Formatter(key), krpretty.Formatter(stats))
+				return false
 			}
 
 			statsTags := req.StaticTags
 			// debian 10 have curl binary linked with openssl and gnutls but use only openssl during tls query (there no runtime flag available)
 			// this make harder to map lib and tags, one set of tag should match but not both
-			if key.Path.Content == "/200/foobar" && (statsTags == network.ConnTagGnuTLS || statsTags == network.ConnTagOpenSSL) {
+			if statsTags == network.ConnTagGnuTLS || statsTags == network.ConnTagOpenSSL {
 				t.Logf("found tag 0x%x %s", statsTags, network.GetStaticTags(statsTags))
-
-				// socket filter is not supported on fentry tracer
-				if fentryTracerEnabled {
-					// so we return early if the test was successful until now
-					return true
-				}
-
-				for _, c := range payload.Conns {
-					if c.SPort == key.SrcPort && c.DPort == key.DstPort && c.ProtocolStack.Contains(protocols.TLS) {
-						return true
-					}
-				}
-				t.Logf("HTTP connection %v doesn't contain ConnTagTLS\n", key)
+				httpKey = key
+				return true
 			}
 			t.Logf("HTTP stat didn't match criteria %v tags 0x%x\n", key, statsTags)
-			for _, c := range payload.Conns {
-				possibleKeyTuples := network.ConnectionKeysFromConnectionStats(c)
-				t.Logf("conn sport %d dport %d tags %x staticTags %x connKey [%v] or [%v]\n", c.SPort, c.DPort, c.Tags, c.StaticTags, possibleKeyTuples[0], possibleKeyTuples[1])
+		}
+		return false
+	}, 15*time.Second, 5*time.Second, "couldn't find USM HTTPS stats")
+
+	// check NPM static TLS tag
+	found := false
+	for _, c := range allConnections {
+		if c.Pid == fetchPid && c.SPort == httpKey.SrcPort && c.DPort == httpKey.DstPort && isTLSTag(c.StaticTags) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("NPM TLS tag not found")
+		for _, c := range allConnections {
+			if c.Pid == fetchPid {
+				t.Logf("pid %d connection %# v \nhttp %# v\n", fetchPid, krpretty.Formatter(c), krpretty.Formatter(httpKey))
 			}
 		}
-
-		return false
-	}, 10*time.Second, 1*time.Second, "couldn't find HTTPS stats")
+	}
 }
 
 const (


### PR DESCRIPTION
### What does this PR do?

Avoid https flaky tests, by checking in 2 stages (USM, then NPM) 
matching the connection, tags and client pid

### Motivation

https flaky tests

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
