### PR TITLE
[Serverless] Address race condition when reading tags map.

### DIFF
--- a/cmd/serverless-init/main.go
+++ b/cmd/serverless-init/main.go
@@ -9,7 +9,6 @@
 package main
 
 import (
-	"github.com/DataDog/datadog-agent/pkg/serverless/tags"
 	"os"
 	"time"
 
@@ -22,6 +21,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/serverless/metrics"
 	"github.com/DataDog/datadog-agent/pkg/serverless/otlp"
 	"github.com/DataDog/datadog-agent/pkg/serverless/random"
+	"github.com/DataDog/datadog-agent/pkg/serverless/tags"
 	"github.com/DataDog/datadog-agent/pkg/serverless/trace"
 	logger "github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -82,7 +82,7 @@ func setupMetricAgent(tags map[string]string) *metrics.ServerlessMetricAgent {
 	config.Datadog.Set("use_v2_api.series", false)
 	metricAgent := &metrics.ServerlessMetricAgent{}
 	// we don't want to add the container_id tag to metrics for cardinality reasons
-	delete(tags, "container_id")
+	tags = tag.WithoutContainerID(tags)
 	tagArray := tag.GetBaseTagsArrayWithMetadataTags(tags)
 	metricAgent.Start(5*time.Second, &metrics.MetricConfig{}, &metrics.MetricDogStatsD{})
 	metricAgent.SetExtraTags(tagArray)

--- a/cmd/serverless-init/main_test.go
+++ b/cmd/serverless-init/main_test.go
@@ -9,14 +9,23 @@
 package main
 
 import (
+	"strings"
+	"testing"
+
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/serverless/logs"
 	"github.com/spf13/cast"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
+func setupTest() {
+	config.Datadog = config.NewConfig("datadog", "DD", strings.NewReplacer(".", "_"))
+	config.InitConfig(config.Datadog)
+}
+
 func TestProxyNotLoaded(t *testing.T) {
+	setupTest()
+
 	proxyHttp := "abc:1234"
 	proxyHttps := "abc:5678"
 	t.Setenv("DD_PROXY_HTTP", proxyHttp)
@@ -28,6 +37,8 @@ func TestProxyNotLoaded(t *testing.T) {
 }
 
 func TestProxyLoaded(t *testing.T) {
+	setupTest()
+
 	proxyHttp := "abc:1234"
 	proxyHttps := "abc:5678"
 	t.Setenv("DD_PROXY_HTTP", proxyHttp)
@@ -40,6 +51,8 @@ func TestProxyLoaded(t *testing.T) {
 }
 
 func TestTagsSetup(t *testing.T) {
+	setupTest()
+
 	ddTagsEnv := "key1:value1 key2:value2 key3:value3:4"
 	ddExtraTagsEnv := "key22:value22 key23:value23"
 	t.Setenv("DD_TAGS", ddTagsEnv)
@@ -49,7 +62,9 @@ func TestTagsSetup(t *testing.T) {
 
 	allTags := append(ddTags, ddExtraTags...)
 
-	_, _, _, metricAgent := setup()
+	_, _, traceAgent, metricAgent := setup()
+	defer traceAgent.Stop()
+	defer metricAgent.Stop()
 	assert.Subset(t, metricAgent.GetExtraTags(), allTags)
 	assert.Subset(t, logs.GetLogsTags(), allTags)
 }

--- a/cmd/serverless-init/tag/tag.go
+++ b/cmd/serverless-init/tag/tag.go
@@ -63,3 +63,14 @@ func GetBaseTagsArrayWithMetadataTags(metadata map[string]string) []string {
 	tagsMap := GetBaseTagsMapWithMetadata(metadata)
 	return tags.MapToArray(tagsMap)
 }
+
+// WithoutContainerID creates a new tag map without the `container_id` tag
+func WithoutContainerID(tags map[string]string) map[string]string {
+	newTags := make(map[string]string, len(tags))
+	for k, v := range tags {
+		if k != "container_id" {
+			newTags[k] = v
+		}
+	}
+	return newTags
+}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Addresses the flaky test `TestTagsSetup` in `cmd/serverless-init`.

This test has failed 9 times of the 4,744 test runs in the last week. Each failure shows the same race condition. We are using the same map object for the metrics and trace agents, but in the metrics agent we mutate the map and remove a key. Since the trace agent is set up in a goroutine, this leads to a race condition.

Note that I was unable to reproduce this race condition locally because of its rarity.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

CI failures such as [this one here](https://app.datadoghq.com/ci/test-runs?query=test_level%3Atest%20%40ci.pipeline.name%3A%22DataDog%2Fdatadog-agent%22%20%40test.codeowners%3A%22%40DataDog%2Fserverless%22%20%40test.name%3ATestTagsSetup%20%40test.status%3Afail%20&cols=%40test.name%2C%40duration%2C%40test.service%2C%40git.branch&currentTab=overview&eventStack=AgAAAYgfeQnU3HAykgAAAAAAAAAYAAAAAEFZZ2ZlUW5VQUFBYWc5SXNEaXZjWVFaSQAAACQAAAAAMDE4ODFmN2YtMGM2Ny00ODBlLTg0YzUtZmMwNjlkZWJiMDg4&index=citest&spanID=5190050964596216494&testId=AgAAAYgfeQnU3HAykgAAAAAAAAAYAAAAAEFZZ2ZlUW5VQUFBYWc5SXNEaXZjWVFaSQAAACQAAAAAMDE4ODFmN2YtMGM2Ny00ODBlLTg0YzUtZmMwNjlkZWJiMDg4&trace=AgAAAYgfeQnU3HAykgAAAAAAAAAYAAAAAEFZZ2ZlUW5VQUFBYWc5SXNEaXZjWVFaSQAAACQAAAAAMDE4ODFmN2YtMGM2Ny00ODBlLTg0YzUtZmMwNjlkZWJiMDg4&start=1683584409580&end=1684189209580&paused=false)

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

I added a few more changes to the tests that will allow us to run them multiple times (using the `-count=x` arg to `go test`).

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

This will slightly increase cold start time because a new map must be allocated.

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
