### PR TITLE
[CWS] Create separate process nodes for each different busybox utils

### DIFF
--- a/pkg/security/probe/field_handlers_linux.go
+++ b/pkg/security/probe/field_handlers_linux.go
@@ -183,7 +183,7 @@ func (fh *FieldHandlers) ResolveProcessCreatedAt(ev *model.Event, e *model.Proce
 
 // ResolveProcessArgv0 resolves the first arg of the event
 func (fh *FieldHandlers) ResolveProcessArgv0(ev *model.Event, process *model.Process) string {
-	arg0, _ := fh.resolvers.ProcessResolver.GetProcessArgv0(process)
+	arg0, _ := sprocess.GetProcessArgv0(process)
 	return arg0
 }
 

--- a/pkg/security/resolvers/process/resolver.go
+++ b/pkg/security/resolvers/process/resolver.go
@@ -632,15 +632,15 @@ func (p *Resolver) SetProcessPath(fileEvent *model.FileEvent, pidCtx *model.PIDC
 	return fileEvent.PathnameStr, nil
 }
 
-func isBusybox(pathname string) bool {
+func IsBusybox(pathname string) bool {
 	return pathname == "/bin/busybox" || pathname == "/usr/bin/busybox"
 }
 
 // SetProcessSymlink resolves process file symlink path
 func (p *Resolver) SetProcessSymlink(entry *model.ProcessCacheEntry) {
 	// TODO: busybox workaround only for now
-	if isBusybox(entry.FileEvent.PathnameStr) {
-		arg0, _ := p.GetProcessArgv0(&entry.Process)
+	if IsBusybox(entry.FileEvent.PathnameStr) {
+		arg0, _ := GetProcessArgv0(&entry.Process)
 		base := path.Base(arg0)
 
 		entry.SymlinkPathnameStr[0] = "/bin/" + base
@@ -889,7 +889,7 @@ func GetProcessArgv(pr *model.Process) ([]string, bool) {
 }
 
 // GetProcessArgv0 returns the first arg of the event
-func (p *Resolver) GetProcessArgv0(pr *model.Process) (string, bool) {
+func GetProcessArgv0(pr *model.Process) (string, bool) {
 	if pr.ArgsEntry == nil {
 		return pr.Argv0, pr.ArgsTruncated
 	}

--- a/pkg/security/security_profile/activity_tree/activity_tree.go
+++ b/pkg/security/security_profile/activity_tree/activity_tree.go
@@ -385,10 +385,10 @@ func (at *ActivityTree) CreateProcessNode(entry *model.ProcessCacheEntry, genera
 	return node, true, nil
 }
 
-func (at *ActivityTree) FindMatchingRootNodes(basename string) []*ProcessNode {
+func (at *ActivityTree) FindMatchingRootNodes(arg0 string) []*ProcessNode {
 	var res []*ProcessNode
 	for _, node := range at.ProcessNodes {
-		if node.Process.FileEvent.BasenameStr == basename {
+		if node.Process.Argv0 == arg0 {
 			res = append(res, node)
 		}
 	}

--- a/pkg/security/security_profile/activity_tree/process_node.go
+++ b/pkg/security/security_profile/activity_tree/process_node.go
@@ -31,7 +31,13 @@ type ProcessNode struct {
 }
 
 func (pn *ProcessNode) getNodeLabel(args string) string {
-	label := fmt.Sprintf("%s %s", pn.Process.FileEvent.PathnameStr, args)
+	var label string
+	if sprocess.IsBusybox(pn.Process.FileEvent.PathnameStr) {
+		arg0, _ := sprocess.GetProcessArgv0(&pn.Process)
+		label = fmt.Sprintf("%s %s", arg0, args)
+	} else {
+		label = fmt.Sprintf("%s %s", pn.Process.FileEvent.PathnameStr, args)
+	}
 	if len(pn.Process.FileEvent.PkgName) != 0 {
 		label += fmt.Sprintf(" \\{%s %s\\}", pn.Process.FileEvent.PkgName, pn.Process.FileEvent.PkgVersion)
 	}
@@ -77,7 +83,7 @@ func (pn *ProcessNode) debug(w io.Writer, prefix string) {
 func (pn *ProcessNode) scrubAndReleaseArgsEnvs(resolver *sprocess.Resolver) {
 	if pn.Process.ArgsEntry != nil {
 		resolver.GetProcessScrubbedArgv(&pn.Process)
-		resolver.GetProcessArgv0(&pn.Process)
+		sprocess.GetProcessArgv0(&pn.Process)
 		pn.Process.ArgsEntry = nil
 
 	}
@@ -90,10 +96,16 @@ func (pn *ProcessNode) scrubAndReleaseArgsEnvs(resolver *sprocess.Resolver) {
 // Matches return true if the process fields used to generate the dump are identical with the provided model.Process
 func (pn *ProcessNode) Matches(entry *model.Process, matchArgs bool) bool {
 	if pn.Process.FileEvent.PathnameStr == entry.FileEvent.PathnameStr {
+		if sprocess.IsBusybox(entry.FileEvent.PathnameStr) {
+			panArg0, _ := sprocess.GetProcessArgv0(&pn.Process)
+			entryArg0, _ := sprocess.GetProcessArgv0(entry)
+			if panArg0 != entryArg0 {
+				return false
+			}
+		}
 		if matchArgs {
-			var panArgs, entryArgs []string
-			panArgs, _ = sprocess.GetProcessArgv(&pn.Process)
-			entryArgs, _ = sprocess.GetProcessArgv(entry)
+			panArgs, _ := sprocess.GetProcessArgv(&pn.Process)
+			entryArgs, _ := sprocess.GetProcessArgv(entry)
 			if len(panArgs) != len(entryArgs) {
 				return false
 			}

--- a/pkg/security/serializers/serializers.go
+++ b/pkg/security/serializers/serializers.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/security/events"
 	"github.com/DataDog/datadog-agent/pkg/security/resolvers"
+	sprocess "github.com/DataDog/datadog-agent/pkg/security/resolvers/process"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
@@ -667,7 +668,7 @@ func newProcessSerializer(ps *model.Process, e *model.Event, resolvers *resolver
 	if ps.IsNotKworker() {
 		argv, argvTruncated := resolvers.ProcessResolver.GetProcessScrubbedArgv(ps)
 		envs, EnvsTruncated := resolvers.ProcessResolver.GetProcessEnvs(ps)
-		argv0, _ := resolvers.ProcessResolver.GetProcessArgv0(ps)
+		argv0, _ := sprocess.GetProcessArgv0(ps)
 
 		psSerializer := &ProcessSerializer{
 			ForkTime: getTimeIfNotZero(ps.ForkTime),

--- a/pkg/security/tests/activity_dumps_test.go
+++ b/pkg/security/tests/activity_dumps_test.go
@@ -83,7 +83,7 @@ func TestActivityDumps(t *testing.T) {
 		}
 
 		validateActivityDumpOutputs(t, test, expectedFormats, dump.OutputFiles, func(ad *activitydump.ActivityDump) bool {
-			nodes := ad.FindMatchingRootNodes("syscall_tester")
+			nodes := ad.FindMatchingRootNodes(syscallTester)
 			if nodes == nil {
 				t.Fatalf("Node not found in activity dump: %+v", nodes)
 			}
@@ -163,7 +163,7 @@ func TestActivityDumps(t *testing.T) {
 		}
 
 		validateActivityDumpOutputs(t, test, expectedFormats, dump.OutputFiles, func(ad *activitydump.ActivityDump) bool {
-			nodes := ad.FindMatchingRootNodes("syscall_tester")
+			nodes := ad.FindMatchingRootNodes(syscallTester)
 			if nodes == nil {
 				t.Fatalf("Node not found in activity dump: %+v", nodes)
 			}
@@ -208,8 +208,7 @@ func TestActivityDumps(t *testing.T) {
 		}
 
 		validateActivityDumpOutputs(t, test, expectedFormats, dump.OutputFiles, func(ad *activitydump.ActivityDump) bool {
-			// searching busybox instead of nslookup because we test on a busybox based alpine
-			nodes := ad.FindMatchingRootNodes("busybox")
+			nodes := ad.FindMatchingRootNodes("nslookup")
 			if nodes == nil {
 				t.Fatal("Node not found in activity dump")
 			}
@@ -249,8 +248,7 @@ func TestActivityDumps(t *testing.T) {
 
 		tempPathParts := strings.Split(temp.Name(), "/")
 		validateActivityDumpOutputs(t, test, expectedFormats, dump.OutputFiles, func(ad *activitydump.ActivityDump) bool {
-			// searching busybox instead of touch because we test on a busybox based alpine
-			nodes := ad.FindMatchingRootNodes("busybox")
+			nodes := ad.FindMatchingRootNodes("touch")
 			if nodes == nil {
 				t.Fatal("Node not found in activity dump")
 			}
@@ -292,7 +290,7 @@ func TestActivityDumps(t *testing.T) {
 		}
 
 		validateActivityDumpOutputs(t, test, expectedFormats, dump.OutputFiles, func(ad *activitydump.ActivityDump) bool {
-			nodes := ad.FindMatchingRootNodes("syscall_tester")
+			nodes := ad.FindMatchingRootNodes(syscallTester)
 			if nodes == nil {
 				t.Fatal("Node not found in activity dump")
 			}
@@ -348,7 +346,7 @@ func TestActivityDumps(t *testing.T) {
 		}
 
 		validateActivityDumpOutputs(t, test, expectedFormats, dump.OutputFiles, func(ad *activitydump.ActivityDump) bool {
-			nodes := ad.FindMatchingRootNodes("syscall_tester")
+			nodes := ad.FindMatchingRootNodes(syscallTester)
 			if nodes == nil {
 				t.Fatal("Node not found in activity dump")
 			}

--- a/pkg/security/tests/security_profile_test.go
+++ b/pkg/security/tests/security_profile_test.go
@@ -183,7 +183,7 @@ func TestSecurityProfile(t *testing.T) {
 		validateActivityDumpOutputs(t, test, expectedFormats, dump.OutputFiles, nil,
 			func(sp *profile.SecurityProfile) bool {
 				nodes := WalkActivityTree(sp.ActivityTree, func(node *ProcessNodeAndParent) bool {
-					if node.Node.Process.FileEvent.BasenameStr == "busybox" {
+					if node.Node.Process.Argv0 == "nslookup" {
 						return true
 					}
 					return false
@@ -763,7 +763,7 @@ func TestSecurityProfileAutoSuppression(t *testing.T) {
 			return err
 		}, func(event *model.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_autosuppression_dns")
-			assert.Equal(t, "busybox", event.ProcessContext.FileEvent.BasenameStr, "wrong exec file")
+			assert.Equal(t, "nslookup", event.ProcessContext.Argv0, "wrong exec file")
 		})
 	})
 

--- a/pkg/security/tests/threat_score_test.go
+++ b/pkg/security/tests/threat_score_test.go
@@ -105,7 +105,7 @@ func TestActivityDumpsThreatScore(t *testing.T) {
 
 		tempPathParts := strings.Split(filePath, "/")
 		validateActivityDumpOutputs(t, test, expectedFormats, dump.OutputFiles, func(ad *activitydump.ActivityDump) bool {
-			nodes := ad.ActivityTree.FindMatchingRootNodes("busybox")
+			nodes := ad.ActivityTree.FindMatchingRootNodes("touch")
 			if nodes == nil || len(nodes) != 1 {
 				t.Fatal("Uniq node not found in activity dump")
 			}
@@ -154,7 +154,7 @@ func TestActivityDumpsThreatScore(t *testing.T) {
 		}
 
 		validateActivityDumpOutputs(t, test, expectedFormats, dump.OutputFiles, func(ad *activitydump.ActivityDump) bool {
-			nodes := ad.ActivityTree.FindMatchingRootNodes("busybox")
+			nodes := ad.ActivityTree.FindMatchingRootNodes("nslookup")
 			if nodes == nil || len(nodes) != 1 {
 				t.Fatal("Uniq node not found in activity dump")
 			}
@@ -195,7 +195,7 @@ func TestActivityDumpsThreatScore(t *testing.T) {
 		}
 
 		validateActivityDumpOutputs(t, test, expectedFormats, dump.OutputFiles, func(ad *activitydump.ActivityDump) bool {
-			nodes := ad.ActivityTree.FindMatchingRootNodes("syscall_tester")
+			nodes := ad.ActivityTree.FindMatchingRootNodes(syscallTester)
 			if nodes == nil || len(nodes) != 1 {
 				t.Fatal("Uniq node not found in activity dump")
 			}
@@ -241,7 +241,7 @@ func TestActivityDumpsThreatScore(t *testing.T) {
 		}
 
 		validateActivityDumpOutputs(t, test, expectedFormats, dump.OutputFiles, func(ad *activitydump.ActivityDump) bool {
-			nodes := ad.ActivityTree.FindMatchingRootNodes("syscall_tester")
+			nodes := ad.ActivityTree.FindMatchingRootNodes(syscallTester)
 			if nodes == nil {
 				t.Fatal("Node not found in activity dump")
 			}


### PR DESCRIPTION

### What does this PR do?

Nodes are actually aggregated based on binary filepath. In case of a busybox image, all utilities activities will be merged on the same process node. This PR adds a custom case for busybox to dissociate them


### Motivation



### Additional Notes

This is the second special treatment for busybox, a previous one was put in place for symlink. We should not forget them and try at some point to have a proper solution without these special cases.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
