### PR TITLE
[CWS] Moved process source from proccess context to process

### DIFF
--- a/docs/cloud-workload-security/backend.md
+++ b/docs/cloud-workload-security/backend.md
@@ -826,6 +826,10 @@ CWS logs have the following JSON schema:
                 "is_kworker": {
                     "type": "boolean",
                     "description": "Indicates whether the process is a kworker"
+                },
+                "source": {
+                    "type": "string",
+                    "description": "Process source"
                 }
             },
             "additionalProperties": false,
@@ -2475,6 +2479,10 @@ CWS logs have the following JSON schema:
         "is_kworker": {
             "type": "boolean",
             "description": "Indicates whether the process is a kworker"
+        },
+        "source": {
+            "type": "string",
+            "description": "Process source"
         }
     },
     "additionalProperties": false,
@@ -2514,6 +2522,7 @@ CWS logs have the following JSON schema:
 | `envs_truncated` | Indicator of environments variable truncation |
 | `is_thread` | Indicates whether the process is considered a thread (that is, a child process that hasn't executed another program) |
 | `is_kworker` | Indicates whether the process is a kworker |
+| `source` | Process source |
 
 | References |
 | ---------- |

--- a/docs/cloud-workload-security/backend.schema.json
+++ b/docs/cloud-workload-security/backend.schema.json
@@ -810,6 +810,10 @@
         "is_kworker": {
           "type": "boolean",
           "description": "Indicates whether the process is a kworker"
+        },
+        "source": {
+          "type": "string",
+          "description": "Process source"
         }
       },
       "additionalProperties": false,

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -579,6 +579,8 @@ type Process struct {
 	Variables             eval.Variables `field:"-" json:"-"`
 
 	IsThread bool `field:"is_thread"` // SECLDoc[is_thread] Definition:`Indicates whether the process is considered a thread (that is, a child process that hasn't executed another program)`
+
+	Source uint64 `field:"-" json:"-"`
 }
 
 // SpanContext describes a span context
@@ -888,7 +890,6 @@ func (p *ProcessContext) HasParent() bool {
 // ProcessContext holds the process context of an event
 type ProcessContext struct {
 	Process
-	Source uint64 `field:"-" json:"-"`
 
 	Parent   *Process           `field:"parent,opts:exposed_at_event_root_only,check:HasParent"`
 	Ancestor *ProcessCacheEntry `field:"ancestors,iterator:ProcessAncestorsIterator,check:IsNotKworker"`

--- a/pkg/security/serializers/serializers.go
+++ b/pkg/security/serializers/serializers.go
@@ -217,6 +217,8 @@ type ProcessSerializer struct {
 	IsThread bool `json:"is_thread,omitempty"`
 	// Indicates whether the process is a kworker
 	IsKworker bool `json:"is_kworker,omitempty"`
+	// Process source
+	Source string `json:"source,omitempty"`
 }
 
 // ContainerContextSerializer serializes a container context to JSON
@@ -264,8 +266,6 @@ type EventContextSerializer struct {
 // easyjson:json
 type ProcessContextSerializer struct {
 	*ProcessSerializer
-	// Process source
-	Source string `json:"source,omitempty"`
 	// Parent process
 	Parent *ProcessSerializer `json:"parent,omitempty"`
 	// Ancestor processes
@@ -689,6 +689,7 @@ func newProcessSerializer(ps *model.Process, e *model.Event, resolvers *resolver
 			EnvsTruncated: EnvsTruncated,
 			IsThread:      ps.IsThread,
 			IsKworker:     ps.IsKworker,
+			Source:        model.ProcessSourceToString(ps.Source),
 		}
 
 		if ps.HasInterpreter() {
@@ -719,6 +720,7 @@ func newProcessSerializer(ps *model.Process, e *model.Event, resolvers *resolver
 			Pid:       ps.Pid,
 			Tid:       ps.Tid,
 			IsKworker: ps.IsKworker,
+			Source:    model.ProcessSourceToString(ps.Source),
 			Credentials: &ProcessCredentialsSerializer{
 				CredentialsSerializer: &CredentialsSerializer{},
 			},
@@ -771,8 +773,6 @@ func newProcessContextSerializer(pc *model.ProcessContext, e *model.Event, resol
 	ps := ProcessContextSerializer{
 		ProcessSerializer: newProcessSerializer(&pc.Process, e, resolvers),
 	}
-
-	ps.Source = model.ProcessSourceToString(pc.Source)
 
 	ctx := eval.NewContext(e)
 

--- a/pkg/security/serializers/serializers_easyjson.go
+++ b/pkg/security/serializers/serializers_easyjson.go
@@ -844,6 +844,8 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecuritySerializers9(i
 			out.IsThread = bool(in.Bool())
 		case "is_kworker":
 			out.IsKworker = bool(in.Bool())
+		case "source":
+			out.Source = string(in.String())
 		default:
 			in.SkipRecursive()
 		}
@@ -1011,6 +1013,11 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecuritySerializers9(o
 		const prefix string = ",\"is_kworker\":"
 		out.RawString(prefix)
 		out.Bool(bool(in.IsKworker))
+	}
+	if in.Source != "" {
+		const prefix string = ",\"source\":"
+		out.RawString(prefix)
+		out.String(string(in.Source))
 	}
 	out.RawByte('}')
 }
@@ -1277,8 +1284,6 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecuritySerializers11(
 			continue
 		}
 		switch key {
-		case "source":
-			out.Source = string(in.String())
 		case "parent":
 			if in.IsNull() {
 				in.Skip()
@@ -1480,6 +1485,8 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecuritySerializers11(
 			out.IsThread = bool(in.Bool())
 		case "is_kworker":
 			out.IsKworker = bool(in.Bool())
+		case "source":
+			out.Source = string(in.String())
 		default:
 			in.SkipRecursive()
 		}
@@ -1494,20 +1501,10 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecuritySerializers11(
 	out.RawByte('{')
 	first := true
 	_ = first
-	if in.Source != "" {
-		const prefix string = ",\"source\":"
-		first = false
-		out.RawString(prefix[1:])
-		out.String(string(in.Source))
-	}
 	if in.Parent != nil {
 		const prefix string = ",\"parent\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
+		first = false
+		out.RawString(prefix[1:])
 		(*in.Parent).MarshalEasyJSON(out)
 	}
 	if len(in.Ancestors) != 0 {
@@ -1690,6 +1687,11 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecuritySerializers11(
 		const prefix string = ",\"is_kworker\":"
 		out.RawString(prefix)
 		out.Bool(bool(in.IsKworker))
+	}
+	if in.Source != "" {
+		const prefix string = ",\"source\":"
+		out.RawString(prefix)
+		out.String(string(in.Source))
 	}
 	out.RawByte('}')
 }


### PR DESCRIPTION
This PR aims to move the source field from the process context context structure to the process's structure. So that we can have the source information for every process present in the hierarchy not just the one that triggered the rule.

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
