### PR TITLE
[CWS] Move proc_cache update to execve return hook point

### DIFF
--- a/pkg/security/ebpf/c/include/helpers/exec.h
+++ b/pkg/security/ebpf/c/include/helpers/exec.h
@@ -20,54 +20,6 @@ int __attribute__((always_inline)) handle_exec_event(struct pt_regs *ctx, struct
     syscall->exec.file.path_key.mount_id = mount_id;
     syscall->exec.file.path_key.path_id = get_path_id(0);
 
-    u64 pid_tgid = bpf_get_current_pid_tgid();
-    u32 tgid = pid_tgid >> 32;
-
-    struct proc_cache_t pc = {
-        .entry = {
-            .executable = {
-                .path_key = {
-                    .ino = syscall->exec.file.path_key.ino,
-                    .mount_id = mount_id,
-                    .path_id = syscall->exec.file.path_key.path_id,
-                },
-                .flags = syscall->exec.file.flags
-            },
-            .exec_timestamp = bpf_ktime_get_ns(),
-        },
-        .container = {},
-    };
-    fill_file_metadata(syscall->exec.dentry, &pc.entry.executable.metadata);
-    bpf_get_current_comm(&pc.entry.comm, sizeof(pc.entry.comm));
-
-    // select the previous cookie entry in cache of the current process
-    // (this entry was created by the fork of the current process)
-    struct pid_cache_t *fork_entry = (struct pid_cache_t *) bpf_map_lookup_elem(&pid_cache, &tgid);
-    if (fork_entry) {
-        // Fetch the parent proc cache entry
-        u32 parent_cookie = fork_entry->cookie;
-        struct proc_cache_t *parent_pc = get_proc_from_cookie(parent_cookie);
-        if (parent_pc) {
-            // inherit the parent container context
-            fill_container_context(parent_pc, &pc.container);
-        }
-    }
-
-    // Insert new proc cache entry (Note: do not move the order of this block with the previous one, we need to inherit
-    // the container ID before saving the entry in proc_cache. Modifying entry after insertion won't work.)
-    u32 cookie = bpf_get_prandom_u32();
-    bpf_map_update_elem(&proc_cache, &cookie, &pc, BPF_ANY);
-
-    // update pid <-> cookie mapping
-    if (fork_entry) {
-        fork_entry->cookie = cookie;
-    } else {
-        struct pid_cache_t new_pid_entry = {
-            .cookie = cookie,
-        };
-        bpf_map_update_elem(&pid_cache, &tgid, &new_pid_entry, BPF_ANY);
-    }
-
     // resolve dentry
     syscall->resolver.key = syscall->exec.file.path_key;
     syscall->resolver.dentry = syscall->exec.dentry;

--- a/pkg/security/ebpf/c/include/helpers/process.h
+++ b/pkg/security/ebpf/c/include/helpers/process.h
@@ -18,16 +18,16 @@ static __attribute__((always_inline)) u32 copy_tty_name(const char src[TTY_NAME_
     return TTY_NAME_LEN;
 }
 
-void __attribute__((always_inline)) copy_proc_entry_except_comm(struct process_entry_t* src, struct process_entry_t* dst) {
+void __attribute__((always_inline)) copy_proc_entry(struct process_entry_t* src, struct process_entry_t* dst) {
     dst->executable = src->executable;
     dst->exec_timestamp = src->exec_timestamp;
     copy_tty_name(src->tty_name, dst->tty_name);
+    bpf_probe_read(dst->comm, TASK_COMM_LEN, src->comm);
 }
 
 void __attribute__((always_inline)) copy_proc_cache(struct proc_cache_t *src, struct proc_cache_t *dst) {
     copy_container_id(src->container.container_id, dst->container.container_id);
-    copy_proc_entry_except_comm(&src->entry, &dst->entry);
-    bpf_probe_read(dst->entry.comm, TASK_COMM_LEN, src->entry.comm);
+    copy_proc_entry(&src->entry, &dst->entry);
 }
 
 void __attribute__((always_inline)) copy_credentials(struct credentials_t* src, struct credentials_t* dst) {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR moves the update of the `proc_cache` map to the execve `return` hook point.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

The reason why we made this change is because in the current state of the agent, the `comm` of the processes in `proc_cache` is "off by one": each process entry contains the `comm` of its parent instead of storing its own `comm`. This means that the `comm` of the process context we add to all our CWS events is wrong when it comes from our kernel space fallback.

Additionally, any event happening in between the entry point and exit point of the execve syscall (tl;dr an event sent by a light thread) would have a mixed process context with both the parent `comm` and the child `FileEvent` context. This means that this event would be falsely attributed to the child process (as the `FileEvent` context is usually what we consider to be "more reliable"), even though it should have been attributed to the parent process.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
