### PR TITLE
[serverless-init] Add wait in signal handler of serverless-init process

### DIFF
--- a/cmd/serverless-init/initcontainer/initcontainer.go
+++ b/cmd/serverless-init/initcontainer/initcontainer.go
@@ -88,6 +88,12 @@ func handleSignals(cloudService cloudservice.CloudService, process *os.Process, 
 			if sig != syscall.SIGCHLD {
 				if process != nil {
 					_ = syscall.Kill(process.Pid, sig.(syscall.Signal))
+					_, err := process.Wait()
+					if err != nil {
+						serverlessLog.Write(config, []byte(fmt.Sprintf("[datadog init process] exiting with code = %s", err)), false)
+					} else {
+						serverlessLog.Write(config, []byte("[datadog init process] exiting successfully"), false)
+					}
 				}
 			}
 			if sig == syscall.SIGTERM {


### PR DESCRIPTION
### What does this PR do?
Added a wait inside the signal handler so that the init process waits for the child to exit instead of immediately exiting.

### Motivation
Fixes #17124. 

### Additional Notes
This wait was necessary even though there is a wait in the main process because as soon as the signal is received by the main process, the wait in main process exits.

### Describe how to test/QA your changes
Setup the serverless-init container with a CMD process and try to send a SIGTERM signal to the container. It should wait for the CMD process to exit and then the init process should exit.

### Reviewer's Checklist
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
