### PR TITLE
[CWS] add procfs rate limiter (#17174)

### DIFF
--- a/pkg/security/probe/field_handlers_linux.go
+++ b/pkg/security/probe/field_handlers_linux.go
@@ -289,7 +289,7 @@ func (fh *FieldHandlers) ResolveProcessCacheEntry(ev *model.Event) (*model.Proce
 		return model.NewEmptyProcessCacheEntry(ev.PIDContext.Pid, ev.PIDContext.Tid, true), false
 	}
 
-	if ev.ProcessCacheEntry == nil {
+	if ev.ProcessCacheEntry == nil && ev.PIDContext.Pid != 0 {
 		ev.ProcessCacheEntry = fh.resolvers.ProcessResolver.Resolve(ev.PIDContext.Pid, ev.PIDContext.Tid, ev.PIDContext.Inode)
 	}
 

--- a/pkg/security/resolvers/mount/resolver.go
+++ b/pkg/security/resolvers/mount/resolver.go
@@ -28,6 +28,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/metrics"
 	"github.com/DataDog/datadog-agent/pkg/security/resolvers/cgroup"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+	"github.com/DataDog/datadog-agent/pkg/security/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 )
 
@@ -105,7 +106,7 @@ type Resolver struct {
 	deleteQueue     []deleteRequest
 	minMountID      uint32
 	redemption      *simplelru.LRU[uint32, *model.Mount]
-	fallbackLimiter *simplelru.LRU[uint32, time.Time]
+	fallbackLimiter *utils.Limiter[uint32]
 
 	// stats
 	cacheHitsStats *atomic.Int64
@@ -404,23 +405,11 @@ func (mr *Resolver) ResolveMountPath(mountID, pid uint32, containerID string) (s
 	return mr.resolveMountPath(mountID, containerID, pid)
 }
 
-func (mr *Resolver) isSyncCacheAllowed(mountID uint32) bool {
-	now := time.Now()
-	if ts, ok := mr.fallbackLimiter.Get(mountID); ok {
-		if now.After(ts) {
-			mr.fallbackLimiter.Remove(mountID)
-		} else {
-			return false
-		}
-	}
-	return true
-}
-
 func (mr *Resolver) syncCacheMiss(mountID uint32) {
 	mr.procMissStats.Inc()
 
 	// add to fallback limiter to avoid storm of file access
-	mr.fallbackLimiter.Add(mountID, time.Now().Add(fallbackLimiterPeriod))
+	mr.fallbackLimiter.Count(mountID)
 }
 
 func (mr *Resolver) resolveMountPath(mountID uint32, containerID string, pids ...uint32) (string, error) {
@@ -451,7 +440,7 @@ func (mr *Resolver) resolveMountPath(mountID uint32, containerID string, pids ..
 		return "", ErrMountNotFound
 	}
 
-	if !mr.isSyncCacheAllowed(mountID) {
+	if !mr.fallbackLimiter.IsAllowed(mountID) {
 		return "", ErrMountNotFound
 	}
 
@@ -642,11 +631,11 @@ func NewResolver(statsdClient statsd.ClientInterface, cgroupsResolver *cgroup.Re
 	}
 	mr.redemption = redemption
 
-	fallbackLimiter, err := simplelru.NewLRU[uint32, time.Time](64, nil)
+	limiter, err := utils.NewLimiter[uint32](64, fallbackLimiterPeriod)
 	if err != nil {
 		return nil, err
 	}
-	mr.fallbackLimiter = fallbackLimiter
+	mr.fallbackLimiter = limiter
 
 	return mr, nil
 }

--- a/pkg/security/utils/limiter.go
+++ b/pkg/security/utils/limiter.go
@@ -1,0 +1,52 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+package utils
+
+import (
+	"time"
+
+	"github.com/hashicorp/golang-lru/v2/simplelru"
+)
+
+// Limiter defines generic rate limiter
+type Limiter[K comparable] struct {
+	cache  *simplelru.LRU[K, time.Time]
+	period time.Duration
+}
+
+// NewLimiter returns a rate limiter
+func NewLimiter[K comparable](size int, period time.Duration) (*Limiter[K], error) {
+	cache, err := simplelru.NewLRU[K, time.Time](size, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Limiter[K]{
+		cache:  cache,
+		period: period,
+	}, nil
+}
+
+// IsAllowed returns whether an entry is allowed or not
+func (l *Limiter[K]) IsAllowed(k K) bool {
+	now := time.Now()
+	if ts, ok := l.cache.Get(k); ok {
+		if now.After(ts) {
+			l.cache.Remove(k)
+		} else {
+			return false
+		}
+	}
+
+	return true
+}
+
+// Count marks the key as used
+func (l *Limiter[K]) Count(k K) {
+	l.cache.Add(k, time.Now().Add(l.period))
+}


### PR DESCRIPTION
* [CWS] do not resolver pid 0

* add rate limiter for procfs fallback

(cherry picked from commit 2976450d272be9eea59bc447ee75c9c1ad02ee3c)

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This PR add a rate limiter to procfs fallback. This reduce a potential CPU impact if the fallback continuously fail.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
