### PR TITLE
Add a test for statement metrics

### DIFF
--- a/pkg/collector/corechecks/oracle-dbm/statements.go
+++ b/pkg/collector/corechecks/oracle-dbm/statements.go
@@ -444,8 +444,8 @@ func (c *Check) StatementMetrics() (int, error) {
 			 */
 			err = c.db.Select(
 				&DDForceMatchingSignatures,
-				"SELECT distinct force_matching_signature FROM v$sqlstats WHERE sql_text like '%/* DD%' and (sysdate-last_active_time)*3600*24 < :1",
-				time.Since(c.statementsLastRun).Seconds(),
+				"SELECT distinct force_matching_signature FROM v$sqlstats WHERE sql_text like '%/* DD%' and (sysdate-last_active_time)*3600*24 <= :1",
+				time.Since(c.statementsLastRun).Seconds()+1,
 			)
 			if err != nil {
 				log.Error("error getting sql_ids from DD queries")
@@ -957,5 +957,8 @@ func (c *Check) StatementMetrics() (int, error) {
 
 	c.statementsLastRun = start
 
+	if SQLTextErrors > 0 || planErrors > 0 {
+		return SQLCount, fmt.Errorf("SQL statements processed: %d, text errors: %d, plan erros: %d", SQLCount, SQLTextErrors, planErrors)
+	}
 	return SQLCount, nil
 }


### PR DESCRIPTION
### What does this PR do?

Add a test for statement metrics.

### Motivation

Bug prevention.

### Describe how to test/QA your changes

```
go clean -testcache                                                         
gotestsum --jsonfile module_test_output.json --format pkgname --packages=./pkg/collector/corechecks/oracle-dbm/... -- -mod=mod -vet=off --tags=oracle
```

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
