### PR TITLE
pkg/trace/api : Inject fargate task tag in telemetry requests

### DIFF
--- a/pkg/trace/api/telemetry.go
+++ b/pkg/trace/api/telemetry.go
@@ -120,19 +120,17 @@ func extractFargateTask(containerTags string) (string, bool) {
 }
 
 func extractTag(tags string, name string) (string, bool) {
-	{
-		leftoverTags := tags
-		for {
-			if leftoverTags == "" {
-				return "", false
-			}
-			var tag string
-			tag, leftoverTags, _ = strings.Cut(leftoverTags, ",")
+	leftoverTags := tags
+	for {
+		if leftoverTags == "" {
+			return "", false
+		}
+		var tag string
+		tag, leftoverTags, _ = strings.Cut(leftoverTags, ",")
 
-			tagName, value, hasValue := strings.Cut(tag, ":")
-			if hasValue && tagName == name {
-				return value, true
-			}
+		tagName, value, hasValue := strings.Cut(tag, ":")
+		if hasValue && tagName == name {
+			return value, true
 		}
 	}
 }

--- a/pkg/trace/api/telemetry.go
+++ b/pkg/trace/api/telemetry.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/trace/api/internal/header"
@@ -86,21 +87,53 @@ func (r *HTTPReceiver) telemetryProxyHandler() http.Handler {
 			req.Header.Set("User-Agent", "")
 		}
 
-		if cid := r.containerIDProvider.GetContainerID(req.Context(), req.Header); cid != "" {
-			req.Header.Set(header.ContainerID, cid)
-		} else {
+		containerID := r.containerIDProvider.GetContainerID(req.Context(), req.Header)
+		if containerID == "" {
 			metrics.Count("datadog.trace_agent.telemetry_proxy.no_container_id_found", 1, []string{}, 1)
 		}
+		containerTags := getContainerTags(r.conf.ContainerTags, containerID)
+
 		req.Header.Set("DD-Agent-Hostname", r.conf.Hostname)
 		req.Header.Set("DD-Agent-Env", r.conf.DefaultEnv)
+		if containerID != "" {
+			req.Header.Set(header.ContainerID, containerID)
+		}
+		if containerTags != "" {
+			req.Header.Set("x-datadog-container-tags", containerTags)
+		}
+		if taskArn, ok := extractFargateTask(containerTags); ok {
+			req.Header.Set("dd-task-arn", taskArn)
+		}
 		if arn, ok := r.conf.GlobalTags[functionARNKey]; ok {
-			req.Header.Set("DD-Function-ARN", arn)
+			req.Header.Set("dd-function-arn", arn)
 		}
 	}
 	return &httputil.ReverseProxy{
 		Director:  director,
 		ErrorLog:  logger,
 		Transport: &transport,
+	}
+}
+
+func extractFargateTask(containerTags string) (string, bool) {
+	return extractTag(containerTags, "task_arn")
+}
+
+func extractTag(tags string, name string) (string, bool) {
+	{
+		leftoverTags := tags
+		for {
+			if leftoverTags == "" {
+				return "", false
+			}
+			var tag string
+			tag, leftoverTags, _ = strings.Cut(leftoverTags, ",")
+
+			tagName, value, hasValue := strings.Cut(tag, ":")
+			if hasValue && tagName == name {
+				return value, true
+			}
+		}
 	}
 }
 

--- a/pkg/trace/api/telemetry_test.go
+++ b/pkg/trace/api/telemetry_test.go
@@ -197,3 +197,41 @@ func TestTelemetryConfig(t *testing.T) {
 		assert.Equal(t, "OK", recordedResponse(t, rec))
 	})
 }
+
+func TestExtractFargateTask(t *testing.T) {
+	t.Run("contains-tag", func(t *testing.T) {
+		tags := "foo:bar,baz:,task_arn:123"
+
+		taskArn, ok := extractFargateTask(tags)
+
+		assert.True(t, ok)
+		assert.Equal(t, "123", taskArn)
+	})
+
+	t.Run("doesnt-contain-tag", func(t *testing.T) {
+		tags := "foo:bar,,"
+
+		taskArn, ok := extractFargateTask(tags)
+
+		assert.False(t, ok)
+		assert.Equal(t, "", taskArn)
+	})
+
+	t.Run("contain-empty-tag", func(t *testing.T) {
+		tags := "foo:bar,task_arn:,baz:abc"
+
+		taskArn, ok := extractFargateTask(tags)
+
+		assert.True(t, ok)
+		assert.Equal(t, "", taskArn)
+	})
+
+	t.Run("empty-string", func(t *testing.T) {
+		tags := ""
+
+		taskArn, ok := extractFargateTask(tags)
+
+		assert.False(t, ok)
+		assert.Equal(t, "", taskArn)
+	})
+}

--- a/releasenotes/notes/inject_task_arn_in_instrumentation_telemetry_payload-25fa30e63a87fc97.yaml
+++ b/releasenotes/notes/inject_task_arn_in_instrumentation_telemetry_payload-25fa30e63a87fc97.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Inject container tags in instrumentation telemetry payloads
+  - |
+    Extract the task_arn tag from container tags and add it as it's own header

--- a/releasenotes/notes/inject_task_arn_in_instrumentation_telemetry_payload-25fa30e63a87fc97.yaml
+++ b/releasenotes/notes/inject_task_arn_in_instrumentation_telemetry_payload-25fa30e63a87fc97.yaml
@@ -10,4 +10,4 @@ enhancements:
   - |
     Inject container tags in instrumentation telemetry payloads
   - |
-    Extract the task_arn tag from container tags and add it as it's own header
+    Extract the `task_arn` tag from container tags and add it as its own header.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

* Add container tags to instrumentation-telemetry requests when applicable
* Extract the task_arn container tag to it's own http header

### Motivation

We would like to identify telemetry data coming from Fargate containers for debugging and billing purpose.
Fargate containers are identified by the presence of a `task_arn` container tag.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

* We will check that we correctly receive task_arn with telemetry payloads from fargate tasks in staging

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
