### PR TITLE
[7.45] Add extra heartbeat sender to CLC loop and change busyness computation to only rely on metric samples

### DIFF
--- a/pkg/clusteragent/clusterchecks/dispatcher_main.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_main.go
@@ -22,9 +22,11 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-const firstRunnerStatsMinutes = 2  // collect runner stats after the first 2 minutes
-const secondRunnerStatsMinutes = 5 // collect runner stats after the first 7 minutes
-const finalRunnerStatsMinutes = 10 // collect runner stats endlessly every 10 minutes
+const (
+	firstRunnerStatsMinutes  = 2  // collect runner stats after the first 2 minutes
+	secondRunnerStatsMinutes = 5  // collect runner stats after the first 7 minutes
+	finalRunnerStatsMinutes  = 10 // collect runner stats endlessly every 10 minutes
+)
 
 // dispatcher holds the management logic for cluster-checks
 type dispatcher struct {

--- a/pkg/clusteragent/clusterchecks/dispatcher_nodes.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_nodes.go
@@ -19,7 +19,9 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-const defaultBusynessValue int = -1
+const (
+	defaultBusynessValue int = -1
+)
 
 // getClusterCheckConfigs returns configurations dispatched to a given node
 func (d *dispatcher) getClusterCheckConfigs(nodeName string) ([]integration.Config, int64, error) {
@@ -50,8 +52,11 @@ func (d *dispatcher) processNodeStatus(nodeName, clientIP string, status types.N
 
 	node.Lock()
 	defer node.Unlock()
-	node.lastStatus = status
 	node.heartbeat = timestampNow()
+	// When we receive ExtraHeartbeatLastChangeValue, we only update heartbeat
+	if status.LastChange == types.ExtraHeartbeatLastChangeValue {
+		return true, nil
+	}
 
 	if node.lastConfigChange == status.LastChange {
 		// Node-agent is up to date

--- a/pkg/clusteragent/clusterchecks/dispatcher_rebalance_test.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_rebalance_test.go
@@ -1365,6 +1365,11 @@ func TestRebalance(t *testing.T) {
 		},
 	} {
 		t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
+			// Tests have been written with this value hardcoded
+			// Changing the values rather than re-writing all the tests.
+			checkExecutionTimeWeight = 0.8
+			checkMetricSamplesWeight = 0.2
+
 			dispatcher := newDispatcher()
 
 			// prepare store

--- a/pkg/clusteragent/clusterchecks/dispatcher_test.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_test.go
@@ -201,7 +201,6 @@ func TestProcessNodeStatus(t *testing.T) {
 	assert.True(t, upToDate)
 	node1, found := dispatcher.store.getNodeStore("node1")
 	assert.True(t, found)
-	assert.Equal(t, status1, node1.lastStatus)
 	assert.True(t, timestampNow() >= node1.heartbeat)
 	assert.True(t, timestampNow() <= node1.heartbeat+1)
 

--- a/pkg/clusteragent/clusterchecks/helpers.go
+++ b/pkg/clusteragent/clusterchecks/helpers.go
@@ -16,9 +16,9 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks/types"
 )
 
-const (
-	checkExecutionTimeWeight = 0.8
-	checkMetricSamplesWeight = 0.2
+var (
+	checkExecutionTimeWeight float64 = 0
+	checkMetricSamplesWeight float64 = 1
 )
 
 // makeConfigArray flattens a map of configs into a slice. Creating a new slice

--- a/pkg/clusteragent/clusterchecks/stores.go
+++ b/pkg/clusteragent/clusterchecks/stores.go
@@ -84,7 +84,6 @@ type nodeStore struct {
 	sync.RWMutex
 	name             string
 	heartbeat        int64
-	lastStatus       types.NodeStatus
 	lastConfigChange int64
 	digestToConfig   map[string]integration.Config
 	clientIP         string

--- a/pkg/clusteragent/clusterchecks/types/types.go
+++ b/pkg/clusteragent/clusterchecks/types/types.go
@@ -9,6 +9,12 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 )
 
+const (
+	// ExtraHeartbeatLastChangeValue is used to instruct the Cluster Agent that we're still alive
+	// despite that the polling loop on CLC side is delayed.
+	ExtraHeartbeatLastChangeValue int64 = -1
+)
+
 // NodeStatus holds the status report from the node-agent
 type NodeStatus struct {
 	LastChange int64 `json:"last_change"`


### PR DESCRIPTION
### What does this PR do?

Backport #17116 

### Motivation

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

No formal QA, see #17116 

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
