### PR TITLE
pkg/clusteragent/admission/common: Add Data Streams to auto onboarding

### DIFF
--- a/pkg/clusteragent/admission/common/lib_config.go
+++ b/pkg/clusteragent/admission/common/lib_config.go
@@ -41,6 +41,7 @@ type LibConfig struct {
 	TracingMethods                 []string                 `yaml:"tracing_methods" json:"tracing_methods,omitempty"`
 	TracingPropagationStyleInject  []string                 `yaml:"tracing_propagation_style_inject" json:"tracing_propagation_style_inject,omitempty"`
 	TracingPropagationStyleExtract []string                 `yaml:"tracing_propagation_style_extract" json:"tracing_propagation_style_extract,omitempty"`
+	DataStreams                    *bool                    `yaml:"data_streams_enabled" json:"data_streams_enabled,omitempty"`
 }
 
 // TracingServiceMapEntry holds service mapping config
@@ -172,6 +173,12 @@ func (lc LibConfig) ToEnvs() []corev1.EnvVar {
 		envs = append(envs, corev1.EnvVar{
 			Name:  "DD_PROPAGATION_STYLE_EXTRACT",
 			Value: strings.Join(lc.TracingPropagationStyleExtract, ","),
+		})
+	}
+	if val, defined := checkFormatVal(lc.DataStreams); defined {
+		envs = append(envs, corev1.EnvVar{
+			Name:  "DD_DATA_STREAMS_ENABLED",
+			Value: val,
 		})
 	}
 	return envs

--- a/pkg/clusteragent/admission/common/lib_config_test.go
+++ b/pkg/clusteragent/admission/common/lib_config_test.go
@@ -33,6 +33,7 @@ func TestLibConfig_ToEnvs(t *testing.T) {
 		TracingHeaderTags              []TracingHeaderTagEntry
 		TracingPartialFlushMinSpans    *int
 		TracingDebug                   *bool
+		DataStreams                    *bool
 		TracingLogLevel                *string
 		TracingMethods                 []string
 		TracingPropagationStyleInject  []string
@@ -76,6 +77,7 @@ func TestLibConfig_ToEnvs(t *testing.T) {
 				},
 				TracingPartialFlushMinSpans:    pointer.Ptr(100),
 				TracingDebug:                   pointer.Ptr(true),
+				DataStreams:                    pointer.Ptr(true),
 				TracingLogLevel:                pointer.Ptr("DEBUG"),
 				TracingMethods:                 []string{"modA.method", "modB.method"},
 				TracingPropagationStyleInject:  []string{"Datadog", "B3", "W3C"},
@@ -154,6 +156,10 @@ func TestLibConfig_ToEnvs(t *testing.T) {
 					Name:  "DD_PROPAGATION_STYLE_EXTRACT",
 					Value: "W3C,B3,Datadog",
 				},
+				{
+					Name:  "DD_DATA_STREAMS_ENABLED",
+					Value: "true",
+				},
 			},
 		},
 		{
@@ -197,6 +203,7 @@ func TestLibConfig_ToEnvs(t *testing.T) {
 				TracingHeaderTags:              tt.fields.TracingHeaderTags,
 				TracingPartialFlushMinSpans:    tt.fields.TracingPartialFlushMinSpans,
 				TracingDebug:                   tt.fields.TracingDebug,
+				DataStreams:                    tt.fields.DataStreams,
 				TracingLogLevel:                tt.fields.TracingLogLevel,
 				TracingMethods:                 tt.fields.TracingMethods,
 				TracingPropagationStyleInject:  tt.fields.TracingPropagationStyleInject,


### PR DESCRIPTION


<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Add the configuration of Data Streams Monitoring to the onboarding flow. That way, data streams can be easily enabled for new services. 

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
