### PR TITLE
fix(pkg/clusteragent/admission): add inject-all config

### DIFF
--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -325,7 +325,7 @@ func start(log log.Component, config config.Component, forwarder defaultforwarde
 			pkglog.Errorf("Could not start admission controller: %v", err)
 		} else {
 			// Webhook and secret controllers are started successfully
-			// Setup the the k8s admission webhook server
+			// Setup the k8s admission webhook server
 			server := admissioncmd.NewServer()
 			server.Register(pkgconfig.Datadog.GetString("admission_controller.inject_config.endpoint"), mutate.InjectConfig, apiCl.DynamicCl)
 			server.Register(pkgconfig.Datadog.GetString("admission_controller.inject_tags.endpoint"), mutate.InjectTags, apiCl.DynamicCl)

--- a/pkg/clusteragent/admission/mutate/auto_instrumentation.go
+++ b/pkg/clusteragent/admission/mutate/auto_instrumentation.go
@@ -319,6 +319,13 @@ func injectAutoInstruConfig(pod *corev1.Pod, libsToInject []libInfo) error {
 		}
 	}
 
+	// try to inject all if the annotation is set
+	if err := injectLibConfig(pod, "all"); err != nil {
+		metrics.LibInjectionErrors.Inc("all")
+		lastError = err
+		log.Errorf("Cannot inject library configuration into pod %s: %s", podString(pod), err)
+	}
+
 	injectLibVolume(pod)
 
 	return lastError
@@ -373,7 +380,7 @@ func initResources() (corev1.ResourceRequirements, bool, error) {
 	return resources, hasResources, nil
 }
 
