### PR TITLE
[system-probe] Fix route cache lru size telemetry

### DIFF
--- a/pkg/network/route_cache.go
+++ b/pkg/network/route_cache.go
@@ -59,6 +59,7 @@ var routeCacheTelemetry = struct {
 	misses  telemetry.Counter
 	lookups telemetry.Counter
 	expires telemetry.Counter
+	evicts  telemetry.Counter
 
 	netlinkLookups telemetry.Counter
 	netlinkErrors  telemetry.Counter
@@ -73,6 +74,7 @@ var routeCacheTelemetry = struct {
 	telemetry.NewCounter(routeCacheTelemetryModuleName, "misses", []string{}, "Counter measuring the number of route cache misses"),
 	telemetry.NewCounter(routeCacheTelemetryModuleName, "lookups", []string{}, "Counter measuring the number of route cache lookups"),
 	telemetry.NewCounter(routeCacheTelemetryModuleName, "expires", []string{}, "Counter measuring the number of route cache expirations"),
+	telemetry.NewCounter(routeCacheTelemetryModuleName, "evicts", []string{}, "Counter measuring the number of route cache evicts"),
 
 	telemetry.NewCounter(routerTelemetryModuleName, "netlink_lookups", []string{}, "Counter measuring the number of netlink lookups"),
 	telemetry.NewCounter(routerTelemetryModuleName, "netlink_errors", []string{}, "Counter measuring the number of netlink errors"),
@@ -113,6 +115,10 @@ func newRouteCache(size int, router Router, ttl time.Duration) *routeCache {
 		ttl:    ttl,
 	}
 
+	rc.cache.OnEvicted = func(_ lru.Key, _ interface{}) {
+		routeCacheTelemetry.evicts.Inc()
+	}
+
 	return rc
 }
 
@@ -126,7 +132,10 @@ func (c *routeCache) Close() {
 
 func (c *routeCache) Get(source, dest util.Address, netns uint32) (Route, bool) {
 	c.Lock()
-	defer c.Unlock()
+	defer func() {
+		routeCacheTelemetry.size.Set(float64(c.cache.Len()))
+		c.Unlock()
+	}()
 
 	routeCacheTelemetry.lookups.Inc()
 	k := newRouteKey(source, dest, netns)
@@ -137,7 +146,6 @@ func (c *routeCache) Get(source, dest util.Address, netns uint32) (Route, bool) 
 
 		routeCacheTelemetry.expires.Inc()
 		c.cache.Remove(k)
-		routeCacheTelemetry.size.Dec()
 	} else {
 		routeCacheTelemetry.misses.Inc()
 	}
@@ -149,7 +157,6 @@ func (c *routeCache) Get(source, dest util.Address, netns uint32) (Route, bool) 
 		}
 
 		c.cache.Add(k, entry)
-		routeCacheTelemetry.size.Inc()
 		return r, true
 	}
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

The route cache telemetry in the network tracer is not tracking the LRU size correctly. In particular it is not tracking the evicts so the size reported is not correct.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
