### PR TITLE
[usm] Refactor Kafka encoder

### DIFF
--- a/pkg/network/encoding/format.go
+++ b/pkg/network/encoding/format.go
@@ -93,10 +93,7 @@ func FormatConnection(
 		c.Http2Aggregations, _ = proto.Marshal(httpStats2)
 	}
 
-	kafkaStats := kafkaEncoder.GetKafkaAggregations(conn)
-	if kafkaStats != nil {
-		c.DataStreamsAggregations, _ = proto.Marshal(kafkaStats)
-	}
+	c.DataStreamsAggregations = kafkaEncoder.GetKafkaAggregations(conn)
 
 	conn.StaticTags |= staticTags
 	c.Tags, c.TagsChecksum = formatTags(tagsSet, conn, dynamicTags)

--- a/pkg/network/encoding/kafka.go
+++ b/pkg/network/encoding/kafka.go
@@ -6,64 +6,29 @@
 package encoding
 
 import (
+	"sync"
+
 	model "github.com/DataDog/agent-payload/v5/process"
-	"github.com/cihub/seelog"
+	"github.com/gogo/protobuf/proto"
 
 	"github.com/DataDog/datadog-agent/pkg/network"
+	"github.com/DataDog/datadog-agent/pkg/network/protocols/kafka"
 	"github.com/DataDog/datadog-agent/pkg/network/types"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
+var kafkaAggregationPool = sync.Pool{
+	New: func() any {
+		return &model.KafkaAggregation{
+			Header: new(model.KafkaRequestHeader),
+		}
+	},
+}
+
 type kafkaEncoder struct {
-	aggregations  map[types.ConnectionKey]*kafkaAggregationWrapper
-	orphanEntries int
-}
+	byConnection *USMConnectionIndex[kafka.Key, *kafka.RequestStat]
 
-// aggregationWrapper is meant to handle collision scenarios where multiple
-// `ConnectionStats` objects may claim the same `DataStreamsAggregations` object because
-// they generate the same connection key
-// TODO: we should probably revist/get rid of this if we ever replace socket
-// filters by kprobes, since in that case we would have access to PIDs, and
-// could incorporate that information in the `types.ConnectionKey` struct.
-type kafkaAggregationWrapper struct {
-	*model.DataStreamsAggregations
-
-	// we keep track of the source and destination ports of the first
-	// `ConnectionStats` to claim this `DataStreamsAggregations` object
-	sport, dport uint16
-}
-
-func (a *kafkaAggregationWrapper) ValueFor(c network.ConnectionStats) *model.DataStreamsAggregations {
-	if a == nil {
-		return nil
-	}
-
-	if a.sport == 0 && a.dport == 0 {
-		// This is the first time a ConnectionStats claim this aggregation. In
-		// this case we return the value and save the source and destination
-		// ports
-		a.sport = c.SPort
-		a.dport = c.DPort
-		return a.DataStreamsAggregations
-	}
-
-	if c.SPort == a.dport && c.DPort == a.sport {
-		// We have a collision with another `ConnectionStats`, but this is a
-		// legit scenario where we're dealing with the opposite ends of the
-		// same connection, which means both server and client are in the same host.
-		// In this particular case it is correct to have both connections
-		// (client:server and server:client) referencing the same Kafka data.
-		return a.DataStreamsAggregations
-	}
-
-	// Return nil otherwise. This is to prevent multiple `ConnectionStats` with
-	// exactly the same source and destination addresses but different PIDs to
-	// "bind" to the same DataStreamsAggregations object, which would result in a
-	// overcount problem. (Note that this is due to the fact that
-	// `types.ConnectionKey` doesn't have a PID field.) This happens mostly in the
-	// context of pre-fork web servers, where multiple worker proceses share the
-	// same socket
-	return nil
+	// cached object
+	aggregations *model.DataStreamsAggregations
 }
 
 func newKafkaEncoder(payload *network.Connections) *kafkaEncoder {
@@ -71,75 +36,83 @@ func newKafkaEncoder(payload *network.Connections) *kafkaEncoder {
 		return nil
 	}
 
-	encoder := &kafkaEncoder{
-		aggregations: make(map[types.ConnectionKey]*kafkaAggregationWrapper, len(payload.Conns)),
+	return &kafkaEncoder{
+		aggregations: &model.DataStreamsAggregations{
+			// It's not that important to get the initial size of this slice
+			// right because we're re-using it multiple times and should quickly
+			// converge to a final size after a few calls to
+			// `GetKafkaAggregations`
+			KafkaAggregations: make([]*model.KafkaAggregation, 0, 10),
+		},
+		byConnection: GroupByConnection("kafka", payload.Kafka, func(key kafka.Key) types.ConnectionKey {
+			return key.ConnectionKey
+		}),
 	}
-
-	// pre-populate aggregation map with keys for all existent connections
-	// this allows us to skip encoding orphan Kafka objects that can't be matched to a connection
-	for _, conn := range payload.Conns {
-		for _, key := range network.ConnectionKeysFromConnectionStats(conn) {
-			if log.ShouldLog(seelog.TraceLvl) {
-				log.Tracef("Payload has a connection %v and was converted to kafka key %v", conn, key)
-			}
-			encoder.aggregations[key] = nil
-		}
-	}
-	encoder.buildAggregations(payload)
-	return encoder
 }
 
-func (e *kafkaEncoder) GetKafkaAggregations(c network.ConnectionStats) *model.DataStreamsAggregations {
+func (e *kafkaEncoder) GetKafkaAggregations(c network.ConnectionStats) []byte {
 	if e == nil {
 		return nil
 	}
 
-	connectionKeys := network.ConnectionKeysFromConnectionStats(c)
-	for _, key := range connectionKeys {
-		if aggregation := e.aggregations[key]; aggregation != nil {
-			return e.aggregations[key].ValueFor(c)
-		}
+	connectionData := e.byConnection.Find(c)
+	if connectionData == nil || len(connectionData.Data) == 0 || connectionData.IsPIDCollision(c) {
+		return nil
 	}
-	return nil
+
+	return e.encodeData(connectionData)
 }
 
-func (e *kafkaEncoder) buildAggregations(payload *network.Connections) {
-	// Count the number of aggregations per connections, so we can set the capacity of the aggregation slice accordingly
-	aggregationsCountPerConnection := make(map[types.ConnectionKey]int)
-	for key := range payload.Kafka {
-		aggregationsCountPerConnection[key.ConnectionKey]++
+func (e *kafkaEncoder) Close() {
+	if e == nil {
+		return
 	}
 
-	for key, stats := range payload.Kafka {
-		aggregation, ok := e.aggregations[key.ConnectionKey]
-		if !ok {
-			// if there is no matching connection don't even bother to serialize Kafka data
-			if log.ShouldLog(seelog.TraceLvl) {
-				log.Tracef("Found kafka orphan connection %v", key.ConnectionKey)
-			}
-			e.orphanEntries++
-			continue
-		}
+	e.reset()
+	e.byConnection.Close()
+}
 
-		if aggregation == nil {
-			// No aggregation created for this connection yet, creating the slice and set the capacity accordingly
-			aggregation = &kafkaAggregationWrapper{
-				DataStreamsAggregations: &model.DataStreamsAggregations{
-					KafkaAggregations: make([]*model.KafkaAggregation, 0, aggregationsCountPerConnection[key.ConnectionKey]),
-				},
-			}
-			e.aggregations[key.ConnectionKey] = aggregation
-		}
+func (e *kafkaEncoder) encodeData(connectionData *USMConnectionData[kafka.Key, *kafka.RequestStat]) []byte {
+	e.reset()
 
-		kafkaAggregation := model.KafkaAggregation{
-			Header: &model.KafkaRequestHeader{
-				RequestType:    uint32(key.RequestAPIKey),
-				RequestVersion: uint32(key.RequestVersion),
-			},
-			Topic: key.TopicName,
-			Count: uint32(stats.Count),
-		}
+	for _, kv := range connectionData.Data {
+		key := kv.Key
+		stats := kv.Value
 
-		aggregation.KafkaAggregations = append(aggregation.KafkaAggregations, &kafkaAggregation)
+		kafkaAggregation := kafkaAggregationPool.Get().(*model.KafkaAggregation)
+
+		kafkaAggregation.Header.RequestType = uint32(key.RequestAPIKey)
+		kafkaAggregation.Header.RequestVersion = uint32(key.RequestVersion)
+		kafkaAggregation.Topic = key.TopicName
+		kafkaAggregation.Count = uint32(stats.Count)
+
+		e.aggregations.KafkaAggregations = append(e.aggregations.KafkaAggregations, kafkaAggregation)
 	}
+
+	serializedData, _ := proto.Marshal(e.aggregations)
+	return serializedData
+}
+
+func (e *kafkaEncoder) reset() {
+	if e == nil {
+		return
+	}
+
+	for i, kafkaAggregation := range e.aggregations.KafkaAggregations {
+		// The pooled *model.KafkaAggregation object comes along with a
+		// pre-allocated *model.KafkaHeader object as well, so we ensure that we
+		// clean both objects but keep them linked together before returning it
+		// to the pool.
+
+		header := kafkaAggregation.Header
+		header.Reset()
+
+		kafkaAggregation.Reset()
+		kafkaAggregation.Header = header
+
+		kafkaAggregationPool.Put(kafkaAggregation)
+		e.aggregations.KafkaAggregations[i] = nil
+	}
+
+	e.aggregations.KafkaAggregations = e.aggregations.KafkaAggregations[:0]
 }

--- a/pkg/network/encoding/kafka.go
+++ b/pkg/network/encoding/kafka.go
@@ -73,8 +73,6 @@ func (e *kafkaEncoder) Close() {
 }
 
 func (e *kafkaEncoder) encodeData(connectionData *USMConnectionData[kafka.Key, *kafka.RequestStat]) []byte {
-	e.reset()
-
 	for _, kv := range connectionData.Data {
 		key := kv.Key
 		stats := kv.Value

--- a/pkg/network/encoding/kafka_test.go
+++ b/pkg/network/encoding/kafka_test.go
@@ -1,0 +1,237 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package encoding
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/gogo/protobuf/proto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	model "github.com/DataDog/agent-payload/v5/process"
+
+	"github.com/DataDog/datadog-agent/pkg/network"
+	"github.com/DataDog/datadog-agent/pkg/network/protocols/kafka"
+	"github.com/DataDog/datadog-agent/pkg/process/util"
+)
+
+func skipIfNotLinux(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("the feature is only supported on linux.")
+	}
+}
+
+const (
+	clientPort  = uint16(1234)
+	serverPort  = uint16(12345)
+	topicName   = "TopicName"
+	apiVersion1 = 1
+	apiVersion2 = 1
+)
+
+var (
+	localhost         = util.AddressFromString("127.0.0.1")
+	defaultConnection = network.ConnectionStats{
+		Source: localhost,
+		Dest:   localhost,
+		SPort:  clientPort,
+		DPort:  serverPort,
+	}
+)
+
+type KafkaSuite struct {
+	suite.Suite
+}
+
+func TestKafkaStats(t *testing.T) {
+	skipIfNotLinux(t)
+	suite.Run(t, &KafkaSuite{})
+}
+
+func (s *KafkaSuite) TestFormatKafkaStats() {
+	t := s.T()
+
+	kafkaKey1 := kafka.NewKey(
+		localhost,
+		localhost,
+		clientPort,
+		serverPort,
+		topicName,
+		kafka.ProduceAPIKey,
+		apiVersion1,
+	)
+	kafkaKey2 := kafka.NewKey(
+		localhost,
+		localhost,
+		clientPort,
+		serverPort,
+		topicName,
+		kafka.FetchAPIKey,
+		apiVersion2,
+	)
+
+	in := &network.Connections{
+		BufferedData: network.BufferedData{
+			Conns: []network.ConnectionStats{
+				defaultConnection,
+			},
+		},
+		Kafka: map[kafka.Key]*kafka.RequestStat{
+			kafkaKey1: {
+				Count: 10,
+			},
+			kafkaKey2: {
+				Count: 2,
+			},
+		},
+	}
+	out := &model.DataStreamsAggregations{
+		KafkaAggregations: []*model.KafkaAggregation{
+			{
+				Header: &model.KafkaRequestHeader{
+					RequestType:    kafka.ProduceAPIKey,
+					RequestVersion: apiVersion1,
+				},
+				Topic: "TopicName",
+				Count: 10,
+			},
+			{
+				Header: &model.KafkaRequestHeader{
+					RequestType:    kafka.FetchAPIKey,
+					RequestVersion: apiVersion2,
+				},
+				Topic: "TopicName",
+				Count: 2,
+			},
+		},
+	}
+
+	encoder := newKafkaEncoder(in)
+	aggregations := getKafkaAggregations(t, encoder, in.Conns[0])
+
+	require.NotNil(t, aggregations)
+	assert.ElementsMatch(t, out.KafkaAggregations, aggregations.KafkaAggregations)
+}
+
+func (s *KafkaSuite) TestKafkaIDCollisionRegression() {
+	t := s.T()
+	assert := assert.New(t)
+	connections := []network.ConnectionStats{
+		{
+			Source: localhost,
+			SPort:  clientPort,
+			Dest:   localhost,
+			DPort:  serverPort,
+			Pid:    1,
+		},
+		{
+			Source: localhost,
+			SPort:  clientPort,
+			Dest:   localhost,
+			DPort:  serverPort,
+			Pid:    2,
+		},
+	}
+
+	kafkaKey := kafka.NewKey(
+		localhost,
+		localhost,
+		clientPort,
+		serverPort,
+		topicName,
+		kafka.ProduceAPIKey,
+		apiVersion1,
+	)
+
+	in := &network.Connections{
+		BufferedData: network.BufferedData{
+			Conns: connections,
+		},
+		Kafka: map[kafka.Key]*kafka.RequestStat{
+			kafkaKey: {
+				Count: 10,
+			},
+		},
+	}
+
+	encoder := newKafkaEncoder(in)
+	aggregations := getKafkaAggregations(t, encoder, in.Conns[0])
+
+	// assert that the first connection matching the Kafka data will get back a non-nil result
+	assert.Equal(topicName, aggregations.KafkaAggregations[0].Topic)
+	assert.Equal(uint32(10), aggregations.KafkaAggregations[0].Count)
+
+	// assert that the other connections sharing the same (source,destination)
+	// addresses but different PIDs *won't* be associated with the Kafka stats
+	// object
+	assert.Nil(encoder.GetKafkaAggregations(in.Conns[1]))
+}
+
+func (s *KafkaSuite) TestKafkaLocalhostScenario() {
+	t := s.T()
+	assert := assert.New(t)
+	connections := []network.ConnectionStats{
+		{
+			Source: localhost,
+			SPort:  clientPort,
+			Dest:   localhost,
+			DPort:  serverPort,
+			Pid:    1,
+		},
+		{
+			Source: localhost,
+			SPort:  serverPort,
+			Dest:   localhost,
+			DPort:  clientPort,
+			Pid:    2,
+		},
+	}
+
+	kafkaKey := kafka.NewKey(
+		localhost,
+		localhost,
+		clientPort,
+		serverPort,
+		topicName,
+		kafka.FetchAPIKey,
+		apiVersion2,
+	)
+
+	in := &network.Connections{
+		BufferedData: network.BufferedData{
+			Conns: connections,
+		},
+		Kafka: map[kafka.Key]*kafka.RequestStat{
+			kafkaKey: {
+				Count: 10,
+			},
+		},
+	}
+
+	encoder := newKafkaEncoder(in)
+
+	// assert that both ends (client:server, server:client) of the connection
+	// will have Kafka stats
+	for _, conn := range in.Conns {
+		aggregations := getKafkaAggregations(t, encoder, conn)
+		assert.Equal(topicName, aggregations.KafkaAggregations[0].Topic)
+		assert.Equal(uint32(10), aggregations.KafkaAggregations[0].Count)
+	}
+}
+
+func getKafkaAggregations(t *testing.T, encoder *kafkaEncoder, c network.ConnectionStats) *model.DataStreamsAggregations {
+	kafkaBlob := encoder.GetKafkaAggregations(c)
+	require.NotNil(t, kafkaBlob)
+
+	aggregations := new(model.DataStreamsAggregations)
+	err := proto.Unmarshal(kafkaBlob, aggregations)
+	require.NoError(t, err)
+
+	return aggregations
+}

--- a/pkg/network/encoding/kafka_test.go
+++ b/pkg/network/encoding/kafka_test.go
@@ -260,7 +260,7 @@ func generateBenchMarkPayloadKafka(entries uint16) network.Connections {
 		payload.Kafka[kafka.NewKey(
 			localhost,
 			localhost,
-			11112,
+			1112,
 			1111,
 			fmt.Sprintf("%s-%d", topicName, index+1),
 			kafka.ProduceAPIKey,

--- a/pkg/network/protocols/kafka/kafka_stats.go
+++ b/pkg/network/protocols/kafka/kafka_stats.go
@@ -24,10 +24,12 @@ type Key struct {
 }
 
 // NewKey generates a new Key
-func NewKey(saddr, daddr util.Address, sport, dport uint16, topicName string) Key {
+func NewKey(saddr, daddr util.Address, sport, dport uint16, topicName string, requestAPIKey, requestAPIVersion uint16) Key {
 	return Key{
-		ConnectionKey: types.NewConnectionKey(saddr, daddr, sport, dport),
-		TopicName:     topicName,
+		ConnectionKey:  types.NewConnectionKey(saddr, daddr, sport, dport),
+		TopicName:      topicName,
+		RequestAPIKey:  requestAPIKey,
+		RequestVersion: requestAPIVersion,
 	}
 }
 

--- a/pkg/network/state_test.go
+++ b/pkg/network/state_test.go
@@ -1905,7 +1905,7 @@ func TestKafkaStats(t *testing.T) {
 		DPort:  80,
 	}
 
-	key := kafka.NewKey(c.Source, c.Dest, c.SPort, c.DPort, "my-topic")
+	key := kafka.NewKey(c.Source, c.Dest, c.SPort, c.DPort, "my-topic", kafka.ProduceAPIKey, 1)
 
 	kafkaStats := make(map[kafka.Key]*kafka.RequestStat)
 	kafkaStats[key] = &kafka.RequestStat{Count: 2}
@@ -1932,7 +1932,7 @@ func TestKafkaStatsWithMultipleClients(t *testing.T) {
 
 	getStats := func(topicName string) map[kafka.Key]*kafka.RequestStat {
 		kafkaStats := make(map[kafka.Key]*kafka.RequestStat)
-		key := kafka.NewKey(c.Source, c.Dest, c.SPort, c.DPort, topicName)
+		key := kafka.NewKey(c.Source, c.Dest, c.SPort, c.DPort, topicName, kafka.ProduceAPIKey, 1)
 		kafkaStats[key] = &kafka.RequestStat{Count: 2}
 		return kafkaStats
 	}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
Refactor the Kafka encoder by leveraging changes introduced in https://github.com/DataDog/datadog-agent/pull/16844
Optimize USM Kafka encoding codepath.
The main idea of this PR is reducing the number of live protobuf `model` objects in the heap at given time. The approach can be summarized as follows:

1. First we group USM data by connection calling `GroupByConnection`;
2. Then, during the encoding phase of each `network.ConnectionStats` we do the following:
  a. First we fetch all USM data for a given connection (which is done by calling `USMConnectionIndex.Find()`)
  b. Then, we generate all Kafka `model` objects for this specific connection
  c. After that, we serialize all objects into a blob of bytes
  d. The associated `model` objects are then moved to an object pool for later reuse.
 
<!-- In aggregate the changes in this PR have yielded a ~20% reduction in RSS and a ~10% reduction in CPU in our load test environment running an Kafka-heavy workload.
 
![rss](https://user-images.githubusercontent.com/692520/235477409-49168161-67be-4353-9217-8b341984ef39.png)
![cpu](https://user-images.githubusercontent.com/692520/235477450-44f34e32-32a8-4212-9990-7f951137b30f.png)
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

Benchmark on the last commit:

```
Before
BenchmarkKafkaEncoder100Requests
BenchmarkKafkaEncoder100Requests-16      	  113868	     10180 ns/op	   12140 B/op	      22 allocs/op
BenchmarkKafkaEncoder10000Requests
BenchmarkKafkaEncoder10000Requests-16    	    1287	    926992 ns/op	 1164124 B/op	      24 allocs/op

After
BenchmarkKafkaEncoder100Requests
BenchmarkKafkaEncoder100Requests-16      	  133870	      8973 ns/op	    9344 B/op	      22 allocs/op
BenchmarkKafkaEncoder10000Requests
BenchmarkKafkaEncoder10000Requests-16    	    1639	    688846 ns/op	  722081 B/op	      23 allocs/op
```

Load test:
A moderate change in avg CPU, up to 10%
![image](https://github.com/DataDog/datadog-agent/assets/17148247/901556df-8dd7-45a6-9344-d6dd34305ad3)

Max CPU seems stable with main
![image](https://github.com/DataDog/datadog-agent/assets/17148247/0916e21f-7db6-4120-90fd-9d02fdce6eaf)

A slight improvement in AVG RSS
![image](https://github.com/DataDog/datadog-agent/assets/17148247/a63c45f3-5dd1-4449-9b71-525c2898532b)


Max RSS looks stable
![image](https://github.com/DataDog/datadog-agent/assets/17148247/315ac638-df58-4b0a-a58b-1c3fc8c55097)

Reduction in working set
![image](https://github.com/DataDog/datadog-agent/assets/17148247/b430ce9c-98c4-473d-9484-3f930f959c09)

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.

