### PR TITLE
Move system-probe kitchen tests to exclusively EC2

### DIFF
--- a/.gitlab/functional_test/system_probe.yml
+++ b/.gitlab/functional_test/system_probe.yml
@@ -37,34 +37,6 @@
   - $S3_CP_CMD $S3_ARTIFACTS_URI/minimized-btfs-${ARCH}.tar.xz /tmp/minimized-btfs.tar.xz
   - cp /tmp/minimized-btfs.tar.xz $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files/minimized-btfs.tar.xz
 
-kitchen_test_system_probe_linux_x64:
-  extends:
-    - .kitchen_test_system_probe
-    - .kitchen_azure_x64
-    - .kitchen_azure_location_north_central_us
-  needs: [ "tests_ebpf_x64", "prepare_ebpf_functional_tests_x64", "generate_minimized_btfs_x64", "pull_test_dockers_x64" ]
-  variables:
-    ARCH: amd64
-    KITCHEN_ARCH: x86_64
-    KITCHEN_IMAGE_SIZE: Standard_D11_v2
-    KITCHEN_CI_MOUNT_PATH: "/mnt/ci"
-    KITCHEN_CI_ROOT_PATH: "/tmp/ci"
-    KITCHEN_DOCKERS: $DD_AGENT_TESTING_DIR/kitchen-dockers-$ARCH
-  before_script:
-    - !reference [.retrieve_test_dockers]
-    - !reference [.retrieve_minimized_btfs]
-    - pushd $DD_AGENT_TESTING_DIR
-    - tasks/kitchen_setup.sh
-  parallel:
-    matrix:
-      - KITCHEN_PLATFORM: "ubuntu"
-        KITCHEN_OSVERS: "ubuntu-18-04,ubuntu-20-04,ubuntu-22-04"
-      - KITCHEN_PLATFORM: "debian"
-        KITCHEN_OSVERS: "debian-10,debian-11"
-      - KITCHEN_PLATFORM: "centos"
-        KITCHEN_OSVERS: "centos-76"
-        KITCHEN_CI_MOUNT_PATH: "/mnt/resource/ci"
-
 kitchen_test_system_probe_linux_x64_ec2:
   extends:
     - .kitchen_test_system_probe
@@ -88,11 +60,16 @@ kitchen_test_system_probe_linux_x64_ec2:
       - KITCHEN_PLATFORM: "amazonlinux"
         KITCHEN_OSVERS: "amazonlinux2-4-14,amazonlinux2-5-10,amazonlinux2022-5-15"
       - KITCHEN_PLATFORM: "centos"
-        KITCHEN_OSVERS: "rhel-86"
+        KITCHEN_OSVERS: "centos-79,rhel-86"
         KITCHEN_EC2_DEVICE_NAME: "/dev/sda1"
       - KITCHEN_PLATFORM: "ubuntu"
         KITCHEN_OSVERS: "ubuntu-16-04-4.4"
         KITCHEN_EC2_DEVICE_NAME: "/dev/sda1"
+      - KITCHEN_PLATFORM: "ubuntu"
+        KITCHEN_OSVERS: "ubuntu-16-04,ubuntu-18-04,ubuntu-20-04,ubuntu-22-04"
+        KITCHEN_EC2_DEVICE_NAME: "/dev/sda1"
+      - KITCHEN_PLATFORM: "debian"
+        KITCHEN_OSVERS: "debian-10,debian-11"
 
 kitchen_test_system_probe_linux_arm64:
   extends:

--- a/.gitlab/junit_upload/functional_test_junit_upload_system_probe.yml
+++ b/.gitlab/junit_upload/functional_test_junit_upload_system_probe.yml
@@ -8,8 +8,6 @@ functional_test_junit_upload_system_probe:
   allow_failure: true
   when: always
   needs:
-    - job: kitchen_test_system_probe_linux_x64
-      optional: true
     - job: kitchen_test_system_probe_linux_x64_ec2
       optional: true
     - job: kitchen_test_system_probe_linux_arm64

--- a/test/kitchen/platforms.json
+++ b/test/kitchen/platforms.json
@@ -12,6 +12,7 @@
         },
         "ec2": {
             "x86_64": {
+                "centos-79": "ami-00e87074e52e6c9f9",
                 "rhel-86": "ami-06640050dc3f556bb"
             },
             "arm64": {
@@ -37,9 +38,13 @@
             }
         },
         "ec2": {
+            "x86_64": {
+                "debian-10": "ami-09c5dc3046df4741f",
+                "debian-11": "ami-09e24b0cfe072ecef"
+            },
             "arm64": {
-                "debian-10": "ami-018ce69d4b9c9e3ec",
-                "debian-11": "ami-0d53a3ba77632d713"
+                "debian-10": "ami-0d35a4c5725fd0da7",
+                "debian-11": "ami-03ea090ddd75eb738"
             }
         }
     },
@@ -72,7 +77,11 @@
         },
         "ec2": {
             "x86_64": {
-                "ubuntu-16-04-4.4": "ami-a4dc46db"
+                "ubuntu-16-04-4.4": "ami-a4dc46db",
+                "ubuntu-16-04": "ami-0b0ea68c435eb488d",
+                "ubuntu-18-04": "ami-0ee23bfc74a881de5",
+                "ubuntu-20-04": "ami-079ca844e323047c2",
+                "ubuntu-22-04": "ami-08c40ec9ead489470"
             },
             "arm64": {
                 "ubuntu-18-04": "ami-02ed82f3a38303e6f",


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Moves remaining system-probe kitchen tests to EC2

### Motivation

Significant speed up in total runtime. Ubuntu and Debian jobs were faster by 15-20 minutes.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
