### PR TITLE
[invoke] Allow non-importable go modules to be tested

### DIFF
--- a/tasks/modules.py
+++ b/tasks/modules.py
@@ -14,11 +14,16 @@ class GoModule:
     If True, a check will run to ensure this is true.
     """
 
-    def __init__(self, path, targets=None, condition=lambda: True, should_tag=True, independent=False):
+    def __init__(self, path, targets=None, condition=lambda: True, should_tag=True, importable=True, independent=False):
         self.path = path
         self.targets = targets if targets else ["."]
         self.condition = condition
         self.should_tag = should_tag
+        # HACK: Workaround for modules that can be tested, but not imported (eg. gohai), because
+        # they define a main package
+        # A better solution would be to automatically detect if a module contains a main package,
+        # at the cost of spending some time parsing the module.
+        self.importable = importable
         self.independent = independent
 
         self._dependencies = None
@@ -158,7 +163,7 @@ def generate_dummy_package(ctx, folder):
     try:
         import_paths = []
         for mod in DEFAULT_MODULES.values():
-            if mod.path != "." and mod.condition():
+            if mod.path != "." and mod.condition() and mod.importable:
                 import_paths.append(mod.import_path)
 
         os.mkdir(folder)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Adds a new option to the modules definition, `importable`. If set to false, the test to check that it can be imported won't be run.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Some modules (like the gohai module, that is currently being imported into the Agent tree, see #16724), have go unit tests that should be run, but are full programs (they have a `main` package), meaning they can't be imported (go complains with `main.go:6:2: import "github.com/DataDog/datadog-agent/pkg/gohai" is a program, not an importable package`).

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

n/a

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

We could be skipping import tests we shouldn't, if someone adds this option by mistake.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Check that, after this is merged, adding the gohai module (with `importable=False`) makes tests pass.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
