### PR TITLE
system-probe: simplify statsd configuration

### DIFF
--- a/cmd/process-agent/main_common.go
+++ b/cmd/process-agent/main_common.go
@@ -215,7 +215,7 @@ type miscDeps struct {
 // initMisc initializes modules that cannot, or have not yet been componetized.
 // Todo: (Components) WorkloadMeta, remoteTagger, statsd
 func initMisc(deps miscDeps) error {
-	if err := statsd.Configure(ddconfig.GetBindHost(), deps.Config.GetInt("dogstatsd_port")); err != nil {
+	if err := statsd.Configure(ddconfig.GetBindHost(), deps.Config.GetInt("dogstatsd_port"), false); err != nil {
 		_ = log.Criticalf("Error configuring statsd: %s", err)
 		return err
 	}

--- a/cmd/system-probe/modules/network_tracer.go
+++ b/cmd/system-probe/modules/network_tracer.go
@@ -20,8 +20,6 @@ import (
 
 	"go.uber.org/atomic"
 
-	"github.com/DataDog/datadog-go/v5/statsd"
-
 	"github.com/DataDog/datadog-agent/cmd/system-probe/api/module"
 	"github.com/DataDog/datadog-agent/cmd/system-probe/config"
 	"github.com/DataDog/datadog-agent/cmd/system-probe/utils"
@@ -32,6 +30,7 @@ import (
 	kafkadebugging "github.com/DataDog/datadog-agent/pkg/network/protocols/kafka/debugging"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/network/tracer"
+	"github.com/DataDog/datadog-agent/pkg/process/statsd"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -306,18 +305,7 @@ func writeConnections(w http.ResponseWriter, marshaler encoding.Marshaler, cs *n
 }
 
 func startTelemetryReporter(cfg *config.Config, done <-chan struct{}) {
-	statsdAddr := os.Getenv("STATSD_URL")
-	if statsdAddr == "" {
-		statsdAddr = fmt.Sprintf("%s:%d", cfg.StatsdHost, cfg.StatsdPort)
-	}
-
-	statsdClient, err := statsd.New(statsdAddr)
-	if err != nil {
-		log.Errorf("failed to start statsd reporter for network_tracer: %s", err)
-		return
-	}
-
-	telemetry.SetStatsdClient(statsdClient)
+	telemetry.SetStatsdClient(statsd.Client)
 	ticker := time.NewTicker(30 * time.Second)
 	go func() {
 		defer ticker.Stop()

--- a/cmd/system-probe/subcommands/run/command.go
+++ b/cmd/system-probe/subcommands/run/command.go
@@ -195,7 +195,7 @@ func startSystemProbe(cliParams *cliParams, log log.Component, sysprobeconfig sy
 		return log.Criticalf("unable to configure auto-exit: %s", err)
 	}
 
-	if err := statsd.Configure(cfg.StatsdHost, cfg.StatsdPort); err != nil {
+	if err := statsd.Configure(cfg.StatsdHost, cfg.StatsdPort, true); err != nil {
 		return log.Criticalf("error configuring statsd: %s", err)
 	}
 

--- a/pkg/eventmonitor/config/config.go
+++ b/pkg/eventmonitor/config/config.go
@@ -6,7 +6,6 @@
 package config
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/DataDog/datadog-agent/cmd/system-probe/config"
@@ -20,9 +19,6 @@ const (
 )
 
 type Config struct {
-	// StatsdAddr defines the statsd address
-	StatsdAddr string
-
 	// SocketPath is the path to the socket that is used to communicate with the security agent and process agent
 	SocketPath string
 
@@ -39,8 +35,6 @@ type Config struct {
 // NewConfig creates a config for the event monitoring module
 func NewConfig(spConfig *config.Config) *Config {
 	return &Config{
-		StatsdAddr: fmt.Sprintf("%s:%d", spConfig.StatsdHost, spConfig.StatsdPort),
-
 		// event server
 		SocketPath:       coreconfig.SystemProbe.GetString(join(evNS, "socket")),
 		EventServerBurst: coreconfig.SystemProbe.GetInt(join(evNS, "event_server.burst")),

--- a/pkg/eventmonitor/eventmonitor.go
+++ b/pkg/eventmonitor/eventmonitor.go
@@ -13,25 +13,21 @@ import (
 	"errors"
 	"fmt"
 	"net"
-	"os"
 	"sync"
 	"time"
 
-	"github.com/DataDog/datadog-agent/cmd/system-probe/api/module"
 	"github.com/DataDog/datadog-go/v5/statsd"
 	"golang.org/x/exp/slices"
 	"google.golang.org/grpc"
 
+	"github.com/DataDog/datadog-agent/cmd/system-probe/api/module"
 	"github.com/DataDog/datadog-agent/pkg/eventmonitor/config"
+	procstatsd "github.com/DataDog/datadog-agent/pkg/process/statsd"
 	secconfig "github.com/DataDog/datadog-agent/pkg/security/config"
 	"github.com/DataDog/datadog-agent/pkg/security/probe"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/seclog"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-)
-
-const (
-	statsdPoolSize = 64
 )
 
 var (
@@ -235,12 +231,7 @@ func (m *EventMonitor) GetStats() map[string]interface{} {
 // NewEventMonitor instantiates an event monitoring system-probe module
 func NewEventMonitor(config *config.Config, secconfig *secconfig.Config, opts Opts) (*EventMonitor, error) {
 	if opts.StatsdClient == nil {
-		statsdClient, err := getStatsdClient(config)
-		if err != nil {
-			log.Info("Unable to init statsd client")
-			return nil, module.ErrNotEnabled
-		}
-		opts.StatsdClient = statsdClient
+		opts.StatsdClient = procstatsd.Client
 	}
 
 	if opts.ProbeOpts.StatsdClient == nil {
@@ -264,13 +255,4 @@ func NewEventMonitor(config *config.Config, secconfig *secconfig.Config, opts Op
 		cancelFnc:     cancelFnc,
 		sendStatsChan: make(chan chan bool, 1),
 	}, nil
-}
-
-func getStatsdClient(cfg *config.Config) (statsd.ClientInterface, error) {
-	statsdAddr := os.Getenv("STATSD_URL")
-	if statsdAddr == "" {
-		statsdAddr = cfg.StatsdAddr
-	}
-
-	return statsd.New(statsdAddr, statsd.WithBufferPoolSize(statsdPoolSize))
 }

--- a/pkg/process/statsd/statsd.go
+++ b/pkg/process/statsd/statsd.go
@@ -6,7 +6,8 @@
 package statsd
 
 import (
-	"fmt"
+	"net"
+	"strconv"
 
 	"github.com/DataDog/datadog-go/v5/statsd"
 )
@@ -17,7 +18,8 @@ var Client *statsd.Client
 
 // Configure creates a statsd client from a dogweb.ini style config file and set it to the global Statsd.
 func Configure(host string, port int) error {
-	client, err := statsd.New(fmt.Sprintf("%s:%d", host, port))
+	url := net.JoinHostPort(host, strconv.Itoa(port))
+	client, err := statsd.New(url)
 	if err != nil {
 		return err
 	}

--- a/pkg/process/statsd/statsd.go
+++ b/pkg/process/statsd/statsd.go
@@ -7,6 +7,7 @@ package statsd
 
 import (
 	"net"
+	"os"
 	"strconv"
 
 	"github.com/DataDog/datadog-go/v5/statsd"
@@ -17,9 +18,17 @@ import (
 var Client *statsd.Client
 
 // Configure creates a statsd client from a dogweb.ini style config file and set it to the global Statsd.
-func Configure(host string, port int) error {
-	url := net.JoinHostPort(host, strconv.Itoa(port))
-	client, err := statsd.New(url)
+func Configure(host string, port int, lookInEnv bool) error {
+	var statsdAddr string
+	if lookInEnv {
+		statsdAddr = os.Getenv("STATSD_URL")
+	}
+
+	if statsdAddr == "" {
+		statsdAddr = net.JoinHostPort(host, strconv.Itoa(port))
+	}
+
+	client, err := statsd.New(statsdAddr)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### What does this PR do?

Currently the system probe creates 3 statsd client (and associated buffer):
- one common for the system probe
- a small one for the event monitor
- one for the network tracer telemetry

This PR makes the network tracer telemetry and the event monitor use the same common statsd client (and thus the same 4Mb buffer).
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
