### PR TITLE
Fix the issue that enable 'logs_config.file_wildcard_selection_mode: `by_name`'config in default datadog.yaml causing agent startup error

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1163,8 +1163,8 @@ api_key:
   #
   # open_files_limit: 500
 
-  ## @param file_wildcard_selection_mode - string - optional - default: `by_name`
-  ## @env DD_LOGS_CONFIG_FILE_WILDCARD_SELECTION_MODE - string - optional - default: `by_name`
+  ## @param file_wildcard_selection_mode - string - optional - default: by_name
+  ## @env DD_LOGS_CONFIG_FILE_WILDCARD_SELECTION_MODE - string - optional - default: by_name
   ## The strategy used to prioritize wildcard matches if they exceed the open file limit.
   ##
   ## Choices are `by_name` and `by_modification_time`.
@@ -1182,7 +1182,7 @@ api_key:
   ## WARNING: `by_modification_time` is less performant than `by_name` and will trigger
   ## more disk I/O at the configured wildcard log paths.
   #
-  # file_wildcard_selection_mode: `by_name`
+  # file_wildcard_selection_mode: by_name
 
 {{ end -}}
 {{- if .TraceAgent }}


### PR DESCRIPTION
After compiled datadog-agent，I found logs_config.file_wildcard_selection_mode config in datadog.yaml as followiing：
\# file_wildcard_selection_mode: \`by_name\` 
when I open the comment，causing agent startup error as following：
`Error: unable to load Datadog config file: While parsing config: yaml: line 1145`
So I adjusted it to **_file_wildcard_selection_mode: by_name_**
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
