### PR TITLE
[rpm] Escape rpm query format in the posttrans script

### DIFF
--- a/omnibus/package-scripts/agent-rpm/posttrans
+++ b/omnibus/package-scripts/agent-rpm/posttrans
@@ -85,7 +85,7 @@ if [ ! -f "$CONFIG_DIR/install_info" ]; then
         # it as a macro (which would expand to the version of Agent being built).
         # NOTE: on some distros (e.g. opensuse 15.4), "rpm" package doesn't exist,
         # it's called "rpm-ndb". We query version of package which contains /bin/rpm file.
-        tool_version=rpm-$(rpm -qf /bin/rpm --queryformat "%%{VERSION}" || echo "unknown")
+        tool_version=rpm-$(rpm -q -f /bin/rpm --queryformat "%%{VERSION}" || echo "unknown")
     else
         tool=unknown
         tool_version=unknown

--- a/omnibus/package-scripts/agent-rpm/posttrans
+++ b/omnibus/package-scripts/agent-rpm/posttrans
@@ -80,7 +80,10 @@ if [ ! -f "$CONFIG_DIR/install_info" ]; then
 
     if command -v rpm >/dev/null 2>&1; then
         tool=rpm
-        tool_version=rpm-$(rpm -q --qf "%{VERSION}" rpm || echo "unknown")
+        # Omnibus will put this script verbatim inside RPM specfile before building.
+        # We need to escape the "%" so that the rpm build machinery doesn't expand
+        # it as a macro (which would expand to the version of Agent being built).
+        tool_version=rpm-$(rpm -q --qf "%%{VERSION}" rpm || echo "unknown")
     else
         tool=unknown
         tool_version=unknown

--- a/omnibus/package-scripts/agent-rpm/posttrans
+++ b/omnibus/package-scripts/agent-rpm/posttrans
@@ -83,7 +83,9 @@ if [ ! -f "$CONFIG_DIR/install_info" ]; then
         # Omnibus will put this script verbatim inside RPM specfile before building.
         # We need to escape the "%" so that the rpm build machinery doesn't expand
         # it as a macro (which would expand to the version of Agent being built).
-        tool_version=rpm-$(rpm -q --qf "%%{VERSION}" rpm || echo "unknown")
+        # NOTE: on some distros (e.g. opensuse 15.4), "rpm" package doesn't exist,
+        # it's called "rpm-ndb". We query version of package which contains /bin/rpm file.
+        tool_version=rpm-$(rpm -qf /bin/rpm --queryformat "%%{VERSION}" || echo "unknown")
     else
         tool=unknown
         tool_version=unknown

--- a/omnibus/package-scripts/iot-agent-rpm/posttrans
+++ b/omnibus/package-scripts/iot-agent-rpm/posttrans
@@ -32,7 +32,9 @@ if [ ! -f "$CONFIG_DIR/install_info" ]; then
         # Omnibus will put this script verbatim inside RPM specfile before building.
         # We need to escape the "%" so that the rpm build machinery doesn't expand
         # it as a macro (which would expand to the version of Agent being built).
-        tool_version=rpm-$(rpm -q --qf "%%{VERSION}" rpm || echo "unknown")
+        # NOTE: on some distros (e.g. opensuse 15.4), "rpm" package doesn't exist,
+        # it's called "rpm-ndb". We query version of package which contains /bin/rpm file.
+        tool_version=rpm-$(rpm -qf /bin/rpm --queryformat "%%{VERSION}" || echo "unknown")
     else
         tool=unknown
         tool_version=unknown

--- a/omnibus/package-scripts/iot-agent-rpm/posttrans
+++ b/omnibus/package-scripts/iot-agent-rpm/posttrans
@@ -34,7 +34,7 @@ if [ ! -f "$CONFIG_DIR/install_info" ]; then
         # it as a macro (which would expand to the version of Agent being built).
         # NOTE: on some distros (e.g. opensuse 15.4), "rpm" package doesn't exist,
         # it's called "rpm-ndb". We query version of package which contains /bin/rpm file.
-        tool_version=rpm-$(rpm -qf /bin/rpm --queryformat "%%{VERSION}" || echo "unknown")
+        tool_version=rpm-$(rpm -q -f /bin/rpm --queryformat "%%{VERSION}" || echo "unknown")
     else
         tool=unknown
         tool_version=unknown

--- a/omnibus/package-scripts/iot-agent-rpm/posttrans
+++ b/omnibus/package-scripts/iot-agent-rpm/posttrans
@@ -29,7 +29,10 @@ if [ ! -f "$CONFIG_DIR/install_info" ]; then
 
     if command -v rpm >/dev/null 2>&1; then
         tool=rpm
-        tool_version=rpm-$(rpm -q --qf "%{VERSION}" rpm || echo "unknown")
+        # Omnibus will put this script verbatim inside RPM specfile before building.
+        # We need to escape the "%" so that the rpm build machinery doesn't expand
+        # it as a macro (which would expand to the version of Agent being built).
+        tool_version=rpm-$(rpm -q --qf "%%{VERSION}" rpm || echo "unknown")
     else
         tool=unknown
         tool_version=unknown


### PR DESCRIPTION
### What does this PR do?

Omnibus will put this script verbatim inside RPM specfile before building.
We need to escape the "%" so that the rpm build machinery doesn't expand
it as a macro (which would expand to the version of Agent being built).

### Motivation

Render the correct version of RPM inside the `install_info` file.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Try this with both datadog-agent and datadog-iot-agent:

* Install the package (without using any installation method, because these override the `install_info` file with their own information)
* `cat /etc/datadog-agent/install_info | grep tool_version` should contain `tool_version: rpm-X.Y.Z` where `X.Y.Z` should correspond to version returned by `rpm --version` on the system.
* Test on two RHEL-family systems (old and new, e.g. CentOS 6 and Rocky 9) and two SUSE-family systems (old and new, e.g. OpenSUSE 42.3 and OpenSUSE 15.4).

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
