### PR TITLE
[CWS] limit the amount of env vars collected when reading procfs

### DIFF
--- a/pkg/security/resolvers/process/resolver.go
+++ b/pkg/security/resolvers/process/resolver.go
@@ -394,8 +394,9 @@ func (p *Resolver) enrichEventFromProc(entry *model.ProcessCacheEntry, proc *pro
 	}
 
 	entry.EnvsEntry = &model.EnvsEntry{}
-	if envs, err := utils.EnvVars(proc.Pid); err == nil {
+	if envs, truncated, err := utils.EnvVars(proc.Pid); err == nil {
 		entry.EnvsEntry.Values = envs
+		entry.EnvsEntry.Truncated = truncated
 	}
 
 	// Heuristic to detect likely interpreter event

--- a/pkg/security/utils/proc.go
+++ b/pkg/security/utils/proc.go
@@ -260,6 +260,8 @@ func GetFilledProcess(p *process.Process) *FilledProcess {
 	}
 }
 
+const MAX_ENV_VARS_COLLECTED = 128
+
 // EnvVars returns a array with the environment variables of the given pid
 func EnvVars(pid int32) ([]string, error) {
 	filename := filepath.Join(util.HostProc(), fmt.Sprintf("/%d/environ", pid))
@@ -290,6 +292,10 @@ func EnvVars(pid int32) ([]string, error) {
 		text := scanner.Text()
 		if len(text) > 0 {
 			envs = append(envs, text)
+		}
+
+		if len(envs) >= MAX_ENV_VARS_COLLECTED {
+			break
 		}
 	}
 


### PR DESCRIPTION
### What does this PR do?

If a process has a lot of env variables, collecting them can lead to overloading of the system probe. This PR caps the amount of env variables to 128, which should be enough for all non-pathological cases.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
