### PR TITLE
Fix cloud provider source when forcing imdsv2

### DIFF
--- a/pkg/util/ec2/imds_helpers.go
+++ b/pkg/util/ec2/imds_helpers.go
@@ -95,7 +95,8 @@ func doHTTPRequest(ctx context.Context, url string, forceIMDSv2 bool) (string, e
 	}
 
 	res, err := httputils.Get(ctx, url, headers, time.Duration(config.Datadog.GetInt("ec2_metadata_timeout"))*time.Millisecond)
-	if err == nil {
+	// We don't want to register the source when we force imdsv2
+	if err == nil && !forceIMDSv2 {
 		setCloudProviderSource(source)
 	}
 	return res, err


### PR DESCRIPTION
### What does this PR do?

Fix cloud provider source when forcing imdsv2

### Describe how to test/QA your changes

QA for this card will be covered by https://github.com/DataDog/datadog-agent/pull/16788

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
