### PR TITLE
[gitlab] Upgrade resources allocated to Windows containers

### DIFF
--- a/.gitlab/binary_build/windows.yml
+++ b/.gitlab/binary_build/windows.yml
@@ -13,7 +13,7 @@ build_windows_container_entrypoint:
     - if (Test-Path build-out) { remove-item -recurse -force build-out }
     - >
       docker run --rm
-      -m 4096M
+      -m 8192M
       -v "$(Get-Location):c:\mnt"
       -e CI_JOB_ID=${CI_JOB_ID}
       -e WINDOWS_BUILDER=true

--- a/.gitlab/deps_build.yml
+++ b/.gitlab/deps_build.yml
@@ -98,7 +98,7 @@ build_vcpkg_deps:
     - if (Test-Path build-out) { remove-item -recurse -force build-out }
     - >
       docker run --rm
-      -m 4096M
+      -m 8192M
       -v "$(Get-Location):c:\mnt"
       -e VCPKG_BINARY_SOURCES="clear;x-azblob,${vcpkgBlobSaSUrl},readwrite"
       486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/windows_1809_${ARCH}${Env:DATADOG_AGENT_WINBUILDIMAGES_SUFFIX}:${Env:DATADOG_AGENT_WINBUILDIMAGES}

--- a/.gitlab/package_build/windows.yml
+++ b/.gitlab/package_build/windows.yml
@@ -13,7 +13,7 @@
     - !reference [.setup_python_mirror_win]
     - >
       docker run --rm
-      -m 4096M
+      -m 8192M
       -v "$(Get-Location):c:\mnt"
       -e CI_JOB_ID=${CI_JOB_ID}
       -e CI_PIPELINE_ID=${CI_PIPELINE_ID}
@@ -100,7 +100,7 @@ windows_zip_agent_binaries_x64-a7:
     - !reference [.setup_python_mirror_win]
     - >
       docker run --rm
-      -m 4096M
+      -m 8192M
       -v "$(Get-Location):c:\mnt"
       -e CI_COMMIT_BRANCH=${CI_COMMIT_BRANCH}
       -e OMNIBUS_TARGET=${OMNIBUS_TARGET}

--- a/.gitlab/source_test/windows.yml
+++ b/.gitlab/source_test/windows.yml
@@ -13,7 +13,7 @@
     - !reference [.setup_python_mirror_win]
     - >
       docker run --rm
-      -m 8192M
+      -m 16384M
       -v "$(Get-Location):c:\mnt"
       -e CI_JOB_URL="${CI_JOB_URL}"
       -e CI_JOB_NAME="${CI_JOB_NAME}"

--- a/docs/dev/agent_omnibus.md
+++ b/docs/dev/agent_omnibus.md
@@ -118,7 +118,7 @@ $opts = "-e OMNIBUS_TARGET=main -e RELEASE_VERSION=$RELEASE_VERSION -e MAJOR_VER
 if ($DEBUG) {
     $opts += " -e DEBUG_CUSTOMACTION=yes "
 }
-$cmd += " -m 4096M -v ""$(Get-Location):c:\mnt"" $opts datadog/agent-buildimages-windows_x64:1809 c:\mnt\tasks\winbuildscripts\buildwin.bat"
+$cmd += " -m 8192M -v ""$(Get-Location):c:\mnt"" $opts datadog/agent-buildimages-windows_x64:1809 c:\mnt\tasks\winbuildscripts\buildwin.bat"
 Write-Host $cmd
 Invoke-Expression -Command $cmd
 ```

--- a/tasks/winbuildscripts/unittests.ps1
+++ b/tasks/winbuildscripts/unittests.ps1
@@ -89,7 +89,7 @@ if($err -ne 0){
 }
 
 & inv -e install-tools
-& inv -e test --skip-linters --junit-tar="$Env:JUNIT_TAR" --race --profile --rerun-fails=2 --cpus 4 --arch $archflag --python-runtimes="$Env:PY_RUNTIMES" --python-home-2=$Env:Python2_ROOT_DIR --python-home-3=$Env:Python3_ROOT_DIR --save-result-json C:\mnt\test_output.json
+& inv -e test --skip-linters --junit-tar="$Env:JUNIT_TAR" --race --profile --rerun-fails=2 --cpus 8 --arch $archflag --python-runtimes="$Env:PY_RUNTIMES" --python-home-2=$Env:Python2_ROOT_DIR --python-home-3=$Env:Python3_ROOT_DIR --save-result-json C:\mnt\test_output.json
 
 $err = $LASTEXITCODE
 Write-Host Test result is $err


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Doubles the memory and CPU allocation for Windows Gitlab CI jobs.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

We upgraded our Windows Gitlab infrastructure with runners twice as powerful. This makes use of them.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

n/a

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

n/a

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

n/a

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
