### PR TITLE
Increase Oracle database timeout (workaround for connection leaks)

### DIFF
--- a/pkg/collector/corechecks/oracle-dbm/statements.go
+++ b/pkg/collector/corechecks/oracle-dbm/statements.go
@@ -444,8 +444,8 @@ func (c *Check) StatementMetrics() (int, error) {
 			 */
 			err = c.db.Select(
 				&DDForceMatchingSignatures,
-				"SELECT distinct force_matching_signature FROM v$sqlstats WHERE sql_text like '%/* DD%' and (sysdate-last_active_time)*3600*24 < :1",
-				time.Since(c.statementsLastRun).Seconds(),
+				"SELECT distinct force_matching_signature FROM v$sqlstats WHERE sql_text like '%/* DD%' and (sysdate-last_active_time)*3600*24 <= :1",
+				time.Since(c.statementsLastRun).Seconds()+1,
 			)
 			if err != nil {
 				log.Error("error getting sql_ids from DD queries")
@@ -957,5 +957,8 @@ func (c *Check) StatementMetrics() (int, error) {
 
 	c.statementsLastRun = start
 
+	if SQLTextErrors > 0 || planErrors > 0 {
+		return SQLCount, fmt.Errorf("SQL statements processed: %d, text errors: %d, plan erros: %d", SQLCount, SQLTextErrors, planErrors)
+	}
 	return SQLCount, nil
 }


### PR DESCRIPTION
### What does this PR do?

We are increasing the timeout on `go-ora` driver from the default value of 30 to 20000. (There is no way to disable the timeout.)

### Motivation

`database/sqlx` `Select` function leaks a database connection after a timeout.

### Additional Notes

Actually, `Select` probably fails to close the statement handle on the timeout statement. Go `database/sql` allocates a dedicated connection for every prepared statement and doesn't return it to the connection pool until the prepared statement is closed. Allocating a dedicated connection for every statement is suboptimal and completely unnecessary. Other programming languages keep prepared statements in the local cache and access them on subsequent query executions.

On other errors the connection doesn't leak.

The problem can be reproduced with the steps below.

Lock a row with the following statements:

```
create table t (n number);
insert into t values (1);
commit;
update t set n=2;
-- no commit here so the row will remained locked
```

Run the following program:
```
package main

import (
    "fmt"

    _ "github.com/godror/godror"
    "github.com/jmoiron/sqlx"
    go_ora "github.com/sijms/go-ora/v2"
)

const HOST = "localhost"
const PORT = 1521
const SERVICE_NAME = "XE"
const USER = 
const PASSWORD = 

type S struct {
    N string `db:"N"`
}

func main() {
    connStr := go_ora.BuildUrl(HOST, PORT, SERVICE_NAME, USER, PASSWORD, map[string]string{"TIMEOUT": "1"})
    db, err := sqlx.Open("oracle", connStr)

    if err != nil {
        fmt.Printf("failed to connect %v \n", err)
        return
    }
    db.SetMaxOpenConns(1)
    r := []S{}
    fmt.Println("Waiting on timeout...")
    // Because of the FOR UPDATE clause, SELECT unsuccessfully waits on a lock,
    // but it times out
    err = db.Select(&r, "select n from t FOR UPDATE")
    if err != nil {
        fmt.Printf("failed sql execution %v \n", err)
    }

    // This statement will never end because the previous failed execution
    // hasn't released the connection
    fmt.Println("Starting another statement...")
    err = db.Select(&r, "select n from t")
    if err != nil {
        fmt.Printf("failed sql execution %v \n", err)
        return
    }
    fmt.Println("END")
}
```

```
go run main.go
Waiting on timeout...
failed sql execution read tcp 127.0.0.1:57796->127.0.0.1:1521: i/o timeout 
Starting another statement...
```

Notice that the error message `tcp i/o timeout` is misleading. The reason was in this case a long SQL execution. The driver cannot now the real cause for the timeout.

### Possible Drawbacks / Trade-offs

There is no drawback in disabling the timeout. Simply put, there's no benefit in timing out a slower execution and retrying it.

### Describe how to test/QA your changes

Run agent for longer under the load and check that it doesn't hang.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
