### PR TITLE
Bump confluent-kafka-python version on omnibus

### DIFF
--- a/omnibus/config/software/confluent-kafka-python.rb
+++ b/omnibus/config/software/confluent-kafka-python.rb
@@ -1,12 +1,12 @@
 # https://github.com/confluentinc/confluent-kafka-python/blob/master/INSTALL.md#install-from-source
 
 name "confluent-kafka-python"
-default_version "2.0.2"
+default_version "2.1.1"
 
 dependency "pip3"
 
 source :url => "https://github.com/confluentinc/confluent-kafka-python/archive/refs/tags/v#{version}.tar.gz",
-       :sha256 => "137c82d23e931e03a2803569d51bb025a7b9a364818b08d1664800abaaa5cc63",
+       :sha256 => "b1abd74866f4dab5042b64262be3d330a67ab7a535d1f7c31d5ecc4834532adf",
        :extract => :seven_zip
 
 relative_path "confluent-kafka-python-#{version}"

--- a/omnibus/config/software/librdkafka.rb
+++ b/omnibus/config/software/librdkafka.rb
@@ -3,12 +3,12 @@
 # https://github.com/confluentinc/confluent-kafka-python/blob/master/tools/windows-install-librdkafka.bat
 
 name "librdkafka"
-default_version "2.0.2"
+default_version "2.1.1"
 
 dependency "cyrus-sasl"
 
 source :url => "https://github.com/confluentinc/librdkafka/archive/refs/tags/v#{version}.tar.gz",
-        :sha256 => "f321bcb1e015a34114c83cf1aa7b99ee260236aab096b85c003170c90a47ca9d",
+        :sha256 => "7be1fc37ab10ebdc037d5c5a9b35b48931edafffae054b488faaff99e60e0108",
         :extract => :seven_zip
 
 relative_path "librdkafka-#{version}"


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Updates confluent-kafka-python version on omnibus script.

### Motivation

In step with update on integrations-core https://github.com/DataDog/integrations-core/pull/14665.

### Additional Notes

The image has been tested locally using ddev on this [integrations-core](https://github.com/DataDog/integrations-core/pull/14665) branch that bumps the version on our side:

```
❯ ddev env start -a 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent:v16364585-4a91d5b1-7-arm64 kafka_consumer py3.8-3.3-kerberos
Setting up environment `py3.8-3.3-kerberos`... success!
Updating `486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent:v16364585-4a91d5b1-7-arm64`... success!
Detecting the major version... Agent 7 detected
Writing configuration for `py3.8-3.3-kerberos`... success!
Starting the Agent... success!

To edit config file, do: ddev env edit kafka_consumer py3.8-3.3-kerberos
Config file (copied to your clipboard): /Users/florent.clarret/Library/Application Support/dd-checks-dev/envs/kafka_consumer/py3.8-3.3-kerberos/config/kafka_consumer.yaml
To reload the config file, do: ddev env reload kafka_consumer py3.8-3.3-kerberos
To run this check, do: ddev env check kafka_consumer py3.8-3.3-kerberos
To stop this check, do: ddev env stop kafka_consumer py3.8-3.3-kerberos

❯ ddev test --e2e kafka_consumer:py3.8-3.3-kerberos
Running only end-to-end tests for `kafka_consumer`os                                                                                                                          ─╯
--------------------------------------------------
────────────────────────────────────────────────────────────────────────────── py3.8-3.3-kerberos ───────────────────────────────────────────────────────────────────────────────
Finished checking dependencies
cmd [1] | pytest -v --benchmark-skip tests
============================================================================== test session starts ==============================================================================
platform darwin -- Python 3.8.14, pytest-7.3.1, pluggy-1.0.0 -- /Users/florent.clarret/Library/Application Support/hatch/env/virtual/datadog-kafka-consumer/KmLHgHe8/py3.8-3.3-kerberos/bin/python
cachedir: .pytest_cache
benchmark: 4.0.0 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
rootdir: /Users/florent.clarret/go/src/github.com/DataDog/integrations-core/kafka_consumer
plugins: memray-1.4.0, datadog-checks-dev-19.3.1, asyncio-0.21.0, ddtrace-0.53.2, flaky-3.7.0, mock-3.10.0, cov-4.1.0, benchmark-4.0.0
asyncio: mode=strict
collected 46 items / 45 deselected / 1 selected                                                                                                                                 

tests/test_e2e.py::test_e2e PASSED                                                                                                                                        [100%]

======================================================================= 1 passed, 45 deselected in 7.56s ========================================================================

Passed!

```

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
