### PR TITLE
[omnibus] Enable systemd probe in OpenSCAP

### DIFF
--- a/omnibus/config/patches/openscap/systemd-dbus-address.patch
+++ b/omnibus/config/patches/openscap/systemd-dbus-address.patch
@@ -1,0 +1,11 @@
+]--- a/src/OVAL/probes/unix/linux/systemdshared.h
++++ b/src/OVAL/probes/unix/linux/systemdshared.h
+@@ -338,6 +338,8 @@ static DBusConnection *connect_dbus()
+ 		setenv("DBUS_SYSTEM_BUS_ADDRESS", dbus_address, 0);
+ 		/* We won't overwrite DBUS_SYSTEM_BUS_ADDRESS so that
+ 		 * user could have a way to define some non-standard system bus socket location */
++	} else {
++		setenv("DBUS_SYSTEM_BUS_ADDRESS", "unix:path=/run/dbus/system_bus_socket", 0);
+ 	}
+ 
+ 	conn = dbus_bus_get(DBUS_BUS_SYSTEM, &err);

--- a/omnibus/config/software/dbus.rb
+++ b/omnibus/config/software/dbus.rb
@@ -1,0 +1,44 @@
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache License Version 2.0.
+# This product includes software developed at Datadog (https:#www.datadoghq.com/).
+# Copyright 2016-present Datadog, Inc.
+
+name "dbus"
+default_version "1.15.4"
+
+dependency "expat"
+dependency "libtool"
+dependency "pkg-config"
+
+license "AFL-2.1"
+license_file "LICENSES/AFL-2.1.txt"
+skip_transitive_dependency_licensing true
+
+version("1.15.4") { source sha256: "bfe53d9e54a4977ec344928521b031af2e97cf78aea58f5d8e2b85ea0a80028b" }
+
+source url: "https://dbus.freedesktop.org/releases/dbus/dbus-#{version}.tar.xz"
+
+relative_path "dbus-#{version}"
+
+build do
+  env = with_standard_compiler_flags(with_embedded_path)
+
+  configure_options = [
+    "--prefix=#{install_dir}/embedded",
+    "--disable-static",
+    "--disable-doxygen-docs",
+    "--disable-ducktype-docs",
+    "--disable-xml-docs",
+    "--disable-stats",
+    "--disable-tests",
+    "--without-x",
+  ]
+
+  configure(*configure_options, env: env)
+
+  make "-j #{workers}", env: env
+  make "install", env: env
+
+  # Remove dbus tools.
+  delete "#{install_dir}/embedded/bin/dbus-*"
+end

--- a/omnibus/config/software/openscap.rb
+++ b/omnibus/config/software/openscap.rb
@@ -21,6 +21,7 @@ dependency 'apt'
 dependency 'attr'
 dependency 'bzip2'
 dependency 'curl'
+dependency 'dbus'
 dependency 'libacl'
 dependency 'libgcrypt'
 dependency 'libselinux'
@@ -59,6 +60,7 @@ build do
   patch source: "dpkginfo-init.patch", env: env # fix memory leak of pkgcache in dpkginfo probe
   patch source: "shadow-chroot.patch", env: env # handle shadow probe in offline mode
   patch source: "fsdev-ignore-host.patch", env: env # ignore /host directory in fsdev probe
+  patch source: "systemd-dbus-address.patch", env: env # fix dbus address in systemd probe
 
   patch source: "oscap-io.patch", env: env # add new oscap-io tool
 
@@ -80,6 +82,8 @@ build do
     "-DBZIP2_LIBRARY_RELEASE:FILEPATH=#{install_dir}/embedded/lib/libbz2.so",
     "-DCURL_INCLUDE_DIR:PATH=#{install_dir}/embedded/include",
     "-DCURL_LIBRARY_RELEASE:FILEPATH=#{install_dir}/embedded/lib/libcurl.so",
+    "-DDBUS_INCLUDE_DIR:PATH=#{install_dir}/embedded/include/dbus-1.0",
+    "-DDBUS_LIBRARIES:FILEPATH=#{install_dir}/embedded/lib/libdbus-1.so",
     "-DGCRYPT_INCLUDE_DIR:PATH=#{install_dir}/embedded/include",
     "-DGCRYPT_LIBRARY:FILEPATH=#{install_dir}/embedded/lib/libgcrypt.so",
     "-DLIBXML2_INCLUDE_DIR:PATH=#{install_dir}/embedded/include/libxml2",


### PR DESCRIPTION
### What does this PR do?

This change enables systemd probes in OpenSCAP:

 - systemdunitproperty
 - systemdunitdependency

The systemd probes depend on the dbus library.

The dbus library depends on the expat XML parser library, which has been fixed and updated in this [PR](https://github.com/DataDog/omnibus-software/pull/450):

### Motivation

The recent versions of the [SCAP security guides](https://github.com/ComplianceAsCode/content/) require the systemd probe to be enabled to be able to retrieve informations about system services status.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