-// injectLibRequirements injects the minimal config requirements to enable instrumentation
+// injectLibRequirements injects the minimal config requirements (env vars and volume mounts) to enable instrumentation
 func injectLibRequirements(pod *corev1.Pod, ctrName string, envVars []envVar) error {
 	for i, ctr := range pod.Spec.Containers {
 		if ctrName != "" && ctrName != ctr.Name {
@@ -416,7 +423,7 @@ func injectLibConfig(pod *corev1.Pod, lang language) error {
 	configAnnotKey := fmt.Sprintf(common.LibConfigV1AnnotKeyFormat, lang)
 	confString, found := pod.GetAnnotations()[configAnnotKey]
 	if !found {
-		log.Debugf("Config annotation key %q not found on pod %s, skipping config injection", configAnnotKey, podString(pod))
+		log.Tracef("Config annotation key %q not found on pod %s, skipping config injection", configAnnotKey, podString(pod))
 		return nil
 	}
 	log.Infof("Config annotation key %q found on pod %s, config: %q", configAnnotKey, podString(pod), confString)

--- a/pkg/clusteragent/admission/mutate/auto_instrumentation_test.go
+++ b/pkg/clusteragent/admission/mutate/auto_instrumentation_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/dynamic/fake"
 )
 
 func TestInjectAutoInstruConfig(t *testing.T) {
@@ -506,6 +507,22 @@ func TestInjectLibConfig(t *testing.T) {
 			},
 		},
 		{
+			name:    "inject all case",
+			pod:     fakePodWithAnnotation("admission.datadoghq.com/all-lib.config.v1", `{"version":1,"service_language":"all","runtime_metrics_enabled":true,"tracing_rate_limit":50}`),
+			lang:    "all",
+			wantErr: false,
+			expectedEnvs: []corev1.EnvVar{
+				{
+					Name:  "DD_RUNTIME_METRICS_ENABLED",
+					Value: "true",
+				},
+				{
+					Name:  "DD_TRACE_RATE_LIMIT",
+					Value: "50",
+				},
+			},
+		},
+		{
 			name:         "invalid json",
 			pod:          fakePodWithAnnotation("admission.datadoghq.com/java-lib.config.v1", "invalid"),
 			lang:         java,
@@ -664,6 +681,267 @@ func TestInjectAll(t *testing.T) {
 			targetNamespaces = tt.targetNamespaces
 			got := injectAll(tt.ns, "gcr.io/datadoghq")
 			require.EqualValues(t, tt.want, got)
+		})
+	}
+}
+
+func TestInjectAutoInstrumentation(t *testing.T) {
+	tests := []struct {
+		name         string
+		pod          *corev1.Pod
+		expectedEnvs []corev1.EnvVar
+		wantErr      bool
+	}{
+		{
+			name: "inject all",
+			pod: fakePodWithAnnotations(map[string]string{
+				"admission.datadoghq.com/all-lib.version":   "latest",
+				"admission.datadoghq.com/all-lib.config.v1": `{"version":1,"runtime_metrics_enabled":true,"tracing_rate_limit":50,"tracing_sampling_rate":0.3}`,
+			}),
+			expectedEnvs: []corev1.EnvVar{
+				{
+					Name:  "DD_RUNTIME_METRICS_ENABLED",
+					Value: "true",
+				},
+				{
+					Name:  "DD_TRACE_RATE_LIMIT",
+					Value: "50",
+				},
+				{
+					Name:  "DD_TRACE_SAMPLE_RATE",
+					Value: "0.30",
+				},
+				{
+					Name:  "PYTHONPATH",
+					Value: "/datadog-lib/",
+				},
+				{
+					Name:  "RUBYOPT",
+					Value: " -r/datadog-lib/auto_inject",
+				},
+				{
+					Name:  "NODE_OPTIONS",
+					Value: " --require=/datadog-lib/node_modules/dd-trace/init",
+				},
+				{
+					Name:  "JAVA_TOOL_OPTIONS",
+					Value: " -javaagent:/datadog-lib/dd-java-agent.jar",
+				},
+				{
+					Name:  "DD_DOTNET_TRACER_HOME",
+					Value: "/datadog-lib",
+				},
+				{
+					Name:  "CORECLR_ENABLE_PROFILING",
+					Value: "1",
+				},
+				{
+					Name:  "CORECLR_PROFILER",
+					Value: "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+				},
+				{
+					Name:  "CORECLR_PROFILER_PATH",
+					Value: "/datadog-lib/Datadog.Trace.ClrProfiler.Native.so",
+				},
+				{
+					Name:  "DD_TRACE_LOG_DIRECTORY",
+					Value: "/datadog-lib/logs",
+				},
+				{
+					Name:  "LD_PRELOAD",
+					Value: "/datadog-lib/continuousprofiler/Datadog.Linux.ApiWrapper.x64.so",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "inject java",
+			pod: fakePodWithAnnotations(map[string]string{
+				"admission.datadoghq.com/java-lib.version":   "latest",
+				"admission.datadoghq.com/java-lib.config.v1": `{"version":1,"tracing_sampling_rate":0.3}`,
+			}),
+			expectedEnvs: []corev1.EnvVar{
+				{
+					Name:  "DD_TRACE_SAMPLE_RATE",
+					Value: "0.30",
+				},
+				{
+					Name:  "JAVA_TOOL_OPTIONS",
+					Value: " -javaagent:/datadog-lib/dd-java-agent.jar",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "inject python",
+			pod: fakePodWithAnnotations(map[string]string{
+				"admission.datadoghq.com/python-lib.version":   "latest",
+				"admission.datadoghq.com/python-lib.config.v1": `{"version":1,"tracing_sampling_rate":0.3}`,
+			}),
+			expectedEnvs: []corev1.EnvVar{
+				{
+					Name:  "DD_TRACE_SAMPLE_RATE",
+					Value: "0.30",
+				},
+				{
+					Name:  "PYTHONPATH",
+					Value: "/datadog-lib/",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "inject node",
+			pod: fakePodWithAnnotations(map[string]string{
+				"admission.datadoghq.com/js-lib.version":   "latest",
+				"admission.datadoghq.com/js-lib.config.v1": `{"version":1,"tracing_sampling_rate":0.3}`,
+			}),
+			expectedEnvs: []corev1.EnvVar{
+				{
+					Name:  "DD_TRACE_SAMPLE_RATE",
+					Value: "0.30",
+				},
+				{
+					Name:  "NODE_OPTIONS",
+					Value: " --require=/datadog-lib/node_modules/dd-trace/init",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "inject library and all",
+			pod: fakePodWithAnnotations(map[string]string{
+				"admission.datadoghq.com/all-lib.version":   "latest",
+				"admission.datadoghq.com/all-lib.config.v1": `{"version":1,"runtime_metrics_enabled":true,"tracing_rate_limit":50,"tracing_sampling_rate":0.3}`,
+				"admission.datadoghq.com/js-lib.version":    "v1.10",
+				"admission.datadoghq.com/js-lib.config.v1":  `{"version":1,"tracing_sampling_rate":0.4}`,
+			}),
+			expectedEnvs: []corev1.EnvVar{
+				{
+					Name:  "DD_RUNTIME_METRICS_ENABLED",
+					Value: "true",
+				},
+				{
+					Name:  "DD_TRACE_RATE_LIMIT",
+					Value: "50",
+				},
+				{
+					Name:  "DD_TRACE_SAMPLE_RATE",
+					Value: "0.40",
+				},
+				{
+					Name:  "NODE_OPTIONS",
+					Value: " --require=/datadog-lib/node_modules/dd-trace/init",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "inject library and all no library version",
+			pod: fakePodWithAnnotations(map[string]string{
+				"admission.datadoghq.com/all-lib.version":   "latest",
+				"admission.datadoghq.com/all-lib.config.v1": `{"version":1,"runtime_metrics_enabled":true,"tracing_rate_limit":50,"tracing_sampling_rate":0.3}`,
+				"admission.datadoghq.com/js-lib.config.v1":  `{"version":1,"tracing_sampling_rate":0.4}`,
+			}),
+			expectedEnvs: []corev1.EnvVar{
+				{
+					Name:  "DD_RUNTIME_METRICS_ENABLED",
+					Value: "true",
+				},
+				{
+					Name:  "DD_TRACE_RATE_LIMIT",
+					Value: "50",
+				},
+				{
+					Name:  "PYTHONPATH",
+					Value: "/datadog-lib/",
+				},
+				{
+					Name:  "RUBYOPT",
+					Value: " -r/datadog-lib/auto_inject",
+				},
+				{
+					Name:  "NODE_OPTIONS",
+					Value: " --require=/datadog-lib/node_modules/dd-trace/init",
+				},
+				{
+					Name:  "JAVA_TOOL_OPTIONS",
+					Value: " -javaagent:/datadog-lib/dd-java-agent.jar",
+				},
+				{
+					Name:  "DD_DOTNET_TRACER_HOME",
+					Value: "/datadog-lib",
+				},
+				{
+					Name:  "CORECLR_ENABLE_PROFILING",
+					Value: "1",
+				},
+				{
+					Name:  "CORECLR_PROFILER",
+					Value: "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+				},
+				{
+					Name:  "CORECLR_PROFILER_PATH",
+					Value: "/datadog-lib/Datadog.Trace.ClrProfiler.Native.so",
+				},
+				{
+					Name:  "DD_TRACE_LOG_DIRECTORY",
+					Value: "/datadog-lib/logs",
+				},
+				{
+					Name:  "LD_PRELOAD",
+					Value: "/datadog-lib/continuousprofiler/Datadog.Linux.ApiWrapper.x64.so",
+				},
+				{
+					Name:  "DD_TRACE_SAMPLE_RATE",
+					Value: "0.40",
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := injectAutoInstrumentation(tt.pod, "", fake.NewSimpleDynamicClient(scheme))
+			require.False(t, (err != nil) != tt.wantErr)
+
+			container := tt.pod.Spec.Containers[0]
+			for _, contEnv := range container.Env {
+				found := false
+				for _, expectEnv := range tt.expectedEnvs {
+					if expectEnv.Name == contEnv.Name {
+						found = true
+						break
+					}
+				}
+				if !found {
+					require.Failf(t, "Unexpected env var injected in container", contEnv.Name)
+				}
+			}
+			for _, expectEnv := range tt.expectedEnvs {
+				found := false
+				for _, contEnv := range container.Env {
+					if expectEnv.Name == contEnv.Name {
+						found = true
+						break
+					}
+				}
+				if !found {
+					require.Failf(t, "Unexpected env var injected in container", expectEnv.Name)
+				}
+			}
+
+			envCount := 0
+			for _, contEnv := range container.Env {
+				for _, expectEnv := range tt.expectedEnvs {
+					if expectEnv.Name == contEnv.Name {
+						require.Equal(t, expectEnv.Value, contEnv.Value)
+						envCount++
+						break
+					}
+				}
+			}
+			require.Equal(t, len(tt.expectedEnvs), envCount)
 		})
 	}
 }

--- a/pkg/clusteragent/admission/mutate/test_utils.go
+++ b/pkg/clusteragent/admission/mutate/test_utils.go
@@ -96,6 +96,16 @@ func fakePodWithAnnotation(k, v string) *corev1.Pod {
 	return withContainer(pod, "-container")
 }
 
+func fakePodWithAnnotations(as map[string]string) *corev1.Pod {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "pod",
+			Annotations: as,
+		},
+	}
+	return withContainer(pod, "-container")
+}
+
 func fakePodWithEnv(name, env string) *corev1.Pod {
 	return fakePodWithContainer(name, corev1.Container{Name: name + "-container", Env: []corev1.EnvVar{fakeEnv(env)}})
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Inject the library configuration when injecting all libraries.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

The configuration for injecting all libraries was not being injected. This issue was detected in the system tests (shared tests) for the batch injection (https://github.com/DataDog/system-tests/pull/1189).


### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

https://github.com/DataDog/system-tests/pull/1189 provides a regression test. Integration tests for the `injectAutoInstrumentation` function are also added which assert the exact environment which should be injected for a given pod. The integration tests assert that the correct configuration is injected for the `all-lib.config.v1` annotation.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
