### PR TITLE
[omnibus] Import memory leak fixes from upstream OpenSCAP

### DIFF
--- a/omnibus/config/patches/openscap/0042-Plug-a-memory-leak.patch
+++ b/omnibus/config/patches/openscap/0042-Plug-a-memory-leak.patch
@@ -1,0 +1,61 @@
+From 1c2863cde0481d77b7f45f90e48db5ce1497372a Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Jan=20=C4=8Cern=C3=BD?= <jcerny@redhat.com>
+Date: Tue, 9 May 2023 16:43:54 +0200
+Subject: [PATCH 42/43] Plug a memory leak
+
+When there already exists a value under the given key in the
+hash table, oscap_htable_add doesn't put the value to the hash table
+and therefore the value isn't freed when the hash table is freed.
+The caller of oscap_htable_add needs to check if oscap_htable_add
+failed and in this situation is responsible to free the value.
+
+Addressing:
+
+oscap  xccdf eval --profile '(all)' --rule xccdf_org.ssgproject.content_rule_accounts_tmout /usr/share/xml/scap/ssg/content/ssg-fedora-ds.xml
+--- Starting Evaluation ---
+
+Title   Set Interactive Session Timeout
+Rule    xccdf_org.ssgproject.content_rule_accounts_tmout
+Result  fail
+
+=================================================================
+==85219==ERROR: LeakSanitizer: detected memory leaks
+
+Direct leak of 49 byte(s) in 1 object(s) allocated from:
+    #0 0x4a3198 in strdup (/home/jcerny/work/git/openscap/build/utils/oscap+0x4a3198) (BuildId: 329fd48580c8ee52863c16be406cb9d7c3df95db)
+    #1 0x7f090491f20c in oscap_strdup /home/jcerny/work/git/openscap/src/common/util.h:312:9
+    #2 0x7f090491e9dd in ds_sds_dump_component_ref_as /home/jcerny/work/git/openscap/src/DS/sds.c:510:26
+    #3 0x7f090491efce in ds_sds_dump_component_ref_as /home/jcerny/work/git/openscap/src/DS/sds.c:574:8
+    #4 0x7f090491f7d3 in ds_sds_dump_component_ref /home/jcerny/work/git/openscap/src/DS/sds.c:601:15
+    #5 0x7f0904917305 in ds_sds_session_register_component_with_dependencies /home/jcerny/work/git/openscap/src/DS/ds_sds_session.c:327:10
+    #6 0x7f0904a0493c in xccdf_session_load_cpe /home/jcerny/work/git/openscap/src/XCCDF/xccdf_session.c:921:8
+    #7 0x7f0904a03dc7 in xccdf_session_load /home/jcerny/work/git/openscap/src/XCCDF/xccdf_session.c:705:14
+    #8 0x53333f in app_evaluate_xccdf /home/jcerny/work/git/openscap/utils/oscap-xccdf.c:641:6
+    #9 0x52fedb in oscap_module_call /home/jcerny/work/git/openscap/utils/oscap-tool.c:295:10
+    #10 0x5307fb in oscap_module_process /home/jcerny/work/git/openscap/utils/oscap-tool.c:389:19
+    #11 0x53cee0 in main /home/jcerny/work/git/openscap/utils/oscap.c:88:15
+    #12 0x7f090390950f in __libc_start_call_main (/lib64/libc.so.6+0x2750f) (BuildId: 81daba31ee66dbd63efdc4252a872949d874d136)
+
+SUMMARY: AddressSanitizer: 49 byte(s) leaked in 1 allocation(s).
+---
+ src/DS/sds.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/src/DS/sds.c b/src/DS/sds.c
+index c82638962..c640c5452 100644
+--- a/src/DS/sds.c
++++ b/src/DS/sds.c
+@@ -509,7 +509,9 @@ int ds_sds_dump_component_ref_as(const xmlNodePtr component_ref, struct ds_sds_s
+ 	// make a copy of xlink_href because ds_sds_dump_component_by_href modifies its second argument
+ 	char *xlink_href_copy = oscap_strdup(xlink_href);
+ 	int ret = ds_sds_dump_component_by_href(session, xlink_href, target_filename_dirname, relative_filepath, cref_id, &component_id);
+-	oscap_htable_add(ds_sds_session_get_component_uris(session), cref_id, xlink_href_copy);
++	if (!oscap_htable_add(ds_sds_session_get_component_uris(session), cref_id, xlink_href_copy)) {
++		free(xlink_href_copy);
++	}
+ 
+ 	xmlFree(xlink_href);
+ 	xmlFree(cref_id);
+-- 
+2.34.1
+

--- a/omnibus/config/patches/openscap/0043-Fix-other-occurences-of-oscap_htable_add.patch
+++ b/omnibus/config/patches/openscap/0043-Fix-other-occurences-of-oscap_htable_add.patch
@@ -1,0 +1,50 @@
+From b4ada9f12ebcc778dff5a63cbdf594c22cbb75f5 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Jan=20=C4=8Cern=C3=BD?= <jcerny@redhat.com>
+Date: Tue, 16 May 2023 14:48:20 +0200
+Subject: [PATCH 43/43] Fix other occurences of oscap_htable_add
+
+If the hash table owns its elements, its responsible for freeing
+them. The callers of oscap_htable_add rely on the fact that the
+elements will be later freed by oscap_htable_free. However, if
+oscap_htable_add fails to insert the elements to the table,
+then the caller needs to free them.
+---
+ src/DS/rds.c              | 5 ++++-
+ src/OVAL/oval_generator.c | 5 ++++-
+ 2 files changed, 8 insertions(+), 2 deletions(-)
+
+diff --git a/src/DS/rds.c b/src/DS/rds.c
+index 5ec98daa2..d2553b2db 100644
+--- a/src/DS/rds.c
++++ b/src/DS/rds.c
+@@ -888,7 +888,10 @@ int ds_rds_create(const char* sds_file, const char* xccdf_result_file, const cha
+ 				result = -1;
+ 				oscap_source_free(oval_source);
+ 			} else {
+-				oscap_htable_add(oval_result_sources, *oval_result_files, oval_source);
++				if (!oscap_htable_add(oval_result_sources, *oval_result_files, oval_source)) {
++					result = -1;
++					oscap_source_free(oval_source);
++				}
+ 			}
+ 			oval_result_files++;
+ 		}
+diff --git a/src/OVAL/oval_generator.c b/src/OVAL/oval_generator.c
+index 267f83037..e423a9551 100644
+--- a/src/OVAL/oval_generator.c
++++ b/src/OVAL/oval_generator.c
+@@ -171,7 +171,10 @@ void oval_generator_update_timestamp(struct oval_generator *generator)
+ 
+ void oval_generator_add_platform_schema_version(struct oval_generator *generator, const char *platform, const char *schema_version)
+ {
+-	oscap_htable_add(generator->platform_schema_versions, platform, oscap_strdup(schema_version));
++	char *schema_version_dup = oscap_strdup(schema_version);
++	if (!oscap_htable_add(generator->platform_schema_versions, platform, schema_version_dup)) {
++		free(schema_version_dup);
++	}
+ }
+ 
+ 
+-- 
+2.34.1
+

--- a/omnibus/config/software/openscap.rb
+++ b/omnibus/config/software/openscap.rb
@@ -52,6 +52,8 @@ build do
   patch source: "0036-Fix-leak-of-regex-structure-in-oval_fts-in-error-cas.patch", env: env
   patch source: "0037-Free-xmlDoc-structure-at-the-end-of-xccdf_session_lo.patch", env: env
   patch source: "0041-Fix-implicitly-declared-function.patch", env: env
+  patch source: "0042-Plug-a-memory-leak.patch", env: env
+  patch source: "0043-Fix-other-occurences-of-oscap_htable_add.patch", env: env
 
   patch source: "get_results_from_session.patch", env: env # add a function to retrieve results from session
   patch source: "session_result_free.patch", env: env # add a function to free results from session


### PR DESCRIPTION
### What does this PR do?
This changes imports memory leak fixes from OpenSCAP maint-1.3 branch, as of 2023-05-17.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
