### PR TITLE
[CWS] split inode and file mode constants

### DIFF
--- a/docs/cloud-workload-security/agent_expressions.md
+++ b/docs/cloud-workload-security/agent_expressions.md
@@ -1934,6 +1934,9 @@ Definition: Mode of the file
 `*.mode` has 38 possible prefixes:
 `chmod.file` `chown.file` `exec.file` `exec.interpreter.file` `exit.file` `exit.interpreter.file` `link.file` `link.file.destination` `load_module.file` `mkdir.file` `mmap.file` `open.file` `process.ancestors.file` `process.ancestors.interpreter.file` `process.file` `process.interpreter.file` `process.parent.file` `process.parent.interpreter.file` `ptrace.tracee.ancestors.file` `ptrace.tracee.ancestors.interpreter.file` `ptrace.tracee.file` `ptrace.tracee.interpreter.file` `ptrace.tracee.parent.file` `ptrace.tracee.parent.interpreter.file` `removexattr.file` `rename.file` `rename.file.destination` `rmdir.file` `setxattr.file` `signal.target.ancestors.file` `signal.target.ancestors.interpreter.file` `signal.target.file` `signal.target.interpreter.file` `signal.target.parent.file` `signal.target.parent.interpreter.file` `splice.file` `unlink.file` `utimes.file`
 
