### PR TITLE
[DCA] Add deprecation warning for k8s < 1.14

### DIFF
--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -178,7 +178,7 @@ func start(log log.Component, config config.Component, forwarder defaultforwarde
 	pkglog.Infof("Got APIClient connection")
 
 	serverVersion, err := apicommon.KubeServerVersion(apiCl.DiscoveryCl, 10*time.Second)
-	if err == nil && semver.IsValid(serverVersion.String()) && semver.Compare(serverVersion.String(), "v1.14.0") < 1 {
+	if err == nil && semver.IsValid(serverVersion.String()) && semver.Compare(serverVersion.String(), "v1.14.0") < 0 {
 		pkglog.Warnf("[DEPRECATION WARNING] DataDog will drop support of Kubernetes older than v1.14. Please update to a newer version to ensure proper functionality and security.")
 	}
 

--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -178,10 +178,7 @@ func start(log log.Component, config config.Component, forwarder defaultforwarde
 	pkglog.Infof("Got APIClient connection")
 
 	serverVersion, err := apicommon.KubeServerVersion(apiCl.DiscoveryCl, 10*time.Second)
-	if !semver.IsValid(serverVersion.String()) {
-		pkglog.Errorf("invalid server version %s", serverVersion.String())
-	}
-	if err == nil && semver.Compare(serverVersion.String(), "v1.14.0") < 1 {
+	if err == nil && semver.IsValid(serverVersion.String()) && semver.Compare(serverVersion.String(), "v1.14.0") < 1 {
 		pkglog.Warnf("[DEPRECATION WARNING] DataDog will drop support of Kubernetes older than v1.14. Please update to a newer version to ensure proper functionality and security.")
 	}
 

--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -55,7 +55,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/clustername"
 	pkglog "github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/version"
-	"golang.org/x/mod/semver"
 
 	"github.com/gorilla/mux"
 	"github.com/spf13/cobra"
@@ -176,11 +175,6 @@ func start(log log.Component, config config.Component, forwarder defaultforwarde
 		return fmt.Errorf("Fatal error: Cannot connect to the apiserver: %v", err)
 	}
 	pkglog.Infof("Got APIClient connection")
-
-	serverVersion, err := apicommon.KubeServerVersion(apiCl.DiscoveryCl, 10*time.Second)
-	if err == nil && semver.IsValid(serverVersion.String()) && semver.Compare(serverVersion.String(), "v1.14.0") < 0 {
-		pkglog.Warnf("[DEPRECATION WARNING] DataDog will drop support of Kubernetes older than v1.14. Please update to a newer version to ensure proper functionality and security.")
-	}
 
 	// Get hostname as aggregator requires hostname
 	hname, err := hostname.Get(mainCtx)

--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -55,6 +55,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/clustername"
 	pkglog "github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/version"
+	"golang.org/x/mod/semver"
 
 	"github.com/gorilla/mux"
 	"github.com/spf13/cobra"
@@ -175,6 +176,14 @@ func start(log log.Component, config config.Component, forwarder defaultforwarde
 		return fmt.Errorf("Fatal error: Cannot connect to the apiserver: %v", err)
 	}
 	pkglog.Infof("Got APIClient connection")
+
+	serverVersion, err := apicommon.KubeServerVersion(apiCl.DiscoveryCl, 10*time.Second)
+	if !semver.IsValid(serverVersion.String()) {
+		pkglog.Errorf("invalid server version %s", serverVersion.String())
+	}
+	if err == nil && semver.Compare(serverVersion.String(), "v1.14.0") < 1 {
+		pkglog.Warnf("[DEPRECATION WARNING] DataDog will drop support of Kubernetes older than v1.14. Please update to a newer version to ensure proper functionality and security.")
+	}
 
 	// Get hostname as aggregator requires hostname
 	hname, err := hostname.Get(mainCtx)

--- a/go.mod
+++ b/go.mod
@@ -534,7 +534,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.14.0 // indirect
 	go.opentelemetry.io/proto/otlp v0.19.0 // indirect
 	golang.org/x/crypto v0.7.0 // indirect
-	golang.org/x/mod v0.10.0 // indirect
+	golang.org/x/mod v0.10.0
 	golang.org/x/oauth2 v0.6.0 // indirect
 	golang.org/x/term v0.7.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.2.0 // indirect

--- a/pkg/util/kubernetes/apiserver/leaderelection/leaderelection.go
+++ b/pkg/util/kubernetes/apiserver/leaderelection/leaderelection.go
@@ -16,6 +16,7 @@ import (
 	"sync"
 	"time"
 
+	"golang.org/x/mod/semver"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	coordinationv1 "k8s.io/client-go/kubernetes/typed/coordination/v1"
@@ -135,6 +136,11 @@ func (le *LeaderEngine) init() error {
 	if err != nil {
 		log.Errorf("Not Able to set up a client for the Leader Election: %s", err)
 		return err
+	}
+
+	serverVersion, err := common.KubeServerVersion(apiClient.DiscoveryCl, 10*time.Second)
+	if err == nil && semver.IsValid(serverVersion.String()) && semver.Compare(serverVersion.String(), "v1.14.0") < 0 {
+		log.Warn("[DEPRECATION WARNING] DataDog will drop support of Kubernetes older than v1.14. Please update to a newer version to ensure proper functionality and security.")
 	}
 
 	le.coreClient = apiClient.Cl.CoreV1()

--- a/pkg/workloadmeta/README.md
+++ b/pkg/workloadmeta/README.md
@@ -26,7 +26,7 @@ When this occurs, information from those sources is merged into one entity.
 
 The _Store_ is the central component of the package, storing the set of entities.
 A store has a set of _collectors_ responsible for notifying the store of workload changes.
-Each collector is specialized to a particular external service such as Kuberntes or ECS, roughly corresponding to a source.
+Each collector is specialized to a particular external service such as Kubernetes or ECS, roughly corresponding to a source.
 Collectors can either poll for updates, or translate a stream of events from the external service, as appropriate.
 
 The store provides information to other components either through subscriptions or by querying the current state.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
Adds a deprecation warning for kubernetes <= 1.13.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Kubernetes drops support of `ConfigMapsLock` for `leaderelection` since `v1.14.0`. We will drop support of this kubernetes version in the future.
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
The log is added in the `leader_election`,
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs
N/A
<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
Deploy on kubernetes < 1.14 and check that the log is present. Check that it is not present with a recent version. However, setting up an environment with kubernetes 1.13 can be tedious. It requires to run an old version of minikube in a virtual machine.

Another solution is to modify the minimum version from `1.14.0` to a recent version, for example `1.26.0`, and check that for older versions we have the log while for more recent version, it is not printed.
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
