### PR TITLE
[usm] Reduce HTTPS protocol classification test flakiness

### DIFF
--- a/pkg/network/tracer/tracer_classification_linux_test.go
+++ b/pkg/network/tracer/tracer_classification_linux_test.go
@@ -64,7 +64,9 @@ func testProtocolClassificationInner(t *testing.T, params protocolClassification
 	tr.removeClient(clientID)
 	initTracerState(t, tr)
 	require.NoError(t, tr.ebpfTracer.Resume(), "enable probes - before post tracer")
-	params.postTracerSetup(t, params.context)
+	if params.postTracerSetup != nil {
+		params.postTracerSetup(t, params.context)
+	}
 	require.NoError(t, tr.ebpfTracer.Pause(), "disable probes - after post tracer")
 
 	params.validation(t, params.context, tr)

--- a/pkg/network/tracer/tracer_usm_linux_test.go
+++ b/pkg/network/tracer/tracer_usm_linux_test.go
@@ -1306,13 +1306,34 @@ func testHTTPSClassification(t *testing.T, tr *Tracer, clientHost, targetHost, s
 				require.NoError(t, err)
 				t.Cleanup(closer)
 			},
-			postTracerSetup: func(t *testing.T, ctx testContext) {
+			validation: func(t *testing.T, ctx testContext, tr *Tracer) {
 				client := nethttp.Client{
 					Transport: &nethttp.Transport{
 						TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 						DialContext:     defaultDialer.DialContext,
 					},
 				}
+
+				// Ensure that we see HTTPS requests being traced *before* the actual test assertions
+				// This is done to reduce test test flakiness due to uprobe attachment delays
+				require.Eventually(t, func() bool {
+					resp, err := client.Get(fmt.Sprintf("https://%s/200/warm-up", ctx.targetAddress))
+					if err != nil {
+						return false
+					}
+					_, _ = io.Copy(io.Discard, resp.Body)
+					_ = resp.Body.Close()
+
+					httpData := getConnections(t, tr).HTTP
+					for httpKey := range httpData {
+						if httpKey.Path.Content == resp.Request.URL.Path {
+							return true
+						}
+					}
+
+					return false
+				}, 5*time.Second, 100*time.Millisecond, "couldn't detect HTTPS traffic being traced (test setup validation)")
+
 				t.Log("run 3 clients request as we can have a race between the closing tcp socket and the http response")
 				for i := 0; i < 3; i++ {
 					resp, err := client.Get(fmt.Sprintf("https://%s/200/request-1", ctx.targetAddress))
@@ -1321,8 +1342,9 @@ func testHTTPSClassification(t *testing.T, tr *Tracer, clientHost, targetHost, s
 					_ = resp.Body.Close()
 					client.CloseIdleConnections()
 				}
+
+				waitForConnectionsWithProtocol(t, tr, ctx.targetAddress, ctx.serverAddress, protocols.HTTP, tlsExpected)
 			},
-			validation: validateProtocolConnection(protocols.HTTP, tlsExpected),
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Reduce HTTPS protocol classification test flakiness.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

At first we thought there could be something wrong with the recent protocol classification refactor, but then we realized that test failures are happening because there was a race between the uprobe attachment for OpenSSL hooks and the HTTPS requests that happen before the test assertion.

Note that even though the Python HTTPS server is being spun up during the `postTracerSetup` stage, the actual shared library loading is deferred until the first request is handled by the server by the Python runtime.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
