### PR TITLE
[gitlab] Update Windows root certificates before tests and builds

### DIFF
--- a/tasks/winbuildscripts/buildwin.bat
+++ b/tasks/winbuildscripts/buildwin.bat
@@ -9,6 +9,9 @@ xcopy /e/s/h/q c:\mnt\*.* || exit /b 4
 
 call %~p0extract-modcache.bat
 
+REM Setup root certificates before build
+Powershell -C "c:\mnt\tasks\winbuildscripts\setup_certificates.ps1" || exit /b 5
+
 REM
 REM after copying files in from the host, execute the build
 REM using `dobuild.bat`
@@ -22,17 +25,17 @@ dir \omnibus-ruby\pkg\
 dir \dev\go\src\github.com\DataDog\datadog-agent\omnibus\pkg\
 
 REM copy resulting packages to expected location for collection by gitlab.
-if not exist c:\mnt\omnibus\pkg\ mkdir c:\mnt\omnibus\pkg\ || exit /b 5
-copy \dev\go\src\github.com\DataDog\datadog-agent\omnibus\pkg\* c:\mnt\omnibus\pkg\ || exit /b 6
+if not exist c:\mnt\omnibus\pkg\ mkdir c:\mnt\omnibus\pkg\ || exit /b 6
+copy \dev\go\src\github.com\DataDog\datadog-agent\omnibus\pkg\* c:\mnt\omnibus\pkg\ || exit /b 7
 
 REM copy wixpdb file for debugging purposes
-if exist \omnibus-ruby\pkg\*.wixpdb copy \omnibus-ruby\pkg\*.wixpdb c:\mnt\omnibus\pkg\ || exit /b 7
+if exist \omnibus-ruby\pkg\*.wixpdb copy \omnibus-ruby\pkg\*.wixpdb c:\mnt\omnibus\pkg\ || exit /b 8
 
 REM copy customaction pdb file for debugging purposes
-if exist \omnibus-ruby\pkg\*.pdb copy \omnibus-ruby\pkg\*.pdb c:\mnt\omnibus\pkg\ || exit /b 8
+if exist \omnibus-ruby\pkg\*.pdb copy \omnibus-ruby\pkg\*.pdb c:\mnt\omnibus\pkg\ || exit /b 9
 
 REM copy Next Gen installer
-if exist \dev\go\src\github.com\DataDog\datadog-agent\tools\windows\DatadogAgentInstaller\WixSetup\*.msi copy \dev\go\src\github.com\DataDog\datadog-agent\tools\windows\DatadogAgentInstaller\WixSetup\*.msi c:\mnt\omnibus\pkg\ || exit /b 8
+if exist \dev\go\src\github.com\DataDog\datadog-agent\tools\windows\DatadogAgentInstaller\WixSetup\*.msi copy \dev\go\src\github.com\DataDog\datadog-agent\tools\windows\DatadogAgentInstaller\WixSetup\*.msi c:\mnt\omnibus\pkg\ || exit /b 10
 
 REM show output binary directories (for debugging)
 dir C:\opt\datadog-agent\bin\agent\

--- a/tasks/winbuildscripts/setup_certificates.ps1
+++ b/tasks/winbuildscripts/setup_certificates.ps1
@@ -1,0 +1,51 @@
+# Taken from https://github.com/actions/runner-images/blob/59997be01ae4da61faedbb48aa5d57f5a5e391c3/images/win/scripts/Installers/Install-RootCA.ps1
+# MIT License
+# Copyright (c) 2020 GitHub
+
+function Invoke-WithRetry {
+     <#
+        .SYNOPSIS
+        Runs $command block until $BreakCondition or $RetryCount is reached.
+     #>
+
+     param([ScriptBlock]$Command, [ScriptBlock] $BreakCondition, [int] $RetryCount=5, [int] $Sleep=10)
+
+     $c = 0
+     while($c -lt $RetryCount){
+        $result = & $Command
+        if(& $BreakCondition){
+            break
+        }
+        Start-Sleep $Sleep
+        $c++
+     }
+     $result
+}
+
+function Import-SSTFromWU {
+    # Serialized Certificate Store File
+    $sstFile = "$env:TEMP\roots.sst"
+    # Generate SST from Windows Update
+    $result = Invoke-WithRetry { certutil.exe -generateSSTFromWU $sstFile } {$LASTEXITCODE -eq 0}
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "[Error]: failed to generate $sstFile sst file`n$result"
+        exit $LASTEXITCODE
+    }
+
+    $result = certutil.exe -dump $sstFile
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "[Error]: failed to dump $sstFile sst file`n$result"
+        exit $LASTEXITCODE
+    }
+
+    try {
+        Import-Certificate -FilePath $sstFile -CertStoreLocation Cert:\LocalMachine\Root
+    } catch {
+        Write-Host "[Error]: failed to import ROOT CA`n$_"
+        exit 1
+    }
+}
+
+Write-Host "Importing certificates from Windows Update"
+Import-SSTFromWU
+Write-Host "Imported certificates from Windows Update"

--- a/tasks/winbuildscripts/unittests.bat
+++ b/tasks/winbuildscripts/unittests.bat
@@ -14,7 +14,10 @@ mkdir \dev\go\src\github.com\DataDog\datadog-agent
 cd \dev\go\src\github.com\DataDog\datadog-agent
 xcopy /e/s/h/q c:\mnt\*.*
 
-Powershell -C "c:\mnt\tasks\winbuildscripts\unittests.ps1" || exit /b 2
+REM Setup root certificates before tests
+Powershell -C "c:\mnt\tasks\winbuildscripts\setup_certificates.ps1" || exit /b 2
+
+Powershell -C "c:\mnt\tasks\winbuildscripts\unittests.ps1" || exit /b 3
 
 goto :EOF
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Updates the Windows CI tests and builds scripts to force the update of root certificates used in the image before they are used to download dependencies (as part of the MSI tests and builds).

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

There is a possible timing issue in the test and build scripts: the base container doesn't contain some of the root certificates needed to install dependencies. These certificates are added while the container is running (probably by a Windows Update process), but if this happens too late, the test and build Windows jobs can fail ([example](https://gitlab.ddbuild.io/DataDog/datadog-agent-old/-/jobs/253012823/raw)).

To prevent this, we force the certificates update to happen before the tests / builds start.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

n/a

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

n/a

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

n/a

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