+Constants: [Inode mode constants](#inode-mode-constants)
+
+
 
 ### `*.modification_time` {#common-filefields-modification_time-doc}
 Type: int
@@ -2071,7 +2074,7 @@ Definition: Rights of the file
 `*.rights` has 38 possible prefixes:
 `chmod.file` `chown.file` `exec.file` `exec.interpreter.file` `exit.file` `exit.interpreter.file` `link.file` `link.file.destination` `load_module.file` `mkdir.file` `mmap.file` `open.file` `process.ancestors.file` `process.ancestors.interpreter.file` `process.file` `process.interpreter.file` `process.parent.file` `process.parent.interpreter.file` `ptrace.tracee.ancestors.file` `ptrace.tracee.ancestors.interpreter.file` `ptrace.tracee.file` `ptrace.tracee.interpreter.file` `ptrace.tracee.parent.file` `ptrace.tracee.parent.interpreter.file` `removexattr.file` `rename.file` `rename.file.destination` `rmdir.file` `setxattr.file` `signal.target.ancestors.file` `signal.target.ancestors.interpreter.file` `signal.target.file` `signal.target.interpreter.file` `signal.target.parent.file` `signal.target.parent.interpreter.file` `splice.file` `unlink.file` `utimes.file`
 
-Constants: [Chmod mode constants](#chmod-mode-constants)
+Constants: [File mode constants](#file-mode-constants)
 
 
 
@@ -2249,7 +2252,7 @@ Type: int
 Definition: New mode of the chmod-ed file
 
 
-Constants: [Chmod mode constants](#chmod-mode-constants)
+Constants: [File mode constants](#file-mode-constants)
 
 
 
@@ -2259,7 +2262,7 @@ Type: int
 Definition: New rights of the chmod-ed file
 
 
-Constants: [Chmod mode constants](#chmod-mode-constants)
+Constants: [File mode constants](#file-mode-constants)
 
 
 
@@ -2415,7 +2418,7 @@ Type: int
 Definition: Mode of the new directory
 
 
-Constants: [Chmod mode constants](#chmod-mode-constants)
+Constants: [File mode constants](#file-mode-constants)
 
 
 
@@ -2425,7 +2428,7 @@ Type: int
 Definition: Rights of the new directory
 
 
-Constants: [Chmod mode constants](#chmod-mode-constants)
+Constants: [File mode constants](#file-mode-constants)
 
 
 
@@ -2537,7 +2540,7 @@ Type: int
 Definition: Mode of the created file
 
 
-Constants: [Chmod mode constants](#chmod-mode-constants)
+Constants: [File mode constants](#file-mode-constants)
 
 
 
@@ -3064,35 +3067,6 @@ BPF program types are the supported eBPF program types.
 | `BPF_PROG_TYPE_LSM` | all |
 | `BPF_PROG_TYPE_SK_LOOKUP` | all |
 
-### `Chmod mode constants` {#chmod-mode-constants}
-Chmod mode constants are the supported modes for the chmod syscall.
-
-| Name | Architectures |
-| ---- |---------------|
-| `S_IFBLK` | all |
-| `S_IFCHR` | all |
-| `S_IFDIR` | all |
-| `S_IFIFO` | all |
-| `S_IFLNK` | all |
-| `S_IFMT` | all |
-| `S_IFREG` | all |
-| `S_IFSOCK` | all |
-| `S_IRGRP` | all |
-| `S_IROTH` | all |
-| `S_IRUSR` | all |
-| `S_IRWXG` | all |
-| `S_IRWXO` | all |
-| `S_IRWXU` | all |
-| `S_ISGID` | all |
-| `S_ISUID` | all |
-| `S_ISVTX` | all |
-| `S_IWGRP` | all |
-| `S_IWOTH` | all |
-| `S_IWUSR` | all |
-| `S_IXGRP` | all |
-| `S_IXOTH` | all |
-| `S_IXUSR` | all |
-
 ### `DNS qclasses` {#dns-qclasses}
 DNS qclasses are the supported DNS query classes.
 
@@ -3333,6 +3307,56 @@ Error constants are the supported error constants.
 | `EWOULDBLOCK` | all |
 | `EXDEV` | all |
 | `EXFULL` | all |
+
+### `File mode constants` {#file-mode-constants}
+File mode constants are the supported file permissions as well as constants for the set-user-ID, set-group-ID, and sticky bits.
+
+| Name | Architectures |
+| ---- |---------------|
+| `S_ISUID` | all |
+| `S_ISGID` | all |
+| `S_ISVTX` | all |
+| `S_IRWXU` | all |
+| `S_IRUSR` | all |
+| `S_IWUSR` | all |
+| `S_IXUSR` | all |
+| `S_IRWXG` | all |
+| `S_IRGRP` | all |
+| `S_IWGRP` | all |
+| `S_IXGRP` | all |
+| `S_IRWXO` | all |
+| `S_IROTH` | all |
+| `S_IWOTH` | all |
+| `S_IXOTH` | all |
+
+### `Inode mode constants` {#inode-mode-constants}
+Inode mode constants are the supported file type constants as well as the file mode constants.
+
+| Name | Architectures |
+| ---- |---------------|
+| `S_IFMT` | all |
+| `S_IFSOCK` | all |
+| `S_IFLNK` | all |
+| `S_IFREG` | all |
+| `S_IFBLK` | all |
+| `S_IFDIR` | all |
+| `S_IFCHR` | all |
+| `S_IFIFO` | all |
+| `S_ISUID` | all |
+| `S_ISGID` | all |
+| `S_ISVTX` | all |
+| `S_IRWXU` | all |
+| `S_IRUSR` | all |
+| `S_IWUSR` | all |
+| `S_IXUSR` | all |
+| `S_IRWXG` | all |
+| `S_IRGRP` | all |
+| `S_IWGRP` | all |
+| `S_IXGRP` | all |
+| `S_IRWXO` | all |
+| `S_IROTH` | all |
+| `S_IWOTH` | all |
+| `S_IXOTH` | all |
 
 ### `Kernel Capability constants` {#kernel-capability-constants}
 Kernel Capability constants are the supported Linux Kernel Capability.

--- a/docs/cloud-workload-security/secl.json
+++ b/docs/cloud-workload-security/secl.json
@@ -7221,8 +7221,8 @@
         "unlink.file",
         "utimes.file"
       ],
-      "constants": "",
-      "constants_link": "",
+      "constants": "Inode mode constants",
+      "constants_link": "inode-mode-constants",
       "examples": []
     },
     {
@@ -7717,8 +7717,8 @@
         "unlink.file",
         "utimes.file"
       ],
-      "constants": "Chmod mode constants",
-      "constants_link": "chmod-mode-constants",
+      "constants": "File mode constants",
+      "constants_link": "file-mode-constants",
       "examples": []
     },
     {
@@ -8064,8 +8064,8 @@
       "prefixes": [
         "chmod"
       ],
-      "constants": "Chmod mode constants",
-      "constants_link": "chmod-mode-constants",
+      "constants": "File mode constants",
+      "constants_link": "file-mode-constants",
       "examples": []
     },
     {
@@ -8076,8 +8076,8 @@
       "prefixes": [
         "chmod"
       ],
-      "constants": "Chmod mode constants",
-      "constants_link": "chmod-mode-constants",
+      "constants": "File mode constants",
+      "constants_link": "file-mode-constants",
       "examples": []
     },
     {
@@ -8328,8 +8328,8 @@
       "prefixes": [
         "mkdir"
       ],
-      "constants": "Chmod mode constants",
-      "constants_link": "chmod-mode-constants",
+      "constants": "File mode constants",
+      "constants_link": "file-mode-constants",
       "examples": []
     },
     {
@@ -8340,8 +8340,8 @@
       "prefixes": [
         "mkdir"
       ],
-      "constants": "Chmod mode constants",
-      "constants_link": "chmod-mode-constants",
+      "constants": "File mode constants",
+      "constants_link": "file-mode-constants",
       "examples": []
     },
     {
@@ -8496,8 +8496,8 @@
       "prefixes": [
         "open"
       ],
-      "constants": "Chmod mode constants",
-      "constants_link": "chmod-mode-constants",
+      "constants": "File mode constants",
+      "constants_link": "file-mode-constants",
       "examples": []
     },
     {
@@ -10038,105 +10038,6 @@
       ]
     },
     {
-      "name": "Chmod mode constants",
-      "link": "chmod-mode-constants",
-      "description": "Chmod mode constants are the supported modes for the chmod syscall.",
-      "all": [
-        {
-          "name": "S_IFBLK",
-          "architecture": "all"
-        },
-        {
-          "name": "S_IFCHR",
-          "architecture": "all"
-        },
-        {
-          "name": "S_IFDIR",
-          "architecture": "all"
-        },
-        {
-          "name": "S_IFIFO",
-          "architecture": "all"
-        },
-        {
-          "name": "S_IFLNK",
-          "architecture": "all"
-        },
-        {
-          "name": "S_IFMT",
-          "architecture": "all"
-        },
-        {
-          "name": "S_IFREG",
-          "architecture": "all"
-        },
-        {
-          "name": "S_IFSOCK",
-          "architecture": "all"
-        },
-        {
-          "name": "S_IRGRP",
-          "architecture": "all"
-        },
-        {
-          "name": "S_IROTH",
-          "architecture": "all"
-        },
-        {
-          "name": "S_IRUSR",
-          "architecture": "all"
-        },
-        {
-          "name": "S_IRWXG",
-          "architecture": "all"
-        },
-        {
-          "name": "S_IRWXO",
-          "architecture": "all"
-        },
-        {
-          "name": "S_IRWXU",
-          "architecture": "all"
-        },
-        {
-          "name": "S_ISGID",
-          "architecture": "all"
-        },
-        {
-          "name": "S_ISUID",
-          "architecture": "all"
-        },
-        {
-          "name": "S_ISVTX",
-          "architecture": "all"
-        },
-        {
-          "name": "S_IWGRP",
-          "architecture": "all"
-        },
-        {
-          "name": "S_IWOTH",
-          "architecture": "all"
-        },
-        {
-          "name": "S_IWUSR",
-          "architecture": "all"
-        },
-        {
-          "name": "S_IXGRP",
-          "architecture": "all"
-        },
-        {
-          "name": "S_IXOTH",
-          "architecture": "all"
-        },
-        {
-          "name": "S_IXUSR",
-          "architecture": "all"
-        }
-      ]
-    },
-    {
       "name": "DNS qclasses",
       "link": "dns-qclasses",
       "description": "DNS qclasses are the supported DNS query classes.",
@@ -11045,6 +10946,172 @@
         },
         {
           "name": "EXFULL",
+          "architecture": "all"
+        }
+      ]
+    },
+    {
+      "name": "File mode constants",
+      "link": "file-mode-constants",
+      "description": "File mode constants are the supported file permissions as well as constants for the set-user-ID, set-group-ID, and sticky bits.",
+      "all": [
+        {
+          "name": "S_ISUID",
+          "architecture": "all"
+        },
+        {
+          "name": "S_ISGID",
+          "architecture": "all"
+        },
+        {
+          "name": "S_ISVTX",
+          "architecture": "all"
+        },
+        {
+          "name": "S_IRWXU",
+          "architecture": "all"
+        },
+        {
+          "name": "S_IRUSR",
+          "architecture": "all"
+        },
+        {
+          "name": "S_IWUSR",
+          "architecture": "all"
+        },
+        {
+          "name": "S_IXUSR",
+          "architecture": "all"
+        },
+        {
+          "name": "S_IRWXG",
+          "architecture": "all"
+        },
+        {
+          "name": "S_IRGRP",
+          "architecture": "all"
+        },
+        {
+          "name": "S_IWGRP",
+          "architecture": "all"
+        },
+        {
+          "name": "S_IXGRP",
+          "architecture": "all"
+        },
+        {
+          "name": "S_IRWXO",
+          "architecture": "all"
+        },
+        {
+          "name": "S_IROTH",
+          "architecture": "all"
+        },
+        {
+          "name": "S_IWOTH",
+          "architecture": "all"
+        },
+        {
+          "name": "S_IXOTH",
+          "architecture": "all"
+        }
+      ]
+    },
+    {
+      "name": "Inode mode constants",
+      "link": "inode-mode-constants",
+      "description": "Inode mode constants are the supported file type constants as well as the file mode constants.",
+      "all": [
+        {
+          "name": "S_IFMT",
+          "architecture": "all"
+        },
+        {
+          "name": "S_IFSOCK",
+          "architecture": "all"
+        },
+        {
+          "name": "S_IFLNK",
+          "architecture": "all"
+        },
+        {
+          "name": "S_IFREG",
+          "architecture": "all"
+        },
+        {
+          "name": "S_IFBLK",
+          "architecture": "all"
+        },
+        {
+          "name": "S_IFDIR",
+          "architecture": "all"
+        },
+        {
+          "name": "S_IFCHR",
+          "architecture": "all"
+        },
+        {
+          "name": "S_IFIFO",
+          "architecture": "all"
+        },
+        {
+          "name": "S_ISUID",
+          "architecture": "all"
+        },
+        {
+          "name": "S_ISGID",
+          "architecture": "all"
+        },
+        {
+          "name": "S_ISVTX",
+          "architecture": "all"
+        },
+        {
+          "name": "S_IRWXU",
+          "architecture": "all"
+        },
+        {
+          "name": "S_IRUSR",
+          "architecture": "all"
+        },
+        {
+          "name": "S_IWUSR",
+          "architecture": "all"
+        },
+        {
+          "name": "S_IXUSR",
+          "architecture": "all"
+        },
+        {
+          "name": "S_IRWXG",
+          "architecture": "all"
+        },
+        {
+          "name": "S_IRGRP",
+          "architecture": "all"
+        },
+        {
+          "name": "S_IWGRP",
+          "architecture": "all"
+        },
+        {
+          "name": "S_IXGRP",
+          "architecture": "all"
+        },
+        {
+          "name": "S_IRWXO",
+          "architecture": "all"
+        },
+        {
+          "name": "S_IROTH",
+          "architecture": "all"
+        },
+        {
+          "name": "S_IWOTH",
+          "architecture": "all"
+        },
+        {
+          "name": "S_IXOTH",
           "architecture": "all"
         }
       ]

--- a/pkg/security/secl/model/consts_common.go
+++ b/pkg/security/secl/model/consts_common.go
@@ -670,6 +670,8 @@ var (
 var (
 	openFlagsStrings          = map[int]string{}
 	chmodModeStrings          = map[int]string{}
+	fileModeStrings           = map[int]string{}
+	inodeModeStrings          = map[int]string{}
 	unlinkFlagsStrings        = map[int]string{}
 	kernelCapabilitiesStrings = map[uint64]string{}
 	bpfCmdStrings             = map[uint32]string{}
@@ -707,10 +709,17 @@ func initOpenConstants() {
 	}
 }
 
-func initChmodConstants() {
-	for k, v := range chmodModeConstants {
+func initFileModeConstants() {
+	for k, v := range fileModeConstants {
 		SECLConstants[k] = &eval.IntEvaluator{Value: v}
-		chmodModeStrings[v] = k
+		fileModeStrings[v] = k
+	}
+}
+
+func initInodeModeConstants() {
+	for k, v := range inodeModeConstants {
+		SECLConstants[k] = &eval.IntEvaluator{Value: v}
+		inodeModeStrings[v] = k
 	}
 }
 
@@ -888,7 +897,8 @@ func initBPFMapNamesConstants() {
 func initConstants() {
 	initErrorConstants()
 	initOpenConstants()
-	initChmodConstants()
+	initFileModeConstants()
+	initInodeModeConstants()
 	initUnlinkConstanst()
 	initKernelCapabilityConstants()
 	initBPFCmdConstants()
@@ -983,11 +993,18 @@ func (f OpenFlags) StringArray() []string {
 	return bitmaskToStringArray(int(f), openFlagsStrings)
 }
 
-// ChmodMode represent a chmod mode bitmask value
-type ChmodMode int
+// FileMode represents a file mode bitmask value
+type FileMode int
 
-func (m ChmodMode) String() string {
-	return bitmaskToString(int(m), chmodModeStrings)
+func (m FileMode) String() string {
+	return bitmaskToString(int(m), fileModeStrings)
+}
+
+// FileMode represents a file mode bitmask value
+type InodeMode int
+
+func (m InodeMode) String() string {
+	return bitmaskToString(int(m), inodeModeStrings)
 }
 
 // UnlinkFlags represents an unlink flags bitmask value

--- a/pkg/security/secl/model/consts_common.go
+++ b/pkg/security/secl/model/consts_common.go
@@ -669,7 +669,6 @@ var (
 
 var (
 	openFlagsStrings          = map[int]string{}
-	chmodModeStrings          = map[int]string{}
 	fileModeStrings           = map[int]string{}
 	inodeModeStrings          = map[int]string{}
 	unlinkFlagsStrings        = map[int]string{}
@@ -1000,7 +999,7 @@ func (m FileMode) String() string {
 	return bitmaskToString(int(m), fileModeStrings)
 }
 
-// FileMode represents a file mode bitmask value
+// InodeMode represents an inode mode bitmask value
 type InodeMode int
 
 func (m InodeMode) String() string {

--- a/pkg/security/secl/model/consts_linux.go
+++ b/pkg/security/secl/model/consts_linux.go
@@ -177,35 +177,55 @@ var (
 		"O_RSYNC":    syscall.O_RSYNC,
 	}
 
-	// chmodModeConstants are the supported modes for the chmod syscall
-	// generate_constants:Chmod mode constants,Chmod mode constants are the supported modes for the chmod syscall.
-	chmodModeConstants = map[string]int{
-		// "S_IEXEC":  syscall.S_IEXEC, deprecated
-		"S_IFBLK":  syscall.S_IFBLK,
-		"S_IFCHR":  syscall.S_IFCHR,
-		"S_IFDIR":  syscall.S_IFDIR,
-		"S_IFIFO":  syscall.S_IFIFO,
-		"S_IFLNK":  syscall.S_IFLNK,
-		"S_IFMT":   syscall.S_IFMT,
-		"S_IFREG":  syscall.S_IFREG,
-		"S_IFSOCK": syscall.S_IFSOCK,
+	// fileModeConstants contains the constants describing file permissions as well as the set-user-ID, set-group-ID, and sticky bits.
+	// generate_constants:File mode constants,File mode constants are the supported file permissions as well as constants for the set-user-ID, set-group-ID, and sticky bits.
+	fileModeConstants = map[string]int{
 		// "S_IREAD":  syscall.S_IREAD, deprecated
-		"S_IRGRP": syscall.S_IRGRP,
-		"S_IROTH": syscall.S_IROTH,
-		"S_IRUSR": syscall.S_IRUSR,
-		"S_IRWXG": syscall.S_IRWXG,
-		"S_IRWXO": syscall.S_IRWXO,
-		"S_IRWXU": syscall.S_IRWXU,
-		"S_ISGID": syscall.S_ISGID,
 		"S_ISUID": syscall.S_ISUID,
+		"S_ISGID": syscall.S_ISGID,
 		"S_ISVTX": syscall.S_ISVTX,
-		"S_IWGRP": syscall.S_IWGRP,
-		"S_IWOTH": syscall.S_IWOTH,
-		// "S_IWRITE": syscall.S_IWRITE, deprecated
+		"S_IRWXU": syscall.S_IRWXU,
+		"S_IRUSR": syscall.S_IRUSR,
 		"S_IWUSR": syscall.S_IWUSR,
-		"S_IXGRP": syscall.S_IXGRP,
-		"S_IXOTH": syscall.S_IXOTH,
 		"S_IXUSR": syscall.S_IXUSR,
+		"S_IRWXG": syscall.S_IRWXG,
+		"S_IRGRP": syscall.S_IRGRP,
+		"S_IWGRP": syscall.S_IWGRP,
+		"S_IXGRP": syscall.S_IXGRP,
+		"S_IRWXO": syscall.S_IRWXO,
+		"S_IROTH": syscall.S_IROTH,
+		"S_IWOTH": syscall.S_IWOTH,
+		"S_IXOTH": syscall.S_IXOTH,
+		// "S_IWRITE": syscall.S_IWRITE, deprecated
+	}
+
+	// inodeModeConstants are the supported file types and file modes
+	// generate_constants:Inode mode constants,Inode mode constants are the supported file type constants as well as the file mode constants.
+	inodeModeConstants = map[string]int{
+		// "S_IEXEC":  syscall.S_IEXEC, deprecated
+		"S_IFMT":   syscall.S_IFMT,
+		"S_IFSOCK": syscall.S_IFSOCK,
+		"S_IFLNK":  syscall.S_IFLNK,
+		"S_IFREG":  syscall.S_IFREG,
+		"S_IFBLK":  syscall.S_IFBLK,
+		"S_IFDIR":  syscall.S_IFDIR,
+		"S_IFCHR":  syscall.S_IFCHR,
+		"S_IFIFO":  syscall.S_IFIFO,
+		"S_ISUID":  syscall.S_ISUID,
+		"S_ISGID":  syscall.S_ISGID,
+		"S_ISVTX":  syscall.S_ISVTX,
+		"S_IRWXU":  syscall.S_IRWXU,
+		"S_IRUSR":  syscall.S_IRUSR,
+		"S_IWUSR":  syscall.S_IWUSR,
+		"S_IXUSR":  syscall.S_IXUSR,
+		"S_IRWXG":  syscall.S_IRWXG,
+		"S_IRGRP":  syscall.S_IRGRP,
+		"S_IWGRP":  syscall.S_IWGRP,
+		"S_IXGRP":  syscall.S_IXGRP,
+		"S_IRWXO":  syscall.S_IRWXO,
+		"S_IROTH":  syscall.S_IROTH,
+		"S_IWOTH":  syscall.S_IWOTH,
+		"S_IXOTH":  syscall.S_IXOTH,
 	}
 
 	// KernelCapabilityConstants list of kernel capabilities

--- a/pkg/security/secl/model/consts_other.go
+++ b/pkg/security/secl/model/consts_other.go
@@ -11,7 +11,8 @@ package model
 var (
 	errorConstants     = map[string]int{}
 	openFlagsConstants = map[string]int{}
-	chmodModeConstants = map[string]int{}
+	fileModeConstants  = map[string]int{}
+	inodeModeConstants = map[string]int{}
 	// KernelCapabilityConstants list of kernel capabilities
 	KernelCapabilityConstants = map[string]uint64{}
 	unlinkFlagsConstants      = map[string]int{}

--- a/pkg/security/secl/model/consts_test.go
+++ b/pkg/security/secl/model/consts_test.go
@@ -20,7 +20,7 @@ func TestFlagsToString(t *testing.T) {
 		t.Errorf("expected flags not found, got: %s", str)
 	}
 
-	str = ChmodMode(syscall.S_IWGRP | syscall.S_IRUSR).String()
+	str = FileMode(syscall.S_IWGRP | syscall.S_IRUSR).String()
 	if str != "S_IRUSR | S_IWGRP" {
 		t.Errorf("expected flags not found, got: %s", str)
 	}

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -133,7 +133,7 @@ func (m *Model) ValidateField(field eval.Field, fieldValue eval.FieldValue) erro
 type ChmodEvent struct {
 	SyscallEvent
 	File FileEvent `field:"file"`
-	Mode uint32    `field:"file.destination.mode; file.destination.rights"` // SECLDoc[file.destination.mode] Definition:`New mode of the chmod-ed file` Constants:`Chmod mode constants` SECLDoc[file.destination.rights] Definition:`New rights of the chmod-ed file` Constants:`Chmod mode constants`
+	Mode uint32    `field:"file.destination.mode; file.destination.rights"` // SECLDoc[file.destination.mode] Definition:`New mode of the chmod-ed file` Constants:`File mode constants` SECLDoc[file.destination.rights] Definition:`New rights of the chmod-ed file` Constants:`File mode constants`
 }
 
 // ChownEvent represents a chown event
@@ -607,7 +607,7 @@ type FileFields struct {
 	User  string `field:"user,handler:ResolveFileFieldsUser"`                          // SECLDoc[user] Definition:`User of the file's owner`
 	GID   uint32 `field:"gid"`                                                         // SECLDoc[gid] Definition:`GID of the file's owner`
 	Group string `field:"group,handler:ResolveFileFieldsGroup"`                        // SECLDoc[group] Definition:`Group of the file's owner`
-	Mode  uint16 `field:"mode;rights,handler:ResolveRights,opts:cacheless_resolution"` // SECLDoc[mode] Definition:`Mode of the file` SECLDoc[rights] Definition:`Rights of the file` Constants:`Chmod mode constants`
+	Mode  uint16 `field:"mode;rights,handler:ResolveRights,opts:cacheless_resolution"` // SECLDoc[mode] Definition:`Mode of the file` Constants:`Inode mode constants` SECLDoc[rights] Definition:`Rights of the file` Constants:`File mode constants`
 	CTime uint64 `field:"change_time"`                                                 // SECLDoc[change_time] Definition:`Change time of the file`
 	MTime uint64 `field:"modification_time"`                                           // SECLDoc[modification_time] Definition:`Modification time of the file`
 
@@ -700,7 +700,7 @@ type LinkEvent struct {
 type MkdirEvent struct {
 	SyscallEvent
 	File FileEvent `field:"file"`
-	Mode uint32    `field:"file.destination.mode; file.destination.rights"` // SECLDoc[file.destination.mode] Definition:`Mode of the new directory` Constants:`Chmod mode constants` SECLDoc[file.destination.rights] Definition:`Rights of the new directory` Constants:`Chmod mode constants`
+	Mode uint32    `field:"file.destination.mode; file.destination.rights"` // SECLDoc[file.destination.mode] Definition:`Mode of the new directory` Constants:`File mode constants` SECLDoc[file.destination.rights] Definition:`Rights of the new directory` Constants:`File mode constants`
 }
 
 // ArgsEnvsEvent defines a args/envs event
@@ -756,7 +756,7 @@ type OpenEvent struct {
 	SyscallEvent
 	File  FileEvent `field:"file"`
 	Flags uint32    `field:"flags"`                 // SECLDoc[flags] Definition:`Flags used when opening the file` Constants:`Open flags`
-	Mode  uint32    `field:"file.destination.mode"` // SECLDoc[file.destination.mode] Definition:`Mode of the created file` Constants:`Chmod mode constants`
+	Mode  uint32    `field:"file.destination.mode"` // SECLDoc[file.destination.mode] Definition:`Mode of the created file` Constants:`File mode constants`
 }
 
 // SELinuxEventKind represents the event kind for SELinux events


### PR DESCRIPTION
This PR distinguishes between constants used for file modes and inodes modes (the latter includes the former but also provides file types constants), thus making the documentation clearer. 

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
