### PR TITLE
[CWS] small improvements to DNS unmarshalling and serialization 

### DIFF
--- a/docs/cloud-workload-security/backend.md
+++ b/docs/cloud-workload-security/backend.md
@@ -158,7 +158,8 @@ CWS logs have the following JSON schema:
             "additionalProperties": false,
             "type": "object",
             "required": [
-                "id"
+                "id",
+                "question"
             ],
             "description": "DNSEventSerializer serializes a DNS event to JSON"
         },
@@ -1544,7 +1545,8 @@ CWS logs have the following JSON schema:
     "additionalProperties": false,
     "type": "object",
     "required": [
-        "id"
+        "id",
+        "question"
     ],
     "description": "DNSEventSerializer serializes a DNS event to JSON"
 }

--- a/docs/cloud-workload-security/backend.schema.json
+++ b/docs/cloud-workload-security/backend.schema.json
@@ -142,7 +142,8 @@
       "additionalProperties": false,
       "type": "object",
       "required": [
-        "id"
+        "id",
+        "question"
       ],
       "description": "DNSEventSerializer serializes a DNS event to JSON"
     },

--- a/pkg/security/secl/model/dns_helpers.go
+++ b/pkg/security/secl/model/dns_helpers.go
@@ -19,7 +19,7 @@ var (
 	ErrDNSNameNonPrintableASCII = errors.New("dns name non-printable ascii")
 )
 
