### PR TITLE
Use repo-relative paths for RC go:generate tools

### DIFF
--- a/pkg/collector/corechecks/ebpf/probe/oom_kill.go
+++ b/pkg/collector/corechecks/ebpf/probe/oom_kill.go
@@ -6,8 +6,8 @@
 //go:build linux_bpf
 // +build linux_bpf
 
-//go:generate go run ../../../../ebpf/include_headers.go ../c/runtime/oom-kill-kern.c ../../../../ebpf/bytecode/build/runtime/oom-kill.c ../../../../ebpf/c
-//go:generate go run ../../../../ebpf/bytecode/runtime/integrity.go ../../../../ebpf/bytecode/build/runtime/oom-kill.c ../../../../ebpf/bytecode/runtime/oom-kill.go runtime
+//go:generate $GOPATH/bin/include_headers pkg/collector/corechecks/ebpf/c/runtime/oom-kill-kern.c pkg/ebpf/bytecode/build/runtime/oom-kill.c pkg/ebpf/c
+//go:generate $GOPATH/bin/integrity pkg/ebpf/bytecode/build/runtime/oom-kill.c pkg/ebpf/bytecode/runtime/oom-kill.go runtime
 
 package probe
 

--- a/pkg/collector/corechecks/ebpf/probe/tcp_queue_length.go
+++ b/pkg/collector/corechecks/ebpf/probe/tcp_queue_length.go
@@ -6,8 +6,8 @@
 //go:build linux_bpf
 // +build linux_bpf
 
-//go:generate go run ../../../../ebpf/include_headers.go ../c/runtime/tcp-queue-length-kern.c ../../../../ebpf/bytecode/build/runtime/tcp-queue-length.c ../../../../ebpf/c
-//go:generate go run ../../../../ebpf/bytecode/runtime/integrity.go ../../../../ebpf/bytecode/build/runtime/tcp-queue-length.c ../../../../ebpf/bytecode/runtime/tcp-queue-length.go runtime
+//go:generate $GOPATH/bin/include_headers pkg/collector/corechecks/ebpf/c/runtime/tcp-queue-length-kern.c pkg/ebpf/bytecode/build/runtime/tcp-queue-length.c pkg/ebpf/c
+//go:generate $GOPATH/bin/integrity pkg/ebpf/bytecode/build/runtime/tcp-queue-length.c pkg/ebpf/bytecode/runtime/tcp-queue-length.go runtime
 
 package probe
 

--- a/pkg/network/tracer/compile.go
+++ b/pkg/network/tracer/compile.go
@@ -14,8 +14,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/process/statsd"
 )
 
-//go:generate go run ../../../pkg/ebpf/include_headers.go ../../../pkg/network/ebpf/c/runtime/conntrack.c ../../../pkg/ebpf/bytecode/build/runtime/conntrack.c ../../../pkg/ebpf/c ../../../pkg/ebpf/c/protocols ../../../pkg/network/ebpf/c/runtime ../../../pkg/network/ebpf/c
-//go:generate go run ../../../pkg/ebpf/bytecode/runtime/integrity.go ../../../pkg/ebpf/bytecode/build/runtime/conntrack.c ../../../pkg/ebpf/bytecode/runtime/conntrack.go runtime
+//go:generate $GOPATH/bin/include_headers pkg/network/ebpf/c/runtime/conntrack.c pkg/ebpf/bytecode/build/runtime/conntrack.c pkg/ebpf/c pkg/ebpf/c/protocols pkg/network/ebpf/c/runtime pkg/network/ebpf/c
+//go:generate $GOPATH/bin/integrity pkg/ebpf/bytecode/build/runtime/conntrack.c pkg/ebpf/bytecode/runtime/conntrack.go runtime
 
 func getRuntimeCompiledConntracker(config *config.Config) (runtime.CompiledOutput, error) {
 	return runtime.Conntrack.Compile(&config.Config, getCFlags(config), statsd.Client)

--- a/pkg/network/tracer/connection/kprobe/compile.go
+++ b/pkg/network/tracer/connection/kprobe/compile.go
@@ -14,8 +14,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/process/statsd"
 )
 
-//go:generate go run ../../../../../pkg/ebpf/include_headers.go ../../../../../pkg/network/ebpf/c/tracer.c ../../../../../pkg/ebpf/bytecode/build/runtime/tracer.c ../../../../../pkg/ebpf/c  ../../../../../pkg/ebpf/c/protocols ../../../../../pkg/network/ebpf/c/runtime ../../../../../pkg/network/ebpf/c
-//go:generate go run ../../../../../pkg/ebpf/bytecode/runtime/integrity.go ../../../../../pkg/ebpf/bytecode/build/runtime/tracer.c ../../../../../pkg/ebpf/bytecode/runtime/tracer.go runtime
+//go:generate $GOPATH/bin/include_headers pkg/network/ebpf/c/tracer.c pkg/ebpf/bytecode/build/runtime/tracer.c pkg/ebpf/c pkg/ebpf/c/protocols pkg/network/ebpf/c/runtime pkg/network/ebpf/c
+//go:generate $GOPATH/bin/integrity pkg/ebpf/bytecode/build/runtime/tracer.c pkg/ebpf/bytecode/runtime/tracer.go runtime
 
 func getRuntimeCompiledTracer(config *config.Config) (runtime.CompiledOutput, error) {
 	return runtime.Tracer.Compile(&config.Config, getCFlags(config), statsd.Client)

--- a/pkg/network/tracer/offsetguess_test.go
+++ b/pkg/network/tracer/offsetguess_test.go
@@ -29,8 +29,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 )
 
