### PR TITLE
[CWS] Rework process args/envs getters

### DIFF
--- a/pkg/security/resolvers/process/resolver.go
+++ b/pkg/security/resolvers/process/resolver.go
@@ -871,29 +871,32 @@ func (p *Resolver) SetProcessArgs(pce *model.ProcessCacheEntry) {
 // GetProcessArgv returns the args of the event as an array
 func GetProcessArgv(pr *model.Process) ([]string, bool) {
 	if pr.ArgsEntry == nil {
-		return nil, false
+		return pr.Argv, pr.ArgsTruncated
 	}
 
 	argv := pr.ArgsEntry.Values
 	if len(argv) > 0 {
 		argv = argv[1:]
+	} else {
+		argv = []string{}
 	}
-
-	return argv, pr.ArgsTruncated || pr.ArgsEntry.Truncated
+	pr.Argv = argv
+	pr.ArgsTruncated = pr.ArgsTruncated || pr.ArgsEntry.Truncated
+	return pr.Argv, pr.ArgsTruncated
 }
 
 // GetProcessArgv0 returns the first arg of the event
 func (p *Resolver) GetProcessArgv0(pr *model.Process) (string, bool) {
 	if pr.ArgsEntry == nil {
-		return "", false
+		return pr.Argv0, pr.ArgsTruncated
 	}
 
 	argv := pr.ArgsEntry.Values
 	if len(argv) > 0 {
-		return argv[0], pr.ArgsTruncated || pr.ArgsEntry.Truncated
+		pr.Argv0 = argv[0]
 	}
-
-	return "", pr.ArgsTruncated || pr.ArgsEntry.Truncated
+	pr.ArgsTruncated = pr.ArgsTruncated || pr.ArgsEntry.Truncated
+	return pr.Argv0, pr.ArgsTruncated
 }
 
 // GetProcessScrubbedArgv returns the scrubbed args of the event as an array
@@ -937,21 +940,24 @@ func (p *Resolver) SetProcessEnvs(pce *model.ProcessCacheEntry) {
 // GetProcessEnvs returns the envs of the event
 func (p *Resolver) GetProcessEnvs(pr *model.Process) ([]string, bool) {
 	if pr.EnvsEntry == nil {
-		return nil, false
+		return pr.Envs, pr.EnvsTruncated
 	}
 
 	keys, truncated := pr.EnvsEntry.FilterEnvs(p.opts.envsWithValue)
-
-	return keys, pr.EnvsTruncated || truncated
+	pr.Envs = keys
+	pr.EnvsTruncated = pr.EnvsTruncated || truncated
+	return pr.Envs, pr.EnvsTruncated
 }
 
 // GetProcessEnvp returns the envs of the event with their values
 func (p *Resolver) GetProcessEnvp(pr *model.Process) ([]string, bool) {
 	if pr.EnvsEntry == nil {
-		return nil, false
+		return pr.Envp, pr.EnvsTruncated
 	}
 
-	return pr.EnvsEntry.Values, pr.EnvsTruncated || pr.EnvsEntry.Truncated
+	pr.Envp = pr.EnvsEntry.Values
+	pr.EnvsTruncated = pr.EnvsTruncated || pr.EnvsEntry.Truncated
+	return pr.Envp, pr.EnvsTruncated
 }
 
 // SetProcessTTY resolves TTY and cache the result

--- a/pkg/security/resolvers/process/resolver.go
+++ b/pkg/security/resolvers/process/resolver.go
@@ -877,8 +877,6 @@ func GetProcessArgv(pr *model.Process) ([]string, bool) {
 	argv := pr.ArgsEntry.Values
 	if len(argv) > 0 {
 		argv = argv[1:]
-	} else {
-		argv = []string{}
 	}
 	pr.Argv = argv
 	pr.ArgsTruncated = pr.ArgsTruncated || pr.ArgsEntry.Truncated

--- a/pkg/security/security_profile/activity_tree/process_node.go
+++ b/pkg/security/security_profile/activity_tree/process_node.go
@@ -76,15 +76,13 @@ func (pn *ProcessNode) debug(w io.Writer, prefix string) {
 // scrubAndReleaseArgsEnvs scrubs the process args and envs, and then releases them
 func (pn *ProcessNode) scrubAndReleaseArgsEnvs(resolver *sprocess.Resolver) {
 	if pn.Process.ArgsEntry != nil {
-		_, _ = resolver.GetProcessScrubbedArgv(&pn.Process)
-		pn.Process.Argv0, _ = resolver.GetProcessArgv0(&pn.Process)
+		resolver.GetProcessScrubbedArgv(&pn.Process)
+		resolver.GetProcessArgv0(&pn.Process)
 		pn.Process.ArgsEntry = nil
 
 	}
 	if pn.Process.EnvsEntry != nil {
-		envs, envsTruncated := resolver.GetProcessEnvs(&pn.Process)
-		pn.Process.Envs = envs
-		pn.Process.EnvsTruncated = envsTruncated
+		resolver.GetProcessEnvs(&pn.Process)
 		pn.Process.EnvsEntry = nil
 	}
 }
@@ -94,36 +92,18 @@ func (pn *ProcessNode) Matches(entry *model.Process, matchArgs bool) bool {
 	if pn.Process.FileEvent.PathnameStr == entry.FileEvent.PathnameStr {
 		if matchArgs {
 			var panArgs, entryArgs []string
-			if pn.Process.ArgsEntry != nil {
-				panArgs, _ = sprocess.GetProcessArgv(&pn.Process)
-			} else {
-				panArgs = pn.Process.Argv
-			}
-			if entry.ArgsEntry != nil {
-				entryArgs, _ = sprocess.GetProcessArgv(entry)
-			} else {
-				entryArgs = entry.Argv
-			}
+			panArgs, _ = sprocess.GetProcessArgv(&pn.Process)
+			entryArgs, _ = sprocess.GetProcessArgv(entry)
 			if len(panArgs) != len(entryArgs) {
 				return false
 			}
-
-			var found bool
-			for _, arg1 := range panArgs {
-				found = false
-				for _, arg2 := range entryArgs {
-					if arg1 == arg2 {
-						found = true
-						break
-					}
-				}
-				if !found {
+			for i, arg := range panArgs {
+				if arg != entryArgs[i] {
 					return false
 				}
 			}
 			return true
 		}
-
 		return true
 	}
 	return false


### PR DESCRIPTION
### What does this PR do?

Little rework to simplify the getters of args/envs, and the process matches func.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
