### PR TITLE
Add filtering to remove copyright with invalid quotes

### DIFF
--- a/.copyright-overrides.yml
+++ b/.copyright-overrides.yml
@@ -184,25 +184,6 @@ github.com/aquasecurity/go-version: Copyright (c) 2020 Teppei Fukuda (knqyf263)
 github.com/spdx/tools-golang: Copyright (c) 2018 The Authors
 github.com/google/flatbuffers: Copyright (c) 2014 Google
 
-# FIXME(AP-2060): inv generate-licenses and inv lint-licenses can generate invalid csv
-# while parsing some files. For instance, in the README.md of github.com/klauspost/compress/s2,
-# there is an example section which contains:
-#    // We are only interested in the contents.
-#    // Assume that files start with "// Copyright (c) 2023".
-#    // Search for the longest match for that.
-#    // This may save a few bytes.
-#    dict := s2.MakeDict(insp.Content(), []byte("// Copyright (c) 2023"))
-# This causes the tasks to add 'Copyright (c) 2023". | Copyright (c) 2023"))' to the copyright
-# information for that file, resulting in an invalid csv (due to the quotes).
-# Until this is fixed, override the copyright value to avoid parsing these files.
-github.com/klauspost/compress/s2:
-  - "Copyright (c) 2011 The Snappy-Go Authors. All rights reserved"
-  - "Copyright (c) 2012 The Go Authors. All rights reserved"
-  - "Copyright (c) 2015 Klaus Post"
-  - "Copyright (c) 2019 Klaus Post. All rights reserved"
-  - "Copyright 2016 The filepathx Authors"
-  - "Copyright 2016-2017 The New York Times Company"
-
 # The Copyright information is not contained in the LICENSE file, but it can be found in other
 # files in the package, such as:
 #  * https://github.com/godror/knownpb/blob/main/timestamppb/timestamp_test.go

--- a/tasks/licenses.py
+++ b/tasks/licenses.py
@@ -98,7 +98,9 @@ def licenses_csv(licenses):
             if is_valid_quote(copyright):
                 filtered_copyright.append(copyright)
             else:
-                print(f'copyright {copyright} was discarded because it contains invalid quotes')
+                print(
+                    f'copyright {copyright} was discarded because it contains invalid quotes. If you want to fix this discarded Copyright, you can modify the .copyright-overrides.yml file to fix the bad-quotes copyright'
+                )
         if len(copyright) == 0:
             copyright = "UNKNOWN"
         copyright = ' | '.join(sorted(filtered_copyright))

--- a/tasks/licenses.py
+++ b/tasks/licenses.py
@@ -85,7 +85,7 @@ def licenses_csv(licenses):
         quotes_to_check = ["'", '"']
         for c in copyright:
             if c in quotes_to_check:
-                if len(stack) != 0 and stack[-1] == c:
+                if stack and stack[-1] == c:
                     stack.pop()
                 else:
                     stack.append(c)

--- a/tasks/licenses.py
+++ b/tasks/licenses.py
@@ -61,9 +61,9 @@ CONTRIBUTORS_WITH_UNCOMMENTED_HEADER = [
     'gopkg.in/Knetic/govaluate.v3',
 ]
 
+
 # FIXME: This doesn't include licenses for non-go dependencies, like the javascript libs we use for the web gui
 def get_licenses_list(ctx):
-
     # we need the full vendor tree in order to perform this analysis
     from .go import deps_vendored
 
@@ -79,16 +79,18 @@ def get_licenses_list(ctx):
 
 def licenses_csv(licenses):
     licenses.sort(key=lambda lic: lic["package"])
+
     def is_valid_quote(copyright):
         stack = []
-        quotes_to_check = ["'",'"']
+        quotes_to_check = ["'", '"']
         for c in copyright:
             if c in quotes_to_check:
-                if len(stack) !=0 and stack[-1] == c:
+                if len(stack) != 0 and stack[-1] == c:
                     stack.pop()
                 else:
                     stack.append(c)
         return len(stack) == 0
