### PR TITLE
[CWS] remove unused mount group id field

### DIFF
--- a/docs/cloud-workload-security/backend.md
+++ b/docs/cloud-workload-security/backend.md
@@ -432,10 +432,6 @@ CWS logs have the following JSON schema:
                     "type": "integer",
                     "description": "New Mount ID"
                 },
-                "group_id": {
-                    "type": "integer",
-                    "description": "Group ID"
-                },
                 "device": {
                     "type": "integer",
                     "description": "Device associated with the file"
@@ -597,9 +593,6 @@ CWS logs have the following JSON schema:
                 "mount_id": {
                     "type": "integer"
                 },
-                "group_id": {
-                    "type": "integer"
-                },
                 "parent_mount_id": {
                     "type": "integer"
                 },
@@ -629,7 +622,6 @@ CWS logs have the following JSON schema:
             "type": "object",
             "required": [
                 "mount_id",
-                "group_id",
                 "parent_mount_id",
                 "bind_src_mount_id",
                 "device"
@@ -1910,10 +1902,6 @@ CWS logs have the following JSON schema:
             "type": "integer",
             "description": "New Mount ID"
         },
-        "group_id": {
-            "type": "integer",
-            "description": "Group ID"
-        },
         "device": {
             "type": "integer",
             "description": "Device associated with the file"
@@ -1958,7 +1946,6 @@ CWS logs have the following JSON schema:
 | `package_version` | System package version |
 | `destination` | Target file information |
 | `new_mount_id` | New Mount ID |
-| `group_id` | Group ID |
 | `device` | Device associated with the file |
 | `fstype` | Filesystem type |
 
@@ -2185,9 +2172,6 @@ CWS logs have the following JSON schema:
         "mount_id": {
             "type": "integer"
         },
-        "group_id": {
-            "type": "integer"
-        },
         "parent_mount_id": {
             "type": "integer"
         },
@@ -2217,7 +2201,6 @@ CWS logs have the following JSON schema:
     "type": "object",
     "required": [
         "mount_id",
-        "group_id",
         "parent_mount_id",
         "bind_src_mount_id",
         "device"

--- a/docs/cloud-workload-security/backend.schema.json
+++ b/docs/cloud-workload-security/backend.schema.json
@@ -416,10 +416,6 @@
           "type": "integer",
           "description": "New Mount ID"
         },
-        "group_id": {
-          "type": "integer",
-          "description": "Group ID"
-        },
         "device": {
           "type": "integer",
           "description": "Device associated with the file"
@@ -581,9 +577,6 @@
         "mount_id": {
           "type": "integer"
         },
-        "group_id": {
-          "type": "integer"
-        },
         "parent_mount_id": {
           "type": "integer"
         },
@@ -613,7 +606,6 @@
       "type": "object",
       "required": [
         "mount_id",
-        "group_id",
         "parent_mount_id",
         "bind_src_mount_id",
         "device"

--- a/pkg/security/ebpf/c/include/constants/offsets/filesystem.h
+++ b/pkg/security/ebpf/c/include/constants/offsets/filesystem.h
@@ -79,14 +79,6 @@ int __attribute__((always_inline)) get_mount_mount_id(void *mnt) {
     return mount_id;
 }
 
-int __attribute__((always_inline)) get_mount_peer_group_id(void *mnt) {
-    int mount_id;
-
-    // bpf_probe_read(&mount_id, sizeof(mount_id), (char *)mnt + offsetof(struct mount, mnt_group_id));
-    bpf_probe_read(&mount_id, sizeof(mount_id), (char *)mnt + get_mount_offset_of_mount_id() + 4);
-    return mount_id;
-}
-
 struct dentry * __attribute__((always_inline)) get_mount_mountpoint_dentry(struct mount *mnt) {
     struct dentry *dentry;
     bpf_probe_read(&dentry, sizeof(dentry), (char *)mnt + 24);

--- a/pkg/security/ebpf/c/include/hooks/mount.h
+++ b/pkg/security/ebpf/c/include/hooks/mount.h
@@ -234,7 +234,6 @@ int __attribute__((always_inline)) kprobe_dr_unshare_mntns_stage_two_callback(st
 
     struct unshare_mntns_event_t event = {
         .mountfields.mount_id = get_mount_mount_id(syscall->unshare_mntns.mnt),
-        .mountfields.group_id = get_mount_peer_group_id(syscall->unshare_mntns.mnt),
         .mountfields.device = get_mount_dev(syscall->unshare_mntns.mnt),
         .mountfields.parent_mount_id = syscall->unshare_mntns.path_key.mount_id,
         .mountfields.parent_inode = syscall->unshare_mntns.path_key.ino,
@@ -393,7 +392,6 @@ int __attribute__((always_inline)) dr_mount_callback(void *ctx, int retval) {
     struct mount_event_t event = {
         .syscall.retval = retval,
         .mountfields.mount_id = get_mount_mount_id(syscall->mount.src_mnt),
-        .mountfields.group_id = get_mount_peer_group_id(syscall->mount.src_mnt),
         .mountfields.device = get_mount_dev(syscall->mount.src_mnt),
         .mountfields.parent_mount_id = syscall->mount.path_key.mount_id,
         .mountfields.parent_inode = syscall->mount.path_key.ino,

--- a/pkg/security/ebpf/c/include/structs/filesystem.h
+++ b/pkg/security/ebpf/c/include/structs/filesystem.h
@@ -15,14 +15,14 @@ struct mount_ref_t {
 };
 
 struct mount_fields_t {
-    u32 mount_id;
-    u32 group_id;
-    dev_t device;
-    u32 parent_mount_id;
     unsigned long parent_inode;
     unsigned long root_inode;
+    dev_t device;
+    u32 mount_id;
+    u32 parent_mount_id;
     u32 root_mount_id;
     u32 bind_src_mount_id;
+    u32 padding;
     char fstype[FSTYPE_LEN];
 };
 

--- a/pkg/security/resolvers/mount/resolver.go
+++ b/pkg/security/resolvers/mount/resolver.go
@@ -10,7 +10,6 @@ package mount
 import (
 	"context"
 	"path"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -35,32 +34,11 @@ const (
 	fallbackLimiterPeriod = 5 * time.Second
 )
 
-func parseGroupID(mnt *mountinfo.Info) (uint32, error) {
-	// Has optional fields, which is a space separated list of values.
-	// Example: shared:2 master:7
-	if len(mnt.Optional) > 0 {
-		for _, field := range strings.Split(mnt.Optional, " ") {
-			target, value, found := strings.Cut(field, ":")
-			if found {
-				if target == "shared" || target == "master" {
-					groupID, err := strconv.ParseUint(value, 10, 32)
-					return uint32(groupID), err
-				}
-			}
-		}
-	}
-	return 0, nil
-}
-
 // newMountFromMountInfo - Creates a new Mount from parsed MountInfo data
 func newMountFromMountInfo(mnt *mountinfo.Info) *model.Mount {
-	// groupID is not use for the path resolution, don't make it critical
-	groupID, _ := parseGroupID(mnt)
-
 	// create a Mount out of the parsed MountInfo
 	return &model.Mount{
 		MountID:       uint32(mnt.ID),
-		GroupID:       groupID,
 		Device:        uint32(unix.Mkdev(uint32(mnt.Major), uint32(mnt.Minor))),
 		ParentMountID: uint32(mnt.Parent),
 		FSType:        mnt.FSType,

--- a/pkg/security/resolvers/mount/resolver_test.go
+++ b/pkg/security/resolvers/mount/resolver_test.go
@@ -46,7 +46,6 @@ func TestMountResolver(t *testing.T) {
 							SyscallEvent: model.SyscallEvent{},
 							Mount: model.Mount{
 								MountID:       27,
-								GroupID:       0,
 								Device:        1,
 								ParentInode:   0,
 								RootMountID:   0,
@@ -77,7 +76,6 @@ func TestMountResolver(t *testing.T) {
 							SyscallEvent: model.SyscallEvent{},
 							Mount: model.Mount{
 								MountID:       27,
-								GroupID:       0,
 								Device:        1,
 								ParentInode:   0,
 								RootMountID:   0,
@@ -108,7 +106,6 @@ func TestMountResolver(t *testing.T) {
 							SyscallEvent: model.SyscallEvent{},
 							Mount: model.Mount{
 								MountID:       127,
-								GroupID:       71,
 								Device:        52,
 								ParentInode:   0,
 								RootMountID:   0,
@@ -169,7 +166,6 @@ func TestMountResolver(t *testing.T) {
 							SyscallEvent: model.SyscallEvent{},
 							Mount: model.Mount{
 								MountID:       27,
-								GroupID:       0,
 								Device:        1,
 								ParentInode:   0,
 								RootMountID:   0,
@@ -186,7 +182,6 @@ func TestMountResolver(t *testing.T) {
 							SyscallEvent: model.SyscallEvent{},
 							Mount: model.Mount{
 								MountID:       22,
-								GroupID:       0,
 								Device:        21,
 								ParentInode:   0,
 								RootMountID:   0,
@@ -203,7 +198,6 @@ func TestMountResolver(t *testing.T) {
 							SyscallEvent: model.SyscallEvent{},
 							Mount: model.Mount{
 								MountID:       31,
-								GroupID:       0,
 								Device:        26,
 								ParentInode:   0,
 								RootMountID:   0,
@@ -274,7 +268,6 @@ func TestMountResolver(t *testing.T) {
 							SyscallEvent: model.SyscallEvent{},
 							Mount: model.Mount{
 								MountID:       27,
-								GroupID:       0,
 								Device:        1,
 								ParentInode:   0,
 								RootMountID:   0,
@@ -291,7 +284,6 @@ func TestMountResolver(t *testing.T) {
 							SyscallEvent: model.SyscallEvent{},
 							Mount: model.Mount{
 								MountID:       176,
-								GroupID:       71,
 								Device:        52,
 								ParentInode:   0,
 								RootMountID:   0,
@@ -308,7 +300,6 @@ func TestMountResolver(t *testing.T) {
 							SyscallEvent: model.SyscallEvent{},
 							Mount: model.Mount{
 								MountID:       638,
-								GroupID:       71,
 								Device:        52,
 								ParentInode:   0,
 								RootMountID:   0,
@@ -325,7 +316,6 @@ func TestMountResolver(t *testing.T) {
 							SyscallEvent: model.SyscallEvent{},
 							Mount: model.Mount{
 								MountID:       639,
-								GroupID:       0,
 								Device:        54,
 								ParentInode:   0,
 								RootMountID:   0,

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -744,7 +744,6 @@ type ArgsEnvsEvent struct {
 // Mount represents a mountpoint (used by MountEvent and UnshareMountNSEvent)
 type Mount struct {
 	MountID        uint32 `field:"-"`
-	GroupID        uint32 `field:"-"`
 	Device         uint32 `field:"-"`
 	ParentMountID  uint32 `field:"-"`
 	ParentInode    uint64 `field:"-"`

--- a/pkg/security/secl/model/unmarshallers.go
+++ b/pkg/security/secl/model/unmarshallers.go
@@ -401,14 +401,15 @@ func (m *Mount) UnmarshalBinary(data []byte) (int, error) {
 		return 0, ErrNotEnoughData
 	}
 
-	m.MountID = ByteOrder.Uint32(data[0:4])
-	m.GroupID = ByteOrder.Uint32(data[4:8])
-	m.Device = ByteOrder.Uint32(data[8:12])
-	m.ParentMountID = ByteOrder.Uint32(data[12:16])
-	m.ParentInode = ByteOrder.Uint64(data[16:24])
-	m.RootInode = ByteOrder.Uint64(data[24:32])
-	m.RootMountID = ByteOrder.Uint32(data[32:36])
-	m.BindSrcMountID = ByteOrder.Uint32(data[36:40])
+	m.ParentInode = ByteOrder.Uint64(data[0:8])
+	m.RootInode = ByteOrder.Uint64(data[8:16])
+	m.Device = ByteOrder.Uint32(data[16:20])
+	m.MountID = ByteOrder.Uint32(data[20:24])
+	m.ParentMountID = ByteOrder.Uint32(data[24:28])
+	m.RootMountID = ByteOrder.Uint32(data[28:32])
+	m.BindSrcMountID = ByteOrder.Uint32(data[32:36])
+
+	// +4 for padding
 
 	var err error
 	m.FSType, err = UnmarshalString(data[40:56], 16)

--- a/pkg/security/serializers/serializers.go
+++ b/pkg/security/serializers/serializers.go
@@ -239,8 +239,6 @@ type FileEventSerializer struct {
 
 	// New Mount ID
 	NewMountID uint32 `json:"new_mount_id,omitempty"`
-	// Group ID
-	GroupID uint32 `json:"group_id,omitempty"`
 	// Device associated with the file
 	Device uint32 `json:"device,omitempty"`
 	// Filesystem type
@@ -513,7 +511,6 @@ type MountEventSerializer struct {
 	MountPoint                     *FileSerializer `json:"mp,omitempty"`                    // Mount point file information
 	Root                           *FileSerializer `json:"root,omitempty"`                  // Root file information
 	MountID                        uint32          `json:"mount_id"`                        // Mount ID of the new mount
-	GroupID                        uint32          `json:"group_id"`                        // ID of the peer group
 	ParentMountID                  uint32          `json:"parent_mount_id"`                 // Mount ID of the parent mount
 	BindSrcMountID                 uint32          `json:"bind_src_mount_id"`               // Mount ID of the source of a bind mount
 	Device                         uint32          `json:"device"`                          // Device associated with the file
@@ -1013,7 +1010,6 @@ func newMountEventSerializer(e *model.Event, resolvers *resolvers.Resolvers) *Mo
 			Inode:   &e.Mount.RootInode,
 		},
 		MountID:         e.Mount.MountID,
-		GroupID:         e.Mount.GroupID,
 		ParentMountID:   e.Mount.ParentMountID,
 		BindSrcMountID:  e.Mount.BindSrcMountID,
 		Device:          e.Mount.Device,

--- a/pkg/security/serializers/serializers_easyjson.go
+++ b/pkg/security/serializers/serializers_easyjson.go
@@ -1987,8 +1987,6 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecuritySerializers15(
 			}
 		case "mount_id":
 			out.MountID = uint32(in.Uint32())
-		case "group_id":
-			out.GroupID = uint32(in.Uint32())
 		case "parent_mount_id":
 			out.ParentMountID = uint32(in.Uint32())
 		case "bind_src_mount_id":
@@ -2044,11 +2042,6 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecuritySerializers15(
 			out.RawString(prefix)
 		}
 		out.Uint32(uint32(in.MountID))
-	}
-	{
-		const prefix string = ",\"group_id\":"
-		out.RawString(prefix)
-		out.Uint32(uint32(in.GroupID))
 	}
 	{
 		const prefix string = ",\"parent_mount_id\":"
@@ -2848,8 +2841,6 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecuritySerializers22(
 			}
 		case "new_mount_id":
 			out.NewMountID = uint32(in.Uint32())
-		case "group_id":
-			out.GroupID = uint32(in.Uint32())
 		case "device":
 			out.Device = uint32(in.Uint32())
 		case "fstype":
@@ -3006,16 +2997,6 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecuritySerializers22(
 			out.RawString(prefix)
 		}
 		out.Uint32(uint32(in.NewMountID))
-	}
-	if in.GroupID != 0 {
-		const prefix string = ",\"group_id\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		out.Uint32(uint32(in.GroupID))
 	}
 	if in.Device != 0 {
 		const prefix string = ",\"device\":"


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
