### PR TITLE
Increase DB timeout

### DIFF
--- a/pkg/collector/corechecks/oracle-dbm/oracle.go
+++ b/pkg/collector/corechecks/oracle-dbm/oracle.go
@@ -26,6 +26,7 @@ import (
 
 var MAX_OPEN_CONNECTIONS = 10
 var DEFAULT_SQL_TRACED_RUNS = 10
+var DB_TIMEOUT = "20000"
 
 // The structure is filled by activity sampling and serves as a filter for query metrics
 type StatementsFilter struct {
@@ -147,7 +148,7 @@ func (c *Check) Connect() (*sqlx.DB, error) {
 			connStr = fmt.Sprintf("%s/%s@%s/%s", c.config.Username, c.config.Password, c.config.Server, c.config.ServiceName)
 		} else {
 			oracleDriver = "oracle"
-			connStr = go_ora.BuildUrl(c.config.Server, c.config.Port, c.config.ServiceName, c.config.Username, c.config.Password, map[string]string{})
+			connStr = go_ora.BuildUrl(c.config.Server, c.config.Port, c.config.ServiceName, c.config.Username, c.config.Password, map[string]string{"TIMEOUT": DB_TIMEOUT})
 			// https://github.com/jmoiron/sqlx/issues/854#issuecomment-1504070464
 			sqlx.BindDriver("oracle", sqlx.NAMED)
 		}


### PR DESCRIPTION
### What does this PR do?

We are increasing the timeout on `go-ora` driver from the default value of 30 to 20000. (There is no way to disable the timeout.)

### Motivation

`database/sqlx` method `Select` leaks a database connection after a timeout.

### Additional Notes

Actually, `Select` probably doesn't fails to close the statement handle on the timeout statement. As Go `database/sql` allocates a dedicated connection for every prepared statement and doesn't return it to the connection pool until the prepared statement is closed. Allocating a dedicated connection for every statement is suboptimal and completely unnecessary. Other programming languages keep prepared statements in the local cache and access them on subsequent query executions.

On other errors the connection doesn't leak.

The problem can be reproduced with the steps below.

Lock a row with the following statements:

```
create table t (n number);
insert into t values (1);
commit;
update t set n=2;
-- no commit here so the row will remained locked
```

Run the following program:
```
package main

import (
    "fmt"

    _ "github.com/godror/godror"
    "github.com/jmoiron/sqlx"
    go_ora "github.com/sijms/go-ora/v2"
)

const HOST = "localhost"
const PORT = 1521
const SERVICE_NAME = "XE"
const USER = 
const PASSWORD = 

type S struct {
    N string `db:"N"`
}

func main() {
    connStr := go_ora.BuildUrl(HOST, PORT, SERVICE_NAME, USER, PASSWORD, map[string]string{"TIMEOUT": "1"})
    db, err := sqlx.Open("oracle", connStr)

    if err != nil {
        fmt.Printf("failed to connect %v \n", err)
        return
    }
    db.SetMaxOpenConns(1)
    r := []S{}
    fmt.Println("Waiting on timeout...")
    // Because of the FOR UPDATE clause SELECT unsuccessfully waits on a lock,
    // but it times out
    err = db.Select(&r, "select n from t FOR UPDATE")
    if err != nil {
        fmt.Printf("failed sql execution %v \n", err)
    }

    // This statement will never end because the previous failed execution
    // hasn't release the connection
    fmt.Println("Starting another statement...")
    err = db.Select(&r, "select n from t")
    if err != nil {
        fmt.Printf("failed sql execution %v \n", err)
        return
    }
    fmt.Println("END")
}
```

```
go run main.go
Waiting on timeout...
failed sql execution read tcp 127.0.0.1:57796->127.0.0.1:1521: i/o timeout 
Starting another statement...
```

Notice that the error message `rcp i/o timeout` is completely misleading. The reason was in this case a long SQL execution. The driver cannot now the real cause for the timeout.

### Possible Drawbacks / Trade-offs

There is no drawback in disabling the timeout. Simply put, there's no benefit in breaking the execution and retrying it.

### Describe how to test/QA your changes

Run agent for longer under the load and check that it doesn't hang.

