### PR TITLE
[7.44.X] Backport Gitlab/Github API 5xx errors retry

### DIFF
--- a/tasks/libs/common/github_workflows.py
+++ b/tasks/libs/common/github_workflows.py
@@ -96,24 +96,20 @@ class GithubWorkflows(RemoteAPI):
         Adds "Authorization: token {self.api_token}" and "Accept: application/vnd.github.v3+json"
         to the headers to be able to authenticate ourselves to GitHub.
         """
-        url = self.BASE_URL + path
-
         headers = dict(headers or [])
         headers["Authorization"] = f"token {self.api_token}"
         headers["Accept"] = "application/vnd.github.v3+json"
 
-        for _ in range(5):  # Retry up to 5 times
-            return self.request(
-                path=path,
-                headers=headers,
-                data=data,
-                json_input=False,
-                json_output=json_output,
-                raw_output=raw_output,
-                stream_output=False,
-                method=method,
-            )
-        raise GithubException(f"Failed while making HTTP request: {method} {url}")
+        return self.request(
+            path=path,
+            headers=headers,
+            data=data,
+            json_input=False,
+            json_output=json_output,
+            raw_output=raw_output,
+            stream_output=False,
+            method=method,
+        )
 
 
 def get_github_app_token():

--- a/tasks/libs/common/githubapp.py
+++ b/tasks/libs/common/githubapp.py
@@ -7,6 +7,7 @@ from datetime import datetime
 logger = logging.getLogger(__name__)
 logger.setLevel(os.environ.get('LOGGING_LEVEL', 'INFO'))
 
+
 # Defining a custom exception class to throw if the requests error out
 class GithubAppException(Exception):
     pass

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -34,7 +34,7 @@ from .utils import DEFAULT_BRANCH, get_build_flags
 
 PROFILE_COV = "profile.cov"
 GO_TEST_RESULT_TMP_JSON = 'module_test_output.json'
-
+UNIT_TEST_FILE_FORMAT = re.compile(r'[^a-zA-Z0-9_\-]')
 
 class TestProfiler:
     times = []

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -123,9 +123,41 @@ def install_tools(ctx):
                     ctx.run(f"go install {tool}")
 
 
-# TODO(AP-1879): The following four functions all do something similar: they run a given command on a list of modules
-# This could be refactored in a core function that does the loop on modules and returns failures, and
-# wrapper functions that craft the command to run and process the results and errors.
+@task
+def invoke_unit_tests(ctx):
+    """
+    Run the unit tests on the invoke tasks
+    """
+    for _, _, files in os.walk("tasks/unit-tests/"):
+        for file in files:
+            if file[-3:] == ".py" and file != "__init__.py" and not bool(UNIT_TEST_FILE_FORMAT.search(file[:-3])):
+                ctx.run(f"python3 -m tasks.unit-tests.{file[:-3]}", env={"GITLAB_TOKEN": "fake_token"})
+
+
+def test_core(
+    modules: List[GoModule],
+    flavor: AgentFlavor,
+    module_class: GoModule,
+    operation_name: str,
+    command,
+    skip_module_class=False,
+):
+    """
+    Run the command function on each module of the modules list.
+    """
+    modules_results = []
+    print(f"--- Flavor {flavor.name}: {operation_name}")
+    for module in modules:
+        module_result = None
+        if not skip_module_class:
+            module_result = module_class(path=module.full_path())
+        print(f"----- Module '{module.full_path()}'")
+        if not module.condition():
+            print("----- Skipped")
+            continue
+
+        command(modules_results, module, module_result)
+    return modules_results
 
 
 def lint_flavor(

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -36,6 +36,7 @@ PROFILE_COV = "profile.cov"
 GO_TEST_RESULT_TMP_JSON = 'module_test_output.json'
 UNIT_TEST_FILE_FORMAT = re.compile(r'[^a-zA-Z0-9_\-]')
 
+
 class TestProfiler:
     times = []
     parser = re.compile(r"^ok\s+github.com\/DataDog\/datadog-agent\/(\S+)\s+([0-9\.]+)s", re.MULTILINE)

--- a/tasks/unit-tests/git_api_tests.py
+++ b/tasks/unit-tests/git_api_tests.py
@@ -1,0 +1,300 @@
+import unittest
+from itertools import cycle
+from unittest import mock
+
+from invoke.exceptions import Exit
+
+from .. import release
+from ..libs.common.github_api import GithubAPI
+from ..libs.common.github_workflows import GithubException, GithubWorkflows
+from ..libs.common.gitlab import Gitlab, get_gitlab_token
+from ..libs.common.remote_api import APIError
+from ..libs.version import Version
+
+
+class MockResponse:
+    def __init__(self, content, status_code):
+        self.content = content
+        self.json_data = content
+        self.status_code = status_code
+
+    def json(self):
+        return self.content
+
+
+#################### FAIL REQUEST  #####################
+
+
+def fail_not_found_request(*_args, **_kwargs):
+    return MockResponse([], 404)
+
+
+##################### MOCKED GITLAB #####################
+
+
+def mocked_502_gitlab_requests(*_args, **_kwargs):
+    return MockResponse(
+        "<html>\r\n<head><title>502 Bad Gateway</title></head>\r\n<body>\r\n<center><h1>502 Bad Gateway</h1></center>\r\n</body>\r\n</html>\r\n",
+        502,
+    )
+
+
+def mocked_gitlab_project_request(*_args, **_kwargs):
+    return MockResponse("name", 200)
+
+
+##################### MOCKED GITHUB #####################
+
+
+def mocked_github_requests_get(*_args, **_kwargs):
+    return MockResponse(
+        [
+            {"ref": "7.28.0-rc.1"},
+            {"ref": "7.28.0"},
+            {"ref": "7.28.1-rc.1"},
+            {"ref": "7.28.1"},
+            {"ref": "7.29.0-rc.1"},
+            {"ref": "7.29.0"},
+        ],
+        200,
+    )
+
+
+def mocked_502_github_requests(*_args, **_kwargs):
+    return MockResponse([], 502)
+
+
+##################### MOCKED GITHUB WORKFLOW #####################
+
+
+def mocked_502_github_workflow_requests(*_args, **_kwargs):
+    return MockResponse([], 502)
+
+
+def mocked_github_workflow_requests(*_args, **_kwargs):
+    return MockResponse("valid content", 200)
+
+
+class SideEffect:
+    def __init__(self, *fargs):
+        self.functions = cycle(fargs)
+
+    def __call__(self, *args, **kwargs):
+        func = next(self.functions)
+        return func(*args, **kwargs)
+
+
+class TestStatusCode5XX(unittest.TestCase):
+    @mock.patch('requests.get', side_effect=SideEffect(mocked_502_github_requests, mocked_github_requests_get))
+    def test_github_one_fail_one_success(self, _):
+        version = release._get_highest_repo_version(
+            "FAKE_TOKEN",
+            "target-repo",
+            "",
+            release.build_compatible_version_re(release.COMPATIBLE_MAJOR_VERSIONS[7], 29),
+            release.COMPATIBLE_MAJOR_VERSIONS[7],
+            request_retry_sleep_time=0,
+        )
+        self.assertEqual(version, Version(major=7, minor=29, patch=0))
+
+    @mock.patch(
+        'requests.get',
+        side_effect=SideEffect(
+            mocked_502_github_requests,
+            mocked_502_github_requests,
+            mocked_502_github_requests,
+            mocked_502_github_requests,
+            mocked_github_requests_get,
+        ),
+    )
+    def test_github_last_one_success(self, _):
+        version = release._get_highest_repo_version(
+            "FAKE_TOKEN",
+            "target-repo",
+            "",
+            release.build_compatible_version_re(release.COMPATIBLE_MAJOR_VERSIONS[7], 29),
+            release.COMPATIBLE_MAJOR_VERSIONS[7],
+            request_retry_sleep_time=0,
+        )
+        self.assertEqual(version, Version(major=7, minor=29, patch=0))
+
+    @mock.patch('requests.get', side_effect=SideEffect(mocked_502_github_requests))
+    def test_github_full_fail(self, _):
+        failed = False
+        try:
+            release._get_highest_repo_version(
+                "FAKE_TOKEN",
+                "target-repo",
+                "",
+                release.build_compatible_version_re(release.COMPATIBLE_MAJOR_VERSIONS[7], 29),
+                release.COMPATIBLE_MAJOR_VERSIONS[7],
+                request_retry_sleep_time=0,
+            )
+        except Exit:
+            failed = True
+        if not failed:
+            Exit("GithubAPI was expected to fail !")
+
+    @mock.patch('requests.get', side_effect=SideEffect(fail_not_found_request, mocked_github_requests_get))
+    def test_github_real_fail(self, _):
+        failed = False
+        try:
+            release._get_highest_repo_version(
+                "FAKE_TOKEN",
+                "target-repo",
+                "",
+                release.build_compatible_version_re(release.COMPATIBLE_MAJOR_VERSIONS[7], 29),
+                release.COMPATIBLE_MAJOR_VERSIONS[7],
+                request_retry_sleep_time=0,
+            )
+        except Exit:
+            failed = True
+        if not failed:
+            Exit("GithubAPI was expected to fail !")
+
+    @mock.patch('requests.get', side_effect=SideEffect(mocked_502_gitlab_requests, mocked_gitlab_project_request))
+    def test_gitlab_one_fail_one_success(self, _):
+        project_name = "DataDog/datadog-agent"
+        gitlab = Gitlab(project_name=project_name, api_token=get_gitlab_token())
+        gitlab.requests_sleep_time = 0
+        gitlab.test_project_found()
+
+    @mock.patch(
+        'requests.get',
+        side_effect=SideEffect(
+            mocked_502_gitlab_requests,
+            mocked_502_gitlab_requests,
+            mocked_502_gitlab_requests,
+            mocked_502_gitlab_requests,
+            mocked_gitlab_project_request,
+        ),
+    )
+    def test_gitlab_last_one_success(self, _):
+        project_name = "DataDog/datadog-agent"
+        gitlab = Gitlab(project_name=project_name, api_token=get_gitlab_token())
+        gitlab.requests_sleep_time = 0
+        gitlab.test_project_found()
+
+    @mock.patch('requests.get', side_effect=SideEffect(mocked_502_gitlab_requests))
+    def test_gitlab_full_fail(self, _):
+        failed = False
+        try:
+            project_name = "DataDog/datadog-agent"
+            gitlab = Gitlab(project_name=project_name, api_token=get_gitlab_token())
+            gitlab.requests_sleep_time = 0
+            gitlab.test_project_found()
+        except Exit:
+            failed = True
+        if not failed:
+            Exit("GitlabAPI was expected to fail")
+
+    @mock.patch('requests.get', side_effect=SideEffect(fail_not_found_request, mocked_gitlab_project_request))
+    def test_gitlab_real_fail(self, _):
+        failed = False
+        try:
+            project_name = "DataDog/datadog-agent"
+            gitlab = Gitlab(project_name=project_name, api_token=get_gitlab_token())
+            gitlab.requests_sleep_time = 0
+            gitlab.test_project_found()
+        except APIError:
+            failed = True
+        if not failed:
+            Exit("GitlabAPI was expected to fail")
+
+    @mock.patch(
+        'requests.get', side_effect=SideEffect(mocked_502_github_workflow_requests, mocked_github_workflow_requests)
+    )
+    def test_github_workflow_one_fail_one_success(self, _):
+        workflow = GithubWorkflows()
+        workflow.requests_sleep_time = 0
+        assert workflow.repo() == "valid content"
+
+    @mock.patch(
+        'requests.get',
+        side_effect=SideEffect(
+            mocked_502_github_workflow_requests,
+            mocked_502_github_workflow_requests,
+            mocked_502_github_workflow_requests,
+            mocked_502_github_workflow_requests,
+            mocked_github_workflow_requests,
+        ),
+    )
+    def test_github_workflow_last_one_success(self, _):
+        workflow = GithubWorkflows()
+        workflow.requests_sleep_time = 0
+        assert workflow.repo() == "valid content"
+
+    @mock.patch('requests.get', side_effect=SideEffect(mocked_502_github_workflow_requests))
+    def test_github_workflow_full_fail(self, _):
+        failed = False
+        try:
+            workflow = GithubWorkflows()
+            workflow.requests_sleep_time = 0
+            workflow.repo()
+        except GithubException:
+            failed = True
+        if not failed:
+            Exit("Github Workflow API was expected to fail !")
+
+    @mock.patch('requests.get', side_effect=SideEffect(fail_not_found_request, mocked_github_workflow_requests))
+    def test_github_workflow_real_fail(self, _):
+        failed = False
+        try:
+            workflow = GithubWorkflows()
+            workflow.requests_sleep_time = 0
+            workflow.repo()
+        except APIError:
+            failed = True
+        if not failed:
+            Exit("Github Workflow API was expected to fail !")
+
+    @mock.patch(
+        'requests.get', side_effect=SideEffect(mocked_502_github_workflow_requests, mocked_github_workflow_requests)
+    )
+    def test_githubapi_one_fail_one_success(self, _):
+        workflow = GithubAPI()
+        workflow.requests_sleep_time = 0
+        assert workflow.repo() == "valid content"
+
+    @mock.patch(
+        'requests.get',
+        side_effect=SideEffect(
+            mocked_502_github_workflow_requests,
+            mocked_502_github_workflow_requests,
+            mocked_502_github_workflow_requests,
+            mocked_502_github_workflow_requests,
+            mocked_github_workflow_requests,
+        ),
+    )
+    def test_githubapi_last_one_success(self, _):
+        workflow = GithubAPI()
+        workflow.requests_sleep_time = 0
+        assert workflow.repo() == "valid content"
+
+    @mock.patch('requests.get', side_effect=SideEffect(mocked_502_github_workflow_requests))
+    def test_githubapi_full_fail(self, _):
+        failed = False
+        try:
+            workflow = GithubAPI()
+            workflow.requests_sleep_time = 0
+            workflow.repo()
+        except Exit:
+            failed = True
+        if not failed:
+            Exit("Github Workflow API was expected to fail !")
+
+    @mock.patch('requests.get', side_effect=SideEffect(fail_not_found_request, mocked_github_workflow_requests))
+    def test_githubapi_real_fail(self, _):
+        failed = False
+        try:
+            workflow = GithubAPI()
+            workflow.requests_sleep_time = 0
+            workflow.repo()
+        except APIError:
+            failed = True
+        if not failed:
+            Exit("Github Workflow API was expected to fail !")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Backport #16288 into 7.44.X

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