-//go:generate go run ../../../pkg/ebpf/include_headers.go ../../../pkg/network/ebpf/c/runtime/offsetguess-test.c ../../../pkg/ebpf/bytecode/build/runtime/offsetguess-test.c ../../../pkg/ebpf/c ../../../pkg/ebpf/c/protocols ../../../pkg/network/ebpf/c/runtime ../../../pkg/network/ebpf/c
-//go:generate go run ../../../pkg/ebpf/bytecode/runtime/integrity.go ../../../pkg/ebpf/bytecode/build/runtime/offsetguess-test.c ../../../pkg/ebpf/bytecode/runtime/offsetguess-test.go runtime
+//go:generate $GOPATH/bin/include_headers pkg/network/ebpf/c/runtime/offsetguess-test.c pkg/ebpf/bytecode/build/runtime/offsetguess-test.c pkg/ebpf/c pkg/ebpf/c/protocols pkg/network/ebpf/c/runtime pkg/network/ebpf/c
+//go:generate $GOPATH/bin/integrity pkg/ebpf/bytecode/build/runtime/offsetguess-test.c pkg/ebpf/bytecode/runtime/offsetguess-test.go runtime
 
 type offsetT int
 

--- a/pkg/network/usm/compile.go
+++ b/pkg/network/usm/compile.go
@@ -14,8 +14,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/process/statsd"
 )
 
-//go:generate go run ../../../pkg/ebpf/include_headers.go ../../../pkg/network/ebpf/c/runtime/usm.c ../../../pkg/ebpf/bytecode/build/runtime/usm.c ../../../pkg/ebpf/c ../../../pkg/ebpf/c/protocols ../../../pkg/network/ebpf/c/runtime ../../../pkg/network/ebpf/c
-//go:generate go run ../../../pkg/ebpf/bytecode/runtime/integrity.go ../../../pkg/ebpf/bytecode/build/runtime/usm.c ../../../pkg/ebpf/bytecode/runtime/usm.go runtime
+//go:generate $GOPATH/bin/include_headers pkg/network/ebpf/c/runtime/usm.c pkg/ebpf/bytecode/build/runtime/usm.c pkg/ebpf/c pkg/ebpf/c/protocols pkg/network/ebpf/c/runtime pkg/network/ebpf/c
+//go:generate $GOPATH/bin/integrity pkg/ebpf/bytecode/build/runtime/usm.c pkg/ebpf/bytecode/runtime/usm.go runtime
 
 func getRuntimeCompiledUSM(config *config.Config) (runtime.CompiledOutput, error) {
 	return runtime.Usm.Compile(&config.Config, getCFlags(config), statsd.Client)

--- a/pkg/security/ebpf/compile.go
+++ b/pkg/security/ebpf/compile.go
@@ -17,8 +17,8 @@ import (
 )
 
 // TODO change probe.c path to runtime-compilation specific version
-//go:generate go run ../../ebpf/include_headers.go ./c/prebuilt/probe.c ../../ebpf/bytecode/build/runtime/runtime-security.c ./c/include ../../ebpf/c
-//go:generate go run ../../ebpf/bytecode/runtime/integrity.go ../../ebpf/bytecode/build/runtime/runtime-security.c ../../ebpf/bytecode/runtime/runtime-security.go runtime
+//go:generate $GOPATH/bin/include_headers pkg/security/ebpf/c/prebuilt/probe.c pkg/ebpf/bytecode/build/runtime/runtime-security.c pkg/security/ebpf/c/include pkg/ebpf/c
+//go:generate $GOPATH/bin/integrity pkg/ebpf/bytecode/build/runtime/runtime-security.c pkg/ebpf/bytecode/runtime/runtime-security.go runtime
 //go:generate go run github.com/DataDog/datadog-agent/pkg/security/secl/model/bpf_maps_generator -runtime-path ../../ebpf/bytecode/build/runtime/runtime-security.c -output ../../security/secl/model/consts_map_names.go -pkg-name model
 
 func getRuntimeCompiledPrograms(config *config.Config, useSyscallWrapper, useRingBuffer bool, client statsd.ClientInterface) (bytecode.AssetReader, error) {

--- a/tasks/utils.py
+++ b/tasks/utils.py
@@ -59,6 +59,17 @@ def get_gopath(ctx):
     return gopath
 
 
+def get_gobin(ctx):
+    gobin = os.environ.get("GOBIN")
+    if not gobin:
+        gobin = ctx.run("go env GOBIN", hide=True).stdout.strip()
+        if not gobin:
+            gopath = get_gopath(ctx)
+            gobin = os.path.join(gopath, "bin")
+
+    return gobin
+
+
 def get_rtloader_paths(embedded_path=None, rtloader_root=None):
     rtloader_lib = []
     rtloader_headers = ""


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Use repo-relative (i.e. `pkg/...`) paths for system-probe runtime compilation `go:generate` tools, rather than lengthy relative paths.

### Motivation

Simpler and easier to understand paths in `go:generate` commands

### Additional Notes

This builds `include_headers` and `integrity` as standalone binaries for use in `go:generate`. The `ninja` file is setup to properly handle the dependency.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
