### PR TITLE
process/util use f.Readdirnames to list pids

### DIFF
--- a/pkg/process/util/util.go
+++ b/pkg/process/util/util.go
@@ -127,29 +127,40 @@ func GetSysRoot() string {
 	return "/sys"
 }
 
+// AllPidsProcs will return all pids under procRoot
+func AllPidsProcs(procRoot string) ([]int, error) {
+	f, err := os.Open(procRoot)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	dirs, err := f.Readdirnames(-1)
+	if err != nil {
+		return nil, err
+	}
+
+	pids := make([]int, 0, len(dirs))
+	for _, name := range dirs {
+		if pid, err := strconv.Atoi(name); err == nil {
+			pids = append(pids, pid)
+		}
+	}
+	return pids, nil
+}
+
 // WithAllProcs will execute `fn` for every pid under procRoot. `fn` is
 // passed the `pid`. If `fn` returns an error the iteration aborts,
 // returning the last error returned from `fn`.
 func WithAllProcs(procRoot string, fn func(int) error) error {
-	files, err := os.ReadDir(procRoot)
+	pids, err := AllPidsProcs(procRoot)
 	if err != nil {
 		return err
 	}
 
-	for _, f := range files {
-		if !f.IsDir() || f.Name() == "." || f.Name() == ".." {
-			continue
-		}
-
-		var pid int
-		if pid, err = strconv.Atoi(f.Name()); err != nil {
-			continue
-		}
-
+	for _, pid := range pids {
 		if err = fn(pid); err != nil {
 			return err
 		}
 	}
-
 	return nil
 }

--- a/pkg/process/util/util_linux_test.go
+++ b/pkg/process/util/util_linux_test.go
@@ -10,6 +10,8 @@ package util
 
 import (
 	"os"
+	"runtime"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -28,4 +30,68 @@ func TestGetRootNSPID(t *testing.T) {
 		assert.NotNil(t, err)
 		assert.Equal(t, 0, pid)
 	})
+}
+
+func oldWithAllProcs(procRoot string, fn func(int) error) error {
+	files, err := os.ReadDir(procRoot)
+	if err != nil {
+		return err
+	}
+
+	for _, f := range files {
+		if !f.IsDir() || f.Name() == "." || f.Name() == ".." {
+			continue
+		}
+
+		var pid int
+		if pid, err = strconv.Atoi(f.Name()); err != nil {
+			continue
+		}
+
+		if err = fn(pid); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func BenchmarkOldWithAllProcs(b *testing.B) {
+
+	var pids []int
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		pids := []int{}
+		oldWithAllProcs("/proc", func(pid int) error {
+			pids = append(pids, pid)
+			return nil
+		})
+	}
+	runtime.KeepAlive(pids)
+}
+
+func BenchmarkWithAllProcs(b *testing.B) {
+	var pids []int
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		pids = []int{}
+		WithAllProcs("/proc", func(pid int) error {
+			pids = append(pids, pid)
+			return nil
+		})
+	}
+	runtime.KeepAlive(pids)
+}
+
+func BenchmarkAllPidsProcs(b *testing.B) {
+	var pids []int
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		pids, _ = AllPidsProcs("/proc")
+	}
+	runtime.KeepAlive(pids)
 }


### PR DESCRIPTION
### What does this PR do?

Speed up listing process by
 * using f.Readdirnames(), this avoid doing lstat() per entry
 * not sorting the directory by names implemented in Readdir()

### Motivation

quick benchmark

```
BenchmarkOldWithAllProcs
BenchmarkOldWithAllProcs-16    	    3429	    328718 ns/op	   87470 B/op	    1233 allocs/op
BenchmarkWithAllProcs
BenchmarkWithAllProcs-16       	    5763	    215248 ns/op	   56332 B/op	     682 allocs/op
BenchmarkAllPidsProcs
BenchmarkAllPidsProcs-16       	    5656	    208567 ns/op	   41296 B/op	     671 allocs/op


```
### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
