### PR TITLE
Fix system-probe config template generation on windows.

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1673,10 +1673,10 @@ api_key:
 #############################################################
 
 # service_monitoring_config:
-## @param enabled - boolean - optional - default: false
-## Set to true to enable the Universal Service Monitoring Module of the System Probe
-#
-# enabled: false
+  ## @param enabled - boolean - optional - default: false
+  ## Set to true to enable the Universal Service Monitoring Module of the System Probe
+  #
+  # enabled: false
 
 {{ end -}}
 

--- a/pkg/config/render_config.go
+++ b/pkg/config/render_config.go
@@ -97,6 +97,7 @@ func mkContext(buildType string) context {
 		return agentContext
 	case "iot-agent":
 		return context{
+			OS:        runtime.GOOS,
 			Common:    true,
 			Agent:     true,
 			Metadata:  true,
@@ -106,6 +107,7 @@ func mkContext(buildType string) context {
 		}
 	case "system-probe":
 		return context{
+			OS:                               runtime.GOOS,
 			SystemProbe:                      true,
 			NetworkModule:                    true,
 			UniversalServiceMonitoringModule: true,
@@ -114,6 +116,7 @@ func mkContext(buildType string) context {
 		}
 	case "dogstatsd":
 		return context{
+			OS:                runtime.GOOS,
 			Common:            true,
 			Dogstatsd:         true,
 			DockerTagging:     true,
@@ -125,6 +128,7 @@ func mkContext(buildType string) context {
 		}
 	case "dca":
 		return context{
+			OS:                  runtime.GOOS,
 			ClusterAgent:        true,
 			Common:              true,
 			Logging:             true,
@@ -134,6 +138,7 @@ func mkContext(buildType string) context {
 		}
 	case "dcacf":
 		return context{
+			OS:              runtime.GOOS,
 			ClusterAgent:    true,
 			Common:          true,
 			Logging:         true,
@@ -143,6 +148,7 @@ func mkContext(buildType string) context {
 		}
 	case "security-agent":
 		return context{
+			OS:            runtime.GOOS,
 			SecurityAgent: true,
 		}
 	}


### PR DESCRIPTION
ORiginal context did not have OS information, so `windows` conditionals in template file were not honored

Also fixed spacing issue in usm config (cross platform)

### What does this PR do?


### Motivation


### Additional Notes


### Possible Drawbacks / Trade-offs


### Describe how to test/QA your changes

On new install, check system-probe.yaml file to ensure entries are correct.
On Linux, only difference would be spacing of comments in USM section.

On Windows, should now correctly list the sysprobe socket as `localhost:3333` rather
than a UDS

Prior to change, even on windows, the network config section would have stated:
```
  ## The full path to the location of the unix socket where system probes are accessed.
  #
  # sysprobe_socket: /opt/datadog-agent/run/sysprobe.sock
  ```
  
  Verify that on windows, the correct output is present:
  
  ```
  ## The TCP address where system probes are accessed.
  #
  # sysprobe_socket: localhost:3333
  ```

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