-const DNS_PREALLOC_SIZE = 128
+const DNS_PREALLOC_SIZE = 256
 
 func decodeDNSName(raw []byte) (string, error) {
 	var (

--- a/pkg/security/secl/model/dns_helpers.go
+++ b/pkg/security/secl/model/dns_helpers.go
@@ -19,6 +19,8 @@ var (
 	ErrDNSNameNonPrintableASCII = errors.New("dns name non-printable ascii")
 )
 
+const DNS_PREALLOC_SIZE = 128
+
 func decodeDNSName(raw []byte) (string, error) {
 	var (
 		i       = 0
@@ -27,6 +29,8 @@ func decodeDNSName(raw []byte) (string, error) {
 		rep     bytes.Buffer
 		err     error
 	)
+
+	rep.Grow(DNS_PREALLOC_SIZE)
 
 LOOP:
 	for i < rawLen {

--- a/pkg/security/serializers/serializers.go
+++ b/pkg/security/serializers/serializers.go
@@ -432,9 +432,9 @@ type NetworkContextSerializer struct {
 	// l4_protocol is the layer 4 protocol name
 	L4Protocol string `json:"l4_protocol"`
 	// source is the emitter of the network event
-	Source *IPPortSerializer `json:"source"`
+	Source IPPortSerializer `json:"source"`
 	// destination is the receiver of the network event
-	Destination *IPPortSerializer `json:"destination"`
+	Destination IPPortSerializer `json:"destination"`
 	// size is the size in bytes of the network event
 	Size uint32 `json:"size"`
 }
@@ -460,7 +460,7 @@ type DNSEventSerializer struct {
 	// id is the unique identifier of the DNS request
 	ID uint16 `json:"id"`
 	// question is a DNS question for the DNS request
-	Question *DNSQuestionSerializer `json:"question,omitempty"`
+	Question DNSQuestionSerializer `json:"question"`
 }
 
 // DDContextSerializer serializes a span context to JSON
@@ -496,7 +496,7 @@ type SpliceEventSerializer struct {
 // easyjson:json
 type BindEventSerializer struct {
 	// Bound address (if any)
-	Addr *IPPortFamilySerializer `json:"addr"`
+	Addr IPPortFamilySerializer `json:"addr"`
 }
 
 // ExitEventSerializer serializes an exit event to JSON
@@ -932,32 +932,28 @@ func newSpliceEventSerializer(e *model.Event) *SpliceEventSerializer {
 	}
 }
 
-func newDNSQuestionSerializer(d *model.DNSEvent) *DNSQuestionSerializer {
-	return &DNSQuestionSerializer{
-		Class: model.QClass(d.Class).String(),
-		Type:  model.QType(d.Type).String(),
-		Name:  d.Name,
-		Size:  d.Size,
-		Count: d.Count,
-	}
-}
-
 func newDNSEventSerializer(d *model.DNSEvent) *DNSEventSerializer {
 	return &DNSEventSerializer{
-		ID:       d.ID,
-		Question: newDNSQuestionSerializer(d),
+		ID: d.ID,
+		Question: DNSQuestionSerializer{
+			Class: model.QClass(d.Class).String(),
+			Type:  model.QType(d.Type).String(),
+			Name:  d.Name,
+			Size:  d.Size,
+			Count: d.Count,
+		},
 	}
 }
 
-func newIPPortSerializer(c *model.IPPortContext) *IPPortSerializer {
-	return &IPPortSerializer{
+func newIPPortSerializer(c *model.IPPortContext) IPPortSerializer {
+	return IPPortSerializer{
 		IP:   c.IPNet.IP.String(),
 		Port: c.Port,
 	}
 }
 
-func newIPPortFamilySerializer(c *model.IPPortContext, family string) *IPPortFamilySerializer {
-	return &IPPortFamilySerializer{
+func newIPPortFamilySerializer(c *model.IPPortContext, family string) IPPortFamilySerializer {
+	return IPPortFamilySerializer{
 		IP:     c.IPNet.IP.String(),
 		Port:   c.Port,
 		Family: family,

--- a/pkg/security/serializers/serializers_easyjson.go
+++ b/pkg/security/serializers/serializers_easyjson.go
@@ -1879,25 +1879,9 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecuritySerializers14(
 		case "l4_protocol":
 			out.L4Protocol = string(in.String())
 		case "source":
-			if in.IsNull() {
-				in.Skip()
-				out.Source = nil
-			} else {
-				if out.Source == nil {
-					out.Source = new(IPPortSerializer)
-				}
-				(*out.Source).UnmarshalEasyJSON(in)
-			}
+			(out.Source).UnmarshalEasyJSON(in)
 		case "destination":
-			if in.IsNull() {
-				in.Skip()
-				out.Destination = nil
-			} else {
-				if out.Destination == nil {
-					out.Destination = new(IPPortSerializer)
-				}
-				(*out.Destination).UnmarshalEasyJSON(in)
-			}
+			(out.Destination).UnmarshalEasyJSON(in)
 		case "size":
 			out.Size = uint32(in.Uint32())
 		default:
@@ -1938,20 +1922,12 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecuritySerializers14(
 	{
 		const prefix string = ",\"source\":"
 		out.RawString(prefix)
-		if in.Source == nil {
-			out.RawString("null")
-		} else {
-			(*in.Source).MarshalEasyJSON(out)
-		}
+		(in.Source).MarshalEasyJSON(out)
 	}
 	{
 		const prefix string = ",\"destination\":"
 		out.RawString(prefix)
-		if in.Destination == nil {
-			out.RawString("null")
-		} else {
-			(*in.Destination).MarshalEasyJSON(out)
-		}
+		(in.Destination).MarshalEasyJSON(out)
 	}
 	{
 		const prefix string = ",\"size\":"
@@ -4101,15 +4077,7 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecuritySerializers29(
 		case "id":
 			out.ID = uint16(in.Uint16())
 		case "question":
-			if in.IsNull() {
-				in.Skip()
-				out.Question = nil
-			} else {
-				if out.Question == nil {
-					out.Question = new(DNSQuestionSerializer)
-				}
-				(*out.Question).UnmarshalEasyJSON(in)
-			}
+			(out.Question).UnmarshalEasyJSON(in)
 		default:
 			in.SkipRecursive()
 		}
@@ -4129,10 +4097,10 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecuritySerializers29(
 		out.RawString(prefix[1:])
 		out.Uint16(uint16(in.ID))
 	}
-	if in.Question != nil {
+	{
 		const prefix string = ",\"question\":"
 		out.RawString(prefix)
-		(*in.Question).MarshalEasyJSON(out)
+		(in.Question).MarshalEasyJSON(out)
 	}
 	out.RawByte('}')
 }
@@ -4636,15 +4604,7 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecuritySerializers34(
 		}
 		switch key {
 		case "addr":
-			if in.IsNull() {
-				in.Skip()
-				out.Addr = nil
-			} else {
-				if out.Addr == nil {
-					out.Addr = new(IPPortFamilySerializer)
-				}
-				(*out.Addr).UnmarshalEasyJSON(in)
-			}
+			(out.Addr).UnmarshalEasyJSON(in)
 		default:
 			in.SkipRecursive()
 		}
@@ -4662,11 +4622,7 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecuritySerializers34(
 	{
 		const prefix string = ",\"addr\":"
 		out.RawString(prefix[1:])
-		if in.Addr == nil {
-			out.RawString("null")
-		} else {
-			(*in.Addr).MarshalEasyJSON(out)
-		}
+		(in.Addr).MarshalEasyJSON(out)
 	}
 	out.RawByte('}')
 }


### PR DESCRIPTION
### What does this PR do?

This PR removes some useless pointers in the DNS/bind serialization. And pre-allocates the buffer when unmarshalling DNS events from the kernel

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
