### PR TITLE
Add k8s node information in the DCA workload meta store

### DIFF
--- a/cmd/cluster-agent/api/v1/kubernetes_metadata.go
+++ b/cmd/cluster-agent/api/v1/kubernetes_metadata.go
@@ -22,6 +22,7 @@ import (
 	as "github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
 	apicommon "github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/common"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 )
 
 func installKubernetesMetadataEndpoints(r *mux.Router) {
@@ -37,7 +38,7 @@ func installKubernetesMetadataEndpoints(r *mux.Router) {
 func installCloudFoundryMetadataEndpoints(r *mux.Router) {}
 
 // getNodeMetadata is only used when the node agent hits the DCA for the list of labels
-func getNodeMetadata(w http.ResponseWriter, r *http.Request, f func(*as.APIClient, string) (map[string]string, error), what string, filterList []string) {
+func getNodeMetadata(w http.ResponseWriter, r *http.Request, f func(*workloadmeta.KubernetesNode) map[string]string, what string, filterList []string) {
 	/*
 		Input
 			localhost:5001/api/v1/tags/node/localhost
@@ -55,24 +56,18 @@ func getNodeMetadata(w http.ResponseWriter, r *http.Request, f func(*as.APIClien
 			Example: "no cached metadata found for the node localhost"
 	*/
 
-	// As HTTP query handler, we do not retry getting the APIServer
-	// Client will have to retry query in case of failure
-	cl, err := as.GetAPIClient()
-	if err != nil {
-		log.Errorf("Can't create client to query the API Server: %v", err) //nolint:errcheck
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-
 	vars := mux.Vars(r)
 	var dataBytes []byte
 	nodeName := vars["nodeName"]
-	nodeData, err := f(cl, nodeName)
+
+	nodeEntity, err := workloadmeta.GetGlobalStore().GetKubernetesNode(nodeName)
 	if err != nil {
 		log.Errorf("Could not retrieve the node %s of %s: %v", what, nodeName, err.Error()) //nolint:errcheck
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+
+	nodeData := f(nodeEntity)
 
 	// Filter data to avoid returning too big useless data
 	if filterList != nil {
@@ -101,11 +96,11 @@ func getNodeMetadata(w http.ResponseWriter, r *http.Request, f func(*as.APIClien
 }
 
 func getNodeLabels(w http.ResponseWriter, r *http.Request) {
-	getNodeMetadata(w, r, as.GetNodeLabels, "labels", nil)
+	getNodeMetadata(w, r, func(e *workloadmeta.KubernetesNode) map[string]string { return e.Labels }, "labels", nil)
 }
 
 func getNodeAnnotations(w http.ResponseWriter, r *http.Request) {
-	getNodeMetadata(w, r, as.GetNodeAnnotations, "annotations", config.Datadog.GetStringSlice("kubernetes_node_annotations_as_host_aliases"))
+	getNodeMetadata(w, r, func(e *workloadmeta.KubernetesNode) map[string]string { return e.Annotations }, "annotations", config.Datadog.GetStringSlice("kubernetes_node_annotations_as_host_aliases"))
 }
 
 // getNamespaceLabels is only used when the node agent hits the DCA for the list of labels

--- a/pkg/tagger/collectors/workloadmeta_main.go
+++ b/pkg/tagger/collectors/workloadmeta_main.go
@@ -24,6 +24,7 @@ const (
 
 	staticSource         = workloadmetaCollectorName + "-static"
 	podSource            = workloadmetaCollectorName + "-" + string(workloadmeta.KindKubernetesPod)
+	nodeSource           = workloadmetaCollectorName + "-" + string(workloadmeta.KindKubernetesNode)
 	taskSource           = workloadmetaCollectorName + "-" + string(workloadmeta.KindECSTask)
 	containerSource      = workloadmetaCollectorName + "-" + string(workloadmeta.KindContainer)
 	containerImageSource = workloadmetaCollectorName + "-" + string(workloadmeta.KindContainerImageMetadata)

--- a/pkg/util/kubernetes/apiserver/metadata_controller.go
+++ b/pkg/util/kubernetes/apiserver/metadata_controller.go
@@ -316,38 +316,6 @@ func GetPodMetadataNames(nodeName, ns, podName string) ([]string, error) {
 	return metaList, nil
 }
 
-func getNode(as *APIClient, nodeName string) (*corev1.Node, error) {
-	if !config.Datadog.GetBool("kubernetes_collect_metadata_tags") {
-		return nil, log.Errorf("Metadata collection is disabled on the Cluster Agent")
-	}
-	node, err := as.InformerFactory.Core().V1().Nodes().Lister().Get(nodeName)
-	if err != nil {
-		return nil, err
-	}
-	if node == nil {
-		return nil, fmt.Errorf("cannot get node %s from the informer's cache", nodeName)
-	}
-	return node, nil
-}
-
-// GetNodeLabels retrieves the labels of the queried node from the cache of the shared informer.
-func GetNodeLabels(as *APIClient, nodeName string) (map[string]string, error) {
-	node, err := getNode(as, nodeName)
-	if err != nil {
-		return nil, err
-	}
-	return node.Labels, nil
-}
-
-// GetNodeAnnotations retrieves the annotations of the queried node from the cache of the shared informer.
-func GetNodeAnnotations(as *APIClient, nodeName string) (map[string]string, error) {
-	node, err := getNode(as, nodeName)
-	if err != nil {
-		return nil, err
-	}
-	return node.Annotations, nil
-}
-
 // GetNamespaceLabels retrieves the labels of the queried namespace from the cache of the shared informer.
 func GetNamespaceLabels(nsName string) (map[string]string, error) {
 	if !config.Datadog.GetBool("kubernetes_collect_metadata_tags") {

--- a/pkg/util/kubernetes/kubelet/kubelet_common.go
+++ b/pkg/util/kubernetes/kubelet/kubelet_common.go
@@ -31,6 +31,12 @@ var (
 
 	// KubePodTaggerEntityPrefix is the tagger entity prefix for Kubernetes pods
 	KubePodTaggerEntityPrefix = KubePodTaggerEntityName + containers.EntitySeparator
+
+	// KubeNodeTaggerEntityName is the tagger entity name for Kubernetes nodes
+	KubeNodeTaggerEntityName = "kubernetes_node_uid"
+
+	// KubeNodeTaggerEntityPrefix is the tagger entity prefix for Kubernetes pods
+	KubeNodeTaggerEntityPrefix = KubeNodeTaggerEntityName + containers.EntitySeparator
 )
 
 // PodUIDToEntityName returns a prefixed entity name from a pod UID
@@ -47,6 +53,14 @@ func PodUIDToTaggerEntityName(uid string) string {
 		return ""
 	}
 	return KubePodTaggerEntityPrefix + uid
+}
+
+// NodeUIDToTaggerEntityName returns a prefixed tagger entity name from a node UID
+func NodeUIDToTaggerEntityName(uid string) string {
+	if uid == "" {
+		return ""
+	}
+	return KubeNodeTaggerEntityPrefix + uid
 }
 
 // ParseMetricFromRaw parses a metric from raw prometheus text

--- a/pkg/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver.go
+++ b/pkg/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver.go
@@ -19,7 +19,6 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
-	"github.com/DataDog/datadog-agent/pkg/errors"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 )
@@ -39,36 +38,52 @@ func init() {
 }
 
 func (c *collector) Start(ctx context.Context, wlmetaStore workloadmeta.Store) error {
-	if !config.Datadog.GetBool("cluster_agent.collect_kubernetes_tags") {
-		return errors.NewDisabled(componentName, "Cluster Agent tag collection is disabled, disabling kubeapiserver collector")
-	}
-
 	apiserverClient, err := apiserver.GetAPIClient()
 	if err != nil {
 		return err
 	}
 
 	client := apiserverClient.Cl
-	namespace := metav1.NamespaceAll
 
-	listerWatcher := &cache.ListWatch{
+	nodeListerWatcher := &cache.ListWatch{
 		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
-			return client.CoreV1().Pods(namespace).List(ctx, options)
+			return client.CoreV1().Nodes().List(ctx, options)
 		},
 		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-			return client.CoreV1().Pods(namespace).Watch(ctx, options)
+			return client.CoreV1().Nodes().Watch(ctx, options)
 		},
 	}
 
-	reflector := cache.NewNamedReflector(
+	nodeReflector := cache.NewNamedReflector(
 		componentName,
-		listerWatcher,
-		&corev1.Pod{},
-		newReflectorStore(wlmetaStore),
+		nodeListerWatcher,
+		&corev1.Node{},
+		newNodeReflectorStore(wlmetaStore),
 		noResync,
 	)
 
-	go reflector.Run(ctx.Done())
+	go nodeReflector.Run(ctx.Done())
+
+	if config.Datadog.GetBool("cluster_agent.collect_kubernetes_tags") {
+		podListerWatcher := &cache.ListWatch{
+			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+				return client.CoreV1().Pods(metav1.NamespaceAll).List(ctx, options)
+			},
+			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+				return client.CoreV1().Pods(metav1.NamespaceAll).Watch(ctx, options)
+			},
+		}
+
+		podReflector := cache.NewNamedReflector(
+			componentName,
+			podListerWatcher,
+			&corev1.Pod{},
+			newPodReflectorStore(wlmetaStore),
+			noResync,
+		)
+
+		go podReflector.Run(ctx.Done())
+	}
 
 	return nil
 }

--- a/pkg/workloadmeta/collectors/internal/kubeapiserver/reflector_store.go
+++ b/pkg/workloadmeta/collectors/internal/kubeapiserver/reflector_store.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	utilserror "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/tools/cache"
 
@@ -25,34 +26,49 @@ import (
 type reflectorStore struct {
 	wlmetaStore workloadmeta.Store
 
-	mu      sync.Mutex
-	seen    map[string]workloadmeta.EntityID
+	mu   sync.Mutex
+	seen map[string]workloadmeta.EntityID
+}
+
+type podReflectorStore struct {
+	reflectorStore
+
 	options *parseOptions
 }
 
-func newReflectorStore(wlmetaStore workloadmeta.Store) cache.Store {
+type nodeReflectorStore struct {
+	reflectorStore
+}
+
+func newPodReflectorStore(wlmetaStore workloadmeta.Store) cache.Store {
 	annotationsExclude := config.Datadog.GetStringSlice("cluster_agent.kubernetes_resources_collection.pod_annotations_exclude")
 	parseOptions, err := newParseOptions(annotationsExclude)
 	if err != nil {
 		_ = log.Errorf("unable to parse all pod_annotations_exclude: %v, err:", err)
 	}
-	return &reflectorStore{
-		wlmetaStore: wlmetaStore,
-		seen:        make(map[string]workloadmeta.EntityID),
-		options:     parseOptions,
+	return &podReflectorStore{
+		reflectorStore: reflectorStore{
+			wlmetaStore: wlmetaStore,
+			seen:        make(map[string]workloadmeta.EntityID),
+		},
+		options: parseOptions,
 	}
 }
 
-// Add notifies the workloadmeta store with  an EventTypeSet for the given
-// object.
-func (r *reflectorStore) Add(obj interface{}) error {
+func newNodeReflectorStore(wlmetaStore workloadmeta.Store) cache.Store {
+	return &nodeReflectorStore{
+		reflectorStore: reflectorStore{
+			wlmetaStore: wlmetaStore,
+			seen:        make(map[string]workloadmeta.EntityID),
+		},
+	}
+}
+
+func (r *reflectorStore) add(uid types.UID, entity workloadmeta.Entity) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	pod := obj.(*corev1.Pod)
-	entity := parsePod(pod, r.options)
-
-	r.seen[string(pod.UID)] = entity.EntityID
+	r.seen[string(uid)] = entity.GetID()
 
 	r.wlmetaStore.Notify([]workloadmeta.CollectorEvent{
 		{
@@ -65,9 +81,33 @@ func (r *reflectorStore) Add(obj interface{}) error {
 	return nil
 }
 
+// Add notifies the workloadmeta store with  an EventTypeSet for the given
+// object.
+func (r *podReflectorStore) Add(obj interface{}) error {
+	pod := obj.(*corev1.Pod)
+	entity := parsePod(pod, r.options)
+
+	return r.add(pod.UID, entity)
+}
+
+// Add notifies the workloadmeta store with  an EventTypeSet for the given
+// object.
+func (r *nodeReflectorStore) Add(obj interface{}) error {
+	node := obj.(*corev1.Node)
+	entity := parseNode(node)
+
+	return r.add(node.UID, entity)
+}
+
 // Update notifies the workloadmeta store with  an EventTypeSet for the given
 // object.
-func (r *reflectorStore) Update(obj interface{}) error {
+func (r *podReflectorStore) Update(obj interface{}) error {
+	return r.Add(obj)
+}
+
+// Update notifies the workloadmeta store with  an EventTypeSet for the given
+// object.
+func (r *nodeReflectorStore) Update(obj interface{}) error {
 	return r.Add(obj)
 }
 
@@ -77,9 +117,17 @@ func (r *reflectorStore) Delete(obj interface{}) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	pod := obj.(*corev1.Pod)
+	var kind workloadmeta.Kind
+	var uid types.UID
+	if pod, ok := obj.(*corev1.Pod); ok {
+		kind = workloadmeta.KindKubernetesPod
+		uid = pod.UID
+	} else if node, ok := obj.(*corev1.Node); ok {
+		kind = workloadmeta.KindKubernetesNode
+		uid = node.UID
+	}
 
-	delete(r.seen, string(pod.UID))
+	delete(r.seen, string(uid))
 
 	r.wlmetaStore.Notify([]workloadmeta.CollectorEvent{
 		{
@@ -87,8 +135,8 @@ func (r *reflectorStore) Delete(obj interface{}) error {
 			Source: collectorID,
 			Entity: &workloadmeta.KubernetesPod{
 				EntityID: workloadmeta.EntityID{
-					Kind: workloadmeta.KindKubernetesPod,
-					ID:   string(pod.UID),
+					Kind: kind,
+					ID:   string(uid),
 				},
 			},
 		},
@@ -97,9 +145,14 @@ func (r *reflectorStore) Delete(obj interface{}) error {
 	return nil
 }
 
+type entityUid struct {
+	entity workloadmeta.Entity
+	uid    types.UID
+}
+
 // Replace diffs the given list with the contents of the workloadmeta store
 // (through r.seen), and updates and deletes the necessary objects.
-func (r *reflectorStore) Replace(list []interface{}, _ string) error {
+func (r *reflectorStore) replace(entities []entityUid) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -108,10 +161,9 @@ func (r *reflectorStore) Replace(list []interface{}, _ string) error {
 	seenNow := make(map[string]workloadmeta.EntityID)
 	seenBefore := r.seen
 
-	for _, obj := range list {
-		pod := obj.(*corev1.Pod)
-		podUID := string(pod.UID)
-		entity := parsePod(pod, r.options)
+	for _, entityuid := range entities {
+		entity := entityuid.entity
+		uid := string(entityuid.uid)
 
 		events = append(events, workloadmeta.CollectorEvent{
 			Type:   workloadmeta.EventTypeSet,
@@ -119,11 +171,11 @@ func (r *reflectorStore) Replace(list []interface{}, _ string) error {
 			Entity: entity,
 		})
 
-		if _, ok := seenBefore[podUID]; ok {
-			delete(seenBefore, podUID)
+		if _, ok := seenBefore[uid]; ok {
+			delete(seenBefore, uid)
 		}
 
-		seenNow[podUID] = entity.EntityID
+		seenNow[uid] = entity.GetID()
 	}
 
 	for _, entityID := range seenBefore {
@@ -141,6 +193,32 @@ func (r *reflectorStore) Replace(list []interface{}, _ string) error {
 	r.seen = seenNow
 
 	return nil
+}
+
+// Replace diffs the given list with the contents of the workloadmeta store
+// (through r.seen), and updates and deletes the necessary objects.
+func (r *podReflectorStore) Replace(list []interface{}, _ string) error {
+	entities := make([]entityUid, 0, len(list))
+
+	for _, obj := range list {
+		pod := obj.(*corev1.Pod)
+		entities = append(entities, entityUid{parsePod(pod, r.options), pod.UID})
+	}
+
+	return r.replace(entities)
+}
+
+// Replace diffs the given list with the contents of the workloadmeta store
+// (through r.seen), and updates and deletes the necessary objects.
+func (r *nodeReflectorStore) Replace(list []interface{}, _ string) error {
+	entities := make([]entityUid, 0, len(list))
+
+	for _, obj := range list {
+		node := obj.(*corev1.Node)
+		entities = append(entities, entityUid{parseNode(node), node.UID})
+	}
+
+	return r.replace(entities)
 }
 
 // List is not implemented
@@ -238,6 +316,20 @@ func parsePod(pod *corev1.Pod, options *parseOptions) *workloadmeta.KubernetesPo
 		// to run in the Cluster Agent, and the total amount of
 		// containers can be quite significant
 		// Containers:                 []workloadmeta.OrchestratorContainer{},
+	}
+}
+
+func parseNode(node *corev1.Node) *workloadmeta.KubernetesNode {
+	return &workloadmeta.KubernetesNode{
+		EntityID: workloadmeta.EntityID{
+			Kind: workloadmeta.KindKubernetesNode,
+			ID:   node.Name,
+		},
+		EntityMeta: workloadmeta.EntityMeta{
+			Name:        node.Name,
+			Annotations: node.Annotations,
+			Labels:      node.Labels,
+		},
 	}
 }
 

--- a/pkg/workloadmeta/dump.go
+++ b/pkg/workloadmeta/dump.go
@@ -53,6 +53,8 @@ func (s *store) Dump(verbose bool) WorkloadDumpResponse {
 			info = e.String(verbose)
 		case *KubernetesPod:
 			info = e.String(verbose)
+		case *KubernetesNode:
+			info = e.String(verbose)
 		case *ECSTask:
 			info = e.String(verbose)
 		case *ContainerImageMetadata:

--- a/pkg/workloadmeta/store.go
+++ b/pkg/workloadmeta/store.go
@@ -294,6 +294,16 @@ func (s *store) GetKubernetesPodForContainer(containerID string) (*KubernetesPod
 	return nil, errors.NewNotFound(containerID)
 }
 
+// GetKubernetesNode implements Store#GetKubernetesNode
+func (s *store) GetKubernetesNode(id string) (*KubernetesNode, error) {
+	entity, err := s.getEntityByKind(KindKubernetesNode, id)
+	if err != nil {
+		return nil, err
+	}
+
+	return entity.(*KubernetesNode), nil
+}
+
 // GetECSTask implements Store#GetECSTask
 func (s *store) GetECSTask(id string) (*ECSTask, error) {
 	entity, err := s.getEntityByKind(KindECSTask, id)

--- a/pkg/workloadmeta/testing/store.go
+++ b/pkg/workloadmeta/testing/store.go
@@ -94,6 +94,16 @@ func (s *Store) GetKubernetesPodForContainer(containerID string) (*workloadmeta.
 	return nil, errors.NewNotFound(containerID)
 }
 
+// GetKubernetesNode returns metadata about a Kubernetes node.
+func (s *Store) GetKubernetesNode(id string) (*workloadmeta.KubernetesNode, error) {
+	entity, err := s.getEntityByKind(workloadmeta.KindKubernetesPod, id)
+	if err != nil {
+		return nil, err
+	}
+
+	return entity.(*workloadmeta.KubernetesNode), nil
+}
+
 // GetECSTask returns metadata about an ECS task.
 func (s *Store) GetECSTask(id string) (*workloadmeta.ECSTask, error) {
 	entity, err := s.getEntityByKind(workloadmeta.KindECSTask, id)

--- a/pkg/workloadmeta/types.go
+++ b/pkg/workloadmeta/types.go
@@ -72,6 +72,10 @@ type Store interface {
 	// for one containing the given container.
 	GetKubernetesPodForContainer(containerID string) (*KubernetesPod, error)
 
+	// GetKubernetesNode returns metadata about a Kubernetes node. It fetches
+	// the entity with kind KindKubernetesNode and the given ID.
+	GetKubernetesNode(id string) (*KubernetesNode, error)
+
 	// GetECSTask returns metadata about an ECS task.  It fetches the entity with
 	// kind KindECSTask and the given ID.
 	GetECSTask(id string) (*ECSTask, error)
@@ -108,6 +112,7 @@ type Kind string
 const (
 	KindContainer              Kind = "container"
 	KindKubernetesPod          Kind = "kubernetes_pod"
+	KindKubernetesNode         Kind = "kubernetes_node"
 	KindECSTask                Kind = "ecs_task"
 	KindContainerImageMetadata Kind = "container_image_metadata"
 )
@@ -623,6 +628,47 @@ func (o KubernetesPodOwner) String(verbose bool) string {
 
 	return sb.String()
 }
+
+// KubernetesNode is an Entity representing a Kubernetes Node.
+type KubernetesNode struct {
+	EntityID
+	EntityMeta
+}
+
+// GetID implements Entity#GetID.
+func (n *KubernetesNode) GetID() EntityID {
+	return n.EntityID
+}
+
+// Merge implements Entity#Merge.
+func (n *KubernetesNode) Merge(e Entity) error {
+	nn, ok := e.(*KubernetesNode)
+	if !ok {
+		return fmt.Errorf("cannot merge KubernetesNode with different kind %T", e)
+	}
+
+	return merge(n, nn)
+}
+
+// DeepCopy implements Entity#DeepCopy.
+func (n KubernetesNode) DeepCopy() Entity {
+	cn := deepcopy.Copy(n).(KubernetesNode)
+	return &cn
+}
+
+// String implements Entity#String
+func (n KubernetesNode) String(verbose bool) string {
+	var sb strings.Builder
+	_, _ = fmt.Fprintln(&sb, "----------- Entity ID -----------")
+	_, _ = fmt.Fprintln(&sb, n.EntityID.String(verbose))
+
+	_, _ = fmt.Fprintln(&sb, "----------- Entity Meta -----------")
+	_, _ = fmt.Fprint(&sb, n.EntityMeta.String(verbose))
+
+	return sb.String()
+}
+
+var _ Entity = &KubernetesNode{}
 
 // ECSTask is an Entity representing an ECS Task.
 type ECSTask struct {


### PR DESCRIPTION
### What does this PR do?

Add Kubernetes nodes inside the cluster-agent workloadmeta store.

### Motivation

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Validate that the features that are requiring node informations are still working as expected.
* `kubernetes_node_labels_as_tags`
* `kubernetes_node_label_as_cluster_name`
* `kubernetes_node_annotations_as_tags`
* `kubernetes_node_annotations_as_host_aliases`

`kubernetes_node_annotations_as_host_aliases` defaults to `[ cluster.k8s.io/machine ]` and `kubernetes_node_annotations_as_tags` defaults to `{ cluster.k8s.io/machine: kube_machine }`.
So, we can validate that, if a node has a `cluster.k8s.io/machine` annotation, it appears properly as a host alias and a host tag.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
