### PR TITLE
[USM] run pkg/network/usm tests on runtime compilation and CORE

### DIFF
--- a/test/kitchen/test/integration/system-probe-test/rspec_datadog/system-probe-test_spec.rb
+++ b/test/kitchen/test/integration/system-probe-test/rspec_datadog/system-probe-test_spec.rb
@@ -13,13 +13,23 @@ skip_prebuilt_tests = Array.[](
   "pkg/collector/corechecks/ebpf/probe"
 )
 
+# most prebuild tests are not running on arm64
+# as tests run only on >=5.5.0 kernels and (runtime or CORE)
+arm64_tests = Array.[](
+  "pkg/network/protocols/events",
+  "pkg/network/protocols/grpc",
+  "pkg/network/tracer/connection/kprobe",
+)
+
 runtime_compiled_tests = Array.[](
+  "pkg/network/usm",
   "pkg/network/tracer",
   "pkg/network/protocols/http",
   "pkg/collector/corechecks/ebpf/probe"
 )
 
 co_re_tests = Array.[](
+  "pkg/network/usm",
   "pkg/network/tracer",
   "pkg/network/protocols/http",
   "pkg/collector/corechecks/ebpf/probe"
@@ -143,6 +153,9 @@ describe "system-probe" do
       "DD_ALLOW_PRECOMPILED_FALLBACK"=>"false",
       "DD_ENABLE_CO_RE"=>"false"
     }
+    if arch == "aarch64"
+      runtime_compiled_tests += arm64_tests
+    end
     include_examples "passes", "runtime", env, runtime_compiled_tests, true
   end
 
@@ -153,6 +166,9 @@ describe "system-probe" do
       "DD_ALLOW_RUNTIME_COMPILED_FALLBACK"=>"false",
       "DD_ALLOW_PRECOMPILED_FALLBACK"=>"false"
     }
+    if arch == "aarch64"
+      co_re_tests += arm64_tests
+    end
     include_examples "passes", "co-re", env, co_re_tests, true
   end
 

--- a/test/kitchen/test/integration/system-probe-test/rspec_datadog/system-probe-test_spec.rb
+++ b/test/kitchen/test/integration/system-probe-test/rspec_datadog/system-probe-test_spec.rb
@@ -13,26 +13,41 @@ skip_prebuilt_tests = Array.[](
   "pkg/collector/corechecks/ebpf/probe"
 )
 
-# most prebuild tests are not running on arm64
-# as tests run only on >=5.5.0 kernels and (runtime or CORE)
-arm64_tests = Array.[](
+# list based on `find pkg -name "*_test.go" | xargs grep -l "linux_bpf" | xargs dirname | sort -u`
+runtime_compiled_tests = Array.[](
+  "pkg/collector/corechecks/ebpf/probe",
+  "pkg/ebpf",
+  "pkg/ebpf/bytecode/runtime",
+  "pkg/ebpf/compiler",
+  "pkg/network",
+  "pkg/network/dns",
+  "pkg/network/netlink",
+  "pkg/network/protocols",
   "pkg/network/protocols/events",
   "pkg/network/protocols/grpc",
-  "pkg/network/tracer/connection/kprobe",
-)
-
-runtime_compiled_tests = Array.[](
-  "pkg/network/usm",
-  "pkg/network/tracer",
   "pkg/network/protocols/http",
-  "pkg/collector/corechecks/ebpf/probe"
+  "pkg/network/tracer",
+  "pkg/network/tracer/connection",
+  "pkg/network/tracer/connection/kprobe",
+  "pkg/network/usm",
 )
 
 co_re_tests = Array.[](
-  "pkg/network/usm",
-  "pkg/network/tracer",
+  "pkg/collector/corechecks/ebpf/probe",
+  "pkg/ebpf",
+  "pkg/ebpf/bytecode/runtime",
+  "pkg/ebpf/compiler",
+  "pkg/network",
+  "pkg/network/dns",
+  "pkg/network/netlink",
+  "pkg/network/protocols",
+  "pkg/network/protocols/events",
+  "pkg/network/protocols/grpc",
   "pkg/network/protocols/http",
-  "pkg/collector/corechecks/ebpf/probe"
+  "pkg/network/tracer",
+  "pkg/network/tracer/connection",
+  "pkg/network/tracer/connection/kprobe",
+  "pkg/network/usm",
 )
 
 TIMEOUTS = {
@@ -153,9 +168,6 @@ describe "system-probe" do
       "DD_ALLOW_PRECOMPILED_FALLBACK"=>"false",
       "DD_ENABLE_CO_RE"=>"false"
     }
-    if arch == "aarch64"
-      runtime_compiled_tests += arm64_tests
-    end
     include_examples "passes", "runtime", env, runtime_compiled_tests, true
   end
 
@@ -166,9 +178,6 @@ describe "system-probe" do
       "DD_ALLOW_RUNTIME_COMPILED_FALLBACK"=>"false",
       "DD_ALLOW_PRECOMPILED_FALLBACK"=>"false"
     }
-    if arch == "aarch64"
-      co_re_tests += arm64_tests
-    end
     include_examples "passes", "co-re", env, co_re_tests, true
   end
 

--- a/test/kitchen/test/integration/system-probe-test/rspec_datadog/system-probe-test_spec.rb
+++ b/test/kitchen/test/integration/system-probe-test/rspec_datadog/system-probe-test_spec.rb
@@ -13,40 +13,19 @@ skip_prebuilt_tests = Array.[](
   "pkg/collector/corechecks/ebpf/probe"
 )
 
-# list based on `find pkg -name "*_test.go" | xargs grep -l "linux_bpf" | xargs dirname | sort -u`
 runtime_compiled_tests = Array.[](
   "pkg/collector/corechecks/ebpf/probe",
-  "pkg/ebpf",
-  "pkg/ebpf/bytecode/runtime",
-  "pkg/ebpf/compiler",
-  "pkg/network",
-  "pkg/network/dns",
-  "pkg/network/netlink",
-  "pkg/network/protocols",
-  "pkg/network/protocols/events",
   "pkg/network/protocols/grpc",
   "pkg/network/protocols/http",
   "pkg/network/tracer",
-  "pkg/network/tracer/connection",
-  "pkg/network/tracer/connection/kprobe",
   "pkg/network/usm",
 )
 
 co_re_tests = Array.[](
   "pkg/collector/corechecks/ebpf/probe",
-  "pkg/ebpf",
-  "pkg/ebpf/bytecode/runtime",
-  "pkg/ebpf/compiler",
-  "pkg/network",
-  "pkg/network/dns",
-  "pkg/network/netlink",
-  "pkg/network/protocols",
-  "pkg/network/protocols/events",
   "pkg/network/protocols/grpc",
   "pkg/network/protocols/http",
   "pkg/network/tracer",
-  "pkg/network/tracer/connection",
-  "pkg/network/tracer/connection/kprobe",
   "pkg/network/usm",
 )
 


### PR DESCRIPTION
### What does this PR do?

Run pkg/network/usm tests on runtime compilation and CORE

### Motivation

some tests are skipped on prebuild as arm64 require `>=5.5.0 kernel and (runtime or CORE)` for http and dependency protocols


### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
