### PR TITLE
[CSPM] Fix nil dogstatsdclient interface

### DIFF
--- a/cmd/security-agent/subcommands/check/command.go
+++ b/cmd/security-agent/subcommands/check/command.go
@@ -104,7 +104,7 @@ func RunCheck(log log.Component, config config.Component, checkArgs *CliParams) 
 		return err
 	}
 
-	var statsdClient ddgostatsd.ClientInterface
+	var statsdClient *ddgostatsd.Client
 	metricsEnabled := config.GetBool("compliance_config.metrics.enabled")
 	if metricsEnabled {
 		// Create a statsd Client

--- a/cmd/security-agent/subcommands/compliance/compliance.go
+++ b/cmd/security-agent/subcommands/compliance/compliance.go
@@ -41,23 +41,25 @@ func StartCompliance(log log.Component, config config.Component, hostname string
 	if err != nil {
 		return nil, err
 	}
+
+	resolverOptions := compliance.ResolverOptions{
+		Hostname:           hostname,
+		HostRoot:           os.Getenv("HOST_ROOT"),
+		DockerProvider:     compliance.DefaultDockerProvider,
+		LinuxAuditProvider: compliance.DefaultLinuxAuditProvider,
+		StatsdClient:       statsdClient,
+	}
 	if !metricsEnabled {
-		statsdClient = nil
+		resolverOptions.StatsdClient = nil
 	}
 
 	runner := runner.NewRunner()
 	stopper.Add(runner)
 	agent := compliance.NewAgent(compliance.AgentOptions{
-		ResolverOptions: compliance.ResolverOptions{
-			Hostname:           hostname,
-			HostRoot:           os.Getenv("HOST_ROOT"),
-			DockerProvider:     compliance.DefaultDockerProvider,
-			LinuxAuditProvider: compliance.DefaultLinuxAuditProvider,
-			StatsdClient:       statsdClient,
-		},
-		ConfigDir:     configDir,
-		Reporter:      reporter,
-		CheckInterval: checkInterval,
+		ResolverOptions: resolverOptions,
+		ConfigDir:       configDir,
+		Reporter:        reporter,
+		CheckInterval:   checkInterval,
 	})
 	err = agent.Start()
 	if err != nil {

--- a/cmd/security-agent/subcommands/compliance/compliance.go
+++ b/cmd/security-agent/subcommands/compliance/compliance.go
@@ -47,10 +47,10 @@ func StartCompliance(log log.Component, config config.Component, hostname string
 		HostRoot:           os.Getenv("HOST_ROOT"),
 		DockerProvider:     compliance.DefaultDockerProvider,
 		LinuxAuditProvider: compliance.DefaultLinuxAuditProvider,
-		StatsdClient:       statsdClient,
 	}
-	if !metricsEnabled {
-		resolverOptions.StatsdClient = nil
+
+	if metricsEnabled {
+		resolverOptions.StatsdClient = statsdClient
 	}
 
 	runner := runner.NewRunner()

--- a/pkg/compliance/resolver.go
+++ b/pkg/compliance/resolver.go
@@ -69,7 +69,7 @@ func DefaultLinuxAuditProvider(ctx context.Context) (LinuxAuditClient, error) {
 type ResolverOptions struct {
 	Hostname     string
 	HostRoot     string
-	StatsdClient statsd.ClientInterface
+	StatsdClient *statsd.Client
 
 	DockerProvider
 	KubernetesProvider

--- a/pkg/compliance/tests/process_test.go
+++ b/pkg/compliance/tests/process_test.go
@@ -195,9 +195,7 @@ valid(p) {
 }
 
 findings[f] {
-	count(input.process) == 2
-	valid(input.process[0])
-	valid(input.process[1])
+	count([p | p := input.process[_]; valid(p)]) == 2
 	f := dd.passed_finding(
 		"sleep",
 		"sleep",


### PR DESCRIPTION
### What does this PR do?

Fixes a case where `dogstatsd.ClientInterface` wrapped a `nil` value.

### Motivation

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
