### PR TITLE
usm: process monitor: Refactor and handle edge cases

### DIFF
--- a/pkg/process/monitor/process_monitor_test.go
+++ b/pkg/process/monitor/process_monitor_test.go
@@ -10,202 +10,235 @@ package monitor
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
 	"regexp"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/vishvananda/netns"
+	"go.uber.org/atomic"
 
 	procutils "github.com/DataDog/datadog-agent/pkg/process/util"
 	"github.com/DataDog/datadog-agent/pkg/util"
+	"github.com/DataDog/gopsutil/process"
 )
 
-func TestProcessMonitorBasics(t *testing.T) {
+func initializePM(t *testing.T, pm *ProcessMonitor) {
+	require.NoError(t, pm.Initialize())
+	t.Cleanup(pm.Stop)
+	time.Sleep(time.Millisecond * 500)
+}
+
+func registerCallback(t *testing.T, pm *ProcessMonitor, isExec bool, callback *ProcessCallback) func() {
+	registrationFunc := pm.SubscribeExit
+	if isExec {
+		registrationFunc = pm.SubscribeExec
+	}
+	unsubscribe, err := registrationFunc(callback)
+	require.NoError(t, err)
+	t.Cleanup(unsubscribe)
+	return unsubscribe
+}
+
+func getTestBinaryPath(t *testing.T) string {
+	tmpFile, err := os.CreateTemp("", "echo")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		os.Remove(tmpFile.Name())
+	})
+	require.NoError(t, util.CopyFile("/bin/echo", tmpFile.Name()))
+
+	return tmpFile.Name()
+}
+
+func TestProcessMonitorSingleton(t *testing.T) {
 	// Making sure we get the same process monitor if we call it twice.
 	pm := GetProcessMonitor()
 	pm2 := GetProcessMonitor()
 
 	require.Equal(t, pm, pm2)
-
-	// Sanity subscribing a callback.
-	callback := &ProcessCallback{
-		Event:    EXEC,
-		Metadata: ANY,
-		Callback: func(pid uint32) {},
-	}
-	unsubscribe, err := pm.Subscribe(callback)
-	require.NoError(t, err)
-
-	// Sanity subscribing a callback.
-	callback2 := &ProcessCallback{
-		Event:    EXEC,
-		Metadata: ANY,
-		Callback: func(pid uint32) {},
-	}
-	unsubscribe2, err := pm.Subscribe(callback2)
-	require.NoError(t, err)
-
-	// duplicated subscription should fail.
-	_, err = pm.Subscribe(callback)
-	require.Error(t, err)
-
-	// making sure unsubscribe works and does not panic for the second unsubscription.
-	unsubscribe()
-	require.NotPanics(t, unsubscribe)
-	unsubscribe2()
-	require.NotPanics(t, unsubscribe2)
 }
 
