### PR TITLE
[usm] Improve `incompleteBuffer`

### DIFF
--- a/pkg/network/protocols/http/incomplete_stats.go
+++ b/pkg/network/protocols/http/incomplete_stats.go
@@ -64,7 +64,7 @@ func newTXParts() *txParts {
 
 func newIncompleteBuffer(c *config.Config, telemetry *Telemetry) *incompleteBuffer {
 	// Only set aside a fraction of MaxHTTPBuffered for incomplete data
-	// as this should only be used rarely (as described in the example below).
+	// as this should only be used rarely (as described in the example above).
 	// If our telemetry indicates that this buffer is filling up often, we need
 	// to better understand what is going on and reassess our approach
 	maxEntries := c.MaxHTTPStatsBuffered / 10

--- a/pkg/network/protocols/http/incomplete_stats.go
+++ b/pkg/network/protocols/http/incomplete_stats.go
@@ -43,10 +43,11 @@ const defaultMinAge = 30 * time.Second
 // request segment at "t0" with response segment "t3". This is why we buffer data here for 30 seconds
 // and then sort all events by their timestamps before joining them.
 type incompleteBuffer struct {
-	data       map[types.ConnectionKey]*txParts
-	maxEntries int
-	telemetry  *Telemetry
-	minAgeNano int64
+	data         map[types.ConnectionKey]*txParts
+	totalEntries int
+	maxEntries   int
+	telemetry    *Telemetry
+	minAgeNano   int64
 }
 
 type txParts struct {
@@ -62,15 +63,26 @@ func newTXParts() *txParts {
 }
 
 func newIncompleteBuffer(c *config.Config, telemetry *Telemetry) *incompleteBuffer {
+	// Only set aside a fraction of MaxHTTPBuffered for incomplete data
+	// as this should only be used rarely (as described in the example below).
+	// If our telemetry indicates that this buffer is filling up often, we need
+	// to better understand what is going on and reassess our approach
+	maxEntries := c.MaxHTTPStatsBuffered / 10
+
 	return &incompleteBuffer{
 		data:       make(map[types.ConnectionKey]*txParts),
-		maxEntries: c.MaxHTTPStatsBuffered,
+		maxEntries: maxEntries,
 		telemetry:  telemetry,
 		minAgeNano: defaultMinAge.Nanoseconds(),
 	}
 }
 
 func (b *incompleteBuffer) Add(tx HttpTX) {
+	if b.totalEntries >= b.maxEntries {
+		b.telemetry.dropped.Add(1)
+		return
+	}
+
 	connTuple := tx.ConnTuple()
 	key := types.ConnectionKey{
 		SrcIPHigh: connTuple.SrcIPHigh,
@@ -80,14 +92,10 @@ func (b *incompleteBuffer) Add(tx HttpTX) {
 
 	parts, ok := b.data[key]
 	if !ok {
-		if len(b.data) >= b.maxEntries {
-			b.telemetry.dropped.Add(1)
-			return
-		}
-
 		parts = newTXParts()
 		b.data[key] = parts
 	}
+	b.totalEntries++
 
 	// copy underlying httpTX value. this is now needed because these objects are
 	// now coming directly from pooled perf records
@@ -116,6 +124,7 @@ func (b *incompleteBuffer) Flush(now time.Time) []HttpTX {
 	)
 
 	b.data = make(map[types.ConnectionKey]*txParts)
+	b.totalEntries = 0
 	for key, parts := range previous {
 		// TODO: in this loop we're sorting all transactions at once, but we could also
 		// consider sorting data during insertion time (using a tree-like structure, for example)
@@ -148,6 +157,7 @@ func (b *incompleteBuffer) Flush(now time.Time) []HttpTX {
 				parts := newTXParts()
 				parts.requests = append(parts.requests, keep...)
 				b.data[key] = parts
+				b.totalEntries += len(parts.requests)
 				break
 			}
 			i++

--- a/pkg/network/protocols/http/incomplete_stats.go
+++ b/pkg/network/protocols/http/incomplete_stats.go
@@ -96,6 +96,7 @@ func (b *incompleteBuffer) Add(tx HttpTX) {
 		b.data[key] = parts
 	}
 	b.totalEntries++
+	b.telemetry.newIncomplete.Add(1)
 
 	// copy underlying httpTX value. this is now needed because these objects are
 	// now coming directly from pooled perf records
@@ -123,6 +124,7 @@ func (b *incompleteBuffer) Flush(now time.Time) []HttpTX {
 		nowUnix  = now.UnixNano()
 	)
 
+	b.telemetry.totalIncomplete.Add(int64(b.totalEntries))
 	b.data = make(map[types.ConnectionKey]*txParts)
 	b.totalEntries = 0
 	for key, parts := range previous {
@@ -164,6 +166,7 @@ func (b *incompleteBuffer) Flush(now time.Time) []HttpTX {
 		}
 	}
 
+	b.telemetry.joinedIncomplete.Add(int64(len(joined)))
 	return joined
 }
 

--- a/pkg/network/protocols/http/incomplete_stats_test.go
+++ b/pkg/network/protocols/http/incomplete_stats_test.go
@@ -9,9 +9,10 @@
 package http
 
 import (
-	"golang.org/x/net/http2/hpack"
 	"testing"
 	"time"
+
+	"golang.org/x/net/http2/hpack"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -75,6 +76,38 @@ func TestOrphanEntries(t *testing.T) {
 		_ = buffer.Flush(now)
 		assert.True(t, len(buffer.data) == 0)
 	})
+}
+
+func TestBufferLimit(t *testing.T) {
+	now := time.Now()
+	tel, err := NewTelemetry()
+	require.NoError(t, err)
+
+	buffer := newIncompleteBuffer(config.New(), tel)
+
+	// Attempt to insert more data then allowed
+	// Since all incomplete parts share the same tuple, this will generate
+	// *one* map key, with many "parts" appended to it
+	//
+	// We're asserting here that our buffer counts the total number of entries
+	// included in the nested structures, and not only the map keys
+	for i := 0; i < 2*buffer.maxEntries; i++ {
+		request := &EbpfHttpTx{
+			Request_fragment: requestFragment([]byte("GET /foo/bar")),
+			Request_started:  uint64(now.UnixNano()),
+		}
+		request.Tup.Sport = 60000
+		buffer.Add(request)
+	}
+
+	// Count total entries
+	total := 0
+	for _, parts := range buffer.data {
+		total += len(parts.requests) + len(parts.responses)
+	}
+
+	// Assert that buffer honored the max number of entries allowed
+	assert.Equal(t, buffer.maxEntries, total)
 }
 
 func TestHTTP2Path(t *testing.T) {

--- a/pkg/network/protocols/http/incomplete_stats_test.go
+++ b/pkg/network/protocols/http/incomplete_stats_test.go
@@ -85,7 +85,7 @@ func TestBufferLimit(t *testing.T) {
 
 	buffer := newIncompleteBuffer(config.New(), tel)
 
-	// Attempt to insert more data then allowed
+	// Attempt to insert more data than allowed
 	// Since all incomplete parts share the same tuple, this will generate
 	// *one* map key, with many "parts" appended to it
 	//

--- a/pkg/network/protocols/http/telemetry.go
+++ b/pkg/network/protocols/http/telemetry.go
@@ -25,6 +25,10 @@ type Telemetry struct {
 	rejected     *libtelemetry.Metric // this happens when an user-defined reject-filter matches a request
 	malformed    *libtelemetry.Metric // this happens when the request doesn't have the expected format
 	aggregations *libtelemetry.Metric
+
+	newIncomplete    *libtelemetry.Metric
+	totalIncomplete  *libtelemetry.Metric
+	joinedIncomplete *libtelemetry.Metric
 }
 
 func NewTelemetry() (*Telemetry, error) {
@@ -42,6 +46,11 @@ func NewTelemetry() (*Telemetry, error) {
 		hits4XX:      metricGroup.NewMetric("hits4xx"),
 		hits5XX:      metricGroup.NewMetric("hits5xx"),
 		aggregations: metricGroup.NewMetric("aggregations"),
+
+		// metrics from `incompleteBuffer`
+		newIncomplete:    metricGroup.NewMetric("new_incomplete"),
+		totalIncomplete:  metricGroup.NewMetric("total_incomplete"),
+		joinedIncomplete: metricGroup.NewMetric("joined_incomplete"),
 
 		// these metrics are also exported as statsd metrics
 		totalHits: metricGroup.NewMetric("total_hits", libtelemetry.OptStatsd),
@@ -84,11 +93,14 @@ func (t *Telemetry) Log() {
 	rejected := t.rejected.Delta()
 	malformed := t.malformed.Delta()
 	aggregations := t.aggregations.Delta()
+	newIncomplete := t.newIncomplete.Delta()
+	joinedIncomplete := t.joinedIncomplete.Delta()
+	totalIncomplete := t.totalIncomplete.Delta()
 	elapsed := now - t.LastCheck.Load()
 	t.LastCheck.Store(now)
 
 	log.Debugf(
-		"http stats summary: requests_processed=%d(%.2f/s) requests_dropped=%d(%.2f/s) requests_rejected=%d(%.2f/s) requests_malformed=%d(%.2f/s) aggregations=%d",
+		"http stats summary: requests_processed=%d(%.2f/s) requests_dropped=%d(%.2f/s) requests_rejected=%d(%.2f/s) requests_malformed=%d(%.2f/s) incomplete_parts=%d(%.2f/s) incomplete_parts_joined=%d(%.2f/s) incomplete_parts_accumulated=%d aggregations=%d",
 		totalRequests,
 		float64(totalRequests)/float64(elapsed),
 		dropped,
@@ -97,6 +109,11 @@ func (t *Telemetry) Log() {
 		float64(rejected)/float64(elapsed),
 		malformed,
 		float64(malformed)/float64(elapsed),
+		newIncomplete,
+		float64(newIncomplete)/float64(elapsed),
+		joinedIncomplete,
+		float64(joinedIncomplete)/float64(elapsed),
+		totalIncomplete,
 		aggregations,
 	)
 }

--- a/pkg/network/usm/monitor.go
+++ b/pkg/network/usm/monitor.go
@@ -267,8 +267,9 @@ func (m *Monitor) GetHTTPStats() map[http.Key]*http.RequestStats {
 		return nil
 	}
 
+	defer m.httpTelemetry.Log()
+
 	m.httpConsumer.Sync()
-	m.httpTelemetry.Log()
 	return m.httpStatkeeper.GetAndResetAllStats()
 }
 
@@ -279,8 +280,9 @@ func (m *Monitor) GetHTTP2Stats() map[http.Key]*http.RequestStats {
 		return nil
 	}
 
+	defer m.http2Telemetry.Log()
+
 	m.http2Consumer.Sync()
-	m.http2Telemetry.Log()
 	return m.http2Statkeeper.GetAndResetAllStats()
 }
 
@@ -290,8 +292,9 @@ func (m *Monitor) GetKafkaStats() map[kafka.Key]*kafka.RequestStat {
 		return nil
 	}
 
+	defer m.kafkaTelemetry.Log()
+
 	m.kafkaConsumer.Sync()
-	m.kafkaTelemetry.Log()
 	return m.kafkaStatkeeper.GetAndResetAllStats()
 }
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

* Improves the way limits are enforced on `incompleteBuffer` 
* Add telemetry for incomplete data
* Reduce total number of data points buffered in `incompleteBuffer`

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Changes covered by unit test

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
