### PR TITLE
Improve the DCA leader election

### DIFF
--- a/pkg/util/kubernetes/apiserver/leaderelection/leaderelection.go
+++ b/pkg/util/kubernetes/apiserver/leaderelection/leaderelection.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
 	"sync"
 	"time"
 
@@ -29,7 +28,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/leaderelection/metrics"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/retry"
-	"github.com/DataDog/datadog-agent/pkg/util/system"
 )
 
 const (
@@ -108,31 +106,6 @@ func GetCustomLeaderEngine(holderIdentity string, ttl time.Duration) (*LeaderEng
 		return nil, err
 	}
 	return globalLeaderEngine, nil
-}
-
-func getSelfPodName() (string, error) {
-	if podName, ok := os.LookupEnv("DD_POD_NAME"); ok {
-		return podName, nil
-	}
-
-	selfUTSInode, err := system.GetProcessNamespaceInode("/proc", "self", "uts")
-	if err != nil {
-		// If we are not able to gather our own UTS Inode, in doubt, authorize fallback to `os.Hostname()`
-		log.Warnf("Unable to get self UTS inode")
-		return os.Hostname()
-	}
-
-	hostUTS := system.IsProcessHostUTSNamespace("/proc", selfUTSInode)
-	if hostUTS == nil {
-		// In doubt, authorize fallback to `os.Hostname()`
-		return os.Hostname()
-	}
-
-	if *hostUTS {
-		return "", fmt.Errorf("DD_POD_NAME is not set and running in host UTS namespace; cannot reliably determine self pod name")
-	}
-
-	return os.Hostname()
 }
 
 func (le *LeaderEngine) init() error {

--- a/pkg/util/kubernetes/apiserver/leaderelection/leaderelection_linux.go
+++ b/pkg/util/kubernetes/apiserver/leaderelection/leaderelection_linux.go
@@ -1,0 +1,41 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+//go:build kubeapiserver && linux
+
+package leaderelection
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/util/system"
+)
+
+func getSelfPodName() (string, error) {
+	if podName, ok := os.LookupEnv("DD_POD_NAME"); ok {
+		return podName, nil
+	}
+
+	selfUTSInode, err := system.GetProcessNamespaceInode("/proc", "self", "uts")
+	if err != nil {
+		// If we are not able to gather our own UTS Inode, in doubt, authorize fallback to `os.Hostname()`
+		log.Warnf("Unable to get self UTS inode")
+		return os.Hostname()
+	}
+
+	hostUTS := system.IsProcessHostUTSNamespace("/proc", selfUTSInode)
+	if hostUTS == nil {
+		// In doubt, authorize fallback to `os.Hostname()`
+		return os.Hostname()
+	}
+
+	if *hostUTS {
+		return "", fmt.Errorf("DD_POD_NAME is not set and running in host UTS namespace; cannot reliably determine self pod name")
+	}
+
+	return os.Hostname()
+}

--- a/pkg/util/kubernetes/apiserver/leaderelection/leaderelection_nolinux.go
+++ b/pkg/util/kubernetes/apiserver/leaderelection/leaderelection_nolinux.go
@@ -1,0 +1,20 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+//go:build kubeapiserver && !linux
+
+package leaderelection
+
+import (
+	"os"
+)
+
+func getSelfPodName() (string, error) {
+	if podName, ok := os.LookupEnv("DD_POD_NAME"); ok {
+		return podName, nil
+	}
+
+	return os.Hostname()
+}

--- a/releasenotes-dca/notes/improve_dca_leader-8444de5fe59ef9d6.yaml
+++ b/releasenotes-dca/notes/improve_dca_leader-8444de5fe59ef9d6.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG-DCA.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    When the cluster-agent is started with ``hostNetwork: true``, the leader election mechanism was using a node name instead of the pod name. This was breaking the “follower to leader” forwarding mechanism.
+    This change introduce the ``DD_POD_NAME`` environment variable as a more reliable way to set the cluster-agent pod name. It is supposed to be filled by the Kubernetes downward API.

--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -92,7 +92,7 @@ AGENT_HEROKU_TAGS = AGENT_TAGS.difference(
 )
 
 # CLUSTER_AGENT_TAGS lists the tags needed when building the cluster-agent
-CLUSTER_AGENT_TAGS = {"clusterchecks", "ec2", "gce", "kubeapiserver", "kubelet", "orchestrator", "secrets", "zlib"}
+CLUSTER_AGENT_TAGS = {"clusterchecks", "kubeapiserver", "orchestrator", "secrets", "zlib", "ec2", "gce"}
 
 # CLUSTER_AGENT_CLOUDFOUNDRY_TAGS lists the tags needed when building the cloudfoundry cluster-agent
 CLUSTER_AGENT_CLOUDFOUNDRY_TAGS = {"clusterchecks", "secrets"}

--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -92,7 +92,7 @@ AGENT_HEROKU_TAGS = AGENT_TAGS.difference(
 )
 
 # CLUSTER_AGENT_TAGS lists the tags needed when building the cluster-agent
-CLUSTER_AGENT_TAGS = {"clusterchecks", "kubeapiserver", "orchestrator", "secrets", "zlib", "ec2", "gce"}
+CLUSTER_AGENT_TAGS = {"clusterchecks", "ec2", "gce", "kubeapiserver", "kubelet", "orchestrator", "secrets", "zlib"}
 
 # CLUSTER_AGENT_CLOUDFOUNDRY_TAGS lists the tags needed when building the cloudfoundry cluster-agent
 CLUSTER_AGENT_CLOUDFOUNDRY_TAGS = {"clusterchecks", "secrets"}


### PR DESCRIPTION
### What does this PR do?

Currently, the holder identity of the DCA lease object for its leader election is determined by `os.Hostname()`.

When the cluster agents do **not** run with `hostNetwork: true`, `os.Hostname()` returns a pod name.
In order to find the leader IP to forward it queries, the cluster-agent looks for the lease holder identity inside the Endpoints object of the cluster agent. That Endpoints always has pod names as target references for each cluster agent.
So, that’s fine.

But when the cluster agents **do** run with `hostNetwork: true`, `os.Hostname()` returns a node name.
While it allows the cluster agents to elect a leader among them, it breaks the logic that parses the Endpoints object to find the leader IP.

This PR uses a `DD_POD_NAME` environment variable instead of `os.Hostname()`. This environment variable is supposed to be set via the downward API. See DataDog/helm-charts#1065 and DataDog/datadog-operator#847.

### Motivation

Make the cluster agent leader election work better when running with `hostNetwork: true`.

### Additional Notes

Needs DataDog/helm-charts#1065 or DataDog/datadog-operator#847.

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Start the cluster agent with `hostNetwork: true`.
Without this change, the cluster agents were logging errors like:
```
2023-05-25 15:48:35 UTC | CLUSTER | WARN | (pkg/clusteragent/clusterchecks/handler.go:192 in leaderWatch) | Could not refresh leadership status: "target named gke-gke-lenaic-ubuntu-containerd-2a3618a5-lzg5" not found, will only log every 100 errors
```

These errors should go away with this change.

In the output of `agent status`, the leader name was a node name before this change. With this change, it should now be the pod name. Same behavior as without `hostNetwork: true`.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