-func TestProcessMonitorCallbacks(t *testing.T) {
+func TestProcessMonitorSanity(t *testing.T) {
+	pm := GetProcessMonitor()
+	numberOfExecs := atomic.Int32{}
+	testBinaryPath := getTestBinaryPath(t)
+	registerCallback(t, pm, true, &ProcessCallback{
+		FilterType: ANY,
+		Callback: func(pid int) {
+			numberOfExecs.Inc()
+		},
+	})
+
+	initializePM(t, pm)
+	require.NoError(t, exec.Command(testBinaryPath, "test").Run())
+	require.Eventuallyf(t, func() bool {
+		return numberOfExecs.Load() > 1
+	}, time.Second, time.Millisecond*200, "didn't capture exec events %d", numberOfExecs.Load())
+
+}
+
+func TestProcessRegisterMultipleExecCallbacks(t *testing.T) {
 	pm := GetProcessMonitor()
 
-	numberOfExecs := 0
-	numberOfExits := 0
-
-	tmpFile, err := ioutil.TempFile("", "echo")
-	require.NoError(t, err)
-	defer os.Remove(tmpFile.Name())
-	err = util.CopyFile("/bin/echo", tmpFile.Name())
-	require.NoError(t, err)
-
-	require.NoError(t, os.Chmod(tmpFile.Name(), 0500))
-
-	require.NoError(t, pm.Initialize())
-	defer pm.Stop()
-	callbackExec := &ProcessCallback{
-		Event:    EXEC,
-		Metadata: NAME,
-		Regex:    regexp.MustCompile(path.Base(tmpFile.Name())),
-		Callback: func(pid uint32) {
-			numberOfExecs++
-		},
-	}
-	callbackExit := &ProcessCallback{
-		Event:    EXIT,
-		Metadata: NAME, // we want only the captured Exec process
-		Regex:    regexp.MustCompile(path.Base(tmpFile.Name())),
-		Callback: func(pid uint32) {
-			numberOfExits++
-		},
+	const iterations = 10
+	counters := make([]*atomic.Int32, iterations)
+	for i := 0; i < iterations; i++ {
+		counters[i] = &atomic.Int32{}
+		c := counters[i]
+		registerCallback(t, pm, true, &ProcessCallback{
+			FilterType: ANY,
+			Callback: func(pid int) {
+				c.Inc()
+			},
+		})
 	}
 
-	unsubscribeExec, err := pm.Subscribe(callbackExec)
-	require.NoError(t, err)
-	unsubscribeExit, err := pm.Subscribe(callbackExit)
-	require.NoError(t, err)
-
-	require.NoError(t, exec.Command(tmpFile.Name(), "test").Run())
+	initializePM(t, pm)
+	require.NoError(t, exec.Command("/bin/echo").Run())
 	require.Eventuallyf(t, func() bool {
-		return numberOfExecs == 1 && numberOfExits == 1
-	}, time.Second, time.Millisecond*200, fmt.Sprintf("didn't capture exec %d and exit %d", numberOfExecs, numberOfExits))
+		for i := 0; i < iterations; i++ {
+			if counters[i].Load() <= int32(0) {
+				t.Logf("iter %d didn't capture event", i)
+				return false
+			}
+		}
+		return true
+	}, time.Second, time.Millisecond*200, "at least of the callbacks didn't capture events")
+}
+
+func TestProcessRegisterMultipleExitCallbacks(t *testing.T) {
+	pm := GetProcessMonitor()
+
+	const iterations = 10
+	counters := make([]*atomic.Int32, iterations)
+	for i := 0; i < iterations; i++ {
+		counters[i] = &atomic.Int32{}
+		c := counters[i]
+		// Sanity subscribing a callback.
+		registerCallback(t, pm, false, &ProcessCallback{
+			FilterType: ANY,
+			Callback: func(pid int) {
+				c.Inc()
+			},
+		})
+	}
+
+	initializePM(t, pm)
+	require.NoError(t, exec.Command("/bin/echo").Run())
+	require.Eventuallyf(t, func() bool {
+		for i := 0; i < iterations; i++ {
+			if counters[i].Load() <= int32(0) {
+				t.Logf("iter %d didn't capture event", i)
+				return false
+			}
+		}
+		return true
+	}, time.Second, time.Millisecond*200, "at least of the callbacks didn't capture events")
+}
+
+func TestProcessRegisterNamedCallbacks(t *testing.T) {
+	pm := GetProcessMonitor()
+
+	numberOfExecs := atomic.Int32{}
+	numberOfExits := atomic.Int32{}
+
+	testBinaryPath := getTestBinaryPath(t)
+
+	unsubscribeExec := registerCallback(t, pm, true, &ProcessCallback{
+		FilterType: NAME,
+		Regex:      regexp.MustCompile(path.Base(testBinaryPath)),
+		Callback: func(pid int) {
+			numberOfExecs.Inc()
+		},
+	})
+
+	unsubscribeExit := registerCallback(t, pm, false, &ProcessCallback{
+		FilterType: NAME,
+		Regex:      regexp.MustCompile(path.Base(testBinaryPath)),
+		Callback: func(pid int) {
+			numberOfExits.Inc()
+		},
+	})
+
+	initializePM(t, pm)
+	require.NoError(t, exec.Command(testBinaryPath, "test").Run())
+	require.Eventuallyf(t, func() bool {
+		return numberOfExecs.Load() == 1 && numberOfExits.Load() == 1
+	}, time.Second, time.Millisecond*200, fmt.Sprintf("didn't capture exec %d and exit %d", numberOfExecs.Load(), numberOfExits.Load()))
 
 	unsubscribeExit()
-	require.NoError(t, exec.Command(tmpFile.Name()).Run())
+	require.NoError(t, exec.Command(testBinaryPath).Run())
 	require.Eventuallyf(t, func() bool {
-		return numberOfExecs == 2 && numberOfExits == 1
-	}, time.Second, time.Millisecond*200, fmt.Sprintf("didn't capture exec %d and exit %d", numberOfExecs, numberOfExits))
+		return numberOfExecs.Load() == 2 && numberOfExits.Load() == 1
+	}, time.Second, time.Millisecond*200, fmt.Sprintf("didn't capture exec %d and exit %d", numberOfExecs.Load(), numberOfExits.Load()))
 
 	unsubscribeExec()
