### PR TITLE
[Serverless] Increase timeout for appsec monitoring test from 4ms to 2s.

### DIFF
--- a/pkg/serverless/appsec/appsec_test.go
+++ b/pkg/serverless/appsec/appsec_test.go
@@ -52,6 +52,7 @@ func TestMonitor(t *testing.T) {
 	}
 
 	t.Setenv("DD_SERVERLESS_APPSEC_ENABLED", "true")
+	t.Setenv("DD_APPSEC_WAF_TIMEOUT", "2s")
 	asm, err := newAppSec()
 	require.NoError(t, err)
 	require.Nil(t, err)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Increases the timeout in the `TestMonitor` test from the default 4ms to 2s.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

We are seeing very [sporadic failures](https://app.datadoghq.com/ci/test-runs?query=test_level%3Atest%20%40ci.pipeline.name%3A%22DataDog%2Fdatadog-agent%22%20%40test.codeowners%3A%22%40DataDog%2Fserverless%22%20%40test.status%3Afail%20%40test.name%3ATestMonitor&cols=%40test.name%2C%40duration%2C%40test.service%2C%40git.branch%2C%40ci.job.name&currentTab=overview&eventStack=&index=citest&start=1676487598225&end=1684263598225&paused=true) of this test.

Note that I was not able to reproduce the test failure locally, so this solution is just an educated guess. I was able to show that if the timeout is too low (by setting it to `1ns` for example) then the test will fail with the same error.

Note that all failures are part of the `tests_macos` suite. I assume this is significant in some way, I'm just not sure how.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
