### PR TITLE
[SBOM] fix high number of goroutines + errors when scan queue is full

### DIFF
--- a/pkg/collector/corechecks/sbom/processor.go
+++ b/pkg/collector/corechecks/sbom/processor.go
@@ -191,6 +191,7 @@ func (p *processor) processHostRefresh() {
 		result := <-ch
 
 		if result.Error != nil {
+			// TODO: add a retry mechanism for retryable errors
 			log.Errorf("Failed to generate SBOM for host: %s", result.Error)
 			return
 		}

--- a/pkg/sbom/collectors/collectors.go
+++ b/pkg/sbom/collectors/collectors.go
@@ -15,7 +15,7 @@ import (
 type Collector interface {
 	CleanCache() error
 	Init(config.Config) error
-	Scan(context.Context, sbom.ScanRequest, sbom.ScanOptions) (sbom.Report, error)
+	Scan(context.Context, sbom.ScanRequest, sbom.ScanOptions) sbom.ScanResult
 }
 
 var Collectors map[string]Collector

--- a/pkg/sbom/collectors/docker/docker.go
+++ b/pkg/sbom/collectors/docker/docker.go
@@ -60,18 +60,24 @@ func (c *Collector) Init(cfg config.Config) error {
 	return nil
 }
 
-func (c *Collector) Scan(ctx context.Context, request sbom.ScanRequest, opts sbom.ScanOptions) (sbom.Report, error) {
+func (c *Collector) Scan(ctx context.Context, request sbom.ScanRequest, opts sbom.ScanOptions) sbom.ScanResult {
 	dockerScanRequest, ok := request.(*ScanRequest)
 	if !ok {
-		return nil, fmt.Errorf("invalid request type '%s' for collector '%s'", reflect.TypeOf(request), collectorName)
+		return sbom.ScanResult{Error: fmt.Errorf("invalid request type '%s' for collector '%s'", reflect.TypeOf(request), collectorName)}
 	}
 
-	return c.trivyCollector.ScanDockerImage(
+	report, err := c.trivyCollector.ScanDockerImage(
 		ctx,
 		dockerScanRequest.ImageMeta,
 		dockerScanRequest.DockerClient,
 		opts,
 	)
+
+	return sbom.ScanResult{
+		Error:   err,
+		Report:  report,
+		ImgMeta: dockerScanRequest.ImageMeta,
+	}
 }
 
 func init() {

--- a/pkg/sbom/collectors/host/host.go
+++ b/pkg/sbom/collectors/host/host.go
@@ -56,13 +56,17 @@ func (c *HostCollector) Init(cfg config.Config) error {
 	return nil
 }
 
-func (c *HostCollector) Scan(ctx context.Context, request sbom.ScanRequest, opts sbom.ScanOptions) (sbom.Report, error) {
+func (c *HostCollector) Scan(ctx context.Context, request sbom.ScanRequest, opts sbom.ScanOptions) sbom.ScanResult {
 	hostScanRequest, ok := request.(*ScanRequest)
 	if !ok {
-		return nil, fmt.Errorf("invalid request type '%s' for collector '%s'", reflect.TypeOf(request), collectorName)
+		return sbom.ScanResult{Error: fmt.Errorf("invalid request type '%s' for collector '%s'", reflect.TypeOf(request), collectorName)}
 	}
 
-	return c.trivyCollector.ScanFilesystem(ctx, hostScanRequest.Path, opts)
+	report, err := c.trivyCollector.ScanFilesystem(ctx, hostScanRequest.Path, opts)
+	return sbom.ScanResult{
+		Error:  err,
+		Report: report,
+	}
 }
 
 func init() {

--- a/pkg/sbom/sbom.go
+++ b/pkg/sbom/sbom.go
@@ -10,6 +10,7 @@ import (
 
 	cyclonedxgo "github.com/CycloneDX/cyclonedx-go"
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 )
 
 const (
@@ -58,4 +59,5 @@ type ScanResult struct {
 	Report    Report
 	CreatedAt time.Time
 	Duration  time.Duration
+	ImgMeta   *workloadmeta.ContainerImageMetadata
 }

--- a/pkg/sbom/scanner/scanner.go
+++ b/pkg/sbom/scanner/scanner.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 	"sync"
 	"time"
 
@@ -122,9 +123,9 @@ func (s *Scanner) start(ctx context.Context) {
 					scanTimeout = defaultScanTimeout
 				}
 
+				log.Info("scanning from %v, id: %s", reflect.TypeOf(request), request.ID())
 				scanContext, cancel := context.WithTimeout(ctx, scanTimeout)
 				createdAt := time.Now()
-				log.Info("scanning image %s", request.ID())
 				scanResult := collector.Scan(scanContext, request.ScanRequest, request.opts)
 				if scanResult.Error != nil {
 					telemetry.SBOMFailures.Inc(request.Collector(), request.Type(), "scan")

--- a/pkg/security/resolvers/sbom/resolver.go
+++ b/pkg/security/resolvers/sbom/resolver.go
@@ -205,6 +205,7 @@ func (r *Resolver) generateSBOM(root string, sbom *SBOM) error {
 	result := <-ch
 
 	if result.Error != nil {
+		// TODO: add a retry mechanism for retryable errors
 		return fmt.Errorf("failed to generate SBOM for %s: %w", root, result.Error)
 	}
 

--- a/pkg/workloadmeta/collectors/internal/containerd/image_sbom_trivy.go
+++ b/pkg/workloadmeta/collectors/internal/containerd/image_sbom_trivy.go
@@ -107,7 +107,7 @@ func (c *collector) startSBOMCollection(ctx context.Context) error {
 	return nil
 }
 
-func (c *collector) extractBOMWithTrivy(ctx context.Context, storedImage *workloadmeta.ContainerImageMetadata, ch chan sbom.ScanResult) error {
+func (c *collector) extractBOMWithTrivy(ctx context.Context, storedImage *workloadmeta.ContainerImageMetadata, resultChan chan<- sbom.ScanResult) error {
 	containerdImage, err := c.containerdClient.Image(storedImage.Namespace, storedImage.Name)
 	if err != nil {
 		return err
@@ -119,7 +119,7 @@ func (c *collector) extractBOMWithTrivy(ctx context.Context, storedImage *worklo
 		ContainerdClient: c.containerdClient,
 		FromFilesystem:   config.Datadog.GetBool("container_image_collection.sbom.use_mount"),
 	}
-	if err = c.sbomScanner.Scan(scanRequest, c.scanOptions, ch); err != nil {
+	if err = c.sbomScanner.Scan(scanRequest, c.scanOptions, resultChan); err != nil {
 		log.Errorf("Failed to trigger SBOM generation for containerd: %s", err)
 		return err
 	}

--- a/pkg/workloadmeta/collectors/internal/containerd/image_sbom_trivy.go
+++ b/pkg/workloadmeta/collectors/internal/containerd/image_sbom_trivy.go
@@ -77,6 +77,7 @@ func (c *collector) startSBOMCollection(ctx context.Context) error {
 	go func() {
 		for result := range resultChan {
 			if result.Error != nil {
+				// TODO: add a retry mechanism for retryable errors
 				log.Errorf("Failed to generate SBOM for containerd image: %s", result.Error)
 				continue
 			}

--- a/pkg/workloadmeta/collectors/internal/docker/image_sbom_trivy.go
+++ b/pkg/workloadmeta/collectors/internal/docker/image_sbom_trivy.go
@@ -119,13 +119,13 @@ func (c *collector) startSBOMCollection(ctx context.Context) error {
 	return nil
 }
 
-func (c *collector) extractBOMWithTrivy(ctx context.Context, storedImage *workloadmeta.ContainerImageMetadata, ch chan sbom.ScanResult) error {
+func (c *collector) extractBOMWithTrivy(ctx context.Context, storedImage *workloadmeta.ContainerImageMetadata, resultChan chan<- sbom.ScanResult) error {
 	scanRequest := &docker.ScanRequest{
 		ImageMeta:    storedImage,
 		DockerClient: c.dockerUtil.RawClient(),
 	}
 
-	if err := c.sbomScanner.Scan(scanRequest, c.scanOptions, ch); err != nil {
+	if err := c.sbomScanner.Scan(scanRequest, c.scanOptions, resultChan); err != nil {
 		log.Errorf("Failed to trigger SBOM generation for docker: %s", err)
 		return err
 	}

--- a/pkg/workloadmeta/collectors/internal/docker/image_sbom_trivy.go
+++ b/pkg/workloadmeta/collectors/internal/docker/image_sbom_trivy.go
@@ -83,6 +83,7 @@ func (c *collector) startSBOMCollection(ctx context.Context) error {
 	go func() {
 		for result := range resultChan {
 			if result.Error != nil {
+				// TODO: add a retry mechanism for retryable errors
 				log.Errorf("Failed to generate SBOM for docker: %s", result.Error)
 				continue
 			}


### PR DESCRIPTION

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
This PR refactors SBOM collection to:
- Use a single goroutine to collect scan results. A single host can have hundreds or thousands of images. We could only use a single goroutine instead of one per image.
- Make the scan queue bigger.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Less resource usage and no error on hosts with more than 500 ongoing scans. 
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
We still need a retry mechanism and we need to avoid scanning twice the same image if we succeeded once.
Some errors still remain and need to be investigated.
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs
N/A
<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
Deploy the agent in a containerized environment, verify that SBOM get collected. Monitor the number of goroutines and check that they are indeed reduced. Deploy the agent on a node with more than 500 big images and check that scans do not fail.
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
