### PR TITLE
DRAFT - DCA profiles in flare

### DIFF
--- a/pkg/cli/subcommands/dcaflare/command.go
+++ b/pkg/cli/subcommands/dcaflare/command.go
@@ -6,8 +6,10 @@ package dcaflare
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 
+	"github.com/DataDog/datadog-agent/cmd/agent/common"
 	"github.com/DataDog/datadog-agent/cmd/agent/common/path"
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/config"
@@ -15,17 +17,24 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/api/util"
 	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/flare"
+	pkgflare "github.com/DataDog/datadog-agent/pkg/flare"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/DataDog/datadog-agent/pkg/util/input"
 	"github.com/fatih/color"
+	"github.com/hashicorp/go-multierror"
 	"github.com/spf13/cobra"
 	"go.uber.org/fx"
 )
 
 type cliParams struct {
-	caseID string
-	email  string
-	send   bool
+	caseID               string
+	email                string
+	send                 bool
+	profiling            int
+	profileMutex         bool
+	profileMutexFraction int
+	profileBlocking      bool
+	profileBlockingRate  int
 }
 
 type GlobalParams struct {
@@ -73,14 +82,62 @@ func MakeCommand(globalParamsGetter func() GlobalParams) *cobra.Command {
 
 	cmd.Flags().StringVarP(&cliParams.email, "email", "e", "", "Your email")
 	cmd.Flags().BoolVarP(&cliParams.send, "send", "s", false, "Automatically send flare (don't prompt for confirmation)")
+	cmd.Flags().IntVarP(&cliParams.profiling, "profile", "p", -1, "Add performance profiling data to the flare. It will collect a heap profile and a CPU profile for the amount of seconds passed to the flag, with a minimum of 30s")
+	cmd.Flags().BoolVarP(&cliParams.profileMutex, "profile-mutex", "M", false, "Add mutex profile to the performance data in the flare")
+	cmd.Flags().IntVarP(&cliParams.profileMutexFraction, "profile-mutex-fraction", "", 100, "Set the fraction of mutex contention events that are reported in the mutex profile")
+	cmd.Flags().BoolVarP(&cliParams.profileBlocking, "profile-blocking", "B", false, "Add gorouting blocking profile to the performance data in the flare")
+	cmd.Flags().IntVarP(&cliParams.profileBlockingRate, "profile-blocking-rate", "", 10000, "Set the fraction of goroutine blocking events that are reported in the blocking profile")
 	cmd.SetArgs([]string{"caseID"})
 
 	return cmd
 }
 
+type profileCollector func(prefix, debugURL string, cpusec int, target *pkgflare.ProfileDataDCA) error
+type agentProfileCollector func(cliParams *cliParams, pdata *pkgflare.ProfileDataDCA, c profileCollector) error
+
+func readProfileData(cliParams *cliParams, pdata *pkgflare.ProfileDataDCA, seconds int, collector profileCollector) error {
+	prevSettings, err := setRuntimeProfilingSettings(cliParams)
+	if err != nil {
+		return err
+	}
+	defer resetRuntimeProfilingSettings(prevSettings)
+
+	type agentCollector struct {
+		name string
+		fn   agentProfileCollector
+	}
+
+	agentCollectors := []agentCollector{{
+		name: "dca",
+		fn:   serviceProfileCollector("dca", "expvar_port", seconds),
+	}}
+
+	var errs error
+	for _, c := range agentCollectors {
+		if err := c.fn(cliParams, pdata, collector); err != nil {
+			errs = multierror.Append(errs, fmt.Errorf("error collecting %s agent profile: %v", c.name, err))
+		}
+	}
+
+	return errs
+}
+
+func serviceProfileCollector(service string, portConfig string, seconds int) agentProfileCollector {
+	return func(cliParams *cliParams, pdata *pkgflare.ProfileDataDCA, collector profileCollector) error {
+		fmt.Fprintln(color.Output, color.BlueString("Getting a %ds profile snapshot from %s.", seconds, service))
+		pprofURL := fmt.Sprintf("http://127.0.0.1:%d/debug/pprof", pkgconfig.Datadog.GetInt(portConfig))
+		return collector(service, pprofURL, seconds, pdata)
+	}
+}
+
 func run(log log.Component, config config.Component, cliParams *cliParams) error {
 	fmt.Fprintln(color.Output, color.BlueString("Asking the Cluster Agent to build the flare archive."))
-	var e error
+
+	var (
+		profile pkgflare.ProfileDataDCA
+		e       error
+	)
+
 	c := util.GetClient(false) // FIX: get certificates right then make this true
 	urlstr := fmt.Sprintf("https://localhost:%v/flare", pkgconfig.Datadog.GetInt("cluster_agent.cmd_port"))
 
@@ -89,22 +146,39 @@ func run(log log.Component, config config.Component, cliParams *cliParams) error
 		logFile = path.DefaultDCALogFile
 	}
 
+	if cliParams.profiling >= 30 {
+		if err := readProfileData(cliParams, &profile, cliParams.profiling, pkgflare.CreatePerformanceProfileDCA); err != nil {
+			fmt.Fprintln(color.Output, color.YellowString(fmt.Sprintf("Could not collect performance profile data: %s", err)))
+		}
+	} else if cliParams.profiling != -1 {
+		fmt.Fprintln(color.Output, color.RedString(fmt.Sprintf("Invalid value for profiling: %d. Please enter an integer of at least 30.", cliParams.profiling)))
+		return e
+	}
+
 	// Set session token
 	e = util.SetAuthToken()
 	if e != nil {
 		return e
 	}
 
-	r, e := util.DoPost(c, urlstr, "application/json", bytes.NewBuffer([]byte{}))
+	p, e := json.Marshal(profile)
+	if e != nil {
+		fmt.Fprintln(color.Output, color.RedString(fmt.Sprintf("Error while encoding profile: %s", e)))
+		return e
+	}
+
+	r, e := util.DoPost(c, urlstr, "application/json", bytes.NewBuffer(p))
+
 	var filePath string
 	if e != nil {
+
 		if r != nil && string(r) != "" {
 			fmt.Fprintln(color.Output, fmt.Sprintf("The agent ran into an error while making the flare: %s", color.RedString(string(r))))
 		} else {
 			fmt.Fprintln(color.Output, color.RedString("The agent was unable to make a full flare: %s.", e.Error()))
 		}
 		fmt.Fprintln(color.Output, color.YellowString("Initiating flare locally, some logs will be missing."))
-		filePath, e = flare.CreateDCAArchive(true, path.GetDistPath(), logFile)
+		filePath, e = flare.CreateDCAArchive(true, path.GetDistPath(), logFile, profile)
 		if e != nil {
 			fmt.Printf("The flare zipfile failed to be created: %s\n", e)
 			return e
@@ -128,4 +202,66 @@ func run(log log.Component, config config.Component, cliParams *cliParams) error
 		return e
 	}
 	return nil
+}
+
+func setRuntimeProfilingSettings(cliParams *cliParams) (map[string]interface{}, error) {
+	prev := make(map[string]interface{})
+	if cliParams.profileMutex && cliParams.profileMutexFraction > 0 {
+		old, err := setRuntimeSetting("runtime_mutex_profile_fraction", cliParams.profileMutexFraction)
+		if err != nil {
+			return nil, err
+		}
+		prev["runtime_mutex_profile_fraction"] = old
+	}
+	if cliParams.profileBlocking && cliParams.profileBlockingRate > 0 {
+		old, err := setRuntimeSetting("runtime_block_profile_rate", cliParams.profileBlockingRate)
+		if err != nil {
+			return nil, err
+		}
+		prev["runtime_block_profile_rate"] = old
+	}
+	return prev, nil
+}
+
+func setRuntimeSetting(name string, new int) (interface{}, error) {
+	c, err := common.NewSettingsClient()
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize settings client: %v", err)
+	}
+
+	fmt.Fprintln(color.Output, color.BlueString("Setting %s to %v", name, new))
+
+	if err := util.SetAuthToken(); err != nil {
+		return nil, fmt.Errorf("unable to set up authentication token: %v", err)
+	}
+
+	oldVal, err := c.Get(name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get current value of %s: %v", name, err)
+	}
+
+	if _, err := c.Set(name, fmt.Sprint(new)); err != nil {
+		return nil, fmt.Errorf("failed to set %s to %v: %v", name, new, err)
+	}
+
+	return oldVal, nil
+}
+
+func resetRuntimeProfilingSettings(prev map[string]interface{}) {
+	if len(prev) == 0 {
+		return
+	}
+
+	c, err := common.NewSettingsClient()
+	if err != nil {
+		fmt.Fprintln(color.Output, color.RedString("Failed to restore runtime settings: %v", err))
+		return
+	}
+
+	for name, value := range prev {
+		fmt.Fprintln(color.Output, color.BlueString("Restoring %s to %v", name, value))
+		if _, err := c.Set(name, fmt.Sprint(value)); err != nil {
+			fmt.Fprintln(color.Output, color.RedString("Failed to restore previous value of %s: %v", name, err))
+		}
+	}
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR will ad the profiles for the Datadog Cluster Agent in the flare when using the --profile option in the flare command.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Dev card: https://datadoghq.atlassian.net/browse/CONT-3593

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

To test this change, you can:

1- Generate a profile in the flare command in the Cluster Agent pod:

```kubectl exec -it <DCA_POD_NAME> agent flare --profile 30```

2- Go the profiles folder created in the flare and use go tools to display it:

```go tool pprof -http=localhost:8080 dca-1st-heap.pprof```

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
