### PR TITLE
macOS install script DD_AGENT_DIST_CHANNEL support

### DIFF
--- a/cmd/agent/install_mac_os.sh
+++ b/cmd/agent/install_mac_os.sh
@@ -40,6 +40,11 @@ if [ -n "$DD_SITE" ]; then
     site=$DD_SITE
 fi
 
+agent_dist_channel=
+if [ -n "$DD_AGENT_DIST_CHANNEL" ]; then
+    agent_dist_channel="$DD_AGENT_DIST_CHANNEL"
+fi
+
 if [ -n "$DD_AGENT_MINOR_VERSION" ]; then
   # Examples:
   #  - 20   = defaults to highest patch version x.20.2
@@ -172,7 +177,12 @@ if [ -z "$dmg_version" ]; then
         dmg_version="${agent_major_version}.${agent_minor_version}-1"
     fi
 fi
-dmg_url="$dmg_base_url/datadog-agent-${dmg_version}.dmg"
+
+if [ -z "$agent_dist_channel" ]; then
+    dmg_url="$dmg_base_url/datadog-agent-${dmg_version}.dmg"
+else
+    dmg_url="$dmg_base_url/$agent_dist_channel/datadog-agent-${dmg_version}.dmg"
+fi
 
 if [ "$upgrade" ]; then
     if [ ! -f $etc_dir/datadog.conf ]; then


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Allows the macOS install script to use the ``DD_AGENT_DIST_CHANNEL`` environment variable to access ``.dmg`` in unstable s3 bucket like RCs.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

RC minor version handling has been added in #16143, without ``DD_AGENT_DIST_CHANNEL`` we can't access unstable builds even if the install script is able to correctly parse the minor version.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

  - Check that you can correctly install the latest version of the agent
  - Check that you can install an RC builds here's an example : 
    - ``DD_API_KEY=<API_KEY> DD_SITE="datadoghq.com" DD_REPO_URL="http://s3.amazonaws.com/dd-agent-macostesting" DD_AGENT_DIST_CHANNEL=beta DD_AGENT_MINOR_VERSION=45.0-rc.4 ./cmd/agent/install_mac_os.sh``

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
