### PR TITLE
[Gohai] Add common elements of the future new API

### DIFF
--- a/pkg/gohai/go.mod
+++ b/pkg/gohai/go.mod
@@ -2,7 +2,7 @@ module github.com/DataDog/datadog-agent/pkg/gohai
 
 // we don't want to just use the agent's go version because gohai might be used outside of it
 // eg. opentelemetry
-go 1.17
+go 1.18
 
 require (
 	github.com/cihub/seelog v0.0.0-20151216151435-d2c6e5aa9fbf

--- a/pkg/gohai/utils/common.go
+++ b/pkg/gohai/utils/common.go
@@ -9,77 +9,36 @@ import (
 	"fmt"
 	"reflect"
 	"runtime"
-	"strings"
 )
 
 var ErrNoFieldCollected = errors.New("no field was collected")
 var ErrArgNotStruct = errors.New("argument is not a struct")
-
-// NotCollectedError represents a value which is not collected on a specific OS / Arch.
-type NotCollectedError struct {
-	PkgName   string
-	ValueName string
-}
-
-// NewNotCollectedError returns a new NotCollectedError
-func NewNotCollectedError(pkgName, valueName string) *NotCollectedError {
-	return &NotCollectedError{
-		pkgName, valueName,
-	}
-}
-
-func (err *NotCollectedError) Error() string {
-	var valuePath string
-	if err.PkgName == "" {
-		valuePath = err.ValueName
-	} else {
-		valuePath = fmt.Sprintf("%s.%s", err.PkgName, err.ValueName)
-	}
-	return fmt.Sprintf("%s is not collected on %s %s", valuePath, runtime.GOOS, runtime.GOARCH)
-}
+var ErrNotExportable = errors.New("cannot be exported")
+var ErrNotCollectable = fmt.Errorf("cannot be collected on %s %s", runtime.GOOS, runtime.GOARCH)
 
 // fieldIsValue returns whether the field has type Value[T] for some T.
 //
-// It actually checks whether the type has the correct name, and has functions Value and NewErrorValue
-// with correct number and types of argument and output
+// # It actually checks whether the type has a function Value with correct number and types of argument and output
+//
+// Since we don't know the specific T, we can't case to an interface, and reflect doesn't have any way to check
+// a generic type as long as https://github.com/golang/go/issues/54393 is not implemented
 func fieldIsValue(fieldTy reflect.StructField) bool {
-	// check that the type is Value[T] for some T
-	// cannot really do better than checking the name as long as
-	// https://github.com/golang/go/issues/54393 is not implemented
-	if !strings.HasPrefix(fieldTy.Type.Name(), "Value[") {
-		return false
-	}
-
 	// check that a pointer to the field has a Value method
 	valueMethod, ok := reflect.PtrTo(fieldTy.Type).MethodByName("Value")
 	if !ok || valueMethod.Type.NumIn() != 1 || valueMethod.Type.NumOut() != 2 {
 		return false
 	}
 
-	// check that the second return value is not an error
+	// check that the second return value is an error
 	reflErrorInterface := reflect.TypeOf((*error)(nil)).Elem()
 	secondRetType := valueMethod.Type.Out(1)
-	if secondRetType.Kind() != reflect.Interface || !secondRetType.Implements(reflErrorInterface) {
-		return false
-	}
-
-	// check that the type has a NewErrorValue method
-	newErrorValueMethod, ok := fieldTy.Type.MethodByName("NewErrorValue")
-	if !ok || newErrorValueMethod.Type.NumIn() != 2 || newErrorValueMethod.Type.NumOut() != 1 {
-		return false
-	}
-
-	// check that the returned value has the same type as the field
-	if newErrorValueMethod.Type.Out(0) != fieldTy.Type {
-		return false
-	}
-
-	return true
+	return secondRetType.Implements(reflErrorInterface)
 }
 
 // fieldIsExportable checks if a field can be exported by AsJSON.
 //
-// A field can be exported if it has type Value, it is exported by the struct and has a json tag.
+// A field can be exported if it has type Value, its inner type can be rendered,
+// it is exported by the struct and has a json tag.
 // The function returns the json tag, the suffix tag and whether the field can be exported.
 //
 // The returned strings are only valid if the field is exportable.
@@ -91,6 +50,14 @@ func fieldIsExportable(fieldTy reflect.StructField) (string, string, bool) {
 
 	// check if field is exported
 	if !fieldTy.IsExported() {
+		return "", "", false
+	}
+
+	// check that the T of Value[T] can be rendered
+	valueMethod, _ := reflect.PtrTo(fieldTy.Type).MethodByName("Value")
+	value := reflect.Zero(valueMethod.Type.Out(0))
+	_, supported := renderValue(value, "")
+	if !supported {
 		return "", "", false
 	}
 
@@ -108,6 +75,8 @@ func fieldIsExportable(fieldTy reflect.StructField) (string, string, bool) {
 
 // renderValue converts the given value to a string, and return a boolean indicating
 // whether it succeeded
+//
+// Supported types are int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, float32, float64, string
 func renderValue(value reflect.Value, suffix string) (string, bool) {
 	var rendered string
 	switch value.Kind() {
@@ -158,15 +127,15 @@ func renderValue(value reflect.Value, suffix string) (string, bool) {
 }
 
 // AsJSON takes an Info struct and returns a marshal-able object representing the fields of the struct,
-// the lists of errors for fields which could not be collected, and an error if it failed or if no
-// information was collected in the Info struct.
+// the lists of errors for fields for which the collection failed, and an error if it failed.
 //
 // If useDefault is true, fields which failed to be collected will be included in the marshal-able object
 // as their default value, otherwise they are ignored.
 //
 // If the error is non-nil, the first two parameters are unspecified.
 //
-// Fields which are not exported, don't have a json tag or are not of type Value[T] are ignored.
+// Fields which are not exported, don't have a json tag or are not of type Value[T] for a T which can
+// be rendered cause the function to return an error.
 func AsJSON[T any](info *T, useDefault bool) (interface{}, []error, error) {
 	reflVal := reflect.ValueOf(info).Elem()
 	reflType := reflect.TypeOf(info).Elem()
@@ -177,12 +146,13 @@ func AsJSON[T any](info *T, useDefault bool) (interface{}, []error, error) {
 	}
 
 	values := make(map[string]interface{})
-	errors := []error{}
+	warns := []error{}
 
 	for i := 0; i < reflVal.NumField(); i++ {
-		fieldName, suffix, isExportable := fieldIsExportable(reflType.Field(i))
+		field := reflType.Field(i)
+		fieldName, suffix, isExportable := fieldIsExportable(field)
 		if !isExportable {
-			continue
+			return nil, nil, fmt.Errorf("%s: %w", field.Name, ErrNotExportable)
 		}
 
 		// Value is a method on *Value[T] so we get a pointer to the value
@@ -192,7 +162,11 @@ func AsJSON[T any](info *T, useDefault bool) (interface{}, []error, error) {
 		retValue := ret[0]
 		if ret[1].Interface() != nil {
 			err := ret[1].Interface().(error)
-			errors = append(errors, err)
+
+			if !errors.Is(err, ErrNotCollectable) {
+				warns = append(warns, err)
+			}
+
 			if !useDefault {
 				continue
 			}
@@ -203,54 +177,15 @@ func AsJSON[T any](info *T, useDefault bool) (interface{}, []error, error) {
 
 		renderedValue, ok := renderValue(retValue, suffix)
 		if !ok {
-			continue
+			return nil, nil, fmt.Errorf("%s: %w", field.Name, ErrNotExportable)
 		}
 
 		values[fieldName] = renderedValue
 	}
 
 	if len(values) == 0 {
-		return nil, errors, ErrNoFieldCollected
+		return nil, warns, ErrNoFieldCollected
 	}
 
-	return values, errors, nil
-}
-
-// GetPkgName returns the package name from the given package path
-func GetPkgName(pkgPath string) string {
-	pkg := strings.Split(pkgPath, "/")
-	if len(pkg) == 0 {
-		return pkgPath
-	}
-	return pkg[len(pkg)-1]
-}
-
-// Initialize sets the value of exportable fields to a NotCollectedError.
-//
-// A field is exportable if it has type Value, has a json tag and is exported by the struct.
-func Initialize[T any](info *T) error {
-	reflVal := reflect.ValueOf(info).Elem()
-	reflType := reflect.TypeOf(info).Elem()
-	pkgName := GetPkgName(reflType.PkgPath())
-
-	// info has to be a struct
-	if reflVal.Kind() != reflect.Struct {
-		return ErrArgNotStruct
-	}
-
-	for i := 0; i < reflVal.NumField(); i++ {
-		fieldName, _, isExportable := fieldIsExportable(reflType.Field(i))
-		if !isExportable {
-			continue
-		}
-
-		err := reflect.ValueOf(NewNotCollectedError(pkgName, fieldName))
-		fieldVal := reflVal.Field(i)
-		newErrorValueMethod, _ := fieldVal.Type().MethodByName("NewErrorValue")
-		ret := newErrorValueMethod.Func.Call([]reflect.Value{fieldVal, err})
-
-		fieldVal.Set(ret[0])
-	}
-
-	return nil
+	return values, warns, nil
 }

--- a/pkg/gohai/utils/common.go
+++ b/pkg/gohai/utils/common.go
@@ -15,7 +15,7 @@ var ErrNoFieldCollected = errors.New("no field was collected")
 var ErrArgNotStruct = errors.New("argument is not a struct")
 var ErrNotCollectable = fmt.Errorf("cannot be collected on %s %s", runtime.GOOS, runtime.GOARCH)
 var ErrNotExported = errors.New("field not exported by the struct")
-var ErrNotRenderable = errors.New("field inner type cannot be rendered")
+var ErrCannotRender = errors.New("field inner type cannot be rendered")
 var ErrNoValueMethod = errors.New("field doesn't have the expected Value method")
 var ErrNoJSONTag = errors.New("field doesn't have a json tag")
 
@@ -165,7 +165,7 @@ func AsJSON[T any](info *T, useDefault bool) (interface{}, []string, error) {
 		// try to render the value
 		renderedValue, ok := reflectValueToString(retValue)
 		if !ok {
-			return nil, nil, fmt.Errorf("%s: %w", fieldName, ErrNotRenderable)
+			return nil, nil, fmt.Errorf("%s: %w", fieldName, ErrCannotRender)
 		}
 
 		// Get returns an empty string if the key does not exists so no need for particular error handling

--- a/pkg/gohai/utils/common.go
+++ b/pkg/gohai/utils/common.go
@@ -22,7 +22,7 @@ type NotCollectedError struct {
 	ValueName string
 }
 
-// NewNotCollectedError return a new NotCollectedError
+// NewNotCollectedError returns a new NotCollectedError
 func NewNotCollectedError(pkgName, valueName string) *NotCollectedError {
 	return &NotCollectedError{
 		pkgName, valueName,

--- a/pkg/gohai/utils/common.go
+++ b/pkg/gohai/utils/common.go
@@ -7,7 +7,6 @@ package utils
 import (
 	"errors"
 	"fmt"
-	"os"
 	"reflect"
 	"runtime"
 	"strings"
@@ -81,7 +80,7 @@ func fieldIsValue(fieldTy reflect.StructField) bool {
 // fieldIsExportable checks if a field can be exported by AsJSON.
 //
 // A field can be exported if it has type Value, it is exported by the struct and has a json tag.
-// The function the json tag, the suffix tag and whether the field can be exported.
+// The function returns the json tag, the suffix tag and whether the field can be exported.
 //
 // The returned strings are only valid if the field is exportable.
 func fieldIsExportable(fieldTy reflect.StructField) (string, string, bool) {
@@ -219,7 +218,6 @@ func AsJSON[T any](info *T, useDefault bool) (interface{}, []error, error) {
 
 // GetPkgName returns the package name from the given package path
 func GetPkgName(pkgPath string) string {
-	fmt.Fprintln(os.Stderr, pkgPath)
 	pkg := strings.Split(pkgPath, "/")
 	if len(pkg) == 0 {
 		return pkgPath

--- a/pkg/gohai/utils/common.go
+++ b/pkg/gohai/utils/common.go
@@ -1,3 +1,7 @@
+// This file is licensed under the MIT License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2014-present Datadog, Inc.
+
 package utils
 
 import (

--- a/pkg/gohai/utils/common.go
+++ b/pkg/gohai/utils/common.go
@@ -1,0 +1,249 @@
+package utils
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"reflect"
+	"runtime"
+	"strings"
+)
+
+var ErrNoFieldCollected = errors.New("no field was collected")
+var ErrArgNotStruct = errors.New("argument is not a struct")
+
+// NotCollectedError represents a value which is not collected on a specific OS / Arch.
+type NotCollectedError struct {
+	PkgName   string
+	ValueName string
+}
+
+// NewNotCollectedError return a new NotCollectedError
+func NewNotCollectedError(pkgName, valueName string) *NotCollectedError {
+	return &NotCollectedError{
+		pkgName, valueName,
+	}
+}
+
+func (err *NotCollectedError) Error() string {
+	var valuePath string
+	if err.PkgName == "" {
+		valuePath = err.ValueName
+	} else {
+		valuePath = fmt.Sprintf("%s.%s", err.PkgName, err.ValueName)
+	}
+	return fmt.Sprintf("%s is not collected on %s %s", valuePath, runtime.GOOS, runtime.GOARCH)
+}
+
+// fieldIsValue returns whether the field has type Value[T] for some T.
+//
+// It actually checks whether the type has the correct name, and has functions Value and NewErrorValue
+// with correct number and types of argument and output
+func fieldIsValue(fieldTy reflect.StructField) bool {
+	// check that the type is Value[T] for some T
+	// cannot really do better than checking the name as long as
+	// https://github.com/golang/go/issues/54393 is not implemented
+	if !strings.HasPrefix(fieldTy.Type.Name(), "Value[") {
+		return false
+	}
+
+	// check that a pointer to the field has a Value method
+	valueMethod, ok := reflect.PtrTo(fieldTy.Type).MethodByName("Value")
+	if !ok || valueMethod.Type.NumIn() != 1 || valueMethod.Type.NumOut() != 2 {
+		return false
+	}
+
+	// check that the second return value is not an error
+	reflErrorInterface := reflect.TypeOf((*error)(nil)).Elem()
+	secondRetType := valueMethod.Type.Out(1)
+	if secondRetType.Kind() != reflect.Interface || !secondRetType.Implements(reflErrorInterface) {
+		return false
+	}
+
+	// check that the type has a NewErrorValue method
+	newErrorValueMethod, ok := fieldTy.Type.MethodByName("NewErrorValue")
+	if !ok || newErrorValueMethod.Type.NumIn() != 2 || newErrorValueMethod.Type.NumOut() != 1 {
+		return false
+	}
+
+	// check that the returned value has the same type as the field
+	if newErrorValueMethod.Type.Out(0) != fieldTy.Type {
+		return false
+	}
+
+	return true
+}
+
+// fieldIsExportable checks if a field can be exported by AsJSON.
+//
+// A field can be exported if it has type Value, it is exported by the struct and has a json tag.
+// The function returns whether a field can be exported as well as its json tag if so.
+func fieldIsExportable(fieldTy reflect.StructField) (string, bool) {
+	// check if field has type Value
+	if !fieldIsValue(fieldTy) {
+		return "", false
+	}
+
+	// check if field is exported
+	if !fieldTy.IsExported() {
+		return "", false
+	}
+
+	// check if field has a json tag
+	fieldName, ok := fieldTy.Tag.Lookup("json")
+	if !ok {
+		return "", false
+	}
+
+	return fieldName, true
+}
+
+// renderValue converts the given value to a string, and return a boolean indicating
+// whether it succeeded
+func renderValue(value reflect.Value) (string, bool) {
+	var rendered string
+	switch value.Kind() {
+	// case reflect.Bool:
+	case reflect.Int:
+		rendered = fmt.Sprintf("%d", value.Interface().(int))
+	case reflect.Int8:
+		rendered = fmt.Sprintf("%d", value.Interface().(int8))
+	case reflect.Int16:
+		rendered = fmt.Sprintf("%d", value.Interface().(int16))
+	case reflect.Int32:
+		rendered = fmt.Sprintf("%d", value.Interface().(int32))
+	case reflect.Int64:
+		rendered = fmt.Sprintf("%d", value.Interface().(int64))
+	case reflect.Uint:
+		rendered = fmt.Sprintf("%d", value.Interface().(uint))
+	case reflect.Uint8:
+		rendered = fmt.Sprintf("%d", value.Interface().(uint8))
+	case reflect.Uint16:
+		rendered = fmt.Sprintf("%d", value.Interface().(uint16))
+	case reflect.Uint32:
+		rendered = fmt.Sprintf("%d", value.Interface().(uint32))
+	case reflect.Uint64:
+		rendered = fmt.Sprintf("%d", value.Interface().(uint64))
+	// case reflect.Uintptr:
+	case reflect.Float32:
+		rendered = fmt.Sprintf("%f", value.Interface().(float32))
+	case reflect.Float64:
+		rendered = fmt.Sprintf("%f", value.Interface().(float64))
+	// case reflect.Complex64:
+	// case reflect.Complex128:
+	// case reflect.Array:
+	// case reflect.Chan:
+	// case reflect.Func:
+	// case reflect.Interface:
+	// case reflect.Map:
+	// case reflect.Pointer:
+	// case reflect.Slice:
+	case reflect.String:
+		rendered = value.String()
+	// case reflect.Struct:
+	// case reflect.UnsafePointer:
+	default:
+		return "", false
+	}
+
+	return rendered, true
+}
+
+// AsJSON takes an Info struct and returns a marshal-able object representing the fields of the struct,
+// the lists of errors for fields which could not be collected, and an error if it failed or if no
+// information was collected in the Info struct.
+//
+// If useDefault is true, fields which failed to be collected will be included in the marshal-able object
+// as their default value, otherwise they are ignored.
+//
+// If the error is non-nil, the first two parameters are unspecified.
+//
+// Fields which are not exported, don't have a json tag or are not of type Value[T] are ignored.
+func AsJSON[T any](info *T, useDefault bool) (interface{}, []error, error) {
+	reflVal := reflect.ValueOf(info).Elem()
+	reflType := reflect.TypeOf(info).Elem()
+
+	// info has to be a struct
+	if reflVal.Kind() != reflect.Struct {
+		return nil, nil, ErrArgNotStruct
+	}
+
+	values := make(map[string]interface{})
+	errors := []error{}
+
+	for i := 0; i < reflVal.NumField(); i++ {
+		fieldName, isExportable := fieldIsExportable(reflType.Field(i))
+		if !isExportable {
+			continue
+		}
+
+		// Value is a method on *Value[T] so we get a pointer to the value
+		fieldPtr := reflVal.Field(i).Addr()
+		valueMethod, _ := fieldPtr.Type().MethodByName("Value")
+		ret := valueMethod.Func.Call([]reflect.Value{fieldPtr})
+		retValue := ret[0]
+		if ret[1].Interface() != nil {
+			err := ret[1].Interface().(error)
+			errors = append(errors, err)
+			if !useDefault {
+				continue
+			}
+
+			// use the default value of the type
+			retValue = reflect.Zero(retValue.Type())
+		}
+
+		renderedValue, ok := renderValue(retValue)
+		if !ok {
+			continue
+		}
+
+		values[fieldName] = renderedValue
+	}
+
+	if len(values) == 0 {
+		return nil, errors, ErrNoFieldCollected
+	}
+
+	return values, errors, nil
+}
+
+// GetPkgName returns the package name from the given package path
+func GetPkgName(pkgPath string) string {
+	fmt.Fprintln(os.Stderr, pkgPath)
+	pkg := strings.Split(pkgPath, "/")
+	if len(pkg) == 0 {
+		return pkgPath
+	}
+	return pkg[len(pkg)-1]
+}
+
+// Initialize sets the value of exportable fields to a NotCollectedError.
+//
+// A field is exportable if it has type Value, has a json tag and is exported by the struct.
+func Initialize[T any](info *T) error {
+	reflVal := reflect.ValueOf(info).Elem()
+	reflType := reflect.TypeOf(info).Elem()
+	pkgName := GetPkgName(reflType.PkgPath())
+
+	// info has to be a struct
+	if reflVal.Kind() != reflect.Struct {
+		return ErrArgNotStruct
+	}
+
+	for i := 0; i < reflVal.NumField(); i++ {
+		fieldName, isExportable := fieldIsExportable(reflType.Field(i))
+		if !isExportable {
+			continue
+		}
+
+		err := reflect.ValueOf(NewNotCollectedError(pkgName, fieldName))
+		fieldVal := reflVal.Field(i)
+		newErrorValueMethod, _ := fieldVal.Type().MethodByName("NewErrorValue")
+		ret := newErrorValueMethod.Func.Call([]reflect.Value{fieldVal, err})
+
+		fieldVal.Set(ret[0])
+	}
+
+	return nil
+}

--- a/pkg/gohai/utils/common.go
+++ b/pkg/gohai/utils/common.go
@@ -103,11 +103,11 @@ func fieldIsValue(fieldTy reflect.StructField) (reflect.Method, bool) {
 // Fields which are not exported, don't have a json tag or are not of type Value[T] for a T which can
 // be rendered cause the function to return an error.
 //
-// The error list contain errors of fields which failed to be collected, fields which are not
+// The string list contain errors of fields which failed to be collected. Fields which are not
 // collected on the platform are ignored.
 //
 // If the error is non-nil, the first two parameters are unspecified.
-func AsJSON[T any](info *T, useDefault bool) (interface{}, []error, error) {
+func AsJSON[T any](info *T, useDefault bool) (interface{}, []string, error) {
 	reflVal := reflect.ValueOf(info).Elem()
 	reflType := reflect.TypeOf(info).Elem()
 
@@ -117,7 +117,7 @@ func AsJSON[T any](info *T, useDefault bool) (interface{}, []error, error) {
 	}
 
 	values := make(map[string]interface{})
-	warns := []error{}
+	warns := []string{}
 
 	for i := 0; i < reflVal.NumField(); i++ {
 		fieldTy := reflType.Field(i)
@@ -150,7 +150,7 @@ func AsJSON[T any](info *T, useDefault bool) (interface{}, []error, error) {
 			// ErrNotCollectable means that the field is not implemented on the current platform
 			// ignore these errors
 			if !errors.Is(err, ErrNotCollectable) {
-				warns = append(warns, err)
+				warns = append(warns, err.Error())
 			}
 
 			// if the field is an error and we don't want to print the default value, continue

--- a/pkg/gohai/utils/common_test.go
+++ b/pkg/gohai/utils/common_test.go
@@ -107,7 +107,7 @@ func TestAsJsonOmit(t *testing.T) {
 	info := &struct {
 		NotValue    int `json:"not_value"`
 		NoTag       Value[int]
-		notExported Value[int]      `json:"not_exported"`
+		notExported Value[int]      `json:"not_exported"` //nolint:govet
 		ValueError  Value[int]      `json:"value_error"`
 		ValueStruct Value[struct{}] `json:"value_struct"`
 		ValuePtr    Value[*int]     `json:"value_ptr"`
@@ -196,7 +196,7 @@ func TestInitializeOmit(t *testing.T) {
 	info := &struct {
 		NotValue    int `json:"not_value"`
 		NoTag       Value[int]
-		notExported Value[int] `json:"not_exported"`
+		notExported Value[int] `json:"not_exported"` //nolint:govet
 	}{}
 
 	err := Initialize(info)

--- a/pkg/gohai/utils/common_test.go
+++ b/pkg/gohai/utils/common_test.go
@@ -1,3 +1,7 @@
+// This file is licensed under the MIT License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2014-present Datadog, Inc.
+
 package utils
 
 import (

--- a/pkg/gohai/utils/common_test.go
+++ b/pkg/gohai/utils/common_test.go
@@ -83,19 +83,11 @@ func TestAsJSONEmpty(t *testing.T) {
 // TestAsJsonInvalidParam tests that using something other than struct returns an error
 func TestAsJsonInvalidParam(t *testing.T) {
 	var err error
-	// function
-	f := func() {}
-	_, _, err = AsJSON(&f, false)
-	require.ErrorIs(t, err, ErrArgNotStruct)
 	// slice
 	_, _, err = AsJSON(&[]int{1}, false)
 	require.ErrorIs(t, err, ErrArgNotStruct)
 	// array
 	_, _, err = AsJSON(&[1]int{1}, false)
-	require.ErrorIs(t, err, ErrArgNotStruct)
-	// basic type (bool)
-	b := true
-	_, _, err = AsJSON(&b, false)
 	require.ErrorIs(t, err, ErrArgNotStruct)
 	// pointer
 	p := &struct{}{}
@@ -225,29 +217,14 @@ func TestAsJSONSuffix(t *testing.T) {
 		FieldSix:   NewErrorValue[int](errors.New(errs[2])),
 	}
 
-	marshallable, warns, err := AsJSON(info, false)
+	marshallable, warns, err := AsJSON(info, true)
 	require.NoError(t, err)
-
 	require.ElementsMatch(t, errs, warns)
 
 	marshalled, err := json.Marshal(marshallable)
 	require.NoError(t, err)
 
 	expected := `{
-		"field_one": "1",
-		"field_two": "2",
-		"field_three": "3kb"
-	}`
-	require.JSONEq(t, expected, string(marshalled))
-
-	marshallable, warns, err = AsJSON(info, true)
-	require.NoError(t, err)
-	require.ElementsMatch(t, errs, warns)
-
-	marshalled, err = json.Marshal(marshallable)
-	require.NoError(t, err)
-
-	expected = `{
 		"field_one": "1",
 		"field_two": "2",
 		"field_three": "3kb",

--- a/pkg/gohai/utils/common_test.go
+++ b/pkg/gohai/utils/common_test.go
@@ -1,0 +1,223 @@
+package utils
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestAsJSONTypes tests that each supported type can appear properly in the output
+func TestAsJSONTypes(t *testing.T) {
+	info := &struct {
+		SomeInt     Value[int]     `json:"my_int"`
+		SomeInt8    Value[int8]    `json:"my_int8"`
+		SomeInt16   Value[int16]   `json:"my_int16"`
+		SomeInt32   Value[int32]   `json:"my_int32"`
+		SomeInt64   Value[int64]   `json:"my_int64"`
+		SomeUint    Value[uint]    `json:"my_uint"`
+		SomeUint8   Value[uint8]   `json:"my_uint8"`
+		SomeUint16  Value[uint16]  `json:"my_uint16"`
+		SomeUint32  Value[uint32]  `json:"my_uint32"`
+		SomeUint64  Value[uint64]  `json:"my_uint64"`
+		SomeFloat32 Value[float32] `json:"my_float32"`
+		SomeFloat64 Value[float64] `json:"my_float64"`
+	}{
+		SomeInt:     NewValue(1),
+		SomeInt8:    NewValue[int8](2),
+		SomeInt16:   NewValue[int16](3),
+		SomeInt32:   NewValue[int32](4),
+		SomeInt64:   NewValue[int64](5),
+		SomeUint:    NewValue[uint](6),
+		SomeUint8:   NewValue[uint8](7),
+		SomeUint16:  NewValue[uint16](8),
+		SomeUint32:  NewValue[uint32](9),
+		SomeUint64:  NewValue[uint64](10),
+		SomeFloat32: NewValue[float32](32.),
+		SomeFloat64: NewValue(64.),
+	}
+
+	marshallable, warns, err := AsJSON(info, false)
+	require.NoError(t, err)
+	require.Empty(t, warns)
+
+	marshalled, err := json.Marshal(marshallable)
+	require.NoError(t, err)
+
+	// use format specifier for floats to make sure the formatting is the same
+	expected := fmt.Sprintf(`{
+		"my_int": "1",
+		"my_int8": "2",
+		"my_int16": "3",
+		"my_int32": "4",
+		"my_int64": "5",
+		"my_uint": "6",
+		"my_uint8": "7",
+		"my_uint16": "8",
+		"my_uint32": "9",
+		"my_uint64": "10",
+		"my_float32": "%f",
+		"my_float64": "%f"
+	}`, float32(32.), 64.)
+	require.JSONEq(t, expected, string(marshalled))
+}
+
+func TestAsJSONEmpty(t *testing.T) {
+	info := &struct{}{}
+	_, _, err := AsJSON(info, false)
+	require.ErrorIs(t, err, ErrNoFieldCollected)
+
+	_, _, err = AsJSON(info, true)
+	require.ErrorIs(t, err, ErrNoFieldCollected)
+}
+
+// TestAsJsonInvalidParam tests that using something other than struct returns an error
+func TestAsJsonInvalidParam(t *testing.T) {
+	var err error
+	// function
+	f := func() {}
+	_, _, err = AsJSON(&f, false)
+	require.ErrorIs(t, err, ErrArgNotStruct)
+	// slice
+	_, _, err = AsJSON(&[]int{1}, false)
+	require.ErrorIs(t, err, ErrArgNotStruct)
+	// array
+	_, _, err = AsJSON(&[1]int{1}, false)
+	require.ErrorIs(t, err, ErrArgNotStruct)
+	// basic type (bool)
+	b := true
+	_, _, err = AsJSON(&b, false)
+	require.ErrorIs(t, err, ErrArgNotStruct)
+	// pointer
+	p := &struct{}{}
+	_, _, err = AsJSON(&p, false)
+	require.ErrorIs(t, err, ErrArgNotStruct)
+}
+
+// TestAsJsonOmit checks that fields which should be omitted are
+// - type is not Value
+// - no json tag
+// - not exported
+// - Value is an error
+// - Value type is not handled (struct, ptr, bool, ...)
+func TestAsJsonOmit(t *testing.T) {
+	myerr := errors.New("this is an error")
+	info := &struct {
+		NotValue    int `json:"not_value"`
+		NoTag       Value[int]
+		notExported Value[int]      `json:"not_exported"`
+		ValueError  Value[int]      `json:"value_error"`
+		ValueStruct Value[struct{}] `json:"value_struct"`
+		ValuePtr    Value[*int]     `json:"value_ptr"`
+		ValueBool   Value[bool]     `json:"value_bool"`
+	}{
+		NotValue:    1,
+		NoTag:       NewValue(2),
+		notExported: NewValue(3),
+		ValueError:  NewErrorValue[int](myerr),
+		ValueStruct: NewValue(struct{}{}),
+		ValuePtr:    NewValue[*int](nil),
+		ValueBool:   NewValue(true),
+	}
+
+	_, _, err := AsJSON(info, false)
+	require.ErrorIs(t, err, ErrNoFieldCollected)
+
+	marshallable, warns, err := AsJSON(info, true)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []error{myerr}, warns)
+
+	marshalled, err := json.Marshal(marshallable)
+	require.NoError(t, err)
+	expected := `{ "value_error": "0" }`
+	require.JSONEq(t, expected, string(marshalled))
+}
+
+func TestAsJsonWarns(t *testing.T) {
+	errs := []error{
+		errors.New("this is the first error"),
+		errors.New("this is the second error"),
+		errors.New("this is the third error"),
+		errors.New("this is the fourth error"),
+	}
+	info := &struct {
+		FieldOne   Value[int] `json:"field_one"`
+		FieldTwo   Value[int] `json:"field_two"`
+		FieldThree Value[int] `json:"field_three"`
+		FieldFour  Value[int] `json:"field_four"`
+		FieldFive  Value[int] `json:"field_five"`
+	}{
+		FieldOne:   NewErrorValue[int](errs[0]),
+		FieldTwo:   NewErrorValue[int](errs[1]),
+		FieldThree: NewErrorValue[int](errs[2]),
+		FieldFour:  NewErrorValue[int](errs[3]),
+		FieldFive:  NewValue(1),
+	}
+
+	marshallable, warns, err := AsJSON(info, false)
+	require.NoError(t, err)
+	require.ElementsMatch(t, errs, warns)
+
+	marshalled, err := json.Marshal(marshallable)
+	require.NoError(t, err)
+
+	expected := `{
+		"field_five": "1"
+	}`
+	require.JSONEq(t, expected, string(marshalled))
+
+	marshallable, warns, err = AsJSON(info, true)
+	require.NoError(t, err)
+	require.ElementsMatch(t, errs, warns)
+
+	marshalled, err = json.Marshal(marshallable)
+	require.NoError(t, err)
+
+	expected = `{
+		"field_one": "0",
+		"field_two": "0",
+		"field_three": "0",
+		"field_four": "0",
+		"field_five": "1"
+	}`
+	require.JSONEq(t, expected, string(marshalled))
+}
+
+func TestGetPkgName(t *testing.T) {
+	require.Equal(t, "", GetPkgName(""))
+
+	longPkgPath := "github.com/DataDog/datadog-agent/pkg/gohai/utils"
+	require.Equal(t, "utils", GetPkgName(longPkgPath))
+}
+
+func TestInitializeOmit(t *testing.T) {
+	info := &struct {
+		NotValue    int `json:"not_value"`
+		NoTag       Value[int]
+		notExported Value[int] `json:"not_exported"`
+	}{}
+
+	err := Initialize(info)
+	require.NoError(t, err)
+	// check that Initialize did not initialize any of the fields
+	require.Zero(t, info.NotValue)
+	require.Zero(t, info.NoTag)
+	require.Zero(t, info.notExported)
+}
+
+func TestInitialize(t *testing.T) {
+	info := &struct {
+		SomeInt Value[int] `json:"some_int"`
+	}{}
+	err := Initialize(info)
+	require.NoError(t, err)
+
+	_, err = info.SomeInt.Value()
+	var targetErr *NotCollectedError
+	require.ErrorAs(t, err, &targetErr)
+	// the struct is not declared so its package path is empty
+	require.Equal(t, "", targetErr.PkgName)
+	require.Equal(t, "some_int", targetErr.ValueName)
+}

--- a/pkg/gohai/utils/common_test.go
+++ b/pkg/gohai/utils/common_test.go
@@ -127,6 +127,8 @@ func TestAsJsonFieldError(t *testing.T) {
 	require.ErrorIs(t, err, ErrNotExportable)
 
 	infoNotExported := &struct {
+		// use a json tag to make sure the error is due to the field not being exported
+		// but govet doesn't like that
 		notExported Value[int] `json:"not_exported"` //nolint:govet
 	}{
 		notExported: NewValue(3),
@@ -209,11 +211,11 @@ func TestAsJSONSuffix(t *testing.T) {
 	}
 	info := &struct {
 		FieldOne   Value[int] `json:"field_one"`
-		FieldTwo   Value[int] `json:"field_two" suffix:""`
-		FieldThree Value[int] `json:"field_three" suffix:"kb"`
+		FieldTwo   Value[int] `json:"field_two" unit:""`
+		FieldThree Value[int] `json:"field_three" unit:"kb"`
 		FieldFour  Value[int] `json:"field_four"`
-		FieldFive  Value[int] `json:"field_five" suffix:""`
-		FieldSix   Value[int] `json:"field_six" suffix:"M"`
+		FieldFive  Value[int] `json:"field_five" unit:""`
+		FieldSix   Value[int] `json:"field_six" unit:"M"`
 	}{
 		FieldOne:   NewValue(1),
 		FieldTwo:   NewValue(2),

--- a/pkg/gohai/utils/common_test.go
+++ b/pkg/gohai/utils/common_test.go
@@ -116,7 +116,7 @@ func TestAsJsonFieldError(t *testing.T) {
 	}
 
 	_, _, err := AsJSON(infoNotValue, false)
-	require.ErrorIs(t, err, ErrNotExportable)
+	require.ErrorIs(t, err, ErrNoValueMethod)
 
 	infoNoTag := &struct {
 		NoTag Value[int]
@@ -124,7 +124,7 @@ func TestAsJsonFieldError(t *testing.T) {
 		NoTag: NewValue(2),
 	}
 	_, _, err = AsJSON(infoNoTag, false)
-	require.ErrorIs(t, err, ErrNotExportable)
+	require.ErrorIs(t, err, ErrNoJSONTag)
 
 	infoNotExported := &struct {
 		// use a json tag to make sure the error is due to the field not being exported
@@ -134,7 +134,7 @@ func TestAsJsonFieldError(t *testing.T) {
 		notExported: NewValue(3),
 	}
 	_, _, err = AsJSON(infoNotExported, false)
-	require.ErrorIs(t, err, ErrNotExportable)
+	require.ErrorIs(t, err, ErrNotExported)
 
 	infoValueStruct := &struct {
 		ValueStruct Value[struct{}] `json:"value_struct"`
@@ -142,7 +142,7 @@ func TestAsJsonFieldError(t *testing.T) {
 		ValueStruct: NewValue(struct{}{}),
 	}
 	_, _, err = AsJSON(infoValueStruct, false)
-	require.ErrorIs(t, err, ErrNotExportable)
+	require.ErrorIs(t, err, ErrCannotRender)
 
 	infoValuePtr := &struct {
 		ValuePtr Value[*int] `json:"value_ptr"`
@@ -150,15 +150,15 @@ func TestAsJsonFieldError(t *testing.T) {
 		ValuePtr: NewValue[*int](nil),
 	}
 	_, _, err = AsJSON(infoValuePtr, false)
-	require.ErrorIs(t, err, ErrNotExportable)
+	require.ErrorIs(t, err, ErrCannotRender)
 }
 
 func TestAsJsonWarns(t *testing.T) {
-	errs := []error{
-		errors.New("this is the first error"),
-		errors.New("this is the second error"),
-		errors.New("this is the third error"),
-		errors.New("this is the fourth error"),
+	errs := []string{
+		"this is the first error",
+		"this is the second error",
+		"this is the third error",
+		"this is the fourth error",
 	}
 	info := &struct {
 		FieldOne   Value[int] `json:"field_one"`
@@ -167,10 +167,10 @@ func TestAsJsonWarns(t *testing.T) {
 		FieldFour  Value[int] `json:"field_four"`
 		FieldFive  Value[int] `json:"field_five"`
 	}{
-		FieldOne:   NewErrorValue[int](errs[0]),
-		FieldTwo:   NewErrorValue[int](errs[1]),
-		FieldThree: NewErrorValue[int](errs[2]),
-		FieldFour:  NewErrorValue[int](errs[3]),
+		FieldOne:   NewErrorValue[int](errors.New(errs[0])),
+		FieldTwo:   NewErrorValue[int](errors.New(errs[1])),
+		FieldThree: NewErrorValue[int](errors.New(errs[2])),
+		FieldFour:  NewErrorValue[int](errors.New(errs[3])),
 		FieldFive:  NewValue(1),
 	}
 
@@ -204,10 +204,10 @@ func TestAsJsonWarns(t *testing.T) {
 }
 
 func TestAsJSONSuffix(t *testing.T) {
-	errs := []error{
-		errors.New("this is the first error"),
-		errors.New("this is the second error"),
-		errors.New("this is the third error"),
+	errs := []string{
+		"this is the first error",
+		"this is the second error",
+		"this is the third error",
 	}
 	info := &struct {
 		FieldOne   Value[int] `json:"field_one"`
@@ -220,13 +220,14 @@ func TestAsJSONSuffix(t *testing.T) {
 		FieldOne:   NewValue(1),
 		FieldTwo:   NewValue(2),
 		FieldThree: NewValue(3),
-		FieldFour:  NewErrorValue[int](errs[0]),
-		FieldFive:  NewErrorValue[int](errs[1]),
-		FieldSix:   NewErrorValue[int](errs[2]),
+		FieldFour:  NewErrorValue[int](errors.New(errs[0])),
+		FieldFive:  NewErrorValue[int](errors.New(errs[1])),
+		FieldSix:   NewErrorValue[int](errors.New(errs[2])),
 	}
 
 	marshallable, warns, err := AsJSON(info, false)
 	require.NoError(t, err)
+
 	require.ElementsMatch(t, errs, warns)
 
 	marshalled, err := json.Marshal(marshallable)

--- a/pkg/gohai/utils/value.go
+++ b/pkg/gohai/utils/value.go
@@ -1,3 +1,7 @@
+// This file is licensed under the MIT License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2014-present Datadog, Inc.
+
 package utils
 
 // Value represents either an error or an actual value of type T.

--- a/pkg/gohai/utils/value.go
+++ b/pkg/gohai/utils/value.go
@@ -10,7 +10,7 @@ import (
 
 // Value represents either an error or an actual value of type T.
 //
-// The default value of the type is the default value of T (no error).
+// The default value of the type is an error saying that the value was not initialized.
 type Value[T any] struct {
 	value       T
 	err         error
@@ -47,7 +47,7 @@ func NewErrorValue[T any](err error) Value[T] {
 	}
 }
 
-// Value returns the value and error stored in the Value[T].
+// Value returns the value and the error stored in the Value[T].
 //
 // If the Value[T] represents an error, it returns the default value of type T
 // and a non-nil error, otherwise the stored value of type T and a nil error.

--- a/pkg/gohai/utils/value.go
+++ b/pkg/gohai/utils/value.go
@@ -4,18 +4,24 @@
 
 package utils
 
+import (
+	"errors"
+)
+
 // Value represents either an error or an actual value of type T.
 //
 // The default value of the type is the default value of T (no error).
 type Value[T any] struct {
-	value T
-	err   error
+	value       T
+	err         error
+	initialized bool
 }
 
 // NewValue initializes a Value[T] with the given value of type T and no error.
 func NewValue[T any](value T) Value[T] {
 	return Value[T]{
-		value: value,
+		value:       value,
+		initialized: true,
 	}
 }
 
@@ -36,18 +42,9 @@ func NewValueFrom[T any](value T, err error) Value[T] {
 // containing the default value of T and no error.
 func NewErrorValue[T any](err error) Value[T] {
 	return Value[T]{
-		err: err,
+		err:         err,
+		initialized: true,
 	}
-}
-
-// NewErrorValue initializes a Value[T] with the given error.
-//
-// Note that if err is nil, the returned Value[T] is fundamentally equivalent to a Value[T]
-// containing the default value of T and no error.
-//
-// This function is equivalent to NewErrorValue[T] but allows not to specify the value of T explicitly
-func (Value[T]) NewErrorValue(err error) Value[T] {
-	return NewErrorValue[T](err)
 }
 
 // Value returns the value and error stored in the Value[T].
@@ -55,5 +52,10 @@ func (Value[T]) NewErrorValue(err error) Value[T] {
 // If the Value[T] represents an error, it returns the default value of type T
 // and a non-nil error, otherwise the stored value of type T and a nil error.
 func (value *Value[T]) Value() (T, error) {
-	return value.value, value.err
+	if value.initialized {
+		return value.value, value.err
+	} else {
+		var def T
+		return def, errors.New("value not initialized")
+	}
 }

--- a/pkg/gohai/utils/value.go
+++ b/pkg/gohai/utils/value.go
@@ -19,6 +19,17 @@ func NewValue[T any](value T) Value[T] {
 	}
 }
 
+// NewValueFrom returns a Value[T] from a value and an error.
+// If the error is non-nil then it represents this error, otherwise it represents the value.
+//
+// This is a convenient function to get a Value from a function which returns a value and an error.
+func NewValueFrom[T any](value T, err error) Value[T] {
+	if err != nil {
+		return NewErrorValue[T](err)
+	}
+	return NewValue(value)
+}
+
 // NewErrorValue initializes a Value[T] with the given error.
 //
 // Note that if err is nil, the returned Value[T] is fundamentally equivalent to a Value[T]

--- a/pkg/gohai/utils/value.go
+++ b/pkg/gohai/utils/value.go
@@ -17,7 +17,7 @@ func NewValue[T any](value T) Value[T] {
 
 // NewErrorValue initializes a Value[T] with the given error.
 //
-// Note that if err is nil, the returned Value[T] is fundamentaly equivalent to a Value[T]
+// Note that if err is nil, the returned Value[T] is fundamentally equivalent to a Value[T]
 // containing the default value of T and no error.
 func NewErrorValue[T any](err error) Value[T] {
 	return Value[T]{
@@ -27,10 +27,10 @@ func NewErrorValue[T any](err error) Value[T] {
 
 // NewErrorValue initializes a Value[T] with the given error.
 //
-// Note that if err is nil, the returned Value[T] is fundamentaly equivalent to a Value[T]
+// Note that if err is nil, the returned Value[T] is fundamentally equivalent to a Value[T]
 // containing the default value of T and no error.
 //
-// This function is equivalent to NewErrorValue[T] but allows not to specify the value of T explicitely
+// This function is equivalent to NewErrorValue[T] but allows not to specify the value of T explicitly
 func (Value[T]) NewErrorValue(err error) Value[T] {
 	return NewErrorValue[T](err)
 }

--- a/pkg/gohai/utils/value.go
+++ b/pkg/gohai/utils/value.go
@@ -1,0 +1,44 @@
+package utils
+
+// Value represents either an error or an actual value of type T.
+//
+// The default value of the type is the default value of T (no error).
+type Value[T any] struct {
+	value T
+	err   error
+}
+
+// NewValue initializes a Value[T] with the given value of type T and no error.
+func NewValue[T any](value T) Value[T] {
+	return Value[T]{
+		value: value,
+	}
+}
+
+// NewErrorValue initializes a Value[T] with the given error.
+//
+// Note that if err is nil, the returned Value[T] is fundamentaly equivalent to a Value[T]
+// containing the default value of T and no error.
+func NewErrorValue[T any](err error) Value[T] {
+	return Value[T]{
+		err: err,
+	}
+}
+
+// NewErrorValue initializes a Value[T] with the given error.
+//
+// Note that if err is nil, the returned Value[T] is fundamentaly equivalent to a Value[T]
+// containing the default value of T and no error.
+//
+// This function is equivalent to NewErrorValue[T] but allows not to specify the value of T explicitely
+func (Value[T]) NewErrorValue(err error) Value[T] {
+	return NewErrorValue[T](err)
+}
+
+// Value returns the value and error stored in the Value[T].
+//
+// If the Value[T] represents an error, it returns the default value of type T
+// and a non-nil error, otherwise the stored value of type T and a nil error.
+func (value *Value[T]) Value() (T, error) {
+	return value.value, value.err
+}

--- a/pkg/gohai/utils/value_test.go
+++ b/pkg/gohai/utils/value_test.go
@@ -1,0 +1,29 @@
+package utils
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewValue(t *testing.T) {
+	value := NewValue(42)
+	v, err := value.Value()
+	require.NoError(t, err)
+	require.Equal(t, 42, v)
+}
+
+func TestNewErrorValue(t *testing.T) {
+	myErr := errors.New("this is an error")
+	value := NewErrorValue[int](myErr)
+	result, err := value.Value()
+	require.ErrorIs(t, err, myErr)
+	require.Equal(t, 0, result)
+
+	myOtherErr := errors.New("this is another error")
+	value = value.NewErrorValue(myOtherErr)
+	result, err = value.Value()
+	require.ErrorIs(t, err, myOtherErr)
+	require.Equal(t, 0, result)
+}

--- a/pkg/gohai/utils/value_test.go
+++ b/pkg/gohai/utils/value_test.go
@@ -6,6 +6,7 @@ package utils
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -30,4 +31,16 @@ func TestNewErrorValue(t *testing.T) {
 	result, err = value.Value()
 	require.ErrorIs(t, err, myOtherErr)
 	require.Equal(t, 0, result)
+}
+
+func TestNewValueFrom(t *testing.T) {
+	myerr := fmt.Errorf("yet another error")
+	value := NewValueFrom(42, myerr)
+	_, err := value.Value()
+	require.ErrorIs(t, err, myerr)
+
+	value = NewValueFrom(42, nil)
+	val, err := value.Value()
+	require.NoError(t, err)
+	require.Equal(t, 42, val)
 }

--- a/pkg/gohai/utils/value_test.go
+++ b/pkg/gohai/utils/value_test.go
@@ -1,3 +1,7 @@
+// This file is licensed under the MIT License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2014-present Datadog, Inc.
+
 package utils
 
 import (

--- a/pkg/gohai/utils/value_test.go
+++ b/pkg/gohai/utils/value_test.go
@@ -12,6 +12,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestValueDefault(t *testing.T) {
+	value := Value[int]{}
+	_, err := value.Value()
+	require.Error(t, err)
+}
+
 func TestNewValue(t *testing.T) {
 	value := NewValue(42)
 	v, err := value.Value()
@@ -24,12 +30,6 @@ func TestNewErrorValue(t *testing.T) {
 	value := NewErrorValue[int](myErr)
 	result, err := value.Value()
 	require.ErrorIs(t, err, myErr)
-	require.Equal(t, 0, result)
-
-	myOtherErr := errors.New("this is another error")
-	value = value.NewErrorValue(myOtherErr)
-	result, err = value.Value()
-	require.ErrorIs(t, err, myOtherErr)
 	require.Equal(t, 0, result)
 }
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR is the first step of the implementation of the [Gohai RFC](https://github.com/DataDog/architecture/blob/master/rfcs/gohai-api-design/rfc.md), it adds
- the `Value` type which represents either an actual value or an error
- the `AsJSON` function which generates a marshallable representation of an `Info` struct
- some error types used in the functions above

The function `AsJSON` returns an error whenever it encounters something it doesn't know how to handle. This is to prevent errors when creating/modifying Info structs.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

These types and functions are needed in order to implement Gohai's new API.
I considered it was better to add them in their own PR so that they can be reviewed properly.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

This is not used by Gohai / the agent yet (follow-up PRs to come) but I tried to write tests as exhaustive as possible to make up for that.

The minimum go version of Gohai is increased from 1.17 to 1.18 in order to be able to use generics.
Both [datadog-agent](https://github.com/DataDog/datadog-agent) and [opentelemetry-collector-contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib) use Go 1.19 so it's not an issue.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

The added code is not used by Gohai yet so no QA is needed.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.

[Jira card](https://datadoghq.atlassian.net/browse/ASC-470)