### PR TITLE
Add cloud_provider_host_id to the payload

### DIFF
--- a/pkg/metadata/inventories/host_metadata.go
+++ b/pkg/metadata/inventories/host_metadata.go
@@ -57,6 +57,7 @@ type HostMetadata struct {
 	CloudProvider          string `json:"cloud_provider"`
 	CloudProviderSource    string `json:"cloud_provider_source"`
 	CloudProviderAccountID string `json:"cloud_provider_account_id"`
+	CloudProviderHostID    string `json:"cloud_provider_host_id"`
 	OsVersion              string `json:"os_version"`
 
 	// From file system
@@ -144,6 +145,7 @@ func getHostMetadata() *HostMetadata {
 
 	metadata.CloudProvider = fetchFromMetadata(string(HostCloudProvider), agentMetadata)
 	metadata.CloudProviderSource = fetchFromMetadata(string(HostCloudProviderSource), hostMetadata)
+	metadata.CloudProviderHostID = fetchFromMetadata(string(HostCloudProviderHostID), hostMetadata)
 	metadata.OsVersion = fetchFromMetadata(string(HostOSVersion), hostMetadata)
 
 	metadata.CloudProviderAccountID = fetchFromMetadata(string(HostCloudProviderAccountID), hostMetadata)

--- a/pkg/metadata/inventories/inventories.go
+++ b/pkg/metadata/inventories/inventories.go
@@ -112,7 +112,7 @@ const (
 	HostCloudProvider          AgentMetadataName = "cloud_provider"
 	HostCloudProviderSource    AgentMetadataName = "cloud_provider_source"
 	HostCloudProviderAccountID AgentMetadataName = "cloud_provider_account_id"
-	HostCloudProviderID        AgentMetadataName = "cloud_provider_host_id"
+	HostCloudProviderHostID    AgentMetadataName = "cloud_provider_host_id"
 )
 
 // Refresh signals that some data has been updated and a new payload should be sent (ex: when configuration is changed

--- a/pkg/metadata/inventories/inventories_test.go
+++ b/pkg/metadata/inventories/inventories_test.go
@@ -297,6 +297,7 @@ func TestGetPayload(t *testing.T) {
 			"cloud_provider": "some_cloud_provider",
 			"cloud_provider_source": "",
 			"cloud_provider_account_id": "",
+			"cloud_provider_host_id": "",
 			"os_version": "testOS",
 			"hypervisor_guest_uuid": "hypervisorUUID",
 			"dmi_product_uuid": "dmiUUID",

--- a/pkg/util/ec2/imds_helpers.go
+++ b/pkg/util/ec2/imds_helpers.go
@@ -30,7 +30,7 @@ func registerCloudProviderHostnameID(ctx context.Context) {
 	log.Debugf("instanceID from IMDSv2 '%s' (error: %v)", instanceID, err)
 
 	if err == nil {
-		inventories.SetHostMetadata(inventories.HostCloudProviderID, instanceID)
+		inventories.SetHostMetadata(inventories.HostCloudProviderHostID, instanceID)
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?

Add cloud_provider_host_id to the payload

### Describe how to test/QA your changes

QA for this should be done as part of #16788.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
