### PR TITLE
Merge some checks and move to utils to reuse lately

### DIFF
--- a/tasks/utils.py
+++ b/tasks/utils.py
@@ -12,6 +12,9 @@ from subprocess import check_output
 from invoke import task
 from invoke.exceptions import Exit
 
+from .libs.common.color import color_message
+from .libs.common.remote_api import APIError
+
 # constants
 ORG_PATH = "github.com/DataDog"
 DEFAULT_BRANCH = "main"
@@ -479,3 +482,70 @@ def nightly_entry_for(agent_major_version):
 
 def release_entry_for(agent_major_version):
     return f"release-a{agent_major_version}"
+
+
+def check_clean_branch_state(ctx, github, branch):
+    """
+    Check we are in a clean situation to create a new branch:
+    No uncommitted change, and branch doesn't exist locally or upstream
+    """
+    if check_uncommitted_changes(ctx):
+        raise Exit(
+            color_message(
+                "There are uncomitted changes in your repository. Please commit or stash them before trying again.",
+                "red",
+            ),
+            code=1,
+        )
+    if check_local_branch(ctx, branch):
+        raise Exit(
+            color_message(
+                f"The branch {branch} already exists locally. Please remove it before trying again.",
+                "red",
+            ),
+            code=1,
+        )
+
+    if check_upstream_branch(github, branch):
+        raise Exit(
+            color_message(
+                f"The branch {branch} already exists upstream. Please remove it before trying again.",
+                "red",
+            ),
+            code=1,
+        )
+
+
+def check_uncommitted_changes(ctx):
+    """
+    Checks if there are uncommitted changes in the local git repository.
+    """
+    modified_files = ctx.run("git --no-pager diff --name-only HEAD | wc -l", hide=True).stdout.strip()
+
+    # Return True if at least one file has uncommitted changes.
+    return modified_files != "0"
+
+
+def check_local_branch(ctx, branch):
+    """
+    Checks if the given branch exists locally
+    """
+    matching_branch = ctx.run(f"git --no-pager branch --list {branch} | wc -l", hide=True).stdout.strip()
+
+    # Return True if a branch is returned by git branch --list
+    return matching_branch != "0"
+
+
+def check_upstream_branch(github, branch):
+    """
+    Checks if the given branch already exists in the upstream repository
+    """
+    try:
+        github_branch = github.get_branch(branch)
+    except APIError as e:
+        if e.status_code == 404:
+            return False
+        raise e
+
+    # Return True if the branch exists
+    return github_branch and github_branch.get('name', False)


### PR DESCRIPTION
### What does this PR do?

Move and merge some branch checks for a future usage on another invoke task

### Motivation

Creation of automated task for buildimage test (https://github.com/DataDog/datadog-agent/pull/17241)

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes
 n/a
### Reviewer's Checklist


- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
