### PR TITLE
[7.45] Backport Prometheus AD fix

### DIFF
--- a/pkg/autodiscovery/common/types/prometheus.go
+++ b/pkg/autodiscovery/common/types/prometheus.go
@@ -176,7 +176,7 @@ func (pc *PrometheusCheck) initAD() error {
 	return pc.AD.setContainersRegex()
 }
 
-// IsExcluded returns whether is the annotations match an AD exclusion rule
+// IsExcluded returns whether the annotations match an AD exclusion rule
 func (pc *PrometheusCheck) IsExcluded(annotations map[string]string, namespacedName string) bool {
 	for k, v := range pc.AD.KubeAnnotations.Excl {
 		if annotations[k] == v {
@@ -185,6 +185,26 @@ func (pc *PrometheusCheck) IsExcluded(annotations map[string]string, namespacedN
 		}
 	}
 	return false
+}
+
+// IsIncluded returns whether the annotations match an AD inclusion rule and is not excluded
+func (pc *PrometheusCheck) IsIncluded(annotations map[string]string) bool {
+	included := false
+	if pc.AD == nil || pc.AD.KubeAnnotations == nil {
+		return false
+	}
+
+	for k, v := range annotations {
+		if pc.AD.KubeAnnotations.Excl[k] == v {
+			return false
+		}
+
+		if pc.AD.KubeAnnotations.Incl[k] == v {
+			included = true
+		}
+	}
+
+	return included
 }
 
 // GetIncludeAnnotations returns the AD include annotations

--- a/pkg/autodiscovery/common/types/prometheus_test.go
+++ b/pkg/autodiscovery/common/types/prometheus_test.go
@@ -134,3 +134,49 @@ func TestPrometheusAnnotationsDiffer(t *testing.T) {
 		})
 	}
 }
+
+func TestPrometheusCheck_IsIncluded(t *testing.T) {
+	tests := []struct {
+		name        string
+		adConfig    *ADConfig
+		annotations map[string]string
+		want        bool
+	}{
+		{
+			name:     "Basic case",
+			adConfig: DefaultPrometheusCheck.AD,
+			annotations: map[string]string{
+				"foo":                      "bar",
+				PrometheusScrapeAnnotation: "true",
+			},
+			want: true,
+		},
+		{
+			name:     "With excluded annotation",
+			adConfig: DefaultPrometheusCheck.AD,
+			annotations: map[string]string{
+				"foo":                      "bar",
+				PrometheusScrapeAnnotation: "false",
+			},
+			want: false,
+		},
+		{
+			name:     "No relevant annotations",
+			adConfig: DefaultPrometheusCheck.AD,
+			annotations: map[string]string{
+				"foo": "bar",
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pc := &PrometheusCheck{
+				AD: tt.adConfig,
+			}
+			if got := pc.IsIncluded(tt.annotations); got != tt.want {
+				t.Errorf("PrometheusCheck.IsIncluded() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/autodiscovery/common/utils/prometheus_apiserver.go
+++ b/pkg/autodiscovery/common/utils/prometheus_apiserver.go
@@ -30,9 +30,6 @@ const (
 func ConfigsForService(pc *types.PrometheusCheck, svc *v1.Service) []integration.Config {
 	var configs []integration.Config
 	namespacedName := fmt.Sprintf("%s/%s", svc.GetNamespace(), svc.GetName())
-	if pc.IsExcluded(svc.GetAnnotations(), namespacedName) {
-		return configs
-	}
 
 	// Ignore headless services because we can't resolve the IP.
 	// Ref: https://kubernetes.io/docs/concepts/services-networking/service/#headless-services
@@ -63,10 +60,6 @@ func ConfigsForService(pc *types.PrometheusCheck, svc *v1.Service) []integration
 func ConfigsForServiceEndpoints(pc *types.PrometheusCheck, svc *v1.Service, ep *v1.Endpoints) []integration.Config {
 	var configs []integration.Config
 	namespacedName := fmt.Sprintf("%s/%s", svc.GetNamespace(), svc.GetName())
-	if pc.IsExcluded(svc.GetAnnotations(), namespacedName) {
-		return configs
-	}
-
 	instances, found := buildInstances(pc, svc.GetAnnotations(), namespacedName)
 	if found {
 		for _, subset := range ep.Subsets {


### PR DESCRIPTION
### What does this PR do?

Backport #16992 and #17028 (QA instructions)

### Motivation

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

See #17028 

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
