### PR TITLE
[kitchen] Use on-demand instances for EC2 security-agent x64 tests

### DIFF
--- a/.gitlab/functional_test/security_agent.yml
+++ b/.gitlab/functional_test/security_agent.yml
@@ -98,13 +98,13 @@ kitchen_test_security_agent_amazonlinux_x64:
   extends:
     - .kitchen_test_security_agent
     - .kitchen_ec2_location_us_east_1
-    - .kitchen_ec2_spot_instances
+    - .kitchen_ec2
   rules:
     !reference [.on_security_agent_changes_or_manual]
   needs: [ "tests_ebpf_x64", "prepare_ebpf_functional_tests_x64" ]
   variables:
     KITCHEN_ARCH: x86_64
-    KITCHEN_EC2_INSTANCE_TYPE: "[t3.medium, t2.xlarge, t3.xlarge]"
+    KITCHEN_EC2_INSTANCE_TYPE: "t3.medium"
     KITCHEN_CI_MOUNT_PATH: "/mnt/ci"
     KITCHEN_CI_ROOT_PATH: "/tmp/ci"
   before_script:

--- a/test/kitchen/drivers/ec2-driver.yml
+++ b/test/kitchen/drivers/ec2-driver.yml
@@ -42,7 +42,9 @@ driver:
   associate_public_ip: false
   subnet_id: <%= ENV['KITCHEN_EC2_SUBNET'] ||= 'subnet-b89e00e2' %>
   iam_profile_name: <%= ENV['KITCHEN_EC2_IAM_PROFILE_NAME'] ||= nil %>
+  <% if ENV['KITCHEN_EC2_SPOT_PRICE'] %>
   spot_price: <%= ENV['KITCHEN_EC2_SPOT_PRICE'] %>
+  <% end %>
   block_duration_minutes: <%= ENV['KITCHEN_EC2_SPOT_DURATION'] ||= '60' %>
   tags:
     Name: ci-datadog-agent-kitchen


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Switches the two security-agent x64 kitchen tests running on EC2 from spot instances to on-demand instances.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Spot instances regularly have availability problems (either we get throttled because spot instance requests are [heavily rate-limited](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/throttling.html), or the instance types we request aren't available).
On-demand instances are more costly, but do not have these issues.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

n/a

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

n/a

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Check that EC2 x64 system-probe and security-agent kitchen tests pass, and use on-demand instances: the kitchen logs should not contain the line `Waited 0/60s for spot request to become fulfilled.`.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
