### PR TITLE
[CWS] fix serialization of container context release callback

### DIFF
--- a/pkg/security/resolvers/cgroup/resolver.go
+++ b/pkg/security/resolvers/cgroup/resolver.go
@@ -55,10 +55,7 @@ func NewResolver(tagsResolver tags.Resolver) (*Resolver, error) {
 		listeners:            make(map[CGroupEvent][]CGroupListener),
 	}
 	workloads, err := simplelru.NewLRU(1024, func(key string, value *cgroupModel.CacheEntry) {
-		if value.OnReleaseCallback != nil {
-			value.OnReleaseCallback()
-		}
-
+		value.CallReleaseCallback()
 		value.Deleted.Store(true)
 
 		cr.listenersLock.Lock()

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -151,13 +151,19 @@ type ChownEvent struct {
 
 // Releasable represents an object than can be released
 type Releasable struct {
-	OnReleaseCallback func() `field:"-"`
+	onReleaseCallback func() `field:"-" json:"-"`
+}
+
+func (r *Releasable) CallReleaseCallback() {
+	if r.onReleaseCallback != nil {
+		r.onReleaseCallback()
+	}
 }
 
 // SetReleaseCallback sets a callback to be called when the cache entry is released
 func (r *Releasable) SetReleaseCallback(callback func()) {
-	previousCallback := r.OnReleaseCallback
-	r.OnReleaseCallback = func() {
+	previousCallback := r.onReleaseCallback
+	r.onReleaseCallback = func() {
 		callback()
 		if previousCallback != nil {
 			previousCallback()
@@ -167,7 +173,7 @@ func (r *Releasable) SetReleaseCallback(callback func()) {
 
 // Release triggers the callback
 func (r *Releasable) OnRelease() {
-	r.OnReleaseCallback()
+	r.onReleaseCallback()
 }
 
 // ContainerContext holds the container context of an event


### PR DESCRIPTION
### What does this PR do?

This PR fixes https://github.com/DataDog/datadog-agent/pull/16733/files#diff-9a27c03e352eac61ba57287634a70ce205aaba7ec0536d2cb3164d706c40b996, precisely the JSON serialization of model.Event used

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
