### PR TITLE
Global dogstatsd context limit

### DIFF
--- a/pkg/aggregator/context_resolver_test.go
+++ b/pkg/aggregator/context_resolver_test.go
@@ -130,17 +130,14 @@ func testExpireContexts(t *testing.T, store *tags.Store) {
 	contextKey2, _ := contextResolver.trackContext(&mSample2, 6)
 
 	// With an expireTimestap of 3, both contexts are still valid
-	assert.Len(t, contextResolver.expireContexts(3, nil), 0)
+	contextResolver.expireContexts(3, nil)
 	_, ok1 := contextResolver.resolver.contextsByKey[contextKey1]
 	_, ok2 := contextResolver.resolver.contextsByKey[contextKey2]
 	assert.True(t, ok1)
 	assert.True(t, ok2)
 
 	// With an expireTimestap of 5, context 1 is expired
-	expiredContextKeys := contextResolver.expireContexts(5, nil)
-	if assert.Len(t, expiredContextKeys, 1) {
-		assert.Equal(t, contextKey1, expiredContextKeys[0])
-	}
+	contextResolver.expireContexts(5, nil)
 
 	// context 1 is not tracked anymore, but context 2 still is
 	_, ok := contextResolver.resolver.contextsByKey[contextKey1]
@@ -183,7 +180,7 @@ func testExpireContextsWithKeep(t *testing.T, store *tags.Store) {
 	}
 
 	// With an expireTimestap of 3, both contexts are still valid
-	assert.Len(t, contextResolver.expireContexts(3, keeper), 0)
+	contextResolver.expireContexts(3, keeper)
 	_, ok1 := contextResolver.resolver.contextsByKey[contextKey1]
 	_, ok2 := contextResolver.resolver.contextsByKey[contextKey2]
 	assert.True(t, ok1)
@@ -191,7 +188,7 @@ func testExpireContextsWithKeep(t *testing.T, store *tags.Store) {
 	assert.Equal(t, keeperCalled, 0)
 
 	// With an expireTimestap of 5, context 1 is expired, but we explicitly keep it
-	assert.Len(t, contextResolver.expireContexts(5, keeper), 0)
+	contextResolver.expireContexts(5, keeper)
 	assert.Equal(t, keeperCalled, 1)
 
 	// both contexts are still tracked
@@ -202,10 +199,7 @@ func testExpireContextsWithKeep(t *testing.T, store *tags.Store) {
 
 	// With an expireTimestap of 6, context 1 is expired, and we don't keep it this time
 	keep = false
-	expiredContextKeys := contextResolver.expireContexts(6, keeper)
-	if assert.Len(t, expiredContextKeys, 1) {
-		assert.Equal(t, contextKey1, expiredContextKeys[0])
-	}
+	contextResolver.expireContexts(6, keeper)
 	assert.Equal(t, keeperCalled, 2)
 
 	// context 1 is not tracked anymore

--- a/pkg/aggregator/demultiplexer_agent.go
+++ b/pkg/aggregator/demultiplexer_agent.go
@@ -178,8 +178,9 @@ func initAgentDemultiplexer(sharedForwarder forwarder.Forwarder, options AgentDe
 		// the sampler
 		tagsStore := tags.NewStore(config.Datadog.GetBool("aggregator_use_tags_store"), fmt.Sprintf("timesampler #%d", i))
 
-		contextsLimiter := limiter.New(
+		contextsLimiter := limiter.NewGlobal(
 			config.Datadog.GetInt("dogstatsd_context_limiter.limit")/statsdPipelinesCount,
+			config.Datadog.GetInt("dogstatsd_context_limiter.entry_timeout"),
 			config.Datadog.GetString("dogstatsd_context_limiter.key_tag_name"),
 			config.Datadog.GetStringSlice("dogstatsd_context_limiter.telemetry_tag_names"),
 		)

--- a/pkg/aggregator/demultiplexer_agent.go
+++ b/pkg/aggregator/demultiplexer_agent.go
@@ -177,15 +177,8 @@ func initAgentDemultiplexer(sharedForwarder forwarder.Forwarder, options AgentDe
 	for i := 0; i < statsdPipelinesCount; i++ {
 		// the sampler
 		tagsStore := tags.NewStore(config.Datadog.GetBool("aggregator_use_tags_store"), fmt.Sprintf("timesampler #%d", i))
-
-		contextsLimiter := limiter.NewGlobal(
-			config.Datadog.GetInt("dogstatsd_context_limiter.limit")/statsdPipelinesCount,
-			config.Datadog.GetInt("dogstatsd_context_limiter.entry_timeout"),
-			config.Datadog.GetString("dogstatsd_context_limiter.key_tag_name"),
-			config.Datadog.GetStringSlice("dogstatsd_context_limiter.telemetry_tag_names"),
-		)
-
 		tagsLimiter := tags_limiter.New(config.Datadog.GetInt("dogstatsd_max_metrics_tags"))
+		contextsLimiter := limiter.FromConfig(statsdPipelinesCount)
 
 		statsdSampler := NewTimeSampler(TimeSamplerID(i), bucketSize, tagsStore, contextsLimiter, tagsLimiter, agg.hostname)
 

--- a/pkg/aggregator/internal/limiter/config.go
+++ b/pkg/aggregator/internal/limiter/config.go
@@ -1,0 +1,47 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package limiter
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// FromConfig builds new Limiter from the configuration.
+func FromConfig(pipelineCount int) *Limiter {
+	return fromConfig(pipelineCount, getCgroupMemoryLimit)
+}
+
+func fromConfig(pipelineCount int, cgroupLimitGetter func() (uint64, error)) *Limiter {
+	limit := 0
+	memoryRatio := config.Datadog.GetFloat64("dogstatsd_context_limiter.cgroup_memory_ratio")
+	bytesPerContext := config.Datadog.GetInt("dogstatsd_context_limiter.bytes_per_context")
+	if memoryRatio > 0 && bytesPerContext > 0 {
+		cgroupLimit, err := cgroupLimitGetter()
+		if err != nil {
+			log.Errorf("dogstatsd context limiter: memory based limit configured, but: %v", err)
+		} else {
+			limit = int(memoryRatio*float64(cgroupLimit)) / bytesPerContext
+			log.Debugf("dogstatsd context limiter: memory limit=%d, ratio=%f, contexts limit=%d", cgroupLimit, memoryRatio, limit)
+		}
+	}
+
+	if limit == 0 {
+		limit = config.Datadog.GetInt("dogstatsd_context_limiter.limit")
+		log.Debugf("dogstatsd context limiter: using fixed global limit %d", limit)
+	}
+
+	if pipelineCount > 0 {
+		limit = limit / pipelineCount
+	}
+
+	return NewGlobal(
+		limit,
+		config.Datadog.GetInt("dogstatsd_context_limiter.entry_timeout"),
+		config.Datadog.GetString("dogstatsd_context_limiter.key_tag_name"),
+		config.Datadog.GetStringSlice("dogstatsd_context_limiter.telemetry_tag_names"),
+	)
+}

--- a/pkg/aggregator/internal/limiter/config.go
+++ b/pkg/aggregator/internal/limiter/config.go
@@ -16,6 +16,16 @@ func FromConfig(pipelineCount int) *Limiter {
 }
 
 func fromConfig(pipelineCount int, cgroupLimitGetter func() (uint64, error)) *Limiter {
+	// If all of the following are true:
+	//
+	// - dogstatsd_context_limiter.cgroup_memory_ratio is set to a valid value
+	// - dogstatsd_context_limiter.bytes_per_context is set to a valid value
+	// - no errors occur while fetching cgroup limit
+	//
+	// Then the mem ratio based limiting will apply.
+	//
+	// Else the static limit defined by dogstatsd_context_limiter.limit will be used.
+
 	limit := 0
 	memoryRatio := config.Datadog.GetFloat64("dogstatsd_context_limiter.cgroup_memory_ratio")
 	bytesPerContext := config.Datadog.GetInt("dogstatsd_context_limiter.bytes_per_context")

--- a/pkg/aggregator/internal/limiter/config_test.go
+++ b/pkg/aggregator/internal/limiter/config_test.go
@@ -1,0 +1,40 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package limiter
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+)
+
+var mockError = errors.New("mock")
+
+func TestConfig(t *testing.T) {
+	m := config.Mock(t)
+
+	// no configuration, disabled by default
+	l := fromConfig(1, func() (uint64, error) { return 0, mockError })
+	assert.Nil(t, l)
+
+	// static limit
+	m.Set("dogstatsd_context_limiter.limit", 500)
+	l = fromConfig(1, func() (uint64, error) { return 0, mockError })
+	assert.Equal(t, 500, l.global)
+
+	// fallback to static limit with error
+	m.Set("dogstatsd_context_limiter.cgroup_memory_ratio", 0.5)
+	l = fromConfig(1, func() (uint64, error) { return 0, mockError })
+	assert.Equal(t, 500, l.global)
+
+	// memory based limit
+	m.Set("dogstatsd_context_limiter.bytes_per_context", 1500)
+	l = fromConfig(1, func() (uint64, error) { return 3_000_000, nil })
+	assert.Equal(t, 1000, l.global)
+}

--- a/pkg/aggregator/internal/limiter/limiter.go
+++ b/pkg/aggregator/internal/limiter/limiter.go
@@ -6,6 +6,7 @@
 package limiter
 
 import (
+	"math"
 	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/metrics"
@@ -15,6 +16,7 @@ import (
 type entry struct {
 	current  int // number of contexts currently in aggregator
 	rejected int // number of rejected samples
+	lastSeen int // epoch count when seen last
 
 	telemetryTags []string
 }
@@ -27,10 +29,17 @@ type Limiter struct {
 	keyTagName        string
 	telemetryTagNames []string
 	limit             int
+	global            int // global limit
+	current           int // sum(usage[*].current)
 	usage             map[string]*entry
+
+	// epoch, maxAge and lastSeen ensure eventual removal of entries that created an entry, but were
+	// never able to create contexts due to the global limit.
+	epoch  int
+	maxAge int
 }
 
-// New returns a new instance of limiter.
+// New returns a limiter with a per-key limit.
 //
 // limit is the maximum number of contexts per sender. If zero or less, the limiter is disabled.
 //
@@ -47,6 +56,20 @@ func New(limit int, keyTagName string, telemetryTagNames []string) *Limiter {
 		return nil
 	}
 
+	return newLimiter(limit, math.MaxInt, 0, keyTagName, telemetryTagNames)
+}
+
+// NewGlobal returns a limiter with a global per-instance limit, that
+// will be equally distributed between origins.
+func NewGlobal(global int, maxAge int, key string, tags []string) *Limiter {
+	if global <= 0 || global == math.MaxInt {
+		return nil
+	}
+
+	return newLimiter(0, global, maxAge, key, tags)
+}
+
+func newLimiter(limit, global int, maxAge int, keyTagName string, telemetryTagNames []string) *Limiter {
 	// Make sure all names end with a colon, so we don't accidentally match a part of the tag name, only the full name.
 	// e.g. keyTagName="pod_name" should not match the tag "pod_name_alias:foo"
 	if !strings.HasSuffix(keyTagName, ":") {
@@ -71,7 +94,9 @@ func New(limit int, keyTagName string, telemetryTagNames []string) *Limiter {
 		keyTagName:        keyTagName,
 		telemetryTagNames: telemetryTagNames,
 		limit:             limit,
+		global:            global,
 		usage:             map[string]*entry{},
+		maxAge:            maxAge,
 	}
 }
 
@@ -102,6 +127,12 @@ func (l *Limiter) extractTelemetryTags(src []string) []string {
 	return dst
 }
 
+func (l *Limiter) updateLimit() {
+	if l.global < math.MaxInt && len(l.usage) > 0 {
+		l.limit = l.global / len(l.usage)
+	}
+}
+
 // Track is called for each new context. Returns true if the sample should be accepted, false
 // otherwise.
 func (l *Limiter) Track(tags []string) bool {
@@ -117,13 +148,17 @@ func (l *Limiter) Track(tags []string) bool {
 			telemetryTags: l.extractTelemetryTags(tags),
 		}
 		l.usage[id] = e
+		l.updateLimit()
 	}
 
-	if e.current >= l.limit {
+	e.lastSeen = l.epoch
+
+	if e.current >= l.limit || l.current >= l.global {
 		e.rejected++
 		return false
 	}
 
+	l.current++
 	e.current++
 	return true
 }
@@ -137,9 +172,43 @@ func (l *Limiter) Remove(tags []string) {
 	id := l.getSenderId(tags)
 
 	if e := l.usage[id]; e != nil {
+		l.current--
 		e.current--
 		if e.current <= 0 {
 			delete(l.usage, id)
+			l.updateLimit()
+		}
+	}
+}
+
+// IsOverLimit returns true if the context sender is over the limit and the context should be
+// dropped.
+func (l *Limiter) IsOverLimit(tags []string) bool {
+	if l == nil {
+		return false
+	}
+
+	if e := l.usage[l.getSenderId(tags)]; e != nil {
+		return e.current > l.limit
+	}
+
+	return false
+}
+
+// ExpireEntries is called once per flush cycle to do internal bookkeeping and cleanups.
+func (l *Limiter) ExpireEntries() {
+	if l == nil {
+		return
+	}
+
+	if l.maxAge >= 0 {
+		l.epoch++
+		tooOld := l.epoch - l.maxAge
+		for id, e := range l.usage {
+			if e.current == 0 && e.lastSeen < tooOld {
+				delete(l.usage, id)
+				l.updateLimit()
+			}
 		}
 	}
 }
@@ -152,6 +221,24 @@ func (l *Limiter) SendTelemetry(timestamp float64, series metrics.SerieSink, hos
 
 	droppedTags := append([]string{}, constTags...)
 	droppedTags = append(droppedTags, "reason:too_many_contexts")
+
+	series.Append(&metrics.Serie{
+		Name:   "datadog.agent.aggregator.dogstatsd_context_limiter.num_origins",
+		Host:   hostname,
+		Tags:   tagset.NewCompositeTags(constTags, nil),
+		MType:  metrics.APIGaugeType,
+		Points: []metrics.Point{{Ts: timestamp, Value: float64(len(l.usage))}},
+	})
+
+	if l.global < math.MaxInt {
+		series.Append(&metrics.Serie{
+			Name:   "datadog.agent.aggregator.dogstatsd_context_limiter.global_limit",
+			Host:   hostname,
+			Tags:   tagset.NewCompositeTags(constTags, nil),
+			MType:  metrics.APIGaugeType,
+			Points: []metrics.Point{{Ts: timestamp, Value: float64(l.global)}},
+		})
+	}
 
 	for _, e := range l.usage {
 		series.Append(&metrics.Serie{

--- a/pkg/aggregator/internal/limiter/limiter.go
+++ b/pkg/aggregator/internal/limiter/limiter.go
@@ -59,7 +59,7 @@ func New(limit int, keyTagName string, telemetryTagNames []string) *Limiter {
 	return newLimiter(limit, math.MaxInt, 0, keyTagName, telemetryTagNames)
 }
 
-// NewGlobal returns a limiter with a global per-instance limit, that
+// NewGlobal returns a limiter with a global limit which will be equally split between senders
 // will be equally distributed between origins.
 func NewGlobal(global int, maxAge int, key string, tags []string) *Limiter {
 	if global <= 0 || global == math.MaxInt {

--- a/pkg/aggregator/internal/limiter/limiter.go
+++ b/pkg/aggregator/internal/limiter/limiter.go
@@ -62,15 +62,15 @@ func New(limit int, keyTagName string, telemetryTagNames []string) *Limiter {
 
 // NewGlobal returns a limiter with a global limit which will be equally split between senders
 // will be equally distributed between origins.
-func NewGlobal(global int, maxAge int, key string, tags []string) *Limiter {
+func NewGlobal(global int, expireCountInterval int, key string, tags []string) *Limiter {
 	if global <= 0 || global == math.MaxInt {
 		return nil
 	}
 
-	return newLimiter(0, global, maxAge, key, tags)
+	return newLimiter(0, global, expireCountInterval, key, tags)
 }
 
-func newLimiter(limit, global int, maxAge int, keyTagName string, telemetryTagNames []string) *Limiter {
+func newLimiter(limit, global int, expireCountInterval int, keyTagName string, telemetryTagNames []string) *Limiter {
 	// Make sure all names end with a colon, so we don't accidentally match a part of the tag name, only the full name.
 	// e.g. keyTagName="pod_name" should not match the tag "pod_name_alias:foo"
 	if !strings.HasSuffix(keyTagName, ":") {
@@ -97,7 +97,7 @@ func newLimiter(limit, global int, maxAge int, keyTagName string, telemetryTagNa
 		limit:               limit,
 		global:              global,
 		usage:               map[string]*entry{},
-		expireCountInterval: maxAge,
+		expireCountInterval: expireCountInterval,
 	}
 }
 

--- a/pkg/aggregator/internal/limiter/limiter.go
+++ b/pkg/aggregator/internal/limiter/limiter.go
@@ -39,7 +39,7 @@ type Limiter struct {
 	maxAge int
 }
 
-// New returns a limiter with a per-key limit.
+// New returns a limiter with a per-sender limit.
 //
 // limit is the maximum number of contexts per sender. If zero or less, the limiter is disabled.
 //

--- a/pkg/aggregator/internal/limiter/memory.go
+++ b/pkg/aggregator/internal/limiter/memory.go
@@ -1,0 +1,16 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !linux
+
+package limiter
+
+import (
+	"errors"
+)
+
+func getCgroupMemoryLimit() (uint64, error) {
+	return 0, errors.New("cgroup memory limit is only supported on Linux")
+}

--- a/pkg/aggregator/internal/limiter/memory_linux.go
+++ b/pkg/aggregator/internal/limiter/memory_linux.go
@@ -1,0 +1,35 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+package limiter
+
+import (
+	"errors"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/cgroups"
+)
+
+func getCgroupMemoryLimit() (uint64, error) {
+	selfReader, err := cgroups.NewSelfReader("/proc", config.IsContainerized())
+	if err != nil {
+		return 0, err
+	}
+	cgroup := selfReader.GetCgroup(cgroups.SelfCgroupIdentifier)
+	if cgroup == nil {
+		return 0, errors.New("cannot get cgroup")
+	}
+	var stats cgroups.MemoryStats
+	if err := cgroup.GetMemoryStats(&stats); err != nil {
+		return 0, err
+	}
+	if stats.Limit == nil || *stats.Limit == 0 {
+		return 0, errors.New("cannot get cgroup memory limit")
+	}
+
+	return *stats.Limit, nil
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -558,7 +558,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("dogstatsd_mem_based_rate_limiter.soft_limit_freeos_check.max", 0.1)
 	config.BindEnvAndSetDefault("dogstatsd_mem_based_rate_limiter.soft_limit_freeos_check.factor", 1.5)
 
-	config.BindEnvAndSetDefault("dogstatsd_context_limiter.limit", 0) // 0 = disabled.
+	config.BindEnvAndSetDefault("dogstatsd_context_limiter.limit", 0)         // 0 = disabled.
 	config.BindEnvAndSetDefault("dogstatsd_context_limiter.entry_timeout", 1) // number of flush intervals
 	config.BindEnvAndSetDefault("dogstatsd_context_limiter.key_tag_name", "pod_name")
 	config.BindEnvAndSetDefault("dogstatsd_context_limiter.telemetry_tag_names", []string{})

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -562,6 +562,8 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("dogstatsd_context_limiter.entry_timeout", 1) // number of flush intervals
 	config.BindEnvAndSetDefault("dogstatsd_context_limiter.key_tag_name", "pod_name")
 	config.BindEnvAndSetDefault("dogstatsd_context_limiter.telemetry_tag_names", []string{})
+	config.BindEnvAndSetDefault("dogstatsd_context_limiter.bytes_per_context", 1500)
+	config.BindEnvAndSetDefault("dogstatsd_context_limiter.cgroup_memory_ratio", 0.0)
 
 	config.BindEnv("dogstatsd_mapper_profiles")
 	config.SetEnvKeyTransformer("dogstatsd_mapper_profiles", func(in string) interface{} {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -559,6 +559,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("dogstatsd_mem_based_rate_limiter.soft_limit_freeos_check.factor", 1.5)
 
 	config.BindEnvAndSetDefault("dogstatsd_context_limiter.limit", 0) // 0 = disabled.
+	config.BindEnvAndSetDefault("dogstatsd_context_limiter.entry_timeout", 1) // number of flush intervals
 	config.BindEnvAndSetDefault("dogstatsd_context_limiter.key_tag_name", "pod_name")
 	config.BindEnvAndSetDefault("dogstatsd_context_limiter.telemetry_tag_names", []string{})
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Add a global dogstatsd contexts limit, which can be set either directly, or as a proportion of the cgroup memory limit.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Make per-origin limits added in #16734 more flexible, allowing fuller utilization of agent memory.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

`removeOverLimit` appears to be slow, but with it running only once every flush, the average overhead from it does not exceed 1% of overall cpu time.

### Describe how to test/QA your changes

Run the agent in docker with a memory limit:

```
-m 1024M
-v /tmp:/tmp
-e DD_DOGSTATSD_SOCKET=/tmp/dsd.sock
-e DD_DOGSTATSD_CONTEXT_LIMITER_CGROUP_MEMORY_RATIO=0.25
-e DD_LOG_LEVEL=debug
```

Send a lot of dogstatsd contexts, the agent RSS should stay within the limit (1024Mb) and the agent should not crash.

Set an API key and verify that regular dogstatsd traffic goes through the agent unhindered.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