+
     def fmt_copyright(lic):
         # discards copyright with invalid quotes to ensure generated csv is valid
         copyright = [f_copyright for f_copyright in lic['copyright'] if is_valid_quote(f_copyright)]

--- a/tasks/licenses.py
+++ b/tasks/licenses.py
@@ -93,9 +93,15 @@ def licenses_csv(licenses):
 
     def fmt_copyright(lic):
         # discards copyright with invalid quotes to ensure generated csv is valid
-        copyright = [f_copyright for f_copyright in lic['copyright'] if is_valid_quote(f_copyright)]
-
-        copyright = ' | '.join(sorted(copyright))
+        filtered_copyright = []
+        for copyright in lic["copyright"]:
+            if is_valid_quote(copyright):
+                filtered_copyright.append(copyright)
+            else:
+                print(f'copyright {copyright} was discarded because it contains invalid quotes')
+        if len(copyright) == 0:
+            copyright = "UNKNOWN"
+        copyright = ' | '.join(sorted(filtered_copyright))
         # quote for inclusion in CSV, if necessary
         if ',' in copyright:
             copyright = copyright.replace('"', '""')

--- a/tasks/licenses.py
+++ b/tasks/licenses.py
@@ -77,19 +77,20 @@ def get_licenses_list(ctx):
         shutil.rmtree("vendor/")
 
 
+def is_valid_quote(copyright):
+    stack = []
+    quotes_to_check = ["'", '"']
+    for c in copyright:
+        if c in quotes_to_check:
+            if stack and stack[-1] == c:
+                stack.pop()
+            else:
+                stack.append(c)
+    return len(stack) == 0
+
+
 def licenses_csv(licenses):
     licenses.sort(key=lambda lic: lic["package"])
-
-    def is_valid_quote(copyright):
-        stack = []
-        quotes_to_check = ["'", '"']
-        for c in copyright:
-            if c in quotes_to_check:
-                if stack and stack[-1] == c:
-                    stack.pop()
-                else:
-                    stack.append(c)
-        return len(stack) == 0
 
     def fmt_copyright(lic):
         # discards copyright with invalid quotes to ensure generated csv is valid

--- a/tasks/licenses.py
+++ b/tasks/licenses.py
@@ -79,9 +79,21 @@ def get_licenses_list(ctx):
 
 def licenses_csv(licenses):
     licenses.sort(key=lambda lic: lic["package"])
-
+    def is_valid_quote(copyright):
+        stack = []
+        quotes_to_check = ["'",'"']
+        for c in copyright:
+            if c in quotes_to_check:
+                if len(stack) !=0 and stack[-1] == c:
+                    stack.pop()
+                else:
+                    stack.append(c)
+        return len(stack) == 0
     def fmt_copyright(lic):
-        copyright = ' | '.join(sorted(lic['copyright']))
+        # discards copyright with invalid quotes to ensure generated csv is valid
+        copyright = [f_copyright for f_copyright in lic['copyright'] if is_valid_quote(f_copyright)]
+
+        copyright = ' | '.join(sorted(copyright))
         # quote for inclusion in CSV, if necessary
         if ',' in copyright:
             copyright = copyright.replace('"', '""')

--- a/tasks/unit-tests/licenses_test.py
+++ b/tasks/unit-tests/licenses_test.py
@@ -1,0 +1,15 @@
+import unittest
+
+from ..licenses import is_valid_quote
+
+
+class TestLicensesMethod(unittest.TestCase):
+    def test_valid_quotes(self):
+        self.assertTrue(is_valid_quote('"\'hello\'"'))
+
+    def test_invalid_quotes(self):
+        self.assertFalse(is_valid_quote('""hello' '"""'))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### What does this PR do?

Change to tasks creating the LICENSE-3rdparty.csv file. To ensure that the csv file is not invalid when parsing files with copyright containing invalid quotes

### Motivation

Enhance efficiency of the license generation tool and remove license-override

### Additional Notes
### Possible Drawbacks / Trade-offs
### Describe how to test/QA your changes
### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
