### PR TITLE
Forwarders process agent

### DIFF
--- a/comp/README.md
+++ b/comp/README.md
@@ -81,6 +81,10 @@ Package containercheck implements a component to handle Container data collectio
 
 Package expvars initializes the expvar server of the process agent.
 
+### [comp/process/forwarders](https://pkg.go.dev/github.com/DataDog/dd-agent-comp-experiments/comp/process/forwarders)
+
+Package forwarders implements a component to provide forwarders used by the process agent.
+
 ### [comp/process/hostinfo](https://pkg.go.dev/github.com/DataDog/dd-agent-comp-experiments/comp/process/hostinfo)
 
 Package hostinfo wraps the hostinfo inside a component. This is useful because it is relied on by other components.

--- a/comp/forwarder/defaultforwarder/forwarder.go
+++ b/comp/forwarder/defaultforwarder/forwarder.go
@@ -17,10 +17,14 @@ type dependencies struct {
 }
 
 func newForwarder(dep dependencies) Component {
-	if dep.Params.UseNoopForwarder {
+	return NewForwarder(dep.Config, dep.Params)
+}
+
+func NewForwarder(config config.Component, params Params) Component {
+	if params.UseNoopForwarder {
 		return NoopForwarder{}
 	}
-	return NewDefaultForwarder(dep.Config, dep.Params.Options)
+	return NewDefaultForwarder(config, params.Options)
 }
 
 func newMockForwarder(config config.Component) Component {

--- a/comp/process/bundle.go
+++ b/comp/process/bundle.go
@@ -17,6 +17,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/process/connectionscheck"
 	"github.com/DataDog/datadog-agent/comp/process/containercheck"
 	"github.com/DataDog/datadog-agent/comp/process/expvars"
+	"github.com/DataDog/datadog-agent/comp/process/forwarders"
 	"github.com/DataDog/datadog-agent/comp/process/hostinfo"
 	"github.com/DataDog/datadog-agent/comp/process/podcheck"
 	"github.com/DataDog/datadog-agent/comp/process/processcheck"
@@ -49,6 +50,7 @@ var Bundle = fxutil.Bundle(
 	hostinfo.Module,
 	expvars.Module,
 	apiserver.Module,
+	forwarders.Module,
 
 	core.Bundle,
 )

--- a/comp/process/expvars/expvars.go
+++ b/comp/process/expvars/expvars.go
@@ -19,7 +19,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig"
 	"github.com/DataDog/datadog-agent/comp/process/hostinfo"
 	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
-	"github.com/DataDog/datadog-agent/pkg/process/runner"
+	"github.com/DataDog/datadog-agent/pkg/process/runner/endpoint"
 	"github.com/DataDog/datadog-agent/pkg/process/status"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 )
@@ -91,7 +91,7 @@ func initStatus(deps dependencies) error {
 
 	// If the sysprobe module is enabled, the process check can call out to the sysprobe for privileged stats
 	_, processModuleEnabled := deps.SysProbeConfig.Object().EnabledModules[sysconfig.ProcessModule]
-	eps, err := runner.GetAPIEndpoints(deps.Config)
+	eps, err := endpoint.GetAPIEndpoints(deps.Config)
 	if err != nil {
 		_ = deps.Log.Criticalf("Failed to initialize Api Endpoints: %s", err.Error())
 	}

--- a/comp/process/forwarders/component.go
+++ b/comp/process/forwarders/component.go
@@ -17,6 +17,9 @@ import (
 
 type Component interface {
 	GetEventForwarder() defaultforwarder.Component
+	GetProcessForwarder() defaultforwarder.Component
+	GetRTProcessForwarder() defaultforwarder.Component
+	GetConnectionsForwarder() defaultforwarder.Component
 }
 
 // Module defines the fx options for this component.

--- a/comp/process/forwarders/component.go
+++ b/comp/process/forwarders/component.go
@@ -1,0 +1,29 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package forwarders implements a component to provide forwarders used by the process agent.
+package forwarders
+
+import (
+	"go.uber.org/fx"
+
+	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+// team: processes
+
+type Component interface {
+	GetEventForwarder() defaultforwarder.Component
+}
+
+// Module defines the fx options for this component.
+var Module = fxutil.Component(
+	fx.Provide(newForwarders),
+)
+
+var MockModule = fxutil.Component(
+	fx.Provide(newMockForwarders),
+)

--- a/comp/process/forwarders/forwarders.go
+++ b/comp/process/forwarders/forwarders.go
@@ -1,0 +1,65 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package forwarders
+
+import (
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/log"
+	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder"
+	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/config/resolver"
+	"github.com/DataDog/datadog-agent/pkg/process/runner/endpoint"
+	apicfg "github.com/DataDog/datadog-agent/pkg/process/util/api/config"
+	"go.uber.org/fx"
+)
+
+type dependencies struct {
+	fx.In
+
+	Config config.Component
+	Logger log.Component
+}
+
+type forwarders struct {
+	eventForwarder defaultforwarder.Component
+}
+
+func newForwarders(deps dependencies) (Component, error) {
+	queueBytes := deps.Config.GetInt("process_config.process_queue_bytes")
+	if queueBytes <= 0 {
+		deps.Logger.Warnf("Invalid queue bytes size: %d. Using default value: %d", queueBytes, ddconfig.DefaultProcessQueueBytes)
+		queueBytes = ddconfig.DefaultProcessQueueBytes
+	}
+
+	eventForwarderOpts, err := createParams(deps.Config, queueBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	return &forwarders{
+		eventForwarder: defaultforwarder.NewForwarder(deps.Config, eventForwarderOpts),
+	}, nil
+
+}
+
+func createParams(config config.Component, queueBytes int) (defaultforwarder.Params, error) {
+	apiEndpoints, err := endpoint.GetEventsAPIEndpoints(config)
+	if err != nil {
+		return defaultforwarder.Params{}, err
+	}
+	forwarderOpts := defaultforwarder.NewOptionsWithResolvers(config, resolver.NewSingleDomainResolvers(apicfg.KeysPerDomains(apiEndpoints)))
+	forwarderOpts.DisableAPIKeyChecking = true
+	forwarderOpts.RetryQueuePayloadsTotalMaxSize = queueBytes // Allow more in-flight requests than the default
+	return defaultforwarder.Params{Options: forwarderOpts}, nil
+}
+
+func (f *forwarders) GetEventForwarder() defaultforwarder.Component {
+	return f.eventForwarder
+}
+
+func newMockForwarders(deps dependencies) (Component, error) {
+	return newForwarders(deps)
+}

--- a/comp/process/submitter/submitter.go
+++ b/comp/process/submitter/submitter.go
@@ -14,6 +14,7 @@ import (
 	"go.uber.org/fx"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/process/forwarders"
 	"github.com/DataDog/datadog-agent/comp/process/hostinfo"
 	"github.com/DataDog/datadog-agent/comp/process/types"
 	processRunner "github.com/DataDog/datadog-agent/pkg/process/runner"
@@ -29,8 +30,9 @@ type dependencies struct {
 	fx.In
 	Lc fx.Lifecycle
 
-	HostInfo hostinfo.Component
-	Config   config.Component
+	HostInfo   hostinfo.Component
+	Config     config.Component
+	Forwarders forwarders.Component
 }
 
 type result struct {
@@ -41,7 +43,7 @@ type result struct {
 }
 
 func newSubmitter(deps dependencies) (result, error) {
-	s, err := processRunner.NewSubmitter(deps.Config, deps.HostInfo.Object().HostName)
+	s, err := processRunner.NewSubmitter(deps.Config, deps.Forwarders, deps.HostInfo.Object().HostName)
 	if err != nil {
 		return result{}, err
 	}

--- a/comp/process/submitter/submitter_test.go
+++ b/comp/process/submitter/submitter_test.go
@@ -11,6 +11,7 @@ import (
 	"go.uber.org/fx"
 
 	"github.com/DataDog/datadog-agent/comp/core"
+	"github.com/DataDog/datadog-agent/comp/process/forwarders"
 	"github.com/DataDog/datadog-agent/comp/process/hostinfo"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
@@ -19,6 +20,7 @@ func TestSubmitterLifecycle(t *testing.T) {
 	_ = fxutil.Test[Component](t, fx.Options(
 		hostinfo.MockModule,
 		core.MockBundle,
+		forwarders.MockModule,
 		Module,
 	))
 }

--- a/pkg/process/runner/collector_api_test.go
+++ b/pkg/process/runner/collector_api_test.go
@@ -572,7 +572,8 @@ func runCollectorTestWithAPIKeys(t *testing.T, check checks.Check, epConfig *end
 	c, err := NewRunnerWithChecks(mockConfig, []checks.Check{check}, true, nil)
 	check.Init(nil, hostInfo)
 	assert.NoError(t, err)
-	c.Submitter, err = NewSubmitter(mockConfig, hostInfo.HostName)
+	forwarders := newForwardersMock(t, mockConfig)
+	c.Submitter, err = NewSubmitter(mockConfig, forwarders, hostInfo.HostName)
 	require.NoError(t, err)
 
 	err = c.Submitter.Start()

--- a/pkg/process/runner/collector_api_test.go
+++ b/pkg/process/runner/collector_api_test.go
@@ -19,6 +19,7 @@ import (
 
 	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/process/checks"
+	"github.com/DataDog/datadog-agent/pkg/process/runner/endpoint"
 	apicfg "github.com/DataDog/datadog-agent/pkg/process/util/api/config"
 	"github.com/DataDog/datadog-agent/pkg/process/util/api/headers"
 	"github.com/DataDog/datadog-agent/pkg/version"
@@ -87,7 +88,7 @@ func TestSendConnectionsMessage(t *testing.T) {
 		assert.Equal(t, "/api/v1/connections", req.uri)
 
 		assert.Equal(t, testHostName, req.headers.Get(headers.HostHeader))
-		apiEps, err := GetAPIEndpoints(cfg)
+		apiEps, err := endpoint.GetAPIEndpoints(cfg)
 		assert.NoError(t, err)
 		assert.Equal(t, apiEps[0].APIKey, req.headers.Get("DD-Api-Key"))
 
@@ -127,7 +128,7 @@ func TestSendContainerMessage(t *testing.T) {
 		assert.Equal(t, "/api/v1/container", req.uri)
 
 		assert.Equal(t, testHostName, req.headers.Get(headers.HostHeader))
-		eps, err := GetAPIEndpoints(cfg)
+		eps, err := endpoint.GetAPIEndpoints(cfg)
 		assert.NoError(t, err)
 		assert.Equal(t, eps[0].APIKey, req.headers.Get("DD-Api-Key"))
 		assert.Equal(t, "1", req.headers.Get(headers.ContainerCountHeader))
@@ -165,7 +166,7 @@ func TestSendProcMessage(t *testing.T) {
 		assert.Equal(t, "/api/v1/collector", req.uri)
 
 		assert.Equal(t, testHostName, req.headers.Get(headers.HostHeader))
-		eps, err := GetAPIEndpoints(cfg)
+		eps, err := endpoint.GetAPIEndpoints(cfg)
 		assert.NoError(t, err)
 		assert.Equal(t, eps[0].APIKey, req.headers.Get("DD-Api-Key"))
 		assert.Equal(t, "1", req.headers.Get(headers.ContainerCountHeader))
@@ -206,7 +207,7 @@ func TestSendProcessDiscoveryMessage(t *testing.T) {
 		assert.Equal(t, "/api/v1/discovery", req.uri)
 
 		assert.Equal(t, testHostName, req.headers.Get(headers.HostHeader))
-		eps, err := GetAPIEndpoints(cfg)
+		eps, err := endpoint.GetAPIEndpoints(cfg)
 		assert.NoError(t, err)
 		assert.Equal(t, eps[0].APIKey, req.headers.Get("DD-Api-Key"))
 		assert.Equal(t, "0", req.headers.Get(headers.ContainerCountHeader))
@@ -256,7 +257,7 @@ func TestSendProcessEventMessage(t *testing.T) {
 		assert.Equal(t, "/api/v2/proclcycle", req.uri)
 
 		assert.Equal(t, testHostName, req.headers.Get(headers.HostHeader))
-		eps, err := getEventsAPIEndpoints(cfg)
+		eps, err := endpoint.GetEventsAPIEndpoints(cfg)
 		assert.NoError(t, err)
 		assert.Equal(t, eps[0].APIKey, req.headers.Get("DD-Api-Key"))
 		assert.Equal(t, "0", req.headers.Get(headers.ContainerCountHeader))
@@ -304,7 +305,7 @@ func TestSendProcMessageWithRetry(t *testing.T) {
 		timestamps := make(map[string]struct{})
 		for _, req := range requests {
 			assert.Equal(t, testHostName, req.headers.Get(headers.HostHeader))
-			eps, err := GetAPIEndpoints(cfg)
+			eps, err := endpoint.GetAPIEndpoints(cfg)
 			assert.NoError(t, err)
 			assert.Equal(t, eps[0].APIKey, req.headers.Get("DD-Api-Key"))
 			assert.Equal(t, "1", req.headers.Get(headers.ContainerCountHeader))

--- a/pkg/process/runner/endpoint/endpoints.go
+++ b/pkg/process/runner/endpoint/endpoints.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-package runner
+package endpoint
 
 import (
 	"fmt"
@@ -18,7 +18,7 @@ func GetAPIEndpoints(config ddconfig.ConfigReader) (eps []apicfg.Endpoint, err e
 	return getAPIEndpointsWithKeys(config, "https://process.", "process_config.process_dd_url", "process_config.additional_endpoints")
 }
 
-func getEventsAPIEndpoints(config ddconfig.ConfigReader) (eps []apicfg.Endpoint, err error) {
+func GetEventsAPIEndpoints(config ddconfig.ConfigReader) (eps []apicfg.Endpoint, err error) {
 	return getAPIEndpointsWithKeys(config, "https://process-events.", "process_config.events_dd_url", "process_config.events_additional_endpoints")
 }
 

--- a/pkg/process/runner/endpoints_test.go
+++ b/pkg/process/runner/endpoints_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/process/runner/endpoint"
 	apicfg "github.com/DataDog/datadog-agent/pkg/process/util/api/config"
 )
 
@@ -93,7 +94,7 @@ func TestGetAPIEndpoints(t *testing.T) {
 				cfg.Set("process_config.additional_endpoints", tc.additionalEndpoints)
 			}
 
-			if eps, err := GetAPIEndpoints(cfg); tc.error {
+			if eps, err := endpoint.GetAPIEndpoints(cfg); tc.error {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
@@ -150,13 +151,13 @@ func TestGetAPIEndpointsSite(t *testing.T) {
 				cfg.Set("process_config.events_dd_url", tc.eventsDDURL)
 			}
 
-			eps, err := GetAPIEndpoints(cfg)
+			eps, err := endpoint.GetAPIEndpoints(cfg)
 			assert.NoError(t, err)
 
 			mainEndpoint := eps[0]
 			assert.Equal(t, tc.expectedHostname, mainEndpoint.Endpoint.Hostname())
 
-			eventsEps, err := getEventsAPIEndpoints(cfg)
+			eventsEps, err := endpoint.GetEventsAPIEndpoints(cfg)
 			assert.NoError(t, err)
 
 			mainEventEndpoint := eventsEps[0]
@@ -298,11 +299,11 @@ func TestGetConcurrentAPIEndpoints(t *testing.T) {
 				cfg.Set("process_config.events_additional_endpoints", tc.additionalEventsEndpoints)
 			}
 
-			eps, err := GetAPIEndpoints(cfg)
+			eps, err := endpoint.GetAPIEndpoints(cfg)
 			assert.NoError(t, err)
 			assert.ElementsMatch(t, tc.expectedEndpoints, eps)
 
-			eventsEps, err := getEventsAPIEndpoints(cfg)
+			eventsEps, err := endpoint.GetEventsAPIEndpoints(cfg)
 			assert.NoError(t, err)
 			assert.ElementsMatch(t, tc.expectedEventsEndpoints, eventsEps)
 		})

--- a/pkg/process/runner/submitter.go
+++ b/pkg/process/runner/submitter.go
@@ -55,9 +55,9 @@ type CheckSubmitter struct {
 	podResults         *api.WeightedQueue
 
 	// Forwarders
-	processForwarder     *forwarder.DefaultForwarder
-	rtProcessForwarder   *forwarder.DefaultForwarder
-	connectionsForwarder *forwarder.DefaultForwarder
+	processForwarder     defaultforwarder.Component
+	rtProcessForwarder   defaultforwarder.Component
+	connectionsForwarder defaultforwarder.Component
 	podForwarder         *forwarder.DefaultForwarder
 	eventForwarder       defaultforwarder.Component
 
@@ -127,16 +127,6 @@ func NewSubmitter(config config.Component, forwarders forwarders.Component, host
 	if err != nil {
 		return nil, err
 	}
-	processForwarderOpts := forwarder.NewOptionsWithResolvers(config, resolver.NewSingleDomainResolvers(apicfg.KeysPerDomains(processAPIEndpoints)))
-	processForwarderOpts.DisableAPIKeyChecking = true
-	processForwarderOpts.RetryQueuePayloadsTotalMaxSize = queueBytes // Allow more in-flight requests than the default
-	processForwarder := forwarder.NewDefaultForwarder(config, processForwarderOpts)
-
-	// rt forwarder reuses processForwarder's config
-	rtProcessForwarder := forwarder.NewDefaultForwarder(config, processForwarderOpts)
-
-	// connections forwarder reuses processForwarder's config
-	connectionsForwarder := forwarder.NewDefaultForwarder(config, processForwarderOpts)
 
 	podForwarderOpts := forwarder.NewOptionsWithResolvers(config, resolver.NewSingleDomainResolvers(apicfg.KeysPerDomains(orchestrator.OrchestratorEndpoints)))
 	podForwarderOpts.DisableAPIKeyChecking = true
@@ -156,9 +146,9 @@ func NewSubmitter(config config.Component, forwarders forwarders.Component, host
 		connectionsResults: connectionsResults,
 		podResults:         podResults,
 
-		processForwarder:     processForwarder,
-		rtProcessForwarder:   rtProcessForwarder,
-		connectionsForwarder: connectionsForwarder,
+		processForwarder:     forwarders.GetProcessForwarder(),
+		rtProcessForwarder:   forwarders.GetRTProcessForwarder(),
+		connectionsForwarder: forwarders.GetConnectionsForwarder(),
 		podForwarder:         podForwarder,
 		eventForwarder:       forwarders.GetEventForwarder(),
 

--- a/pkg/process/runner/submitter.go
+++ b/pkg/process/runner/submitter.go
@@ -24,6 +24,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/orchestrator"
 	oconfig "github.com/DataDog/datadog-agent/pkg/orchestrator/config"
 	"github.com/DataDog/datadog-agent/pkg/process/checks"
+	"github.com/DataDog/datadog-agent/pkg/process/runner/endpoint"
 	"github.com/DataDog/datadog-agent/pkg/process/statsd"
 	"github.com/DataDog/datadog-agent/pkg/process/status"
 	"github.com/DataDog/datadog-agent/pkg/process/util/api"
@@ -119,7 +120,7 @@ func NewSubmitter(config config.Component, hostname string) (*CheckSubmitter, er
 	status.UpdateDropCheckPayloads(dropCheckPayloads)
 
 	// Forwarder initialization
-	processAPIEndpoints, err := GetAPIEndpoints(config)
+	processAPIEndpoints, err := endpoint.GetAPIEndpoints(config)
 	if err != nil {
 		return nil, err
 	}
@@ -139,7 +140,7 @@ func NewSubmitter(config config.Component, hostname string) (*CheckSubmitter, er
 	podForwarderOpts.RetryQueuePayloadsTotalMaxSize = queueBytes // Allow more in-flight requests than the default
 	podForwarder := forwarder.NewDefaultForwarder(config, podForwarderOpts)
 
-	processEventsAPIEndpoints, err := getEventsAPIEndpoints(config)
+	processEventsAPIEndpoints, err := endpoint.GetEventsAPIEndpoints(config)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/process/runner/submitter_test.go
+++ b/pkg/process/runner/submitter_test.go
@@ -11,9 +11,12 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/fx"
 
 	model "github.com/DataDog/agent-payload/v5/process"
 	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/log"
+	"github.com/DataDog/datadog-agent/comp/process/forwarders"
 	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/process/util/api/headers"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
@@ -59,8 +62,8 @@ func TestNewCollectorQueueSize(t *testing.T) {
 			if tc.override {
 				mockConfig.Set("process_config.queue_size", tc.queueSize)
 			}
-
-			c, err := NewSubmitter(mockConfig, testHostName)
+			forwarders := newForwardersMock(t, mockConfig)
+			c, err := NewSubmitter(mockConfig, forwarders, testHostName)
 			assert.NoError(t, err)
 			assert.Equal(t, tc.expectedQueueSize, c.processResults.MaxSize())
 			assert.Equal(t, tc.expectedQueueSize, c.podResults.MaxSize())
@@ -107,8 +110,8 @@ func TestNewCollectorRTQueueSize(t *testing.T) {
 			if tc.override {
 				mockConfig.Set("process_config.rt_queue_size", tc.queueSize)
 			}
-
-			c, err := NewSubmitter(mockConfig, testHostName)
+			forwarders := newForwardersMock(t, mockConfig)
+			c, err := NewSubmitter(mockConfig, forwarders, testHostName)
 			assert.NoError(t, err)
 			assert.Equal(t, tc.expectedQueueSize, c.rtProcessResults.MaxSize())
 		})
@@ -154,8 +157,8 @@ func TestNewCollectorProcessQueueBytes(t *testing.T) {
 			if tc.override {
 				mockConfig.Set("process_config.process_queue_bytes", tc.queueBytes)
 			}
-
-			s, err := NewSubmitter(mockConfig, testHostName)
+			forwarders := newForwardersMock(t, mockConfig)
+			s, err := NewSubmitter(mockConfig, forwarders, testHostName)
 			assert.NoError(t, err)
 			assert.Equal(t, int64(tc.expectedQueueSize), s.processResults.MaxWeight())
 			assert.Equal(t, int64(tc.expectedQueueSize), s.rtProcessResults.MaxWeight())
@@ -165,8 +168,8 @@ func TestNewCollectorProcessQueueBytes(t *testing.T) {
 }
 
 func TestCollectorMessagesToCheckResult(t *testing.T) {
-	config := fxutil.Test[config.Component](t, config.MockModule)
-	submitter, err := NewSubmitter(config, testHostName)
+	deps := newSubmitterDeps(t)
+	submitter, err := NewSubmitter(deps.Config, deps.Forwarders, testHostName)
 	assert.NoError(t, err)
 
 	now := time.Now()
@@ -284,8 +287,8 @@ func TestCollectorMessagesToCheckResult(t *testing.T) {
 }
 
 func Test_getRequestID(t *testing.T) {
-	config := fxutil.Test[config.Component](t, config.MockModule)
-	s, err := NewSubmitter(config, testHostName)
+	deps := newSubmitterDeps(t)
+	s, err := NewSubmitter(deps.Config, deps.Forwarders, testHostName)
 	assert.NoError(t, err)
 
 	fixedDate1 := time.Date(2022, 9, 1, 0, 0, 1, 0, time.Local)
@@ -311,4 +314,23 @@ func Test_getRequestID(t *testing.T) {
 	s.requestIDCachedHash = nil
 	id5 := s.getRequestID(fixedDate1, 1)
 	assert.NotEqual(t, id1, id5)
+}
+
+type submitterDeps struct {
+	fx.In
+	Config     config.Component
+	Forwarders forwarders.Component
+}
+
+func newSubmitterDeps(t *testing.T) submitterDeps {
+	return fxutil.Test[submitterDeps](t, getForwardersMockModules(nil))
+}
+
+func newForwardersMock(t *testing.T, config ddconfig.Config) forwarders.Component {
+	overrides := config.AllSettings()
+	return fxutil.Test[forwarders.Component](t, getForwardersMockModules(overrides))
+}
+
+func getForwardersMockModules(configOverrides map[string]interface{}) fx.Option {
+	return fx.Options(config.MockModule, fx.Replace(config.MockParams{Overrides: configOverrides}), forwarders.MockModule, log.MockModule)
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This PR injects the forwarders in the process agent.

Note: `podForwarder` cannot be injected until orchestrator is a component.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

https://github.com/DataDog/datadog-agent/pull/16563#discussion_r1166952911

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
