### PR TITLE
[WIP] Fix permission check on $SECURITY_AGENT_CONFIG_FILE

### DIFF
--- a/omnibus/config/templates/datadog-agent/sysvinit_debian.security.erb
+++ b/omnibus/config/templates/datadog-agent/sysvinit_debian.security.erb
@@ -24,12 +24,12 @@ DESC="Datadog Security Agent"
 
 
 if [ ! -x $AGENTPATH ]; then
-	echo "$AGENTPATH not found. Exiting $NAME"
+	echo "$AGENTPATH not found or not executable. Exiting $NAME"
 	exit 0
 fi
 
-if [ ! -x $SECURITY_AGENT_CONFIG_FILE ]; then
-	echo "$SECURITY_AGENT_CONFIG_FILE not found. Exiting $NAME"
+if [ ! -r $SECURITY_AGENT_CONFIG_FILE ]; then
+	echo "$SECURITY_AGENT_CONFIG_FILE not found or not readable. Exiting $NAME"
 	exit 0
 fi
 


### PR DESCRIPTION
$SECURITY_AGENT_CONFIG_FILE does not need to be executable, merely readable.

This fixes spurious error `/etc/datadog-agent/security-agent.yaml not found. Exiting datadog-agent-security`, caused by the startupscript wrongly checking for an executable config file instead of a readable one.

TODO:
- [ ] check other (non-Debian) service files for faulty check logic
- [ ] go down PR checklist / read Contributing.md

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
