### PR TITLE
[NG] create user on domain controller

### DIFF
--- a/tools/windows/DatadogAgentInstaller/CustomActions.Tests/UserCustomActions/UserCustomActionsDomainControllerTests.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions.Tests/UserCustomActions/UserCustomActionsDomainControllerTests.cs
@@ -22,8 +22,33 @@ namespace CustomActions.Tests.UserCustomActions
                 .Be(ActionResult.Failure);
 
             Test.Properties.Should()
-                .OnlyContain(kvp => (kvp.Key == "DDAGENTUSER_FOUND" && kvp.Value == "false") ||
-                                    (kvp.Key == "DDAGENTUSER_SID" && string.IsNullOrEmpty(kvp.Value)));
+                .BeEmpty();
+        }
+
+        [Theory]
+        [AutoData]
+        public void ProcessDdAgentUserCredentials_Succeeds_With_Creating_DomainUser_On_Domain_Controllers(
+            string ddAgentUserName,
+            string ddAgentUserPassword)
+        {
+            Test.Session
+                .Setup(session => session["DDAGENTUSER_NAME"]).Returns($"{Domain}\\{ddAgentUserName}");
+            Test.Session
+                .Setup(session => session["DDAGENTUSER_PASSWORD"]).Returns(ddAgentUserPassword);
+
+            Test.Create()
+                .ProcessDdAgentUserCredentials()
+                .Should()
+                .Be(ActionResult.Success);
+
+            Test.Properties.Should()
+                .Contain("DDAGENTUSER_FOUND", "false").And
+                .Contain(kvp => kvp.Key == "DDAGENTUSER_SID" && string.IsNullOrEmpty(kvp.Value)).And
+                .Contain("DDAGENTUSER_PROCESSED_NAME", ddAgentUserName).And
+                .Contain("DDAGENTUSER_PROCESSED_DOMAIN", Domain).And
+                .Contain("DDAGENTUSER_PROCESSED_FQ_NAME", $"{Domain}\\{ddAgentUserName}").And
+                .Contain(kvp => kvp.Key == "DDAGENTUSER_RESET_PASSWORD" && string.IsNullOrEmpty(kvp.Value)).And
+                .Contain(kvp => kvp.Key == "DDAGENTUSER_PROCESSED_PASSWORD" && kvp.Value == ddAgentUserPassword);
         }
 
         [Theory]
@@ -158,7 +183,7 @@ namespace CustomActions.Tests.UserCustomActions
                 .Should()
                 .Be(ActionResult.Failure);
 
-            // The install will proceed with the default `ddagentuser` in the machine domain
+            // services don't exist so password is required
             Test.Properties.Should()
                 .OnlyContain(kvp => (kvp.Key == "DDAGENTUSER_FOUND" && kvp.Value == "true") ||
                                     (kvp.Key == "DDAGENTUSER_SID" && !string.IsNullOrEmpty(kvp.Value)));
@@ -180,30 +205,9 @@ namespace CustomActions.Tests.UserCustomActions
                 .Should()
                 .Be(ActionResult.Failure);
 
-            // The install will proceed with the default `ddagentuser` in the machine domain
+            // Domain controller requires username be present
             Test.Properties.Should()
-                .OnlyContain(kvp => (kvp.Key == "DDAGENTUSER_FOUND" && kvp.Value == "false") ||
-                                    (kvp.Key == "DDAGENTUSER_SID" && string.IsNullOrEmpty(kvp.Value)));
-        }
-
-        [Theory]
-        [AutoData]
-        public void ProcessDdAgentUserCredentials_Fails_With_gMsaAccount_Missing_Domain_Part_On_DomainController(
-            string ddAgentUserName)
-        {
-            Test.WithManagedServiceAccount(ddAgentUserName);
-
-            Test.Session
-                .Setup(session => session["DDAGENTUSER_NAME"]).Returns($"\\{ddAgentUserName}");
-
-            Test.Create()
-                .ProcessDdAgentUserCredentials()
-                .Should()
-                .Be(ActionResult.Failure);
-
-            Test.Properties.Should()
-                .OnlyContain(kvp => (kvp.Key == "DDAGENTUSER_FOUND" && kvp.Value == "false") ||
-                                    (kvp.Key == "DDAGENTUSER_SID" && string.IsNullOrEmpty(kvp.Value)));
+                .BeEmpty();
         }
     }
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Allows installation on a DC to continue when the user account does not exist. If a username and password are provided, the account will be created.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
compatibility with OG installer
https://datadoghq.atlassian.net/browse/WA-363

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
no changelog needed, NG installer is not yet released

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
On initial install on domain controller
* if both username and password are provided, installation should create the user account and succeed

On upgrade/change/repair on domain controller
* installation should succeed without the password (as long as the services exist)

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
