### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ To start working on the Agent, you can build the `main` branch:
        invoke agent.build \
          --python-runtimes 2,3 \
          --python-home-2=$GOPATH/src/github.com/DataDog/datadog-agent/venv2 \
-         --python-home-3=$GOPATH/src/github.com/DataDog/datadog-agent/venv3 .
+         --python-home-3=$GOPATH/src/github.com/DataDog/datadog-agent/venv3
 
     Running `invoke agent.build`:
 


### PR DESCRIPTION
Remove trailing dot which can cause issue if command is copied directly from the README file

### What does this PR do?

Minor correction on a command that can be copied in the main README.md file

### Motivation

As newbie I read the doc and try to review it. Copied as is the command triggers a "No idea what '.' is!"

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

This is a readme file

### Reviewer's Checklist

- [X] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [X] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [X] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [X] Changed code has automated tests for its functionality.
- [X] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [X] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [X] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [X] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [X] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [X] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
