### PR TITLE
[SBOM] Add memory based cache for Trivy

### DIFF
--- a/pkg/collector/corechecks/sbom/processor.go
+++ b/pkg/collector/corechecks/sbom/processor.go
@@ -52,6 +52,7 @@ type processor struct {
 
 func newProcessor(workloadmetaStore workloadmeta.Store, sender aggregator.Sender, maxNbItem int, maxRetentionTime time.Duration, hostSBOM bool) (*processor, error) {
 	hostScanOpts := sbom.ScanOptionsFromConfig(ddConfig.Datadog, false)
+	hostScanOpts.NoCache = true
 	sbomScanner := sbomscanner.GetGlobalScanner()
 	if sbomScanner == nil {
 		return nil, errors.New("failed to get global SBOM scanner")

--- a/pkg/sbom/sbom.go
+++ b/pkg/sbom/sbom.go
@@ -29,6 +29,7 @@ type ScanOptions struct {
 	Timeout          time.Duration
 	WaitAfter        time.Duration
 	Fast             bool
+	NoCache          bool
 }
 
 // ScanOptionsFromConfig loads the scanning options from the configuration

--- a/pkg/sbom/sbom.go
+++ b/pkg/sbom/sbom.go
@@ -29,7 +29,7 @@ type ScanOptions struct {
 	Timeout          time.Duration
 	WaitAfter        time.Duration
 	Fast             bool
-	NoCache          bool
+	NoCache          bool // Caching doesn't really provide any value when scanning filesystem as the filesystem has to be walked to compute the keys
 }
 
 // ScanOptionsFromConfig loads the scanning options from the configuration

--- a/pkg/util/trivy/cache.go
+++ b/pkg/util/trivy/cache.go
@@ -10,6 +10,7 @@ package trivy
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -523,4 +524,86 @@ func (cache *PersistentCache) collectTelemetry() {
 		log.Errorf("could not collect telemetry: %v", err)
 	}
 	telemetry.SBOMCacheDiskSize.Set(float64(diskSize))
+}
+
+type memoryCache struct {
+	blobInfo *struct {
+		*types.BlobInfo
+		id string
+	}
+	artifactInfo *struct {
+		*types.ArtifactInfo
+		id string
+	}
+}
+
+func (c *memoryCache) MissingBlobs(artifactID string, blobIDs []string) (missingArtifact bool, missingBlobIDs []string, err error) {
+	for _, blobID := range blobIDs {
+		if _, err := c.GetBlob(blobID); err != nil {
+			missingBlobIDs = append(missingBlobIDs, blobID)
+		}
+	}
+
+	if _, err := c.GetArtifact(artifactID); err != nil {
+		missingArtifact = true
+	}
+
+	return
+}
+
+func (c *memoryCache) PutArtifact(artifactID string, artifactInfo types.ArtifactInfo) (err error) {
+	c.artifactInfo = &struct {
+		*types.ArtifactInfo
+		id string
+	}{
+		id:           artifactID,
+		ArtifactInfo: &artifactInfo,
+	}
+	return nil
+}
+
+func (c *memoryCache) PutBlob(blobID string, blobInfo types.BlobInfo) (err error) {
+	c.blobInfo = &struct {
+		*types.BlobInfo
+		id string
+	}{
+		id:       blobID,
+		BlobInfo: &blobInfo,
+	}
+	return nil
+}
+
+func (c *memoryCache) DeleteBlobs(blobIDs []string) error {
+	if c.blobInfo != nil {
+		for _, blobID := range blobIDs {
+			if blobID == c.blobInfo.id {
+				c.blobInfo = nil
+			}
+		}
+	}
+	return nil
+}
+
+func (c *memoryCache) GetArtifact(artifactID string) (artifactInfo types.ArtifactInfo, err error) {
+	if c.artifactInfo != nil && c.artifactInfo.id == artifactID {
+		return *c.artifactInfo.ArtifactInfo, nil
+	}
+	return types.ArtifactInfo{}, nil
+}
+
+func (c *memoryCache) GetBlob(blobID string) (blobInfo types.BlobInfo, err error) {
+	if c.blobInfo != nil && c.blobInfo.id == blobID {
+		return *c.blobInfo.BlobInfo, nil
+	}
+	return types.BlobInfo{}, errors.New("not found")
+}
+
+func (c *memoryCache) Close() (err error) {
+	c.artifactInfo = nil
+	c.blobInfo = nil
+	return nil
+}
+
+func (c *memoryCache) Clear() (err error) {
+	return c.Close()
 }

--- a/pkg/util/trivy/trivy.go
+++ b/pkg/util/trivy/trivy.go
@@ -63,7 +63,6 @@ type Collector struct {
 	config       CollectorConfig
 	cache        cache.Cache
 	cacheCleaner CacheCleaner
-	applier      local.Applier
 	detector     local.OspkgDetector
 	dbConfig     db.Config
 	vulnClient   vulnerability.Client
@@ -97,9 +96,9 @@ func getDefaultArtifactOption(root string, opts sbom.ScanOptions) artifact.Optio
 	return option
 }
 
-// DefaultCollectorConfig returns a default collector configuration
+// defaultCollectorConfig returns a default collector configuration
 // However, accessors still need to be filled in externally
-func DefaultCollectorConfig(cacheLocation string) CollectorConfig {
+func defaultCollectorConfig(cacheLocation string) CollectorConfig {
 	collectorConfig := CollectorConfig{
 		ClearCacheOnClose: true,
 	}
@@ -157,7 +156,7 @@ func DefaultDisabledHandlers() []ftypes.HandlerType {
 }
 
 func NewCollector(cfg config.Config) (*Collector, error) {
-	config := DefaultCollectorConfig(cfg.GetString("sbom.cache_directory"))
+	config := defaultCollectorConfig(cfg.GetString("sbom.cache_directory"))
 	config.ClearCacheOnClose = cfg.GetBool("sbom.clear_cache_on_exit")
 
 	dbConfig := db.Config{}
@@ -170,7 +169,6 @@ func NewCollector(cfg config.Config) (*Collector, error) {
 		config:       config,
 		cache:        fanalCache,
 		cacheCleaner: cacheCleaner,
-		applier:      applier.NewApplier(fanalCache),
 		detector:     ospkg.Detector{},
 		dbConfig:     dbConfig,
 		vulnClient:   vulnerability.NewClient(dbConfig),
@@ -265,12 +263,17 @@ func (c *Collector) ScanContainerdImageFromFilesystem(ctx context.Context, imgMe
 }
 
 func (c *Collector) scanFilesystem(ctx context.Context, path string, imgMeta *workloadmeta.ContainerImageMetadata, scanOptions sbom.ScanOptions) (sbom.Report, error) {
-	fsArtifact, err := local2.NewArtifact(path, c.cache, getDefaultArtifactOption(path, scanOptions))
+	cache := c.cache
+	if scanOptions.NoCache {
+		cache = &memoryCache{}
+	}
+
+	fsArtifact, err := local2.NewArtifact(path, cache, getDefaultArtifactOption(path, scanOptions))
 	if err != nil {
 		return nil, fmt.Errorf("unable to create artifact from fs, err: %w", err)
 	}
 
-	bom, err := c.scan(ctx, fsArtifact, imgMeta)
+	bom, err := c.scan(ctx, fsArtifact, applier.NewApplier(cache), imgMeta)
 	if err != nil {
 		return nil, fmt.Errorf("unable to marshal report to sbom format, err: %w", err)
 	}
@@ -282,7 +285,7 @@ func (c *Collector) ScanFilesystem(ctx context.Context, path string, scanOptions
 	return c.scanFilesystem(ctx, path, nil, scanOptions)
 }
 
-func (c *Collector) scan(ctx context.Context, artifact artifact.Artifact, imgMeta *workloadmeta.ContainerImageMetadata) (sbom.Report, error) {
+func (c *Collector) scan(ctx context.Context, artifact artifact.Artifact, applier applier.Applier, imgMeta *workloadmeta.ContainerImageMetadata) (sbom.Report, error) {
 	if imgMeta != nil {
 		artifactReference, err := artifact.Inspect(ctx) // called by the scanner as well
 		if err != nil {
@@ -291,7 +294,7 @@ func (c *Collector) scan(ctx context.Context, artifact artifact.Artifact, imgMet
 		c.cacheCleaner.setKeysForEntity(imgMeta.EntityID.ID, append(artifactReference.BlobIDs, artifactReference.ID))
 	}
 
-	s := scanner.NewScanner(local.NewScanner(c.applier, c.detector, c.vulnClient), artifact)
+	s := scanner.NewScanner(local.NewScanner(applier, c.detector, c.vulnClient), artifact)
 	trivyReport, err := s.ScanArtifact(ctx, types.ScanOptions{
 		VulnType:            []string{},
 		SecurityChecks:      []string{},
@@ -314,7 +317,7 @@ func (c *Collector) scanImage(ctx context.Context, fanalImage ftypes.Image, imgM
 		return nil, fmt.Errorf("unable to create artifact from image, err: %w", err)
 	}
 
-	bom, err := c.scan(ctx, imageArtifact, imgMeta)
+	bom, err := c.scan(ctx, imageArtifact, applier.NewApplier(c.cache), imgMeta)
 	if err != nil {
 		return nil, fmt.Errorf("unable to marshal report to sbom format, err: %w", err)
 	}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Add a memory based cache for Trivy

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

When scanning filesystems, Trivy computes the checksum of all the scanned dependencies,
store into the persistent cache. It can be pretty big (around to 30M) with little value as a
rescan of the filesystem will still cause a scan of the filesystems. If the checksum of the new
result is the same, it will use what's stored in the cache instead.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
