### PR TITLE
Add ability to exclude cluster checks on Cluster Agent

### DIFF
--- a/pkg/clusteragent/clusterchecks/dispatcher_main.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_main.go
@@ -35,6 +35,7 @@ type dispatcher struct {
 	extraTags             []string
 	clcRunnersClient      clusteragent.CLCRunnerClientInterface
 	advancedDispatching   bool
+	excludedChecks        map[string]struct{}
 }
 
 func newDispatcher() *dispatcher {
@@ -43,6 +44,15 @@ func newDispatcher() *dispatcher {
 	}
 	d.nodeExpirationSeconds = config.Datadog.GetInt64("cluster_checks.node_expiration_timeout")
 	d.extraTags = config.Datadog.GetStringSlice("cluster_checks.extra_tags")
+
+	excludedChecks := config.Datadog.GetStringSlice("cluster_checks.exclude_checks")
+	// This option will almost always be empty
+	if len(excludedChecks) > 0 {
+		d.excludedChecks = make(map[string]struct{}, len(excludedChecks))
+		for _, checkName := range excludedChecks {
+			d.excludedChecks[checkName] = struct{}{}
+		}
+	}
 
 	hname, _ := hostname.Get(context.TODO())
 	clusterTagValue := clustername.GetClusterName(context.TODO(), hname)
@@ -77,6 +87,11 @@ func (d *dispatcher) Stop() {
 // Schedule implements the scheduler.Scheduler interface
 func (d *dispatcher) Schedule(configs []integration.Config) {
 	for _, c := range configs {
+		if _, found := d.excludedChecks[c.Name]; found {
+			log.Infof("Excluding check due to config: %s", c.Name)
+			continue
+		}
+
 		if !c.ClusterCheck {
 			continue // Ignore non cluster-check configs
 		}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -997,6 +997,8 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("cluster_checks.extra_tags", []string{})
 	config.BindEnvAndSetDefault("cluster_checks.advanced_dispatching_enabled", false)
 	config.BindEnvAndSetDefault("cluster_checks.clc_runners_port", 5005)
+	config.BindEnvAndSetDefault("cluster_checks.exclude_checks", []string{})
+
 	// Cluster check runner
 	config.BindEnvAndSetDefault("clc_runner_enabled", false)
 	config.BindEnvAndSetDefault("clc_runner_id", "")


### PR DESCRIPTION
### What does this PR do?

Add ability to exclude cluster checks on Cluster Agent.

### Motivation

Add some control on scheduled checks for Agent/Cluster Agent ops.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

QA done internally.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
