### PR TITLE
[SEC-8657][CWS] split snapshot env collection between priority and non-priority envs

### DIFF
--- a/pkg/security/resolvers/envvars/resolver.go
+++ b/pkg/security/resolvers/envvars/resolver.go
@@ -18,9 +18,14 @@ type Resolver struct {
 }
 
 func NewEnvVarsResolver(cfg *config.Config) *Resolver {
-	pe := make([]string, 0, len(cfg.EnvsWithValue)+1)
+	var envsWithValue []string
+	if cfg != nil {
+		envsWithValue = cfg.EnvsWithValue
+	}
+
+	pe := make([]string, 0, len(envsWithValue)+1)
 	pe = append(pe, "DD_SERVICE")
-	pe = append(pe, cfg.EnvsWithValue...)
+	pe = append(pe, envsWithValue...)
 
 	return &Resolver{
 		priorityEnvs: pe,

--- a/pkg/security/resolvers/envvars/resolver.go
+++ b/pkg/security/resolvers/envvars/resolver.go
@@ -1,0 +1,32 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+// +build linux
+
+package envvars
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/security/probe/config"
+	"github.com/DataDog/datadog-agent/pkg/security/utils"
+)
+
+type Resolver struct {
+	priorityEnvs []string
+}
+
+func NewEnvVarsResolver(cfg *config.Config) *Resolver {
+	pe := make([]string, 0, len(cfg.EnvsWithValue)+1)
+	pe = append(pe, "DD_SERVICE")
+	pe = append(pe, cfg.EnvsWithValue...)
+
+	return &Resolver{
+		priorityEnvs: pe,
+	}
+}
+
+func (r *Resolver) ResolveEnvVars(pid int32) ([]string, bool, error) {
+	return utils.EnvVars(r.priorityEnvs, pid)
+}

--- a/pkg/security/resolvers/process/resolver.go
+++ b/pkg/security/resolvers/process/resolver.go
@@ -1274,6 +1274,7 @@ func NewResolver(manager *manager.Manager, config *config.Config, statsdClient s
 		userGroupResolver:         userGroupResolver,
 		timeResolver:              timeResolver,
 		pathResolver:              pathResolver,
+		envVarsResolver:           envvars.NewEnvVarsResolver(config),
 	}
 	for _, t := range metrics.AllTypesTags {
 		p.hitsStats[t] = atomic.NewInt64(0)

--- a/pkg/security/resolvers/process/resolver.go
+++ b/pkg/security/resolvers/process/resolver.go
@@ -33,6 +33,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/probe/managerhelper"
 	"github.com/DataDog/datadog-agent/pkg/security/resolvers/cgroup"
 	"github.com/DataDog/datadog-agent/pkg/security/resolvers/container"
+	"github.com/DataDog/datadog-agent/pkg/security/resolvers/envvars"
 	"github.com/DataDog/datadog-agent/pkg/security/resolvers/mount"
 	spath "github.com/DataDog/datadog-agent/pkg/security/resolvers/path"
 	stime "github.com/DataDog/datadog-agent/pkg/security/resolvers/time"
@@ -73,6 +74,7 @@ type Resolver struct {
 	userGroupResolver *usergroup.Resolver
 	timeResolver      *stime.Resolver
 	pathResolver      spath.ResolverInterface
+	envVarsResolver   *envvars.Resolver
 
 	execFileCacheMap *lib.Map
 	procCacheMap     *lib.Map
@@ -394,7 +396,7 @@ func (p *Resolver) enrichEventFromProc(entry *model.ProcessCacheEntry, proc *pro
 	}
 
 	entry.EnvsEntry = &model.EnvsEntry{}
-	if envs, truncated, err := utils.EnvVars(proc.Pid); err == nil {
+	if envs, truncated, err := p.envVarsResolver.ResolveEnvVars(proc.Pid); err == nil {
 		entry.EnvsEntry.Values = envs
 		entry.EnvsEntry.Truncated = truncated
 	}

--- a/pkg/security/utils/proc.go
+++ b/pkg/security/utils/proc.go
@@ -287,11 +287,6 @@ func newEnvScanner(f *os.File) (*bufio.Scanner, error) {
 	return scanner, nil
 }
 
-var priorityEnvsPrefixes = []string{
-	"DD_SERVICE",
-	"LD_PRELOAD",
-}
-
 func matchesOnePrefix(text string, prefixes []string) bool {
 	for _, prefix := range prefixes {
 		if strings.HasPrefix(text, prefix) {
@@ -302,7 +297,7 @@ func matchesOnePrefix(text string, prefixes []string) bool {
 }
 
 // EnvVars returns a array with the environment variables of the given pid
-func EnvVars(pid int32) ([]string, bool, error) {
+func EnvVars(priorityEnvsPrefixes []string, pid int32) ([]string, bool, error) {
 	filename := filepath.Join(util.HostProc(), fmt.Sprintf("/%d/environ", pid))
 
 	f, err := os.Open(filename)

--- a/pkg/security/utils/proc.go
+++ b/pkg/security/utils/proc.go
@@ -261,7 +261,7 @@ func GetFilledProcess(p *process.Process) *FilledProcess {
 	}
 }
 
-const MAX_ENV_VARS_COLLECTED = 128
+const MAX_ENV_VARS_COLLECTED = 256
 
 func zeroSplitter(data []byte, atEOF bool) (advance int, token []byte, err error) {
 	for i := 0; i < len(data); i++ {


### PR DESCRIPTION
### What does this PR do?

The goal of this PR is to split the collection of env vars when snapshotting process into 2 steps:
- collection of important env variables, like `DD_SERVICE` and values configured in `envs_with_value`
- best effort collection of other env variables, bounded by a max amount of entries (256 for now)

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