-	require.NoError(t, exec.Command(tmpFile.Name()).Run())
+	require.NoError(t, exec.Command(testBinaryPath).Run())
 	require.Eventuallyf(t, func() bool {
-		return numberOfExecs == 2 && numberOfExits == 1
-	}, time.Second, time.Millisecond*200, fmt.Sprintf("didn't capture exec %d and exit %d", numberOfExecs, numberOfExits))
+		return numberOfExecs.Load() == 2 && numberOfExits.Load() == 1
+	}, time.Second, time.Millisecond*200, fmt.Sprintf("didn't capture exec %d and exit %d", numberOfExecs.Load(), numberOfExits.Load()))
+}
 
+func TestProcessRegisterNameExitCallbackWithoutExec(t *testing.T) {
+	pm := GetProcessMonitor()
+
+	_, err := pm.SubscribeExit(&ProcessCallback{
+		FilterType: NAME,
+		Regex:      regexp.MustCompile("test"),
+		Callback:   func(pid int) {},
+	})
+	require.Error(t, err)
 }
 
 func TestProcessMonitorRefcount(t *testing.T) {
 	pm := GetProcessMonitor()
-	require.Equal(t, pm.refcount, 0)
-	err := pm.Initialize()
-	require.Equal(t, pm.refcount, 1)
-	require.NoError(t, err)
-	pm.Stop()
-	require.Equal(t, pm.refcount, 0)
+	require.Equal(t, pm.refcount.Load(), int32(0))
 
-	pm2 := GetProcessMonitor()
-
-	numberOfExecs := 0
-	callbackExec := &ProcessCallback{
-		Event:    EXEC,
-		Metadata: ANY,
-		Callback: func(pid uint32) {
-			numberOfExecs++
-		},
+	for i := 1; i <= 10; i++ {
+		require.NoError(t, pm.Initialize())
+		require.Equal(t, pm.refcount.Load(), int32(i))
 	}
-	_, err = pm.Subscribe(callbackExec)
-	require.NoError(t, err)
-	require.NoError(t, pm2.Initialize())
-	require.Equal(t, pm.refcount, 1)
 
-	oldNumberOfExecs := numberOfExecs
-	require.NoError(t, exec.Command("/bin/echo").Run())
-	require.Eventuallyf(t, func() bool {
-		return numberOfExecs > oldNumberOfExecs
-	}, time.Second, time.Millisecond*200, fmt.Sprintf("didn't capture a new exec %d old %d", numberOfExecs, oldNumberOfExecs))
-
-	require.NoError(t, pm2.Initialize())
-	require.Equal(t, pm.refcount, 2)
-
-	oldNumberOfExecs = numberOfExecs
-	require.NoError(t, exec.Command("/bin/echo").Run())
-	require.Eventuallyf(t, func() bool {
-		return numberOfExecs > oldNumberOfExecs
-	}, time.Second, time.Millisecond*200, fmt.Sprintf("didn't capture a new exec %d old %d", numberOfExecs, oldNumberOfExecs))
-
-	require.Equal(t, pm.refcount, 2)
-	pm2.Stop()
-	require.Equal(t, pm.refcount, 1)
-
-	oldNumberOfExecs = numberOfExecs
-	require.NoError(t, exec.Command("/bin/echo").Run())
-	require.Eventuallyf(t, func() bool {
-		return numberOfExecs > oldNumberOfExecs
-	}, time.Second, time.Millisecond*200, fmt.Sprintf("didn't capture a new exec %d old %d", numberOfExecs, oldNumberOfExecs))
-
-	pm2.Stop()
-	require.Equal(t, pm.refcount, 0)
-
-	oldNumberOfExecs = numberOfExecs
-	require.NoError(t, exec.Command("/bin/echo").Run())
-	require.Eventuallyf(t, func() bool {
-		return numberOfExecs == oldNumberOfExecs
-	}, time.Second, time.Millisecond*200, fmt.Sprintf("capture a new exec %d old %d", numberOfExecs, oldNumberOfExecs))
+	for i := 1; i <= 10; i++ {
+		pm.Stop()
+		require.Equal(t, pm.refcount.Load(), int32(10-i))
+	}
 }
 
 func TestProcessMonitorInNamespace(t *testing.T) {
 	execSet := sync.Map{}
 
 	pm := GetProcessMonitor()
-	unsubscribeExec, err := pm.Subscribe(&ProcessCallback{
-		Event:    EXEC,
-		Metadata: ANY,
-		Callback: func(pid uint32) {
+
+	registerCallback(t, pm, true, &ProcessCallback{
+		FilterType: ANY,
+		Callback: func(pid int) {
 			execSet.Store(pid, struct{}{})
 		},
 	})
-	require.NoError(t, err, "could not subscribe to EXEC events")
-	defer unsubscribeExec()
 
 	monNs, err := netns.New()
 	require.NoError(t, err, "could not create network namespace for process monitor")
-	defer monNs.Close()
+	t.Cleanup(func() { monNs.Close() })
 
 	require.NoError(t, procutils.WithNS(monNs, pm.Initialize), "could not start process monitor in netNS")
+	t.Cleanup(pm.Stop)
 
+	time.Sleep(500 * time.Millisecond)
 	// Process in root NS
 	cmd := exec.Command("/bin/echo")
 	require.NoError(t, cmd.Run(), "could not run process in root namespace")
 
 	require.Eventually(t, func() bool {
-		_, captured := execSet.Load(uint32(cmd.ProcessState.Pid()))
+		_, captured := execSet.Load(cmd.ProcessState.Pid())
 		return captured
-	}, time.Second, 200*time.Millisecond, "did not capture process EXEC from root namespace")
+	}, time.Second, time.Millisecond*200, "did not capture process EXEC from root namespace")
 
 	// Process in another NS
 	cmdNs, err := netns.New()
@@ -216,7 +249,97 @@ func TestProcessMonitorInNamespace(t *testing.T) {
 	require.NoError(t, procutils.WithNS(cmdNs, cmd.Run), "could not run process in other network namespace")
 
 	require.Eventually(t, func() bool {
-		_, captured := execSet.Load(uint32(cmd.ProcessState.Pid()))
+		_, captured := execSet.Load(cmd.ProcessState.Pid())
 		return captured
 	}, time.Second, 200*time.Millisecond, "did not capture process EXEC from other namespace")
+}
+
+func TestRegisterMultipleSameCallbacks(t *testing.T) {
+	pm := GetProcessMonitor()
+
+	callback := &ProcessCallback{
+		FilterType: ANY,
+		Callback:   func(pid int) {},
+	}
+	registerCallback(t, pm, true, callback)
+	_, err := pm.SubscribeExec(callback)
+	require.Error(t, err)
+}
+
+func T1estProcessMonitorLoad(t *testing.T) {
+	execSet := atomic.Uint32{}
+	exitSet := atomic.Uint32{}
+	exec2 := atomic.Uint32{}
+
+	execM := sync.Map{}
+	exit := sync.Map{}
+	execM2 := sync.Map{}
+	pm := GetProcessMonitor()
+	unsubscribeExec, err := pm.SubscribeExec(&ProcessCallback{
+		FilterType: ANY,
+		Callback: func(pid int) {
+			execM.Store(pid, struct{}{})
+			p, err := process.NewProcess(int32(pid))
+			if err != nil {
+				return
+			}
+			name, err := p.Name()
+			if err != nil {
+				return
+			}
+			if strings.Contains(name, "curl") {
+				execSet.Inc()
+			}
+		},
+	})
+	require.NoError(t, err, "could not subscribe to EXEC events")
+	defer unsubscribeExec()
+	unsubscribeExit, err := pm.SubscribeExit(&ProcessCallback{
+		FilterType: ANY,
+		Callback: func(pid int) {
+			exit.Store(pid, struct{}{})
+			p, err := process.NewProcess(int32(pid))
+			if err != nil {
+				return
+			}
+			name, err := p.Name()
+			if err != nil {
+				return
+			}
+			if strings.Contains(name, "curl") {
+				exitSet.Inc()
+			}
+		},
+	})
+	require.NoError(t, err, "could not subscribe to Exit events")
+	defer unsubscribeExit()
+
+	require.NoError(t, pm.Initialize())
+
+	processNum := 5000
+
+	for j := 0; j < 7; j++ {
+		wg := sync.WaitGroup{}
+		wg.Add(processNum)
+		for i := 0; i < processNum; i++ {
+			go func() {
+				defer wg.Done()
+				p := exec.Command("curl", "http://localhost:8080/delay/3")
+				err := p.Start()
+				if err != nil {
+					t.Log(err)
+					return
+				}
+				exec2.Inc()
+				execM2.Load(p.Process.Pid)
+			}()
+		}
+
+		wg.Wait()
+
+		time.Sleep(time.Second * 5)
+	}
+
+	fmt.Println(execSet.Load(), exitSet.Load(), exec2.Load())
+	time.Sleep(time.Second * 30)
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
The new change reinitialize process monitor after such crash, intorducing improvement in the performance by getting rid of mutexes, and introduces a safe guard of periordic scanning of the proc directory and looking for terminated processes.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

We found out that process event monitor from netlink can return an error of 'not enough space', which caused our main event loop to terminate That behavior lead into leaking FDs and memory, and for process monitor consumers, once the process monitor crashed, we didn't report on processes that ended.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
