### PR TITLE
[CWS] improvement to CWS events tagging lifecycle

### DIFF
--- a/pkg/security/module/cws.go
+++ b/pkg/security/module/cws.go
@@ -452,7 +452,7 @@ func (c *CWSConsumer) HandleEvent(event *model.Event) {
 
 // HandleCustomEvent is called by the probe when an event should be sent to Datadog but doesn't need evaluation
 func (c *CWSConsumer) HandleCustomEvent(rule *rules.Rule, event *events.CustomEvent) {
-	c.eventSender.SendEvent(rule, event, func() []string { return nil }, "")
+	c.eventSender.SendEvent(rule, event, nil, "")
 }
 
 // RuleMatch is called by the ruleset when a rule matches
@@ -481,7 +481,6 @@ func (c *CWSConsumer) RuleMatch(rule *rules.Rule, event eval.Event) {
 
 	extTagsCb := func() []string {
 		return c.probe.GetEventTags(ev)
-
 	}
 
 	// send if not selftest related events

--- a/pkg/security/module/policy_monitor.go
+++ b/pkg/security/module/policy_monitor.go
@@ -135,7 +135,7 @@ func ReportRuleSetLoaded(sender EventSender, statsdClient statsd.ClientInterface
 		log.Error(fmt.Errorf("failed to send ruleset_loaded metric: %w", err))
 	}
 
-	sender.SendEvent(rule, event, func() []string { return nil }, "")
+	sender.SendEvent(rule, event, nil, "")
 }
 
 // RuleLoaded defines a loaded rule

--- a/pkg/security/module/self_tests.go
+++ b/pkg/security/module/self_tests.go
@@ -51,5 +51,5 @@ func ReportSelfTest(sender EventSender, statsdClient statsd.ClientInterface, suc
 
 	// send the custom event with the list of succeed and failed self tests
 	rule, event := NewSelfTestEvent(success, fails)
-	sender.SendEvent(rule, event, func() []string { return nil }, "")
+	sender.SendEvent(rule, event, nil, "")
 }

--- a/pkg/security/module/server.go
+++ b/pkg/security/module/server.go
@@ -483,7 +483,7 @@ func (a *APIServer) GetStats() map[string]int64 {
 	a.expiredEventsLock.RLock()
 	defer a.expiredEventsLock.RUnlock()
 
-	stats := make(map[string]int64)
+	stats := make(map[string]int64, len(a.expiredEvents))
 	for ruleID, val := range a.expiredEvents {
 		stats[ruleID] = val.Swap(0)
 	}

--- a/pkg/security/module/server.go
+++ b/pkg/security/module/server.go
@@ -52,7 +52,6 @@ type APIServer struct {
 	activityDumps     chan *api.ActivityDumpStreamMessage
 	expiredEventsLock sync.RWMutex
 	expiredEvents     map[rules.RuleID]*atomic.Int64
-	expiredDumpsLock  sync.RWMutex
 	expiredDumps      *atomic.Int64
 	limiter           *StdLimiter
 	statsdClient      statsd.ClientInterface
@@ -473,11 +472,8 @@ func (a *APIServer) expireEvent(msg *api.SecurityEventMessage) {
 
 // expireDump updates the count of expired dumps
 func (a *APIServer) expireDump(dump *api.ActivityDumpStreamMessage) {
-	a.expiredDumpsLock.Lock()
-	defer a.expiredDumpsLock.Unlock()
-
 	// update metric
-	_ = a.expiredDumps.Inc()
+	a.expiredDumps.Inc()
 	seclog.Tracef("the activity dump server channel is full, a dump of [%s] was dropped\n", dump.GetDump().GetMetadata().GetName())
 }
 

--- a/pkg/security/module/server.go
+++ b/pkg/security/module/server.go
@@ -307,11 +307,8 @@ func (a *APIServer) start(ctx context.Context) {
 				}
 
 				// recopy tags
-				var tags []string
 				hasService := len(msg.service) != 0
 				for _, tag := range msg.tags {
-					tags = append(tags, tag)
-
 					// look for the service tag if we don't have one yet
 					if !hasService {
 						if strings.HasPrefix(tag, "service:") {
@@ -325,7 +322,7 @@ func (a *APIServer) start(ctx context.Context) {
 					RuleID:  msg.ruleID,
 					Data:    msg.data,
 					Service: msg.service,
-					Tags:    tags,
+					Tags:    msg.tags,
 				}
 
 				select {

--- a/pkg/security/module/server.go
+++ b/pkg/security/module/server.go
@@ -302,8 +302,10 @@ func (a *APIServer) start(ctx context.Context) {
 		select {
 		case now := <-ticker.C:
 			a.dequeue(now, func(msg *pendingMsg) {
-				for _, tag := range msg.extTagsCb() {
-					msg.tags[tag] = true
+				if msg.extTagsCb != nil {
+					for _, tag := range msg.extTagsCb() {
+						msg.tags[tag] = true
+					}
 				}
 
 				// recopy tags


### PR DESCRIPTION
### What does this PR do?

The goal of this PR is to remove maps and useless allocation when tagging CWS events.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
