### PR TITLE
Append the "_test_only" suffix to docker image

### DIFF
--- a/.gitlab/kernel_version_testing/system_probe.yml
+++ b/.gitlab/kernel_version_testing/system_probe.yml
@@ -33,7 +33,7 @@ pull_test_dockers_arm64:
   stage: kernel_matrix_testing
   rules:
     !reference [.on_system_probe_changes_or_manual]
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/btf-gen:$DATADOG_AGENT_BTF_GEN_BUILDIMAGES
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/btf-gen$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BTF_GEN_BUILDIMAGES
   tags: ["runner:main"]
   script:
     # Build dependencies directory


### PR DESCRIPTION
Duplicate from #17075 

##What does this PR do?
I observed a failure in the pipeline while trying to test it (https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/265704789). The job passed successfully with this patch on my branch (https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/266189688)

##Motivation
Have a successful build when testing new images from agent-buildimages

##Additional Notes
##Possible Drawbacks / Trade-offs
##Describe how to test/QA your changes
##Reviewer's Checklist
 If known, an appropriate milestone has been selected; otherwise the Triage milestone is set.
 Use the major_change label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
 A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the changelog/no-changelog label has been applied.
 Changed code has automated tests for its functionality.
 Adequate QA/testing plan information is provided if the qa/skip-qa label is not applied.
 At least one team/.. label has been applied, indicating the team(s) that should QA this change.
 If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
 If applicable, the need-change/operator and need-change/helm labels have been applied.
 If applicable, the k8s/<min-version> label, indicating the lowest Kubernetes version compatible with this feature.
 If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.