### PR TITLE
[backport][usm] Improve `incompleteBuffer`

### DIFF
--- a/pkg/network/protocols/http/incomplete_stats.go
+++ b/pkg/network/protocols/http/incomplete_stats.go
@@ -64,7 +64,7 @@ func newTXParts() *txParts {
 
 func newIncompleteBuffer(c *config.Config, telemetry *telemetry) *incompleteBuffer {
 	// Only set aside a fraction of MaxHTTPBuffered for incomplete data
-	// as this should only be used rarely (as described in the example below).
+	// as this should only be used rarely (as described in the example above).
 	// If our telemetry indicates that this buffer is filling up often, we need
 	// to better understand what is going on and reassess our approach
 	maxEntries := c.MaxHTTPStatsBuffered / 10

--- a/pkg/network/protocols/http/incomplete_stats.go
+++ b/pkg/network/protocols/http/incomplete_stats.go
@@ -96,6 +96,7 @@ func (b *incompleteBuffer) Add(tx httpTX) {
 		b.data[key] = parts
 	}
 	b.totalEntries++
+	b.telemetry.newIncomplete.Add(1)
 
 	// copy underlying httpTX value. this is now needed because these objects are
 	// now coming directly from pooled perf records
@@ -123,6 +124,7 @@ func (b *incompleteBuffer) Flush(now time.Time) []httpTX {
 		nowUnix  = now.UnixNano()
 	)
 
+	b.telemetry.totalIncomplete.Add(int64(b.totalEntries))
 	b.data = make(map[types.ConnectionKey]*txParts)
 	b.totalEntries = 0
 	for key, parts := range previous {
@@ -164,6 +166,7 @@ func (b *incompleteBuffer) Flush(now time.Time) []httpTX {
 		}
 	}
 
+	b.telemetry.joinedIncomplete.Add(int64(len(joined)))
 	return joined
 }
 

--- a/pkg/network/protocols/http/incomplete_stats_test.go
+++ b/pkg/network/protocols/http/incomplete_stats_test.go
@@ -77,7 +77,7 @@ func TestBufferLimit(t *testing.T) {
 
 	buffer := newIncompleteBuffer(config.New(), tel)
 
-	// Attempt to insert more data then allowed
+	// Attempt to insert more data than allowed
 	// Since all incomplete parts share the same tuple, this will generate
 	// *one* map key, with many "parts" appended to it
 	//

--- a/pkg/network/protocols/http/monitor.go
+++ b/pkg/network/protocols/http/monitor.go
@@ -14,13 +14,12 @@ import (
 	"syscall"
 	"unsafe"
 
-	"github.com/DataDog/datadog-agent/pkg/network/ebpf/probes"
-
 	"github.com/cilium/ebpf"
 
 	manager "github.com/DataDog/ebpf-manager"
 
 	"github.com/DataDog/datadog-agent/pkg/network/config"
+	"github.com/DataDog/datadog-agent/pkg/network/ebpf/probes"
 	filterpkg "github.com/DataDog/datadog-agent/pkg/network/filter"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/events"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/kafka"

--- a/pkg/network/protocols/http/monitor.go
+++ b/pkg/network/protocols/http/monitor.go
@@ -11,9 +11,10 @@ package http
 import (
 	"errors"
 	"fmt"
-	"github.com/DataDog/datadog-agent/pkg/network/ebpf/probes"
 	"syscall"
 	"unsafe"
+
+	"github.com/DataDog/datadog-agent/pkg/network/ebpf/probes"
 
 	"github.com/cilium/ebpf"
 
@@ -256,8 +257,9 @@ func (m *Monitor) GetHTTPStats() map[Key]*RequestStats {
 		return nil
 	}
 
+	defer m.httpTelemetry.log()
+
 	m.httpConsumer.Sync()
-	m.httpTelemetry.log()
 	return m.statkeeper.GetAndResetAllStats()
 }
 
@@ -268,8 +270,9 @@ func (m *Monitor) GetHTTP2Stats() map[Key]*RequestStats {
 		return nil
 	}
 
+	defer m.http2Telemetry.log()
+
 	m.http2Consumer.Sync()
-	m.http2Telemetry.log()
 	return m.http2Statkeeper.GetAndResetAllStats()
 }
 
@@ -279,8 +282,9 @@ func (m *Monitor) GetKafkaStats() map[kafka.Key]*kafka.RequestStat {
 		return nil
 	}
 
+	defer m.kafkaTelemetry.Log()
+
 	m.kafkaConsumer.Sync()
-	m.kafkaTelemetry.Log()
 	return m.kafkaStatkeeper.GetAndResetAllStats()
 }
 

--- a/pkg/network/protocols/http/telemetry.go
+++ b/pkg/network/protocols/http/telemetry.go
@@ -27,6 +27,10 @@ type telemetry struct {
 	rejected     *libtelemetry.Metric // this happens when an user-defined reject-filter matches a request
 	malformed    *libtelemetry.Metric // this happens when the request doesn't have the expected format
 	aggregations *libtelemetry.Metric
+
+	newIncomplete    *libtelemetry.Metric
+	totalIncomplete  *libtelemetry.Metric
+	joinedIncomplete *libtelemetry.Metric
 }
 
 func newTelemetry() (*telemetry, error) {
@@ -44,6 +48,11 @@ func newTelemetry() (*telemetry, error) {
 		hits4XX:      metricGroup.NewMetric("hits4xx"),
 		hits5XX:      metricGroup.NewMetric("hits5xx"),
 		aggregations: metricGroup.NewMetric("aggregations"),
+
+		// metrics from `incompleteBuffer`
+		newIncomplete:    metricGroup.NewMetric("new_incomplete"),
+		totalIncomplete:  metricGroup.NewMetric("total_incomplete"),
+		joinedIncomplete: metricGroup.NewMetric("joined_incomplete"),
 
 		// these metrics are also exported as statsd metrics
 		totalHits: metricGroup.NewMetric("total_hits", libtelemetry.OptStatsd),
@@ -81,10 +90,13 @@ func (t *telemetry) log() {
 	rejected := t.rejected.Delta()
 	malformed := t.malformed.Delta()
 	aggregations := t.aggregations.Delta()
+	newIncomplete := t.newIncomplete.Delta()
+	joinedIncomplete := t.joinedIncomplete.Delta()
+	totalIncomplete := t.totalIncomplete.Delta()
 	elapsed := now - then
 
 	log.Debugf(
-		"http stats summary: requests_processed=%d(%.2f/s) requests_dropped=%d(%.2f/s) requests_rejected=%d(%.2f/s) requests_malformed=%d(%.2f/s) aggregations=%d",
+		"http stats summary: requests_processed=%d(%.2f/s) requests_dropped=%d(%.2f/s) requests_rejected=%d(%.2f/s) requests_malformed=%d(%.2f/s) incomplete_parts=%d(%.2f/s) incomplete_parts_joined=%d(%.2f/s) incomplete_parts_accumulated=%d aggregations=%d",
 		totalRequests,
 		float64(totalRequests)/float64(elapsed),
 		dropped,
@@ -93,6 +105,11 @@ func (t *telemetry) log() {
 		float64(rejected)/float64(elapsed),
 		malformed,
 		float64(malformed)/float64(elapsed),
+		newIncomplete,
+		float64(newIncomplete)/float64(elapsed),
+		joinedIncomplete,
+		float64(joinedIncomplete)/float64(elapsed),
+		totalIncomplete,
 		aggregations,
 	)
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Backport of https://github.com/DataDog/datadog-agent/pull/17164/

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
