### PR TITLE
[serverless-init] Simplify log buffering

### DIFF
--- a/cmd/serverless-init/initcontainer/initcontainer.go
+++ b/cmd/serverless-init/initcontainer/initcontainer.go
@@ -9,7 +9,6 @@
 package initcontainer
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"os"
@@ -47,13 +46,11 @@ func execute(cloudService cloudservice.CloudService, config *serverlessLog.Confi
 	commandName, commandArgs := buildCommandParam(args)
 	cmd := exec.Command(commandName, commandArgs...)
 	cmd.Stdout = &serverlessLog.CustomWriter{
-		LogConfig:  config,
-		LineBuffer: bytes.Buffer{},
+		LogConfig: config,
 	}
 	cmd.Stderr = &serverlessLog.CustomWriter{
-		LogConfig:  config,
-		LineBuffer: bytes.Buffer{},
-		IsError:    true,
+		LogConfig: config,
+		IsError:   true,
 	}
 	err := cmd.Start()
 	if err != nil {

--- a/cmd/serverless-init/log/log.go
+++ b/cmd/serverless-init/log/log.go
@@ -6,8 +6,6 @@
 package log
 
 import (
-	"bufio"
-	"bytes"
 	"fmt"
 	"os"
 	"strings"
@@ -40,9 +38,8 @@ type Config struct {
 
 // CustomWriter wraps the log config to allow stdout/stderr redirection
 type CustomWriter struct {
-	LogConfig  *Config
-	LineBuffer bytes.Buffer
-	IsError    bool
+	LogConfig *Config
+	IsError   bool
 }
 
 // CreateConfig builds and returns a log config
@@ -96,17 +93,7 @@ func SetupLog(conf *Config, tags map[string]string) {
 
 func (cw *CustomWriter) Write(p []byte) (n int, err error) {
 	fmt.Print(string(p))
-	cw.LineBuffer.Write(p)
-	scanner := bufio.NewScanner(&cw.LineBuffer)
-	for scanner.Scan() {
-		logLine := scanner.Bytes()
-		// Don't write anything if we don't actually have a message.
-		// This can happen in the case of consecutive newlines.
-		if len(logLine) == 0 {
-			continue
-		}
-		Write(cw.LogConfig, logLine, cw.IsError)
-	}
+	Write(cw.LogConfig, p, cw.IsError)
 	return len(p), nil
 }
 


### PR DESCRIPTION
### What does this PR do?

Simplifies log buffering/splitting logic in serverless-init binary. Works by passing through the line buffering behaviour of stdout and stderr, instead of attempting to buffer and split on new lines. I've tested this approach in python and node, and seen  improved splitting behaviour.

### Motivation
Common multiline logs, such as stack traces, or pretty printed JSON payloads, are being split over multiple log lines.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
