### PR TITLE
Fix info log in SBOM scanner

### DIFF
--- a/pkg/sbom/collectors/containerd/containerd.go
+++ b/pkg/sbom/collectors/containerd/containerd.go
@@ -17,6 +17,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/sbom"
 	"github.com/DataDog/datadog-agent/pkg/sbom/collectors"
 	cutil "github.com/DataDog/datadog-agent/pkg/util/containerd"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/trivy"
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 
@@ -71,6 +72,10 @@ func (c *ContainerdCollector) Scan(ctx context.Context, request sbom.ScanRequest
 	containerdScanRequest, ok := request.(*ScanRequest)
 	if !ok {
 		return sbom.ScanResult{Error: fmt.Errorf("invalid request type '%s' for collector '%s'", reflect.TypeOf(request), collectorName)}
+	}
+
+	if containerdScanRequest.ImageMeta != nil {
+		log.Infof("containerd scan request [%v]: scanning image %v", containerdScanRequest.ID(), containerdScanRequest.ImageMeta.Name)
 	}
 
 	var report sbom.Report

--- a/pkg/sbom/collectors/docker/docker.go
+++ b/pkg/sbom/collectors/docker/docker.go
@@ -18,6 +18,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/sbom"
 	"github.com/DataDog/datadog-agent/pkg/sbom/collectors"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/trivy"
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 )
@@ -64,6 +65,10 @@ func (c *Collector) Scan(ctx context.Context, request sbom.ScanRequest, opts sbo
 	dockerScanRequest, ok := request.(*ScanRequest)
 	if !ok {
 		return sbom.ScanResult{Error: fmt.Errorf("invalid request type '%s' for collector '%s'", reflect.TypeOf(request), collectorName)}
+	}
+
+	if dockerScanRequest.ImageMeta != nil {
+		log.Infof("docker scan request [%v]: scanning image %v", dockerScanRequest.ID(), dockerScanRequest.ImageMeta.Name)
 	}
 
 	report, err := c.trivyCollector.ScanDockerImage(

--- a/pkg/sbom/collectors/host/host.go
+++ b/pkg/sbom/collectors/host/host.go
@@ -16,6 +16,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/sbom"
 	"github.com/DataDog/datadog-agent/pkg/sbom/collectors"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/trivy"
 )
 
@@ -62,7 +63,6 @@ func (c *HostCollector) Scan(ctx context.Context, request sbom.ScanRequest, opts
 		return sbom.ScanResult{Error: fmt.Errorf("invalid request type '%s' for collector '%s'", reflect.TypeOf(request), collectorName)}
 	}
 	log.Infof("host scan request [%v]", hostScanRequest.ID())
-	
 
 	report, err := c.trivyCollector.ScanFilesystem(ctx, hostScanRequest.Path, opts)
 	return sbom.ScanResult{

--- a/pkg/sbom/collectors/host/host.go
+++ b/pkg/sbom/collectors/host/host.go
@@ -61,6 +61,8 @@ func (c *HostCollector) Scan(ctx context.Context, request sbom.ScanRequest, opts
 	if !ok {
 		return sbom.ScanResult{Error: fmt.Errorf("invalid request type '%s' for collector '%s'", reflect.TypeOf(request), collectorName)}
 	}
+	log.Infof("host scan request [%v]", hostScanRequest.ID())
+	
 
 	report, err := c.trivyCollector.ScanFilesystem(ctx, hostScanRequest.Path, opts)
 	return sbom.ScanResult{

--- a/pkg/sbom/scanner/scanner.go
+++ b/pkg/sbom/scanner/scanner.go
@@ -122,7 +122,6 @@ func (s *Scanner) start(ctx context.Context) {
 					scanTimeout = defaultScanTimeout
 				}
 
-				log.Infof("scanning from %v, id: %s", request.Collector(), request.ID())
 				scanContext, cancel := context.WithTimeout(ctx, scanTimeout)
 				createdAt := time.Now()
 				scanResult := collector.Scan(scanContext, request.ScanRequest, request.opts)

--- a/pkg/sbom/scanner/scanner.go
+++ b/pkg/sbom/scanner/scanner.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"reflect"
 	"sync"
 	"time"
 
@@ -123,7 +122,7 @@ func (s *Scanner) start(ctx context.Context) {
 					scanTimeout = defaultScanTimeout
 				}
 
-				log.Info("scanning from %v, id: %s", reflect.TypeOf(request), request.ID())
+				log.Infof("scanning from %v, id: %s", request.Collector(), request.ID())
 				scanContext, cancel := context.WithTimeout(ctx, scanTimeout)
 				createdAt := time.Now()
 				scanResult := collector.Scan(scanContext, request.ScanRequest, request.opts)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
Fix the info log on SBOM scanner which currently prints:
```
scanning from %v, id: %s scanner.scanRequest sha256:931d2566a6bdd209cbe53a963582c5719c1f7e1e885bc066604d6e32d4dcb074
```
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Current log does not have the expected behavior
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
N/A
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs
None
<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
Deploy the agent with SBOM scan enabled.
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
