### PR TITLE
[CSPM] Allow to specify a rule as being skipped

### DIFF
--- a/pkg/compliance/evaluator_rego.go
+++ b/pkg/compliance/evaluator_rego.go
@@ -120,6 +120,8 @@ func newCheckEventFromRegoResult(data interface{}, rule *Rule, resolvedInputs Re
 		result = CheckPassed
 	case "failing", "fail":
 		result = CheckFailed
+	case "skipped":
+		result = CheckSkipped
 	case "err", "error":
 		d, _ := m["data"].(map[string]interface{})
 		errMsg, _ := d["error"].(string)
@@ -181,6 +183,12 @@ passed_finding(resource_type, resource_id, event_data) = f {
 
 failing_finding(resource_type, resource_id, event_data) = f {
 	f := raw_finding("failing", resource_type, resource_id, event_data)
+}
+
+skipped_finding(resource_type, resource_id, error_msg) = f {
+	f := raw_finding("skipped", resource_type, resource_id, {
+		"error": error_msg
+	})
 }
 
 error_finding(resource_type, resource_id, error_msg) = f {


### PR DESCRIPTION
### What does this PR do?

Support the `skipped` status for a rego rule.

### Motivation

- better describes the status of some of our rule results (specifically for cis-kubernetes)
- saves throughput to avoid sending false errors to the backend
- skipped rules are still counted as part of our metrics

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
