### PR TITLE
Add documentation for e2e.Suite

### DIFF
--- a/test/new-e2e/README.md
+++ b/test/new-e2e/README.md
@@ -2,6 +2,10 @@
 
 This folder contains tests and utilities to write and run agent end to end tests based on Pulumi.
 
+## Documentation 
+
+See https://pkg.go.dev/github.com/DataDog/datadog-agent/test/new-e2e@main/utils/e2e.
+
 ## Development in VSCode
 
 This is a sub-module within `datadog-agent`. VSCode will complain about the multiple `go.mod` files. While waiting for a full repo migration to go workspaces, create a go workspace file and add `test/new-e2e` to workspaces

--- a/test/new-e2e/utils/e2e/client/agent.go
+++ b/test/new-e2e/utils/e2e/client/agent.go
@@ -70,7 +70,7 @@ func (a *Agent) IsReady() (bool, error) {
 	return a.Status().isReady()
 }
 
-// WaitForReady blocks up for one minute waiting for agent to be ready.
+// WaitForReady blocks up to one minute waiting for agent to be ready.
 // Retries every 100 ms up to one minute.
 // Returns error on failure.
 func (a *Agent) WaitForReady() error {

--- a/test/new-e2e/utils/e2e/client/agent.go
+++ b/test/new-e2e/utils/e2e/client/agent.go
@@ -77,7 +77,7 @@ func (a *Agent) WaitForReady() error {
 	return a.WaitForReadyTimeout(1 * time.Minute)
 }
 
-// WaitForReady blocks up for timeout waiting for agent to be ready.
+// WaitForReady blocks up to timeout waiting for agent to be ready.
 // Retries every 100 ms up to timeout.
 // Returns error on failure.
 func (a *Agent) WaitForReadyTimeout(timeout time.Duration) error {

--- a/test/new-e2e/utils/e2e/client/agent.go
+++ b/test/new-e2e/utils/e2e/client/agent.go
@@ -17,7 +17,9 @@ import (
 
 var _ clientService[agent.ClientData] = (*Agent)(nil)
 
-// A client Agent that is connected to an agent.Installer defined in test-infra-definition.
+// A client Agent that is connected to an [agent.Installer].
+//
+// [agent.Installer]: https://pkg.go.dev/github.com/DataDog/test-infra-definitions@main/components/datadog/agent#Installer
 type Agent struct {
 	*UpResultDeserializer[agent.ClientData]
 	*vmClient
@@ -62,22 +64,22 @@ func (agent *Agent) Status() *Status {
 	return newStatus(agent.vmClient.Execute("sudo datadog-agent status"))
 }
 
-// IsReady runs status command and returns true if the agent is ready
-// Use this to wait for agent to be ready before running any command
+// IsReady runs status command and returns true if the agent is ready.
+// Use this to wait for agent to be ready before running any command.
 func (a *Agent) IsReady() (bool, error) {
 	return a.Status().isReady()
 }
 
-// WaitForReady blocks up for one minute waiting for agent to be ready
-// Retries every 100 ms up to one minute
-// Returns error on failure
+// WaitForReady blocks up for one minute waiting for agent to be ready.
+// Retries every 100 ms up to one minute.
+// Returns error on failure.
 func (a *Agent) WaitForReady() error {
 	return a.WaitForReadyTimeout(1 * time.Minute)
 }
 
-// WaitForReady blocks up for timeout waiting for agent to be ready
-// Retries every 100 ms up to timeout
-// Returns error on failure
+// WaitForReady blocks up for timeout waiting for agent to be ready.
+// Retries every 100 ms up to timeout.
+// Returns error on failure.
 func (a *Agent) WaitForReadyTimeout(timeout time.Duration) error {
 	interval := 100 * time.Millisecond
 	maxRetries := timeout.Milliseconds() / interval.Milliseconds()

--- a/test/new-e2e/utils/e2e/client/vm.go
+++ b/test/new-e2e/utils/e2e/client/vm.go
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+// Package client contains clients used to communicate with the remote service
 package client
 
 import (
@@ -13,13 +14,13 @@ import (
 
 var _ clientService[commonvm.ClientData] = (*VM)(nil)
 
-// A client VM that is connected to a VM defined in test-infra-definition.
+// VM is a client VM that is connected to a VM defined in test-infra-definition.
 type VM struct {
 	*UpResultDeserializer[commonvm.ClientData]
 	*vmClient
 }
 
-// Create a new instance of VM
+// NewVM creates a new instance of VM
 func NewVM(infraVM commonvm.VM) *VM {
 	vm := &VM{}
 	vm.UpResultDeserializer = NewUpResultDeserializer[commonvm.ClientData](infraVM, vm)

--- a/test/new-e2e/utils/e2e/e2e.go
+++ b/test/new-e2e/utils/e2e/e2e.go
@@ -3,8 +3,218 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-// Package e2e provides tools to manage environments and run E2E tests.
-// See [Suite] for an example of the usage.
+// Package e2e provides the API to manage environments and organize E2E tests.
+//
+// Here is a simple example of E2E tests.
+// E2E tests use [testify Suite] and it is strongly recommended to read the documentation of
+// [testify Suite] if you are not familiar with it.
+//
+//	import (
+//		"testing"
+//
+//		"github.com/DataDog/datadog-agent/test/new-e2e/utils/e2e"
+//	)
+//
+//	type vmSuite struct {
+//		e2e.Suite[e2e.VMEnv]
+//	}
+//
+//	func TestVMSuite(t *testing.T) {
+//		e2e.Run(t, &vmSuite{}, e2e.EC2VMStackDef())
+//	}
+//
+//	func (v *vmSuite) TestBasicVM() {
+//		v.Env().VM.Execute("ls")
+//	}
+//
+// Writing a E2E test requires several steps.
+//
+// 1. Define your own type with the embedded [e2e.Suite] struct.
+//
+//	type vmSuite struct {
+//		e2e.Suite[e2e.VMEnv]
+//	}
+//
+// [e2e.VMEnv] defines the components available in your environment. See "Using existing stack definition section" for more information.
+//
+// 2. Write a regular Go test function that runs the test suite using [e2e.Run].
+//
+//	func TestVMSuite(t *testing.T) {
+//		e2e.Run(t, &vmSuite{}, e2e.EC2VMStackDef())
+//	}
+//
+// The first argument of [e2e.Run] is an instance of type [*testing.T].
+//
+// The second argument is a pointer to the previous defined structure (&vmSuite{} in our example)
+//
+// The third parameter defines the environment. See "Using existing stack definition section" for more information about a stack definition.
+//
+// 3. Write your test function
+//
+//	func (v *vmSuite) TestBasicVM() {
+//		v.Env().VM.Execute("ls")
+//	}
+//
+// [suite.Env] gives the access to the components in your environment.
+//
+// Depending on your stack definition, [e2e.Suite.Env] can provide the following objects:
+//   - [client.VM]: A virtual machine where you can execute commands.
+//   - [client.Agent]: A struct that provides methods to run datadog agent commands.
+//
+// # Using an existing stack definition
+//
+// The stack definition defines the components available in your environment.
+//
+//	type vmSuite struct {
+//		e2e.Suite[e2e.VMEnv]
+//	}
+//
+//	func TestVMSuite(t *testing.T) {
+//		e2e.Run(t, &vmSuite{}, e2e.EC2VMStackDef())
+//	}
+//
+// In this example, the components available are defined by the struct [e2e.VMEnv] which contains a virtual machine.
+// The generic type of [e2e.Suite] must match the type of the stack definition.
+// In our example, [e2e.EC2VMStackDef] returns an instance of [*e2e.StackDefinition][[e2e.VMEnv]].
+//
+// The following default stack definitions are provided:
+//   - [e2e.EC2VMStackDef] creates an environment with a virtual machine. See [e2e.EC2VMStackDef] for more information about the supported options.
+//   - [e2e.AgentStackDef] creates an environment with an Agent installed on a virtual machine. See [e2e.AgentStackDef] for more information about the supported options.
+//
+// # Defining your stack definition
+//
+// In some special cases, you have to define a custom environment.
+// Here is an example on how to define an environment with Docker installed on a virtual machine.
+//
+//	type dockerSuite struct {
+//		e2e.Suite[e2e.VMEnv]
+//	}
+//
+//	func TestDockerSuite(t *testing.T) {
+//		e2e.Run(t, &dockerSuite{}, e2e.EnvFactoryStackDef(dockerEnvFactory))
+//	}
+//
+//	func dockerEnvFactory(ctx *pulumi.Context) (*e2e.VMEnv, error) {
+//		vm, err := ec2vm.NewUnixEc2VM(ctx)
+//		if err != nil {
+//			return nil, err
+//		}
+//
+//		_, err = docker.NewAgentDockerInstaller(vm.UnixVM, docker.WithAgent(docker.WithAgentImageTag("7.42.0")))
+//
+//		if err != nil {
+//			return nil, err
+//		}
+//
+//		return &e2e.VMEnv{
+//			VM: client.NewVM(vm),
+//		}, nil
+//	}
+//
+//	func (docker *dockerSuite) TestDocker() {
+//		docker.Env().VM.Execute("docker container ls")
+//	}
+//
+// [e2e.EnvFactoryStackDef] is used to define a custom environment.
+// Here is a non exhaustive list of components that can be used to create a custom environment:
+//   - [EC2 VM]: Provide methods to create a virtual machine on EC2.
+//   - [Agent]: Provide methods to install the Agent on a virtual machine
+//   - [File Manager]: Provide methods to manipulate files and folders
+//
+// # Organizing your tests
+//
+// # Having a single environment
+//
+// In the simple case, there is a single environment and each test checks one specific thing.
+//
+//	type singleEnvSuite struct {
+//		e2e.Suite[e2e.AgentEnv]
+//	}
+//
+//	func TestSingleEnvSuite(t *testing.T) {
+//		e2e.Run(t, &singleEnvSuite{}, e2e.AgentStackDef(nil))
+//	}
+//
+//	func (suite *singleEnvSuite) Test1() {
+//		// Check feature 1
+//	}
+//
+//	func (suite *singleEnvSuite) Test2() {
+//		// Check feature 2
+//	}
+//
+//	func (suite *singleEnvSuite) Test3() {
+//		// Check feature 3
+//	}
+//
+// # Having different environments
+//
+// In this scenario, the environment is different for each test (or for most of them).
+// [e2e.Suite.UpdateEnv] is used to update the environment.
+// Keep in mind that using [e2e.Suite.UpdateEnv] to update virtual machine settings can destroy
+// the current virtal machine and create a new one when updating the operating system for example.
+//
+// Note: Calling twice [e2e.Suite.UpdateEnv] with the same argument does nothing.
+//
+//	type multipleEnvSuite struct {
+//		e2e.Suite[e2e.AgentEnv]
+//	}
+//
+//	func TestMultipleEnvSuite(t *testing.T) {
+//		e2e.Run(t, &multipleEnvSuite{}, e2e.AgentStackDef(nil))
+//	}
+//
+//	func (suite *multipleEnvSuite) TestLogDebug() {
+//		suite.UpdateEnv(e2e.AgentStackDef(nil, agent.WithAgentConfig("log_level: debug")))
+//		config := suite.Env().Agent.Config()
+//		require.Contains(suite.T(), config, "log_level: debug")
+//	}
+//
+//	func (suite *multipleEnvSuite) TestLogInfo() {
+//		suite.UpdateEnv(e2e.AgentStackDef(nil, agent.WithAgentConfig("log_level: info")))
+//		config := suite.Env().Agent.Config()
+//		require.Contains(suite.T(), config, "log_level: info")
+//	}
+//
+// # Having few environments
+//
+// You may sometime have few environments but several tests for each on them.
+// You can still use [e2e.Suite.UpdateEnv] as explained in the previous section but using
+// [Subtests] is an alternative solution.
+//
+//	type subTestSuite struct {
+//		e2e.Suite[e2e.AgentEnv]
+//	}
+//
+//	func TestSubTestSuite(t *testing.T) {
+//		e2e.Run(t, &subTestSuite{}, e2e.AgentStackDef(nil))
+//	}
+//
+//	func (suite *subTestSuite) TestLogDebug() {
+//		suite.UpdateEnv(e2e.AgentStackDef(nil, agent.WithAgentConfig("log_level: debug")))
+//		suite.T().Run("MySubTest1", func(t *testing.T) {
+//			// Sub test 1
+//		})
+//		suite.T().Run("MySubTest2", func(t *testing.T) {
+//			// Sub test 2
+//		})
+//	}
+//
+//	func (suite *subTestSuite) TestLogInfo() {
+//		suite.UpdateEnv(e2e.AgentStackDef(nil, agent.WithAgentConfig("log_level: info")))
+//		suite.T().Run("MySubTest1", func(t *testing.T) {
+//			// Sub test 1
+//		})
+//		suite.T().Run("MySubTest2", func(t *testing.T) {
+//			// Sub test 2
+//		})
+//	}
+//
+// [Subtests]: https://go.dev/blog/subtests
+// [testify Suite]: https://pkg.go.dev/github.com/stretchr/testify/suite
+// [File Manager]: https://pkg.go.dev/github.com/DataDog/test-infra-definitions@main/components/command#FileManager
+// [EC2 VM]: https://pkg.go.dev/github.com/DataDog/test-infra-definitions@main/scenarios/aws/vm/ec2VM
+// [Agent]: https://pkg.go.dev/github.com/DataDog/test-infra-definitions@v0.0.0-20230523141914-dd356f2194c1/components/datadog/agent#Installer
 package e2e
 
 import (
@@ -55,6 +265,21 @@ type suiteConstraint[Env any] interface {
 	initSuite(stackName string, stackDef *StackDefinition[Env], options ...func(*Suite[Env]))
 }
 
+// Run run the tests defined in e2eSuite
+//
+// t is an instance of type [*testing.T].
+//
+// e2eSuite is a pointer to a structure with a [e2e.Suite] embbeded struct.
+//
+// stackDef defines the stack definition.
+//
+// options is an optional list of options like [DevMode], [SkipDeleteOnFailure] or [WithStackName].
+//
+//	type vmSuite struct {
+//		e2e.Suite[e2e.VMEnv]
+//	}
+//	// ...
+//	e2e.Run(t, &vmSuite{}, e2e.EC2VMStackDef())
 func Run[Env any, T suiteConstraint[Env]](t *testing.T, e2eSuite T, stackDef *StackDefinition[Env], options ...func(*Suite[Env])) {
 	suiteType := reflect.TypeOf(e2eSuite).Elem()
 	name := suiteType.Name()
@@ -79,20 +304,24 @@ func (suite *Suite[Env]) initSuite(stackName string, stackDef *StackDefinition[E
 	}
 }
 
-// WithStackName overrides the stack name.
-// This function is useful only when using e2e.Run.
+// WithStackName overrides the default stack name.
+// This function is useful only when using [Run].
 func WithStackName[Env any](stackName string) func(*Suite[Env]) {
 	return func(suite *Suite[Env]) {
 		suite.stackName = stackName
 	}
 }
 
+// DevMode enables dev mode.
+// Dev mode doesn't destroy the environment when the test finished which can
+// be useful when writing a new E2E test.
 func DevMode[Env any]() func(*Suite[Env]) {
 	return func(suite *Suite[Env]) {
 		suite.devMode = true
 	}
 }
 
+// SkipDeleteOnFailure doesn't destroy the environment when a test fail.
 func SkipDeleteOnFailure[Env any]() func(*Suite[Env]) {
 	return func(suite *Suite[Env]) {
 		suite.skipDeleteOnFailure = true
@@ -101,10 +330,10 @@ func SkipDeleteOnFailure[Env any]() func(*Suite[Env]) {
 
 // Env returns the current environment.
 // In order to improve the efficiency, this function behaves as follow:
-//   - It creates the default environment if no environment exists. It happens only during the first call of the test suite.
-//   - It restores the default environment if UpdateEnv was not already called during this test.
-//     This avoid having to restore the default environment for each test even if UpdateEnv immedialy
-//     overrides this environment.
+//   - It creates the default environment if no environment exists.
+//   - It restores the default environment if [suite.UpdateEnv] was not already called during this test.
+//     This avoid having to restore the default environment for each test even if [suite.UpdateEnv] immedialy
+//     overrides the environment.
 func (suite *Suite[Env]) Env() *Env {
 	if suite.env == nil || !suite.isUpdateEnvCalledInThisTest {
 		suite.UpdateEnv(suite.defaultStackDef)
@@ -112,10 +341,22 @@ func (suite *Suite[Env]) Env() *Env {
 	return suite.env
 }
 
+// BeforeTest is executed right before the test starts and receives the suite and test names as input.
+// This function is called by [testify Suite].
+//
+// If you override BeforeTest in your custom test suite type, the function must call [e2e.Suite.BeforeTest].
+//
+// [testify Suite]: https://pkg.go.dev/github.com/stretchr/testify/suite
 func (suite *Suite[Env]) BeforeTest(suiteName, testName string) {
 	suite.isUpdateEnvCalledInThisTest = false
 }
 
+// AfterTest is executed right after the test finishes and receives the suite and test names as input.
+// This function is called by [testify Suite].
+//
+// If you override AfterTest in your custom test suite type, the function must call [e2e.Suite.AfterTest].
+//
+// [testify Suite]: https://pkg.go.dev/github.com/stretchr/testify/suite
 func (suite *Suite[Env]) AfterTest(suiteName, testName string) {
 	if suite.T().Failed() && suite.firstFailTest == "" {
 		// As far as I know, there is no way to prevent other tests from being
@@ -130,6 +371,10 @@ func (suite *Suite[Env]) AfterTest(suiteName, testName string) {
 
 // SetupSuite method will run before the tests in the suite are run.
 // This function is called by [testify Suite].
+//
+// If you override SetupSuite in your custom test suite type, the function must call [e2e.Suite.SetupSuite].
+//
+// [testify Suite]: https://pkg.go.dev/github.com/stretchr/testify/suite
 func (suite *Suite[Env]) SetupSuite() {
 	skipDelete, _ := runner.GetProfile().ParamStore().GetBoolWithDefault(parameters.SkipDeleteOnFailure, false)
 	if skipDelete {
@@ -144,6 +389,8 @@ func (suite *Suite[Env]) SetupSuite() {
 
 // TearDownTestSuite run after all the tests in the suite have been run.
 // This function is called by [testify Suite].
+//
+// If you override TearDownSuite in your custom test suite type, the function must call [e2e.Suite.TearDownSuite].
 //
 // [testify Suite]: https://pkg.go.dev/github.com/stretchr/testify/suite
 func (suite *Suite[Env]) TearDownSuite() {
@@ -184,6 +431,7 @@ func createEnv[Env any](suite *Suite[Env], stackDef *StackDefinition[Env]) (*Env
 	return env, stackOutput, err
 }
 
+// UpdateEnv update the current environment.
 func (suite *Suite[Env]) UpdateEnv(stackDef *StackDefinition[Env]) {
 	if stackDef != suite.currentStackDef {
 		if (suite.firstFailTest != "" || suite.T().Failed()) && suite.skipDeleteOnFailure {

--- a/test/new-e2e/utils/e2e/e2e.go
+++ b/test/new-e2e/utils/e2e/e2e.go
@@ -216,7 +216,7 @@
 // [testify Suite]: https://pkg.go.dev/github.com/stretchr/testify/suite
 // [File Manager]: https://pkg.go.dev/github.com/DataDog/test-infra-definitions@main/components/command#FileManager
 // [EC2 VM]: https://pkg.go.dev/github.com/DataDog/test-infra-definitions@main/scenarios/aws/vm/ec2VM
-// [Agent]: https://pkg.go.dev/github.com/DataDog/test-infra-definitions@v0.0.0-20230523141914-dd356f2194c1/components/datadog/agent#Installer
+// [Agent]: https://pkg.go.dev/github.com/DataDog/test-infra-definitions@main/components/datadog/agent#Installer
 package e2e
 
 import (

--- a/test/new-e2e/utils/e2e/e2e.go
+++ b/test/new-e2e/utils/e2e/e2e.go
@@ -60,6 +60,7 @@
 // Depending on your stack definition, [e2e.Suite.Env] can provide the following objects:
 //   - [client.VM]: A virtual machine where you can execute commands.
 //   - [client.Agent]: A struct that provides methods to run datadog agent commands.
+//   - [client.Fakeintake]: A struct that provides methods to run queries to a fake instance of Datadog intake.
 //
 // # Using an existing stack definition
 //

--- a/test/new-e2e/utils/e2e/e2e.go
+++ b/test/new-e2e/utils/e2e/e2e.go
@@ -124,6 +124,9 @@
 //
 // # Organizing your tests
 //
+// The execution order for tests in [testify Suite] is IMPLEMENTATION SPECIFIC
+// UNLIKE REGULAR GO TESTS.
+//
 // # Having a single environment
 //
 // In the simple case, there is a single environment and each test checks one specific thing.

--- a/test/new-e2e/utils/e2e/e2e.go
+++ b/test/new-e2e/utils/e2e/e2e.go
@@ -27,7 +27,7 @@
 //		v.Env().VM.Execute("ls")
 //	}
 //
-// Writing a E2E test requires several steps.
+// To write an E2E test:
 //
 // 1. Define your own type with the embedded [e2e.Suite] struct.
 //

--- a/test/new-e2e/utils/e2e/e2e.go
+++ b/test/new-e2e/utils/e2e/e2e.go
@@ -55,7 +55,7 @@
 //		v.Env().VM.Execute("ls")
 //	}
 //
-// [suite.Env] gives the access to the components in your environment.
+// [suite.Env] gives access to the components in your environment.
 //
 // Depending on your stack definition, [e2e.Suite.Env] can provide the following objects:
 //   - [client.VM]: A virtual machine where you can execute commands.

--- a/test/new-e2e/utils/e2e/e2e.go
+++ b/test/new-e2e/utils/e2e/e2e.go
@@ -5,7 +5,7 @@
 
 // Package e2e provides the API to manage environments and organize E2E tests.
 //
-// Here is a simple example of E2E tests.
+// Here is a small example of E2E tests.
 // E2E tests use [testify Suite] and it is strongly recommended to read the documentation of
 // [testify Suite] if you are not familiar with it.
 //

--- a/test/new-e2e/utils/e2e/e2e.go
+++ b/test/new-e2e/utils/e2e/e2e.go
@@ -433,7 +433,9 @@ func createEnv[Env any](suite *Suite[Env], stackDef *StackDefinition[Env]) (*Env
 	return env, stackOutput, err
 }
 
-// UpdateEnv updates the current environment.
+// UpdateEnv updates the environment.
+// This affects only the test that calls this function.
+// Test functions that don't call UpdateEnv have the environment defined by [e2e.Run].
 func (suite *Suite[Env]) UpdateEnv(stackDef *StackDefinition[Env]) {
 	if stackDef != suite.currentStackDef {
 		if (suite.firstFailTest != "" || suite.T().Failed()) && suite.skipDeleteOnFailure {

--- a/test/new-e2e/utils/e2e/e2e.go
+++ b/test/new-e2e/utils/e2e/e2e.go
@@ -29,7 +29,7 @@
 //
 // To write an E2E test:
 //
-// 1. Define your own type with the embedded [e2e.Suite] struct.
+// 1. Define your own [suite] type with the embedded [e2e.Suite] struct.
 //
 //	type vmSuite struct {
 //		e2e.Suite[e2e.VMEnv]
@@ -212,6 +212,7 @@
 //	}
 //
 // [Subtests]: https://go.dev/blog/subtests
+// [suite]: https://pkg.go.dev/github.com/stretchr/testify/suite
 // [testify Suite]: https://pkg.go.dev/github.com/stretchr/testify/suite
 // [File Manager]: https://pkg.go.dev/github.com/DataDog/test-infra-definitions@main/components/command#FileManager
 // [EC2 VM]: https://pkg.go.dev/github.com/DataDog/test-infra-definitions@main/scenarios/aws/vm/ec2VM

--- a/test/new-e2e/utils/e2e/e2e.go
+++ b/test/new-e2e/utils/e2e/e2e.go
@@ -49,7 +49,7 @@
 //
 // The third parameter defines the environment. See "Using existing stack definition section" for more information about a stack definition.
 //
-// 3. Write your test function
+// 3. Write a test function
 //
 //	func (v *vmSuite) TestBasicVM() {
 //		v.Env().VM.Execute("ls")

--- a/test/new-e2e/utils/e2e/e2e.go
+++ b/test/new-e2e/utils/e2e/e2e.go
@@ -84,7 +84,7 @@
 // # Defining your stack definition
 //
 // In some special cases, you have to define a custom environment.
-// Here is an example on how to define an environment with Docker installed on a virtual machine.
+// Here is an example of an environment with Docker installed on a virtual machine.
 //
 //	type dockerSuite struct {
 //		e2e.Suite[e2e.VMEnv]

--- a/test/new-e2e/utils/e2e/e2e.go
+++ b/test/new-e2e/utils/e2e/e2e.go
@@ -433,7 +433,7 @@ func createEnv[Env any](suite *Suite[Env], stackDef *StackDefinition[Env]) (*Env
 	return env, stackOutput, err
 }
 
-// UpdateEnv update the current environment.
+// UpdateEnv updates the current environment.
 func (suite *Suite[Env]) UpdateEnv(stackDef *StackDefinition[Env]) {
 	if stackDef != suite.currentStackDef {
 		if (suite.firstFailTest != "" || suite.T().Failed()) && suite.skipDeleteOnFailure {

--- a/test/new-e2e/utils/e2e/e2e.go
+++ b/test/new-e2e/utils/e2e/e2e.go
@@ -267,7 +267,7 @@ type suiteConstraint[Env any] interface {
 	initSuite(stackName string, stackDef *StackDefinition[Env], options ...func(*Suite[Env]))
 }
 
-// Run run the tests defined in e2eSuite
+// Run runs the tests defined in e2eSuite
 //
 // t is an instance of type [*testing.T].
 //

--- a/test/new-e2e/utils/e2e/e2e.go
+++ b/test/new-e2e/utils/e2e/e2e.go
@@ -47,7 +47,7 @@
 //
 // The second argument is a pointer to an empty instance of the previous defined structure (&vmSuite{} in our example)
 //
-// The third parameter defines the environment. See "Using existing stack definition section" for more information about a stack definition.
+// The third parameter defines the environment. See "Using existing stack definition section" for more information about a environment definition.
 //
 // 3. Write a test function
 //

--- a/test/new-e2e/utils/e2e/e2e.go
+++ b/test/new-e2e/utils/e2e/e2e.go
@@ -35,7 +35,7 @@
 //		e2e.Suite[e2e.VMEnv]
 //	}
 //
-// [e2e.VMEnv] defines the components available in your stack. See "Using existing stack definition section" for more information.
+// [e2e.VMEnv] defines the components available in your stack. See "Using existing stack definition" section for more information.
 //
 // 2. Write a regular Go test function that runs the test suite using [e2e.Run].
 //
@@ -47,7 +47,7 @@
 //
 // The second argument is a pointer to an empty instance of the previous defined structure (&vmSuite{} in our example)
 //
-// The third parameter defines the environment. See "Using existing stack definition section" for more information about a environment definition.
+// The third parameter defines the environment. See "Using existing stack definition" section for more information about a environment definition.
 //
 // 3. Write a test function
 //
@@ -55,7 +55,7 @@
 //		v.Env().VM.Execute("ls")
 //	}
 //
-// [suite.Env] gives access to the components in your environment.
+// [e2e.Suite.Env] gives access to the components in your environment.
 //
 // Depending on your stack definition, [e2e.Suite.Env] can provide the following objects:
 //   - [client.VM]: A virtual machine where you can execute commands.
@@ -333,7 +333,7 @@ func SkipDeleteOnFailure[Env any]() func(*Suite[Env]) {
 // Env returns the current environment.
 // In order to improve the efficiency, this function behaves as follow:
 //   - It creates the default environment if no environment exists.
-//   - It restores the default environment if [suite.UpdateEnv] was not already called during this test.
+//   - It restores the default environment if [e2e.Suite.UpdateEnv] was not already called during this test.
 //     This avoid having to restore the default environment for each test even if [suite.UpdateEnv] immedialy
 //     overrides the environment.
 func (suite *Suite[Env]) Env() *Env {

--- a/test/new-e2e/utils/e2e/e2e.go
+++ b/test/new-e2e/utils/e2e/e2e.go
@@ -45,7 +45,7 @@
 //
 // The first argument of [e2e.Run] is an instance of type [*testing.T].
 //
-// The second argument is a pointer to the previous defined structure (&vmSuite{} in our example)
+// The second argument is a pointer to an empty instance of the previous defined structure (&vmSuite{} in our example)
 //
 // The third parameter defines the environment. See "Using existing stack definition section" for more information about a stack definition.
 //

--- a/test/new-e2e/utils/e2e/e2e.go
+++ b/test/new-e2e/utils/e2e/e2e.go
@@ -35,7 +35,7 @@
 //		e2e.Suite[e2e.VMEnv]
 //	}
 //
-// [e2e.VMEnv] defines the components available in your environment. See "Using existing stack definition section" for more information.
+// [e2e.VMEnv] defines the components available in your stack. See "Using existing stack definition section" for more information.
 //
 // 2. Write a regular Go test function that runs the test suite using [e2e.Run].
 //

--- a/test/new-e2e/utils/e2e/e2e.go
+++ b/test/new-e2e/utils/e2e/e2e.go
@@ -152,7 +152,7 @@
 // In this scenario, the environment is different for each test (or for most of them).
 // [e2e.Suite.UpdateEnv] is used to update the environment.
 // Keep in mind that using [e2e.Suite.UpdateEnv] to update virtual machine settings can destroy
-// the current virtal machine and create a new one when updating the operating system for example.
+// the current virtual machine and create a new one when updating the operating system for example.
 //
 // Note: Calling twice [e2e.Suite.UpdateEnv] with the same argument does nothing.
 //

--- a/test/new-e2e/utils/e2e/stack_definition.go
+++ b/test/new-e2e/utils/e2e/stack_definition.go
@@ -23,6 +23,7 @@ func NewStackDef[Env any](envFactory func(ctx *pulumi.Context) (*Env, error), co
 	return &StackDefinition[Env]{envFactory: envFactory, configMap: configMap}
 }
 
+// EnvFactoryStackDef create a custom stack definition
 func EnvFactoryStackDef[Env any](envFactory func(ctx *pulumi.Context) (*Env, error)) *StackDefinition[Env] {
 	return NewStackDef(envFactory, runner.ConfigMap{})
 }
@@ -31,6 +32,10 @@ type VMEnv struct {
 	VM *client.VM
 }
 
+// EC2VMStackDef creates a stack definition containing a virtual machine.
+// See [ec2vm.Params] for available options.
+//
+// [ec2vm.Params]: https://pkg.go.dev/github.com/DataDog/test-infra-definitions@main/scenarios/aws/vm/ec2VM#pkg-variables
 func EC2VMStackDef(options ...func(*ec2vm.Params) error) *StackDefinition[VMEnv] {
 	noop := func(vm.VM) (VMEnv, error) { return VMEnv{}, nil }
 	return CustomEC2VMStackDef(noop, options...)
@@ -59,6 +64,14 @@ type AgentEnv struct {
 
 type Ec2VMOption = func(*ec2vm.Params) error
 
+// AgentStackDef creates a stack definition containing a virtual machine and an Agent.
+//
+// See [ec2vm.Params] for available options for vmParams.
+//
+// See [Agent functions] starting with "With" for available options for agentParams.
+//
+// [ec2vm.Params]: https://pkg.go.dev/github.com/DataDog/test-infra-definitions@main/scenarios/aws/vm/ec2VM#pkg-variables
+// [Agent functions]: https://pkg.go.dev/github.com/DataDog/test-infra-definitions@main/components/datadog/agent#pkg-functions
 func AgentStackDef(vmParams []Ec2VMOption, agentParams ...func(*agent.Params) error) *StackDefinition[AgentEnv] {
 	return EnvFactoryStackDef(
 		func(ctx *pulumi.Context) (*AgentEnv, error) {

--- a/test/new-e2e/utils/e2e/stack_definition.go
+++ b/test/new-e2e/utils/e2e/stack_definition.go
@@ -35,7 +35,7 @@ type VMEnv struct {
 // EC2VMStackDef creates a stack definition containing a virtual machine.
 // See [ec2vm.Params] for available options.
 //
-// [ec2vm.Params]: https://pkg.go.dev/github.com/DataDog/test-infra-definitions@main/scenarios/aws/vm/ec2VM#pkg-variables
+// [ec2vm.Params]: https://pkg.go.dev/github.com/DataDog/test-infra-definitions@main/scenarios/aws/vm/ec2VM#Params
 func EC2VMStackDef(options ...func(*ec2vm.Params) error) *StackDefinition[VMEnv] {
 	noop := func(vm.VM) (VMEnv, error) { return VMEnv{}, nil }
 	return CustomEC2VMStackDef(noop, options...)
@@ -68,10 +68,10 @@ type Ec2VMOption = func(*ec2vm.Params) error
 //
 // See [ec2vm.Params] for available options for vmParams.
 //
-// See [Agent functions] starting with "With" for available options for agentParams.
+// See [agent.Params] for available options for agentParams.
 //
-// [ec2vm.Params]: https://pkg.go.dev/github.com/DataDog/test-infra-definitions@main/scenarios/aws/vm/ec2VM#pkg-variables
-// [Agent functions]: https://pkg.go.dev/github.com/DataDog/test-infra-definitions@main/components/datadog/agent#pkg-functions
+// [ec2vm.Params]: https://pkg.go.dev/github.com/DataDog/test-infra-definitions@main/scenarios/aws/vm/ec2VM#Params
+// [agent.Params]: https://pkg.go.dev/github.com/DataDog/test-infra-definitions@main/components/datadog/agent#Params
 func AgentStackDef(vmParams []Ec2VMOption, agentParams ...func(*agent.Params) error) *StackDefinition[AgentEnv] {
 	return EnvFactoryStackDef(
 		func(ctx *pulumi.Context) (*AgentEnv, error) {

--- a/test/new-e2e/utils/e2e/stack_definition.go
+++ b/test/new-e2e/utils/e2e/stack_definition.go
@@ -23,7 +23,7 @@ func NewStackDef[Env any](envFactory func(ctx *pulumi.Context) (*Env, error), co
 	return &StackDefinition[Env]{envFactory: envFactory, configMap: configMap}
 }
 
-// EnvFactoryStackDef create a custom stack definition
+// EnvFactoryStackDef creates a custom stack definition
 func EnvFactoryStackDef[Env any](envFactory func(ctx *pulumi.Context) (*Env, error)) *StackDefinition[Env] {
 	return NewStackDef(envFactory, runner.ConfigMap{})
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This PR adds the documentation for the E2E test framework.
To generate the doc, run `pkgsite` (`go get golang.org/x/pkgsite/cmd/pkgsite@latest`) and browse `http://localhost:8080/github.com/DataDog/datadog-agent/test/new-e2e@v0.0.0/utils/e2e`

The documentation of test-infra-definition especially the VM and the Agent options must be improved.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
