### PR TITLE
[Github actions] Use cache by default for python requirements

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -24,10 +24,8 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.9.16'
-
-      - name: Install Python requirements
-        run: |
-          pip3 install -r requirements.txt
+          cache: 'pip'
+      - run: pip3 install -r requirements.txt
 
       - name: Setup env variables
         run: |

--- a/.github/workflows/cws-btfhub-sync.yml
+++ b/.github/workflows/cws-btfhub-sync.yml
@@ -30,15 +30,12 @@ jobs:
         with:
           python-version: '3.9'
           cache: 'pip'
+      - run: pip install -r requirements.txt
 
       - name: Install go
         uses: actions/setup-go@v4
         with:
           go-version-file: '.go-version'
-
-      - name: Install python requirements
-        run: |
-          pip install -r requirements.txt
 
       - name: Install go deps
         run: |

--- a/.github/workflows/go_mod_tidy.yml
+++ b/.github/workflows/go_mod_tidy.yml
@@ -33,6 +33,7 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: '3.9.12'
+        cache: 'pip'
     - name: Install python requirements.txt
       run: python3 -m pip install -r requirements.txt
     - name: Go mod tidy

--- a/.github/workflows/windows-lint-go.yml
+++ b/.github/workflows/windows-lint-go.yml
@@ -24,6 +24,10 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.9.5'
+          cache: 'pip'
+      - run: |
+          python -m pip install -r requirements.txt
+          If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
 
       - name: Install go
         uses: actions/setup-go@v3
@@ -34,8 +38,6 @@ jobs:
         run: |
           $ErrorActionPreference = 'Stop';
           # install dependencies
-          python -m pip install -r requirements.txt
-          If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
           inv -e install-tools
           If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
           inv -e deps

--- a/.github/workflows/windows-unittests.yml
+++ b/.github/workflows/windows-unittests.yml
@@ -24,6 +24,10 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.9.5'
+          cache: 'pip'
+      - run: |
+          python -m pip install -r requirements.txt
+          If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
 
       - name: Install go
         uses: actions/setup-go@v3
@@ -34,8 +38,6 @@ jobs:
         run: |
           $ErrorActionPreference = 'Stop';
           # install dependencies
-          python -m pip install -r requirements.txt
-          If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
           inv -e install-tools
           If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
           inv -e deps


### PR DESCRIPTION
### What does this PR do?

Bundle `pip install` command in python setup step, and use cache y default

### Motivation
Micro optimisation and readability improvement

### Additional Notes


### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes
n/a

### Reviewer's Checklist


- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
