### PR TITLE
Don't fetch ECS tags when they're not consumed

### DIFF
--- a/pkg/util/containers/metrics/ecsfargate/collector.go
+++ b/pkg/util/containers/metrics/ecsfargate/collector.go
@@ -45,7 +45,7 @@ func init() {
 }
 
 type ecsFargateCollector struct {
-	client *v2.Client
+	client v2.Client
 
 	taskSpec *v2.Task
 	taskLock sync.Mutex

--- a/pkg/util/ecs/metadata/clients.go
+++ b/pkg/util/ecs/metadata/clients.go
@@ -39,15 +39,15 @@ type util struct {
 	initV1          sync.Once
 	initV2          sync.Once
 	initV3orV4      sync.Once
-	v1              *v1.Client
-	v2              *v2.Client
-	v3or4           *v3or4.Client
+	v1              v1.Client
+	v2              v2.Client
+	v3or4           v3or4.Client
 }
 
 // V1 returns a client for the ECS metadata API v1, also called introspection
 // endpoint, by detecting the endpoint address. Returns an error if it was not
 // possible to detect the endpoint address.
-func V1() (*v1.Client, error) {
+func V1() (v1.Client, error) {
 	if !config.IsCloudProviderEnabled(common.CloudProviderName) {
 		return nil, fmt.Errorf("Cloud Provider %s is disabled by configuration", common.CloudProviderName)
 	}
@@ -70,7 +70,7 @@ func V1() (*v1.Client, error) {
 
 // V2 returns a client for the ECS metadata API v2 that uses the default
 // endpoint address.
-func V2() (*v2.Client, error) {
+func V2() (v2.Client, error) {
 	if !config.IsCloudProviderEnabled(common.CloudProviderName) {
 		return nil, fmt.Errorf("Cloud Provider %s is disabled by configuration", common.CloudProviderName)
 	}
@@ -96,7 +96,7 @@ func V2() (*v2.Client, error) {
 // the endpoint address from the task the executable is running in. Returns an
 // error if it was not possible to detect the endpoint address.
 // v4 metadata API is preferred over v3 if both are available.
-func V3orV4FromCurrentTask() (*v3or4.Client, error) {
+func V3orV4FromCurrentTask() (v3or4.Client, error) {
 	if !config.IsCloudProviderEnabled(common.CloudProviderName) {
 		return nil, fmt.Errorf("Cloud Provider %s is disabled by configuration", common.CloudProviderName)
 	}
@@ -119,7 +119,7 @@ func V3orV4FromCurrentTask() (*v3or4.Client, error) {
 
 // newAutodetectedClientV1 detects the metadata v1 API endpoint and creates a new
 // client for it. Returns an error if it was not possible to find the endpoint.
-func newAutodetectedClientV1() (*v1.Client, error) {
+func newAutodetectedClientV1() (v1.Client, error) {
 	agentURL, err := detectAgentV1URL()
 	if err != nil {
 		return nil, err
@@ -129,7 +129,7 @@ func newAutodetectedClientV1() (*v1.Client, error) {
 
 // newClientV3ForCurrentTask detects the metadata API v3 endpoint from the current
 // task and creates a new client for it.
-func newClientV3ForCurrentTask() (*v3or4.Client, error) {
+func newClientV3ForCurrentTask() (v3or4.Client, error) {
 	agentURL, err := getAgentV3URLFromEnv()
 	if err != nil {
 		return nil, err
@@ -139,7 +139,7 @@ func newClientV3ForCurrentTask() (*v3or4.Client, error) {
 
 // newClientV4ForCurrentTask detects the metadata API v4 endpoint from the current
 // task and creates a new client for it.
-func newClientV4ForCurrentTask() (*v3or4.Client, error) {
+func newClientV4ForCurrentTask() (v3or4.Client, error) {
 	agentURL, err := getAgentV4URLFromEnv()
 	if err != nil {
 		return nil, err

--- a/pkg/util/ecs/metadata/v1/client.go
+++ b/pkg/util/ecs/metadata/v1/client.go
@@ -31,7 +31,7 @@ const (
 )
 
 type Client interface {
-	GetInstance(context.Context) (*Instance, error) 
+	GetInstance(context.Context) (*Instance, error)
 	GetTasks(context.Context) ([]Task, error)
 }
 

--- a/pkg/util/ecs/metadata/v1/client.go
+++ b/pkg/util/ecs/metadata/v1/client.go
@@ -30,20 +30,25 @@ const (
 	taskMetadataPath = "/tasks"
 )
 
+type Client interface {
+	GetInstance(context.Context) (*Instance, error) 
+	GetTasks(context.Context) ([]Task, error)
+}
+
 // Client represents a client for a metadata v1 API endpoint.
-type Client struct {
+type client struct {
 	agentURL string
 }
 
 // NewClient creates a new client for the specified metadata v1 API endpoint.
-func NewClient(agentURL string) *Client {
-	return &Client{
+func NewClient(agentURL string) Client {
+	return &client{
 		agentURL: agentURL,
 	}
 }
 
 // GetInstance returns metadata for the current container instance.
-func (c *Client) GetInstance(ctx context.Context) (*Instance, error) {
+func (c *client) GetInstance(ctx context.Context) (*Instance, error) {
 	var i Instance
 	if err := c.get(ctx, instancePath, &i); err != nil {
 		return nil, err
@@ -52,7 +57,7 @@ func (c *Client) GetInstance(ctx context.Context) (*Instance, error) {
 }
 
 // GetTasks returns the list of task on the current container instance.
-func (c *Client) GetTasks(ctx context.Context) ([]Task, error) {
+func (c *client) GetTasks(ctx context.Context) ([]Task, error) {
 	var t Tasks
 	if err := c.get(ctx, taskMetadataPath, &t); err != nil {
 		return nil, err
@@ -60,7 +65,7 @@ func (c *Client) GetTasks(ctx context.Context) ([]Task, error) {
 	return t.Tasks, nil
 }
 
-func (c *Client) makeURL(requestPath string) (string, error) {
+func (c *client) makeURL(requestPath string) (string, error) {
 	u, err := url.Parse(c.agentURL)
 	if err != nil {
 		return "", err
@@ -69,7 +74,7 @@ func (c *Client) makeURL(requestPath string) (string, error) {
 	return u.String(), nil
 }
 
-func (c *Client) get(ctx context.Context, path string, v interface{}) error {
+func (c *client) get(ctx context.Context, path string, v interface{}) error {
 	client := http.Client{Timeout: common.MetadataTimeout()}
 	url, err := c.makeURL(path)
 	if err != nil {

--- a/pkg/util/ecs/metadata/v2/client.go
+++ b/pkg/util/ecs/metadata/v2/client.go
@@ -32,25 +32,31 @@ const (
 	containerStatsPath       = "/stats"
 )
 
+type Client interface {
+	GetContainerStats(ctx context.Context, id string) (*ContainerStats, error)
+	GetTask(ctx context.Context) (*Task, error)
+	GetTaskWithTags(ctx context.Context) (*Task, error)
+}
+
 // Client represents a client for a metadata v2 API endpoint.
-type Client struct {
+type client struct {
 	agentURL string
 }
 
 // NewClient creates a new client for the specified metadata v2 API endpoint.
-func NewClient(agentURL string) *Client {
-	return &Client{
+func NewClient(agentURL string) Client {
+	return &client{
 		agentURL: agentURL,
 	}
 }
 
 // NewDefaultClient creates a new client for the default metadata v2 API endpoint.
-func NewDefaultClient() *Client {
+func NewDefaultClient() Client {
 	return NewClient(defaultAgentURL)
 }
 
 // GetContainerStats returns stastics for a container.
-func (c *Client) GetContainerStats(ctx context.Context, id string) (*ContainerStats, error) {
+func (c *client) GetContainerStats(ctx context.Context, id string) (*ContainerStats, error) {
 	var stats map[string]*ContainerStats
 	// There is a difference in reported JSON in v 1.4.0 vs v1.3.0 so we should
 	// avoid using /v2/stats/{container_id}
@@ -66,16 +72,16 @@ func (c *Client) GetContainerStats(ctx context.Context, id string) (*ContainerSt
 }
 
 // GetTask returns the current task.
-func (c *Client) GetTask(ctx context.Context) (*Task, error) {
+func (c *client) GetTask(ctx context.Context) (*Task, error) {
 	return c.getTaskMetadataAtPath(ctx, taskMetadataPath)
 }
 
 // GetTaskWithTags returns the current task, including propagated resource tags.
-func (c *Client) GetTaskWithTags(ctx context.Context) (*Task, error) {
+func (c *client) GetTaskWithTags(ctx context.Context) (*Task, error) {
 	return c.getTaskMetadataAtPath(ctx, taskMetadataWithTagsPath)
 }
 
-func (c *Client) get(ctx context.Context, path string, v interface{}) error {
+func (c *client) get(ctx context.Context, path string, v interface{}) error {
 	client := http.Client{Timeout: common.MetadataTimeout()}
 	url, err := c.makeURL(path)
 	if err != nil {
@@ -113,7 +119,7 @@ func (c *Client) get(ctx context.Context, path string, v interface{}) error {
 	return nil
 }
 
-func (c *Client) getTaskMetadataAtPath(ctx context.Context, path string) (*Task, error) {
+func (c *client) getTaskMetadataAtPath(ctx context.Context, path string) (*Task, error) {
 	var t Task
 	if err := c.get(ctx, path, &t); err != nil {
 		return nil, err
@@ -121,7 +127,7 @@ func (c *Client) getTaskMetadataAtPath(ctx context.Context, path string) (*Task,
 	return &t, nil
 }
 
-func (c *Client) makeURL(requestPath string) (string, error) {
+func (c *client) makeURL(requestPath string) (string, error) {
 	u, err := url.Parse(c.agentURL)
 	if err != nil {
 		return "", err

--- a/pkg/workloadmeta/collectors/internal/ecs/ecs.go
+++ b/pkg/workloadmeta/collectors/internal/ecs/ecs.go
@@ -30,7 +30,7 @@ const (
 type collector struct {
 	store               workloadmeta.Store
 	metaV1              v1.Client
-	metaV3or4			func(metaURI, metaVersion string) (v3or4.Client)
+	metaV3or4           func(metaURI, metaVersion string) v3or4.Client
 	clusterName         string
 	hasResourceTags     bool
 	collectResourceTags bool
@@ -66,7 +66,7 @@ func (c *collector) Start(ctx context.Context, store workloadmeta.Store) error {
 	}
 
 	// This only exists to allow overriding for testing
-	c.metaV3or4 = func(metaURI , metaVersion string) v3or4.Client {
+	c.metaV3or4 = func(metaURI, metaVersion string) v3or4.Client {
 		return v3or4.NewClient(metaURI, metaVersion)
 	}
 

--- a/pkg/workloadmeta/collectors/internal/ecs/ecs_test.go
+++ b/pkg/workloadmeta/collectors/internal/ecs/ecs_test.go
@@ -44,7 +44,6 @@ func (c *fakev1EcsClient) GetTasks(ctx context.Context) ([]v1.Task, error) {
 	return c.mockGetTasks(ctx)
 }
 
-// TODO: can just delete?
 func (c *fakev1EcsClient) GetInstance(ctx context.Context) (*v1.Instance, error) {
 	return nil, errors.New("unimplemented")
 }

--- a/pkg/workloadmeta/collectors/internal/ecs/ecs_test.go
+++ b/pkg/workloadmeta/collectors/internal/ecs/ecs_test.go
@@ -9,14 +9,14 @@
 package ecs
 
 import (
-	"errors"
 	"context"
-	"testing"
+	"errors"
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 	"github.com/stretchr/testify/assert"
+	"testing"
 
-	"github.com/DataDog/datadog-agent/pkg/util/ecs/metadata/v3or4"
 	v1 "github.com/DataDog/datadog-agent/pkg/util/ecs/metadata/v1"
+	"github.com/DataDog/datadog-agent/pkg/util/ecs/metadata/v3or4"
 )
 
 type fakeWorkloadmetaStore struct {
@@ -37,7 +37,7 @@ func (store *fakeWorkloadmetaStore) GetContainer(id string) (*workloadmeta.Conta
 }
 
 type fakev1EcsClient struct {
-	mockGetTasks func(context.Context) ([]v1.Task, error) 
+	mockGetTasks func(context.Context) ([]v1.Task, error)
 }
 
 func (c *fakev1EcsClient) GetTasks(ctx context.Context) ([]v1.Task, error) {
@@ -50,7 +50,7 @@ func (c *fakev1EcsClient) GetInstance(ctx context.Context) (*v1.Instance, error)
 }
 
 type fakev3or4EcsClient struct {
-	mockGetTaskWithTags func(context.Context) (*v3or4.Task, error) 
+	mockGetTaskWithTags func(context.Context) (*v3or4.Task, error)
 }
 
 func (store *fakev3or4EcsClient) GetTask(ctx context.Context) (*v3or4.Task, error) {
@@ -70,24 +70,24 @@ func TestPull(t *testing.T) {
 	tags := map[string]string{"foo": "bar"}
 
 	tests := []struct {
-		name string
+		name                string
 		collectResourceTags bool
-		expectedTags map[string]string
+		expectedTags        map[string]string
 	}{
 		{
-			name: "collect tags",
+			name:                "collect tags",
 			collectResourceTags: true,
-			expectedTags: tags,
+			expectedTags:        tags,
 		},
 		{
-			name: "don't collect tags",
+			name:                "don't collect tags",
 			collectResourceTags: false,
-			expectedTags: nil,
+			expectedTags:        nil,
 		},
 	}
 
 	for _, test := range tests {
-		t.Run(test.name, func(t * testing.T) {
+		t.Run(test.name, func(t *testing.T) {
 			c := collector{
 				resourceTags: make(map[string]resourceTags),
 				seen:         make(map[workloadmeta.EntityID]struct{}),
@@ -106,7 +106,7 @@ func TestPull(t *testing.T) {
 				},
 			}
 			c.store = &fakeWorkloadmetaStore{}
-			c.metaV3or4 = func(metaURI, metaVersion string) (v3or4.Client) {
+			c.metaV3or4 = func(metaURI, metaVersion string) v3or4.Client {
 				return &fakev3or4EcsClient{
 					mockGetTaskWithTags: func(context.Context) (*v3or4.Task, error) {
 						return &v3or4.Task{

--- a/pkg/workloadmeta/collectors/internal/ecs/ecs_test.go
+++ b/pkg/workloadmeta/collectors/internal/ecs/ecs_test.go
@@ -1,0 +1,131 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build docker
+// +build docker
+
+package ecs
+
+import (
+	"errors"
+	"context"
+	"testing"
+	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/pkg/util/ecs/metadata/v3or4"
+	v1 "github.com/DataDog/datadog-agent/pkg/util/ecs/metadata/v1"
+)
+
+type fakeWorkloadmetaStore struct {
+	workloadmeta.Store
+	notifiedEvents []workloadmeta.CollectorEvent
+}
+
+func (store *fakeWorkloadmetaStore) Notify(events []workloadmeta.CollectorEvent) {
+	store.notifiedEvents = append(store.notifiedEvents, events...)
+}
+
+func (store *fakeWorkloadmetaStore) GetContainer(id string) (*workloadmeta.Container, error) {
+	return &workloadmeta.Container{
+		EnvVars: map[string]string{
+			v3or4.DefaultMetadataURIv4EnvVariable: "fake_uri",
+		},
+	}, nil
+}
+
+type fakev1EcsClient struct {
+	mockGetTasks func(context.Context) ([]v1.Task, error) 
+}
+
+func (c *fakev1EcsClient) GetTasks(ctx context.Context) ([]v1.Task, error) {
+	return c.mockGetTasks(ctx)
+}
+
+// TODO: can just delete?
+func (c *fakev1EcsClient) GetInstance(ctx context.Context) (*v1.Instance, error) {
+	return nil, errors.New("unimplemented")
+}
+
+type fakev3or4EcsClient struct {
+	mockGetTaskWithTags func(context.Context) (*v3or4.Task, error) 
+}
+
+func (store *fakev3or4EcsClient) GetTask(ctx context.Context) (*v3or4.Task, error) {
+	return nil, errors.New("unimplemented")
+}
+
+func (c *fakev3or4EcsClient) GetTaskWithTags(ctx context.Context) (*v3or4.Task, error) {
+	return c.mockGetTaskWithTags(ctx)
+}
+
+func (store *fakev3or4EcsClient) GetContainer(ctx context.Context) (*v3or4.Container, error) {
+	return nil, errors.New("unimplemented")
+}
+
+func TestPull(t *testing.T) {
+	entityID := "task1"
+	tags := map[string]string{"foo": "bar"}
+
+	tests := []struct {
+		name string
+		collectResourceTags bool
+		expectedTags map[string]string
+	}{
+		{
+			name: "collect tags",
+			collectResourceTags: true,
+			expectedTags: tags,
+		},
+		{
+			name: "don't collect tags",
+			collectResourceTags: false,
+			expectedTags: nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t * testing.T) {
+			c := collector{
+				resourceTags: make(map[string]resourceTags),
+				seen:         make(map[workloadmeta.EntityID]struct{}),
+			}
+
+			c.metaV1 = &fakev1EcsClient{
+				mockGetTasks: func(ctx context.Context) ([]v1.Task, error) {
+					return []v1.Task{
+						{
+							Arn: entityID,
+							Containers: []v1.Container{
+								{DockerID: "foo"},
+							},
+						},
+					}, nil
+				},
+			}
+			c.store = &fakeWorkloadmetaStore{}
+			c.metaV3or4 = func(metaURI, metaVersion string) (v3or4.Client) {
+				return &fakev3or4EcsClient{
+					mockGetTaskWithTags: func(context.Context) (*v3or4.Task, error) {
+						return &v3or4.Task{
+							TaskTags: map[string]string{
+								"foo": "bar",
+							},
+						}, nil
+					},
+				}
+			}
+
+			c.hasResourceTags = true
+			c.collectResourceTags = test.collectResourceTags
+
+			c.Pull(context.TODO())
+
+			taskTags := c.resourceTags[entityID].tags
+			assert.Equal(t, taskTags, test.expectedTags)
+		})
+	}
+
+}

--- a/pkg/workloadmeta/collectors/internal/ecsfargate/ecsfargate.go
+++ b/pkg/workloadmeta/collectors/internal/ecsfargate/ecsfargate.go
@@ -28,7 +28,7 @@ const (
 
 type collector struct {
 	store  workloadmeta.Store
-	metaV2 *v2.Client
+	metaV2 v2.Client
 	seen   map[workloadmeta.EntityID]struct{}
 }
 

--- a/releasenotes/notes/dont-fetch-ecs-tags-unless-used-cd96c60f2a3e23a0.yaml
+++ b/releasenotes/notes/dont-fetch-ecs-tags-unless-used-cd96c60f2a3e23a0.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Avoids fetching tags for ECS tasks when they're not consumed.


### PR DESCRIPTION
### What does this PR do?

This avoids calling ECS `ListTagsForResource` when the `ecs_collect_resource_tags_ec2` configuration setting is not enabled.

### Motivation

I observed rate-limiting from AWS during deployments to large ECS cluster when this agent is in use. Looking at cloudtrail, it's clear that `ListTagsForResource` originating from the datadog agent is the culprit. While this could likely be tuned with better backoff/retry behaviour, I don't believe we even use the results from this (`ecs_collect_resource_tags_ec2` is defaulted to off), so it's easier to avoid the calls altogether.

### Additional Notes

There were no previous tests here, but I've added some for the new functionality. I had to slightly change the ECS client interface to make this more testable.

### Possible Drawbacks / Trade-offs

It's possible that these tags are used elsewhere that I didn't notice, feel free to correct me if that's the case.

### Describe how to test/QA your changes

It should be easy to run this version of the agent and check cloudtrail/logs to see that tags are not fetched.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
