### PR TITLE
[backport][CWS] limit the amount of env vars collected when reading procfs (#17084)

### DIFF
--- a/pkg/security/resolvers/process/resolver.go
+++ b/pkg/security/resolvers/process/resolver.go
@@ -402,8 +402,9 @@ func (p *Resolver) enrichEventFromProc(entry *model.ProcessCacheEntry, proc *pro
 	}
 
 	entry.EnvsEntry = &model.EnvsEntry{}
-	if envs, err := utils.EnvVars(proc.Pid); err == nil {
+	if envs, truncated, err := utils.EnvVars(proc.Pid); err == nil {
 		entry.EnvsEntry.Values = envs
+		entry.EnvsEntry.Truncated = truncated
 	}
 
 	// Heuristic to detect likely interpreter event

--- a/pkg/security/utils/proc.go
+++ b/pkg/security/utils/proc.go
@@ -250,13 +250,15 @@ func GetFilledProcess(p *process.Process) *process.FilledProcess {
 	}
 }
 
+const MAX_ENV_VARS_COLLECTED = 128
+
 // EnvVars returns a array with the environment variables of the given pid
-func EnvVars(pid int32) ([]string, error) {
+func EnvVars(pid int32) ([]string, bool, error) {
 	filename := filepath.Join(util.HostProc(), fmt.Sprintf("/%d/environ", pid))
 
 	f, err := os.Open(filename)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	defer f.Close()
 
@@ -277,13 +279,17 @@ func EnvVars(pid int32) ([]string, error) {
 
 	var envs []string
 	for scanner.Scan() {
+		if len(envs) >= MAX_ENV_VARS_COLLECTED {
+			return envs, true, nil
+		}
+
 		text := scanner.Text()
 		if len(text) > 0 {
 			envs = append(envs, text)
 		}
 	}
 
-	return envs, nil
+	return envs, false, nil
 }
 
 // ProcFSModule is a representation of a line in /proc/modules

--- a/pkg/security/utils/proc.go
+++ b/pkg/security/utils/proc.go
@@ -250,7 +250,7 @@ func GetFilledProcess(p *process.Process) *process.FilledProcess {
 	}
 }
 
-const MAX_ENV_VARS_COLLECTED = 128
+const MAX_ENV_VARS_COLLECTED = 256
 
 // EnvVars returns a array with the environment variables of the given pid
 func EnvVars(pid int32) ([]string, bool, error) {


### PR DESCRIPTION

* [CWS] limit the amount of env vars collected when reading procfs

* catch truncation marker as well

(cherry picked from commit cb39066500a530d610b39f4a17b3f481ecaf69a6)

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
