### PR TITLE
Remove globalSocketPath and pass in path directly to system-probe

### DIFF
--- a/cmd/process-agent/subcommands/check/check.go
+++ b/cmd/process-agent/subcommands/check/check.go
@@ -28,7 +28,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/process/types"
 	"github.com/DataDog/datadog-agent/pkg/metadata/host"
 	"github.com/DataDog/datadog-agent/pkg/process/checks"
-	"github.com/DataDog/datadog-agent/pkg/process/net"
 	"github.com/DataDog/datadog-agent/pkg/tagger"
 	"github.com/DataDog/datadog-agent/pkg/tagger/local"
 	"github.com/DataDog/datadog-agent/pkg/tagger/remote"
@@ -153,19 +152,13 @@ func runCheckCmd(deps dependencies) error {
 		}
 	}()
 
-	// If the sysprobe module is enabled, the process check can call out to the sysprobe for privileged stats
-	_, processModuleEnabled := deps.Syscfg.Object().EnabledModules[sysconfig.ProcessModule]
-
-	if processModuleEnabled {
-		net.SetSystemProbePath(deps.Syscfg.Object().SocketAddress)
-	}
-
 	names := make([]string, 0, len(deps.Checks))
 	for _, checkComponent := range deps.Checks {
 		ch := checkComponent.Object()
 
 		names = append(names, ch.Name())
 
+		_, processModuleEnabled := deps.Syscfg.Object().EnabledModules[sysconfig.ProcessModule]
 		cfg := &checks.SysProbeConfig{
 			MaxConnsPerMessage:   deps.Syscfg.Object().MaxConnsPerMessage,
 			SystemProbeAddress:   deps.Syscfg.Object().SocketAddress,

--- a/pkg/collector/corechecks/ebpf/oom_kill.go
+++ b/pkg/collector/corechecks/ebpf/oom_kill.go
@@ -69,9 +69,6 @@ func (c *OOMKillConfig) Parse(data []byte) error {
 
 // Configure parses the check configuration and init the check
 func (m *OOMKillCheck) Configure(integrationConfigDigest uint64, config, initConfig integration.Data, source string) error {
-	// TODO: Remove that hard-code and put it somewhere else
-	process_net.SetSystemProbePath(dd_config.SystemProbe.GetString("system_probe_config.sysprobe_socket"))
-
 	err := m.CommonConfigure(integrationConfigDigest, initConfig, config, source)
 	if err != nil {
 		return err
@@ -86,7 +83,8 @@ func (m *OOMKillCheck) Run() error {
 		return nil
 	}
 
-	sysProbeUtil, err := process_net.GetRemoteSystemProbeUtil()
+	sysProbeUtil, err := process_net.GetRemoteSystemProbeUtil(
+		dd_config.SystemProbe.GetString("system_probe_config.sysprobe_socket"))
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/ebpf/tcp_queue_length.go
+++ b/pkg/collector/corechecks/ebpf/tcp_queue_length.go
@@ -66,9 +66,6 @@ func (t *TCPQueueLengthConfig) Parse(data []byte) error {
 
 // Configure parses the check configuration and init the check
 func (t *TCPQueueLengthCheck) Configure(integrationConfigDigest uint64, config, initConfig integration.Data, source string) error {
-	// TODO: Remove that hard-code and put it somewhere else
-	process_net.SetSystemProbePath(dd_config.SystemProbe.GetString("system_probe_config.sysprobe_socket"))
-
 	err := t.CommonConfigure(integrationConfigDigest, initConfig, config, source)
 	if err != nil {
 		return err
@@ -83,7 +80,8 @@ func (t *TCPQueueLengthCheck) Run() error {
 		return nil
 	}
 
-	sysProbeUtil, err := process_net.GetRemoteSystemProbeUtil()
+	sysProbeUtil, err := process_net.GetRemoteSystemProbeUtil(
+		dd_config.SystemProbe.GetString("system_probe_config.sysprobe_socket"))
 	if err != nil {
 		return err
 	}

--- a/pkg/process/checks/net.go
+++ b/pkg/process/checks/net.go
@@ -79,8 +79,7 @@ func (c *ConnectionsCheck) Init(syscfg *SysProbeConfig, hostInfo *HostInfo) erro
 	c.tracerClientID = ProcessAgentClientID
 
 	// Calling the remote tracer will cause it to initialize and check connectivity
-	net.SetSystemProbePath(syscfg.SystemProbeAddress)
-	tu, err := net.GetRemoteSystemProbeUtil()
+	tu, err := net.GetRemoteSystemProbeUtil(syscfg.SystemProbeAddress)
 
 	if err != nil {
 		log.Warnf("could not initiate connection with system probe: %s", err)
@@ -167,7 +166,7 @@ func (c *ConnectionsCheck) Run(nextGroupID func() int32, _ *RunOptions) (RunResu
 func (c *ConnectionsCheck) Cleanup() {}
 
 func (c *ConnectionsCheck) getConnections() (*model.Connections, error) {
-	tu, err := net.GetRemoteSystemProbeUtil()
+	tu, err := net.GetRemoteSystemProbeUtil(c.syscfg.SocketAddress)
 	if err != nil {
 		if c.notInitializedLogLimit.ShouldLog() {
 			log.Warnf("could not initialize system-probe connection: %v (will only log every 10 minutes)", err)

--- a/pkg/process/checks/process_test.go
+++ b/pkg/process/checks/process_test.go
@@ -50,6 +50,7 @@ func processCheckWithMockProbe(t *testing.T) (*ProcessCheck, *mocks.Probe) {
 		scrubber:          procutil.NewDefaultDataScrubber(),
 		hostInfo:          hostInfo,
 		containerProvider: mockContainerProvider(t),
+		sysProbeConfig:    &SysProbeConfig{},
 		checkCount:        0,
 		skipAmount:        2,
 	}, probe

--- a/pkg/process/net/common_linux.go
+++ b/pkg/process/net/common_linux.go
@@ -25,12 +25,12 @@ const (
 
 // CheckPath is used in conjunction with calling the stats endpoint, since we are calling this
 // From the main agent and want to ensure the socket exists
-func CheckPath() error {
-	if globalSocketPath == "" {
-		return fmt.Errorf("remote tracer has no path defined")
+func CheckPath(path string) error {
+	if path == "" {
+		return fmt.Errorf("socket path is empty")
 	}
 
-	if _, err := os.Stat(globalSocketPath); err != nil {
+	if _, err := os.Stat(path); err != nil {
 		return fmt.Errorf("socket path does not exist: %v", err)
 	}
 	return nil

--- a/pkg/process/net/common_unsupported.go
+++ b/pkg/process/net/common_unsupported.go
@@ -19,18 +19,13 @@ var _ SysProbeUtil = &RemoteSysProbeUtil{}
 // RemoteSysProbeUtil is not supported
 type RemoteSysProbeUtil struct{}
 
-// SetSystemProbePath is not supported
-func SetSystemProbePath(_ string) {
-	// no-op
-}
-
 // CheckPath is not supported
-func CheckPath() error {
+func CheckPath(path string) error {
 	return ebpf.ErrNotImplemented
 }
 
 // GetRemoteSystemProbeUtil is not supported
-func GetRemoteSystemProbeUtil() (*RemoteSysProbeUtil, error) {
+func GetRemoteSystemProbeUtil(path string) (*RemoteSysProbeUtil, error) {
 	return &RemoteSysProbeUtil{}, ebpf.ErrNotImplemented
 }
 

--- a/pkg/process/net/common_windows.go
+++ b/pkg/process/net/common_windows.go
@@ -25,9 +25,9 @@ const (
 )
 
 // CheckPath is used to make sure the globalSocketPath has been set before attempting to connect
-func CheckPath() error {
-	if globalSocketPath == "" {
-		return fmt.Errorf("remote tracer has no path defined")
+func CheckPath(path string) error {
+	if path == "" {
+		return fmt.Errorf("socket path is empty")
 	}
 	return nil
 }

--- a/pkg/status/status_system_probe.go
+++ b/pkg/status/status_system_probe.go
@@ -16,8 +16,7 @@ import (
 
 // GetSystemProbeStats returns the expvar stats of the system probe
 func GetSystemProbeStats(socketPath string) map[string]interface{} {
-	net.SetSystemProbePath(socketPath)
-	probeUtil, err := net.GetRemoteSystemProbeUtil()
+	probeUtil, err := net.GetRemoteSystemProbeUtil(socketPath)
 
 	if err != nil {
 		return map[string]interface{}{

--- a/releasenotes/notes/proc-check-sys-probe-295b4549e0be07d6.yaml
+++ b/releasenotes/notes/proc-check-sys-probe-295b4549e0be07d6.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix collection of I/O and open files data in the process check.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Remove the global variable `globalSocketPath`, and pass the path directly to the system-probe getter. This also fixes a regression where the path was not set for the process check. 

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Customer identified a regression where the process agent was no longer collecting privileged I/O & open files data.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Ensure that I/O and open files info is collected in the following cases:
* Process agent running with process check enabled, system-probe running with process module enabled and network **disabled**.
* Process agent and system-probe running with network check enabled.
* Process check run manually with system-probe process module enabled.

Ensure that the system-probe status command works

Ensure that the process agent connections check works

Ensure that the OOMKill and TCP queue length checks work

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
