### PR TITLE
E2E test: Add some helpers

### DIFF
--- a/test/new-e2e/test-infra-definition/vm_test.go
+++ b/test/new-e2e/test-infra-definition/vm_test.go
@@ -1,0 +1,24 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package testinfradefinition
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/test/new-e2e/utils/e2e"
+)
+
+type vmSuite struct {
+	e2e.Suite[e2e.VMEnv]
+}
+
+func TestVMSuite(t *testing.T) {
+	e2e.Run(t, &vmSuite{}, e2e.EC2VMStackDef())
+}
+
+func (v *vmSuite) TestBasicVM() {
+	v.Env().VM.Execute("ls")
+}

--- a/test/new-e2e/utils/e2e/client/agent.go
+++ b/test/new-e2e/utils/e2e/client/agent.go
@@ -6,6 +6,8 @@
 package client
 
 import (
+	"testing"
+
 	"github.com/DataDog/test-infra-definitions/datadog/agent"
 )
 
@@ -25,12 +27,12 @@ func NewAgent(installer *agent.Installer) *Agent {
 }
 
 //lint:ignore U1000 Ignore unused function as this function is call using reflection
-func (agent *Agent) initService(data *agent.ClientData) error {
+func (agent *Agent) initService(t *testing.T, data *agent.ClientData) error {
 	var err error
-	agent.sshClient, err = newSSHClient("", &data.Connection)
+	agent.sshClient, err = newSSHClient(t, "", &data.Connection)
 	return err
 }
 
-func (agent *Agent) Status() (string, error) {
+func (agent *Agent) Status() string {
 	return agent.sshClient.Execute("sudo datadog-agent status")
 }

--- a/test/new-e2e/utils/e2e/client/agent.go
+++ b/test/new-e2e/utils/e2e/client/agent.go
@@ -16,7 +16,7 @@ var _ clientService[agent.ClientData] = (*Agent)(nil)
 // A client Agent that is connected to an agent.Installer defined in test-infra-definition.
 type Agent struct {
 	*UpResultDeserializer[agent.ClientData]
-	*sshClient
+	*vmClient
 }
 
 // Create a new instance of Agent
@@ -29,18 +29,18 @@ func NewAgent(installer *agent.Installer) *Agent {
 //lint:ignore U1000 Ignore unused function as this function is call using reflection
 func (agent *Agent) initService(t *testing.T, data *agent.ClientData) error {
 	var err error
-	agent.sshClient, err = newSSHClient(t, "", &data.Connection)
+	agent.vmClient, err = newVMClient(t, "", &data.Connection)
 	return err
 }
 
 func (agent *Agent) Status() string {
-	return agent.sshClient.Execute("sudo datadog-agent status")
+	return agent.vmClient.Execute("sudo datadog-agent status")
 }
 
 func (agent *Agent) Version() string {
-	return agent.sshClient.Execute("datadog-agent version")
+	return agent.vmClient.Execute("datadog-agent version")
 }
 
 func (agent *Agent) Config() string {
-	return agent.sshClient.Execute("sudo datadog-agent config")
+	return agent.vmClient.Execute("sudo datadog-agent config")
 }

--- a/test/new-e2e/utils/e2e/client/agent.go
+++ b/test/new-e2e/utils/e2e/client/agent.go
@@ -36,3 +36,11 @@ func (agent *Agent) initService(t *testing.T, data *agent.ClientData) error {
 func (agent *Agent) Status() string {
 	return agent.sshClient.Execute("sudo datadog-agent status")
 }
+
+func (agent *Agent) Version() string {
+	return agent.sshClient.Execute("datadog-agent version")
+}
+
+func (agent *Agent) Config() string {
+	return agent.sshClient.Execute("sudo datadog-agent config")
+}

--- a/test/new-e2e/utils/e2e/client/ec2_metadata.go
+++ b/test/new-e2e/utils/e2e/client/ec2_metadata.go
@@ -1,0 +1,28 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package client
+
+import (
+	"fmt"
+)
+
+type EC2Metadata struct {
+	vm    *VM
+	token string
+}
+
+const metadataEndPoint = "http://169.254.169.254"
+
+func NewEC2Metadata(vm *VM) *EC2Metadata {
+	cmd := fmt.Sprintf(`curl -s -X PUT "%v/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600"`, metadataEndPoint)
+	output := vm.Execute(cmd)
+	return &EC2Metadata{vm: vm, token: output}
+}
+
+func (m *EC2Metadata) Get(name string) string {
+	cmd := fmt.Sprintf(`curl -s -H "X-aws-ec2-metadata-token: %v" "%v/latest/meta-data/%v"`, m.token, metadataEndPoint, name)
+	return m.vm.Execute(cmd)
+}

--- a/test/new-e2e/utils/e2e/client/stack_initializer.go
+++ b/test/new-e2e/utils/e2e/client/stack_initializer.go
@@ -8,12 +8,13 @@ package client
 import (
 	"fmt"
 	"reflect"
+	"testing"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/auto"
 )
 
 type stackInitializer interface {
-	setStack(stackResult auto.UpResult) error
+	setStack(t *testing.T, stackResult auto.UpResult) error
 }
 
 func CheckEnvStructValid[Env any]() error {
@@ -22,7 +23,7 @@ func CheckEnvStructValid[Env any]() error {
 	return err
 }
 
-func CallStackInitializers[Env any](env *Env, upResult auto.UpResult) error {
+func CallStackInitializers[Env any](t *testing.T, env *Env, upResult auto.UpResult) error {
 	fields, err := getFields(env)
 
 	for _, field := range fields {
@@ -31,7 +32,7 @@ func CallStackInitializers[Env any](env *Env, upResult auto.UpResult) error {
 			return fmt.Errorf("the field %v of %v is nil", field.name, reflect.TypeOf(env))
 		}
 
-		if err = initializer.setStack(upResult); err != nil {
+		if err = initializer.setStack(t, upResult); err != nil {
 			return err
 		}
 	}

--- a/test/new-e2e/utils/e2e/client/up_result_deserializer.go
+++ b/test/new-e2e/utils/e2e/client/up_result_deserializer.go
@@ -6,6 +6,8 @@
 package client
 
 import (
+	"testing"
+
 	"github.com/DataDog/test-infra-definitions/common/utils"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto"
 )
@@ -16,7 +18,7 @@ type clientService[T any] interface {
 }
 
 type clientServiceInitializer[T any] interface {
-	initService(*T) error
+	initService(*testing.T, *T) error
 }
 
 // UpResultDeserializer is an helper to build a new type that can be used in an environment.
@@ -39,10 +41,10 @@ func NewUpResultDeserializer[T any](
 	}
 }
 
-func (d *UpResultDeserializer[T]) setStack(stackResult auto.UpResult) error {
+func (d *UpResultDeserializer[T]) setStack(t *testing.T, stackResult auto.UpResult) error {
 	value, err := d.deserializer.Deserialize(stackResult)
 	if err != nil {
 		return err
 	}
-	return d.initializer.initService(value)
+	return d.initializer.initService(t, value)
 }

--- a/test/new-e2e/utils/e2e/client/vm.go
+++ b/test/new-e2e/utils/e2e/client/vm.go
@@ -6,6 +6,8 @@
 package client
 
 import (
+	"testing"
+
 	commonvm "github.com/DataDog/test-infra-definitions/common/vm"
 )
 
@@ -25,8 +27,8 @@ func NewVM(infraVM commonvm.VM) *VM {
 }
 
 //lint:ignore U1000 Ignore unused function as this function is call using reflection
-func (vm *VM) initService(data *commonvm.ClientData) error {
+func (vm *VM) initService(t *testing.T, data *commonvm.ClientData) error {
 	var err error
-	vm.sshClient, err = newSSHClient("", &data.Connection)
+	vm.sshClient, err = newSSHClient(t, "", &data.Connection)
 	return err
 }

--- a/test/new-e2e/utils/e2e/client/vm.go
+++ b/test/new-e2e/utils/e2e/client/vm.go
@@ -16,7 +16,7 @@ var _ clientService[commonvm.ClientData] = (*VM)(nil)
 // A client VM that is connected to a VM defined in test-infra-definition.
 type VM struct {
 	*UpResultDeserializer[commonvm.ClientData]
-	*sshClient
+	*vmClient
 }
 
 // Create a new instance of VM
@@ -29,6 +29,6 @@ func NewVM(infraVM commonvm.VM) *VM {
 //lint:ignore U1000 Ignore unused function as this function is call using reflection
 func (vm *VM) initService(t *testing.T, data *commonvm.ClientData) error {
 	var err error
-	vm.sshClient, err = newSSHClient(t, "", &data.Connection)
+	vm.vmClient, err = newVMClient(t, "", &data.Connection)
 	return err
 }

--- a/test/new-e2e/utils/e2e/client/vm_client.go
+++ b/test/new-e2e/utils/e2e/client/vm_client.go
@@ -16,31 +16,31 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
-type sshClient struct {
+type vmClient struct {
 	client *ssh.Client
 	t      *testing.T
 }
 
-func newSSHClient(t *testing.T, sshKey string, connection *utils.Connection) (*sshClient, error) {
+func newVMClient(t *testing.T, sshKey string, connection *utils.Connection) (*vmClient, error) {
 	client, _, err := clients.GetSSHClient(
 		connection.User,
 		fmt.Sprintf("%s:%d", connection.Host, 22),
 		sshKey,
 		2*time.Second, 5)
-	return &sshClient{
+	return &vmClient{
 		client: client,
 		t:      t,
 	}, err
 }
 
 // ExecuteWithError executes a command and returns an error if any.
-func (sshClient *sshClient) ExecuteWithError(command string) (string, error) {
-	return clients.ExecuteCommand(sshClient.client, command)
+func (vmClient *vmClient) ExecuteWithError(command string) (string, error) {
+	return clients.ExecuteCommand(vmClient.client, command)
 }
 
 // Execute execute a command and asserts there is no error.
-func (sshClient *sshClient) Execute(command string) string {
-	output, err := sshClient.ExecuteWithError(command)
-	require.NoError(sshClient.t, err)
+func (vmClient *vmClient) Execute(command string) string {
+	output, err := vmClient.ExecuteWithError(command)
+	require.NoError(vmClient.t, err)
 	return output
 }

--- a/test/new-e2e/utils/e2e/e2e.go
+++ b/test/new-e2e/utils/e2e/e2e.go
@@ -205,7 +205,7 @@ func (suite *Suite[Env]) UpdateEnv(stackDef *StackDefinition[Env]) {
 		}
 		env, upResult, err := createEnv(suite, stackDef)
 		suite.Require().NoError(err)
-		err = client.CallStackInitializers(env, upResult)
+		err = client.CallStackInitializers(suite.T(), env, upResult)
 		suite.Require().NoError(err)
 		suite.env = env
 		suite.currentStackDef = stackDef

--- a/test/new-e2e/utils/e2e/e2e.go
+++ b/test/new-e2e/utils/e2e/e2e.go
@@ -71,16 +71,6 @@ func Run[Env any, T suiteConstraint[Env]](t *testing.T, e2eSuite T, stackDef *St
 	suite.Run(t, e2eSuite)
 }
 
-// NewSuite creates a new Suite.
-// stackName is the name of the stack and should be unique across suites.
-// stackDef is the stack definition.
-// options are optional parameters for example [e2e.KeepEnv].
-func NewSuite[Env any](stackName string, stackDef *StackDefinition[Env], options ...func(*Suite[Env])) *Suite[Env] {
-	testSuite := Suite[Env]{}
-	testSuite.initSuite(stackName, stackDef, options...)
-	return &testSuite
-}
-
 func (suite *Suite[Env]) initSuite(stackName string, stackDef *StackDefinition[Env], options ...func(*Suite[Env])) {
 	suite.stackName = stackName
 	suite.defaultStackDef = stackDef
@@ -140,9 +130,6 @@ func (suite *Suite[Env]) AfterTest(suiteName, testName string) {
 
 // SetupSuite method will run before the tests in the suite are run.
 // This function is called by [testify Suite].
-// Note: Having initialization code in this function allows `NewSuite` to not
-// return an error in order to write a single line for
-// `suite.Run(t, &vmSuite{Suite: e2e.NewSuite(...)})`
 func (suite *Suite[Env]) SetupSuite() {
 	skipDelete, _ := runner.GetProfile().ParamStore().GetBoolWithDefault(parameters.SkipDeleteOnFailure, false)
 	if skipDelete {

--- a/test/new-e2e/utils/e2e/e2e_test.go
+++ b/test/new-e2e/utils/e2e/e2e_test.go
@@ -22,7 +22,7 @@ type e2eSuite struct {
 
 func TestE2ESuite(t *testing.T) {
 	e2eSuite := &e2eSuite{}
-	innerSuite := NewSuite("e2eSuite", e2eSuite.createStack("default"))
+	innerSuite := newSuite("e2eSuite", e2eSuite.createStack("default"))
 	e2eSuite.Suite = innerSuite
 	e2eSuite.updateEnvStack = e2eSuite.createStack("updateEnvStack")
 	suite.Run(t, e2eSuite)
@@ -71,7 +71,7 @@ type skipDeleteOnFailureSuite struct {
 // prefixed by `Test` and so not run.
 func E2ESuiteSkipDeleteOnFailure(t *testing.T) {
 	e2e2Suite := &skipDeleteOnFailureSuite{
-		Suite: NewSuite("SkipDeleteOnFailure", nil, SkipDeleteOnFailure[struct{}]()),
+		Suite: newSuite("SkipDeleteOnFailure", nil, SkipDeleteOnFailure[struct{}]()),
 	}
 	suite.Run(t, e2e2Suite)
 	require.Equal(t, []string{"Test1"}, e2e2Suite.testsRun)
@@ -91,8 +91,14 @@ func (s *skipDeleteOnFailureSuite) Test3() {
 }
 
 func (suite *skipDeleteOnFailureSuite) updateStack(testName string) *StackDefinition[struct{}] {
-	return EnvFactoryStackDef[struct{}](func(ctx *pulumi.Context) (*struct{}, error) {
+	return EnvFactoryStackDef(func(ctx *pulumi.Context) (*struct{}, error) {
 		suite.testsRun = append(suite.testsRun, testName)
 		return &struct{}{}, nil
 	})
+}
+
+func newSuite[Env any](stackName string, stackDef *StackDefinition[Env], options ...func(*Suite[Env])) *Suite[Env] {
+	testSuite := Suite[Env]{}
+	testSuite.initSuite(stackName, stackDef, options...)
+	return &testSuite
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This PR adds some helpers for the E2E test framework:
 - Improve the API for `VM` and `Agent`
 - Add support for retrieving EC2Metadata
- Add a function to create a custom stack def  `CustomEC2VMStackDef`

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
