### PR TITLE
usm: Fixed races during components cleanups

### DIFF
--- a/pkg/network/usm/ebpf_main.go
+++ b/pkg/network/usm/ebpf_main.go
@@ -269,11 +269,10 @@ func (e *ebpfProgram) Start() error {
 
 func (e *ebpfProgram) Close() error {
 	e.mapCleaner.Stop()
-	err := e.Stop(manager.CleanAll)
 	for _, s := range e.subprograms {
 		s.Stop()
 	}
-	return err
+	return e.Stop(manager.CleanAll)
 }
 
 func (e *ebpfProgram) initCORE() error {

--- a/pkg/network/usm/ebpf_ssl.go
+++ b/pkg/network/usm/ebpf_ssl.go
@@ -233,7 +233,6 @@ func newSSLProgram(c *config.Config, sockFDMap *ebpf.Map) *sslProgram {
 }
 
 func (o *sslProgram) ConfigureManager(m *errtelemetry.Manager) {
-
 	o.manager = m
 
 	m.PerfMaps = append(m.PerfMaps, &manager.PerfMap{
@@ -318,6 +317,7 @@ func (o *sslProgram) Start() {
 
 func (o *sslProgram) Stop() {
 	o.perfHandler.Stop()
+	o.watcher.Stop()
 }
 
 func addHooks(m *errtelemetry.Manager, probes []manager.ProbesSelector) func(pathIdentifier, string, string) error {

--- a/pkg/network/usm/shared_libraries.go
+++ b/pkg/network/usm/shared_libraries.go
@@ -95,6 +95,8 @@ type soRule struct {
 
 // soWatcher provides a way to tie callback functions to the lifecycle of shared libraries
 type soWatcher struct {
+	wg             sync.WaitGroup
+	done           chan struct{}
 	procRoot       string
 	rules          []soRule
 	loadEvents     *ddebpf.PerfHandler
@@ -115,6 +117,8 @@ type soRegistry struct {
 
 func newSOWatcher(perfHandler *ddebpf.PerfHandler, rules ...soRule) *soWatcher {
 	return &soWatcher{
+		wg:             sync.WaitGroup{},
+		done:           make(chan struct{}),
 		procRoot:       util.GetProcRoot(),
 		rules:          rules,
 		loadEvents:     perfHandler,
@@ -153,6 +157,11 @@ func newRegistration(unregister func(pathIdentifier) error) *soRegistration {
 		unregisterCB:         unregister,
 		uniqueProcessesCount: 1,
 	}
+}
+
+func (w *soWatcher) Stop() {
+	close(w.done)
+	w.wg.Wait()
 }
 
 // Start consuming shared-library events
@@ -207,14 +216,17 @@ func (w *soWatcher) Start() {
 		return
 	}
 
+	w.wg.Add(1)
 	go func() {
+		defer w.wg.Done()
 		defer cleanupExit()
-		defer w.processMonitor.Stop()
 		// cleanup all uprobes
 		defer w.registry.cleanup()
 
 		for {
 			select {
+			case <-w.done:
+				return
 			case event, ok := <-w.loadEvents.DataChannel:
 				if !ok {
 					return

--- a/pkg/network/usm/shared_libraries.go
+++ b/pkg/network/usm/shared_libraries.go
@@ -220,6 +220,7 @@ func (w *soWatcher) Start() {
 	go func() {
 		defer w.wg.Done()
 		defer cleanupExit()
+		defer w.processMonitor.Stop()
 		// cleanup all uprobes
 		defer w.registry.cleanup()
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

wrong order of closing components, alongside counting of parallel cleanups can create errors log which can confuse us during escalations.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
